### PR TITLE
fix(daemon): strip web_search_tool_result on mid-loop compaction

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1382,6 +1382,14 @@ export async function runAgentLoopImpl(
       if (isTrustedActor && currentInjectionMode !== "minimal") {
         ctx.graphMemory.retrackCachedNodes();
       }
+      const midLoopCompactStrip = stripHistoricalWebSearchResults(runMessages);
+      if (midLoopCompactStrip.stats.blocksStripped > 0) {
+        rlog.info(
+          { phase: "mid-loop-compact", ...midLoopCompactStrip.stats },
+          "Converted historical web_search_tool_result blocks to text summaries",
+        );
+        runMessages = midLoopCompactStrip.messages;
+      }
       preRepairMessages = runMessages;
       preRunHistoryLength = runMessages.length;
 


### PR DESCRIPTION
Addresses review feedback on #26780 — the mid-loop compaction path was missed when adding strip calls to the three other runtime-injection sites.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
