### PR TITLE
fix(macos): preserve local guardian token fallback; honor delete failure

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -234,15 +234,39 @@ extension AppDelegate {
     /// failures. `performInitialBootstrap()` imports that file ahead of any
     /// HTTP path, so without deleting it we would silently re-arm the bad
     /// credential and the re-pair would "succeed" only to fall right back
-    /// into 401s. Delete the file here so the bootstrap is forced down a
-    /// genuine reprovision path.
+    /// into 401s. Delete the file for remote hatches (Docker/cloud/managed),
+    /// where the CLI or launcher will re-provision and rewrite the file,
+    /// so the bootstrap is forced down a genuine reprovision path.
+    ///
+    /// For local/bare-metal assistants the on-disk token is the only
+    /// recovery artifact — nothing is guaranteed to rewrite it — so preserve
+    /// it. Bootstrap will still skip the (now-wiped) in-memory credentials
+    /// and re-import from the file, which is the intended local fallback.
+    ///
+    /// If the delete is attempted but fails (e.g. filesystem permissions),
+    /// the stale file would otherwise be re-imported by
+    /// `performInitialBootstrap()`, defeating the fix. In that case pass
+    /// `skipFileImport: true` so the bootstrap ignores the file entirely
+    /// and drives the HTTP reprovision path.
     func forceReBootstrap() async {
         log.info("forceReBootstrap: clearing stored credentials and re-running bootstrap")
         ActorTokenManager.deleteAllCredentials()
+
+        var skipFileImport = false
         if let assistantId = LockfileAssistant.loadActiveAssistantId() {
-            GuardianTokenFileReader.deleteTokenFile(assistantId: assistantId)
+            let assistant = LockfileAssistant.loadByName(assistantId)
+            let isRemoteHatch = assistant?.isRemote ?? false
+            if isRemoteHatch {
+                let deleted = GuardianTokenFileReader.deleteTokenFile(assistantId: assistantId)
+                if !deleted {
+                    log.warning("forceReBootstrap: failed to delete stale guardian token file — skipping file import to avoid re-arming the revoked token")
+                    skipFileImport = true
+                }
+            } else {
+                log.info("forceReBootstrap: local/bare-metal hatch — preserving guardian token file as the only recovery artifact")
+            }
         }
-        await performInitialBootstrap()
+        await performInitialBootstrap(skipFileImport: skipFileImport)
     }
 
     /// Performs the initial actor token bootstrap, reactively waiting for a
@@ -252,35 +276,45 @@ extension AppDelegate {
     /// Before hitting the network, checks whether the CLI already persisted a
     /// guardian token to disk (e.g. during a Docker or cloud hatch). If found,
     /// imports it directly and skips the HTTP bootstrap entirely.
-    func performInitialBootstrap() async {
+    ///
+    /// `skipFileImport`: when `true`, bypass the guardian-token.json import
+    /// entirely and jump straight to the HTTP fallback. Used by
+    /// `forceReBootstrap()` when a stale file could not be deleted — leaving
+    /// the import path enabled in that case would silently re-arm the revoked
+    /// token the re-bootstrap is meant to discard.
+    func performInitialBootstrap(skipFileImport: Bool = false) async {
         guard let assistantId = LockfileAssistant.loadActiveAssistantId() else { return }
 
-        // Try importing a guardian token that was already written to disk
-        // (e.g. by the CLI during hatch or by AppleContainersLauncher).
-        if GuardianTokenFileReader.importIfAvailable(assistantId: assistantId) {
-            log.info("Imported guardian token from file — skipping HTTP bootstrap")
-            return
-        }
-
-        // The token file doesn't exist yet — the launcher/CLI may still be
-        // writing it. Poll for up to ~60s before falling back to HTTP bootstrap.
-        let maxAttempts = 30
-        let delay: UInt64 = 2_000_000_000 // 2 seconds per poll
-        for attempt in 1...maxAttempts {
-            guard !Task.isCancelled else { return }
-            try? await Task.sleep(nanoseconds: delay)
-            guard !Task.isCancelled else { return }
-
+        if !skipFileImport {
+            // Try importing a guardian token that was already written to disk
+            // (e.g. by the CLI during hatch or by AppleContainersLauncher).
             if GuardianTokenFileReader.importIfAvailable(assistantId: assistantId) {
-                log.info("Imported guardian token from file after \(attempt) poll(s)")
+                log.info("Imported guardian token from file — skipping HTTP bootstrap")
                 return
             }
-        }
 
-        // Token file never appeared — fall back to HTTP bootstrap via
-        // /v1/guardian/init. This path generates its own random bootstrap
-        // secret which may fail if the runtime already consumed the real one.
-        log.warning("Guardian token file not found after \(maxAttempts) polls — falling back to /v1/guardian/init")
+            // The token file doesn't exist yet — the launcher/CLI may still be
+            // writing it. Poll for up to ~60s before falling back to HTTP bootstrap.
+            let maxAttempts = 30
+            let delay: UInt64 = 2_000_000_000 // 2 seconds per poll
+            for attempt in 1...maxAttempts {
+                guard !Task.isCancelled else { return }
+                try? await Task.sleep(nanoseconds: delay)
+                guard !Task.isCancelled else { return }
+
+                if GuardianTokenFileReader.importIfAvailable(assistantId: assistantId) {
+                    log.info("Imported guardian token from file after \(attempt) poll(s)")
+                    return
+                }
+            }
+
+            // Token file never appeared — fall back to HTTP bootstrap via
+            // /v1/guardian/init. This path generates its own random bootstrap
+            // secret which may fail if the runtime already consumed the real one.
+            log.warning("Guardian token file not found after \(maxAttempts) polls — falling back to /v1/guardian/init")
+        } else {
+            log.info("performInitialBootstrap: skipFileImport=true — driving HTTP reprovision path directly")
+        }
 
         let deviceId = PairingQRCodeSheet.computeHostId()
         let retryDelay: UInt64 = 500_000_000


### PR DESCRIPTION
Addresses review feedback on #26833.

- **Codex:** `forceReBootstrap()` unconditionally deleted `guardian-token.json` before re-running bootstrap. That works for Docker/cloud hatches (where the CLI/launcher rewrites the file on re-provision), but for local/bare-metal the on-disk token is the only recovery artifact — nothing is guaranteed to rewrite it. Gate the delete on `LockfileAssistant.isRemote` so local hatches preserve the fallback file.
- **Devin:** `GuardianTokenFileReader.deleteTokenFile` returns `Bool` but the caller ignored it via `@discardableResult`. If the delete failed (e.g. filesystem permissions), `performInitialBootstrap()` would then call `importIfAvailable()` and silently re-arm the stale/revoked token, defeating the fix. Check the return value and, when the delete fails, pass `skipFileImport: true` to `performInitialBootstrap()` so it skips the import and drives the HTTP reprovision path.

## Test plan

- [ ] Re-pair a Docker instance whose `guardian-token.json` still holds a revoked token — confirm the file is removed and bootstrap re-imports the freshly-written one (or falls back to HTTP if the delete fails).
- [ ] Re-pair a local/bare-metal instance — confirm the guardian token file is preserved and the file-import path still functions as the recovery route.
- [ ] Simulate a `deleteTokenFile` failure in a Docker re-pair — confirm the HTTP reprovision path runs and no stale token is re-imported.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
