### PR TITLE
fix(watcher): include ping_failed in credential health gates

### DIFF
--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -298,7 +298,9 @@ export class HeartbeatService {
 
     for (const result of results) {
       const urgency =
-        result.status === "revoked" || result.status === "expired"
+        result.status === "revoked" ||
+        result.status === "expired" ||
+        result.status === "ping_failed"
           ? ("high" as const)
           : ("medium" as const);
 

--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -90,6 +90,7 @@ export async function runWatchersOnce(
         health &&
         (health.status === "revoked" ||
           health.status === "missing_token" ||
+          health.status === "ping_failed" ||
           (health.status === "expired" && !health.canAutoRecover))
       ) {
         skipWatcherPoll(watcher.id, `Credential unhealthy: ${health.details}`);


### PR DESCRIPTION
## Summary
- When a provider's liveness ping fails (e.g. network timeout to Google), the credential was marked `ping_failed` but the watcher still attempted polling — which would also fail
- Now `ping_failed` is included in the watcher engine's pre-poll credential gate, preventing wasted API calls
- Elevated `ping_failed` to "high" urgency in heartbeat notifications so users learn their provider is unreachable

Part of a series of 6 PRs to fix silent OAuth failure handling.

## Test plan
- [x] Type-checks clean
- [x] Heartbeat tests pass (37/37)
- [ ] Manual: disconnect network, verify watcher skips polling with `ping_failed` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
