### PR TITLE
fix(skills/gmail): preserve inbox-management config in loadPreferences

### DIFF
--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -18,28 +18,28 @@ All operations use CLI scripts that return JSON:
 - **Success**: `{ "ok": true, "data": ... }`
 - **Failure**: `{ "ok": false, "error": "..." }`
 
-| Script             | Operation          | Description                                                                  |
-| ------------------ | ------------------ | ---------------------------------------------------------------------------- |
-| `gmail-email.ts`   | `draft`            | Create email drafts in the Drafts folder (including reply drafts)            |
-| `gmail-email.ts`   | `send-draft`       | Send an existing draft (**requires explicit user confirmation**)             |
-| `gmail-email.ts`   | `forward`          | Create forward drafts, preserving attachments                                |
-| `gmail-email.ts`   | `trash`            | Move messages to Trash                                                       |
-| `gmail-manage.ts`  | `label`            | Add or remove labels on messages                                             |
-| `gmail-manage.ts`  | `follow-up`        | Track/untrack messages for follow-up using a dedicated "Follow-up" label     |
-| `gmail-manage.ts`  | `attachments`      | List and download email attachments                                          |
-| `gmail-manage.ts`  | `filters`          | Create, list, and delete Gmail filters                                       |
-| `gmail-manage.ts`  | `vacation`         | Get, enable, or disable the vacation auto-responder                          |
-| `gmail-manage.ts`  | `unsubscribe`      | Unsubscribe from mailing lists (**requires explicit user confirmation**)     |
-| `gmail-scan.ts`    | `sender-digest`    | Scan inbox and group messages by sender for declutter workflows              |
-| `gmail-scan.ts`    | `outreach-scan`    | Identify cold outreach senders (no List-Unsubscribe header)                  |
-| `gmail-archive.ts` | `archive`          | Archive messages (single, batch message_ids, cache_key+sender-emails, query) |
-| `gmail-prefs.ts`   | `list`             | List blocklist and safelist preferences                                      |
-| `gmail-prefs.ts`   | `add-blocklist`    | Add sender emails to the blocklist                                           |
-| `gmail-prefs.ts`   | `add-safelist`     | Add sender emails to the safelist                                            |
-| `gmail-prefs.ts`   | `remove-blocklist` | Remove sender emails from the blocklist                                      |
-| `gmail-prefs.ts`   | `remove-safelist`  | Remove sender emails from the safelist                                       |
-| `gmail-prefs.ts`   | `get-management-config` | Get inbox management config (stage, interrupt threshold, last run)      |
-| `gmail-prefs.ts`   | `set-management-config` | Update inbox management config (--stage, --interrupt-threshold, --last-run) |
+| Script             | Operation               | Description                                                                  |
+| ------------------ | ----------------------- | ---------------------------------------------------------------------------- |
+| `gmail-email.ts`   | `draft`                 | Create email drafts in the Drafts folder (including reply drafts)            |
+| `gmail-email.ts`   | `send-draft`            | Send an existing draft (**requires explicit user confirmation**)             |
+| `gmail-email.ts`   | `forward`               | Create forward drafts, preserving attachments                                |
+| `gmail-email.ts`   | `trash`                 | Move messages to Trash                                                       |
+| `gmail-manage.ts`  | `label`                 | Add or remove labels on messages                                             |
+| `gmail-manage.ts`  | `follow-up`             | Track/untrack messages for follow-up using a dedicated "Follow-up" label     |
+| `gmail-manage.ts`  | `attachments`           | List and download email attachments                                          |
+| `gmail-manage.ts`  | `filters`               | Create, list, and delete Gmail filters                                       |
+| `gmail-manage.ts`  | `vacation`              | Get, enable, or disable the vacation auto-responder                          |
+| `gmail-manage.ts`  | `unsubscribe`           | Unsubscribe from mailing lists (**requires explicit user confirmation**)     |
+| `gmail-scan.ts`    | `sender-digest`         | Scan inbox and group messages by sender for declutter workflows              |
+| `gmail-scan.ts`    | `outreach-scan`         | Identify cold outreach senders (no List-Unsubscribe header)                  |
+| `gmail-archive.ts` | `archive`               | Archive messages (single, batch message_ids, cache_key+sender-emails, query) |
+| `gmail-prefs.ts`   | `list`                  | List blocklist and safelist preferences                                      |
+| `gmail-prefs.ts`   | `add-blocklist`         | Add sender emails to the blocklist                                           |
+| `gmail-prefs.ts`   | `add-safelist`          | Add sender emails to the safelist                                            |
+| `gmail-prefs.ts`   | `remove-blocklist`      | Remove sender emails from the blocklist                                      |
+| `gmail-prefs.ts`   | `remove-safelist`       | Remove sender emails from the safelist                                       |
+| `gmail-prefs.ts`   | `get-management-config` | Get inbox management config (stage, interrupt threshold, last run)           |
+| `gmail-prefs.ts`   | `set-management-config` | Update inbox management config (--stage, --interrupt-threshold, --last-run)  |
 
 ### Email Operations
 

