### PR TITLE
fix(slack): defer clearThreadTs until processMessage is accepted

### DIFF
--- a/assistant/src/memory/slack-thread-store.ts
+++ b/assistant/src/memory/slack-thread-store.ts
@@ -74,6 +74,20 @@ export function getThreadTs(conversationId: string): string | null {
 }
 
 /**
+ * Read both `threadTs` and `channelId` without mutating the entry. Used by
+ * dispatch to snapshot pre-update state so a turn that ends up rejected
+ * as already-processing can restore the in-flight turn's mapping.
+ */
+export function peekThreadMapping(
+  conversationId: string,
+): { threadTs: string; channelId: string } | null {
+  const mapping = threadMappings.get(conversationId);
+  return mapping
+    ? { threadTs: mapping.threadTs, channelId: mapping.channelId }
+    : null;
+}
+
+/**
  * Drop any thread mapping associated with this conversation. Called on
  * inbound Slack turns that arrive at the channel root (no `threadTs` on
  * the callback URL) so that a stale mapping from a prior in-thread turn

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -1,6 +1,36 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
-import { isBoundGuardianActor } from "./background-dispatch.js";
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../../memory/delivery-channels.js", () => ({
+  updateDeliveredSegmentCount: () => {},
+}));
+
+mock.module("../../../memory/delivery-crud.js", () => ({
+  linkMessage: () => {},
+}));
+
+mock.module("../../../memory/delivery-status.js", () => ({
+  markProcessed: () => {},
+  recordProcessingFailure: () => {},
+}));
+
+import type { TrustContext } from "../../../daemon/conversation-runtime-assembly.js";
+import {
+  clearThreadTs,
+  getThreadTs,
+  setThreadTs,
+} from "../../../memory/slack-thread-store.js";
+import type { MessageProcessor } from "../../http-types.js";
+import {
+  isBoundGuardianActor,
+  processChannelMessageInBackground,
+} from "./background-dispatch.js";
 
 describe("isBoundGuardianActor", () => {
   test("returns true only when requester matches bound guardian", () => {
@@ -40,5 +70,86 @@ describe("isBoundGuardianActor", () => {
         requesterExternalUserId: "requester-1",
       }),
     ).toBe(false);
+  });
+});
+
+describe("processChannelMessageInBackground — slack thread mapping", () => {
+  const trustCtx: TrustContext = {
+    trustClass: "guardian",
+    guardianExternalUserId: "guardian-1",
+    requesterExternalUserId: "guardian-1",
+  } as unknown as TrustContext;
+
+  const flush = (): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, 10));
+
+  test("restores prior thread mapping when processMessage is rejected as already-processing", async () => {
+    const conversationId = "conv-restore-on-busy";
+    const channelId = "C-RESTORE";
+    const inFlightThreadTs = "1700000000.000001";
+
+    // Simulate a prior threaded turn that installed the mapping and is
+    // still in flight when a new channel-root event arrives.
+    setThreadTs(conversationId, channelId, inFlightThreadTs);
+
+    const processMessage: MessageProcessor = async () => {
+      throw new Error("Conversation is already processing a message");
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-1",
+      content: "root-level message",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      // Callback URL has no threadTs query param → channel-root event
+      // that would otherwise call `clearThreadTs`.
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}`,
+      mintBearerToken: () => "test-token",
+    });
+
+    await flush();
+
+    // The in-flight threaded turn's mapping must survive the busy rejection.
+    expect(getThreadTs(conversationId)).toBe(inFlightThreadTs);
+
+    clearThreadTs(conversationId);
+  });
+
+  test("retains updated mapping when processMessage succeeds", async () => {
+    const conversationId = "conv-retain-on-success";
+    const channelId = "C-SUCCESS";
+    const newThreadTs = "1700000000.000002";
+
+    // No prior mapping; this turn arrives in a thread and should install one.
+    clearThreadTs(conversationId);
+
+    const processMessage: MessageProcessor = async () => ({
+      messageId: "user-msg-1",
+    });
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-2",
+      content: "thread reply",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${newThreadTs}`,
+      mintBearerToken: () => "test-token",
+    });
+
+    await flush();
+
+    expect(getThreadTs(conversationId)).toBe(newThreadTs);
+
+    clearThreadTs(conversationId);
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -18,6 +18,7 @@ import {
   extractChannelFromCallbackUrl,
   extractMessageTsFromCallbackUrl,
   extractThreadTsFromCallbackUrl,
+  peekThreadMapping,
   setThreadTs,
 } from "../../../memory/slack-thread-store.js";
 import { resolveGuardianName } from "../../../prompts/user-reference.js";
@@ -178,13 +179,26 @@ export function processChannelMessageInBackground(
     // at outbound-persistence time, so the mapping must reflect the
     // current turn — a lingering mapping from a prior thread turn
     // would otherwise be stamped onto a channel-root reply.
+    //
+    // The update must happen BEFORE `processMessage` runs because outbound
+    // persistence (inside the agent loop) reads the mapping. But if a prior
+    // threaded turn is still in flight, our `processMessage` call will be
+    // rejected as already-processing and our update would erase that
+    // in-flight turn's mapping. Snapshot the prior state here and restore
+    // it in the `already processing` rejection path below.
+    let priorSlackMapping: { threadTs: string; channelId: string } | null =
+      null;
+    let slackMappingMutated = false;
     if (sourceChannel === "slack" && replyCallbackUrl) {
+      priorSlackMapping = peekThreadMapping(conversationId);
       const inboundThreadTs = extractThreadTsFromCallbackUrl(replyCallbackUrl);
       const inboundChannel = extractChannelFromCallbackUrl(replyCallbackUrl);
       if (inboundThreadTs && inboundChannel) {
         setThreadTs(conversationId, inboundChannel, inboundThreadTs);
+        slackMappingMutated = true;
       } else {
         clearThreadTs(conversationId);
+        slackMappingMutated = true;
       }
     }
 
@@ -238,6 +252,27 @@ export function processChannelMessageInBackground(
         );
       }
     } catch (err) {
+      // When another turn is already processing this conversation,
+      // `prepareConversationForMessage` throws before any of this turn's
+      // work runs. Our pre-await mapping update would otherwise stomp the
+      // in-flight turn's mapping, causing its outbound persistence to
+      // record `slackMeta` with the wrong (or missing) `threadTs`. Restore
+      // the snapshot so the in-flight turn sees the mapping it installed.
+      if (
+        slackMappingMutated &&
+        err instanceof Error &&
+        err.message.includes("already processing a message")
+      ) {
+        if (priorSlackMapping) {
+          setThreadTs(
+            conversationId,
+            priorSlackMapping.channelId,
+            priorSlackMapping.threadTs,
+          );
+        } else {
+          clearThreadTs(conversationId);
+        }
+      }
       log.error(
         { err, conversationId },
         "Background channel message processing failed",


### PR DESCRIPTION
Addresses review feedback on #26815 — clear ran before the processMessage acceptance check, so a busy-rejected channel-root event could erase the mapping of the in-flight threaded turn.

Fix uses snapshot+restore: the mapping still has to be updated before `processMessage` (outbound persistence inside the agent loop reads it), so the dispatch path snapshots the prior mapping before the update and restores it when `prepareConversationForMessage` throws "already processing a message". In that case the in-flight turn's mapping survives, and its outbound persistence sees the correct `threadTs`.

Also adds a regression test covering both paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
