### PR TITLE
docs(slack): rewrite overflow-trailer comment to describe current state

### DIFF
--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -278,7 +278,7 @@ function buildMessageContentBlocks(
  * (`[…and N more reactions to Mxxx]`, singular `reaction` when N===1), emitted
  * at the point the overflow window closes — i.e. immediately before the next
  * event that is not an overflowing reaction for the same target — so trailers
- * stay in chronological position instead of batching at the tail.
+ * stay in chronological position rather than clustered at the end.
  */
 export function renderSlackTranscript(
   messages: RenderableSlackMessage[],


### PR DESCRIPTION
Addresses review feedback on #26808 — comment narrated prior behavior ('instead of batching at the tail').
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
