### PR TITLE
fix(openrouter): merge provider.only with existing provider overrides

### DIFF
--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -42,9 +42,7 @@ export function extractOnlyList(config: unknown): string[] {
   const cfg = config as { openrouter?: { only?: unknown } } | undefined;
   const only = cfg?.openrouter?.only;
   if (!Array.isArray(only)) return [];
-  return only.filter(
-    (x): x is string => typeof x === "string" && x.length > 0,
-  );
+  return only.filter((x): x is string => typeof x === "string" && x.length > 0);
 }
 
 /**
@@ -66,7 +64,11 @@ export function withOpenRouterBodyExtras(
     string,
     unknown
   >;
-  return { ...options, config: { ...rest, provider: { only } } };
+  const existingProvider = (rest.provider ?? {}) as Record<string, unknown>;
+  return {
+    ...options,
+    config: { ...rest, provider: { ...existingProvider, only } },
+  };
 }
 
 export class OpenRouterProvider extends OpenAIChatCompletionsProvider {


### PR DESCRIPTION
Addresses review feedback on #26674 — previous spread clobbered `provider.order`/`allow_fallbacks`/`ignore` fields.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
