### PR TITLE
feat(home): add HomeGreetingHeader with avatar + title + New Chat CTA

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeGreetingHeader.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGreetingHeader.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// Greeting header for the Home feed.
+///
+/// Displays a caller-provided avatar, a greeting title (e.g. "Here's what's
+/// been going on"), and a primary "New Chat" pill CTA on the trailing edge.
+///
+/// The caller is responsible for sizing the avatar (typical: 40x40pt) and for
+/// any outer padding around the header.
+struct HomeGreetingHeader<Avatar: View>: View {
+    let greeting: String
+    let onStartNewChat: () -> Void
+    @ViewBuilder let avatar: () -> Avatar
+
+    var body: some View {
+        HStack(alignment: .center, spacing: VSpacing.md) {
+            avatar()
+
+            Text(greeting)
+                .font(VFont.titleLarge)
+                .foregroundStyle(VColor.contentEmphasized)
+                .lineLimit(1)
+
+            Spacer()
+
+            // `leftIcon` is the VButton API for a leading icon (there is no
+            // `iconLeft`). `VIcon.squarePen` is the codebase's existing token
+            // for the "pen-to-square" / new conversation glyph.
+            VButton(
+                label: "New Chat",
+                leftIcon: VIcon.squarePen.rawValue,
+                style: .primary,
+                size: .pillRegular,
+                action: onStartNewChat
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add HomeGreetingHeader — generic over an avatar ViewBuilder, plus a greeting title and a primary "New Chat" pill CTA
- Uses VFont.titleLarge / VColor.contentEmphasized tokens; matches VButton signature in the DS
- Caller owns internal sizing for the avatar slot and outer padding

Part of plan: home-figma-redesign.md (PR 5 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
