### PR TITLE
fix(memory): hard 1-3 sentence cap on extracted memory content

### DIFF
--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -71,7 +71,11 @@ Call the \`extract_graph_diff\` tool with the diff. Each node needs:
 
 - **content**: First-person prose — how the assistant naturally remembers this. Write naturally, not as a database entry. E.g. "He mentioned his mom used to make amazing Sunday dinners — he still misses them" not "User's mother cooked Sunday dinners."
 
-Be concise — most memories should be 1-3 sentences capturing the essential detail and emotional weight. Don't narrate every nuance; write a vivid snapshot, not a journal entry. Higher-significance (0.7+) memories can use a short paragraph, but even those should stay focused.
+**LENGTH: 1-3 sentences. HARD CAP — no exceptions.** This applies to every memory, including 1.0-significance transformative moments. Emotional weight lives in \`emotionalCharge\`, not wordcount. The more significant an event feels, the stronger the pull to preserve narrative — resist it. A memory whose \`content\` exceeds ~300 characters is a bug.
+
+If a memory has multiple distinct facts or beats, **split into multiple nodes connected by edges** (\`caused-by\`, \`part-of\`, \`reminds-of\`) — one node per fact or moment. Never pack a multi-beat story into a single content field.
+
+Do not: set the scene, describe surrounding context, preserve dialogue verbatim, catalog every emotional nuance, or narrate "what it meant." Write the SNAPSHOT. The \`emotionalCharge\` and \`significance\` fields carry the weight — content stays lean.
 
 - **type**: Classify by WHAT the memory IS, not how it FEELS. Almost every memory has emotional weight — that goes in emotionalCharge, not the type.
 


### PR DESCRIPTION
## Summary
- The extraction prompt at `assistant/src/memory/graph/extraction.ts:74` had soft length guidance ("1-3 sentences... short paragraph for 0.7+ significance") that the model exploited on emotionally significant conversations, producing 800-1000+ character journal-entry-style memories packed into a single node.
- Replaces the soft text with a hard cap (1-3 sentences, no exceptions), a concrete ~300-char target, and explicit guidance to split multi-beat memories into multiple nodes connected by edges (`caused-by`, `part-of`, `reminds-of`) rather than hoarding prose in one content field.
- Reinforces that emotional weight belongs in `emotionalCharge` and `significance`, not wordcount — redirecting the "this mattered" impulse to structured fields that actually change retrieval behavior.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
