### PR TITLE
fix(home): align skeleton spacing/radius with real layout to eliminate layout jump

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -342,14 +342,19 @@ struct HomePageView<DetailPanel: View>: View {
             .padding(.top, VSpacing.xxl)
 
             // Suggestion bar
-            VSkeletonBone(height: 72, radius: VRadius.lg)
+            VSkeletonBone(height: 72, radius: VRadius.xl)
 
-            // First time group: "Today" label + three recap-row bones
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            // First time group: "Today" label + three recap-row bones.
+            // Mirrors the real content nesting: outer md-spaced stack
+            // separates the group header from the inner rows sub-stack,
+            // which uses xs spacing between rows.
+            VStack(alignment: .leading, spacing: VSpacing.md) {
                 VSkeletonBone(width: 60, height: 12)
-                VSkeletonBone(height: 48, radius: VRadius.md)
-                VSkeletonBone(height: 48, radius: VRadius.md)
-                VSkeletonBone(height: 48, radius: VRadius.md)
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VSkeletonBone(height: 48, radius: VRadius.md)
+                    VSkeletonBone(height: 48, radius: VRadius.md)
+                    VSkeletonBone(height: 48, radius: VRadius.md)
+                }
             }
         }
         .frame(maxWidth: maxContentWidth, alignment: .top)


### PR DESCRIPTION
## Summary
Addresses AGENTS.md match-skeleton-anatomy rule flagged during plan self-review.

- Nest the Today-group skeleton: outer VStack(spacing: VSpacing.md) with the group-header bone + inner VStack(spacing: VSpacing.xs) with three 48pt row bones, mirroring the real layout
- Change the suggestion-bar bone radius from VRadius.lg (12pt) to VRadius.xl (16pt) to match the real HomeSuggestionPillBar container

Part of plan: home-figma-redesign.md (self-review round 1 fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
