### PR TITLE
fix(meet-ext): wait for interactable prejoin controls, not DOM presence

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/wait.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/wait.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { JSDOM } from "jsdom";
+
+import { waitForAny, waitForSelector } from "../wait.js";
+
+/**
+ * `waitForSelector` / `waitForAny` read `MutationObserver` from `globalThis`.
+ * Bun has no DOM, so we borrow it from a scratch JSDOM window for the life
+ * of this test file and restore the prior value afterwards — mirroring the
+ * pattern in `src/__tests__/join.test.ts`.
+ */
+const JSDOM_GLOBALS = ["MutationObserver"] as const;
+const previousGlobals: Record<string, unknown> = {};
+
+beforeAll(() => {
+  const dom = new JSDOM("<html><body></body></html>");
+  for (const key of JSDOM_GLOBALS) {
+    previousGlobals[key] = (globalThis as unknown as Record<string, unknown>)[
+      key
+    ];
+    (globalThis as unknown as Record<string, unknown>)[key] = (
+      dom.window as unknown as Record<string, unknown>
+    )[key];
+  }
+});
+
+afterAll(() => {
+  for (const key of JSDOM_GLOBALS) {
+    (globalThis as unknown as Record<string, unknown>)[key] =
+      previousGlobals[key];
+  }
+});
+
+/**
+ * The `interactable` filter's purpose is to skip hidden template/transition
+ * nodes Meet keeps in the prejoin tree. These tests assert the filter rejects
+ * the forms of "hidden" we can express in jsdom — inline style and aria/hidden
+ * attributes on self or ancestor — and accepts a plain visible node.
+ *
+ * jsdom has no layout engine, so the `Element.checkVisibility()` branch is
+ * exercised only in a real browser. The attribute/style branch is what
+ * protects us in tests and in production for the explicit-hidden cases.
+ */
+
+function buildDoc(html: string): Document {
+  return new JSDOM(html).window.document;
+}
+
+describe("waitForSelector interactable filter", () => {
+  test("matches a plain visible button synchronously", async () => {
+    const doc = buildDoc(`<body><button id="a">go</button></body>`);
+    const el = await waitForSelector("#a", 100, doc, { interactable: true });
+    expect(el.id).toBe("a");
+  });
+
+  test("skips aria-hidden elements and falls through to timeout", async () => {
+    const doc = buildDoc(
+      `<body><button id="a" aria-hidden="true">ghost</button></body>`,
+    );
+    await expect(
+      waitForSelector("#a", 50, doc, { interactable: true }),
+    ).rejects.toThrow(/timeout waiting for #a/);
+  });
+
+  test("skips elements hidden via inline display:none", async () => {
+    const doc = buildDoc(
+      `<body><button id="a" style="display:none">ghost</button></body>`,
+    );
+    await expect(
+      waitForSelector("#a", 50, doc, { interactable: true }),
+    ).rejects.toThrow(/timeout waiting for #a/);
+  });
+
+  test("skips elements whose ancestor is hidden", async () => {
+    const doc = buildDoc(
+      `<body><div aria-hidden="true"><button id="a">ghost</button></div></body>`,
+    );
+    await expect(
+      waitForSelector("#a", 50, doc, { interactable: true }),
+    ).rejects.toThrow(/timeout waiting for #a/);
+  });
+
+  test("resolves once a hidden match becomes interactable", async () => {
+    const doc = buildDoc(
+      `<body><button id="a" aria-hidden="true">pending</button></body>`,
+    );
+    // Flip the attribute after a tick — the observer should pick it up.
+    setTimeout(() => {
+      doc.getElementById("a")?.removeAttribute("aria-hidden");
+    }, 10);
+    const el = await waitForSelector("#a", 500, doc, { interactable: true });
+    expect(el.id).toBe("a");
+  });
+
+  test("without the flag, hidden nodes still match", async () => {
+    const doc = buildDoc(
+      `<body><button id="a" aria-hidden="true">ghost</button></body>`,
+    );
+    const el = await waitForSelector("#a", 100, doc);
+    expect(el.id).toBe("a");
+  });
+});
+
+describe("waitForAny interactable filter", () => {
+  test("skips a hidden earlier match and resolves on a later visible one", async () => {
+    const doc = buildDoc(
+      `<body>
+        <button id="ghost" aria-label="Join now" aria-hidden="true">ghost</button>
+        <button id="real" aria-label="Ask to join">real</button>
+      </body>`,
+    );
+    const { selector, element } = await waitForAny(
+      ['button[aria-label="Join now"]', 'button[aria-label="Ask to join"]'],
+      100,
+      doc,
+      { interactable: true },
+    );
+    expect(selector).toBe('button[aria-label="Ask to join"]');
+    expect(element.id).toBe("real");
+  });
+
+  test("matches the first visible candidate", async () => {
+    const doc = buildDoc(
+      `<body>
+        <button aria-label="Join now">real</button>
+        <button aria-label="Ask to join">also real</button>
+      </body>`,
+    );
+    const { selector } = await waitForAny(
+      ['button[aria-label="Join now"]', 'button[aria-label="Ask to join"]'],
+      100,
+      doc,
+      { interactable: true },
+    );
+    expect(selector).toBe('button[aria-label="Join now"]');
+  });
+
+  test("times out when every candidate is hidden", async () => {
+    const doc = buildDoc(
+      `<body>
+        <button aria-label="Join now" style="display:none">a</button>
+        <button aria-label="Ask to join" aria-hidden="true">b</button>
+      </body>`,
+    );
+    await expect(
+      waitForAny(
+        ['button[aria-label="Join now"]', 'button[aria-label="Ask to join"]'],
+        50,
+        doc,
+        { interactable: true },
+      ),
+    ).rejects.toThrow(/timeout waiting for any of/);
+  });
+});

--- a/skills/meet-join/meet-controller-ext/src/dom/wait.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/wait.ts
@@ -21,7 +21,80 @@
  *     on regex.
  *   - A `document`-scoped argument is exposed so tests can substitute a JSDOM
  *     document; production callers use the real `document` default.
+ *   - The optional `interactable` filter gates resolution on the element being
+ *     user-interactable, not merely present. Meet keeps hidden template and
+ *     transition nodes in the tree (e.g. during prejoin → in-meeting
+ *     transitions); a raw `querySelector` can match one before it becomes
+ *     clickable, which then makes the join flow click the wrong path and
+ *     time out in admission. The filter rejects elements that are explicitly
+ *     marked hidden (via `hidden` / `aria-hidden="true"` on self or ancestor,
+ *     or inline `display: none` / `visibility: hidden` / `pointer-events:
+ *     none`). When available it also defers to `Element.checkVisibility()`
+ *     for the layout-aware cases (opacity, content-visibility, off-screen
+ *     offsetParent) — jsdom has no layout engine, so we fall back to the
+ *     attribute/style checks alone in tests.
  */
+
+/**
+ * Return `true` when `el` looks user-interactable, `false` when it's a hidden
+ * template/transition node that happens to match a selector.
+ *
+ * Conservative: only filters out elements that are *demonstrably* hidden via
+ * explicit attributes, inline styles, or the native visibility check. Elements
+ * that merely lack positive evidence of being interactable (common in jsdom,
+ * where there is no layout) pass through.
+ */
+function isInteractable(el: Element): boolean {
+  const html = el as HTMLElement;
+
+  // Ancestor-or-self check: `hidden` / `aria-hidden="true"` on any enclosing
+  // node hides this one too. `closest` matches self, so a direct attribute
+  // on `el` is also caught here.
+  if (el.closest('[hidden], [aria-hidden="true"]')) return false;
+
+  const style = html.style;
+  if (style) {
+    if (style.display === "none") return false;
+    if (style.visibility === "hidden") return false;
+    if (style.pointerEvents === "none") return false;
+  }
+
+  // Chrome 105+ ships `Element.checkVisibility()`, which handles the
+  // layout-dependent cases (detached subtree, `content-visibility: hidden`,
+  // zero opacity) that our attribute sniffing cannot. Skip the call in
+  // environments that lack it (e.g. jsdom).
+  const check = (
+    el as unknown as {
+      checkVisibility?: (opts?: {
+        checkOpacity?: boolean;
+        checkVisibilityCSS?: boolean;
+      }) => boolean;
+    }
+  ).checkVisibility;
+  if (typeof check === "function") {
+    try {
+      if (!check.call(el, { checkOpacity: true, checkVisibilityCSS: true })) {
+        return false;
+      }
+    } catch {
+      // Defensive: if `checkVisibility` throws on some quirky element, fall
+      // through to accept the match — we've already applied the stricter
+      // attribute filters above.
+    }
+  }
+
+  return true;
+}
+
+export interface WaitOptions {
+  /**
+   * When `true`, reject selector matches whose element is demonstrably
+   * hidden (see {@link isInteractable}). Default `false` preserves the
+   * original "any matching node" semantics for callers that do not care
+   * about interactability.
+   */
+  interactable?: boolean;
+}
 
 /**
  * Resolve with the first element matching `sel`. Rejects with
@@ -42,12 +115,18 @@ export function waitForSelector(
   sel: string,
   timeoutMs: number,
   doc: Document = document,
+  opts: WaitOptions = {},
 ): Promise<Element> {
+  const wantInteractable = opts.interactable === true;
+  const accept = (el: Element | null): el is Element =>
+    el !== null && (!wantInteractable || isInteractable(el));
+
   return new Promise<Element>((resolve, reject) => {
-    // Synchronous check — if it's already there, return immediately. This
-    // short-circuits the happy path without touching MutationObserver.
+    // Synchronous check — if it's already there (and interactable, when
+    // requested), return immediately. This short-circuits the happy path
+    // without touching MutationObserver.
     const existing = doc.querySelector(sel);
-    if (existing) {
+    if (accept(existing)) {
       resolve(existing);
       return;
     }
@@ -56,7 +135,7 @@ export function waitForSelector(
     const observer = new MutationObserver(() => {
       if (settled) return;
       const match = doc.querySelector(sel);
-      if (match) {
+      if (accept(match)) {
         settled = true;
         observer.disconnect();
         clearTimeout(timer);
@@ -93,30 +172,38 @@ export function waitForAny(
   selectors: string[],
   timeoutMs: number,
   doc: Document = document,
+  opts: WaitOptions = {},
 ): Promise<{ selector: string; element: Element }> {
+  const wantInteractable = opts.interactable === true;
+  const firstMatch = (): { selector: string; element: Element } | null => {
+    for (const selector of selectors) {
+      const el = doc.querySelector(selector);
+      if (el && (!wantInteractable || isInteractable(el))) {
+        return { selector, element: el };
+      }
+    }
+    return null;
+  };
+
   return new Promise<{ selector: string; element: Element }>(
     (resolve, reject) => {
-      // Synchronous check — return the first selector that already matches.
-      for (const selector of selectors) {
-        const existing = doc.querySelector(selector);
-        if (existing) {
-          resolve({ selector, element: existing });
-          return;
-        }
+      // Synchronous check — return the first selector whose element already
+      // matches (and is interactable, when requested).
+      const initial = firstMatch();
+      if (initial) {
+        resolve(initial);
+        return;
       }
 
       let settled = false;
       const observer = new MutationObserver(() => {
         if (settled) return;
-        for (const selector of selectors) {
-          const match = doc.querySelector(selector);
-          if (match) {
-            settled = true;
-            observer.disconnect();
-            clearTimeout(timer);
-            resolve({ selector, element: match });
-            return;
-          }
+        const match = firstMatch();
+        if (match) {
+          settled = true;
+          observer.disconnect();
+          clearTimeout(timer);
+          resolve(match);
         }
       });
 

--- a/skills/meet-join/meet-controller-ext/src/features/join.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/join.ts
@@ -134,6 +134,7 @@ export async function runJoinFlow(opts: RunJoinFlowOptions): Promise<void> {
       selectors.PREJOIN_MEDIA_PROMPT_ACCEPT_BUTTON,
       MEDIA_PROMPT_TIMEOUT_MS,
       doc,
+      { interactable: true },
     );
     (modal as HTMLElement).click();
   } catch {
@@ -153,6 +154,11 @@ export async function runJoinFlow(opts: RunJoinFlowOptions): Promise<void> {
       ],
       PREJOIN_TIMEOUT_MS,
       doc,
+      // Meet leaves hidden template/transition copies of these nodes in the
+      // tree during the prejoin mount; we must wait for a genuinely
+      // interactable match so the admission click path doesn't branch on a
+      // ghost node and then time out waiting for the in-meeting UI.
+      { interactable: true },
     );
   } catch {
     fail(


### PR DESCRIPTION
## Summary
- Adds an opt-in \`interactable\` option to \`waitForSelector\` / \`waitForAny\` that rejects matches which are explicitly hidden (\`hidden\` / \`aria-hidden=\"true\"\` on self or ancestor, inline \`display:none\` / \`visibility:hidden\` / \`pointer-events:none\`) and defers to \`Element.checkVisibility()\` when available.
- Threads \`{ interactable: true }\` through \`runJoinFlow\`'s prejoin waits (media-prompt accept button and the prejoin surface race) so the flow does not branch on Meet's hidden template/transition nodes.
- Adds \`src/dom/__tests__/wait.test.ts\` covering the new filter in isolation.

## Why
Addresses the second Codex review item on #26581 (the generation-counter fix from that review landed in #26861): \`dom/wait.ts\` was resolving on raw \`querySelector\` matches, so hidden template nodes Meet keeps in the prejoin tree could satisfy the wait before the real controls were clickable. The flow would then click a ghost button and time out in admission. The filter is opt-in to keep \`waitForSelector\`'s behavior unchanged for the chat / in-meeting call sites that don't need it.

## Test plan
- [x] \`bun test src/dom/__tests__/wait.test.ts\` — 9/9 pass.
- [x] \`bun test src/__tests__/join.test.ts src/dom/__tests__/\` — same pre-existing chat-consent failure as \`main\`; all other 46 tests pass.
- [x] \`bunx tsc --noEmit\` — no new diagnostics from the changed files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
