### PR TITLE
fix(slack): fix stale step reference in SKILL.md after renumbering

### DIFF
--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -33,6 +33,10 @@ All operations use CLI scripts that return JSON:
 | `gmail-scan.ts`    | `sender-digest`         | Scan inbox and group messages by sender for declutter workflows              |
 | `gmail-scan.ts`    | `outreach-scan`         | Identify cold outreach senders (no List-Unsubscribe header)                  |
 | `gmail-archive.ts` | `archive`               | Archive messages (single, batch message_ids, cache_key+sender-emails, query) |
+| `gmail-archive.ts` | `archive --resume`      | Resume an interrupted archive run from its last checkpoint                    |
+| `gmail-runs.ts`    | `list`                  | List recent operation runs with status summaries                             |
+| `gmail-runs.ts`    | `inspect`               | Show detailed log entries for a specific run                                 |
+| `gmail-runs.ts`    | `prune`                 | Delete operation logs older than 30 days                                     |
 | `gmail-prefs.ts`   | `list`                  | List blocklist and safelist preferences                                      |
 | `gmail-prefs.ts`   | `add-blocklist`         | Add sender emails to the blocklist                                           |
 | `gmail-prefs.ts`   | `add-safelist`          | Add sender emails to the safelist                                            |
@@ -117,6 +121,33 @@ bun run scripts/gmail-archive.ts archive --message-id "18f..."
 # Archive by query
 bun run scripts/gmail-archive.ts archive --query "from:newsletter@example.com in:inbox"
 ```
+
+### Operation Runs
+
+All destructive archive operations are logged to a JSONL operation log for resumability and auditing. Each batch of archives is tracked as a "run" with a unique ID.
+
+```bash
+# List recent runs with status summaries
+bun run scripts/gmail-runs.ts list [--limit 20]
+
+# Show detailed log entries for a specific run
+bun run scripts/gmail-runs.ts inspect --run-id "run_20260420_a1b2c3d4"
+
+# Delete logs older than 30 days
+bun run scripts/gmail-runs.ts prune
+```
+
+Archive operations now return a `run_id` in their output. Use this to resume interrupted runs:
+
+```bash
+# Resume an interrupted run (e.g. after daily quota hit)
+bun run scripts/gmail-archive.ts archive --resume "run_20260420_a1b2c3d4"
+
+# Pass --run-id to group multiple archive calls under one run
+bun run scripts/gmail-archive.ts archive --query "..." --run-id "run_20260420_a1b2c3d4" --phase "noise_archive"
+```
+
+When a run is interrupted (e.g. Gmail daily quota exceeded), the operation log records the interruption with a resume hint. The assistant should detect interrupted runs and offer to resume them rather than starting fresh.
 
 ### Preferences Operations
 

--- a/skills/gmail/scripts/gmail-archive.ts
+++ b/skills/gmail/scripts/gmail-archive.ts
@@ -13,8 +13,20 @@ import {
   optionalArg,
   parseCsv,
 } from "./lib/common.js";
-import { gmailGet, gmailPost } from "./lib/gmail-client.js";
+import { gmailGet, gmailPost, DailyQuotaExceededError } from "./lib/gmail-client.js";
 import { addToBlocklist } from "./gmail-prefs.js";
+import {
+  generateRunId,
+  writeStaged,
+  writeCommitted,
+  writeFailed,
+  writeInterrupted,
+  writeCheckpoint,
+  writeCompleted,
+  summarizeRun,
+  getPendingOps,
+  runExists,
+} from "./lib/op-log.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -80,33 +92,80 @@ function recordBlocklist(senderEmails: string[]): void {
   }
 }
 
-/** Batch modify messages in chunks of BATCH_MODIFY_LIMIT. */
+/**
+ * Batch modify messages in chunks of BATCH_MODIFY_LIMIT.
+ * Each chunk is logged to the op log before execution for resumability.
+ */
 async function batchArchive(
   messageIds: string[],
   account?: string,
-): Promise<void> {
+  opts?: { runId?: string; phase?: string; reason?: string },
+): Promise<{ runId: string; committed: number; failed: number }> {
+  const runId = opts?.runId ?? generateRunId();
+  let committed = 0;
+  let failed = 0;
+
   for (let i = 0; i < messageIds.length; i += BATCH_MODIFY_LIMIT) {
+    const chunkIndex = Math.floor(i / BATCH_MODIFY_LIMIT);
     const chunk = messageIds.slice(i, i + BATCH_MODIFY_LIMIT);
-    const resp = await gmailPost(
-      "/messages/batchModify",
-      { ids: chunk, removeLabelIds: ["INBOX"] },
-      account,
-    );
-    if (!resp.ok) {
-      throw new Error(
-        `batchModify failed (status ${resp.status}): ${JSON.stringify(resp.data)}`,
+
+    writeStaged({
+      run_id: runId,
+      phase: opts?.phase,
+      op: "archive",
+      chunk_index: chunkIndex,
+      message_ids: chunk,
+      reason: opts?.reason,
+    });
+
+    try {
+      const resp = await gmailPost(
+        "/messages/batchModify",
+        { ids: chunk, removeLabelIds: ["INBOX"] },
+        account,
       );
+      if (!resp.ok) {
+        const errMsg = `batchModify failed (status ${resp.status}): ${JSON.stringify(resp.data)}`;
+        writeFailed(runId, chunkIndex, errMsg);
+        failed++;
+        continue;
+      }
+      writeCommitted(runId, chunkIndex);
+      committed++;
+    } catch (err) {
+      if (err instanceof DailyQuotaExceededError) {
+        writeInterrupted({
+          run_id: runId,
+          reason: "daily_quota",
+          resume_hint: "Resume after midnight PT",
+          checkpoint: { processed_count: i, query: opts?.reason },
+        });
+        throw err;
+      }
+      const errMsg = err instanceof Error ? err.message : String(err);
+      writeFailed(runId, chunkIndex, errMsg);
+      failed++;
     }
   }
+
+  writeCompleted(runId, committed, failed);
+  return { runId, committed, failed };
 }
 
-/** Paginate Gmail message search, collecting all message IDs up to MAX_MESSAGES. */
+/** Checkpoint interval — write pagination state every N IDs. */
+const CHECKPOINT_INTERVAL = 500;
+
+/**
+ * Paginate Gmail message search, collecting all message IDs up to MAX_MESSAGES.
+ * Supports resuming from a page token and writes checkpoints for resumability.
+ */
 async function collectMessageIds(
   query: string,
   account?: string,
+  opts?: { runId?: string; startPageToken?: string },
 ): Promise<string[]> {
   const allIds: string[] = [];
-  let pageToken: string | undefined;
+  let pageToken: string | undefined = opts?.startPageToken;
 
   while (allIds.length < MAX_MESSAGES) {
     const remaining = MAX_MESSAGES - allIds.length;
@@ -133,6 +192,16 @@ async function collectMessageIds(
     allIds.push(...ids.slice(0, remaining));
 
     pageToken = resp.data.nextPageToken ?? undefined;
+
+    // Write a checkpoint every CHECKPOINT_INTERVAL IDs
+    if (opts?.runId && allIds.length % CHECKPOINT_INTERVAL < ids.length) {
+      writeCheckpoint(opts.runId, {
+        page_token: pageToken,
+        processed_count: allIds.length,
+        query,
+      });
+    }
+
     if (!pageToken) break;
   }
 
@@ -148,7 +217,11 @@ async function archiveByQuery(
   query: string,
   account?: string,
   skipConfirm?: boolean,
+  runId?: string,
+  phase?: string,
 ): Promise<void> {
+  const rid = runId ?? generateRunId();
+
   if (!skipConfirm) {
     const confirmed = await requestConfirmation({
       title: "Archive messages",
@@ -161,15 +234,25 @@ async function archiveByQuery(
     }
   }
 
-  const messageIds = await collectMessageIds(query, account);
+  const messageIds = await collectMessageIds(query, account, { runId: rid });
 
   if (messageIds.length === 0) {
     ok({ archived: 0, method: "query", note: "No messages matched the query" });
     return;
   }
 
-  await batchArchive(messageIds, account);
-  ok({ archived: messageIds.length, method: "query" });
+  const result = await batchArchive(messageIds, account, {
+    runId: rid,
+    phase,
+    reason: `query:${query}`,
+  });
+  ok({
+    archived: messageIds.length,
+    method: "query",
+    run_id: result.runId,
+    committed: result.committed,
+    failed: result.failed,
+  });
 }
 
 /** Path 2: --cache-key + --sender-emails — retrieve from cache, fall back to per-sender query. */
@@ -178,7 +261,11 @@ async function archiveByCacheKey(
   senderEmails: string[],
   account?: string,
   skipConfirm?: boolean,
+  runId?: string,
+  phase?: string,
 ): Promise<void> {
+  const rid = runId ?? generateRunId();
+
   if (!skipConfirm) {
     const confirmed = await requestConfirmation({
       title: "Archive messages",
@@ -231,7 +318,7 @@ async function archiveByCacheKey(
     for (const email of senderEmails) {
       const sanitized = email.replace(/"/g, "");
       const query = `from:"${sanitized}" in:inbox`;
-      const ids = await collectMessageIds(query, account);
+      const ids = await collectMessageIds(query, account, { runId: rid });
       allMessageIds.push(...ids);
       if (allMessageIds.length >= MAX_MESSAGES) break;
     }
@@ -242,9 +329,19 @@ async function archiveByCacheKey(
     return;
   }
 
-  await batchArchive(allMessageIds, account);
+  const result = await batchArchive(allMessageIds, account, {
+    runId: rid,
+    phase,
+    reason: `cache:${senderEmails.join(",")}`,
+  });
   recordBlocklist(senderEmails);
-  ok({ archived: allMessageIds.length, method: "cache" });
+  ok({
+    archived: allMessageIds.length,
+    method: "cache",
+    run_id: result.runId,
+    committed: result.committed,
+    failed: result.failed,
+  });
 }
 
 /** Path 3: --message-ids — direct batch archive. */
@@ -252,7 +349,11 @@ async function archiveByMessageIds(
   messageIds: string[],
   account?: string,
   skipConfirm?: boolean,
+  runId?: string,
+  phase?: string,
 ): Promise<void> {
+  const rid = runId ?? generateRunId();
+
   if (!skipConfirm) {
     const confirmed = await requestConfirmation({
       title: "Archive messages",
@@ -265,8 +366,18 @@ async function archiveByMessageIds(
     }
   }
 
-  await batchArchive(messageIds, account);
-  ok({ archived: messageIds.length, method: "batch" });
+  const result = await batchArchive(messageIds, account, {
+    runId: rid,
+    phase,
+    reason: `batch:${messageIds.length} messages`,
+  });
+  ok({
+    archived: messageIds.length,
+    method: "batch",
+    run_id: result.runId,
+    committed: result.committed,
+    failed: result.failed,
+  });
 }
 
 /** Path 4: --message-id — single message archive (no confirmation). */
@@ -290,6 +401,82 @@ async function archiveSingleMessage(
 }
 
 // ---------------------------------------------------------------------------
+// Resume
+// ---------------------------------------------------------------------------
+
+/**
+ * Resume an interrupted or partially-failed run.
+ * Loads the op log, finds pending (staged but not committed/failed) ops,
+ * and re-executes them.
+ */
+async function resumeRun(
+  resumeRunId: string,
+  account?: string,
+): Promise<void> {
+  if (!runExists(resumeRunId)) {
+    printError(`Run not found: ${resumeRunId}`);
+    return;
+  }
+
+  const pending = getPendingOps(resumeRunId);
+  if (pending.length === 0) {
+    const summary = summarizeRun(resumeRunId);
+    ok({
+      resumed: false,
+      run_id: resumeRunId,
+      note: "No pending operations to resume",
+      summary,
+    });
+    return;
+  }
+
+  let committed = 0;
+  let failed = 0;
+
+  for (const entry of pending) {
+    if (!entry.message_ids || entry.chunk_index === undefined) continue;
+
+    try {
+      const resp = await gmailPost(
+        "/messages/batchModify",
+        { ids: entry.message_ids, removeLabelIds: ["INBOX"] },
+        account,
+      );
+      if (!resp.ok) {
+        const errMsg = `batchModify failed (status ${resp.status}): ${JSON.stringify(resp.data)}`;
+        writeFailed(resumeRunId, entry.chunk_index, errMsg);
+        failed++;
+        continue;
+      }
+      writeCommitted(resumeRunId, entry.chunk_index);
+      committed++;
+    } catch (err) {
+      if (err instanceof DailyQuotaExceededError) {
+        writeInterrupted({
+          run_id: resumeRunId,
+          reason: "daily_quota",
+          resume_hint: "Resume after midnight PT",
+        });
+        throw err;
+      }
+      const errMsg = err instanceof Error ? err.message : String(err);
+      writeFailed(resumeRunId, entry.chunk_index, errMsg);
+      failed++;
+    }
+  }
+
+  writeCompleted(resumeRunId, committed, failed);
+  const summary = summarizeRun(resumeRunId);
+  ok({
+    resumed: true,
+    run_id: resumeRunId,
+    committed,
+    failed,
+    summary,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Main dispatcher
 // ---------------------------------------------------------------------------
 
@@ -298,6 +485,15 @@ async function main(): Promise<void> {
 
   const account = optionalArg(args, "account");
   const skipConfirm = args["skip-confirm"] === true;
+  const runId = optionalArg(args, "run-id");
+  const phase = optionalArg(args, "phase");
+
+  // Resume mode
+  const resumeRunId = optionalArg(args, "resume");
+  if (resumeRunId) {
+    await resumeRun(resumeRunId, account);
+    return;
+  }
 
   const query = optionalArg(args, "query");
   const cacheKey = optionalArg(args, "cache-key");
@@ -307,24 +503,40 @@ async function main(): Promise<void> {
 
   // Priority: --query > --cache-key > --message-ids > --message-id
   if (query) {
-    await archiveByQuery(query, account, skipConfirm);
+    await archiveByQuery(query, account, skipConfirm, runId, phase);
   } else if (cacheKey && senderEmailsRaw) {
     const senderEmails = parseCsv(senderEmailsRaw);
-    await archiveByCacheKey(cacheKey, senderEmails, account, skipConfirm);
+    await archiveByCacheKey(
+      cacheKey,
+      senderEmails,
+      account,
+      skipConfirm,
+      runId,
+      phase,
+    );
   } else if (messageIdsRaw) {
     const messageIds = parseCsv(messageIdsRaw);
-    await archiveByMessageIds(messageIds, account, skipConfirm);
+    await archiveByMessageIds(messageIds, account, skipConfirm, runId, phase);
   } else if (messageId) {
     await archiveSingleMessage(messageId, account);
   } else {
     printError(
-      "Provide --query, --cache-key + --sender-emails, --message-ids, or --message-id.",
+      "Provide --query, --cache-key + --sender-emails, --message-ids, --message-id, or --resume <run-id>.",
     );
   }
 }
 
 if (import.meta.main) {
   main().catch((err) => {
+    if (err instanceof DailyQuotaExceededError) {
+      // Already written to op log — surface a user-friendly message
+      ok({
+        interrupted: true,
+        reason: "daily_quota",
+        note: "Gmail daily quota exceeded. Resume after midnight PT with --resume <run-id>.",
+      });
+      return;
+    }
     printError(err instanceof Error ? err.message : String(err));
   });
 }

--- a/skills/gmail/scripts/gmail-runs.ts
+++ b/skills/gmail/scripts/gmail-runs.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env bun
+
+/**
+ * Gmail operation run management.
+ * Subcommands:
+ *   list    — List recent runs with status summary
+ *   inspect — Show detailed log entries for a specific run
+ *   prune   — Delete op logs older than 30 days
+ */
+
+import { parseArgs, optionalArg, printError, ok } from "./lib/common.js";
+import {
+  listRuns,
+  summarizeRun,
+  readLog,
+  pruneOldRuns,
+  runExists,
+} from "./lib/op-log.js";
+
+// ---------------------------------------------------------------------------
+// Subcommands
+// ---------------------------------------------------------------------------
+
+function listCmd(args: Record<string, string | boolean>) {
+  const limit = parseInt(optionalArg(args, "limit") ?? "20", 10);
+  const runIds = listRuns().slice(0, limit);
+
+  if (runIds.length === 0) {
+    ok({ runs: [], note: "No operation logs found" });
+    return;
+  }
+
+  const runs = runIds
+    .map((id) => summarizeRun(id))
+    .filter((s) => s !== null);
+
+  ok({ runs });
+}
+
+function inspectCmd(args: Record<string, string | boolean>) {
+  const runId = optionalArg(args, "run-id");
+  if (!runId) {
+    printError("Missing required argument: --run-id");
+    return;
+  }
+
+  if (!runExists(runId)) {
+    printError(`Run not found: ${runId}`);
+    return;
+  }
+
+  const entries = readLog(runId);
+  const summary = summarizeRun(runId);
+
+  ok({ summary, entries });
+}
+
+function pruneCmd() {
+  const pruned = pruneOldRuns();
+  ok({ pruned, note: `Deleted ${pruned} log(s) older than 30 days` });
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const subcommand = process.argv[2];
+  const args = parseArgs(process.argv.slice(3));
+
+  switch (subcommand) {
+    case "list":
+      listCmd(args);
+      break;
+    case "inspect":
+      inspectCmd(args);
+      break;
+    case "prune":
+      pruneCmd();
+      break;
+    default:
+      printError(
+        `Unknown subcommand: "${subcommand ?? "(none)"}". Use "list", "inspect", or "prune".`,
+      );
+  }
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/skills/gmail/scripts/lib/gmail-client.ts
+++ b/skills/gmail/scripts/lib/gmail-client.ts
@@ -43,6 +43,8 @@ export interface GmailMessagePart {
 }
 
 const MAX_RETRIES = 3;
+/** Higher retry count for batch modify — each retry is cheap relative to restarting the whole run. */
+const MAX_RETRIES_BATCH_MODIFY = 5;
 const INITIAL_BACKOFF_MS = 1_000;
 const IDEMPOTENT_METHODS = new Set([
   "GET",
@@ -55,6 +57,18 @@ const IDEMPOTENT_METHODS = new Set([
 const BATCH_CONCURRENCY = 10;
 
 /**
+ * Thrown when Gmail returns a 403 indicating the daily sending/read quota
+ * has been exhausted. Callers should write an `interrupted` op-log entry
+ * and bail — retrying before midnight PT is pointless.
+ */
+export class DailyQuotaExceededError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DailyQuotaExceededError";
+  }
+}
+
+/**
  * Execute an authenticated Gmail API request via `assistant oauth request`.
  * Retries 429 and 5xx errors with exponential backoff for idempotent methods.
  */
@@ -62,9 +76,14 @@ export async function gmailRequest<T = unknown>(
   opts: GmailRequestOptions,
 ): Promise<GmailResponse<T>> {
   const method = (opts.method ?? "GET").toUpperCase();
-  const canRetry = IDEMPOTENT_METHODS.has(method);
+  // batchModify is effectively idempotent — re-removing INBOX from an already-
+  // archived message is a no-op — so we allow retries for it.
+  const isBatchModify =
+    method === "POST" && opts.path === "/messages/batchModify";
+  const canRetry = IDEMPOTENT_METHODS.has(method) || isBatchModify;
+  const maxRetries = isBatchModify ? MAX_RETRIES_BATCH_MODIFY : MAX_RETRIES;
 
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
     const args: string[] = [
       "assistant",
       "oauth",
@@ -136,10 +155,21 @@ export async function gmailRequest<T = unknown>(
       );
     }
 
-    // Retry on 429 (rate limit) and 5xx (server error) for idempotent methods
+    // 403 with quota/rate keywords = daily quota exhausted.
+    // This is NOT retryable — the quota resets at midnight PT.
+    if (
+      result.status === 403 &&
+      /quota|rate/i.test(JSON.stringify(result.body))
+    ) {
+      throw new DailyQuotaExceededError(
+        "Gmail daily quota exceeded. Resume after midnight PT.",
+      );
+    }
+
+    // Retry on 429 (rate limit) and 5xx (server error) for retryable methods
     const isRetryable =
       result.status === 429 || (result.status >= 500 && result.status < 600);
-    if (canRetry && isRetryable && attempt < MAX_RETRIES) {
+    if (canRetry && isRetryable && attempt < maxRetries) {
       const retryAfter = result.headers?.["retry-after"];
       const delayMs = retryAfter
         ? parseInt(retryAfter, 10) * 1000

--- a/skills/gmail/scripts/lib/op-log.ts
+++ b/skills/gmail/scripts/lib/op-log.ts
@@ -1,0 +1,400 @@
+#!/usr/bin/env bun
+
+/**
+ * Gmail operation log — append-only JSONL journal for destructive operations.
+ *
+ * Every archive/label/filter/trash operation writes a `staged` entry before
+ * the API call and a `committed` or `failed` entry after. This enables:
+ *   - Resumability: load the log, skip committed ops, retry staged/failed
+ *   - Audit trail: every destructive action is recorded with reason + metadata
+ *   - Dry-run (PR 2): write staged entries without executing
+ *   - Reversal (PR 3): read committed entries and apply inverse operations
+ *
+ * Log location: skills/gmail/data/ops/<run-id>.jsonl
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SKILL_ROOT = path.resolve(import.meta.dir, "../..");
+const OPS_DIR = path.join(SKILL_ROOT, "data", "ops");
+
+/** How many days to retain op logs before pruning. */
+const RETENTION_DAYS = 30;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type OpStatus =
+  | "staged"
+  | "committed"
+  | "failed"
+  | "interrupted"
+  | "completed";
+
+export type OpType =
+  | "archive"
+  | "label_add"
+  | "label_remove"
+  | "filter_create"
+  | "trash";
+
+export interface OpEntry {
+  ts: string;
+  run_id: string;
+  /** The pipeline phase that produced this op. */
+  phase?: string;
+  /** The destructive operation type. */
+  op?: OpType;
+  /** Index of the batch chunk (for archive operations). */
+  chunk_index?: number;
+  /** Gmail message IDs affected by this op. */
+  message_ids?: string[];
+  /** Human-readable reason this op was triggered. */
+  reason?: string;
+  /** Sender "from" header for audit purposes. */
+  from?: string;
+  /** Email subject for audit purposes. */
+  subject?: string;
+  /** Lifecycle status. */
+  status: OpStatus;
+  /** Error message (when status = "failed"). */
+  error?: string;
+  /** Interruption reason (when status = "interrupted"). */
+  interrupt_reason?: string;
+  /** Hint for when to resume (e.g. "after midnight PT"). */
+  resume_hint?: string;
+  /** Checkpoint data for resuming pagination. */
+  checkpoint?: CheckpointData;
+  /** Total ops committed (when status = "completed"). */
+  total_committed?: number;
+  /** Total ops failed (when status = "completed"). */
+  total_failed?: number;
+}
+
+export interface CheckpointData {
+  page_token?: string;
+  processed_count: number;
+  query?: string;
+}
+
+export interface RunSummary {
+  run_id: string;
+  started_at: string;
+  status: "in_progress" | "interrupted" | "completed";
+  phases: Record<string, { staged: number; committed: number; failed: number }>;
+  total_staged: number;
+  total_committed: number;
+  total_failed: number;
+  interrupt_reason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Directory helpers
+// ---------------------------------------------------------------------------
+
+function ensureOpsDir(): void {
+  fs.mkdirSync(OPS_DIR, { recursive: true });
+}
+
+function logPath(runId: string): string {
+  return path.join(OPS_DIR, `${runId}.jsonl`);
+}
+
+// ---------------------------------------------------------------------------
+// Run ID generation
+// ---------------------------------------------------------------------------
+
+/** Generate a new run ID using crypto.randomUUID with a timestamp prefix. */
+export function generateRunId(): string {
+  const now = new Date();
+  const ts = now.toISOString().replace(/[-:T]/g, "").slice(0, 14);
+  const uuid = crypto.randomUUID().slice(0, 8);
+  return `run_${ts}_${uuid}`;
+}
+
+// ---------------------------------------------------------------------------
+// Write operations
+// ---------------------------------------------------------------------------
+
+/** Append a single op entry to the run's JSONL log. */
+export function appendOp(entry: OpEntry): void {
+  ensureOpsDir();
+  const line = JSON.stringify(entry) + "\n";
+  fs.appendFileSync(logPath(entry.run_id), line);
+}
+
+/** Write a staged entry before executing a destructive operation. */
+export function writeStaged(opts: {
+  run_id: string;
+  phase?: string;
+  op: OpType;
+  chunk_index: number;
+  message_ids: string[];
+  reason?: string;
+  from?: string;
+  subject?: string;
+}): void {
+  appendOp({
+    ts: new Date().toISOString(),
+    run_id: opts.run_id,
+    phase: opts.phase,
+    op: opts.op,
+    chunk_index: opts.chunk_index,
+    message_ids: opts.message_ids,
+    reason: opts.reason,
+    from: opts.from,
+    subject: opts.subject,
+    status: "staged",
+  });
+}
+
+/** Write a committed entry after a successful API call. */
+export function writeCommitted(run_id: string, chunk_index: number): void {
+  appendOp({
+    ts: new Date().toISOString(),
+    run_id,
+    chunk_index,
+    status: "committed",
+  });
+}
+
+/** Write a failed entry after a failed API call. */
+export function writeFailed(
+  run_id: string,
+  chunk_index: number,
+  error: string,
+): void {
+  appendOp({
+    ts: new Date().toISOString(),
+    run_id,
+    chunk_index,
+    status: "failed",
+    error,
+  });
+}
+
+/** Write an interrupted entry when a run is halted (e.g. daily quota). */
+export function writeInterrupted(opts: {
+  run_id: string;
+  reason: string;
+  resume_hint?: string;
+  checkpoint?: CheckpointData;
+}): void {
+  appendOp({
+    ts: new Date().toISOString(),
+    run_id: opts.run_id,
+    status: "interrupted",
+    interrupt_reason: opts.reason,
+    resume_hint: opts.resume_hint,
+    checkpoint: opts.checkpoint,
+  });
+}
+
+/** Write a checkpoint entry for pagination state. */
+export function writeCheckpoint(
+  run_id: string,
+  checkpoint: CheckpointData,
+): void {
+  appendOp({
+    ts: new Date().toISOString(),
+    run_id,
+    status: "staged",
+    checkpoint,
+  });
+}
+
+/** Write a completion entry summarizing the run. */
+export function writeCompleted(
+  run_id: string,
+  total_committed: number,
+  total_failed: number,
+): void {
+  appendOp({
+    ts: new Date().toISOString(),
+    run_id,
+    status: "completed",
+    total_committed,
+    total_failed,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Read operations
+// ---------------------------------------------------------------------------
+
+/** Read all entries from a run's JSONL log. */
+export function readLog(runId: string): OpEntry[] {
+  const p = logPath(runId);
+  if (!fs.existsSync(p)) return [];
+  const content = fs.readFileSync(p, "utf-8");
+  return content
+    .split("\n")
+    .filter((line: string) => line.trim().length > 0)
+    .map((line: string) => JSON.parse(line) as OpEntry);
+}
+
+/** Check if a run log exists. */
+export function runExists(runId: string): boolean {
+  return fs.existsSync(logPath(runId));
+}
+
+/** Get the set of chunk indexes that have been committed. */
+export function getCommittedChunks(runId: string): Set<number> {
+  const entries = readLog(runId);
+  const committed = new Set<number>();
+  for (const entry of entries) {
+    if (entry.status === "committed" && entry.chunk_index !== undefined) {
+      committed.add(entry.chunk_index);
+    }
+  }
+  return committed;
+}
+
+/** Get the latest checkpoint from a run log. */
+export function getLatestCheckpoint(
+  runId: string,
+): CheckpointData | undefined {
+  const entries = readLog(runId);
+  let latest: CheckpointData | undefined;
+  for (const entry of entries) {
+    if (entry.checkpoint) {
+      latest = entry.checkpoint;
+    }
+  }
+  return latest;
+}
+
+/** Get all staged entries that have NOT been committed or failed. */
+export function getPendingOps(runId: string): OpEntry[] {
+  const entries = readLog(runId);
+  const resolved = new Set<number>();
+  for (const entry of entries) {
+    if (
+      (entry.status === "committed" || entry.status === "failed") &&
+      entry.chunk_index !== undefined
+    ) {
+      resolved.add(entry.chunk_index);
+    }
+  }
+  return entries.filter(
+    (e) =>
+      e.status === "staged" &&
+      e.chunk_index !== undefined &&
+      !resolved.has(e.chunk_index),
+  );
+}
+
+/** Summarize a run's log into counts by phase. */
+export function summarizeRun(runId: string): RunSummary | null {
+  const entries = readLog(runId);
+  if (entries.length === 0) return null;
+
+  const phases: Record<
+    string,
+    { staged: number; committed: number; failed: number }
+  > = {};
+  let totalStaged = 0;
+  let totalCommitted = 0;
+  let totalFailed = 0;
+  let startedAt = "";
+  let status: RunSummary["status"] = "in_progress";
+  let interruptReason: string | undefined;
+
+  for (const entry of entries) {
+    if (!startedAt && entry.ts) startedAt = entry.ts;
+
+    if (entry.status === "completed") {
+      status = "completed";
+      continue;
+    }
+    if (entry.status === "interrupted") {
+      status = "interrupted";
+      interruptReason = entry.interrupt_reason;
+      continue;
+    }
+
+    const phase = entry.phase ?? "unknown";
+    if (!phases[phase]) {
+      phases[phase] = { staged: 0, committed: 0, failed: 0 };
+    }
+
+    if (entry.status === "staged" && entry.op) {
+      phases[phase].staged++;
+      totalStaged++;
+    } else if (entry.status === "committed") {
+      phases[phase].committed++;
+      totalCommitted++;
+    } else if (entry.status === "failed") {
+      phases[phase].failed++;
+      totalFailed++;
+    }
+  }
+
+  return {
+    run_id: runId,
+    started_at: startedAt,
+    status,
+    phases,
+    total_staged: totalStaged,
+    total_committed: totalCommitted,
+    total_failed: totalFailed,
+    interrupt_reason: interruptReason,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Listing & pruning
+// ---------------------------------------------------------------------------
+
+/** List all run IDs, most recent first. */
+export function listRuns(): string[] {
+  ensureOpsDir();
+  const files = fs
+    .readdirSync(OPS_DIR)
+    .filter((f: string) => f.endsWith(".jsonl"));
+  // Sort by modification time, newest first
+  return files
+    .map((f: string) => ({
+      name: f.replace(".jsonl", ""),
+      mtime: fs.statSync(path.join(OPS_DIR, f)).mtimeMs,
+    }))
+    .sort((a: { mtime: number }, b: { mtime: number }) => b.mtime - a.mtime)
+    .map((f: { name: string }) => f.name);
+}
+
+/** Delete op logs older than RETENTION_DAYS. */
+export function pruneOldRuns(): number {
+  ensureOpsDir();
+  const cutoff = Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  const files = fs
+    .readdirSync(OPS_DIR)
+    .filter((f: string) => f.endsWith(".jsonl"));
+  let pruned = 0;
+  for (const file of files) {
+    const filePath = path.join(OPS_DIR, file);
+    const stat = fs.statSync(filePath);
+    if (stat.mtimeMs < cutoff) {
+      fs.unlinkSync(filePath);
+      pruned++;
+    }
+  }
+  return pruned;
+}
+
+/** Find the most recent interrupted run, if any. */
+export function findInterruptedRun(): string | null {
+  const runs = listRuns();
+  for (const runId of runs) {
+    const summary = summarizeRun(runId);
+    if (summary?.status === "interrupted") {
+      return runId;
+    }
+  }
+  return null;
+}

--- a/skills/inbox-cleanup/SKILL.md
+++ b/skills/inbox-cleanup/SKILL.md
@@ -139,6 +139,19 @@ For emails not caught by pattern queries, use LLM-based classification in Standa
 
 ---
 
+## Error Recovery & Resume
+
+Archive operations are logged to an operation log for resumability. If a pass fails mid-run (rate limit, daily quota, OAuth expiry, crash):
+
+1. **Check for interrupted runs** before starting a new cleanup: `bun run scripts/gmail-runs.ts list`. If a recent run shows `status: "interrupted"`, offer to resume it.
+2. **Resume**: `bun run scripts/gmail-archive.ts archive --resume "<run-id>"`. This skips already-committed chunks and retries pending ones.
+3. **Daily quota (403)**: The archive script detects daily quota exhaustion and writes an `interrupted` log entry with a resume hint. Do not retry until after midnight PT — offer to resume the run later.
+4. **Rate limit (429)**: Handled automatically with exponential backoff (up to 5 retries for batch operations). No user intervention needed.
+
+All archive outputs now include a `run_id`. Pass `--run-id` to group multiple passes under one run, and `--phase` to label the pipeline phase (e.g. `--phase "noise_archive"`).
+
+---
+
 ## Phase 5: Post-Cleanup
 
 1. **Report totals** — how many archived per pass, which categories

--- a/skills/inbox-management/SKILL.md
+++ b/skills/inbox-management/SKILL.md
@@ -112,7 +112,9 @@ Confirm the user wants drafts generated. Some prefer flag-only forever.
 
 Each step is silent unless something qualifies for interrupt. Run these in order.
 
-### Step 0: Missed-run check
+### Step 0: Missed-run check & resume
+
+**Resume interrupted runs first.** Before starting a new pipeline pass, check `bun run scripts/gmail-runs.ts list`. If the most recent run has `status: "interrupted"`, resume it via `bun run scripts/gmail-archive.ts archive --resume "<run-id>"` before proceeding. Also run `bun run scripts/gmail-runs.ts prune` to clean up logs older than 30 days.
 
 Read the last-run timestamp via `gmail-prefs.ts --action get-management-config`. If `last-run` is more than 2x the scheduled interval ago (e.g. >6 hours for a 3-hour schedule), notify the user:
 - **Slack:** "📬 Inbox management hasn't run since [time]. I'm catching up now."

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -48,7 +48,7 @@ Then branch on the state of `app_token` and `bot_token` first (those are the req
 
 - If `app_token` and `bot_token` are **both** present:
   - If `user_token` is also present — Slack is fully configured with full triage visibility. Offer to show status or reconfigure.
-  - If `user_token` is missing — Slack is connected with **bot-only visibility**. Offer to collect the user token now (Step 3) to enable full triage visibility across all channels the user is in. The user token is optional; if they decline, leave the setup as-is.
+  - If `user_token` is missing — Slack is connected with **bot-only visibility**. Offer to collect the user token now (Step 2) to enable full triage visibility across all channels the user is in. The user token is optional; if they decline, leave the setup as-is.
 - If exactly **one** of `app_token` or `bot_token` is present — offer to resume setup from the missing step. (If a `user_token` is also present, leave it in place; it will be re-validated against the bot's workspace once setup completes.)
 - If **neither** `app_token` nor `bot_token` is present — continue to Step 1. (If a `user_token` is present without a paired bot/app, it is orphaned from a prior incomplete setup. Tell the user it will be replaced during this run, and proceed.)
 


### PR DESCRIPTION
Addresses review feedback from PR #26980. Both Codex and Devin flagged a stale '(Step 3)' reference that should be '(Step 2)' after the one-click manifest PR renumbered the steps.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
