### PR TITLE
fix(home): forward meetStatusViewModel through HomePageView EmptyView init

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -243,6 +243,7 @@ extension HomePageView where DetailPanel == EmptyView {
     init(
         store: HomeStore,
         feedStore: HomeFeedStore,
+        meetStatusViewModel: MeetStatusViewModel,
         onPrimaryCTA: @escaping (Capability) -> Void,
         onShortcutCTA: @escaping (Capability) -> Void,
         onFeedConversationOpened: @escaping (String) -> Void,
@@ -251,6 +252,7 @@ extension HomePageView where DetailPanel == EmptyView {
         self.init(
             store: store,
             feedStore: feedStore,
+            meetStatusViewModel: meetStatusViewModel,
             onPrimaryCTA: onPrimaryCTA,
             onShortcutCTA: onShortcutCTA,
             onFeedConversationOpened: onFeedConversationOpened,


### PR DESCRIPTION
## Summary
CI on \`main\` is broken after \`Jasonnnz/home-detail-panel\` (#26245) merged alongside the \`meetStatusViewModel\` addition. The primary \`HomePageView\` init gained \`meetStatusViewModel: MeetStatusViewModel\`, but the backward-compatible extension init (specialized for \`DetailPanel == EmptyView\`) never learned about it. That leaves \`PanelCoordinator\`'s call site unable to resolve to the convenience init — the compiler falls through to the primary init and then fails on the missing \`detailPanel\` closure plus the unrecoverable generic parameter.

Thread the new parameter through the extension init so
\`HomePageView(store:feedStore:meetStatusViewModel:onPrimaryCTA:…)\`
resolves to the \`EmptyView\` specialization as intended.

## Test plan
- [x] \`swift build\` from \`clients/\` green
- [ ] macOS CI turns green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
