### PR TITLE
fix(migration): clarify workspace migration AGENTS.md allows runtime built-ins

### DIFF
--- a/assistant/src/workspace/migrations/AGENTS.md
+++ b/assistant/src/workspace/migrations/AGENTS.md
@@ -6,6 +6,6 @@ Each migration file must be **fully self-contained**. All helper functions, cons
 
 - **No external exports.** Migration files must not export anything other than the single `WorkspaceMigration` object. Other code must never import from a migration file.
 - **Duplicate rather than share.** If two migrations need the same helper, duplicate it in both files. Migrations are write-once code — they run once per assistant and are never modified after release. Duplication is preferable to coupling.
-- **Allowed imports:** `./types.js` (for the `WorkspaceMigration` interface) and `../../util/logger.js` (for structured logging). All other dependencies should be inlined.
+- **Allowed imports:** `./types.js` (for the `WorkspaceMigration` interface), `../../util/logger.js` (for structured logging), and Node/Bun runtime built-ins (`node:fs`, `node:path`, `node:crypto`, `bun:sqlite`, etc.). All other project-internal dependencies should be inlined — do not import from shared modules like `../../memory/` or `../../config/`.
 - **Graceful on all platforms.** Migrations run on macOS, Linux, and in Docker. Platform-specific operations must no-op gracefully on unsupported platforms — never throw.
 - **Idempotent.** Migrations must be safe to re-run if interrupted. The runner checkpoints state as `"started"` before execution and `"completed"` after, so a crash mid-migration triggers a re-run on next startup.


### PR DESCRIPTION
## Summary
- Clarifies the workspace migration AGENTS.md import rule to explicitly list Node/Bun runtime built-ins (`node:fs`, `node:path`, `node:crypto`, `bun:sqlite`, etc.) as allowed imports.
- The rule previously said "All other dependencies should be inlined" which was ambiguous — many existing migrations (025, 026, 040, etc.) already import `node:fs` and `node:path` without issue.
- Migration 042 correctly uses `bun:sqlite` for self-contained database access (avoiding imports from `../../memory/`), which is the intended pattern per the self-containment principle.

Addresses feedback from #26960.

## Test plan
- [ ] No code changes — documentation-only clarification
- [ ] Verify existing migrations continue to pass (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
