### PR TITLE
feat(permissions): honor autoApproveUpTo threshold in approval policy

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1568,16 +1568,17 @@ graph TB
     RISK_CHECK -->|"Low / Medium"| AUTO_ALLOW["decision: allow<br/>Auto-allowed by rule"]
     RISK_CHECK -->|"High"| HIGH_CHECK{"shouldAutoAllowHighRisk()<br/>(containerized bash?)"}
     HIGH_CHECK -->|"yes"| AUTO_ALLOW
-    HIGH_CHECK -->|"no"| PROMPT_HIGH["decision: prompt<br/>High risk requires approval"]
+    HIGH_CHECK -->|"no"| RISK_THRESHOLD{"Risk-based<br/>threshold fallback"}
 
     NO_MATCH -->|"tool.origin === 'skill'"| PROMPT_SKILL["decision: prompt<br/>Skill tools always ask"]
     NO_MATCH -->|"strict mode"| PROMPT_STRICT["decision: prompt<br/>No implicit auto-allow"]
-    NO_MATCH -->|"workspace mode (default)"| WS_CHECK{"Workspace-scoped<br/>invocation?"}
+    NO_MATCH -->|"workspace mode (default)"| WS_CHECK{"Workspace-scoped<br/>+ Low risk?"}
     WS_CHECK -->|"yes"| AUTO_WS["decision: allow<br/>Workspace-scoped auto-allow"]
-    WS_CHECK -->|"no"| RISK_FALLBACK_WS{"Risk level?"}
-    RISK_FALLBACK_WS -->|"Low"| AUTO_WS_LOW["decision: allow<br/>Low risk auto-allow"]
-    RISK_FALLBACK_WS -->|"Medium"| PROMPT_WS_MED["decision: prompt"]
-    RISK_FALLBACK_WS -->|"High"| PROMPT_WS_HIGH["decision: prompt"]
+    WS_CHECK -->|"no"| RISK_THRESHOLD
+
+    RISK_THRESHOLD{"risk ≤ autoApproveUpTo<br/>threshold?"}
+    RISK_THRESHOLD -->|"yes"| AUTO_THRESHOLD["decision: allow<br/>within auto-approve threshold"]
+    RISK_THRESHOLD -->|"no"| PROMPT_THRESHOLD["decision: prompt<br/>above auto-approve threshold"]
 ```
 
 ### Permission Modes: Workspace and Strict
@@ -1710,7 +1711,7 @@ When a permission prompt is sent to the client (via `confirmation_request` SSE e
 | `allowlistOptions` | Suggested patterns for "always allow" rules         |
 | `scopeOptions`     | Suggested scopes for rule persistence               |
 
-The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). High-risk operations in containerized environments are auto-allowed at runtime by `shouldAutoAllowHighRisk()` without requiring persisted state.
+The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). High-risk operations with an allow rule in containerized environments are auto-allowed at runtime by `DefaultApprovalPolicy.shouldAutoAllowHighRisk()` without requiring persisted state. All other risk-based decisions use the `autoApproveUpTo` threshold (default: `"low"`) -- tools at or below the threshold are auto-allowed, those above are prompted.
 
 ### Canonical Paths
 

--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -22,16 +22,17 @@ graph TB
     RISK_CHECK -->|"Low / Medium"| AUTO_ALLOW["decision: allow<br/>Auto-allowed by rule"]
     RISK_CHECK -->|"High"| HIGH_CHECK{"shouldAutoAllowHighRisk()<br/>(containerized bash?)"}
     HIGH_CHECK -->|"yes"| AUTO_ALLOW
-    HIGH_CHECK -->|"no"| PROMPT_HIGH["decision: prompt<br/>High risk requires approval"]
+    HIGH_CHECK -->|"no"| RISK_THRESHOLD{"Risk-based<br/>threshold fallback"}
 
     NO_MATCH -->|"tool.origin === 'skill'"| PROMPT_SKILL["decision: prompt<br/>Skill tools always ask"]
     NO_MATCH -->|"strict mode"| PROMPT_STRICT["decision: prompt<br/>No implicit auto-allow"]
-    NO_MATCH -->|"workspace mode (default)"| WS_CHECK{"Workspace-scoped<br/>invocation?"}
+    NO_MATCH -->|"workspace mode (default)"| WS_CHECK{"Workspace-scoped<br/>+ Low risk?"}
     WS_CHECK -->|"yes"| AUTO_WS["decision: allow<br/>Workspace-scoped auto-allow"]
-    WS_CHECK -->|"no"| RISK_FALLBACK_WS{"Risk level?"}
-    RISK_FALLBACK_WS -->|"Low"| AUTO_WS_LOW["decision: allow<br/>Low risk auto-allow"]
-    RISK_FALLBACK_WS -->|"Medium"| PROMPT_WS_MED["decision: prompt"]
-    RISK_FALLBACK_WS -->|"High"| PROMPT_WS_HIGH["decision: prompt"]
+    WS_CHECK -->|"no"| RISK_THRESHOLD
+
+    RISK_THRESHOLD{"risk ≤ autoApproveUpTo<br/>threshold?"}
+    RISK_THRESHOLD -->|"yes"| AUTO_THRESHOLD["decision: allow<br/>within auto-approve threshold"]
+    RISK_THRESHOLD -->|"no"| PROMPT_THRESHOLD["decision: prompt<br/>above auto-approve threshold"]
 ```
 
 ### Permission Modes: Workspace and Strict
