### PR TITLE
chore(permissions): add TODO for scope-option system consolidation in Phase 3

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -759,6 +759,10 @@ function shellAllowlistStrategy(
   input: Record<string, unknown>,
 ): Promise<AllowlistOption[]> {
   const command = ((input.command as string) ?? "").trim();
+  // TODO(phase-3): Wire RiskAssessment.scopeOptions into permission prompts
+  // and retire buildShellAllowlistOptions + buildShellCommandCandidates from
+  // shell-identity.ts. The classifier's generateScopeOptions produces the
+  // canonical scope ladder; this legacy path should not diverge further.
   return buildShellAllowlistOptions(command);
 }
 


### PR DESCRIPTION
## Summary
- Add TODO(phase-3) comment at buildShellAllowlistOptions usage site documenting plan to consolidate scope-option systems

Part of plan: risk-classifier-phase2-fixes.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
