### PR TITLE
feat(memory): add `memory compact` CLI for long-node content backfill

### DIFF
--- a/assistant/src/cli/commands/memory.ts
+++ b/assistant/src/cli/commands/memory.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 
 import {
   cleanupShortSegments,
+  compactLongMemoryNodes,
   findReextractTarget,
   findReextractTargets,
   getMemorySystemStatus,
@@ -35,7 +36,7 @@ Key concepts:
 Examples:
   $ assistant memory status
   $ assistant memory query "What is the project deadline?"
-  $ assistant memory backfill`
+  $ assistant memory backfill`,
   );
 
   memory
@@ -57,7 +58,7 @@ Fields shown:
   jobs               Status of background jobs (backfill, cleanup, rebuild-index)
 
 Examples:
-  $ assistant memory status`
+  $ assistant memory status`,
     )
     .action(async () => {
       initializeDb();
@@ -97,7 +98,7 @@ useful after bulk imports or if the incremental state has become inconsistent.
 
 Examples:
   $ assistant memory backfill
-  $ assistant memory backfill --force`
+  $ assistant memory backfill --force`,
     )
     .action((opts: { force?: boolean }) => {
       initializeDb();
@@ -121,20 +122,20 @@ existing short segments that were stored before the filter was added.
 
 Examples:
   $ assistant memory cleanup-segments
-  $ assistant memory cleanup-segments --dry-run`
+  $ assistant memory cleanup-segments --dry-run`,
     )
     .action(async (opts: { dryRun?: boolean }) => {
       initializeDb();
       const result = await cleanupShortSegments({ dryRun: opts.dryRun });
       if (opts.dryRun) {
         log.info(
-          `Dry run: ${result.dryRunCount} short segment(s) would be removed.`
+          `Dry run: ${result.dryRunCount} short segment(s) would be removed.`,
         );
       } else {
         log.info(`Removed ${result.removed} short segment(s).`);
         if (result.failed > 0) {
           log.warn(
-            `${result.failed} segment(s) skipped — Qdrant deletion failed. Re-run when Qdrant is available.`
+            `${result.failed} segment(s) skipped — Qdrant deletion failed. Re-run when Qdrant is available.`,
           );
         }
       }
@@ -143,7 +144,7 @@ Examples:
   memory
     .command("query <text>")
     .description(
-      "Run a memory recall query and print the injected memory payload"
+      "Run a memory recall query and print the injected memory payload",
     )
     .option("-c, --conversation <id>", "Optional conversation ID")
     .addHelpText(
@@ -164,7 +165,7 @@ context-aware recall. If omitted, the most recent conversation is used.
 Examples:
   $ assistant memory query "What is the project deadline?"
   $ assistant memory query "preferred communication style" --conversation conv_abc123
-  $ assistant memory query "API rate limits"`
+  $ assistant memory query "API rate limits"`,
     )
     .action(async (text: string, opts?: { conversation?: string }) => {
       initializeDb();
@@ -181,8 +182,8 @@ Examples:
         for (const r of result.results) {
           log.info(
             `[${r.type}] (confidence: ${r.confidence.toFixed(
-              2
-            )}, score: ${r.score.toFixed(3)})`
+              2,
+            )}, score: ${r.score.toFixed(3)})`,
           );
           log.info(r.content);
           log.info("");
@@ -208,7 +209,7 @@ status" to monitor job progress.
 
 Examples:
   $ assistant memory rebuild-index
-  $ assistant memory status`
+  $ assistant memory status`,
     )
     .action(() => {
       initializeDb();
@@ -219,13 +220,13 @@ Examples:
   memory
     .command("re-extract")
     .description(
-      "Re-extract memories from conversations using the latest extraction prompt"
+      "Re-extract memories from conversations using the latest extraction prompt",
     )
     .option(
       "-c, --conversation <id>",
       "Target a specific conversation by ID (repeatable)",
       (val: string, prev: string[]) => [...prev, val],
-      [] as string[]
+      [] as string[],
     )
     .option("-t, --top <n>", "Auto-select top N conversations by message count")
     .option("--dry-run", "Show what would be re-extracted without doing it")
@@ -248,7 +249,7 @@ background worker).
 Examples:
   $ assistant memory re-extract --top 20
   $ assistant memory re-extract --conversation conv_abc123
-  $ assistant memory re-extract --top 10 --dry-run`
+  $ assistant memory re-extract --top 10 --dry-run`,
     )
     .action(
       (opts: { conversation?: string[]; top?: string; dryRun?: boolean }) => {
@@ -288,7 +289,7 @@ Examples:
 
         if (targets.length === 0) {
           log.info(
-            "No targets specified. Use --conversation <id> or --top <n>."
+            "No targets specified. Use --conversation <id> or --top <n>.",
           );
           return;
         }
@@ -307,8 +308,105 @@ Examples:
 
         const { jobIds } = requestReextract(targets);
         log.info(
-          `\nQueued ${jobIds.length} re-extraction job(s). The assistant will process them in the background.`
+          `\nQueued ${jobIds.length} re-extraction job(s). The assistant will process them in the background.`,
         );
-      }
+      },
+    );
+
+  memory
+    .command("compact")
+    .description(
+      "Rewrite memory nodes whose content exceeds the length cap (backfill)",
+    )
+    .option(
+      "--threshold <n>",
+      "Content length threshold — nodes longer than this are candidates (default: 400)",
+      (v: string) => Number.parseInt(v, 10),
+      400,
+    )
+    .option(
+      "--limit <n>",
+      "Maximum number of candidates to process (default: no limit)",
+      (v: string) => Number.parseInt(v, 10),
+    )
+    .option("--apply", "Rewrite content (default is a candidate-only preview)")
+    .addHelpText(
+      "after",
+      `
+One-off backfill for memory graphs that accumulated over-long content before
+the extraction prompt was tightened to enforce the 1-3 sentence / ~300
+character cap. Scans memory_graph_nodes (skipping fidelity=gone) for entries
+whose content length exceeds --threshold, then either lists them (default)
+or rewrites each via the memoryConsolidation LLM call site (--apply).
+
+Only the content field is rewritten; significance, emotionalCharge, edges,
+triggers, and image_refs are preserved. Each rewrite is logged in
+memory_graph_node_edits with source="manual" so it is reversible.
+
+Start with a bounded spot-check before processing the whole graph:
+
+  $ assistant memory compact --limit 3 --apply
+
+Examples:
+  $ assistant memory compact                     # preview candidates
+  $ assistant memory compact --threshold 500     # tighter threshold
+  $ assistant memory compact --limit 5 --apply   # rewrite first 5
+  $ assistant memory compact --apply             # rewrite everything`,
+    )
+    .action(
+      async (opts: { threshold: number; limit?: number; apply?: boolean }) => {
+        initializeDb();
+        const apply = Boolean(opts.apply);
+
+        log.info(
+          `Scanning memory_graph_nodes for content > ${opts.threshold} chars${
+            apply ? "" : " (preview — no changes will be written)"
+          }...`,
+        );
+
+        const result = await compactLongMemoryNodes({
+          threshold: opts.threshold,
+          limit: opts.limit,
+          apply,
+          onCandidates: (candidates) => {
+            log.info(`Found ${candidates.length} candidate node(s)`);
+            if (!apply) {
+              for (const c of candidates) {
+                log.info(`  ${c.id}  ${c.beforeLen} chars`);
+              }
+            }
+          },
+          onProgress: (evt) => {
+            const tag = `[${evt.action}]`;
+            log.info(
+              `${tag} ${evt.nodeId}: ${evt.beforeLen} → ${evt.afterLen} chars${
+                evt.reason ? ` (${evt.reason})` : ""
+              }`,
+            );
+            if (evt.newContent && evt.action === "compacted") {
+              log.info(`  new: ${evt.newContent}`);
+            }
+          },
+        });
+
+        log.info("");
+        log.info(`Scanned above threshold: ${result.scanned}`);
+        log.info(`Processed:               ${result.processed}`);
+        if (apply) {
+          log.info(`Compacted:               ${result.compacted}`);
+          log.info(`Skipped:                 ${result.skipped}`);
+          log.info(`Failures:                ${result.failures}`);
+          if (result.processed > 0) {
+            log.info(
+              `Chars: ${result.beforeChars} → ${result.afterChars} (saved ${
+                result.beforeChars - result.afterChars
+              })`,
+            );
+          }
+        } else if (result.processed > 0) {
+          log.info("");
+          log.info("Preview only. Re-run with --apply to rewrite.");
+        }
+      },
     );
 }

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -6,6 +6,11 @@ import { deleteMemoryCheckpoint } from "./checkpoints.js";
 import { getConversationMemoryScopeId } from "./conversation-crud.js";
 import { getDb, rawGet } from "./db.js";
 import { getMemoryBackendStatus } from "./embedding-backend.js";
+import {
+  type CompactionOptions,
+  type CompactionResult,
+  compactLongMemories,
+} from "./graph/compaction.js";
 import { handleRecall, type RecallResult } from "./graph/tool-handlers.js";
 import {
   enqueueBackfillJob,
@@ -136,6 +141,19 @@ export async function cleanupShortSegments(opts?: {
     "Cleaned up short segments",
   );
   return { removed, failed };
+}
+
+// ── Long-memory compaction ────────────────────────────────────────────
+
+/**
+ * One-off backfill that rewrites over-long memory node content to fit the
+ * extraction prompt's 1-3 sentence / ~300 character length cap. Preview
+ * mode (opts.apply=false) lists candidates without calling the LLM.
+ */
+export async function compactLongMemoryNodes(
+  opts: CompactionOptions = {},
+): Promise<CompactionResult> {
+  return compactLongMemories(opts);
 }
 
 // ── Re-extraction ──────────────────────────────────────────────────────

--- a/assistant/src/memory/graph/compaction.ts
+++ b/assistant/src/memory/graph/compaction.ts
@@ -1,0 +1,276 @@
+// ---------------------------------------------------------------------------
+// Memory Graph — One-off backfill to compact over-long node content
+//
+// Scans memory_graph_nodes for entries whose `content` exceeds a length
+// threshold and rewrites them via an LLM call constrained to the same
+// "1-3 sentences / ~300 chars" rule the extraction prompt now enforces.
+// Preserves all other node fields (significance, emotionalCharge, edges,
+// triggers, image_refs). Each rewrite is logged in memory_graph_node_edits
+// with source="manual" so it is reversible and auditable.
+// ---------------------------------------------------------------------------
+
+import { and, sql } from "drizzle-orm";
+
+import {
+  extractToolUse,
+  getConfiguredProvider,
+  userMessage,
+} from "../../providers/provider-send-message.js";
+import { BackendUnavailableError } from "../../util/errors.js";
+import { getLogger } from "../../util/logger.js";
+import { getDb } from "../db.js";
+import { memoryGraphNodes } from "../schema.js";
+import { recordNodeEdit, updateNode } from "./store.js";
+
+const log = getLogger("graph-compaction");
+
+const COMPACTION_TOOL_SCHEMA = {
+  name: "compact_memory",
+  description: "Rewrite a memory node's content to fit the length cap",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      compacted_content: {
+        type: "string" as const,
+        description:
+          "The rewritten content — 1-3 sentences, first-person, ~300 characters or fewer",
+      },
+    },
+    required: ["compacted_content"] as const,
+  },
+};
+
+const COMPACTION_SYSTEM_PROMPT = `You are compacting an over-long memory node in an AI assistant's memory graph. The original content exceeds the extraction prompt's 1-3 sentence / ~300 character cap because it was written before the cap existed. Rewrite it to fit.
+
+## Rules
+
+**LENGTH: 1-3 sentences. Target ~300 characters. Hard cap ~400.** No exceptions.
+
+**Preserve:**
+- The core fact, event, or moment being remembered
+- First-person prose style if the original is first-person
+- The essential emotional tone of the memory
+
+**Drop:**
+- Scene-setting and surrounding context
+- Dialogue preservation (unless one short quote IS the memory)
+- Narrative "what it meant" commentary
+- Cataloging of every emotional nuance
+- Image descriptions packed into prose (images live in image_refs, not content)
+
+**Never:**
+- Invent facts not present in the original
+- Change the core subject or emotional valence
+- Pad to hit a target length — shorter than 300 chars is fine if the essence is there
+
+The node's \`emotionalCharge\` and \`significance\` fields (not shown) already carry the weight. Content stays lean.
+
+Call the \`compact_memory\` tool with the rewritten content. No preamble.`;
+
+export interface CompactionCandidate {
+  id: string;
+  beforeLen: number;
+}
+
+export interface CompactionProgress {
+  nodeId: string;
+  beforeLen: number;
+  afterLen: number;
+  action: "compacted" | "skipped" | "failed";
+  newContent?: string;
+  reason?: string;
+}
+
+export interface CompactionResult {
+  /** Nodes whose content exceeded the threshold (before --limit is applied). */
+  scanned: number;
+  /** Nodes actually processed (scanned ∩ limit). */
+  processed: number;
+  compacted: number;
+  skipped: number;
+  failures: number;
+  beforeChars: number;
+  afterChars: number;
+}
+
+export interface CompactionOptions {
+  /** Content length threshold — nodes above this get compacted. Default 400. */
+  threshold?: number;
+  /** If true, write changes. If false, only list candidates (no LLM calls). Default false. */
+  apply?: boolean;
+  /** Max nodes to process. Default: no limit. */
+  limit?: number;
+  /** Called for each node as it is processed in apply mode. */
+  onProgress?: (evt: CompactionProgress) => void;
+  /** Called once with the full candidate list (both preview and apply modes). */
+  onCandidates?: (candidates: CompactionCandidate[]) => void;
+}
+
+/**
+ * Find over-length nodes in the memory graph and (optionally) rewrite their
+ * content to fit the length cap. In preview mode (apply=false) no LLM calls
+ * are made — only the candidate list is returned.
+ */
+export async function compactLongMemories(
+  opts: CompactionOptions = {},
+): Promise<CompactionResult> {
+  const threshold = opts.threshold ?? 400;
+  const apply = opts.apply ?? false;
+
+  const db = getDb();
+  const rows = db
+    .select({
+      id: memoryGraphNodes.id,
+      content: memoryGraphNodes.content,
+    })
+    .from(memoryGraphNodes)
+    .where(
+      and(
+        // Skip already-dead nodes — rewriting content on "gone" fidelity is wasted work
+        sql`${memoryGraphNodes.fidelity} != 'gone'`,
+        sql`LENGTH(${memoryGraphNodes.content}) > ${threshold}`,
+      ),
+    )
+    .all();
+
+  const candidates = opts.limit != null ? rows.slice(0, opts.limit) : rows;
+
+  opts.onCandidates?.(
+    candidates.map((r) => ({ id: r.id, beforeLen: r.content.length })),
+  );
+
+  const result: CompactionResult = {
+    scanned: rows.length,
+    processed: candidates.length,
+    compacted: 0,
+    skipped: 0,
+    failures: 0,
+    beforeChars: candidates.reduce((sum, r) => sum + r.content.length, 0),
+    afterChars: 0,
+  };
+
+  if (!apply) {
+    // Preview mode: record beforeChars as afterChars (no rewrites attempted)
+    result.afterChars = result.beforeChars;
+    return result;
+  }
+
+  if (candidates.length === 0) return result;
+
+  const provider = await getConfiguredProvider("memoryConsolidation");
+  if (!provider) {
+    throw new BackendUnavailableError(
+      "Provider unavailable for memory compaction",
+    );
+  }
+
+  for (const row of candidates) {
+    const beforeLen = row.content.length;
+
+    try {
+      const response = await provider.sendMessage(
+        [
+          userMessage(
+            `Original memory content (length: ${beforeLen} chars):\n\n${row.content}`,
+          ),
+        ],
+        [COMPACTION_TOOL_SCHEMA],
+        COMPACTION_SYSTEM_PROMPT,
+        {
+          config: {
+            callSite: "memoryConsolidation" as const,
+            tool_choice: {
+              type: "tool" as const,
+              name: "compact_memory",
+            },
+          },
+        },
+      );
+
+      const toolBlock = extractToolUse(response);
+      if (!toolBlock) {
+        result.failures += 1;
+        result.afterChars += beforeLen;
+        opts.onProgress?.({
+          nodeId: row.id,
+          beforeLen,
+          afterLen: beforeLen,
+          action: "failed",
+          reason: "no tool_use block in response",
+        });
+        continue;
+      }
+
+      const input = toolBlock.input as { compacted_content?: string };
+      const newContent =
+        typeof input.compacted_content === "string"
+          ? input.compacted_content.trim()
+          : "";
+
+      if (!newContent) {
+        result.failures += 1;
+        result.afterChars += beforeLen;
+        opts.onProgress?.({
+          nodeId: row.id,
+          beforeLen,
+          afterLen: beforeLen,
+          action: "failed",
+          reason: "empty compacted_content",
+        });
+        continue;
+      }
+
+      // If the model didn't actually shrink it, skip — never overwrite with
+      // something equivalent or longer. Preserves the original when the LLM
+      // fails to compress.
+      if (newContent.length >= beforeLen) {
+        result.skipped += 1;
+        result.afterChars += beforeLen;
+        opts.onProgress?.({
+          nodeId: row.id,
+          beforeLen,
+          afterLen: newContent.length,
+          action: "skipped",
+          reason: "rewrite was not shorter than original",
+          newContent,
+        });
+        continue;
+      }
+
+      recordNodeEdit({
+        nodeId: row.id,
+        previousContent: row.content,
+        newContent,
+        source: "manual",
+      });
+      updateNode(row.id, {
+        content: newContent,
+        lastConsolidated: Date.now(),
+      });
+
+      result.compacted += 1;
+      result.afterChars += newContent.length;
+      opts.onProgress?.({
+        nodeId: row.id,
+        beforeLen,
+        afterLen: newContent.length,
+        action: "compacted",
+        newContent,
+      });
+    } catch (err) {
+      result.failures += 1;
+      result.afterChars += beforeLen;
+      const reason = err instanceof Error ? err.message : String(err);
+      log.warn({ nodeId: row.id, err: reason }, "Compaction failed for node");
+      opts.onProgress?.({
+        nodeId: row.id,
+        beforeLen,
+        afterLen: beforeLen,
+        action: "failed",
+        reason,
+      });
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Adds \`assistant memory compact\` subcommand that scans \`memory_graph_nodes\` for entries whose \`content\` exceeds a length threshold (default 400 chars) and rewrites them to fit the new 1-3 sentence / ~300 char cap from PR #26965. Addresses existing long memories that the tightened extraction prompt won't retroactively fix.
- Preview mode is the default (lists candidates, no LLM calls). \`--apply\` runs the rewrite via the \`memoryConsolidation\` call site; \`--limit N\` bounds the batch for spot-checking before processing the whole graph.
- Only the \`content\` field is rewritten — \`significance\`, \`emotionalCharge\`, \`edges\`, \`triggers\`, and \`image_refs\` are preserved. Each rewrite is logged in \`memory_graph_node_edits\` with \`source="manual"\` for auditability/reversibility, and rewrites that fail to shrink are skipped rather than overwriting with equivalent-or-longer content.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
