### PR TITLE
fix(macos/tts): always enable Test button in voice settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -403,20 +403,6 @@ struct VoiceSettingsView: View {
         return "Hey! It's \(name). How does this sound?"
     }
 
-    /// Test button is enabled only when there are no unsaved changes AND a
-    /// key is stored for the active provider AND playback isn't already in
-    /// flight. Forcing Save before Test means we always exercise the same
-    /// configured TTS path used by the rest of the app — no override state.
-    private var ttsTestEnabled: Bool {
-        !ttsHasChanges && ttsProviderHasKey && !testPlayer.isLoading
-    }
-
-    private var ttsTestDisabledHint: String? {
-        if ttsHasChanges { return "Save your changes before testing" }
-        if !ttsProviderHasKey { return "Save an API key before testing" }
-        return nil
-    }
-
     private var ttsProviderCard: some View {
         SettingsCard(title: "Text-to-Speech", subtitle: "Choose a TTS provider for voice conversations and read-aloud. The selected provider is used globally across all speech features.") {
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -451,18 +437,14 @@ struct VoiceSettingsView: View {
                 // Credentials guide — contextual help for obtaining an API key
                 ttsCredentialsGuideView
 
-                // Test + Save + Reset actions. Test is gated by
-                // `ttsTestEnabled` so it always runs against the saved
-                // configuration — no separate test path on the backend.
                 HStack(spacing: VSpacing.sm) {
                     VButton(
                         label: testPlayer.isLoading ? "Testing\u{2026}" : "Test",
                         style: .outlined,
-                        isDisabled: !ttsTestEnabled
+                        isDisabled: false
                     ) {
                         Task { await testPlayer.playTest(text: ttsTestPhrase) }
                     }
-                    .help(ttsTestDisabledHint ?? "")
 
                     ServiceCardActions(
                         hasChanges: ttsHasChanges,


### PR DESCRIPTION
## Summary
- Remove gating on the TTS Test button so it can be tapped regardless of unsaved changes, key presence, or in-flight playback.
- `TTSTestPlayer.playTest` already surfaces `.notConfigured`, feature-disabled, and network errors inline, so users get actionable feedback when a tap fails instead of a disabled button with no signal.

## Original prompt
[Image #1] let's make it so that the test button is always enabled
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
