### PR TITLE
fix(migrations): suppress stale migration warning + map upstream body drops to 502

### DIFF
--- a/assistant/src/__tests__/migration-import-from-url.test.ts
+++ b/assistant/src/__tests__/migration-import-from-url.test.ts
@@ -33,6 +33,7 @@ import {
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import {
   afterAll,
   afterEach,
@@ -117,6 +118,7 @@ mock.module("../config/env.js", () => ({
 // Imports (after mocks so module-level code picks up the stubs)
 // ---------------------------------------------------------------------------
 
+import { resetDb } from "../memory/db-connection.js";
 import { buildVBundle } from "../runtime/migrations/vbundle-builder.js";
 import {
   _setUrlImportValidatorOptionsForTests,
@@ -473,6 +475,179 @@ describe("handleMigrationImport — URL body memory ceiling", () => {
       await fixture.close();
     }
   }, 90_000);
+});
+
+// ---------------------------------------------------------------------------
+// Gap A regression: no-swap success path must not append a stale
+// "newer migration" warning sourced from the live DB. The warning would
+// wrongly attribute live-DB state to the imported bundle when no bundle
+// files actually land on disk (e.g. credentials-only bundle).
+// ---------------------------------------------------------------------------
+
+describe("handleMigrationImport — no-swap path omits newer-migration warning", () => {
+  test("credentials-only bundle does not inherit live-DB migration warnings", async () => {
+    // Seed the live workspace DB with a migration_* checkpoint that's NOT
+    // in the registry. validateMigrationState treats this as a "newer
+    // version" and would otherwise push a warning into the report. With
+    // the gate in appendNewerMigrationWarningsIfAny the warning must be
+    // suppressed when the import didn't modify the workspace.
+    const dbDir = join(testWorkspaceRoot, "data", "db");
+    mkdirSync(dbDir, { recursive: true });
+    const dbPath = join(dbDir, "assistant.db");
+    const seed = new Database(dbPath);
+    try {
+      seed.exec(`
+        CREATE TABLE memory_checkpoints (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+      `);
+      seed
+        .query(
+          `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES (?, ?, ?)`,
+        )
+        .run("migration_from_the_future", "1", Date.now());
+    } finally {
+      seed.close();
+    }
+
+    // Drop any cached Drizzle singleton so getDb() re-opens from the
+    // seeded path above when the handler calls it post-import.
+    resetDb();
+
+    // All-`vellum:*` credentials bundle: the streaming importer returns
+    // ok=true with zero files_created/overwritten (no-swap success),
+    // and the credential-import callback filters every entry as a
+    // platform credential so CES is never invoked.
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "credentials/vellum:device-id",
+          data: new TextEncoder().encode("test-device-id"),
+        },
+      ],
+    });
+    const bundlePath = join(testParent, "fixture-creds-only.vbundle");
+    writeFileSync(bundlePath, archive);
+
+    const fixture = await startFixtureServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/octet-stream" });
+      createReadStream(bundlePath).pipe(res);
+    });
+
+    try {
+      const req = new Request("http://localhost/v1/migrations/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: makeFakeSignedUrl(fixture.port) }),
+      });
+
+      const res = await handleMigrationImport(req);
+      const body = (await res.json()) as ImportCommitResponse;
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      // Zero files touched — this is the no-swap success path.
+      expect(body.summary.files_created).toBe(0);
+      expect(body.summary.files_overwritten).toBe(0);
+
+      // The gate must suppress the newer-migration warning text. The
+      // helper's wording starts with "Imported data contains" and ends
+      // with "migration(s) from a newer version" — matching either
+      // substring is sufficient.
+      const stale = body.warnings.filter((w) =>
+        w.includes("from a newer version"),
+      );
+      expect(stale).toEqual([]);
+    } finally {
+      await fixture.close();
+      // Close the cached DB handle before the workspace dir gets rm'd
+      // in afterEach so we don't leak WAL/SHM files across tests.
+      resetDb();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gap B regression: an upstream body that drops mid-stream (peer reset,
+// socket.destroy() after headers are sent) must surface as 502
+// fetch_failed, not 500 extraction_failed. The tag-at-source plumbing in
+// the URL handler routes importer-rethrown upstream errors to the fetch-
+// failed branch.
+// ---------------------------------------------------------------------------
+
+describe("handleMigrationImport — upstream body dropped mid-stream", () => {
+  test("socket destroy mid-body returns 502 with reason: fetch_failed", async () => {
+    // Build a real gzipped tar prefix, then serve only the first N bytes
+    // and tear down the connection. gunzip inside streamCommitImport
+    // will surface this as a stream error; we tag it at the source so
+    // the handler maps it to 502 fetch_failed. Use random payload bytes
+    // so the gzip output is ~incompressible — a compressed all-zeros
+    // payload shrinks to <500 bytes total, which doesn't give us enough
+    // material to reliably deliver a partial body with gunzip state
+    // still alive across the socket teardown.
+    const incompressible = new Uint8Array(64 * 1024);
+    for (let i = 0; i < incompressible.length; i += 1) {
+      incompressible[i] = Math.floor(Math.random() * 256);
+    }
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "workspace/data/db/assistant.db",
+          data: incompressible,
+        },
+      ],
+    });
+    // Safety net: if someone changes buildVBundle to return very small
+    // outputs, drop the test early rather than flaking on a too-short
+    // truncation window. 512 bytes is plenty given 64 KB of random data
+    // gzips to essentially its original size.
+    expect(archive.byteLength).toBeGreaterThan(512);
+
+    // Truncate to the first 256 bytes so upstream cannot deliver a
+    // usable tar stream. gunzip will error on the abrupt close.
+    const truncatedPrefix = archive.slice(0, 256);
+
+    const fixture = await startFixtureServer((_req, res) => {
+      // Chunked transfer (no Content-Length) + socket.destroy() mid-body
+      // is the cleanest way to force Bun's fetch to surface a
+      // post-headers stream error rather than an initial-fetch throw.
+      // We write the prefix in a couple of chunks so the client side can
+      // return from fetch() and hand the body stream to the importer
+      // before we tear the socket down.
+      res.writeHead(200, {
+        "Content-Type": "application/octet-stream",
+        "Transfer-Encoding": "chunked",
+      });
+      const half = Math.floor(truncatedPrefix.byteLength / 2);
+      res.write(truncatedPrefix.slice(0, half), () => {
+        // Give the runtime a chance to deliver the first chunk to the
+        // consumer and enter the streaming import pipeline, then rip
+        // the socket out so the body stream surfaces an abort error.
+        setTimeout(() => {
+          res.socket?.destroy();
+        }, 100);
+      });
+    });
+
+    try {
+      const req = new Request("http://localhost/v1/migrations/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: makeFakeSignedUrl(fixture.port) }),
+      });
+
+      const res = await handleMigrationImport(req);
+      const body = (await res.json()) as FetchFailedResponse;
+
+      expect(res.status).toBe(502);
+      expect(body.success).toBe(false);
+      expect(body.reason).toBe("fetch_failed");
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -15,7 +15,7 @@
  */
 
 import { createReadStream } from "node:fs";
-import { Readable } from "node:stream";
+import { PassThrough, Readable } from "node:stream";
 import { Database } from "bun:sqlite";
 
 import { z } from "zod";
@@ -521,6 +521,41 @@ const URL_FETCH_TIMEOUT_MS = 60 * 60 * 1000;
 const MigrationImportUrlBody = z.object({ url: z.string().min(1) });
 
 /**
+ * Marker attached to errors that originate from the upstream HTTP body
+ * stream (peer reset, abort mid-stream, DNS/transport failure after
+ * headers were received). The handler's catch/result-mapping path looks
+ * for this tag to return 502 `fetch_failed` instead of 500
+ * `extraction_failed` for truncated bodies, matching the OpenAPI
+ * contract.
+ */
+const kFetchBodyError = Symbol.for("vellum.migrationImport.fetchBodyError");
+
+/**
+ * Sidecar flag on the wrapper PassThrough indicating that its upstream
+ * was torn down by a tagged fetch-body error. Checked after
+ * streamCommitImport returns — the importer preserves the error message
+ * in `result.reason = "extraction_failed"` but strips the tag.
+ */
+const kFetchBodyTornDown = Symbol.for(
+  "vellum.migrationImport.fetchBodyTornDown",
+);
+
+function tagFetchBodyError(err: NodeJS.ErrnoException): void {
+  (err as unknown as Record<symbol, boolean>)[kFetchBodyError] = true;
+}
+
+function isFetchBodyError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  return (err as unknown as Record<symbol, boolean>)[kFetchBodyError] === true;
+}
+
+function wasFetchBodyTornDown(stream: PassThrough): boolean {
+  return (
+    (stream as unknown as Record<symbol, boolean>)[kFetchBodyTornDown] === true
+  );
+}
+
+/**
  * Test seam: the integration test needs to point the validator at a local
  * HTTP server fixture. Production callers never pass this — the default
  * keeps the validator strict (GCS host, HTTPS only, no explicit port).
@@ -647,9 +682,48 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
   // Convert the WHATWG ReadableStream from fetch() into a Node Readable so
   // the tar-stream / gunzip / hash-verifier pipeline inside
   // streamCommitImport can consume it via `.pipe()`.
-  const nodeStream = Readable.fromWeb(
+  const upstreamNodeStream = Readable.fromWeb(
     upstream.body as unknown as import("node:stream/web").ReadableStream<Uint8Array>,
   );
+
+  // Wrap the upstream stream in a PassThrough that tags any error bubbling
+  // from the upstream HTTP body (peer reset, abort mid-stream, etc.) with a
+  // known symbol. When that tagged error surfaces out of
+  // streamCommitImport's gunzip/tar pipeline, we can distinguish it from a
+  // legitimate bundle-format failure and map it to 502 fetch_failed instead
+  // of 500 extraction_failed — matching the OpenAPI contract for the URL
+  // body shape. We also propagate errors from the wrapper back to the
+  // upstream stream so its underlying connection is torn down cleanly.
+  //
+  // Bun's `Readable.fromWeb(fetchBody)` does NOT emit `'error'` when the
+  // TCP socket is torn down mid-response — it just emits `'close'` with
+  // no final `'end'`. We therefore track BOTH signals:
+  //   • explicit `'error'`   → tag the error, destroy the wrapper.
+  //   • premature `'close'`  → synthesize an error, tag it, destroy the
+  //     wrapper. "Premature" = close fired without end first.
+  const taggedSource = new PassThrough();
+  let upstreamEnded = false;
+  upstreamNodeStream.on("end", () => {
+    upstreamEnded = true;
+  });
+  upstreamNodeStream.on("error", (err: NodeJS.ErrnoException) => {
+    tagFetchBodyError(err);
+    (taggedSource as unknown as Record<symbol, boolean>)[kFetchBodyTornDown] =
+      true;
+    taggedSource.destroy(err);
+  });
+  upstreamNodeStream.on("close", () => {
+    if (upstreamEnded) return;
+    const err = new Error(
+      "Upstream body stream closed before end",
+    ) as NodeJS.ErrnoException;
+    err.code = "ERR_UPSTREAM_BODY_CLOSED";
+    tagFetchBodyError(err);
+    (taggedSource as unknown as Record<symbol, boolean>)[kFetchBodyTornDown] =
+      true;
+    taggedSource.destroy(err);
+  });
+  upstreamNodeStream.pipe(taggedSource);
 
   const pathResolver = new DefaultPathResolver(
     getWorkspaceDir(),
@@ -669,7 +743,7 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
 
   try {
     result = await streamCommitImport({
-      source: nodeStream,
+      source: taggedSource,
       pathResolver,
       workspaceDir: getWorkspaceDir(),
       importCredentials: async (bundleCredentials) => {
@@ -683,6 +757,20 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
       },
     });
   } catch (err) {
+    if (isFetchBodyError(err)) {
+      log.error(
+        {
+          host: validated.host,
+          path: validated.path,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Upstream body stream failed mid-import",
+      );
+      return Response.json(
+        { success: false, reason: "fetch_failed" },
+        { status: 502 },
+      );
+    }
     log.error(
       {
         host: validated.host,
@@ -699,6 +787,25 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
   }
 
   if (!result.ok) {
+    // streamCommitImport swallows the raw cause and maps any
+    // non-validation throw to `extraction_failed`. If the cause was an
+    // upstream body failure that we tagged at the source, surface the
+    // tag through the result (the importer preserves the message) by
+    // detecting the latched flag on the wrapper stream.
+    if (wasFetchBodyTornDown(taggedSource)) {
+      log.error(
+        {
+          host: validated.host,
+          path: validated.path,
+          reason: result.reason,
+        },
+        "Upstream body stream failed mid-import (detected via result)",
+      );
+      return Response.json(
+        { success: false, reason: "fetch_failed" },
+        { status: 502 },
+      );
+    }
     log.warn(
       {
         host: validated.host,
@@ -837,8 +944,18 @@ async function importBundleCredentialsIntoCes(
  * Append a warning to `report` when the newly-imported database contains
  * migration checkpoints from a daemon version newer than this one. Silent
  * on any validation error — the import has already succeeded.
+ *
+ * Gated on the report's own file counts: if the import didn't create or
+ * overwrite any workspace files (no-swap success — e.g. credentials-only
+ * bundle, all-skipped legacy bundle), the live DB is unchanged and any
+ * "newer migrations" detected there came from the existing workspace,
+ * NOT from the imported bundle. Attributing them to the bundle would be a
+ * false positive, so skip the check entirely in that case.
  */
 function appendNewerMigrationWarningsIfAny(report: ImportCommitReport): void {
+  if (report.summary.files_created + report.summary.files_overwritten === 0) {
+    return;
+  }
   try {
     const migrationValidation = validateMigrationState(getDb());
     if (migrationValidation.unknownCheckpoints.length > 0) {


### PR DESCRIPTION
## Summary

Addresses self-review gaps from plan execution of gcs-stream-import.md (remediation round 1).

- Gate newer-migration warning on actual DB writes so the URL path doesn't surface false positives for no-swap imports.
- Tag upstream-body errors at the source so handleMigrationImportFromUrl can map them to 502 fetch_failed, not 500 extraction_failed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
