### PR TITLE
feat(permissions): add Risk-to-RiskLevel mapping utility

### DIFF
--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -20,6 +20,8 @@ import {
 } from "./bash-risk-classifier.js";
 import { DEFAULT_COMMAND_REGISTRY } from "./command-registry.js";
 import type { ArgRule, CommandRiskSpec } from "./risk-types.js";
+import { riskToRiskLevel } from "./risk-types.js";
+import { RiskLevel } from "./types.js";
 
 // ── Helper ───────────────────────────────────────────────────────────────────
 
@@ -915,5 +917,25 @@ describe("P3 regression: non-empty reason for low-risk commands", () => {
     });
     expect(result.riskLevel).toBe("low");
     expect(result.reason).toBeTruthy();
+  });
+});
+
+// ── riskToRiskLevel mapping ──────────────────────────────────────────────────
+
+describe("riskToRiskLevel", () => {
+  test("low → RiskLevel.Low", () => {
+    expect(riskToRiskLevel("low")).toBe(RiskLevel.Low);
+  });
+
+  test("medium → RiskLevel.Medium", () => {
+    expect(riskToRiskLevel("medium")).toBe(RiskLevel.Medium);
+  });
+
+  test("high → RiskLevel.High", () => {
+    expect(riskToRiskLevel("high")).toBe(RiskLevel.High);
+  });
+
+  test("unknown → RiskLevel.Medium (fallback)", () => {
+    expect(riskToRiskLevel("unknown")).toBe(RiskLevel.Medium);
   });
 });

--- a/assistant/src/permissions/risk-types.ts
+++ b/assistant/src/permissions/risk-types.ts
@@ -9,6 +9,8 @@
  * @see /docs/bash-risk-classifier-design.md
  */
 
+import { RiskLevel } from "./types.js";
+
 // ── Risk levels ──────────────────────────────────────────────────────────────
 
 /**
@@ -160,4 +162,25 @@ export interface UserRule {
   createdAt: string;
   /** How the rule was created. */
   source: "scope_ladder" | "manual";
+}
+
+// ── Risk → RiskLevel mapping ─────────────────────────────────────────────────
+
+/**
+ * Map a classifier `Risk` value to the permission system's `RiskLevel` enum.
+ *
+ * `"unknown"` maps to `RiskLevel.Medium` — matching the existing checker.ts
+ * behavior where unrecognized commands are treated as medium-risk.
+ */
+export function riskToRiskLevel(risk: Risk): RiskLevel {
+  switch (risk) {
+    case "low":
+      return RiskLevel.Low;
+    case "medium":
+      return RiskLevel.Medium;
+    case "high":
+      return RiskLevel.High;
+    case "unknown":
+      return RiskLevel.Medium;
+  }
 }


### PR DESCRIPTION
## Summary
- Add riskToRiskLevel function mapping Risk union type to RiskLevel enum
- Maps unknown → Medium (matching existing checker.ts behavior)
- Add unit tests verifying all four mappings

Part of plan: bash-risk-registry-phase2.md (PR 1 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
