### PR TITLE
feat(onboarding): replace WakeUp buttons with Vellum Cloud + Advanced cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -88,7 +88,7 @@ struct OnboardingFlowView: View {
                 VStack(spacing: 0) {
                     if state.currentStep == 0 {
                         // Step 0 only: top inset + app icon
-                        Color.clear.frame(height: 80)
+                        Color.clear.frame(height: VSpacing.xxl)
 
                         if let nsImage = Self.appIcon {
                             Image(nsImage: nsImage)
@@ -97,7 +97,7 @@ struct OnboardingFlowView: View {
                                 .frame(width: 80, height: 80)
                                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                                 .shadow(color: VColor.auxBlack.opacity(0.15), radius: 1, x: 0, y: 1)
-                                .padding(.bottom, 78)
+                                .padding(.bottom, VSpacing.xl)
                         }
                     } else {
                         // Steps 1–3: top inset only (no icon)
@@ -195,7 +195,7 @@ struct OnboardingFlowView: View {
             }
         }
         }
-        .frame(minWidth: 440, minHeight: 630)
+        .frame(minWidth: 440, minHeight: 720)
         .task {
             if !authManager.isAuthenticated {
                 await authManager.checkSession()

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingVellumCloudCard.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingVellumCloudCard.swift
@@ -17,9 +17,9 @@ struct OnboardingVellumCloudCard: View {
         "Automatic two-way transfer & backup",
     ]
     let primaryCTA: String = "Continue with Vellum"
-    let isLoading: Bool = false
-    let isDisabled: Bool = false
-    let onContinue: () -> Void
+    var isLoading: Bool = false
+    var isDisabled: Bool = false
+    var onContinue: () -> Void
 
     // MARK: - Body
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -14,8 +14,9 @@ struct WakeUpStepView: View {
     /// When true, disables all buttons (e.g. during 0.3s advance delay).
     var isAdvancing: Bool = false
 
-    /// When true, the primary action triggers managed sign-in ("Log In").
-    /// When false, the primary action is "Get Started" and advances directly.
+    /// When true, the managed sign-in Vellum Cloud card + Advanced disclosure
+    /// are rendered. When false, the primary action is a single "Get Started"
+    /// button that advances directly.
     var managedSignInEnabled: Bool = false
 
     // Callbacks
@@ -24,74 +25,35 @@ struct WakeUpStepView: View {
 
     // MARK: - Private State
 
-    @State private var showTitle = false
-    @State private var showSubtext = false
-    @State private var showButtons = false
-    @State private var showCharacters = false
-
-    private static let welcomeCharacters: NSImage? = {
-        guard let url = ResourceBundle.bundle.url(forResource: "welcome-characters", withExtension: "png") else { return nil }
-        return NSImage(contentsOf: url)
-    }()
+    @State private var showCards = false
+    @State private var isAdvancedExpanded: Bool = false
 
     // MARK: - Body
 
     var body: some View {
-        // Title
-        Text("Welcome to Vellum")
-            .font(VFont.titleLarge)
-            .foregroundStyle(VColor.contentDefault)
-            .opacity(showTitle ? 1 : 0)
-            .offset(y: showTitle ? 0 : 8)
-            .padding(.bottom, VSpacing.md)
+        VStack(spacing: VSpacing.md) {
+            if managedSignInEnabled {
+                OnboardingVellumCloudCard(
+                    isLoading: authManager?.isLoading == true || authManager?.isSubmitting == true,
+                    isDisabled: isAdvancing,
+                    onContinue: { onContinueWithVellum() }
+                )
 
-        // Subtitle
-        Text("The safest way to create your personal assistant.")
-            .font(VFont.bodyMediumLighter)
-            .foregroundStyle(VColor.contentSecondary)
-            .multilineTextAlignment(.center)
-            .opacity(showSubtext ? 1 : 0)
-            .offset(y: showSubtext ? 0 : 8)
-            .padding(.bottom, VSpacing.xxl)
-
-        // Buttons
-        VStack(spacing: VSpacing.sm) {
-            if authManager?.isLoading == true {
-                HStack(spacing: VSpacing.sm) {
-                    ProgressView()
-                        .controlSize(.small)
-                        .progressViewStyle(.circular)
-                    Text("Checking...")
-                        .font(VFont.titleSmall)
-                        .foregroundStyle(VColor.contentSecondary)
-                }
-                .frame(height: 36)
-            } else if authManager?.isSubmitting == true {
-                HStack(spacing: VSpacing.sm) {
-                    ProgressView()
-                        .controlSize(.small)
-                        .progressViewStyle(.circular)
-                    Text("Logging in...")
-                        .font(VFont.titleSmall)
-                        .foregroundStyle(VColor.contentSecondary)
-                }
-                .frame(height: 36)
-            } else if managedSignInEnabled {
-                VButton(label: "Log In", style: .primary, isFullWidth: true) {
-                    onContinueWithVellum()
-                }
-
-                VButton(label: "Continue without account", style: .ghost) {
-                    state?.skippedAuth = true
-                    onStartWithAPIKey()
-                }
+                OnboardingLocalModeDisclosure(
+                    isExpanded: $isAdvancedExpanded,
+                    isDisabled: isAdvancing,
+                    onUseLocalMode: {
+                        state?.skippedAuth = true
+                        onStartWithAPIKey()
+                    }
+                )
             } else {
+                // Unchanged fallback
                 VButton(label: "Get Started", style: .primary, isFullWidth: true) {
                     onStartWithAPIKey()
                 }
             }
 
-            // Auth error message
             if let error = authManager?.errorMessage {
                 Text(error)
                     .font(VFont.labelDefault)
@@ -101,47 +63,13 @@ struct WakeUpStepView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.horizontal, VSpacing.xxl)
-        .opacity(showButtons ? 1 : 0)
-        .offset(y: showButtons ? 0 : 12)
+        .opacity(showCards ? 1 : 0)
+        .offset(y: showCards ? 0 : 12)
         .disabled(isAdvancing || authManager?.isSubmitting == true)
         .onAppear {
             withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
-                showTitle = true
+                showCards = true
             }
-            withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
-                showSubtext = true
-            }
-            withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
-                showButtons = true
-            }
-        }
-
-        Spacer()
-
-        Text("2026 Vellum Inc.")
-            .font(VFont.bodySmallDefault)
-            .foregroundStyle(VColor.borderElement)
-            .padding(.bottom, VSpacing.sm)
-
-        // Characters peeking up from the bottom — single composed image
-        // exported from Figma, displayed edge-to-edge at the window bottom.
-        // Clip bottom corners to match the macOS window corner radius.
-        if let characters = Self.welcomeCharacters {
-            Image(nsImage: characters)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(maxWidth: .infinity)
-                .clipShape(UnevenRoundedRectangle(
-                    topLeadingRadius: 0,
-                    bottomLeadingRadius: VRadius.window,
-                    bottomTrailingRadius: VRadius.window,
-                    topTrailingRadius: 0
-                ))
-                .opacity(showCharacters ? 1 : 0)
-                .offset(y: showCharacters ? 0 : 30)
-                .animation(.easeOut(duration: 0.6).delay(0.7), value: showCharacters)
-                .onAppear { showCharacters = true }
-                .accessibilityHidden(true)
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -41,7 +41,9 @@ struct WakeUpStepView: View {
 
                 OnboardingLocalModeDisclosure(
                     isExpanded: $isAdvancedExpanded,
-                    isDisabled: isAdvancing,
+                    isDisabled: isAdvancing
+                        || authManager?.isLoading == true
+                        || authManager?.isSubmitting == true,
                     onUseLocalMode: {
                         state?.skippedAuth = true
                         onStartWithAPIKey()
@@ -65,7 +67,11 @@ struct WakeUpStepView: View {
         .padding(.horizontal, VSpacing.xxl)
         .opacity(showCards ? 1 : 0)
         .offset(y: showCards ? 0 : 12)
-        .disabled(isAdvancing || authManager?.isSubmitting == true)
+        .disabled(
+            isAdvancing
+                || authManager?.isLoading == true
+                || authManager?.isSubmitting == true
+        )
         .onAppear {
             withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
                 showCards = true


### PR DESCRIPTION
## Summary
- Compose OnboardingVellumCloudCard and OnboardingLocalModeDisclosure on the WakeUp step (managedSignInEnabled path).
- Remove Welcome to Vellum title/subtitle and the welcome-characters footer — cards are the new hero.
- OnboardingFlowView step-0 top inset + app icon padding reduced; frame minHeight bumped to 720 so expanded Advanced state fits without scroll.

Part of plan: onboarding-setup-cards.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
