### PR TITLE
fix(meet-ext): early-return when participants panel is closed

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/participants.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/participants.test.ts
@@ -265,6 +265,43 @@ describe("startParticipantScraper", () => {
     expect(first.joined.map((p) => p.id)).toEqual(["p-alice"]);
   });
 
+  test("does not emit synthetic left/join churn when the panel is auto-collapsed mid-meeting", async () => {
+    // Regression: if a sibling feature (e.g. the chat reader) toggles its
+    // panel and Meet auto-collapses the participants panel, a subsequent
+    // poll sees `rows = []`. Without the panel-closed early return, the
+    // diff would emit `left` for every previously-known attendee, then
+    // `joined` again once the panel was reopened on the next tick.
+    installed = installPanelFixture([
+      { id: "p-alice", name: "Alice" },
+      { id: "p-bob", name: "Bob" },
+    ]);
+    const dom = installed.dom;
+    const handle = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 30,
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+
+    // Simulate Meet collapsing the participants panel: the list container
+    // disappears entirely.
+    const list = dom.window.document.querySelector(
+      '[role="list"][aria-label="Participants"]',
+    );
+    list?.remove();
+
+    // Let a couple of polls elapse with the panel closed.
+    await sleep(100);
+
+    // The scraper must not emit any event just because the panel is
+    // temporarily closed — the attendees are still in the meeting.
+    expect(events.length).toBe(1);
+  });
+
   test("does not re-click the toggle when the panel is already open", async () => {
     installed = installPanelFixture([{ id: "p-alice", name: "Alice" }]);
     let toggleClicks = 0;

--- a/skills/meet-join/meet-controller-ext/src/features/participants.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/participants.ts
@@ -173,12 +173,16 @@ export function startParticipantScraper(
       rows = scrapeRows();
       // If the panel was closed out from under us (e.g. the chat reader
       // toggled its panel and Meet auto-collapsed participants), retry
-      // opening on the next tick.
+      // opening on the next tick. Return early so we don't diff against
+      // `rows = []` and emit synthetic `left` events for participants who
+      // are still in the meeting — the next tick will reopen the panel
+      // and the diff will stay stable.
       if (
         rows.length === 0 &&
         !document.querySelector(selectors.INGAME_PARTICIPANT_LIST)
       ) {
         panelOpenAttempted = false;
+        return;
       }
     } catch {
       // Transient DOM error (navigation, panel auto-closed, etc.). Skip this


### PR DESCRIPTION
Addresses review feedback on #26804.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