@@ -164,7 +165,7 @@ When a permission prompt is sent to the client (via `confirmation_request` SSE e
 | `allowlistOptions` | Suggested patterns for "always allow" rules         |
 | `scopeOptions`     | Suggested scopes for rule persistence               |
 
-The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). High-risk operations in containerized environments are auto-allowed at runtime by `shouldAutoAllowHighRisk()` without requiring persisted state.
+The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). High-risk operations with an allow rule in containerized environments are auto-allowed at runtime by `DefaultApprovalPolicy.shouldAutoAllowHighRisk()` without requiring persisted state. All other risk-based decisions use the `autoApproveUpTo` threshold (default: `"low"`) -- tools at or below the threshold are auto-allowed, those above are prompted.
 
 ### Canonical Paths
 

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -713,7 +713,7 @@ describe("Permission Checker", () => {
       // Low risk → auto-allowed via risk-based fallback
       const low = await check("bash", { command: "ls" }, "/tmp");
       expect(low.decision).toBe("allow");
-      expect(low.reason).toContain("Low risk");
+      expect(low.reason).toContain("low risk");
     });
 
     test("host_bash high risk → always prompt", async () => {
@@ -760,7 +760,7 @@ describe("Permission Checker", () => {
       addRule("bash", "rm *", "/tmp");
       const result = await check("bash", { command: "rm file.txt" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
 
     test("file_read → auto-allow", async () => {
@@ -942,7 +942,7 @@ describe("Permission Checker", () => {
       );
       // High-risk tools always prompt even with allow rules
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
 
     test("allow rule for scaffold_managed_skill does not match other skill ids", async () => {
@@ -976,7 +976,7 @@ describe("Permission Checker", () => {
       );
       // High-risk tools always prompt even with allow rules
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
 
     test("computer_use_click prompts by default via computer-use ask rule", async () => {
@@ -1087,7 +1087,7 @@ describe("Permission Checker", () => {
       addRule("bash", "sudo *", "everywhere");
       const result = await check("bash", { command: "sudo rm -rf /" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
 
     // Deny rule tests
@@ -1463,7 +1463,7 @@ describe("Permission Checker", () => {
       // Use a path outside the workspace to test the risk-based fallback.
       const result = await check("file_read", { path: "/etc/hosts" }, "/tmp");
       expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("Low risk");
+      expect(result.reason).toContain("low risk");
     });
 
     // Regression: trust rules properly override the default-ask policy
@@ -1522,7 +1522,7 @@ describe("Permission Checker", () => {
       // reason discriminator to verify it's the high-risk fallback path, not
       // the generic skill-tool default-ask policy.
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
   });
 
@@ -2646,7 +2646,7 @@ describe("Permission Checker", () => {
       addRule("bash", "sudo *", "everywhere", "allow");
       const result = await check("bash", { command: "sudo rm -rf /" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
   });
 
@@ -2657,7 +2657,7 @@ describe("Permission Checker", () => {
       addRule("bash", "kill *", "everywhere", "allow", 2000);
       const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
 
     test("high-risk bash with allow rule in containerized environment auto-allows", async () => {
@@ -2780,7 +2780,7 @@ describe("Permission Checker", () => {
       addRule("bash", "kill *", "everywhere", "allow", 2000);
       const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
 
     test("strict mode: medium-risk with matching allow rule auto-allows", async () => {
@@ -4046,7 +4046,7 @@ describe("Permission Checker", () => {
         addRule("file_write", `file_write:${checkerTestDir}/skills/**`, "/tmp");
         const result = await check("file_write", { path: skillPath }, "/tmp");
         expect(result.decision).toBe("prompt");
-        expect(result.reason).toContain("High risk");
+        expect(result.reason).toContain("high risk");
       });
 
       test("allow rule for skill mutation prompts (high risk, non-bash tool)", async () => {
@@ -4775,7 +4775,7 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
       workspaceDir,
     );
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   test("file_write outside workspace → allow (Low risk fallback)", async () => {
@@ -4785,7 +4785,7 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
       workspaceDir,
     );
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   // ── bash (non-containerized) — workspace auto-allow blocked, risk-based fallback ──
@@ -4795,7 +4795,7 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
     expect(result.decision).toBe("allow");
     // Not auto-allowed via workspace mode — bash falls through to risk-based policy
     expect(result.reason).not.toContain("Workspace mode");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   test("bash in workspace (medium risk) → prompt (not auto-allowed)", async () => {
@@ -4883,7 +4883,7 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
       workspaceDir,
     );
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   test("network_request → prompt (Medium risk, not workspace-scoped)", async () => {

--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -131,7 +131,7 @@ describe("allow rule", () => {
       isContainerized: false,
     });
     expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("High risk");
+    expect(result.reason).toContain("high risk");
     // Decision is driven by risk-based fallback, not the rule
     expect(result.matchedRule).toBeUndefined();
   });
@@ -156,7 +156,7 @@ describe("allow rule", () => {
       isContainerized: true,
     });
     expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("High risk");
+    expect(result.reason).toContain("high risk");
     // Decision is driven by risk-based fallback, not the rule
     expect(result.matchedRule).toBeUndefined();
   });
@@ -169,7 +169,7 @@ describe("allow rule", () => {
       isContainerized: false,
     });
     expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("High risk");
+    expect(result.reason).toContain("high risk");
     // Decision is driven by risk-based fallback, not the rule
     expect(result.matchedRule).toBeUndefined();
   });
@@ -289,9 +289,9 @@ describe("no rule — workspace mode", () => {
       permissionsMode: "workspace",
       isWorkspaceScoped: false,
     });
-    // Falls through to risk-based: Low → allow
+    // Falls through to risk-based: Low → allow (within default "low" threshold)
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   test("workspace mode, Medium risk → falls through to risk-based prompt", () => {
@@ -314,9 +314,9 @@ describe("no rule — workspace mode", () => {
       isWorkspaceScoped: true,
     });
     // Non-containerized bash falls through the workspace check.
-    // Then hits risk-based: Low → allow
+    // Then hits risk-based: Low → allow (within default "low" threshold)
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   test("workspace mode, bash, containerized, Low risk, workspace-scoped → allow via workspace mode", () => {
@@ -368,7 +368,7 @@ describe("no rule — bundled skill tool", () => {
       isSkillBundled: true,
     });
     expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("High risk");
+    expect(result.reason).toContain("high risk");
   });
 });
 
@@ -381,7 +381,7 @@ describe("risk-based fallback (no rule, no special case)", () => {
       toolName: "some_tool",
     });
     expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("High risk");
+    expect(result.reason).toContain("high risk");
   });
 
   test("Low risk → allow", () => {
@@ -390,7 +390,7 @@ describe("risk-based fallback (no rule, no special case)", () => {
       toolName: "some_tool",
     });
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   test("Medium risk → prompt", () => {
@@ -442,7 +442,7 @@ describe("edge cases", () => {
     });
     // Allow rule + High risk + non-bash → falls through to risk-based: High → prompt
     expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("High risk");
+    expect(result.reason).toContain("high risk");
   });
 
   test("reason includes the matched rule pattern", () => {
@@ -474,7 +474,7 @@ describe("edge cases", () => {
     expect(result.decision).toBe("allow");
   });
 
-  test("workspace mode non-containerized bash, Low risk, workspace-scoped → Low risk allow (not workspace allow)", () => {
+  test("workspace mode non-containerized bash, Low risk, workspace-scoped → low risk allow (not workspace allow)", () => {
     // This is the subtle bash host exception. The workspace mode check
     // specifically skips bash when not containerized, so it falls through
     // to the risk-based path where Low risk still auto-allows.
@@ -486,10 +486,10 @@ describe("edge cases", () => {
       isWorkspaceScoped: true,
     });
     expect(result.decision).toBe("allow");
-    // The reason should be "Low risk" not "Workspace mode" — the workspace
+    // The reason should be "low risk" not "Workspace mode" — the workspace
     // auto-allow was bypassed because bash is on the host.
     expect(result.reason).not.toContain("Workspace mode");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   test("hasManifestOverride with toolOrigin set to skill — third-party check triggers on origin", () => {
@@ -513,8 +513,200 @@ describe("edge cases", () => {
     });
     // toolOrigin is "builtin", so the third-party skill check doesn't trigger.
     // The hasManifestOverride check requires !toolOrigin, but toolOrigin is set.
-    // Falls through to risk-based: Low → allow.
+    // Falls through to risk-based: Low → allow (within default "low" threshold).
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
+  });
+});
+
+// ── autoApproveUpTo threshold ─────────────────────────────────────────────────
+
+describe("autoApproveUpTo threshold", () => {
+  describe('autoApproveUpTo: "none" — everything prompts', () => {
+    test("Low risk → prompt", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "some_tool",
+        autoApproveUpTo: "none",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+
+    test("Medium risk → prompt", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Medium,
+        toolName: "some_tool",
+        autoApproveUpTo: "none",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+
+    test("High risk → prompt", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.High,
+        toolName: "some_tool",
+        autoApproveUpTo: "none",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+  });
+
+  describe('autoApproveUpTo: "low" — default, matches existing behavior', () => {
+    test("Low risk → allow", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "some_tool",
+        autoApproveUpTo: "low",
+      });
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("within auto-approve threshold");
+    });
+
+    test("Medium risk → prompt", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Medium,
+        toolName: "some_tool",
+        autoApproveUpTo: "low",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+
+    test("High risk → prompt", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.High,
+        toolName: "some_tool",
+        autoApproveUpTo: "low",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+  });
+
+  describe('autoApproveUpTo: "medium" — Low and Medium auto-allow', () => {
+    test("Low risk → allow", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "some_tool",
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("within auto-approve threshold");
+    });
+
+    test("Medium risk → allow", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Medium,
+        toolName: "some_tool",
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("within auto-approve threshold");
+    });
+
+    test("High risk → prompt", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.High,
+        toolName: "some_tool",
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+  });
+
+  describe("threshold interacts correctly with rule-based decisions", () => {
+    test("deny rule still denies regardless of threshold", () => {
+      const denyRule = makeRule({ decision: "deny" });
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "bash",
+        matchedRule: denyRule,
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("deny");
+      expect(result.matchedRule).toBe(denyRule);
+    });
+
+    test("ask rule still prompts regardless of threshold", () => {
+      const askRule = makeRule({ decision: "ask" });
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "bash",
+        matchedRule: askRule,
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.matchedRule).toBe(askRule);
+    });
+
+    test("allow rule still allows non-High regardless of threshold", () => {
+      const allowRule = makeRule({ decision: "allow" });
+      const result = evaluate({
+        riskLevel: RiskLevel.Medium,
+        toolName: "file_write",
+        matchedRule: allowRule,
+        autoApproveUpTo: "none",
+      });
+      expect(result.decision).toBe("allow");
+      expect(result.matchedRule).toBe(allowRule);
+    });
+  });
+
+  describe("threshold interacts correctly with strict mode", () => {
+    test("strict mode still prompts even with medium threshold", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "file_read",
+        permissionsMode: "strict",
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("Strict mode");
+    });
+  });
+
+  describe("threshold interacts correctly with workspace mode", () => {
+    test("workspace mode workspace-scoped Low still allows via workspace path (before threshold)", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "file_read",
+        permissionsMode: "workspace",
+        isWorkspaceScoped: true,
+        autoApproveUpTo: "none",
+      });
+      // Workspace mode auto-allow fires before the threshold fallback
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("Workspace mode");
+    });
+
+    test("workspace mode non-workspace-scoped Low with none threshold → prompt", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "file_read",
+        permissionsMode: "workspace",
+        isWorkspaceScoped: false,
+        autoApproveUpTo: "none",
+      });
+      // Falls through workspace check (not workspace-scoped), then threshold
+      // "none" means Low risk is above threshold → prompt
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+  });
+
+  describe("threshold defaults to low when omitted", () => {
+    test("omitted autoApproveUpTo behaves as low", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "some_tool",
+        // autoApproveUpTo not set
+      });
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("within auto-approve threshold");
+    });
   });
 });

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -17,6 +17,13 @@ export interface ApprovalContext {
   isSkillBundled?: boolean;
   /** Whether the tool has a manifest override (unregistered skill tool). */
   hasManifestOverride?: boolean;
+  /**
+   * Auto-approve tools at or below this risk level when no rule matches.
+   * - "none": prompt for everything (strictest)
+   * - "low": auto-approve Low risk (default, matches existing behavior)
+   * - "medium": auto-approve Low and Medium risk
+   */
+  autoApproveUpTo?: "none" | "low" | "medium";
 }
 
 /** The outcome of an approval policy evaluation. */
@@ -51,9 +58,8 @@ export interface ApprovalPolicy {
  * 8. No rule + workspace mode + Low + workspace-scoped → allow
  *    (except non-containerized bash — never auto-allow)
  * 9. No rule + Low + bundled skill → allow
- * 10. High → prompt
- * 11. Low → allow
- * 12. Medium → prompt
+ * 10. Risk ≤ autoApproveUpTo threshold → allow
+ * 11. Risk > autoApproveUpTo threshold → prompt
  */
 export class DefaultApprovalPolicy implements ApprovalPolicy {
   evaluate(context: ApprovalContext): ApprovalDecision {
@@ -163,22 +169,25 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       }
     }
 
-    // ── 10–12. Risk-based fallback ────────────────────────────────────
-    if (riskLevel === RiskLevel.High) {
+    // ── 10–11. Risk-based fallback: compare risk against configured threshold ─
+    const autoApproveUpTo = context.autoApproveUpTo ?? "low";
+    const riskOrdinal: Record<string, number> = { low: 0, medium: 1, high: 2 };
+    const thresholdOrdinal: Record<string, number> = {
+      none: -1,
+      low: 0,
+      medium: 1,
+    };
+    const risk = riskOrdinal[riskLevel] ?? 2;
+    const threshold = thresholdOrdinal[autoApproveUpTo] ?? 0;
+    if (risk <= threshold) {
       return {
-        decision: "prompt",
-        reason: "High risk: always requires approval",
+        decision: "allow",
+        reason: `${riskLevel} risk: within auto-approve threshold`,
       };
     }
-
-    if (riskLevel === RiskLevel.Low) {
-      return { decision: "allow", reason: "Low risk: auto-allowed" };
-    }
-
-    // Medium (or any unrecognized risk level)
     return {
       decision: "prompt",
-      reason: `${riskLevel} risk: requires approval`,
+      reason: `${riskLevel} risk: above auto-approve threshold`,
     };
   }
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -591,11 +591,12 @@ export async function check(
 
   // Build approval context from local variables
   const tool = getTool(toolName);
+  const config = getConfig();
   const approvalContext: ApprovalContext = {
     riskLevel: risk,
     toolName,
     matchedRule: matchedRule ?? undefined,
-    permissionsMode: getConfig().permissions.mode,
+    permissionsMode: config.permissions.mode,
     isContainerized: getIsContainerized(),
     isWorkspaceScoped:
       risk === RiskLevel.Low
@@ -605,6 +606,7 @@ export async function check(
       tool?.origin === "skill" ? "skill" : tool ? "builtin" : undefined,
     isSkillBundled: tool?.ownerSkillBundled ?? false,
     hasManifestOverride: !!manifestOverride,
+    autoApproveUpTo: config.permissions.autoApproveUpTo,
   };
 
   // Delegate the allow/prompt/deny decision to the approval policy

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -187,7 +187,7 @@ User approval decisions are persisted as trust rules in `~/.vellum/protected/tru
 
 - **Pattern matching**: Minimatch glob patterns for tool commands and file paths.
 - **Execution target binding**: Rules can be scoped to `sandbox` or `host` execution contexts.
-- **Runtime high-risk auto-allow**: High-risk bash commands in containerized environments are auto-allowed at runtime by `shouldAutoAllowHighRisk()` without requiring persisted state.
+- **Runtime high-risk auto-allow**: High-risk bash commands with an allow rule in containerized environments are auto-allowed at runtime by `DefaultApprovalPolicy.shouldAutoAllowHighRisk()` without requiring persisted state. Other risk-based decisions use the `autoApproveUpTo` threshold (default: `"low"`).
 
 #### Shell command allowlist options
 


### PR DESCRIPTION
## Summary
- Add autoApproveUpTo field to ApprovalContext for configurable risk thresholds
- Replace hardcoded risk-based fallback with threshold comparison in DefaultApprovalPolicy
- Wire autoApproveUpTo from config into checker.ts approval context
- Default 'low' preserves existing behavior (Low→allow, Medium→prompt, High→prompt)

Part of plan: bash-risk-approval-policy.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
