### PR TITLE
fix(macos): overwrite stale local subagent status with history-derived terminal status

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1928,9 +1928,14 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.activeSubagents = [
             SubagentInfo(id: "s-stuck", label: "Stuck", status: .running)
         ]
+        // Non-empty text required: HistoryReconstructionService.reconstructMessages
+        // skips items with empty text/no tool calls/no attachments/no surfaces/no
+        // thinking BEFORE reading `subagentNotification`, so an empty-text fixture
+        // never reaches the reconcile branch. Real subagent-notification messages
+        // from the daemon carry non-empty notification text.
         let historyItems: [HistoryResponseMessage] = [
             HistoryResponseMessage(
-                id: nil, role: "assistant", text: "", timestamp: 1000,
+                id: nil, role: "assistant", text: "subagent notification", timestamp: 1000,
                 toolCalls: nil, toolCallsBeforeText: nil, attachments: nil,
                 textSegments: nil, thinkingSegments: nil, contentOrder: nil, surfaces: nil,
                 subagentNotification: HistoryResponseMessageSubagentNotification(
@@ -1951,9 +1956,11 @@ final class ChatViewModelTests: XCTestCase {
             SubagentInfo(id: "s-live", label: "Live", status: .running, parentMessageId: UUID())
         ]
         let originalParentId = viewModel.activeSubagents[0].parentMessageId
+        // Non-empty text required: reconstructMessages skips empty-text entries
+        // before reading `subagentNotification`.
         let historyItems: [HistoryResponseMessage] = [
             HistoryResponseMessage(
-                id: nil, role: "assistant", text: "", timestamp: 1000,
+                id: nil, role: "assistant", text: "subagent notification", timestamp: 1000,
                 toolCalls: nil, toolCallsBeforeText: nil, attachments: nil,
                 textSegments: nil, thinkingSegments: nil, contentOrder: nil, surfaces: nil,
                 subagentNotification: HistoryResponseMessageSubagentNotification(
@@ -1982,9 +1989,11 @@ final class ChatViewModelTests: XCTestCase {
             SubagentInfo(id: "s-done", label: "Done", status: .completed)
         ]
         XCTAssertNil(viewModel.activeSubagents.first(where: { $0.id == "s-done" })?.conversationId)
+        // Non-empty text required: reconstructMessages skips empty-text entries
+        // before reading `subagentNotification`.
         let historyItems: [HistoryResponseMessage] = [
             HistoryResponseMessage(
-                id: nil, role: "assistant", text: "", timestamp: 1000,
+                id: nil, role: "assistant", text: "subagent notification", timestamp: 1000,
                 toolCalls: nil, toolCallsBeforeText: nil, attachments: nil,
                 textSegments: nil, thinkingSegments: nil, contentOrder: nil, surfaces: nil,
                 subagentNotification: HistoryResponseMessageSubagentNotification(
@@ -1996,6 +2005,55 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.populateFromHistory(historyItems, hasMore: false)
         XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-done" })?.conversationId, "sub-conv-done",
                        "populateFromHistory must backfill conversationId onto an existing local entry")
+    }
+
+    func testPopulateFromHistoryBackfillsParentMessageIdOnExistingEntry() {
+        // Seed a local entry that has no parentMessageId — simulates a live
+        // spawn event that was lost (or never populated that field), leaving
+        // the detail-panel chip with nowhere to anchor.
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s-orphan", label: "Orphan", status: .running)
+        ]
+        XCTAssertNil(viewModel.activeSubagents.first(where: { $0.id == "s-orphan" })?.parentMessageId)
+
+        // History must contain TWO messages:
+        //   1. An assistant message with a `subagent_spawn` tool call whose
+        //      result JSON includes `subagentId`. `HistoryReconstructionService`
+        //      records this message's UUID in `spawnParentMap[subagentId]`.
+        //   2. A subsequent assistant message with a matching
+        //      `subagentNotification`. The reconstructed `SubagentInfo` picks
+        //      up `parentMessageId` from `spawnParentMap`.
+        //
+        // The first message needs a stable UUID so the test can assert that
+        // the local entry's `parentMessageId` matches it post-reconcile.
+        let parentId = UUID()
+        let spawnToolCall = HistoryResponseToolCall(
+            name: "subagent_spawn",
+            input: ["task": AnyCodable("do a thing")],
+            result: "{\"subagentId\": \"s-orphan\"}",
+            isError: nil
+        )
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(
+                id: parentId.uuidString, role: "assistant", text: "spawning subagent",
+                timestamp: 1000, toolCalls: [spawnToolCall], toolCallsBeforeText: nil,
+                attachments: nil, textSegments: nil, thinkingSegments: nil,
+                contentOrder: nil, surfaces: nil, subagentNotification: nil
+            ),
+            HistoryResponseMessage(
+                id: nil, role: "assistant", text: "subagent notification",
+                timestamp: 1100, toolCalls: nil, toolCallsBeforeText: nil,
+                attachments: nil, textSegments: nil, thinkingSegments: nil,
+                contentOrder: nil, surfaces: nil,
+                subagentNotification: HistoryResponseMessageSubagentNotification(
+                    subagentId: "s-orphan", label: "Orphan", status: "running",
+                    error: nil, conversationId: "sub-conv-orphan"
+                )
+            ),
+        ]
+        viewModel.populateFromHistory(historyItems, hasMore: false)
+        XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-orphan" })?.parentMessageId, parentId,
+                       "populateFromHistory must backfill parentMessageId onto an existing local entry")
     }
 
     // MARK: - Interleaved Text/Tool-Call Segments

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1935,13 +1935,15 @@ final class ChatViewModelTests: XCTestCase {
                 textSegments: nil, thinkingSegments: nil, contentOrder: nil, surfaces: nil,
                 subagentNotification: HistoryResponseMessageSubagentNotification(
                     subagentId: "s-stuck", label: "Stuck", status: "completed",
-                    error: nil, conversationId: nil
+                    error: nil, conversationId: "sub-conv-1"
                 )
             ),
         ]
         viewModel.populateFromHistory(historyItems, hasMore: false)
         XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-stuck" })?.status, .completed,
                        "History's terminal status must overwrite a locally-stuck `.running` entry")
+        XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-stuck" })?.conversationId, "sub-conv-1",
+                       "History's conversationId must be propagated onto the reconciled entry so detail lazy-load works")
     }
 
     func testPopulateFromHistoryDoesNotOverwriteRunningWithRunning() {
@@ -1956,7 +1958,7 @@ final class ChatViewModelTests: XCTestCase {
                 textSegments: nil, thinkingSegments: nil, contentOrder: nil, surfaces: nil,
                 subagentNotification: HistoryResponseMessageSubagentNotification(
                     subagentId: "s-live", label: "Live", status: "running",
-                    error: nil, conversationId: nil
+                    error: nil, conversationId: "sub-conv-live"
                 )
             ),
         ]
