### PR TITLE
feat(home): redesign Home skeleton to mirror greeting + suggestions + time-feed layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -332,25 +332,24 @@ struct HomePageView<DetailPanel: View>: View {
     /// first paint doesn't shift when real data lands.
     private var skeleton: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxl) {
-            // Greeting row
+            // Greeting row: avatar + title bone + New Chat CTA bone
             HStack(spacing: VSpacing.md) {
                 VSkeletonBone(width: 40, height: 40, radius: 20)
-                VSkeletonBone(width: 280, height: 24)
+                VSkeletonBone(width: 280, height: 28)
                 Spacer()
+                VSkeletonBone(width: 96, height: 32, radius: VRadius.md)
             }
             .padding(.top, VSpacing.xxl)
 
             // Suggestion bar
-            VSkeletonBone(height: 60, radius: VRadius.xl)
+            VSkeletonBone(height: 72, radius: VRadius.lg)
 
-            // First time group
-            VStack(alignment: .leading, spacing: VSpacing.md) {
+            // First time group: "Today" label + three recap-row bones
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 VSkeletonBone(width: 60, height: 12)
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    VSkeletonBone(height: 48, radius: VRadius.md)
-                    VSkeletonBone(height: 48, radius: VRadius.md)
-                    VSkeletonBone(height: 48, radius: VRadius.md)
-                }
+                VSkeletonBone(height: 48, radius: VRadius.md)
+                VSkeletonBone(height: 48, radius: VRadius.md)
+                VSkeletonBone(height: 48, radius: VRadius.md)
             }
         }
         .frame(maxWidth: maxContentWidth, alignment: .top)


### PR DESCRIPTION
## Summary
- Refresh the HomePageView skeleton to match the new layout silhouette: avatar+title+New-Chat bone row, 72pt suggestion-bar bone, a Today label bone + three 48pt feed-row bones
- Outer spacing stays VSpacing.xxl so layout doesn't jump when real content loads

Part of plan: home-figma-redesign.md (PR 9 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
