### PR TITLE
fix(gateway): enforce settings.write scope on Slack OAuth install route

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -782,7 +782,8 @@ async function main() {
     {
       path: "/v1/integrations/slack/channel/oauth-install",
       method: "POST",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req) => slackControlPlaneProxy.handleSlackOAuthInstall(req),
     },
 


### PR DESCRIPTION
## Summary
- Enforce `settings.write` scope on the `/v1/integrations/slack/channel/oauth-install` route
- The original PR #26597 used `auth: "edge"` which drops scope enforcement, allowing any caller with a valid edge JWT (including read-only profiles) to perform a write-level integration action
- Switches to `auth: "edge-scoped"` with `scope: "settings.write"` to match the pattern used by other write endpoints in the gateway

## Test plan
- [ ] Verify that callers with `settings.write` scope can still invoke the Slack OAuth install endpoint
- [ ] Verify that callers without `settings.write` scope (e.g. `ui_page_v1`) are rejected

Closes feedback from PR #26597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
