### PR TITLE
fix(permissions): resolve subcommands for CLIs with global value flags (gh, docker, npm)

### DIFF
--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -411,6 +411,38 @@ describe("subcommand resolution", () => {
     });
     expect(result.riskLevel).toBe("high");
   });
+
+  test("gh --repo owner/repo pr merge 123 → high (resolves past --repo value flag)", async () => {
+    const result = await classifier.classify({
+      command: "gh --repo owner/repo pr merge 123",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("docker --host tcp://remote:2375 rm container1 → high (resolves past --host value flag)", async () => {
+    const result = await classifier.classify({
+      command: "docker --host tcp://remote:2375 rm container1",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("npm --prefix /some/path test → high (resolves past --prefix value flag)", async () => {
+    const result = await classifier.classify({
+      command: "npm --prefix /some/path test",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("gh pr view 123 → low (no global flags, still works)", async () => {
+    const result = await classifier.classify({
+      command: "gh pr view 123",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
 });
 
 // ── Wrapper unwrapping ───────────────────────────────────────────────────────

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -173,17 +173,6 @@ function getWrappedProgramWithArgs(seg: {
   return undefined;
 }
 
-// ── Git value flags (for subcommand extraction) ──────────────────────────────
-const GIT_VALUE_FLAGS = new Set([
-  "-C",
-  "-c",
-  "--git-dir",
-  "--work-tree",
-  "--namespace",
-  "--super-prefix",
-  "--config-env",
-]);
-
 /**
  * Extract the first positional (non-flag) arg, skipping value-consuming flags.
  */
@@ -220,14 +209,14 @@ const RM_SAFE_BARE_FILES = new Set(["BOOTSTRAP.md", "UPDATES.md"]);
 function resolveSubcommand(
   spec: CommandRiskSpec,
   args: string[],
-  program: string,
 ): { spec: CommandRiskSpec; remainingArgs: string[] } {
   if (!spec.subcommands || args.length === 0) {
     return { spec, remainingArgs: args };
   }
 
-  // For git, skip global flags that consume a value
-  const valueFlags = program === "git" ? GIT_VALUE_FLAGS : undefined;
+  const valueFlags = spec.globalValueFlags
+    ? new Set(spec.globalValueFlags)
+    : undefined;
   const subcommandName = firstPositionalArg(args, valueFlags);
 
   if (!subcommandName || !spec.subcommands[subcommandName]) {
@@ -239,7 +228,7 @@ function resolveSubcommand(
   const remainingArgs = args.slice(subIdx + 1);
 
   // Recurse for nested subcommands (e.g., git stash drop, gh pr view)
-  return resolveSubcommand(subSpec, remainingArgs, subcommandName);
+  return resolveSubcommand(subSpec, remainingArgs);
 }
 
 /**
@@ -338,7 +327,7 @@ export function classifySegment(
 
   // 4. Subcommand resolution
   const { spec: resolvedSpec, remainingArgs: _remainingArgs } =
-    resolveSubcommand(spec, segment.args, programName);
+    resolveSubcommand(spec, segment.args);
 
   // 5. Evaluate arg rules
   //

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -254,6 +254,15 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // Divergences are noted inline.
   git: {
     baseRisk: "medium",
+    globalValueFlags: [
+      "-C",
+      "-c",
+      "--git-dir",
+      "--work-tree",
+      "--namespace",
+      "--super-prefix",
+      "--config-env",
+    ],
     subcommands: {
       // LOW_RISK_GIT_SUBCOMMANDS from checker.ts:
       status: { baseRisk: "low" },
@@ -348,6 +357,7 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // they download and execute code, with subcommand-level overrides.
   npm: {
     baseRisk: "medium",
+    globalValueFlags: ["--prefix", "--userconfig", "--globalconfig", "--cache"],
     subcommands: {
       ls: { baseRisk: "low" },
       list: { baseRisk: "low" },
@@ -510,6 +520,15 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // ── Docker ─────────────────────────────────────────────────────────────────
   docker: {
     baseRisk: "medium",
+    globalValueFlags: [
+      "--host",
+      "-H",
+      "--config",
+      "--context",
+      "-c",
+      "--log-level",
+      "-l",
+    ],
     subcommands: {
       ps: { baseRisk: "low" },
       images: { baseRisk: "low" },
@@ -708,6 +727,7 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // ── Version control tools ──────────────────────────────────────────────────
   gh: {
     baseRisk: "low",
+    globalValueFlags: ["--repo", "-R"],
     subcommands: {
       pr: {
         baseRisk: "low",

--- a/assistant/src/permissions/risk-types.ts
+++ b/assistant/src/permissions/risk-types.ts
@@ -139,6 +139,12 @@ export interface CommandRiskSpec {
   complexSyntax?: boolean;
   /** Human-readable reason for the base risk (shown when no arg rule matches). */
   reason?: string;
+  /**
+   * Global flags that consume the next token as a value (e.g. git -C <path>).
+   * Used by resolveSubcommand to skip past flag-value pairs when locating the
+   * first positional arg (the subcommand name).
+   */
+  globalValueFlags?: string[];
 }
 
 // ── User rule types ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add globalValueFlags field to CommandRiskSpec and populate for git, gh, docker, npm
- Wire resolveSubcommand to read globalValueFlags from spec instead of hardcoded git check
- Remove GIT_VALUE_FLAGS constant; add test coverage for gh, docker, npm subcommand resolution

Part of plan: risk-classifier-phase2-fixes.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
