### PR TITLE
fix(oauth): retry and escalate SQLite update failure after token refresh

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4243,6 +4243,7 @@ paths:
                             - new
                             - seen
                             - acted_on
+                            - dismissed
                         expiresAt:
                           type: string
                         minTimeAway:
@@ -4265,6 +4266,13 @@ paths:
                               - label
                               - prompt
                             additionalProperties: false
+                        urgency:
+                          type: string
+                          enum:
+                            - low
+                            - medium
+                            - high
+                            - critical
                         author:
                           type: string
                           enum:
@@ -4365,6 +4373,7 @@ paths:
                       - new
                       - seen
                       - acted_on
+                      - dismissed
                   expiresAt:
                     type: string
                   minTimeAway:
@@ -4387,6 +4396,13 @@ paths:
                         - label
                         - prompt
                       additionalProperties: false
+                  urgency:
+                    type: string
+                    enum:
+                      - low
+                      - medium
+                      - high
+                      - critical
                   author:
                     type: string
                     enum:
@@ -4424,6 +4440,7 @@ paths:
                     - new
                     - seen
                     - acted_on
+                    - dismissed
               required:
                 - status
               additionalProperties: false

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -269,17 +269,30 @@ async function doRefresh(service: string, connId: string): Promise<string> {
     );
   }
 
-  // Update oauth_connection row with new expiry.
-  try {
-    updateConnection(connId, {
-      expiresAt: persisted.expiresAt,
-      hasRefreshToken: persisted.hasRefreshToken,
-    });
-  } catch (err) {
-    log.warn(
-      { err, service },
-      "Failed to update oauth_connection after refresh",
-    );
+  // Update oauth_connection row with new expiry. Retry once on failure
+  // to reduce the risk of stale expiresAt metadata in SQLite while the
+  // actual token in secure storage is valid.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      updateConnection(connId, {
+        expiresAt: persisted.expiresAt,
+        hasRefreshToken: persisted.hasRefreshToken,
+      });
+      break;
+    } catch (err) {
+      if (attempt === 0) {
+        log.warn(
+          { err, service },
+          "Failed to update oauth_connection after refresh, retrying",
+        );
+      } else {
+        log.error(
+          { err, service, expiresAt: persisted.expiresAt },
+          "Failed to update oauth_connection after refresh — token is valid " +
+            "in secure storage but SQLite expiry metadata is stale",
+        );
+      }
+    }
   }
 
   circuitBreaker.recordSuccess(connId);


### PR DESCRIPTION
## Summary
- When `updateConnection()` fails after a successful token refresh, the new token is valid in secure storage but SQLite has stale `expiresAt` metadata — causing future expiry checks to be wrong
- Now retries the SQLite update once on failure
- Escalates to ERROR level if both attempts fail, making stale metadata visible in error monitoring

Part of a series of 6 PRs to fix silent OAuth failure handling.

## Test plan
- [x] Credential vault tests pass (49/49)
- [x] Type-checks clean
- [ ] Manual: verify ERROR log appears when SQLite write fails after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
