### PR TITLE
feat(migrations): accept {url} JSON body on POST /v1/migrations/import

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -1338,6 +1338,562 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/btw:
+    post:
+      operationId: btw_post
+      summary: Run ephemeral LLM side-chain
+      description:
+        Stream an ephemeral LLM call reusing the conversation's provider and message history. Response is SSE
+        (btw_text_delta, btw_complete, btw_error).
+      tags:
+        - btw
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationKey:
+                  type: string
+                  description: Conversation key to scope the call
+                content:
+                  type: string
+                  description: User prompt content
+              required:
+                - conversationKey
+                - content
+              additionalProperties: false
+  /v1/calls/{id}:
+    get:
+      operationId: calls_by_id_get
+      summary: Get call status
+      description: Return the current status and details of a call session.
+      tags:
+        - calls
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  callSessionId:
+                    type: string
+                  conversationId:
+                    type: string
+                  status:
+                    type: string
+                  toNumber:
+                    type: string
+                  fromNumber:
+                    type: string
+                  provider:
+                    type: string
+                  providerCallSid:
+                    type: string
+                  task:
+                    type: string
+                  startedAt:
+                    type: string
+                  endedAt:
+                    type: string
+                  lastError:
+                    type: string
+                  pendingQuestion:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                  createdAt:
+                    type: string
+                  updatedAt:
+                    type: string
+                required:
+                  - callSessionId
+                  - conversationId
+                  - status
+                  - toNumber
+                  - fromNumber
+                  - provider
+                  - providerCallSid
+                  - task
+                  - startedAt
+                  - endedAt
+                  - lastError
+                  - pendingQuestion
+                  - createdAt
+                  - updatedAt
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/calls/{id}/answer:
+    post:
+      operationId: calls_by_id_answer_post
+      summary: Answer a pending call question
+      description: Provide an answer to a pending question during an active call.
+      tags:
+        - calls
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  questionId:
+                    type: string
+                required:
+                  - ok
+                  - questionId
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                answer:
+                  type: string
+                  description: Answer text
+                pendingQuestionId:
+                  type: string
+                  description: ID of the pending question
+              required:
+                - answer
+                - pendingQuestionId
+              additionalProperties: false
+  /v1/calls/{id}/cancel:
+    post:
+      operationId: calls_by_id_cancel_post
+      summary: Cancel a call
+      description: Cancel an active or pending call.
+      tags:
+        - calls
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  callSessionId:
+                    type: string
+                  status:
+                    type: string
+                required:
+                  - callSessionId
+                  - status
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                  description: Cancellation reason
+              required:
+                - reason
+              additionalProperties: false
+  /v1/calls/{id}/instruction:
+    post:
+      operationId: calls_by_id_instruction_post
+      summary: Relay instruction to active call
+      description: Send a real-time instruction to an active call.
+      tags:
+        - calls
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instruction:
+                  type: string
+                  description: Instruction text to relay
+              required:
+                - instruction
+              additionalProperties: false
+  /v1/calls/start:
+    post:
+      operationId: calls_start_post
+      summary: Start a call
+      description: Initiate a new outbound phone call. Supports idempotency keys to prevent duplicate calls.
+      tags:
+        - calls
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  callSessionId:
+                    type: string
+                  callSid:
+                    type: string
+                  status:
+                    type: string
+                  toNumber:
+                    type: string
+                  fromNumber:
+                    type: string
+                  callerIdentityMode:
+                    type: string
+                required:
+                  - callSessionId
+                  - callSid
+                  - status
+                  - toNumber
+                  - fromNumber
+                  - callerIdentityMode
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                phoneNumber:
+                  type: string
+                  description: Phone number to call
+                task:
+                  type: string
+                  description: Task description for the call
+                context:
+                  type: string
+                  description: Additional context for the call
+                conversationId:
+                  type: string
+                  description: Conversation to associate with
+                callerIdentityMode:
+                  type: string
+                  description: "Caller identity: 'assistant_number' or 'user_number'"
+                idempotencyKey:
+                  type: string
+                  description: Idempotency key to prevent duplicate calls
+              required:
+                - conversationId
+              additionalProperties: false
+  /v1/channel-verification-sessions:
+    delete:
+      operationId: channelverificationsessions_delete
+      summary: Cancel verification sessions
+      description: Cancel all active inbound and outbound verification sessions.
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  channel:
+                    type: string
+                required:
+                  - success
+                  - channel
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+              required:
+                - channel
+              additionalProperties: false
+    post:
+      operationId: channelverificationsessions_post
+      summary: Create verification session
+      description: Create a channel verification session (inbound challenge, outbound, or trusted contact).
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                  description: Channel ID
+                destination:
+                  type: string
+                  description: Outbound destination
+                rebind:
+                  type: boolean
+                conversationId:
+                  type: string
+                originConversationId:
+                  type: string
+                purpose:
+                  type: string
+                  description: guardian or trusted_contact
+                contactChannelId:
+                  type: string
+              required:
+                - channel
+                - destination
+                - rebind
+                - conversationId
+                - originConversationId
+                - purpose
+                - contactChannelId
+              additionalProperties: false
+  /v1/channel-verification-sessions/resend:
+    post:
+      operationId: channelverificationsessions_resend_post
+      summary: Resend verification code
+      description: Resend the outbound verification code.
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                originConversationId:
+                  type: string
+              required:
+                - channel
+              additionalProperties: false
+  /v1/channel-verification-sessions/revoke:
+    post:
+      operationId: channelverificationsessions_revoke_post
+      summary: Revoke verification binding
+      description: Cancel all sessions and revoke the guardian binding.
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+              required:
+                - channel
+              additionalProperties: false
+  /v1/channel-verification-sessions/status:
+    get:
+      operationId: channelverificationsessions_status_get
+      summary: Get verification status
+      description: Check guardian binding and verification session status.
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: channel
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional channel ID filter
+  /v1/channels/conversation:
+    delete:
+      operationId: channels_conversation_delete
+      summary: Delete channel conversation
+      description: Delete a conversation by channel source.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+  /v1/channels/dead-letters:
+    get:
+      operationId: channels_deadletters_get
+      summary: List dead letters
+      description: Return undeliverable channel messages.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+  /v1/channels/delivery-ack:
+    post:
+      operationId: channels_deliveryack_post
+      summary: Acknowledge channel delivery
+      description: Acknowledge delivery of a channel message.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+  /v1/channels/inbound:
+    post:
+      operationId: channels_inbound_post
+      summary: Process inbound channel message
+      description: Receive an inbound message from a channel integration.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+  /v1/channels/readiness:
+    get:
+      operationId: channels_readiness_get
+      summary: Get channel readiness
+      description: Return readiness snapshots for one or all channels.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  snapshots:
+                    type: array
+                    items: {}
+                    description: Channel readiness snapshots
+                required:
+                  - success
+                  - snapshots
+                additionalProperties: false
+      parameters:
+        - name: channel
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional channel ID filter
+        - name: includeRemote
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Include remote checks (default true)
+  /v1/channels/readiness/refresh:
+    post:
+      operationId: channels_readiness_refresh_post
+      summary: Refresh channel readiness
+      description: Invalidate cache and re-evaluate channel readiness.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  snapshots:
+                    type: array
+                    items: {}
+                    description: Refreshed readiness snapshots
+                required:
+                  - success
+                  - snapshots
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                  description: Optional channel ID to refresh
+                includeRemote:
+                  type: boolean
+                  description: Include remote checks (default true)
+              required:
+                - channel
+                - includeRemote
+              additionalProperties: false
+  /v1/channels/replay:
+    post:
+      operationId: channels_replay_post
+      summary: Replay dead letters
+      description: Retry delivery of dead-letter messages.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
   /v1/computer-use/watch:
     post:
       operationId: computeruse_watch_post
@@ -1404,6 +1960,58 @@ paths:
                 - captureIndex
                 - totalExpected
               additionalProperties: false
+  /v1/config:
+    get:
+      operationId: config_get
+      summary: Get full config
+      description: Return the raw settings.json configuration object.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+    patch:
+      operationId: config_patch
+      summary: Patch config
+      description: Deep-merge a partial JSON object into the settings.json configuration.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+  /v1/config/embeddings:
+    get:
+      operationId: config_embeddings_get
+      summary: Get embedding config
+      description: Return the active embedding provider, model, and available options.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+    put:
+      operationId: config_embeddings_put
+      summary: Set embedding config
+      description: Change the embedding provider and optionally model.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                provider:
+                  type: string
+                model:
+                  type: string
+              required:
+                - provider
+              additionalProperties: false
   /v1/config/platform:
     get:
       operationId: config_platform_get
@@ -1447,6 +2055,49 @@ paths:
                   type: string
               required:
                 - baseUrl
+              additionalProperties: false
+  /v1/confirm:
+    post:
+      operationId: confirm_post
+      summary: Resolve a pending confirmation
+      description: Approve or deny a pending tool confirmation by requestId.
+      tags:
+        - approvals
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: boolean
+                required:
+                  - accepted
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Pending interaction request ID
+                decision:
+                  type: string
+                  description: "One of: allow, allow_10m, allow_conversation, deny, always_allow, always_deny, always_allow_high_risk"
+                selectedPattern:
+                  type: string
+                  description: Allowlist pattern for persistent decisions
+                selectedScope:
+                  type: string
+                  description: Scope for persistent decisions
+              required:
+                - requestId
+                - decision
               additionalProperties: false
   /v1/contact-channels/{contactChannelId}:
     patch:
@@ -1682,6 +2333,223 @@ paths:
                 - address
                 - externalUserId
               additionalProperties: false
+  /v1/contacts/invites:
+    get:
+      operationId: contacts_invites_get
+      summary: List invites
+      description: Return all invites, optionally filtered by sourceChannel or status.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  invites:
+                    type: array
+                    items: {}
+                    description: Invite objects
+                required:
+                  - ok
+                  - invites
+                additionalProperties: false
+      parameters:
+        - name: sourceChannel
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by source channel
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by invite status
+    post:
+      operationId: contacts_invites_post
+      summary: Create an invite
+      description: Create a new invite. Supports voice invites when sourceChannel is "phone".
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  invite:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Created invite
+                required:
+                  - ok
+                  - invite
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                contactId:
+                  type: string
+                  description: Contact to invite
+                sourceChannel:
+                  type: string
+                  description: Source channel (e.g. phone)
+                note:
+                  type: string
+                  description: Optional note
+                maxUses:
+                  type: number
+                  description: Max redemptions
+                expiresInMs:
+                  type: number
+                  description: Expiry duration in ms
+                contactName:
+                  type: string
+                  description: Contact display name
+                expectedExternalUserId:
+                  type: string
+                  description: Expected user ID (E.164 for phone)
+                friendName:
+                  type: string
+                  description: Friend name for the invite
+                guardianName:
+                  type: string
+                  description: Guardian name
+              required:
+                - contactId
+              additionalProperties: false
+  /v1/contacts/invites/{id}:
+    delete:
+      operationId: contacts_invites_by_id_delete
+      summary: Revoke an invite
+      description: Revoke an invite by ID.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/contacts/invites/{id}/call:
+    post:
+      operationId: contacts_invites_by_id_call_post
+      summary: Trigger invite call
+      description: Trigger an outbound call for a phone invite.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  callSid:
+                    type: string
+                    description: Call SID from the provider
+                required:
+                  - ok
+                  - callSid
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/contacts/invites/redeem:
+    post:
+      operationId: contacts_invites_redeem_post
+      summary: Redeem an invite
+      description: Redeem an invite by token or voice code.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  invite:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Redeemed invite (token path)
+                  type:
+                    type: string
+                    description: Redemption type (voice path)
+                  memberId:
+                    type: string
+                    description: Member ID (voice path)
+                required:
+                  - ok
+                  - invite
+                  - type
+                  - memberId
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+                  description: Invite token (token-based redemption)
+                code:
+                  type: string
+                  description: Voice code (voice-code redemption)
+                callerExternalUserId:
+                  type: string
+                  description: Caller E.164 phone (voice-code)
+                externalUserId:
+                  type: string
+                  description: External user ID (token-based)
+                externalChatId:
+                  type: string
+                  description: External chat ID (token-based)
+                sourceChannel:
+                  type: string
+                  description: Source channel (token-based)
+                assistantId:
+                  type: string
+                  description: Assistant ID (voice-code)
+              required:
+                - token
+                - code
+                - callerExternalUserId
+                - externalUserId
+                - externalChatId
+                - sourceChannel
+                - assistantId
+              additionalProperties: false
   /v1/contacts/merge:
     post:
       operationId: contacts_merge_post
