### PR TITLE
feat(assembly): capture unifiedTurnContext bytes in return blocks

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1609,6 +1609,55 @@ describe("applyRuntimeInjections with unifiedTurnContext", () => {
 });
 
 // ---------------------------------------------------------------------------
+// applyRuntimeInjections blocks.unifiedTurnContext
+// ---------------------------------------------------------------------------
+
+describe("applyRuntimeInjections blocks.unifiedTurnContext", () => {
+  const userTailMessages: Message[] = [
+    {
+      role: "user",
+      content: [{ type: "text", text: "Hello there" }],
+    },
+  ];
+
+  const sampleBlock =
+    "<turn_context>\ncurrent_time: 2026-04-02T12:00:00Z\ninterface: macos\n</turn_context>";
+
+  test("captures unifiedTurnContext when tail is a user message", async () => {
+    const result = await applyRuntimeInjections(userTailMessages, {
+      unifiedTurnContext: sampleBlock,
+    });
+
+    expect(result.blocks.unifiedTurnContext).toBe(sampleBlock);
+  });
+
+  test("does not capture when tail is not a user message", async () => {
+    const assistantTailMessages: Message[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hello" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Hi back" }],
+      },
+    ];
+
+    const result = await applyRuntimeInjections(assistantTailMessages, {
+      unifiedTurnContext: sampleBlock,
+    });
+
+    expect(result.blocks.unifiedTurnContext).toBeUndefined();
+  });
+
+  test("does not capture when unifiedTurnContext option is absent", async () => {
+    const result = await applyRuntimeInjections(userTailMessages, {});
+
+    expect(result.blocks.unifiedTurnContext).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // findLastInjectedNowContent
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1819,6 +1819,7 @@ export async function applyRuntimeInjections(
   // rows, so suppress hint injection for any Slack conversation. Other
   // channels (telegram, email, etc.) keep the generic hint pipeline.
   const slackConversation = options.channelCapabilities?.channel === "slack";
+  let turnContextCaptured: string | undefined;
   let result = runMessages;
   // Slack channels AND DMs both override `runMessages` with a pre-rendered
   // chronological transcript built from persisted message rows. The shared
@@ -2014,6 +2015,7 @@ export async function applyRuntimeInjections(
   if (options.unifiedTurnContext) {
     const userTail = result[result.length - 1];
     if (userTail && userTail.role === "user") {
+      turnContextCaptured = options.unifiedTurnContext;
       result = [
         ...result.slice(0, -1),
         {
@@ -2094,5 +2096,8 @@ export async function applyRuntimeInjections(
     }
   }
 
-  return { messages: result, blocks: {} };
+  return {
+    messages: result,
+    blocks: { unifiedTurnContext: turnContextCaptured },
+  };
 }


### PR DESCRIPTION
## Summary
- Populate `blocks.unifiedTurnContext` with the exact bytes injected into the tail user message, enabling later persistence.
- No behavior change — the returned `messages` array is unchanged; only the `blocks` return shape gains a field.

Part of plan: injection-metadata-persistence.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
