### PR TITLE
fix: address self-review gaps on onboarding setup cards

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -93,28 +93,34 @@ extension AppDelegate {
 
         let hostingController = NSHostingController(rootView: authView)
 
+        // ReauthView is a compact sign-in surface; OnboardingFlowView hosts
+        // the full onboarding including the WakeUp cards which require at
+        // least 440×720 per the view's `.frame(minWidth:minHeight:)`.
+        let windowWidth: CGFloat = 460
+        let windowHeight: CGFloat = hasManagedAssistants ? 620 : 720
+        let minWidth: CGFloat = hasManagedAssistants ? 420 : 440
+        let minHeight: CGFloat = hasManagedAssistants ? 580 : 720
+
         let window: NSWindow
         if let existingWindow {
             window = existingWindow
             window.contentViewController = hostingController
             window.isMovableByWindowBackground = true
             window.backgroundColor = NSColor(VColor.surfaceOverlay)
-            window.contentMinSize = NSSize(width: 420, height: 580)
+            window.contentMinSize = NSSize(width: minWidth, height: minHeight)
             window.setFrameAutosaveName("")
 
-            let targetWidth: CGFloat = 460
-            let targetHeight: CGFloat = 620
             let currentFrame = window.frame
             let newFrame = NSRect(
-                x: currentFrame.midX - targetWidth / 2,
-                y: currentFrame.midY - targetHeight / 2,
-                width: targetWidth,
-                height: targetHeight
+                x: currentFrame.midX - windowWidth / 2,
+                y: currentFrame.midY - windowHeight / 2,
+                width: windowWidth,
+                height: windowHeight
             )
             window.setFrame(newFrame, display: true, animate: true)
         } else {
             window = NSWindow(
-                contentRect: NSRect(x: 0, y: 0, width: 460, height: 620),
+                contentRect: NSRect(x: 0, y: 0, width: windowWidth, height: windowHeight),
                 styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
                 backing: .buffered,
                 defer: false
@@ -125,16 +131,14 @@ extension AppDelegate {
             window.isMovableByWindowBackground = true
             window.backgroundColor = NSColor(VColor.surfaceOverlay)
             window.isReleasedWhenClosed = false
-            window.contentMinSize = NSSize(width: 420, height: 580)
+            window.contentMinSize = NSSize(width: minWidth, height: minHeight)
 
-            let startWidth: CGFloat = 460
-            let startHeight: CGFloat = 620
             if let visibleFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame {
-                let x = visibleFrame.midX - startWidth / 2
-                let y = visibleFrame.midY - startHeight / 2
-                window.setFrame(NSRect(x: x, y: y, width: startWidth, height: startHeight), display: true)
+                let x = visibleFrame.midX - windowWidth / 2
+                let y = visibleFrame.midY - windowHeight / 2
+                window.setFrame(NSRect(x: x, y: y, width: windowWidth, height: windowHeight), display: true)
             } else {
-                window.setContentSize(NSSize(width: startWidth, height: startHeight))
+                window.setContentSize(NSSize(width: windowWidth, height: windowHeight))
                 window.center()
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
@@ -7,6 +7,7 @@ import SwiftUI
 ///
 /// The parent owns `isExpanded` so the card's transition can be coordinated
 /// with sibling animations.
+@MainActor
 internal struct OnboardingLocalModeDisclosure: View {
     @Binding var isExpanded: Bool
 
@@ -101,7 +102,7 @@ internal struct OnboardingLocalModeDisclosure: View {
             top: VSpacing.md,
             leading: VSpacing.lg,
             bottom: VSpacing.md,
-            trailing: VSpacing.lg
+            trailing: VSpacing.md
         ))
         .frame(maxWidth: .infinity)
         .background(

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingVellumCloudCard.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingVellumCloudCard.swift
@@ -5,6 +5,7 @@ import SwiftUI
 ///
 /// Self-contained subview: no outside state. Composed into
 /// `WakeUpStepView` alongside the sibling "Your Machine" card.
+@MainActor
 struct OnboardingVellumCloudCard: View {
     // MARK: - Configuration
 
@@ -18,6 +19,9 @@ struct OnboardingVellumCloudCard: View {
     ]
     let primaryCTA: String = "Continue with Vellum"
     var isLoading: Bool = false
+    /// When true, the primary CTA is replaced with a "Logging in…" progress
+    /// row. Takes precedence over `isLoading`, which renders "Checking…".
+    var isSubmitting: Bool = false
     var isDisabled: Bool = false
     var onContinue: () -> Void
 
@@ -56,27 +60,25 @@ struct OnboardingVellumCloudCard: View {
                     benefitRow(benefit)
                 }
             }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(Text("Vellum Cloud benefits"))
 
             Spacer().frame(height: VSpacing.lg)
 
-            // CTA
-            if isLoading {
-                HStack(spacing: VSpacing.sm) {
-                    ProgressView()
-                        .controlSize(.small)
-                        .progressViewStyle(.circular)
-                    Text("Checking…")
-                        .font(VFont.bodyMediumLighter)
-                        .foregroundStyle(VColor.contentSecondary)
-                }
-                .frame(maxWidth: .infinity, minHeight: 32)
+            // CTA — "Logging in…" wins over "Checking…" when both bits are set,
+            // since the user has just submitted credentials and a generic
+            // "Checking…" would be misleading during the WorkOS round-trip.
+            if isSubmitting {
+                loadingRow(label: "Logging in…")
+            } else if isLoading {
+                loadingRow(label: "Checking…")
             } else {
                 VButton(
                     label: primaryCTA,
                     style: .primary,
                     size: .pillRegular,
                     isFullWidth: true,
-                    isDisabled: isDisabled || isLoading
+                    isDisabled: isDisabled
                 ) {
                     onContinue()
                 }
@@ -113,5 +115,20 @@ struct OnboardingVellumCloudCard: View {
                 .foregroundStyle(VColor.contentDefault)
                 .fixedSize(horizontal: false, vertical: true)
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(text))
+    }
+
+    @ViewBuilder
+    private func loadingRow(label: String) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            ProgressView()
+                .controlSize(.small)
+                .progressViewStyle(.circular)
+            Text(label)
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentSecondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 32)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -41,7 +41,7 @@ final class OnboardingWindow {
         let hostingController = NSHostingController(rootView: flowView)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 440, height: 630),
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 720),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -54,10 +54,10 @@ final class OnboardingWindow {
         window.backgroundColor = NSColor(VColor.surfaceOverlay)
         window.isReleasedWhenClosed = false
 
-        window.contentMinSize = NSSize(width: 440, height: 630)
+        window.contentMinSize = NSSize(width: 440, height: 720)
 
         let startWidth: CGFloat = 440
-        let startHeight: CGFloat = 630
+        let startHeight: CGFloat = 720
         if let visibleFrame = Self.visibleScreenFrame() {
             let x = visibleFrame.midX - startWidth / 2
             let y = visibleFrame.midY - startHeight / 2

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -34,7 +34,8 @@ struct WakeUpStepView: View {
         VStack(spacing: VSpacing.md) {
             if managedSignInEnabled {
                 OnboardingVellumCloudCard(
-                    isLoading: authManager?.isLoading == true || authManager?.isSubmitting == true,
+                    isLoading: authManager?.isLoading == true,
+                    isSubmitting: authManager?.isSubmitting == true,
                     isDisabled: isAdvancing,
                     onContinue: { onContinueWithVellum() }
                 )


### PR DESCRIPTION
## Summary
Bundled remediation of gaps surfaced during self-review for the `onboarding-setup-cards` plan.

Fixes:
- **Window minimums propagated.** `OnboardingFlowView` declared `.frame(minWidth: 440, minHeight: 720)` in PR 3 but both window hosts (`OnboardingWindow`, `AppDelegate+AuthLifecycle`) still used the old 630/620 numbers, so the ScrollView would engage in the expanded Advanced state. `OnboardingWindow` now uses 720 everywhere; `AppDelegate+AuthLifecycle` is conditional so the reauth flow (`ReauthView`) keeps its original 460×620 while the full-onboarding path uses 460×720 / 440×720.
- **Loading label regression.** The card collapsed `isLoading` (session check → "Checking…") and `isSubmitting` (active WorkOS login → "Logging in…") into one `isLoading: Bool`. Restored the pre-refactor label differentiation via a new `isSubmitting` prop.
- **Benefits a11y.** Wrapped the benefits `VStack` with `accessibilityElement(children: .contain)` + `accessibilityLabel(Text("Vellum Cloud benefits"))` and added `.accessibilityLabel(Text(text))` on each row, per the plan spec.
- **`@MainActor` on both new subviews.** Every other view in `Features/Onboarding/` is explicitly `@MainActor`; matching that convention.
- **Disclosure trailing padding.** Reverted from `VSpacing.lg` back to `VSpacing.md` per the plan's asymmetric inset spec.

Part of plan: `onboarding-setup-cards.md` (self-review remediation round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
