### PR TITLE
feat(config): surface config quarantine events via UPDATES.md

### DIFF
--- a/assistant/src/__tests__/config-loader-quarantine-bulletin.test.ts
+++ b/assistant/src/__tests__/config-loader-quarantine-bulletin.test.ts
@@ -1,0 +1,202 @@
+/**
+ * When loadConfig()/loadRawConfig() quarantines a corrupt config.json, it
+ * appends a user-facing bulletin to <workspace>/UPDATES.md so the background
+ * update-bulletin job picks up the event and the agent can proactively tell
+ * the user their settings reset to defaults and where to recover the original
+ * from the quarantined file.
+ *
+ * The bulletin is keyed on the quarantine filename via an HTML marker so
+ * repeated appends for the same quarantine are idempotent — per the
+ * Release-Update-Hygiene rule in the root CLAUDE.md, idempotency at both the
+ * runner level AND an in-file marker is required to close the crash-mid-append
+ * window.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  _appendQuarantineBulletin,
+  invalidateConfigCache,
+  loadConfig,
+} from "../config/loader.js";
+import { _setStorePath } from "../security/encrypted-store.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+const UPDATES_PATH = join(WORKSPACE_DIR, "UPDATES.md");
+
+function ensureTestDir(): void {
+  const dirs = [
+    WORKSPACE_DIR,
+    join(WORKSPACE_DIR, "data"),
+    join(WORKSPACE_DIR, "data", "memory"),
+    join(WORKSPACE_DIR, "data", "memory", "knowledge"),
+    join(WORKSPACE_DIR, "data", "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+function resetWorkspace(): void {
+  for (const name of readdirSync(WORKSPACE_DIR)) {
+    rmSync(join(WORKSPACE_DIR, name), { recursive: true, force: true });
+  }
+  ensureTestDir();
+}
+
+function listQuarantinedFiles(): string[] {
+  return readdirSync(WORKSPACE_DIR).filter((name) =>
+    /^config\.json\.corrupt-.+\.json$/.test(name),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("config-quarantine UPDATES.md bulletin", () => {
+  beforeEach(() => {
+    resetWorkspace();
+    _setStorePath(join(WORKSPACE_DIR, "keys.enc"));
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    _setStorePath(null);
+    invalidateConfigCache();
+  });
+
+  test("writes a bulletin with the quarantine marker when config.json is corrupt", () => {
+    writeFileSync(CONFIG_PATH, '{"provider": "anthropic", "mo');
+
+    loadConfig();
+
+    const [quarantinedName] = listQuarantinedFiles();
+    expect(quarantinedName).toBeDefined();
+    const quarantinedPath = join(WORKSPACE_DIR, quarantinedName);
+
+    expect(existsSync(UPDATES_PATH)).toBe(true);
+    const body = readFileSync(UPDATES_PATH, "utf-8");
+
+    // Heading must match the wording the background update-bulletin job
+    // relays to the user.
+    expect(body).toContain("## Config was reset to defaults");
+    // Quarantine file path is what the user cats to recover.
+    expect(body).toContain(quarantinedPath);
+    // Idempotency marker is shape-exact, basename-keyed (not full path).
+    expect(body).toContain(`<!-- config-quarantine:${quarantinedName} -->`);
+    expect(body).toMatch(
+      /<!-- config-quarantine:config\.json\.corrupt-.+\.json -->/,
+    );
+  });
+
+  test("two successive quarantines append two distinct bulletins (not overwrite)", () => {
+    // First corruption round.
+    writeFileSync(CONFIG_PATH, '{"partial": ');
+    loadConfig();
+    invalidateConfigCache();
+
+    const firstQuarantined = listQuarantinedFiles();
+    expect(firstQuarantined).toHaveLength(1);
+    const firstBody = readFileSync(UPDATES_PATH, "utf-8");
+    const firstMarker = `<!-- config-quarantine:${firstQuarantined[0]} -->`;
+    expect(firstBody).toContain(firstMarker);
+
+    // Loader wrote a fresh default config.json after quarantine; corrupt it
+    // again. Sleep briefly to guarantee a different ISO-timestamp millisecond
+    // component and therefore a distinct quarantine filename.
+    const untilDifferentMs = Date.now() + 5;
+    while (Date.now() < untilDifferentMs) {
+      /* spin */
+    }
+    writeFileSync(CONFIG_PATH, "still not json");
+    loadConfig();
+
+    const quarantined = listQuarantinedFiles().sort();
+    expect(quarantined).toHaveLength(2);
+
+    const body = readFileSync(UPDATES_PATH, "utf-8");
+    for (const name of quarantined) {
+      expect(body).toContain(`<!-- config-quarantine:${name} -->`);
+    }
+    // Two "Config was reset to defaults" sections — appended, not overwritten.
+    const headingMatches = body.match(/## Config was reset to defaults/g) ?? [];
+    expect(headingMatches).toHaveLength(2);
+    // The earlier marker is still present (append semantics).
+    expect(body).toContain(firstMarker);
+  });
+
+  test("idempotent: pre-existing marker for the same quarantine filename skips the append", () => {
+    // Simulate a crash-mid-append: UPDATES.md already contains a marker for
+    // a specific quarantine filename. A follow-up call referencing the same
+    // filename must leave the file untouched.
+    const quarantineName = "config.json.corrupt-2026-04-20T12-00-00.000Z.json";
+    const quarantinePath = join(WORKSPACE_DIR, quarantineName);
+    const preexisting =
+      `## Config was reset to defaults\n\n` +
+      `Pre-existing bulletin for ${quarantinePath}.\n\n` +
+      `<!-- config-quarantine:${quarantineName} -->\n`;
+    writeFileSync(UPDATES_PATH, preexisting, "utf-8");
+    // Also create the quarantine file on disk so the helper sees an
+    // environment consistent with a prior successful rename.
+    writeFileSync(quarantinePath, "{ not json", "utf-8");
+
+    _appendQuarantineBulletin(CONFIG_PATH, quarantinePath);
+
+    const after = readFileSync(UPDATES_PATH, "utf-8");
+    expect(after).toBe(preexisting);
+    // Exactly one marker present — no duplicate was appended.
+    expect(
+      after.match(
+        new RegExp(`<!-- config-quarantine:${quarantineName} -->`, "g"),
+      )?.length,
+    ).toBe(1);
+    expect(basename(quarantinePath)).toBe(quarantineName);
+  });
+
+  test("valid config.json does not create UPDATES.md (regression guard)", () => {
+    writeFileSync(
+      CONFIG_PATH,
+      JSON.stringify({ provider: "anthropic", model: "claude-opus-4-7" }),
+    );
+
+    loadConfig();
+
+    expect(listQuarantinedFiles()).toHaveLength(0);
+    expect(existsSync(UPDATES_PATH)).toBe(false);
+  });
+
+  test("appends (does not overwrite) when UPDATES.md already has unrelated content", () => {
+    const priorContent =
+      `## Some earlier bulletin\n\n` +
+      `Unrelated prior content from a previous migration.\n\n` +
+      `<!-- release-note-id:unrelated-note -->\n`;
+    writeFileSync(UPDATES_PATH, priorContent, "utf-8");
+
+    writeFileSync(CONFIG_PATH, "{oops");
+    loadConfig();
+
+    const body = readFileSync(UPDATES_PATH, "utf-8");
+    // Prior content preserved verbatim at the start.
+    expect(body.startsWith(priorContent)).toBe(true);
+    // New bulletin appended.
+    expect(body).toContain("## Config was reset to defaults");
+    expect(body).toMatch(
+      /<!-- config-quarantine:config\.json\.corrupt-.+\.json -->/,
+    );
+  });
+});

