### PR TITLE
fix(slack): guard initial runtime injection against post-compaction snapshot

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -396,9 +396,9 @@ describe("isSlackChannelConversation", () => {
   });
 
   test("returns false for Slack DMs regardless of chatType shape", () => {
-    // Gateway omits chatType entirely for DM message events — the prior
-    // `chatType !== "im"` check misclassified these (undefined !== "im")
-    // as channels and leaked thread-only behaviour into DMs.
+    // Gateway omits chatType entirely for DM message events, so
+    // `isSlackChannelConversation` must return false for both the
+    // `chatType === undefined` and `chatType === "im"` shapes.
     expect(isSlackChannelConversation({ channel: "slack", ...base })).toBe(
       false,
     );
@@ -2967,8 +2967,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
   });
 
   // ── trust-filter regression for loadSlackChronologicalMessages ───────
-  // PR 26628 originally bypassed the trust filter by calling `getMessages`
-  // directly. For untrusted actors, guardian-scoped rows must be excluded
+  // For untrusted actors, guardian-scoped rows must be excluded
   // from the chronological transcript the same way `loadFromDb` filters
   // them out of the default history.
   test("loadSlackChronologicalMessages filters guardian-scoped rows for untrusted actors", () => {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -972,6 +972,9 @@ export async function runAgentLoopImpl(
 
     const injection = await applyRuntimeInjections(runMessages, {
       ...injectionOpts,
+      slackChronologicalMessages: reducerCompacted
+        ? null
+        : injectionOpts.slackChronologicalMessages,
       mode: currentInjectionMode,
     });
     runMessages = injection.messages;

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1209,9 +1209,9 @@ export function stripTransportHints(messages: Message[]): Message[] {
  * The gateway normalizer sets `chatType: "channel"` for every non-DM Slack
  * conversation (public, private, and mpim alike — see
  * `gateway/src/slack/normalize.ts`) and omits the field entirely for DMs.
- * We therefore accept on `chatType === "channel"` rather than negating
- * against `"im"` — the prior `!== "im"` check incorrectly classified DMs
- * (where the gateway-omitted field is `undefined`) as channels.
+ * We therefore accept only `chatType === "channel"` — when the gateway
+ * omits `chatType` (as it does for DMs), the check correctly returns
+ * `false`.
  *
  * The chronological-transcript override applies to ALL Slack
  * conversations (channels and DMs) — gate that on
@@ -1585,8 +1585,7 @@ export function assembleSlackActiveThreadFocusBlock(
   // DMs do not have threads, so the focus block is always a no-op.
   // The gateway sets `chatType: "channel"` for every non-DM Slack
   // conversation and omits the field for DMs, so gate the focus block
-  // on the positive match rather than negating against `"im"` (which
-  // leaks through when `chatType` is `undefined`).
+  // on the positive `"channel"` match.
   if (capabilities.chatType !== "channel") return null;
   const renderable = rows.map(rowToRenderable);
   const activeThreadTs = detectActiveThreadTs(renderable);


### PR DESCRIPTION
Addresses review feedback on #26847.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
