### PR TITLE
fix(prompt): demote Connected Services heading from ## to #

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -97,7 +97,7 @@ function basePrompt(result: string): string {
     "## Configuration",
     "## Skills Catalog",
     "## External Communications Identity",
-    "## Connected Services",
+    "# Connected Services",
     "## Dynamic Skill Authoring Workflow",
   ]) {
     if (s.startsWith(heading)) {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -416,7 +416,7 @@ function buildIntegrationSection(): string {
 
   if (connections.length === 0) return "";
 
-  const lines = ["## Connected Services", ""];
+  const lines = ["# Connected Services", ""];
   for (const conn of connections) {
     const state = conn.accountInfo
       ? `Connected (${conn.accountInfo})`


### PR DESCRIPTION
## Summary
- Change the Connected Services section heading in the system prompt from `##` to `#`, and update the matching test expectation.

## Original prompt
The Connected Services section should only have one # not two.
```
assistant/src/prompts/system-prompt.ts
419:  const lines = ["## Connected Services", ""];

assistant/src/__tests__/system-prompt.test.ts
100:    "## Connected Services",
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
