### PR TITLE
fix(gateway): apply DM channel-ID prefix fallback to normalizeSlackMessageEdit

### DIFF
--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -961,6 +961,38 @@ describe("normalizeSlackMessageEdit", () => {
 
     expect(result).toBeNull();
   });
+
+  it("infers DM from channel ID prefix when channel_type is absent", () => {
+    const config = makeConfig({ unmappedPolicy: "reject" });
+    // Build the event directly so `channel_type` is truly absent — the
+    // makeMessageChangedEvent helper coalesces undefined back to "channel".
+    const event: SlackMessageChangedEvent = {
+      type: "message",
+      subtype: "message_changed",
+      channel: "D789",
+      ts: "1700000000.000200",
+      event_ts: "1700000000.000200",
+      message: {
+        user: "U123",
+        text: "edited content",
+        ts: "1700000000.000100",
+      },
+      previous_message: {
+        user: "U123",
+        text: "original content",
+        ts: "1700000000.000100",
+      },
+    };
+    const result = normalizeSlackMessageEdit(event, "Ev5", config);
+
+    // Without the DM-prefix fallback this would be null (unmapped + reject).
+    expect(result).not.toBeNull();
+    expect(result!.routing.assistantId).toBe("ast-1");
+    // DMs should not be tagged as channel chat even when inferred.
+    expect(result!.event.source.chatType).toBeUndefined();
+    // DM without thread_ts — threadTs should be omitted so replies go inline.
+    expect(result!.threadTs).toBeUndefined();
+  });
 });
 
 // --- normalizeSlackMessageDelete ---

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -800,8 +800,13 @@ export function normalizeSlackMessageEdit(
   // user is required for routing
   if (!edited.user) return null;
 
-  // Try channel routing, fall back to default for DMs
-  const isDm = event.channel_type === "im";
+  // Try channel routing, fall back to default for DMs. Slack's
+  // `message_changed` payload can omit `channel_type`, but DM channel IDs
+  // always start with "D" — fall back to the ID prefix so edits in DMs still
+  // take the defaultAssistantId routing branch.
+  const isDm =
+    event.channel_type === "im" ||
+    (event.channel_type === undefined && event.channel.startsWith("D"));
   let routing = resolveAssistant(config, event.channel, edited.user);
   if (isRejection(routing) && isDm && config.defaultAssistantId) {
     routing = {


### PR DESCRIPTION
Addresses review feedback on #26805 — the edit normalizer had the same omit-channel_type bug as the delete and reaction normalizers. Without the fallback, Slack edits whose payload omits `channel_type` would be rejected for unrouted DMs, drop the defaultAssistantId routing branch, and unconditionally set `chatType: channel` and `threadTs`. Falls back to the "D" channel-ID prefix like the delete normalizer (lines 883-885) and adds a regression test.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