@@ -1965,6 +1967,35 @@ final class ChatViewModelTests: XCTestCase {
         // (preserving `parentMessageId` and the live in-memory copy).
         XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-live" })?.status, .running)
         XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-live" })?.parentMessageId, originalParentId)
+        // conversationId must still be backfilled even though status was not changed —
+        // the live `.subagentSpawned` path does not populate it, so history is the
+        // only source for it and the detail panel's lazy-load depends on it.
+        XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-live" })?.conversationId, "sub-conv-live",
+                       "conversationId must be backfilled from history even when status is unchanged")
+    }
+
+    func testPopulateFromHistoryBackfillsConversationIdOnExistingEntry() {
+        // Seed with a locally-completed entry that has no conversationId —
+        // the live `.subagentSpawned` path never populates it, so any entry
+        // that was born from a live event has conversationId == nil.
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s-done", label: "Done", status: .completed)
+        ]
+        XCTAssertNil(viewModel.activeSubagents.first(where: { $0.id == "s-done" })?.conversationId)
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(
+                id: nil, role: "assistant", text: "", timestamp: 1000,
+                toolCalls: nil, toolCallsBeforeText: nil, attachments: nil,
+                textSegments: nil, thinkingSegments: nil, contentOrder: nil, surfaces: nil,
+                subagentNotification: HistoryResponseMessageSubagentNotification(
+                    subagentId: "s-done", label: "Done", status: "completed",
+                    error: nil, conversationId: "sub-conv-done"
+                )
+            ),
+        ]
+        viewModel.populateFromHistory(historyItems, hasMore: false)
+        XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-done" })?.conversationId, "sub-conv-done",
+                       "populateFromHistory must backfill conversationId onto an existing local entry")
     }
 
     // MARK: - Interleaved Text/Tool-Call Segments

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1924,6 +1924,49 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.count, 0)
     }
 
