### PR TITLE
fix(tts-xai): disable voice-selection UI until persistence is wired

### DIFF
--- a/clients/shared/Utilities/TTSProviderRegistry.swift
+++ b/clients/shared/Utilities/TTSProviderRegistry.swift
@@ -212,7 +212,7 @@ private let fallbackRegistry = TTSProviderRegistry(
             credentialMode: .credential,
             credentialNamespace: "xai",
             apiKeyProviderName: nil,
-            supportsVoiceSelection: true,
+            supportsVoiceSelection: false,
             credentialsGuide: TTSCredentialsGuide(
                 description: "Sign in to the xAI console, navigate to API Keys, and create a new key.",
                 url: "https://console.x.ai/",

--- a/meta/tts-provider-catalog.json
+++ b/meta/tts-provider-catalog.json
@@ -54,7 +54,7 @@
       "setupHint": "Run the setup commands in your terminal to configure xAI credentials.",
       "credentialMode": "credential",
       "credentialNamespace": "xai",
-      "supportsVoiceSelection": true,
+      "supportsVoiceSelection": false,
       "credentialsGuide": {
         "description": "Sign in to the xAI console, navigate to API Keys, and create a new key.",
         "url": "https://console.x.ai/",


### PR DESCRIPTION
Addresses review feedback on #26887.

The xAI catalog entry set `supportsVoiceSelection: true`, which caused the macOS settings UI to render a Voice ID field, but `saveTTS()` and `storedVoiceId(for:)` in `VoiceSettingsView` only handle `elevenlabs` and `fish-audio` — any value the user typed would be dropped on save and empty on reload. Setting it to `false` hides the broken UI until voice-id persistence is wired end-to-end.

Updated both the canonical `meta/tts-provider-catalog.json` and the Swift fallback catalog in `TTSProviderRegistry.swift`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
