### PR TITLE
fix(meet-bot): reset playback clock per /play_audio stream

### DIFF
--- a/skills/meet-join/bot/__tests__/audio-playback.test.ts
+++ b/skills/meet-join/bot/__tests__/audio-playback.test.ts
@@ -192,6 +192,34 @@ describe("audio-playback module", () => {
     await flushSilence(10); // no active handle
     // No throw = pass.
   });
+
+  test("resetPlaybackClock rewinds the utterance-relative clock back to 0 so the next write starts from 0 again", async () => {
+    const shim = makePacatShim();
+    const handle = startAudioPlayback({ spawn: () => shim.proc });
+
+    const observed: number[] = [];
+    handle.onPlaybackTimestamp((ts) => {
+      observed.push(ts);
+    });
+
+    // Utterance 1: 10ms of audio. At 48kHz mono s16le that's
+    // 10 * 96 = 960 bytes; the handle should emit ts = 10ms.
+    await handle.write(new Uint8Array(10 * DEFAULT_BYTES_PER_MS));
+    expect(observed).toEqual([10]);
+
+    // Reset the clock — simulates the HTTP server at the start of a
+    // second POST /play_audio. No emission; the clock is silently
+    // rewound to 0.
+    handle.resetPlaybackClock();
+    expect(observed).toEqual([10]);
+
+    // Utterance 2: 5ms of audio. Without the reset the next emission
+    // would have been 15ms (10 + 5). With the reset the handle must
+    // emit ts = 5ms — the start of the new utterance's coordinate
+    // system, matching how the daemon stamps VisemeEvent.timestamp.
+    await handle.write(new Uint8Array(5 * DEFAULT_BYTES_PER_MS));
+    expect(observed).toEqual([10, 5]);
+  });
 });
 
 /** ---------------------- HTTP endpoint tests ----------------------- */

--- a/skills/meet-join/bot/__tests__/avatar-lipsync.test.ts
+++ b/skills/meet-join/bot/__tests__/avatar-lipsync.test.ts
@@ -310,6 +310,60 @@ describe("TalkingHead renderer lip-sync alignment", () => {
     expect(nativeMessaging.pushVisemes()).toHaveLength(0);
   });
 
