### PR TITLE
fix(macos): fix Cmd+Up/Down conversation nav shortcut issues

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -84,6 +84,18 @@ extension UserDefaults {
         }
         return string(forKey: "popOutShortcut") ?? ""
     }
+    @objc dynamic var previousConversationShortcut: String {
+        if UserDefaults.standard.object(forKey: "previousConversationShortcut") == nil {
+            return "cmd+up"
+        }
+        return string(forKey: "previousConversationShortcut") ?? ""
+    }
+    @objc dynamic var nextConversationShortcut: String {
+        if UserDefaults.standard.object(forKey: "nextConversationShortcut") == nil {
+            return "cmd+down"
+        }
+        return string(forKey: "nextConversationShortcut") ?? ""
+    }
     @objc dynamic var connectedOrganizationId: String? {
         return string(forKey: "connectedOrganizationId")
     }
@@ -105,6 +117,7 @@ extension AppDelegate {
         registerCurrentConversationMonitor()
         registerMarkConversationUnreadMonitor()
         registerPopOutMonitor()
+        registerConversationNavMonitor()
 
         globalHotkeyObserver = Publishers.Merge4(
             UserDefaults.standard.publisher(for: \.globalHotkeyShortcut).map { _ in () },
@@ -116,6 +129,8 @@ extension AppDelegate {
         .merge(with: UserDefaults.standard.publisher(for: \.currentConversationShortcut).map { _ in () })
         .merge(with: UserDefaults.standard.publisher(for: \.markConversationUnreadShortcut).map { _ in () })
         .merge(with: UserDefaults.standard.publisher(for: \.popOutShortcut).map { _ in () })
+        .merge(with: UserDefaults.standard.publisher(for: \.previousConversationShortcut).map { _ in () })
+        .merge(with: UserDefaults.standard.publisher(for: \.nextConversationShortcut).map { _ in () })
         .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
         .sink { [weak self] _ in
             self?.registerGlobalHotkeyMonitor()
@@ -125,6 +140,7 @@ extension AppDelegate {
             self?.registerCurrentConversationMonitor()
             self?.registerMarkConversationUnreadMonitor()
             self?.registerPopOutMonitor()
+            self?.registerConversationNavMonitor()
             self?.updateNewChatMenuItemShortcut()
             self?.updateCurrentConversationMenuItemShortcut()
             self?.updateMarkConversationUnreadMenuItemShortcut()
@@ -474,27 +490,49 @@ extension AppDelegate {
         popOutLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
-    /// Registers Cmd+Up / Cmd+Down as local shortcuts for navigating between
-    /// conversations in the sidebar. Uses arrow key codes (126 = up, 125 = down)
-    /// rather than `charactersIgnoringModifiers` which is unreliable for arrow keys
-    /// on some keyboard layouts.
+    /// Registers configurable shortcuts for navigating between conversations
+    /// in the sidebar (default: Cmd+Up / Cmd+Down). The shortcuts are read
+    /// dynamically from UserDefaults so they can be reconfigured without
+    /// restarting. Skips the event when the first responder is a text view
+    /// to avoid stealing standard text editing key bindings.
     func registerConversationNavMonitor() {
-        guard conversationNavLocalMonitor == nil else { return }
+        if let existing = conversationNavLocalMonitor {
+            NSEvent.removeMonitor(existing)
+            conversationNavLocalMonitor = nil
+        }
+
+        let prevShortcut = UserDefaults.standard.string(forKey: "previousConversationShortcut") ?? "cmd+up"
+        let nextShortcut = UserDefaults.standard.string(forKey: "nextConversationShortcut") ?? "cmd+down"
+
+        guard !prevShortcut.isEmpty || !nextShortcut.isEmpty else { return }
+
+        let (prevModifiers, prevKey) = ShortcutHelper.parseShortcut(prevShortcut)
+        let (nextModifiers, nextKey) = ShortcutHelper.parseShortcut(nextShortcut)
+
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
             guard self?.isBootstrapping != true,
                   self?.mainWindow?.isVisible == true else { return event }
-            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting(.numericPad)
-            guard mods == [.command] else { return event }
-            switch event.keyCode {
-            case 126: // Up arrow
+
+            // Don't steal shortcuts from text views (e.g. Cmd+Up/Down for caret movement)
+            if NSApp.mainWindow?.firstResponder is NSTextView { return event }
+
+            // Arrow keys include .numericPad and .function in modifierFlags — strip both
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                .subtracting([.numericPad, .function])
+
+            if !prevShortcut.isEmpty,
+               mods == prevModifiers,
+               event.charactersIgnoringModifiers?.lowercased() == prevKey.lowercased() {
                 Task { @MainActor in self?.selectPreviousConversation() }
                 return nil
-            case 125: // Down arrow
+            }
+            if !nextShortcut.isEmpty,
+               mods == nextModifiers,
+               event.charactersIgnoringModifiers?.lowercased() == nextKey.lowercased() {
                 Task { @MainActor in self?.selectNextConversation() }
                 return nil
-            default:
-                return event
             }
+            return event
         }
         conversationNavLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -670,7 +670,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         setupFileMenu()
         patchAppMenuTitles()
         registerNavigationMonitor()
-        registerConversationNavMonitor()
         registerZoomMonitor()
         registerSidebarToggleMonitor()
         setupHotKey()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -15,6 +15,8 @@ struct SettingsAppearanceTab: View {
     @State private var isRecordingCurrentConversation = false
     @State private var isRecordingMarkConversationUnread = false
     @State private var isRecordingPopOut = false
+    @State private var isRecordingPreviousConversation = false
+    @State private var isRecordingNextConversation = false
     @State private var isRecordingVoiceInput = false
     @State private var shortcutMonitor: Any?
     @State private var flagsMonitor: Any?
@@ -428,6 +430,72 @@ struct SettingsAppearanceTab: View {
 
                 SettingsDivider()
 
+                // Previous conversation (configurable)
+                HStack {
+                    Text("Previous conversation")
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentSecondary)
+                    Spacer()
+                    if isRecordingPreviousConversation, let display = recordingDisplayString, !display.isEmpty {
+                        VShortcutTag(display)
+                    } else {
+                        VShortcutTag(ShortcutHelper.displayString(for: store.previousConversationShortcut))
+                    }
+
+                    if isRecordingPreviousConversation {
+                        VButton(label: "Press shortcut...", style: .outlined) {
+                            stopRecording()
+                        }
+                    } else {
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Change", style: .outlined) {
+                                startRecordingPreviousConversation()
+                            }
+                            if !store.previousConversationShortcut.isEmpty {
+                                VButton(label: "Remove", style: .outlined) {
+                                    store.previousConversationShortcut = ""
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, VSpacing.md)
+
+                SettingsDivider()
+
+                // Next conversation (configurable)
+                HStack {
+                    Text("Next conversation")
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentSecondary)
+                    Spacer()
+                    if isRecordingNextConversation, let display = recordingDisplayString, !display.isEmpty {
+                        VShortcutTag(display)
+                    } else {
+                        VShortcutTag(ShortcutHelper.displayString(for: store.nextConversationShortcut))
+                    }
+
+                    if isRecordingNextConversation {
+                        VButton(label: "Press shortcut...", style: .outlined) {
+                            stopRecording()
+                        }
+                    } else {
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Change", style: .outlined) {
+                                startRecordingNextConversation()
+                            }
+                            if !store.nextConversationShortcut.isEmpty {
+                                VButton(label: "Remove", style: .outlined) {
+                                    store.nextConversationShortcut = ""
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, VSpacing.md)
+
+                SettingsDivider()
+
                 VToggle(
                     isOn: Binding(
                         get: { store.cmdEnterToSend },
@@ -658,6 +726,20 @@ struct SettingsAppearanceTab: View {
         isRecordingPopOut = true
     }
 
+    private func startRecordingPreviousConversation() {
+        startRecordingShortcut { shortcut, _ in
+            store.previousConversationShortcut = shortcut
+        }
+        isRecordingPreviousConversation = true
+    }
+
+    private func startRecordingNextConversation() {
+        startRecordingShortcut { shortcut, _ in
+            store.nextConversationShortcut = shortcut
+        }
+        isRecordingNextConversation = true
+    }
+
     /// Shared recording logic. The callback receives the shortcut string and the raw NSEvent key code.
     private func startRecordingShortcut(onRecord: @escaping (String, UInt16) -> Void) {
         stopRecording()
@@ -706,6 +788,8 @@ struct SettingsAppearanceTab: View {
         isRecordingCurrentConversation = false
         isRecordingMarkConversationUnread = false
         isRecordingPopOut = false
+        isRecordingPreviousConversation = false
+        isRecordingNextConversation = false
         recordingDisplayString = nil
         if let monitor = shortcutMonitor {
             NSEvent.removeMonitor(monitor)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -91,6 +91,8 @@ public final class SettingsStore: ObservableObject {
     @Published var currentConversationShortcut: String
     @Published var markConversationUnreadShortcut: String
     @Published var popOutShortcut: String
+    @Published var previousConversationShortcut: String
+    @Published var nextConversationShortcut: String
     @Published var cmdEnterToSend: Bool
 
     // MARK: - Media Embed Settings
@@ -505,6 +507,16 @@ public final class SettingsStore: ObservableObject {
         } else {
             self.popOutShortcut = UserDefaults.standard.string(forKey: "popOutShortcut") ?? ""
         }
+        if UserDefaults.standard.object(forKey: "previousConversationShortcut") == nil {
+            self.previousConversationShortcut = "cmd+up"
+        } else {
+            self.previousConversationShortcut = UserDefaults.standard.string(forKey: "previousConversationShortcut") ?? ""
+        }
+        if UserDefaults.standard.object(forKey: "nextConversationShortcut") == nil {
+            self.nextConversationShortcut = "cmd+down"
+        } else {
+            self.nextConversationShortcut = UserDefaults.standard.string(forKey: "nextConversationShortcut") ?? ""
+        }
 
         // Use defaults for config-dependent properties; the daemon will
         // provide authoritative values once reachable via loadConfigFromDaemon().
@@ -601,6 +613,16 @@ public final class SettingsStore: ObservableObject {
         $popOutShortcut
             .dropFirst()
             .sink { value in UserDefaults.standard.set(value, forKey: "popOutShortcut") }
+            .store(in: &cancellables)
+
+        $previousConversationShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "previousConversationShortcut") }
+            .store(in: &cancellables)
+
+        $nextConversationShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "nextConversationShortcut") }
             .store(in: &cancellables)
 
         // Re-resolve lockfile-derived state whenever the connected assistant changes


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #26968:

- Strip `.function` modifier flag from arrow key events so `Cmd+Up/Down` actually fires (macOS arrow keys set both `.numericPad` and `.function` in `modifierFlags`)
- Check first responder before consuming the event — don't steal `Cmd+Up/Down` from `NSTextView` (standard caret movement in text fields)
- Wire Previous/Next Conversation shortcuts into the configurable key bindings system (SettingsStore, SettingsAppearanceTab, UserDefaults KVO observer)

## Test plan
- [ ] Verify Cmd+Up/Down navigates between conversations in the sidebar
- [ ] Verify Cmd+Up/Down still works for caret movement when focused in a text input
- [ ] Verify Previous/Next Conversation shortcuts appear in Settings > General > Keyboard Shortcuts
- [ ] Verify changing the shortcut in Settings takes effect immediately
- [ ] Verify removing the shortcut disables it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
