### PR TITLE
feat(assembly): capture pkbSystemReminder bytes in return blocks

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -4270,3 +4270,46 @@ describe("assembleSlackChronologicalMessages", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// applyRuntimeInjections blocks.pkbSystemReminder
+// ---------------------------------------------------------------------------
+
+describe("applyRuntimeInjections blocks.pkbSystemReminder", () => {
+  const baseMessages: Message[] = [
+    {
+      role: "user",
+      content: [{ type: "text", text: "Hello" }],
+    },
+  ];
+
+  test("captures exact reminder bytes when full mode and PKB active", async () => {
+    pkbSearchResults = [];
+    pkbSearchThrows = null;
+    const { blocks } = await applyRuntimeInjections(baseMessages, {
+      pkbActive: true,
+      mode: "full",
+    });
+
+    const expected = buildPkbReminder([]);
+    expect(blocks.pkbSystemReminder).toBe(expected);
+  });
+
+  test("not captured in minimal mode", async () => {
+    const { blocks } = await applyRuntimeInjections(baseMessages, {
+      pkbActive: true,
+      mode: "minimal",
+    });
+
+    expect(blocks.pkbSystemReminder).toBeUndefined();
+  });
+
+  test("not captured when PKB inactive", async () => {
+    const { blocks } = await applyRuntimeInjections(baseMessages, {
+      pkbActive: false,
+      mode: "full",
+    });
+
+    expect(blocks.pkbSystemReminder).toBeUndefined();
+  });
+});

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1814,6 +1814,7 @@ export async function applyRuntimeInjections(
   },
 ): Promise<RuntimeInjectionResult> {
   const mode = options.mode ?? "full";
+  let pkbSystemReminderCaptured: string | undefined;
   const slackChannel = isSlackChannelConversation(options.channelCapabilities);
   // Slack DMs and channels both assemble context from persisted message
   // rows, so suppress hint injection for any Slack conversation. Other
@@ -1948,6 +1949,7 @@ export async function applyRuntimeInjections(
       }
 
       const reminder = buildPkbReminder(hints);
+      pkbSystemReminderCaptured = reminder;
       result = [
         ...result.slice(0, -1),
         {
@@ -2094,5 +2096,10 @@ export async function applyRuntimeInjections(
     }
   }
 
-  return { messages: result, blocks: {} };
+  return {
+    messages: result,
+    blocks: {
+      pkbSystemReminder: pkbSystemReminderCaptured,
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- Populate `blocks.pkbSystemReminder` with the exact bytes appended to the tail user message when PKB is active in full mode.
- No behavior change — the returned `messages` array is unchanged; only the `blocks` return shape gains a field.

Part of plan: injection-metadata-persistence.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
