### PR TITLE
fix(macos): self-heal stuck subagent + compaction UI (LUM-1062)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -381,7 +381,7 @@ struct ChatView: View {
                 onInspectMessage: onInspectMessage,
                 mediaEmbedSettings: mediaEmbedSettings,
                 onAbortSubagent: { subagentId in
-                    Task { await SubagentClient().abort(subagentId: subagentId, conversationId: viewModel.conversationId) }
+                    Task { await viewModel.abortSubagent(subagentId) }
                 },
                 onSubagentTap: onSubagentTap,
                 onRehydrateMessage: { messageId in viewModel.rehydrateMessage(id: messageId) },

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -493,7 +493,7 @@ extension MainWindowView {
                         viewModel: viewModel,
                         detailStore: viewModel.subagentDetailStore,
                         showInspectButton: assistantFeatureFlagStore.isEnabled("settings-developer-nav"),
-                        onAbort: { Task { await SubagentClient().abort(subagentId: subagentId, conversationId: viewModel.conversationId) } },
+                        onAbort: { Task { await viewModel.abortSubagent(subagentId) } },
                         onRequestDetail: {
                             if let conversationId = viewModel.activeSubagents.first(where: { $0.id == subagentId })?.conversationId {
                                 Task {

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -107,6 +107,15 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.errorText)
     }
 
+    func testSendUserMessageClearsStuckCompactingFlag() {
+        viewModel.conversationId = "conv-1"
+        viewModel.isCompacting = true
+        viewModel.inputText = "hello"
+        viewModel.sendMessage()
+        XCTAssertFalse(viewModel.isCompacting,
+                       "Sending a user message must clear a stranded compaction indicator (LUM-1062)")
+    }
+
     func testClearingInputRestoresExistingSuggestion() {
         viewModel.suggestion = "Summarize the last response"
 

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -116,6 +116,21 @@ final class ChatViewModelTests: XCTestCase {
                        "Sending a user message must clear a stranded compaction indicator (LUM-1062)")
     }
 
+    func testSendUserMessageClearsStuckCompactingFlagWhenOffline() {
+        // Regression: the LUM-1062 self-heal must fire even when the daemon is
+        // disconnected. The offline-queue branch returns before the final send,
+        // but isCompacting is a stale-UI self-heal — clearing it does not depend
+        // on the send actually reaching the daemon. A user typing a new message
+        // is ground truth that compaction is over, connectivity notwithstanding.
+        viewModel.conversationId = "conv-1"
+        viewModel.isCompacting = true
+        connectionManager.isConnected = false
+        viewModel.inputText = "hello"
+        viewModel.sendMessage()
+        XCTAssertFalse(viewModel.isCompacting,
+                       "Sending a user message while offline must still clear a stranded compaction indicator (LUM-1062)")
+    }
+
     func testClearingInputRestoresExistingSuggestion() {
         viewModel.suggestion = "Summarize the last response"
 

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1883,6 +1883,48 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.count, 0)
     }
 
+    // MARK: - Subagent Abort
+
+    func testAbortSubagentMarksLocalAsAbortedOn404() async throws {
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s1", label: "Test", status: .running)
+        ]
+        let client = FakeSubagentClient(abortResult: .alreadyTerminal) // simulates 404 / already-terminal
+        await viewModel.abortSubagent("s1", client: client)
+        XCTAssertEqual(viewModel.activeSubagents.first?.status, .aborted)
+    }
+
+    func testAbortSubagentMarksLocalAsAbortedOnSuccess() async throws {
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s1", label: "Test", status: .running)
+        ]
+        let client = FakeSubagentClient(abortResult: .success)
+        await viewModel.abortSubagent("s1", client: client)
+        XCTAssertEqual(viewModel.activeSubagents.first?.status, .aborted)
+    }
+
+    func testAbortSubagentDoesNotDowngradeTerminalStatus() async throws {
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s1", label: "Test", status: .completed)
+        ]
+        let client = FakeSubagentClient(abortResult: .alreadyTerminal)
+        await viewModel.abortSubagent("s1", client: client)
+        // If the daemon already sent `completed`, don't clobber it to `aborted`.
+        XCTAssertEqual(viewModel.activeSubagents.first?.status, .completed)
+    }
+
+    func testAbortSubagentLeavesRunningOnNetworkFailure() async throws {
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s1", label: "Test", status: .running)
+        ]
+        let client = FakeSubagentClient(abortResult: .failed)
+        await viewModel.abortSubagent("s1", client: client)
+        // On a genuine failure (network, timeout, 5xx, non-404 client error)
+        // the subagent is possibly still running — do NOT flip the local entry
+        // to `.aborted`, otherwise the UI hides the Abort button and blocks retry.
+        XCTAssertEqual(viewModel.activeSubagents.first?.status, .running)
+    }
+
     // MARK: - History Attachment Hydration
 
     func testPopulateFromHistoryHydratesAssistantAttachments() {
@@ -3386,4 +3428,11 @@ final class MockConversationQueueClient: ConversationQueueClientProtocol, @unche
         }
         return deleteResult
     }
