### PR TITLE
feat(home): add HomeFeedGroupHeader view for time-bucketed sections

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedGroupHeader.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedGroupHeader.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Section header for time-bucketed feed groups (Today / Yesterday / Older).
+///
+/// Renders as a leading-aligned 12pt label using the shared design tokens
+/// so it matches the Figma spec (#5A6672 / 12pt medium / leading aligned).
+/// Intentionally pads nothing — the caller owns spacing around the header.
+struct HomeFeedGroupHeader: View {
+    let label: String
+
+    var body: some View {
+        Text(label)
+            .font(VFont.bodySmallDefault)
+            .foregroundStyle(VColor.contentSecondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityAddTraits(.isHeader)
+    }
+}


### PR DESCRIPTION
## Summary
- Add HomeFeedGroupHeader — a leading-aligned 12pt label used as a section header for time-bucketed feed groups (Today/Yesterday/Older)
- Uses VFont.bodySmallDefault + VColor.contentSecondary tokens; caller owns spacing

Part of plan: home-figma-redesign.md (PR 2 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
