### PR TITLE
fix(clients/Network): use sleep-inclusive clock in AuthFailureTracker

### DIFF
--- a/clients/shared/Network/AuthFailureTracker.swift
+++ b/clients/shared/Network/AuthFailureTracker.swift
@@ -16,12 +16,19 @@ import Foundation
 /// jitter. A 30s window (the original default) could hold at most 3 such
 /// entries and so could never trip the detector.
 ///
-/// The clock source is **monotonic** (backed by `DispatchTime.now()`), not
-/// wall-clock (`Date()`). Pruning compares elapsed seconds since an arbitrary
-/// fixed reference, so NTP adjustments, manual clock changes, and daylight-
-/// savings transitions cannot corrupt the window — a backward wall-clock jump
-/// would otherwise keep stale failures live, and a forward jump would prune
-/// real ones. The clock is injected so tests can drive time deterministically
+/// The clock source is **monotonic and sleep-inclusive** (backed by
+/// `mach_continuous_time()`), not wall-clock (`Date()`) and not
+/// `DispatchTime.now()` / `mach_absolute_time()`. Pruning compares elapsed
+/// seconds since an arbitrary fixed reference, so NTP adjustments, manual
+/// clock changes, and daylight-savings transitions cannot corrupt the window
+/// — a backward wall-clock jump would otherwise keep stale failures live, and
+/// a forward jump would prune real ones. It also must advance while the
+/// system is asleep: on macOS (the primary target), `DispatchTime.now()` and
+/// `ProcessInfo.systemUptime` both pause during sleep, so a laptop that
+/// accumulates 3 failures, sleeps for hours, and hits one more failure on
+/// wake would trip the detector on what is really a single fresh failure.
+/// `mach_continuous_time()` keeps advancing across sleep, so the window ages
+/// correctly. The clock is injected so tests can drive time deterministically
 /// without relying on `sleep`. All mutation is serialized through a private
 /// `DispatchQueue` so the tracker is safe to call from a periodic health-check
 /// task and from request-completion callbacks concurrently.
@@ -51,11 +58,21 @@ public final class AuthFailureTracker {
         self.now = now
     }
 
+    private static let machTimebase: mach_timebase_info_data_t = {
+        var info = mach_timebase_info_data_t()
+        mach_timebase_info(&info)
+        return info
+    }()
+
     /// Default monotonic clock: seconds since an arbitrary fixed reference,
-    /// sourced from `DispatchTime.now()` (which wraps Apple's monotonic
-    /// mach clock). Immune to wall-clock jumps.
+    /// sourced from `mach_continuous_time()`. Unlike `mach_absolute_time()`
+    /// (which backs `DispatchTime.now()`), the continuous clock keeps
+    /// advancing while the system is asleep — required on macOS so the
+    /// 90s sliding window ages correctly across laptop sleep.
     public static func monotonicNow() -> TimeInterval {
-        TimeInterval(DispatchTime.now().uptimeNanoseconds) / 1_000_000_000
+        let ticks = mach_continuous_time()
+        let nanos = ticks &* UInt64(machTimebase.numer) / UInt64(machTimebase.denom)
+        return TimeInterval(nanos) / 1_000_000_000
     }
 
     /// Record a completed HTTP response. Only 401 and 429 contribute to the


### PR DESCRIPTION
Addresses review feedback on #26795 — `DispatchTime.now()` pauses during system sleep (it's backed by `mach_absolute_time()`), so stale auth-failure entries survive across laptop sleep on macOS, the target env for this PR.

Real scenario Codex flagged: 3 auth failures before laptop sleep, one fresh failure after wake trips the detector because the 90s sliding window stopped aging during sleep.

Switch to `mach_continuous_time()`, which keeps advancing while the system is asleep. `ProcessInfo.systemUptime` was also considered but it too pauses during sleep on Apple platforms (mach_absolute_time-based), so it doesn't fix the regression.

## Test plan
- [x] Swift build passes in clients/
- [ ] Existing `AuthFailureTrackerTests` still pass (clock injection unchanged — only the default production clock source changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
