### PR TITLE
fix(macos): reset progress card completion anchor on tool resume; preserve across view recycling

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -134,9 +134,17 @@ struct AssistantProgressView: View {
         _processingStartDate = State(initialValue: initialProcessingStartDate)
         _thinkingAfterToolsStartDate = State(initialValue: initialThinkingStart)
         _thinkingAfterToolsEndDate = State(initialValue: initialThinkingEnd)
-        // On rehydration the card is already complete; fall back to latestCompletedAt
-        // so the header duration matches what it displayed before recycling.
-        let initialCardCompletedAt: Date? = model.phase == .complete ? model.latestCompletedAt : nil
+        // Seed the completion anchor from persisted state first so rehydration
+        // is lossless across view recycling. Falling back to `latestCompletedAt`
+        // (last tool end) drops any post-tool thinking/latency tail and
+        // re-introduces the duration regression the anchor exists to prevent.
+        let persistedCardCompletedAt = cardKeyForInit.flatMap {
+            progressUIState.wrappedValue.cardCompletedAt(for: $0)
+        }
+        let initialCardCompletedAt: Date? = {
+            if let persisted = persistedCardCompletedAt { return persisted }
+            return model.phase == .complete ? model.latestCompletedAt : nil
+        }()
         _cardCompletedAt = State(initialValue: initialCardCompletedAt)
     }
 
@@ -302,14 +310,22 @@ struct AssistantProgressView: View {
                     startDate = Date()
                 }
             }
-            // Reset thinking anchor when tools resume. Also reset on streamingCode
-            // when tools are still incomplete — phase resolution returns streamingCode
-            // before toolRunning whenever a code preview lingers, so in multi-wave runs
-            // the card can skip toolRunning and keep a stale anchor from the previous wave.
+            // Reset thinking + completion anchors when tools resume. Also reset on
+            // streamingCode when tools are still incomplete — phase resolution
+            // returns streamingCode before toolRunning whenever a code preview
+            // lingers, so in multi-wave runs the card can skip toolRunning and
+            // keep a stale anchor from the previous wave. Without clearing
+            // `cardCompletedAt` here the guard below (`cardCompletedAt == nil`)
+            // would block the second `.complete` from updating it, leaving the
+            // header stuck on wave 1's end time.
             if newPhase == .toolRunning
                 || (newPhase == .streamingCode && !model.allComplete && model.hasTools) {
                 thinkingAfterToolsStartDate = nil
                 thinkingAfterToolsEndDate = nil
+                cardCompletedAt = nil
+                if let key = cardKey {
+                    progressUIState.clearCardCompletedAt(for: key)
+                }
             }
             // Track thinking phase start only when the daemon explicitly
             // signaled thinking-after-tools. .processing fires only when
