### PR TITLE
fix(gateway): add 403 response to OpenAPI schema for scoped Slack OAuth route

### DIFF
--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1956,7 +1956,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Slack OAuth install",
           description:
-            "Authenticated gateway endpoint that initiates the Slack OAuth loopback flow to capture bot and user tokens. This endpoint blocks while the user completes the Slack consent screen (up to 6 minutes).",
+            "Scope-protected gateway endpoint that initiates the Slack OAuth loopback flow to capture bot and user tokens. This endpoint blocks while the user completes the Slack consent screen (up to 6 minutes). Requires a bearer token with `settings.write` scope.",
           operationId: "slackChannelOAuthInstallPost",
           security: [{ BearerAuth: [] }],
           requestBody: {
@@ -1973,6 +1973,7 @@ export function buildSchema(): Record<string, unknown> {
             "401": {
               description: "Unauthorized — missing or invalid bearer token",
             },
+            "403": { description: "Insufficient scope" },
             "502": { description: "Failed to reach assistant runtime" },
             "504": { description: "Assistant runtime request timed out" },
           },


### PR DESCRIPTION
## Summary
- Adds `"403": { description: "Insufficient scope" }` response to the `/v1/integrations/slack/channel/oauth-install` endpoint in the OpenAPI schema
- Updates description from "Authenticated gateway endpoint" to "Scope-protected gateway endpoint ... Requires a bearer token with `settings.write` scope." to match other scoped endpoints

## Context
Addresses feedback from #26958 — the OpenAPI schema was not updated when the Slack OAuth install route was upgraded from `auth: "edge"` to `auth: "edge-scoped"`.

## Test plan
- [ ] Verify schema change matches the pattern of other `edge-scoped` endpoints in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
