### PR TITLE
fix(macos): optimistically mark subagent as aborted on Abort click so stuck UI self-heals

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -381,7 +381,7 @@ struct ChatView: View {
                 onInspectMessage: onInspectMessage,
                 mediaEmbedSettings: mediaEmbedSettings,
                 onAbortSubagent: { subagentId in
-                    Task { await SubagentClient().abort(subagentId: subagentId, conversationId: viewModel.conversationId) }
+                    Task { await viewModel.abortSubagent(subagentId) }
                 },
                 onSubagentTap: onSubagentTap,
                 onRehydrateMessage: { messageId in viewModel.rehydrateMessage(id: messageId) },

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -493,7 +493,7 @@ extension MainWindowView {
                         viewModel: viewModel,
                         detailStore: viewModel.subagentDetailStore,
                         showInspectButton: assistantFeatureFlagStore.isEnabled("settings-developer-nav"),
-                        onAbort: { Task { await SubagentClient().abort(subagentId: subagentId, conversationId: viewModel.conversationId) } },
+                        onAbort: { Task { await viewModel.abortSubagent(subagentId) } },
                         onRequestDetail: {
                             if let conversationId = viewModel.activeSubagents.first(where: { $0.id == subagentId })?.conversationId {
                                 Task {

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1880,7 +1880,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.activeSubagents = [
             SubagentInfo(id: "s1", label: "Test", status: .running)
         ]
-        let client = FakeSubagentClient(abortResult: false) // simulates 404 / already-terminal
+        let client = FakeSubagentClient(abortResult: .alreadyTerminal) // simulates 404 / already-terminal
         await viewModel.abortSubagent("s1", client: client)
         XCTAssertEqual(viewModel.activeSubagents.first?.status, .aborted)
     }
@@ -1889,7 +1889,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.activeSubagents = [
             SubagentInfo(id: "s1", label: "Test", status: .running)
         ]
-        let client = FakeSubagentClient(abortResult: true)
+        let client = FakeSubagentClient(abortResult: .success)
         await viewModel.abortSubagent("s1", client: client)
         XCTAssertEqual(viewModel.activeSubagents.first?.status, .aborted)
     }
@@ -1898,10 +1898,22 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.activeSubagents = [
             SubagentInfo(id: "s1", label: "Test", status: .completed)
         ]
-        let client = FakeSubagentClient(abortResult: false)
+        let client = FakeSubagentClient(abortResult: .alreadyTerminal)
         await viewModel.abortSubagent("s1", client: client)
         // If the daemon already sent `completed`, don't clobber it to `aborted`.
         XCTAssertEqual(viewModel.activeSubagents.first?.status, .completed)
+    }
+
+    func testAbortSubagentLeavesRunningOnNetworkFailure() async throws {
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s1", label: "Test", status: .running)
+        ]
+        let client = FakeSubagentClient(abortResult: .failed)
+        await viewModel.abortSubagent("s1", client: client)
+        // On a genuine failure (network, timeout, 5xx, non-404 client error)
+        // the subagent is possibly still running — do NOT flip the local entry
+        // to `.aborted`, otherwise the UI hides the Abort button and blocks retry.
+        XCTAssertEqual(viewModel.activeSubagents.first?.status, .running)
     }
 
     // MARK: - History Attachment Hydration
@@ -3410,8 +3422,8 @@ final class MockConversationQueueClient: ConversationQueueClientProtocol, @unche
 }
 
 private struct FakeSubagentClient: SubagentClientProtocol {
-    let abortResult: Bool
-    func abort(subagentId: String, conversationId: String?) async -> Bool { abortResult }
+    let abortResult: SubagentAbortResult
+    func abort(subagentId: String, conversationId: String?) async -> SubagentAbortResult { abortResult }
     func fetchDetail(subagentId: String, conversationId: String) async -> SubagentDetailResponse? { nil }
     func sendMessage(subagentId: String, content: String, conversationId: String?) async -> Bool { true }
 }

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1874,6 +1874,36 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.count, 0)
     }
 
