### PR TITLE
fix(tests): add countMessagesWithSlackMeta to conversation-init benchmark mock

### DIFF
--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -202,6 +202,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   getTurnTimeBounds: () => null,
   PRIVATE_CONVERSATION_FORK_ERROR: "Cannot fork a private conversation",
   countConversationsByScheduleJobId: () => 0,
+  countMessagesWithSlackMeta: () => 0,
   forkConversation: () => null,
   wipeConversation: () => ({
     conversations: 0,


### PR DESCRIPTION
## Summary
- The CI Benchmark Regression Detection job was failing on `main` because `conversation-init.benchmark.test.ts` mocks `../memory/conversation-crud.js` but the mock was missing `countMessagesWithSlackMeta`, a newer export that `inbound-message-handler.ts` imports (transitively loaded through the Conversation class).
- Bun's `mock.module` fully replaces the module namespace, so any missing export causes a `SyntaxError` at import time and the whole benchmark file fails before any tests run.
- Added a `countMessagesWithSlackMeta: () => 0` stub next to the other count helpers. Verified locally: all 8 benchmark tests pass.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24697872377/job/72234521651
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
