### PR TITLE
fix(macos): reorder SBPL rules so CES deny overrides working-dir allow

### DIFF
--- a/assistant/src/__tests__/tcc-sandbox-deny.test.ts
+++ b/assistant/src/__tests__/tcc-sandbox-deny.test.ts
@@ -137,6 +137,36 @@ describe("macOS TCC sandbox deny rules", () => {
       expect(allowWorkDirIdx).toBeGreaterThan(denyIdx);
     });
 
+    test("CES deny-read rules override working-dir allow (credential isolation)", async () => {
+      const { NativeBackend } =
+        await import("../tools/terminal/backends/native.js");
+      const backend = new NativeBackend();
+      const home = process.env.HOME ?? "";
+      // Simulate a working directory that overlaps with a CES-protected path
+      const workDir = join(home, "Documents", "my-project");
+      const cesProtectedPath = join(workDir, ".credentials");
+      const result = backend.wrap("true", workDir, {
+        networkMode: "off",
+        denyReadPaths: [cesProtectedPath],
+      });
+
+      const profilePath = result.args[1]!;
+      profilePaths.push(profilePath);
+      const profile = readFileSync(profilePath, "utf-8");
+
+      // The working-dir allow should be present
+      const allowWorkDirIdx = profile.indexOf(
+        `(allow file-read* (subpath "${workDir}"))`,
+      );
+      expect(allowWorkDirIdx).toBeGreaterThanOrEqual(0);
+
+      // The CES deny rule should appear AFTER the working-dir allow
+      const cesDenyIdx = profile.indexOf(
+        `(deny file-read* (subpath "${cesProtectedPath}")`,
+      );
+      expect(cesDenyIdx).toBeGreaterThan(allowWorkDirIdx);
+    });
+
     test("paths with spaces are handled correctly", async () => {
       const { NativeBackend } =
         await import("../tools/terminal/backends/native.js");

--- a/assistant/src/tools/terminal/backends/native.ts
+++ b/assistant/src/tools/terminal/backends/native.ts
@@ -97,12 +97,13 @@ function buildSandboxProfile(
 ;; Allow read access to the filesystem (tools, libraries, etc.)
 (allow file-read*)
 ${tccDenyRules}
-${denyReadRules}
 
 ;; Re-allow reads for the working directory even if it falls under a TCC-denied
 ;; subtree (e.g. ~/Desktop/my-project). SBPL is last-match-wins, so this
-;; override must come after the deny rules above.
+;; override must come after the TCC deny rules above but BEFORE the CES
+;; deny-read rules below — credential isolation always takes precedence.
 (allow file-read* (subpath "__WORKING_DIR__"))
+${denyReadRules}
 
 ;; Allow write access to the working directory and its children
 (allow file-write*


### PR DESCRIPTION
## Summary
- Moves the working-directory `file-read*` re-allow rule to come BETWEEN the TCC deny rules and the CES deny-read rules in the SBPL sandbox profile
- Previously it was placed after both, which due to SBPL last-match-wins semantics would override credential isolation
- Adds a regression test verifying that CES deny rules take precedence over the working-dir allow when paths overlap

Addresses feedback from #26957.

## Test plan
- [ ] Existing TCC sandbox tests pass (working-dir under ~/Documents still gets re-allowed)
- [ ] New regression test confirms CES deny appears after working-dir allow in generated profile
- [ ] Manual: run a sandboxed command in a project under ~/Documents, verify it works but credential paths remain blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
