### PR TITLE
fix(context-window): clamp targetInputTokensOverride to enforce stricter-fit contract

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -837,13 +837,9 @@ describe("ContextWindowManager", () => {
   });
 
   test("force compaction with loose target override still summarizes persisted messages", async () => {
-    // Regression: a mid-loop compaction that fires above the compact
-    // threshold with a loose `targetInputTokensOverride` (looser than
-    // `config.targetInputTokens`) must still summarize persisted
-    // messages rather than short-circuiting into the truncate-only
-    // early-exit. The window manager guarantees this by clamping the
-    // override to no looser than the configured target in
-    // `pickKeepBoundary`.
+    // `pickKeepBoundary` clamps `targetInputTokensOverride` to
+    // `config.targetInputTokens`, so a loose override cannot
+    // short-circuit summarization into the truncate-only early-exit.
 
     let summaryCalls = 0;
     const provider = createProvider(() => {
@@ -856,18 +852,9 @@ describe("ContextWindowManager", () => {
       };
     });
 
-    // Scaled mirror of production config (200k → 1000):
-    //   maxInputTokens       = 1000 (prod 200k)
-    //   compactThreshold     = 0.3  → threshold 300   (prod 160k)
-    //   targetBudgetRatio    = 0.1  → post-compact target 50 (prod 50k)
-    //   summaryBudgetRatio   = 0.05
-    //
-    // Production uses maxInputTokens=200_000, compactThreshold=0.8,
-    // targetBudgetRatio=0.3, summaryBudgetRatio=0.05. We shrink the
-    // absolute numbers to keep the test fast while preserving the key
-    // ratio: the mid-loop override (~0.85 × max) is roughly 17× the
-    // post-compaction target (~0.05 × max), so any history that sits
-    // between "above threshold" and "below override" hits the bug.
+    // Scaled from prod (max 200k → 1000) preserving key ratios: the
+    // loose override (~0.85×max) is ~17× the post-compaction target
+    // (~0.05×max), so history between the two exercises the clamp.
     const manager = new ContextWindowManager({
       provider,
       systemPrompt: "system prompt",
@@ -879,9 +866,7 @@ describe("ContextWindowManager", () => {
       }),
     });
 
-    // Build a history sized in the "no-op zone": well above the
-    // 300-token compact threshold, well below the 850-token preflight
-    // budget analog.
+    // History in the "no-op zone": above threshold (300), below override (850).
     const long = "x".repeat(180);
     const history: Message[] = [
       message("user", `u1 ${long}`),
@@ -895,16 +880,13 @@ describe("ContextWindowManager", () => {
       message("user", `u5 ${long}`),
     ];
 
-    // Simulate the mid-loop caller pattern: force + override set to
-    // preflightBudget (maxInputTokens * 0.85 = 850).
     const preflightBudgetAnalog = Math.floor(1000 * 0.85);
     const result = await manager.maybeCompact(history, undefined, {
       force: true,
       targetInputTokensOverride: preflightBudgetAnalog,
     });
 
-    // The reported token count (to prove we were actually in the
-    // "should compact" zone).
+    // Guard: we're actually above the compact threshold.
     expect(result.previousEstimatedInputTokens).toBeGreaterThan(
       result.thresholdTokens,
     );

--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -836,102 +836,83 @@ describe("ContextWindowManager", () => {
     );
   });
 
-  test.todo(
-    "force compaction with loose target override still summarizes persisted messages",
-    async () => {
-      // Regression test for a mid-loop compaction no-op observed in a
-      // user feedback report: a long conversation reached ~247k tokens
-      // against a 200k budget with the UI spinning on "compacting"
-      // while compaction ran repeatedly and summarized nothing.
-      //
-      // Root cause (window-manager.ts:278-312 truncate-only early-exit):
-      // mid-loop compaction invokes maybeCompact with
-      //   { force: true, targetInputTokensOverride: preflightBudget }
-      // where preflightBudget ≈ maxInputTokens * 0.85. When the current
-      // history estimate is BELOW the override, pickKeepBoundary's
-      // projected-fit check finds "all turns already fit" and takes the
-      // early-exit branch that truncates tool results without running a
-      // summary call. Result: `compacted: true` but
-      // `compactedPersistedMessages: 0` — a silent no-op.
-      //
-      // Expected behavior (once compaction logic is cleaned up): a
-      // forced compaction that fires above the compact threshold must
-      // actually summarize persisted messages, regardless of whether a
-      // loose override was passed.
+  test("force compaction with loose target override still summarizes persisted messages", async () => {
+    // Regression: a mid-loop compaction that fires above the compact
+    // threshold with a loose `targetInputTokensOverride` (looser than
+    // `config.targetInputTokens`) must still summarize persisted
+    // messages rather than short-circuiting into the truncate-only
+    // early-exit. The window manager guarantees this by clamping the
+    // override to no looser than the configured target in
+    // `pickKeepBoundary`.
 
-      let summaryCalls = 0;
-      const provider = createProvider(() => {
-        summaryCalls += 1;
-        return {
-          content: [{ type: "text", text: "## Goals\n- real summary" }],
-          model: "mock-model",
-          usage: { inputTokens: 80, outputTokens: 20 },
-          stopReason: "end_turn",
-        };
-      });
+    let summaryCalls = 0;
+    const provider = createProvider(() => {
+      summaryCalls += 1;
+      return {
+        content: [{ type: "text", text: "## Goals\n- real summary" }],
+        model: "mock-model",
+        usage: { inputTokens: 80, outputTokens: 20 },
+        stopReason: "end_turn",
+      };
+    });
 
-      // Scaled mirror of production config (200k → 1000):
-      //   maxInputTokens       = 1000 (prod 200k)
-      //   compactThreshold     = 0.3  → threshold 300   (prod 160k)
-      //   targetBudgetRatio    = 0.1  → post-compact target 50 (prod 50k)
-      //   summaryBudgetRatio   = 0.05
-      //
-      // Production uses maxInputTokens=200_000, compactThreshold=0.8,
-      // targetBudgetRatio=0.3, summaryBudgetRatio=0.05. We shrink the
-      // absolute numbers to keep the test fast while preserving the key
-      // ratio: the mid-loop override (~0.85 × max) is roughly 17× the
-      // post-compaction target (~0.05 × max), so any history that sits
-      // between "above threshold" and "below override" hits the bug.
-      const manager = new ContextWindowManager({
-        provider,
-        systemPrompt: "system prompt",
-        config: makeConfig({
-          maxInputTokens: 1000,
-          targetBudgetRatio: 0.1,
-          summaryBudgetRatio: 0.05,
-          compactThreshold: 0.3,
-        }),
-      });
+    // Scaled mirror of production config (200k → 1000):
+    //   maxInputTokens       = 1000 (prod 200k)
+    //   compactThreshold     = 0.3  → threshold 300   (prod 160k)
+    //   targetBudgetRatio    = 0.1  → post-compact target 50 (prod 50k)
+    //   summaryBudgetRatio   = 0.05
+    //
+    // Production uses maxInputTokens=200_000, compactThreshold=0.8,
+    // targetBudgetRatio=0.3, summaryBudgetRatio=0.05. We shrink the
+    // absolute numbers to keep the test fast while preserving the key
+    // ratio: the mid-loop override (~0.85 × max) is roughly 17× the
+    // post-compaction target (~0.05 × max), so any history that sits
+    // between "above threshold" and "below override" hits the bug.
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({
+        maxInputTokens: 1000,
+        targetBudgetRatio: 0.1,
+        summaryBudgetRatio: 0.05,
+        compactThreshold: 0.3,
+      }),
+    });
 
-      // Build a history sized in the "no-op zone": well above the
-      // 300-token compact threshold, well below the 850-token preflight
-      // budget analog.
-      const long = "x".repeat(180);
-      const history: Message[] = [
-        message("user", `u1 ${long}`),
-        message("assistant", `a1 ${long}`),
-        message("user", `u2 ${long}`),
-        message("assistant", `a2 ${long}`),
-        message("user", `u3 ${long}`),
-        message("assistant", `a3 ${long}`),
-        message("user", `u4 ${long}`),
-        message("assistant", `a4 ${long}`),
-        message("user", `u5 ${long}`),
-      ];
+    // Build a history sized in the "no-op zone": well above the
+    // 300-token compact threshold, well below the 850-token preflight
+    // budget analog.
+    const long = "x".repeat(180);
+    const history: Message[] = [
+      message("user", `u1 ${long}`),
+      message("assistant", `a1 ${long}`),
+      message("user", `u2 ${long}`),
+      message("assistant", `a2 ${long}`),
+      message("user", `u3 ${long}`),
+      message("assistant", `a3 ${long}`),
+      message("user", `u4 ${long}`),
+      message("assistant", `a4 ${long}`),
+      message("user", `u5 ${long}`),
+    ];
 
-      // Simulate the mid-loop caller pattern: force + override set to
-      // preflightBudget (maxInputTokens * 0.85 = 850).
-      const preflightBudgetAnalog = Math.floor(1000 * 0.85);
-      const result = await manager.maybeCompact(history, undefined, {
-        force: true,
-        targetInputTokensOverride: preflightBudgetAnalog,
-      });
+    // Simulate the mid-loop caller pattern: force + override set to
+    // preflightBudget (maxInputTokens * 0.85 = 850).
+    const preflightBudgetAnalog = Math.floor(1000 * 0.85);
+    const result = await manager.maybeCompact(history, undefined, {
+      force: true,
+      targetInputTokensOverride: preflightBudgetAnalog,
+    });
 
-      // The reported token count (to prove we were actually in the
-      // "should compact" zone).
-      expect(result.previousEstimatedInputTokens).toBeGreaterThan(
-        result.thresholdTokens,
-      );
+    // The reported token count (to prove we were actually in the
+    // "should compact" zone).
+    expect(result.previousEstimatedInputTokens).toBeGreaterThan(
+      result.thresholdTokens,
+    );
 
-      // ── Expected post-fix behavior ───────────────────────────────
-      // At least one real summarization happened. (Under the current
-      // buggy code path this fails — `compactedPersistedMessages` is 0
-      // and `summaryCalls` is 0 because pickKeepBoundary short-circuits
-      // into the truncate-only early-exit.)
-      expect(result.compactedPersistedMessages).toBeGreaterThan(0);
-      expect(summaryCalls).toBeGreaterThan(0);
-    },
-  );
+    // A real summarization happened (not the truncate-only no-op).
+    expect(result.compactedPersistedMessages).toBeGreaterThan(0);
+    expect(summaryCalls).toBeGreaterThan(0);
+  });
 
   test("force=true compacts below minFloor when a kept turn exceeds target", async () => {
     // A giant paste in the last user turn means minFloor=1 alone exceeds target.

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -100,8 +100,10 @@ export interface ContextWindowCompactOptions {
   conversationOriginChannel?: string;
   /**
    * Override the target input token budget used for keep-boundary
-   * projected-fit checks. Allows the caller to demand a stricter fit
-   * than the normal `config.targetInputTokens` during forced recovery.
+   * projected-fit checks. Clamped to no looser than `config.targetInputTokens`
+   * — i.e. the override may only demand a *stricter* fit. Passing a looser
+   * value has no effect. Intended for forced recovery paths that need a
+   * tighter target than the default.
    */
   targetInputTokensOverride?: number;
   /**
@@ -593,8 +595,11 @@ export class ContextWindowManager {
       Math.max(0, Math.floor(opts?.minKeepRecentUserTurns ?? defaultTurns)),
       userTurnStarts.length,
     );
+    const overrideTarget = opts?.targetInputTokensOverride;
     const targetTokens =
-      opts?.targetInputTokensOverride ?? this.targetInputTokens;
+      overrideTarget !== undefined
+        ? Math.min(overrideTarget, this.targetInputTokens)
+        : this.targetInputTokens;
 
     // Binary search for the maximum keepTurns whose projected tokens fit
     // within the budget. Token count is monotonically non-decreasing with

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -595,11 +595,10 @@ export class ContextWindowManager {
       Math.max(0, Math.floor(opts?.minKeepRecentUserTurns ?? defaultTurns)),
       userTurnStarts.length,
     );
-    const overrideTarget = opts?.targetInputTokensOverride;
-    const targetTokens =
-      overrideTarget !== undefined
-        ? Math.min(overrideTarget, this.targetInputTokens)
-        : this.targetInputTokens;
+    const targetTokens = Math.min(
+      opts?.targetInputTokensOverride ?? this.targetInputTokens,
+      this.targetInputTokens,
+    );
 
     // Binary search for the maximum keepTurns whose projected tokens fit
     // within the budget. Token count is monotonically non-decreasing with


### PR DESCRIPTION
## Summary

Restores the documented "stricter-fit only" contract for `ContextWindowCompactOptions.targetInputTokensOverride`. Before this change, `pickKeepBoundary` honored any override verbatim — but every production caller (`context-overflow-reducer.ts:176`, `conversation-agent-loop.ts:1263/1639/1775`) passes `preflightBudget` (~85% of `maxInputTokens`), which is looser than `config.targetInputTokens` (~25% of max). That caused `pickKeepBoundary`'s binary search to decide "all turns fit", hit the truncate-only early-exit at `window-manager.ts:299`, and return `compacted: true` with `compactedPersistedMessages: 0` — a silent no-op while conversations kept growing past the provider cap.

The clamp pins the effective target to `min(override, this.targetInputTokens)` inside `pickKeepBoundary`, so an override can only ever make the target *stricter*, never looser. Defense-in-depth against future callers re-introducing the same bug.

## Self-review result

PASS — all 3 passes (external feedback, plan faithfulness, repo integration) returned PASS. Pass 3 flagged that emergency-recovery paths at `conversation-agent-loop.ts:1639/1775` now target ~25% of max instead of ~85%; this is intentional and was called out in the plan.

## PRs merged into feature branch

- #27099: fix(context-window): clamp targetInputTokensOverride to enforce stricter-fit contract

Part of plan: compact-noop-clamp.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