+  test("resetPlaybackTimestamp rewinds the clock and drops stale buffered visemes so the next utterance's visemes are not flushed immediately", async () => {
+    // Regression guard for the multi-utterance accumulation bug: the
+    // `/play_audio` handle is a module-level singleton, and the daemon
+    // stamps VisemeEvent.timestamp as ms-from-start-of-THIS-utterance
+    // (so each utterance resets to 0). Without a per-utterance clock
+    // reset the renderer's `currentPlaybackTimestamp` would sit at the
+    // end-of-prior-utterance value (say 550 ms), and every viseme from
+    // utterance 2 would satisfy `timestamp <= 550` and flush
+    // immediately — defeating the buffering that makes this alignment
+    // work in the first place.
+    const nativeMessaging = new FakeNativeMessaging();
+    const renderer = await startRenderer(nativeMessaging);
+
+    // Utterance 1: advance the clock to 550 ms. This models having
+    // pushed ~550 ms of PCM for the first utterance.
+    renderer.notifyPlaybackTimestamp(550);
+
+    // Leave one viseme from utterance 1 still buffered in the future
+    // (e.g. a late-declared viseme whose audio had not yet played).
+    // It belongs to utterance 1 and must NOT leak into utterance 2.
+    renderer.pushViseme({ phoneme: "stale", weight: 0.1, timestamp: 900 });
+    expect(nativeMessaging.pushVisemes()).toHaveLength(0);
+
+    // Simulate the HTTP server starting a fresh /play_audio POST: it
+    // rewinds the renderer's clock in lockstep with the handle's
+    // `resetPlaybackClock()`.
+    expect(typeof renderer.resetPlaybackTimestamp).toBe("function");
+    renderer.resetPlaybackTimestamp!();
+
+    // Utterance 2's visemes arrive with ts values restarting at 0.
+    // They must be buffered — the clock was rewound past them — not
+    // flushed immediately.
+    renderer.pushViseme({ phoneme: "a", weight: 0.2, timestamp: 100 });
+    renderer.pushViseme({ phoneme: "b", weight: 0.3, timestamp: 200 });
+    expect(nativeMessaging.pushVisemes()).toHaveLength(0);
+
+    // Advance the clock into utterance 2's range. `a` (t=100) should
+    // flush; `b` (t=200) stays buffered. The stale viseme from
+    // utterance 1 must NOT surface.
+    renderer.notifyPlaybackTimestamp(100);
+    let pushed = nativeMessaging.pushVisemes();
+    expect(pushed.map((v) => v.phoneme)).toEqual(["a"]);
+
+    renderer.notifyPlaybackTimestamp(200);
+    pushed = nativeMessaging.pushVisemes();
+    expect(pushed.map((v) => v.phoneme)).toEqual(["a", "b"]);
+
+    // Push a very-large timestamp to confirm the stale utterance-1
+    // viseme (t=900) was dropped by the reset, not just hidden.
+    renderer.notifyPlaybackTimestamp(10_000);
+    pushed = nativeMessaging.pushVisemes();
+    expect(pushed.map((v) => v.phoneme)).toEqual(["a", "b"]);
+  });
+
   test("visemes with identical timestamps are forwarded in arrival order", async () => {
     // ElevenLabs' viseme stream can legitimately produce back-to-back
     // events with the same millisecond timestamp. The buffer drain

--- a/skills/meet-join/bot/src/control/http-server.ts
+++ b/skills/meet-join/bot/src/control/http-server.ts
@@ -451,6 +451,27 @@ export function createHttpServer(
         return c.json({ error: `failed to start playback: ${message}` }, 500);
       }
 
+      // The playback handle is a module-level singleton (see
+      // `audio-playback.ts` — the same `handle` is returned across every
+      // POST). Its utterance-relative clock accumulates across POSTs
+      // unless we explicitly reset it, which would cause every viseme
+      // from the second-and-later utterance (daemon-stamped as ms from
+      // THAT utterance's start, so also restarting at 0) to satisfy
+      // `visemeTs < effectivePlaybackMs` and flush immediately on
+      // arrival — defeating the point of buffering. Reset here so each
+      // stream gets a fresh 0-based clock matching the daemon's
+      // per-utterance timestamp coordinate system. Reset the viseme-
+      // driven renderer's mirror clock in lockstep for the same reason.
+      handle.resetPlaybackClock();
+      const rendererAtStreamStart = avatarRenderer;
+      if (
+        rendererAtStreamStart !== null &&
+        rendererAtStreamStart.capabilities.needsVisemes &&
+        typeof rendererAtStreamStart.resetPlaybackTimestamp === "function"
+      ) {
+        rendererAtStreamStart.resetPlaybackTimestamp();
+      }
+
       const controller = new AbortController();
       activeStreams.set(streamId, { controller, handle });
 

--- a/skills/meet-join/bot/src/media/audio-playback.ts
+++ b/skills/meet-join/bot/src/media/audio-playback.ts
@@ -124,11 +124,31 @@ export interface AudioPlaybackHandle {
    * directly. Returns an unsubscribe function; calling it more than
    * once is a no-op.
    *
-   * Timestamps are strictly monotonic: each emission advances the clock
-   * by exactly `byteCount / bytesPerMs` past the previous emission, so
-   * subscribers don't have to worry about equal-timestamp reordering.
+   * Timestamps are strictly monotonic WITHIN a single utterance: each
+   * emission advances the clock by exactly `byteCount / bytesPerMs`
+   * past the previous emission. Callers that reuse the singleton handle
+   * across multiple utterances must call `resetPlaybackClock()` between
+   * them (see its docstring) — that resets the clock back to 0, which
+   * is a deliberate, caller-controlled monotonicity break.
    */
   onPlaybackTimestamp(cb: (ts: number) => void): () => void;
+  /**
+   * Reset the utterance-relative playback clock back to 0. Intended to
+   * be called by the HTTP server at the start of every new `/play_audio`
+   * stream: because `startAudioPlayback` is a module-level singleton,
+   * the same handle is handed back across utterances and without this
+   * reset the clock would accumulate across every POST — leaving
+   * subsequent utterances' visemes (which the daemon stamps as ms from
+   * the start of THEIR utterance, i.e. also restarting at 0) all
+   * satisfying `visemeTs < effectivePlaybackMs` and flushing immediately
+   * on arrival, which defeats the point of buffering.
+   *
+   * After the reset the next `write()` emits a timestamp measured from
+   * 0 again. Subscribers that maintain their own monotonic clock (e.g.
+   * the TalkingHead renderer) should reset in lockstep — see
+   * `AvatarRenderer.resetPlaybackTimestamp`.
+   */
+  resetPlaybackClock(): void;
 }
 
 /** Default spawn factory — wraps `Bun.spawn` with the pacat flags. */
@@ -284,6 +304,9 @@ export function startAudioPlayback(
         const idx = timestampSubscribers.indexOf(cb);
         if (idx !== -1) timestampSubscribers.splice(idx, 1);
       };
+    },
+    resetPlaybackClock(): void {
+      effectivePlaybackMs = 0;
     },
   };
 