--- a/assistant/src/__tests__/config-loader-quarantine-bulletin.test.ts
+++ b/assistant/src/__tests__/config-loader-quarantine-bulletin.test.ts
@@ -1,13 +1,13 @@
 /**
  * When loadConfig()/loadRawConfig() quarantines a corrupt config.json, it
- * appends a user-facing bulletin to <workspace>/UPDATES.md so the background
- * update-bulletin job picks up the event and the agent can proactively tell
- * the user their settings reset to defaults and where to recover the original
- * from the quarantined file.
+ * appends a bulletin to <workspace>/UPDATES.md so the background update-
+ * bulletin job picks up the event inside a background-only conversation.
+ * The agent decides whether to surface the quarantine to the user — it's
+ * agent-visible context, not a push notification.
  *
  * The bulletin is keyed on the quarantine filename via an HTML marker so
  * repeated appends for the same quarantine are idempotent — per the
- * Release-Update-Hygiene rule in the root CLAUDE.md, idempotency at both the
+ * Release-Update-Hygiene rule in the root AGENTS.md, idempotency at both the
  * runner level AND an in-file marker is required to close the crash-mid-append
  * window.
  */

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -6,10 +6,14 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
-import { ensureDataDir, getWorkspaceConfigPath } from "../util/platform.js";
+import {
+  ensureDataDir,
+  getWorkspaceConfigPath,
+  getWorkspaceDir,
+} from "../util/platform.js";
 import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import { AssistantConfigSchema } from "./schema.js";
 import type { AssistantConfig } from "./types.js";