@@ -1782,17 +2650,334 @@ paths:
             type: string
           description: Scope ID (default "default")
   /v1/conversations:
+    delete:
+      operationId: conversations_delete
+      summary: Clear all conversations
+      description: Permanently delete ALL conversations, messages, and memory. Requires X-Confirm-Destructive header.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
     get:
       operationId: conversations_get
       responses:
         "200":
           description: Successful response
+    post:
+      operationId: conversations_post
+      summary: Create a conversation
+      description: Create or get an existing conversation by key.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  conversationKey:
+                    type: string
+                  conversationType:
+                    type: string
+                required:
+                  - id
+                  - conversationKey
+                  - conversationType
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationKey:
+                  type: string
+                  description: Idempotency key for the conversation
+                conversationType:
+                  type: string
+                  description: "'standard' (default) or 'private'"
+              required:
+                - conversationKey
+                - conversationType
+              additionalProperties: false
   /v1/conversations/{id}:
+    delete:
+      operationId: conversations_by_id_delete
+      summary: Delete a conversation
+      description: Permanently delete a single conversation and its messages.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
     get:
       operationId: conversations_by_id_get
       responses:
         "200":
           description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/analyze:
+    post:
+      operationId: conversations_by_id_analyze_post
+      summary: Analyze a conversation
+      description: Create a new conversation with a structured self-assessment of an existing conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/archive:
+    post:
+      operationId: conversations_by_id_archive_post
+      summary: Archive a conversation
+      description:
+        Move a conversation to the archived state. Archived conversations are hidden from the default sidebar but
+        preserved for search and recall.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/cancel:
+    post:
+      operationId: conversations_by_id_cancel_post
+      summary: Cancel generation
+      description: Abort the in-progress assistant response for a conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/host-access:
+    get:
+      operationId: conversations_by_id_hostaccess_get
+      summary: Get conversation host access
+      description: Return whether the conversation can use host tools.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  hostAccess:
+                    type: boolean
+                required:
+                  - conversationId
+                  - hostAccess
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    patch:
+      operationId: conversations_by_id_hostaccess_patch
+      summary: Update conversation host access
+      description: Enable or disable host access for a conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  hostAccess:
+                    type: boolean
+                required:
+                  - conversationId
+                  - hostAccess
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                hostAccess:
+                  type: boolean
+              required:
+                - hostAccess
+              additionalProperties: false
+  /v1/conversations/{id}/name:
+    patch:
+      operationId: conversations_by_id_name_patch
+      summary: Rename a conversation
+      description: Update the display name of a conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+              additionalProperties: false
+  /v1/conversations/{id}/regenerate:
+    post:
+      operationId: conversations_by_id_regenerate_post
+      summary: Regenerate response
+      description: Re-run the assistant for the last user message in a conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/unarchive:
+    post:
+      operationId: conversations_by_id_unarchive_post
+      summary: Unarchive a conversation
+      description: Restore an archived conversation back to the default sidebar.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/undo:
+    post:
+      operationId: conversations_by_id_undo_post
+      summary: Undo last message
+      description: Remove the most recent user+assistant message pair from the conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  removedCount:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                  conversationId:
+                    type: string
+                required:
+                  - removedCount
+                  - conversationId
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/wipe:
+    post:
+      operationId: conversations_by_id_wipe_post
+      summary: Wipe a conversation
+      description: Delete all messages in a conversation and revert associated memory changes.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  wiped:
+                    type: boolean
+                  unsupersededItems:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                  deletedSummaries:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                  cancelledJobs:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                required:
+                  - wiped
+                  - unsupersededItems
+                  - deletedSummaries
+                  - cancelledJobs
+                additionalProperties: false
       parameters:
         - name: id
           in: path
@@ -1855,12 +3040,129 @@ paths:
           schema:
             type: number
           description: Cursor for pagination (timestamp)
+  /v1/conversations/fork:
+    post:
+      operationId: conversations_fork_post
+      summary: Fork a conversation
+      description: Create a copy of a conversation, optionally truncated at a specific message.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                throughMessageId:
+                  type: string
+                  description: Truncate the fork at this message
+              required:
+                - conversationId
+              additionalProperties: false
+  /v1/conversations/reorder:
+    post:
+      operationId: conversations_reorder_post
+      summary: Reorder conversations
+      description: Batch-update display order and pin state for conversations.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                updates:
+                  type: array
+                  items: {}
+                  description: Array of { conversationId, displayOrder?, isPinned? } objects
+              required:
+                - updates
+              additionalProperties: false
+  /v1/conversations/search:
+    get:
+      operationId: conversations_search_get
+      summary: Search conversations
+      description: Full-text search across conversation titles and message content.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  query:
+                    type: string
+                  results:
+                    type: array
+                    items: {}
+                required:
+                  - query
+                  - results
+                additionalProperties: false
   /v1/conversations/seen:
     post:
       operationId: conversations_seen_post
       responses:
         "200":
           description: Successful response
+  /v1/conversations/switch:
+    post:
+      operationId: conversations_switch_post
+      summary: Switch active conversation
+      description: Set the active conversation for the current session.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  title:
+                    type: string
+                  conversationType:
+                    type: string
+                  hostAccess:
+                    type: boolean
+                required:
+                  - conversationId
+                  - title
+                  - conversationType
+                  - hostAccess
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                conversationKey:
+                  type: string
+                  description: Optional key to register for this conversation
+              required:
+                - conversationId
+              additionalProperties: false
   /v1/conversations/unread:
     post:
       operationId: conversations_unread_post
@@ -2114,6 +3416,23 @@ paths:
           required: true
           schema:
             type: string
+  /v1/events:
+    get:
+      operationId: events_get
+      summary: Subscribe to assistant events
+      description: Stream assistant events as Server-Sent Events (SSE).
+      tags:
+        - events
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: conversationKey
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Scope to a single conversation
   /v1/export:
     post:
       operationId: export_post
@@ -2330,6 +3649,87 @@ paths:
               required:
                 - updates
               additionalProperties: false
+  /v1/guardian-actions/decision:
+    post:
+      operationId: guardianactions_decision_post
+      summary: Submit guardian decision
+      description: Submit a guardian action decision (approve/reject).
+      tags:
+        - guardian
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  applied:
+                    type: boolean
+                  requestId:
+                    type: string
+                  reason:
+                    description: Decline reason (present only when applied is false)
+                    type: string
+                  replyText:
+                    description: Resolver reply text for the guardian (e.g. verification code)
+                    type: string
+                required:
+                  - applied
+                  - requestId
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Guardian request ID
+                action:
+                  type: string
+                  description: Decision action
+                conversationId:
+                  type: string
+                  description: Conversation ID
+              required:
+                - requestId
+                - action
+              additionalProperties: false
+  /v1/guardian-actions/pending:
+    get:
+      operationId: guardianactions_pending_get
+      summary: List pending guardian actions
+      description: Return pending guardian decision prompts for a conversation.
+      tags:
+        - guardian
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  prompts:
+                    type: array
+                    items: {}
+                    description: Guardian decision prompt objects
+                required:
+                  - conversationId
+                  - prompts
+                additionalProperties: false
+      parameters:
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Conversation ID (required)
   /v1/guardian/init:
     post:
       operationId: guardian_init_post
@@ -3691,6 +5091,36 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/llm-request-logs/{id}/payload:
+    get:
+      operationId: llmrequestlogs_by_id_payload_get
+      summary: Get raw payload for a single LLM request log
+      description: Return the full request and response payloads for a specific log entry.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  requestPayload: {}
+                  responsePayload: {}
+                required:
+                  - id
+                  - requestPayload
+                  - responsePayload
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/logs/export:
     post:
       operationId: logs_export_post
@@ -3941,6 +5371,120 @@ paths:
                 importance:
                   type: number
               additionalProperties: false
+  /v1/messages:
+    get:
+      operationId: messages_get
+      summary: List messages
+      description: Return messages for a conversation, including attachments and interface file metadata.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messages:
+                    type: array
+                    items: {}
+                    description: Array of message objects
+                  hasMore:
+                    description: Whether older messages exist beyond this page
+                    type: boolean
+                  oldestTimestamp:
+                    description: Timestamp of the oldest message in this page (ms since epoch)
+                    type: number
+                  oldestMessageId:
+                    description: ID of the oldest message in this page
+                    type: string
+                required:
+                  - messages
+                additionalProperties: false
+    post:
+      operationId: messages_post
+      summary: Send a message
+      description: Send a user message to a conversation and trigger the assistant response.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationKey:
+                  type: string
+                content:
+                  type: string
+                  description: Message text content
+                attachments:
+                  type: array
+                  items: {}
+                  description: Optional file attachments
+                conversationType:
+                  type: string
+                slashCommand:
+                  type: string
+              required:
+                - content
+              additionalProperties: false
+  /v1/messages/{id}/content:
+    get:
+      operationId: messages_by_id_content_get
+      summary: Get message content
+      description: Return the full content of a single message by ID.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/messages/{id}/llm-context:
+    get:
+      operationId: messages_by_id_llmcontext_get
+      summary: Get LLM context for a message
+      description: Return request/response logs and memory recall data for a specific message.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messageId:
+                    type: string
+                  logs:
+                    type: array
+                    items: {}
+                  memoryRecall:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                required:
+                  - messageId
+                  - logs
+                  - memoryRecall
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/messages/{id}/tts:
     post:
       operationId: messages_by_id_tts_post
@@ -3963,6 +5507,22 @@ paths:
           schema:
             type: string
           description: Conversation that contains the message
+  /v1/messages/queued/{id}:
+    delete:
+      operationId: messages_queued_by_id_delete
+      summary: Delete a queued message
+      description: Remove a pending message from the conversation queue before it is processed.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/migrations/export:
     post:
       operationId: migrations_export_post
@@ -3990,7 +5550,10 @@ paths:
     post:
       operationId: migrations_import_post
       summary: Import a .vbundle archive
-      description: Commit a .vbundle archive import to disk — destructive. Backs up existing files before overwriting.
+      description:
+        Commit a .vbundle archive import to disk — destructive. Accepts the bundle as raw bytes
+        (application/octet-stream), multipart/form-data, or a JSON body carrying a signed URL the daemon fetches and
+        streams through the importer.
       tags:
         - migrations
       responses:
@@ -4024,6 +5587,56 @@ paths:
                   - manifest
                   - warnings
                 additionalProperties: false
+        "502":
+          description:
+            "Upstream fetch failed (URL body only). Body shape: { success: false, reason: 'fetch_failed',
+            upstream_status?: number }."
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  reason:
+                    type: string
+                    enum:
+                      - fetch_failed
+                  upstream_status:
+                    type: integer
+                required:
+                  - success
+                  - reason
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+              description: Raw .vbundle archive bytes.
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: The .vbundle archive uploaded as a file field.
+              required:
+                - file
+          application/json:
+            schema:
+              type: object
+              properties:
+                url:
+                  type: string
+                  format: uri
+                  description:
+                    A signed GCS URL pointing to the .vbundle archive. The daemon fetches the URL and streams the body through
+                    the importer.
+              required:
+                - url
   /v1/migrations/import-preflight:
     post:
       operationId: migrations_importpreflight_post
@@ -4091,6 +5704,62 @@ paths:
                   - errors
                   - manifest
                 additionalProperties: false
+  /v1/model:
+    get:
+      operationId: model_get
+      summary: Get current model config
+      description: Return the active LLM model ID, provider, and available models.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+    put:
+      operationId: model_put
+      summary: Set LLM model
+      description: Change the active LLM model and optionally its provider.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                modelId:
+                  type: string
+                provider:
+                  type: string
+                  description: Optional provider override
+              required:
+                - modelId
+              additionalProperties: false
+  /v1/model/image-gen:
+    put:
+      operationId: model_imagegen_put
+      summary: Set image generation model
+      description: Change the active image generation model.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                modelId:
+                  type: string
+              required:
+                - modelId
+              additionalProperties: false
   /v1/notification-intent-result:
     post:
       operationId: notificationintentresult_post
@@ -4304,6 +5973,48 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/pending-interactions:
+    get:
+      operationId: pendinginteractions_get
+      summary: List pending interactions
+      description: Return pending confirmations and secrets for a conversation.
+      tags:
+        - approvals
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pendingConfirmation:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Pending confirmation details or null
+                  pendingSecret:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Pending secret request or null
+                required:
+                  - pendingConfirmation
+                  - pendingSecret
+                additionalProperties: false
+      parameters:
+        - name: conversationKey
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Conversation key
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Conversation ID
   /v1/profiler/runs:
     get:
       operationId: profiler_runs_get
@@ -4688,6 +6399,239 @@ paths:
               required:
                 - conversationId
               additionalProperties: false
