### PR TITLE
fix(config): quarantine corrupt config.json and load defaults (daemon must not block startup)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4243,6 +4243,7 @@ paths:
                             - new
                             - seen
                             - acted_on
+                            - dismissed
                         expiresAt:
                           type: string
                         minTimeAway:
@@ -4265,6 +4266,13 @@ paths:
                               - label
                               - prompt
                             additionalProperties: false
+                        urgency:
+                          type: string
+                          enum:
+                            - low
+                            - medium
+                            - high
+                            - critical
                         author:
                           type: string
                           enum:
@@ -4365,6 +4373,7 @@ paths:
                       - new
                       - seen
                       - acted_on
+                      - dismissed
                   expiresAt:
                     type: string
                   minTimeAway:
@@ -4387,6 +4396,13 @@ paths:
                         - label
                         - prompt
                       additionalProperties: false
+                  urgency:
+                    type: string
+                    enum:
+                      - low
+                      - medium
+                      - high
+                      - critical
                   author:
                     type: string
                     enum:
@@ -4424,6 +4440,7 @@ paths:
                     - new
                     - seen
                     - acted_on
+                    - dismissed
               required:
                 - status
               additionalProperties: false

--- a/assistant/src/__tests__/config-loader-corrupt.test.ts
+++ b/assistant/src/__tests__/config-loader-corrupt.test.ts
@@ -1,13 +1,10 @@
 /**
- * Regression tests for JARVIS-409: the daemon must never block startup when
- * ~/.vellum/workspace/config.json is corrupt.
- *
- * A corrupt config (truncated during a power-loss mid-write, or hand-edited to
- * invalid JSON) previously caused loadConfig() / loadRawConfig() to throw
- * ConfigError, which hard-failed daemon startup and surfaced /v1/config as a
- * 500 response. The loader now quarantines the corrupt file, logs an error
- * with a remediation hint, and falls through to the default-config path so
- * startup proceeds.
+ * A corrupt config.json (truncated during a power-loss mid-write, or
+ * hand-edited to invalid JSON) is quarantined by the loader, which
+ * logs an error with a remediation hint and falls through to the
+ * default-config path so startup proceeds. These tests verify that
+ * loadConfig() / loadRawConfig() never throw on corrupt input, and
+ * that the corrupt file is preserved for debugging.
  */
 
 import {

--- a/assistant/src/__tests__/config-loader-corrupt.test.ts
+++ b/assistant/src/__tests__/config-loader-corrupt.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Regression tests for JARVIS-409: the daemon must never block startup when
+ * ~/.vellum/workspace/config.json is corrupt.
+ *
+ * A corrupt config (truncated during a power-loss mid-write, or hand-edited to
+ * invalid JSON) previously caused loadConfig() / loadRawConfig() to throw
+ * ConfigError, which hard-failed daemon startup and surfaced /v1/config as a
+ * 500 response. The loader now quarantines the corrupt file, logs an error
+ * with a remediation hint, and falls through to the default-config path so
+ * startup proceeds.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  invalidateConfigCache,
+  loadConfig,
+  loadRawConfig,
+} from "../config/loader.js";
+import { _setStorePath } from "../security/encrypted-store.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  const dirs = [
+    WORKSPACE_DIR,
+    join(WORKSPACE_DIR, "data"),
+    join(WORKSPACE_DIR, "data", "memory"),
+    join(WORKSPACE_DIR, "data", "memory", "knowledge"),
+    join(WORKSPACE_DIR, "data", "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+function resetWorkspace(): void {
+  for (const name of readdirSync(WORKSPACE_DIR)) {
+    rmSync(join(WORKSPACE_DIR, name), { recursive: true, force: true });
+  }
+  ensureTestDir();
+}
+
+function listQuarantinedFiles(): string[] {
+  return readdirSync(WORKSPACE_DIR).filter((name) =>
+    /^config\.json\.corrupt-.+\.json$/.test(name),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("loadConfig corrupt-file recovery", () => {
+  beforeEach(() => {
+    resetWorkspace();
+    _setStorePath(join(WORKSPACE_DIR, "keys.enc"));
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    _setStorePath(null);
+    invalidateConfigCache();
+  });
+
+  test("quarantines corrupt config.json and returns defaults", () => {
+    // Simulate a truncated mid-write: valid JSON prefix, abrupt end.
+    writeFileSync(CONFIG_PATH, '{"provider": "anthropic", "mo');
+
+    // Must not throw — the daemon must never block startup on corrupt config.
+    const config = loadConfig();
+
+    // Defaults loaded — config is populated through the Zod schema.
+    expect(config).toBeDefined();
+    expect(config.memory).toBeDefined();
+
+    // Corrupt file renamed, not deleted — content preserved for debug.
+    const quarantined = listQuarantinedFiles();
+    expect(quarantined).toHaveLength(1);
+    const quarantinedPath = join(WORKSPACE_DIR, quarantined[0]);
+    expect(readFileSync(quarantinedPath, "utf-8")).toBe(
+      '{"provider": "anthropic", "mo',
+    );
+
+    // After quarantine the daemon wrote a fresh default config.json.
+    expect(existsSync(CONFIG_PATH)).toBe(true);
+  });
+
+  test("loads a valid config without renaming (regression guard)", () => {
+    writeFileSync(
+      CONFIG_PATH,
+      JSON.stringify({ provider: "anthropic", model: "claude-opus-4-7" }),
+    );
+
+    const config = loadConfig();
+    expect(config).toBeDefined();
+
+    // No quarantine file for valid JSON.
+    expect(listQuarantinedFiles()).toHaveLength(0);
+    // The original file is still present.
+    expect(existsSync(CONFIG_PATH)).toBe(true);
+  });
+
+  test("does not re-quarantine existing quarantine files on subsequent startups", () => {
+    // First startup: corrupt config is quarantined.
+    writeFileSync(CONFIG_PATH, "}{not json");
+    loadConfig();
+
+    const firstBatch = listQuarantinedFiles();
+    expect(firstBatch).toHaveLength(1);
+
+    // Daemon restart with no new config.json (the loader wrote defaults after
+    // the quarantine on the previous load, so there IS now a valid config.json
+    // on disk — no second quarantine should occur).
+    invalidateConfigCache();
+    loadConfig();
+
+    // Still exactly one quarantined file — the loader did not re-rename a
+    // pristine or already-quarantined file.
+    expect(listQuarantinedFiles()).toHaveLength(1);
+    expect(listQuarantinedFiles()[0]).toBe(firstBatch[0]);
+  });
+
+  test("quarantine filenames are filesystem-safe (no colons)", () => {
+    writeFileSync(CONFIG_PATH, "not-valid-json");
+    loadConfig();
+
+    const quarantined = listQuarantinedFiles();
+    expect(quarantined).toHaveLength(1);
+    // ISO-8601 colons must have been replaced — filenames with `:` are
+    // invalid on Windows and awkward on macOS Finder.
+    expect(quarantined[0]).not.toContain(":");
+    // Should match the documented shape: config.json.corrupt-<ISO>.json
+    expect(quarantined[0]).toMatch(
+      /^config\.json\.corrupt-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z\.json$/,
+    );
+  });
+});
+
+describe("loadRawConfig corrupt-file recovery", () => {
+  beforeEach(() => {
+    resetWorkspace();
+    _setStorePath(join(WORKSPACE_DIR, "keys.enc"));
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    _setStorePath(null);
+    invalidateConfigCache();
+  });
+
+  test("returns {} and quarantines corrupt file instead of throwing", () => {
+    writeFileSync(CONFIG_PATH, "this is not json at all");
+
+    // Must not throw — the /v1/config handler depends on this.
+    const raw = loadRawConfig();
+
+    expect(raw).toEqual({});
+    expect(listQuarantinedFiles()).toHaveLength(1);
+  });
+
+  test("returns parsed object when config is valid", () => {
+    writeFileSync(
+      CONFIG_PATH,
+      JSON.stringify({ foo: "bar", nested: { k: 1 } }),
+    );
+
+    const raw = loadRawConfig();
+    expect(raw).toEqual({ foo: "bar", nested: { k: 1 } });
+    expect(listQuarantinedFiles()).toHaveLength(0);
+  });
+});

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -8,7 +8,6 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 
-import { ConfigError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { ensureDataDir, getWorkspaceConfigPath } from "../util/platform.js";
 import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
@@ -45,6 +44,45 @@ export function applyNestedDefaults(config: unknown): AssistantConfig {
 
 function cloneDefaultConfig(): AssistantConfig {
   return applyNestedDefaults({});
+}
+
+/**
+ * Build a filesystem-safe ISO-8601 timestamp for use in quarantine filenames.
+ * Replaces `:` (invalid on Windows, confusing on macOS Finder) with `-` so the
+ * resulting string is safe on every supported platform.
+ */
+function filesystemSafeTimestamp(date: Date = new Date()): string {
+  return date.toISOString().replace(/:/g, "-");
+}
+
+/**
+ * Rename a corrupt config file to a quarantine path so the bad content is
+ * preserved for debug while the daemon falls through to defaults. Logs at
+ * `error` level with a remediation hint. Best-effort: if the rename itself
+ * fails (missing permissions, readonly FS, etc.) we still fall through to
+ * defaults — startup must never block.
+ *
+ * The quarantine filename encodes a millisecond-precision timestamp and ends
+ * in `.json` so editors syntax-highlight the preserved content:
+ *   `<path>.corrupt-<ISO-timestamp>.json`
+ */
+function quarantineCorruptConfig(configPath: string, err: unknown): string {
+  const quarantinePath = `${configPath}.corrupt-${filesystemSafeTimestamp()}.json`;
+  try {
+    renameSync(configPath, quarantinePath);
+    log.error(
+      `config file at ${configPath} was corrupt (${String(err)}); ` +
+        `quarantined to ${quarantinePath} and loaded defaults. ` +
+        `Inspect the quarantined file to recover any hand-edited settings.`,
+    );
+  } catch (renameErr) {
+    log.error(
+      { renameErr },
+      `config file at ${configPath} was corrupt (${String(err)}) but could ` +
+        `not be renamed for quarantine; loaded defaults.`,
+    );
+  }
+  return quarantinePath;
 }
 
 /**
@@ -418,9 +456,14 @@ export function loadConfig(): AssistantConfig {
       try {
         fileConfig = JSON.parse(readFileSync(configPath, "utf-8"));
       } catch (err) {
-        throw new ConfigError(
-          `Failed to parse config at ${configPath}: ${err}`,
-        );
+        // The daemon must never block startup (assistant/CLAUDE.md). A config
+        // file that fails JSON.parse — truncated during a mid-write crash, or
+        // hand-edited to invalid JSON — is quarantined so the content is
+        // preserved for debug, and startup proceeds with the same default-
+        // config path used when config.json does not exist.
+        quarantineCorruptConfig(configPath, err);
+        fileConfig = {};
+        configFileExisted = false;
       }
     } else {
       configFileExisted = false;
@@ -576,7 +619,11 @@ export function loadRawConfig(): Record<string, unknown> {
     try {
       raw = JSON.parse(readFileSync(configPath, "utf-8"));
     } catch (err) {
-      throw new ConfigError(`Failed to parse config at ${configPath}: ${err}`);
+      // Mirror loadConfig(): quarantine the corrupt file and return an empty
+      // object rather than throwing. This prevents /v1/config from surfacing
+      // a 500 when the user's config.json is malformed.
+      quarantineCorruptConfig(configPath, err);
+      raw = {};
     }
   }
 


### PR DESCRIPTION
## Summary

- The daemon must **never** block startup (assistant/CLAUDE.md). A corrupt `~/.vellum/workspace/config.json` — truncated during a crash, or hand-edited to invalid JSON — previously threw `ConfigError` out of `loadConfig()` / `loadRawConfig()`, hard-failing startup and surfacing `GET /v1/config` as 500.
- `loader.ts` now catches JSON parse failures, renames the corrupt file to `config.json.corrupt-<ISO-timestamp>.json` (colons replaced with hyphens for Windows/macOS safety), logs at `error` level with a remediation hint, and falls through to the default-config path. Startup proceeds and the user's bad content is preserved for debug.
- Both `loadConfig()` (daemon startup) and `loadRawConfig()` (HTTP `/v1/config` + CLI `assistant config get/set`) share the same `quarantineCorruptConfig()` helper, so the fix covers all callers uniformly.
- `getConfigReadOnly()` already swallowed the parse error and returned defaults. Its read-only contract (no disk writes) is preserved — it does not quarantine, and any subsequent `loadConfig()` / `loadRawConfig()` call will.
- No change needed in `conversation-query-routes.ts`: the only 500 path was triggered by `loadRawConfig()` throwing, which no longer happens for corrupt JSON. The handler's try/catch remains as defensive cover for unrelated errors (permission denied, disk full).

## Test plan

- [x] `bunx tsc --noEmit` clean.
- [x] `bun run lint` clean.
- [x] `bun test src/__tests__/config-loader-corrupt.test.ts` — 6 tests pass:
  - Corrupt `config.json` (truncated mid-string) is quarantined; default config loaded; fresh default config written to disk.
  - Valid `config.json` loads normally, no quarantine file created (regression guard).
  - After first-quarantine + daemon restart, the now-valid fresh config does NOT get re-quarantined.
  - Quarantine filename contains no colons and matches the documented shape `config.json.corrupt-YYYY-MM-DDTHH-MM-SS.sssZ.json`.
  - `loadRawConfig()` returns `{}` + quarantines on corrupt input (vs throwing).
  - `loadRawConfig()` returns the parsed object on valid input (regression guard).
- [x] `bun test src/__tests__/config-loader-backfill.test.ts src/__tests__/config-managed-gemini-defaults.test.ts` — 36 related tests still pass.

Closes JARVIS-409
Closes JARVIS-408
Closes JARVIS-424
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
