### PR TITLE
fix(security): move web-fetch title/description inside external_content boundary

### DIFF
--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -482,13 +482,6 @@ function formatWebFetchOutput(params: {
     lines.push(`Markdown-Tokens: ${params.markdownTokens}`);
   }
 
-  if (params.title) {
-    lines.push(`Title: ${params.title}`);
-  }
-  if (params.description) {
-    lines.push(`Description: ${params.description}`);
-  }
-
   if (params.notices.length > 0) {
     lines.push("Notices:");
     for (const notice of params.notices) {


### PR DESCRIPTION
## Summary
- Removes duplicate Title/Description metadata lines that were placed outside the `<external_content>` security wrapper in `formatWebFetchOutput`
- The metadata (from attacker-controlled HTML `<title>` and `<meta>` tags) is already included inside the `wrapUntrustedContent()` boundary, so the outer copy was redundant and a prompt injection vector
- Addresses review feedback from Codex and Devin on #26946

## Test plan
- [ ] Verify `formatWebFetchOutput` no longer emits title/description outside the `<external_content>` tags
- [ ] Confirm title/description still appear inside the wrapped content block

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
