### PR TITLE
fix(context): retained-thread-refs regex must match edited replies

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -1372,6 +1372,55 @@ describe("ContextWindowManager", () => {
     expect(userPromptText).toContain("→ M1a2b3c");
   });
 
+  test("summary prompt lists retained-tail thread-reply references for edited replies", async () => {
+    const capturedMessages: Message[][] = [];
+    const provider: Provider = {
+      name: "mock",
+      async sendMessage(messages: Message[]): Promise<ProviderResponse> {
+        capturedMessages.push(messages);
+        return {
+          content: [{ type: "text", text: "## Goals\n- ok" }],
+          model: "mock-model",
+          usage: { inputTokens: 60, outputTokens: 12 },
+          stopReason: "end_turn",
+        };
+      },
+    };
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({ maxInputTokens: 600 }),
+    });
+    const long = "x".repeat(240);
+    // An edited reply renders with `, edited …` between the parent alias and
+    // the closing bracket: `→ Mxxxxxx, edited MM/DD/YY HH:MM]`. The regex
+    // must still flag these lines so retention works for edited replies.
+    const history: Message[] = [
+      message("user", `[11/14/23 14:25 @alice]: parent kickoff ${long}`),
+      message("assistant", `a1 ${long}`),
+      message("user", `u2 ${long}`),
+      message("assistant", `a2 ${long}`),
+      message(
+        "user",
+        `[11/14/23 14:28 @bob → M1a2b3c, edited 11/14/23 14:32]: reply ${long}`,
+      ),
+      message("assistant", `a3 ${long}`),
+    ];
+
+    const result = await manager.maybeCompact(history);
+    expect(result.compacted).toBe(true);
+    expect(capturedMessages.length).toBeGreaterThan(0);
+    const userPromptText = capturedMessages[0]
+      .flatMap((m) => m.content)
+      .filter(
+        (b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text",
+      )
+      .map((b) => b.text)
+      .join("\n");
+    expect(userPromptText).toContain("### Retained Thread References");
+    expect(userPromptText).toContain("→ M1a2b3c, edited 11/14/23 14:32");
+  });
+
   test("summary prompt omits retained references when retained tail has no thread markers", async () => {
     const capturedMessages: Message[][] = [];
     const provider: Provider = {

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -44,13 +44,16 @@ const SUMMARY_SYSTEM_PROMPT = [
 /**
  * Pattern matching a Slack-style reply tag-line's parent-alias reference.
  * The chronological renderer emits reply lines as
- * `[MM/DD/YY HH:MM @sender → Mxxxxxx]: body`, where `Mxxxxxx` is the first 6
- * hex chars of sha256(threadTs). A retained-tail text block that contains
- * this pattern is carrying a live reference to a parent that may still live
- * in the compactable region — the summarizer needs to know about it to act
- * on the Thread-anchors clause of SUMMARY_SYSTEM_PROMPT.
+ * `[MM/DD/YY HH:MM @sender → Mxxxxxx]: body`, or, for edited replies,
+ * `[MM/DD/YY HH:MM @sender → Mxxxxxx, edited MM/DD/YY HH:MM]: body`. The
+ * character after the 6-hex parent alias is therefore `]` for a plain reply
+ * or `,` for an edited one — the regex accepts either. `Mxxxxxx` is the
+ * first 6 hex chars of sha256(threadTs). A retained-tail text block that
+ * contains this pattern is carrying a live reference to a parent that may
+ * still live in the compactable region — the summarizer needs to know about
+ * it to act on the Thread-anchors clause of SUMMARY_SYSTEM_PROMPT.
  */
-const THREAD_REPLY_REFERENCE_PATTERN = /→ M[0-9a-f]{6}]/;
+const THREAD_REPLY_REFERENCE_PATTERN = /→ M[0-9a-f]{6}[,\]]/;
 
 export interface ContextWindowResult {
   messages: Message[];


### PR DESCRIPTION
Addresses review feedback on #26849.

The regex `/→ M[0-9a-f]{6}]/` required a literal `]` right after the hex alias, but the chronological renderer emits edited replies as `→ Mxxxxxx, edited …]` — so every edited reply was silently skipped by the retained-thread-reference scan. Change the regex to accept either `,` or `]` after the hex.

Also adds a regression test for the edited-reply shape.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
