### PR TITLE
fix(meet): race-safe orphan reaper on startup

### DIFF
--- a/skills/meet-join/daemon/__tests__/docker-runner.test.ts
+++ b/skills/meet-join/daemon/__tests__/docker-runner.test.ts
@@ -944,6 +944,84 @@ describe("reapOrphanedMeetBots", () => {
     expect(result.kept).toEqual([]);
   });
 
+  test("skips containers created at or after createdBefore cutoff", async () => {
+    const killCalls: Array<{ id: string; signal: string | undefined }> = [];
+    const docker: FakeDocker = {
+      listContainers: async () => [
+        {
+          Id: "c-old",
+          Created: 1000,
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-old",
+          },
+        },
+        {
+          Id: "c-new",
+          Created: 2500,
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-new",
+          },
+        },
+      ],
+      kill: async (id, signal) => {
+        killCalls.push({ id, signal });
+      },
+    };
+
+    const result = await reapOrphanedMeetBots({
+      docker,
+      activeMeetingIds: new Set(),
+      createdBefore: 2000,
+      logger: silentLogger(),
+    });
+
+    expect(result.killed).toEqual(["c-old"]);
+    expect(result.kept).toEqual(["c-new"]);
+    expect(killCalls.filter((c) => c.signal === "SIGTERM")).toEqual([
+      { id: "c-old", signal: "SIGTERM" },
+    ]);
+  });
+
+  test("consults activeMeetingIds getter per-container so mid-sweep joins are observed", async () => {
+    const killCalls: Array<{ id: string; signal: string | undefined }> = [];
+    const live = new Set<string>();
+    const docker: FakeDocker = {
+      listContainers: async () => [
+        {
+          Id: "c-a",
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-a",
+          },
+        },
+        {
+          Id: "c-b",
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-b",
+          },
+        },
+      ],
+      kill: async (id, signal) => {
+        killCalls.push({ id, signal });
+        // Simulate a concurrent join that lands between the two iterations:
+        // once c-a has been reaped, meeting-b becomes active.
+        if (id === "c-a" && signal === "SIGTERM") live.add("meeting-b");
+      },
+    };
+
+    const result = await reapOrphanedMeetBots({
+      docker,
+      activeMeetingIds: () => live,
+      logger: silentLogger(),
+    });
+
+    expect(result.killed).toEqual(["c-a"]);
+    expect(result.kept).toEqual(["c-b"]);
+  });
+
   test("returns empty result and logs a warning if listContainers throws", async () => {
     const docker: FakeDocker = {
       listContainers: async () => {

--- a/skills/meet-join/daemon/docker-runner.ts
+++ b/skills/meet-join/daemon/docker-runner.ts
@@ -192,6 +192,13 @@ export interface ContainerListEntry {
   Labels?: Record<string, string>;
   State?: string;
   Status?: string;
+  /**
+   * Container creation time as Unix epoch seconds (Docker's
+   * `/containers/json` returns this as the `Created` field). Used by the
+   * orphan reaper to skip containers created after the daemon started, so
+   * joins that race the startup sweep are never misidentified as orphans.
+   */
+  Created?: number;
   [key: string]: unknown;
 }
 
@@ -918,9 +925,13 @@ export const REAPER_TERM_KILL_GRACE_MS = 10_000;
  *
  * @param opts.docker Docker client — typically a {@link DockerRunner}.
  * @param opts.activeMeetingIds Meeting IDs that currently map to a live
- *   in-process session. On boot this is an empty set (no sessions yet),
- *   but the signature accepts any set so the same helper can be called
- *   from a later "cleanup unexpected orphans" sweep during runtime.
+ *   in-process session. Accepts either a static set or a zero-arg getter;
+ *   the getter is consulted per-container so a join that lands mid-sweep
+ *   is observed before its container is evaluated.
+ * @param opts.createdBefore Optional Unix-epoch-seconds cutoff. Containers
+ *   with `Created >= createdBefore` are kept unconditionally. Pass the
+ *   daemon's start time during the startup sweep so new joins launched
+ *   concurrently can never be misidentified as orphans from a prior run.
  * @param opts.logger Structured logger — one INFO line per kill.
  * @returns Summary of which container ids were killed vs kept.
  */
@@ -939,10 +950,15 @@ export interface ReaperLogger {
 
 export async function reapOrphanedMeetBots(opts: {
   docker: DockerClientForReaper;
-  activeMeetingIds: ReadonlySet<string>;
+  activeMeetingIds: ReadonlySet<string> | (() => ReadonlySet<string>);
+  createdBefore?: number;
   logger: ReaperLogger;
 }): Promise<{ killed: string[]; kept: string[] }> {
-  const { docker, activeMeetingIds, logger } = opts;
+  const { docker, activeMeetingIds, createdBefore, logger } = opts;
+  const resolveActive =
+    typeof activeMeetingIds === "function"
+      ? activeMeetingIds
+      : () => activeMeetingIds;
   const killed: string[] = [];
   const kept: string[] = [];
 
@@ -962,7 +978,18 @@ export async function reapOrphanedMeetBots(opts: {
     const labels = container.Labels ?? {};
     const meetingId = labels[MEET_BOT_MEETING_ID_LABEL];
 
-    if (meetingId && activeMeetingIds.has(meetingId)) {
+    // Skip containers created after the cutoff — they belong to this
+    // daemon's lifetime (or later) and cannot be orphans from a prior run.
+    if (
+      createdBefore !== undefined &&
+      typeof container.Created === "number" &&
+      container.Created >= createdBefore
+    ) {
+      kept.push(containerId);
+      continue;
+    }
+
+    if (meetingId && resolveActive().has(meetingId)) {
       kept.push(containerId);
       continue;
     }

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -781,18 +781,33 @@ class MeetSessionManagerImpl {
       return this.pendingBotTokens.get(meetingId) ?? null;
     });
 
-    // One-shot startup orphan sweep. On a fresh boot no sessions exist, so
-    // the active-id set is empty — any `vellum.meet.bot`-labeled container
+    // One-shot startup orphan sweep. Any `vellum.meet.bot`-labeled container
     // still running came from a crashed prior daemon run and must be
     // reaped. Fire-and-forget so construction stays synchronous; the
     // reaper logs its own outcome and catches per-container errors so a
     // transient docker-engine hiccup never tears down the session-manager
     // singleton. Tests opt out via {@link MeetSessionManagerDeps.disableStartupOrphanReaper}.
+    //
+    // Two guards make the sweep race-safe with concurrent joins:
+    //   1. `createdBefore` — Docker's `Created` timestamp for every
+    //      container the reaper considers must predate this moment, so any
+    //      container spawned by a join that races the sweep is skipped.
+    //   2. `activeMeetingIds` — passed as a live getter that reads
+    //      `this.sessions` (and `pendingBotTokens` for the brief window
+    //      before the session lands in the map) per-container, so a join
+    //      that lands mid-sweep is observed before its meeting ID is
+    //      evaluated.
     if (!this.deps.disableStartupOrphanReaper) {
       const reaperDocker = this.deps.dockerRunnerFactory();
+      const daemonStartEpochSeconds = Math.floor(Date.now() / 1000);
       void reapOrphanedMeetBots({
         docker: reaperDocker,
-        activeMeetingIds: new Set<string>(),
+        activeMeetingIds: () => {
+          const ids = new Set<string>(this.sessions.keys());
+          for (const id of this.pendingBotTokens.keys()) ids.add(id);
+          return ids;
+        },
+        createdBefore: daemonStartEpochSeconds,
         logger: log,
       }).catch((err: unknown) => {
         log.warn({ err }, "Startup orphan-reaper sweep threw — continuing");


### PR DESCRIPTION
Addresses review feedback on #26649 — sweep used empty activeMeetingIds captured at construction, so concurrent joins got killed.

- reapOrphanedMeetBots now accepts activeMeetingIds as either a set or a live getter; getter is consulted per-container so joins landing mid-sweep are observed.
- Added createdBefore (Unix epoch seconds) cutoff. Startup call passes Date.now()/1000 so any container created after daemon boot is kept unconditionally — this is the strongest safety net: new joins literally cannot be misidentified as orphans.
- Session-manager passes a live getter that unions this.sessions and pendingBotTokens (covers the brief container-spawn / audio-ingest window before the session lands in the map).
- New regression tests cover both the createdBefore guard and the per-container getter behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
