### PR TITLE
fix(slack): harden DM backfill — bound ts, preserve role, cap scan

### DIFF
--- a/assistant/src/__tests__/dm-backfill.test.ts
+++ b/assistant/src/__tests__/dm-backfill.test.ts
@@ -212,7 +212,12 @@ describe("PR 23 — Slack DM cold-start backfill", () => {
     expect(backfillDmMock).toHaveBeenCalledTimes(1);
     const [channelArg, optsArg] = backfillDmMock.mock.calls[0];
     expect(channelArg).toBe(SLACK_DM_CHANNEL_ID);
-    expect(optsArg).toEqual({ limit: 50 });
+    // The webhook message's own ts must be passed as `before` so Slack's
+    // history window excludes it — otherwise backfill would re-insert the
+    // message that the live inbound path is already persisting.
+    expect(optsArg?.limit).toBe(50);
+    expect(typeof optsArg?.before).toBe("string");
+    expect(optsArg?.before).toMatch(/^1700000000\.10000/);
 
     // All three backfilled rows are persisted with a slackMeta envelope.
     // The live new DM's row is enqueued on the agent loop's persistence path
@@ -344,6 +349,37 @@ describe("PR 23 — Slack DM cold-start backfill", () => {
     expect(rows.length).toBe(2);
     const texts = rows.map((r) => r.content).sort();
     expect(texts).toEqual(["older A", "older B"]);
+  });
+
+  test("bot-authored backfilled messages are persisted with role=assistant", async () => {
+    // Slack DM history includes our own prior bot replies. If those rows
+    // were rehydrated as `user` turns, the assistant would later treat its
+    // own output as new user input and speaker attribution would break.
+    backfillDmMock.mockImplementation(async () => [
+      makeBackfilledMessage({
+        id: "1700000000.000001",
+        text: "user reply",
+        sender: { id: SLACK_DM_USER_ID, name: "Alice" },
+      }),
+      makeBackfilledMessage({
+        id: "1700000000.000002",
+        text: "assistant reply",
+        sender: { id: "B_BOT", name: "assistant-bot" },
+        metadata: { isBot: true },
+      }),
+    ]);
+
+    await handleChannelInbound(
+      buildDmRequest("live new DM"),
+      noopProcessMessage,
+      TEST_BEARER_TOKEN,
+    );
+
+    const rows = readPersistedSlackRows();
+    expect(rows.length).toBe(2);
+    const byText = new Map(rows.map((r) => [r.content, r.role]));
+    expect(byText.get("user reply")).toBe("user");
+    expect(byText.get("assistant reply")).toBe("assistant");
   });
 
   test("backfill skips channelTs values already stored", async () => {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -10,6 +10,7 @@ import {
   gte,
   inArray,
   isNull,
+  like,
   lt,
   lte,
   sql,
@@ -1044,6 +1045,33 @@ export function getMessages(conversationId: string): MessageRow[] {
     .orderBy(asc(messages.createdAt))
     .all()
     .map(parseMessage);
+}
+
+/**
+ * Count messages whose metadata JSON contains a `slackMeta` envelope, capped
+ * at `limit`. Pushes the cap into SQL (`LIKE` + `LIMIT`) so warm Slack DM
+ * conversations don't require a full-table scan + JSON parse on every
+ * inbound message to confirm the cold-start threshold has been cleared.
+ * Returns the number of matching rows up to `limit`; callers compare against
+ * the cold-start threshold to decide whether to backfill.
+ */
+export function countMessagesWithSlackMeta(
+  conversationId: string,
+  limit: number,
+): number {
+  const db = getDb();
+  const rows = db
+    .select({ one: sql`1` })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        like(messages.metadata, '%"slackMeta"%'),
+      ),
+    )
+    .limit(limit)
+    .all();
+  return rows.length;
 }
 
 /**

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -108,7 +108,8 @@ async function runReadWithFallback<T>(
   if (connection) return call(connection);
   const auth = getReadAuth(undefined);
   const usingUserToken =
-    _cachedSlackWriteAuth !== null && _cachedSlackReadAuth !== _cachedSlackWriteAuth;
+    _cachedSlackWriteAuth !== null &&
+    _cachedSlackReadAuth !== _cachedSlackWriteAuth;
   try {
     return await call(auth);
   } catch (err) {
@@ -203,6 +204,11 @@ function mapMessage(
   channelId: string,
   senderName: string,
 ): Message {
+  // Bot-authored when Slack sets `subtype: "bot_message"` or attributes the
+  // row to a `bot_id` with no user. Backfill callers rely on this flag to
+  // avoid rehydrating assistant/bot replies as user turns.
+  const isBot =
+    msg.subtype === "bot_message" || (msg.bot_id != null && !msg.user);
   return {
     id: msg.ts,
     conversationId: channelId,
@@ -214,6 +220,7 @@ function mapMessage(
     platform: "slack",
     reactions: msg.reactions?.map((r) => ({ name: r.name, count: r.count })),
     hasAttachments: (msg.files?.length ?? 0) > 0,
+    ...(isBot ? { metadata: { isBot: true } } : {}),
   };
 }
 
@@ -234,7 +241,12 @@ export const slackProvider: MessagingProvider = {
   id: "slack",
   displayName: "Slack",
   credentialService: "slack",
-  capabilities: new Set(["reactions", "threads", "join_channel", "leave_channel"]),
+  capabilities: new Set([
+    "reactions",
+    "threads",
+    "join_channel",
+    "leave_channel",
+  ]),
 
   async isConnected(): Promise<boolean> {
     // Socket Mode: check for bot token directly in credential store.

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -21,6 +21,7 @@ import {
 } from "../../memory/conversation-attention-store.js";
 import {
   addMessage,
+  countMessagesWithSlackMeta,
   getMessageById,
   getMessages,
   updateMessageMetadata,
@@ -1039,6 +1040,10 @@ export async function handleChannelInbound(
         await tryBackfillSlackDmIfCold({
           conversationId: result.conversationId,
           channelId: conversationExternalId,
+          // Exclude the just-arrived webhook message from the history window —
+          // the normal inbound persistence path writes it separately, so
+          // including it here would produce duplicate user turns.
+          latestTs: slackInbound?.channelTs,
         });
       }
 
@@ -1226,41 +1231,16 @@ async function persistSlackReactionAsMessage(params: {
 const SLACK_DM_BACKFILL_WARM_THRESHOLD = 3;
 
 /**
- * Count messages in a conversation whose `metadata` carries a parseable
- * `slackMeta` envelope. Used as the warm-storage signal for cold-start
- * backfill: any conversation with fewer than the warm threshold is treated
- * as a candidate for one-shot history hydration.
- *
- * Tolerant of legacy / malformed rows: rows without metadata, with invalid
- * JSON, or without a `slackMeta` key are skipped. Counting is intentionally
- * cheap (no SQL JSON probing) so it stays portable across drivers.
+ * Count messages in a conversation whose `metadata` carries a `slackMeta`
+ * envelope, capped at the warm threshold. Delegates to the DB helper which
+ * pushes both `LIKE` and `LIMIT` into SQL so a warm DM conversation never
+ * scans beyond the threshold's worth of rows on the webhook critical path.
  */
 function countSlackMetaMessages(conversationId: string): number {
-  const rows = getMessages(conversationId);
-  let count = 0;
-  for (const row of rows) {
-    if (!row.metadata) continue;
-    let parent: Record<string, unknown> | null = null;
-    try {
-      const parsed = JSON.parse(row.metadata) as unknown;
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        parent = parsed as Record<string, unknown>;
-      }
-    } catch {
-      continue;
-    }
-    if (!parent) continue;
-    const raw = parent.slackMeta;
-    if (typeof raw !== "string") continue;
-    if (readSlackMetadata(raw)) {
-      count++;
-      // Early-return: callers only need to know if the count meets the
-      // warm threshold. Avoids parsing every row on warm conversations
-      // that would otherwise full-scan on each Slack DM.
-      if (count >= SLACK_DM_BACKFILL_WARM_THRESHOLD) return count;
-    }
-  }
-  return count;
+  return countMessagesWithSlackMeta(
+    conversationId,
+    SLACK_DM_BACKFILL_WARM_THRESHOLD,
+  );
 }
 
 /**
@@ -1299,12 +1279,14 @@ function readStoredSlackChannelTs(conversationId: string): Set<string> {
  * Persist a single backfilled Slack message as a `messages` row with a
  * `slackMeta` envelope.
  *
- * Shared insertion point for both DM cold-start backfill and thread-ancestor
- * backfill. Backfilled rows are always recorded with role `"user"` — the
- * renderer reads `slackMeta` to format author / timestamp / thread context,
- * so the role distinction is not used for display. Caller is responsible
- * for dedup checks before invoking; this helper performs no idempotency
- * check itself.
+ * Shared insertion point for any path that hydrates Slack history lazily
+ * (DM cold-start backfill, thread-ancestor backfill, etc.). Role is derived
+ * from `message.metadata.isBot` — bot-authored rows map to `"assistant"` so
+ * our own prior replies (and any other bot traffic) are not rehydrated as
+ * user turns, which would otherwise corrupt speaker attribution and make
+ * the assistant treat its own outputs as new user input on later turns.
+ * Caller is responsible for dedup checks before invoking; this helper
+ * performs no idempotency check itself.
  */
 async function persistBackfilledSlackMessage(params: {
   conversationId: string;
@@ -1320,7 +1302,8 @@ async function persistBackfilledSlackMessage(params: {
     ...(message.threadId ? { threadTs: message.threadId } : {}),
     ...(message.sender?.name ? { displayName: message.sender.name } : {}),
   };
-  await addMessage(params.conversationId, "user", message.text ?? "", {
+  const role = message.metadata?.isBot === true ? "assistant" : "user";
+  await addMessage(params.conversationId, role, message.text ?? "", {
     slackMeta: writeSlackMetadata(slackMeta),
   });
 }
@@ -1350,6 +1333,7 @@ const _dmBackfillInFlight = new Map<string, Promise<void>>();
 async function tryBackfillSlackDmIfCold(params: {
   conversationId: string;
   channelId: string;
+  latestTs?: string;
 }): Promise<void> {
   const existing = _dmBackfillInFlight.get(params.conversationId);
   if (existing) {
@@ -1366,6 +1350,7 @@ async function tryBackfillSlackDmIfCold(params: {
 async function runBackfillSlackDmIfCold(params: {
   conversationId: string;
   channelId: string;
+  latestTs?: string;
 }): Promise<void> {
   try {
     const storedCount = countSlackMetaMessages(params.conversationId);
@@ -1373,7 +1358,15 @@ async function runBackfillSlackDmIfCold(params: {
       return;
     }
 
-    const fetched = await backfillDm(params.channelId, { limit: 50 });
+    // Pass the webhook message's ts as `before` (Slack's `latest`,
+    // exclusive) so history never contains the message that's about to be
+    // persisted by the live inbound path. Without this bound the just-arrived
+    // DM would be written twice — once here and once via normal persistence —
+    // producing duplicate user turns.
+    const fetched = await backfillDm(params.channelId, {
+      limit: 50,
+      before: params.latestTs,
+    });
     if (fetched.length === 0) {
       log.debug(
         { conversationId: params.conversationId, channelId: params.channelId },


### PR DESCRIPTION
Addresses review feedback on #26626.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