+  /v1/schedules:
+    get:
+      operationId: schedules_get
+      summary: List schedules
+      description: Return all scheduled jobs.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Schedule objects
+                required:
+                  - schedules
+                additionalProperties: false
+  /v1/schedules/{id}:
+    delete:
+      operationId: schedules_by_id_delete
+      summary: Delete schedule
+      description: Remove a schedule by ID.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    patch:
+      operationId: schedules_by_id_patch
+      summary: Update schedule
+      description: Partially update fields on a schedule.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                expression:
+                  type: string
+                timezone:
+                  type: string
+                message:
+                  type: string
+                mode:
+                  type: string
+                  description: notify or execute
+                routingIntent:
+                  type: string
+                  description: single_channel, multi_channel, or all_channels
+                quiet:
+                  type: boolean
+                reuseConversation:
+                  type: boolean
+              required:
+                - name
+                - expression
+                - timezone
+                - message
+                - mode
+                - routingIntent
+                - quiet
+                - reuseConversation
+              additionalProperties: false
+  /v1/schedules/{id}/cancel:
+    post:
+      operationId: schedules_by_id_cancel_post
+      summary: Cancel schedule
+      description: Cancel a pending schedule.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/schedules/{id}/run:
+    post:
+      operationId: schedules_by_id_run_post
+      summary: Run schedule now
+      description: Trigger an immediate execution of a schedule.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/schedules/{id}/toggle:
+    post:
+      operationId: schedules_by_id_toggle_post
+      summary: Toggle schedule
+      description: Enable or disable a schedule.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: New enabled state
+              required:
+                - enabled
+              additionalProperties: false
+  /v1/search:
+    get:
+      operationId: search_get
+      summary: Search conversations
+      description: Full-text search across all conversations.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  query:
+                    type: string
+                  results:
+                    type: array
+                    items: {}
+                required:
+                  - query
+                  - results
+                additionalProperties: false
   /v1/search/global:
     get:
       operationId: search_global_get
@@ -4739,6 +6683,45 @@ paths:
           schema:
             type: string
           description: Enable semantic search for memories (true/false)
+  /v1/secret:
+    post:
+      operationId: secret_post
+      summary: Resolve a pending secret request
+      description: Provide a secret value for a pending secret request.
+      tags:
+        - approvals
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: boolean
+                required:
+                  - accepted
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Pending interaction request ID
+                value:
+                  type: string
+                  description: Secret value
+                delivery:
+                  type: string
+                  description: "Delivery mode: store or transient_send"
+              required:
+                - requestId
+              additionalProperties: false
   /v1/secrets:
     delete:
       operationId: secrets_delete
@@ -4974,6 +6957,1110 @@ paths:
               required:
                 - activationKey
               additionalProperties: false
+  /v1/skills:
+    get:
+      operationId: skills_get
+      summary: List all skills
+      description:
+        "Return all installed skills. Pass ?include=catalog to also include available catalog skills. Supports
+        optional filter params: origin, kind, q, category."
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  skills:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: vellum
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: clawhub
+                            slug:
+                              type: string
+                            author:
+                              type: string
+                            stars:
+                              type: number
+                            installs:
+                              type: number
+                            reports:
+                              type: number
+                            publishedAt:
+                              type: string
+                            version:
+                              type: string
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                            - slug
+                            - author
+                            - stars
+                            - installs
+                            - reports
+                            - version
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: skillssh
+                            slug:
+                              type: string
+                            sourceRepo:
+                              type: string
+                            installs:
+                              type: number
+                            audit:
+                              type: object
+                              propertyNames:
+                                type: string
+                              additionalProperties:
+                                type: object
+                                properties:
+                                  risk:
+                                    type: string
+                                    enum:
+                                      - safe
+                                      - low
+                                      - medium
+                                      - high
+                                      - critical
+                                      - unknown
+                                  alerts:
+                                    type: number
+                                  score:
+                                    type: number
+                                  analyzedAt:
+                                    type: string
+                                required:
+                                  - risk
+                                  - analyzedAt
+                                additionalProperties: false
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                            - slug
+                            - sourceRepo
+                            - installs
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: custom
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
+                    description: Skill objects
+                  categoryCounts:
+                    description: Count of skills per category (before category filter is applied)
+                    type: object
+                    propertyNames:
+                      type: string
+                    additionalProperties:
+                      type: number
+                  totalCount:
+                    description: Total number of skills matching non-category filters
+                    type: number
+                required:
+                  - skills
+                additionalProperties: false
+      parameters:
+        - name: include
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - catalog
+          description: Optional inclusion flag. Use 'catalog' to merge available Vellum catalog skills into the response.
+        - name: origin
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by skill origin (e.g. 'vellum', 'clawhub', 'skillssh', 'custom').
+        - name: kind
+          in: query
+          required: false
+          schema:
+            type: string
+          description: "Filter by kind: 'installed' (includes bundled), 'available', or pass through as skill.kind."
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Text search across skill name, description, id, and origin label.
+        - name: category
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by inferred category (e.g. 'communication', 'productivity').
+    post:
+      operationId: skills_post
+      summary: Create skill
+      description: Create a new skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                skillId:
+                  type: string
+                name:
+                  type: string
+                description:
+                  type: string
+                bodyMarkdown:
+                  type: string
+              required:
+                - skillId
+                - name
+                - description
+                - bodyMarkdown
+              additionalProperties: false
+  /v1/skills/{id}:
+    delete:
+      operationId: skills_by_id_delete
+      summary: Uninstall skill
+      description: Remove an installed skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    get:
+      operationId: skills_by_id_get
+      summary: Get skill
+      description: Return a single skill by ID with enriched detail fields.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  skill:
+                    oneOf:
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: vellum
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: clawhub
+                          slug:
+                            type: string
+                          author:
+                            type: string
+                          stars:
+                            type: number
+                          installs:
+                            type: number
+                          reports:
+                            type: number
+                          publishedAt:
+                            type: string
+                          version:
+                            type: string
+                          owner:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  handle:
+                                    type: string
+                                  displayName:
+                                    type: string
+                                  image:
+                                    type: string
+                                required:
+                                  - handle
+                                  - displayName
+                                additionalProperties: false
+                              - type: "null"
+                          stats:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  stars:
+                                    type: number
+                                  installs:
+                                    type: number
+                                  downloads:
+                                    type: number
+                                  versions:
+                                    type: number
+                                required:
+                                  - stars
+                                  - installs
+                                  - downloads
+                                  - versions
+                                additionalProperties: false
+                              - type: "null"
+                          latestVersion:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  version:
+                                    type: string
+                                  changelog:
+                                    type: string
+                                required:
+                                  - version
+                                additionalProperties: false
+                              - type: "null"
+                          createdAt:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                          updatedAt:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                          - slug
+                          - author
+                          - stars
+                          - installs
+                          - reports
+                          - version
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: skillssh
+                          slug:
+                            type: string
+                          sourceRepo:
+                            type: string
+                          installs:
+                            type: number
+                          audit:
+                            type: object
+                            propertyNames:
+                              type: string
+                            additionalProperties:
+                              type: object
+                              properties:
+                                risk:
+                                  type: string
+                                  enum:
+                                    - safe
+                                    - low
+                                    - medium
+                                    - high
+                                    - critical
+                                    - unknown
+                                alerts:
+                                  type: number
+                                score:
+                                  type: number
+                                analyzedAt:
+                                  type: string
+                              required:
+                                - risk
+                                - analyzedAt
+                              additionalProperties: false
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                          - slug
+                          - sourceRepo
+                          - installs
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: custom
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                        additionalProperties: false
+                    description: Skill detail object
+                required:
+                  - skill
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/config:
+    patch:
+      operationId: skills_by_id_config_patch
+      summary: Configure skill
+      description: Update skill configuration (env, apiKey, config).
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                env:
+                  type: object
+                  properties: {}
+                  additionalProperties: {}
+                  description: Environment variables
+                apiKey:
+                  type: string
+                config:
+                  type: object
+                  properties: {}
+                  additionalProperties: {}
+                  description: Arbitrary config
+              required:
+                - env
+                - apiKey
+                - config
+              additionalProperties: false
+  /v1/skills/{id}/disable:
+    post:
+      operationId: skills_by_id_disable_post
+      summary: Disable skill
+      description: Disable an installed skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/enable:
+    post:
+      operationId: skills_by_id_enable_post
+      summary: Enable skill
+      description: Enable an installed skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/files:
+    get:
+      operationId: skills_by_id_files_get
+      summary: Get skill files
+      description: Return skill metadata and directory contents.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/files/content:
+    get:
+      operationId: skills_by_id_files_content_get
+      summary: Get skill file content
+      description: Return the content of a single file belonging to an installed or catalog skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  path:
+                    type: string
+                  name:
+                    type: string
+                  size:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                  mimeType:
+                    type: string
+                  isBinary:
+                    type: boolean
+                  content:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                required:
+                  - path
+                  - name
+                  - size
+                  - mimeType
+                  - isBinary
+                  - content
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Relative path of the file within the skill directory
+  /v1/skills/{id}/inspect:
+    get:
+      operationId: skills_by_id_inspect_get
+      summary: Inspect skill
+      description: Return detailed skill information.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/update:
+    post:
+      operationId: skills_by_id_update_post
+      summary: Update skill
+      description: Update an installed skill to the latest version.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/check-updates:
+    post:
+      operationId: skills_checkupdates_post
+      summary: Check skill updates
+      description: Check for available updates to installed skills.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Update availability info
+                required:
+                  - data
+                additionalProperties: false
+  /v1/skills/draft:
+    post:
+      operationId: skills_draft_post
+      summary: Draft a skill
+      description: Generate a skill draft from source text.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sourceText:
+                  type: string
+                  description: Source text for drafting
+              required:
+                - sourceText
+              additionalProperties: false
+  /v1/skills/install:
+    post:
+      operationId: skills_install_post
+      summary: Install skill
+      description: Install a skill by slug, URL, or spec.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  skillId:
+                    type: string
+                required:
+                  - ok
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                slug:
+                  type: string
+                  description: Skill slug
+                url:
+                  type: string
+                  description: Skill URL
+                spec:
+                  type: string
+                  description: Skill spec
+                version:
+                  type: string
+                origin:
+                  description: Which registry to install from. When omitted, the install flow auto-detects based on slug format.
+                  type: string
+                  enum:
+                    - clawhub
+                    - skillssh
+              required:
+                - slug
+                - url
+                - spec
+                - version
+              additionalProperties: false
+  /v1/skills/search:
+    get:
+      operationId: skills_search_get
+      summary: Search skill catalog
+      description: Search the skill catalog by query string.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  skills:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: vellum
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: clawhub
+                            slug:
+                              type: string
+                            author:
+                              type: string
+                            stars:
+                              type: number
+                            installs:
+                              type: number
+                            reports:
+                              type: number
+                            publishedAt:
+                              type: string
+                            version:
+                              type: string
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                            - slug
+                            - author
+                            - stars
+                            - installs
+                            - reports
+                            - version
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: skillssh
+                            slug:
+                              type: string
+                            sourceRepo:
+                              type: string
+                            installs:
+                              type: number
+                            audit:
+                              type: object
+                              propertyNames:
+                                type: string
+                              additionalProperties:
+                                type: object
+                                properties:
+                                  risk:
+                                    type: string
+                                    enum:
+                                      - safe
+                                      - low
+                                      - medium
+                                      - high
+                                      - critical
+                                      - unknown
+                                  alerts:
+                                    type: number
+                                  score:
+                                    type: number
+                                  analyzedAt:
+                                    type: string
+                                required:
+                                  - risk
+                                  - analyzedAt
+                                additionalProperties: false
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                            - slug
+                            - sourceRepo
+                            - installs
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: custom
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
+                    description: Skill objects matching the search query
+                required:
+                  - skills
+                additionalProperties: false
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Search query (required)
   /v1/slack/channels:
     get:
       operationId: slack_channels_get
@@ -5022,6 +8109,157 @@ paths:
                 - audioBase64
                 - mimeType
               additionalProperties: false