@@ -338,8 +354,13 @@ struct AssistantProgressView: View {
             // Unlike the thinking anchor above this fires regardless of whether
             // `.processing` was ever observed, keeping the header total monotonic
             // when the daemon skips straight from `.toolsCompleteThinking`.
+            // Persist on the shared state so the anchor survives view recycling.
             if newPhase == .complete, cardCompletedAt == nil {
-                cardCompletedAt = Date()
+                let now = Date()
+                cardCompletedAt = now
+                if let key = cardKey {
+                    progressUIState.setCardCompletedAt(for: key, date: now)
+                }
             }
             if shouldAutoExpandOnPhaseChange, !isExpanded {
                 ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(

--- a/clients/macos/vellum-assistant/Features/Chat/ProgressCardUIState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ProgressCardUIState.swift
@@ -34,6 +34,15 @@ struct ProgressCardUIState: Equatable, Sendable {
     /// Persisted so the thinking row survives view recycling with correct timing.
     var thinkingDurations: [UUID: TimeInterval] = [:]
 
+    // MARK: - Card Completion Anchor Persistence
+
+    /// Per-card completion timestamp captured at the first `.complete` phase
+    /// transition. Persisted so the header total duration survives view
+    /// recycling — rehydrating from `model.latestCompletedAt` (the last tool's
+    /// end) loses any post-tool thinking/latency tail and re-introduces the
+    /// exact regression the anchor is meant to prevent.
+    var cardCompletedDates: [UUID: Date] = [:]
+
     // MARK: - Rehydration Tracking
 
     /// Set of group IDs (first tool call UUID) for which rehydration has already
@@ -69,6 +78,11 @@ struct ProgressCardUIState: Equatable, Sendable {
     /// Returns the persisted thinking duration for the given card, or nil if none.
     func thinkingDuration(for cardKey: UUID) -> TimeInterval? {
         thinkingDurations[cardKey]
+    }
+
+    /// Returns the persisted completion timestamp for the given card, or nil if none.
+    func cardCompletedAt(for cardKey: UUID) -> Date? {
+        cardCompletedDates[cardKey]
     }
 
     /// Whether rehydration has already been performed for the given group.
@@ -107,6 +121,18 @@ struct ProgressCardUIState: Equatable, Sendable {
         thinkingDurations[cardKey] = duration
     }
 
+    /// Stores the card's completion timestamp so it survives view recycling.
+    mutating func setCardCompletedAt(for cardKey: UUID, date: Date) {
+        cardCompletedDates[cardKey] = date
+    }
+
+    /// Clears the persisted completion timestamp for a card. Called when tools
+    /// resume after a transient `.complete` (multi-wave execution) so the next
+    /// completion captures a fresh anchor.
+    mutating func clearCardCompletedAt(for cardKey: UUID) {
+        cardCompletedDates.removeValue(forKey: cardKey)
+    }
+
     /// Marks a group as having been rehydrated.
     mutating func markRehydrated(groupId: UUID) {
         rehydratedGroupIds.insert(groupId)
@@ -117,6 +143,7 @@ struct ProgressCardUIState: Equatable, Sendable {
         expandedStepIds.removeAll()
         cardExpansionOverrides.removeAll()
         thinkingDurations.removeAll()
+        cardCompletedDates.removeAll()
         rehydratedGroupIds.removeAll()
     }
 }


### PR DESCRIPTION
Addresses review feedback on #26783.

## Fix 1 (Devin / Codex P1): reset on tool resume

`cardCompletedAt` was not cleared when tools resumed after a transient `.complete` (multi-wave execution). `handlePhaseChange` already reset `thinkingAfterToolsStartDate/EndDate`, but the `cardCompletedAt == nil` guard below then prevented the second `.complete` from overwriting it — so the header showed `wave1End - startDate` instead of `wave2End - startDate`.

Now the same block that clears the thinking dates also clears `cardCompletedAt` (and its persisted mirror on `ProgressCardUIState`).

## Fix 2 (Codex P2): preserve the anchor across view recycling

When a completed card was recreated (scroll away + back), `cardCompletedAt` was re-seeded from `model.latestCompletedAt` (the last tool's end time) rather than the card's actual completion time. In the no-`.processing` path this dropped the post-tool latency tail and re-introduced the exact regression the anchor exists to prevent.

Persist the completion anchor on `ProgressCardUIState` alongside the thinking-duration anchor, and seed from it first on init. Falls back to `latestCompletedAt` only when no anchor has ever been captured (historical conversations rehydrated from disk).

## Files

- `clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift`
- `clients/macos/vellum-assistant/Features/Chat/ProgressCardUIState.swift`

## Test plan

- [ ] Multi-wave run (`.complete` → `.toolRunning` → `.complete`): header total reflects the second wave's end, not the first.
- [ ] Single-wave completion: header total is stable at `completionTime - startDate`.
- [ ] Scroll card off-screen and back: header total is identical to pre-recycle value (no drop back to last-tool-end).
- [ ] Card with real `.processing` thinking: `ThinkingStepRow` renders unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
