### PR TITLE
fix(token-estimator): honor tokenEstimationProvider for OpenRouter Anthropic

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1013,7 +1013,10 @@ export async function runAgentLoopImpl(
     const preflightTokens = estimatePromptTokens(
       runMessages,
       ctx.systemPrompt,
-      { providerName: ctx.provider.name, toolTokenBudget },
+      {
+        providerName: ctx.provider.tokenEstimationProvider ?? ctx.provider.name,
+        toolTokenBudget,
+      },
     );
 
     if (overflowRecovery.enabled && preflightTokens > preflightBudget) {
@@ -1043,7 +1046,8 @@ export async function runAgentLoopImpl(
         const step = await reduceContextOverflow(
           ctx.messages,
           {
-            providerName: ctx.provider.name,
+            providerName:
+              ctx.provider.tokenEstimationProvider ?? ctx.provider.name,
             systemPrompt: ctx.systemPrompt,
             contextWindow: config.llm.default.contextWindow,
             targetTokens: preflightBudget,
@@ -1141,7 +1145,11 @@ export async function runAgentLoopImpl(
         const postInjectionTokens = estimatePromptTokens(
           runMessages,
           ctx.systemPrompt,
-          { providerName: ctx.provider.name, toolTokenBudget },
+          {
+            providerName:
+              ctx.provider.tokenEstimationProvider ?? ctx.provider.name,
+            toolTokenBudget,
+          },
         );
 
         if (postInjectionTokens <= preflightBudget) break;
@@ -1215,7 +1223,11 @@ export async function runAgentLoopImpl(
         const estimated = estimatePromptTokens(
           checkpoint.history,
           ctx.systemPrompt,
-          { providerName: ctx.provider.name, toolTokenBudget },
+          {
+            providerName:
+              ctx.provider.tokenEstimationProvider ?? ctx.provider.name,
+            toolTokenBudget,
+          },
         );
         if (estimated > midLoopThreshold) {
           rlog.warn(
@@ -1481,7 +1493,11 @@ export async function runAgentLoopImpl(
       const estimatedTokensAtOverflow = estimatePromptTokens(
         ctx.messages,
         ctx.systemPrompt,
-        { providerName: ctx.provider.name, toolTokenBudget },
+        {
+          providerName:
+            ctx.provider.tokenEstimationProvider ?? ctx.provider.name,
+          toolTokenBudget,
+        },
       );
       let correctedTarget = preflightBudget;
       if (actualTokens && estimatedTokensAtOverflow > 0) {
@@ -1529,7 +1545,8 @@ export async function runAgentLoopImpl(
         const step = await reduceContextOverflow(
           ctx.messages,
           {
-            providerName: ctx.provider.name,
+            providerName:
+              ctx.provider.tokenEstimationProvider ?? ctx.provider.name,
             systemPrompt: ctx.systemPrompt,
             contextWindow: config.llm.default.contextWindow,
             targetTokens: correctedTarget,


### PR DESCRIPTION
Addresses review feedback on #26789 — OpenRouter Anthropic models serialize via the Anthropic wire format but report name=openrouter, so anthropicDropsErrorImage missed them.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
