### PR TITLE
fix(cli-tts): guard stdin read with isTTY to avoid interactive hang

### DIFF
--- a/assistant/src/cli/commands/inference.ts
+++ b/assistant/src/cli/commands/inference.ts
@@ -70,7 +70,7 @@ Examples:
         // Determine user message: positional args or stdin.
         let messageText = messageParts.length > 0 ? messageParts.join(" ") : "";
 
-        if (!messageText) {
+        if (!messageText && !process.stdin.isTTY) {
           try {
             messageText = readFileSync("/dev/stdin", "utf-8").trim();
           } catch {

--- a/assistant/src/cli/commands/tts.ts
+++ b/assistant/src/cli/commands/tts.ts
@@ -173,7 +173,7 @@ Examples:
         let messageText =
           opts.text ??
           (positionalParts.length > 0 ? positionalParts.join(" ") : "");
-        if (!messageText) {
+        if (!messageText && !process.stdin.isTTY) {
           try {
             messageText = readFileSync("/dev/stdin", "utf-8").trim();
           } catch {


### PR DESCRIPTION
Addresses review feedback on #26877.

When `tts synthesize` (and `inference`) had no `--text`, no positional args, and no piped stdin, the code called `readFileSync("/dev/stdin")` unconditionally, blocking in an interactive terminal while waiting for EOF.

Wraps the stdin read in `if (!process.stdin.isTTY)` so interactive invocations fall through to the "No text provided" error instead of hanging. Matches the existing pattern in `email.ts:697`, `cache.ts:74`, `ui.ts:111`, `conversations-import.ts:284`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
