### PR TITLE
docs(meet-join): align AGENTS.md isolation paragraph with .dockerignore allowlist

### DIFF
--- a/skills/meet-join/AGENTS.md
+++ b/skills/meet-join/AGENTS.md
@@ -8,8 +8,9 @@ entirely — without hunting down scattered references across the monorepo.
 ## The isolation rule
 
 The `assistant/` module must **never** import from `skills/meet-join/` via
-relative paths. The Docker build copies `assistant/` and `packages/` but not
-`skills/`, so any such import breaks at runtime.
+relative paths. The Docker build context only exposes a curated subset of
+`skills/` — whitelisted by the repo-root `.dockerignore` — so an import
+reaching into an unlisted skill path breaks at runtime.
 
 There is one narrow exception:
 `assistant/src/daemon/external-skills-bootstrap.ts` may do a single


### PR DESCRIPTION
Addresses review feedback on #26876 — opening paragraph still described the pre-allowlist Docker build behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
