### PR TITLE
fix(heartbeat): filter credential status gate to hard failures and deduplicate providers

### DIFF
--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -269,7 +269,17 @@ export class HeartbeatService {
       const report = await checkAllCredentials();
       if (report.unhealthy.length > 0) {
         await this.notifyUnhealthyCredentials(report.unhealthy);
-        return report.unhealthy.map((r) => r.provider);
+        // Only block providers for hard-failure statuses — expiring and ping_failed
+        // are transient/still-usable and should not disable provider tools.
+        const hardFailureStatuses = new Set([
+          "revoked",
+          "missing_token",
+          "expired",
+        ]);
+        const hardFailures = report.unhealthy.filter((r) =>
+          hardFailureStatuses.has(r.status),
+        );
+        return [...new Set(hardFailures.map((r) => r.provider))];
       }
     } catch (err) {
       log.error({ err }, "Credential health check failed");


### PR DESCRIPTION
## Summary
- Only block providers in heartbeat prompt for truly broken statuses (`revoked`, `missing_token`, `expired` without auto-recovery)
- Excludes `expiring` and `ping_failed` which are still potentially usable
- Deduplicates provider names when multiple connections for the same provider are unhealthy

Addresses feedback from PR #26927.

## Test plan
- [ ] Verify heartbeat prompt no longer blocks providers with `expiring` or `ping_failed` status
- [ ] Verify duplicate provider names are eliminated from the blocklist
- [ ] Verify providers with `revoked`, `missing_token`, or `expired` status are still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
