### PR TITLE
chore(permissions): remove Phase 1 scaffolding and update classifier docs

### DIFF
--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -256,7 +256,7 @@ export function classifySegment(
   toolName: "bash" | "host_bash" = "bash",
 ): { risk: Risk; reason: string; matchType: RiskAssessment["matchType"] } {
   // 1. Check user rules first (highest priority)
-  // TODO: Phase 2 — implement user rule matching with specificity ordering.
+  // TODO: implement user rule matching with specificity ordering.
   // For now, userRules is always empty so this is a no-op.
   for (const rule of userRules) {
     const re = getCompiledPattern(rule.pattern);
@@ -673,7 +673,7 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
       matchType,
     };
 
-    // Log for Phase 1 analytics
+    // Risk assessment analytics
     const primaryProgram = parsed.segments[0]?.program ?? "(none)";
     log.info(
       {


### PR DESCRIPTION
## Summary
- Update classifier doc comments to reflect Phase 2 primary classifier status
- Remove Phase 1/observe-only references from permissions code
- Clean up unused imports

Part of plan: bash-risk-registry-phase2.md (PR 9 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
