### PR TITLE
fix(macos-client): check cancellation after avatar/traits HTTP fetch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -256,6 +256,7 @@ final class AvatarAppearanceManager {
             try? await Task.sleep(nanoseconds: Self.transientRetryDelayNs)
             guard !Task.isCancelled, let self else { return }
             await self.fetchAvatarViaHTTP()
+            guard !Task.isCancelled else { return }
             self.avatarRetryInFlight = false
             self.avatarRetryTask = nil
         }
@@ -268,6 +269,7 @@ final class AvatarAppearanceManager {
             try? await Task.sleep(nanoseconds: Self.transientRetryDelayNs)
             guard !Task.isCancelled, let self else { return }
             await self.fetchTraitsViaHTTP()
+            guard !Task.isCancelled else { return }
             self.traitsRetryInFlight = false
             self.traitsRetryTask = nil
         }


### PR DESCRIPTION
Addresses review feedback on #26880 — stale retry task could resume post-fetch and clobber new retry's bookkeeping.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
