### PR TITLE
feat(macos): add Cmd+Up/Down to navigate between conversations

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -237,6 +237,10 @@ extension AppDelegate {
             NSEvent.removeMonitor(monitor)
             popOutLocalMonitor = nil
         }
+        if let monitor = conversationNavLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            conversationNavLocalMonitor = nil
+        }
     }
 
     /// Registers Cmd+Shift+V as a global shortcut to open the quick input text field.
@@ -468,6 +472,66 @@ extension AppDelegate {
             return nil
         }
         popOutLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+    }
+
+    /// Registers Cmd+Up / Cmd+Down as local shortcuts for navigating between
+    /// conversations in the sidebar. Uses arrow key codes (126 = up, 125 = down)
+    /// rather than `charactersIgnoringModifiers` which is unreliable for arrow keys
+    /// on some keyboard layouts.
+    func registerConversationNavMonitor() {
+        guard conversationNavLocalMonitor == nil else { return }
+        let handler: (NSEvent) -> NSEvent? = { [weak self] event in
+            guard self?.isBootstrapping != true,
+                  self?.mainWindow?.isVisible == true else { return event }
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting(.numericPad)
+            guard mods == [.command] else { return event }
+            switch event.keyCode {
+            case 126: // Up arrow
+                Task { @MainActor in self?.selectPreviousConversation() }
+                return nil
+            case 125: // Down arrow
+                Task { @MainActor in self?.selectNextConversation() }
+                return nil
+            default:
+                return event
+            }
+        }
+        conversationNavLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+    }
+
+    /// Select the previous conversation in the sidebar's visible list.
+    private func selectPreviousConversation() {
+        guard let mainWindow else { return }
+        let visible = mainWindow.conversationManager.visibleConversations
+        guard !visible.isEmpty else { return }
+        let activeId = mainWindow.conversationManager.activeConversationId
+        guard let currentIndex = visible.firstIndex(where: { $0.id == activeId }) else {
+            // No active conversation or not in visible list — select the first one
+            mainWindow.conversationManager.selectConversation(id: visible[0].id)
+            mainWindow.windowState.selection = .conversation(visible[0].id)
+            return
+        }
+        guard currentIndex > 0 else { return } // already at top
+        let targetId = visible[currentIndex - 1].id
+        mainWindow.conversationManager.selectConversation(id: targetId)
+        mainWindow.windowState.selection = .conversation(targetId)
+    }
+
+    /// Select the next conversation in the sidebar's visible list.
+    private func selectNextConversation() {
+        guard let mainWindow else { return }
+        let visible = mainWindow.conversationManager.visibleConversations
+        guard !visible.isEmpty else { return }
+        let activeId = mainWindow.conversationManager.activeConversationId
+        guard let currentIndex = visible.firstIndex(where: { $0.id == activeId }) else {
+            mainWindow.conversationManager.selectConversation(id: visible[0].id)
+            mainWindow.windowState.selection = .conversation(visible[0].id)
+            return
+        }
+        guard currentIndex < visible.count - 1 else { return } // already at bottom
+        let targetId = visible[currentIndex + 1].id
+        mainWindow.conversationManager.selectConversation(id: targetId)
+        mainWindow.windowState.selection = .conversation(targetId)
     }
 
     /// Registers Cmd+=/Cmd+-/Cmd+0 as local shortcuts for window zoom.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -74,6 +74,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var zoomLocalMonitor: Any?
     var sidebarToggleLocalMonitor: Any?
     var popOutLocalMonitor: Any?
+    var conversationNavLocalMonitor: Any?
     public let services = AppServices()
     let vellumCli = VellumCli()
     let appleContainersLauncher: AssistantManagementClient? = {
@@ -669,6 +670,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         setupFileMenu()
         patchAppMenuTitles()
         registerNavigationMonitor()
+        registerConversationNavMonitor()
         registerZoomMonitor()
         registerSidebarToggleMonitor()
         setupHotKey()


### PR DESCRIPTION
## Summary
- Adds **Cmd+Up** and **Cmd+Down** keyboard shortcuts to navigate to the previous/next conversation in the sidebar's visible list
- Follows the same `NSEvent.addLocalMonitorForEvents` pattern as existing shortcuts (Cmd+[/] for history nav, Cmd+N for new chat, etc.)
- Handles `.numericPad` modifier flag stripping (arrow keys report this on macOS)
- No-ops at list boundaries (top/bottom) rather than wrapping

## Test plan
- [ ] Open the app with multiple conversations in the sidebar
- [ ] Press Cmd+Down — should select the next conversation below the current one
- [ ] Press Cmd+Up — should select the previous conversation above
- [ ] Verify no-op at the top (Cmd+Up on first conversation) and bottom (Cmd+Down on last)
- [ ] Verify the shortcut doesn't fire when the main window is hidden or during bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
