### PR TITLE
fix(test): add updateMessageContentAndMetadata to benchmark mock for conversation-crud

### DIFF
--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -165,6 +165,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   updateConversationTitle: () => {},
   updateConversationUsage: () => {},
   updateMessageContent: () => {},
+  updateMessageContentAndMetadata: () => {},
   batchSetDisplayOrders: () => {},
   getDisplayMetaForConversations: () => [],
   messageMetadataSchema: {


### PR DESCRIPTION
## Summary
- Adds the missing `updateMessageContentAndMetadata` export to the `conversation-crud` mock in `conversation-init.benchmark.test.ts`, fixing the benchmark CI job that was failing with `SyntaxError: Export named 'updateMessageContentAndMetadata' not found`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24693973515/job/72222369775
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
