### PR TITLE
feat(providers): extend model-catalog types with capability and pricing fields

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1,6 +1,18 @@
 export interface CatalogModel {
   id: string;
   displayName: string;
+  contextWindowTokens?: number;
+  maxOutputTokens?: number;
+  supportsThinking?: boolean;
+  supportsCaching?: boolean;
+  supportsVision?: boolean;
+  supportsToolUse?: boolean;
+  pricing?: {
+    inputPer1mTokens: number;
+    outputPer1mTokens: number;
+    cacheWritePer1mTokens?: number;
+    cacheReadPer1mTokens?: number;
+  };
 }
 
 export interface ProviderCatalogEntry {
@@ -10,6 +22,15 @@ export interface ProviderCatalogEntry {
   defaultModel: string;
   apiKeyUrl?: string;
   apiKeyPlaceholder?: string;
+  subtitle?: string;
+  setupMode?: "api-key" | "keyless";
+  setupHint?: string;
+  envVar?: string;
+  credentialsGuide?: {
+    description: string;
+    url: string;
+    linkLabel: string;
+  };
 }
 
 /** Single source of truth for all inference provider metadata and models. */


### PR DESCRIPTION
## Summary
- Added optional capability flags (supportsThinking/Caching/Vision/ToolUse), contextWindowTokens, maxOutputTokens, and pricing to `CatalogModel`.
- Added optional subtitle, setupMode, setupHint, envVar, credentialsGuide to `ProviderCatalogEntry`.
- No existing data changed; all fields are optional.

Part of plan: llm-provider-catalog.md (PR 1 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
