### PR TITLE
fix(messaging): classify Outlook messages as email source type

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-read.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-read.ts
@@ -7,7 +7,8 @@ import type {
 import { err, getProviderConnection, ok, resolveProvider } from "./shared.js";
 
 function wrapMessageContent(msg: Message): Message {
-  const source = msg.platform === "gmail" ? "email" : "slack";
+  const source =
+    msg.platform === "gmail" || msg.platform === "outlook" ? "email" : "slack";
   return {
     ...msg,
     text: wrapUntrustedContent(msg.text, {

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-search.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-search.ts
@@ -7,7 +7,8 @@ import type {
 import { err, getProviderConnection, ok, resolveProvider } from "./shared.js";
 
 function wrapMessageContent(msg: Message): Message {
-  const source = msg.platform === "gmail" ? "email" : "slack";
+  const source =
+    msg.platform === "gmail" || msg.platform === "outlook" ? "email" : "slack";
   return {
     ...msg,
     text: wrapUntrustedContent(msg.text, {


### PR DESCRIPTION
## Summary
- Fixes platform mapping in `messaging-read.ts` and `messaging-search.ts` to recognize Outlook as an email provider
- Previously Outlook emails were labeled `source="slack"` with the wrong character budget (10k instead of 20k)

Addresses review feedback on #26935.

## Test plan
- [x] Type-check passes
- [ ] Verify Outlook messages get `<external_content source="email">` wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
