### PR TITLE
fix(heartbeat): add missing_scopes to hard-failure credential gate

### DIFF
--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -271,10 +271,13 @@ export class HeartbeatService {
         await this.notifyUnhealthyCredentials(report.unhealthy);
         // Only block providers for hard-failure statuses — expiring and ping_failed
         // are transient/still-usable and should not disable provider tools.
+        // missing_scopes is a hard failure because required scopes are absent and
+        // provider tools will predictably fail.
         const hardFailureStatuses = new Set([
           "revoked",
           "missing_token",
           "expired",
+          "missing_scopes",
         ]);
         const hardFailures = report.unhealthy.filter((r) =>
           hardFailureStatuses.has(r.status),


### PR DESCRIPTION
## Summary
- Adds `missing_scopes` to the `hardFailureStatuses` Set in `runCredentialHealthCheck()` — when required scopes are absent, provider tools will predictably fail, so it should block like other hard failures.
- Updates the comment to accurately document which statuses are excluded (`expiring` and `ping_failed` only) and why `missing_scopes` is included.

Addresses feedback from #26954.

## Test plan
- [x] Verify `missing_scopes` credentials now block provider tools in heartbeat
- [x] Confirm `expiring` and `ping_failed` remain non-blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