+}
+
+private struct FakeSubagentClient: SubagentClientProtocol {
+    let abortResult: SubagentAbortResult
+    func abort(subagentId: String, conversationId: String?) async -> SubagentAbortResult { abortResult }
+    func fetchDetail(subagentId: String, conversationId: String) async -> SubagentDetailResponse? { nil }
+    func sendMessage(subagentId: String, content: String, conversationId: String?) async -> Bool { true }
 }

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1975,6 +1975,138 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.count, 0)
     }
 
+    func testPopulateFromHistoryReconcilesStaleRunningSubagentToTerminal() {
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s-stuck", label: "Stuck", status: .running)
+        ]
+        // Non-empty text required: HistoryReconstructionService.reconstructMessages
+        // skips items with empty text/no tool calls/no attachments/no surfaces/no
+        // thinking BEFORE reading `subagentNotification`, so an empty-text fixture
+        // never reaches the reconcile branch. Real subagent-notification messages
+        // from the daemon carry non-empty notification text.
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(
+                id: nil, role: "assistant", text: "subagent notification", timestamp: 1000,
+                toolCalls: nil, toolCallsBeforeText: nil, attachments: nil,
+                textSegments: nil, thinkingSegments: nil, contentOrder: nil, surfaces: nil,
+                subagentNotification: HistoryResponseMessageSubagentNotification(
+                    subagentId: "s-stuck", label: "Stuck", status: "completed",
+                    error: nil, conversationId: "sub-conv-1"
+                )
+            ),
+        ]
+        viewModel.populateFromHistory(historyItems, hasMore: false)
+        XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-stuck" })?.status, .completed,
+                       "History's terminal status must overwrite a locally-stuck `.running` entry")
+        XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-stuck" })?.conversationId, "sub-conv-1",
+                       "History's conversationId must be propagated onto the reconciled entry so detail lazy-load works")
+    }
+
+    func testPopulateFromHistoryDoesNotOverwriteRunningWithRunning() {
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s-live", label: "Live", status: .running, parentMessageId: UUID())
+        ]
+        let originalParentId = viewModel.activeSubagents[0].parentMessageId
+        // Non-empty text required: reconstructMessages skips empty-text entries
+        // before reading `subagentNotification`.
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(
+                id: nil, role: "assistant", text: "subagent notification", timestamp: 1000,
+                toolCalls: nil, toolCallsBeforeText: nil, attachments: nil,
+                textSegments: nil, thinkingSegments: nil, contentOrder: nil, surfaces: nil,
+                subagentNotification: HistoryResponseMessageSubagentNotification(
+                    subagentId: "s-live", label: "Live", status: "running",
+                    error: nil, conversationId: "sub-conv-live"
+                )
+            ),
+        ]
+        viewModel.populateFromHistory(historyItems, hasMore: false)
+        // Non-terminal history status must not replace the existing entry
+        // (preserving `parentMessageId` and the live in-memory copy).
+        XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-live" })?.status, .running)
+        XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-live" })?.parentMessageId, originalParentId)
+        // conversationId must still be backfilled even though status was not changed —
+        // the live `.subagentSpawned` path does not populate it, so history is the
+        // only source for it and the detail panel's lazy-load depends on it.
+        XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-live" })?.conversationId, "sub-conv-live",
+                       "conversationId must be backfilled from history even when status is unchanged")
+    }
+
+    func testPopulateFromHistoryBackfillsConversationIdOnExistingEntry() {
+        // Seed with a locally-completed entry that has no conversationId —
+        // the live `.subagentSpawned` path never populates it, so any entry
+        // that was born from a live event has conversationId == nil.
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s-done", label: "Done", status: .completed)
+        ]
+        XCTAssertNil(viewModel.activeSubagents.first(where: { $0.id == "s-done" })?.conversationId)
+        // Non-empty text required: reconstructMessages skips empty-text entries
+        // before reading `subagentNotification`.
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(
+                id: nil, role: "assistant", text: "subagent notification", timestamp: 1000,
+                toolCalls: nil, toolCallsBeforeText: nil, attachments: nil,
+                textSegments: nil, thinkingSegments: nil, contentOrder: nil, surfaces: nil,
+                subagentNotification: HistoryResponseMessageSubagentNotification(
+                    subagentId: "s-done", label: "Done", status: "completed",
+                    error: nil, conversationId: "sub-conv-done"
+                )
+            ),
+        ]
+        viewModel.populateFromHistory(historyItems, hasMore: false)
+        XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-done" })?.conversationId, "sub-conv-done",
+                       "populateFromHistory must backfill conversationId onto an existing local entry")
+    }
+
+    func testPopulateFromHistoryBackfillsParentMessageIdOnExistingEntry() {
+        // Seed a local entry that has no parentMessageId — simulates a live
+        // spawn event that was lost (or never populated that field), leaving
+        // the detail-panel chip with nowhere to anchor.
+        viewModel.activeSubagents = [
+            SubagentInfo(id: "s-orphan", label: "Orphan", status: .running)
+        ]
+        XCTAssertNil(viewModel.activeSubagents.first(where: { $0.id == "s-orphan" })?.parentMessageId)
+
+        // History must contain TWO messages:
+        //   1. An assistant message with a `subagent_spawn` tool call whose
+        //      result JSON includes `subagentId`. `HistoryReconstructionService`
+        //      records this message's UUID in `spawnParentMap[subagentId]`.
+        //   2. A subsequent assistant message with a matching
+        //      `subagentNotification`. The reconstructed `SubagentInfo` picks
+        //      up `parentMessageId` from `spawnParentMap`.
+        //
+        // The first message needs a stable UUID so the test can assert that
+        // the local entry's `parentMessageId` matches it post-reconcile.
+        let parentId = UUID()
+        let spawnToolCall = HistoryResponseToolCall(
+            name: "subagent_spawn",
+            input: ["task": AnyCodable("do a thing")],
+            result: "{\"subagentId\": \"s-orphan\"}",
+            isError: nil
+        )
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(
+                id: parentId.uuidString, role: "assistant", text: "spawning subagent",
+                timestamp: 1000, toolCalls: [spawnToolCall], toolCallsBeforeText: nil,
+                attachments: nil, textSegments: nil, thinkingSegments: nil,
+                contentOrder: nil, surfaces: nil, subagentNotification: nil
+            ),
+            HistoryResponseMessage(
+                id: nil, role: "assistant", text: "subagent notification",
+                timestamp: 1100, toolCalls: nil, toolCallsBeforeText: nil,
+                attachments: nil, textSegments: nil, thinkingSegments: nil,
+                contentOrder: nil, surfaces: nil,
+                subagentNotification: HistoryResponseMessageSubagentNotification(
+                    subagentId: "s-orphan", label: "Orphan", status: "running",
+                    error: nil, conversationId: "sub-conv-orphan"
+                )
+            ),
+        ]
+        viewModel.populateFromHistory(historyItems, hasMore: false)
+        XCTAssertEqual(viewModel.activeSubagents.first(where: { $0.id == "s-orphan" })?.parentMessageId, parentId,
+                       "populateFromHistory must backfill parentMessageId onto an existing local entry")
+    }
+
     // MARK: - Interleaved Text/Tool-Call Segments
 
     func testTextToolTextCreatesInterleavedSegments() {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2146,9 +2146,31 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         let chatMessages = result.messages
         let reconstructedSubagents = result.subagents
 
-        // Merge reconstructed subagents into activeSubagents (avoid duplicates)
-        for info in reconstructedSubagents where !activeSubagents.contains(where: { $0.id == info.id }) {
-            activeSubagents.append(info)
+        // Merge reconstructed subagents into activeSubagents. When history shows
+        // a terminal status for a subagent that is still locally `.running` or
+        // `.pending`, overwrite the local status — a missed `subagentStatusChanged`
+        // event otherwise leaves the UI stuck forever (LUM-1062). History is the
+        // daemon's authoritative record, so it's safe to trust over local state.
+        // Also backfill `conversationId` and `parentMessageId` from history when
+        // the local entry is missing them — the live `subagentSpawned` path does
+        // not populate `conversationId`, and either field can be missing if the
+        // initial spawn event was lost too. `SubagentClient.fetchDetail` and the
+        // detail panel's chip placement rely on these being present.
+        for info in reconstructedSubagents {
+            if let index = activeSubagents.firstIndex(where: { $0.id == info.id }) {
+                if info.isTerminal && !activeSubagents[index].isTerminal {
+                    activeSubagents[index].status = info.status
+                    activeSubagents[index].error = info.error
+                }
+                if activeSubagents[index].conversationId == nil, let convId = info.conversationId {
+                    activeSubagents[index].conversationId = convId
+                }
+                if activeSubagents[index].parentMessageId == nil, let parentId = info.parentMessageId {
+                    activeSubagents[index].parentMessageId = parentId
+                }
+            } else {
+                activeSubagents.append(info)
+            }
         }
 
         // Update daemon pagination cursor from the response metadata.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -481,6 +481,34 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         get { messageManager.activeSubagents }
         set { messageManager.activeSubagents = newValue }
     }
+    /// Invoke the daemon's abort endpoint for a subagent and optimistically
+    /// mark the local entry as `.aborted` when the daemon confirms the
+    /// subagent is no longer running.
+    ///
+    /// Rationale: LUM-1062. The daemon pushes terminal status via SSE, but
+    /// that event can be lost on reconnect, leaving the UI stuck showing a
+    /// running subagent that cannot actually be aborted. When the abort HTTP
+    /// call returns 2xx or 404, we know the daemon has no live subagent for
+    /// this id, so local reconciliation unsticks the UI immediately; if the
+    /// subagent is in fact still running, the next `subagentStatusChanged`
+    /// from the daemon re-asserts the real status in place.
+    ///
+    /// On genuine failure (network error, timeout, 5xx, non-404 client
+    /// error) we do NOT mutate the local status — the subagent is possibly
+    /// still running and the Abort button must remain available for retry.
+    public func abortSubagent(_ subagentId: String, client: SubagentClientProtocol = SubagentClient()) async {
+        let result = await client.abort(subagentId: subagentId, conversationId: conversationId)
+        switch result {
+        case .success, .alreadyTerminal:
+            if let index = activeSubagents.firstIndex(where: { $0.id == subagentId }),
+               !activeSubagents[index].status.isTerminal {
+                activeSubagents[index].status = .aborted
+            }
+        case .failed:
+            // Leave the entry as-is so the Abort button stays available for retry.
+            break
+        }
+    }
     /// Widget IDs dismissed by the user, persisted across view recreation.
     public var dismissedDocumentSurfaceIds: Set<String> {
         get { messageManager.dismissedDocumentSurfaceIds }

--- a/clients/shared/Features/Chat/MessageSendCoordinator.swift
+++ b/clients/shared/Features/Chat/MessageSendCoordinator.swift
@@ -409,6 +409,16 @@ final class MessageSendCoordinator {
         guard let delegate else { return }
         guard let conversationId = delegate.conversationId else { return }
 
+        // LUM-1062: The compaction indicator is cleared by a non-`aux` messageComplete
+        // or by a later `assistantActivityState` with a non-compacting reason. If both
+        // of those events are lost (reconnect race, replay gap), the indicator is
+        // stranded — but a user actively typing a new message is ground truth that
+        // compaction is no longer in progress, so clear it here defensively. This must
+        // fire before the offline-queue early-return below so the self-heal also runs
+        // when the daemon is disconnected (otherwise the very stuck-compaction case
+        // this targets is unrecoverable while offline).
+        messageManager.isCompacting = false
+
         // Check connectivity before entering sending state so the UI
         // doesn't get stuck with isSending/isThinking = true when the
         // daemon has disconnected between turns.
@@ -457,12 +467,6 @@ final class MessageSendCoordinator {
             return
         }
 
-        // LUM-1062: The compaction indicator is cleared by a non-`aux` messageComplete
-        // or by a later `assistantActivityState` with a non-compacting reason. If both
-        // of those events are lost (reconnect race, replay gap), the indicator is
-        // stranded — but a user actively typing a new message is ground truth that
-        // compaction is no longer in progress, so clear it here defensively.
-        messageManager.isCompacting = false
         messageManager.isSending = true
         // Only show "Thinking" for the primary send. Queued messages will
         // set isThinking = true when they are dequeued for processing.

--- a/clients/shared/Features/Chat/MessageSendCoordinator.swift
+++ b/clients/shared/Features/Chat/MessageSendCoordinator.swift
@@ -457,6 +457,12 @@ final class MessageSendCoordinator {
             return
         }
 
+        // LUM-1062: The compaction indicator is cleared by a non-`aux` messageComplete
+        // or by a later `assistantActivityState` with a non-compacting reason. If both
+        // of those events are lost (reconnect race, replay gap), the indicator is
+        // stranded — but a user actively typing a new message is ground truth that
+        // compaction is no longer in progress, so clear it here defensively.
+        messageManager.isCompacting = false
         messageManager.isSending = true
         // Only show "Thinking" for the primary send. Queued messages will
         // set isThinking = true when they are dequeued for processing.

--- a/clients/shared/Network/SubagentClient.swift
+++ b/clients/shared/Network/SubagentClient.swift
@@ -3,9 +3,29 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "SubagentClient")
 
+/// Outcome of a subagent abort request.
+///
+/// The distinction between `.alreadyTerminal` and `.failed` matters because
+/// the UI uses it to decide whether to optimistically mark the local entry
+/// as `.aborted`:
+/// - `.success` and `.alreadyTerminal` are both positive signals that the
+///   subagent is not running (or no longer running) on the daemon.
+/// - `.failed` means we genuinely don't know — the abort didn't land, so the
+///   subagent may still be running, and the Abort button should remain
+///   available for retry.
+public enum SubagentAbortResult: Equatable, Sendable {
+    /// HTTP 2xx — daemon acknowledged the abort request.
+    case success
+    /// HTTP 404 — daemon has no live subagent for this id (already terminal or unknown).
+    /// From the client's POV this is a success signal: the subagent is definitely not running anymore.
+    case alreadyTerminal
+    /// Any other outcome (network error, 5xx, non-404 client error). The abort did NOT land.
+    case failed
+}
+
 /// Focused client for subagent operations routed through the gateway.
 public protocol SubagentClientProtocol {
-    func abort(subagentId: String, conversationId: String?) async -> Bool
+    func abort(subagentId: String, conversationId: String?) async -> SubagentAbortResult
     func fetchDetail(subagentId: String, conversationId: String) async -> SubagentDetailResponse?
     func sendMessage(subagentId: String, content: String, conversationId: String?) async -> Bool
 }
@@ -14,7 +34,7 @@ public protocol SubagentClientProtocol {
 public struct SubagentClient: SubagentClientProtocol {
     nonisolated public init() {}
 
-    public func abort(subagentId: String, conversationId: String? = nil) async -> Bool {
+    public func abort(subagentId: String, conversationId: String? = nil) async -> SubagentAbortResult {
         do {
             var body: [String: Any] = [:]
             if let conversationId { body["conversationId"] = conversationId }
@@ -24,14 +44,20 @@ public struct SubagentClient: SubagentClientProtocol {
                 json: body,
                 timeout: 10
             )
-            guard response.isSuccess else {
-                log.error("abort failed (HTTP \(response.statusCode))")
-                return false
+            if response.isSuccess {
+                return .success
             }
-            return true
+            if response.statusCode == 404 {
+                // Daemon reports no live subagent for this id — either unknown
+                // or already in a terminal state. Treated as a success signal.
+                log.info("abort returned 404 — subagent already terminal or unknown")
+                return .alreadyTerminal
+            }
+            log.error("abort failed (HTTP \(response.statusCode))")
+            return .failed
         } catch {
             log.error("abort error: \(error.localizedDescription)")
-            return false
+            return .failed
         }
     }
 


### PR DESCRIPTION
## Summary

Three independent self-healing paths so the macOS chat UI recovers from stuck subagent and compaction indicators without requiring a new conversation. Bug report: [LUM-1062](https://linear.app/vellum/issue/LUM-1062/subagent-and-context-compaction-ui-get-stuck) — Noa observed subagents perpetually showing "running" with a non-functional Abort button, and a "Compacting context…" indicator stuck after compaction had finished. Logs showed all daemon-pushed terminal events were missed (likely a reconnect replay gap).

Self-review caught one additional gap in PR 3's placement which was fixed by #27106 — see "Self-review result" below.

## Self-review result

PASS after one round of remediation. Pass 1 (external feedback) — all bot comments addressed during per-PR feedback loops. Pass 2 (plan faithfulness) — clean. Pass 3 (repo integration) — round 1 caught the offline-path issue; round 2 PASS.

## PRs merged into feature branch

- #27093: fix(macos): optimistically mark subagent as aborted on Abort click — wires both abort callsites through a new `ChatViewModel.abortSubagent` helper that uses a `SubagentAbortResult` enum to distinguish HTTP 404 ("already terminal" — safe to optimistically mark) from genuine failure (network/5xx — leave entry alone).
- #27094: fix(macos): clear stuck Compacting context indicator on user send — initial placement that #27106 then corrected.
- #27095: fix(macos): overwrite stale local subagent status with history-derived terminal status — `populateFromHistory` now reconciles status, conversationId, and parentMessageId from history when local entries are stale.

### Round-1 fix PR

- #27106: fix(macos): clear isCompacting on every send, not only when daemon is connected — moved the `isCompacting = false` clear above the `isConnected` guard so the self-heal fires for offline-buffered sends too. Added an offline-path regression test.

Part of plan: lum-1062-unstick-subagent-ui.md
Closes LUM-1062
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
