### PR TITLE
docs(slack-render): rewrite test comment to describe current behavior

### DIFF
--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -1053,13 +1053,11 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
   });
 
   test("row with only non-replayable blocks emits fallback tag line annotated with what was stripped", () => {
-    // Regression: previously `buildMessageContentBlocks` returned an empty
-    // array when every block was filtered out (e.g. a row whose only
-    // blocks are `server_tool_use` and `ui_surface`), causing the caller
-    // to drop the turn entirely — silently altering chronology and
-    // potentially orphaning adjacent tool_result context. The renderer
-    // now preserves the turn by emitting a single fallback text block
-    // annotated with the stripped block types/names.
+    // Rows whose only content blocks are non-replayable (e.g. `server_tool_use`,
+    // `ui_surface`) must still produce a turn so chronology and adjacent
+    // tool_result context are preserved. `buildMessageContentBlocks` emits a
+    // single fallback text block whose tag line names each stripped block's
+    // type (and tool name, when available).
     const base: RenderableSlackMessage = {
       ...userMsg(TS_14_25, null, "ran a web search", { role: "assistant" }),
       contentBlocks: [


### PR DESCRIPTION
Addresses review feedback on #26837 — comment narrated the pre-PR state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