+  /v1/subagents/{id}:
+    get:
+      operationId: subagents_by_id_get
+      summary: Get subagent detail
+      description: Return subagent objective and event history.
+      tags:
+        - subagents
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subagentId:
+                    type: string
+                  objective:
+                    type: string
+                  events:
+                    type: array
+                    items: {}
+                    description: Subagent event objects
+                required:
+                  - subagentId
+                  - objective
+                  - events
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Parent conversation ID (required)
+  /v1/subagents/{id}/abort:
+    post:
+      operationId: subagents_by_id_abort_post
+      summary: Abort subagent
+      description: Abort a running subagent.
+      tags:
+        - subagents
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subagentId:
+                    type: string
+                  aborted:
+                    type: boolean
+                required:
+                  - subagentId
+                  - aborted
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+              required:
+                - conversationId
+              additionalProperties: false
+  /v1/subagents/{id}/message:
+    post:
+      operationId: subagents_by_id_message_post
+      summary: Send message to subagent
+      description: Send a text message to a running subagent.
+      tags:
+        - subagents
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subagentId:
+                    type: string
+                  sent:
+                    type: boolean
+                required:
+                  - subagentId
+                  - sent
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                content:
+                  type: string
+              required:
+                - conversationId
+                - content
+              additionalProperties: false
+  /v1/suggestion:
+    get:
+      operationId: suggestion_get
+      summary: Get reply suggestion
+      description: Return an LLM-generated follow-up suggestion for the most recent assistant message.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  suggestion:
+                    type: string
+                  messageId:
+                    type: string
+                  source:
+                    type: string
+                required:
+                  - suggestion
+                  - messageId
+                  - source
+                additionalProperties: false
   /v1/surface-actions:
     post:
       operationId: surfaceactions_post
@@ -5289,6 +8527,54 @@ paths:
           schema:
             type: integer
           description: Return events after this sequence number
+  /v1/trust-rules:
+    post:
+      operationId: trustrules_post
+      summary: Add a trust rule for a pending confirmation
+      description: Add a trust rule bound to a pending confirmation without resolving it.
+      tags:
+        - approvals
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: boolean
+                required:
+                  - accepted
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Pending confirmation request ID
+                pattern:
+                  type: string
+                  description: Allowlist pattern
+                scope:
+                  type: string
+                  description: Scope for the rule
+                decision:
+                  type: string
+                  description: allow or deny
+                allowHighRisk:
+                  type: boolean
+                  description: Allow high-risk invocations
+              required:
+                - requestId
+                - pattern
+                - scope
+                - decision
+              additionalProperties: false
   /v1/trust-rules/manage:
     get:
       operationId: trustrules_manage_get
@@ -5593,6 +8879,247 @@ paths:
           schema:
             type: integer
           description: End epoch millis (required)
+  /v1/work-items:
+    get:
+      operationId: workitems_get
+      summary: List work items
+      description: Return work items, optionally filtered by status.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items: {}
+                required:
+                  - items
+                additionalProperties: false
+  /v1/work-items/{id}:
+    delete:
+      operationId: workitems_by_id_delete
+      summary: Delete a work item
+      description: Permanently remove a work item.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    get:
+      operationId: workitems_by_id_get
+      summary: Get a work item
+      description: Return a single work item by ID.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    patch:
+      operationId: workitems_by_id_patch
+      summary: Update a work item
+      description: Partially update a work item's title, notes, status, or priority.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                notes:
+                  type: string
+                status:
+                  type: string
+                priorityTier:
+                  type: integer
+                  minimum: -9007199254740991
+                  maximum: 9007199254740991
+                sortIndex:
+                  type: integer
+                  minimum: -9007199254740991
+                  maximum: 9007199254740991
+              required:
+                - title
+                - notes
+                - status
+                - priorityTier
+                - sortIndex
+              additionalProperties: false
+  /v1/work-items/{id}/approve-permissions:
+    post:
+      operationId: workitems_by_id_approvepermissions_post
+      summary: Approve tool permissions
+      description: Pre-approve a set of tools for a work item before it runs.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                approvedTools:
+                  type: array
+                  items: {}
+                  description: Array of tool names to approve
+              required:
+                - approvedTools
+              additionalProperties: false
+  /v1/work-items/{id}/cancel:
+    post:
+      operationId: workitems_by_id_cancel_post
+      summary: Cancel a running work item
+      description: Abort a running work item and set its status to cancelled.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/work-items/{id}/complete:
+    post:
+      operationId: workitems_by_id_complete_post
+      summary: Complete a work item
+      description: Transition a work item from awaiting_review to done.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/work-items/{id}/output:
+    get:
+      operationId: workitems_by_id_output_get
+      summary: Get work item output
+      description: Return the final output of a completed work item run.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  success:
+                    type: boolean
+                  output:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                required:
+                  - id
+                  - success
+                  - output
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/work-items/{id}/preflight:
+    post:
+      operationId: workitems_by_id_preflight_post
+      summary: Preflight check
+      description: Check tool permissions needed before running a work item.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  success:
+                    type: boolean
+                  permissions:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                required:
+                  - id
+                  - success
+                  - permissions
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/work-items/{id}/run:
+    post:
+      operationId: workitems_by_id_run_post
+      summary: Run a work item
+      description: Execute the task associated with a work item. Returns immediately; execution happens in the background.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/workspace-files:
     get:
       operationId: workspacefiles_get

--- a/assistant/scripts/generate-openapi.ts
+++ b/assistant/scripts/generate-openapi.ts
@@ -56,6 +56,17 @@ const RouteBodySchemaSchema = z.any().refine(
   { message: "Expected a Zod schema or a plain JSON Schema object" },
 );
 