+    // MARK: - Subagent Abort
+
+    func testAbortSubagentMarksLocalAsAbortedOn404() async throws {
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s1", label: "Test", status: .running)
+        ]
+        let client = FakeSubagentClient(abortResult: false) // simulates 404 / already-terminal
+        await viewModel.abortSubagent("s1", client: client)
+        XCTAssertEqual(viewModel.activeSubagents.first?.status, .aborted)
+    }
+
+    func testAbortSubagentMarksLocalAsAbortedOnSuccess() async throws {
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s1", label: "Test", status: .running)
+        ]
+        let client = FakeSubagentClient(abortResult: true)
+        await viewModel.abortSubagent("s1", client: client)
+        XCTAssertEqual(viewModel.activeSubagents.first?.status, .aborted)
+    }
+
+    func testAbortSubagentDoesNotDowngradeTerminalStatus() async throws {
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s1", label: "Test", status: .completed)
+        ]
+        let client = FakeSubagentClient(abortResult: false)
+        await viewModel.abortSubagent("s1", client: client)
+        // If the daemon already sent `completed`, don't clobber it to `aborted`.
+        XCTAssertEqual(viewModel.activeSubagents.first?.status, .completed)
+    }
+
     // MARK: - History Attachment Hydration
 
     func testPopulateFromHistoryHydratesAssistantAttachments() {
@@ -3377,4 +3407,11 @@ final class MockConversationQueueClient: ConversationQueueClientProtocol, @unche
         }
         return deleteResult
     }
+}
+
+private struct FakeSubagentClient: SubagentClientProtocol {
+    let abortResult: Bool
+    func abort(subagentId: String, conversationId: String?) async -> Bool { abortResult }
+    func fetchDetail(subagentId: String, conversationId: String) async -> SubagentDetailResponse? { nil }
+    func sendMessage(subagentId: String, content: String, conversationId: String?) async -> Bool { true }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -481,19 +481,32 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         get { messageManager.activeSubagents }
         set { messageManager.activeSubagents = newValue }
     }
-    /// Invoke the daemon's abort endpoint for a subagent, then optimistically
-    /// mark the local entry as `.aborted` regardless of the HTTP result.
+    /// Invoke the daemon's abort endpoint for a subagent and optimistically
+    /// mark the local entry as `.aborted` when the daemon confirms the
+    /// subagent is no longer running.
+    ///
     /// Rationale: LUM-1062. The daemon pushes terminal status via SSE, but
     /// that event can be lost on reconnect, leaving the UI stuck showing a
-    /// running subagent that cannot actually be aborted. Optimistic local
-    /// reconciliation unsticks the UI immediately; if the subagent is in
-    /// fact still running, the next `subagentStatusChanged` from the daemon
-    /// re-asserts the real status in place.
+    /// running subagent that cannot actually be aborted. When the abort HTTP
+    /// call returns 2xx or 404, we know the daemon has no live subagent for
+    /// this id, so local reconciliation unsticks the UI immediately; if the
+    /// subagent is in fact still running, the next `subagentStatusChanged`
+    /// from the daemon re-asserts the real status in place.
+    ///
+    /// On genuine failure (network error, timeout, 5xx, non-404 client
+    /// error) we do NOT mutate the local status — the subagent is possibly
+    /// still running and the Abort button must remain available for retry.
     public func abortSubagent(_ subagentId: String, client: SubagentClientProtocol = SubagentClient()) async {
-        _ = await client.abort(subagentId: subagentId, conversationId: conversationId)
-        if let index = activeSubagents.firstIndex(where: { $0.id == subagentId }),
-           !activeSubagents[index].status.isTerminal {
-            activeSubagents[index].status = .aborted
+        let result = await client.abort(subagentId: subagentId, conversationId: conversationId)
+        switch result {
+        case .success, .alreadyTerminal:
+            if let index = activeSubagents.firstIndex(where: { $0.id == subagentId }),
+               !activeSubagents[index].status.isTerminal {
+                activeSubagents[index].status = .aborted
+            }
+        case .failed:
+            // Leave the entry as-is so the Abort button stays available for retry.
+            break
         }
     }
     /// Widget IDs dismissed by the user, persisted across view recreation.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -481,6 +481,21 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         get { messageManager.activeSubagents }
         set { messageManager.activeSubagents = newValue }
     }
