### PR TITLE
fix(agent-loop): clear pkbSystemReminderBlock metadata when compaction-strip runs

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -127,11 +127,16 @@ mock.module("../hooks/manager.js", () => ({
 const updateMessageMetadataMock = mock(
   (_id: string, _updates: Record<string, unknown>) => {},
 );
+const clearPkbSystemReminderMetadataForConversationMock = mock(
+  (_conversationId: string) => {},
+);
 mock.module("../memory/conversation-crud.js", () => ({
   getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationUsage: () => {},
   updateMessageMetadata: updateMessageMetadataMock,
+  clearPkbSystemReminderMetadataForConversation:
+    clearPkbSystemReminderMetadataForConversationMock,
   getMessages: () => [],
   getConversation: () => ({
     id: "conv-1",
@@ -514,6 +519,10 @@ beforeEach(() => {
   rebuildConversationDiskViewFromDbStateMock.mockClear();
   updateMessageMetadataMock.mockClear();
   updateMessageMetadataMock.mockImplementation(() => {});
+  clearPkbSystemReminderMetadataForConversationMock.mockClear();
+  clearPkbSystemReminderMetadataForConversationMock.mockImplementation(
+    () => {},
+  );
   applyRuntimeInjectionsMock.mockClear();
 });
 
@@ -2343,6 +2352,166 @@ describe("session-agent-loop", () => {
       expect(
         (pkbCalls[0][1] as Record<string, unknown>).pkbSystemReminderBlock,
       ).toBe(reminder);
+    });
+  });
+
+  describe("compaction-strip metadata consistency", () => {
+    test("clears pkbSystemReminderBlock metadata when convergence strip runs", async () => {
+      // Reducer: succeed on first call, returning reduced messages.
+      mockReducerStepFn = (msgs: Message[]) => ({
+        messages: msgs,
+        tier: "forced_compaction",
+        state: {
+          appliedTiers: ["forced_compaction"],
+          injectionMode: "full",
+          exhausted: false,
+        },
+        estimatedTokens: 5000,
+      });
+
+      let callCount = 0;
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        callCount++;
+        if (callCount === 1) {
+          // Trigger convergence path: error + appended assistant message so
+          // updatedHistory.length > preRunHistoryLength at the strip site.
+          onEvent({
+            type: "error",
+            error: new Error("context_length_exceeded"),
+          });
+          onEvent({
+            type: "usage",
+            inputTokens: 100,
+            outputTokens: 0,
+            model: "test-model",
+            providerDurationMs: 50,
+          });
+          return [
+            ...messages,
+            {
+              role: "assistant" as const,
+              content: [{ type: "text", text: "partial" }] as ContentBlock[],
+            },
+          ];
+        }
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "recovered" }],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 50,
+          outputTokens: 25,
+          model: "test-model",
+          providerDurationMs: 100,
+        });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "recovered" }] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        agentLoopRun,
+        contextWindowManager: {
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+          maybeCompact: async () => ({ compacted: false }),
+        } as unknown as AgentLoopConversationContext["contextWindowManager"],
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      // The bulk-clear helper must have been called with the conversation id
+      // at least once (one of the three strip sites fired).
+      const clearCalls =
+        clearPkbSystemReminderMetadataForConversationMock.mock.calls.filter(
+          (call) => call[0] === "test-conv",
+        );
+      expect(clearCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test("strip-site clear is non-fatal when the helper throws", async () => {
+      clearPkbSystemReminderMetadataForConversationMock.mockImplementation(
+        () => {
+          throw new Error("db write failed");
+        },
+      );
+
+      mockReducerStepFn = (msgs: Message[]) => ({
+        messages: msgs,
+        tier: "forced_compaction",
+        state: {
+          appliedTiers: ["forced_compaction"],
+          injectionMode: "full",
+          exhausted: false,
+        },
+        estimatedTokens: 5000,
+      });
+
+      let callCount = 0;
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        callCount++;
+        if (callCount === 1) {
+          onEvent({
+            type: "error",
+            error: new Error("context_length_exceeded"),
+          });
+          onEvent({
+            type: "usage",
+            inputTokens: 100,
+            outputTokens: 0,
+            model: "test-model",
+            providerDurationMs: 50,
+          });
+          return [
+            ...messages,
+            {
+              role: "assistant" as const,
+              content: [{ type: "text", text: "partial" }] as ContentBlock[],
+            },
+          ];
+        }
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "recovered" }],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 50,
+          outputTokens: 25,
+          model: "test-model",
+          providerDurationMs: 100,
+        });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "recovered" }] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        agentLoopRun,
+        contextWindowManager: {
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+          maybeCompact: async () => ({ compacted: false }),
+        } as unknown as AgentLoopConversationContext["contextWindowManager"],
+      });
+
+      // Must not throw — the strip-site clear is wrapped in try/catch.
+      await expect(
+        runAgentLoopImpl(ctx, "hello", "msg-1", () => {}),
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -45,6 +45,7 @@ import { getApp, listAppFiles, resolveAppDir } from "../memory/app-store.js";
 import { enqueueAutoAnalysisOnCompaction } from "../memory/auto-analysis-enqueue.js";
 import {
   addMessage,
+  clearPkbSystemReminderMetadataForConversation,
   deleteMessageById,
   getConversation,
   getConversationOriginChannel,
@@ -1279,6 +1280,14 @@ export async function runAgentLoopImpl(
       // so we compact the "raw" persistent messages.
       const rawHistory = stripInjectionsForCompaction(updatedHistory);
       ctx.messages = rawHistory;
+      try {
+        clearPkbSystemReminderMetadataForConversation(ctx.conversationId);
+      } catch (err) {
+        rlog.warn(
+          { err },
+          "Failed to clear pkbSystemReminderBlock metadata after compaction strip (non-fatal)",
+        );
+      }
 
       ctx.emitActivityState(
         "thinking",
@@ -1450,6 +1459,14 @@ export async function runAgentLoopImpl(
 
       if (updatedHistory.length > preRunHistoryLength) {
         ctx.messages = stripInjectionsForCompaction(updatedHistory);
+        try {
+          clearPkbSystemReminderMetadataForConversation(ctx.conversationId);
+        } catch (err) {
+          rlog.warn(
+            { err },
+            "Failed to clear pkbSystemReminderBlock metadata after compaction strip (non-fatal)",
+          );
+        }
         convergenceStripped = true;
         preRepairMessages = updatedHistory;
         preRunHistoryLength = updatedHistory.length;
@@ -1639,6 +1656,14 @@ export async function runAgentLoopImpl(
           // pre-rerun messages.
           if (updatedHistory.length > preRunHistoryLength) {
             ctx.messages = stripInjectionsForCompaction(updatedHistory);
+            try {
+              clearPkbSystemReminderMetadataForConversation(ctx.conversationId);
+            } catch (err) {
+              rlog.warn(
+                { err },
+                "Failed to clear pkbSystemReminderBlock metadata after compaction strip (non-fatal)",
+              );
+            }
             convergenceStripped = true;
             preRepairMessages = updatedHistory;
             preRunHistoryLength = updatedHistory.length;

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1472,6 +1472,27 @@ export function updateMessageMetadata(
 }
 
 /**
+ * Bulk-remove the `pkbSystemReminderBlock` field from every user-message
+ * metadata row in a conversation. Called from compaction-strip sites so
+ * post-restart rehydration stays consistent with the in-memory state
+ * produced by `stripInjectionsForCompaction` (which removes
+ * `<system_reminder>` from live messages but cannot touch the DB).
+ */
+export function clearPkbSystemReminderMetadataForConversation(
+  conversationId: string,
+): void {
+  rawRun(
+    `UPDATE messages
+        SET metadata = json_remove(metadata, '$.pkbSystemReminderBlock')
+      WHERE conversation_id = ?
+        AND role = 'user'
+        AND metadata IS NOT NULL
+        AND json_extract(metadata, '$.pkbSystemReminderBlock') IS NOT NULL`,
+    conversationId,
+  );
+}
+
+/**
  * Atomically update both `content` and (shallow-merged) `metadata` for a
  * message. Used by edit-propagation paths that need to update the message
  * body and stamp metadata (e.g. `slackMeta.editedAt`) in a single


### PR DESCRIPTION
## Summary
- `stripInjectionsForCompaction` removes `<system_reminder>` from in-memory rows during error-recovery paths but couldn't touch the DB metadata written by PR 6 of the injection-persistence plan, causing post-restart rehydration to resurrect stripped content and silently break the cache-hit path we were trying to optimize.
- Add a bulk-clear helper `clearPkbSystemReminderMetadataForConversation` and invoke it at all three strip call sites so the DB stays consistent with the live memory state.
- `<turn_context>` is unaffected — it's explicitly excluded from the strip list (conversation-runtime-assembly.ts:1632–1633), so its rehydration was already correct.

Fix for gap identified during plan review: injection-metadata-persistence.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
