### PR TITLE
fix(meet-ext): reject join on non-matching tab so bridge retries real tab

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/content-bridge.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/content-bridge.test.ts
@@ -60,6 +60,7 @@ interface FakeChrome {
   queryCalls: Array<chrome.tabs.QueryInfo>;
   runtimeListeners: RuntimeOnMessageListener[];
   emitFromContent(msg: unknown): void;
+  tabResponses: Map<number, (msg: unknown) => unknown>;
   runtime: {
     onMessage: {
       addListener: (cb: RuntimeOnMessageListener) => void;
@@ -67,7 +68,7 @@ interface FakeChrome {
   };
   tabs: {
     query: (q: chrome.tabs.QueryInfo) => Promise<chrome.tabs.Tab[]>;
-    sendMessage: (tabId: number, msg: unknown) => Promise<void>;
+    sendMessage: (tabId: number, msg: unknown) => Promise<unknown>;
   };
 }
 
@@ -75,10 +76,12 @@ function installFakeChrome(): FakeChrome {
   const sendMessageCalls: FakeChrome["sendMessageCalls"] = [];
   const queryCalls: FakeChrome["queryCalls"] = [];
   const runtimeListeners: RuntimeOnMessageListener[] = [];
+  const tabResponses = new Map<number, (msg: unknown) => unknown>();
   const fake: FakeChrome = {
     sendMessageCalls,
     queryCalls,
     runtimeListeners,
+    tabResponses,
     emitFromContent(msg) {
       for (const cb of runtimeListeners.slice())
         cb(msg, undefined, () => {});
@@ -97,6 +100,9 @@ function installFakeChrome(): FakeChrome {
       },
       async sendMessage(tabId, msg) {
         sendMessageCalls.push({ tabId, msg });
+        const responder = tabResponses.get(tabId);
+        if (responder) return responder(msg);
+        return undefined;
       },
     },
   };
@@ -159,6 +165,33 @@ describe("startContentBridge bot→content fan-out", () => {
       msg: leave,
     });
   });
+
+  test(
+    "join retries when the only tab responds with {ok:false}",
+    async () => {
+      // Simulate a profile that has exactly one Meet tab open and that tab is
+      // not for the target meeting (e.g. a stray lobby tab). The content
+      // script rejects the join with {ok:false}. The bridge must NOT treat
+      // that as a successful delivery — otherwise a real tab that mounts a
+      // moment later never receives the join command.
+      fake.tabs.sendMessage = async (tabId, msg) => {
+        fake.sendMessageCalls.push({ tabId, msg });
+        return { ok: false, reason: "non-matching-tab" };
+      };
+      const join: BotToExtensionMessage = {
+        type: "join",
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        displayName: "Bot",
+        consentMessage: "hello",
+      };
+      port.emitFromBot(join);
+      // Wait long enough for at least the first retry (100ms) to elapse.
+      await new Promise((resolve) => setTimeout(resolve, 180));
+      expect(fake.queryCalls.length).toBeGreaterThanOrEqual(2);
+      expect(fake.sendMessageCalls.length).toBeGreaterThanOrEqual(2);
+    },
+    5_000,
+  );
 });
 
 describe("startContentBridge content→bot forwarding", () => {

--- a/skills/meet-join/meet-controller-ext/src/content.ts
+++ b/skills/meet-join/meet-controller-ext/src/content.ts
@@ -212,7 +212,7 @@ chrome.runtime.onMessage.addListener(
   (
     raw: unknown,
     _sender: chrome.runtime.MessageSender,
-    _sendResponse: (response?: unknown) => void,
+    sendResponse: (response?: unknown) => void,
   ): boolean => {
     const parsed = BotToExtensionMessageSchema.safeParse(raw);
     if (!parsed.success) {
@@ -241,6 +241,13 @@ chrome.runtime.onMessage.addListener(
           `target=${targetMeetingId ?? "<unparseable>"}`,
           `current=${currentMeetingId}`,
         );
+        // Respond with an explicit rejection so the background bridge
+        // does not treat this silent drop as a successful delivery. If
+        // a stray Meet tab in the same Chrome profile received the
+        // `join` and we returned undefined, `chrome.tabs.sendMessage`
+        // would resolve and the bridge would stop retrying before the
+        // real tab's content script mounted.
+        sendResponse({ ok: false, reason: "non-matching-tab" });
         return false;
       }
       void handleJoin(msg.meetingUrl, msg.displayName, msg.consentMessage);

--- a/skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts
+++ b/skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts
@@ -119,7 +119,18 @@ async function fanOutToMeetTabs(msg: BotToExtensionMessage): Promise<void> {
     for (const tab of tabs) {
       if (typeof tab.id !== "number") continue;
       try {
-        await chrome.tabs.sendMessage(tab.id, msg);
+        const response = (await chrome.tabs.sendMessage(tab.id, msg)) as
+          | { ok?: boolean; reason?: string }
+          | undefined;
+        // A non-matching tab responds with `{ ok: false }` so we don't
+        // count it as delivery. Without this, a stray Meet tab in the
+        // same profile would silently consume a join command while the
+        // real tab's content script was still mounting, and the retry
+        // loop would exit before reaching the real tab.
+        if (response && response.ok === false) {
+          lastError = response.reason ?? "rejected by content script";
+          continue;
+        }
         anyDelivered = true;
       } catch (err) {
         lastError = err;


### PR DESCRIPTION
Addresses review feedback on #26793.

Codex flagged that the content script's silent drop for non-matching Meet tabs
made `chrome.tabs.sendMessage` resolve with `undefined`, so the
content-bridge treated stray-tab consumption as a successful delivery and
stopped retrying before the real tab's content script mounted. Now:

- The non-matching-tab branch in `content.ts` responds with
  `{ ok: false, reason: "non-matching-tab" }`.
- `content-bridge.ts` treats that response as non-delivery and continues
  the retry loop.

Added a regression test that simulates a profile with only a stray Meet tab
and verifies the bridge retries rather than claiming delivery.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
