### PR TITLE
refactor(permissions): extract check() decision logic into ApprovalPolicy

### DIFF
--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -49,6 +49,7 @@ describe("deny rule", () => {
     });
     expect(result.decision).toBe("deny");
     expect(result.reason).toContain("deny rule");
+    expect(result.matchedRule).toBe(denyRule);
   });
 
   test("deny at Medium risk", () => {
@@ -77,6 +78,7 @@ describe("ask rule", () => {
     const result = evaluate({ riskLevel: RiskLevel.Low, matchedRule: askRule });
     expect(result.decision).toBe("prompt");
     expect(result.reason).toContain("ask rule");
+    expect(result.matchedRule).toBe(askRule);
   });
 
   test("ask at Medium risk", () => {
@@ -108,6 +110,7 @@ describe("allow rule", () => {
     });
     expect(result.decision).toBe("allow");
     expect(result.reason).toContain("Matched trust rule");
+    expect(result.matchedRule).toBe(allowRule);
   });
 
   test("allow at Medium risk", () => {
@@ -117,9 +120,10 @@ describe("allow rule", () => {
     });
     expect(result.decision).toBe("allow");
     expect(result.reason).toContain("Matched trust rule");
+    expect(result.matchedRule).toBe(allowRule);
   });
 
-  test("allow at High risk — non-containerized bash → prompt", () => {
+  test("allow at High risk — non-containerized bash → prompt, no matchedRule in decision", () => {
     const result = evaluate({
       riskLevel: RiskLevel.High,
       toolName: "bash",
@@ -128,9 +132,11 @@ describe("allow rule", () => {
     });
     expect(result.decision).toBe("prompt");
     expect(result.reason).toContain("High risk");
+    // Decision is driven by risk-based fallback, not the rule
+    expect(result.matchedRule).toBeUndefined();
   });
 
-  test("allow at High risk — containerized bash → allow (auto-allow)", () => {
+  test("allow at High risk — containerized bash → allow (auto-allow), matchedRule present", () => {
     const result = evaluate({
       riskLevel: RiskLevel.High,
       toolName: "bash",
@@ -139,9 +145,10 @@ describe("allow rule", () => {
     });
     expect(result.decision).toBe("allow");
     expect(result.reason).toContain("auto-allow-high-risk");
+    expect(result.matchedRule).toBe(allowRule);
   });
 
-  test("allow at High risk — non-bash tool, containerized → prompt", () => {
+  test("allow at High risk — non-bash tool, containerized → prompt, no matchedRule in decision", () => {
     const result = evaluate({
       riskLevel: RiskLevel.High,
       toolName: "file_write",
@@ -150,9 +157,11 @@ describe("allow rule", () => {
     });
     expect(result.decision).toBe("prompt");
     expect(result.reason).toContain("High risk");
+    // Decision is driven by risk-based fallback, not the rule
+    expect(result.matchedRule).toBeUndefined();
   });
 
-  test("allow at High risk — non-bash tool, non-containerized → prompt", () => {
+  test("allow at High risk — non-bash tool, non-containerized → prompt, no matchedRule in decision", () => {
     const result = evaluate({
       riskLevel: RiskLevel.High,
       toolName: "file_write",
@@ -161,6 +170,8 @@ describe("allow rule", () => {
     });
     expect(result.decision).toBe("prompt");
     expect(result.reason).toContain("High risk");
+    // Decision is driven by risk-based fallback, not the rule
+    expect(result.matchedRule).toBeUndefined();
   });
 });
 

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -23,6 +23,8 @@ export interface ApprovalContext {
 export interface ApprovalDecision {
   decision: "allow" | "prompt" | "deny";
   reason: string;
+  /** Present only when the decision was driven by a matched rule. */
+  matchedRule?: TrustRule;
 }
 
 /** An object that evaluates an approval context and returns a decision. */
@@ -33,9 +35,9 @@ export interface ApprovalPolicy {
 // ── Default implementation ───────────────────────────────────────────────────
 
 /**
- * Replicates the exact approval decision logic from `check()` in checker.ts
- * (lines 604-725). Each branch is annotated with the corresponding checker.ts
- * code path so reviewers can verify 1:1 parity.
+ * Implements the approval decision policy used by `check()` in checker.ts.
+ * Each branch is annotated with the corresponding decision path so reviewers
+ * can verify 1:1 parity.
  *
  * The decision flow:
  *
@@ -72,6 +74,7 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       return {
         decision: "deny",
         reason: `Blocked by deny rule: ${matchedRule.pattern}`,
+        matchedRule,
       };
     }
 
@@ -80,6 +83,7 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       return {
         decision: "prompt",
         reason: `Matched ask rule: ${matchedRule.pattern}`,
+        matchedRule,
       };
     }
 
@@ -90,6 +94,7 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
         return {
           decision: "allow",
           reason: `Matched trust rule: ${matchedRule.pattern}`,
+          matchedRule,
         };
       }
 
@@ -98,10 +103,13 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
         return {
           decision: "allow",
           reason: `Matched trust rule in auto-allow-high-risk context: ${matchedRule.pattern}`,
+          matchedRule,
         };
       }
 
       // 5. Allow rule + High (no auto-allow) → fall through to risk-based
+      // Note: matchedRule is intentionally omitted from the risk-based
+      // fallback return — the decision is driven by risk, not the rule.
     }
 
     // ── 6. No rule + third-party skill tool → prompt ──────────────────
@@ -176,7 +184,7 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
 
   /**
    * Determines at runtime whether a high-risk operation should be auto-allowed.
-   * Mirrors `shouldAutoAllowHighRisk()` in checker.ts.
+   * Auto-allows high-risk operations when running in a containerized sandbox.
    *
    * Auto-allow cases:
    * - Containerized bash: all commands are sandboxed, so high-risk is safe.

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -25,6 +25,10 @@ import {
   getProtectedDir,
   getWorkspaceHooksDir,
 } from "../util/platform.js";
+import {
+  type ApprovalContext,
+  DefaultApprovalPolicy,
+} from "./approval-policy.js";
 import { bashRiskClassifier } from "./bash-risk-classifier.js";
 import { riskToRiskLevel } from "./risk-types.js";
 import {
@@ -88,24 +92,8 @@ function ensureRiskCacheInvalidationHook(): void {
   onRulesChanged(clearRiskCache);
 }
 
-/**
- * Determines at runtime whether a high-risk operation should be auto-allowed
- * without requiring a persisted allowHighRisk flag. This replaces the
- * stateful allowHighRisk field on trust rules with a context-aware check.
- *
- * Auto-allow cases:
- * - Containerized bash: all commands are sandboxed, so high-risk is safe.
- *
- * Note: `rm BOOTSTRAP.md` and `rm UPDATES.md` are already classified as
- * Medium risk (not High) by the BashRiskClassifier's rm safe-file
- * downgrade, so they don't need special handling here.
- */
-function shouldAutoAllowHighRisk(toolName: string): boolean {
-  if (toolName === "bash" && getIsContainerized()) {
-    return true;
-  }
-  return false;
-}
+// ── Approval policy singleton ────────────────────────────────────────────────
+const defaultApprovalPolicy = new DefaultApprovalPolicy();
 
 function getStringField(
   input: Record<string, unknown>,
@@ -601,127 +589,31 @@ export async function check(
     policyContext,
   );
 
-  // Deny rules apply at ALL risk levels — including proxied network mode.
-  // Evaluate them first so hard blocks are never downgraded to a prompt.
-  if (matchedRule && matchedRule.decision === "deny") {
-    return {
-      decision: "deny",
-      reason: `Blocked by deny rule: ${matchedRule.pattern}`,
-      matchedRule,
-    };
-  }
+  // Build approval context from local variables
+  const tool = getTool(toolName);
+  const approvalContext: ApprovalContext = {
+    riskLevel: risk,
+    toolName,
+    matchedRule: matchedRule ?? undefined,
+    permissionsMode: getConfig().permissions.mode,
+    isContainerized: getIsContainerized(),
+    isWorkspaceScoped:
+      risk === RiskLevel.Low
+        ? isWorkspaceScopedInvocation(toolName, input, workingDir)
+        : false,
+    toolOrigin:
+      tool?.origin === "skill" ? "skill" : tool ? "builtin" : undefined,
+    isSkillBundled: tool?.ownerSkillBundled ?? false,
+    hasManifestOverride: !!manifestOverride,
+  };
 
-  if (matchedRule) {
-    if (matchedRule.decision === "ask") {
-      // Ask rules always prompt — never auto-allow or auto-deny
-      return {
-        decision: "prompt",
-        reason: `Matched ask rule: ${matchedRule.pattern}`,
-        matchedRule,
-      };
-    }
+  // Delegate the allow/prompt/deny decision to the approval policy
+  const approvalDecision = defaultApprovalPolicy.evaluate(approvalContext);
 
-    // Allow rule: auto-allow for non-High risk
-    if (risk !== RiskLevel.High) {
-      return {
-        decision: "allow",
-        reason: `Matched trust rule: ${matchedRule.pattern}`,
-        matchedRule,
-      };
-    }
-    // High risk with allow rule — check runtime context for auto-allow
-    if (shouldAutoAllowHighRisk(toolName)) {
-      return {
-        decision: "allow",
-        reason: `Matched trust rule in auto-allow-high-risk context: ${matchedRule.pattern}`,
-        matchedRule,
-      };
-    }
-    // High risk with allow rule (no runtime auto-allow) → fall through to prompt
-  }
-
-  // No matching rule (or High risk with allow rule) → risk-based fallback
-
-  // Third-party skill-origin tools default to prompting when no trust rule
-  // matches, regardless of risk level. Bundled skill tools are first-party
-  // and trusted, so they fall through to the normal risk-based policy.
-  // When manifestOverride is present, the tool comes from a skill manifest
-  // but isn't registered — treat it as a third-party skill tool.
-  if (!matchedRule) {
-    const tool = getTool(toolName);
-    if (tool?.origin === "skill" && !tool.ownerSkillBundled) {
-      return {
-        decision: "prompt",
-        reason: "Skill tool: requires approval by default",
-      };
-    }
-    if (!tool && manifestOverride) {
-      return {
-        decision: "prompt",
-        reason: "Skill tool: requires approval by default",
-      };
-    }
-  }
-
-  // In strict mode, every tool without an explicit matching rule must be
-  // prompted — there is no implicit auto-allow for any risk level.
-  // This explicitly covers skill_load: activating a skill can grant the
-  // agent new capabilities, so in strict mode users must approve each
-  // skill load via an exact-version or wildcard trust rule.
-  const permissionsMode = getConfig().permissions.mode;
-
-  if (permissionsMode === "strict" && !matchedRule) {
-    return {
-      decision: "prompt",
-      reason: `Strict mode: no matching rule, requires approval`,
-    };
-  }
-
-  // Workspace mode: auto-allow workspace-scoped operations that don't have
-  // an explicit rule, but only when risk is Low. Medium and High risk operations
-  // fall through to risk-based policy and always require approval.
-  if (
-    permissionsMode === "workspace" &&
-    !matchedRule &&
-    risk === RiskLevel.Low
-  ) {
-    // Outside a container, bash runs on the host — don't auto-allow
-    if (toolName === "bash" && !getIsContainerized()) {
-      // Fall through to risk-based policy below
-    } else if (isWorkspaceScopedInvocation(toolName, input, workingDir)) {
-      return {
-        decision: "allow",
-        reason: "Workspace mode: workspace-scoped operation auto-allowed",
-      };
-    }
-  }
-
-  // Auto-allow low-risk bundled skill tools even without explicit trust rules.
-  // These are first-party tools with a vetted risk declaration.
-  // This block must come AFTER the strict mode check so that strict mode
-  // still prompts for bundled skill tools without explicit rules.
-  if (!matchedRule && risk === RiskLevel.Low) {
-    const tool = getTool(toolName);
-    if (tool?.origin === "skill" && tool.ownerSkillBundled) {
-      return {
-        decision: "allow",
-        reason: "Bundled skill tool: low risk, auto-allowed",
-      };
-    }
-  }
-
-  if (risk === RiskLevel.High) {
-    return {
-      decision: "prompt",
-      reason: `High risk: always requires approval`,
-    };
-  }
-
-  if (risk === RiskLevel.Low) {
-    return { decision: "allow", reason: "Low risk: auto-allowed" };
-  }
-
-  return { decision: "prompt", reason: `${risk} risk: requires approval` };
+  return {
+    ...approvalDecision,
+    matchedRule: approvalContext.matchedRule,
+  };
 }
 
 const TOOL_DISPLAY_NAMES: Record<string, string> = {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -611,8 +611,9 @@ export async function check(
   const approvalDecision = defaultApprovalPolicy.evaluate(approvalContext);
 
   return {
-    ...approvalDecision,
-    matchedRule: approvalContext.matchedRule,
+    decision: approvalDecision.decision,
+    reason: approvalDecision.reason,
+    matchedRule: approvalDecision.matchedRule,
   };
 }
 


### PR DESCRIPTION
## Summary
- Replace ~80 lines of inline decision logic in check() with a single DefaultApprovalPolicy.evaluate() call
- Remove shouldAutoAllowHighRisk() from checker.ts (logic moved into policy)
- Build ApprovalContext from existing check() local variables
- Zero behavioral change — all checker.test.ts tests pass without modification

Part of plan: bash-risk-approval-policy.md (PR 3 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
