### PR TITLE
fix(test): stub workspace-git in conversation-process-callsite test

### DIFF
--- a/assistant/src/__tests__/conversation-process-callsite.test.ts
+++ b/assistant/src/__tests__/conversation-process-callsite.test.ts
@@ -105,6 +105,22 @@ mock.module("../security/secret-allowlist.js", () => ({
   resetAllowlist: () => {},
 }));
 
+// Stub workspace-git so the test doesn't run real `git init` / `git add -A`
+// against the workingDir. On GitHub-hosted runners /tmp contains
+// root-owned systemd-private-* directories that return EACCES, and the
+// resulting retry/backoff path takes several seconds — enough to time
+// out this test even though the callSite-threading assertion is unrelated.
+mock.module("../workspace/turn-commit.js", () => ({
+  commitTurnChanges: async () => {},
+}));
+
+mock.module("../workspace/git-service.js", () => ({
+  getWorkspaceGitService: () => ({
+    ensureInitialized: async () => {},
+    commitIfDirty: async () => ({ committed: false }),
+  }),
+}));
+
 let mockDbMessages: Array<{ id: string; role: string; content: string }> = [];
 let mockConversation: Record<string, unknown> | null = null;
 


### PR DESCRIPTION
## Summary
- Test `conversation-process-callsite.test.ts` was timing out on CI (5007ms / 5000ms limit) because the real workspace-git service's `ensureInitialized` and `commitTurnChanges` hit EACCES on GitHub runner `/tmp` directories and burn several seconds retrying.
- Added `mock.module` stubs for `../workspace/git-service.js` and `../workspace/turn-commit.js`, matching the pattern already used in sibling `conversation-agent-loop.test.ts`. The test asserts `callSite` threading through `processMessage` → `runAgentLoop` → `agentLoop.run()`; git init/commit are orthogonal.
- Test now runs in ~500ms locally (was timing out at 5s in CI).

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24695484708/job/72227157506
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
