### PR TITLE
test(meet-join): complete MeetTtsBridgeLike stub in session-manager.test.ts

### DIFF
--- a/skills/meet-join/daemon/__tests__/session-manager.test.ts
+++ b/skills/meet-join/daemon/__tests__/session-manager.test.ts
@@ -1833,6 +1833,8 @@ describe("MeetSessionManager TTS lip-sync forwarder wiring", () => {
     // exercised by this test — the session manager only calls cancelAll
     // during leave.
     const ttsBridgeFactory = () => ({
+      meetingId: "m-lipsync-order",
+      botBaseUrl: "http://unused",
       speak: async () => ({
         streamId: "unused",
         completion: Promise.resolve(),
@@ -1842,6 +1844,7 @@ describe("MeetSessionManager TTS lip-sync forwarder wiring", () => {
         callOrder.push("ttsBridge.cancelAll");
       },
       activeStreamCount: () => 0,
+      onViseme: () => () => {},
     });
 
     const manager = _createMeetSessionManagerForTests({


### PR DESCRIPTION
Addresses review feedback on #26858.

The lipsync-order test's local ttsBridgeFactory stub was missing `meetingId`, `botBaseUrl`, and `onViseme` — the three members added to `MeetTtsBridgeLike` in #26858.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
