### PR TITLE
fix(heartbeat): escalate notification pipeline failures to error level

### DIFF
--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -272,7 +272,18 @@ export class HeartbeatService {
         return report.unhealthy.map((r) => r.provider);
       }
     } catch (err) {
-      log.warn({ err }, "Credential health check failed (non-fatal)");
+      log.error({ err }, "Credential health check failed");
+      try {
+        this.deps.alerter({
+          type: "heartbeat_alert",
+          title: "Credential Health Check Failed",
+          body:
+            "Could not verify OAuth credential health. " +
+            (err instanceof Error ? err.message : String(err)),
+        });
+      } catch {
+        // Last resort — alerter itself failed. Already logged above.
+      }
     }
     return [];
   }
@@ -291,8 +302,11 @@ export class HeartbeatService {
     try {
       ({ emitNotificationSignal } =
         await import("../notifications/emit-signal.js"));
-    } catch {
-      log.warn("Failed to import notification signal emitter");
+    } catch (importErr) {
+      log.error(
+        { err: importErr },
+        "Failed to import notification signal emitter",
+      );
       return;
     }
 
@@ -324,7 +338,7 @@ export class HeartbeatService {
           routingIntent: "single_channel",
         });
       } catch (err) {
-        log.warn(
+        log.error(
           { err, provider: result.provider, connectionId: result.connectionId },
           "Failed to emit credential health notification",
         );
@@ -378,7 +392,7 @@ export class HeartbeatService {
           body: err instanceof Error ? err.message : String(err),
         });
       } catch (alertErr) {
-        log.warn({ alertErr }, "Failed to broadcast heartbeat alert");
+        log.error({ alertErr }, "Failed to broadcast heartbeat alert");
       }
     }
   }


### PR DESCRIPTION
## Summary
- Three places in the heartbeat notification pipeline silently swallowed errors at WARN level, making credential alert delivery failures invisible in error monitoring
- Credential health check failure: now logs at ERROR and fires the alerter as a fallback
- Notification signal emitter import failure: escalated to ERROR
- Individual credential alert emission + alerter broadcast failures: escalated to ERROR

Part of a series of 6 PRs to fix silent OAuth failure handling.

## Test plan
- [x] Heartbeat tests pass
- [x] Type-checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
