### PR TITLE
fix(test): add getConversationSource to benchmark mock

### DIFF
--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -148,6 +148,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   getConversationOriginChannel: () => null,
   getConversationOriginInterface: () => null,
   getConversationType: () => "standard",
+  getConversationSource: () => null,
   getConversationMemoryScopeId: () => "default",
   getConversationHostAccess: () => false,
   getConversationGroupId: () => null,


### PR DESCRIPTION
## Summary
- Add missing `getConversationSource` export to the `conversation-crud.js` mock in `conversation-init.benchmark.test.ts`.
- Fixes failing benchmark CI job — the function is imported transitively through `auto-analysis-guard.js`, and bun's ESM mock enforcement surfaces missing named exports as `SyntaxError`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24693478129/job/72220761582
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
