### PR TITLE
feat(migrations): add streaming manifest validator and hash-verifying transform

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-streaming-validator.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-streaming-validator.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for the streaming validator primitives:
+ * - `readAndValidateManifest` consumes the first tar entry and runs the
+ *   full manifest validation pipeline.
+ * - `createHashVerifier` is a passthrough Transform that aborts with a
+ *   typed error on digest/size mismatch.
+ *
+ * Happy-path fixtures are built with the existing `buildVBundle` helper.
+ * Negative-path fixtures (non-manifest first, oversize manifest, malformed
+ * JSON, schema fail, sha mismatch) are hand-constructed because
+ * `buildVBundle` always produces valid, manifest-first archives.
+ */
+
+import { createHash } from "node:crypto";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { gzipSync } from "node:zlib";
+import { describe, expect, test } from "bun:test";
+
+import { buildVBundle } from "../vbundle-builder.js";
+import {
+  createHashVerifier,
+  readAndValidateManifest,
+  StreamingValidationError,
+} from "../vbundle-streaming-validator.js";
+import {
+  parseVBundleStream,
+  type StreamedTarEntry,
+} from "../vbundle-tar-stream.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BLOCK_SIZE = 512;
+
+function readableFromBuffer(buf: Uint8Array): Readable {
+  return Readable.from([Buffer.from(buf)]);
+}
+
+/** Minimal hand-rolled tar entry builder (ustar regular file). */
+function buildTarEntry(name: string, data: Uint8Array): Uint8Array {
+  const encoder = new TextEncoder();
+  const nameBytes = encoder.encode(name);
+  if (nameBytes.length > 100) {
+    throw new Error(`test helper: name too long (${nameBytes.length} bytes)`);
+  }
+
+  const header = new Uint8Array(BLOCK_SIZE);
+  header.set(nameBytes, 0);
+
+  const writeOctal = (offset: number, length: number, value: number) => {
+    const str = value.toString(8).padStart(length - 1, "0");
+    for (let i = 0; i < str.length; i++) {
+      header[offset + i] = str.charCodeAt(i);
+    }
+    header[offset + length - 1] = 0;
+  };
+
+  writeOctal(100, 8, 0o644); // mode
+  writeOctal(108, 8, 0); // uid
+  writeOctal(116, 8, 0); // gid
+  writeOctal(124, 12, data.length); // size
+  writeOctal(136, 12, Math.floor(Date.now() / 1000)); // mtime
+  header[156] = "0".charCodeAt(0); // typeflag = regular file
+
+  const magic = encoder.encode("ustar\0");
+  header.set(magic, 257);
+  header[263] = "0".charCodeAt(0);
+  header[264] = "0".charCodeAt(0);
+
+  // Header checksum: sum of all bytes with the checksum field treated
+  // as 8 ASCII spaces.
+  let sum = 0;
+  for (let i = 0; i < BLOCK_SIZE; i++) {
+    sum += i >= 148 && i < 156 ? 0x20 : header[i];
+  }
+  writeOctal(148, 7, sum);
+  header[155] = 0x20;
+
+  // Pad data out to the next 512-byte boundary.
+  const remainder = data.length % BLOCK_SIZE;
+  const padded =
+    remainder === 0
+      ? data
+      : (() => {
+          const out = new Uint8Array(data.length + (BLOCK_SIZE - remainder));
+          out.set(data, 0);
+          return out;
+        })();
+
+  const entry = new Uint8Array(header.length + padded.length);
+  entry.set(header, 0);
+  entry.set(padded, header.length);
+  return entry;
+}
+
+/** Hand-build a gzipped tar archive from the given entries (no manifest injected). */
+function buildRawVBundle(
+  entries: Array<{ name: string; data: Uint8Array }>,
+): Uint8Array {
+  const parts: Uint8Array[] = entries.map((e) => buildTarEntry(e.name, e.data));
+  // End-of-archive marker: two zero blocks.
+  parts.push(new Uint8Array(BLOCK_SIZE * 2));
+
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const tar = new Uint8Array(total);
+  let offset = 0;
+  for (const p of parts) {
+    tar.set(p, offset);
+    offset += p.length;
+  }
+  return gzipSync(tar);
+}
+
+/** Fetch the first entry of a streaming archive; drain+close the iterator after. */
+async function firstEntryOf(
+  archive: Uint8Array,
+): Promise<{ entry: StreamedTarEntry; drainRest: () => Promise<void> }> {
+  const iter = parseVBundleStream(readableFromBuffer(archive));
+  const first = await iter.next();
+  if (first.done || !first.value) {
+    throw new Error("archive contained no entries");
+  }
+  const drainRest = async () => {
+    for await (const rest of iter) {
+      rest.body.resume();
+    }
+  };
+  return { entry: first.value, drainRest };
+}
+
+// ---------------------------------------------------------------------------
+// readAndValidateManifest — happy path
+// ---------------------------------------------------------------------------
+
+describe("readAndValidateManifest — happy path", () => {
+  test("parses manifest and populates expected map from manifest.files", async () => {
+    const fileA = new TextEncoder().encode("alpha payload\n");
+    const fileB = new TextEncoder().encode("beta payload\n");
+    const { archive, manifest } = buildVBundle({
+      files: [
+        { path: "workspace/a.txt", data: fileA },
+        { path: "workspace/b.txt", data: fileB },
+      ],
+      source: "test",
+    });
+
+    const { entry, drainRest } = await firstEntryOf(archive);
+    const result = await readAndValidateManifest(entry);
+    await drainRest();
+
+    expect(result.manifest.schema_version).toBe(manifest.schema_version);
+    expect(result.manifest.files).toHaveLength(2);
+    expect(result.manifest.manifest_sha256).toBe(manifest.manifest_sha256);
+
+    expect(result.expected.size).toBe(2);
+    const expectA = result.expected.get("workspace/a.txt");
+    expect(expectA?.size).toBe(fileA.length);
+    expect(expectA?.sha256).toBe(
+      manifest.files.find((f) => f.path === "workspace/a.txt")?.sha256,
+    );
+    const expectB = result.expected.get("workspace/b.txt");
+    expect(expectB?.size).toBe(fileB.length);
+    expect(expectB?.sha256).toBe(
+      manifest.files.find((f) => f.path === "workspace/b.txt")?.sha256,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readAndValidateManifest — negative paths
+// ---------------------------------------------------------------------------
+
+describe("readAndValidateManifest — negative paths", () => {
+  test("throws manifest_not_first when first entry is not manifest.json", async () => {
+    const archive = buildRawVBundle([
+      { name: "workspace/a.txt", data: new TextEncoder().encode("hello") },
+    ]);
+    const { entry, drainRest } = await firstEntryOf(archive);
+
+    let err: StreamingValidationError | null = null;
+    try {
+      await readAndValidateManifest(entry);
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+    await drainRest();
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("manifest_not_first");
+  });
+
+  test("throws manifest_too_large when manifest body exceeds 1 MiB", async () => {
+    // 1 MiB + 1 byte of filler — cheap to build, sails past the cap.
+    const oversize = new Uint8Array(1 * 1024 * 1024 + 1);
+    oversize.fill(0x20); // spaces — still triggers JSON parse failure too,
+    // but the size cap is checked first, so we never reach JSON parsing.
+    const archive = buildRawVBundle([
+      { name: "manifest.json", data: oversize },
+    ]);
+    const { entry, drainRest } = await firstEntryOf(archive);
+
+    let err: StreamingValidationError | null = null;
+    try {
+      await readAndValidateManifest(entry);
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+    await drainRest();
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("manifest_too_large");
+  });
+
+  test("throws manifest_malformed when manifest body is not valid JSON", async () => {
+    const archive = buildRawVBundle([
+      { name: "manifest.json", data: new TextEncoder().encode("{not-json") },
+    ]);
+    const { entry, drainRest } = await firstEntryOf(archive);
+
+    let err: StreamingValidationError | null = null;
+    try {
+      await readAndValidateManifest(entry);
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+    await drainRest();
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("manifest_malformed");
+  });
+
+  test("throws manifest_schema when a required field is missing", async () => {
+    // Valid JSON but missing `files`, `manifest_sha256`, etc.
+    const bogus = new TextEncoder().encode(
+      JSON.stringify({ schema_version: "1.0", created_at: "now" }),
+    );
+    const archive = buildRawVBundle([{ name: "manifest.json", data: bogus }]);
+    const { entry, drainRest } = await firstEntryOf(archive);
+
+    let err: StreamingValidationError | null = null;
+    try {
+      await readAndValidateManifest(entry);
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+    await drainRest();
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("manifest_schema");
+  });
+
+  test("throws manifest_sha256 when the declared digest doesn't match canonical JSON", async () => {
+    const badManifest = {
+      schema_version: "1.0",
+      created_at: new Date().toISOString(),
+      files: [],
+      // Deliberately wrong digest. The canonical hash of a 4-field manifest
+      // won't match this, regardless of ordering.
+      manifest_sha256:
+        "0000000000000000000000000000000000000000000000000000000000000000",
+    };
+    const archive = buildRawVBundle([
+      {
+        name: "manifest.json",
+        data: new TextEncoder().encode(JSON.stringify(badManifest)),
+      },
+    ]);
+    const { entry, drainRest } = await firstEntryOf(archive);
+
+    let err: StreamingValidationError | null = null;
+    try {
+      await readAndValidateManifest(entry);
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+    await drainRest();
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("manifest_sha256");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createHashVerifier
+// ---------------------------------------------------------------------------
+
+describe("createHashVerifier — identity + integrity", () => {
+  const payload = Buffer.from(
+    "the quick brown fox jumps over the lazy dog".repeat(100),
+    "utf8",
+  );
+  // Precomputed digest for the payload above.
+  const payloadSha = createHash("sha256").update(payload).digest("hex");
+
+  test("is an identity Transform for correct inputs", async () => {
+    const verifier = createHashVerifier({
+      sha256: payloadSha,
+      size: payload.length,
+      archivePath: "workspace/ok.txt",
+    });
+
+    // Feed the payload in two chunks to exercise multi-call _transform.
+    const half = payload.length >>> 1;
+    const source = Readable.from([
+      payload.subarray(0, half),
+      payload.subarray(half),
+    ]);
+
+    const collected: Buffer[] = [];
+    verifier.on("data", (chunk: Buffer) => collected.push(chunk));
+
+    await pipeline(source, verifier);
+
+    const out = Buffer.concat(collected);
+    expect(out.length).toBe(payload.length);
+    expect(out.equals(payload)).toBe(true);
+  });
+
+  test("errors with code entry_hash on digest mismatch", async () => {
+    const verifier = createHashVerifier({
+      sha256:
+        // Wrong digest.
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      size: payload.length,
+      archivePath: "workspace/bad-hash.txt",
+    });
+
+    let err: StreamingValidationError | null = null;
+    try {
+      await pipeline(
+        Readable.from([payload]),
+        verifier,
+        async function* (source: AsyncIterable<Buffer>) {
+          // Drain the transform so _flush runs.
+          for await (const _chunk of source) {
+            // discard
+          }
+        },
+      );
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("entry_hash");
+    expect(err?.archivePath).toBe("workspace/bad-hash.txt");
+  });
+
+  test("errors with code entry_size on byte-count mismatch", async () => {
+    // Right digest, wrong declared size.
+    const verifier = createHashVerifier({
+      sha256: payloadSha,
+      size: payload.length + 1,
+      archivePath: "workspace/bad-size.txt",
+    });
+
+    let err: StreamingValidationError | null = null;
+    try {
+      await pipeline(
+        Readable.from([payload]),
+        verifier,
+        async function* (source: AsyncIterable<Buffer>) {
+          for await (const _chunk of source) {
+            // discard
+          }
+        },
+      );
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("entry_size");
+    expect(err?.archivePath).toBe("workspace/bad-size.txt");
+  });
+});

--- a/assistant/src/runtime/migrations/__tests__/vbundle-streaming-validator.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-streaming-validator.test.ts
@@ -191,15 +191,39 @@ describe("readAndValidateManifest — negative paths", () => {
     expect(err?.code).toBe("manifest_not_first");
   });
 
-  test("throws manifest_too_large when manifest body exceeds 1 MiB", async () => {
-    // 1 MiB + 1 byte of filler — cheap to build, sails past the cap.
-    const oversize = new Uint8Array(1 * 1024 * 1024 + 1);
-    oversize.fill(0x20); // spaces — still triggers JSON parse failure too,
-    // but the size cap is checked first, so we never reach JSON parsing.
-    const archive = buildRawVBundle([
-      { name: "manifest.json", data: oversize },
-    ]);
-    const { entry, drainRest } = await firstEntryOf(archive);
+  test("throws manifest_too_large and fails fast before draining the whole body", async () => {
+    // Fake a tar entry whose body would emit 5 MiB if fully drained. The
+    // validator must destroy() the stream and throw the moment the running
+    // byte count crosses the 1 MiB cap — it must NOT keep pulling chunks.
+    //
+    // We count bytes emitted via a _read implementation, and after the
+    // throw assert both that destroy() fired and that far fewer than 5 MiB
+    // were ever pulled out of the stream.
+    const CHUNK = 512 * 1024; // 512 KiB
+    const TOTAL_CHUNKS = 10; // 5 MiB worth — way past the 1 MiB cap
+    let chunksEmitted = 0;
+    let bytesEmitted = 0;
+    const body = new Readable({
+      read() {
+        if (chunksEmitted >= TOTAL_CHUNKS) {
+          this.push(null);
+          return;
+        }
+        const buf = Buffer.alloc(CHUNK, 0x20);
+        chunksEmitted += 1;
+        bytesEmitted += buf.length;
+        this.push(buf);
+      },
+    });
+
+    const entry: StreamedTarEntry = {
+      header: {
+        name: "manifest.json",
+        size: CHUNK * TOTAL_CHUNKS,
+        type: "file",
+      },
+      body,
+    };
 
     let err: StreamingValidationError | null = null;
     try {
@@ -207,10 +231,15 @@ describe("readAndValidateManifest — negative paths", () => {
     } catch (e) {
       err = e as StreamingValidationError;
     }
-    await drainRest();
 
     expect(err).toBeInstanceOf(StreamingValidationError);
     expect(err?.code).toBe("manifest_too_large");
+    // Fail-fast assertions: destroy() was called, and we didn't drain past
+    // ~1 MiB + one chunk. If the validator had drained to EOF we'd see the
+    // full 5 MiB / 10 chunks here.
+    expect(body.destroyed).toBe(true);
+    expect(chunksEmitted).toBeLessThanOrEqual(3);
+    expect(bytesEmitted).toBeLessThan(2 * 1024 * 1024);
   });
 
   test("throws manifest_malformed when manifest body is not valid JSON", async () => {

--- a/assistant/src/runtime/migrations/__tests__/vbundle-streaming-validator.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-streaming-validator.test.ts
@@ -27,6 +27,7 @@ import {
   parseVBundleStream,
   type StreamedTarEntry,
 } from "../vbundle-tar-stream.js";
+import { computeManifestSha256 } from "../vbundle-validator.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -308,6 +309,51 @@ describe("readAndValidateManifest — negative paths", () => {
 
     expect(err).toBeInstanceOf(StreamingValidationError);
     expect(err?.code).toBe("manifest_sha256");
+  });
+
+  test("throws manifest_duplicate_path when the same archive path appears twice", async () => {
+    const baseManifest = {
+      schema_version: "1.0",
+      created_at: new Date().toISOString(),
+      files: [
+        {
+          path: "workspace/a.txt",
+          sha256:
+            "1111111111111111111111111111111111111111111111111111111111111111",
+          size: 10,
+        },
+        {
+          // Deliberately duplicate path — malicious bundle could exploit this
+          // to bypass per-entry integrity checks if we silently collapsed.
+          path: "workspace/a.txt",
+          sha256:
+            "2222222222222222222222222222222222222222222222222222222222222222",
+          size: 20,
+        },
+      ],
+      manifest_sha256: "",
+    };
+    baseManifest.manifest_sha256 = computeManifestSha256(baseManifest);
+
+    const archive = buildRawVBundle([
+      {
+        name: "manifest.json",
+        data: new TextEncoder().encode(JSON.stringify(baseManifest)),
+      },
+    ]);
+    const { entry, drainRest } = await firstEntryOf(archive);
+
+    let err: StreamingValidationError | null = null;
+    try {
+      await readAndValidateManifest(entry);
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+    await drainRest();
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("manifest_duplicate_path");
+    expect(err?.message).toContain("workspace/a.txt");
   });
 });
 

--- a/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
@@ -97,26 +97,24 @@ export async function readAndValidateManifest(
     );
   }
 
-  // Drain the entry body into a Buffer, enforcing the size cap as we go
-  // so a pathological entry can't OOM us before we notice.
+  // Drain the entry body into a Buffer, enforcing the size cap as we go.
+  // The moment we cross the cap we destroy the entry stream — this signals
+  // the tar extractor (and therefore gunzip + upstream source) to abort,
+  // so a malicious archive whose "manifest" is a multi-GB decompressed
+  // stream can't force us to read through all of it before rejecting.
   const chunks: Buffer[] = [];
   let total = 0;
-  let tooLarge = false;
   for await (const chunk of first.body) {
     const buf = chunk instanceof Buffer ? chunk : Buffer.from(chunk);
     total += buf.length;
     if (total > MANIFEST_MAX_BYTES) {
-      tooLarge = true;
-      // Keep draining so the extractor can advance; we just stop buffering.
-      continue;
+      first.body.destroy();
+      throw new StreamingValidationError(
+        "manifest_too_large",
+        `manifest.json exceeds ${MANIFEST_MAX_BYTES} byte limit (read ${total} bytes before aborting)`,
+      );
     }
     chunks.push(buf);
-  }
-  if (tooLarge) {
-    throw new StreamingValidationError(
-      "manifest_too_large",
-      `manifest.json exceeds ${MANIFEST_MAX_BYTES} byte limit (read ${total} bytes)`,
-    );
   }
 
   const bodyBuf = Buffer.concat(chunks, total);

--- a/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
@@ -157,6 +157,12 @@ export async function readAndValidateManifest(
 
   const expected = new Map<string, { sha256: string; size: number }>();
   for (const file of manifest.files) {
+    if (expected.has(file.path)) {
+      throw new StreamingValidationError(
+        "manifest_duplicate_path",
+        `Manifest contains duplicate entry for path: ${file.path}`,
+      );
+    }
     expected.set(file.path, { sha256: file.sha256, size: file.size });
   }
 

--- a/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
@@ -1,0 +1,240 @@
+/**
+ * Streaming validation primitives for `.vbundle` archives.
+ *
+ * The non-streaming `validateVBundle` decompresses the entire archive into
+ * memory and walks the tar buffer to compute per-file SHA-256s. That is fine
+ * for small bundles but peaks at 2x the decompressed size in RAM — an 8 GB
+ * bundle OOMs a 3 GB pod.
+ *
+ * This module lets a caller validate a bundle while streaming:
+ * - `readAndValidateManifest` consumes the first tar entry (which must be
+ *   `manifest.json`), validates the schema, and verifies the self-referencing
+ *   `manifest_sha256` against the canonicalized JSON.
+ * - `createHashVerifier` returns a passthrough `Transform` that hashes bytes
+ *   flowing through it and errors the pipeline if the final digest or byte
+ *   count does not match the expected values from the manifest.
+ *
+ * Together, these let a consumer (PR 4) pipe every subsequent tar entry
+ * through a hash verifier before writing it to disk, without ever buffering
+ * the full bundle.
+ */
+
+import { createHash } from "node:crypto";
+import { Transform, type TransformCallback } from "node:stream";
+
+import type { StreamedTarEntry } from "./vbundle-tar-stream.js";
+import {
+  computeManifestSha256,
+  ManifestSchema,
+  type ManifestType,
+} from "./vbundle-validator.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ManifestReadResult {
+  manifest: ManifestType;
+  /** Fast lookup from archive path -> expected sha256 + size (from manifest.files). */
+  expected: Map<string, { sha256: string; size: number }>;
+}
+
+/**
+ * All failure modes produced by this module. Every throw/error includes a
+ * stable `code` string so callers can branch on the failure kind without
+ * string-matching the message.
+ */
+export class StreamingValidationError extends Error {
+  public readonly code: string;
+  public readonly archivePath?: string;
+
+  constructor(code: string, message: string, archivePath?: string) {
+    super(message);
+    this.name = "StreamingValidationError";
+    this.code = code;
+    if (archivePath !== undefined) {
+      this.archivePath = archivePath;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Manifest validation
+// ---------------------------------------------------------------------------
+
+// Manifests are metadata only — typically tens to hundreds of KB even for
+// huge bundles. A 1 MiB cap is comfortably above realistic sizes and
+// protects against a malicious archive whose "manifest" is actually a
+// multi-GB stream intended to OOM the validator.
+const MANIFEST_MAX_BYTES = 1 * 1024 * 1024;
+
+/**
+ * Drain the first tar entry — which MUST be `manifest.json` — and run the
+ * full manifest-level validation pipeline:
+ *   1. Entry name check.
+ *   2. Size cap (1 MiB).
+ *   3. JSON parse.
+ *   4. Zod schema validation.
+ *   5. Self-referencing `manifest_sha256` verification against the
+ *      canonicalized JSON (minus that field).
+ *
+ * On success, returns the parsed manifest plus a `Map` keyed by archive
+ * path that PR 4 will consult as each subsequent entry streams past.
+ *
+ * On failure, throws a `StreamingValidationError` with a distinct `code`
+ * for every failure mode.
+ */
+export async function readAndValidateManifest(
+  first: StreamedTarEntry,
+): Promise<ManifestReadResult> {
+  if (first.header.name !== "manifest.json") {
+    // Drain the body so the underlying tar extractor isn't left dangling
+    // on backpressure before the caller reports the error.
+    first.body.resume();
+    throw new StreamingValidationError(
+      "manifest_not_first",
+      `Expected manifest.json as the first tar entry, got "${first.header.name}"`,
+    );
+  }
+
+  // Drain the entry body into a Buffer, enforcing the size cap as we go
+  // so a pathological entry can't OOM us before we notice.
+  const chunks: Buffer[] = [];
+  let total = 0;
+  let tooLarge = false;
+  for await (const chunk of first.body) {
+    const buf = chunk instanceof Buffer ? chunk : Buffer.from(chunk);
+    total += buf.length;
+    if (total > MANIFEST_MAX_BYTES) {
+      tooLarge = true;
+      // Keep draining so the extractor can advance; we just stop buffering.
+      continue;
+    }
+    chunks.push(buf);
+  }
+  if (tooLarge) {
+    throw new StreamingValidationError(
+      "manifest_too_large",
+      `manifest.json exceeds ${MANIFEST_MAX_BYTES} byte limit (read ${total} bytes)`,
+    );
+  }
+
+  const bodyBuf = Buffer.concat(chunks, total);
+
+  let manifestRaw: unknown;
+  try {
+    manifestRaw = JSON.parse(bodyBuf.toString("utf8"));
+  } catch (err) {
+    throw new StreamingValidationError(
+      "manifest_malformed",
+      `manifest.json is not valid JSON: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  const parseResult = ManifestSchema.safeParse(manifestRaw);
+  if (!parseResult.success) {
+    const issues = parseResult.error.issues
+      .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
+      .join("; ");
+    throw new StreamingValidationError(
+      "manifest_schema",
+      `manifest.json failed schema validation: ${issues}`,
+    );
+  }
+
+  const manifest = parseResult.data;
+
+  // Recompute the self-referencing checksum using the exact canonicalization
+  // that vbundle-validator.ts uses. Any drift here would silently reject
+  // valid bundles produced by buildVBundle.
+  const computed = computeManifestSha256(manifestRaw);
+  if (computed !== manifest.manifest_sha256) {
+    throw new StreamingValidationError(
+      "manifest_sha256",
+      `Manifest checksum mismatch: expected ${manifest.manifest_sha256}, computed ${computed}`,
+    );
+  }
+
+  const expected = new Map<string, { sha256: string; size: number }>();
+  for (const file of manifest.files) {
+    expected.set(file.path, { sha256: file.sha256, size: file.size });
+  }
+
+  return { manifest, expected };
+}
+
+// ---------------------------------------------------------------------------
+// Per-entry hash + size verifier
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a passthrough `Transform` that:
+ *   - forwards every chunk unchanged (identity transform for correct input),
+ *   - incrementally SHA-256s the byte stream,
+ *   - on `_flush`, errors the pipeline if the final digest or total byte
+ *     count differs from `expected`.
+ *
+ * Errors are emitted as `StreamingValidationError` with `code` set to
+ * `"entry_hash"` or `"entry_size"` and `archivePath` populated so callers
+ * can surface which file failed.
+ *
+ * Consumers should pipe the entry body through this transform before
+ * writing to disk — that way a bad payload is caught before the byte
+ * reaches storage rather than after a whole 8 GB write completes.
+ */
+export function createHashVerifier(expected: {
+  sha256: string;
+  size: number;
+  archivePath: string;
+}): Transform {
+  const hash = createHash("sha256");
+  let bytes = 0;
+
+  return new Transform({
+    transform(
+      chunk: Buffer | string,
+      encoding: BufferEncoding,
+      callback: TransformCallback,
+    ) {
+      try {
+        const buf =
+          typeof chunk === "string" ? Buffer.from(chunk, encoding) : chunk;
+        hash.update(buf);
+        bytes += buf.length;
+        callback(null, buf);
+      } catch (err) {
+        callback(err instanceof Error ? err : new Error(String(err)));
+      }
+    },
+    flush(callback: TransformCallback) {
+      // Size check first — a wrong size is a sharper signal than a hash
+      // collision, and a truncated payload frequently triggers both.
+      if (bytes !== expected.size) {
+        callback(
+          new StreamingValidationError(
+            "entry_size",
+            `Size mismatch for ${expected.archivePath}: expected ${expected.size} bytes, got ${bytes}`,
+            expected.archivePath,
+          ),
+        );
+        return;
+      }
+
+      const digest = hash.digest("hex");
+      if (digest !== expected.sha256) {
+        callback(
+          new StreamingValidationError(
+            "entry_hash",
+            `Checksum mismatch for ${expected.archivePath}: expected ${expected.sha256}, computed ${digest}`,
+            expected.archivePath,
+          ),
+        );
+        return;
+      }
+
+      callback();
+    },
+  });
+}

--- a/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
@@ -14,9 +14,9 @@
  *   flowing through it and errors the pipeline if the final digest or byte
  *   count does not match the expected values from the manifest.
  *
- * Together, these let a consumer (PR 4) pipe every subsequent tar entry
- * through a hash verifier before writing it to disk, without ever buffering
- * the full bundle.
+ * Together, these let a consumer pipe every subsequent tar entry through a
+ * hash verifier before writing it to disk, without ever buffering the full
+ * bundle.
  */
 
 import { createHash } from "node:crypto";
@@ -79,7 +79,7 @@ const MANIFEST_MAX_BYTES = 1 * 1024 * 1024;
  *      canonicalized JSON (minus that field).
  *
  * On success, returns the parsed manifest plus a `Map` keyed by archive
- * path that PR 4 will consult as each subsequent entry streams past.
+ * path that callers consult as each subsequent entry streams past.
  *
  * On failure, throws a `StreamingValidationError` with a distinct `code`
  * for every failure mode.

--- a/assistant/src/runtime/migrations/vbundle-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-validator.ts
@@ -29,7 +29,7 @@ const ManifestFileEntry = z.object({
   size: z.number().int().nonnegative(),
 });
 
-const ManifestSchema = z.object({
+export const ManifestSchema = z.object({
   schema_version: z.string(),
   created_at: z.string(),
   source: z.string().optional(),
@@ -176,7 +176,7 @@ function sha256Hex(data: Uint8Array | string): string {
  * Canonicalize a JSON object by sorting keys recursively, then SHA-256 hash it.
  * This matches the platform's canonicalization approach.
  */
-function canonicalizeJson(obj: unknown): string {
+export function canonicalizeJson(obj: unknown): string {
   return JSON.stringify(obj, (_key, value) => {
     if (value && typeof value === "object" && !Array.isArray(value)) {
       const sorted: Record<string, unknown> = {};
@@ -187,6 +187,18 @@ function canonicalizeJson(obj: unknown): string {
     }
     return value;
   });
+}
+
+/**
+ * Recompute the `manifest_sha256` field for a manifest object. Strips the
+ * `manifest_sha256` property, canonicalizes the remaining JSON, and returns
+ * the SHA-256 hex digest. Centralized here so the streaming validator and
+ * the in-memory validator agree on the exact canonicalization.
+ */
+export function computeManifestSha256(manifest: unknown): string {
+  const copy = { ...(manifest as Record<string, unknown>) };
+  delete copy.manifest_sha256;
+  return sha256Hex(canonicalizeJson(copy));
 }
 
 // ---------------------------------------------------------------------------
@@ -300,10 +312,7 @@ export function validateVBundle(data: Uint8Array): VBundleValidationResult {
   // Step 5: Verify manifest checksum
   // The manifest_sha256 field is the SHA-256 of the canonicalized JSON
   // with the manifest_sha256 field itself excluded.
-  const manifestForChecksum = { ...(manifestRaw as Record<string, unknown>) };
-  delete manifestForChecksum.manifest_sha256;
-  const canonicalized = canonicalizeJson(manifestForChecksum);
-  const computedManifestSha256 = sha256Hex(canonicalized);
+  const computedManifestSha256 = computeManifestSha256(manifestRaw);
 
   if (computedManifestSha256 !== manifest.manifest_sha256) {
     errors.push({


### PR DESCRIPTION
## Summary

- Adds `readAndValidateManifest` — drains the first tar entry (must be `manifest.json`), caps body at 1 MiB, runs the existing Zod schema, and verifies the self-referencing `manifest_sha256` against canonicalized JSON. Throws `StreamingValidationError` with a distinct `code` for every failure mode.
- Adds `createHashVerifier` — a passthrough `Transform` that SHA-256s bytes in flight and errors the pipeline on `_flush` with `entry_hash` or `entry_size` when the final digest or total byte count differs from expected.
- Centralizes manifest canonicalization in `vbundle-validator.ts` via a new `computeManifestSha256` helper so the streaming and in-memory validators cannot drift. `validateVBundle` calls it; behavior is unchanged.

Not wired into any caller yet — PR 4 will consume these primitives to orchestrate a full streaming import.

Part of plan: gcs-stream-import.md (PR 3 of 5)

## Test plan

- [x] `cd assistant && bun test src/runtime/migrations/__tests__/vbundle-streaming-validator.test.ts` — 9 pass / 0 fail
- [x] Re-ran `vbundle-tar-stream.test.ts`, `vbundle-pax-and-symlink.test.ts`, `migration-export-streaming.test.ts` — all still green (validator refactor preserves behavior)
- [x] `bunx tsc --noEmit` — no new errors in touched files (only pre-existing baseline errors elsewhere, pushed with --no-verify per PR guidance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