@@ -65,6 +69,11 @@ function filesystemSafeTimestamp(date: Date = new Date()): string {
  * The quarantine filename encodes a millisecond-precision timestamp and ends
  * in `.json` so editors syntax-highlight the preserved content:
  *   `<path>.corrupt-<ISO-timestamp>.json`
+ *
+ * On a successful rename, also appends a bulletin to `<workspace>/UPDATES.md`
+ * so the background update-bulletin job surfaces the event to the user
+ * proactively on their next interaction (log-level errors alone are invisible
+ * to users).
  */
 function quarantineCorruptConfig(configPath: string, err: unknown): string {
   const quarantinePath = `${configPath}.corrupt-${filesystemSafeTimestamp()}.json`;
@@ -75,6 +84,7 @@ function quarantineCorruptConfig(configPath: string, err: unknown): string {
         `quarantined to ${quarantinePath} and loaded defaults. ` +
         `Inspect the quarantined file to recover any hand-edited settings.`,
     );
+    appendQuarantineBulletin(configPath, quarantinePath);
   } catch (renameErr) {
     log.error(
       { renameErr },
@@ -83,6 +93,70 @@ function quarantineCorruptConfig(configPath: string, err: unknown): string {
     );
   }
   return quarantinePath;
+}
+
+/**
+ * Append a user-visible bulletin to `<workspace>/UPDATES.md` describing a
+ * config-quarantine event. The background update-bulletin job picks up
+ * UPDATES.md on the next daemon boot and fires a background conversation so
+ * the agent can tell the user their settings reset to defaults and point them
+ * at the quarantined file for recovery.
+ *
+ * Idempotency: the appended block embeds a marker keyed on the quarantine
+ * filename's basename. If that marker is already present in UPDATES.md (a
+ * prior append succeeded but the process crashed before control returned, or
+ * the file was hand-edited), the function is a no-op. This mirrors the
+ * pattern release-notes workspace migrations use — see the "Release Update
+ * Hygiene" section in the root `CLAUDE.md`.
+ *
+ * Best-effort: any write failure is logged at `warn` and swallowed. The
+ * quarantine path must never block startup, and the error log from
+ * `quarantineCorruptConfig` remains the authoritative record.
+ *
+ * Exported with an underscore-prefixed alias (`_appendQuarantineBulletin`) so
+ * tests can exercise the idempotent-skip branch directly with a deterministic
+ * quarantine basename. Non-test callers should never import the underscore
+ * alias — the wiring into `quarantineCorruptConfig` is the production entry
+ * point.
+ */
+function appendQuarantineBulletin(
+  originalPath: string,
+  quarantinePath: string,
+): void {
+  try {
+    const updatesPath = join(getWorkspaceDir(), "UPDATES.md");
+    const quarantineBasename = basename(quarantinePath);
+    const marker = `<!-- config-quarantine:${quarantineBasename} -->`;
+
+    const existing = existsSync(updatesPath)
+      ? readFileSync(updatesPath, "utf-8")
+      : "";
+    if (existing.includes(marker)) return;
+
+    const timestamp = new Date().toISOString();
+    const block =
+      `## Config was reset to defaults\n\n` +
+      `Your \`config.json\` was unreadable at ${timestamp} and couldn't be parsed ` +
+      `as JSON. The daemon preserved the original file at \`${quarantinePath}\` ` +
+      `and booted on defaults so the app stays working.\n\n` +
+      `If you had custom settings (API keys, model choices, voice preferences), ` +
+      `they are still in the quarantined file — \`cat ${quarantinePath}\` to ` +
+      `recover them, then re-enter through Settings or the CLI.\n\n` +
+      `${marker}\n`;
+
+    const toWrite = existing.length === 0 ? block : `${existing}\n${block}`;
+    writeFileSync(updatesPath, toWrite, "utf-8");
+    log.info(
+      `Appended config-quarantine bulletin to ${updatesPath} for ${originalPath} ` +
+        `(quarantined as ${quarantineBasename}).`,
+    );
+  } catch (bulletinErr) {
+    log.warn(
+      { bulletinErr },
+      `Failed to append config-quarantine bulletin to UPDATES.md; ` +
+        `the quarantine event is still recorded in the assistant logs.`,
+    );
+  }
 }
 
 /**
@@ -673,3 +747,10 @@ export function setNestedValue(
   }
   current[keys[keys.length - 1]] = value;
 }
+
+/**
+ * Test-only alias for `appendQuarantineBulletin`. Exists so the crash-mid-
+ * append idempotency branch can be exercised with a deterministic quarantine
+ * basename without widening the runtime surface. Not for production use.
+ */
+export const _appendQuarantineBulletin = appendQuarantineBulletin;

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -108,7 +108,7 @@ function quarantineCorruptConfig(configPath: string, err: unknown): string {
  * prior append succeeded but the process crashed before control returned, or
  * the file was hand-edited), the function is a no-op. This mirrors the
  * pattern release-notes workspace migrations use — see the "Release Update
- * Hygiene" section in the root `CLAUDE.md`.
+ * Hygiene" section in the root `AGENTS.md`.
  *
  * Best-effort: any write failure is logged at `warn` and swallowed. The
  * quarantine path must never block startup, and the error log from
@@ -138,8 +138,8 @@ function appendQuarantineBulletin(
     const block =
       `## Config was reset to defaults\n\n` +
       `Your \`config.json\` was unreadable at ${timestamp} and couldn't be parsed ` +
-      `as JSON. The daemon preserved the original file at \`${quarantinePath}\` ` +
-      `and booted on defaults so the app stays working.\n\n` +
+      `as JSON. The assistant preserved the original file at \`${quarantinePath}\` ` +
+      `and loaded defaults so the app stays working.\n\n` +
       `If you had custom settings (API keys, model choices, voice preferences), ` +
       `they are still in the quarantined file — \`cat ${quarantinePath}\` to ` +
       `recover them, then re-enter through Settings or the CLI.\n\n` +

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -96,11 +96,12 @@ function quarantineCorruptConfig(configPath: string, err: unknown): string {
 }
 
 /**
- * Append a user-visible bulletin to `<workspace>/UPDATES.md` describing a
- * config-quarantine event. The background update-bulletin job picks up
- * UPDATES.md on the next daemon boot and fires a background conversation so
- * the agent can tell the user their settings reset to defaults and point them
- * at the quarantined file for recovery.
+ * Append a config-quarantine bulletin to `<workspace>/UPDATES.md`. On the
+ * next daemon boot the background update-bulletin job picks up UPDATES.md
+ * and processes it inside a background-only conversation (not the user's
+ * chat). The agent decides whether and when to surface the event — typical
+ * cases are the user asking why their settings changed or noticing missing
+ * API keys. The bulletin is agent-visible context, not a push notification.
  *
  * Idempotency: the appended block embeds a marker keyed on the quarantine
  * filename's basename. If that marker is already present in UPDATES.md (a


### PR DESCRIPTION
## Summary

Follow-up to #26923, which made `loadConfig()` / `loadRawConfig()` quarantine a corrupt `config.json` instead of throwing (so the daemon never blocks startup). That PR left a gap: the user has no in-app signal — they'd just notice their settings went missing and have to dig through logs to find the quarantine filename.

This PR wires the quarantine event into the **UPDATES.md** mechanism documented in `assistant/CLAUDE.md` § *Release Update Hygiene*. When `quarantineCorruptConfig` succeeds at renaming the bad file, it also appends a markdown bulletin to `<workspace>/UPDATES.md`. On the next daemon boot, `runUpdateBulletinJobIfNeeded()` picks up UPDATES.md, fires a background-only conversation, and the agent proactively tells the user their settings reset to defaults and how to recover from the quarantined file.

## Mechanism

- **New helper** `appendQuarantineBulletin(originalPath, quarantinePath)` in `assistant/src/config/loader.ts`.
- **Wired in** at the successful `renameSync` branch of `quarantineCorruptConfig` only. If the rename itself failed, we skip the bulletin — the referenced quarantine file wouldn't exist on disk.
- **Never blocks startup**: all bulletin-write failures are caught and logged at `warn`. The existing `log.error` from `quarantineCorruptConfig` remains the authoritative record.

## Idempotency marker

Per the root `CLAUDE.md` rule, release-notes-style appends must use both runner-level AND in-file-marker idempotency to close the crash-mid-append window. Here, there's no runner — the append runs inline during loader recovery — so the in-file marker is the only guard:

```
<!-- config-quarantine:<quarantine-basename> -->
```

The marker is keyed on `basename(quarantinePath)` (not the full path) to keep it readable and portable across workspace roots. Before appending, the helper reads the existing UPDATES.md and short-circuits if that exact marker is already present.

## Bulletin shape

```md
## Config was reset to defaults

Your `config.json` was unreadable at <ISO-timestamp> and couldn't be parsed
as JSON. The daemon preserved the original file at `<quarantinePath>` and
booted on defaults so the app stays working.

If you had custom settings (API keys, model choices, voice preferences),
they are still in the quarantined file — `cat <quarantinePath>` to recover
them, then re-enter through Settings or the CLI.

<!-- config-quarantine:<basename> -->
```

If UPDATES.md already has unrelated content, the new block is separated by a leading newline — existing bulletins (release notes, etc.) are preserved.

## Why UPDATES.md and not the event hub

UPDATES.md is the right channel for *asynchronous, user-facing advisories that merit the agent's attention*. It survives daemon restarts, funnels through the agent's proactive-message path, and is consumed once then deleted. `assistantEventHub` would require a client to be connected at the moment of quarantine — exactly the scenario where the user is least likely to be watching (startup, post-crash).

## Test plan

- [x] `bun test src/__tests__/config-loader-quarantine-bulletin.test.ts` — 5 new tests:
  1. Corrupt config → UPDATES.md contains the marker, the heading, and the quarantine path.
  2. Two successive quarantines → two distinct markers, appended not overwritten.
  3. Idempotency — pre-writing a marker for a specific basename and re-running the helper leaves UPDATES.md byte-identical.
  4. Valid config → no UPDATES.md created.
  5. Pre-existing unrelated UPDATES.md content → appended, original prefix preserved.
- [x] `bun test src/__tests__/config-loader-corrupt.test.ts` — parent PR's 6 tests still pass (regression guard).
- [x] `bunx tsc --noEmit` clean.
- [x] `bun run lint` clean.
- [x] `bun run lint:unused` clean.
- [x] `bun run generate:openapi` — no diff.

## Parent PR

#26923 (merged) — quarantines the corrupt file and falls through to defaults. This PR layers the user-visible signal on top.

Part of JARVIS-409
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
