### PR TITLE
fix(chrome-ext): clear selected assistant ID on environment switch

### DIFF
--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -143,9 +143,14 @@ async function setOverrideEnvironment(env: ExtensionEnvironment | null): Promise
 }
 
 /**
- * Remove all stored auth tokens (cloud and local) for every assistant.
- * Called when the effective environment changes so stale tokens minted
- * against the previous environment are not reused on the next connect.
+ * Remove all stored auth tokens (cloud and local) for every assistant
+ * and clear the selected assistant ID. Called when the effective
+ * environment changes so stale tokens minted against the previous
+ * environment are not reused on the next connect. The selected assistant
+ * ID is cleared because it references an assistant from the old
+ * environment's catalog — the next `resolveSelectedAssistant` call will
+ * auto-select from the new environment's catalog.
+ *
  * Token storage keys use a well-known prefix (`vellum.cloudAuthToken` /
  * `vellum.localCapabilityToken`) — we enumerate all storage keys and
  * remove those matching either prefix.
@@ -155,9 +160,11 @@ async function invalidateAuthTokens(): Promise<void> {
   const keysToRemove = Object.keys(all).filter(
     (k) => k.startsWith('vellum.cloudAuthToken') || k.startsWith('vellum.localCapabilityToken'),
   );
-  if (keysToRemove.length > 0) {
-    await chrome.storage.local.remove(keysToRemove);
-  }
+  // Also clear the selected assistant — it belongs to the old
+  // environment's catalog and would cause the connect flow to either
+  // pick the wrong assistant or fall through to the legacy path.
+  keysToRemove.push(SELECTED_ASSISTANT_ID_KEY);
+  await chrome.storage.local.remove(keysToRemove);
 }
 
 /**


### PR DESCRIPTION
## Summary
- When switching environments via the popup selector, `invalidateAuthTokens()` now also clears `vellum.selectedAssistantId`
- Without this, the stale assistant ID from the old environment causes the connect flow to either match the wrong assistant or fall through to the legacy unscoped-token path, connecting to a daemon from the wrong environment
- The next `resolveSelectedAssistant()` call auto-selects from the new environment's catalog

## Root cause
`environment-set` handler invalidated auth tokens but left the selected assistant ID intact. On reconnect, `resolveSelectedAssistant` checked the stored ID against the new environment's catalog, found no match, and fell to "default to first entry." But in certain flows (e.g., when the reconnect errored on cloud sign-in and the user re-paired manually), the stale selected ID persisted and the extension connected to the wrong daemon.

## Original prompt
lets remove it entirely.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
