### PR TITLE
fix(test): add archive/unarchive conversation to benchmark mock

### DIFF
--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -192,6 +192,8 @@ mock.module("../memory/conversation-crud.js", () => ({
   }),
   getMessagesPaginated: () => ({ messages: [], hasMore: false }),
   getLastAssistantTimestampBefore: () => null,
+  archiveConversation: () => false,
+  unarchiveConversation: () => false,
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({


### PR DESCRIPTION
## Summary
- The `conversation-init` benchmark was failing in CI with `SyntaxError: Export named 'unarchiveConversation' not found` because the inline mock of `../memory/conversation-crud.js` in `conversation-init.benchmark.test.ts` didn't export `unarchiveConversation` (added to the real module in #25876) — when `conversation-management-routes.ts` is loaded transitively, its named import fails against the mock.
- Added stub `archiveConversation` and `unarchiveConversation` entries to the mock. Included `archiveConversation` as well since it is imported alongside `unarchiveConversation` from the same routes file, so it would be the next domino to fall.

## Original prompt
Make this CI check pass: https://github.com/vellum-ai/vellum-assistant/actions/workflows/ci-benchmarks.yaml
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
