### PR TITLE
feat(permissions): bash risk registry Phase 2 — registry drives classification

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -388,9 +388,16 @@ describe("Permission Checker", () => {
         );
       });
 
-      test("bun is low risk", async () => {
+      test("bun --version is medium risk (bun base risk)", async () => {
+        // bun is medium base risk in the registry since it can execute code
+        expect(await classifyRisk("bash", { command: "bun --version" })).toBe(
+          RiskLevel.Medium,
+        );
+      });
+
+      test("bun test is high risk (executes arbitrary scripts)", async () => {
         expect(await classifyRisk("bash", { command: "bun test" })).toBe(
-          RiskLevel.Low,
+          RiskLevel.High,
         );
       });
 
@@ -427,22 +434,22 @@ describe("Permission Checker", () => {
         );
       });
 
-      test("chmod is medium risk", async () => {
+      test("chmod is high risk (permission changes)", async () => {
         expect(
           await classifyRisk("bash", { command: "chmod 644 file.txt" }),
-        ).toBe(RiskLevel.Medium);
+        ).toBe(RiskLevel.High);
       });
 
-      test("chown is medium risk", async () => {
+      test("chown is high risk (ownership changes)", async () => {
         expect(
           await classifyRisk("bash", { command: "chown user file.txt" }),
-        ).toBe(RiskLevel.Medium);
+        ).toBe(RiskLevel.High);
       });
 
-      test("chgrp is medium risk", async () => {
+      test("chgrp is high risk (group changes)", async () => {
         expect(
           await classifyRisk("bash", { command: "chgrp group file.txt" }),
-        ).toBe(RiskLevel.Medium);
+        ).toBe(RiskLevel.High);
       });
 
       test("git push (non-read-only) is medium risk", async () => {
@@ -489,16 +496,16 @@ describe("Permission Checker", () => {
         ).toBe(RiskLevel.Medium);
       });
 
-      test("opaque construct (eval) is medium risk", async () => {
+      test("opaque construct (eval) is high risk (registry: executes arbitrary code)", async () => {
         expect(await classifyRisk("bash", { command: 'eval "ls"' })).toBe(
-          RiskLevel.Medium,
+          RiskLevel.High,
         );
       });
 
-      test("opaque construct (bash -c) is medium risk", async () => {
+      test("opaque construct (bash -c) is high risk (registry: executes arbitrary code)", async () => {
         expect(
           await classifyRisk("bash", { command: 'bash -c "echo hi"' }),
-        ).toBe(RiskLevel.Medium);
+        ).toBe(RiskLevel.High);
       });
     });
 
@@ -848,7 +855,8 @@ describe("Permission Checker", () => {
 
     test("host_bash reuses bash-style command matching", async () => {
       addRule("host_bash", "npm *", "everywhere", "allow", 2000);
-      const result = await check("host_bash", { command: "npm test" }, "/tmp");
+      // npm list is low-risk and matches the npm * allow rule
+      const result = await check("host_bash", { command: "npm list" }, "/tmp");
       expect(result.decision).toBe("allow");
       expect(result.matchedRule?.pattern).toBe("npm *");
     });
@@ -1375,11 +1383,13 @@ describe("Permission Checker", () => {
 
     // Priority-based rule resolution
     test("higher-priority allow rule overrides lower-priority deny rule", async () => {
-      addRule("bash", "chmod *", "/tmp", "deny", 0);
-      addRule("bash", "chmod *", "/tmp", "allow", 100);
+      // Use git push (medium risk) since chmod is now high-risk in the registry
+      // and high-risk commands are never auto-allowed by allow rules
+      addRule("bash", "git push *", "/tmp", "deny", 0);
+      addRule("bash", "git push *", "/tmp", "allow", 100);
       const result = await check(
         "bash",
-        { command: "chmod 644 file.txt" },
+        { command: "git push origin main" },
         "/tmp",
       );
       expect(result.decision).toBe("allow");
@@ -2699,10 +2709,11 @@ describe("Permission Checker", () => {
     });
 
     test("medium-risk tool with allow rule auto-allows normally", async () => {
-      addRule("bash", "chmod *", "/tmp", "allow", 100);
+      // Use git push (medium risk) since chmod is now high-risk in the registry
+      addRule("bash", "git push *", "/tmp", "allow", 100);
       const result = await check(
         "bash",
-        { command: "chmod 644 file.txt" },
+        { command: "git push origin main" },
         "/tmp",
       );
       expect(result.decision).toBe("allow");
@@ -2774,10 +2785,11 @@ describe("Permission Checker", () => {
 
     test("strict mode: medium-risk with matching allow rule auto-allows", async () => {
       testConfig.permissions.mode = "strict";
-      addRule("bash", "chmod *", "/tmp", "allow");
+      // Use git push (medium risk) since chmod is now high-risk in the registry
+      addRule("bash", "git push *", "/tmp", "allow");
       const result = await check(
         "bash",
-        { command: "chmod 644 file.txt" },
+        { command: "git push origin main" },
         "/tmp",
       );
       expect(result.decision).toBe("allow");
@@ -4064,9 +4076,11 @@ describe("Permission Checker", () => {
       test("wildcard allow rule matches any command in workspace mode", async () => {
         testConfig.permissions.mode = "workspace";
         addRule("bash", "*", "everywhere");
+        // Use curl (medium risk) since chmod is now high-risk and
+        // allow rules don't auto-allow high-risk commands
         const result = await check(
           "bash",
-          { command: "chmod 644 file.txt" },
+          { command: "curl https://example.com" },
           "/tmp",
         );
         expect(result.decision).toBe("allow");
@@ -4076,9 +4090,11 @@ describe("Permission Checker", () => {
       test("wildcard allow rule matches any command in strict mode", async () => {
         testConfig.permissions.mode = "strict";
         addRule("bash", "*", "everywhere");
+        // Use curl (medium risk) since chmod is now high-risk and
+        // allow rules don't auto-allow high-risk commands
         const result = await check(
           "bash",
-          { command: "chmod 644 file.txt" },
+          { command: "curl https://example.com" },
           "/tmp",
         );
         expect(result.decision).toBe("allow");
@@ -4432,12 +4448,14 @@ describe("bash network_mode=proxied — risk capped at medium", () => {
     expect(risk).toBe(RiskLevel.Medium);
   });
 
-  test("pipe to python3 -c is not high risk (inline code, not stdin exec)", async () => {
+  test("pipe to python3 -c is high risk (registry: python3 executes arbitrary code)", async () => {
+    // python3 is classified as high-risk in the registry because it can
+    // execute arbitrary Python code. The -c flag does not downgrade the risk.
     const risk = await classifyRisk("bash", {
       command:
         'cat data.json | python3 -c "import sys; print(sys.stdin.read())"',
     });
-    expect(risk).toBe(RiskLevel.Low);
+    expect(risk).toBe(RiskLevel.High);
   });
 
   test("pipe to python3 without -c is high risk (stdin exec)", async () => {
@@ -4476,10 +4494,12 @@ describe("bash network_mode=proxied — risk capped at medium", () => {
   });
 
   test("non-proxied bash with trust rule follows normal flow", async () => {
-    addRule("bash", "chmod *", "/tmp");
+    // Use git push (medium risk) since chmod is now high-risk in the registry
+    // and high-risk commands are never auto-allowed by allow rules
+    addRule("bash", "git push *", "/tmp");
     const result = await check(
       "bash",
-      { command: "chmod 644 file.txt" },
+      { command: "git push origin main" },
       "/tmp",
     );
     expect(result.decision).toBe("allow");
@@ -4938,15 +4958,17 @@ describe("integration regressions (PR 11)", () => {
     // Simulate a user who saved an action:npm rule
     addRule("bash", "action:npm", "everywhere");
 
-    // Various npm commands should be auto-allowed via the action key
-    const r1 = await check("bash", { command: "npm install" }, "/tmp");
+    // npm list is low-risk and should be auto-allowed via the action key
+    const r1 = await check("bash", { command: "npm list" }, "/tmp");
     expect(r1.decision).toBe("allow");
 
+    // npm test and npm run build are high-risk (execute arbitrary scripts)
+    // so they prompt even with an allow rule
     const r2 = await check("bash", { command: "npm test" }, "/tmp");
-    expect(r2.decision).toBe("allow");
+    expect(r2.decision).toBe("prompt");
 
     const r3 = await check("bash", { command: "npm run build" }, "/tmp");
-    expect(r3.decision).toBe("allow");
+    expect(r3.decision).toBe("prompt");
   });
 
   test("action key rule does not match when command is part of complex chain", async () => {
@@ -4965,7 +4987,7 @@ describe("integration regressions (PR 11)", () => {
   });
 
   test("raw legacy rule still works alongside new action key system", async () => {
-    // Use host_bash with medium-risk commands (chmod) so they aren't
+    // Use host_bash with medium-risk commands (curl) so they aren't
     // auto-allowed by low-risk classification or a default allow-all rule.
     try {
       rmSync(join(checkerTestDir, "protected", "trust.json"));
@@ -4973,20 +4995,20 @@ describe("integration regressions (PR 11)", () => {
       /* may not exist */
     }
     clearCache();
-    addRule("host_bash", "chmod 644 file.txt", "everywhere");
+    addRule("host_bash", "curl https://example.com", "everywhere");
 
     // Exact match still works
     const r1 = await check(
       "host_bash",
-      { command: "chmod 644 file.txt" },
+      { command: "curl https://example.com" },
       "/tmp",
     );
     expect(r1.decision).toBe("allow");
 
-    // Different chmod argument should not match this exact raw rule
+    // Different curl argument should not match this exact raw rule
     const r2 = await check(
       "host_bash",
-      { command: "chmod 755 other.txt" },
+      { command: "curl https://other.com" },
       "/tmp",
     );
     expect(r2.decision).not.toBe("allow");

--- a/assistant/src/__tests__/risk-classifier-parity.test.ts
+++ b/assistant/src/__tests__/risk-classifier-parity.test.ts
@@ -1,14 +1,13 @@
 /**
- * Risk classifier parity validation — Phase 1.
+ * Risk classifier parity validation — Phase 2 (registry-driven).
  *
- * Runs every bash/host_bash test case from checker.test.ts through BOTH the
- * existing classifyRiskUncached (via classifyRisk) and the new
- * BashRiskClassifier, comparing results. This test serves as the migration
- * safety net — when Phase 2 swaps the classifier, it becomes the regression
- * suite.
+ * After Phase 2, classifyRisk delegates to BashRiskClassifier for all
+ * bash/host_bash commands. This test verifies that both entry points
+ * (classifyRisk and bashRiskClassifier.classify) produce consistent results
+ * against a baseline of expected risk levels.
  *
- * Expected divergences are documented in EXPECTED_DIVERGENCES with explanations
- * for each intentional difference.
+ * Since both code paths now route through the same registry-driven classifier,
+ * EXPECTED_DIVERGENCES should remain empty. Any divergence indicates a bug.
  */
 import { describe, expect, test } from "bun:test";
 
@@ -52,7 +51,6 @@ const BASH_TEST_CASES: Array<[string, RiskLevel]> = [
   ["echo hello", RiskLevel.Low],
   ["pwd", RiskLevel.Low],
   ["node --version", RiskLevel.Low],
-  ["bun test", RiskLevel.Low],
   ["", RiskLevel.Low],
   ["   ", RiskLevel.Low],
   ["cat file | grep pattern | wc -l", RiskLevel.Low],
@@ -61,21 +59,22 @@ const BASH_TEST_CASES: Array<[string, RiskLevel]> = [
 
   // Medium risk
   ["some_custom_tool", RiskLevel.Medium],
-  ["chmod 644 file.txt", RiskLevel.Medium],
-  ["chown user file.txt", RiskLevel.Medium],
-  ["chgrp group file.txt", RiskLevel.Medium],
   ["git push origin main", RiskLevel.Medium],
   ['git commit -m "msg"', RiskLevel.Medium],
   ["git -C status commit", RiskLevel.Medium],
   ["git -C /path push", RiskLevel.Medium],
   ["git --git-dir /path/to/.git push", RiskLevel.Medium],
   ["git --no-pager push", RiskLevel.Medium],
-  ['eval "ls"', RiskLevel.Medium],
-  ['bash -c "echo hi"', RiskLevel.Medium],
   ["rm BOOTSTRAP.md", RiskLevel.Medium],
   ["rm UPDATES.md", RiskLevel.Medium],
 
-  // High risk
+  // High risk — registry classifies these commands as high
+  ["bun test", RiskLevel.High],
+  ["chmod 644 file.txt", RiskLevel.High],
+  ["chown user file.txt", RiskLevel.High],
+  ["chgrp group file.txt", RiskLevel.High],
+  ['eval "ls"', RiskLevel.High],
+  ['bash -c "echo hi"', RiskLevel.High],
   ["assistant trust clear", RiskLevel.High],
   ["sudo rm -rf /", RiskLevel.High],
   ["rm -rf /tmp/stuff", RiskLevel.High],
@@ -105,11 +104,10 @@ const BASH_TEST_CASES: Array<[string, RiskLevel]> = [
 
 // ── Expected divergences ─────────────────────────────────────────────────────
 //
-// Commands where the new classifier intentionally produces a different risk
-// level than the old system. Each entry explains the divergence.
-//
-// The old system uses flat lists (LOW_RISK_PROGRAMS, HIGH_RISK_PROGRAMS) that
-// don't capture arg-level nuance. The new registry is more precise.
+// After Phase 2, classifyRisk delegates to BashRiskClassifier for all
+// bash/host_bash commands. Both entry points now use the same registry-driven
+// classifier, so there should be NO divergences. Any entry here indicates
+// a bug that needs investigation.
 
 interface Divergence {
   oldRisk: Risk;
@@ -118,103 +116,17 @@ interface Divergence {
 }
 
 const EXPECTED_DIVERGENCES: Record<string, Divergence> = {
-  // ── Runtime interpreters ────────────────────────────────────────────────────
-  // node --version: RESOLVED — now both systems agree (low). The --version
-  // arg rule de-escalates node's baseRisk=high to low. No longer a divergence.
-  "bun test": {
-    oldRisk: "low",
-    newRisk: "high",
-    reason:
-      "Old: bun in LOW_RISK_PROGRAMS. New: bun is high (arbitrary code execution). Subcommand allowlist needed.",
-  },
-
-  // ── Unknown programs: old=medium, new=unknown ──────────────────────────────
-  "some_custom_tool": {
+  // ── "unknown" → Medium mapping divergence ──────────────────────────────────
+  // classifyRisk maps the raw "unknown" risk to RiskLevel.Medium via
+  // riskToRiskLevel. The parity comparison uses riskLevelToRisk to convert
+  // back to "medium", but bashRiskClassifier.classify returns raw "unknown".
+  // This is an expected mapping-layer difference, not a classifier bug.
+  some_custom_tool: {
     oldRisk: "medium",
     newRisk: "unknown",
     reason:
-      'Old system defaults unknown programs to Medium. New system returns "unknown" — the approval policy layer decides what to do.',
+      'Registry returns "unknown" for unrecognized commands. classifyRisk maps unknown→Medium via riskToRiskLevel.',
   },
-
-  // ── Opaque constructs: old=medium, new=high ────────────────────────────────
-  // The old system treats eval/bash-c as "opaque constructs" → Medium.
-  // The new system correctly classifies these as high risk (arbitrary code).
-  'eval "ls"': {
-    oldRisk: "medium",
-    newRisk: "high",
-    reason:
-      "Old: opaque constructs → Medium. New: eval is high (arbitrary code execution).",
-  },
-  'bash -c "echo hi"': {
-    oldRisk: "medium",
-    newRisk: "high",
-    reason:
-      "Old: opaque constructs → Medium. New: bash is high (arbitrary shell execution).",
-  },
-
-  // ── rm safe-file carve-out: old=medium, new=high ───────────────────────────
-  // Old system has a special exception: rm of a bare safe file (BOOTSTRAP.md,
-  // UPDATES.md) without flags or paths → Medium. New system classifies rm
-  // uniformly as high. The safe-file exception is context-specific logic that
-  // belongs in the approval policy layer, not the classifier.
-  "rm BOOTSTRAP.md": {
-    oldRisk: "medium",
-    newRisk: "high",
-    reason:
-      "Old: rm of known safe file without flags → Medium. New: rm is uniformly high. Safe-file logic belongs in approval policy.",
-  },
-  "rm UPDATES.md": {
-    oldRisk: "medium",
-    newRisk: "high",
-    reason: "Same as rm BOOTSTRAP.md — safe-file carve-out is policy, not classification.",
-  },
-
-  // ── Permission commands: old=medium, new=high ──────────────────────────────
-  // The old system classifies chmod/chown/chgrp as Medium. The new registry
-  // classifies them as High — changing file permissions/ownership can break
-  // system security. This is a deliberate upgrade.
-  "chmod 644 file.txt": {
-    oldRisk: "medium",
-    newRisk: "high",
-    reason:
-      "Old: chmod → Medium. New: chmod → High (permission changes are security-sensitive).",
-  },
-  "chown user file.txt": {
-    oldRisk: "medium",
-    newRisk: "high",
-    reason: "Old: chown → Medium. New: chown → High (ownership changes are security-sensitive).",
-  },
-  "chgrp group file.txt": {
-    oldRisk: "medium",
-    newRisk: "high",
-    reason: "Old: chgrp → Medium. New: chgrp → High (group changes are security-sensitive).",
-  },
-
-  // ── command -v/-V: old=low, new=high ───────────────────────────────────────
-  // The old system has explicit handling: `command -v` and `command -V` are
-  // read-only lookups that skip wrapper unwrapping entirely. The new system
-  // treats `command` as a wrapper and unwraps to the inner program (rm/sudo).
-  // Phase 2 will add flag-specific rules to command that recognize -v/-V as
-  // safe (low risk) regardless of the inner program.
-  "command -v rm": {
-    oldRisk: "low",
-    newRisk: "high",
-    reason:
-      "Old: command -v/-V explicitly handled as read-only lookup. New: command unwraps to rm (high). Phase 2: add -v/-V safe-flag rule.",
-  },
-  "command -V sudo": {
-    oldRisk: "low",
-    newRisk: "high",
-    reason:
-      "Old: command -V explicitly handled as read-only lookup. New: command unwraps to sudo (high). Phase 2: add -v/-V safe-flag rule.",
-  },
-
-  // ── env sudo apt-get: old=high, new=high ───────────────────────────────────
-  // Actually env → sudo → apt-get. The old system unwraps env, finds sudo
-  // (HIGH_RISK_PROGRAMS), returns High. The new system should also return High
-  // via wrapper unwrapping. Let's verify — if it does, this entry can be removed.
-  // UPDATE: env unwraps to sudo, sudo unwraps to apt-get, which is now in
-  // the registry as high. Both agree. This is NOT a divergence.
 };
 
 // ── Parity tests ─────────────────────────────────────────────────────────────
@@ -286,9 +198,7 @@ describe("risk-classifier-parity", () => {
       );
       if (unexpected.length > 0) {
         const details = unexpected
-          .map(
-            (r) => `  "${r.command}": old=${r.old}, new=${r.new}`,
-          )
+          .map((r) => `  "${r.command}": old=${r.old}, new=${r.new}`)
           .join("\n");
         throw new Error(
           `${unexpected.length} unexpected divergence(s):\n${details}`,

--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -920,6 +920,95 @@ describe("P3 regression: non-empty reason for low-risk commands", () => {
   });
 });
 
+// ── rm safe-file downgrade ───────────────────────────────────────────────────
+
+describe("rm safe-file downgrade", () => {
+  const classifier = makeClassifier();
+
+  test("rm BOOTSTRAP.md with toolName bash → medium", async () => {
+    const result = await classifier.classify({
+      command: "rm BOOTSTRAP.md",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+    expect(result.reason).toContain("BOOTSTRAP.md");
+  });
+
+  test("rm BOOTSTRAP.md with toolName host_bash → high (no downgrade on host)", async () => {
+    const result = await classifier.classify({
+      command: "rm BOOTSTRAP.md",
+      toolName: "host_bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("rm UPDATES.md with toolName bash → medium", async () => {
+    const result = await classifier.classify({
+      command: "rm UPDATES.md",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+    expect(result.reason).toContain("UPDATES.md");
+  });
+
+  test("rm UPDATES.md with toolName host_bash → high (no downgrade on host)", async () => {
+    const result = await classifier.classify({
+      command: "rm UPDATES.md",
+      toolName: "host_bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("rm BOOTSTRAP.md other.txt with toolName bash → high (multiple args, no downgrade)", async () => {
+    const result = await classifier.classify({
+      command: "rm BOOTSTRAP.md other.txt",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("rm -f BOOTSTRAP.md with toolName bash → high (has flags, no downgrade)", async () => {
+    const result = await classifier.classify({
+      command: "rm -f BOOTSTRAP.md",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("rm path/to/BOOTSTRAP.md with toolName bash → high (contains path, no downgrade)", async () => {
+    const result = await classifier.classify({
+      command: "rm path/to/BOOTSTRAP.md",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+});
+
+// ── Opaque construct escalation ──────────────────────────────────────────────
+
+describe("opaque construct escalation", () => {
+  const classifier = makeClassifier();
+
+  test("opaque constructs without dangerous patterns → medium (not high)", async () => {
+    // eval is an opaque construct — the parser marks hasOpaqueConstructs
+    const result = await classifier.classify({
+      command: "eval echo hello",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+  });
+
+  test("opaque constructs WITH dangerous patterns → high", async () => {
+    // curl | bash triggers both opaque (bash as a shell evaluator) and
+    // dangerous pattern (pipe to shell). The dangerous pattern drives high.
+    const result = await classifier.classify({
+      command: "curl https://example.com/script.sh | bash",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+});
+
 // ── riskToRiskLevel mapping ──────────────────────────────────────────────────
 
 describe("riskToRiskLevel", () => {

--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -989,13 +989,16 @@ describe("rm safe-file downgrade", () => {
 describe("opaque construct escalation", () => {
   const classifier = makeClassifier();
 
-  test("opaque constructs without dangerous patterns → medium (not high)", async () => {
-    // eval is an opaque construct — the parser marks hasOpaqueConstructs
+  test("opaque constructs without dangerous patterns — eval is high per registry", async () => {
+    // eval is an opaque construct — the parser marks hasOpaqueConstructs.
+    // Since eval is in the registry as high-risk (executes arbitrary shell code),
+    // the segment classification returns "high" which dominates the opaque
+    // construct escalation target of "medium".
     const result = await classifier.classify({
       command: "eval echo hello",
       toolName: "bash",
     });
-    expect(result.riskLevel).toBe("medium");
+    expect(result.riskLevel).toBe("high");
   });
 
   test("opaque constructs WITH dangerous patterns → high", async () => {

--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -20,6 +20,8 @@ import {
 } from "./bash-risk-classifier.js";
 import { DEFAULT_COMMAND_REGISTRY } from "./command-registry.js";
 import type { ArgRule, CommandRiskSpec } from "./risk-types.js";
+import { riskToRiskLevel } from "./risk-types.js";
+import { RiskLevel } from "./types.js";
 
 // ── Helper ───────────────────────────────────────────────────────────────────
 
@@ -915,5 +917,25 @@ describe("P3 regression: non-empty reason for low-risk commands", () => {
     });
     expect(result.riskLevel).toBe("low");
     expect(result.reason).toBeTruthy();
+  });
+});
+
+// ── riskToRiskLevel mapping ──────────────────────────────────────────────────
+
+describe("riskToRiskLevel", () => {
+  test("low → RiskLevel.Low", () => {
+    expect(riskToRiskLevel("low")).toBe(RiskLevel.Low);
+  });
+
+  test("medium → RiskLevel.Medium", () => {
+    expect(riskToRiskLevel("medium")).toBe(RiskLevel.Medium);
+  });
+
+  test("high → RiskLevel.High", () => {
+    expect(riskToRiskLevel("high")).toBe(RiskLevel.High);
+  });
+
+  test("unknown → RiskLevel.Medium (fallback)", () => {
+    expect(riskToRiskLevel("unknown")).toBe(RiskLevel.Medium);
   });
 });

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -266,15 +266,22 @@ export function classifySegment(
   }
 
   // 2. Look up command in default registry
+  //    Use Object.hasOwn to avoid prototype pollution — program names like
+  //    "toString" or "hasOwnProperty" exist on Object.prototype and would
+  //    return truthy for `registry[name]` even though they're not real entries.
   let programName = segment.program;
-  let spec = registry[programName];
+  let spec = Object.hasOwn(registry, programName)
+    ? registry[programName]
+    : undefined;
 
   if (!spec) {
     // Strip path prefix: /usr/bin/rm → rm
     const bare = programName.split("/").pop();
     if (bare) {
       programName = bare;
-      spec = registry[programName];
+      spec = Object.hasOwn(registry, programName)
+        ? registry[programName]
+        : undefined;
     }
   }
 

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -256,7 +256,7 @@ export function classifySegment(
   toolName: "bash" | "host_bash" = "bash",
 ): { risk: Risk; reason: string; matchType: RiskAssessment["matchType"] } {
   // 1. Check user rules first (highest priority)
-  // TODO: Phase 2 — implement user rule matching with specificity ordering.
+  // TODO: implement user rule matching with specificity ordering.
   // For now, userRules is always empty so this is a no-op.
   for (const rule of userRules) {
     const re = getCompiledPattern(rule.pattern);
@@ -673,7 +673,7 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
       matchType,
     };
 
-    // Log for Phase 1 analytics
+    // Risk assessment analytics
     const primaryProgram = parsed.segments[0]?.program ?? "(none)";
     log.info(
       {

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -9,7 +9,10 @@
  * @see /docs/bash-risk-classifier-design.md
  */
 
-import type { CommandSegment, ParsedCommand } from "../tools/terminal/parser.js";
+import type {
+  CommandSegment,
+  ParsedCommand,
+} from "../tools/terminal/parser.js";
 import { getLogger } from "../util/logger.js";
 import { DEFAULT_COMMAND_REGISTRY } from "./command-registry.js";
 import type {
@@ -172,8 +175,13 @@ function getWrappedProgramWithArgs(seg: {
 
 // ── Git value flags (for subcommand extraction) ──────────────────────────────
 const GIT_VALUE_FLAGS = new Set([
-  "-C", "-c", "--git-dir", "--work-tree",
-  "--namespace", "--super-prefix", "--config-env",
+  "-C",
+  "-c",
+  "--git-dir",
+  "--work-tree",
+  "--namespace",
+  "--super-prefix",
+  "--config-env",
 ]);
 
 /**
@@ -193,6 +201,11 @@ function firstPositionalArg(
   }
   return undefined;
 }
+
+// ── Safe-file downgrade for rm ────────────────────────────────────────────────
+// Bare filenames that `rm` is allowed to delete at Medium risk (instead of
+// High) in sandboxed bash. Matches checker.ts isRmOfKnownSafeFile behavior.
+const RM_SAFE_BARE_FILES = new Set(["BOOTSTRAP.md", "UPDATES.md"]);
 
 // ── Segment classification ───────────────────────────────────────────────────
 
@@ -231,11 +244,16 @@ function resolveSubcommand(
 
 /**
  * Classify a single command segment against user rules and the registry.
+ *
+ * @param toolName - Which tool is being invoked. Used for sandbox-specific
+ *   downgrades (e.g. rm safe-file downgrade only applies in sandboxed "bash",
+ *   not "host_bash").
  */
 export function classifySegment(
   segment: CommandSegment,
   userRules: UserRule[],
   registry: Record<string, CommandRiskSpec>,
+  toolName: "bash" | "host_bash" = "bash",
 ): { risk: Risk; reason: string; matchType: RiskAssessment["matchType"] } {
   // 1. Check user rules first (highest priority)
   // TODO: Phase 2 — implement user rule matching with specificity ordering.
@@ -279,10 +297,16 @@ export function classifySegment(
         args: inner.args,
         operator: segment.operator,
       };
-      const innerResult = classifySegment(innerSegment, userRules, registry);
+      const innerResult = classifySegment(
+        innerSegment,
+        userRules,
+        registry,
+        toolName,
+      );
       return {
         risk: maxRisk(spec.baseRisk as Risk, innerResult.risk),
-        reason: innerResult.reason || `${programName} wrapping ${inner.program}`,
+        reason:
+          innerResult.reason || `${programName} wrapping ${inner.program}`,
         matchType: innerResult.matchType,
       };
     }
@@ -295,9 +319,8 @@ export function classifySegment(
   }
 
   // 4. Subcommand resolution
-  const { spec: resolvedSpec, remainingArgs: _remainingArgs } = resolveSubcommand(
-    spec, segment.args, programName,
-  );
+  const { spec: resolvedSpec, remainingArgs: _remainingArgs } =
+    resolveSubcommand(spec, segment.args, programName);
 
   // 5. Evaluate arg rules
   //
@@ -328,7 +351,10 @@ export function classifySegment(
       for (const rule of argRules) {
         // Standard match: flag or positional against this arg
         if (matchesArgRule(rule, arg)) {
-          if (!anyArgRuleMatched || riskOrd(rule.risk) > riskOrd(argRuleMaxRisk)) {
+          if (
+            !anyArgRuleMatched ||
+            riskOrd(rule.risk) > riskOrd(argRuleMaxRisk)
+          ) {
             argRuleMaxRisk = rule.risk;
             argRuleReason = rule.reason;
           }
@@ -348,7 +374,10 @@ export function classifySegment(
         ) {
           const nextArg = allArgs[i + 1];
           if (getCompiledPattern(rule.valuePattern).test(nextArg)) {
-            if (!anyArgRuleMatched || riskOrd(rule.risk) > riskOrd(argRuleMaxRisk)) {
+            if (
+              !anyArgRuleMatched ||
+              riskOrd(rule.risk) > riskOrd(argRuleMaxRisk)
+            ) {
               argRuleMaxRisk = rule.risk;
               argRuleReason = rule.reason;
             }
@@ -390,6 +419,28 @@ export function classifySegment(
     }
   }
 
+  // 7. rm safe-file downgrade (sandbox only)
+  // When rm targets a single known safe bare file (no flags, no path separators),
+  // downgrade to medium in sandboxed bash. host_bash keeps high because it has a
+  // global ask rule that would prompt medium-risk commands. Matches checker.ts
+  // isRmOfKnownSafeFile + toolName guard.
+  if (
+    programName === "rm" &&
+    toolName === "bash" &&
+    risk === "high" &&
+    segment.args.length === 1
+  ) {
+    const target = segment.args[0];
+    if (
+      !target.startsWith("-") &&
+      !target.includes("/") &&
+      RM_SAFE_BARE_FILES.has(target)
+    ) {
+      risk = "medium";
+      reason = `rm of known safe file: ${target}`;
+    }
+  }
+
   return { risk, reason, matchType: "registry" };
 }
 
@@ -427,10 +478,7 @@ export function generateScopeOptions(
   // and individual segment programs for broader options
   if (parsed.segments.length > 1) {
     const fullCommand = parsed.segments.map((s) => s.command).join(" | ");
-    addOption(
-      `^${escapeRegex(fullCommand)}$`,
-      fullCommand,
-    );
+    addOption(`^${escapeRegex(fullCommand)}$`, fullCommand);
     // Add command-level wildcards for each unique program
     const programs = new Set(parsed.segments.map((s) => s.program));
     for (const prog of programs) {
@@ -448,10 +496,7 @@ export function generateScopeOptions(
   const isComplex = spec?.complexSyntax === true;
 
   // 1. Exact match
-  addOption(
-    `^${escapeRegex(seg.command)}$`,
-    seg.command,
-  );
+  addOption(`^${escapeRegex(seg.command)}$`, seg.command);
 
   if (isComplex) {
     // For complex syntax, skip intermediate options
@@ -492,9 +537,7 @@ export function generateScopeOptions(
 
   // 3. Drop flags (keep command + subcommand + wildcard)
   if (flags.length > 0) {
-    const parts = subcommand
-      ? [programName, subcommand]
-      : [programName];
+    const parts = subcommand ? [programName, subcommand] : [programName];
     addOption(
       `^${parts.map(escapeRegex).join("\\s+")}\\b`,
       [...parts, "*"].join(" "),
@@ -541,7 +584,7 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
   }
 
   async classify(input: BashClassifierInput): Promise<RiskAssessment> {
-    const { command } = input;
+    const { command, toolName } = input;
 
     if (!command.trim()) {
       return {
@@ -560,7 +603,12 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
 
     // Classify each segment
     for (const segment of parsed.segments) {
-      const result = classifySegment(segment, this.userRules, this.registry);
+      const result = classifySegment(
+        segment,
+        this.userRules,
+        this.registry,
+        toolName,
+      );
       if (riskOrd(result.risk) > riskOrd(maxRiskLevel)) {
         maxRiskLevel = result.risk;
         maxReason = result.reason;
@@ -588,10 +636,16 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
       maxReason = parsed.dangerousPatterns[0].description;
     }
 
-    // Opaque constructs escalate to at least high
+    // Opaque constructs escalation (matches checker.ts behavior):
+    // - With dangerous patterns present → escalate to high
+    // - Without dangerous patterns → escalate to medium only
+    // checker.ts returns Medium for opaque constructs before the per-segment
+    // loop, so opaque-without-danger is medium, not high.
     if (parsed.hasOpaqueConstructs) {
-      if (riskOrd("high") > riskOrd(maxRiskLevel)) {
-        maxRiskLevel = "high";
+      const opaqueTarget: Risk =
+        parsed.dangerousPatterns.length > 0 ? "high" : "medium";
+      if (riskOrd(opaqueTarget) > riskOrd(maxRiskLevel)) {
+        maxRiskLevel = opaqueTarget;
       }
       if (!maxReason) {
         maxReason = "Command contains opaque constructs";
@@ -609,13 +663,16 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
 
     // Log for Phase 1 analytics
     const primaryProgram = parsed.segments[0]?.program ?? "(none)";
-    log.info({
-      command,
-      program: primaryProgram,
-      riskLevel: assessment.riskLevel,
-      reason: assessment.reason,
-      matchType: assessment.matchType,
-    }, "Risk assessment");
+    log.info(
+      {
+        command,
+        program: primaryProgram,
+        riskLevel: assessment.riskLevel,
+        reason: assessment.reason,
+        matchType: assessment.matchType,
+      },
+      "Risk assessment",
+    );
 
     return assessment;
   }

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -2,9 +2,9 @@
  * Bash risk classifier — data-driven command risk classification.
  *
  * Implements RiskClassifier<BashClassifierInput> using the default command
- * registry and user rules. Runs alongside (not replacing) the existing
- * checker.ts logic in Phase 1 — it logs assessments but doesn't drive
- * permission decisions yet.
+ * registry and user rules. This is the primary classifier for bash/host_bash
+ * tools — checker.ts delegates to `bashRiskClassifier.classify()` and maps
+ * the result to the permission system's RiskLevel enum.
  *
  * @see /docs/bash-risk-classifier-design.md
  */
@@ -287,35 +287,46 @@ export function classifySegment(
   }
 
   // 3. Handle wrappers — unwrap and classify inner command (recursive)
+  //    Special case: `command -v` / `command -V` are read-only lookups, not
+  //    wrapper invocations. Don't unwrap — instead fall through to arg/base
+  //    risk evaluation (the argRule for -v/-V will keep it low).
   if (spec.isWrapper) {
-    const inner = getWrappedProgramWithArgs(segment);
-    if (inner) {
-      // Build a synthetic segment for the inner command
-      const innerSegment: CommandSegment = {
-        command: [inner.program, ...inner.args].join(" "),
-        program: inner.program,
-        args: inner.args,
-        operator: segment.operator,
-      };
-      const innerResult = classifySegment(
-        innerSegment,
-        userRules,
-        registry,
-        toolName,
-      );
+    const isCommandLookup =
+      programName === "command" &&
+      segment.args.length > 0 &&
+      (segment.args[0] === "-v" || segment.args[0] === "-V");
+
+    if (!isCommandLookup) {
+      const inner = getWrappedProgramWithArgs(segment);
+      if (inner) {
+        // Build a synthetic segment for the inner command
+        const innerSegment: CommandSegment = {
+          command: [inner.program, ...inner.args].join(" "),
+          program: inner.program,
+          args: inner.args,
+          operator: segment.operator,
+        };
+        const innerResult = classifySegment(
+          innerSegment,
+          userRules,
+          registry,
+          toolName,
+        );
+        return {
+          risk: maxRisk(spec.baseRisk as Risk, innerResult.risk),
+          reason:
+            innerResult.reason || `${programName} wrapping ${inner.program}`,
+          matchType: innerResult.matchType,
+        };
+      }
+      // Wrapper with no inner command (bare `sudo`, `env`)
       return {
-        risk: maxRisk(spec.baseRisk as Risk, innerResult.risk),
-        reason:
-          innerResult.reason || `${programName} wrapping ${inner.program}`,
-        matchType: innerResult.matchType,
+        risk: spec.baseRisk,
+        reason: spec.reason || programName,
+        matchType: "registry",
       };
     }
-    // Wrapper with no inner command (bare `sudo`, `env`)
-    return {
-      risk: spec.baseRisk,
-      reason: spec.reason || programName,
-      matchType: "registry",
-    };
+    // `command -v/-V`: fall through to subcommand/arg rule evaluation
   }
 
   // 4. Subcommand resolution
@@ -568,8 +579,9 @@ function escapeRegex(s: string): string {
 /**
  * Bash risk classifier implementation.
  *
- * Phase 1: runs alongside existing checker.ts logic, logs assessments.
- * Phase 2: replaces the imperative classification in classifyRiskUncached.
+ * Primary classifier for bash/host_bash tools. checker.ts delegates to
+ * the singleton `bashRiskClassifier` instance for all bash command
+ * risk classification.
  */
 export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
   private readonly registry: Record<string, CommandRiskSpec>;
@@ -675,35 +687,6 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
     );
 
     return assessment;
-  }
-
-  /**
-   * Convenience method for the Phase 1 parallel wiring in checker.ts.
-   * Classifies a command and logs the result alongside the existing
-   * classifier's risk level for comparison. Fire-and-forget — errors are
-   * swallowed by the caller.
-   */
-  static async classifyAndLog(
-    command: string,
-    toolName: "bash" | "host_bash",
-    existingRiskLevel: string,
-  ): Promise<void> {
-    const assessment = await bashRiskClassifier.classify({
-      command,
-      toolName,
-    });
-    log.info(
-      {
-        command,
-        program: command.trim().split(/\s+/)[0] ?? "(none)",
-        newRiskLevel: assessment.riskLevel,
-        existingRiskLevel,
-        reason: assessment.reason,
-        matchType: assessment.matchType,
-        match: assessment.riskLevel === existingRiskLevel,
-      },
-      "Risk classifier comparison",
-    );
   }
 }
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -25,7 +25,8 @@ import {
   getProtectedDir,
   getWorkspaceHooksDir,
 } from "../util/platform.js";
-import { BashRiskClassifier } from "./bash-risk-classifier.js";
+import { bashRiskClassifier } from "./bash-risk-classifier.js";
+import { riskToRiskLevel } from "./risk-types.js";
 import {
   buildShellAllowlistOptions,
   buildShellCommandCandidates,
@@ -87,75 +88,6 @@ function ensureRiskCacheInvalidationHook(): void {
   onRulesChanged(clearRiskCache);
 }
 
-// Low-risk shell programs that are read-only / informational
-const LOW_RISK_PROGRAMS = new Set([
-  "ls",
-  "cat",
-  "head",
-  "tail",
-  "less",
-  "more",
-  "wc",
-  "file",
-  "stat",
-  "grep",
-  "rg",
-  "ag",
-  "ack",
-  "find",
-  "fd",
-  "which",
-  "where",
-  "whereis",
-  "type",
-  "echo",
-  "printf",
-  "date",
-  "cal",
-  "uptime",
-  "whoami",
-  "hostname",
-  "uname",
-  "pwd",
-  "realpath",
-  "dirname",
-  "basename",
-  "git",
-  "node",
-  "bun",
-  "deno",
-  "npm",
-  "npx",
-  "yarn",
-  "pnpm",
-  "python",
-  "python3",
-  "pip",
-  "pip3",
-  "man",
-  "help",
-  "info",
-  "env",
-  "printenv",
-  "set",
-  "diff",
-  "sort",
-  "uniq",
-  "cut",
-  "tr",
-  "tee",
-  "xargs",
-  "jq",
-  "yq",
-  "http",
-  "dig",
-  "nslookup",
-  "ping",
-  "tree",
-  "du",
-  "df",
-]);
-
 /**
  * Determines at runtime whether a high-risk operation should be auto-allowed
  * without requiring a persisted allowHighRisk flag. This replaces the
@@ -165,258 +97,14 @@ const LOW_RISK_PROGRAMS = new Set([
  * - Containerized bash: all commands are sandboxed, so high-risk is safe.
  *
  * Note: `rm BOOTSTRAP.md` and `rm UPDATES.md` are already classified as
- * Medium risk (not High) by `isRmOfKnownSafeFile()`, so they don't need
- * special handling here.
+ * Medium risk (not High) by the BashRiskClassifier's rm safe-file
+ * downgrade, so they don't need special handling here.
  */
 function shouldAutoAllowHighRisk(toolName: string): boolean {
   if (toolName === "bash" && getIsContainerized()) {
     return true;
   }
   return false;
-}
-
-// High-risk shell programs / patterns
-const HIGH_RISK_PROGRAMS = new Set([
-  "sudo",
-  "su",
-  "doas",
-  "dd",
-  "mkfs",
-  "fdisk",
-  "parted",
-  "mount",
-  "umount",
-  "systemctl",
-  "service",
-  "launchctl",
-  "useradd",
-  "userdel",
-  "usermod",
-  "groupadd",
-  "groupdel",
-  "iptables",
-  "ufw",
-  "firewall-cmd",
-  "reboot",
-  "shutdown",
-  "halt",
-  "poweroff",
-  "kill",
-  "killall",
-  "pkill",
-]);
-
-// Git subcommands that are low-risk (read-only)
-const LOW_RISK_GIT_SUBCOMMANDS = new Set([
-  "status",
-  "log",
-  "diff",
-  "show",
-  "branch",
-  "tag",
-  "remote",
-  "stash",
-  "blame",
-  "shortlog",
-  "describe",
-  "rev-parse",
-  "ls-files",
-  "ls-tree",
-  "cat-file",
-  "reflog",
-]);
-
-/**
- * Classify risk for `assistant` CLI subcommands. Multi-word subcommands
- * (e.g. `assistant oauth token`) are matched by walking the positional args.
- */
-function classifyAssistantSubcommand(args: string[]): RiskLevel {
-  const sub = firstPositionalArg(args);
-  if (!sub) return RiskLevel.Low;
-
-  if (sub === "oauth") {
-    const oauthSub = firstPositionalArg(args.slice(args.indexOf(sub) + 1));
-    if (oauthSub === "token") return RiskLevel.High;
-    if (oauthSub === "mode") {
-      // `oauth mode --set` is high risk; bare `oauth mode` (read) is low.
-      // Match both `--set value` (two tokens) and `--set=value` (one token).
-      if (args.some((a) => a === "--set" || a.startsWith("--set=")))
-        return RiskLevel.High;
-      return RiskLevel.Low;
-    }
-    if (oauthSub === "request") return RiskLevel.Medium;
-    if (oauthSub === "connect" || oauthSub === "disconnect")
-      return RiskLevel.Medium;
-    return RiskLevel.Low;
-  }
-
-  if (sub === "credentials") {
-    const credSub = firstPositionalArg(args.slice(args.indexOf(sub) + 1));
-    if (credSub === "reveal") return RiskLevel.High;
-    if (credSub === "set" || credSub === "delete") return RiskLevel.High;
-    return RiskLevel.Low;
-  }
-
-  if (sub === "keys") {
-    const keysSub = firstPositionalArg(args.slice(args.indexOf(sub) + 1));
-    if (keysSub === "set" || keysSub === "delete") return RiskLevel.High;
-    return RiskLevel.Low;
-  }
-
-  if (sub === "trust") {
-    const trustSub = firstPositionalArg(args.slice(args.indexOf(sub) + 1));
-    if (trustSub === "remove" || trustSub === "clear") return RiskLevel.High;
-    return RiskLevel.Low;
-  }
-
-  return RiskLevel.Low;
-}
-
-// Commands that wrap another program — the real program appears as the first
-// non-flag argument.  When one of these is the segment program we look through
-// its args to find the effective program (e.g. `env curl …` → curl).
-const WRAPPER_PROGRAMS = new Set([
-  "env",
-  "nice",
-  "nohup",
-  "time",
-  "command",
-  "exec",
-  "strace",
-  "ltrace",
-  "ionice",
-  "taskset",
-  "timeout",
-]);
-
-// `env` flags that consume the next positional argument as their value.
-// Without this, `env -u curl echo` would incorrectly identify `curl` (the
-// value of -u) as the wrapped program instead of `echo`.
-const ENV_VALUE_FLAGS = new Set(["-u", "--unset", "-C", "--chdir"]);
-
-// `timeout` flags that consume the next positional argument as their value.
-const TIMEOUT_VALUE_FLAGS = new Set(["-s", "--signal", "-k", "--kill-after"]);
-
-// Wrapper programs where the first non-flag positional argument is a
-// configuration value (duration, CPU mask), not the wrapped program name.
-// For these wrappers, the second non-flag positional is the real program.
-const WRAPPER_SKIP_FIRST_POSITIONAL = new Set(["timeout", "taskset"]);
-
-// `git` global flags that consume the next positional argument as their value.
-// Without this, `git -C status commit` would incorrectly identify `status`
-// (the directory path) as the subcommand instead of `commit`.
-const GIT_VALUE_FLAGS = new Set([
-  "-C",
-  "-c",
-  "--git-dir",
-  "--work-tree",
-  "--namespace",
-  "--super-prefix",
-  "--config-env",
-]);
-
-/**
- * Return the first non-flag argument from an argument list, optionally
- * skipping value-taking flags.  Flags are arguments that start with `-`.
- * This is used to skip global options (e.g. `--verbose`, `-h`, `-C <path>`)
- * when extracting the subcommand from CLIs like `git`, `vellum`, and
- * `assistant`.
- *
- * When `valueFlags` is provided, any flag in that set causes the next
- * argument to be skipped as well (it is the flag's value, not a positional).
- */
-function firstPositionalArg(
-  args: string[],
-  valueFlags?: Set<string>,
-): string | undefined {
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg.startsWith("-")) {
-      if (valueFlags?.has(arg)) i++; // skip the next arg (the flag's value)
-      continue;
-    }
-    return arg;
-  }
-  return undefined;
-}
-
-// Bare filenames that `rm` is allowed to delete at Medium risk (instead of
-// High) so workspace-scoped allow rules can approve them without prompting.
-// Only matches when the args contain no flags and exactly one of these filenames.
-const RM_SAFE_BARE_FILES = new Set(["BOOTSTRAP.md", "UPDATES.md"]);
-
-function isRmOfKnownSafeFile(args: string[]): boolean {
-  if (args.length !== 1) return false;
-  const target = args[0];
-  if (target.startsWith("-") || target.includes("/")) return false;
-  return RM_SAFE_BARE_FILES.has(target);
-}
-
-/**
- * Given a segment whose program is a known wrapper, return the first
- * non-flag argument (i.e. the wrapped program name).  Returns `undefined`
- * when no suitable argument is found.
- *
- * Handles `env` specially: skips `VAR=value` pairs and value-taking flags
- * like `-u NAME` and `-C DIR`.
- *
- * Handles `timeout` and `taskset` specially: their first non-flag positional
- * argument is a duration or CPU mask, not the wrapped program. The second
- * non-flag positional is the real program.
- */
-function getWrappedProgram(seg: {
-  program: string;
-  args: string[];
-}): string | undefined {
-  const isEnv = seg.program === "env";
-  const isTimeout = seg.program === "timeout";
-  const skipFirst = WRAPPER_SKIP_FIRST_POSITIONAL.has(seg.program);
-  let skippedFirstPositional = false;
-  for (let i = 0; i < seg.args.length; i++) {
-    const arg = seg.args[i];
-    if (arg.startsWith("-")) {
-      if (isEnv && ENV_VALUE_FLAGS.has(arg)) i++; // skip the value argument
-      if (isTimeout && TIMEOUT_VALUE_FLAGS.has(arg)) i++; // skip the value argument
-      continue;
-    }
-    if (isEnv && arg.includes("=")) continue; // skip env VAR=value pairs
-    if (skipFirst && !skippedFirstPositional) {
-      skippedFirstPositional = true;
-      continue; // skip the duration/CPU mask
-    }
-    return arg;
-  }
-  return undefined;
-}
-
-/**
- * Like `getWrappedProgram`, but also returns the remaining args after the
- * wrapped program name. This allows callers to propagate subcommand-aware
- * classification (e.g. `env assistant oauth token` → classify `oauth token`).
- */
-function getWrappedProgramWithArgs(seg: {
-  program: string;
-  args: string[];
-}): { program: string; args: string[] } | undefined {
-  const isEnv = seg.program === "env";
-  const isTimeout = seg.program === "timeout";
-  const skipFirst = WRAPPER_SKIP_FIRST_POSITIONAL.has(seg.program);
-  let skippedFirstPositional = false;
-  for (let i = 0; i < seg.args.length; i++) {
-    const arg = seg.args[i];
-    if (arg.startsWith("-")) {
-      if (isEnv && ENV_VALUE_FLAGS.has(arg)) i++;
-      if (isTimeout && TIMEOUT_VALUE_FLAGS.has(arg)) i++;
-      continue;
-    }
-    if (isEnv && arg.includes("=")) continue;
-    if (skipFirst && !skippedFirstPositional) {
-      skippedFirstPositional = true;
-      continue; // skip the duration/CPU mask
-    }
-    return { program: arg, args: seg.args.slice(i + 1) };
-  }
-  return undefined;
 }
 
 function getStringField(
@@ -693,29 +381,31 @@ export async function classifyRisk(
       // LRU refresh
       riskCache.delete(cacheKey);
       riskCache.set(cacheKey, cached);
-
-      // Phase 1 observe-only: fire comparison logging even on cache hits
-      // so analytics aren't biased toward cold paths.
-      if (toolName === "bash" || toolName === "host_bash") {
-        const command = ((input.command as string) ?? "").trim();
-        if (command) {
-          BashRiskClassifier.classifyAndLog(command, toolName, cached).catch(
-            () => {},
-          );
-        }
-      }
-
       return cached;
     }
   }
 
-  let result = await classifyRiskUncached(
-    toolName,
-    input,
-    workingDir,
-    preParsed,
-    manifestOverride,
-  );
+  // ── Bash/host_bash: delegate to the registry-driven BashRiskClassifier ────
+  let result: RiskLevel;
+  if (toolName === "bash" || toolName === "host_bash") {
+    const command = ((input.command as string) ?? "").trim();
+    if (!command) {
+      result = RiskLevel.Low;
+    } else {
+      const assessment = await bashRiskClassifier.classify({
+        command,
+        toolName: toolName as "bash" | "host_bash",
+      });
+      result = riskToRiskLevel(assessment.riskLevel);
+    }
+  } else {
+    result = await classifyRiskUncached(
+      toolName,
+      input,
+      workingDir,
+      manifestOverride,
+    );
+  }
 
   // Proxied bash commands route through the credential proxy which handles
   // per-request approval separately. Cap the bash tool's own risk at Medium
@@ -736,19 +426,6 @@ export async function classifyRisk(
     riskCache.set(cacheKey, result);
   }
 
-  // ── Parallel risk classifier (Phase 1: observe-only) ──────────────────────
-  // Run the new data-driven classifier alongside the existing logic.
-  // The result is logged for comparison but does NOT affect the decision.
-  // This will become the primary classifier in Phase 2.
-  if (toolName === "bash" || toolName === "host_bash") {
-    const command = ((input.command as string) ?? "").trim();
-    if (command) {
-      BashRiskClassifier.classifyAndLog(command, toolName, result).catch(
-        () => {},
-      );
-    }
-  }
-
   return result;
 }
 
@@ -756,7 +433,6 @@ async function classifyRiskUncached(
   toolName: string,
   input: Record<string, unknown>,
   workingDir?: string,
-  preParsed?: ParsedCommand,
   manifestOverride?: ManifestOverride,
 ): Promise<RiskLevel> {
   if (toolName === "file_read") {
@@ -839,138 +515,6 @@ async function classifyRiskUncached(
       }
     }
     // Fall through to the tool registry default (Medium) below.
-  }
-
-  if (toolName === "bash" || toolName === "host_bash") {
-    const command = (input.command as string) ?? "";
-    if (!command.trim()) return RiskLevel.Low;
-
-    const parsed = preParsed ?? (await cachedParse(command));
-
-    // Dangerous patterns → High
-    if (parsed.dangerousPatterns.length > 0) return RiskLevel.High;
-
-    // Opaque constructs → at least Medium (never Low)
-    if (parsed.hasOpaqueConstructs) return RiskLevel.Medium;
-
-    // Check each segment
-    let maxRisk = RiskLevel.Low;
-
-    for (const seg of parsed.segments) {
-      const prog = seg.program;
-
-      if (HIGH_RISK_PROGRAMS.has(prog)) return RiskLevel.High;
-
-      if (prog === "rm") {
-        // Only downgrade rm of known safe workspace files for sandboxed bash.
-        // host_bash has a global ask rule that would prompt Medium-risk
-        // commands, so rm on the host must always require explicit approval.
-        if (toolName === "bash" && isRmOfKnownSafeFile(seg.args)) {
-          maxRisk = RiskLevel.Medium;
-          continue;
-        }
-        return RiskLevel.High;
-      }
-
-      if (
-        prog === "chmod" ||
-        prog === "chown" ||
-        prog === "chgrp" ||
-        prog === "sed" ||
-        prog === "awk"
-      ) {
-        maxRisk = RiskLevel.Medium;
-        continue;
-      }
-
-      // curl/wget can download and execute arbitrary code from the internet.
-      // Also catch wrapped invocations like `env curl …` or `nice wget …`.
-      if (prog === "curl" || prog === "wget") {
-        maxRisk = RiskLevel.Medium;
-        continue;
-      }
-
-      if (WRAPPER_PROGRAMS.has(prog)) {
-        // `command -v` and `command -V` are read-only lookups (print where
-        // a command lives) — don't escalate to high risk for those.
-        if (
-          prog === "command" &&
-          seg.args.length > 0 &&
-          (seg.args[0] === "-v" || seg.args[0] === "-V")
-        ) {
-          continue;
-        }
-        const wrapped = getWrappedProgram(seg);
-        if (wrapped === "rm") return RiskLevel.High;
-        if (wrapped && HIGH_RISK_PROGRAMS.has(wrapped)) return RiskLevel.High;
-        if (wrapped === "curl" || wrapped === "wget") {
-          maxRisk = RiskLevel.Medium;
-          continue;
-        }
-        // Propagate subcommand-aware classification for wrapped git/assistant
-        if (wrapped === "git") {
-          const wrappedWithArgs = getWrappedProgramWithArgs(seg);
-          if (wrappedWithArgs) {
-            const subcommand = firstPositionalArg(
-              wrappedWithArgs.args,
-              GIT_VALUE_FLAGS,
-            );
-            if (subcommand && LOW_RISK_GIT_SUBCOMMANDS.has(subcommand)) {
-              continue;
-            }
-            maxRisk = RiskLevel.Medium;
-            continue;
-          }
-        }
-        if (wrapped === "assistant") {
-          const wrappedWithArgs = getWrappedProgramWithArgs(seg);
-          if (wrappedWithArgs) {
-            const assistantRisk = classifyAssistantSubcommand(
-              wrappedWithArgs.args,
-            );
-            if (assistantRisk === RiskLevel.High) return RiskLevel.High;
-            if (assistantRisk === RiskLevel.Medium) {
-              maxRisk = RiskLevel.Medium;
-            }
-            continue;
-          }
-        }
-      }
-
-      if (prog === "git") {
-        const subcommand = firstPositionalArg(seg.args, GIT_VALUE_FLAGS);
-        if (subcommand && LOW_RISK_GIT_SUBCOMMANDS.has(subcommand)) {
-          // Stay at current risk
-          continue;
-        }
-        // Non-read-only git commands are medium
-        maxRisk = RiskLevel.Medium;
-        continue;
-      }
-
-      if (prog === "assistant") {
-        const assistantRisk = classifyAssistantSubcommand(seg.args);
-        if (assistantRisk === RiskLevel.High) return RiskLevel.High;
-        if (assistantRisk === RiskLevel.Medium) {
-          maxRisk = RiskLevel.Medium;
-        }
-        continue;
-      }
-
-      if (!LOW_RISK_PROGRAMS.has(prog)) {
-        // Unknown program → medium
-        if (maxRisk === RiskLevel.Low) {
-          maxRisk = RiskLevel.Medium;
-        }
-      }
-    }
-
-    // If no segments could be extracted, treat as opaque
-    if (parsed.segments.length === 0) {
-      return RiskLevel.Medium;
-    }
-
-    return maxRisk;
   }
 
   // Check the tool registry for a declared default risk level

--- a/assistant/src/permissions/command-registry.test.ts
+++ b/assistant/src/permissions/command-registry.test.ts
@@ -299,6 +299,23 @@ describe("command-registry", () => {
       expect(missing).toEqual([]);
     });
 
+    test("every program in HIGH_RISK_PROGRAMS has baseRisk high in the registry", () => {
+      const errors: string[] = [];
+      for (const prog of HIGH_RISK_PROGRAMS) {
+        const spec = (
+          DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>
+        )[prog];
+        if (!spec) {
+          errors.push(`${prog}: missing from registry`);
+        } else if (spec.baseRisk !== "high") {
+          errors.push(
+            `${prog}: expected baseRisk "high", got "${spec.baseRisk}"`,
+          );
+        }
+      }
+      expect(errors).toEqual([]);
+    });
+
     test("every LOW_RISK_GIT_SUBCOMMAND has baseRisk low in the registry", () => {
       const gitSpec = DEFAULT_COMMAND_REGISTRY.git;
       const errors: string[] = [];
@@ -319,6 +336,28 @@ describe("command-registry", () => {
       }
 
       expect(errors).toEqual([]);
+    });
+  });
+
+  describe("command and exec special cases", () => {
+    test("command has isWrapper: true and argRule for -v/-V lookup", () => {
+      const spec = DEFAULT_COMMAND_REGISTRY.command;
+      expect(spec.isWrapper).toBe(true);
+      expect(spec.baseRisk).toBe("low");
+      expect(spec.argRules).toBeDefined();
+
+      const lookupRule = spec.argRules!.find((r) => r.id === "command:lookup");
+      expect(lookupRule).toBeDefined();
+      expect(lookupRule!.flags).toContain("-v");
+      expect(lookupRule!.flags).toContain("-V");
+      expect(lookupRule!.risk).toBe("low");
+    });
+
+    test("exec is high risk wrapper (replaces current shell process)", () => {
+      const spec = DEFAULT_COMMAND_REGISTRY.exec;
+      expect(spec.baseRisk).toBe("high");
+      expect(spec.isWrapper).toBe(true);
+      expect(spec.reason).toBe("Replaces current shell process");
     });
   });
 

--- a/assistant/src/permissions/command-registry.test.ts
+++ b/assistant/src/permissions/command-registry.test.ts
@@ -53,35 +53,137 @@ function collectBaseRisks(spec: CommandRiskSpec): string[] {
 // Replicated here for test validation. Every program in this set must have an
 // entry in the registry.
 const LOW_RISK_PROGRAMS = new Set([
-  "ls", "cat", "head", "tail", "less", "more", "wc", "file", "stat",
-  "grep", "rg", "ag", "ack", "find", "fd", "which", "where", "whereis",
-  "type", "echo", "printf", "date", "cal", "uptime", "whoami", "hostname",
-  "uname", "pwd", "realpath", "dirname", "basename", "git", "node", "bun",
-  "deno", "npm", "npx", "yarn", "pnpm", "python", "python3", "pip", "pip3",
-  "man", "help", "info", "env", "printenv", "set", "diff", "sort", "uniq",
-  "cut", "tr", "tee", "xargs", "jq", "yq", "http", "dig", "nslookup",
-  "ping", "tree", "du", "df",
+  "ls",
+  "cat",
+  "head",
+  "tail",
+  "less",
+  "more",
+  "wc",
+  "file",
+  "stat",
+  "grep",
+  "rg",
+  "ag",
+  "ack",
+  "find",
+  "fd",
+  "which",
+  "where",
+  "whereis",
+  "type",
+  "echo",
+  "printf",
+  "date",
+  "cal",
+  "uptime",
+  "whoami",
+  "hostname",
+  "uname",
+  "pwd",
+  "realpath",
+  "dirname",
+  "basename",
+  "git",
+  "node",
+  "bun",
+  "deno",
+  "npm",
+  "npx",
+  "yarn",
+  "pnpm",
+  "python",
+  "python3",
+  "pip",
+  "pip3",
+  "man",
+  "help",
+  "info",
+  "env",
+  "printenv",
+  "set",
+  "diff",
+  "sort",
+  "uniq",
+  "cut",
+  "tr",
+  "tee",
+  "xargs",
+  "jq",
+  "yq",
+  "http",
+  "dig",
+  "nslookup",
+  "ping",
+  "tree",
+  "du",
+  "df",
 ]);
 
 // ── HIGH_RISK_PROGRAMS from checker.ts ───────────────────────────────────────
 const HIGH_RISK_PROGRAMS = new Set([
-  "sudo", "su", "doas", "dd", "mkfs", "fdisk", "parted", "mount", "umount",
-  "systemctl", "service", "launchctl", "useradd", "userdel", "usermod",
-  "groupadd", "groupdel", "iptables", "ufw", "firewall-cmd", "reboot",
-  "shutdown", "halt", "poweroff", "kill", "killall", "pkill",
+  "sudo",
+  "su",
+  "doas",
+  "dd",
+  "mkfs",
+  "fdisk",
+  "parted",
+  "mount",
+  "umount",
+  "systemctl",
+  "service",
+  "launchctl",
+  "useradd",
+  "userdel",
+  "usermod",
+  "groupadd",
+  "groupdel",
+  "iptables",
+  "ufw",
+  "firewall-cmd",
+  "reboot",
+  "shutdown",
+  "halt",
+  "poweroff",
+  "kill",
+  "killall",
+  "pkill",
 ]);
 
 // ── WRAPPER_PROGRAMS from checker.ts ─────────────────────────────────────────
 const WRAPPER_PROGRAMS = new Set([
-  "env", "nice", "nohup", "time", "command", "exec", "strace", "ltrace",
-  "ionice", "taskset", "timeout",
+  "env",
+  "nice",
+  "nohup",
+  "time",
+  "command",
+  "exec",
+  "strace",
+  "ltrace",
+  "ionice",
+  "taskset",
+  "timeout",
 ]);
 
 // ── LOW_RISK_GIT_SUBCOMMANDS from checker.ts ─────────────────────────────────
 const LOW_RISK_GIT_SUBCOMMANDS = new Set([
-  "status", "log", "diff", "show", "branch", "tag", "remote", "stash",
-  "blame", "shortlog", "describe", "rev-parse", "ls-files", "ls-tree",
-  "cat-file", "reflog",
+  "status",
+  "log",
+  "diff",
+  "show",
+  "branch",
+  "tag",
+  "remote",
+  "stash",
+  "blame",
+  "shortlog",
+  "describe",
+  "rev-parse",
+  "ls-files",
+  "ls-tree",
+  "cat-file",
+  "reflog",
 ]);
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -108,7 +210,9 @@ describe("command-registry", () => {
       const duplicates: string[] = [];
       for (const { id, path } of allIds) {
         if (seen.has(id)) {
-          duplicates.push(`"${id}" appears in both "${seen.get(id)}" and "${path}"`);
+          duplicates.push(
+            `"${id}" appears in both "${seen.get(id)}" and "${path}"`,
+          );
         }
         seen.set(id, path);
       }
@@ -168,7 +272,9 @@ describe("command-registry", () => {
     test("every program in WRAPPER_PROGRAMS has isWrapper: true", () => {
       const errors: string[] = [];
       for (const prog of WRAPPER_PROGRAMS) {
-        const spec = (DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>)[prog];
+        const spec = (
+          DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>
+        )[prog];
         if (!spec) {
           errors.push(`${prog}: missing from registry`);
         } else if (!spec.isWrapper) {
@@ -206,7 +312,9 @@ describe("command-registry", () => {
           // args defaults to `git stash push`, and the checker treated the bare
           // command as low. Our registry has it as medium with low subcommands.
           if (sub === "stash") continue;
-          errors.push(`git ${sub}: expected baseRisk "low", got "${subSpec.baseRisk}"`);
+          errors.push(
+            `git ${sub}: expected baseRisk "low", got "${subSpec.baseRisk}"`,
+          );
         }
       }
 
@@ -218,6 +326,171 @@ describe("command-registry", () => {
     test("has at least 90 entries (comprehensive coverage)", () => {
       const count = Object.keys(DEFAULT_COMMAND_REGISTRY).length;
       expect(count).toBeGreaterThanOrEqual(90);
+    });
+  });
+
+  // ── assistant subcommand risk levels ─────────────────────────────────────
+  // These tests verify the registry matches classifyAssistantSubcommand()
+  // from checker.ts, covering every branch of that function.
+  describe("assistant subcommand classifications match classifyAssistantSubcommand", () => {
+    const assistantSpec = DEFAULT_COMMAND_REGISTRY.assistant;
+
+    test("assistant (bare) is low risk", () => {
+      expect(assistantSpec.baseRisk).toBe("low");
+    });
+
+    // ── oauth subcommand ──────────────────────────────────────────────────
+    describe("oauth", () => {
+      const oauthSpec = assistantSpec.subcommands!.oauth;
+
+      test("assistant oauth (bare) is low risk", () => {
+        expect(oauthSpec.baseRisk).toBe("low");
+      });
+
+      test("assistant oauth token is high risk", () => {
+        expect(oauthSpec.subcommands!.token.baseRisk).toBe("high");
+      });
+
+      test("assistant oauth mode (bare) is low risk", () => {
+        expect(oauthSpec.subcommands!.mode.baseRisk).toBe("low");
+      });
+
+      test("assistant oauth mode has --set argRule escalating to high", () => {
+        const modeSpec = oauthSpec.subcommands!.mode;
+        expect(modeSpec.argRules).toBeDefined();
+        const setRule = modeSpec.argRules!.find((r) =>
+          r.flags?.includes("--set"),
+        );
+        expect(setRule).toBeDefined();
+        expect(setRule!.risk).toBe("high");
+      });
+
+      test("assistant oauth request is medium risk", () => {
+        expect(oauthSpec.subcommands!.request.baseRisk).toBe("medium");
+      });
+
+      test("assistant oauth connect is medium risk", () => {
+        expect(oauthSpec.subcommands!.connect.baseRisk).toBe("medium");
+      });
+
+      test("assistant oauth disconnect is medium risk", () => {
+        expect(oauthSpec.subcommands!.disconnect.baseRisk).toBe("medium");
+      });
+    });
+
+    // ── credentials subcommand ────────────────────────────────────────────
+    describe("credentials", () => {
+      const credSpec = assistantSpec.subcommands!.credentials;
+
+      test("assistant credentials (bare) is low risk", () => {
+        expect(credSpec.baseRisk).toBe("low");
+      });
+
+      test("assistant credentials reveal is high risk", () => {
+        expect(credSpec.subcommands!.reveal.baseRisk).toBe("high");
+      });
+
+      test("assistant credentials set is high risk", () => {
+        expect(credSpec.subcommands!.set.baseRisk).toBe("high");
+      });
+
+      test("assistant credentials delete is high risk", () => {
+        expect(credSpec.subcommands!.delete.baseRisk).toBe("high");
+      });
+    });
+
+    // ── keys subcommand ───────────────────────────────────────────────────
+    describe("keys", () => {
+      const keysSpec = assistantSpec.subcommands!.keys;
+
+      test("assistant keys (bare) is low risk", () => {
+        expect(keysSpec.baseRisk).toBe("low");
+      });
+
+      test("assistant keys set is high risk", () => {
+        expect(keysSpec.subcommands!.set.baseRisk).toBe("high");
+      });
+
+      test("assistant keys delete is high risk", () => {
+        expect(keysSpec.subcommands!.delete.baseRisk).toBe("high");
+      });
+    });
+
+    // ── trust subcommand ──────────────────────────────────────────────────
+    describe("trust", () => {
+      const trustSpec = assistantSpec.subcommands!.trust;
+
+      test("assistant trust (bare) is low risk", () => {
+        expect(trustSpec.baseRisk).toBe("low");
+      });
+
+      test("assistant trust remove is high risk", () => {
+        expect(trustSpec.subcommands!.remove.baseRisk).toBe("high");
+      });
+
+      test("assistant trust clear is high risk", () => {
+        expect(trustSpec.subcommands!.clear.baseRisk).toBe("high");
+      });
+    });
+
+    // ── low-risk subcommands (no further subcommands) ────────────────────
+    describe("simple low-risk subcommands", () => {
+      test("assistant platform is low risk", () => {
+        expect(assistantSpec.subcommands!.platform.baseRisk).toBe("low");
+      });
+
+      test("assistant backup is low risk", () => {
+        expect(assistantSpec.subcommands!.backup.baseRisk).toBe("low");
+      });
+
+      test("assistant help is low risk", () => {
+        expect(assistantSpec.subcommands!.help.baseRisk).toBe("low");
+      });
+    });
+
+    // ── completeness check ────────────────────────────────────────────────
+    test("all assistant subcommand groups from classifyAssistantSubcommand are present", () => {
+      const requiredSubcommands = ["oauth", "credentials", "keys", "trust"];
+      const actualSubcommands = Object.keys(assistantSpec.subcommands!);
+      for (const sub of requiredSubcommands) {
+        expect(actualSubcommands).toContain(sub);
+      }
+    });
+
+    test("oauth has all expected sub-subcommands", () => {
+      const oauthSubs = Object.keys(
+        assistantSpec.subcommands!.oauth.subcommands!,
+      );
+      expect(oauthSubs).toContain("token");
+      expect(oauthSubs).toContain("mode");
+      expect(oauthSubs).toContain("request");
+      expect(oauthSubs).toContain("connect");
+      expect(oauthSubs).toContain("disconnect");
+    });
+
+    test("credentials has all expected sub-subcommands", () => {
+      const credSubs = Object.keys(
+        assistantSpec.subcommands!.credentials.subcommands!,
+      );
+      expect(credSubs).toContain("reveal");
+      expect(credSubs).toContain("set");
+      expect(credSubs).toContain("delete");
+    });
+
+    test("keys has all expected sub-subcommands", () => {
+      const keysSubs = Object.keys(
+        assistantSpec.subcommands!.keys.subcommands!,
+      );
+      expect(keysSubs).toContain("set");
+      expect(keysSubs).toContain("delete");
+    });
+
+    test("trust has all expected sub-subcommands", () => {
+      const trustSubs = Object.keys(
+        assistantSpec.subcommands!.trust.subcommands!,
+      );
+      expect(trustSubs).toContain("remove");
+      expect(trustSubs).toContain("clear");
     });
   });
 });

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -30,470 +30,764 @@ const TMP_PATHS = String.raw`^(?:/tmp|/var/tmp|\./|\.\.\/)`;
 // ── Default command registry ──────────────────────────────────────────────────
 
 export const DEFAULT_COMMAND_REGISTRY = {
-
   // ── Read-only filesystem commands ──────────────────────────────────────────
-  ls:       { baseRisk: "low" },
-  cat:      { baseRisk: "low", argRules: [
-    { id: "cat:sensitive", valuePattern: SENSITIVE_PATHS, risk: "high",
-      reason: "Reads sensitive file" },
-  ]},
-  head:     { baseRisk: "low" },
-  tail:     { baseRisk: "low" },
-  less:     { baseRisk: "low" },
-  more:     { baseRisk: "low" },
-  wc:       { baseRisk: "low" },
-  file:     { baseRisk: "low" },
-  stat:     { baseRisk: "low" },
-  du:       { baseRisk: "low" },
-  df:       { baseRisk: "low" },
-  diff:     { baseRisk: "low" },
-  tree:     { baseRisk: "low" },
-  pwd:      { baseRisk: "low" },
+  ls: { baseRisk: "low" },
+  cat: {
+    baseRisk: "low",
+    argRules: [
+      {
+        id: "cat:sensitive",
+        valuePattern: SENSITIVE_PATHS,
+        risk: "high",
+        reason: "Reads sensitive file",
+      },
+    ],
+  },
+  head: { baseRisk: "low" },
+  tail: { baseRisk: "low" },
+  less: { baseRisk: "low" },
+  more: { baseRisk: "low" },
+  wc: { baseRisk: "low" },
+  file: { baseRisk: "low" },
+  stat: { baseRisk: "low" },
+  du: { baseRisk: "low" },
+  df: { baseRisk: "low" },
+  diff: { baseRisk: "low" },
+  tree: { baseRisk: "low" },
+  pwd: { baseRisk: "low" },
   realpath: { baseRisk: "low" },
   basename: { baseRisk: "low" },
-  dirname:  { baseRisk: "low" },
+  dirname: { baseRisk: "low" },
 
   // ── Search / filter / text processing ──────────────────────────────────────
-  grep:     { baseRisk: "low" },
-  rg:       { baseRisk: "low" },
-  ag:       { baseRisk: "low" },
-  ack:      { baseRisk: "low" },
-  sort:     { baseRisk: "low" },
-  uniq:     { baseRisk: "low" },
-  cut:      { baseRisk: "low" },
-  tr:       { baseRisk: "low" },
-  sed:      { baseRisk: "low", argRules: [
-    { id: "sed:inplace", flags: ["-i", "--in-place"], risk: "medium",
-      reason: "Edits files in place" },
-  ]},
-  awk:      { baseRisk: "low", complexSyntax: true },
+  grep: { baseRisk: "low" },
+  rg: { baseRisk: "low" },
+  ag: { baseRisk: "low" },
+  ack: { baseRisk: "low" },
+  sort: { baseRisk: "low" },
+  uniq: { baseRisk: "low" },
+  cut: { baseRisk: "low" },
+  tr: { baseRisk: "low" },
+  sed: {
+    baseRisk: "low",
+    argRules: [
+      {
+        id: "sed:inplace",
+        flags: ["-i", "--in-place"],
+        risk: "medium",
+        reason: "Edits files in place",
+      },
+    ],
+  },
+  awk: { baseRisk: "low", complexSyntax: true },
 
   // ── System information (read-only) ─────────────────────────────────────────
-  echo:     { baseRisk: "low" },
-  printf:   { baseRisk: "low" },
-  whoami:   { baseRisk: "low" },
-  uname:    { baseRisk: "low" },
-  uptime:   { baseRisk: "low" },
+  echo: { baseRisk: "low" },
+  printf: { baseRisk: "low" },
+  whoami: { baseRisk: "low" },
+  uname: { baseRisk: "low" },
+  uptime: { baseRisk: "low" },
   hostname: { baseRisk: "low" },
-  date:     { baseRisk: "low" },
-  cal:      { baseRisk: "low" },
-  id:       { baseRisk: "low" },
-  ps:       { baseRisk: "low" },
-  free:     { baseRisk: "low" },
-  which:    { baseRisk: "low" },
-  where:    { baseRisk: "low" },
-  whereis:  { baseRisk: "low" },
-  type:     { baseRisk: "low" },
+  date: { baseRisk: "low" },
+  cal: { baseRisk: "low" },
+  id: { baseRisk: "low" },
+  ps: { baseRisk: "low" },
+  free: { baseRisk: "low" },
+  which: { baseRisk: "low" },
+  where: { baseRisk: "low" },
+  whereis: { baseRisk: "low" },
+  type: { baseRisk: "low" },
   printenv: { baseRisk: "low" },
-  man:      { baseRisk: "low" },
-  help:     { baseRisk: "low" },
-  info:     { baseRisk: "low" },
+  man: { baseRisk: "low" },
+  help: { baseRisk: "low" },
+  info: { baseRisk: "low" },
 
   // ── Checksum / hex tools ───────────────────────────────────────────────────
   sha256sum: { baseRisk: "low" },
-  md5sum:   { baseRisk: "low" },
-  xxd:      { baseRisk: "low" },
-  hexdump:  { baseRisk: "low" },
+  md5sum: { baseRisk: "low" },
+  xxd: { baseRisk: "low" },
+  hexdump: { baseRisk: "low" },
 
   // ── Data processing ────────────────────────────────────────────────────────
-  jq:       { baseRisk: "low" },
-  yq:       { baseRisk: "low" },
+  jq: { baseRisk: "low" },
+  yq: { baseRisk: "low" },
 
   // ── Find ───────────────────────────────────────────────────────────────────
   // DIVERGENCE: checker.ts lists `find` as LOW_RISK unconditionally. Our
   // registry adds arg rules for -exec/-execdir/-delete which escalate to high.
-  find:     { baseRisk: "low", complexSyntax: true, argRules: [
-    { id: "find:exec",   flags: ["-exec", "-execdir"], risk: "high",
-      reason: "Executes arbitrary commands on matched files" },
-    { id: "find:delete", flags: ["-delete"],           risk: "high",
-      reason: "Deletes matched files" },
-  ]},
-  fd:       { baseRisk: "low" },
+  find: {
+    baseRisk: "low",
+    complexSyntax: true,
+    argRules: [
+      {
+        id: "find:exec",
+        flags: ["-exec", "-execdir"],
+        risk: "high",
+        reason: "Executes arbitrary commands on matched files",
+      },
+      {
+        id: "find:delete",
+        flags: ["-delete"],
+        risk: "high",
+        reason: "Deletes matched files",
+      },
+    ],
+  },
+  fd: { baseRisk: "low" },
 
   // ── Write commands ─────────────────────────────────────────────────────────
-  cp:       { baseRisk: "medium", argRules: [
-    { id: "cp:system", valuePattern: SYSTEM_PATHS, risk: "high",
-      reason: "Copies to system path" },
-  ]},
-  mv:       { baseRisk: "medium", argRules: [
-    { id: "mv:system", valuePattern: SYSTEM_PATHS, risk: "high",
-      reason: "Moves to system path" },
-  ]},
-  mkdir:    { baseRisk: "medium" },
-  touch:    { baseRisk: "medium" },
+  cp: {
+    baseRisk: "medium",
+    argRules: [
+      {
+        id: "cp:system",
+        valuePattern: SYSTEM_PATHS,
+        risk: "high",
+        reason: "Copies to system path",
+      },
+    ],
+  },
+  mv: {
+    baseRisk: "medium",
+    argRules: [
+      {
+        id: "mv:system",
+        valuePattern: SYSTEM_PATHS,
+        risk: "high",
+        reason: "Moves to system path",
+      },
+    ],
+  },
+  mkdir: { baseRisk: "medium" },
+  touch: { baseRisk: "medium" },
   // DIVERGENCE: checker.ts lists `tee` as LOW_RISK. Our registry classifies
   // it as medium because it writes to files.
-  tee:      { baseRisk: "medium" },
+  tee: { baseRisk: "medium" },
 
   // ── Delete commands ────────────────────────────────────────────────────────
-  rm:       { baseRisk: "high", argRules: [
-    { id: "rm:recursive-force", flags: ["-rf", "-fr", "-Rf", "-fR"],
-      risk: "high", reason: "Recursive force delete" },
-    { id: "rm:recursive", flags: ["-r", "-R", "--recursive"],
-      risk: "high", reason: "Recursive delete" },
-    { id: "rm:tmp", valuePattern: TMP_PATHS,
-      risk: "medium", reason: "Removes temp files" },
-    { id: "rm:system", valuePattern: SYSTEM_PATHS,
-      risk: "high", reason: "Removes system files" },
-    { id: "rm:sensitive", valuePattern: SENSITIVE_PATHS,
-      risk: "high", reason: "Removes sensitive files" },
-  ]},
-  rmdir:    { baseRisk: "high" },
+  rm: {
+    baseRisk: "high",
+    argRules: [
+      {
+        id: "rm:recursive-force",
+        flags: ["-rf", "-fr", "-Rf", "-fR"],
+        risk: "high",
+        reason: "Recursive force delete",
+      },
+      {
+        id: "rm:recursive",
+        flags: ["-r", "-R", "--recursive"],
+        risk: "high",
+        reason: "Recursive delete",
+      },
+      {
+        id: "rm:tmp",
+        valuePattern: TMP_PATHS,
+        risk: "medium",
+        reason: "Removes temp files",
+      },
+      {
+        id: "rm:system",
+        valuePattern: SYSTEM_PATHS,
+        risk: "high",
+        reason: "Removes system files",
+      },
+      {
+        id: "rm:sensitive",
+        valuePattern: SENSITIVE_PATHS,
+        risk: "high",
+        reason: "Removes sensitive files",
+      },
+    ],
+  },
+  rmdir: { baseRisk: "high" },
 
   // ── Network commands ───────────────────────────────────────────────────────
-  curl:     { baseRisk: "medium", argRules: [
-    { id: "curl:upload-data", flags: ["-d", "--data", "--data-binary", "--data-raw"],
-      valuePattern: String.raw`^@`, risk: "high", reason: "Uploads file contents" },
-    { id: "curl:upload-file", flags: ["-T", "--upload-file"],
-      risk: "high", reason: "Uploads file" },
-    { id: "curl:output-sensitive", flags: ["-o", "--output"],
-      valuePattern: SENSITIVE_PATHS, risk: "high", reason: "Writes to sensitive path" },
-    { id: "curl:localhost", valuePattern: String.raw`^https?://(localhost|127\.0\.0\.1|\[::1\])`,
-      risk: "low", reason: "Local request" },
-  ]},
-  wget:     { baseRisk: "medium" },
+  curl: {
+    baseRisk: "medium",
+    argRules: [
+      {
+        id: "curl:upload-data",
+        flags: ["-d", "--data", "--data-binary", "--data-raw"],
+        valuePattern: String.raw`^@`,
+        risk: "high",
+        reason: "Uploads file contents",
+      },
+      {
+        id: "curl:upload-file",
+        flags: ["-T", "--upload-file"],
+        risk: "high",
+        reason: "Uploads file",
+      },
+      {
+        id: "curl:output-sensitive",
+        flags: ["-o", "--output"],
+        valuePattern: SENSITIVE_PATHS,
+        risk: "high",
+        reason: "Writes to sensitive path",
+      },
+      {
+        id: "curl:localhost",
+        valuePattern: String.raw`^https?://(localhost|127\.0\.0\.1|\[::1\])`,
+        risk: "low",
+        reason: "Local request",
+      },
+    ],
+  },
+  wget: { baseRisk: "medium" },
   // DIVERGENCE: checker.ts lists `http` (httpie) as LOW_RISK. Our registry
   // classifies it as medium because it can make network requests with side effects.
-  http:     { baseRisk: "medium" },
-  ping:     { baseRisk: "low" },
-  dig:      { baseRisk: "low" },
+  http: { baseRisk: "medium" },
+  ping: { baseRisk: "low" },
+  dig: { baseRisk: "low" },
   nslookup: { baseRisk: "low" },
-  ssh:      { baseRisk: "high", reason: "Opens remote shell" },
-  scp:      { baseRisk: "high", reason: "Remote file transfer" },
-  rsync:    { baseRisk: "high", reason: "Remote file sync" },
+  ssh: { baseRisk: "high", reason: "Opens remote shell" },
+  scp: { baseRisk: "high", reason: "Remote file transfer" },
+  rsync: { baseRisk: "high", reason: "Remote file sync" },
 
   // ── Git ────────────────────────────────────────────────────────────────────
   // Every subcommand in checker.ts's LOW_RISK_GIT_SUBCOMMANDS must appear here.
   // Divergences are noted inline.
-  git:      { baseRisk: "medium", subcommands: {
-    // LOW_RISK_GIT_SUBCOMMANDS from checker.ts:
-    status:    { baseRisk: "low" },
-    log:       { baseRisk: "low" },
-    diff:      { baseRisk: "low" },
-    show:      { baseRisk: "low" },
-    branch:    { baseRisk: "low" },
-    tag:       { baseRisk: "low", argRules: [
-      { id: "git-tag:delete", flags: ["-d", "--delete"], risk: "high",
-        reason: "Deletes git tag" },
-    ]},
-    remote:    { baseRisk: "low" },
-    // DIVERGENCE: checker.ts lists `stash` as LOW_RISK. Our registry classifies
-    // the base stash command as medium (it modifies working tree), with read-only
-    // subcommands (list, show) as low and destructive ones (drop) as high.
-    stash:     { baseRisk: "medium", subcommands: {
-      list: { baseRisk: "low" },
+  git: {
+    baseRisk: "medium",
+    subcommands: {
+      // LOW_RISK_GIT_SUBCOMMANDS from checker.ts:
+      status: { baseRisk: "low" },
+      log: { baseRisk: "low" },
+      diff: { baseRisk: "low" },
       show: { baseRisk: "low" },
-      drop: { baseRisk: "high", reason: "Permanently drops stashed changes" },
-    }},
-    blame:     { baseRisk: "low" },
-    shortlog:  { baseRisk: "low" },
-    describe:  { baseRisk: "low" },
-    "rev-parse": { baseRisk: "low" },
-    "ls-files":  { baseRisk: "low" },
-    "ls-tree":   { baseRisk: "low" },
-    "cat-file":  { baseRisk: "low" },
-    reflog:    { baseRisk: "low" },
-    // Write operations:
-    add:       { baseRisk: "medium" },
-    commit:    { baseRisk: "medium" },
-    checkout:  { baseRisk: "medium" },
-    switch:    { baseRisk: "medium" },
-    merge:     { baseRisk: "medium" },
-    rebase:    { baseRisk: "medium", argRules: [
-      { id: "git-rebase:interactive", flags: ["-i", "--interactive"],
-        risk: "high", reason: "Interactive rebase rewrites history" },
-    ]},
-    push:      { baseRisk: "medium", argRules: [
-      { id: "git-push:force", flags: ["--force", "-f", "--force-with-lease"],
-        risk: "high", reason: "Force push rewrites remote history" },
-    ]},
-    pull:      { baseRisk: "medium" },
-    fetch:     { baseRisk: "low" },
-    reset:     { baseRisk: "medium", argRules: [
-      { id: "git-reset:hard", flags: ["--hard"],
-        risk: "high", reason: "Discards uncommitted changes" },
-    ]},
-    clean:     { baseRisk: "high", reason: "Removes untracked files" },
-    bisect:    { baseRisk: "low" },
-    worktree:  { baseRisk: "medium" },
-  }},
+      branch: { baseRisk: "low" },
+      tag: {
+        baseRisk: "low",
+        argRules: [
+          {
+            id: "git-tag:delete",
+            flags: ["-d", "--delete"],
+            risk: "high",
+            reason: "Deletes git tag",
+          },
+        ],
+      },
+      remote: { baseRisk: "low" },
+      // DIVERGENCE: checker.ts lists `stash` as LOW_RISK. Our registry classifies
+      // the base stash command as medium (it modifies working tree), with read-only
+      // subcommands (list, show) as low and destructive ones (drop) as high.
+      stash: {
+        baseRisk: "medium",
+        subcommands: {
+          list: { baseRisk: "low" },
+          show: { baseRisk: "low" },
+          drop: {
+            baseRisk: "high",
+            reason: "Permanently drops stashed changes",
+          },
+        },
+      },
+      blame: { baseRisk: "low" },
+      shortlog: { baseRisk: "low" },
+      describe: { baseRisk: "low" },
+      "rev-parse": { baseRisk: "low" },
+      "ls-files": { baseRisk: "low" },
+      "ls-tree": { baseRisk: "low" },
+      "cat-file": { baseRisk: "low" },
+      reflog: { baseRisk: "low" },
+      // Write operations:
+      add: { baseRisk: "medium" },
+      commit: { baseRisk: "medium" },
+      checkout: { baseRisk: "medium" },
+      switch: { baseRisk: "medium" },
+      merge: { baseRisk: "medium" },
+      rebase: {
+        baseRisk: "medium",
+        argRules: [
+          {
+            id: "git-rebase:interactive",
+            flags: ["-i", "--interactive"],
+            risk: "high",
+            reason: "Interactive rebase rewrites history",
+          },
+        ],
+      },
+      push: {
+        baseRisk: "medium",
+        argRules: [
+          {
+            id: "git-push:force",
+            flags: ["--force", "-f", "--force-with-lease"],
+            risk: "high",
+            reason: "Force push rewrites remote history",
+          },
+        ],
+      },
+      pull: { baseRisk: "medium" },
+      fetch: { baseRisk: "low" },
+      reset: {
+        baseRisk: "medium",
+        argRules: [
+          {
+            id: "git-reset:hard",
+            flags: ["--hard"],
+            risk: "high",
+            reason: "Discards uncommitted changes",
+          },
+        ],
+      },
+      clean: { baseRisk: "high", reason: "Removes untracked files" },
+      bisect: { baseRisk: "low" },
+      worktree: { baseRisk: "medium" },
+    },
+  },
 
   // ── Package managers ───────────────────────────────────────────────────────
   // DIVERGENCE: checker.ts lists `npm`, `npx`, `yarn`, `pnpm`, `bun`, `pip`,
   // `pip3` as LOW_RISK. Our registry classifies them as medium (base) because
   // they download and execute code, with subcommand-level overrides.
-  npm:      { baseRisk: "medium", subcommands: {
-    ls:       { baseRisk: "low" },
-    list:     { baseRisk: "low" },
-    outdated: { baseRisk: "low" },
-    view:     { baseRisk: "low" },
-    info:     { baseRisk: "low" },
-    install:  { baseRisk: "medium", reason: "Runs lifecycle scripts, downloads code" },
-    ci:       { baseRisk: "medium", reason: "Clean install, runs lifecycle scripts" },
-    test:     { baseRisk: "high", reason: "Executes arbitrary package scripts" },
-    run:      { baseRisk: "high", reason: "Executes arbitrary package scripts" },
-    publish:  { baseRisk: "high", reason: "Publishes package to registry" },
-  }},
+  npm: {
+    baseRisk: "medium",
+    subcommands: {
+      ls: { baseRisk: "low" },
+      list: { baseRisk: "low" },
+      outdated: { baseRisk: "low" },
+      view: { baseRisk: "low" },
+      info: { baseRisk: "low" },
+      install: {
+        baseRisk: "medium",
+        reason: "Runs lifecycle scripts, downloads code",
+      },
+      ci: {
+        baseRisk: "medium",
+        reason: "Clean install, runs lifecycle scripts",
+      },
+      test: { baseRisk: "high", reason: "Executes arbitrary package scripts" },
+      run: { baseRisk: "high", reason: "Executes arbitrary package scripts" },
+      publish: { baseRisk: "high", reason: "Publishes package to registry" },
+    },
+  },
   // DIVERGENCE: checker.ts lists `npx` as LOW_RISK. Our registry classifies it
   // as high because it downloads and executes arbitrary packages.
-  npx:      { baseRisk: "high", reason: "Downloads and executes arbitrary packages" },
-  yarn:     { baseRisk: "medium", subcommands: {
-    list:     { baseRisk: "low" },
-    info:     { baseRisk: "low" },
-    why:      { baseRisk: "low" },
-    install:  { baseRisk: "medium" },
-    add:      { baseRisk: "medium" },
-    test:     { baseRisk: "high", reason: "Executes arbitrary package scripts" },
-    run:      { baseRisk: "high", reason: "Executes arbitrary package scripts" },
-  }},
-  pnpm:     { baseRisk: "medium", subcommands: {
-    list:     { baseRisk: "low" },
-    install:  { baseRisk: "medium" },
-    add:      { baseRisk: "medium" },
-    test:     { baseRisk: "high", reason: "Executes arbitrary package scripts" },
-    run:      { baseRisk: "high", reason: "Executes arbitrary package scripts" },
-  }},
+  npx: {
+    baseRisk: "high",
+    reason: "Downloads and executes arbitrary packages",
+  },
+  yarn: {
+    baseRisk: "medium",
+    subcommands: {
+      list: { baseRisk: "low" },
+      info: { baseRisk: "low" },
+      why: { baseRisk: "low" },
+      install: { baseRisk: "medium" },
+      add: { baseRisk: "medium" },
+      test: { baseRisk: "high", reason: "Executes arbitrary package scripts" },
+      run: { baseRisk: "high", reason: "Executes arbitrary package scripts" },
+    },
+  },
+  pnpm: {
+    baseRisk: "medium",
+    subcommands: {
+      list: { baseRisk: "low" },
+      install: { baseRisk: "medium" },
+      add: { baseRisk: "medium" },
+      test: { baseRisk: "high", reason: "Executes arbitrary package scripts" },
+      run: { baseRisk: "high", reason: "Executes arbitrary package scripts" },
+    },
+  },
   // DIVERGENCE: checker.ts lists `bun` as LOW_RISK. Our registry classifies it
   // as medium (base) with subcommand overrides because it can execute code.
-  bun:      { baseRisk: "medium", subcommands: {
-    install:  { baseRisk: "medium" },
-    add:      { baseRisk: "medium" },
-    test:     { baseRisk: "high", reason: "Executes arbitrary test code" },
-    run:      { baseRisk: "high", reason: "Executes arbitrary scripts" },
-  }},
-  pip:      { baseRisk: "medium", subcommands: {
-    list:     { baseRisk: "low" },
-    show:     { baseRisk: "low" },
-    install:  { baseRisk: "medium" },
-  }},
-  pip3:     { baseRisk: "medium", subcommands: {
-    list:     { baseRisk: "low" },
-    show:     { baseRisk: "low" },
-    install:  { baseRisk: "medium" },
-  }},
-  brew:     { baseRisk: "medium", subcommands: {
-    list:     { baseRisk: "low" },
-    info:     { baseRisk: "low" },
-    search:   { baseRisk: "low" },
-    install:  { baseRisk: "medium" },
-    uninstall: { baseRisk: "high" },
-  }},
-  cargo:    { baseRisk: "medium", subcommands: {
-    build:    { baseRisk: "medium" },
-    test:     { baseRisk: "high", reason: "Executes arbitrary test code" },
-    run:      { baseRisk: "high", reason: "Compiles and executes code" },
-  }},
+  bun: {
+    baseRisk: "medium",
+    subcommands: {
+      install: { baseRisk: "medium" },
+      add: { baseRisk: "medium" },
+      test: { baseRisk: "high", reason: "Executes arbitrary test code" },
+      run: { baseRisk: "high", reason: "Executes arbitrary scripts" },
+    },
+  },
+  pip: {
+    baseRisk: "medium",
+    subcommands: {
+      list: { baseRisk: "low" },
+      show: { baseRisk: "low" },
+      install: { baseRisk: "medium" },
+    },
+  },
+  pip3: {
+    baseRisk: "medium",
+    subcommands: {
+      list: { baseRisk: "low" },
+      show: { baseRisk: "low" },
+      install: { baseRisk: "medium" },
+    },
+  },
+  brew: {
+    baseRisk: "medium",
+    subcommands: {
+      list: { baseRisk: "low" },
+      info: { baseRisk: "low" },
+      search: { baseRisk: "low" },
+      install: { baseRisk: "medium" },
+      uninstall: { baseRisk: "high" },
+    },
+  },
+  cargo: {
+    baseRisk: "medium",
+    subcommands: {
+      build: { baseRisk: "medium" },
+      test: { baseRisk: "high", reason: "Executes arbitrary test code" },
+      run: { baseRisk: "high", reason: "Compiles and executes code" },
+    },
+  },
 
   // ── Build tools (inherently opaque) ────────────────────────────────────────
-  make:     { baseRisk: "high", reason: "Executes arbitrary Makefile targets" },
+  make: { baseRisk: "high", reason: "Executes arbitrary Makefile targets" },
 
   // ── Language runtimes ──────────────────────────────────────────────────────
   // DIVERGENCE: checker.ts lists `node` as LOW_RISK. Our registry classifies it
   // as high because it executes arbitrary JavaScript.
-  node:     { baseRisk: "high", reason: "Executes arbitrary JavaScript", argRules: [
-    { id: "node:version", flags: ["--version", "-v"], risk: "low",
-      reason: "Prints version" },
-    { id: "node:eval", flags: ["-e", "--eval"], risk: "high",
-      reason: "Evaluates inline JavaScript" },
-  ]},
+  node: {
+    baseRisk: "high",
+    reason: "Executes arbitrary JavaScript",
+    argRules: [
+      {
+        id: "node:version",
+        flags: ["--version", "-v"],
+        risk: "low",
+        reason: "Prints version",
+      },
+      {
+        id: "node:eval",
+        flags: ["-e", "--eval"],
+        risk: "high",
+        reason: "Evaluates inline JavaScript",
+      },
+    ],
+  },
   // DIVERGENCE: checker.ts lists `deno` as LOW_RISK. Our registry classifies it
   // as high because it executes arbitrary code.
-  deno:     { baseRisk: "high", reason: "Executes arbitrary code" },
+  deno: { baseRisk: "high", reason: "Executes arbitrary code" },
   // DIVERGENCE: checker.ts lists `python` and `python3` as LOW_RISK. Our registry
   // classifies them as high because they execute arbitrary Python code.
-  python:   { baseRisk: "high", reason: "Executes arbitrary Python code", argRules: [
-    { id: "python:version", flags: ["--version", "-V"], risk: "low",
-      reason: "Prints version" },
-  ]},
-  python3:  { baseRisk: "high", reason: "Executes arbitrary Python code", argRules: [
-    { id: "python3:version", flags: ["--version", "-V"], risk: "low",
-      reason: "Prints version" },
-  ]},
-  ruby:     { baseRisk: "high", reason: "Executes arbitrary Ruby code" },
-  go:       { baseRisk: "low", subcommands: {
-    mod:      { baseRisk: "low" },
-    vet:      { baseRisk: "low" },
-    version:  { baseRisk: "low" },
-    build:    { baseRisk: "medium" },
-    test:     { baseRisk: "high", reason: "Executes arbitrary test code" },
-    run:      { baseRisk: "high", reason: "Compiles and executes Go code" },
-  }},
+  python: {
+    baseRisk: "high",
+    reason: "Executes arbitrary Python code",
+    argRules: [
+      {
+        id: "python:version",
+        flags: ["--version", "-V"],
+        risk: "low",
+        reason: "Prints version",
+      },
+    ],
+  },
+  python3: {
+    baseRisk: "high",
+    reason: "Executes arbitrary Python code",
+    argRules: [
+      {
+        id: "python3:version",
+        flags: ["--version", "-V"],
+        risk: "low",
+        reason: "Prints version",
+      },
+    ],
+  },
+  ruby: { baseRisk: "high", reason: "Executes arbitrary Ruby code" },
+  go: {
+    baseRisk: "low",
+    subcommands: {
+      mod: { baseRisk: "low" },
+      vet: { baseRisk: "low" },
+      version: { baseRisk: "low" },
+      build: { baseRisk: "medium" },
+      test: { baseRisk: "high", reason: "Executes arbitrary test code" },
+      run: { baseRisk: "high", reason: "Compiles and executes Go code" },
+    },
+  },
 
   // ── Docker ─────────────────────────────────────────────────────────────────
-  docker:   { baseRisk: "medium", subcommands: {
-    ps:       { baseRisk: "low" },
-    images:   { baseRisk: "low" },
-    inspect:  { baseRisk: "low" },
-    logs:     { baseRisk: "low" },
-    info:     { baseRisk: "low" },
-    version:  { baseRisk: "low" },
-    build:    { baseRisk: "medium" },
-    pull:     { baseRisk: "medium" },
-    push:     { baseRisk: "high", reason: "Pushes image to registry" },
-    run:      { baseRisk: "high", reason: "Runs arbitrary container", argRules: [
-      { id: "docker-run:privileged", flags: ["--privileged"],
-        risk: "high", reason: "Privileged container with full host access" },
-      { id: "docker-run:volume-root", flags: ["-v", "--volume"],
-        valuePattern: String.raw`^/:`, risk: "high",
-        reason: "Mounts host root filesystem" },
-    ]},
-    exec:     { baseRisk: "high", reason: "Executes command in running container" },
-    rm:       { baseRisk: "high" },
-    rmi:      { baseRisk: "high" },
-    stop:     { baseRisk: "medium" },
-    start:    { baseRisk: "medium" },
-  }},
+  docker: {
+    baseRisk: "medium",
+    subcommands: {
+      ps: { baseRisk: "low" },
+      images: { baseRisk: "low" },
+      inspect: { baseRisk: "low" },
+      logs: { baseRisk: "low" },
+      info: { baseRisk: "low" },
+      version: { baseRisk: "low" },
+      build: { baseRisk: "medium" },
+      pull: { baseRisk: "medium" },
+      push: { baseRisk: "high", reason: "Pushes image to registry" },
+      run: {
+        baseRisk: "high",
+        reason: "Runs arbitrary container",
+        argRules: [
+          {
+            id: "docker-run:privileged",
+            flags: ["--privileged"],
+            risk: "high",
+            reason: "Privileged container with full host access",
+          },
+          {
+            id: "docker-run:volume-root",
+            flags: ["-v", "--volume"],
+            valuePattern: String.raw`^/:`,
+            risk: "high",
+            reason: "Mounts host root filesystem",
+          },
+        ],
+      },
+      exec: {
+        baseRisk: "high",
+        reason: "Executes command in running container",
+      },
+      rm: { baseRisk: "high" },
+      rmi: { baseRisk: "high" },
+      stop: { baseRisk: "medium" },
+      start: { baseRisk: "medium" },
+    },
+  },
 
   // ── Privilege / system ─────────────────────────────────────────────────────
-  sudo:     { baseRisk: "high", isWrapper: true,
-    reason: "Elevates to superuser privileges" },
-  su:       { baseRisk: "high", reason: "Switches user identity" },
-  doas:     { baseRisk: "high", isWrapper: true,
-    reason: "Elevates privileges (OpenBSD sudo alternative)" },
-  chmod:    { baseRisk: "high", reason: "Changes file permissions" },
-  chown:    { baseRisk: "high", reason: "Changes file ownership" },
-  chgrp:    { baseRisk: "high", reason: "Changes file group" },
-  mount:    { baseRisk: "high", reason: "Mounts filesystem" },
-  umount:   { baseRisk: "high", reason: "Unmounts filesystem" },
+  sudo: {
+    baseRisk: "high",
+    isWrapper: true,
+    reason: "Elevates to superuser privileges",
+  },
+  su: { baseRisk: "high", reason: "Switches user identity" },
+  doas: {
+    baseRisk: "high",
+    isWrapper: true,
+    reason: "Elevates privileges (OpenBSD sudo alternative)",
+  },
+  chmod: { baseRisk: "high", reason: "Changes file permissions" },
+  chown: { baseRisk: "high", reason: "Changes file ownership" },
+  chgrp: { baseRisk: "high", reason: "Changes file group" },
+  mount: { baseRisk: "high", reason: "Mounts filesystem" },
+  umount: { baseRisk: "high", reason: "Unmounts filesystem" },
   systemctl: { baseRisk: "high", reason: "Controls system services" },
-  service:  { baseRisk: "high", reason: "Controls system services" },
+  service: { baseRisk: "high", reason: "Controls system services" },
   launchctl: { baseRisk: "high", reason: "Controls macOS services" },
 
   // ── User management ────────────────────────────────────────────────────────
-  useradd:  { baseRisk: "high", reason: "Creates system user" },
-  userdel:  { baseRisk: "high", reason: "Deletes system user" },
-  usermod:  { baseRisk: "high", reason: "Modifies system user" },
+  useradd: { baseRisk: "high", reason: "Creates system user" },
+  userdel: { baseRisk: "high", reason: "Deletes system user" },
+  usermod: { baseRisk: "high", reason: "Modifies system user" },
   groupadd: { baseRisk: "high", reason: "Creates system group" },
   groupdel: { baseRisk: "high", reason: "Deletes system group" },
 
   // ── Firewall ───────────────────────────────────────────────────────────────
-  iptables:     { baseRisk: "high", reason: "Modifies firewall rules" },
-  ufw:          { baseRisk: "high", reason: "Modifies firewall rules" },
+  iptables: { baseRisk: "high", reason: "Modifies firewall rules" },
+  ufw: { baseRisk: "high", reason: "Modifies firewall rules" },
   "firewall-cmd": { baseRisk: "high", reason: "Modifies firewall rules" },
 
   // ── System lifecycle ───────────────────────────────────────────────────────
-  reboot:   { baseRisk: "high", reason: "Reboots the system" },
+  reboot: { baseRisk: "high", reason: "Reboots the system" },
   shutdown: { baseRisk: "high", reason: "Shuts down the system" },
-  halt:     { baseRisk: "high", reason: "Halts the system" },
+  halt: { baseRisk: "high", reason: "Halts the system" },
   poweroff: { baseRisk: "high", reason: "Powers off the system" },
 
   // ── Process management ─────────────────────────────────────────────────────
-  kill:     { baseRisk: "high", reason: "Sends signal to process" },
-  killall:  { baseRisk: "high", reason: "Kills processes by name" },
-  pkill:    { baseRisk: "high", reason: "Kills processes by pattern" },
+  kill: { baseRisk: "high", reason: "Sends signal to process" },
+  killall: { baseRisk: "high", reason: "Kills processes by name" },
+  pkill: { baseRisk: "high", reason: "Kills processes by pattern" },
 
   // ── Catastrophic ───────────────────────────────────────────────────────────
-  mkfs:     { baseRisk: "high", reason: "Formats filesystem — destroys all data" },
-  dd:       { baseRisk: "high", reason: "Low-level block device copy — can destroy disks" },
-  fdisk:    { baseRisk: "high", reason: "Modifies disk partitions" },
-  parted:   { baseRisk: "high", reason: "Modifies disk partitions" },
+  mkfs: { baseRisk: "high", reason: "Formats filesystem — destroys all data" },
+  dd: {
+    baseRisk: "high",
+    reason: "Low-level block device copy — can destroy disks",
+  },
+  fdisk: { baseRisk: "high", reason: "Modifies disk partitions" },
+  parted: { baseRisk: "high", reason: "Modifies disk partitions" },
 
   // ── Wrapper commands ───────────────────────────────────────────────────────
   // These unwrap to find and classify the inner command. The classifier takes
   // max(wrapper.baseRisk, inner.risk).
-  env:      { baseRisk: "low", isWrapper: true },
-  nice:     { baseRisk: "low", isWrapper: true },
-  nohup:    { baseRisk: "low", isWrapper: true },
-  timeout:  { baseRisk: "low", isWrapper: true },
-  time:     { baseRisk: "low", isWrapper: true },
-  command:  { baseRisk: "low", isWrapper: true },
-  exec:     { baseRisk: "low", isWrapper: true },
-  strace:   { baseRisk: "medium", isWrapper: true, reason: "Traces system calls" },
-  ltrace:   { baseRisk: "medium", isWrapper: true, reason: "Traces library calls" },
-  ionice:   { baseRisk: "low", isWrapper: true },
-  taskset:  { baseRisk: "low", isWrapper: true },
+  env: { baseRisk: "low", isWrapper: true },
+  nice: { baseRisk: "low", isWrapper: true },
+  nohup: { baseRisk: "low", isWrapper: true },
+  timeout: { baseRisk: "low", isWrapper: true },
+  time: { baseRisk: "low", isWrapper: true },
+  command: {
+    baseRisk: "low",
+    isWrapper: true,
+    argRules: [
+      {
+        id: "command:lookup",
+        flags: ["-v", "-V"],
+        risk: "low",
+        reason: "Command lookup",
+      },
+    ],
+  },
+  exec: {
+    baseRisk: "high",
+    isWrapper: true,
+    reason: "Replaces current shell process",
+  },
+  strace: {
+    baseRisk: "medium",
+    isWrapper: true,
+    reason: "Traces system calls",
+  },
+  ltrace: {
+    baseRisk: "medium",
+    isWrapper: true,
+    reason: "Traces library calls",
+  },
+  ionice: { baseRisk: "low", isWrapper: true },
+  taskset: { baseRisk: "low", isWrapper: true },
 
   // ── Shell interpreters ──────────────────────────────────────────────────────
   // These execute arbitrary code via -c, script files, or stdin.
-  bash:     { baseRisk: "high", reason: "Executes arbitrary shell commands", complexSyntax: true },
-  sh:       { baseRisk: "high", reason: "Executes arbitrary shell commands", complexSyntax: true },
-  zsh:      { baseRisk: "high", reason: "Executes arbitrary shell commands", complexSyntax: true },
-  dash:     { baseRisk: "high", reason: "Executes arbitrary shell commands", complexSyntax: true },
-  fish:     { baseRisk: "high", reason: "Executes arbitrary shell commands", complexSyntax: true },
+  bash: {
+    baseRisk: "high",
+    reason: "Executes arbitrary shell commands",
+    complexSyntax: true,
+  },
+  sh: {
+    baseRisk: "high",
+    reason: "Executes arbitrary shell commands",
+    complexSyntax: true,
+  },
+  zsh: {
+    baseRisk: "high",
+    reason: "Executes arbitrary shell commands",
+    complexSyntax: true,
+  },
+  dash: {
+    baseRisk: "high",
+    reason: "Executes arbitrary shell commands",
+    complexSyntax: true,
+  },
+  fish: {
+    baseRisk: "high",
+    reason: "Executes arbitrary shell commands",
+    complexSyntax: true,
+  },
 
   // ── Package managers (additional) ──────────────────────────────────────────
   "apt-get": { baseRisk: "high", reason: "Installs/removes system packages" },
-  apt:       { baseRisk: "high", reason: "Installs/removes system packages" },
-  dnf:       { baseRisk: "high", reason: "Installs/removes system packages" },
-  yum:       { baseRisk: "high", reason: "Installs/removes system packages" },
-  pacman:    { baseRisk: "high", reason: "Installs/removes system packages" },
-  apk:       { baseRisk: "high", reason: "Installs/removes system packages" },
+  apt: { baseRisk: "high", reason: "Installs/removes system packages" },
+  dnf: { baseRisk: "high", reason: "Installs/removes system packages" },
+  yum: { baseRisk: "high", reason: "Installs/removes system packages" },
+  pacman: { baseRisk: "high", reason: "Installs/removes system packages" },
+  apk: { baseRisk: "high", reason: "Installs/removes system packages" },
 
   // ── Shell builtins ─────────────────────────────────────────────────────────
-  cd:       { baseRisk: "low" },
-  pushd:    { baseRisk: "low" },
-  popd:     { baseRisk: "low" },
-  export:   { baseRisk: "low" },
-  unset:    { baseRisk: "low" },
-  alias:    { baseRisk: "low" },
-  history:  { baseRisk: "low" },
+  cd: { baseRisk: "low" },
+  pushd: { baseRisk: "low" },
+  popd: { baseRisk: "low" },
+  export: { baseRisk: "low" },
+  unset: { baseRisk: "low" },
+  alias: { baseRisk: "low" },
+  history: { baseRisk: "low" },
   // DIVERGENCE: checker.ts lists `set` as LOW_RISK. Our registry classifies it
   // as medium because it can modify shell options and behavior.
-  set:      { baseRisk: "medium", reason: "Modifies shell options" },
-  source:   { baseRisk: "high", reason: "Executes arbitrary shell script" },
-  eval:     { baseRisk: "high", reason: "Evaluates arbitrary shell code" },
+  set: { baseRisk: "medium", reason: "Modifies shell options" },
+  source: { baseRisk: "high", reason: "Executes arbitrary shell script" },
+  eval: { baseRisk: "high", reason: "Evaluates arbitrary shell code" },
 
   // ── Misc tools ─────────────────────────────────────────────────────────────
   // DIVERGENCE: checker.ts lists `xargs` as LOW_RISK. Our registry classifies
   // it as medium because it executes commands with piped arguments.
-  xargs:    { baseRisk: "medium", complexSyntax: true,
-    reason: "Executes command with piped arguments" },
-  tar:      { baseRisk: "medium", complexSyntax: true },
-  zip:      { baseRisk: "medium" },
-  unzip:    { baseRisk: "medium" },
-  gzip:     { baseRisk: "medium" },
-  gunzip:   { baseRisk: "medium" },
+  xargs: {
+    baseRisk: "medium",
+    complexSyntax: true,
+    reason: "Executes command with piped arguments",
+  },
+  tar: { baseRisk: "medium", complexSyntax: true },
+  zip: { baseRisk: "medium" },
+  unzip: { baseRisk: "medium" },
+  gzip: { baseRisk: "medium" },
+  gunzip: { baseRisk: "medium" },
 
   // ── Version control tools ──────────────────────────────────────────────────
-  gh:       { baseRisk: "low", subcommands: {
-    pr:       { baseRisk: "low", subcommands: {
-      view:   { baseRisk: "low" },
-      list:   { baseRisk: "low" },
-      create: { baseRisk: "medium" },
-      merge:  { baseRisk: "high", reason: "Merges pull request" },
-    }},
-    issue:    { baseRisk: "low", subcommands: {
-      view:   { baseRisk: "low" },
-      list:   { baseRisk: "low" },
-      create: { baseRisk: "medium" },
-    }},
-    repo:     { baseRisk: "low", subcommands: {
-      view:   { baseRisk: "low" },
-      clone:  { baseRisk: "low" },
-      create: { baseRisk: "high" },
-      delete: { baseRisk: "high" },
-    }},
-    api:      { baseRisk: "medium", reason: "Makes arbitrary GitHub API calls" },
-  }},
+  gh: {
+    baseRisk: "low",
+    subcommands: {
+      pr: {
+        baseRisk: "low",
+        subcommands: {
+          view: { baseRisk: "low" },
+          list: { baseRisk: "low" },
+          create: { baseRisk: "medium" },
+          merge: { baseRisk: "high", reason: "Merges pull request" },
+        },
+      },
+      issue: {
+        baseRisk: "low",
+        subcommands: {
+          view: { baseRisk: "low" },
+          list: { baseRisk: "low" },
+          create: { baseRisk: "medium" },
+        },
+      },
+      repo: {
+        baseRisk: "low",
+        subcommands: {
+          view: { baseRisk: "low" },
+          clone: { baseRisk: "low" },
+          create: { baseRisk: "high" },
+          delete: { baseRisk: "high" },
+        },
+      },
+      api: { baseRisk: "medium", reason: "Makes arbitrary GitHub API calls" },
+    },
+  },
 
   // ── Vellum assistant CLI ───────────────────────────────────────────────────
   // Classification matches classifyAssistantSubcommand() from checker.ts exactly.
-  assistant: { baseRisk: "low", subcommands: {
-    platform: { baseRisk: "low" },
-    backup:   { baseRisk: "low" },
-    help:     { baseRisk: "low" },
-    oauth:    { baseRisk: "low", subcommands: {
-      token:      { baseRisk: "high", reason: "Exposes OAuth token" },
-      mode:       { baseRisk: "low", argRules: [
-        { id: "assistant-oauth-mode:set", flags: ["--set"],
-          risk: "high", reason: "Changes OAuth mode" },
-      ]},
-      request:    { baseRisk: "medium", reason: "Makes OAuth request" },
-      connect:    { baseRisk: "medium", reason: "Connects OAuth integration" },
-      disconnect: { baseRisk: "medium", reason: "Disconnects OAuth integration" },
-    }},
-    credentials: { baseRisk: "low", subcommands: {
-      reveal: { baseRisk: "high", reason: "Reveals credential value" },
-      set:    { baseRisk: "high", reason: "Sets credential value" },
-      delete: { baseRisk: "high", reason: "Deletes credential" },
-    }},
-    keys:      { baseRisk: "low", subcommands: {
-      set:    { baseRisk: "high", reason: "Sets key value" },
-      delete: { baseRisk: "high", reason: "Deletes key" },
-    }},
-    trust:     { baseRisk: "low", subcommands: {
-      remove: { baseRisk: "high", reason: "Removes trust rule" },
-      clear:  { baseRisk: "high", reason: "Clears all trust rules" },
-    }},
-  }},
+  assistant: {
+    baseRisk: "low",
+    subcommands: {
+      platform: { baseRisk: "low" },
+      backup: { baseRisk: "low" },
+      help: { baseRisk: "low" },
+      oauth: {
+        baseRisk: "low",
+        subcommands: {
+          token: { baseRisk: "high", reason: "Exposes OAuth token" },
+          mode: {
+            baseRisk: "low",
+            argRules: [
+              {
+                id: "assistant-oauth-mode:set",
+                flags: ["--set"],
+                risk: "high",
+                reason: "Changes OAuth mode",
+              },
+            ],
+          },
+          request: { baseRisk: "medium", reason: "Makes OAuth request" },
+          connect: { baseRisk: "medium", reason: "Connects OAuth integration" },
+          disconnect: {
+            baseRisk: "medium",
+            reason: "Disconnects OAuth integration",
+          },
+        },
+      },
+      credentials: {
+        baseRisk: "low",
+        subcommands: {
+          reveal: { baseRisk: "high", reason: "Reveals credential value" },
+          set: { baseRisk: "high", reason: "Sets credential value" },
+          delete: { baseRisk: "high", reason: "Deletes credential" },
+        },
+      },
+      keys: {
+        baseRisk: "low",
+        subcommands: {
+          set: { baseRisk: "high", reason: "Sets key value" },
+          delete: { baseRisk: "high", reason: "Deletes key" },
+        },
+      },
+      trust: {
+        baseRisk: "low",
+        subcommands: {
+          remove: { baseRisk: "high", reason: "Removes trust rule" },
+          clear: { baseRisk: "high", reason: "Clears all trust rules" },
+        },
+      },
+    },
+  },
 } satisfies Record<string, CommandRiskSpec>;

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -79,7 +79,11 @@ export const DEFAULT_COMMAND_REGISTRY = {
       },
     ],
   },
-  awk: { baseRisk: "low", complexSyntax: true },
+  awk: {
+    baseRisk: "medium",
+    complexSyntax: true,
+    reason: "Can execute shell commands via system()",
+  },
 
   // ── System information (read-only) ─────────────────────────────────────────
   echo: { baseRisk: "low" },

--- a/assistant/src/permissions/risk-types.ts
+++ b/assistant/src/permissions/risk-types.ts
@@ -9,6 +9,8 @@
  * @see /docs/bash-risk-classifier-design.md
  */
 
+import { RiskLevel } from "./types.js";
+
 // ── Risk levels ──────────────────────────────────────────────────────────────
 
 /**
@@ -160,4 +162,25 @@ export interface UserRule {
   createdAt: string;
   /** How the rule was created. */
   source: "scope_ladder" | "manual";
+}
+
+// ── Risk → RiskLevel mapping ─────────────────────────────────────────────────
+
+/**
+ * Map a classifier `Risk` value to the permission system's `RiskLevel` enum.
+ *
+ * `"unknown"` maps to `RiskLevel.Medium` — matching the existing checker.ts
+ * behavior where unrecognized commands are treated as medium-risk.
+ */
+export function riskToRiskLevel(risk: Risk): RiskLevel {
+  switch (risk) {
+    case "low":
+      return RiskLevel.Low;
+    case "medium":
+      return RiskLevel.Medium;
+    case "high":
+      return RiskLevel.High;
+    case "unknown":
+      return RiskLevel.Medium;
+  }
 }


### PR DESCRIPTION
## Summary
Replace the imperative ~130-line bash/host_bash classification in `checker.ts` with the data-driven `BashRiskClassifier` that was built during Phase 1. The registry is now the primary classifier for all bash command risk assessment.

## What changed
- **Risk-to-RiskLevel mapping** — New `riskToRiskLevel()` bridges the classifier's `Risk` type to the permission system's `RiskLevel` enum
- **Registry parity** — Added all missing programs from `LOW_RISK_PROGRAMS` / `HIGH_RISK_PROGRAMS` to the command registry, plus `assistant` CLI subcommand hierarchy
- **Classifier alignment** — rm safe-file downgrade (BOOTSTRAP.md/UPDATES.md → medium in sandbox), opaque construct escalation (medium not high when no dangerous patterns)
- **Core swap** — `classifyRisk()` now delegates to `BashRiskClassifier` for bash/host_bash; removed ~448 lines of imperative classification, wrapper constants, and helper functions from checker.ts
- **Phase 1 cleanup** — Removed observe-only parallel logging scaffolding

## PRs merged into feature branch
- #26993: feat(permissions): add Risk-to-RiskLevel mapping utility
- #26998: feat(permissions): add assistant CLI subcommand specs to command registry
- #26997: feat(permissions): registry parity with checker.ts LOW_RISK/HIGH_RISK sets
- #26999: feat(permissions): rm safe-file downgrade and opaque construct handling in classifier
- #27010: feat(permissions): replace imperative bash classification with registry classifier
- #27014: chore(permissions): remove Phase 1 scaffolding and update classifier docs

## Test results
- bash-risk-classifier.test.ts: 110/110 pass
- checker.test.ts: 372/372 pass

## Deferred to follow-up
PRs 6-8 from the plan (scope ladder UI integration, user rule storage, scope ladder → user rule creation) are additive features that build on top of the core classification swap. They'll be implemented in a separate plan iteration.

Part of plan: bash-risk-registry-phase2.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
