### PR TITLE
chore(memory): declare injected-block fields on messageMetadataSchema

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -103,6 +103,9 @@ export const messageMetadataSchema = z
     forkSourceMessageId: z.string().optional(),
     /** Image source paths from desktop attachments, keyed by filename. */
     imageSourcePaths: z.record(z.string(), z.string()).optional(),
+    memoryInjectedBlock: z.string().optional(),
+    turnContextBlock: z.string().optional(),
+    pkbSystemReminderBlock: z.string().optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Summary
- Add explicit `z.string().optional()` entries for `memoryInjectedBlock`, `turnContextBlock`, and `pkbSystemReminderBlock` on `messageMetadataSchema`. These were previously flowing through via `.passthrough()` without type safety.
- No behavior change — passthrough still accepts unknown fields, existing rows remain valid, no migration required.

Fix for gap identified during plan review: injection-metadata-persistence.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
