### PR TITLE
feat(pkb): move <system_reminder> above the user's typed text

### DIFF
--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -216,7 +216,7 @@ describe("loadFromDb metadata injection rehydration", () => {
 
     expect(messages).toHaveLength(3);
     // m1 is historical (not tail) — all three blocks should rehydrate in the
-    // documented shape: [<turn_context>, <memory __injected>, ...original, <system_reminder>]
+    // documented shape: [<turn_context>, <memory __injected>, <system_reminder>, ...original]
     expect(messages[0].role).toBe("user");
     expect(messages[0].content).toEqual([
       {
@@ -227,11 +227,11 @@ describe("loadFromDb metadata injection rehydration", () => {
         type: "text",
         text: "<memory __injected>\nmem payload\n</memory>",
       },
-      { type: "text", text: "First turn" },
       {
         type: "text",
         text: "<system_reminder>\npkb payload\n</system_reminder>",
       },
+      { type: "text", text: "First turn" },
     ]);
   });
 

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2003,6 +2003,26 @@ describe("applyRuntimeInjections — PKB relevance hints", () => {
     expect(reminder).toContain("- topics/alpha.md");
   });
 
+  test("<system_reminder> is injected immediately before the user's typed text (above, not below)", async () => {
+    pkbSearchResults = [];
+    pkbSearchThrows = null;
+
+    const { messages: result } = await applyRuntimeInjections(
+      baseMessages,
+      makePkbOptions(),
+    );
+    const texts = extractTexts(result);
+    const reminderIdx = texts.findIndex((t) =>
+      t.startsWith("<system_reminder>"),
+    );
+    const userTextIdx = texts.findIndex(
+      (t) => t === "Tell me about project foo",
+    );
+    expect(reminderIdx).toBeGreaterThanOrEqual(0);
+    expect(userTextIdx).toBeGreaterThanOrEqual(0);
+    expect(reminderIdx).toBeLessThan(userTextIdx);
+  });
+
   test("in-context paths are filtered out of hints", async () => {
     pkbSearchResults = [
       { path: "topics/alpha.md", score: 0.9 },

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -215,6 +215,21 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
           const meta = JSON.parse(m.metadata);
           const isTail = index === arr.length - 1;
 
+          // turn_context and system_reminder rehydrate for historical rows
+          // only; the tail gets fresh blocks via applyRuntimeInjections on
+          // the next turn. All three rehydration steps are prepends — the
+          // ordering below (system_reminder first, memory second,
+          // turn_context last) builds the documented shape right-to-left,
+          // since each prepend shifts previously-prepended blocks one slot
+          // right:
+          //   [<turn_context>, <memory __injected>, <system_reminder>, ...original]
+          if (!isTail && typeof meta.pkbSystemReminderBlock === "string") {
+            content = [
+              { type: "text" as const, text: meta.pkbSystemReminderBlock },
+              ...content,
+            ];
+          }
+
           // Memory remains rehydrated on all rows (existing behavior).
           if (typeof meta.memoryInjectedBlock === "string") {
             content = [
@@ -226,25 +241,11 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
             ];
           }
 
-          // turn_context and system_reminder rehydrate for historical rows
-          // only. The tail gets fresh blocks via applyRuntimeInjections on
-          // the next turn. Ordering: memory was prepended first above, so
-          // prepending turn_context here places it at index 0, matching the
-          // documented shape:
-          //   [<turn_context>, <memory __injected>, ...original, <system_reminder>]
-          if (!isTail) {
-            if (typeof meta.turnContextBlock === "string") {
-              content = [
-                { type: "text" as const, text: meta.turnContextBlock },
-                ...content,
-              ];
-            }
-            if (typeof meta.pkbSystemReminderBlock === "string") {
-              content = [
-                ...content,
-                { type: "text" as const, text: meta.pkbSystemReminderBlock },
-              ];
-            }
+          if (!isTail && typeof meta.turnContextBlock === "string") {
+            content = [
+              { type: "text" as const, text: meta.turnContextBlock },
+              ...content,
+            ];
           }
         } catch {
           /* ignore parse errors — metadata may be malformed */

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -14,7 +14,10 @@ import {
   getMessages as defaultGetMessages,
   type MessageRow,
 } from "../memory/conversation-crud.js";
-import { extractMemoryPrefixBlocks } from "../memory/graph/conversation-graph-memory.js";
+import {
+  countMemoryPrefixBlocks,
+  extractMemoryPrefixBlocks,
+} from "../memory/graph/conversation-graph-memory.js";
 import { searchPkbFiles } from "../memory/pkb/pkb-search.js";
 import type { QdrantSparseVector } from "../memory/qdrant-client.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
@@ -1951,13 +1954,19 @@ export async function applyRuntimeInjections(
 
       const reminder = buildPkbReminder(hints);
       pkbSystemReminderCaptured = reminder;
+      // Splice the reminder in right after the memory prefix blocks so it
+      // lands above the user's typed text, producing the tail shape
+      // `[<turn_context>, <memory __injected>, <system_reminder>, ...your_text, ...later_appends]`
+      // after `unifiedTurnContext` later prepends `<turn_context>` at index 0.
+      const memoryPrefixCount = countMemoryPrefixBlocks(userTail.content);
       result = [
         ...result.slice(0, -1),
         {
           ...userTail,
           content: [
-            ...userTail.content,
+            ...userTail.content.slice(0, memoryPrefixCount),
             { type: "text" as const, text: reminder },
+            ...userTail.content.slice(memoryPrefixCount),
           ],
         },
       ];


### PR DESCRIPTION
## Summary
- Splice the PKB `<system_reminder>` block in between `<memory __injected>` and the user's typed text in the tail user message (was previously appended at the end).
- Reorder rehydration in `loadFromDb` so historical rows land in the same shape on reload: `[<turn_context>, <memory __injected>, <system_reminder>, ...original]`.
- Update the lifecycle ordering assertion and add a runtime regression test that asserts the reminder appears before the user's typed text.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