--- a/skills/gmail/scripts/gmail-prefs.ts
+++ b/skills/gmail/scripts/gmail-prefs.ts
@@ -42,10 +42,14 @@ export function loadPreferences(): GmailPreferences {
   try {
     const raw = readFileSync(PREFS_PATH, "utf-8");
     const parsed = JSON.parse(raw) as Partial<GmailPreferences>;
-    return {
+    const prefs: GmailPreferences = {
       blocklist: Array.isArray(parsed.blocklist) ? parsed.blocklist : [],
       safelist: Array.isArray(parsed.safelist) ? parsed.safelist : [],
     };
+    if (parsed["inbox-management"]) {
+      prefs["inbox-management"] = parsed["inbox-management"];
+    }
+    return prefs;
   } catch {
     return { blocklist: [], safelist: [] };
   }

--- a/skills/gmail/scripts/gmail-prefs.ts
+++ b/skills/gmail/scripts/gmail-prefs.ts
@@ -131,7 +131,10 @@ function getManagementConfig(): InboxManagementConfig {
 
 function setManagementConfig(updates: Partial<InboxManagementConfig>): void {
   const prefs = loadPreferences();
-  const current = { ...DEFAULT_MANAGEMENT_CONFIG, ...prefs["inbox-management"] };
+  const current = {
+    ...DEFAULT_MANAGEMENT_CONFIG,
+    ...prefs["inbox-management"],
+  };
   prefs["inbox-management"] = { ...current, ...updates };
   savePreferences(prefs);
 }
@@ -242,10 +245,19 @@ function main(): void {
       }
       if (args["interrupt-threshold"] != null) {
         const threshold = args["interrupt-threshold"] as string;
-        if (threshold !== "default" && threshold !== "high" && threshold !== "low") {
-          printError('--interrupt-threshold must be "default", "high", or "low"');
+        if (
+          threshold !== "default" &&
+          threshold !== "high" &&
+          threshold !== "low"
+        ) {
+          printError(
+            '--interrupt-threshold must be "default", "high", or "low"',
+          );
         }
-        updates["interrupt-threshold"] = threshold as "default" | "high" | "low";
+        updates["interrupt-threshold"] = threshold as
+          | "default"
+          | "high"
+          | "low";
       }
       if (args["last-run"] != null) {
         updates["last-run"] = args["last-run"] as string;


### PR DESCRIPTION
## Summary
- Fix `loadPreferences()` dropping the `inbox-management` field from on-disk JSON
- `getManagementConfig()` and `setManagementConfig()` now correctly persist state across reads/writes

## Test plan
- [ ] Verify `set-management-config --stage 1` followed by `set-management-config --last-run "2024-01-01"` preserves both fields
- [ ] Verify `get-management-config` returns saved values instead of defaults

Closes feedback from PR #26606.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
