### PR TITLE
feat(home): add HomeFeedTimeGroup bucketing helper for Today/Yesterday/Older

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedTimeGroup.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedTimeGroup.swift
@@ -1,0 +1,74 @@
+import Foundation
+import VellumAssistantShared
+
+/// Canonical day-bucket grouping for Home feed items.
+///
+/// Used by the Home page to split the feed into Today / Yesterday / Older
+/// sections. The enum is Sendable so it can be passed across actor
+/// boundaries alongside the `FeedItem` values it partitions.
+///
+/// See ``bucket(_:now:calendar:)`` for the grouping entry point.
+enum HomeFeedTimeGroup: String, CaseIterable, Sendable {
+    case today
+    case yesterday
+    case older
+
+    /// User-facing section label for the group.
+    var label: String {
+        switch self {
+        case .today:     return "Today"
+        case .yesterday: return "Yesterday"
+        case .older:     return "Older"
+        }
+    }
+
+    /// Partitions `items` into `.today` / `.yesterday` / `.older` buckets
+    /// based on each item's ``FeedItem/createdAt`` relative to `now`.
+    ///
+    /// - Parameters:
+    ///   - items: Feed items to bucket. Input order is preserved within
+    ///     each resulting group — the caller owns sort.
+    ///   - now: Reference "current" moment. Defaults to `Date()`. Passed
+    ///     explicitly by tests for determinism.
+    ///   - calendar: Calendar used for the day comparisons. Defaults to
+    ///     `.current`. Tests pass a calendar with a fixed `timeZone`.
+    ///
+    /// - Returns: Groups in canonical order `[.today, .yesterday, .older]`,
+    ///   omitting any groups that would be empty.
+    static func bucket(
+        _ items: [FeedItem],
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [(group: HomeFeedTimeGroup, items: [FeedItem])] {
+        guard !items.isEmpty else { return [] }
+
+        var today: [FeedItem] = []
+        var yesterday: [FeedItem] = []
+        var older: [FeedItem] = []
+
+        // `isDateInToday` / `isDateInYesterday` on a custom `Calendar`
+        // (one with a fixed `timeZone`, for tests) don't consult `now` —
+        // they compare against the calendar's current date. To get
+        // deterministic bucketing with an injected `now`, fall back to
+        // comparing calendar days directly.
+        let todayDay = calendar.startOfDay(for: now)
+        let yesterdayDay = calendar.date(byAdding: .day, value: -1, to: todayDay) ?? todayDay
+
+        for item in items {
+            let itemDay = calendar.startOfDay(for: item.createdAt)
+            if itemDay == todayDay {
+                today.append(item)
+            } else if itemDay == yesterdayDay {
+                yesterday.append(item)
+            } else {
+                older.append(item)
+            }
+        }
+
+        var result: [(group: HomeFeedTimeGroup, items: [FeedItem])] = []
+        if !today.isEmpty { result.append((.today, today)) }
+        if !yesterday.isEmpty { result.append((.yesterday, yesterday)) }
+        if !older.isEmpty { result.append((.older, older)) }
+        return result
+    }
+}

--- a/clients/macos/vellum-assistantTests/Features/Home/HomeFeedTimeGroupTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Home/HomeFeedTimeGroupTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Unit tests for ``HomeFeedTimeGroup/bucket(_:now:calendar:)``.
+///
+/// All tests that care about day boundaries drive the helper with a
+/// fixed `now` and a calendar pinned to a single time zone so they are
+/// deterministic regardless of the runner's locale or the real clock.
+final class HomeFeedTimeGroupTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Canonical "reference now" used throughout the day-boundary tests:
+    /// 2025-06-15 12:00:00 UTC.
+    private let referenceNow = Date(timeIntervalSince1970: 1_749_988_800)
+
+    private func utcCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }
+
+    private func makeItem(
+        id: String,
+        createdAt: Date
+    ) -> FeedItem {
+        FeedItem(
+            id: id,
+            type: .nudge,
+            priority: 50,
+            title: "t-\(id)",
+            summary: "s-\(id)",
+            source: nil,
+            timestamp: createdAt,
+            status: .new,
+            expiresAt: nil,
+            minTimeAway: nil,
+            actions: nil,
+            urgency: nil,
+            author: .assistant,
+            createdAt: createdAt
+        )
+    }
+
+    // MARK: - Tests
+
+    func testEmptyInputReturnsEmptyArray() {
+        let groups = HomeFeedTimeGroup.bucket([], now: referenceNow, calendar: utcCalendar())
+        XCTAssertTrue(groups.isEmpty)
+    }
+
+    func testThreeBucketsReturnedInCanonicalOrder() {
+        let calendar = utcCalendar()
+
+        let todayItem = makeItem(
+            id: "today",
+            createdAt: referenceNow  // same day as reference now (UTC)
+        )
+        let yesterdayItem = makeItem(
+            id: "yesterday",
+            createdAt: referenceNow.addingTimeInterval(-86_400)
+        )
+        let olderItem = makeItem(
+            id: "older",
+            createdAt: referenceNow.addingTimeInterval(-10 * 86_400)
+        )
+
+        // Deliberately pass in non-canonical order.
+        let groups = HomeFeedTimeGroup.bucket(
+            [olderItem, todayItem, yesterdayItem],
+            now: referenceNow,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(groups.count, 3)
+        XCTAssertEqual(groups[0].group, .today)
+        XCTAssertEqual(groups[0].items.map(\.id), ["today"])
+        XCTAssertEqual(groups[1].group, .yesterday)
+        XCTAssertEqual(groups[1].items.map(\.id), ["yesterday"])
+        XCTAssertEqual(groups[2].group, .older)
+        XCTAssertEqual(groups[2].items.map(\.id), ["older"])
+    }
+
+    func testOnlyOlderReturnsSingleGroup() {
+        let calendar = utcCalendar()
+        let items = [
+            makeItem(id: "a", createdAt: referenceNow.addingTimeInterval(-7 * 86_400)),
+            makeItem(id: "b", createdAt: referenceNow.addingTimeInterval(-30 * 86_400)),
+        ]
+
+        let groups = HomeFeedTimeGroup.bucket(items, now: referenceNow, calendar: calendar)
+
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(groups[0].group, .older)
+        XCTAssertEqual(groups[0].items.map(\.id), ["a", "b"])
+    }
+
+    func testInputOrderPreservedWithinBucket() {
+        let calendar = utcCalendar()
+        let first = makeItem(
+            id: "first",
+            createdAt: referenceNow.addingTimeInterval(-3_600)
+        )
+        let second = makeItem(
+            id: "second",
+            createdAt: referenceNow.addingTimeInterval(-7_200)
+        )
+
+        let groups = HomeFeedTimeGroup.bucket([first, second], now: referenceNow, calendar: calendar)
+
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(groups[0].group, .today)
+        // The helper must NOT re-sort — input order owns.
+        XCTAssertEqual(groups[0].items.map(\.id), ["first", "second"])
+    }
+
+    func testMidnightBoundary() {
+        let calendar = utcCalendar()
+
+        // Start of "today" in UTC for the reference `now`.
+        let startOfToday = calendar.startOfDay(for: referenceNow)
+        let oneSecondBefore = startOfToday.addingTimeInterval(-1)
+
+        let atMidnight = makeItem(id: "midnight", createdAt: startOfToday)
+        let justBefore = makeItem(id: "before", createdAt: oneSecondBefore)
+
+        let groups = HomeFeedTimeGroup.bucket(
+            [atMidnight, justBefore],
+            now: referenceNow,
+            calendar: calendar
+        )
+
+        // Exactly midnight → today bucket.
+        // One second earlier → yesterday bucket.
+        XCTAssertEqual(groups.count, 2)
+        XCTAssertEqual(groups[0].group, .today)
+        XCTAssertEqual(groups[0].items.map(\.id), ["midnight"])
+        XCTAssertEqual(groups[1].group, .yesterday)
+        XCTAssertEqual(groups[1].items.map(\.id), ["before"])
+    }
+}


### PR DESCRIPTION
## Summary
- Add HomeFeedTimeGroup enum (today/yesterday/older) with labels
- Add static bucket(_:now:calendar:) that groups FeedItems by day using Calendar.isDateInToday/isDateInYesterday, preserving input order within groups and canonical order [today, yesterday, older] across groups
- Add unit tests covering empty input, single group, three groups, order preservation, and midnight boundary

Part of plan: home-figma-redesign.md (PR 1 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
