### PR TITLE
fix(permissions): allow benign flags in rm safe-file downgrade

### DIFF
--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -967,9 +967,35 @@ describe("rm safe-file downgrade", () => {
     expect(result.riskLevel).toBe("high");
   });
 
-  test("rm -f BOOTSTRAP.md with toolName bash → high (has flags, no downgrade)", async () => {
+  test("rm -f BOOTSTRAP.md with toolName bash → medium (benign flag, safe file)", async () => {
     const result = await classifier.classify({
       command: "rm -f BOOTSTRAP.md",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+    expect(result.reason).toContain("BOOTSTRAP.md");
+  });
+
+  test("rm -v UPDATES.md with toolName bash → medium (benign flag)", async () => {
+    const result = await classifier.classify({
+      command: "rm -v UPDATES.md",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+    expect(result.reason).toContain("UPDATES.md");
+  });
+
+  test("rm -fi BOOTSTRAP.md with toolName bash → high (combined flag not in benign set)", async () => {
+    const result = await classifier.classify({
+      command: "rm -fi BOOTSTRAP.md",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("rm -rf BOOTSTRAP.md with toolName bash → high (-rf not benign)", async () => {
+    const result = await classifier.classify({
+      command: "rm -rf BOOTSTRAP.md",
       toolName: "bash",
     });
     expect(result.riskLevel).toBe("high");

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -207,6 +207,17 @@ function firstPositionalArg(
 // High) in sandboxed bash. Matches checker.ts isRmOfKnownSafeFile behavior.
 const RM_SAFE_BARE_FILES = new Set(["BOOTSTRAP.md", "UPDATES.md"]);
 
+// Flags that don't affect rm safety — they don't enable recursive deletion or
+// change which files are targeted.
+const RM_BENIGN_FLAGS = new Set([
+  "-f",
+  "-i",
+  "-v",
+  "--force",
+  "--interactive",
+  "--verbose",
+]);
+
 // ── Segment classification ───────────────────────────────────────────────────
 
 /**
@@ -438,24 +449,24 @@ export function classifySegment(
   }
 
   // 7. rm safe-file downgrade (sandbox only)
-  // When rm targets a single known safe bare file (no flags, no path separators),
+  // When rm targets a single known safe bare file (with only benign flags),
   // downgrade to medium in sandboxed bash. host_bash keeps high because it has a
   // global ask rule that would prompt medium-risk commands. Matches checker.ts
   // isRmOfKnownSafeFile + toolName guard.
-  if (
-    programName === "rm" &&
-    toolName === "bash" &&
-    risk === "high" &&
-    segment.args.length === 1
-  ) {
-    const target = segment.args[0];
+  if (programName === "rm" && toolName === "bash" && risk === "high") {
+    // Strip benign flags (-f, -i, -v) and check if exactly one bare filename remains
+    const positionalArgs = segment.args.filter((a) => !a.startsWith("-"));
+    const flagArgs = segment.args.filter((a) => a.startsWith("-"));
+    const allFlagsBenign = flagArgs.every((f) => RM_BENIGN_FLAGS.has(f));
+
     if (
-      !target.startsWith("-") &&
-      !target.includes("/") &&
-      RM_SAFE_BARE_FILES.has(target)
+      positionalArgs.length === 1 &&
+      allFlagsBenign &&
+      !positionalArgs[0].includes("/") &&
+      RM_SAFE_BARE_FILES.has(positionalArgs[0])
     ) {
       risk = "medium";
-      reason = `rm of known safe file: ${target}`;
+      reason = `rm of known safe file: ${positionalArgs[0]}`;
     }
   }
 


### PR DESCRIPTION
## Summary
- Add RM_BENIGN_FLAGS constant for flags that don't affect rm safety (-f, -i, -v)
- Refactor rm safe-file downgrade to allow benign flags while keeping combined flags like -rf at high risk
- Add test coverage for benign flags, combined flags, and regression cases

Part of plan: risk-classifier-phase2-fixes.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