--- a/skills/meet-join/bot/src/media/avatar/talking-head/renderer.ts
+++ b/skills/meet-join/bot/src/media/avatar/talking-head/renderer.ts
@@ -413,6 +413,22 @@ export class TalkingHeadRenderer implements AvatarRenderer {
   }
 
   /**
+   * Reset the internal playback clock back to the "no audio queued yet"
+   * state and drop any visemes still buffered from the prior utterance.
+   * The HTTP server calls this at the start of every new `/play_audio`
+   * stream, in lockstep with `AudioPlaybackHandle.resetPlaybackClock()`.
+   * Without this reset the clock would sit at the end-of-prior-utterance
+   * timestamp and subsequent visemes (daemon-stamped as ms-from-THAT-
+   * utterance-start, restarting at 0) would all satisfy the `timestamp
+   * <= currentPlaybackTimestamp` check and flush immediately on arrival.
+   */
+  resetPlaybackTimestamp(): void {
+    if (this.stopped) return;
+    this.currentPlaybackTimestamp = Number.NEGATIVE_INFINITY;
+    this.visemeBuffer.length = 0;
+  }
+
+  /**
    * Drain every buffered viseme whose declared `timestamp` is
    * `<= currentPlaybackTimestamp`, forwarding each to the extension in
    * arrival order. Buffered visemes that remain in the future relative

--- a/skills/meet-join/bot/src/media/avatar/types.ts
+++ b/skills/meet-join/bot/src/media/avatar/types.ts
@@ -127,6 +127,23 @@ export interface AvatarRenderer {
    * for those backends.
    */
   notifyPlaybackTimestamp?(ts: number): void;
+  /**
+   * Optional — reset the renderer's internal audio-playback clock back
+   * to its "no audio queued yet" state. Called by the HTTP server at
+   * the start of every new `/play_audio` stream, in lockstep with the
+   * audio-playback handle's `resetPlaybackClock()`. Without this reset
+   * the renderer's monotonic clock would sit at the end-of-prior-
+   * utterance timestamp, and every viseme from the next utterance
+   * (stamped as ms-from-THAT-utterance-start, i.e. restarting at 0)
+   * would satisfy `visemeTs <= currentPlaybackTimestamp` and flush
+   * immediately on arrival — the exact bug `notifyPlaybackTimestamp`
+   * exists to prevent.
+   *
+   * Implementations should also drop any buffered viseme state that
+   * belonged to the prior utterance so it cannot leak into the fresh
+   * stream.
+   */
+  resetPlaybackTimestamp?(): void;
 }
 
 /**


### PR DESCRIPTION
Addresses review feedback on #26856 — the `effectivePlaybackMs` clock was a property of the module-level singleton handle, so it accumulated across every `/play_audio` POST. VisemeEvent.timestamp is ms-from-start-of-THIS-utterance (restarts at 0 each utterance), so after the first utterance every subsequent utterance's visemes satisfied `visemeTs < effectivePlaybackMs` and flushed immediately on arrival — defeating the buffering.

Fix is option (a) from Devin's comment: reset the clock at the start of each `/play_audio` stream. Also reset the viseme-driven renderer's mirror clock in lockstep (otherwise its monotonic `currentPlaybackTimestamp` sits at the end-of-prior-utterance value with the same symptom). Added `resetPlaybackClock()` on `AudioPlaybackHandle` and optional `resetPlaybackTimestamp()` on `AvatarRenderer`, plus regression tests for both.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
