### PR TITLE
feat(gmail): dry-run mode with commit/cancel workflow

### DIFF
--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -33,7 +33,10 @@ All operations use CLI scripts that return JSON:
 | `gmail-scan.ts`    | `sender-digest`         | Scan inbox and group messages by sender for declutter workflows              |
 | `gmail-scan.ts`    | `outreach-scan`         | Identify cold outreach senders (no List-Unsubscribe header)                  |
 | `gmail-archive.ts` | `archive`               | Archive messages (single, batch message_ids, cache_key+sender-emails, query) |
+| `gmail-archive.ts` | `archive --dry-run`     | Preview what would be archived without executing (writes staged ops to log)  |
 | `gmail-archive.ts` | `archive --resume`      | Resume an interrupted archive run from its last checkpoint                    |
+| `gmail-commit.ts`  | `commit`                | Execute all staged ops from a dry-run                                        |
+| `gmail-commit.ts`  | `cancel`                | Delete a run log without executing anything                                  |
 | `gmail-runs.ts`    | `list`                  | List recent operation runs with status summaries                             |
 | `gmail-runs.ts`    | `inspect`               | Show detailed log entries for a specific run                                 |
 | `gmail-runs.ts`    | `prune`                 | Delete operation logs older than 30 days                                     |
@@ -135,6 +138,30 @@ bun run scripts/gmail-runs.ts inspect --run-id "run_20260420_a1b2c3d4"
 
 # Delete logs older than 30 days
 bun run scripts/gmail-runs.ts prune
