### PR TITLE
refactor(context-window): inline clamp and trim test commentary

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -837,13 +837,9 @@ describe("ContextWindowManager", () => {
   });
 
   test("force compaction with loose target override still summarizes persisted messages", async () => {
-    // Regression: a mid-loop compaction that fires above the compact
-    // threshold with a loose `targetInputTokensOverride` (looser than
-    // `config.targetInputTokens`) must still summarize persisted
-    // messages rather than short-circuiting into the truncate-only
-    // early-exit. The window manager guarantees this by clamping the
-    // override to no looser than the configured target in
-    // `pickKeepBoundary`.
+    // `pickKeepBoundary` clamps `targetInputTokensOverride` to
+    // `config.targetInputTokens`, so a loose override cannot
+    // short-circuit summarization into the truncate-only early-exit.
 
     let summaryCalls = 0;
     const provider = createProvider(() => {
@@ -856,18 +852,9 @@ describe("ContextWindowManager", () => {
       };
     });
 
-    // Scaled mirror of production config (200k → 1000):
-    //   maxInputTokens       = 1000 (prod 200k)
-    //   compactThreshold     = 0.3  → threshold 300   (prod 160k)
-    //   targetBudgetRatio    = 0.1  → post-compact target 50 (prod 50k)
-    //   summaryBudgetRatio   = 0.05
-    //
-    // Production uses maxInputTokens=200_000, compactThreshold=0.8,
-    // targetBudgetRatio=0.3, summaryBudgetRatio=0.05. We shrink the
-    // absolute numbers to keep the test fast while preserving the key
-    // ratio: the mid-loop override (~0.85 × max) is roughly 17× the
-    // post-compaction target (~0.05 × max), so any history that sits
-    // between "above threshold" and "below override" hits the bug.
+    // Scaled from prod (max 200k → 1000) preserving key ratios: the
+    // loose override (~0.85×max) is ~17× the post-compaction target
+    // (~0.05×max), so history between the two exercises the clamp.
     const manager = new ContextWindowManager({
       provider,
       systemPrompt: "system prompt",
@@ -879,9 +866,7 @@ describe("ContextWindowManager", () => {
       }),
     });
 
-    // Build a history sized in the "no-op zone": well above the
-    // 300-token compact threshold, well below the 850-token preflight
-    // budget analog.
+    // History in the "no-op zone": above threshold (300), below override (850).
     const long = "x".repeat(180);
     const history: Message[] = [
       message("user", `u1 ${long}`),
@@ -895,16 +880,13 @@ describe("ContextWindowManager", () => {
       message("user", `u5 ${long}`),
     ];
 
-    // Simulate the mid-loop caller pattern: force + override set to
-    // preflightBudget (maxInputTokens * 0.85 = 850).
     const preflightBudgetAnalog = Math.floor(1000 * 0.85);
     const result = await manager.maybeCompact(history, undefined, {
       force: true,
       targetInputTokensOverride: preflightBudgetAnalog,
     });
 
-    // The reported token count (to prove we were actually in the
-    // "should compact" zone).
+    // Guard: we're actually above the compact threshold.
     expect(result.previousEstimatedInputTokens).toBeGreaterThan(
       result.thresholdTokens,
     );

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -595,11 +595,10 @@ export class ContextWindowManager {
       Math.max(0, Math.floor(opts?.minKeepRecentUserTurns ?? defaultTurns)),
       userTurnStarts.length,
     );
-    const overrideTarget = opts?.targetInputTokensOverride;
-    const targetTokens =
-      overrideTarget !== undefined
-        ? Math.min(overrideTarget, this.targetInputTokens)
-        : this.targetInputTokens;
+    const targetTokens = Math.min(
+      opts?.targetInputTokensOverride ?? this.targetInputTokens,
+      this.targetInputTokens,
+    );
 
     // Binary search for the maximum keepTurns whose projected tokens fit
     // within the budget. Token count is monotonically non-decreasing with


### PR DESCRIPTION
## Summary
- Collapse the 4-line `overrideTarget` ternary in `pickKeepBoundary` to a one-line `Math.min(opts?.targetInputTokensOverride ?? this.targetInputTokens, this.targetInputTokens)`.
- Trim ~30 lines of test commentary in `context-window-manager.test.ts`: replace the 7-line regression preamble with 3 lines, collapse the scaled-config explainer, drop WHAT-narrating inline comments, keep only non-obvious WHY.
- No behavior change. 35/35 tests still pass.

Followup to #27099.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
