### PR TITLE
docs(stt-xai): describe current guard invariant, drop history-narrating comment

### DIFF
--- a/assistant/src/providers/speech-to-text/xai-realtime.ts
+++ b/assistant/src/providers/speech-to-text/xai-realtime.ts
@@ -682,10 +682,10 @@ export class XAIRealtimeTranscriber implements StreamingTranscriber {
     }
 
     this.inactivityTimer = setTimeout(() => {
-      // Belt-and-suspenders guard. stop() clears this timer before the
-      // CLOSE_GRACE window starts, but a future refactor that re-arms
-      // or forgets to clear it must not resurrect the spurious-timeout
-      // bug where an intentional stop emits a timeout error event.
+      // Belt-and-suspenders guard: stop() clears this timer before the
+      // CLOSE_GRACE window starts, but if a future refactor re-arms it
+      // or forgets to clear it, this check prevents the inactivity
+      // callback from emitting a timeout error during an intentional stop.
       if (this.closed || this.stopping) return;
 
       log.warn("xAI realtime inactivity timeout");


### PR DESCRIPTION
Addresses review feedback on #26900 — comment narrated the pre-fix bug instead of the current state (violates AGENTS.md comment rule).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
