### PR TITLE
fix(onboarding): restore Welcome hero + characters footer; only replace the buttons

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -94,12 +94,13 @@ extension AppDelegate {
         let hostingController = NSHostingController(rootView: authView)
 
         // ReauthView is a compact sign-in surface; OnboardingFlowView hosts
-        // the full onboarding including the WakeUp cards which require at
-        // least 440×720 per the view's `.frame(minWidth:minHeight:)`.
+        // the full onboarding including the WakeUp cards, welcome hero,
+        // and the characters footer, which together require at least
+        // 440×980 per the view's `.frame(minWidth:minHeight:)`.
         let windowWidth: CGFloat = 460
-        let windowHeight: CGFloat = hasManagedAssistants ? 620 : 720
+        let windowHeight: CGFloat = hasManagedAssistants ? 620 : 980
         let minWidth: CGFloat = hasManagedAssistants ? 420 : 440
-        let minHeight: CGFloat = hasManagedAssistants ? 580 : 720
+        let minHeight: CGFloat = hasManagedAssistants ? 580 : 980
 
         let window: NSWindow
         if let existingWindow {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -88,7 +88,7 @@ struct OnboardingFlowView: View {
                 VStack(spacing: 0) {
                     if state.currentStep == 0 {
                         // Step 0 only: top inset + app icon
-                        Color.clear.frame(height: VSpacing.xxl)
+                        Color.clear.frame(height: 80)
 
                         if let nsImage = Self.appIcon {
                             Image(nsImage: nsImage)
@@ -97,7 +97,7 @@ struct OnboardingFlowView: View {
                                 .frame(width: 80, height: 80)
                                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                                 .shadow(color: VColor.auxBlack.opacity(0.15), radius: 1, x: 0, y: 1)
-                                .padding(.bottom, VSpacing.xl)
+                                .padding(.bottom, 78)
                         }
                     } else {
                         // Steps 1–3: top inset only (no icon)
@@ -195,7 +195,7 @@ struct OnboardingFlowView: View {
             }
         }
         }
-        .frame(minWidth: 440, minHeight: 720)
+        .frame(minWidth: 440, minHeight: 980)
         .task {
             if !authManager.isAuthenticated {
                 await authManager.checkSession()

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingVellumCloudCard.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingVellumCloudCard.swift
@@ -29,10 +29,13 @@ struct OnboardingVellumCloudCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header: serif title + RECOMMENDED chip
+            // Header: title + RECOMMENDED chip. Uses `titleMedium` so it
+            // sits a notch below the page title (`VFont.titleLarge` on
+            // `WakeUpStepView`) without clashing with the page's sans
+            // family.
             HStack(alignment: .top) {
                 Text(title)
-                    .font(VFont.brandSmall)
+                    .font(VFont.titleMedium)
                     .foregroundStyle(VColor.contentEmphasized)
 
                 Spacer(minLength: VSpacing.sm)
@@ -85,10 +88,10 @@ struct OnboardingVellumCloudCard: View {
             }
         }
         .padding(EdgeInsets(
-            top: VSpacing.xl,
-            leading: VSpacing.xl,
-            bottom: VSpacing.xl,
-            trailing: VSpacing.xl
+            top: VSpacing.lg,
+            leading: VSpacing.lg,
+            bottom: VSpacing.lg,
+            trailing: VSpacing.lg
         ))
         .frame(maxWidth: .infinity)
         .background(

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -41,7 +41,7 @@ final class OnboardingWindow {
         let hostingController = NSHostingController(rootView: flowView)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 440, height: 720),
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 980),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -54,10 +54,10 @@ final class OnboardingWindow {
         window.backgroundColor = NSColor(VColor.surfaceOverlay)
         window.isReleasedWhenClosed = false
 
-        window.contentMinSize = NSSize(width: 440, height: 720)
+        window.contentMinSize = NSSize(width: 440, height: 980)
 
         let startWidth: CGFloat = 440
-        let startHeight: CGFloat = 720
+        let startHeight: CGFloat = 980
         if let visibleFrame = Self.visibleScreenFrame() {
             let x = visibleFrame.midX - startWidth / 2
             let y = visibleFrame.midY - startHeight / 2

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -25,13 +25,39 @@ struct WakeUpStepView: View {
 
     // MARK: - Private State
 
+    @State private var showTitle = false
+    @State private var showSubtext = false
     @State private var showCards = false
+    @State private var showCharacters = false
     @State private var isAdvancedExpanded: Bool = false
+
+    private static let welcomeCharacters: NSImage? = {
+        guard let url = ResourceBundle.bundle.url(forResource: "welcome-characters", withExtension: "png") else { return nil }
+        return NSImage(contentsOf: url)
+    }()
 
     // MARK: - Body
 
     var body: some View {
-        VStack(spacing: VSpacing.md) {
+        // Title
+        Text("Welcome to Vellum")
+            .font(VFont.titleLarge)
+            .foregroundStyle(VColor.contentDefault)
+            .opacity(showTitle ? 1 : 0)
+            .offset(y: showTitle ? 0 : 8)
+            .padding(.bottom, VSpacing.md)
+
+        // Subtitle
+        Text("The safest way to create your personal assistant.")
+            .font(VFont.bodyMediumLighter)
+            .foregroundStyle(VColor.contentSecondary)
+            .multilineTextAlignment(.center)
+            .opacity(showSubtext ? 1 : 0)
+            .offset(y: showSubtext ? 0 : 8)
+            .padding(.bottom, VSpacing.xl)
+
+        // Setup-option cards (managed path) or single "Get Started" fallback.
+        VStack(spacing: VSpacing.sm) {
             if managedSignInEnabled {
                 OnboardingVellumCloudCard(
                     isLoading: authManager?.isLoading == true,
@@ -51,7 +77,6 @@ struct WakeUpStepView: View {
                     }
                 )
             } else {
-                // Unchanged fallback
                 VButton(label: "Get Started", style: .primary, isFullWidth: true) {
                     onStartWithAPIKey()
                 }
@@ -75,8 +100,42 @@ struct WakeUpStepView: View {
         )
         .onAppear {
             withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
+                showTitle = true
+            }
+            withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
+                showSubtext = true
+            }
+            withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
                 showCards = true
             }
+        }
+
+        Spacer(minLength: VSpacing.lg)
+
+        Text("2026 Vellum Inc.")
+            .font(VFont.bodySmallDefault)
+            .foregroundStyle(VColor.borderElement)
+            .padding(.bottom, VSpacing.sm)
+
+        // Characters peeking up from the bottom — single composed image
+        // exported from Figma, displayed edge-to-edge at the window bottom.
+        // Clip bottom corners to match the macOS window corner radius.
+        if let characters = Self.welcomeCharacters {
+            Image(nsImage: characters)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: .infinity)
+                .clipShape(UnevenRoundedRectangle(
+                    topLeadingRadius: 0,
+                    bottomLeadingRadius: VRadius.window,
+                    bottomTrailingRadius: VRadius.window,
+                    topTrailingRadius: 0
+                ))
+                .opacity(showCharacters ? 1 : 0)
+                .offset(y: showCharacters ? 0 : 30)
+                .animation(.easeOut(duration: 0.6).delay(0.7), value: showCharacters)
+                .onAppear { showCharacters = true }
+                .accessibilityHidden(true)
         }
     }
 }


### PR DESCRIPTION
## Summary
PR 3 removed the whole step-0 chrome along with the buttons — but the mock was only meant to replace the two CTAs with cards, keeping the hero, footer, and characters illustration intact. Restoring them.

- **WakeUpStepView**: "Welcome to Vellum" title, subtitle, "2026 Vellum Inc." footer, and the welcome-characters bottom image are all back, along with the original staggered showTitle / showSubtext / showCards / showCharacters entrance animations.
- **OnboardingFlowView**: restored the original step-0 preamble (80pt top + 80x80 icon + 78pt bottom padding). `minHeight` bumped from 720 to 980 so the expanded Advanced state fits below the hero + above the characters without scroll.
- **OnboardingVellumCloudCard**: card title font switched from `VFont.brandSmall` (Instrument Serif 22pt) → `VFont.titleMedium` (DM Sans 20pt) so it sits a notch below the page title (`VFont.titleLarge`, 24pt) in the same family instead of clashing serif-vs-sans. Outer padding tightened from `VSpacing.xl` (24pt) → `VSpacing.lg` (16pt) so the card reads as a subordinate section under the page title.
- **OnboardingWindow + AppDelegate+AuthLifecycle**: NSWindow default and minSize bumped 720 → 980 on the onboarding path. Reauth path (ReauthView) stays at 620 / 580.

## Test plan
- [x] `swift build` from `clients/` green
- [ ] Launch onboarding → confirm "Welcome to Vellum" title + subtitle + cards + footer + characters all render in order
- [ ] Expand the Advanced disclosure — no scroll, characters stay pinned at the bottom
- [ ] Resize window up: cards anchor to the top under the hero, characters stay at the bottom
- [ ] Resize window down to minHeight: layout is still complete without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
