### PR TITLE
fix(oauth): correct JSDoc for circuit breaker transient error handling

### DIFF
--- a/packages/credential-storage/src/oauth-runtime.ts
+++ b/packages/credential-storage/src/oauth-runtime.ts
@@ -136,8 +136,9 @@ export class RefreshCircuitBreaker {
    * @param isCredential - When true, the failure is a credential error
    *   (revoked token, invalid client) that no amount of retrying will fix.
    *   Only credential errors count toward opening the circuit breaker.
-   *   Transient errors (network timeouts, 5xx) are recorded for diagnostics
-   *   but do not trip the breaker — they are handled by upstream retry logic.
+   *   Transient errors (network timeouts, 5xx) are silently ignored here —
+   *   they do not trip the breaker and are not recorded. Upstream retry logic
+   *   in refreshOAuth2Token handles transient failures with exponential backoff.
    */
   recordFailure(key: string, isCredential = true): void {
     if (!isCredential) {


### PR DESCRIPTION
## Summary
- Fixes misleading JSDoc on `recordFailure` that claimed transient errors are "recorded for diagnostics" when they are actually silently ignored.
- Clarifies that transient failures are handled by upstream retry logic in `refreshOAuth2Token` with exponential backoff, not the circuit breaker.

Closes feedback from PR #26924.

## Test plan
- [x] Documentation-only change; no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
