### PR TITLE
fix(test): add findAnalysisConversationFor to benchmark mock for conversation-crud

### DIFF
--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -149,6 +149,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   getConversationOriginInterface: () => null,
   getConversationType: () => "standard",
   getConversationSource: () => null,
+  findAnalysisConversationFor: () => null,
   getConversationMemoryScopeId: () => "default",
   getConversationHostAccess: () => false,
   getConversationGroupId: () => null,


### PR DESCRIPTION
## Summary
- Add `findAnalysisConversationFor: () => null` to the mocked `conversation-crud.js` module in `conversation-init.benchmark.test.ts`.
- Follows the same pattern as #27004 (which fixed the analogous `getConversationSource` omission). The benchmark transitively imports this symbol via the analyze-conversation service; Bun's ESM mock enforcement throws `SyntaxError: Export named 'findAnalysisConversationFor' not found in module` when the mock omits a re-exported named binding, failing the benchmark CI job.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24693872110/job/72222039207
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
