### PR TITLE
fix(tests): add clearPkbSystemReminder + updateMessageMetadata to conversation-crud mocks

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -166,6 +166,8 @@ mock.module("../memory/conversation-crud.js", () => ({
   getConversationOriginChannel: () => null,
   getMessageById: () => null,
   updateMessageContent: () => {},
+  updateMessageMetadata: () => {},
+  clearPkbSystemReminderMetadataForConversation: () => {},
 }));
 
 mock.module("../memory/retriever.js", () => ({

--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -194,6 +194,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   getLastAssistantTimestampBefore: () => null,
   archiveConversation: () => false,
   unarchiveConversation: () => false,
+  clearPkbSystemReminderMetadataForConversation: () => {},
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({


### PR DESCRIPTION
## Summary
- Two test files mocking `conversation-crud.js` were missing stubs for recently-added exports. The production code's try/catch wrappers swallowed the resulting `TypeError`s, so tests stayed green but behavior wasn't observed.
- Add no-op stubs for `updateMessageMetadata` (overflow test only) and `clearPkbSystemReminderMetadataForConversation` (both) to keep the mock surface in parity with the real module.

Fix for gap identified during plan review: injection-metadata-persistence.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
