### PR TITLE
fix(ci): install meet-join skill deps in benchmark workflow

### DIFF
--- a/.github/workflows/ci-benchmarks.yaml
+++ b/.github/workflows/ci-benchmarks.yaml
@@ -33,7 +33,9 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install linked package dependencies
-        run: cd ../packages/ces-contracts && bun install --frozen-lockfile
+        run: |
+          cd ../packages/ces-contracts && bun install --frozen-lockfile
+          cd ../../skills/meet-join && bun install --frozen-lockfile
 
       - name: Download previous baseline
         id: baseline


### PR DESCRIPTION
## Summary
- The benchmark CI has been failing on every push to main since the meet-avatar tools landed (PR #26672), with `Cannot find package 'zod' from '.../skills/meet-join/tools/meet-avatar-tool.ts'`.
- The benchmark tests load `external-skills-bootstrap.ts` which transitively imports `meet-avatar-tool.ts`. Bun's package resolution starts from the importing file's directory, so it can't see the assistant's `node_modules/zod`.
- Add the same `cd ../../skills/meet-join && bun install --frozen-lockfile` step that `pr-assistant.yaml`, `ci-main-assistant.yaml`, and the other assistant workflows already run.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24693087101/job/72219470581
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
