### PR TITLE
fix(macos): strip .function from parsed nav shortcut modifiers

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -508,6 +508,8 @@ extension AppDelegate {
 
         let (prevModifiers, prevKey) = ShortcutHelper.parseShortcut(prevShortcut)
         let (nextModifiers, nextKey) = ShortcutHelper.parseShortcut(nextShortcut)
+        let prevMods = prevModifiers.subtracting(.function)
+        let nextMods = nextModifiers.subtracting(.function)
 
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
             guard self?.isBootstrapping != true,
@@ -521,13 +523,13 @@ extension AppDelegate {
                 .subtracting([.numericPad, .function])
 
             if !prevShortcut.isEmpty,
-               mods == prevModifiers,
+               mods == prevMods,
                event.charactersIgnoringModifiers?.lowercased() == prevKey.lowercased() {
                 Task { @MainActor in self?.selectPreviousConversation() }
                 return nil
             }
             if !nextShortcut.isEmpty,
-               mods == nextModifiers,
+               mods == nextMods,
                event.charactersIgnoringModifiers?.lowercased() == nextKey.lowercased() {
                 Task { @MainActor in self?.selectNextConversation() }
                 return nil


### PR DESCRIPTION
## Summary
- Strip .function from parsed shortcut modifiers before comparing with event modifiers in the conversation nav handler
- Fixes mismatch where re-recorded arrow-key shortcuts include fn but the handler strips it from the event

Addresses review feedback from #26988.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
