### PR TITLE
docs(slack): correct slackMeta hoist comment scope

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1523,11 +1523,13 @@ export class DaemonServer {
     };
     const slashResult = await resolveSlash(content, slashContext);
 
-    // Slack inbound metadata is materialized once here so every persistence
-    // branch below (slash-command bypass paths and the agent-loop path) writes
-    // the same `slackMeta` envelope. Without this, unknown-slash and /compact
-    // rows land without the envelope and the chronological renderer sees
-    // inconsistent metadata across a single conversation.
+    // Slack inbound metadata is materialized once here for the slash-command
+    // bypass paths (unknown-slash and /compact), which persist the user row
+    // directly via `addMessage` and would otherwise drop the envelope. The
+    // agent-loop path does not consume this variable — it forwards
+    // `options.slackInbound` through `persistMetadata` and the envelope is
+    // built internally by `buildSlackMetaForPersistence` inside
+    // `persistQueuedMessageBody`.
     const slackMeta = buildSlackMetaForPersistence({
       slackInbound: options?.slackInbound,
       turnChannel: conversation.getTurnChannelContext()?.userMessageChannel,


### PR DESCRIPTION
Addresses review feedback on #26818 — comment claimed agent-loop path consumed the hoisted variable, but it has its own envelope construction via `buildSlackMetaForPersistence` inside `persistQueuedMessageBody`. This rewrites the comment to scope correctly to the slash-command bypass paths and notes where the agent-loop path constructs its own envelope.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
