### PR TITLE
fix(home): flatten HomeSuggestionPill paddings and drop no-op Color.clear background

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeSuggestionPillBar.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeSuggestionPillBar.swift
@@ -31,9 +31,7 @@ private struct HomeSuggestionPill: View {
                     .font(VFont.bodyMediumEmphasised)
                     .foregroundStyle(VColor.contentDefault)
             }
-            .padding(.leading, 4)
-            .padding(.trailing, VSpacing.md)
-            .padding(.vertical, 4)
+            .padding(EdgeInsets(top: 4, leading: 4, bottom: 4, trailing: VSpacing.md))
             .background(Capsule().fill(VColor.surfaceActive))
         }
         .buttonStyle(.plain)
@@ -85,10 +83,6 @@ struct HomeSuggestionPillBar: View {
             }
         }
         .padding(VSpacing.lg)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.xl, style: .continuous)
-                .fill(Color.clear)
-        )
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.xl, style: .continuous)
                 .stroke(VColor.borderBase, lineWidth: 1)


### PR DESCRIPTION
## Summary
Addresses AGENTS.md flatten-modifier-chains and no-op-backgrounds rules flagged during plan self-review.

- Collapse stacked .padding(.leading:/.trailing:/.vertical:) chain on HomeSuggestionPill into a single EdgeInsets padding
- Remove .background(RoundedRectangle(...).fill(Color.clear)) no-op — .overlay stroke already draws the visible outline

Part of plan: home-figma-redesign.md (self-review round 1 fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
