### PR TITLE
fix(macos): add file-read allow for working dir after TCC deny rules

### DIFF
--- a/assistant/src/__tests__/tcc-sandbox-deny.test.ts
+++ b/assistant/src/__tests__/tcc-sandbox-deny.test.ts
@@ -108,6 +108,35 @@ describe("macOS TCC sandbox deny rules", () => {
       }
     });
 
+    test("working directory under TCC path gets file-read re-allowed", async () => {
+      const { NativeBackend } =
+        await import("../tools/terminal/backends/native.js");
+      const backend = new NativeBackend();
+      const home = process.env.HOME ?? "";
+      const workDir = join(home, "Documents", "my-project");
+      const result = backend.wrap("true", workDir, {
+        networkMode: "off",
+      });
+
+      const profilePath = result.args[1]!;
+      profilePaths.push(profilePath);
+      const profile = readFileSync(profilePath, "utf-8");
+
+      // The deny rule for Documents should still be present
+      expect(profile).toContain(
+        `(deny file-read* (subpath "${join(home, "Documents")}") (with no-log))`,
+      );
+
+      // But the working directory should have a file-read allow AFTER the deny
+      const denyIdx = profile.indexOf(
+        `(deny file-read* (subpath "${join(home, "Documents")}")`,
+      );
+      const allowWorkDirIdx = profile.indexOf(
+        `(allow file-read* (subpath "${workDir}"))`,
+      );
+      expect(allowWorkDirIdx).toBeGreaterThan(denyIdx);
+    });
+
     test("paths with spaces are handled correctly", async () => {
       const { NativeBackend } =
         await import("../tools/terminal/backends/native.js");

--- a/assistant/src/tools/terminal/backends/native.ts
+++ b/assistant/src/tools/terminal/backends/native.ts
@@ -99,6 +99,11 @@ function buildSandboxProfile(
 ${tccDenyRules}
 ${denyReadRules}
 
+;; Re-allow reads for the working directory even if it falls under a TCC-denied
+;; subtree (e.g. ~/Desktop/my-project). SBPL is last-match-wins, so this
+;; override must come after the deny rules above.
+(allow file-read* (subpath "__WORKING_DIR__"))
+
 ;; Allow write access to the working directory and its children
 (allow file-write*
   (literal "/dev/null")


### PR DESCRIPTION
## Summary
- Adds an explicit `(allow file-read* (subpath WORKING_DIR))` rule after the TCC deny block in the SBPL sandbox profile, so that working directories under `~/Desktop` or `~/Documents` are not silently blocked by the TCC deny rules (SBPL last-match-wins semantics).
- Adds a regression test verifying that the working-directory file-read allow appears after TCC deny rules when the working dir is under a TCC-protected path.

## Test plan
- [ ] Existing `tcc-sandbox-deny.test.ts` tests continue to pass
- [ ] New test validates `(allow file-read*)` for working dir appears after TCC deny rules
- [ ] Manual: run a command with working dir under ~/Documents and verify reads succeed

Closes feedback from PR #26594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
