### PR TITLE
fix(permissions): risk classifier Phase 2 follow-ups

### DIFF
--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -13,6 +13,7 @@ mock.module("../util/logger.js", () => ({
 
 import {
   BashRiskClassifier,
+  clearCompiledPatterns,
   escalateOne,
   matchesArgRule,
   maxRisk,
@@ -1029,5 +1030,35 @@ describe("riskToRiskLevel", () => {
 
   test("unknown → RiskLevel.Medium (fallback)", () => {
     expect(riskToRiskLevel("unknown")).toBe(RiskLevel.Medium);
+  });
+});
+
+// ── Go subcommand classification ──────────────────────────────────────────────
+
+describe("go subcommand classification", () => {
+  const classifier = makeClassifier();
+
+  test("go get github.com/pkg → medium", async () => {
+    const result = await classifier.classify({
+      command: "go get github.com/pkg",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+  });
+
+  test("go generate ./... → high", async () => {
+    const result = await classifier.classify({
+      command: "go generate ./...",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+});
+
+// ── clearCompiledPatterns smoke test ──────────────────────────────────────────
+
+describe("clearCompiledPatterns", () => {
+  test("runs without error", () => {
+    expect(() => clearCompiledPatterns()).not.toThrow();
   });
 });

--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -700,6 +700,36 @@ describe("variable expansion", () => {
     });
     expect(result.riskLevel).toBe("medium");
   });
+
+  test("sed -i $VAR → arg rule raises to medium, $VAR escalates to high", async () => {
+    const result = await classifier.classify({
+      command: "sed -i $PATTERN file.txt",
+      toolName: "bash",
+    });
+    // sed baseRisk is low, -i flag raises to medium via sed:inplace rule,
+    // then $PATTERN escalateOne(medium) = high
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("echo $VAR → low with no arg rule match, $VAR escalates to medium (unchanged behavior)", async () => {
+    const result = await classifier.classify({
+      command: "echo $SOMETHING",
+      toolName: "bash",
+    });
+    // echo baseRisk is low, no arg rules match, escalateOne(low) = medium
+    expect(result.riskLevel).toBe("medium");
+  });
+
+  test("curl http://localhost:$PORT → high (baseRisk=medium is floor for escalation after de-escalation)", async () => {
+    const result = await classifier.classify({
+      command: "curl http://localhost:$PORT",
+      toolName: "bash",
+    });
+    // curl baseRisk=medium, curl:localhost arg rule de-escalates to low,
+    // but variable expansion uses max(computedRisk=low, baseRisk=medium)=medium
+    // as the floor, so escalateOne(medium) = high
+    expect(result.riskLevel).toBe("high");
+  });
 });
 
 // ── Assistant subcommand classification ──────────────────────────────────────

--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -412,6 +412,38 @@ describe("subcommand resolution", () => {
     });
     expect(result.riskLevel).toBe("high");
   });
+
+  test("gh --repo owner/repo pr merge 123 → high (resolves past --repo value flag)", async () => {
+    const result = await classifier.classify({
+      command: "gh --repo owner/repo pr merge 123",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("docker --host tcp://remote:2375 rm container1 → high (resolves past --host value flag)", async () => {
+    const result = await classifier.classify({
+      command: "docker --host tcp://remote:2375 rm container1",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("npm --prefix /some/path test → high (resolves past --prefix value flag)", async () => {
+    const result = await classifier.classify({
+      command: "npm --prefix /some/path test",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("gh pr view 123 → low (no global flags, still works)", async () => {
+    const result = await classifier.classify({
+      command: "gh pr view 123",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
 });
 
 // ── Wrapper unwrapping ───────────────────────────────────────────────────────

--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -968,9 +968,35 @@ describe("rm safe-file downgrade", () => {
     expect(result.riskLevel).toBe("high");
   });
 
-  test("rm -f BOOTSTRAP.md with toolName bash → high (has flags, no downgrade)", async () => {
+  test("rm -f BOOTSTRAP.md with toolName bash → medium (benign flag, safe file)", async () => {
     const result = await classifier.classify({
       command: "rm -f BOOTSTRAP.md",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+    expect(result.reason).toContain("BOOTSTRAP.md");
+  });
+
+  test("rm -v UPDATES.md with toolName bash → medium (benign flag)", async () => {
+    const result = await classifier.classify({
+      command: "rm -v UPDATES.md",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+    expect(result.reason).toContain("UPDATES.md");
+  });
+
+  test("rm -fi BOOTSTRAP.md with toolName bash → high (combined flag not in benign set)", async () => {
+    const result = await classifier.classify({
+      command: "rm -fi BOOTSTRAP.md",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("rm -rf BOOTSTRAP.md with toolName bash → high (-rf not benign)", async () => {
+    const result = await classifier.classify({
+      command: "rm -rf BOOTSTRAP.md",
       toolName: "bash",
     });
     expect(result.riskLevel).toBe("high");

--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -522,6 +522,62 @@ describe("wrapper unwrapping", () => {
     });
     expect(result.riskLevel).toBe("low");
   });
+
+  test("command -v git → low (nonExecFlags, no unwrapping)", async () => {
+    const result = await classifier.classify({
+      command: "command -v git",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
+
+  test("command -V ls → low (nonExecFlags, no unwrapping)", async () => {
+    const result = await classifier.classify({
+      command: "command -V ls",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
+
+  test("env -0 → low (no wrapped command, stays at base risk)", async () => {
+    const result = await classifier.classify({
+      command: "env -0",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
+
+  test("env -0 rm -rf / → high (unwraps to rm despite -0 flag)", async () => {
+    const result = await classifier.classify({
+      command: "env -0 rm -rf /",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("env -u FOO rm -rf / → high (unwraps to rm despite -u flag)", async () => {
+    const result = await classifier.classify({
+      command: "env -u FOO rm -rf /",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("timeout --help → low (nonExecFlags, non-exec mode)", async () => {
+    const result = await classifier.classify({
+      command: "timeout --help",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
+
+  test("env PATH=/usr/bin node script.js → high (wrapper unwraps, no non-exec flag matched)", async () => {
+    const result = await classifier.classify({
+      command: "env PATH=/usr/bin node script.js",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
 });
 
 // ── Pipeline composition ─────────────────────────────────────────────────────

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -178,17 +178,6 @@ function getWrappedProgramWithArgs(seg: {
   return undefined;
 }
 
-// ── Git value flags (for subcommand extraction) ──────────────────────────────
-const GIT_VALUE_FLAGS = new Set([
-  "-C",
-  "-c",
-  "--git-dir",
-  "--work-tree",
-  "--namespace",
-  "--super-prefix",
-  "--config-env",
-]);
-
 /**
  * Extract the first positional (non-flag) arg, skipping value-consuming flags.
  */
@@ -236,14 +225,14 @@ const RM_BENIGN_FLAGS = new Set([
 function resolveSubcommand(
   spec: CommandRiskSpec,
   args: string[],
-  program: string,
 ): { spec: CommandRiskSpec; remainingArgs: string[] } {
   if (!spec.subcommands || args.length === 0) {
     return { spec, remainingArgs: args };
   }
 
-  // For git, skip global flags that consume a value
-  const valueFlags = program === "git" ? GIT_VALUE_FLAGS : undefined;
+  const valueFlags = spec.globalValueFlags
+    ? new Set(spec.globalValueFlags)
+    : undefined;
   const subcommandName = firstPositionalArg(args, valueFlags);
 
   if (!subcommandName || !spec.subcommands[subcommandName]) {
@@ -255,7 +244,7 @@ function resolveSubcommand(
   const remainingArgs = args.slice(subIdx + 1);
 
   // Recurse for nested subcommands (e.g., git stash drop, gh pr view)
-  return resolveSubcommand(subSpec, remainingArgs, subcommandName);
+  return resolveSubcommand(subSpec, remainingArgs);
 }
 
 /**
@@ -354,7 +343,7 @@ export function classifySegment(
 
   // 4. Subcommand resolution
   const { spec: resolvedSpec, remainingArgs: _remainingArgs } =
-    resolveSubcommand(spec, segment.args, programName);
+    resolveSubcommand(spec, segment.args);
 
   // 5. Evaluate arg rules
   //

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -303,6 +303,9 @@ export function classifySegment(
   //    in a non-exec mode (e.g. `command -v`, `env -0`). Skip unwrapping and
   //    fall through to arg/base risk evaluation.
   if (spec.isWrapper) {
+    // nonExecFlags only checks args[0] — a flag in a later position won't
+    // suppress unwrapping.  This is intentional: wrappers place their mode
+    // flag first (e.g. `command -v`, `timeout --help`).
     const isNonExecMode =
       spec.nonExecFlags &&
       segment.args.length > 0 &&

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -299,16 +299,16 @@ export function classifySegment(
   }
 
   // 3. Handle wrappers — unwrap and classify inner command (recursive)
-  //    Special case: `command -v` / `command -V` are read-only lookups, not
-  //    wrapper invocations. Don't unwrap — instead fall through to arg/base
-  //    risk evaluation (the argRule for -v/-V will keep it low).
+  //    When a wrapper's first arg matches a nonExecFlags entry, the wrapper is
+  //    in a non-exec mode (e.g. `command -v`, `env -0`). Skip unwrapping and
+  //    fall through to arg/base risk evaluation.
   if (spec.isWrapper) {
-    const isCommandLookup =
-      programName === "command" &&
+    const isNonExecMode =
+      spec.nonExecFlags &&
       segment.args.length > 0 &&
-      (segment.args[0] === "-v" || segment.args[0] === "-V");
+      spec.nonExecFlags.includes(segment.args[0]);
 
-    if (!isCommandLookup) {
+    if (!isNonExecMode) {
       const inner = getWrappedProgramWithArgs(segment);
       if (inner) {
         // Build a synthetic segment for the inner command
@@ -338,7 +338,7 @@ export function classifySegment(
         matchType: "registry",
       };
     }
-    // `command -v/-V`: fall through to subcommand/arg rule evaluation
+    // Non-exec mode: fall through to subcommand/arg rule evaluation
   }
 
   // 4. Subcommand resolution

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -434,8 +434,13 @@ export function classifySegment(
   }
 
   // 6. Check for variable expansion in args (conservative escalation)
+  // Use max(computedRisk, baseRisk) as the floor for escalation so that
+  // de-escalated commands still escalate from at least baseRisk.
+  // Example: `curl http://localhost:$PORT` — arg rule de-escalates to low,
+  // but baseRisk=medium is the floor, so escalateOne(medium) → high.
   if (segment.args.some((a) => a.includes("$"))) {
-    const escalated = escalateOne(resolvedSpec.baseRisk);
+    const escalationBase = maxRisk(risk, resolvedSpec.baseRisk);
+    const escalated = escalateOne(escalationBase);
     if (riskOrd(escalated) > riskOrd(risk)) {
       risk = escalated;
       reason = `${segment.program} with variable expansion`;

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -47,7 +47,7 @@ const RISK_ORD: Record<Risk, number> = {
  * known-medium one, but not as definitive as a known-high one.
  */
 export function riskOrd(risk: Risk): number {
-  return RISK_ORD[risk] ?? 2; // default to unknown
+  return RISK_ORD[risk];
 }
 
 /** Return the higher of two risk levels. */
@@ -82,6 +82,11 @@ function getCompiledPattern(pattern: string): RegExp {
     compiledPatterns.set(pattern, re);
   }
   return re;
+}
+
+/** Clear the compiled regex cache. Exposed for tests and hot-swap scenarios. */
+export function clearCompiledPatterns(): void {
+  compiledPatterns.clear();
 }
 
 // ── Arg rule matching ────────────────────────────────────────────────────────

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -212,6 +212,17 @@ function firstPositionalArg(
 // High) in sandboxed bash. Matches checker.ts isRmOfKnownSafeFile behavior.
 const RM_SAFE_BARE_FILES = new Set(["BOOTSTRAP.md", "UPDATES.md"]);
 
+// Flags that don't affect rm safety — they don't enable recursive deletion or
+// change which files are targeted.
+const RM_BENIGN_FLAGS = new Set([
+  "-f",
+  "-i",
+  "-v",
+  "--force",
+  "--interactive",
+  "--verbose",
+]);
+
 // ── Segment classification ───────────────────────────────────────────────────
 
 /**
@@ -443,24 +454,24 @@ export function classifySegment(
   }
 
   // 7. rm safe-file downgrade (sandbox only)
-  // When rm targets a single known safe bare file (no flags, no path separators),
+  // When rm targets a single known safe bare file (with only benign flags),
   // downgrade to medium in sandboxed bash. host_bash keeps high because it has a
   // global ask rule that would prompt medium-risk commands. Matches checker.ts
   // isRmOfKnownSafeFile + toolName guard.
-  if (
-    programName === "rm" &&
-    toolName === "bash" &&
-    risk === "high" &&
-    segment.args.length === 1
-  ) {
-    const target = segment.args[0];
+  if (programName === "rm" && toolName === "bash" && risk === "high") {
+    // Strip benign flags (-f, -i, -v) and check if exactly one bare filename remains
+    const positionalArgs = segment.args.filter((a) => !a.startsWith("-"));
+    const flagArgs = segment.args.filter((a) => a.startsWith("-"));
+    const allFlagsBenign = flagArgs.every((f) => RM_BENIGN_FLAGS.has(f));
+
     if (
-      !target.startsWith("-") &&
-      !target.includes("/") &&
-      RM_SAFE_BARE_FILES.has(target)
+      positionalArgs.length === 1 &&
+      allFlagsBenign &&
+      !positionalArgs[0].includes("/") &&
+      RM_SAFE_BARE_FILES.has(positionalArgs[0])
     ) {
       risk = "medium";
-      reason = `rm of known safe file: ${target}`;
+      reason = `rm of known safe file: ${positionalArgs[0]}`;
     }
   }
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -759,6 +759,10 @@ function shellAllowlistStrategy(
   input: Record<string, unknown>,
 ): Promise<AllowlistOption[]> {
   const command = ((input.command as string) ?? "").trim();
+  // TODO(phase-3): Wire RiskAssessment.scopeOptions into permission prompts
+  // and retire buildShellAllowlistOptions + buildShellCommandCandidates from
+  // shell-identity.ts. The classifier's generateScopeOptions produces the
+  // canonical scope ladder; this legacy path should not diverge further.
   return buildShellAllowlistOptions(command);
 }
 

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -496,6 +496,8 @@ export const DEFAULT_COMMAND_REGISTRY = {
   },
   ruby: { baseRisk: "high", reason: "Executes arbitrary Ruby code" },
   go: {
+    // baseRisk is low (unlike npm's medium) because bare `go` prints help.
+    // Dangerous subcommands (run, test, generate, get) are handled individually.
     baseRisk: "low",
     subcommands: {
       mod: { baseRisk: "low" },
@@ -504,6 +506,15 @@ export const DEFAULT_COMMAND_REGISTRY = {
       build: { baseRisk: "medium" },
       test: { baseRisk: "high", reason: "Executes arbitrary test code" },
       run: { baseRisk: "high", reason: "Compiles and executes Go code" },
+      get: {
+        baseRisk: "medium",
+        reason:
+          "Downloads and installs packages; can execute arbitrary code via install hooks",
+      },
+      generate: {
+        baseRisk: "high",
+        reason: "Runs arbitrary commands via //go:generate directives",
+      },
     },
   },
 

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -519,7 +519,7 @@ export const DEFAULT_COMMAND_REGISTRY = {
       get: {
         baseRisk: "medium",
         reason:
-          "Downloads and installs packages; can execute arbitrary code via install hooks",
+          "Downloads and installs packages; may execute arbitrary code via tool directives",
       },
       generate: {
         baseRisk: "high",
@@ -531,15 +531,7 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // ── Docker ─────────────────────────────────────────────────────────────────
   docker: {
     baseRisk: "medium",
-    globalValueFlags: [
-      "--host",
-      "-H",
-      "--config",
-      "--context",
-      "-c",
-      "--log-level",
-      "-l",
-    ],
+    globalValueFlags: ["--host", "-H", "--config", "--context", "--log-level"],
     subcommands: {
       ps: { baseRisk: "low" },
       images: { baseRisk: "low" },

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -639,11 +639,16 @@ export const DEFAULT_COMMAND_REGISTRY = {
   env: { baseRisk: "low", isWrapper: true },
   nice: { baseRisk: "low", isWrapper: true },
   nohup: { baseRisk: "low", isWrapper: true },
-  timeout: { baseRisk: "low", isWrapper: true },
+  timeout: {
+    baseRisk: "low",
+    isWrapper: true,
+    nonExecFlags: ["--help", "--version"],
+  },
   time: { baseRisk: "low", isWrapper: true },
   command: {
     baseRisk: "low",
     isWrapper: true,
+    nonExecFlags: ["-v", "-V"],
     argRules: [
       {
         id: "command:lookup",

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -254,6 +254,15 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // Divergences are noted inline.
   git: {
     baseRisk: "medium",
+    globalValueFlags: [
+      "-C",
+      "-c",
+      "--git-dir",
+      "--work-tree",
+      "--namespace",
+      "--super-prefix",
+      "--config-env",
+    ],
     subcommands: {
       // LOW_RISK_GIT_SUBCOMMANDS from checker.ts:
       status: { baseRisk: "low" },
@@ -348,6 +357,7 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // they download and execute code, with subcommand-level overrides.
   npm: {
     baseRisk: "medium",
+    globalValueFlags: ["--prefix", "--userconfig", "--globalconfig", "--cache"],
     subcommands: {
       ls: { baseRisk: "low" },
       list: { baseRisk: "low" },
@@ -521,6 +531,15 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // ── Docker ─────────────────────────────────────────────────────────────────
   docker: {
     baseRisk: "medium",
+    globalValueFlags: [
+      "--host",
+      "-H",
+      "--config",
+      "--context",
+      "-c",
+      "--log-level",
+      "-l",
+    ],
     subcommands: {
       ps: { baseRisk: "low" },
       images: { baseRisk: "low" },
@@ -719,6 +738,7 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // ── Version control tools ──────────────────────────────────────────────────
   gh: {
     baseRisk: "low",
+    globalValueFlags: ["--repo", "-R"],
     subcommands: {
       pr: {
         baseRisk: "low",

--- a/assistant/src/permissions/risk-types.ts
+++ b/assistant/src/permissions/risk-types.ts
@@ -139,6 +139,12 @@ export interface CommandRiskSpec {
   complexSyntax?: boolean;
   /** Human-readable reason for the base risk (shown when no arg rule matches). */
   reason?: string;
+  /**
+   * Global flags that consume the next token as a value (e.g. git -C <path>).
+   * Used by resolveSubcommand to skip past flag-value pairs when locating the
+   * first positional arg (the subcommand name).
+   */
+  globalValueFlags?: string[];
 }
 
 // ── User rule types ──────────────────────────────────────────────────────────

--- a/assistant/src/permissions/risk-types.ts
+++ b/assistant/src/permissions/risk-types.ts
@@ -132,6 +132,12 @@ export interface CommandRiskSpec {
    */
   isWrapper?: boolean;
   /**
+   * Flags that put a wrapper into a non-exec mode (e.g. command -v, env -0).
+   * When the first arg matches a non-exec flag, skip unwrapping and classify
+   * the wrapper standalone against its own arg rules.
+   */
+  nonExecFlags?: string[];
+  /**
    * Does this command have non-standard syntax where intermediate scope
    * options would be confusing? (find, xargs, awk, etc.)
    * When true, the scope ladder only offers exact match and command-level wildcard.


### PR DESCRIPTION
## Summary
Fix all P1-P3 issues and nits from the Phase 2 review of the bash risk classifier: subcommand resolution for non-git global value flags, variable expansion escalation fix, wrapper non-exec flag generalization, rm safe-file flag handling, and code quality items.

## Self-review result
PASS — 2 gaps found during review were plan errors (not implementation errors), both already addressed via reviewer feedback during the review gate.

## PRs merged into feature branch
- #27085: fix(permissions): resolve subcommands for CLIs with global value flags (gh, docker, npm)
- #27086: feat(permissions): generalize wrapper non-exec flag handling via nonExecFlags
- #27087: chore(permissions): add TODO for scope-option system consolidation in Phase 3
- #27088: fix(permissions): escalate variable expansion from computed risk, not baseRisk
- #27089: chore(permissions): address Phase 2 nits — riskOrd fallback, regex cache, go comment
- #27091: fix(permissions): allow benign flags in rm safe-file downgrade

Part of plan: risk-classifier-phase2-fixes.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