+const RouteRequestBodyVariantSchema = z.object({
+  contentType: z.string(),
+  /** Zod schema OR plain JSON Schema fragment. */
+  schema: z.any(),
+});
+
+const RouteAdditionalResponseSchema = z.object({
+  description: z.string(),
+  schema: z.any().optional(),
+});
+
 const RouteEntrySchema = z.object({
   method: z.string(),
   /** Endpoint path relative to /v1/ (e.g. "conversations/:id"). */
@@ -70,8 +81,14 @@ const RouteEntrySchema = z.object({
   queryParams: z.array(RouteQueryParamSchema).optional(),
   /** JSON Schema for the request body. */
   requestBody: RouteBodySchemaSchema.optional(),
+  /** Multi-content-type request body variants (overrides `requestBody` when present). */
+  requestBodies: z.array(RouteRequestBodyVariantSchema).optional(),
   /** JSON Schema for the 200 response body. */
   responseBody: RouteBodySchemaSchema.optional(),
+  /** Extra non-200 responses documented in the spec. */
+  additionalResponses: z
+    .record(z.string(), RouteAdditionalResponseSchema)
+    .optional(),
   /** Source module filename, used for auto-deriving tags. */
   sourceModule: z.string().optional(),
 });
@@ -298,21 +315,13 @@ interface OpenApiOperation {
   parameters?: OpenApiParameter[];
   requestBody?: {
     required: boolean;
-    content: {
-      "application/json": {
-        schema: JSONSchemaObject;
-      };
-    };
+    content: Record<string, { schema: JSONSchemaObject }>;
   };
   responses: Record<
     string,
     {
       description: string;
-      content?: {
-        "application/json": {
-          schema: JSONSchemaObject;
-        };
-      };
+      content?: Record<string, { schema: JSONSchemaObject }>;
     }
   >;
 }
@@ -446,7 +455,19 @@ function buildSpec(
       operation.parameters = parameters;
     }
 
-    if (entry.requestBody) {
+    // Multi-content-type request bodies take precedence over the single
+    // application/json requestBody. This lets an endpoint advertise a
+    // `oneOf`-style choice between `application/octet-stream`,
+    // `multipart/form-data`, and `application/json` on the same URL.
+    if (entry.requestBodies && entry.requestBodies.length > 0) {
+      const content: Record<string, { schema: JSONSchemaObject }> = {};
+      for (const variant of entry.requestBodies) {
+        content[variant.contentType] = {
+          schema: toJSONSchemaObject(variant.schema),
+        };
+      }
+      operation.requestBody = { required: true, content };
+    } else if (entry.requestBody) {
       operation.requestBody = {
         required: true,
         content: {
@@ -455,6 +476,24 @@ function buildSpec(
           },
         },
       };
+    }
+
+    // Extra documented response variants (e.g. 502 fetch_failed).
+    if (entry.additionalResponses) {
+      for (const [status, resp] of Object.entries(entry.additionalResponses)) {
+        operation.responses[status] = {
+          description: resp.description,
+          ...(resp.schema
+            ? {
+                content: {
+                  "application/json": {
+                    schema: toJSONSchemaObject(resp.schema),
+                  },
+                },
+              }
+            : {}),
+        };
+      }
     }
 
     paths[route.path][methodLower] = operation;

--- a/assistant/src/__tests__/migration-import-from-url.test.ts
+++ b/assistant/src/__tests__/migration-import-from-url.test.ts
@@ -1,0 +1,505 @@
+/**
+ * Integration tests for the JSON `{url}` body on POST /v1/migrations/import.
+ *
+ * Covered:
+ * - Happy path: a local http server serves a valid .vbundle, the handler
+ *   fetches it, streams it through `streamCommitImport`, and returns the
+ *   same success-report shape the raw-bytes path returns.
+ * - GCS 500: upstream server returns 500 → handler returns 502 with
+ *   `{ reason: "fetch_failed", upstream_status: 500 }`.
+ * - Malformed body: `{}` and `{ "url": "" }` → 400.
+ * - Invalid GCS URL: a real https://evil.com URL is rejected with the
+ *   redacted `Invalid URL: host` message; the raw URL is not echoed back
+ *   in the response body.
+ * - Memory ceiling: a 100 MB fixture streams through with peak RSS delta
+ *   under ~128 MB (looser than PR 4's 64 MB bound to allow for HTTP +
+ *   gunzip + tar-stream overhead on top of the streamCommitImport path).
+ *
+ * The raw-bytes regression path is exercised by the separate test file
+ * `migration-import-commit-http.test.ts`, which this PR must leave
+ * untouched.
+ */
+
+import {
+  createReadStream,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Test isolation: per-file workspace root.
+//
+// The shared test preload points VELLUM_WORKSPACE_DIR at a tmp dir. The
+// streaming importer does an atomic rename of the workspace dir itself,
+// which implicitly invalidates the shared tmp dir for subsequent tests in
+// the same file. Each test below creates its own isolated workspace and
+// re-points getWorkspaceDir() at it via the env var before invoking the
+// handler.
+// ---------------------------------------------------------------------------
+
+const originalWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+
+function freshWorkspaceRoot(): string {
+  const parent = realpathSync(
+    mkdtempSync(join(tmpdir(), "migration-import-from-url-")),
+  );
+  // The streaming importer renames workspaceDir itself, so put the
+  // workspace inside a parent dir we own.
+  const workspaceDir = join(parent, "workspace");
+  mkdirSync(workspaceDir, { recursive: true });
+  return workspaceDir;
+}
+
+function setWorkspaceDir(dir: string): void {
+  process.env.VELLUM_WORKSPACE_DIR = dir;
+}
+
+// ---------------------------------------------------------------------------
+// Mocks (mirrors migration-import-commit-http.test.ts)
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  getAllRules: () => [],
+  isStarterBundleAccepted: () => false,
+  clearCache: () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  getGatewayPort: () => 7830,
+  getRuntimeHttpPort: () => 7821,
+  getRuntimeHttpHost: () => "127.0.0.1",
+  getRuntimeGatewayOriginSecret: () => undefined,
+  getIngressPublicBaseUrl: () => undefined,
+  setIngressPublicBaseUrl: () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks so module-level code picks up the stubs)
+// ---------------------------------------------------------------------------
+
+import { buildVBundle } from "../runtime/migrations/vbundle-builder.js";
+import {
+  _setUrlImportValidatorOptionsForTests,
+  handleMigrationImport,
+} from "../runtime/routes/migration-routes.js";
+
+// ---------------------------------------------------------------------------
+// Local http fixture server
+// ---------------------------------------------------------------------------
+
+interface FixtureServer {
+  server: Server;
+  port: number;
+  close: () => Promise<void>;
+}
+
+async function startFixtureServer(
+  handler: (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
+  ) => void,
+): Promise<FixtureServer> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fixture server bound to unexpected address");
+  }
+  const port = address.port;
+  return {
+    server,
+    port,
+    close: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+function makeFakeSignedUrl(port: number): string {
+  // `validateGcsSignedUrl` requires a signature query param; pin a dummy.
+  return `http://127.0.0.1:${port}/bundle?X-Goog-Signature=fake`;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeSmallValidBundlePath(parent: string): string {
+  const { archive } = buildVBundle({
+    files: [
+      {
+        path: "workspace/data/db/assistant.db",
+        data: new TextEncoder().encode("SQLite format 3\0"),
+      },
+      {
+        path: "workspace/config.json",
+        data: new TextEncoder().encode(
+          JSON.stringify({ provider: "anthropic", model: "test-model" }),
+        ),
+      },
+    ],
+  });
+  const bundlePath = join(parent, "fixture-small.vbundle");
+  writeFileSync(bundlePath, archive);
+  return bundlePath;
+}
+
+// ---------------------------------------------------------------------------
+// Global test-only allowlist: widen the URL validator to accept 127.0.0.1.
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  _setUrlImportValidatorOptionsForTests({
+    allowedHosts: ["127.0.0.1", "storage.googleapis.com"],
+  });
+});
+
+afterAll(() => {
+  _setUrlImportValidatorOptionsForTests(undefined);
+  if (originalWorkspaceDir !== undefined) {
+    process.env.VELLUM_WORKSPACE_DIR = originalWorkspaceDir;
+  }
+});
+
+// Each test gets its own workspace dir so the streaming importer's atomic
+// swap doesn't leak state across tests.
+let testWorkspaceRoot: string;
+let testParent: string;
+
+beforeEach(() => {
+  testWorkspaceRoot = freshWorkspaceRoot();
+  testParent = join(testWorkspaceRoot, "..");
+  setWorkspaceDir(testWorkspaceRoot);
+});
+
+afterEach(() => {
+  try {
+    rmSync(testParent, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Response shape types
+// ---------------------------------------------------------------------------
+
+interface ImportCommitResponse {
+  success: boolean;
+  summary: {
+    total_files: number;
+    files_created: number;
+    files_overwritten: number;
+    files_skipped: number;
+    backups_created: number;
+  };
+  files: Array<{
+    path: string;
+    disk_path: string;
+    action: string;
+    size: number;
+    sha256: string;
+    backup_path: string | null;
+  }>;
+  manifest: Record<string, unknown>;
+  warnings: string[];
+}
+
+interface FetchFailedResponse {
+  success: false;
+  reason: "fetch_failed";
+  upstream_status?: number;
+}
+
+interface BadRequestResponse {
+  error: { code: string; message: string };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: JSON URL body
+// ---------------------------------------------------------------------------
+
+describe("handleMigrationImport — JSON {url} body", () => {
+  test("happy path: fetches fixture bundle from local http server and imports", async () => {
+    const bundlePath = makeSmallValidBundlePath(testParent);
+
+    const fixture = await startFixtureServer((req, res) => {
+      // Prove the server itself streams the response body.
+      res.writeHead(200, { "Content-Type": "application/octet-stream" });
+      createReadStream(bundlePath).pipe(res);
+    });
+
+    try {
+      const req = new Request("http://localhost/v1/migrations/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: makeFakeSignedUrl(fixture.port) }),
+      });
+
+      const res = await handleMigrationImport(req);
+      const body = (await res.json()) as ImportCommitResponse;
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.summary).toBeDefined();
+      expect(body.summary.total_files).toBeGreaterThan(0);
+      expect(body.files.length).toBeGreaterThan(0);
+      expect(body.manifest).toBeDefined();
+
+      // Workspace was swapped into place and contains the fixture files.
+      expect(
+        existsSync(join(testWorkspaceRoot, "data", "db", "assistant.db")),
+      ).toBe(true);
+      expect(existsSync(join(testWorkspaceRoot, "config.json"))).toBe(true);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("upstream 500 returns 502 with reason: fetch_failed", async () => {
+    const fixture = await startFixtureServer((_req, res) => {
+      res.writeHead(500);
+      res.end("oh no");
+    });
+
+    try {
+      const req = new Request("http://localhost/v1/migrations/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: makeFakeSignedUrl(fixture.port) }),
+      });
+
+      const res = await handleMigrationImport(req);
+      const body = (await res.json()) as FetchFailedResponse;
+
+      expect(res.status).toBe(502);
+      expect(body.success).toBe(false);
+      expect(body.reason).toBe("fetch_failed");
+      expect(body.upstream_status).toBe(500);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test('malformed body: {"url": ""} returns 400', async () => {
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "" }),
+    });
+
+    const res = await handleMigrationImport(req);
+    const body = (await res.json()) as BadRequestResponse;
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  test("missing url key: {} returns 400", async () => {
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const res = await handleMigrationImport(req);
+    const body = (await res.json()) as BadRequestResponse;
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  test("unparseable JSON body returns 400", async () => {
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not-json",
+    });
+
+    const res = await handleMigrationImport(req);
+    const body = (await res.json()) as BadRequestResponse;
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  test("invalid GCS URL returns 400 and does not leak the URL", async () => {
+    const rawUrl = "https://evil.example.com/bucket/obj?X-Goog-Signature=fake";
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: rawUrl }),
+    });
+
+    const res = await handleMigrationImport(req);
+    const rawBody = await res.text();
+
+    expect(res.status).toBe(400);
+
+    const parsed = JSON.parse(rawBody) as BadRequestResponse;
+    expect(parsed.error.code).toBe("BAD_REQUEST");
+    // The message should carry the redacted reason, not the URL itself.
+    expect(parsed.error.message.toLowerCase()).toContain("invalid url");
+    // Defense-in-depth: the raw URL must not appear anywhere in the response.
+    expect(rawBody).not.toContain("evil.example.com");
+    expect(rawBody).not.toContain("X-Goog-Signature=fake");
+  });
+
+  test("non-https scheme on default allowlist is rejected", async () => {
+    // Temporarily reset to the strict default allowlist so this test
+    // exercises the production validator configuration.
+    _setUrlImportValidatorOptionsForTests(undefined);
+    try {
+      const req = new Request("http://localhost/v1/migrations/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          url: "http://storage.googleapis.com/b/o?X-Goog-Signature=x",
+        }),
+      });
+
+      const res = await handleMigrationImport(req);
+      const body = (await res.json()) as BadRequestResponse;
+
+      expect(res.status).toBe(400);
+      expect(body.error.code).toBe("BAD_REQUEST");
+      expect(body.error.message).toContain("scheme");
+    } finally {
+      _setUrlImportValidatorOptionsForTests({
+        allowedHosts: ["127.0.0.1", "storage.googleapis.com"],
+      });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Memory ceiling — streams a 100 MB fixture through and caps RSS.
+// ---------------------------------------------------------------------------
+
+function writeLargeFixtureToDisk(archivePath: string): void {
+  const CHUNK = 25 * 1024 * 1024;
+  const files = [0, 1, 2, 3].map((i) => ({
+    path: `workspace/big-${i}.bin`,
+    data: new Uint8Array(CHUNK).fill(0x41 + i),
+  }));
+  const { archive } = buildVBundle({ files });
+  writeFileSync(archivePath, archive);
+}
+
+describe("handleMigrationImport — URL body memory ceiling", () => {
+  test("100 MB fixture streams in without pushing RSS past ~128 MB over baseline", async () => {
+    const archivePath = join(testParent, "fixture-large.vbundle");
+    writeLargeFixtureToDisk(archivePath);
+
+    const fixture = await startFixtureServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/octet-stream" });
+      createReadStream(archivePath).pipe(res);
+    });
+
+    try {
+      // Force a GC opportunity before measuring baseline so stale fixture
+      // buffers don't count against the importer's budget. Bun exposes
+      // `Bun.gc` but not process.gc; gate on whether it exists.
+      const maybeBunGc = (
+        globalThis as { Bun?: { gc?: (sync?: boolean) => void } }
+      ).Bun?.gc;
+      if (typeof maybeBunGc === "function") maybeBunGc(true);
+
+      const baselineRss = process.memoryUsage().rss;
+
+      const req = new Request("http://localhost/v1/migrations/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: makeFakeSignedUrl(fixture.port) }),
+      });
+
+      const res = await handleMigrationImport(req);
+      const body = (await res.json()) as ImportCommitResponse;
+
+      const peakRss = process.memoryUsage().rss;
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+
+      // 128 MB is the looser bound documented in the PR 5 plan — adds
+      // headroom for HTTP response buffers + gunzip + tar-stream state
+      // on top of the per-entry working set the streaming importer uses.
+      const delta = peakRss - baselineRss;
+      expect(delta).toBeLessThan(128 * 1024 * 1024);
+    } finally {
+      await fixture.close();
+    }
+  }, 90_000);
+});
+
+// ---------------------------------------------------------------------------
+// Regression: raw-bytes path still works through the same handler.
+// ---------------------------------------------------------------------------
+
+describe("handleMigrationImport — raw-bytes regression", () => {
+  test("application/octet-stream body still imports successfully", async () => {
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "workspace/data/db/assistant.db",
+          data: new TextEncoder().encode("SQLite format 3\0"),
+        },
+      ],
+    });
+
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: archive.buffer.slice(
+        archive.byteOffset,
+        archive.byteOffset + archive.byteLength,
+      ) as ArrayBuffer,
+    });
+
+    const res = await handleMigrationImport(req);
+    const body = (await res.json()) as ImportCommitResponse;
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.files.length).toBeGreaterThan(0);
+  });
+});

--- a/assistant/src/__tests__/migration-import-from-url.test.ts
+++ b/assistant/src/__tests__/migration-import-from-url.test.ts
@@ -12,12 +12,13 @@
  *   redacted `Invalid URL: host` message; the raw URL is not echoed back
  *   in the response body.
  * - Memory ceiling: a 100 MB fixture streams through with peak RSS delta
- *   under ~128 MB (looser than PR 4's 64 MB bound to allow for HTTP +
- *   gunzip + tar-stream overhead on top of the streamCommitImport path).
+ *   bounded at ~128 MB. The ceiling is wider than the direct
+ *   `streamCommitImport` ceiling because the URL handler stacks a Node
+ *   HTTP response body + gunzip state + tar-stream state on top of the
+ *   importer's per-entry working set.
  *
