### PR TITLE
feat(gallery): register HomeSuggestionPillBar and HomeGreetingHeader

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -398,6 +398,79 @@ struct HomeGallerySection: View {
 
                 HomeSplitLayoutDemo()
             }
+
+            // MARK: - HomeSuggestionPillBar
+
+            if filter == nil || filter == "homeSuggestionPillBar" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeSuggestionPillBar",
+                    description: "Dismissible \"by the way, have you tried…\" container with a headline and horizontal row of icon+label suggestion pills. Renders no pills when the suggestions array is empty."
+                )
+
+                VCard(background: VColor.surfaceBase) {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("With suggestions")
+                            .font(VFont.bodySmallEmphasised)
+                            .foregroundStyle(VColor.contentSecondary)
+
+                        HomeSuggestionPillBar(
+                            headline: "By the way, have you tried one of these:",
+                            suggestions: [
+                                HomeSuggestion(id: "baby", icon: .gamepad, label: "App for baby names"),
+                                HomeSuggestion(id: "car", icon: .car, label: "Get your cars spring-ready"),
+                                HomeSuggestion(id: "vacation", icon: .plane, label: "Plan your next vacation"),
+                            ],
+                            onSelect: { _ in },
+                            onDismiss: {}
+                        )
+
+                        Divider().background(VColor.borderBase)
+
+                        Text("Empty suggestions (edge case — renders no pills)")
+                            .font(VFont.bodySmallEmphasised)
+                            .foregroundStyle(VColor.contentSecondary)
+
+                        HomeSuggestionPillBar(
+                            headline: "By the way, have you tried one of these:",
+                            suggestions: [],
+                            onSelect: { _ in },
+                            onDismiss: {}
+                        )
+                    }
+                }
+            }
+
+            // MARK: - HomeGreetingHeader
+
+            if filter == nil || filter == "homeGreetingHeader" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeGreetingHeader",
+                    description: "Home feed header with a leading avatar, a greeting title, and a trailing New Chat pill CTA."
+                )
+
+                VCard(background: VColor.surfaceBase) {
+                    HomeGreetingHeader(
+                        greeting: "Here's what's been going on",
+                        onStartNewChat: {}
+                    ) {
+                        if let image = NSImage(systemSymbolName: "person.circle.fill", accessibilityDescription: nil) {
+                            VAvatarImage(image: image, size: 40)
+                        } else {
+                            Circle()
+                                .fill(VColor.surfaceActive)
+                                .frame(width: 40, height: 40)
+                        }
+                    }
+                }
+            }
         }
     }
 }
@@ -562,6 +635,8 @@ extension HomeGallerySection {
         case "homeEmailEditor": HomeGallerySection(filter: "homeEmailEditor")
         case "homeInvoicePreview": HomeGallerySection(filter: "homeInvoicePreview")
         case "homeSplitLayout": HomeGallerySection(filter: "homeSplitLayout")
+        case "homeSuggestionPillBar": HomeGallerySection(filter: "homeSuggestionPillBar")
+        case "homeGreetingHeader": HomeGallerySection(filter: "homeGreetingHeader")
         default: EmptyView()
         }
     }

--- a/clients/macos/vellum-assistant/Features/Home/HomeGreetingHeader.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGreetingHeader.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import VellumAssistantShared
 
 /// Greeting header for the Home feed.
 ///

--- a/clients/macos/vellum-assistant/Features/Home/HomeSuggestionPillBar.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeSuggestionPillBar.swift
@@ -95,19 +95,3 @@ struct HomeSuggestionPillBar: View {
         )
     }
 }
-
-#Preview("HomeSuggestionPillBar") {
-    HomeSuggestionPillBar(
-        headline: "By the way, have you tried one of these:",
-        suggestions: [
-            HomeSuggestion(id: "a", icon: .sparkles, label: "Summarize my inbox"),
-            HomeSuggestion(id: "b", icon: .calendar, label: "Plan my week"),
-            HomeSuggestion(id: "c", icon: .listChecks, label: "Draft a standup"),
-        ],
-        onSelect: { _ in },
-        onDismiss: {}
-    )
-    .padding(32)
-    .frame(width: 720)
-    .background(VColor.surfaceBase)
-}

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -135,6 +135,18 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                     keywords: ["home", "split", "side by side", "layout"],
                     description: "Composite demo: home + right-side HomeDetailPanel showing the side-by-side layout."
                 ),
+                GalleryComponent(
+                    "homeSuggestionPillBar",
+                    "HomeSuggestionPillBar",
+                    keywords: ["suggestion", "pill", "bar", "have you tried", "home"],
+                    description: "Dismissible \"by the way, have you tried…\" container with a headline and horizontal row of icon+label suggestion pills."
+                ),
+                GalleryComponent(
+                    "homeGreetingHeader",
+                    "HomeGreetingHeader",
+                    keywords: ["greeting", "header", "home", "avatar", "new chat"],
+                    description: "Home feed header with a leading avatar, a greeting title, and a trailing New Chat pill CTA."
+                ),
             ]
         case .icons:
             return [


### PR DESCRIPTION
## Summary
- Add homeSuggestionPillBar gallery block with two variants (3-item suggestions + empty-array edge case)
- Add homeGreetingHeader gallery block with a single example using an avatar fixture
- Register both ids in componentPage(_:) switch

Part of plan: home-figma-redesign.md (PR 7 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
