### PR TITLE
fix(memory): allow new-to-new edges in extraction tool

### DIFF
--- a/assistant/src/memory/graph/extraction.test.ts
+++ b/assistant/src/memory/graph/extraction.test.ts
@@ -458,6 +458,221 @@ describe("parseExtractionResponse — edges", () => {
     expect(diff.createEdges).toHaveLength(0);
   });
 
+  test("new_edges resolves temp_ids to new→new deferred edges", () => {
+    const { diff, deferredEdges } = parse({
+      create_nodes: [
+        {
+          temp_id: "new-1",
+          content: "First beat.",
+          type: "episodic",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.8,
+          source_type: "direct",
+        },
+        {
+          temp_id: "new-2",
+          content: "Second beat.",
+          type: "episodic",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.8,
+          source_type: "direct",
+        },
+      ],
+      reinforce_node_ids: [],
+      new_edges: [
+        {
+          source_node_id: "new-1",
+          target_node_id: "new-2",
+          relationship: "part-of",
+          weight: 0.6,
+        },
+      ],
+    });
+
+    expect(diff.createEdges).toHaveLength(0);
+    expect(deferredEdges).toHaveLength(1);
+    expect(deferredEdges[0].source).toEqual({ kind: "new", newNodeIndex: 0 });
+    expect(deferredEdges[0].target).toEqual({ kind: "new", newNodeIndex: 1 });
+    expect(deferredEdges[0].relationship).toBe("part-of");
+  });
+
+  test("new_edges resolves existing→new via temp_id", () => {
+    const { diff, deferredEdges } = parse(
+      {
+        create_nodes: [
+          {
+            temp_id: "n1",
+            content: "A new memory linked from an old one.",
+            type: "episodic",
+            emotional_charge: {
+              valence: 0,
+              intensity: 0,
+              decay_curve: "linear",
+              decay_rate: 0.05,
+            },
+            significance: 0.5,
+            confidence: 0.8,
+            source_type: "direct",
+          },
+        ],
+        reinforce_node_ids: [],
+        new_edges: [
+          {
+            source_node_id: "existing-1",
+            target_node_id: "n1",
+            relationship: "reminds-of",
+          },
+        ],
+      },
+      ["existing-1"],
+    );
+
+    expect(diff.createEdges).toHaveLength(0);
+    expect(deferredEdges).toHaveLength(1);
+    expect(deferredEdges[0].source).toEqual({
+      kind: "existing",
+      nodeId: "existing-1",
+    });
+    expect(deferredEdges[0].target).toEqual({ kind: "new", newNodeIndex: 0 });
+  });
+
+  test("new_edges with two existing endpoints lands in diff.createEdges", () => {
+    const { diff, deferredEdges } = parse(
+      {
+        create_nodes: [],
+        reinforce_node_ids: [],
+        new_edges: [
+          {
+            source_node_id: "a",
+            target_node_id: "b",
+            relationship: "depends-on",
+            weight: 0.5,
+          },
+        ],
+      },
+      ["a", "b"],
+    );
+
+    expect(diff.createEdges).toHaveLength(1);
+    expect(diff.createEdges[0].sourceNodeId).toBe("a");
+    expect(diff.createEdges[0].targetNodeId).toBe("b");
+    expect(deferredEdges).toHaveLength(0);
+  });
+
+  test("new_edges skips references to unknown temp_ids", () => {
+    const { diff, deferredEdges } = parse(
+      {
+        create_nodes: [
+          {
+            temp_id: "n1",
+            content: "Something.",
+            type: "semantic",
+            emotional_charge: {
+              valence: 0,
+              intensity: 0,
+              decay_curve: "linear",
+              decay_rate: 0.05,
+            },
+            significance: 0.5,
+            confidence: 0.8,
+            source_type: "direct",
+          },
+        ],
+        reinforce_node_ids: [],
+        new_edges: [
+          {
+            source_node_id: "n1",
+            target_node_id: "n-does-not-exist",
+            relationship: "caused-by",
+          },
+        ],
+      },
+      [],
+    );
+
+    expect(diff.createEdges).toHaveLength(0);
+    expect(deferredEdges).toHaveLength(0);
+  });
+
+  test("candidate ID takes precedence over colliding temp_id", () => {
+    const { diff, deferredEdges } = parse(
+      {
+        create_nodes: [
+          {
+            temp_id: "collide",
+            content: "New node.",
+            type: "semantic",
+            emotional_charge: {
+              valence: 0,
+              intensity: 0,
+              decay_curve: "linear",
+              decay_rate: 0.05,
+            },
+            significance: 0.5,
+            confidence: 0.8,
+            source_type: "direct",
+          },
+        ],
+        reinforce_node_ids: [],
+        new_edges: [
+          {
+            source_node_id: "other",
+            target_node_id: "collide",
+            relationship: "reminds-of",
+          },
+        ],
+      },
+      ["collide", "other"],
+    );
+
+    // "collide" resolves to the existing candidate, not the new node's temp_id.
+    expect(diff.createEdges).toHaveLength(1);
+    expect(diff.createEdges[0].targetNodeId).toBe("collide");
+    expect(deferredEdges).toHaveLength(0);
+  });
+
+  test("edges_to_existing self-loop (same-node temp_id) is dropped", () => {
+    const { deferredEdges, diff } = parse({
+      create_nodes: [
+        {
+          temp_id: "n1",
+          content: "Self-referential.",
+          type: "semantic",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.8,
+          source_type: "direct",
+          edges_to_existing: [
+            {
+              target_node_id: "n1",
+              relationship: "part-of",
+            },
+          ],
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+    expect(diff.createNodes).toHaveLength(1);
+    expect(deferredEdges).toHaveLength(0);
+  });
+
   test("defaults edge weight to 1.0", () => {
     const { diff } = parse(
       {
@@ -512,10 +727,65 @@ describe("parseExtractionResponse — deferred edges", () => {
       ["existing-1"],
     );
     expect(deferredEdges).toHaveLength(1);
-    expect(deferredEdges[0].newNodeIndex).toBe(0);
-    expect(deferredEdges[0].targetNodeId).toBe("existing-1");
+    expect(deferredEdges[0].source).toEqual({ kind: "new", newNodeIndex: 0 });
+    expect(deferredEdges[0].target).toEqual({
+      kind: "existing",
+      nodeId: "existing-1",
+    });
     expect(deferredEdges[0].relationship).toBe("caused-by");
     expect(deferredEdges[0].weight).toBe(0.7);
+  });
+
+  test("resolves new→new edges in edges_to_existing via temp_ids", () => {
+    const { deferredEdges, diff } = parse({
+      create_nodes: [
+        {
+          temp_id: "n1",
+          content: "Event A happened.",
+          type: "episodic",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.8,
+          source_type: "direct",
+          edges_to_existing: [
+            {
+              target_node_id: "n2",
+              relationship: "caused-by",
+              weight: 0.9,
+            },
+          ],
+        },
+        {
+          temp_id: "n2",
+          content: "Event B happened as a result.",
+          type: "episodic",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.8,
+          source_type: "direct",
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    expect(diff.createNodes).toHaveLength(2);
+    // Edge should NOT land in diff.createEdges (both endpoints are new).
+    expect(diff.createEdges).toHaveLength(0);
+    expect(deferredEdges).toHaveLength(1);
+    expect(deferredEdges[0].source).toEqual({ kind: "new", newNodeIndex: 0 });
+    expect(deferredEdges[0].target).toEqual({ kind: "new", newNodeIndex: 1 });
+    expect(deferredEdges[0].relationship).toBe("caused-by");
+    expect(deferredEdges[0].weight).toBe(0.9);
   });
 
   test("ignores deferred edges to non-candidate targets", () => {

--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -73,7 +73,7 @@ Call the \`extract_graph_diff\` tool with the diff. Each node needs:
 
 **LENGTH: 1-3 sentences. HARD CAP — no exceptions.** This applies to every memory, including 1.0-significance transformative moments. Emotional weight lives in \`emotionalCharge\`, not wordcount. The more significant an event feels, the stronger the pull to preserve narrative — resist it. A memory whose \`content\` exceeds ~300 characters is a bug.
 
-If a memory has multiple distinct facts or beats, **split into multiple nodes connected by edges** (\`caused-by\`, \`part-of\`, \`reminds-of\`) — one node per fact or moment. Never pack a multi-beat story into a single content field.
+If a memory has multiple distinct facts or beats, **split into multiple nodes connected by edges** (\`caused-by\`, \`part-of\`, \`reminds-of\`) — one node per fact or moment. Never pack a multi-beat story into a single content field. To connect two NEW nodes you create in the same diff, assign each a distinct \`temp_id\` (e.g. \`"new-1"\`, \`"new-2"\`) and reference that temp_id from \`edges_to_existing\` or \`new_edges\`. Temp IDs live only inside this single extraction call — pick values that clearly don't collide with existing candidate IDs.
 
 Do not: set the scene, describe surrounding context, preserve dialogue verbatim, catalog every emotional nuance, or narrate "what it meant." Write the SNAPSHOT. The \`emotionalCharge\` and \`significance\` fields carry the weight — content stays lean.
 
@@ -123,6 +123,8 @@ Create edges between nodes when there's a meaningful relationship:
 - "part-of": belongs to a larger concept
 - "supersedes": replaces an outdated memory (new node inherits old node's durability)
 - "resolved-by": an event, plan, or task was completed, canceled, or its outcome is now known
+
+Edges can connect any pair of nodes: existing ↔ existing, new ↔ existing, or new ↔ new. Use \`edges_to_existing\` on a new node to declare outbound edges from that node (target may be an existing candidate ID or a sibling new node's \`temp_id\`). Use top-level \`new_edges\` for edges where the source is existing or where it's cleaner to declare the edge once by referencing both endpoints by ID/temp_id.
 
 ## Triggers
 
@@ -235,6 +237,11 @@ const EXTRACT_TOOL_SCHEMA = {
         items: {
           type: "object",
           properties: {
+            temp_id: {
+              type: "string",
+              description:
+                "Optional local identifier for this new node. Reference it from edges_to_existing.target_node_id or new_edges.source_node_id/target_node_id to connect two new nodes created in the same diff. Scope is this single call only — pick distinctive values (e.g. 'new-1') that won't collide with existing candidate IDs.",
+            },
             content: {
               type: "string",
               description: "First-person prose memory",
@@ -303,11 +310,15 @@ const EXTRACT_TOOL_SCHEMA = {
             edges_to_existing: {
               type: "array",
               description:
-                "Edges from this new node to existing candidate nodes",
+                "Outbound edges from this new node. target_node_id may be an existing candidate node ID OR the temp_id of another new node in this same extraction.",
               items: {
                 type: "object",
                 properties: {
-                  target_node_id: { type: "string" },
+                  target_node_id: {
+                    type: "string",
+                    description:
+                      "An existing candidate node ID, or the temp_id of another node in create_nodes.",
+                  },
                   relationship: {
                     type: "string",
                     enum: [
@@ -387,12 +398,21 @@ const EXTRACT_TOOL_SCHEMA = {
       },
       new_edges: {
         type: "array",
-        description: "Edges between existing nodes",
+        description:
+          "Edges between any pair of nodes (existing ↔ existing, new ↔ existing, or new ↔ new). Each endpoint may be an existing candidate node ID or the temp_id of a node declared in create_nodes.",
         items: {
           type: "object",
           properties: {
-            source_node_id: { type: "string" },
-            target_node_id: { type: "string" },
+            source_node_id: {
+              type: "string",
+              description:
+                "An existing candidate node ID, or the temp_id of a node in create_nodes.",
+            },
+            target_node_id: {
+              type: "string",
+              description:
+                "An existing candidate node ID, or the temp_id of a node in create_nodes.",
+            },
             relationship: { type: "string" },
             weight: { type: "number" },
           },
@@ -409,6 +429,7 @@ const EXTRACT_TOOL_SCHEMA = {
 // ---------------------------------------------------------------------------
 
 interface RawCreateNode {
+  temp_id?: string;
   content?: string;
   type?: string;
   emotional_charge?: {
@@ -502,6 +523,22 @@ export function parseEpochMs(value: unknown): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+/**
+ * An edge endpoint that may reference either a pre-existing candidate node
+ * (by its real ID) or a brand-new node being created in the same diff
+ * (by its index into `diff.createNodes`, resolved to a real ID after apply).
+ */
+export type DeferredEdgeEndpoint =
+  | { kind: "existing"; nodeId: string }
+  | { kind: "new"; newNodeIndex: number };
+
+export interface DeferredEdge {
+  source: DeferredEdgeEndpoint;
+  target: DeferredEdgeEndpoint;
+  relationship: string;
+  weight: number;
+}
+
 export function parseExtractionResponse(
   input: Record<string, unknown>,
   conversationId: string,
@@ -511,13 +548,12 @@ export function parseExtractionResponse(
   conversationTimestamp: number,
 ): {
   diff: MemoryDiff;
-  /** Edges from new nodes → existing nodes. Applied after node creation (needs IDs). */
-  deferredEdges: Array<{
-    newNodeIndex: number;
-    targetNodeId: string;
-    relationship: string;
-    weight: number;
-  }>;
+  /**
+   * Edges with at least one endpoint that is a new node (new→existing,
+   * existing→new, or new→new). Applied after node creation so new node IDs
+   * can be resolved from their indices.
+   */
+  deferredEdges: DeferredEdge[];
   /** Triggers for new nodes. Applied after node creation (needs IDs). */
   deferredTriggers: Array<{
     newNodeIndex: number;
@@ -541,16 +577,17 @@ export function parseExtractionResponse(
     reinforceNodeIds: reinforceNodeIds.filter((id) => candidateNodeIds.has(id)),
   };
 
-  const deferredEdges: Array<{
-    newNodeIndex: number;
-    targetNodeId: string;
-    relationship: string;
-    weight: number;
-  }> = [];
+  const deferredEdges: DeferredEdge[] = [];
   const deferredTriggers: Array<{
     newNodeIndex: number;
     trigger: Omit<NewTrigger, "nodeId">;
   }> = [];
+
+  // Track raw-index → diff-index for nodes that pass validation. Edges
+  // reference nodes by temp_id, which resolves via the raw index — but
+  // deferredEdges must carry the diff index (aligns with createdNodeIds
+  // in applyDiff's return value).
+  const rawIndexToDiffIndex = new Map<number, number>();
 
   // Parse new nodes
   for (let i = 0; i < createNodes.length; i++) {
@@ -610,22 +647,11 @@ export function parseExtractionResponse(
 
     diff.createNodes.push(node);
     const nodeIndex = diff.createNodes.length - 1;
+    rawIndexToDiffIndex.set(i, nodeIndex);
 
-    // Collect edges to existing nodes (need new node ID after creation)
-    if (Array.isArray(raw.edges_to_existing)) {
-      for (const edge of raw.edges_to_existing) {
-        if (!edge.target_node_id || !candidateNodeIds.has(edge.target_node_id))
-          continue;
-        if (!edge.relationship || !VALID_RELATIONSHIPS.has(edge.relationship))
-          continue;
-        deferredEdges.push({
-          newNodeIndex: nodeIndex,
-          targetNodeId: edge.target_node_id,
-          relationship: edge.relationship,
-          weight: clamp(Number(edge.weight) || 1.0, 0, 1),
-        });
-      }
-    }
+    // Edges declared on this new node are processed in a second pass below
+    // — they can reference sibling new nodes via temp_id, which may appear
+    // later in create_nodes than the edge's declaring node.
 
     // Collect triggers
     if (Array.isArray(raw.triggers)) {
@@ -714,6 +740,81 @@ export function parseExtractionResponse(
     }
   }
 
+  // Build temp_id → diff.createNodes-index map from nodes that passed
+  // validation. A temp_id that collides with an existing candidate ID is
+  // skipped so real IDs win on lookup — the prompt instructs the LLM to
+  // choose distinctive values so this should be rare.
+  const tempIdToDiffIndex = new Map<string, number>();
+  for (let i = 0; i < createNodes.length; i++) {
+    const raw = createNodes[i];
+    const tempId = raw?.temp_id;
+    if (typeof tempId !== "string" || tempId.length === 0) continue;
+    if (candidateNodeIds.has(tempId)) continue;
+    if (tempIdToDiffIndex.has(tempId)) continue; // first writer wins
+    const diffIndex = rawIndexToDiffIndex.get(i);
+    if (diffIndex == null) continue; // raw node was rejected during validation
+    tempIdToDiffIndex.set(tempId, diffIndex);
+  }
+
+  const resolveEndpoint = (id: string): DeferredEdgeEndpoint | null => {
+    if (candidateNodeIds.has(id)) return { kind: "existing", nodeId: id };
+    const idx = tempIdToDiffIndex.get(id);
+    if (idx != null) return { kind: "new", newNodeIndex: idx };
+    return null;
+  };
+
+  const pushResolvedEdge = (
+    source: DeferredEdgeEndpoint,
+    target: DeferredEdgeEndpoint,
+    relationship: string,
+    weight: number,
+  ) => {
+    // Both endpoints existing → apply directly via diff.createEdges.
+    // Otherwise defer until new node IDs are known post-applyDiff.
+    if (source.kind === "existing" && target.kind === "existing") {
+      diff.createEdges.push({
+        sourceNodeId: source.nodeId,
+        targetNodeId: target.nodeId,
+        relationship: relationship as NewEdge["relationship"],
+        weight,
+        created: now,
+      });
+    } else {
+      deferredEdges.push({ source, target, relationship, weight });
+    }
+  };
+
+  // Second pass: resolve edges_to_existing on each raw create_nodes entry.
+  // The source is always the containing new node; the target may be either
+  // an existing candidate or a sibling new node referenced by temp_id.
+  for (let i = 0; i < createNodes.length; i++) {
+    const raw = createNodes[i];
+    const sourceDiffIndex = rawIndexToDiffIndex.get(i);
+    if (sourceDiffIndex == null) continue;
+    if (!Array.isArray(raw.edges_to_existing)) continue;
+
+    for (const edge of raw.edges_to_existing) {
+      if (!edge.target_node_id) continue;
+      if (!edge.relationship || !VALID_RELATIONSHIPS.has(edge.relationship))
+        continue;
+      const target = resolveEndpoint(edge.target_node_id);
+      if (!target) continue;
+      const source: DeferredEdgeEndpoint = {
+        kind: "new",
+        newNodeIndex: sourceDiffIndex,
+      };
+      // Skip self-loops.
+      if (target.kind === "new" && target.newNodeIndex === sourceDiffIndex)
+        continue;
+      pushResolvedEdge(
+        source,
+        target,
+        edge.relationship,
+        clamp(Number(edge.weight) || 1.0, 0, 1),
+      );
+    }
+  }
+
   // Parse updates
   for (const raw of updateNodes) {
     if (!raw.id || !candidateNodeIds.has(raw.id)) continue;
@@ -735,23 +836,34 @@ export function parseExtractionResponse(
     }
   }
 
-  // Parse edges between existing nodes
+  // Parse top-level edges — each endpoint may be an existing candidate ID or
+  // the temp_id of a new node declared in create_nodes.
   for (const raw of newEdges) {
     if (!raw.source_node_id || !raw.target_node_id) continue;
-    if (
-      !candidateNodeIds.has(raw.source_node_id) ||
-      !candidateNodeIds.has(raw.target_node_id)
-    )
-      continue;
     if (!raw.relationship || !VALID_RELATIONSHIPS.has(raw.relationship))
       continue;
-    diff.createEdges.push({
-      sourceNodeId: raw.source_node_id,
-      targetNodeId: raw.target_node_id,
-      relationship: raw.relationship as NewEdge["relationship"],
-      weight: clamp(Number(raw.weight) || 1.0, 0, 1),
-      created: now,
-    });
+    const source = resolveEndpoint(raw.source_node_id);
+    const target = resolveEndpoint(raw.target_node_id);
+    if (!source || !target) continue;
+    // Skip self-loops.
+    if (
+      source.kind === "new" &&
+      target.kind === "new" &&
+      source.newNodeIndex === target.newNodeIndex
+    )
+      continue;
+    if (
+      source.kind === "existing" &&
+      target.kind === "existing" &&
+      source.nodeId === target.nodeId
+    )
+      continue;
+    pushResolvedEdge(
+      source,
+      target,
+      raw.relationship,
+      clamp(Number(raw.weight) || 1.0, 0, 1),
+    );
   }
 
   return { diff, deferredEdges, deferredTriggers };
@@ -969,13 +1081,19 @@ export async function runGraphExtraction(
   let edgesCreated = result.edgesCreated;
   let triggersCreated = result.triggersCreated;
 
+  const resolveCreatedEndpoint = (ep: DeferredEdgeEndpoint): string | null => {
+    if (ep.kind === "existing") return ep.nodeId;
+    return createdNodeIds[ep.newNodeIndex] ?? null;
+  };
+
   for (const de of deferredEdges) {
-    const newNodeId = createdNodeIds[de.newNodeIndex];
-    if (!newNodeId) continue;
+    const sourceNodeId = resolveCreatedEndpoint(de.source);
+    const targetNodeId = resolveCreatedEndpoint(de.target);
+    if (!sourceNodeId || !targetNodeId) continue;
 
     createEdge({
-      sourceNodeId: newNodeId,
-      targetNodeId: de.targetNodeId,
+      sourceNodeId,
+      targetNodeId,
       relationship: de.relationship as NewEdge["relationship"],
       weight: de.weight,
       created: conversationTimestamp,


### PR DESCRIPTION
Addresses review feedback on #26965 — split-and-connect memory extraction silently dropped edges between newly created nodes because `new_edges` filtered to pre-existing candidate IDs only.

## Context

The extraction prompt tells the LLM to split multi-beat memories into multiple nodes connected by edges (`caused-by`, `part-of`, `reminds-of`), but the tool schema and parser only accepted edges whose source AND target were pre-existing candidate node IDs. Any edge between two brand-new nodes was silently filtered out, so "split and connect" collapsed to "split without connections" for novel multi-beat memories — defeating the PR's retrieval-quality intent.

## Fix (option (a) from the review)

Relax the schema/parser to accept temp IDs for new nodes.

- Add optional `temp_id` to each `create_nodes` entry.
- Relax `edges_to_existing.target_node_id` and `new_edges.{source,target}_node_id` to accept either an existing candidate ID or a sibling node's `temp_id`.
- Unified resolver prefers candidate IDs over temp_ids on collision so real IDs stay authoritative; the prompt instructs the LLM to pick distinctive values to avoid collisions.
- `deferredEdges` now carries discriminated `source`/`target` endpoints; edges with both endpoints existing still short-circuit to `diff.createEdges`.
- Self-loops dropped; unknown references continue to be skipped.

## Tests

- Existing 40 tests pass unchanged (new→existing covered; field-shape expectations updated to the new discriminated endpoints).
- Added 7 tests: new→new via `edges_to_existing`, new→new via `new_edges`, existing→new via `new_edges`, existing→existing still lands in `diff.createEdges`, unknown temp_id is skipped, candidate ID wins over colliding temp_id, self-loop rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
