### PR TITLE
fix(permissions): escalate variable expansion from computed risk, not baseRisk

### DIFF
--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -630,6 +630,17 @@ describe("variable expansion", () => {
     // echo baseRisk is low, no arg rules match, escalateOne(low) = medium
     expect(result.riskLevel).toBe("medium");
   });
+
+  test("curl http://localhost:$PORT → high (baseRisk=medium is floor for escalation after de-escalation)", async () => {
+    const result = await classifier.classify({
+      command: "curl http://localhost:$PORT",
+      toolName: "bash",
+    });
+    // curl baseRisk=medium, curl:localhost arg rule de-escalates to low,
+    // but variable expansion uses max(computedRisk=low, baseRisk=medium)=medium
+    // as the floor, so escalateOne(medium) = high
+    expect(result.riskLevel).toBe("high");
+  });
 });
 
 // ── Assistant subcommand classification ──────────────────────────────────────

--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -611,6 +611,25 @@ describe("variable expansion", () => {
     });
     expect(result.riskLevel).toBe("medium");
   });
+
+  test("sed -i $VAR → arg rule raises to medium, $VAR escalates to high", async () => {
+    const result = await classifier.classify({
+      command: "sed -i $PATTERN file.txt",
+      toolName: "bash",
+    });
+    // sed baseRisk is low, -i flag raises to medium via sed:inplace rule,
+    // then $PATTERN escalateOne(medium) = high
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("echo $VAR → low with no arg rule match, $VAR escalates to medium (unchanged behavior)", async () => {
+    const result = await classifier.classify({
+      command: "echo $SOMETHING",
+      toolName: "bash",
+    });
+    // echo baseRisk is low, no arg rules match, escalateOne(low) = medium
+    expect(result.riskLevel).toBe("medium");
+  });
 });
 
 // ── Assistant subcommand classification ──────────────────────────────────────

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -430,7 +430,7 @@ export function classifySegment(
 
   // 6. Check for variable expansion in args (conservative escalation)
   if (segment.args.some((a) => a.includes("$"))) {
-    const escalated = escalateOne(resolvedSpec.baseRisk);
+    const escalated = escalateOne(risk);
     if (riskOrd(escalated) > riskOrd(risk)) {
       risk = escalated;
       reason = `${segment.program} with variable expansion`;

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -429,8 +429,13 @@ export function classifySegment(
   }
 
   // 6. Check for variable expansion in args (conservative escalation)
+  // Use max(computedRisk, baseRisk) as the floor for escalation so that
+  // de-escalated commands still escalate from at least baseRisk.
+  // Example: `curl http://localhost:$PORT` — arg rule de-escalates to low,
+  // but baseRisk=medium is the floor, so escalateOne(medium) → high.
   if (segment.args.some((a) => a.includes("$"))) {
-    const escalated = escalateOne(risk);
+    const escalationBase = maxRisk(risk, resolvedSpec.baseRisk);
+    const escalated = escalateOne(escalationBase);
     if (riskOrd(escalated) > riskOrd(risk)) {
       risk = escalated;
       reason = `${segment.program} with variable expansion`;


### PR DESCRIPTION
## Summary
- Change escalateOne call to use current computed risk instead of resolvedSpec.baseRisk
- Add test: sed -i $PATTERN escalates from medium (arg-rule) to high (var expansion)
- Add test: low-risk command with $VAR escalates to medium (existing behavior preserved)

Part of plan: risk-classifier-phase2-fixes.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
