### PR TITLE
refactor(settings): move per-task overrides badge inside Inference card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -119,63 +119,62 @@ struct InferenceServiceCard: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            ServiceModeCard(
-                title: "Inference",
-                subtitle: draftMode == "managed"
-                    ? "Configure which model to use to power your assistant"
-                    : "Configure which LLM provider and model to use to power your assistant",
-                draftMode: $draftMode,
-                managedContent: {
-                    if isLoggedIn {
-                        VStack(alignment: .leading, spacing: VSpacing.sm) {
-                            managedProviderPicker
-                            PickerWithInlineSave(
-                                hasChanges: hasChanges,
-                                isSaving: store.apiKeySaving,
-                                onSave: { save() }
-                            ) {
-                                modelPicker
-                            }
-                        }
-                    } else {
-                        managedLoginPrompt
-                    }
-                },
-                yourOwnContent: {
+        ServiceModeCard(
+            title: "Inference",
+            subtitle: draftMode == "managed"
+                ? "Configure which model to use to power your assistant"
+                : "Configure which LLM provider and model to use to power your assistant",
+            draftMode: $draftMode,
+            managedContent: {
+                if isLoggedIn {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        providerPicker
-
-                        // Model picker
-                        modelPicker
-
-                        // API Key field
-                        apiKeyField
-
-                        // Action buttons
-                        ServiceCardActions(
+                        managedProviderPicker
+                        PickerWithInlineSave(
                             hasChanges: hasChanges,
                             isSaving: store.apiKeySaving,
-                            onSave: { save() },
-                            savingLabel: "Validating...",
-                            onReset: {
-                                store.clearAPIKeyForProvider(effectiveProvider)
-                                providerHasKey = false
-                                apiKeyText = ""
-                            },
-                            showReset: providerHasKey
-                        )
+                            onSave: { save() }
+                        ) {
+                            modelPicker
+                        }
                     }
+                } else {
+                    managedLoginPrompt
                 }
-            )
+            },
+            yourOwnContent: {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    providerPicker
 
-            // Per-call-site overrides badge — only visible when the user has
-            // at least one override configured. Tapping opens the overrides
-            // sheet.
-            if store.overridesCount > 0 {
-                overridesBadge
+                    // Model picker
+                    modelPicker
+
+                    // API Key field
+                    apiKeyField
+
+                    // Action buttons
+                    ServiceCardActions(
+                        hasChanges: hasChanges,
+                        isSaving: store.apiKeySaving,
+                        onSave: { save() },
+                        savingLabel: "Validating...",
+                        onReset: {
+                            store.clearAPIKeyForProvider(effectiveProvider)
+                            providerHasKey = false
+                            apiKeyText = ""
+                        },
+                        showReset: providerHasKey
+                    )
+                }
+            },
+            footer: {
+                // Per-call-site overrides badge — only visible when the user has
+                // at least one override configured. Tapping opens the overrides
+                // sheet.
+                if store.overridesCount > 0 {
+                    overridesBadge
+                }
             }
-        }
+        )
         .sheet(isPresented: $showOverridesSheet) {
             CallSiteOverridesSheet(store: store, isPresented: $showOverridesSheet)
         }

--- a/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
@@ -8,12 +8,13 @@ import VellumAssistantShared
 /// buttons — to callers via ViewBuilder closures. Each card is responsible
 /// for placing its own save/reset actions contextually within its content.
 @MainActor
-struct ServiceModeCard<ManagedContent: View, YourOwnContent: View>: View {
+struct ServiceModeCard<ManagedContent: View, YourOwnContent: View, Footer: View>: View {
     let title: String
     let subtitle: String
     @Binding var draftMode: String
     @ViewBuilder let managedContent: () -> ManagedContent
     @ViewBuilder let yourOwnContent: () -> YourOwnContent
+    @ViewBuilder let footer: () -> Footer
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -30,6 +31,8 @@ struct ServiceModeCard<ManagedContent: View, YourOwnContent: View>: View {
             } else {
                 yourOwnContent()
             }
+
+            footer()
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -60,6 +63,23 @@ struct ServiceModeCard<ManagedContent: View, YourOwnContent: View>: View {
                 .frame(width: 220)
             }
         }
+    }
+}
+
+extension ServiceModeCard where Footer == EmptyView {
+    init(
+        title: String,
+        subtitle: String,
+        draftMode: Binding<String>,
+        @ViewBuilder managedContent: @escaping () -> ManagedContent,
+        @ViewBuilder yourOwnContent: @escaping () -> YourOwnContent
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self._draftMode = draftMode
+        self.managedContent = managedContent
+        self.yourOwnContent = yourOwnContent
+        self.footer = { EmptyView() }
     }
 }
 


### PR DESCRIPTION
## Summary
- Added a `Footer` generic parameter to `ServiceModeCard` so callers can render content at the bottom of the card, after the mode-specific content
- Moved the "n per-task override(s)" badge from outside the Inference card into the card's footer slot
- Existing `ServiceModeCard` callers (WebSearch, ImageGeneration) are unaffected via a convenience initializer that defaults the footer to `EmptyView`

## Original prompt
can you move the "n per-task overrides" within the Inference card rather than outside of it?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
