### PR TITLE
fix(macos): clear stuck "Compacting context…" indicator when user initiates a send

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -107,6 +107,15 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.errorText)
     }
 
+    func testSendUserMessageClearsStuckCompactingFlag() {
+        viewModel.conversationId = "conv-1"
+        viewModel.isCompacting = true
+        viewModel.inputText = "hello"
+        viewModel.sendMessage()
+        XCTAssertFalse(viewModel.isCompacting,
+                       "Sending a user message must clear a stranded compaction indicator (LUM-1062)")
+    }
+
     func testClearingInputRestoresExistingSuggestion() {
         viewModel.suggestion = "Summarize the last response"
 

--- a/clients/shared/Features/Chat/MessageSendCoordinator.swift
+++ b/clients/shared/Features/Chat/MessageSendCoordinator.swift
@@ -457,6 +457,12 @@ final class MessageSendCoordinator {
             return
         }
 
+        // LUM-1062: The compaction indicator is cleared by a non-`aux` messageComplete
+        // or by a later `assistantActivityState` with a non-compacting reason. If both
+        // of those events are lost (reconnect race, replay gap), the indicator is
+        // stranded — but a user actively typing a new message is ground truth that
+        // compaction is no longer in progress, so clear it here defensively.
+        messageManager.isCompacting = false
         messageManager.isSending = true
         // Only show "Thinking" for the primary send. Queued messages will
         // set isThinking = true when they are dequeued for processing.


### PR DESCRIPTION
## Summary
- In `MessageSendCoordinator.sendUserMessage`, defensively clear `messageManager.isCompacting` once we've passed the offline-queue early return and are about to mark `isSending = true`.
- Adds a unit test that asserts a stranded `isCompacting=true` is cleared by sending a new user message.

Part of LUM-1062.
Part of plan: lum-1062-unstick-subagent-ui.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
