### PR TITLE
fix(meet-bot): short-circuit boot sequence when shutdown is in progress

### DIFF
--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -860,12 +860,22 @@ export async function runBot(deps: BotDeps): Promise<void> {
     // test timing semantics (`joinedSettleMs`) intact.
     await deps.sleep(deps.joinedSettleMs);
 
+    // A terminal lifecycle (`left`/`error`) or chrome-exit that landed
+    // during the settle window already fire-and-forgot `shutdown(...)`.
+    // Short-circuit the rest of the boot sequence so we don't bring up
+    // audio/HTTP against subsystems that are already being torn down —
+    // otherwise `meet-bot ready` can log after the meeting has already
+    // terminally failed, and the HTTP control surface briefly accepts
+    // requests. All subsequent awaits carry the same guard.
+    if (shutdownInProgress) return;
+
     // ---------------------------------------------------------------------
     // Step 7 — audio capture.
     // ---------------------------------------------------------------------
     subsystems.audioCapture = await deps.startAudioCapture({
       socketPath: `${env.socketDir}/audio.sock`,
     });
+    if (shutdownInProgress) return;
 
     // ---------------------------------------------------------------------
     // Step 8 — HTTP control surface.
@@ -900,6 +910,7 @@ export async function runBot(deps: BotDeps): Promise<void> {
       avatar: avatarHttpOptions,
     });
     await subsystems.httpServer.start(env.httpPort);
+    if (shutdownInProgress) return;
 
     deps.logInfo(`meet-bot ready (meetingId=${meetingId})`);
   } catch (err) {


### PR DESCRIPTION
Addresses review feedback on #26814 — lifecycle:error during startup fire-and-forgot shutdown but runBot continued past joinedSettleMs to start audio/HTTP.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
