### PR TITLE
fix(credentials): prevent silent hang when secret prompt triggered from Slack

### DIFF
--- a/assistant/src/__tests__/secret-prompter-channel-fallback.test.ts
+++ b/assistant/src/__tests__/secret-prompter-channel-fallback.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  SecretRequest,
+  ServerMessage,
+} from "../daemon/message-protocol.js";
+
+// Use a tiny timeout so the setTimeout branch fires quickly in tests
+const mockConfig = {
+  timeouts: { permissionTimeoutSec: 0.01 },
+  secretDetection: { allowOneTimeSend: false },
+};
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+const { SecretPrompter } = await import("../permissions/secret-prompter.js");
+
+describe("secret prompter channel fallback", () => {
+  let sentMessages: ServerMessage[];
+  let broadcastMessages: ServerMessage[];
+
+  beforeEach(() => {
+    sentMessages = [];
+    broadcastMessages = [];
+  });
+
+  test("fails fast with unsupported_channel error when channel lacks dynamic UI and no broadcast available", async () => {
+    const prompter = new SecretPrompter((msg) => sentMessages.push(msg));
+    prompter.setChannelContext({
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+
+    const result = await prompter.prompt("myservice", "apikey", "API Key");
+
+    expect(result.value).toBeNull();
+    expect(result.error).toBe("unsupported_channel");
+    // No message should have been sent since we failed fast
+    expect(sentMessages).toHaveLength(0);
+  });
+
+  test("broadcasts secret_request via SSE hub when channel lacks dynamic UI but broadcast is available", async () => {
+    const prompter = new SecretPrompter(
+      (msg) => sentMessages.push(msg),
+      (msg) => broadcastMessages.push(msg),
+    );
+    prompter.setChannelContext({
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+
+    const promise = prompter.prompt("myservice", "apikey", "API Key");
+
+    // Should have broadcast the message, not sent via per-channel sender
+    expect(sentMessages).toHaveLength(0);
+    expect(broadcastMessages).toHaveLength(1);
+    expect(broadcastMessages[0]!.type).toBe("secret_request");
+
+    // Resolve the prompt so it doesn't hang
+    const requestId = (broadcastMessages[0] as SecretRequest).requestId;
+    prompter.resolveSecret(requestId, "test-secret", "store");
+    const result = await promise;
+    expect(result.value).toBe("test-secret");
+    expect(result.error).toBeUndefined();
+  });
+
+  test("uses sendToClient when channel supports dynamic UI", async () => {
+    const prompter = new SecretPrompter(
+      (msg) => sentMessages.push(msg),
+      (msg) => broadcastMessages.push(msg),
+    );
+    prompter.setChannelContext({
+      channel: "macos",
+      supportsDynamicUi: true,
+    });
+
+    const promise = prompter.prompt("myservice", "apikey", "API Key");
+
+    // Should use per-channel sender, not broadcast
+    expect(sentMessages).toHaveLength(1);
+    expect(broadcastMessages).toHaveLength(0);
+    expect(sentMessages[0]!.type).toBe("secret_request");
+
+    const requestId = (sentMessages[0] as SecretRequest).requestId;
+    prompter.resolveSecret(requestId, "test-secret", "store");
+    await promise;
+  });
+
+  test("uses sendToClient when no channel context is set (desktop default)", async () => {
+    const prompter = new SecretPrompter(
+      (msg) => sentMessages.push(msg),
+      (msg) => broadcastMessages.push(msg),
+    );
+    // No setChannelContext call — desktop default
+
+    const promise = prompter.prompt("myservice", "apikey", "API Key");
+
+    expect(sentMessages).toHaveLength(1);
+    expect(broadcastMessages).toHaveLength(0);
+
+    const requestId = (sentMessages[0] as SecretRequest).requestId;
+    prompter.resolveSecret(requestId, "val", "store");
+    await promise;
+  });
+});

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -409,7 +409,10 @@ export class Conversation {
         );
       }
     });
-    this.secretPrompter = new SecretPrompter(sendToClient);
+    this.secretPrompter = new SecretPrompter(
+      sendToClient,
+      broadcastToAllClients,
+    );
 
     // Register watch/call notifiers (reads ctx properties lazily)
     registerConversationNotifiers(conversationId, this);
@@ -1244,6 +1247,14 @@ export class Conversation {
 
   setChannelCapabilities(caps: ChannelCapabilities | null): void {
     this.channelCapabilities = caps ?? undefined;
+    this.secretPrompter.setChannelContext(
+      caps
+        ? {
+            channel: caps.channel,
+            supportsDynamicUi: caps.supportsDynamicUi,
+          }
+        : undefined,
+    );
   }
 
   setTrustContext(ctx: TrustContext | null): void {

--- a/assistant/src/permissions/secret-prompter.ts
+++ b/assistant/src/permissions/secret-prompter.ts
@@ -14,6 +14,8 @@ export type SecretDelivery = "store" | "transient_send";
 export interface SecretPromptResult {
   value: string | null;
   delivery: SecretDelivery;
+  /** When set, the prompt could not be delivered and the value is null due to a delivery failure (not user cancellation). */
+  error?: "unsupported_channel";
 }
 
 interface PendingSecretPrompt {
@@ -22,20 +24,47 @@ interface PendingSecretPrompt {
   timer: ReturnType<typeof setTimeout>;
 }
 
+export interface SecretPrompterChannelContext {
+  /** The channel the conversation was initiated from (e.g. "slack", "macos"). */
+  channel?: string;
+  /** Whether the channel supports rendering dynamic UI (secure prompt dialogs). */
+  supportsDynamicUi?: boolean;
+}
+
 export class SecretPrompter {
   private pending = new Map<string, PendingSecretPrompt>();
   private sendToClient: (msg: ServerMessage) => void;
+  private broadcastToAllClients?: (msg: ServerMessage) => void;
+  private channelContext?: SecretPrompterChannelContext;
 
-  constructor(sendToClient: (msg: ServerMessage) => void) {
+  constructor(
+    sendToClient: (msg: ServerMessage) => void,
+    broadcastToAllClients?: (msg: ServerMessage) => void,
+  ) {
     this.sendToClient = sendToClient;
+    this.broadcastToAllClients = broadcastToAllClients;
   }
 
   updateSender(sendToClient: (msg: ServerMessage) => void): void {
     this.sendToClient = sendToClient;
   }
 
+  updateBroadcast(broadcastToAllClients?: (msg: ServerMessage) => void): void {
+    this.broadcastToAllClients = broadcastToAllClients;
+  }
+
+  setChannelContext(ctx: SecretPrompterChannelContext | undefined): void {
+    this.channelContext = ctx;
+  }
+
   /**
    * Send a secret_request to the client and wait for the response.
+   *
+   * When the conversation originates from a channel that cannot render secure
+   * prompts (e.g. Slack), the request is broadcast to all connected clients
+   * via the SSE hub so the desktop app can display it. If no broadcast path
+   * is available and the channel doesn't support dynamic UI, the method
+   * fails fast with an error result rather than hanging until timeout.
    *
    * SECURITY: Logs only metadata (requestId, service, field) — never the
    * returned secret value. The timeout path also returns a null value
@@ -52,6 +81,20 @@ export class SecretPrompter {
     allowedTools?: string[],
     allowedDomains?: string[],
   ): Promise<SecretPromptResult> {
+    // Determine whether the originating channel can render secure prompts.
+    const channelSupportsPrompt =
+      this.channelContext?.supportsDynamicUi !== false;
+
+    // If the channel cannot render the prompt and there's no broadcast path
+    // to reach a desktop client, fail fast instead of hanging for 5 minutes.
+    if (!channelSupportsPrompt && !this.broadcastToAllClients) {
+      log.warn(
+        { service, field, channel: this.channelContext?.channel },
+        "Secret prompt requested from a channel that cannot render it and no broadcast path is available",
+      );
+      return { value: null, delivery: "store", error: "unsupported_channel" };
+    }
+
     const requestId = uuid();
 
     return new Promise((resolve, reject) => {
@@ -79,7 +122,15 @@ export class SecretPrompter {
         allowedDomains,
         allowOneTimeSend: config.secretDetection.allowOneTimeSend,
       };
-      this.sendToClient(msg);
+
+      // Use broadcastToAllClients when the originating channel cannot render
+      // secure prompts — this routes the request to the SSE hub where a
+      // connected desktop client can pick it up.
+      if (!channelSupportsPrompt && this.broadcastToAllClients) {
+        this.broadcastToAllClients(msg);
+      } else {
+        this.sendToClient(msg);
+      }
     });
   }
 

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -691,6 +691,13 @@ class CredentialStoreTool implements Tool {
               : undefined,
         });
         if (!result.value) {
+          if (result.error === "unsupported_channel") {
+            return {
+              content:
+                "Secure credential entry cannot be opened over this channel. The user needs to complete this step from the desktop app, or run this flow from there directly.",
+              isError: true,
+            };
+          }
           return {
             content: "User cancelled the credential prompt.",
             isError: false,


### PR DESCRIPTION
## Summary
- SecretPrompter now broadcasts `secret_request` to the SSE hub when the conversation's channel doesn't support dynamic UI (e.g. Slack), so the desktop app can render the prompt
- Fails fast with a clear error (`unsupported_channel`) when no broadcast path is available, instead of silently timing out for 5 minutes
- vault.ts surfaces a user-friendly error message when the channel can't support secure prompts

## Test plan
- [x] New test: `secret-prompter-channel-fallback.test.ts` covers fail-fast, broadcast, and normal paths
- [x] Existing `secret-prompt-log-hygiene.test.ts` passes (no regressions)
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
