### PR TITLE
feat(permissions): replace imperative bash classification with registry classifier

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -388,9 +388,16 @@ describe("Permission Checker", () => {
         );
       });
 
-      test("bun is low risk", async () => {
+      test("bun --version is medium risk (bun base risk)", async () => {
+        // bun is medium base risk in the registry since it can execute code
+        expect(await classifyRisk("bash", { command: "bun --version" })).toBe(
+          RiskLevel.Medium,
+        );
+      });
+
+      test("bun test is high risk (executes arbitrary scripts)", async () => {
         expect(await classifyRisk("bash", { command: "bun test" })).toBe(
-          RiskLevel.Low,
+          RiskLevel.High,
         );
       });
 
@@ -427,22 +434,22 @@ describe("Permission Checker", () => {
         );
       });
 
-      test("chmod is medium risk", async () => {
+      test("chmod is high risk (permission changes)", async () => {
         expect(
           await classifyRisk("bash", { command: "chmod 644 file.txt" }),
-        ).toBe(RiskLevel.Medium);
+        ).toBe(RiskLevel.High);
       });
 
-      test("chown is medium risk", async () => {
+      test("chown is high risk (ownership changes)", async () => {
         expect(
           await classifyRisk("bash", { command: "chown user file.txt" }),
-        ).toBe(RiskLevel.Medium);
+        ).toBe(RiskLevel.High);
       });
 
-      test("chgrp is medium risk", async () => {
+      test("chgrp is high risk (group changes)", async () => {
         expect(
           await classifyRisk("bash", { command: "chgrp group file.txt" }),
-        ).toBe(RiskLevel.Medium);
+        ).toBe(RiskLevel.High);
       });
 
       test("git push (non-read-only) is medium risk", async () => {
@@ -489,16 +496,16 @@ describe("Permission Checker", () => {
         ).toBe(RiskLevel.Medium);
       });
 
-      test("opaque construct (eval) is medium risk", async () => {
+      test("opaque construct (eval) is high risk (registry: executes arbitrary code)", async () => {
         expect(await classifyRisk("bash", { command: 'eval "ls"' })).toBe(
-          RiskLevel.Medium,
+          RiskLevel.High,
         );
       });
 
-      test("opaque construct (bash -c) is medium risk", async () => {
+      test("opaque construct (bash -c) is high risk (registry: executes arbitrary code)", async () => {
         expect(
           await classifyRisk("bash", { command: 'bash -c "echo hi"' }),
-        ).toBe(RiskLevel.Medium);
+        ).toBe(RiskLevel.High);
       });
     });
 
@@ -848,7 +855,8 @@ describe("Permission Checker", () => {
 
     test("host_bash reuses bash-style command matching", async () => {
       addRule("host_bash", "npm *", "everywhere", "allow", 2000);
-      const result = await check("host_bash", { command: "npm test" }, "/tmp");
+      // npm list is low-risk and matches the npm * allow rule
+      const result = await check("host_bash", { command: "npm list" }, "/tmp");
       expect(result.decision).toBe("allow");
       expect(result.matchedRule?.pattern).toBe("npm *");
     });
@@ -1375,11 +1383,13 @@ describe("Permission Checker", () => {
 
     // Priority-based rule resolution
     test("higher-priority allow rule overrides lower-priority deny rule", async () => {
-      addRule("bash", "chmod *", "/tmp", "deny", 0);
-      addRule("bash", "chmod *", "/tmp", "allow", 100);
+      // Use git push (medium risk) since chmod is now high-risk in the registry
+      // and high-risk commands are never auto-allowed by allow rules
+      addRule("bash", "git push *", "/tmp", "deny", 0);
+      addRule("bash", "git push *", "/tmp", "allow", 100);
       const result = await check(
         "bash",
-        { command: "chmod 644 file.txt" },
+        { command: "git push origin main" },
         "/tmp",
       );
       expect(result.decision).toBe("allow");
@@ -2699,10 +2709,11 @@ describe("Permission Checker", () => {
     });
 
     test("medium-risk tool with allow rule auto-allows normally", async () => {
-      addRule("bash", "chmod *", "/tmp", "allow", 100);
+      // Use git push (medium risk) since chmod is now high-risk in the registry
+      addRule("bash", "git push *", "/tmp", "allow", 100);
       const result = await check(
         "bash",
-        { command: "chmod 644 file.txt" },
+        { command: "git push origin main" },
         "/tmp",
       );
       expect(result.decision).toBe("allow");
@@ -2774,10 +2785,11 @@ describe("Permission Checker", () => {
 
     test("strict mode: medium-risk with matching allow rule auto-allows", async () => {
       testConfig.permissions.mode = "strict";
-      addRule("bash", "chmod *", "/tmp", "allow");
+      // Use git push (medium risk) since chmod is now high-risk in the registry
+      addRule("bash", "git push *", "/tmp", "allow");
       const result = await check(
         "bash",
-        { command: "chmod 644 file.txt" },
+        { command: "git push origin main" },
         "/tmp",
       );
       expect(result.decision).toBe("allow");
@@ -4064,9 +4076,11 @@ describe("Permission Checker", () => {
       test("wildcard allow rule matches any command in workspace mode", async () => {
         testConfig.permissions.mode = "workspace";
         addRule("bash", "*", "everywhere");
+        // Use curl (medium risk) since chmod is now high-risk and
+        // allow rules don't auto-allow high-risk commands
         const result = await check(
           "bash",
-          { command: "chmod 644 file.txt" },
+          { command: "curl https://example.com" },
           "/tmp",
         );
         expect(result.decision).toBe("allow");
@@ -4076,9 +4090,11 @@ describe("Permission Checker", () => {
       test("wildcard allow rule matches any command in strict mode", async () => {
         testConfig.permissions.mode = "strict";
         addRule("bash", "*", "everywhere");
+        // Use curl (medium risk) since chmod is now high-risk and
+        // allow rules don't auto-allow high-risk commands
         const result = await check(
           "bash",
-          { command: "chmod 644 file.txt" },
+          { command: "curl https://example.com" },
           "/tmp",
         );
         expect(result.decision).toBe("allow");
@@ -4432,12 +4448,14 @@ describe("bash network_mode=proxied — risk capped at medium", () => {
     expect(risk).toBe(RiskLevel.Medium);
   });
 
-  test("pipe to python3 -c is not high risk (inline code, not stdin exec)", async () => {
+  test("pipe to python3 -c is high risk (registry: python3 executes arbitrary code)", async () => {
+    // python3 is classified as high-risk in the registry because it can
+    // execute arbitrary Python code. The -c flag does not downgrade the risk.
     const risk = await classifyRisk("bash", {
       command:
         'cat data.json | python3 -c "import sys; print(sys.stdin.read())"',
     });
-    expect(risk).toBe(RiskLevel.Low);
+    expect(risk).toBe(RiskLevel.High);
   });
 
   test("pipe to python3 without -c is high risk (stdin exec)", async () => {
@@ -4476,10 +4494,12 @@ describe("bash network_mode=proxied — risk capped at medium", () => {
   });
 
   test("non-proxied bash with trust rule follows normal flow", async () => {
-    addRule("bash", "chmod *", "/tmp");
+    // Use git push (medium risk) since chmod is now high-risk in the registry
+    // and high-risk commands are never auto-allowed by allow rules
+    addRule("bash", "git push *", "/tmp");
     const result = await check(
       "bash",
-      { command: "chmod 644 file.txt" },
+      { command: "git push origin main" },
       "/tmp",
     );
     expect(result.decision).toBe("allow");
@@ -4938,15 +4958,17 @@ describe("integration regressions (PR 11)", () => {
     // Simulate a user who saved an action:npm rule
     addRule("bash", "action:npm", "everywhere");
 
-    // Various npm commands should be auto-allowed via the action key
-    const r1 = await check("bash", { command: "npm install" }, "/tmp");
+    // npm list is low-risk and should be auto-allowed via the action key
+    const r1 = await check("bash", { command: "npm list" }, "/tmp");
     expect(r1.decision).toBe("allow");
 
+    // npm test and npm run build are high-risk (execute arbitrary scripts)
+    // so they prompt even with an allow rule
     const r2 = await check("bash", { command: "npm test" }, "/tmp");
-    expect(r2.decision).toBe("allow");
+    expect(r2.decision).toBe("prompt");
 
     const r3 = await check("bash", { command: "npm run build" }, "/tmp");
-    expect(r3.decision).toBe("allow");
+    expect(r3.decision).toBe("prompt");
   });
 
   test("action key rule does not match when command is part of complex chain", async () => {
@@ -4965,7 +4987,7 @@ describe("integration regressions (PR 11)", () => {
   });
 
   test("raw legacy rule still works alongside new action key system", async () => {
-    // Use host_bash with medium-risk commands (chmod) so they aren't
+    // Use host_bash with medium-risk commands (curl) so they aren't
     // auto-allowed by low-risk classification or a default allow-all rule.
     try {
       rmSync(join(checkerTestDir, "protected", "trust.json"));
@@ -4973,20 +4995,20 @@ describe("integration regressions (PR 11)", () => {
       /* may not exist */
     }
     clearCache();
-    addRule("host_bash", "chmod 644 file.txt", "everywhere");
+    addRule("host_bash", "curl https://example.com", "everywhere");
 
     // Exact match still works
     const r1 = await check(
       "host_bash",
-      { command: "chmod 644 file.txt" },
+      { command: "curl https://example.com" },
       "/tmp",
     );
     expect(r1.decision).toBe("allow");
 
-    // Different chmod argument should not match this exact raw rule
+    // Different curl argument should not match this exact raw rule
     const r2 = await check(
       "host_bash",
-      { command: "chmod 755 other.txt" },
+      { command: "curl https://other.com" },
       "/tmp",
     );
     expect(r2.decision).not.toBe("allow");

--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -989,13 +989,16 @@ describe("rm safe-file downgrade", () => {
 describe("opaque construct escalation", () => {
   const classifier = makeClassifier();
 
-  test("opaque constructs without dangerous patterns → medium (not high)", async () => {
-    // eval is an opaque construct — the parser marks hasOpaqueConstructs
+  test("opaque constructs without dangerous patterns — eval is high per registry", async () => {
+    // eval is an opaque construct — the parser marks hasOpaqueConstructs.
+    // Since eval is in the registry as high-risk (executes arbitrary shell code),
+    // the segment classification returns "high" which dominates the opaque
+    // construct escalation target of "medium".
     const result = await classifier.classify({
       command: "eval echo hello",
       toolName: "bash",
     });
-    expect(result.riskLevel).toBe("medium");
+    expect(result.riskLevel).toBe("high");
   });
 
   test("opaque constructs WITH dangerous patterns → high", async () => {

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -2,9 +2,9 @@
  * Bash risk classifier — data-driven command risk classification.
  *
  * Implements RiskClassifier<BashClassifierInput> using the default command
- * registry and user rules. Runs alongside (not replacing) the existing
- * checker.ts logic in Phase 1 — it logs assessments but doesn't drive
- * permission decisions yet.
+ * registry and user rules. This is the primary classifier for bash/host_bash
+ * tools — checker.ts delegates to `bashRiskClassifier.classify()` and maps
+ * the result to the permission system's RiskLevel enum.
  *
  * @see /docs/bash-risk-classifier-design.md
  */
@@ -287,35 +287,46 @@ export function classifySegment(
   }
 
   // 3. Handle wrappers — unwrap and classify inner command (recursive)
+  //    Special case: `command -v` / `command -V` are read-only lookups, not
+  //    wrapper invocations. Don't unwrap — instead fall through to arg/base
+  //    risk evaluation (the argRule for -v/-V will keep it low).
   if (spec.isWrapper) {
-    const inner = getWrappedProgramWithArgs(segment);
-    if (inner) {
-      // Build a synthetic segment for the inner command
-      const innerSegment: CommandSegment = {
-        command: [inner.program, ...inner.args].join(" "),
-        program: inner.program,
-        args: inner.args,
-        operator: segment.operator,
-      };
-      const innerResult = classifySegment(
-        innerSegment,
-        userRules,
-        registry,
-        toolName,
-      );
+    const isCommandLookup =
+      programName === "command" &&
+      segment.args.length > 0 &&
+      (segment.args[0] === "-v" || segment.args[0] === "-V");
+
+    if (!isCommandLookup) {
+      const inner = getWrappedProgramWithArgs(segment);
+      if (inner) {
+        // Build a synthetic segment for the inner command
+        const innerSegment: CommandSegment = {
+          command: [inner.program, ...inner.args].join(" "),
+          program: inner.program,
+          args: inner.args,
+          operator: segment.operator,
+        };
+        const innerResult = classifySegment(
+          innerSegment,
+          userRules,
+          registry,
+          toolName,
+        );
+        return {
+          risk: maxRisk(spec.baseRisk as Risk, innerResult.risk),
+          reason:
+            innerResult.reason || `${programName} wrapping ${inner.program}`,
+          matchType: innerResult.matchType,
+        };
+      }
+      // Wrapper with no inner command (bare `sudo`, `env`)
       return {
-        risk: maxRisk(spec.baseRisk as Risk, innerResult.risk),
-        reason:
-          innerResult.reason || `${programName} wrapping ${inner.program}`,
-        matchType: innerResult.matchType,
+        risk: spec.baseRisk,
+        reason: spec.reason || programName,
+        matchType: "registry",
       };
     }
-    // Wrapper with no inner command (bare `sudo`, `env`)
-    return {
-      risk: spec.baseRisk,
-      reason: spec.reason || programName,
-      matchType: "registry",
-    };
+    // `command -v/-V`: fall through to subcommand/arg rule evaluation
   }
 
   // 4. Subcommand resolution
@@ -568,8 +579,9 @@ function escapeRegex(s: string): string {
 /**
  * Bash risk classifier implementation.
  *
- * Phase 1: runs alongside existing checker.ts logic, logs assessments.
- * Phase 2: replaces the imperative classification in classifyRiskUncached.
+ * Primary classifier for bash/host_bash tools. checker.ts delegates to
+ * the singleton `bashRiskClassifier` instance for all bash command
+ * risk classification.
  */
 export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
   private readonly registry: Record<string, CommandRiskSpec>;
@@ -675,35 +687,6 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
     );
 
     return assessment;
-  }
-
-  /**
-   * Convenience method for the Phase 1 parallel wiring in checker.ts.
-   * Classifies a command and logs the result alongside the existing
-   * classifier's risk level for comparison. Fire-and-forget — errors are
-   * swallowed by the caller.
-   */
-  static async classifyAndLog(
-    command: string,
-    toolName: "bash" | "host_bash",
-    existingRiskLevel: string,
-  ): Promise<void> {
-    const assessment = await bashRiskClassifier.classify({
-      command,
-      toolName,
-    });
-    log.info(
-      {
-        command,
-        program: command.trim().split(/\s+/)[0] ?? "(none)",
-        newRiskLevel: assessment.riskLevel,
-        existingRiskLevel,
-        reason: assessment.reason,
-        matchType: assessment.matchType,
-        match: assessment.riskLevel === existingRiskLevel,
-      },
-      "Risk classifier comparison",
-    );
   }
 }
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -25,7 +25,8 @@ import {
   getProtectedDir,
   getWorkspaceHooksDir,
 } from "../util/platform.js";
-import { BashRiskClassifier } from "./bash-risk-classifier.js";
+import { bashRiskClassifier } from "./bash-risk-classifier.js";
+import { riskToRiskLevel } from "./risk-types.js";
 import {
   buildShellAllowlistOptions,
   buildShellCommandCandidates,
@@ -87,75 +88,6 @@ function ensureRiskCacheInvalidationHook(): void {
   onRulesChanged(clearRiskCache);
 }
 
-// Low-risk shell programs that are read-only / informational
-const LOW_RISK_PROGRAMS = new Set([
-  "ls",
-  "cat",
-  "head",
-  "tail",
-  "less",
-  "more",
-  "wc",
-  "file",
-  "stat",
-  "grep",
-  "rg",
-  "ag",
-  "ack",
-  "find",
-  "fd",
-  "which",
-  "where",
-  "whereis",
-  "type",
-  "echo",
-  "printf",
-  "date",
-  "cal",
-  "uptime",
-  "whoami",
-  "hostname",
-  "uname",
-  "pwd",
-  "realpath",
-  "dirname",
-  "basename",
-  "git",
-  "node",
-  "bun",
-  "deno",
-  "npm",
-  "npx",
-  "yarn",
-  "pnpm",
-  "python",
-  "python3",
-  "pip",
-  "pip3",
-  "man",
-  "help",
-  "info",
-  "env",
-  "printenv",
-  "set",
-  "diff",
-  "sort",
-  "uniq",
-  "cut",
-  "tr",
-  "tee",
-  "xargs",
-  "jq",
-  "yq",
-  "http",
-  "dig",
-  "nslookup",
-  "ping",
-  "tree",
-  "du",
-  "df",
-]);
-
 /**
  * Determines at runtime whether a high-risk operation should be auto-allowed
  * without requiring a persisted allowHighRisk flag. This replaces the
@@ -165,258 +97,14 @@ const LOW_RISK_PROGRAMS = new Set([
  * - Containerized bash: all commands are sandboxed, so high-risk is safe.
  *
  * Note: `rm BOOTSTRAP.md` and `rm UPDATES.md` are already classified as
- * Medium risk (not High) by `isRmOfKnownSafeFile()`, so they don't need
- * special handling here.
+ * Medium risk (not High) by the BashRiskClassifier's rm safe-file
+ * downgrade, so they don't need special handling here.
  */
 function shouldAutoAllowHighRisk(toolName: string): boolean {
   if (toolName === "bash" && getIsContainerized()) {
     return true;
   }
   return false;
-}
-
-// High-risk shell programs / patterns
-const HIGH_RISK_PROGRAMS = new Set([
-  "sudo",
-  "su",
-  "doas",
-  "dd",
-  "mkfs",
-  "fdisk",
-  "parted",
-  "mount",
-  "umount",
-  "systemctl",
-  "service",
-  "launchctl",
-  "useradd",
-  "userdel",
-  "usermod",
-  "groupadd",
-  "groupdel",
-  "iptables",
-  "ufw",
-  "firewall-cmd",
-  "reboot",
-  "shutdown",
-  "halt",
-  "poweroff",
-  "kill",
-  "killall",
-  "pkill",
-]);
-
-// Git subcommands that are low-risk (read-only)
-const LOW_RISK_GIT_SUBCOMMANDS = new Set([
-  "status",
-  "log",
-  "diff",
-  "show",
-  "branch",
-  "tag",
-  "remote",
-  "stash",
-  "blame",
-  "shortlog",
-  "describe",
-  "rev-parse",
-  "ls-files",
-  "ls-tree",
-  "cat-file",
-  "reflog",
-]);
-
-/**
- * Classify risk for `assistant` CLI subcommands. Multi-word subcommands
- * (e.g. `assistant oauth token`) are matched by walking the positional args.
- */
-function classifyAssistantSubcommand(args: string[]): RiskLevel {
-  const sub = firstPositionalArg(args);
-  if (!sub) return RiskLevel.Low;
-
-  if (sub === "oauth") {
-    const oauthSub = firstPositionalArg(args.slice(args.indexOf(sub) + 1));
-    if (oauthSub === "token") return RiskLevel.High;
-    if (oauthSub === "mode") {
-      // `oauth mode --set` is high risk; bare `oauth mode` (read) is low.
-      // Match both `--set value` (two tokens) and `--set=value` (one token).
-      if (args.some((a) => a === "--set" || a.startsWith("--set=")))
-        return RiskLevel.High;
-      return RiskLevel.Low;
-    }
-    if (oauthSub === "request") return RiskLevel.Medium;
-    if (oauthSub === "connect" || oauthSub === "disconnect")
-      return RiskLevel.Medium;
-    return RiskLevel.Low;
-  }
-
-  if (sub === "credentials") {
-    const credSub = firstPositionalArg(args.slice(args.indexOf(sub) + 1));
-    if (credSub === "reveal") return RiskLevel.High;
-    if (credSub === "set" || credSub === "delete") return RiskLevel.High;
-    return RiskLevel.Low;
-  }
-
-  if (sub === "keys") {
-    const keysSub = firstPositionalArg(args.slice(args.indexOf(sub) + 1));
-    if (keysSub === "set" || keysSub === "delete") return RiskLevel.High;
-    return RiskLevel.Low;
-  }
-
-  if (sub === "trust") {
-    const trustSub = firstPositionalArg(args.slice(args.indexOf(sub) + 1));
-    if (trustSub === "remove" || trustSub === "clear") return RiskLevel.High;
-    return RiskLevel.Low;
-  }
-
-  return RiskLevel.Low;
-}
-
-// Commands that wrap another program — the real program appears as the first
-// non-flag argument.  When one of these is the segment program we look through
-// its args to find the effective program (e.g. `env curl …` → curl).
-const WRAPPER_PROGRAMS = new Set([
-  "env",
-  "nice",
-  "nohup",
-  "time",
-  "command",
-  "exec",
-  "strace",
-  "ltrace",
-  "ionice",
-  "taskset",
-  "timeout",
-]);
-
-// `env` flags that consume the next positional argument as their value.
-// Without this, `env -u curl echo` would incorrectly identify `curl` (the
-// value of -u) as the wrapped program instead of `echo`.
-const ENV_VALUE_FLAGS = new Set(["-u", "--unset", "-C", "--chdir"]);
-
-// `timeout` flags that consume the next positional argument as their value.
-const TIMEOUT_VALUE_FLAGS = new Set(["-s", "--signal", "-k", "--kill-after"]);
-
-// Wrapper programs where the first non-flag positional argument is a
-// configuration value (duration, CPU mask), not the wrapped program name.
-// For these wrappers, the second non-flag positional is the real program.
-const WRAPPER_SKIP_FIRST_POSITIONAL = new Set(["timeout", "taskset"]);
-
-// `git` global flags that consume the next positional argument as their value.
-// Without this, `git -C status commit` would incorrectly identify `status`
-// (the directory path) as the subcommand instead of `commit`.
-const GIT_VALUE_FLAGS = new Set([
-  "-C",
-  "-c",
-  "--git-dir",
-  "--work-tree",
-  "--namespace",
-  "--super-prefix",
-  "--config-env",
-]);
-
-/**
- * Return the first non-flag argument from an argument list, optionally
- * skipping value-taking flags.  Flags are arguments that start with `-`.
- * This is used to skip global options (e.g. `--verbose`, `-h`, `-C <path>`)
- * when extracting the subcommand from CLIs like `git`, `vellum`, and
- * `assistant`.
- *
- * When `valueFlags` is provided, any flag in that set causes the next
- * argument to be skipped as well (it is the flag's value, not a positional).
- */
-function firstPositionalArg(
-  args: string[],
-  valueFlags?: Set<string>,
-): string | undefined {
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg.startsWith("-")) {
-      if (valueFlags?.has(arg)) i++; // skip the next arg (the flag's value)
-      continue;
-    }
-    return arg;
-  }
-  return undefined;
-}
-
-// Bare filenames that `rm` is allowed to delete at Medium risk (instead of
-// High) so workspace-scoped allow rules can approve them without prompting.
-// Only matches when the args contain no flags and exactly one of these filenames.
-const RM_SAFE_BARE_FILES = new Set(["BOOTSTRAP.md", "UPDATES.md"]);
-
-function isRmOfKnownSafeFile(args: string[]): boolean {
-  if (args.length !== 1) return false;
-  const target = args[0];
-  if (target.startsWith("-") || target.includes("/")) return false;
-  return RM_SAFE_BARE_FILES.has(target);
-}
-
-/**
- * Given a segment whose program is a known wrapper, return the first
- * non-flag argument (i.e. the wrapped program name).  Returns `undefined`
- * when no suitable argument is found.
- *
- * Handles `env` specially: skips `VAR=value` pairs and value-taking flags
- * like `-u NAME` and `-C DIR`.
- *
- * Handles `timeout` and `taskset` specially: their first non-flag positional
- * argument is a duration or CPU mask, not the wrapped program. The second
- * non-flag positional is the real program.
- */
-function getWrappedProgram(seg: {
-  program: string;
-  args: string[];
-}): string | undefined {
-  const isEnv = seg.program === "env";
-  const isTimeout = seg.program === "timeout";
-  const skipFirst = WRAPPER_SKIP_FIRST_POSITIONAL.has(seg.program);
-  let skippedFirstPositional = false;
-  for (let i = 0; i < seg.args.length; i++) {
-    const arg = seg.args[i];
-    if (arg.startsWith("-")) {
-      if (isEnv && ENV_VALUE_FLAGS.has(arg)) i++; // skip the value argument
-      if (isTimeout && TIMEOUT_VALUE_FLAGS.has(arg)) i++; // skip the value argument
-      continue;
-    }
-    if (isEnv && arg.includes("=")) continue; // skip env VAR=value pairs
-    if (skipFirst && !skippedFirstPositional) {
-      skippedFirstPositional = true;
-      continue; // skip the duration/CPU mask
-    }
-    return arg;
-  }
-  return undefined;
-}
-
-/**
- * Like `getWrappedProgram`, but also returns the remaining args after the
- * wrapped program name. This allows callers to propagate subcommand-aware
- * classification (e.g. `env assistant oauth token` → classify `oauth token`).
- */
-function getWrappedProgramWithArgs(seg: {
-  program: string;
-  args: string[];
-}): { program: string; args: string[] } | undefined {
-  const isEnv = seg.program === "env";
-  const isTimeout = seg.program === "timeout";
-  const skipFirst = WRAPPER_SKIP_FIRST_POSITIONAL.has(seg.program);
-  let skippedFirstPositional = false;
-  for (let i = 0; i < seg.args.length; i++) {
-    const arg = seg.args[i];
-    if (arg.startsWith("-")) {
-      if (isEnv && ENV_VALUE_FLAGS.has(arg)) i++;
-      if (isTimeout && TIMEOUT_VALUE_FLAGS.has(arg)) i++;
-      continue;
-    }
-    if (isEnv && arg.includes("=")) continue;
-    if (skipFirst && !skippedFirstPositional) {
-      skippedFirstPositional = true;
-      continue; // skip the duration/CPU mask
-    }
-    return { program: arg, args: seg.args.slice(i + 1) };
-  }
-  return undefined;
 }
 
 function getStringField(
@@ -693,29 +381,31 @@ export async function classifyRisk(
       // LRU refresh
       riskCache.delete(cacheKey);
       riskCache.set(cacheKey, cached);
-
-      // Phase 1 observe-only: fire comparison logging even on cache hits
-      // so analytics aren't biased toward cold paths.
-      if (toolName === "bash" || toolName === "host_bash") {
-        const command = ((input.command as string) ?? "").trim();
-        if (command) {
-          BashRiskClassifier.classifyAndLog(command, toolName, cached).catch(
-            () => {},
-          );
-        }
-      }
-
       return cached;
     }
   }
 
-  let result = await classifyRiskUncached(
-    toolName,
-    input,
-    workingDir,
-    preParsed,
-    manifestOverride,
-  );
+  // ── Bash/host_bash: delegate to the registry-driven BashRiskClassifier ────
+  let result: RiskLevel;
+  if (toolName === "bash" || toolName === "host_bash") {
+    const command = ((input.command as string) ?? "").trim();
+    if (!command) {
+      result = RiskLevel.Low;
+    } else {
+      const assessment = await bashRiskClassifier.classify({
+        command,
+        toolName: toolName as "bash" | "host_bash",
+      });
+      result = riskToRiskLevel(assessment.riskLevel);
+    }
+  } else {
+    result = await classifyRiskUncached(
+      toolName,
+      input,
+      workingDir,
+      manifestOverride,
+    );
+  }
 
   // Proxied bash commands route through the credential proxy which handles
   // per-request approval separately. Cap the bash tool's own risk at Medium
@@ -736,19 +426,6 @@ export async function classifyRisk(
     riskCache.set(cacheKey, result);
   }
 
-  // ── Parallel risk classifier (Phase 1: observe-only) ──────────────────────
-  // Run the new data-driven classifier alongside the existing logic.
-  // The result is logged for comparison but does NOT affect the decision.
-  // This will become the primary classifier in Phase 2.
-  if (toolName === "bash" || toolName === "host_bash") {
-    const command = ((input.command as string) ?? "").trim();
-    if (command) {
-      BashRiskClassifier.classifyAndLog(command, toolName, result).catch(
-        () => {},
-      );
-    }
-  }
-
   return result;
 }
 
@@ -756,7 +433,6 @@ async function classifyRiskUncached(
   toolName: string,
   input: Record<string, unknown>,
   workingDir?: string,
-  preParsed?: ParsedCommand,
   manifestOverride?: ManifestOverride,
 ): Promise<RiskLevel> {
   if (toolName === "file_read") {
@@ -839,138 +515,6 @@ async function classifyRiskUncached(
       }
     }
     // Fall through to the tool registry default (Medium) below.
-  }
-
-  if (toolName === "bash" || toolName === "host_bash") {
-    const command = (input.command as string) ?? "";
-    if (!command.trim()) return RiskLevel.Low;
-
-    const parsed = preParsed ?? (await cachedParse(command));
-
-    // Dangerous patterns → High
-    if (parsed.dangerousPatterns.length > 0) return RiskLevel.High;
-
-    // Opaque constructs → at least Medium (never Low)
-    if (parsed.hasOpaqueConstructs) return RiskLevel.Medium;
-
-    // Check each segment
-    let maxRisk = RiskLevel.Low;
-
-    for (const seg of parsed.segments) {
-      const prog = seg.program;
-
-      if (HIGH_RISK_PROGRAMS.has(prog)) return RiskLevel.High;
-
-      if (prog === "rm") {
-        // Only downgrade rm of known safe workspace files for sandboxed bash.
-        // host_bash has a global ask rule that would prompt Medium-risk
-        // commands, so rm on the host must always require explicit approval.
-        if (toolName === "bash" && isRmOfKnownSafeFile(seg.args)) {
-          maxRisk = RiskLevel.Medium;
-          continue;
-        }
-        return RiskLevel.High;
-      }
-
-      if (
-        prog === "chmod" ||
-        prog === "chown" ||
-        prog === "chgrp" ||
-        prog === "sed" ||
-        prog === "awk"
-      ) {
-        maxRisk = RiskLevel.Medium;
-        continue;
-      }
-
-      // curl/wget can download and execute arbitrary code from the internet.
-      // Also catch wrapped invocations like `env curl …` or `nice wget …`.
-      if (prog === "curl" || prog === "wget") {
-        maxRisk = RiskLevel.Medium;
-        continue;
-      }
-
-      if (WRAPPER_PROGRAMS.has(prog)) {
-        // `command -v` and `command -V` are read-only lookups (print where
-        // a command lives) — don't escalate to high risk for those.
-        if (
-          prog === "command" &&
-          seg.args.length > 0 &&
-          (seg.args[0] === "-v" || seg.args[0] === "-V")
-        ) {
-          continue;
-        }
-        const wrapped = getWrappedProgram(seg);
-        if (wrapped === "rm") return RiskLevel.High;
-        if (wrapped && HIGH_RISK_PROGRAMS.has(wrapped)) return RiskLevel.High;
-        if (wrapped === "curl" || wrapped === "wget") {
-          maxRisk = RiskLevel.Medium;
-          continue;
-        }
-        // Propagate subcommand-aware classification for wrapped git/assistant
-        if (wrapped === "git") {
-          const wrappedWithArgs = getWrappedProgramWithArgs(seg);
-          if (wrappedWithArgs) {
-            const subcommand = firstPositionalArg(
-              wrappedWithArgs.args,
-              GIT_VALUE_FLAGS,
-            );
-            if (subcommand && LOW_RISK_GIT_SUBCOMMANDS.has(subcommand)) {
-              continue;
-            }
-            maxRisk = RiskLevel.Medium;
-            continue;
-          }
-        }
-        if (wrapped === "assistant") {
-          const wrappedWithArgs = getWrappedProgramWithArgs(seg);
-          if (wrappedWithArgs) {
-            const assistantRisk = classifyAssistantSubcommand(
-              wrappedWithArgs.args,
-            );
-            if (assistantRisk === RiskLevel.High) return RiskLevel.High;
-            if (assistantRisk === RiskLevel.Medium) {
-              maxRisk = RiskLevel.Medium;
-            }
-            continue;
-          }
-        }
-      }
-
-      if (prog === "git") {
-        const subcommand = firstPositionalArg(seg.args, GIT_VALUE_FLAGS);
-        if (subcommand && LOW_RISK_GIT_SUBCOMMANDS.has(subcommand)) {
-          // Stay at current risk
-          continue;
-        }
-        // Non-read-only git commands are medium
-        maxRisk = RiskLevel.Medium;
-        continue;
-      }
-
-      if (prog === "assistant") {
-        const assistantRisk = classifyAssistantSubcommand(seg.args);
-        if (assistantRisk === RiskLevel.High) return RiskLevel.High;
-        if (assistantRisk === RiskLevel.Medium) {
-          maxRisk = RiskLevel.Medium;
-        }
-        continue;
-      }
-
-      if (!LOW_RISK_PROGRAMS.has(prog)) {
-        // Unknown program → medium
-        if (maxRisk === RiskLevel.Low) {
-          maxRisk = RiskLevel.Medium;
-        }
-      }
-    }
-
-    // If no segments could be extracted, treat as opaque
-    if (parsed.segments.length === 0) {
-      return RiskLevel.Medium;
-    }
-
-    return maxRisk;
   }
 
   // Check the tool registry for a declared default risk level


### PR DESCRIPTION
## Summary
- Replace ~130 lines of imperative bash/host_bash classification in classifyRiskUncached with BashRiskClassifier
- Remove LOW_RISK_PROGRAMS, HIGH_RISK_PROGRAMS, wrapper constants, and helper functions from checker.ts
- Remove Phase 1 observe-only parallel logging (classifyAndLog)
- Registry-driven classification now drives permission decisions for all bash commands
- Fix `command -v` / `command -V` handling in classifier to preserve read-only lookup behavior
- Update checker.test.ts for intentional registry-driven classification changes (chmod/chown/chgrp → high, eval/bash -c → high, bun/npm subcommand-aware risk)

Part of plan: bash-risk-registry-phase2.md (PR 5 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
