### PR TITLE
fix(macos): back dismisses LLM Context Inspector instead of skipping conversation

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -395,7 +395,7 @@ extension AppDelegate {
             guard let chars = event.charactersIgnoringModifiers else { return event }
             switch chars {
             case "[":
-                guard self?.mainWindow?.windowState.navigationHistory.canGoBack == true else { return event }
+                guard self?.mainWindow?.windowState.canGoBack == true else { return event }
                 Task { @MainActor in
                     self?.mainWindow?.windowState.navigateBack()
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -172,11 +172,21 @@ public final class MainWindowState {
         selection = newSelection
     }
 
+    /// Whether `navigateBack()` will change visible state. True when the
+    /// inspector overlay is open (back dismisses it) OR when the history
+    /// back stack has entries. The inspector isn't a `ViewSelection`, so
+    /// opening it never pushes onto the back stack — this accessor lets
+    /// the Cmd+[ keybinding and top-bar Back button stay enabled so they
+    /// route through `navigateBack()` to dismiss the overlay.
+    var canGoBack: Bool {
+        navigationHistory.canGoBack || inspectorMessageId != nil
+    }
+
     /// Navigate back through history, falling back to `dismissOverlay()` when
     /// the back stack is empty (e.g. panel restored on app restart via
     /// `restoreLastActivePanel()` which suppresses history recording).
     func navigateBackOrDismiss() {
-        if navigationHistory.canGoBack {
+        if canGoBack {
             navigateBack()
         } else {
             dismissOverlay()
@@ -184,6 +194,16 @@ public final class MainWindowState {
     }
 
     func navigateBack() {
+        // If the inspector overlay is open, "back" dismisses it and keeps
+        // the user on the current conversation. The inspector isn't tracked
+        // in `navigationHistory`, so popping here would skip past the
+        // current conversation to whatever page preceded it.
+        if inspectorMessageId != nil {
+            withAnimation(VAnimation.standard) {
+                inspectorMessageId = nil
+            }
+            return
+        }
         guard let destination = navigationHistory.popBack(
             currentSelection: selection,
             persistentConversationId: persistentConversationId

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -461,8 +461,8 @@ struct MainWindowView: View {
                     VButton(label: "Back", iconOnly: VIcon.chevronLeft.rawValue, style: .ghost, tooltip: "Back (\u{2318}[)") {
                         windowState.navigateBack()
                     }
-                    .disabled(!windowState.navigationHistory.canGoBack)
-                    .opacity(windowState.navigationHistory.canGoBack ? 1 : 0.35)
+                    .disabled(!windowState.canGoBack)
+                    .opacity(windowState.canGoBack ? 1 : 0.35)
 
                     VButton(label: "Forward", iconOnly: VIcon.chevronRight.rawValue, style: .ghost, tooltip: "Forward (\u{2318}])") {
                         windowState.navigateForward()

--- a/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
@@ -130,4 +130,36 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
         XCTAssertNil(state.activeDynamicParsedSurface)
         XCTAssertNil(state.selection)
     }
+
+    // MARK: - Inspector overlay interaction
+
+    func testCanGoBackTrueWhenInspectorOpenEvenWithEmptyHistory() {
+        let state = MainWindowState()
+        XCTAssertFalse(state.canGoBack)
+
+        state.inspectorMessageId = "msg-1"
+
+        // Inspector open ⇒ back must stay enabled so Cmd+[ / top-bar
+        // Back route through navigateBack() and dismiss the overlay.
+        XCTAssertTrue(state.canGoBack)
+        XCTAssertTrue(state.navigationHistory.backStack.isEmpty)
+    }
+
+    func testNavigateBackClosesInspectorAndKeepsConversation() {
+        let state = MainWindowState()
+        let convId = UUID()
+        state.selection = .conversation(convId)
+        // nil → .conversation(convId) records one chat-default entry.
+        let backStackBefore = state.navigationHistory.backStack
+
+        state.inspectorMessageId = "msg-1"
+        state.navigateBack()
+
+        // Inspector is dismissed, selection is untouched, and the back
+        // stack is unchanged — navigateBack short-circuited instead of
+        // popping the prior entry.
+        XCTAssertNil(state.inspectorMessageId)
+        XCTAssertEqual(state.selection, .conversation(convId))
+        XCTAssertEqual(state.navigationHistory.backStack, backStackBefore)
+    }
 }


### PR DESCRIPTION
## Summary
- Cmd+[, the top-bar Back arrow, and the Command Palette's Back action now dismiss the LLM Context Inspector overlay instead of popping past the current conversation to whichever page preceded it.
- `MainWindowState.navigateBack()` short-circuits to clear `inspectorMessageId` when the overlay is open; the inspector isn't tracked in `NavigationHistory`, so popping there skipped the conversation the user expected to return to.
- New `MainWindowState.canGoBack` wraps `navigationHistory.canGoBack || inspectorMessageId != nil` so the keybinding guard and the top-bar Back button stay enabled while the inspector is the only thing back can dismiss.
- The inspector's in-view Back chevron already called `dismissInspector()` directly, so it was unaffected by the bug and stays unchanged.

## Original prompt
The LLM Context Inspector should be part of the page history in the desktop app. Currently when I press "back" it doesn't go to the current conversation, it goes to whatever page I was on before it. If I go from conversation -> LLM context inspector and press back, it should go back to the same conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
