### PR TITLE
fix(macos): clear isCompacting on every send including offline-queue path

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -116,6 +116,21 @@ final class ChatViewModelTests: XCTestCase {
                        "Sending a user message must clear a stranded compaction indicator (LUM-1062)")
     }
 
+    func testSendUserMessageClearsStuckCompactingFlagWhenOffline() {
+        // Regression: the LUM-1062 self-heal must fire even when the daemon is
+        // disconnected. The offline-queue branch returns before the final send,
+        // but isCompacting is a stale-UI self-heal — clearing it does not depend
+        // on the send actually reaching the daemon. A user typing a new message
+        // is ground truth that compaction is over, connectivity notwithstanding.
+        viewModel.conversationId = "conv-1"
+        viewModel.isCompacting = true
+        connectionManager.isConnected = false
+        viewModel.inputText = "hello"
+        viewModel.sendMessage()
+        XCTAssertFalse(viewModel.isCompacting,
+                       "Sending a user message while offline must still clear a stranded compaction indicator (LUM-1062)")
+    }
+
     func testClearingInputRestoresExistingSuggestion() {
         viewModel.suggestion = "Summarize the last response"
 

--- a/clients/shared/Features/Chat/MessageSendCoordinator.swift
+++ b/clients/shared/Features/Chat/MessageSendCoordinator.swift
@@ -409,6 +409,16 @@ final class MessageSendCoordinator {
         guard let delegate else { return }
         guard let conversationId = delegate.conversationId else { return }
 
+        // LUM-1062: The compaction indicator is cleared by a non-`aux` messageComplete
+        // or by a later `assistantActivityState` with a non-compacting reason. If both
+        // of those events are lost (reconnect race, replay gap), the indicator is
+        // stranded — but a user actively typing a new message is ground truth that
+        // compaction is no longer in progress, so clear it here defensively. This must
+        // fire before the offline-queue early-return below so the self-heal also runs
+        // when the daemon is disconnected (otherwise the very stuck-compaction case
+        // this targets is unrecoverable while offline).
+        messageManager.isCompacting = false
+
         // Check connectivity before entering sending state so the UI
         // doesn't get stuck with isSending/isThinking = true when the
         // daemon has disconnected between turns.
@@ -457,12 +467,6 @@ final class MessageSendCoordinator {
             return
         }
 
-        // LUM-1062: The compaction indicator is cleared by a non-`aux` messageComplete
-        // or by a later `assistantActivityState` with a non-compacting reason. If both
-        // of those events are lost (reconnect race, replay gap), the indicator is
-        // stranded — but a user actively typing a new message is ground truth that
-        // compaction is no longer in progress, so clear it here defensively.
-        messageManager.isCompacting = false
         messageManager.isSending = true
         // Only show "Thinking" for the primary send. Queued messages will
         // set isThinking = true when they are dequeued for processing.


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for lum-1062-unstick-subagent-ui.md.

**Gap:** isCompacting = false clear is unreachable on the offline-queue path
**What was expected:** isCompacting should clear on every user-initiated send, online or offline (the rationale 'user typing is ground truth that compaction is over' holds in both cases).
**What was found:** The clear sat after the connectionManager.isConnected guard, so offline sends left the stuck indicator stranded — defeating the LUM-1062 self-heal intent for users who happen to be offline.

Fix: move the isCompacting=false line + LUM-1062 comment above the offline guard. Add regression test.

Part of LUM-1062.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
