### PR TITLE
perf(agent-loop): merge turn_context and pkb_reminder metadata writes into one call

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2318,11 +2318,10 @@ describe("session-agent-loop", () => {
       ).resolves.toBeUndefined();
     });
 
-    test("coexists with turnContextBlock write as independent calls", async () => {
-      // If PR 5 landed, both blocks will be persisted by separate calls.
-      // This test asserts the pkbSystemReminderBlock write is independent
-      // (keyed on its own call site) so merging with turnContextBlock is
-      // never required for correctness.
+    test("writes both blocks in a single combined updateMessageMetadata call", async () => {
+      // Both blocks are persisted via one combined call to halve SQLite
+      // SELECT+UPDATE work on the hot user-turn path (the common case with
+      // PKB active).
       const reminder = "<system_reminder>\npkb\n</system_reminder>";
       const turnContext = "<turn_context>\nnow\n</turn_context>";
       mockInjectionBlocks = {
@@ -2333,16 +2332,25 @@ describe("session-agent-loop", () => {
 
       await runAgentLoopImpl(ctx, "hello", "user-msg-4", () => {});
 
-      const pkbCalls = updateMessageMetadataMock.mock.calls.filter(
-        (call) =>
-          (call[1] as Record<string, unknown>).pkbSystemReminderBlock !==
-          undefined,
+      const injectionCalls = updateMessageMetadataMock.mock.calls.filter(
+        (call) => {
+          const payload = call[1] as Record<string, unknown>;
+          return (
+            payload != null &&
+            (Object.prototype.hasOwnProperty.call(
+              payload,
+              "pkbSystemReminderBlock",
+            ) ||
+              Object.prototype.hasOwnProperty.call(payload, "turnContextBlock"))
+          );
+        },
       );
-      expect(pkbCalls.length).toBe(1);
-      expect(pkbCalls[0][0]).toBe("user-msg-4");
-      expect(
-        (pkbCalls[0][1] as Record<string, unknown>).pkbSystemReminderBlock,
-      ).toBe(reminder);
+      expect(injectionCalls.length).toBe(1);
+      expect(injectionCalls[0]![0]).toBe("user-msg-4");
+      expect(injectionCalls[0]![1]).toEqual({
+        turnContextBlock: turnContext,
+        pkbSystemReminderBlock: reminder,
+      });
     });
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -966,34 +966,29 @@ export async function runAgentLoopImpl(
     });
     runMessages = injection.messages;
 
-    // Persist the injected <turn_context> block in message metadata so it
-    // survives conversation reloads (eviction, restart, fork). loadFromDb
-    // re-injects from metadata. Only the first call site persists — the
-    // overflow-recovery re-entry sites send identical bytes and the tail
-    // row may not correspond to `userMessageId`.
-    if (injection.blocks.unifiedTurnContext) {
+    // Persist injected blocks in message metadata so they survive conversation
+    // reloads (eviction, restart, fork). loadFromDb re-injects from metadata.
+    // Only the first call site persists — the overflow-recovery re-entry sites
+    // send identical bytes and the tail row may not correspond to
+    // `userMessageId`. Both blocks are written in a single call to avoid
+    // doubling SQLite SELECT+UPDATE work on every turn.
+    if (
+      injection.blocks.unifiedTurnContext ||
+      injection.blocks.pkbSystemReminder
+    ) {
       try {
-        updateMessageMetadata(userMessageId, {
-          turnContextBlock: injection.blocks.unifiedTurnContext,
-        });
+        const metadataUpdates: Record<string, unknown> = {};
+        if (injection.blocks.unifiedTurnContext) {
+          metadataUpdates.turnContextBlock =
+            injection.blocks.unifiedTurnContext;
+        }
+        if (injection.blocks.pkbSystemReminder) {
+          metadataUpdates.pkbSystemReminderBlock =
+            injection.blocks.pkbSystemReminder;
+        }
+        updateMessageMetadata(userMessageId, metadataUpdates);
       } catch (err) {
-        rlog.warn(
-          { err },
-          "Failed to persist turnContextBlock metadata (non-fatal)",
-        );
-      }
-    }
-
-    if (injection.blocks.pkbSystemReminder) {
-      try {
-        updateMessageMetadata(userMessageId, {
-          pkbSystemReminderBlock: injection.blocks.pkbSystemReminder,
-        });
-      } catch (err) {
-        rlog.warn(
-          { err },
-          "Failed to persist pkbSystemReminderBlock metadata (non-fatal)",
-        );
+        rlog.warn({ err }, "Failed to persist injection metadata (non-fatal)");
       }
     }
 


### PR DESCRIPTION
## Summary
- Consolidate the two consecutive `updateMessageMetadata` calls from PR 5/PR 6 of the injection-persistence plan into one combined call. Halves SQLite SELECT+UPDATE work on every user turn where both blocks are captured (the common case with PKB active).
- The PR 5/PR 6 rationale for keeping them separate (merge-conflict risk for parallel PRs) no longer applies now that both have landed.

Fix for gap identified during plan review: injection-metadata-persistence.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
