### PR TITLE
fix: rename <pkb> XML tag to <knowledge_base>

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -702,7 +702,7 @@ describe("applyRuntimeInjections — injection mode", () => {
     expect(allText).toContain("<non_interactive_context>");
     expect(allText).toContain("<NOW.md");
     expect(allText).toContain("<system_reminder>");
-    expect(allText).toContain("<pkb>");
+    expect(allText).toContain("<knowledge_base>");
   });
 
   test("explicit mode: 'full' behaves the same as default", async () => {
@@ -737,7 +737,7 @@ describe("applyRuntimeInjections — injection mode", () => {
     expect(allText).not.toContain("<active_workspace>");
     expect(allText).not.toContain("<NOW.md");
     expect(allText).not.toContain("<system_reminder>");
-    expect(allText).not.toContain("<pkb>");
+    expect(allText).not.toContain("<knowledge_base>");
   });
 
   test("minimal mode preserves safety-critical blocks", async () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -731,10 +731,13 @@ export function readPkbContext(): string | null {
  */
 export function injectPkbContext(message: Message, content: string): Message {
   // Escape closing tags that could break out of the XML wrapper
-  const escaped = content.replace(/<\/pkb\s*>/gi, "&lt;/pkb&gt;");
+  const escaped = content.replace(
+    /<\/knowledge_base\s*>/gi,
+    "&lt;/knowledge_base&gt;",
+  );
   const pkbBlock = {
     type: "text" as const,
-    text: `<pkb>\n${escaped}\n</pkb>`,
+    text: `<knowledge_base>\n${escaped}\n</knowledge_base>`,
   };
 
   // Find insertion point: skip any leading memory/image blocks
@@ -766,9 +769,12 @@ export function injectPkbContext(message: Message, content: string): Message {
   };
 }
 
-/** Strip `<pkb>` blocks injected by `injectPkbContext`. */
+/** Strip `<knowledge_base>` blocks injected by `injectPkbContext`. */
 export function stripPkbContext(messages: Message[]): Message[] {
-  return stripUserTextBlocksByPrefix(messages, ["<pkb>"]);
+  return stripUserTextBlocksByPrefix(messages, [
+    "<knowledge_base>",
+    "<pkb>", // backward-compat: strip legacy blocks from pre-rename history
+  ]);
 }
 
 /**
@@ -1645,7 +1651,8 @@ const RUNTIME_INJECTION_PREFIXES = [
   // variant that may linger in in-flight histories during a rolling deploy.
   "<NOW.md Always keep this up to date",
   "<now_scratchpad>", // backward-compat: strip legacy blocks from pre-rename history
-  "<pkb>",
+  "<knowledge_base>",
+  "<pkb>", // backward-compat: strip legacy tag from pre-rename history
   "<system_reminder>",
   "<transport_hints>",
   // The Slack active-thread focus block is non-persisted and injected on


### PR DESCRIPTION
## Summary
- Renamed the `<pkb>` XML wrapper tag to `<knowledge_base>` so the model stops echoing "PKB" in user-facing text
- Added backward-compat entries to strip legacy `<pkb>` tags from in-flight conversation history
- Updated tests to match new tag name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
