### PR TITLE
fix(cli-tts): include key arg in keys-set recovery hint

### DIFF
--- a/assistant/src/cli/commands/tts.ts
+++ b/assistant/src/cli/commands/tts.ts
@@ -217,7 +217,7 @@ Examples:
             err.code === "TTS_PROVIDER_NOT_CONFIGURED"
           ) {
             emitError(
-              `No TTS provider configured or registered. Run 'assistant config set services.tts.provider <provider>' to select one (e.g. ${listCatalogProviderIds().join(", ")}), then 'assistant keys set <provider>' to add the API key.`,
+              `No TTS provider configured or registered. Run 'assistant config set services.tts.provider <provider>' to select one (e.g. ${listCatalogProviderIds().join(", ")}), then 'assistant keys set <provider> <key>' to add the API key.`,
             );
             process.exitCode = 1;
             return;


### PR DESCRIPTION
Addresses review feedback on #26870 — 'assistant keys set <provider>' produces a commander usage error because keys.ts requires both provider AND key positional args.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
