### PR TITLE
fix(macos-menu): interpolate assistant name into Re-pair menu title

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -451,7 +451,7 @@ extension AppDelegate {
 
             if currentAssistantStatus == .authFailed {
                 let item = NSMenuItem(
-                    title: "Re-pair Assistant",
+                    title: "Re-pair \(name)",
                     action: #selector(rePairAssistant),
                     keyEquivalent: ""
                 )


### PR DESCRIPTION
Addresses review feedback on #26866 — status message referenced dynamic name but menu item was hardcoded 'Re-pair Assistant'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
