### PR TITLE
fix(macos/voice-settings): speak user-facing assistant name in TTS test

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -395,11 +395,14 @@ struct VoiceSettingsView: View {
         ttsProviderHasKey && SettingsStore.ttsKeyIsExclusive(for: draftTTSProvider)
     }
 
-    /// Phrase synthesized when the Test button is tapped. Uses the active
-    /// assistant's lockfile name so the user hears their assistant's name
-    /// spoken in the configured voice.
+    /// Phrase synthesized when the Test button is tapped. Uses the
+    /// user-facing assistant name from IDENTITY.md — not the container id
+    /// — so the voice speaks the name the user actually chose.
     private var ttsTestPhrase: String {
-        let name = LockfileAssistant.loadActiveAssistantId() ?? "your assistant"
+        let name = AssistantDisplayName.resolve(
+            IdentityInfo.loadFromDiskCache()?.name,
+            fallback: "your assistant"
+        )
         return "Hey! It's \(name). How does this sound?"
     }
 


### PR DESCRIPTION
## Summary
- Voice settings Test button now speaks the user-facing assistant name (from IDENTITY.md) rather than the container id (e.g. `vellum-tame-pike-7x4z7i`).
- Swaps `LockfileAssistant.loadActiveAssistantId()` for the standard `AssistantDisplayName.resolve(IdentityInfo.loadFromDiskCache()?.name, fallback:)` pattern used elsewhere in the macOS app, so the bootstrap sentinel is masked and the fallback stays graceful when the identity cache hasn't been warmed yet.

## Original prompt
[Image #1] pressing the test button results in the voice saying the literal name of the assistant container (e.g. `vellum-tame-pike-7x4z7i`). It should say the user facing name of the *assistant* instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
