### PR TITLE
fix(test): hydrate benchmark mocks with missing exports and llm.default config

### DIFF
--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -107,6 +107,24 @@ const mockConfig = {
     summaryBudgetRatio: 0.05,
   },
   thinking: { enabled: false },
+  llm: {
+    default: {
+      provider: "mock",
+      model: "mock-model",
+      speed: "standard",
+      thinking: { enabled: false, streamThinking: false },
+      effort: "medium",
+      contextWindow: {
+        enabled: true,
+        maxInputTokens: 180000,
+        targetBudgetRatio: 0.3,
+        compactThreshold: 0.8,
+        summaryBudgetRatio: 0.05,
+      },
+    },
+    profiles: {},
+    callSites: {},
+  },
 };
 
 mock.module("../config/loader.js", () => ({
@@ -120,6 +138,7 @@ mock.module("../config/loader.js", () => ({
     "perplexity",
   ],
   getConfig: () => mockConfig,
+  getConfigReadOnly: () => mockConfig,
   loadConfig: () => mockConfig,
   saveConfig: () => {},
   invalidateConfigCache: () => {},
@@ -127,6 +146,10 @@ mock.module("../config/loader.js", () => ({
   saveRawConfig: () => {},
   getNestedValue: () => undefined,
   setNestedValue: () => {},
+  applyNestedDefaults: (c: unknown) => c,
+  deepMergeMissing: () => {},
+  deepMergeOverwrite: () => {},
+  mergeDefaultWorkspaceConfig: () => {},
 }));
 
 // Additional mocks required for Conversation constructor and end-to-end tests
@@ -134,6 +157,7 @@ mock.module("../config/loader.js", () => ({
 mock.module("../memory/conversation-crud.js", () => ({
   addMessage: () => ({ id: "msg-1" }),
   getMessages: () => [],
+  hasMessages: () => false,
   getMessageById: () => null,
   getConversation: () => null,
   createConversation: () => ({
@@ -198,11 +222,14 @@ mock.module("../memory/conversation-crud.js", () => ({
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({
+  buildFtsMatchQuery: () => "",
   countConversations: () => 0,
   listConversations: () => [],
+  listPinnedConversations: () => [],
   getLatestConversation: () => null,
   isLastUserMessageToolResult: () => false,
   searchConversations: () => [],
+  buildExcerpt: () => "",
 }));
 
 mock.module("../hooks/manager.js", () => ({
@@ -267,6 +294,8 @@ mock.module("../calls/call-store.js", () => ({
 mock.module("../daemon/watch-handler.js", () => ({
   lastCommentaryByConversation: new Map(),
   lastSummaryByConversation: new Map(),
+  handleWatchObservation: () => Promise.resolve(),
+  generateSummary: () => Promise.resolve(),
 }));
 
 mock.module("../tools/browser/browser-screencast.js", () => ({


### PR DESCRIPTION
## Summary
- Add missing exports to the `mock.module` declarations in `conversation-init.benchmark.test.ts` (`deepMergeOverwrite`, `hasMessages`, `listPinnedConversations`, `handleWatchObservation`, `buildExcerpt`, etc.) so Bun's ESM resolver does not throw `SyntaxError: Export named 'X' not found` when the mocked modules are transitively imported.
- Populate `mockConfig` with a full `llm.default` branch (`thinking.streamThinking`, `effort`, `contextWindow`) so the `Conversation` constructor reads valid values through `getConfig()`.
- Restores the `CI Benchmark Regression Detection` workflow on `main` (was failing on `deepMergeOverwrite`).

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24694919068/job/72225380051
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