+```
+
+#### Dry-Run Mode
+
+Dry-run mode runs the full pipeline (scanning, collecting message IDs) but skips all destructive API calls. Staged entries are written to the op log for review.
+
+```bash
+# Preview what would be archived
+bun run scripts/gmail-archive.ts archive --query "..." --dry-run
+
+# Review the staged operations
+bun run scripts/gmail-runs.ts inspect --run-id "<run-id>"
+
+# Commit the staged operations (executes the archive)
+bun run scripts/gmail-commit.ts commit --run-id "<run-id>"
+
+# Cancel (delete the log, nothing executed)
+bun run scripts/gmail-commit.ts cancel --run-id "<run-id>"
+```
+
+Label and filter operations also support `--dry-run`:
+```bash
+bun run scripts/gmail-manage.ts label --message-ids "..." --add-labels "..." --dry-run
+bun run scripts/gmail-manage.ts filters --action create --from "..." --remove-labels "INBOX" --dry-run
 ```
 
 Archive operations now return a `run_id` in their output. Use this to resume interrupted runs:

--- a/skills/gmail/scripts/gmail-archive.ts
+++ b/skills/gmail/scripts/gmail-archive.ts
@@ -24,6 +24,7 @@ import {
   writeCheckpoint,
   writeCompleted,
   summarizeRun,
+  summarizeDryRun,
   getPendingOps,
   runExists,
 } from "./lib/op-log.js";
@@ -95,15 +96,17 @@ function recordBlocklist(senderEmails: string[]): void {
 /**
  * Batch modify messages in chunks of BATCH_MODIFY_LIMIT.
  * Each chunk is logged to the op log before execution for resumability.
+ * In dry-run mode, writes staged entries but skips all API calls.
  */
 async function batchArchive(
   messageIds: string[],
   account?: string,
-  opts?: { runId?: string; phase?: string; reason?: string },
-): Promise<{ runId: string; committed: number; failed: number }> {
+  opts?: { runId?: string; phase?: string; reason?: string; dryRun?: boolean },
+): Promise<{ runId: string; committed: number; failed: number; staged: number }> {
   const runId = opts?.runId ?? generateRunId();
   let committed = 0;
   let failed = 0;
+  let staged = 0;
 
   for (let i = 0; i < messageIds.length; i += BATCH_MODIFY_LIMIT) {
     const chunkIndex = Math.floor(i / BATCH_MODIFY_LIMIT);
@@ -117,6 +120,10 @@ async function batchArchive(
       message_ids: chunk,
       reason: opts?.reason,
     });
+    staged++;
+
+    // In dry-run mode, only stage — don't execute
+    if (opts?.dryRun) continue;
 
     try {
       const resp = await gmailPost(
@@ -148,8 +155,10 @@ async function batchArchive(
     }
   }
 
-  writeCompleted(runId, committed, failed);
-  return { runId, committed, failed };
+  if (!opts?.dryRun) {
+    writeCompleted(runId, committed, failed);
+  }
+  return { runId, committed, failed, staged };
 }
 
 /** Checkpoint interval — write pagination state every N IDs. */
@@ -219,10 +228,11 @@ async function archiveByQuery(
   skipConfirm?: boolean,
   runId?: string,
   phase?: string,
+  dryRun?: boolean,
 ): Promise<void> {
   const rid = runId ?? generateRunId();
 
-  if (!skipConfirm) {
+  if (!dryRun && !skipConfirm) {
     const confirmed = await requestConfirmation({
       title: "Archive messages",
       message: `Archive all messages matching query: ${query}`,
@@ -245,14 +255,29 @@ async function archiveByQuery(
     runId: rid,
     phase,
     reason: `query:${query}`,
+    dryRun,
   });
-  ok({
-    archived: messageIds.length,
-    method: "query",
-    run_id: result.runId,
-    committed: result.committed,
-    failed: result.failed,
-  });
+
+  if (dryRun) {
+    const summary = summarizeDryRun(rid);
+    ok({
+      dry_run: true,
+      run_id: result.runId,
+      would_archive: messageIds.length,
+      method: "query",
+      summary,
+      commit_command: `bun run scripts/gmail-commit.ts commit --run-id ${result.runId}`,
+      cancel_command: `bun run scripts/gmail-commit.ts cancel --run-id ${result.runId}`,
+    });
+  } else {
+    ok({
+      archived: messageIds.length,
+      method: "query",
+      run_id: result.runId,
+      committed: result.committed,
+      failed: result.failed,
+    });
+  }
 }
 
 /** Path 2: --cache-key + --sender-emails — retrieve from cache, fall back to per-sender query. */
@@ -263,10 +288,11 @@ async function archiveByCacheKey(
   skipConfirm?: boolean,
   runId?: string,
   phase?: string,
+  dryRun?: boolean,
 ): Promise<void> {
   const rid = runId ?? generateRunId();
 
-  if (!skipConfirm) {
+  if (!dryRun && !skipConfirm) {
     const confirmed = await requestConfirmation({
       title: "Archive messages",
       message: `Archive messages from ${senderEmails.length} sender(s)`,
@@ -333,15 +359,30 @@ async function archiveByCacheKey(
     runId: rid,
     phase,
     reason: `cache:${senderEmails.join(",")}`,
+    dryRun,
   });
-  recordBlocklist(senderEmails);
-  ok({
-    archived: allMessageIds.length,
-    method: "cache",
-    run_id: result.runId,
-    committed: result.committed,
-    failed: result.failed,
-  });
+
+  if (dryRun) {
+    const summary = summarizeDryRun(rid);
+    ok({
+      dry_run: true,
+      run_id: result.runId,
+      would_archive: allMessageIds.length,
+      method: "cache",
+      summary,
+      commit_command: `bun run scripts/gmail-commit.ts commit --run-id ${result.runId}`,
+      cancel_command: `bun run scripts/gmail-commit.ts cancel --run-id ${result.runId}`,
+    });
+  } else {
+    recordBlocklist(senderEmails);
+    ok({
+      archived: allMessageIds.length,
+      method: "cache",
+      run_id: result.runId,
+      committed: result.committed,
+      failed: result.failed,
+    });
+  }
 }
 
 /** Path 3: --message-ids — direct batch archive. */
@@ -351,10 +392,11 @@ async function archiveByMessageIds(
   skipConfirm?: boolean,
   runId?: string,
   phase?: string,
+  dryRun?: boolean,
 ): Promise<void> {
   const rid = runId ?? generateRunId();
 
-  if (!skipConfirm) {
+  if (!dryRun && !skipConfirm) {
     const confirmed = await requestConfirmation({
       title: "Archive messages",
       message: `Archive ${messageIds.length} message(s)`,
@@ -370,14 +412,29 @@ async function archiveByMessageIds(
     runId: rid,
     phase,
     reason: `batch:${messageIds.length} messages`,
+    dryRun,
   });
-  ok({
-    archived: messageIds.length,
-    method: "batch",
-    run_id: result.runId,
-    committed: result.committed,
-    failed: result.failed,
-  });
+
+  if (dryRun) {
+    const summary = summarizeDryRun(rid);
+    ok({
+      dry_run: true,
+      run_id: result.runId,
+      would_archive: messageIds.length,
+      method: "batch",
+      summary,
+      commit_command: `bun run scripts/gmail-commit.ts commit --run-id ${result.runId}`,
+      cancel_command: `bun run scripts/gmail-commit.ts cancel --run-id ${result.runId}`,
+    });
+  } else {
+    ok({
+      archived: messageIds.length,
+      method: "batch",
+      run_id: result.runId,
+      committed: result.committed,
+      failed: result.failed,
+    });
+  }
 }
 
 /** Path 4: --message-id — single message archive (no confirmation). */
@@ -485,6 +542,7 @@ async function main(): Promise<void> {
 
   const account = optionalArg(args, "account");
   const skipConfirm = args["skip-confirm"] === true;
+  const dryRun = args["dry-run"] === true;
   const runId = optionalArg(args, "run-id");
   const phase = optionalArg(args, "phase");
 
@@ -503,7 +561,7 @@ async function main(): Promise<void> {
 
   // Priority: --query > --cache-key > --message-ids > --message-id
   if (query) {
-    await archiveByQuery(query, account, skipConfirm, runId, phase);
+    await archiveByQuery(query, account, skipConfirm, runId, phase, dryRun);
   } else if (cacheKey && senderEmailsRaw) {
     const senderEmails = parseCsv(senderEmailsRaw);
     await archiveByCacheKey(
@@ -513,10 +571,11 @@ async function main(): Promise<void> {
       skipConfirm,
       runId,
       phase,
+      dryRun,
     );
   } else if (messageIdsRaw) {
     const messageIds = parseCsv(messageIdsRaw);
-    await archiveByMessageIds(messageIds, account, skipConfirm, runId, phase);
+    await archiveByMessageIds(messageIds, account, skipConfirm, runId, phase, dryRun);
   } else if (messageId) {
     await archiveSingleMessage(messageId, account);
   } else {

--- a/skills/gmail/scripts/gmail-commit.ts
+++ b/skills/gmail/scripts/gmail-commit.ts
@@ -1,0 +1,226 @@
+#!/usr/bin/env bun
+
+/**
+ * Gmail operation commit/cancel.
+ * Subcommands:
+ *   commit <run-id> — Execute all staged ops from a dry-run
+ *   cancel <run-id> — Delete the run log without executing anything
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  parseArgs,
+  printError,
+  ok,
+  optionalArg,
+} from "./lib/common.js";
+import { gmailPost, DailyQuotaExceededError } from "./lib/gmail-client.js";
+import {
+  readLog,
+  runExists,
+  writeCommitted,
+  writeFailed,
+  writeInterrupted,
+  writeCompleted,
+  summarizeRun,
+  type OpEntry,
+} from "./lib/op-log.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SKILL_ROOT = path.resolve(import.meta.dir, "..");
+const OPS_DIR = path.join(SKILL_ROOT, "data", "ops");
+
+// ---------------------------------------------------------------------------
+// Commit
+// ---------------------------------------------------------------------------
+
+async function commitRun(
+  runId: string,
+  account?: string,
+): Promise<void> {
+  if (!runExists(runId)) {
+    printError(`Run not found: ${runId}`);
+    return;
+  }
+
+  const entries = readLog(runId);
+
+  // Collect committed chunk indexes to skip
+  const alreadyCommitted = new Set<number>();
+  const alreadyFailed = new Set<number>();
+  for (const entry of entries) {
+    if (entry.status === "committed" && entry.chunk_index !== undefined) {
+      alreadyCommitted.add(entry.chunk_index);
+    }
+    if (entry.status === "failed" && entry.chunk_index !== undefined) {
+      alreadyFailed.add(entry.chunk_index);
+    }
+  }
+
+  // Find staged entries that haven't been committed or failed
+  const staged = entries.filter(
+    (e): e is OpEntry & { chunk_index: number; message_ids: string[] } =>
+      e.status === "staged" &&
+      e.op !== undefined &&
+      e.chunk_index !== undefined &&
+      e.message_ids !== undefined &&
+      !alreadyCommitted.has(e.chunk_index) &&
+      !alreadyFailed.has(e.chunk_index),
+  );
+
+  if (staged.length === 0) {
+    ok({
+      committed: 0,
+      failed: 0,
+      run_id: runId,
+      note: "No staged operations to commit",
+      summary: summarizeRun(runId),
+    });
+    return;
+  }
+
+  let committed = 0;
+  let failed = 0;
+
+  for (const entry of staged) {
+    try {
+      if (entry.op === "archive") {
+        const resp = await gmailPost(
+          "/messages/batchModify",
+          { ids: entry.message_ids, removeLabelIds: ["INBOX"] },
+          account,
+        );
+        if (!resp.ok) {
+          const errMsg = `batchModify failed (status ${resp.status}): ${JSON.stringify(resp.data)}`;
+          writeFailed(runId, entry.chunk_index, errMsg);
+          failed++;
+          continue;
+        }
+      } else if (entry.op === "label_add" || entry.op === "label_remove") {
+        // Label ops store label info in the reason field as "label:<action>:<labelIds>"
+        const labelParts = entry.reason?.split(":") ?? [];
+        const labelAction = labelParts[1]; // "add" or "remove"
+        const labelIds = labelParts.slice(2);
+        const body =
+          labelAction === "add"
+            ? { ids: entry.message_ids, addLabelIds: labelIds }
+            : { ids: entry.message_ids, removeLabelIds: labelIds };
+        const resp = await gmailPost("/messages/batchModify", body, account);
+        if (!resp.ok) {
+          const errMsg = `label batchModify failed (status ${resp.status})`;
+          writeFailed(runId, entry.chunk_index, errMsg);
+          failed++;
+          continue;
+        }
+      } else if (entry.op === "filter_create") {
+        // Filter ops store criteria in the reason field as JSON
+        const filterData = entry.reason
+          ? JSON.parse(entry.reason)
+          : null;
+        if (filterData) {
+          const resp = await gmailPost(
+            "/settings/filters",
+            filterData,
+            account,
+          );
+          if (!resp.ok) {
+            const errMsg = `filter create failed (status ${resp.status})`;
+            writeFailed(runId, entry.chunk_index, errMsg);
+            failed++;
+            continue;
+          }
+        }
+      }
+
+      writeCommitted(runId, entry.chunk_index);
+      committed++;
+    } catch (err) {
+      if (err instanceof DailyQuotaExceededError) {
+        writeInterrupted({
+          run_id: runId,
+          reason: "daily_quota",
+          resume_hint: "Resume after midnight PT",
+        });
+        ok({
+          interrupted: true,
+          run_id: runId,
+          committed,
+          failed,
+          note: "Daily quota exceeded. Resume with: bun run scripts/gmail-commit.ts commit " + runId,
+        });
+        return;
+      }
+      const errMsg = err instanceof Error ? err.message : String(err);
+      writeFailed(runId, entry.chunk_index, errMsg);
+      failed++;
+    }
+  }
+
+  writeCompleted(runId, committed, failed);
+  ok({
+    committed,
+    failed,
+    run_id: runId,
+    summary: summarizeRun(runId),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Cancel
+// ---------------------------------------------------------------------------
+
+function cancelRun(runId: string): void {
+  const logPath = path.join(OPS_DIR, `${runId}.jsonl`);
+  if (!fs.existsSync(logPath)) {
+    printError(`Run not found: ${runId}`);
+    return;
+  }
+
+  fs.unlinkSync(logPath);
+  ok({ cancelled: true, run_id: runId });
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const subcommand = process.argv[2];
+  const args = parseArgs(process.argv.slice(3));
+
+  const runId = optionalArg(args, "run-id") ?? process.argv[3];
+
+  switch (subcommand) {
+    case "commit": {
+      if (!runId || runId.startsWith("--")) {
+        printError("Usage: gmail-commit.ts commit --run-id <run-id>");
+        return;
+      }
+      const account = optionalArg(args, "account");
+      await commitRun(runId, account);
+      break;
+    }
+    case "cancel": {
+      if (!runId || runId.startsWith("--")) {
+        printError("Usage: gmail-commit.ts cancel --run-id <run-id>");
+        return;
+      }
+      cancelRun(runId);
+      break;
+    }
+    default:
+      printError(
+        `Unknown subcommand: "${subcommand ?? "(none)"}". Use "commit" or "cancel".`,
+      );
+  }
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    printError(err instanceof Error ? err.message : String(err));
+  });
+}

--- a/skills/gmail/scripts/gmail-manage.ts
+++ b/skills/gmail/scripts/gmail-manage.ts
@@ -27,6 +27,11 @@ import {
   type GmailMessage,
   type GmailMessagePart,
 } from "./lib/gmail-client.js";
+import {
+  generateRunId,
+  writeStaged,
+  type OpType,
+} from "./lib/op-log.js";
 
 // ---------------------------------------------------------------------------
 // label
@@ -40,6 +45,9 @@ async function handleLabel(
   const messageIdsStr = optionalArg(args, "message-ids");
   const addLabelsStr = optionalArg(args, "add-labels");
   const removeLabelsStr = optionalArg(args, "remove-labels");
+  const dryRun = args["dry-run"] === true;
+  const runId = optionalArg(args, "run-id");
+  const phase = optionalArg(args, "phase");
 
   const addLabelIds = addLabelsStr ? parseCsv(addLabelsStr) : undefined;
   const removeLabelIds = removeLabelsStr
@@ -48,6 +56,23 @@ async function handleLabel(
 
   if (messageIdsStr) {
     const ids = parseCsv(messageIdsStr);
+
+    if (dryRun) {
+      const rid = runId ?? generateRunId();
+      const opType: OpType = addLabelIds?.length ? "label_add" : "label_remove";
+      const labelIds = addLabelIds?.length ? addLabelIds : (removeLabelIds ?? []);
+      writeStaged({
+        run_id: rid,
+        phase,
+        op: opType,
+        chunk_index: 0,
+        message_ids: ids,
+        reason: `label:${addLabelIds?.length ? "add" : "remove"}:${labelIds.join(",")}`,
+      });
+      ok({ dry_run: true, run_id: rid, would_update: ids.length });
+      return;
+    }
+
     const res = await gmailPost(
       "/messages/batchModify",
       {
@@ -65,6 +90,22 @@ async function handleLabel(
   }
 
   if (messageId) {
+    if (dryRun) {
+      const rid = runId ?? generateRunId();
+      const opType: OpType = addLabelIds?.length ? "label_add" : "label_remove";
+      const labelIds = addLabelIds?.length ? addLabelIds : (removeLabelIds ?? []);
+      writeStaged({
+        run_id: rid,
+        phase,
+        op: opType,
+        chunk_index: 0,
+        message_ids: [messageId],
+        reason: `label:${addLabelIds?.length ? "add" : "remove"}:${labelIds.join(",")}`,
+      });
+      ok({ dry_run: true, run_id: rid, would_update: 1 });
+      return;
+    }
+
     const res = await gmailPost(
       `/messages/${messageId}/modify`,
       {
@@ -334,6 +375,9 @@ async function handleFilters(
 ): Promise<void> {
   const action = requireArg(args, "action");
   const account = optionalArg(args, "account");
+  const dryRun = args["dry-run"] === true;
+  const runId = optionalArg(args, "run-id");
+  const phase = optionalArg(args, "phase");
 
   switch (action) {
     case "list": {
@@ -377,6 +421,20 @@ async function handleFilters(
       if (removeLabelsStr)
         filterAction.removeLabelIds = parseCsv(removeLabelsStr);
       if (forward) filterAction.forward = forward;
+
+      if (dryRun) {
+        const rid = runId ?? generateRunId();
+        writeStaged({
+          run_id: rid,
+          phase,
+          op: "filter_create",
+          chunk_index: 0,
+          message_ids: [],
+          reason: JSON.stringify({ criteria, action: filterAction }),
+        });
+        ok({ dry_run: true, run_id: rid, would_create_filter: criteria });
+        break;
+      }
 
       const res = await gmailPost<GmailFilter>(
         "/settings/filters",

--- a/skills/gmail/scripts/lib/op-log.ts
+++ b/skills/gmail/scripts/lib/op-log.ts
@@ -349,6 +349,51 @@ export function summarizeRun(runId: string): RunSummary | null {
 }
 
 // ---------------------------------------------------------------------------
+// Dry-run summary
+// ---------------------------------------------------------------------------
+
+export interface DryRunSummary {
+  run_id: string;
+  total_ops: number;
+  by_op: Record<string, number>;
+  by_phase: Record<string, { count: number; examples: string[] }>;
+}
+
+/** Build a summary suitable for dry-run output — counts by op type and phase with examples. */
+export function summarizeDryRun(runId: string): DryRunSummary | null {
+  const entries = readLog(runId);
+  if (entries.length === 0) return null;
+
+  const byOp: Record<string, number> = {};
+  const byPhase: Record<string, { count: number; examples: string[] }> = {};
+  let totalOps = 0;
+
+  for (const entry of entries) {
+    if (entry.status !== "staged" || !entry.op) continue;
+    totalOps++;
+
+    const opKey = entry.op;
+    byOp[opKey] = (byOp[opKey] ?? 0) + 1;
+
+    const phase = entry.phase ?? "unknown";
+    if (!byPhase[phase]) {
+      byPhase[phase] = { count: 0, examples: [] };
+    }
+    byPhase[phase].count++;
+
+    // Collect up to 3 example descriptions per phase
+    if (byPhase[phase].examples.length < 3) {
+      const desc = [entry.from, entry.subject, entry.reason]
+        .filter(Boolean)
+        .join(" — ");
+      if (desc) byPhase[phase].examples.push(desc);
+    }
+  }
+
+  return { run_id: runId, total_ops: totalOps, by_op: byOp, by_phase: byPhase };
+}
+
+// ---------------------------------------------------------------------------
 // Listing & pruning
 // ---------------------------------------------------------------------------
 

--- a/skills/inbox-cleanup/SKILL.md
+++ b/skills/inbox-cleanup/SKILL.md
@@ -139,6 +139,20 @@ For emails not caught by pattern queries, use LLM-based classification in Standa
 
 ---
 
+## Dry-Run Defaults
+
+When the user's inbox management trust stage is 0 (flag-only), or when a batch exceeds 1,000 operations at stage 1, default to `--dry-run` mode:
+
+1. Run the pipeline with `--dry-run` on all archive calls
+2. At the end, show a summary: counts by phase with example subjects
+3. Ask the user to confirm before committing: "This would archive X,XXX emails across Y passes. Commit?"
+4. If confirmed, commit via `bun run scripts/gmail-commit.ts commit --run-id "<run-id>"`
+5. If rejected, cancel via `bun run scripts/gmail-commit.ts cancel --run-id "<run-id>"`
+
+At stage 2 or for small batches at stage 1, archive directly (but still log for audit/reversal).
+
+---
+
 ## Error Recovery & Resume
 
 Archive operations are logged to an operation log for resumability. If a pass fails mid-run (rate limit, daily quota, OAuth expiry, crash):

--- a/skills/inbox-management/SKILL.md
+++ b/skills/inbox-management/SKILL.md
@@ -34,9 +34,9 @@ A single wrong archive of an important email kills trust. Earn autonomy in stage
 
 | Stage | Archive behavior | Draft behavior | Alerts |
 |-------|------------------|----------------|--------|
-| **0 — Flag-only** (default) | Nothing archived. Everything that *would* be archived is listed in a summary for user review. | Drafts created in-thread, listed in summary. | Urgent scan active. |
-| **1 — Standard** | Silent archive of known-safe categories only (calendar responses, no-reply, newsletters). Cold outreach still flagged. | Drafts created in-thread, summarized per run. | Urgent scan active. |
-| **2 — Aggressive** | Above + cold outreach archived by LLM judgment (default archive, flag only when relevant to user). | Same as Stage 1. | Urgent scan active. |
+| **0 — Flag-only** (default) | Nothing archived. All archive calls use `--dry-run`. Summary shows what *would* be archived for user review. | Drafts created in-thread, listed in summary. | Urgent scan active. |
+| **1 — Standard** | Silent archive of known-safe categories only (calendar responses, no-reply, newsletters). Cold outreach still flagged. Batches > 1,000 ops auto-dry-run. | Drafts created in-thread, summarized per run. | Urgent scan active. |
+| **2 — Aggressive** | Above + cold outreach archived by LLM judgment (default archive, flag only when relevant to user). All ops logged for reversal. | Same as Stage 1. | Urgent scan active. |
 
 **Graduation requires the user to explicitly say "graduate me" or equivalent.** Do not infer from silence.
 


### PR DESCRIPTION
## Summary

- Adds `--dry-run` flag to archive, label, and filter operations — runs full pipeline but skips destructive API calls
- New `gmail-commit.ts` script: `commit` executes staged ops from a dry run, `cancel` deletes the log
- Stage 0 trust-ladder users default to dry-run; stage 1 auto-dry-runs batches > 1,000 ops
- Dry-run output includes phase-grouped summary with examples and ready-to-copy commit/cancel commands

Stacked on #26982 (op log + resume).

## Files

| File | Change |
|---|---|
| `skills/gmail/scripts/gmail-commit.ts` | **New** — commit/cancel subcommands |
| `skills/gmail/scripts/gmail-archive.ts` | `--dry-run` flag, skip API calls in dry-run, summary output |
| `skills/gmail/scripts/gmail-manage.ts` | `--dry-run` for label batch + filter create |
| `skills/gmail/scripts/lib/op-log.ts` | `summarizeDryRun()` function |
| `skills/gmail/SKILL.md` | Document dry-run, commit, cancel |
| `skills/inbox-cleanup/SKILL.md` | Dry-run defaults for stage 0/1 |
| `skills/inbox-management/SKILL.md` | Trust ladder updated with dry-run behavior |

## Test plan

- [ ] `bun run scripts/gmail-archive.ts archive --query "..." --dry-run` — verify no API calls, staged entries in log, summary output
- [ ] `bun run scripts/gmail-commit.ts commit --run-id <id>` — verify staged ops execute, committed entries written
- [ ] `bun run scripts/gmail-commit.ts cancel --run-id <id>` — verify log deleted
- [ ] `bun run scripts/gmail-manage.ts label --message-ids "..." --add-labels "test" --dry-run` — verify staged entry, no API call
- [ ] `bun run scripts/gmail-manage.ts filters --action create --from "test@example.com" --remove-labels "INBOX" --dry-run` — verify staged entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part 2 of 3: Dry-run mode (builds on op log from PR 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
