### PR TITLE
fix(slack): fix stale step reference in SKILL.md after renumbering

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -438,7 +438,7 @@
     {
       "id": "slack-app-setup",
       "name": "slack-app-setup",
-      "description": "Connect a Slack app to the Vellum Assistant via Socket Mode with guided app creation and identity verification",
+      "description": "Connect a Slack app to the Vellum Assistant via Socket Mode with one-click app creation and identity verification",
       "metadata": {
         "emoji": "💬",
         "vellum": {

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -48,7 +48,7 @@ Then branch on the state of `app_token` and `bot_token` first (those are the req
 
 - If `app_token` and `bot_token` are **both** present:
   - If `user_token` is also present — Slack is fully configured with full triage visibility. Offer to show status or reconfigure.
-  - If `user_token` is missing — Slack is connected with **bot-only visibility**. Offer to collect the user token now (Step 3) to enable full triage visibility across all channels the user is in. The user token is optional; if they decline, leave the setup as-is.
+  - If `user_token` is missing — Slack is connected with **bot-only visibility**. Offer to collect the user token now (Step 2) to enable full triage visibility across all channels the user is in. The user token is optional; if they decline, leave the setup as-is.
 - If exactly **one** of `app_token` or `bot_token` is present — offer to resume setup from the missing step. (If a `user_token` is also present, leave it in place; it will be re-validated against the bot's workspace once setup completes.)
 - If **neither** `app_token` nor `bot_token` is present — continue to Step 1. (If a `user_token` is present without a paired bot/app, it is orphaned from a prior incomplete setup. Tell the user it will be replaced during this run, and proceed.)
 

--- a/skills/slack-app-setup/generate-manifest-url.ts
+++ b/skills/slack-app-setup/generate-manifest-url.ts
@@ -12,7 +12,9 @@ const name = process.argv[2];
 const desc = process.argv[3] ?? "";
 
 if (!name) {
-  console.error("Usage: bun generate-manifest-url.ts <bot-name> [bot-description]");
+  console.error(
+    "Usage: bun generate-manifest-url.ts <bot-name> [bot-description]",
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
Addresses review feedback from PR #26980. Both Codex and Devin flagged a stale '(Step 3)' reference that should be '(Step 2)' after the one-click manifest PR renumbered the steps.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
