### PR TITLE
fix(oauth): retry and escalate SQLite update failure after token refresh

### DIFF
--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -270,17 +270,30 @@ async function doRefresh(service: string, connId: string): Promise<string> {
     );
   }
 
-  // Update oauth_connection row with new expiry.
-  try {
-    updateConnection(connId, {
-      expiresAt: persisted.expiresAt,
-      hasRefreshToken: persisted.hasRefreshToken,
-    });
-  } catch (err) {
-    log.warn(
-      { err, service },
-      "Failed to update oauth_connection after refresh",
-    );
+  // Update oauth_connection row with new expiry. Retry once on failure
+  // to reduce the risk of stale expiresAt metadata in SQLite while the
+  // actual token in secure storage is valid.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      updateConnection(connId, {
+        expiresAt: persisted.expiresAt,
+        hasRefreshToken: persisted.hasRefreshToken,
+      });
+      break;
+    } catch (err) {
+      if (attempt === 0) {
+        log.warn(
+          { err, service },
+          "Failed to update oauth_connection after refresh, retrying",
+        );
+      } else {
+        log.error(
+          { err, service, expiresAt: persisted.expiresAt },
+          "Failed to update oauth_connection after refresh — token is valid " +
+            "in secure storage but SQLite expiry metadata is stale",
+        );
+      }
+    }
   }
 
   circuitBreaker.recordSuccess(connId);


### PR DESCRIPTION
## Summary
- When `updateConnection()` fails after a successful token refresh, the new token is valid in secure storage but SQLite has stale `expiresAt` metadata
- Now retries the SQLite update once on failure
- Escalates to ERROR level if both attempts fail, making stale metadata visible in error monitoring

Part of a series of 6 PRs to fix silent OAuth failure handling.

## Test plan
- [x] Type-checks clean
- [x] Credential vault tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
