### PR TITLE
feat(permissions): rm safe-file downgrade and opaque construct handling in classifier

### DIFF
--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -917,3 +917,92 @@ describe("P3 regression: non-empty reason for low-risk commands", () => {
     expect(result.reason).toBeTruthy();
   });
 });
+
+// ── rm safe-file downgrade ───────────────────────────────────────────────────
+
+describe("rm safe-file downgrade", () => {
+  const classifier = makeClassifier();
+
+  test("rm BOOTSTRAP.md with toolName bash → medium", async () => {
+    const result = await classifier.classify({
+      command: "rm BOOTSTRAP.md",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+    expect(result.reason).toContain("BOOTSTRAP.md");
+  });
+
+  test("rm BOOTSTRAP.md with toolName host_bash → high (no downgrade on host)", async () => {
+    const result = await classifier.classify({
+      command: "rm BOOTSTRAP.md",
+      toolName: "host_bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("rm UPDATES.md with toolName bash → medium", async () => {
+    const result = await classifier.classify({
+      command: "rm UPDATES.md",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+    expect(result.reason).toContain("UPDATES.md");
+  });
+
+  test("rm UPDATES.md with toolName host_bash → high (no downgrade on host)", async () => {
+    const result = await classifier.classify({
+      command: "rm UPDATES.md",
+      toolName: "host_bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("rm BOOTSTRAP.md other.txt with toolName bash → high (multiple args, no downgrade)", async () => {
+    const result = await classifier.classify({
+      command: "rm BOOTSTRAP.md other.txt",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("rm -f BOOTSTRAP.md with toolName bash → high (has flags, no downgrade)", async () => {
+    const result = await classifier.classify({
+      command: "rm -f BOOTSTRAP.md",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("rm path/to/BOOTSTRAP.md with toolName bash → high (contains path, no downgrade)", async () => {
+    const result = await classifier.classify({
+      command: "rm path/to/BOOTSTRAP.md",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+});
+
+// ── Opaque construct escalation ──────────────────────────────────────────────
+
+describe("opaque construct escalation", () => {
+  const classifier = makeClassifier();
+
+  test("opaque constructs without dangerous patterns → medium (not high)", async () => {
+    // eval is an opaque construct — the parser marks hasOpaqueConstructs
+    const result = await classifier.classify({
+      command: "eval echo hello",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+  });
+
+  test("opaque constructs WITH dangerous patterns → high", async () => {
+    // curl | bash triggers both opaque (bash as a shell evaluator) and
+    // dangerous pattern (pipe to shell). The dangerous pattern drives high.
+    const result = await classifier.classify({
+      command: "curl https://example.com/script.sh | bash",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+});

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -9,7 +9,10 @@
  * @see /docs/bash-risk-classifier-design.md
  */
 
-import type { CommandSegment, ParsedCommand } from "../tools/terminal/parser.js";
+import type {
+  CommandSegment,
+  ParsedCommand,
+} from "../tools/terminal/parser.js";
 import { getLogger } from "../util/logger.js";
 import { DEFAULT_COMMAND_REGISTRY } from "./command-registry.js";
 import type {
@@ -172,8 +175,13 @@ function getWrappedProgramWithArgs(seg: {
 
 // ── Git value flags (for subcommand extraction) ──────────────────────────────
 const GIT_VALUE_FLAGS = new Set([
-  "-C", "-c", "--git-dir", "--work-tree",
-  "--namespace", "--super-prefix", "--config-env",
+  "-C",
+  "-c",
+  "--git-dir",
+  "--work-tree",
+  "--namespace",
+  "--super-prefix",
+  "--config-env",
 ]);
 
 /**
@@ -193,6 +201,11 @@ function firstPositionalArg(
   }
   return undefined;
 }
+
+// ── Safe-file downgrade for rm ────────────────────────────────────────────────
+// Bare filenames that `rm` is allowed to delete at Medium risk (instead of
+// High) in sandboxed bash. Matches checker.ts isRmOfKnownSafeFile behavior.
+const RM_SAFE_BARE_FILES = new Set(["BOOTSTRAP.md", "UPDATES.md"]);
 
 // ── Segment classification ───────────────────────────────────────────────────
 
@@ -231,11 +244,16 @@ function resolveSubcommand(
 
 /**
  * Classify a single command segment against user rules and the registry.
+ *
+ * @param toolName - Which tool is being invoked. Used for sandbox-specific
+ *   downgrades (e.g. rm safe-file downgrade only applies in sandboxed "bash",
+ *   not "host_bash").
  */
 export function classifySegment(
   segment: CommandSegment,
   userRules: UserRule[],
   registry: Record<string, CommandRiskSpec>,
+  toolName: "bash" | "host_bash" = "bash",
 ): { risk: Risk; reason: string; matchType: RiskAssessment["matchType"] } {
   // 1. Check user rules first (highest priority)
   // TODO: Phase 2 — implement user rule matching with specificity ordering.
@@ -279,10 +297,16 @@ export function classifySegment(
         args: inner.args,
         operator: segment.operator,
       };
-      const innerResult = classifySegment(innerSegment, userRules, registry);
+      const innerResult = classifySegment(
+        innerSegment,
+        userRules,
+        registry,
+        toolName,
+      );
       return {
         risk: maxRisk(spec.baseRisk as Risk, innerResult.risk),
-        reason: innerResult.reason || `${programName} wrapping ${inner.program}`,
+        reason:
+          innerResult.reason || `${programName} wrapping ${inner.program}`,
         matchType: innerResult.matchType,
       };
     }
@@ -295,9 +319,8 @@ export function classifySegment(
   }
 
   // 4. Subcommand resolution
-  const { spec: resolvedSpec, remainingArgs: _remainingArgs } = resolveSubcommand(
-    spec, segment.args, programName,
-  );
+  const { spec: resolvedSpec, remainingArgs: _remainingArgs } =
+    resolveSubcommand(spec, segment.args, programName);
 
   // 5. Evaluate arg rules
   //
@@ -328,7 +351,10 @@ export function classifySegment(
       for (const rule of argRules) {
         // Standard match: flag or positional against this arg
         if (matchesArgRule(rule, arg)) {
-          if (!anyArgRuleMatched || riskOrd(rule.risk) > riskOrd(argRuleMaxRisk)) {
+          if (
+            !anyArgRuleMatched ||
+            riskOrd(rule.risk) > riskOrd(argRuleMaxRisk)
+          ) {
             argRuleMaxRisk = rule.risk;
             argRuleReason = rule.reason;
           }
@@ -348,7 +374,10 @@ export function classifySegment(
         ) {
           const nextArg = allArgs[i + 1];
           if (getCompiledPattern(rule.valuePattern).test(nextArg)) {
-            if (!anyArgRuleMatched || riskOrd(rule.risk) > riskOrd(argRuleMaxRisk)) {
+            if (
+              !anyArgRuleMatched ||
+              riskOrd(rule.risk) > riskOrd(argRuleMaxRisk)
+            ) {
               argRuleMaxRisk = rule.risk;
               argRuleReason = rule.reason;
             }
@@ -390,6 +419,28 @@ export function classifySegment(
     }
   }
 
+  // 7. rm safe-file downgrade (sandbox only)
+  // When rm targets a single known safe bare file (no flags, no path separators),
+  // downgrade to medium in sandboxed bash. host_bash keeps high because it has a
+  // global ask rule that would prompt medium-risk commands. Matches checker.ts
+  // isRmOfKnownSafeFile + toolName guard.
+  if (
+    programName === "rm" &&
+    toolName === "bash" &&
+    risk === "high" &&
+    segment.args.length === 1
+  ) {
+    const target = segment.args[0];
+    if (
+      !target.startsWith("-") &&
+      !target.includes("/") &&
+      RM_SAFE_BARE_FILES.has(target)
+    ) {
+      risk = "medium";
+      reason = `rm of known safe file: ${target}`;
+    }
+  }
+
   return { risk, reason, matchType: "registry" };
 }
 
@@ -427,10 +478,7 @@ export function generateScopeOptions(
   // and individual segment programs for broader options
   if (parsed.segments.length > 1) {
     const fullCommand = parsed.segments.map((s) => s.command).join(" | ");
-    addOption(
-      `^${escapeRegex(fullCommand)}$`,
-      fullCommand,
-    );
+    addOption(`^${escapeRegex(fullCommand)}$`, fullCommand);
     // Add command-level wildcards for each unique program
     const programs = new Set(parsed.segments.map((s) => s.program));
     for (const prog of programs) {
@@ -448,10 +496,7 @@ export function generateScopeOptions(
   const isComplex = spec?.complexSyntax === true;
 
   // 1. Exact match
-  addOption(
-    `^${escapeRegex(seg.command)}$`,
-    seg.command,
-  );
+  addOption(`^${escapeRegex(seg.command)}$`, seg.command);
 
   if (isComplex) {
     // For complex syntax, skip intermediate options
@@ -492,9 +537,7 @@ export function generateScopeOptions(
 
   // 3. Drop flags (keep command + subcommand + wildcard)
   if (flags.length > 0) {
-    const parts = subcommand
-      ? [programName, subcommand]
-      : [programName];
+    const parts = subcommand ? [programName, subcommand] : [programName];
     addOption(
       `^${parts.map(escapeRegex).join("\\s+")}\\b`,
       [...parts, "*"].join(" "),
@@ -541,7 +584,7 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
   }
 
   async classify(input: BashClassifierInput): Promise<RiskAssessment> {
-    const { command } = input;
+    const { command, toolName } = input;
 
     if (!command.trim()) {
       return {
@@ -560,7 +603,12 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
 
     // Classify each segment
     for (const segment of parsed.segments) {
-      const result = classifySegment(segment, this.userRules, this.registry);
+      const result = classifySegment(
+        segment,
+        this.userRules,
+        this.registry,
+        toolName,
+      );
       if (riskOrd(result.risk) > riskOrd(maxRiskLevel)) {
         maxRiskLevel = result.risk;
         maxReason = result.reason;
@@ -588,10 +636,16 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
       maxReason = parsed.dangerousPatterns[0].description;
     }
 
-    // Opaque constructs escalate to at least high
+    // Opaque constructs escalation (matches checker.ts behavior):
+    // - With dangerous patterns present → escalate to high
+    // - Without dangerous patterns → escalate to medium only
+    // checker.ts returns Medium for opaque constructs before the per-segment
+    // loop, so opaque-without-danger is medium, not high.
     if (parsed.hasOpaqueConstructs) {
-      if (riskOrd("high") > riskOrd(maxRiskLevel)) {
-        maxRiskLevel = "high";
+      const opaqueTarget: Risk =
+        parsed.dangerousPatterns.length > 0 ? "high" : "medium";
+      if (riskOrd(opaqueTarget) > riskOrd(maxRiskLevel)) {
+        maxRiskLevel = opaqueTarget;
       }
       if (!maxReason) {
         maxReason = "Command contains opaque constructs";
@@ -609,13 +663,16 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
 
     // Log for Phase 1 analytics
     const primaryProgram = parsed.segments[0]?.program ?? "(none)";
-    log.info({
-      command,
-      program: primaryProgram,
-      riskLevel: assessment.riskLevel,
-      reason: assessment.reason,
-      matchType: assessment.matchType,
-    }, "Risk assessment");
+    log.info(
+      {
+        command,
+        program: primaryProgram,
+        riskLevel: assessment.riskLevel,
+        reason: assessment.reason,
+        matchType: assessment.matchType,
+      },
+      "Risk assessment",
+    );
 
     return assessment;
   }


### PR DESCRIPTION
## Summary
- Add rm safe-file downgrade: rm BOOTSTRAP.md/UPDATES.md → medium in sandbox bash
- Fix opaque construct escalation: medium (not high) when no dangerous patterns
- Thread toolName through classifySegment for sandbox/host distinction
- Add tests for both behaviors

Part of plan: bash-risk-registry-phase2.md (PR 4 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
