### PR TITLE
fix: update web-fetch tests after external_content output change

### DIFF
--- a/assistant/src/__tests__/web-fetch.test.ts
+++ b/assistant/src/__tests__/web-fetch.test.ts
@@ -1059,51 +1059,10 @@ describe("web_fetch tool", () => {
 
     const result = await executeWithMockFetch({ url: "https://example.com" });
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Title: Example Title");
-    expect(result.content).toContain("Description: Example Description");
+    expect(result.content).toContain("Example Title");
     expect(result.content).toContain("Hello");
     expect(result.content).toContain("World");
     expect(result.content).not.toContain("window.evil");
-  });
-
-  test("extracts full meta descriptions that contain apostrophes", async () => {
-    globalThis.fetch = (async () =>
-      new Response(
-        [
-          "<html><head>",
-          `<meta name="description" content="We've updated our privacy policy">`,
-          "</head><body>Body</body></html>",
-        ].join(""),
-        {
-          status: 200,
-          headers: { "content-type": "text/html; charset=utf-8" },
-        },
-      )) as any;
-
-    const result = await executeWithMockFetch({ url: "https://example.com" });
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain(
-      `Description: We've updated our privacy policy`,
-    );
-  });
-
-  test("extracts full og:description when quoted value contains double quotes", async () => {
-    globalThis.fetch = (async () =>
-      new Response(
-        [
-          "<html><head>",
-          `<meta content='She said "hello" today' property='og:description'>`,
-          "</head><body>Body</body></html>",
-        ].join(""),
-        {
-          status: 200,
-          headers: { "content-type": "text/html; charset=utf-8" },
-        },
-      )) as any;
-
-    const result = await executeWithMockFetch({ url: "https://example.com" });
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain('Description: She said "hello" today');
   });
 
   test("keeps malformed decimal entities unchanged", async () => {
@@ -1566,7 +1525,7 @@ describe("web_fetch tool", () => {
 
     const result = await executeWithMockFetch({ url: "https://example.com" });
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Title: HTML Page");
+    expect(result.content).toContain("HTML Page");
     expect(result.content).toContain("Hello");
     expect(result.content).toContain("World");
     expect(result.content).not.toContain("window.evil");


### PR DESCRIPTION
## Summary
- Remove test assertions for `Title:` and `Description:` prefix lines that were removed in #26939
- Remove two description-only tests that no longer apply (meta descriptions are not surfaced in formatted output)
- Keep assertions that verify extracted text content (title text, body text) still appears correctly

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/24690263872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
