### PR TITLE
fix(telemetry): delay first flush to avoid credential race condition

### DIFF
--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -13,6 +13,8 @@ import { getLogger } from "../util/logger.js";
 
 const log = getLogger("platform-client");
 
+let _missingPrereqsWarned = false;
+
 export class VellumPlatformClient {
   private readonly platformBaseUrl: string;
   private readonly apiKey: string;
@@ -70,7 +72,9 @@ export class VellumPlatformClient {
     }
 
     if (!baseUrl || !apiKey) {
-      log.warn(
+      const level = _missingPrereqsWarned ? "debug" : "warn";
+      _missingPrereqsWarned = true;
+      log[level](
         {
           hasBaseUrl: !!baseUrl,
           hasApiKey: !!apiKey,

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -70,10 +70,11 @@ export class VellumPlatformClient {
     }
 
     if (!baseUrl || !apiKey) {
-      log.debug(
+      log.warn(
         {
           hasBaseUrl: !!baseUrl,
           hasApiKey: !!apiKey,
+          hasAssistantId: !!assistantId,
           managedProxyEnabled: ctx.enabled,
         },
         "Platform client prerequisites missing — returning null",

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -55,6 +55,7 @@ const TELEMETRY_PATH = "/v1/telemetry/ingest/";
 // ---------------------------------------------------------------------------
 
 export class UsageTelemetryReporter {
+  private initialFlushTimer: ReturnType<typeof setTimeout> | null = null;
   private timer: ReturnType<typeof setInterval> | null = null;
   private activeFlush: Promise<void> | null = null;
 
@@ -63,7 +64,8 @@ export class UsageTelemetryReporter {
     // handshake) to complete. Without this delay, VellumPlatformClient.create()
     // returns null because the credential backend hasn't resolved yet, causing
     // telemetry to fall back to anonymous mode permanently.
-    setTimeout(() => {
+    this.initialFlushTimer = setTimeout(() => {
+      this.initialFlushTimer = null;
       this.flush().catch((err) => {
         log.warn({ err }, "Initial usage telemetry flush failed");
       });
@@ -76,6 +78,10 @@ export class UsageTelemetryReporter {
   }
 
   async stop(): Promise<void> {
+    if (this.initialFlushTimer) {
+      clearTimeout(this.initialFlushTimer);
+      this.initialFlushTimer = null;
+    }
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -45,6 +45,7 @@ const CHECKPOINT_KEY_LIFECYCLE_WATERMARK =
 const CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID =
   "telemetry:lifecycle:last_reported_id";
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
+const INITIAL_FLUSH_DELAY_MS = 30_000; // Delay first flush to let CES handshake complete
 const BATCH_SIZE = 500;
 const MAX_CONSECUTIVE_BATCHES = 10;
 const TELEMETRY_PATH = "/v1/telemetry/ingest/";
@@ -58,9 +59,15 @@ export class UsageTelemetryReporter {
   private activeFlush: Promise<void> | null = null;
 
   start(): void {
-    this.flush().catch((err) => {
-      log.warn({ err }, "Initial usage telemetry flush failed");
-    });
+    // Delay the first flush to allow the credential infrastructure (CES
+    // handshake) to complete. Without this delay, VellumPlatformClient.create()
+    // returns null because the credential backend hasn't resolved yet, causing
+    // telemetry to fall back to anonymous mode permanently.
+    setTimeout(() => {
+      this.flush().catch((err) => {
+        log.warn({ err }, "Initial usage telemetry flush failed");
+      });
+    }, INITIAL_FLUSH_DELAY_MS);
     this.timer = setInterval(() => {
       this.flush().catch((err) => {
         log.warn({ err }, "Scheduled usage telemetry flush failed");


### PR DESCRIPTION
## Summary
- Delays the first telemetry flush by 30 seconds (new `INITIAL_FLUSH_DELAY_MS` constant) instead of flushing immediately on `start()`. This gives the CES credential backend time to complete its handshake before the first `VellumPlatformClient.create()` call.
- Upgrades the "Platform client prerequisites missing" log from `debug` to `warn` with an additional `hasAssistantId` field for better production observability when telemetry falls back to anonymous mode.

## Context
The daemon startup sequence in `lifecycle.ts` starts the telemetry reporter (line 580) BEFORE CES startup completes (line 587+). The CES handshake can take up to 20 seconds. Without credentials available, `VellumPlatformClient.create()` returns null and telemetry sends anonymously — meaning `user_id` and `organization_id` are never populated in the platform's telemetry data.

## Original prompt
Fix the telemetry auth race condition where the reporter flushes before CES is ready, causing VellumPlatformClient.create() to return null.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