+    func testPopulateFromHistoryReconcilesStaleRunningSubagentToTerminal() {
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s-stuck", label: "Stuck", status: .running)
+        ]
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(
+                id: nil, role: "assistant", text: "", timestamp: 1000,
+                toolCalls: nil, toolCallsBeforeText: nil, attachments: nil,
+                textSegments: nil, thinkingSegments: nil, contentOrder: nil, surfaces: nil,
+                subagentNotification: HistoryResponseMessageSubagentNotification(
+                    subagentId: "s-stuck", label: "Stuck", status: "completed",
+                    error: nil, conversationId: nil
+                )
+            ),
+        ]
+        viewModel.populateFromHistory(historyItems, hasMore: false)
+        XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-stuck" })?.status, .completed,
+                       "History's terminal status must overwrite a locally-stuck `.running` entry")
+    }
+
+    func testPopulateFromHistoryDoesNotOverwriteRunningWithRunning() {
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s-live", label: "Live", status: .running, parentMessageId: UUID())
+        ]
+        let originalParentId = viewModel.activeSubagents[0].parentMessageId
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(
+                id: nil, role: "assistant", text: "", timestamp: 1000,
+                toolCalls: nil, toolCallsBeforeText: nil, attachments: nil,
+                textSegments: nil, thinkingSegments: nil, contentOrder: nil, surfaces: nil,
+                subagentNotification: HistoryResponseMessageSubagentNotification(
+                    subagentId: "s-live", label: "Live", status: "running",
+                    error: nil, conversationId: nil
+                )
+            ),
+        ]
+        viewModel.populateFromHistory(historyItems, hasMore: false)
+        // Non-terminal history status must not replace the existing entry
+        // (preserving `parentMessageId` and the live in-memory copy).
+        XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-live" })?.status, .running)
+        XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-live" })?.parentMessageId, originalParentId)
+    }
+
     // MARK: - Interleaved Text/Tool-Call Segments
 
     func testTextToolTextCreatesInterleavedSegments() {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2123,11 +2123,17 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         // `.pending`, overwrite the local status — a missed `subagentStatusChanged`
         // event otherwise leaves the UI stuck forever (LUM-1062). History is the
         // daemon's authoritative record, so it's safe to trust over local state.
+        // Also backfill `conversationId` from history in any case — the live
+        // `subagentSpawned` path does not populate it, and `SubagentClient.fetchDetail`
+        // / the detail panel rely on it being present for lazy-loaded events.
         for info in reconstructedSubagents {
             if let index = activeSubagents.firstIndex(where: { $0.id == info.id }) {
                 if info.isTerminal && !activeSubagents[index].isTerminal {
                     activeSubagents[index].status = info.status
                     activeSubagents[index].error = info.error
+                }
+                if activeSubagents[index].conversationId == nil, let convId = info.conversationId {
+                    activeSubagents[index].conversationId = convId
                 }
             } else {
                 activeSubagents.append(info)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2123,9 +2123,11 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         // `.pending`, overwrite the local status — a missed `subagentStatusChanged`
         // event otherwise leaves the UI stuck forever (LUM-1062). History is the
         // daemon's authoritative record, so it's safe to trust over local state.
-        // Also backfill `conversationId` from history in any case — the live
-        // `subagentSpawned` path does not populate it, and `SubagentClient.fetchDetail`
-        // / the detail panel rely on it being present for lazy-loaded events.
+        // Also backfill `conversationId` and `parentMessageId` from history when
+        // the local entry is missing them — the live `subagentSpawned` path does
+        // not populate `conversationId`, and either field can be missing if the
+        // initial spawn event was lost too. `SubagentClient.fetchDetail` and the
+        // detail panel's chip placement rely on these being present.
         for info in reconstructedSubagents {
             if let index = activeSubagents.firstIndex(where: { $0.id == info.id }) {
                 if info.isTerminal && !activeSubagents[index].isTerminal {
@@ -2134,6 +2136,9 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                 }
                 if activeSubagents[index].conversationId == nil, let convId = info.conversationId {
                     activeSubagents[index].conversationId = convId
+                }
+                if activeSubagents[index].parentMessageId == nil, let parentId = info.parentMessageId {
+                    activeSubagents[index].parentMessageId = parentId
                 }
             } else {
                 activeSubagents.append(info)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2118,9 +2118,20 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         let chatMessages = result.messages
         let reconstructedSubagents = result.subagents
 
-        // Merge reconstructed subagents into activeSubagents (avoid duplicates)
-        for info in reconstructedSubagents where !activeSubagents.contains(where: { $0.id == info.id }) {
-            activeSubagents.append(info)
+        // Merge reconstructed subagents into activeSubagents. When history shows
+        // a terminal status for a subagent that is still locally `.running` or
+        // `.pending`, overwrite the local status — a missed `subagentStatusChanged`
+        // event otherwise leaves the UI stuck forever (LUM-1062). History is the
+        // daemon's authoritative record, so it's safe to trust over local state.
+        for info in reconstructedSubagents {
+            if let index = activeSubagents.firstIndex(where: { $0.id == info.id }) {
+                if info.isTerminal && !activeSubagents[index].isTerminal {
+                    activeSubagents[index].status = info.status
+                    activeSubagents[index].error = info.error
+                }
+            } else {
+                activeSubagents.append(info)
+            }
         }
 
         // Update daemon pagination cursor from the response metadata.


### PR DESCRIPTION
## Summary
- `populateFromHistory` now reconciles existing `activeSubagents` entries: if history shows terminal status (`completed`/`failed`/`aborted`) and the local entry is still `running`/`pending`, the history status wins.
- Adds two unit tests covering reconcile-to-terminal and don't-clobber-running cases.

Part of LUM-1062.
Part of plan: lum-1062-unstick-subagent-ui.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
