### PR TITLE
feat(pkb): compute user-query sparse vector + dense-gate hybrid ranking

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, mock, test } from "bun:test";
 // PKB search is mocked so the reminder-hints tests can assert behavior
 // without standing up Qdrant. The mock returns whatever is staged in
 // `pkbSearchResults` / `pkbSearchThrows` for the enclosing test.
-let pkbSearchResults: Array<{ path: string; score: number }> = [];
+let pkbSearchResults: Array<{
+  path: string;
+  denseScore: number;
+  hybridScore?: number;
+}> = [];
 let pkbSearchThrows: Error | null = null;
 mock.module("../memory/pkb/pkb-search.js", () => ({
   searchPkbFiles: async () => {
@@ -1948,9 +1952,9 @@ describe("applyRuntimeInjections — PKB relevance hints", () => {
 
   test("three uninvolved hits → reminder contains all three bullets", async () => {
     pkbSearchResults = [
-      { path: "topics/alpha.md", score: 0.9 },
-      { path: "topics/beta.md", score: 0.8 },
-      { path: "topics/gamma.md", score: 0.7 },
+      { path: "topics/alpha.md", denseScore: 0.9 },
+      { path: "topics/beta.md", denseScore: 0.8 },
+      { path: "topics/gamma.md", denseScore: 0.7 },
     ];
     pkbSearchThrows = null;
 
@@ -1975,8 +1979,8 @@ describe("applyRuntimeInjections — PKB relevance hints", () => {
     // are already injected. The agent-loop passes the effective auto-inject
     // list (via `getPkbAutoInjectList`) to `applyRuntimeInjections`.
     pkbSearchResults = [
-      { path: "essentials.md", score: 0.95 },
-      { path: "topics/alpha.md", score: 0.9 },
+      { path: "essentials.md", denseScore: 0.95 },
+      { path: "topics/alpha.md", denseScore: 0.9 },
     ];
     pkbSearchThrows = null;
 
@@ -2025,9 +2029,9 @@ describe("applyRuntimeInjections — PKB relevance hints", () => {
 
   test("in-context paths are filtered out of hints", async () => {
     pkbSearchResults = [
-      { path: "topics/alpha.md", score: 0.9 },
-      { path: "topics/beta.md", score: 0.8 },
-      { path: "topics/gamma.md", score: 0.7 },
+      { path: "topics/alpha.md", denseScore: 0.9 },
+      { path: "topics/beta.md", denseScore: 0.8 },
+      { path: "topics/gamma.md", denseScore: 0.7 },
     ];
     pkbSearchThrows = null;
 
@@ -2099,6 +2103,73 @@ describe("applyRuntimeInjections — PKB relevance hints", () => {
     expect(reminder).toBe(FLAT_REMINDER);
   });
 
+  test("gate uses denseScore — hybridScore alone cannot pass the threshold", async () => {
+    // Simulates the situation where sparse-only matches (which surface via
+    // hybrid's prefetch beyond the dense prefetch limit) pick up RRF hits
+    // but fail the absolute cosine quality bar.
+    pkbSearchResults = [
+      { path: "topics/alpha.md", denseScore: 0.9, hybridScore: 0.02 },
+      { path: "topics/noise.md", denseScore: 0.3, hybridScore: 0.03 },
+    ];
+    pkbSearchThrows = null;
+
+    const { messages: result } = await applyRuntimeInjections(
+      baseMessages,
+      makePkbOptions(),
+    );
+    const texts = extractTexts(result);
+    const reminder = texts.find((t) => t.startsWith("<system_reminder>"));
+    expect(reminder).toBeDefined();
+    expect(reminder).toContain("- topics/alpha.md");
+    // Below-threshold dense score is filtered even though its hybrid score
+    // is higher than alpha's.
+    expect(reminder).not.toContain("- topics/noise.md");
+  });
+
+  test("ranking follows hybridScore when present — lexical winner surfaces first", async () => {
+    // Sparse re-ranks alpha ahead of beta even though beta's dense cosine is
+    // higher. Both pass the dense threshold, so both survive filtering; the
+    // hybrid score drives ordering among survivors.
+    pkbSearchResults = [
+      { path: "topics/beta.md", denseScore: 0.9, hybridScore: 0.02 },
+      { path: "topics/alpha.md", denseScore: 0.75, hybridScore: 0.04 },
+    ];
+    pkbSearchThrows = null;
+
+    const { messages: result } = await applyRuntimeInjections(
+      baseMessages,
+      makePkbOptions(),
+    );
+    const texts = extractTexts(result);
+    const reminder = texts.find((t) => t.startsWith("<system_reminder>"));
+    expect(reminder).toBeDefined();
+    const alphaIdx = reminder!.indexOf("- topics/alpha.md");
+    const betaIdx = reminder!.indexOf("- topics/beta.md");
+    expect(alphaIdx).toBeGreaterThanOrEqual(0);
+    expect(betaIdx).toBeGreaterThanOrEqual(0);
+    expect(alphaIdx).toBeLessThan(betaIdx);
+  });
+
+  test("archive/ threshold is stricter (0.7) and applies to denseScore", async () => {
+    pkbSearchResults = [
+      { path: "topics/alpha.md", denseScore: 0.55 }, // passes 0.5
+      { path: "archive/old.md", denseScore: 0.55 }, // fails 0.7
+      { path: "archive/solid.md", denseScore: 0.75 }, // passes 0.7
+    ];
+    pkbSearchThrows = null;
+
+    const { messages: result } = await applyRuntimeInjections(
+      baseMessages,
+      makePkbOptions(),
+    );
+    const texts = extractTexts(result);
+    const reminder = texts.find((t) => t.startsWith("<system_reminder>"));
+    expect(reminder).toBeDefined();
+    expect(reminder).toContain("- topics/alpha.md");
+    expect(reminder).not.toContain("- archive/old.md");
+    expect(reminder).toContain("- archive/solid.md");
+  });
+
   test("stripInjectionsForCompaction removes the PKB reminder (flat and hinted)", () => {
     // Verifies the existing strip pipeline still catches the new reminder
     // text — it still opens with `<system_reminder>`, which is already in
@@ -2133,9 +2204,9 @@ describe("applyRuntimeInjections — PKB relevance hints", () => {
 
   test("after simulated compaction (strip + rebuild), fresh hints are emitted from post-compaction tool_use blocks", async () => {
     pkbSearchResults = [
-      { path: "topics/alpha.md", score: 0.9 },
-      { path: "topics/beta.md", score: 0.8 },
-      { path: "topics/gamma.md", score: 0.7 },
+      { path: "topics/alpha.md", denseScore: 0.9 },
+      { path: "topics/beta.md", denseScore: 0.8 },
+      { path: "topics/gamma.md", denseScore: 0.7 },
     ];
     pkbSearchThrows = null;
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -667,13 +667,22 @@ export async function runAgentLoopImpl(
         onEvent,
       );
       runMessages = graphResult.runMessages;
-      pkbQueryVector = graphResult.userQueryVector ?? graphResult.queryVector;
-      // Reset sparse vector when the dense vector came from `userQueryVector` —
-      // there is no matching user-query sparse vector today, and pairing a
-      // user-query dense with a summary-aligned sparse is incorrect.
-      pkbSparseVector = graphResult.userQueryVector
-        ? undefined
-        : graphResult.sparseVector;
+      // Select dense+sparse as a matched pair so RRF fusion combines two
+      // signals aligned to the same query text:
+      //   1. Context-load with a user query: user-query dense + user-query
+      //      sparse — the cleanest pairing.
+      //   2. Otherwise (context-load without a user query, or per-turn):
+      //      whatever `queryVector` / `sparseVector` the retriever produced,
+      //      which are themselves co-aligned (both summary-derived in
+      //      context-load, both user-last-message-derived in per-turn).
+      // Never pair a user-query dense with a summary-aligned sparse.
+      if (graphResult.userQueryVector) {
+        pkbQueryVector = graphResult.userQueryVector;
+        pkbSparseVector = graphResult.userQuerySparseVector;
+      } else {
+        pkbQueryVector = graphResult.queryVector;
+        pkbSparseVector = graphResult.sparseVector;
+      }
 
       // Persist the injected block text in message metadata so it survives
       // conversation reloads (eviction, restart, fork). loadFromDb re-injects

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1930,6 +1930,12 @@ export async function applyRuntimeInjections(
             workingDir,
           );
           const pkbRoot = options.pkbRoot;
+          // Gate on `denseScore` (cosine, [0, 1]) so the quality bar is stable
+          // regardless of whether sparse was provided. Rank by `hybridScore`
+          // (RRF) when available — that captures the sparse signal for
+          // re-ordering eligible hits. hybridScore and denseScore live on
+          // different scales, so items with hybridScore are ordered together
+          // and placed ahead of items that only have denseScore.
           hints = results
             .filter((r) => {
               const abs = resolve(pkbRoot, r.path);
@@ -1939,7 +1945,17 @@ export async function applyRuntimeInjections(
                 .startsWith("archive/")
                 ? PKB_HINT_ARCHIVE_THRESHOLD
                 : PKB_HINT_THRESHOLD;
-              return r.score >= threshold;
+              return r.denseScore >= threshold;
+            })
+            .sort((a, b) => {
+              const aHasHybrid = a.hybridScore !== undefined;
+              const bHasHybrid = b.hybridScore !== undefined;
+              if (aHasHybrid && !bHasHybrid) return -1;
+              if (!aHasHybrid && bHasHybrid) return 1;
+              if (aHasHybrid && bHasHybrid) {
+                return b.hybridScore! - a.hybridScore!;
+              }
+              return b.denseScore - a.denseScore;
             })
             .slice(0, 3)
             .map((r) => r.path);

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -311,6 +311,13 @@ export class ConversationGraphMemory {
      * embed was computed.
      */
     userQueryVector?: number[];
+    /**
+     * Sparse (TF-IDF) vector of the user's latest message. Paired with
+     * `userQueryVector` by PKB hint search to run a hybrid dense+sparse
+     * query. `undefined` on the per-turn path and when no user query was
+     * available (empty message or embedding skipped).
+     */
+    userQuerySparseVector?: QdrantSparseVector;
   }> {
     this.tracker.advanceTurn();
 
@@ -396,6 +403,7 @@ export class ConversationGraphMemory {
         queryVector: result.queryVector,
         sparseVector: result.sparseVector,
         userQueryVector: result.userQueryVector,
+        userQuerySparseVector: result.userQuerySparseVector,
       };
     }
 
@@ -418,6 +426,7 @@ export class ConversationGraphMemory {
         queryVector: result.queryVector,
         sparseVector: result.sparseVector,
         userQueryVector: result.userQueryVector,
+        userQuerySparseVector: result.userQuerySparseVector,
       };
     }
 
@@ -453,6 +462,7 @@ export class ConversationGraphMemory {
       queryVector: result.queryVector,
       sparseVector: result.sparseVector,
       userQueryVector: result.userQueryVector,
+      userQuerySparseVector: result.userQuerySparseVector,
     };
   }
 
@@ -635,9 +645,7 @@ export function stripExistingMemoryInjections(messages: Message[]): Message[] {
  * memory block through transcript replacements (e.g. Slack chronological
  * rendering) that otherwise discard the prepended content.
  */
-export function extractMemoryPrefixBlocks(
-  messages: Message[],
-): ContentBlock[] {
+export function extractMemoryPrefixBlocks(messages: Message[]): ContentBlock[] {
   if (messages.length === 0) return [];
   const last = messages[messages.length - 1];
   if (!last || last.role !== "user") return [];

--- a/assistant/src/memory/graph/retriever.test.ts
+++ b/assistant/src/memory/graph/retriever.test.ts
@@ -197,7 +197,10 @@ describe("retrieveForTurn — query/sparse vector surfacing", () => {
     // nothing), the queryVector should still be surfaced so the PKB hint
     // retriever can fire on every turn.
     expect(result.queryVector).toEqual([0.9, 0.8, 0.7]);
-    expect(result.sparseVector).toBeUndefined();
+    // Per-turn now populates sparseVector from the user message (TF-IDF),
+    // paired with the combined-text dense for PKB hybrid search.
+    expect(result.sparseVector).toBeDefined();
+    expect(result.sparseVector!.indices.length).toBeGreaterThan(0);
   });
 
   test("returns undefined queryVector when the embedding backend throws", async () => {
@@ -212,10 +215,12 @@ describe("retrieveForTurn — query/sparse vector surfacing", () => {
       tracker,
     });
 
-    // Circuit-breaker path: embedding failure is swallowed; no throw and no
-    // vector surfaced.
+    // Circuit-breaker path: embedding failure is swallowed; no dense vector
+    // surfaced. Sparse vector (local TF-IDF) is independent of the embedding
+    // backend, so it is still produced from the user message.
     expect(result.queryVector).toBeUndefined();
-    expect(result.sparseVector).toBeUndefined();
+    expect(result.sparseVector).toBeDefined();
+    expect(result.sparseVector!.indices.length).toBeGreaterThan(0);
   });
 
   test("returns undefined queryVector when there is no text to embed", async () => {
@@ -383,6 +388,45 @@ describe("loadContextMemory — dual-query capability ranking (PR 3)", () => {
 
     expect(result.userQueryVector).toBeDefined();
     expect(embedCallCount).toBe(2);
+  });
+
+  test("produces userQuerySparseVector alongside userQueryVector when user query is non-empty", async () => {
+    embedRouter = keywordEmbedRouter;
+    searchRouter = vectorSearchRouter;
+
+    const result = await loadContextMemory({
+      scopeId: "default",
+      recentSummaries: [LONG_HEARTBEAT_SUMMARY],
+      userQuery: "clean up my inbox",
+      config: DUAL_QUERY_CONFIG,
+    });
+
+    expect(result.userQueryVector).toBeDefined();
+    expect(result.userQuerySparseVector).toBeDefined();
+    expect(result.userQuerySparseVector!.indices.length).toBeGreaterThan(0);
+    expect(result.userQuerySparseVector!.values.length).toBe(
+      result.userQuerySparseVector!.indices.length,
+    );
+  });
+
+  test("omits userQuerySparseVector when user query is absent or whitespace-only", async () => {
+    embedRouter = keywordEmbedRouter;
+    searchRouter = vectorSearchRouter;
+
+    const missing = await loadContextMemory({
+      scopeId: "default",
+      recentSummaries: [LONG_HEARTBEAT_SUMMARY],
+      config: DUAL_QUERY_CONFIG,
+    });
+    expect(missing.userQuerySparseVector).toBeUndefined();
+
+    const blank = await loadContextMemory({
+      scopeId: "default",
+      recentSummaries: [LONG_HEARTBEAT_SUMMARY],
+      userQuery: "   ",
+      config: DUAL_QUERY_CONFIG,
+    });
+    expect(blank.userQuerySparseVector).toBeUndefined();
   });
 
   test("skips the dedicated embed when userQuery is missing or empty", async () => {

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -15,7 +15,10 @@ import {
 import type { ContentBlock, ImageContent } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import { embedWithRetry } from "../embed.js";
-import { selectedBackendSupportsMultimodal } from "../embedding-backend.js";
+import {
+  generateSparseEmbedding,
+  selectedBackendSupportsMultimodal,
+} from "../embedding-backend.js";
 import type { QdrantSparseVector } from "../qdrant-client.js";
 import { searchGraphNodes } from "./graph-search.js";
 import type { InContextTracker } from "./injection.js";
@@ -396,6 +399,16 @@ export interface ContextLoadResult {
    * or the dedicated embed call was skipped/failed.
    */
   userQueryVector?: number[];
+  /**
+   * Sparse (TF-IDF) vector of `opts.userQuery`. Surfaced so PKB hint search
+   * can pair it with `userQueryVector` to run a hybrid dense+sparse query —
+   * RRF fusion captures lexical matches (exact filenames, proper nouns,
+   * uncommon tokens) that pure dense embeddings wash out. Computed locally
+   * (no embedding-service call), so it's cheap to produce whenever the user
+   * query is non-empty. `undefined` on the same conditions as
+   * `userQueryVector`.
+   */
+  userQuerySparseVector?: QdrantSparseVector;
 }
 
 /**
@@ -448,6 +461,7 @@ export async function loadContextMemory(
   //     especially in workloads with short summaries and a substantive
   //     user question.
   let userQueryVector: number[] | null = null;
+  let userQuerySparseVector: QdrantSparseVector | undefined = undefined;
   const userQueryCandidateIds = new Map<string, number>(); // nodeId → score
   const trimmedUserQuery = opts.userQuery?.trim() ?? "";
   const shouldEmbedUserQuery = trimmedUserQuery.length > 0;
@@ -463,6 +477,14 @@ export async function loadContextMemory(
       }
     } catch (err) {
       log.warn({ err }, "Failed to embed userQuery for context load");
+    }
+    // Sparse embedding is a local TF-IDF computation — no network call, so
+    // compute it independently of the dense embed. Even if the dense call
+    // failed, a sparse vector is still useful for downstream consumers that
+    // can operate on it alone.
+    const sparse = generateSparseEmbedding(trimmedUserQuery);
+    if (sparse.indices.length > 0) {
+      userQuerySparseVector = sparse;
     }
   }
 
@@ -816,6 +838,7 @@ export async function loadContextMemory(
     queryVector: queryVector ?? undefined,
     sparseVector,
     userQueryVector: userQueryVector ?? undefined,
+    userQuerySparseVector,
   };
 }
 
@@ -900,6 +923,24 @@ export async function retrieveForTurn(
     .filter((m) => m.length > 0)
     .join("\n\n");
 
+  // Sparse (TF-IDF) vector of the user's last message only. Surfaced so PKB
+  // hint search can pair it with the per-turn dense vector, pulling in
+  // lexical matches (exact filenames, proper nouns, uncommon tokens) that
+  // pure dense embeddings wash out. Computed locally with no network call.
+  // The dense `queryVector` for per-turn is the combined assistant+user
+  // embedding (it drives graph search), so this pairing is slightly
+  // asymmetric — the sparse signal is user-only while the dense is mixed.
+  // That's acceptable for PKB's purpose: lexical matches are overwhelmingly
+  // driven by the user's own wording.
+  const trimmedUserLast = opts.userLastMessage.trim();
+  let perTurnSparseVector: QdrantSparseVector | undefined = undefined;
+  if (trimmedUserLast.length > 0) {
+    const sparse = generateSparseEmbedding(trimmedUserLast);
+    if (sparse.indices.length > 0) {
+      perTurnSparseVector = sparse;
+    }
+  }
+
   // Image-to-image search: embed incoming user images as queries
   // Runs before the text-empty early return so image-only turns are handled
   const imageBlocks = (opts.userLastMessageBlocks ?? []).filter(
@@ -963,7 +1004,7 @@ export async function retrieveForTurn(
         queryContext: queryText || null,
       },
       queryVector: undefined,
-      sparseVector: undefined,
+      sparseVector: perTurnSparseVector,
     };
   }
 
@@ -1037,7 +1078,7 @@ export async function retrieveForTurn(
             queryContext: queryText || null,
           },
           queryVector: undefined,
-          sparseVector: undefined,
+          sparseVector: perTurnSparseVector,
         };
       }
     }
@@ -1091,7 +1132,7 @@ export async function retrieveForTurn(
         queryContext: queryText || null,
       },
       queryVector: queryEmbeddings[0],
-      sparseVector: undefined,
+      sparseVector: perTurnSparseVector,
     };
   }
 
@@ -1275,6 +1316,6 @@ export async function retrieveForTurn(
       topCandidates,
     },
     queryVector: queryEmbeddings[0],
-    sparseVector: undefined,
+    sparseVector: perTurnSparseVector,
   };
 }

--- a/assistant/src/memory/pkb/pkb-search.test.ts
+++ b/assistant/src/memory/pkb/pkb-search.test.ts
@@ -65,11 +65,22 @@ describe("searchPkbFiles", () => {
     denseResults = [];
   });
 
-  test("filter payload targets pkb_file (hybrid path)", async () => {
+  test("filter payload targets pkb_file (hybrid path runs both queries)", async () => {
+    denseResults = [
+      {
+        id: "a",
+        score: 0.8,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-1",
+          path: "/notes/a.md",
+        },
+      },
+    ];
     hybridResults = [
       {
         id: "a",
-        score: 0.9,
+        score: 0.03,
         payload: {
           target_type: "pkb_file",
           target_id: "t-1",
@@ -85,6 +96,7 @@ describe("searchPkbFiles", () => {
     );
 
     expect(hybridSearchCalls).toHaveLength(1);
+    expect(searchCalls).toHaveLength(1);
     const filter = hybridSearchCalls[0]?.filter as {
       must: Array<Record<string, unknown>>;
     };
@@ -94,7 +106,7 @@ describe("searchPkbFiles", () => {
     expect(targetTypeClause?.match.value).toBe("pkb_file");
   });
 
-  test("filter payload targets pkb_file (dense-only path)", async () => {
+  test("dense-only path: no sparse vector, no hybrid query", async () => {
     denseResults = [
       {
         id: "a",
@@ -107,9 +119,14 @@ describe("searchPkbFiles", () => {
       },
     ];
 
-    await searchPkbFiles([0.1, 0.2, 0.3], undefined, 5);
+    const results = await searchPkbFiles([0.1, 0.2, 0.3], undefined, 5);
 
     expect(searchCalls).toHaveLength(1);
+    expect(hybridSearchCalls).toHaveLength(0);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.denseScore).toBe(0.8);
+    expect(results[0]?.hybridScore).toBeUndefined();
+
     const filter = searchCalls[0]?.filter as {
       must: Array<Record<string, unknown>>;
     };
@@ -122,11 +139,8 @@ describe("searchPkbFiles", () => {
   test("both search paths exclude _meta sentinel points", async () => {
     // Hybrid path
     hybridResults = [];
-    await searchPkbFiles(
-      [0.1],
-      { indices: [1], values: [1] },
-      5,
-    );
+    denseResults = [];
+    await searchPkbFiles([0.1], { indices: [1], values: [1] }, 5);
     const hybridFilter = hybridSearchCalls[0]?.filter as {
       must_not: Array<Record<string, unknown>>;
     };
@@ -135,7 +149,17 @@ describe("searchPkbFiles", () => {
     ) as { match: { value: boolean } } | undefined;
     expect(hybridMetaClause?.match.value).toBe(true);
 
+    const denseSideFilter = searchCalls[0]?.filter as {
+      must_not: Array<Record<string, unknown>>;
+    };
+    const denseSideMetaClause = denseSideFilter.must_not.find(
+      (c) => c.key === "_meta",
+    ) as { match: { value: boolean } } | undefined;
+    expect(denseSideMetaClause?.match.value).toBe(true);
+
     // Dense-only path (no sparse vector)
+    searchCalls.length = 0;
+    hybridSearchCalls.length = 0;
     denseResults = [];
     await searchPkbFiles([0.1], undefined, 5);
     const denseFilter = searchCalls[0]?.filter as {
@@ -147,8 +171,8 @@ describe("searchPkbFiles", () => {
     expect(denseMetaClause?.match.value).toBe(true);
   });
 
-  test("two points on the same path collapse to the higher score", async () => {
-    hybridResults = [
+  test("chunks on the same path collapse to the highest score per query", async () => {
+    denseResults = [
       {
         id: "chunk-1",
         score: 0.5,
@@ -177,6 +201,26 @@ describe("searchPkbFiles", () => {
         },
       },
     ];
+    hybridResults = [
+      {
+        id: "chunk-2",
+        score: 0.03,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-2",
+          path: "/notes/same.md",
+        },
+      },
+      {
+        id: "chunk-1",
+        score: 0.02,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-1",
+          path: "/notes/same.md",
+        },
+      },
+    ];
 
     const results = await searchPkbFiles(
       [0.1, 0.2, 0.3],
@@ -184,14 +228,59 @@ describe("searchPkbFiles", () => {
       10,
     );
 
-    expect(results).toHaveLength(2);
     const same = results.find((r) => r.path === "/notes/same.md");
     const other = results.find((r) => r.path === "/notes/other.md");
-    expect(same?.score).toBe(0.9);
-    expect(other?.score).toBe(0.7);
-    // Sorted by score desc
-    expect(results[0]?.path).toBe("/notes/same.md");
-    expect(results[1]?.path).toBe("/notes/other.md");
+    expect(same?.denseScore).toBe(0.9);
+    expect(same?.hybridScore).toBe(0.03);
+    expect(other?.denseScore).toBe(0.7);
+    expect(other?.hybridScore).toBeUndefined();
+  });
+
+  test("result present only in hybrid returns denseScore=0 and a hybridScore", async () => {
+    denseResults = [
+      {
+        id: "a",
+        score: 0.8,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-1",
+          path: "/notes/a.md",
+        },
+      },
+    ];
+    hybridResults = [
+      {
+        id: "a",
+        score: 0.03,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-1",
+          path: "/notes/a.md",
+        },
+      },
+      {
+        id: "b",
+        score: 0.02,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-2",
+          path: "/notes/b.md",
+        },
+      },
+    ];
+
+    const results = await searchPkbFiles(
+      [0.1],
+      { indices: [1], values: [1] },
+      10,
+    );
+
+    const a = results.find((r) => r.path === "/notes/a.md");
+    const b = results.find((r) => r.path === "/notes/b.md");
+    expect(a?.denseScore).toBe(0.8);
+    expect(a?.hybridScore).toBe(0.03);
+    expect(b?.denseScore).toBe(0);
+    expect(b?.hybridScore).toBe(0.02);
   });
 
   test("empty Qdrant response yields []", async () => {
@@ -234,8 +323,8 @@ describe("searchPkbFiles", () => {
     expect(searchCalls).toHaveLength(0);
   });
 
-  test("caps results at limit and sorts by score desc", async () => {
-    hybridResults = [
+  test("caps results at limit and sorts by hybrid score desc when available", async () => {
+    denseResults = [
       {
         id: "a",
         score: 0.3,
@@ -264,6 +353,27 @@ describe("searchPkbFiles", () => {
         },
       },
     ];
+    // Hybrid puts c ahead of b (lexical match) — ranking should follow hybrid.
+    hybridResults = [
+      {
+        id: "c",
+        score: 0.04,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-3",
+          path: "/c.md",
+        },
+      },
+      {
+        id: "b",
+        score: 0.02,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-2",
+          path: "/b.md",
+        },
+      },
+    ];
 
     const results = await searchPkbFiles(
       [0.1],
@@ -272,26 +382,57 @@ describe("searchPkbFiles", () => {
     );
 
     expect(results).toHaveLength(2);
-    expect(results[0]?.path).toBe("/b.md");
-    expect(results[1]?.path).toBe("/c.md");
+    expect(results[0]?.path).toBe("/c.md");
+    expect(results[1]?.path).toBe("/b.md");
   });
 
-  test("adds memory_scope_id clause when scopeIds provided", async () => {
+  test("dense-only path sorts by denseScore when no sparse provided", async () => {
+    denseResults = [
+      {
+        id: "a",
+        score: 0.3,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-1",
+          path: "/a.md",
+        },
+      },
+      {
+        id: "b",
+        score: 0.9,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-2",
+          path: "/b.md",
+        },
+      },
+    ];
+
+    const results = await searchPkbFiles([0.1], undefined, 5);
+    expect(results[0]?.path).toBe("/b.md");
+    expect(results[1]?.path).toBe("/a.md");
+  });
+
+  test("adds memory_scope_id clause when scopeIds provided (both queries)", async () => {
     hybridResults = [];
+    denseResults = [];
 
-    await searchPkbFiles(
-      [0.1],
-      { indices: [1], values: [1] },
-      5,
-      ["scope-a", "scope-b"],
-    );
+    await searchPkbFiles([0.1], { indices: [1], values: [1] }, 5, [
+      "scope-a",
+      "scope-b",
+    ]);
 
-    const filter = hybridSearchCalls[0]?.filter as {
+    const hybridFilter = hybridSearchCalls[0]?.filter as {
       must: Array<Record<string, unknown>>;
     };
-    const scopeClause = filter.must.find(
-      (c) => c.key === "memory_scope_id",
-    ) as { match: { any: string[] } } | undefined;
-    expect(scopeClause?.match.any).toEqual(["scope-a", "scope-b"]);
+    const denseFilter = searchCalls[0]?.filter as {
+      must: Array<Record<string, unknown>>;
+    };
+    for (const filter of [hybridFilter, denseFilter]) {
+      const scopeClause = filter.must.find(
+        (c) => c.key === "memory_scope_id",
+      ) as { match: { any: string[] } } | undefined;
+      expect(scopeClause?.match.any).toEqual(["scope-a", "scope-b"]);
+    }
   });
 });

--- a/assistant/src/memory/pkb/pkb-search.ts
+++ b/assistant/src/memory/pkb/pkb-search.ts
@@ -17,16 +17,20 @@ import { PKB_TARGET_TYPE, type PkbSearchResult } from "./types.js";
 const log = getLogger("pkb-search");
 
 /**
- * Hybrid semantic search across indexed PKB markdown files in Qdrant.
+ * Semantic search across indexed PKB markdown files in Qdrant.
  *
- * Mirrors `searchGraphNodes` — dense + sparse with RRF fusion when a
- * non-empty sparse vector is provided, dense-only fallback otherwise —
- * but filters to `target_type: "pkb_file"`.
+ * Always runs a dense-only cosine query so callers have a cosine-scaled
+ * score they can threshold against. When a non-empty sparse vector is
+ * provided, runs a parallel hybrid (dense + sparse with RRF fusion) query
+ * and attaches its RRF score to each result as `hybridScore`. Consumers
+ * filter by `denseScore` (absolute cosine quality bar) and rank by
+ * `hybridScore ?? denseScore` (sparse-aware ordering when available).
  *
  * PKB files are chunked at index time, so a single path can match on
- * multiple chunks. Results are grouped by `payload.path`, keeping the
- * highest score per path, then sorted by score descending and capped
- * at `limit`.
+ * multiple chunks. Scores collapse to the highest per path, per query.
+ * The two queries are unioned by path — a path present in only one
+ * response still surfaces, with the missing score left `undefined` on
+ * its result.
  */
 export async function searchPkbFiles(
   queryVector: number[],
@@ -45,65 +49,89 @@ export async function searchPkbFiles(
   // from the same file collapse to a single result.
   const prefetchLimit = Math.max(limit * 3, limit);
 
-  let results: QdrantSearchResult[];
+  const baseMust: Record<string, unknown>[] = [
+    { key: "target_type", match: { value: PKB_TARGET_TYPE } },
+    ...(scopeIds && scopeIds.length > 0
+      ? [{ key: "memory_scope_id", match: { any: scopeIds } }]
+      : []),
+  ];
+  const filter = {
+    must: baseMust,
+    must_not: [{ key: "_meta", match: { value: true } }],
+  };
 
-  if (sparseVector && sparseVector.indices.length > 0) {
-    const must: Record<string, unknown>[] = [
-      { key: "target_type", match: { value: PKB_TARGET_TYPE } },
-      ...(scopeIds && scopeIds.length > 0
-        ? [{ key: "memory_scope_id", match: { any: scopeIds } }]
-        : []),
-    ];
-    const filter = {
-      must,
-      must_not: [{ key: "_meta", match: { value: true } }],
-    };
+  const densePromise = withQdrantBreaker(() =>
+    client.search(queryVector, prefetchLimit, filter),
+  );
 
-    results = await withQdrantBreaker(() =>
-      client.hybridSearch({
-        denseVector: queryVector,
-        sparseVector,
-        filter,
-        limit: prefetchLimit,
-        prefetchLimit: prefetchLimit * 3,
-      }),
-    );
-  } else {
-    const denseMusts: Record<string, unknown>[] = [
-      { key: "target_type", match: { value: PKB_TARGET_TYPE } },
-    ];
+  const useHybrid = !!(sparseVector && sparseVector.indices.length > 0);
+  const hybridPromise: Promise<QdrantSearchResult[]> = useHybrid
+    ? withQdrantBreaker(() =>
+        client.hybridSearch({
+          denseVector: queryVector,
+          sparseVector: sparseVector!,
+          filter,
+          limit: prefetchLimit,
+          prefetchLimit: prefetchLimit * 3,
+        }),
+      )
+    : Promise.resolve([]);
 
-    if (scopeIds && scopeIds.length > 0) {
-      denseMusts.push({
-        key: "memory_scope_id",
-        match: { any: scopeIds },
-      });
-    }
+  const [denseResults, hybridResults] = await Promise.all([
+    densePromise,
+    hybridPromise,
+  ]);
 
-    const filter: Record<string, unknown> = {
-      must: denseMusts,
-      must_not: [{ key: "_meta", match: { value: true } }],
-    };
+  const denseByPath = collapseByPath(denseResults);
+  const hybridByPath = useHybrid ? collapseByPath(hybridResults) : new Map();
 
-    results = await withQdrantBreaker(async () => {
-      return client.search(queryVector, prefetchLimit, filter);
+  const allPaths = new Set<string>([
+    ...denseByPath.keys(),
+    ...hybridByPath.keys(),
+  ]);
+
+  const merged: PkbSearchResult[] = [];
+  for (const path of allPaths) {
+    const denseScore = denseByPath.get(path);
+    const hybridScore = hybridByPath.get(path);
+    // A path that only shows up in the hybrid query (past the dense prefetch
+    // limit) has no cosine score to gate on. Carry denseScore = 0 so callers
+    // see it but can filter it out with their threshold.
+    merged.push({
+      path,
+      denseScore: denseScore ?? 0,
+      ...(useHybrid && hybridScore !== undefined ? { hybridScore } : {}),
     });
   }
 
-  // Collapse chunk-level hits to one result per path, keeping the best score.
-  const bestByPath = new Map<string, PkbSearchResult>();
+  // Ranking: items that appear in the hybrid query are ordered amongst
+  // themselves by hybridScore (RRF fusion's sparse-aware ordering), and
+  // placed ahead of items that only appeared in the dense query. Dense-only
+  // items are ordered by denseScore. Scales differ across the two groups so
+  // we must not compare a hybridScore to a denseScore directly.
+  merged.sort((a, b) => {
+    const aHasHybrid = a.hybridScore !== undefined;
+    const bHasHybrid = b.hybridScore !== undefined;
+    if (aHasHybrid && !bHasHybrid) return -1;
+    if (!aHasHybrid && bHasHybrid) return 1;
+    if (aHasHybrid && bHasHybrid) return b.hybridScore! - a.hybridScore!;
+    return b.denseScore - a.denseScore;
+  });
+
+  return merged.slice(0, limit);
+}
+
+/** Collapse chunk-level Qdrant hits to one score per payload.path (max). */
+function collapseByPath(results: QdrantSearchResult[]): Map<string, number> {
+  const best = new Map<string, number>();
   for (const r of results) {
     const payload = r.payload as unknown as { path?: unknown };
     const path = typeof payload.path === "string" ? payload.path : undefined;
     if (!path) continue;
-
-    const existing = bestByPath.get(path);
-    if (!existing || r.score > existing.score) {
-      bestByPath.set(path, { path, score: r.score });
+    const existing = best.get(path);
+    if (existing === undefined || r.score > existing) {
+      best.set(path, r.score);
     }
   }
-
-  return [...bestByPath.values()]
-    .sort((a, b) => b.score - a.score)
-    .slice(0, limit);
+  return best;
 }

--- a/assistant/src/memory/pkb/types.ts
+++ b/assistant/src/memory/pkb/types.ts
@@ -19,7 +19,19 @@ export const PKB_WORKSPACE_SCOPE = "_pkb_workspace" as const;
 
 export interface PkbSearchResult {
   path: string;
-  score: number;
+  /**
+   * Cosine similarity from the dense-only Qdrant query. Always present —
+   * acts as the threshold gate for hint eligibility since it lives on the
+   * stable `[0, 1]` cosine scale regardless of whether sparse was provided.
+   */
+  denseScore: number;
+  /**
+   * Qdrant RRF fusion score from the hybrid (dense + sparse) query. Present
+   * only when a sparse vector was supplied to `searchPkbFiles`. Lives on a
+   * different (much smaller) scale than `denseScore`, so it is used for
+   * ranking within the gated set — not for quality thresholding.
+   */
+  hybridScore?: number;
   snippet?: string;
 }
 


### PR DESCRIPTION
## Summary
- Retriever now emits a TF-IDF sparse vector for the user query (context-load: new `userQuerySparseVector` field paired with `userQueryVector`; per-turn: populates `sparseVector` from `userLastMessage`). Sparse generation is local — no embedding call.
- `searchPkbFiles` always runs a dense-only cosine query for threshold gating and, when a sparse vector is supplied, runs a parallel hybrid RRF query for sparse-aware ranking. Each `PkbSearchResult` carries `denseScore` (always) and `hybridScore` (when available).
- `applyRuntimeInjections` gates on `denseScore` against the existing 0.5 / 0.7 thresholds (absolute cosine quality bar preserved) and sorts by `hybridScore` first, falling back to `denseScore` — the two scales are never mixed.
- PKB hint selection in `conversation-agent-loop` updated so user-query dense pairs with user-query sparse (never with summary-aligned sparse).

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