- * The raw-bytes regression path is exercised by the separate test file
- * `migration-import-commit-http.test.ts`, which this PR must leave
- * untouched.
+ * The raw-bytes ingress path is exercised by a separate test file,
+ * `migration-import-commit-http.test.ts`.
  */
 
 import {
@@ -460,9 +461,12 @@ describe("handleMigrationImport — URL body memory ceiling", () => {
       expect(res.status).toBe(200);
       expect(body.success).toBe(true);
 
-      // 128 MB is the looser bound documented in the PR 5 plan — adds
-      // headroom for HTTP response buffers + gunzip + tar-stream state
-      // on top of the per-entry working set the streaming importer uses.
+      // 128 MB ceiling: the URL handler pipes the HTTP response body
+      // through gunzip + tar-stream on top of the streaming importer's
+      // per-entry working set. The extra framing state is bigger than
+      // raw-stream importing (which fits in ~64 MB), so 128 MB keeps
+      // enough headroom to detect full-bundle buffering without
+      // flapping on normal streaming-mode overhead.
       const delta = peakRss - baselineRss;
       expect(delta).toBeLessThan(128 * 1024 * 1024);
     } finally {

--- a/assistant/src/runtime/http-router.ts
+++ b/assistant/src/runtime/http-router.ts
@@ -49,6 +49,29 @@ export interface RouteQueryParam {
 export type RouteBodySchema = z.ZodType;
 
 /**
+ * Description for a non-200 response variant. Used when an endpoint has
+ * meaningful alternate response shapes that clients should handle (e.g.
+ * 502 `fetch_failed` on POST /v1/migrations/import when the URL body path
+ * can't reach the upstream bundle host).
+ */
+export interface RouteAdditionalResponse {
+  description: string;
+  /** Zod schema or plain JSON Schema fragment. */
+  schema?: RouteBodySchema | Record<string, unknown>;
+}
+
+/**
+ * Request-body variant keyed by Content-Type. Use this when an endpoint
+ * accepts multiple body shapes (e.g. `application/octet-stream` OR
+ * `application/json`). For the common single-JSON case, use `requestBody`.
+ */
+export interface RouteRequestBodyVariant {
+  contentType: string;
+  /** Zod schema or plain JSON Schema fragment. Plain objects are embedded verbatim. */
+  schema: RouteBodySchema | Record<string, unknown>;
+}
+
+/**
  * A single route entry in the declarative table.
  *
  * - `endpoint`: The endpoint pattern after `/v1/`. Use `:paramName` for
@@ -76,8 +99,17 @@ export interface RouteDefinition {
   queryParams?: RouteQueryParam[];
   /** Zod schema for the request body (POST/PUT/PATCH/DELETE). */
   requestBody?: RouteBodySchema;
+  /**
+   * Alternate request-body variants keyed by Content-Type. When set,
+   * overrides `requestBody` in the generated OpenAPI spec — use this for
+   * endpoints that accept multiple body shapes on the same URL (e.g.
+   * raw bytes OR JSON URL).
+   */
+  requestBodies?: RouteRequestBodyVariant[];
   /** Zod schema for the 200 response body. */
   responseBody?: RouteBodySchema;
+  /** Additional non-200 responses documented in the generated OpenAPI spec. */
+  additionalResponses?: Record<string, RouteAdditionalResponse>;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
@@ -1025,3 +1025,138 @@ describe("streamCommitImport — legacy USER.md skip on customized persona", () 
     ).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Carry-over parity: live workspace paths that the buffer-based importer
+// preserves (data/db, data/qdrant, embedding-models, deprecated) must also
+// survive the streaming importer's temp-dir atomic swap when the bundle
+// does not carry them. Without this behavior, a partial bundle (e.g. one
+// that only ships prompts + config) would wipe the user's SQLite DB and
+// Qdrant vector store when imported through the streaming path.
+// ---------------------------------------------------------------------------
+
+describe("streamCommitImport — preserves live workspace paths when bundle omits them", () => {
+  let workspaceDir: string;
+  beforeEach(() => {
+    workspaceDir = freshWorkspace();
+  });
+  afterEach(() => {
+    const parent = join(workspaceDir, "..");
+    try {
+      rmSync(parent, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  test("keeps the live data/db/assistant.db when the bundle omits data/db/*", async () => {
+    // Seed the live workspace with a fake SQLite DB whose contents we
+    // can identify post-import.
+    mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+    const dbContent = Buffer.from("SQLite-format-3\0live-db-payload");
+    writeFileSync(join(workspaceDir, "data", "db", "assistant.db"), dbContent);
+
+    // A bundle that writes a config file but carries nothing under
+    // workspace/data/db/.
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "workspace/skills/example.md",
+          data: new TextEncoder().encode("# skill\n"),
+        },
+      ],
+    });
+
+    const result = await streamCommitImport({
+      source: readableFrom(archive),
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+
+    // Live DB survived the atomic swap with its exact original bytes.
+    const postDbPath = join(workspaceDir, "data", "db", "assistant.db");
+    expect(existsSync(postDbPath)).toBe(true);
+    expect(readFileSync(postDbPath)).toEqual(dbContent);
+
+    // The bundle-provided file also landed.
+    expect(
+      readFileSync(join(workspaceDir, "skills", "example.md"), "utf8"),
+    ).toBe("# skill\n");
+  });
+
+  test("keeps the live data/qdrant/ directory when the bundle omits qdrant entries", async () => {
+    // Populate a fake qdrant store with a nested file.
+    mkdirSync(join(workspaceDir, "data", "qdrant", "segments"), {
+      recursive: true,
+    });
+    const segmentBytes = Buffer.from("qdrant-segment-bytes");
+    writeFileSync(
+      join(workspaceDir, "data", "qdrant", "segments", "0.seg"),
+      segmentBytes,
+    );
+
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "workspace/config.json",
+          data: new TextEncoder().encode("{}"),
+        },
+      ],
+    });
+
+    const result = await streamCommitImport({
+      source: readableFrom(archive),
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+
+    const postSegPath = join(
+      workspaceDir,
+      "data",
+      "qdrant",
+      "segments",
+      "0.seg",
+    );
+    expect(existsSync(postSegPath)).toBe(true);
+    expect(readFileSync(postSegPath)).toEqual(segmentBytes);
+  });
+
+  test("lets the bundle overwrite data/db when it does carry an assistant.db entry", async () => {
+    // Seed the live workspace with OLD content so we can tell whether the
+    // carry-over logic accidentally kept it instead of honoring the
+    // bundle's new DB file.
+    mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+    writeFileSync(
+      join(workspaceDir, "data", "db", "assistant.db"),
+      "OLD-LIVE-DB",
+    );
+
+    const newDbBytes = new TextEncoder().encode("NEW-BUNDLE-DB");
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "workspace/data/db/assistant.db",
+          data: newDbBytes,
+        },
+      ],
+    });
+
+    const result = await streamCommitImport({
+      source: readableFrom(archive),
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+
+    const postDbPath = join(workspaceDir, "data", "db", "assistant.db");
+    expect(readFileSync(postDbPath)).toEqual(Buffer.from(newDbBytes));
+  });
+});

--- a/assistant/src/runtime/migrations/gcs-signed-url.ts
+++ b/assistant/src/runtime/migrations/gcs-signed-url.ts
@@ -29,8 +29,22 @@ export type GcsUrlValidation =
   | { ok: false; reason: string };
 
 const EXPECTED_HOST = "storage.googleapis.com";
+const DEFAULT_ALLOWED_HOSTS: readonly string[] = [EXPECTED_HOST];
 
-export function validateGcsSignedUrl(raw: string): GcsUrlValidation {
+export interface ValidateGcsSignedUrlOptions {
+  /**
+   * Allowlisted hosts. Defaults to `["storage.googleapis.com"]` — the only
+   * production value. Test-only callers can widen this to point at a local
+   * HTTP fixture (the `scheme` check also relaxes to accept `http:` for
+   * non-default hosts). Production code MUST NOT pass a wider list.
+   */
+  allowedHosts?: readonly string[];
+}
+
+export function validateGcsSignedUrl(
+  raw: string,
+  options?: ValidateGcsSignedUrlOptions,
+): GcsUrlValidation {
   let parsed: URL;
   try {
     parsed = new URL(raw);
@@ -38,11 +52,25 @@ export function validateGcsSignedUrl(raw: string): GcsUrlValidation {
     return { ok: false, reason: "invalid_url" };
   }
 
-  if (parsed.protocol !== "https:") {
-    return { ok: false, reason: "scheme" };
+  const allowedHosts = options?.allowedHosts ?? DEFAULT_ALLOWED_HOSTS;
+  const isDefaultHostList =
+    allowedHosts.length === 1 && allowedHosts[0] === EXPECTED_HOST;
+
+  // When the allowlist is the production default (GCS only), require HTTPS.
+  // When a caller passes a non-default allowlist (tests pointing at a local
+  // HTTP server), allow http too — same-process tests cannot reasonably
+  // stand up HTTPS. We still refuse non-http(s) schemes (file:, data:, etc).
+  if (isDefaultHostList) {
+    if (parsed.protocol !== "https:") {
+      return { ok: false, reason: "scheme" };
+    }
+  } else {
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      return { ok: false, reason: "scheme" };
+    }
   }
 
-  if (parsed.hostname !== EXPECTED_HOST) {
+  if (!allowedHosts.includes(parsed.hostname)) {
     return { ok: false, reason: "host" };
   }
 
@@ -51,7 +79,11 @@ export function validateGcsSignedUrl(raw: string): GcsUrlValidation {
   // string for HTTPS — so a correctly-issued signed URL always has
   // `parsed.port === ""`. A non-empty port indicates an attacker is
   // trying to redirect the fetch to a non-default port (SSRF vector).
-  if (parsed.port !== "") {
+  //
+  // For the non-default (test) allowlist, an explicit port is expected
+  // (local servers bind to arbitrary ephemeral ports), so the check is
+  // skipped in that case.
+  if (isDefaultHostList && parsed.port !== "") {
     return { ok: false, reason: "port" };
   }
 

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -46,6 +46,32 @@ export const CONFIG_ARCHIVE_PATHS: ReadonlySet<string> = new Set([
   "config/settings.json",
 ]);
 
+/**
+ * Paths inside the workspace directory that must be preserved across an
+ * import when the bundle does not carry entries for them.
+ *
+ * Each entry is a path RELATIVE to the workspace root. Two kinds of live
+ * data warrant carry-over:
+ *
+ * - `embedding-models` / `deprecated`: large local caches / quarantine
+ *   directories that are never shipped inside bundles but are expensive
+ *   or impossible to reconstruct from an import.
+ * - `data/db` / `data/qdrant`: user-critical state (SQLite assistant DB;
+ *   Qdrant vector store). If the bundle omits them — e.g. a partial
+ *   bundle covering only prompts/config — the live copies must survive.
+ *
+ * Both the buffer-based `commitImport` (which selectively clears the
+ * workspace in place) and the streaming importer (which swaps the
+ * workspace with a freshly-populated temp tree) consult this list so
+ * their behavior stays in sync.
+ */
+export const WORKSPACE_PRESERVE_PATHS: readonly string[] = [
+  "embedding-models",
+  "deprecated",
+  "data/db",
+  "data/qdrant",
+];
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -181,10 +207,19 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
     entryMap = validation.entries;
   }
 
-  // Directories to preserve when clearing the workspace.
-  const WORKSPACE_SKIP_DIRS = new Set(["embedding-models", "deprecated"]);
-  // data/qdrant and data/db are nested — we skip them inside "data/"
-  const DATA_SKIP_DIRS = new Set(["qdrant", "db"]);
+  // Directories to preserve when clearing the workspace. Derived from the
+  // shared WORKSPACE_PRESERVE_PATHS list so the streaming importer's
+  // carry-over logic and this in-place clear stay in sync.
+  const WORKSPACE_SKIP_DIRS = new Set<string>();
+  const DATA_SKIP_DIRS = new Set<string>();
+  for (const rel of WORKSPACE_PRESERVE_PATHS) {
+    const parts = rel.split("/");
+    if (parts.length === 1) {
+      WORKSPACE_SKIP_DIRS.add(parts[0]);
+    } else if (parts.length === 2 && parts[0] === "data") {
+      DATA_SKIP_DIRS.add(parts[1]);
+    }
+  }
 
   // Step 1b: Clear the workspace directory before restore if the bundle
   // contains new-format workspace/ entries. This ensures an exact-match

--- a/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
@@ -27,9 +27,9 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { createWriteStream } from "node:fs";
-import { mkdir, rename, rm, writeFile } from "node:fs/promises";
-import { dirname, resolve, sep } from "node:path";
+import { createWriteStream, existsSync } from "node:fs";
+import { cp, mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, join, resolve, sep } from "node:path";
 import type { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
@@ -47,6 +47,7 @@ import {
   type ImportedFileReport,
   type ImportFileAction,
   LEGACY_USER_MD_ARCHIVE_PATH,
+  WORKSPACE_PRESERVE_PATHS,
 } from "./vbundle-importer.js";
 import {
   createHashVerifier,
@@ -512,6 +513,24 @@ export async function streamCommitImport(
     log.warn({ err }, "resetDb threw before swap; continuing");
   }
 
+  // Carry-over: for every path in WORKSPACE_PRESERVE_PATHS, if the bundle
+  // did NOT populate it inside the temp workspace but the LIVE workspace
+  // has it, move the live copy into the temp workspace at the same
+  // relative location. Without this step the atomic swap erases live
+  // user data (SQLite DB, Qdrant store, embedding-models cache,
+  // deprecated/ quarantine) whenever the bundle omits those paths —
+  // e.g. partial bundles carrying only prompts/config.
+  try {
+    await carryOverPreservedPaths(realWorkspaceDir, tempWorkspaceDir);
+  } catch (err) {
+    await cleanupTempDir();
+    return {
+      ok: false,
+      reason: "write_failed",
+      message: `Failed to carry over preserved workspace paths: ${errMessage(err)}`,
+    };
+  }
+
   const backupDir = `${realWorkspaceDir}.pre-import-${Date.now()}`;
   let realDirRenamedToBackup = false;
   try {
@@ -626,6 +645,70 @@ function buildReport(
     manifest,
     warnings,
   };
+}
+
+/**
+ * Copy any WORKSPACE_PRESERVE_PATHS entries from the live workspace into
+ * the temp workspace when the bundle did not already write them. Runs
+ * immediately before the atomic swap so the swap-in tree has the union
+ * of bundle-provided files and live-preserved files.
+ *
+ * For each preserved relative path:
+ *   - If the temp workspace already contains something at that path, the
+ *     bundle populated it. Leave it untouched.
+ *   - Otherwise, if the live workspace has the path, try `fs.rename`
+ *     first (atomic & cheap when both dirs are on the same filesystem);
+ *     fall back to `fs.cp` with recursive copy on EXDEV or similar.
+ *   - If neither has it, there's nothing to preserve.
+ */
+async function carryOverPreservedPaths(
+  realWorkspaceDir: string,
+  tempWorkspaceDir: string,
+): Promise<void> {
+  for (const rel of WORKSPACE_PRESERVE_PATHS) {
+    const livePath = join(realWorkspaceDir, rel);
+    const tempPath = join(tempWorkspaceDir, rel);
+
+    // Bundle already wrote to this path — leave it alone.
+    if (existsSync(tempPath)) continue;
+
+    // Live workspace doesn't have it either — nothing to carry.
+    let liveStat;
+    try {
+      liveStat = await stat(livePath);
+    } catch (err) {
+      if (isENOENT(err)) continue;
+      throw err;
+    }
+
+    // Make sure the temp-side parent directory exists so the rename /
+    // copy can land.
+    await mkdir(dirname(tempPath), { recursive: true });
+
+    try {
+      await rename(livePath, tempPath);
+    } catch (err) {
+      // EXDEV: different filesystems — rename can't work. Fall back to a
+      // recursive copy, then remove the live copy so the swap leaves a
+      // clean state.
+      if (isEXDEV(err)) {
+        await cp(livePath, tempPath, {
+          recursive: true,
+          preserveTimestamps: true,
+          // Dereference is false by default — symlinks stay symlinks.
+        });
+        await rm(livePath, { recursive: true, force: true });
+      } else {
+        throw err;
+      }
+    }
+    // Log only when we actually preserved something, to keep successful
+    // imports quiet in the common no-op case.
+    log.debug(
+      { rel, size: liveStat.size, isDir: liveStat.isDirectory() },
+      "Preserved live workspace path across streaming import swap",
+    );
+  }
 }
 
 /**
@@ -744,5 +827,13 @@ function isENOENT(err: unknown): boolean {
     typeof err === "object" &&
     err !== null &&
     (err as { code?: string }).code === "ENOENT"
+  );
+}
+
+function isEXDEV(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: string }).code === "EXDEV"
   );
 }

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -6,9 +6,12 @@
  * POST /v1/migrations/import-preflight — dry-run import analysis of a .vbundle archive.
  * POST /v1/migrations/import          — commit a .vbundle archive import to disk.
  *
- * Accepts raw binary body (Content-Type: application/octet-stream) or
- * multipart form data with a "file" field. Returns structured validation
- * results with is_valid flag and detailed error descriptions.
+ * Accepts raw binary body (Content-Type: application/octet-stream),
+ * multipart form data with a "file" field, or — on /import only — a JSON
+ * body of shape `{ "url": "<signed-gcs-url>" }` that causes the daemon to
+ * fetch the bundle from GCS and stream it through `streamCommitImport`.
+ * Returns structured validation results with is_valid flag and detailed
+ * error descriptions.
  */
 
 import { createReadStream } from "node:fs";
@@ -34,6 +37,10 @@ import {
 } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
+import {
+  validateGcsSignedUrl,
+  type ValidateGcsSignedUrlOptions,
+} from "../migrations/gcs-signed-url.js";
 import { streamExportVBundle } from "../migrations/vbundle-builder.js";
 import {
   analyzeImport,
@@ -42,7 +49,10 @@ import {
 import {
   commitImport,
   extractCredentialsFromBundle,
+  type ImportCommitReport,
+  type ImportCommitResult,
 } from "../migrations/vbundle-importer.js";
+import { streamCommitImport } from "../migrations/vbundle-streaming-importer.js";
 import { validateVBundle } from "../migrations/vbundle-validator.js";
 
 /** Credentials with this prefix are platform-identity keys and must not be imported. */
@@ -380,11 +390,15 @@ export async function handleMigrationImportPreflight(
  * 5. Verifies post-write integrity (SHA-256 check)
  * 6. Returns a detailed report of what was imported
  *
- * The file can be sent as:
+ * The bundle can be supplied in any of three ways:
  * - Raw binary body with Content-Type: application/octet-stream
  * - Multipart form data with a "file" field
+ * - JSON body `{ "url": "<signed-gcs-url>" }` (Content-Type:
+ *   application/json). The daemon fetches and streams the archive
+ *   through `streamCommitImport`, so peak memory stays bounded by a
+ *   single tar entry rather than bundle size.
  *
- * Returns:
+ * Returns (all three paths):
  *   200: {
  *     success: true,
  *     summary: { total_files, files_created, files_overwritten, files_skipped, backups_created },
@@ -393,12 +407,25 @@ export async function handleMigrationImportPreflight(
  *     warnings: [...]
  *   }
  *   200: { success: false, reason: "validation_failed", errors: [...] }
- *   400: Standard error envelope for missing/empty body
+ *   400: Standard error envelope for missing/empty body or malformed URL
  *   500: Standard error envelope for unexpected failures
+ *   502: { success: false, reason: "fetch_failed", upstream_status?: number }
+ *        (URL path only — upstream GCS fetch failed)
  *
  * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, svc_daemon, local.
  */
 export async function handleMigrationImport(req: Request): Promise<Response> {
+  // JSON body means the caller is asking us to fetch the bundle from a
+  // signed URL and stream it through the importer. This keeps the daemon's
+  // peak memory bounded by one tar entry instead of bundle size, which is
+  // the whole point of supporting URL-based imports for large bundles.
+  //
+  // Raw-bytes path (octet-stream / multipart) is untouched below.
+  const contentType = req.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return handleMigrationImportFromUrl(req);
+  }
+
   const extracted = await extractFileData(req);
   if ("error" in extracted) {
     return extracted.error;
@@ -445,120 +472,22 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
     });
 
     if (!result.ok) {
-      if (result.reason === "validation_failed") {
-        return Response.json({
-          success: false,
-          reason: "validation_failed",
-          errors: result.errors,
-        });
-      }
-
-      if (result.reason === "extraction_failed") {
-        return Response.json(
-          {
-            success: false,
-            reason: "extraction_failed",
-            message: result.message,
-          },
-          { status: 500 },
-        );
-      }
-
-      // write_failed
-      return Response.json(
-        {
-          success: false,
-          reason: "write_failed",
-          message: result.message,
-          ...(result.partial_report
-            ? { partial_report: result.partial_report }
-            : {}),
-        },
-        { status: 500 },
-      );
+      return importCommitFailureResponse(result);
     }
 
     // Import credentials from the bundle into CES (non-blocking — failures
     // are logged as warnings but do not fail the overall import).
-    let credentialsImported:
-      | {
-          total: number;
-          succeeded: number;
-          failed: number;
-          failedAccounts: string[];
-          skippedPlatform: number;
-        }
-      | undefined;
+    let credentialsImported: CredentialImportSummary | undefined;
 
     if (validation.entries) {
       const bundleCredentials = extractCredentialsFromBundle(
         validation.entries,
         validation.manifest!,
       );
-
-      // Filter out platform-identity credentials (vellum:*) — these are
-      // environment-specific and must not overwrite the target's own identity.
-      const userCredentials = bundleCredentials.filter(
-        (c) => !c.account.startsWith(PLATFORM_CREDENTIAL_PREFIX),
+      credentialsImported = await importBundleCredentialsIntoCes(
+        bundleCredentials,
+        result.report,
       );
-      const skippedPlatform = bundleCredentials.length - userCredentials.length;
-      if (skippedPlatform > 0) {
-        log.info(
-          `Skipped ${skippedPlatform} platform credential(s) from import`,
-        );
-      }
-
-      if (userCredentials.length > 0) {
-        try {
-          const credResults = await bulkSetSecureKeysAsync(userCredentials);
-          const failedResults = credResults.filter((r) => !r.ok);
-          if (failedResults.length > 0) {
-            log.warn(
-              { failed: failedResults.map((f) => f.account) },
-              "Some credentials failed to import",
-            );
-          }
-          log.info(
-            { total: userCredentials.length, failed: failedResults.length },
-            "Credential import complete",
-          );
-          const succeeded = userCredentials.length - failedResults.length;
-          credentialsImported = {
-            total: userCredentials.length,
-            succeeded,
-            failed: failedResults.length,
-            failedAccounts: failedResults.map((f) => f.account),
-            skippedPlatform,
-          };
-          if (failedResults.length > 0) {
-            result.report.warnings.push(
-              `Imported ${succeeded} credential(s), ${failedResults.length} failed`,
-            );
-          }
-        } catch (err) {
-          log.warn({ err }, "Credential import failed entirely");
-          result.report.warnings.push(
-            `Credential import failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
-          credentialsImported = {
-            total: userCredentials.length,
-            succeeded: 0,
-            failed: userCredentials.length,
-            failedAccounts: userCredentials.map((c) => c.account),
-            skippedPlatform,
-          };
-        }
-      } else if (skippedPlatform > 0) {
-        // All credentials in the bundle were platform credentials — report
-        // the skip count even though nothing was sent to CES.
-        credentialsImported = {
-          total: userCredentials.length,
-          succeeded: 0,
-          failed: 0,
-          failedAccounts: [],
-          skippedPlatform,
-        };
-      }
     }
 
     // Invalidate in-process caches so imported settings.json and trust.json take effect
@@ -569,21 +498,9 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
     // a newer version. This is non-blocking — the import has already
     // succeeded — but we surface a warning so the caller knows some data may
     // not be fully compatible with this daemon's schema.
-    try {
-      const migrationValidation = validateMigrationState(getDb());
-      if (migrationValidation.unknownCheckpoints.length > 0) {
-        result.report.warnings.push(
-          `Imported data contains ${migrationValidation.unknownCheckpoints.length} migration(s) from a newer version. Some data may not be fully compatible.`,
-        );
-      }
-    } catch {
-      // Don't fail the import if validation itself errors
-    }
+    appendNewerMigrationWarningsIfAny(result.report);
 
-    return Response.json({
-      ...result.report,
-      ...(credentialsImported ? { credentialsImported } : {}),
-    });
+    return importCommitSuccessResponse(result.report, credentialsImported);
   } catch (err) {
     log.error({ err }, "Unexpected error during import commit");
     return httpError(
@@ -592,6 +509,402 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
       500,
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// URL-body variant of POST /v1/migrations/import
+// ---------------------------------------------------------------------------
+
+/** 60 minutes — matches the gateway's upstream fetch deadline. */
+const URL_FETCH_TIMEOUT_MS = 60 * 60 * 1000;
+
+const MigrationImportUrlBody = z.object({ url: z.string().min(1) });
+
+/**
+ * Test seam: the integration test needs to point the validator at a local
+ * HTTP server fixture. Production callers never pass this — the default
+ * keeps the validator strict (GCS host, HTTPS only, no explicit port).
+ */
+let urlValidatorOptions: ValidateGcsSignedUrlOptions | undefined;
+
+/**
+ * Test-only: override the allowed-host list used by the URL-body import
+ * handler. Call with `undefined` (or no arguments) to reset to production
+ * defaults. This is intentionally not exported from the module's public
+ * surface — tests import it directly from this file.
+ */
+export function _setUrlImportValidatorOptionsForTests(
+  options: ValidateGcsSignedUrlOptions | undefined,
+): void {
+  urlValidatorOptions = options;
+}
+
+/**
+ * Handle a JSON `{ "url": "..." }` body on POST /v1/migrations/import.
+ *
+ * Fetches the signed URL, pipes the response body through the streaming
+ * importer, and returns the same response shapes as the raw-bytes path.
+ * The signed URL is never logged or included in error responses — only the
+ * extracted host and path make it into logs.
+ */
+async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
+  // ── 1. Parse JSON body ────────────────────────────────────────────────
+  let rawBody: unknown;
+  try {
+    rawBody = await req.json();
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to parse JSON body on migration import URL request",
+    );
+    return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+  }
+
+  const parsed = MigrationImportUrlBody.safeParse(rawBody);
+  if (!parsed.success) {
+    return httpError(
+      "BAD_REQUEST",
+      "Request body must be { url: string } with a non-empty url",
+      400,
+    );
+  }
+
+  // ── 2. Validate the URL (defense-in-depth; never log `parsed.data.url`).
+  const validated = validateGcsSignedUrl(parsed.data.url, urlValidatorOptions);
+  if (!validated.ok) {
+    // `reason` is a stable enum string and safe to include. The raw URL is
+    // not — it may contain a live signature. Callers get the reason so they
+    // can correct the URL without leaking anything into observability.
+    log.warn({ reason: validated.reason }, "Rejected migration import URL");
+    return httpError("BAD_REQUEST", `Invalid URL: ${validated.reason}`, 400);
+  }
+
+  log.info(
+    { host: validated.host, path: validated.path },
+    "migration import from URL",
+  );
+
+  const startedAt = Date.now();
+
+  // ── 3. Fetch the URL ──────────────────────────────────────────────────
+  let upstream: Response;
+  try {
+    upstream = await fetch(parsed.data.url, {
+      signal: AbortSignal.timeout(URL_FETCH_TIMEOUT_MS),
+    });
+  } catch (err) {
+    log.error(
+      {
+        host: validated.host,
+        path: validated.path,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "Failed to fetch migration import URL",
+    );
+    return Response.json(
+      { success: false, reason: "fetch_failed" },
+      { status: 502 },
+    );
+  }
+
+  if (!upstream.ok) {
+    log.error(
+      {
+        host: validated.host,
+        path: validated.path,
+        upstream_status: upstream.status,
+      },
+      "Migration import URL fetch returned non-2xx",
+    );
+    // Drain the body so the underlying socket can be released promptly.
+    try {
+      await upstream.body?.cancel();
+    } catch {
+      /* best effort */
+    }
+    return Response.json(
+      {
+        success: false,
+        reason: "fetch_failed",
+        upstream_status: upstream.status,
+      },
+      { status: 502 },
+    );
+  }
+
+  if (!upstream.body) {
+    log.error(
+      { host: validated.host, path: validated.path },
+      "Migration import URL fetch returned no body",
+    );
+    return Response.json(
+      { success: false, reason: "fetch_failed" },
+      { status: 502 },
+    );
+  }
+
+  // ── 4. Stream the response through the importer ──────────────────────
+  // Convert the WHATWG ReadableStream from fetch() into a Node Readable so
+  // the tar-stream / gunzip / hash-verifier pipeline inside
+  // streamCommitImport can consume it via `.pipe()`.
+  const nodeStream = Readable.fromWeb(
+    upstream.body as unknown as import("node:stream/web").ReadableStream<Uint8Array>,
+  );
+
+  const pathResolver = new DefaultPathResolver(
+    getWorkspaceDir(),
+    getWorkspaceHooksDir(),
+  );
+
+  // streamCommitImport does its own resetDb() internally before the atomic
+  // swap, so we don't need to call it here.
+  let result: ImportCommitResult;
+  // Track credential-import outcome for inclusion in the success response.
+  // The streaming importer invokes our callback only after the atomic swap,
+  // so filling this in here is safe.
+  let credentialsImported: CredentialImportSummary | undefined;
+  // Per-invocation warning collector — scoped to this request so concurrent
+  // URL imports can't trample each other's warnings.
+  const credentialImportWarningSink: CredentialWarningSink = { warnings: [] };
+
+  try {
+    result = await streamCommitImport({
+      source: nodeStream,
+      pathResolver,
+      workspaceDir: getWorkspaceDir(),
+      importCredentials: async (bundleCredentials) => {
+        // We can't mutate `result.report.warnings` in place here — the
+        // streaming importer hasn't returned its report yet. Accumulate
+        // into a sidecar and merge into the final report below.
+        credentialsImported = await importBundleCredentialsIntoCes(
+          bundleCredentials,
+          credentialImportWarningSink,
+        );
+      },
+    });
+  } catch (err) {
+    log.error(
+      {
+        host: validated.host,
+        path: validated.path,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "streamCommitImport threw during URL-body import",
+    );
+    return httpError(
+      "INTERNAL_ERROR",
+      err instanceof Error ? err.message : "Unexpected import error",
+      500,
+    );
+  }
+
+  if (!result.ok) {
+    log.warn(
+      {
+        host: validated.host,
+        path: validated.path,
+        reason: result.reason,
+      },
+      "streamCommitImport returned failure during URL-body import",
+    );
+    return importCommitFailureResponse(result);
+  }
+
+  // Merge any warnings accumulated by the credential-import callback into
+  // the final report.
+  if (credentialImportWarningSink.warnings.length > 0) {
+    result.report.warnings.push(...credentialImportWarningSink.warnings);
+  }
+
+  // streamCommitImport already invalidated config + trust caches inside its
+  // post-swap cleanup. We only need to check whether the newly-imported DB
+  // carries migration checkpoints from a newer daemon version.
+  appendNewerMigrationWarningsIfAny(result.report);
+
+  const elapsedMs = Date.now() - startedAt;
+  log.info(
+    {
+      host: validated.host,
+      path: validated.path,
+      files_written: result.report.summary.files_created,
+      bytes_written: result.report.files.reduce((n, f) => n + f.size, 0),
+      elapsed_ms: elapsedMs,
+    },
+    "Migration import from URL complete",
+  );
+
+  return importCommitSuccessResponse(result.report, credentialsImported);
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers for raw-bytes and URL paths
+// ---------------------------------------------------------------------------
+
+interface CredentialImportSummary {
+  total: number;
+  succeeded: number;
+  failed: number;
+  failedAccounts: string[];
+  skippedPlatform: number;
+}
+
+/**
+ * Minimal surface the credential-import helper needs to stash warnings —
+ * either a full `ImportCommitReport` (raw-bytes path, after commitImport
+ * returns) or an ephemeral per-request collector (streaming path, where the
+ * report doesn't exist yet when the callback fires).
+ */
+interface CredentialWarningSink {
+  warnings: string[];
+}
+
+/**
+ * Filter platform-identity (vellum:*) credentials out of the bundle, push
+ * user credentials into CES via `bulkSetSecureKeysAsync`, and return a
+ * structured summary. Never throws — CES failures become report warnings.
+ */
+async function importBundleCredentialsIntoCes(
+  bundleCredentials: Array<{ account: string; value: string }>,
+  warningSink: CredentialWarningSink,
+): Promise<CredentialImportSummary | undefined> {
+  // Filter out platform-identity credentials (vellum:*) — these are
+  // environment-specific and must not overwrite the target's own identity.
+  const userCredentials = bundleCredentials.filter(
+    (c) => !c.account.startsWith(PLATFORM_CREDENTIAL_PREFIX),
+  );
+  const skippedPlatform = bundleCredentials.length - userCredentials.length;
+  if (skippedPlatform > 0) {
+    log.info(`Skipped ${skippedPlatform} platform credential(s) from import`);
+  }
+
+  if (userCredentials.length === 0) {
+    if (skippedPlatform > 0) {
+      // All credentials in the bundle were platform credentials — report
+      // the skip count even though nothing was sent to CES.
+      return {
+        total: 0,
+        succeeded: 0,
+        failed: 0,
+        failedAccounts: [],
+        skippedPlatform,
+      };
+    }
+    return undefined;
+  }
+
+  try {
+    const credResults = await bulkSetSecureKeysAsync(userCredentials);
+    const failedResults = credResults.filter((r) => !r.ok);
+    if (failedResults.length > 0) {
+      log.warn(
+        { failed: failedResults.map((f) => f.account) },
+        "Some credentials failed to import",
+      );
+    }
+    log.info(
+      { total: userCredentials.length, failed: failedResults.length },
+      "Credential import complete",
+    );
+    const succeeded = userCredentials.length - failedResults.length;
+    if (failedResults.length > 0) {
+      warningSink.warnings.push(
+        `Imported ${succeeded} credential(s), ${failedResults.length} failed`,
+      );
+    }
+    return {
+      total: userCredentials.length,
+      succeeded,
+      failed: failedResults.length,
+      failedAccounts: failedResults.map((f) => f.account),
+      skippedPlatform,
+    };
+  } catch (err) {
+    log.warn({ err }, "Credential import failed entirely");
+    warningSink.warnings.push(
+      `Credential import failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return {
+      total: userCredentials.length,
+      succeeded: 0,
+      failed: userCredentials.length,
+      failedAccounts: userCredentials.map((c) => c.account),
+      skippedPlatform,
+    };
+  }
+}
+
+/**
+ * Append a warning to `report` when the newly-imported database contains
+ * migration checkpoints from a daemon version newer than this one. Silent
+ * on any validation error — the import has already succeeded.
+ */
+function appendNewerMigrationWarningsIfAny(report: ImportCommitReport): void {
+  try {
+    const migrationValidation = validateMigrationState(getDb());
+    if (migrationValidation.unknownCheckpoints.length > 0) {
+      report.warnings.push(
+        `Imported data contains ${migrationValidation.unknownCheckpoints.length} migration(s) from a newer version. Some data may not be fully compatible.`,
+      );
+    }
+  } catch {
+    // Don't fail the import if validation itself errors
+  }
+}
+
+/**
+ * Build a success Response from an ImportCommitReport. Matches the byte-path
+ * shape exactly: the report fields are spread at the top level, with an
+ * optional `credentialsImported` summary alongside.
+ */
+function importCommitSuccessResponse(
+  report: ImportCommitReport,
+  credentialsImported: CredentialImportSummary | undefined,
+): Response {
+  return Response.json({
+    ...report,
+    ...(credentialsImported ? { credentialsImported } : {}),
+  });
+}
+
+/**
+ * Map an `ImportCommitResult` failure to the exact Response shape the
+ * byte-path returned before the PR-5 refactor. Status codes and body shapes
+ * must stay stable — existing callers rely on them.
+ */
+function importCommitFailureResponse(
+  result: Extract<ImportCommitResult, { ok: false }>,
+): Response {
+  if (result.reason === "validation_failed") {
+    return Response.json({
+      success: false,
+      reason: "validation_failed",
+      errors: result.errors,
+    });
+  }
+
+  if (result.reason === "extraction_failed") {
+    return Response.json(
+      {
+        success: false,
+        reason: "extraction_failed",
+        message: result.message,
+      },
+      { status: 500 },
+    );
+  }
+
+  // write_failed
+  return Response.json(
+    {
+      success: false,
+      reason: "write_failed",
+      message: result.message,
+      ...(result.partial_report
+        ? { partial_report: result.partial_report }
+        : {}),
+    },
+    { status: 500 },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -647,8 +960,62 @@ export function migrationRouteDefinitions(): RouteDefinition[] {
       method: "POST",
       summary: "Import a .vbundle archive",
       description:
-        "Commit a .vbundle archive import to disk — destructive. Backs up existing files before overwriting.",
+        "Commit a .vbundle archive import to disk — destructive. Accepts the bundle as raw bytes (application/octet-stream), multipart/form-data, or a JSON body carrying a signed URL the daemon fetches and streams through the importer.",
       tags: ["migrations"],
+      requestBodies: [
+        {
+          contentType: "application/octet-stream",
+          schema: {
+            type: "string",
+            format: "binary",
+            description: "Raw .vbundle archive bytes.",
+          },
+        },
+        {
+          contentType: "multipart/form-data",
+          schema: {
+            type: "object",
+            properties: {
+              file: {
+                type: "string",
+                format: "binary",
+                description: "The .vbundle archive uploaded as a file field.",
+              },
+            },
+            required: ["file"],
+          },
+        },
+        {
+          contentType: "application/json",
+          schema: {
+            type: "object",
+            properties: {
+              url: {
+                type: "string",
+                format: "uri",
+                description:
+                  "A signed GCS URL pointing to the .vbundle archive. The daemon fetches the URL and streams the body through the importer.",
+              },
+            },
+            required: ["url"],
+          },
+        },
+      ],
+      additionalResponses: {
+        "502": {
+          description:
+            "Upstream fetch failed (URL body only). Body shape: { success: false, reason: 'fetch_failed', upstream_status?: number }.",
+          schema: {
+            type: "object",
+            properties: {
+              success: { type: "boolean" },
+              reason: { type: "string", enum: ["fetch_failed"] },
+              upstream_status: { type: "integer" },
+            },
+            required: ["success", "reason"],
+          },
+        },
+      },
       responseBody: z.object({
         success: z.boolean(),
         summary: z.object({}).passthrough(),

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -852,9 +852,9 @@ function appendNewerMigrationWarningsIfAny(report: ImportCommitReport): void {
 }
 
 /**
- * Build a success Response from an ImportCommitReport. Matches the byte-path
- * shape exactly: the report fields are spread at the top level, with an
- * optional `credentialsImported` summary alongside.
+ * Build a success Response from an ImportCommitReport. The report fields
+ * are spread at the top level, with an optional `credentialsImported`
+ * summary alongside.
  */
 function importCommitSuccessResponse(
   report: ImportCommitReport,
@@ -867,9 +867,9 @@ function importCommitSuccessResponse(
 }
 
 /**
- * Map an `ImportCommitResult` failure to the exact Response shape the
- * byte-path returned before the PR-5 refactor. Status codes and body shapes
- * must stay stable — existing callers rely on them.
+ * Map an `ImportCommitResult` failure to the Response shape callers of
+ * `POST /v1/migrations/import` depend on. Status codes and body shapes
+ * are part of the public contract and must remain stable.
  */
 function importCommitFailureResponse(
   result: Extract<ImportCommitResult, { ok: false }>,


### PR DESCRIPTION
## Summary
- Adds a JSON request body variant to POST /v1/migrations/import that accepts {url: string}. On this path, the daemon fetches the bundle from a signed GCS URL as a stream and pipes it through gunzip → tar-parser → hash verifier → per-entry disk writer via streamCommitImport (PR 4), bounding memory by one tar entry rather than bundle size.
- Raw-bytes path (octet-stream/multipart) is untouched. Behavior for existing clients (docker teleport, local .vbundle restore) is bit-for-bit identical.
- Updates openapi.yaml to document the JSON variant and the 502 fetch_failed response. Covered by a new integration test (assistant/src/__tests__/migration-import-from-url.test.ts) with happy path, GCS-500, malformed body, invalid URL (leak check), and 100 MB memory-ceiling test.

Part of plan: gcs-stream-import.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
