### PR TITLE
feat(onboarding): add OnboardingLocalModeDisclosure subview

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
@@ -101,7 +101,7 @@ internal struct OnboardingLocalModeDisclosure: View {
             top: VSpacing.md,
             leading: VSpacing.lg,
             bottom: VSpacing.md,
-            trailing: VSpacing.md
+            trailing: VSpacing.lg
         ))
         .frame(maxWidth: .infinity)
         .background(
@@ -129,31 +129,3 @@ internal struct OnboardingLocalModeDisclosure: View {
         }
     }
 }
-
-#if DEBUG
-#Preview("Local Mode Disclosure") {
-    struct PreviewHost: View {
-        @State private var collapsed = false
-        @State private var expanded = true
-
-        var body: some View {
-            VStack(spacing: VSpacing.lg) {
-                OnboardingLocalModeDisclosure(
-                    isExpanded: $collapsed,
-                    onUseLocalMode: {}
-                )
-
-                OnboardingLocalModeDisclosure(
-                    isExpanded: $expanded,
-                    onUseLocalMode: {}
-                )
-            }
-            .padding(VSpacing.lg)
-            .frame(width: 420)
-            .background(VColor.contentBackground)
-        }
-    }
-
-    return PreviewHost()
-}
-#endif

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
@@ -1,0 +1,159 @@
+import VellumAssistantShared
+import SwiftUI
+
+/// Collapsible "Advanced" disclosure that reveals Local Mode trade-offs and
+/// a secondary "USE LOCAL MODE" call-to-action. Designed to live inside the
+/// onboarding first step's setup cards.
+///
+/// The parent owns `isExpanded` so the card's transition can be coordinated
+/// with sibling animations.
+internal struct OnboardingLocalModeDisclosure: View {
+    @Binding var isExpanded: Bool
+
+    var kicker: String = "ADVANCED"
+    var title: String = "Continue without an account (Local Mode)"
+    var tradeoffsKicker: String = "TRADE-OFFS"
+    var tradeoffs: [String] = [
+        "Requires your own OpenAI API key",
+        "Only awake when your Mac is active",
+        "Available on this device only",
+        "No cloud sync or automated backup",
+    ]
+    var secondaryCTA: String = "USE LOCAL MODE"
+    var isDisabled: Bool = false
+    var onUseLocalMode: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header row: kicker + title on the left, expand/collapse button on the right.
+            HStack(alignment: .top, spacing: VSpacing.sm) {
+                Button {
+                    withAnimation(VAnimation.fast) { isExpanded.toggle() }
+                } label: {
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                        Text(kicker)
+                            .font(VFont.labelSmall)
+                            .foregroundStyle(VColor.contentTertiary)
+                            .textCase(.uppercase)
+                            .tracking(0.6)
+                        Text(title)
+                            .font(VFont.bodyMediumEmphasised)
+                            .foregroundStyle(VColor.contentDefault)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+
+                Spacer(minLength: 0)
+
+                VButton(
+                    label: isExpanded ? "Collapse" : "Expand",
+                    iconOnly: isExpanded ? VIcon.x.rawValue : VIcon.plus.rawValue,
+                    style: .outlined,
+                    size: .pillRegular,
+                    iconColor: VColor.contentSecondary
+                ) {
+                    withAnimation(VAnimation.fast) { isExpanded.toggle() }
+                }
+            }
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 0) {
+                    Spacer().frame(height: VSpacing.md)
+
+                    VColor.borderBase
+                        .frame(height: 1)
+                        .accessibilityHidden(true)
+
+                    Spacer().frame(height: VSpacing.md)
+
+                    Text(tradeoffsKicker)
+                        .font(VFont.labelSmall)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .textCase(.uppercase)
+                        .tracking(0.6)
+
+                    Spacer().frame(height: VSpacing.sm)
+
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        ForEach(tradeoffs, id: \.self) { item in
+                            tradeoffRow(item)
+                        }
+                    }
+
+                    Spacer().frame(height: VSpacing.md)
+
+                    VButton(
+                        label: secondaryCTA,
+                        style: .outlined,
+                        size: .pillRegular,
+                        isFullWidth: true,
+                        isDisabled: isDisabled
+                    ) {
+                        onUseLocalMode()
+                    }
+                }
+                .transition(.opacity.combined(with: .offset(y: -4)))
+            }
+        }
+        .padding(EdgeInsets(
+            top: VSpacing.md,
+            leading: VSpacing.lg,
+            bottom: VSpacing.md,
+            trailing: VSpacing.md
+        ))
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg, style: .continuous)
+                .fill(VColor.surfaceOverlay)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg, style: .continuous)
+                .strokeBorder(VColor.borderBase, lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private func tradeoffRow(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            Circle()
+                .fill(VColor.contentTertiary)
+                .frame(width: 3, height: 3)
+                .padding(.top, 7)
+                .accessibilityHidden(true)
+            Text(text)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentDefault)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+#if DEBUG
+#Preview("Local Mode Disclosure") {
+    struct PreviewHost: View {
+        @State private var collapsed = false
+        @State private var expanded = true
+
+        var body: some View {
+            VStack(spacing: VSpacing.lg) {
+                OnboardingLocalModeDisclosure(
+                    isExpanded: $collapsed,
+                    onUseLocalMode: {}
+                )
+
+                OnboardingLocalModeDisclosure(
+                    isExpanded: $expanded,
+                    onUseLocalMode: {}
+                )
+            }
+            .padding(VSpacing.lg)
+            .frame(width: 420)
+            .background(VColor.contentBackground)
+        }
+    }
+
+    return PreviewHost()
+}
+#endif


### PR DESCRIPTION
## Summary
- Adds OnboardingLocalModeDisclosure: ADVANCED kicker + Local Mode title, +/× expand button, expanded TRADE-OFFS list with outlined USE LOCAL MODE button.
- isExpanded is a binding so the parent owns the state.
- Animates under VAnimation.fast.
- Only design-system tokens + components used.

Part of plan: onboarding-setup-cards.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
