### PR TITLE
fix(home): flatten HomeRecapRow stacked paddings into single EdgeInsets

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
@@ -83,8 +83,7 @@ struct HomeRecapRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, VSpacing.md)
-        .padding(.vertical, VSpacing.sm)
+        .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.md, bottom: VSpacing.sm, trailing: VSpacing.md))
         .background(
             RoundedRectangle(cornerRadius: VRadius.md, style: .continuous)
                 .fill(VColor.surfaceOverlay)


### PR DESCRIPTION
## Summary
Addresses AGENTS.md flatten-modifier-chains rule flagged during plan self-review.

- Collapse .padding(.horizontal, VSpacing.md).padding(.vertical, VSpacing.sm) into a single EdgeInsets padding

Part of plan: home-figma-redesign.md (self-review round 1 fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
