### PR TITLE
chore(permissions): address Phase 2 nits — riskOrd fallback, regex cache, go comment

### DIFF
--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -13,6 +13,7 @@ mock.module("../util/logger.js", () => ({
 
 import {
   BashRiskClassifier,
+  clearCompiledPatterns,
   escalateOne,
   matchesArgRule,
   maxRisk,
@@ -1029,5 +1030,35 @@ describe("riskToRiskLevel", () => {
 
   test("unknown → RiskLevel.Medium (fallback)", () => {
     expect(riskToRiskLevel("unknown")).toBe(RiskLevel.Medium);
+  });
+});
+
+// ── Go subcommand classification ──────────────────────────────────────────────
+
+describe("go subcommand classification", () => {
+  const classifier = makeClassifier();
+
+  test("go get github.com/pkg → medium", async () => {
+    const result = await classifier.classify({
+      command: "go get github.com/pkg",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+  });
+
+  test("go generate ./... → high", async () => {
+    const result = await classifier.classify({
+      command: "go generate ./...",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+});
+
+// ── clearCompiledPatterns smoke test ──────────────────────────────────────────
+
+describe("clearCompiledPatterns", () => {
+  test("runs without error", () => {
+    expect(() => clearCompiledPatterns()).not.toThrow();
   });
 });

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -47,7 +47,7 @@ const RISK_ORD: Record<Risk, number> = {
  * known-medium one, but not as definitive as a known-high one.
  */
 export function riskOrd(risk: Risk): number {
-  return RISK_ORD[risk] ?? 2; // default to unknown
+  return RISK_ORD[risk];
 }
 
 /** Return the higher of two risk levels. */
@@ -82,6 +82,11 @@ function getCompiledPattern(pattern: string): RegExp {
     compiledPatterns.set(pattern, re);
   }
   return re;
+}
+
+/** Clear the compiled regex cache. Exposed for tests and hot-swap scenarios. */
+export function clearCompiledPatterns(): void {
+  compiledPatterns.clear();
 }
 
 // ── Arg rule matching ────────────────────────────────────────────────────────

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -496,6 +496,8 @@ export const DEFAULT_COMMAND_REGISTRY = {
   },
   ruby: { baseRisk: "high", reason: "Executes arbitrary Ruby code" },
   go: {
+    // baseRisk is low (unlike npm's medium) because bare `go` prints help.
+    // Dangerous subcommands (run, test, generate, get) are handled individually.
     baseRisk: "low",
     subcommands: {
       mod: { baseRisk: "low" },
@@ -504,6 +506,15 @@ export const DEFAULT_COMMAND_REGISTRY = {
       build: { baseRisk: "medium" },
       test: { baseRisk: "high", reason: "Executes arbitrary test code" },
       run: { baseRisk: "high", reason: "Compiles and executes Go code" },
+      get: {
+        baseRisk: "medium",
+        reason:
+          "Downloads and installs packages; can execute arbitrary code via install hooks",
+      },
+      generate: {
+        baseRisk: "high",
+        reason: "Runs arbitrary commands via //go:generate directives",
+      },
     },
   },
 


### PR DESCRIPTION
## Summary
- Remove dead-code riskOrd ?? 2 fallback
- Export clearCompiledPatterns() for test/hot-swap cache clearing
- Add go get/generate subcommands and comment explaining go vs npm base risk asymmetry

Part of plan: risk-classifier-phase2-fixes.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