+    /// Invoke the daemon's abort endpoint for a subagent, then optimistically
+    /// mark the local entry as `.aborted` regardless of the HTTP result.
+    /// Rationale: LUM-1062. The daemon pushes terminal status via SSE, but
+    /// that event can be lost on reconnect, leaving the UI stuck showing a
+    /// running subagent that cannot actually be aborted. Optimistic local
+    /// reconciliation unsticks the UI immediately; if the subagent is in
+    /// fact still running, the next `subagentStatusChanged` from the daemon
+    /// re-asserts the real status in place.
+    public func abortSubagent(_ subagentId: String, client: SubagentClientProtocol = SubagentClient()) async {
+        _ = await client.abort(subagentId: subagentId, conversationId: conversationId)
+        if let index = activeSubagents.firstIndex(where: { $0.id == subagentId }),
+           !activeSubagents[index].status.isTerminal {
+            activeSubagents[index].status = .aborted
+        }
+    }
     /// Widget IDs dismissed by the user, persisted across view recreation.
     public var dismissedDocumentSurfaceIds: Set<String> {
         get { messageManager.dismissedDocumentSurfaceIds }

--- a/clients/shared/Network/SubagentClient.swift
+++ b/clients/shared/Network/SubagentClient.swift
@@ -3,9 +3,29 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "SubagentClient")
 
+/// Outcome of a subagent abort request.
+///
+/// The distinction between `.alreadyTerminal` and `.failed` matters because
+/// the UI uses it to decide whether to optimistically mark the local entry
+/// as `.aborted`:
+/// - `.success` and `.alreadyTerminal` are both positive signals that the
+///   subagent is not running (or no longer running) on the daemon.
+/// - `.failed` means we genuinely don't know — the abort didn't land, so the
+///   subagent may still be running, and the Abort button should remain
+///   available for retry.
+public enum SubagentAbortResult: Equatable, Sendable {
+    /// HTTP 2xx — daemon acknowledged the abort request.
+    case success
+    /// HTTP 404 — daemon has no live subagent for this id (already terminal or unknown).
+    /// From the client's POV this is a success signal: the subagent is definitely not running anymore.
+    case alreadyTerminal
+    /// Any other outcome (network error, 5xx, non-404 client error). The abort did NOT land.
+    case failed
+}
+
 /// Focused client for subagent operations routed through the gateway.
 public protocol SubagentClientProtocol {
-    func abort(subagentId: String, conversationId: String?) async -> Bool
+    func abort(subagentId: String, conversationId: String?) async -> SubagentAbortResult
     func fetchDetail(subagentId: String, conversationId: String) async -> SubagentDetailResponse?
     func sendMessage(subagentId: String, content: String, conversationId: String?) async -> Bool
 }
@@ -14,7 +34,7 @@ public protocol SubagentClientProtocol {
 public struct SubagentClient: SubagentClientProtocol {
     nonisolated public init() {}
 
-    public func abort(subagentId: String, conversationId: String? = nil) async -> Bool {
+    public func abort(subagentId: String, conversationId: String? = nil) async -> SubagentAbortResult {
         do {
             var body: [String: Any] = [:]
             if let conversationId { body["conversationId"] = conversationId }
@@ -24,14 +44,20 @@ public struct SubagentClient: SubagentClientProtocol {
                 json: body,
                 timeout: 10
             )
-            guard response.isSuccess else {
-                log.error("abort failed (HTTP \(response.statusCode))")
-                return false
+            if response.isSuccess {
+                return .success
             }
-            return true
+            if response.statusCode == 404 {
+                // Daemon reports no live subagent for this id — either unknown
+                // or already in a terminal state. Treated as a success signal.
+                log.info("abort returned 404 — subagent already terminal or unknown")
+                return .alreadyTerminal
+            }
+            log.error("abort failed (HTTP \(response.statusCode))")
+            return .failed
         } catch {
             log.error("abort error: \(error.localizedDescription)")
-            return false
+            return .failed
         }
     }
 


### PR DESCRIPTION
## Summary
- New `ChatViewModel.abortSubagent(_:client:)` helper POSTs the abort then optimistically marks the local entry `.aborted` (only if not already terminal).
- Both abort callsites (`PanelCoordinator` side panel + `ChatView` inline chip) now go through the helper.
- Adds `SubagentClientProtocol`-based `FakeSubagentClient` and three unit tests covering 404, success, and don't-downgrade-terminal cases.

Part of LUM-1062.
Part of plan: lum-1062-unstick-subagent-ui.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
