### PR TITLE
feat(permissions): add autoApproveUpTo threshold to permissions config

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -137,7 +137,11 @@ describe("AssistantConfigSchema", () => {
   test("accepts valid complete config", () => {
     const input = {
       llm: {
-        default: { provider: "openai" as const, model: "gpt-4", maxTokens: 4096 },
+        default: {
+          provider: "openai" as const,
+          model: "gpt-4",
+          maxTokens: 4096,
+        },
       },
       timeouts: {
         shellDefaultTimeoutSec: 30,
@@ -671,6 +675,7 @@ describe("AssistantConfigSchema", () => {
     expect(result.permissions).toEqual({
       mode: "workspace",
       hostAccess: false,
+      autoApproveUpTo: "low",
     });
   });
 
@@ -705,6 +710,57 @@ describe("AssistantConfigSchema", () => {
       const msgs = result.error.issues.map((i) => i.message);
       expect(msgs.some((m) => m.includes("permissions.mode"))).toBe(true);
     }
+  });
+
+  test("defaults autoApproveUpTo to low when not specified", () => {
+    const result = AssistantConfigSchema.parse({
+      permissions: { mode: "workspace" },
+    });
+    expect(result.permissions.autoApproveUpTo).toBe("low");
+  });
+
+  test("accepts autoApproveUpTo none", () => {
+    const result = AssistantConfigSchema.parse({
+      permissions: { autoApproveUpTo: "none" },
+    });
+    expect(result.permissions.autoApproveUpTo).toBe("none");
+  });
+
+  test("accepts autoApproveUpTo low", () => {
+    const result = AssistantConfigSchema.parse({
+      permissions: { autoApproveUpTo: "low" },
+    });
+    expect(result.permissions.autoApproveUpTo).toBe("low");
+  });
+
+  test("accepts autoApproveUpTo medium", () => {
+    const result = AssistantConfigSchema.parse({
+      permissions: { autoApproveUpTo: "medium" },
+    });
+    expect(result.permissions.autoApproveUpTo).toBe("medium");
+  });
+
+  test("rejects autoApproveUpTo high", () => {
+    const result = AssistantConfigSchema.safeParse({
+      permissions: { autoApproveUpTo: "high" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid autoApproveUpTo string", () => {
+    const result = AssistantConfigSchema.safeParse({
+      permissions: { autoApproveUpTo: "everything" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("autoApproveUpTo round-trips through JSON serialization", () => {
+    const original = AssistantConfigSchema.parse({
+      permissions: { autoApproveUpTo: "medium" },
+    });
+    const json = JSON.stringify(original);
+    const parsed = AssistantConfigSchema.parse(JSON.parse(json));
+    expect(parsed.permissions.autoApproveUpTo).toBe("medium");
   });
 
   test("applies workspaceGit defaults including interactiveGitTimeoutMs", () => {
@@ -2251,6 +2307,7 @@ describe("loadConfig with schema validation", () => {
     expect(config.permissions).toEqual({
       mode: "workspace",
       hostAccess: false,
+      autoApproveUpTo: "low",
     });
   });
 

--- a/assistant/src/__tests__/permission-mode.test.ts
+++ b/assistant/src/__tests__/permission-mode.test.ts
@@ -40,6 +40,7 @@ describe("PermissionsConfigSchema", () => {
     expect(PermissionsConfigSchema.parse({})).toEqual({
       mode: "workspace",
       hostAccess: false,
+      autoApproveUpTo: "low",
     });
   });
 
@@ -47,6 +48,7 @@ describe("PermissionsConfigSchema", () => {
     expect(PermissionsConfigSchema.parse({ mode: "strict" })).toEqual({
       mode: "strict",
       hostAccess: false,
+      autoApproveUpTo: "low",
     });
   });
 
@@ -59,6 +61,7 @@ describe("PermissionsConfigSchema", () => {
     ).toEqual({
       mode: "workspace",
       hostAccess: true,
+      autoApproveUpTo: "low",
     });
   });
 
@@ -66,6 +69,7 @@ describe("PermissionsConfigSchema", () => {
     const input = {
       mode: "workspace" as const,
       hostAccess: true,
+      autoApproveUpTo: "low" as const,
     };
     const json = JSON.stringify(input);
     expect(PermissionsConfigSchema.parse(JSON.parse(json))).toEqual(input);

--- a/assistant/src/config/schemas/security.ts
+++ b/assistant/src/config/schemas/security.ts
@@ -87,6 +87,16 @@ export const PermissionsConfigSchema = z
       .describe(
         "Whether the assistant can execute commands on the host machine without prompting",
       ),
+    autoApproveUpTo: z
+      .enum(["none", "low", "medium"], {
+        error: "permissions.autoApproveUpTo must be one of: none, low, medium",
+      })
+      .default("low")
+      .describe(
+        "Auto-approve tools at or below this risk level without prompting. " +
+          "'none' prompts for everything (strictest), 'low' auto-approves read-only " +
+          "operations (default), 'medium' auto-approves writes and network access too.",
+      ),
   })
   .describe("Permission enforcement mode for tool operations");
 


### PR DESCRIPTION
## Summary
- Add autoApproveUpTo field to PermissionsConfigSchema with values none/low/medium (default: low)
- Add config schema tests for default value, accepted values, rejection of high, and JSON round-trip
- Update permission-mode tests to include the new default field

Part of plan: bash-risk-approval-policy.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
