### PR TITLE
chore(permissions): clean up checker.ts after approval policy extraction

### DIFF
--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -36,8 +36,6 @@ export interface ApprovalPolicy {
 
 /**
  * Implements the approval decision policy used by `check()` in checker.ts.
- * Each branch is annotated with the corresponding decision path so reviewers
- * can verify 1:1 parity.
  *
  * The decision flow:
  *

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -135,8 +135,6 @@ export function matchesArgRule(rule: ArgRule, arg: string): boolean {
 }
 
 // ── Wrapper unwrapping ───────────────────────────────────────────────────────
-// Reuses the same logic as checker.ts for wrapper unwrapping. We inline the
-// relevant constants and algorithm here to avoid needing to export from checker.ts.
 
 const WRAPPER_SKIP_FIRST_POSITIONAL = new Set(["timeout", "taskset"]);
 const ENV_VALUE_FLAGS = new Set(["-u", "--unset", "-C", "--chdir"]);
@@ -145,8 +143,6 @@ const TIMEOUT_VALUE_FLAGS = new Set(["-s", "--signal", "-k", "--kill-after"]);
 /**
  * Given a wrapper segment, extract the wrapped program and its args.
  * Returns undefined when no suitable argument is found.
- *
- * Replicates getWrappedProgramWithArgs from checker.ts.
  */
 function getWrappedProgramWithArgs(seg: {
   program: string;
@@ -204,7 +200,7 @@ function firstPositionalArg(
 
 // ── Safe-file downgrade for rm ────────────────────────────────────────────────
 // Bare filenames that `rm` is allowed to delete at Medium risk (instead of
-// High) in sandboxed bash. Matches checker.ts isRmOfKnownSafeFile behavior.
+// High) in sandboxed bash.
 const RM_SAFE_BARE_FILES = new Set(["BOOTSTRAP.md", "UPDATES.md"]);
 
 // ── Segment classification ───────────────────────────────────────────────────
@@ -440,8 +436,7 @@ export function classifySegment(
   // 7. rm safe-file downgrade (sandbox only)
   // When rm targets a single known safe bare file (no flags, no path separators),
   // downgrade to medium in sandboxed bash. host_bash keeps high because it has a
-  // global ask rule that would prompt medium-risk commands. Matches checker.ts
-  // isRmOfKnownSafeFile + toolName guard.
+  // global ask rule that would prompt medium-risk commands.
   if (
     programName === "rm" &&
     toolName === "bash" &&
@@ -655,11 +650,9 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
       maxReason = parsed.dangerousPatterns[0].description;
     }
 
-    // Opaque constructs escalation (matches checker.ts behavior):
+    // Opaque constructs escalation:
     // - With dangerous patterns present → escalate to high
     // - Without dangerous patterns → escalate to medium only
-    // checker.ts returns Medium for opaque constructs before the per-segment
-    // loop, so opaque-without-danger is medium, not high.
     if (parsed.hasOpaqueConstructs) {
       const opaqueTarget: Risk =
         parsed.dangerousPatterns.length > 0 ? "high" : "medium";


### PR DESCRIPTION
## Summary
- Remove unused imports and dead code from checker.ts after approval policy extraction
- Clean up Phase 1/Phase 2 scaffolding comments in permissions directory

Part of plan: bash-risk-approval-policy.md (PR 8 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
