### PR TITLE
fix(web-search): keep citation instruction outside external_content boundary

### DIFF
--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -93,7 +93,7 @@ function formatBraveResults(
     lines.push("");
   }
 
-  return lines.join("\n") + CITATION_INSTRUCTION;
+  return lines.join("\n");
 }
 
 function formatPerplexityResults(
@@ -115,7 +115,7 @@ function formatPerplexityResults(
     }
   }
 
-  return lines.join("\n") + CITATION_INSTRUCTION;
+  return lines.join("\n");
 }
 
 async function executeBraveSearch(
@@ -153,10 +153,11 @@ async function executeBraveSearch(
       const data = (await response.json()) as BraveSearchResponse;
       const results = data.web?.results ?? [];
       return {
-        content: wrapUntrustedContent(formatBraveResults(results, query), {
-          source: "search",
-          sourceDetail: "brave",
-        }),
+        content:
+          wrapUntrustedContent(formatBraveResults(results, query), {
+            source: "search",
+            sourceDetail: "brave",
+          }) + CITATION_INSTRUCTION,
         isError: false,
       };
     }
@@ -227,10 +228,11 @@ async function executePerplexitySearch(
     if (response.ok) {
       const data = (await response.json()) as PerplexityResponse;
       return {
-        content: wrapUntrustedContent(formatPerplexityResults(data, query), {
-          source: "search",
-          sourceDetail: "perplexity",
-        }),
+        content:
+          wrapUntrustedContent(formatPerplexityResults(data, query), {
+            source: "search",
+            sourceDetail: "perplexity",
+          }) + CITATION_INSTRUCTION,
         isError: false,
       };
     }


### PR DESCRIPTION
## Summary
- Moves CITATION_INSTRUCTION outside the `<external_content>` wrapper in both Brave and Perplexity search paths
- The instruction is a model directive (cite sources inline) that was incorrectly being marked as third-party data

Addresses review feedback on #26939.

## Test plan
- [x] Type-check passes
- [ ] Verify search results still include citation instruction after the `</external_content>` closing tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
