### PR TITLE
fix(meet-chat): scale xdotool-type timeout with message length end-to-end

### DIFF
--- a/skills/meet-join/bot/__tests__/main.test.ts
+++ b/skills/meet-join/bot/__tests__/main.test.ts
@@ -271,6 +271,7 @@ function makeDeps(opts: MakeDepsOpts = {}): {
         text: typeOpts.text,
         delayMs: typeOpts.delayMs,
         display: typeOpts.display,
+        timeoutMs: typeOpts.timeoutMs,
       });
       if (opts.xdotoolTypeError) throw opts.xdotoolTypeError;
     },
@@ -643,12 +644,37 @@ describe("runBot — extension message routing", () => {
     expect(typeCall!.text).toBe("hello world");
     expect(typeCall!.delayMs).toBe(25);
     expect(typeCall!.display).toBe(":99");
+    // timeoutMs must scale with text length — the legacy fixed 15s
+    // default killed xdotool mid-type for messages above ~590 chars.
+    // 11 chars * 25ms/char + 250ms overhead + 5000ms safety slack.
+    expect(typeCall!.timeoutMs).toBe(11 * 25 + 250 + 5_000);
     // Success should surface via logInfo with the character count.
     expect(
       handles.infos.some((m) =>
         m.includes("trusted_type dispatched (11 chars)"),
       ),
     ).toBe(true);
+  });
+
+  test("trusted_type scales xdotool kill timeout for long messages", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    // 2000-char Meet-chat maximum — the case where the legacy fixed 15s
+    // xdotool timeout truncated the message mid-type.
+    const longText = "x".repeat(2000);
+    handles.fireExtensionMessage({
+      type: "trusted_type",
+      text: longText,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const typeCall = handles.calls.find((c) => c.kind === "xdotool.type");
+    expect(typeCall).toBeDefined();
+    // 2000 chars * 25ms (default delay) + 250ms overhead + 5000ms slack.
+    expect(typeCall!.timeoutMs).toBe(2000 * 25 + 250 + 5_000);
+    expect(typeCall!.timeoutMs).toBeGreaterThan(15_000);
   });
 
   test("trusted_type xdotool failures surface via logError but don't shut down", async () => {

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -58,6 +58,10 @@ import type {
   BotToExtensionMessage,
   ExtensionToBotMessage,
 } from "../../contracts/native-messaging.js";
+import {
+  trustedTypeKillTimeoutMs,
+  trustedTypeReplyTimeoutMs,
+} from "../../contracts/native-messaging.js";
 
 import {
   launchChrome,
@@ -245,6 +249,15 @@ export interface BotDeps {
     text: string;
     display: string;
     delayMs?: number;
+    /**
+     * Per-call kill timeout. When omitted, `xdotool-type.ts` falls back to
+     * its own default (which does NOT scale with text length). The
+     * `trusted_type` handler below computes a scaled value via
+     * {@link trustedTypeKillTimeoutMs} so long chats (≥ ~590 chars at the
+     * default 25ms/keystroke) are not truncated by the legacy fixed
+     * 15s ceiling.
+     */
+    timeoutMs?: number;
   }) => Promise<void>;
   startAudioCapture: (opts: AudioCaptureOptions) => Promise<AudioCaptureHandle>;
   createDaemonClient: (opts: {
@@ -1032,11 +1045,17 @@ export async function runBot(deps: BotDeps): Promise<void> {
         // failure, never cascade into a bot shutdown. The extension has
         // already focused the target element; the bot just types into
         // whatever is focused on the Xvfb display.
+        //
+        // We pass an explicit `timeoutMs` scaled to the message length so
+        // xdotool is not killed mid-type on long chats. `xdotool-type.ts`'s
+        // built-in default is a fixed 15s, which truncated any message
+        // above ~590 characters at the default 25ms/keystroke delay.
         deps
           .xdotoolType({
             text: msg.text,
             delayMs: msg.delayMs,
             display: env.xvfbDisplay,
+            timeoutMs: trustedTypeKillTimeoutMs(msg.text.length, msg.delayMs),
           })
           .then(() =>
             deps.logInfo(
@@ -1080,23 +1099,34 @@ export async function runBot(deps: BotDeps): Promise<void> {
   /**
    * Dispatch a `send_chat` command to the extension and wait for the
    * matching `send_chat_result`. Resolves on `ok: true`, rejects on
-   * `ok: false` or on a 10s timeout. Called from the HTTP `/send_chat`
-   * route.
+   * `ok: false` or on a length-scaled timeout. Called from the HTTP
+   * `/send_chat` route.
+   *
+   * The reply timeout scales with text length via
+   * {@link trustedTypeReplyTimeoutMs} because the extension types the
+   * text one keystroke at a time (25ms default) before clicking send —
+   * a fixed 10s ceiling would fail valid messages above ~390 chars.
+   * `deps.sendChatTimeoutMs` stays a floor so short messages retain
+   * their original budget.
    */
   async function sendChatViaExtension(text: string): Promise<void> {
     if (!subsystems.socketServer) {
       throw new Error("send_chat: socket server not started");
     }
     const requestId = deps.generateRequestId();
+    const timeoutMs = Math.max(
+      deps.sendChatTimeoutMs,
+      trustedTypeReplyTimeoutMs(text.length),
+    );
     const waitForResult = new Promise<void>((resolve, reject) => {
       const timer = setTimeout(() => {
         pendingSendChat.delete(requestId);
         reject(
           new Error(
-            `send_chat: extension did not reply within ${deps.sendChatTimeoutMs}ms (requestId=${requestId})`,
+            `send_chat: extension did not reply within ${timeoutMs}ms (requestId=${requestId})`,
           ),
         );
-      }, deps.sendChatTimeoutMs);
+      }, timeoutMs);
       pendingSendChat.set(requestId, { resolve, reject, timer });
     });
 

--- a/skills/meet-join/contracts/native-messaging.ts
+++ b/skills/meet-join/contracts/native-messaging.ts
@@ -181,6 +181,125 @@ export type ExtensionTrustedTypeMessage = z.infer<
   typeof ExtensionTrustedTypeMessageSchema
 >;
 
+// ---------------------------------------------------------------------------
+// Shared trusted-type timing helpers
+// ---------------------------------------------------------------------------
+//
+// xdotool's per-keystroke delay (default 25ms) makes typing duration scale
+// linearly with text length: a 2000-char chat (Meet's max) takes 50s of
+// real-time keystroke dispatch on the bot's Xvfb display. The four sites
+// that bound this round-trip — extension wait between trusted_type emit
+// and send-button click, bot xdotoolType kill timer, bot send_chat reply
+// timer, daemon HTTP timeout — must all derive from the SAME formula or
+// the chain pre-empts itself: short timeouts kill xdotool mid-type and
+// post truncated text; mismatched timeouts surface false failures while
+// the extension still completes successfully.
+//
+// These helpers are the single source of truth shared across all four
+// sites. The reason each successive timeout is larger than the one inside
+// it is simply that the outer waiter has to cover the inner work plus
+// transit (native-messaging hop, HTTP round-trip).
+
+/**
+ * Default xdotool `--delay` value in milliseconds. Mirrors
+ * `DEFAULT_DELAY_MS` in `bot/src/browser/xdotool-type.ts` — kept aligned
+ * so the timing helpers below correctly predict typing duration when the
+ * extension does not pass an explicit `delayMs`.
+ */
+export const TRUSTED_TYPE_DEFAULT_DELAY_MS = 25;
+
+/**
+ * Fixed overhead for the xdotool spawn + the native-messaging round-trip
+ * from extension → bot → X server (emit → first keystroke dispatched).
+ * Sized from observed production latency with a small safety margin.
+ */
+export const TRUSTED_TYPE_OVERHEAD_MS = 250;
+
+/**
+ * Extra slack added on top of the predicted typing duration when sizing
+ * the xdotool kill timer in the bot. Covers OS-scheduling jitter on the
+ * Xvfb display and the time xdotool itself takes to release after the
+ * final keystroke. Independent of the extension wait so a larger value
+ * here cannot push xdotool past the moment the extension dispatches the
+ * send-button click.
+ */
+const TRUSTED_TYPE_KILL_SLACK_MS = 5_000;
+
+/**
+ * Slack added on top of the typing duration when sizing the bot's
+ * `send_chat` reply timer. Must cover: extension's typing wait → send-
+ * button click → DOM transition → `send_chat_result` native-messaging
+ * frame back to the bot. Generous enough that minor extension scheduling
+ * slips don't surface as user-visible failures.
+ */
+const TRUSTED_TYPE_REPLY_SLACK_MS = 10_000;
+
+/**
+ * Slack added on top of the bot's `send_chat` reply timer when sizing
+ * the daemon's `/send_chat` HTTP timeout. Covers the HTTP round-trip
+ * between daemon and bot container so the daemon does not pre-empt a
+ * reply that is genuinely on its way.
+ */
+const TRUSTED_TYPE_HTTP_SLACK_MS = 5_000;
+
+/**
+ * Predict how long xdotool will spend typing `textLength` characters at
+ * the given per-keystroke `delayMs` (default
+ * {@link TRUSTED_TYPE_DEFAULT_DELAY_MS}). This is the lower bound the
+ * extension must wait between emitting `trusted_type` and clicking the
+ * send button — clicking earlier would post a partial message.
+ */
+export function trustedTypeDurationMs(
+  textLength: number,
+  delayMs: number = TRUSTED_TYPE_DEFAULT_DELAY_MS,
+): number {
+  return textLength * delayMs + TRUSTED_TYPE_OVERHEAD_MS;
+}
+
+/**
+ * Recommended kill timeout for the bot-side xdotool process. Returns the
+ * predicted typing duration plus {@link TRUSTED_TYPE_KILL_SLACK_MS}. The
+ * bot's `trusted_type` handler passes this to `xdotoolType` so long
+ * messages are not killed mid-type (the legacy fixed 15s ceiling truncated
+ * any chat above ~590 characters).
+ */
+export function trustedTypeKillTimeoutMs(
+  textLength: number,
+  delayMs?: number,
+): number {
+  return trustedTypeDurationMs(textLength, delayMs) + TRUSTED_TYPE_KILL_SLACK_MS;
+}
+
+/**
+ * Recommended `send_chat` reply timeout for the bot. Must exceed the
+ * extension's typing wait plus the post-type click round-trip. The bot's
+ * `sendChatViaExtension` uses this value when starting the reply timer so
+ * valid sub-2000-char messages do not surface false failures.
+ */
+export function trustedTypeReplyTimeoutMs(
+  textLength: number,
+  delayMs?: number,
+): number {
+  return (
+    trustedTypeDurationMs(textLength, delayMs) + TRUSTED_TYPE_REPLY_SLACK_MS
+  );
+}
+
+/**
+ * Recommended `/send_chat` HTTP timeout for the daemon. Sized to outlive
+ * the bot's reply timer by a small margin so the HTTP layer never
+ * pre-empts a reply that is genuinely in flight. The daemon's
+ * `defaultBotSendChatFetch` uses this value per request.
+ */
+export function trustedTypeHttpTimeoutMs(
+  textLength: number,
+  delayMs?: number,
+): number {
+  return (
+    trustedTypeReplyTimeoutMs(textLength, delayMs) + TRUSTED_TYPE_HTTP_SLACK_MS
+  );
+}
+
 /**
  * Result of a prior `send_chat` command, correlated by `requestId`.
  *

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -77,6 +77,7 @@ import { resolveTtsConfig } from "../../../assistant/src/tts/tts-config-resolver
 import type { TtsProvider } from "../../../assistant/src/tts/types.js";
 import { getLogger } from "../../../assistant/src/util/logger.js";
 import { getWorkspaceDir } from "../../../assistant/src/util/platform.js";
+import { trustedTypeHttpTimeoutMs } from "../contracts/native-messaging.js";
 import { getMeetConfig } from "../meet-config.js";
 import { MeetAudioIngest } from "./audio-ingest.js";
 import {
@@ -141,7 +142,13 @@ export const MEET_BOT_HOST_IP = "127.0.0.1";
 /** Timeout for the best-effort bot `/leave` HTTP call before falling back to stop. */
 export const BOT_LEAVE_HTTP_TIMEOUT_MS = 10_000;
 
-/** Timeout for the bot `/send_chat` HTTP call before giving up. */
+/**
+ * Floor for the bot `/send_chat` HTTP timeout. The per-request ceiling
+ * scales with text length via {@link trustedTypeHttpTimeoutMs} — xdotool
+ * types at 25ms/char inside the bot, so a 2000-char chat takes ~50s to
+ * land before the extension can reply. The actual timeout applied per
+ * request is `max(FLOOR, trustedTypeHttpTimeoutMs(text.length))`.
+ */
 export const BOT_SEND_CHAT_HTTP_TIMEOUT_MS = 10_000;
 
 /**
@@ -2412,6 +2419,16 @@ async function defaultBotSendChatFetch(
   text: string,
   meetingId: string,
 ): Promise<void> {
+  // xdotool types at 25ms/char inside the bot container, so the bot's
+  // reply genuinely cannot arrive before `text.length * 25ms` — a fixed
+  // 10s ceiling times out valid sub-2000-char chats above ~390 chars
+  // even when the extension eventually completes them successfully.
+  // Scale per request via the shared helper; floor at the legacy fixed
+  // budget so short messages keep the same (already-tight) ceiling.
+  const timeoutMs = Math.max(
+    BOT_SEND_CHAT_HTTP_TIMEOUT_MS,
+    trustedTypeHttpTimeoutMs(text.length),
+  );
   let response: Response;
   try {
     response = await fetch(url, {
@@ -2421,7 +2438,7 @@ async function defaultBotSendChatFetch(
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ type: "send_chat", text }),
-      signal: AbortSignal.timeout(BOT_SEND_CHAT_HTTP_TIMEOUT_MS),
+      signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);

--- a/skills/meet-join/meet-controller-ext/src/features/chat.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/chat.ts
@@ -40,6 +40,7 @@ import type {
   ExtensionInboundChatMessage,
   ExtensionToBotMessage,
 } from "../../../contracts/native-messaging.js";
+import { trustedTypeDurationMs } from "../../../contracts/native-messaging.js";
 import { chatSelectors } from "../dom/selectors.js";
 import { waitForSelector } from "../dom/wait.js";
 
@@ -65,22 +66,6 @@ const ENSURE_PANEL_OPEN_TIMEOUT_MS = 2000;
  * `skills/meet-join/bot/src/control/http-server.ts`.
  */
 export const MEET_CHAT_MAX_LENGTH = 2000;
-
-/**
- * Per-character wait (ms) after emitting `trusted_type` so xdotool's
- * X-server keystrokes finish landing in the composer before we dispatch
- * the send-button click. Must match `xdotool --delay` (25ms/char) inside
- * the bot — see `bot/src/browser/xdotool-type.ts`'s `DEFAULT_DELAY_MS`.
- */
-const TRUSTED_TYPE_PER_CHAR_MS = 25;
-
-/**
- * Fixed overhead added on top of the per-character scaling to cover
- * xdotool startup + the native-messaging round-trip from extension →
- * bot → X server. Sized from observed production latency (emit → first
- * keystroke dispatched) plus a small safety margin.
- */
-const TRUSTED_TYPE_OVERHEAD_MS = 250;
 
 /** Options passed to {@link startChatReader}. */
 export interface ChatReaderOptions {
@@ -233,11 +218,14 @@ export function startChatReader(opts: ChatReaderOptions): ChatReader {
  *    fallback only for the `onEvent`-less case (jsdom tests and any Meet
  *    build where synthetic input is accepted).
  *
- *    After emitting, we wait `text.length * TRUSTED_TYPE_PER_CHAR_MS +
- *    TRUSTED_TYPE_OVERHEAD_MS` so the (async) xdotool keystrokes have
- *    time to land before the send-button click is dispatched. A fixed
- *    250ms window was too short for messages longer than ~10 characters
- *    (xdotool's default per-keystroke delay is 25ms).
+ *    After emitting, we wait {@link trustedTypeDurationMs}(`text.length`)
+ *    so the (async) xdotool keystrokes have time to land before the send-
+ *    button click is dispatched. A fixed 250ms window was too short for
+ *    messages longer than ~10 characters (xdotool's default per-keystroke
+ *    delay is 25ms). The wait formula is the single source of truth for
+ *    the extension wait, the bot's xdotool kill timer, and the bot /
+ *    daemon `send_chat` reply timers — see the helper's definition in
+ *    `contracts/native-messaging.ts`.
  *
  * 2. Before the send-button `.click()`, a `trusted_click` is emitted for
  *    the button's screen coordinates. This mirrors the panel-toggle fix
@@ -296,8 +284,11 @@ export async function sendChat(
       // does not require focus to succeed.
     }
     opts.onEvent({ type: "trusted_type", text });
-    const waitMs =
-      text.length * TRUSTED_TYPE_PER_CHAR_MS + TRUSTED_TYPE_OVERHEAD_MS;
+    // Wait exactly as long as xdotool needs to type the text — the
+    // shared helper returns `text.length * 25ms + 250ms` by default and
+    // stays in sync with the bot's xdotool kill timer and the bot/daemon
+    // `send_chat` timeouts that scale off the same formula.
+    const waitMs = trustedTypeDurationMs(text.length);
     await new Promise<void>((resolve) => setTimeout(resolve, waitMs));
   } else {
     // No `onEvent` sink — we can't drive xdotool, so fall back to the


### PR DESCRIPTION
Addresses review feedback on #26850.

Both Codex and Devin flagged the same root cause: four timeouts along the trusted-type chain (extension wait, bot xdotool kill timer, bot send_chat reply timer, daemon HTTP timeout) were independent and inconsistent, so valid sub-2000-char messages either truncated mid-type (Devin) or surfaced false failures while the extension still completed them (Codex).

Single source of truth now in `contracts/native-messaging.ts`: `trustedTypeDurationMs` / `trustedTypeKillTimeoutMs` / `trustedTypeReplyTimeoutMs` / `trustedTypeHttpTimeoutMs`, all derived from `text.length * delayMs + overhead`, each adding a progressively larger safety slack so the outer timer never pre-empts the inner one. Extension, bot `trusted_type` handler, bot `sendChatViaExtension`, and daemon `defaultBotSendChatFetch` all consume the helper.

Regression test: `trusted_type scales xdotool kill timeout for long messages` verifies a 2000-char payload gets a timeout above the legacy 15s ceiling.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
