### PR TITLE
fix(watcher): remove ping_failed from irrecoverable credential gate and downgrade urgency

### DIFF
--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -312,9 +312,7 @@ export class HeartbeatService {
 
     for (const result of results) {
       const urgency =
-        result.status === "revoked" ||
-        result.status === "expired" ||
-        result.status === "ping_failed"
+        result.status === "revoked" || result.status === "expired"
           ? ("high" as const)
           : ("medium" as const);
 

--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -90,7 +90,6 @@ export async function runWatchersOnce(
         health &&
         (health.status === "revoked" ||
           health.status === "missing_token" ||
-          health.status === "ping_failed" ||
           (health.status === "expired" && !health.canAutoRecover))
       ) {
         skipWatcherPoll(watcher.id, `Credential unhealthy: ${health.details}`);


### PR DESCRIPTION
Removes ping_failed from the watcher pre-poll credential gate since it's a transient status that doesn't indicate irrecoverable credential failure. Also downgrades ping_failed notification urgency from high to medium to match the health service's own characterization. Closes feedback from PR #26929.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
