### PR TITLE
fix: restore Title/Description metadata in web-fetch output

### DIFF
--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -482,6 +482,13 @@ function formatWebFetchOutput(params: {
     lines.push(`Markdown-Tokens: ${params.markdownTokens}`);
   }
 
+  if (params.title) {
+    lines.push(`Title: ${params.title}`);
+  }
+  if (params.description) {
+    lines.push(`Description: ${params.description}`);
+  }
+
   if (params.notices.length > 0) {
     lines.push("Notices:");
     for (const notice of params.notices) {


### PR DESCRIPTION
## Summary
- The `external_content` wrapping refactor (#26939) accidentally removed Title/Description metadata output lines from `formatWebFetchOutput()`
- The params were still accepted and extracted but never written to the output string
- Restores the 2 conditionals that emit `Title:` and `Description:` lines

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/24690235243

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
