### PR TITLE
feat(gallery): register HomeFeedGroupHeader and HomeRecapRow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -320,6 +320,96 @@ struct HomeGallerySection: View {
                 }
             }
 
+            // MARK: - HomeFeedGroupHeader
+
+            if filter == nil || filter == "homeFeedGroupHeader" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeFeedGroupHeader",
+                    description: "Section header for time-bucketed feed groups (Today / Yesterday / Older)."
+                )
+
+                VCard(background: VColor.surfaceBase) {
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        HomeFeedGroupHeader(label: "Today")
+                        Divider().background(VColor.borderBase)
+                        HomeFeedGroupHeader(label: "Yesterday")
+                        Divider().background(VColor.borderBase)
+                        HomeFeedGroupHeader(label: "Older")
+                    }
+                }
+            }
+
+            // MARK: - HomeRecapRow
+
+            if filter == nil || filter == "homeRecapRow" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeRecapRow",
+                    description: "Compact row used in the time-bucketed Home feed. Icon tint communicates severity; optional trailing Action button is isolated from the row tap."
+                )
+
+                VCard(background: VColor.surfaceBase) {
+                    VStack(spacing: VSpacing.xs) {
+                        // Heartbeat: danger tint, no action.
+                        // Note: plan referenced `Danger._500` / `Danger._900`, which do
+                        // not exist in this codebase; using the closest semantic pair
+                        // `systemNegativeStrong` / `systemNegativeWeak` (see
+                        // HomeRecapRow docs + ColorTokens.swift).
+                        HomeRecapRow(
+                            icon: .heart,
+                            iconForeground: VColor.systemNegativeStrong,
+                            iconBackground: VColor.systemNegativeWeak,
+                            title: "Heartbeat – all systems healthy",
+                            onTap: {}
+                        )
+
+                        // Permission: blue/primary tint, with action.
+                        // Note: plan referenced a blue/primary scale; the codebase
+                        // has no semantic blue pair, so using `funBlue` for the
+                        // glyph and `surfaceLift` for the subtle tinted background.
+                        HomeRecapRow(
+                            icon: .arrowLeft,
+                            iconForeground: VColor.funBlue,
+                            iconBackground: VColor.surfaceLift,
+                            title: "I need your permission on authorising a transaction to NBA",
+                            actionLabel: "Action",
+                            onAction: {},
+                            onTap: {}
+                        )
+
+                        // Digest: emerald tint, with action.
+                        // Note: plan referenced `Forest._500` / `Forest._900`, which
+                        // do not exist; using the closest semantic pair
+                        // `systemPositiveStrong` / `systemPositiveWeak`.
+                        HomeRecapRow(
+                            icon: .bell,
+                            iconForeground: VColor.systemPositiveStrong,
+                            iconBackground: VColor.systemPositiveWeak,
+                            title: "Last, while you were away, I ran the email clean job and deleted 26 emails…",
+                            actionLabel: "Action",
+                            onAction: {},
+                            onTap: {}
+                        )
+
+                        // Passive digest: emerald tint, no action.
+                        HomeRecapRow(
+                            icon: .bell,
+                            iconForeground: VColor.systemPositiveStrong,
+                            iconBackground: VColor.systemPositiveWeak,
+                            title: "There's also 4 low priority updates if you want to have a look.",
+                            onTap: {}
+                        )
+                    }
+                }
+            }
+
             // MARK: - HomeDetailPanel
 
             if filter == nil || filter == "homeDetailPanel" {
@@ -558,6 +648,8 @@ extension HomeGallerySection {
         case "homeImageCard": HomeGallerySection(filter: "homeImageCard")
         case "homeFileCard": HomeGallerySection(filter: "homeFileCard")
         case "homeUpdatesListCard": HomeGallerySection(filter: "homeUpdatesListCard")
+        case "homeFeedGroupHeader": HomeGallerySection(filter: "homeFeedGroupHeader")
+        case "homeRecapRow": HomeGallerySection(filter: "homeRecapRow")
         case "homeDetailPanel": HomeGallerySection(filter: "homeDetailPanel")
         case "homeEmailEditor": HomeGallerySection(filter: "homeEmailEditor")
         case "homeInvoicePreview": HomeGallerySection(filter: "homeInvoicePreview")

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -111,6 +111,8 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                 GalleryComponent("homeImageCard", "HomeImageCard", keywords: ["image", "photo", "preview"], description: "Image preview card"),
                 GalleryComponent("homeFileCard", "HomeFileCard", keywords: ["file", "document", "attachment"], description: "File reference card"),
                 GalleryComponent("homeUpdatesListCard", "HomeUpdatesListCard", keywords: ["updates", "list", "grouped"], description: "Grouped update notifications card"),
+                GalleryComponent("homeFeedGroupHeader", "HomeFeedGroupHeader", keywords: ["feed", "group", "header", "section", "today", "yesterday"], description: "Section header for time-bucketed feed groups (Today / Yesterday / Older)."),
+                GalleryComponent("homeRecapRow", "HomeRecapRow", keywords: ["recap", "row", "feed", "bucket"], description: "Compact row used in the time-bucketed Home feed with tinted icon and optional trailing action."),
                 GalleryComponent(
                     "homeDetailPanel",
                     "HomeDetailPanel",


### PR DESCRIPTION
## Summary
- Registers `HomeFeedGroupHeader` and `HomeRecapRow` in the Home gallery (`HomeGallerySection.swift`) so the new time-bucketed feed primitives are browsable alongside existing Home components.
- Adds filter cases (`homeFeedGroupHeader`, `homeRecapRow`) to the gallery preview switch so each section can be rendered in isolation.
- Showcases four `HomeRecapRow` variants (danger heartbeat, blue permission w/ action, emerald digest w/ action, emerald passive) and three `HomeFeedGroupHeader` labels (Today / Yesterday / Older).

## Notes
- Plan referenced `Danger._500/_900` and `Forest._500/_900` which do not exist in this codebase; the gallery uses the closest semantic pairs (`systemNegativeStrong/Weak`, `systemPositiveStrong/Weak`) and `funBlue` + `surfaceLift` for the blue/primary example. Rationale is inline in comments.
- Gallery-only change; no production component behavior is modified.

## Test plan
- [ ] Open the macOS app, navigate to the Home gallery, confirm both new sections render.
- [ ] Deep-link via filter (`homeFeedGroupHeader`, `homeRecapRow`) and confirm each renders in isolation.
- [ ] Verify icon tint colors across all four `HomeRecapRow` variants match design intent.
- [ ] Confirm the trailing `Action` button taps are isolated from the row tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
