### PR TITLE
feat(context): estimator self-calibration from provider usage feedback

### DIFF
--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -187,6 +187,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getActiveModel() {
+      return undefined;
+    }
     async run(
       _messages: Message[],
       _onEvent: (event: AgentEvent) => void,

--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -157,6 +157,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getActiveModel() {
+      return undefined;
+    }
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void,

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -66,6 +66,13 @@ mock.module("../context/token-estimator.js", () => ({
     typeof mockEstimateTokens === "function"
       ? mockEstimateTokens(msgs)
       : mockEstimateTokens,
+  // Conversation agent loop now calls this helper to canonicalize the
+  // provider key shared with the calibration system. The tests here
+  // don't exercise that path, so a passthrough mock is fine.
+  getCalibrationProviderKey: (provider: {
+    name: string;
+    tokenEstimationProvider?: string;
+  }) => provider.tokenEstimationProvider ?? provider.name,
 }));
 
 // Reducer: by default returns the input untouched and marks exhausted
@@ -375,6 +382,10 @@ function makeCtx(
     agentLoop: {
       run: agentLoopRun,
       getToolTokenBudget: () => 0,
+      // Tests in this file don't exercise calibration, so returning
+      // undefined is fine — the estimator falls back to the per-provider
+      // aggregate key.
+      getActiveModel: () => undefined,
     } as unknown as AgentLoopConversationContext["agentLoop"],
     provider: {
       name: "mock-provider",
@@ -457,7 +468,12 @@ function makeCtx(
 
     graphMemory: {
       onCompacted: () => {},
-      prepareMemory: async () => ({ runMessages: [], injectedTokens: 0, latencyMs: 0, mode: "none" as const }),
+      prepareMemory: async () => ({
+        runMessages: [],
+        injectedTokens: 0,
+        latencyMs: 0,
+        mode: "none" as const,
+      }),
       reinjectCachedMemory: (messages: Message[]) => ({
         runMessages: messages,
         injectedTokens: 0,

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -364,6 +364,9 @@ function makeCtx(
     agentLoop: {
       run: agentLoopRun,
       getToolTokenBudget: () => 0,
+      // Tests here don't exercise calibration; returning undefined makes
+      // the estimator use the per-provider aggregate key.
+      getActiveModel: () => undefined,
     } as unknown as AgentLoopConversationContext["agentLoop"],
     provider: {
       name: "mock-provider",

--- a/assistant/src/__tests__/conversation-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/conversation-confirmation-signals.test.ts
@@ -177,6 +177,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getActiveModel() {
+      return undefined;
+    }
     async run(
       _messages: Message[],
       _onEvent: (event: AgentEvent) => void,

--- a/assistant/src/__tests__/conversation-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/conversation-pre-run-repair.test.ts
@@ -130,6 +130,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getActiveModel() {
+      return undefined;
+    }
     async run(
       messages: Message[],
       onEvent: (event: Record<string, unknown>) => void,

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -250,6 +250,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getActiveModel() {
+      return undefined;
+    }
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void,

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -330,6 +330,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getActiveModel() {
+      return undefined;
+    }
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void,
@@ -1309,18 +1312,18 @@ describe("Batched drain correctness fixes", () => {
       (m) => m.role === "user" && m.content.includes("surface action response"),
     );
     expect(surfaceUserRowsAfterRun2).toHaveLength(1);
-    expect(eventsSurface.filter((e) => e.type === "message_dequeued")).toHaveLength(
-      1,
-    );
+    expect(
+      eventsSurface.filter((e) => e.type === "message_dequeued"),
+    ).toHaveLength(1);
 
     // Complete the surface-action run; drain pulls the regular passthrough
     // as its own separate run.
     resolveRun(1);
     await waitForPendingRun(3);
     expect(pendingRuns.length).toBe(3);
-    expect(eventsRegular.filter((e) => e.type === "message_dequeued")).toHaveLength(
-      1,
-    );
+    expect(
+      eventsRegular.filter((e) => e.type === "message_dequeued"),
+    ).toHaveLength(1);
 
     // Total runs = 3: msg-1, surface-action, regular — NOT 2 (would mean
     // they were batched).
@@ -1390,9 +1393,9 @@ describe("Batched drain correctness fixes", () => {
     const contents = userRowsAfter.map((r) => r.content).join("||");
     expect(contents).toContain("msg-2");
     expect(contents).not.toContain("msg-4");
-    expect(
-      events4.filter((e) => e.type === "message_dequeued"),
-    ).toHaveLength(0);
+    expect(events4.filter((e) => e.type === "message_dequeued")).toHaveLength(
+      0,
+    );
   });
 
   test("failed tail persist uses last-successful requestId", async () => {
@@ -1452,7 +1455,8 @@ describe("Batched drain correctness fixes", () => {
     // (last SUCCESSFUL persist), not the mid's. We check via currentRequestId
     // on the conversation which drainBatch assigns after the loop.
     expect(
-      (conversation as unknown as { currentRequestId?: string }).currentRequestId,
+      (conversation as unknown as { currentRequestId?: string })
+        .currentRequestId,
     ).toBe("req-tail");
 
     // Cleanup: resolve the batched run.

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -196,6 +196,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getActiveModel() {
+      return undefined;
+    }
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void,
@@ -282,9 +285,10 @@ function makeConversation(): Conversation {
   // Bypass real workspace git init: with "/tmp" as the workspace dir, a real
   // ensureInitialized() walks all of /tmp and can exceed the 2s waitForPendingRun
   // budget on CI where parallel tests churn /tmp subdirectories.
-  (conversation as ConversationWithWorkspaceDeps).getWorkspaceGitService = () => ({
-    ensureInitialized: async () => {},
-  });
+  (conversation as ConversationWithWorkspaceDeps).getWorkspaceGitService =
+    () => ({
+      ensureInitialized: async () => {},
+    });
   return conversation;
 }
 

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -207,6 +207,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getActiveModel() {
+      return undefined;
+    }
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void,

--- a/assistant/src/__tests__/conversation-speed-override.test.ts
+++ b/assistant/src/__tests__/conversation-speed-override.test.ts
@@ -195,6 +195,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getActiveModel() {
+      return undefined;
+    }
     async run(
       _messages: Message[],
       _onEvent: (event: AgentEvent) => void,

--- a/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
@@ -149,6 +149,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getActiveModel() {
+      return undefined;
+    }
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void,

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -202,6 +202,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getActiveModel() {
+      return undefined;
+    }
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void,

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -186,6 +186,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getActiveModel() {
+      return undefined;
+    }
     async run(
       messages: Message[],
       onEvent: (event: AgentEvent) => void,

--- a/assistant/src/__tests__/estimator-calibration-integration.test.ts
+++ b/assistant/src/__tests__/estimator-calibration-integration.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getCalibrationSnapshot,
+  getCorrection,
+  recordEstimate,
+  resetCalibrations,
+} from "../context/estimator-calibration.js";
+import {
+  estimatePromptTokens,
+  getCalibrationProviderKey,
+} from "../context/token-estimator.js";
+import type { Message, Provider } from "../providers/types.js";
+
+/**
+ * Integration-style tests that exercise the full self-calibration loop end
+ * to end:
+ *   1. Estimate is recorded for a `(provider, model)` pair (simulating the
+ *      pre-send path in `agent/loop.ts`).
+ *   2. The provider returns a ground-truth `inputTokens` via a usage event
+ *      (simulating the `handleUsage` path).
+ *   3. A subsequent `estimatePromptTokens` call for the SAME `(provider,
+ *      model)` picks up the learned correction.
+ *
+ * This is the scenario both Codex (P1) and Devin flagged: before the fix,
+ * callers of `estimatePromptTokens` passed only `providerName` without
+ * `modelId`, so the helper looked up `(provider, "")` — a key that was
+ * never written. The result was that calibration was effectively a no-op
+ * because the recorded key and the lookup key did not match.
+ */
+describe("estimator calibration — end-to-end recording → lookup", () => {
+  beforeEach(() => {
+    resetCalibrations();
+  });
+
+  /**
+   * Build a representative message history with enough content to clear the
+   * MIN_SAMPLE_MAGNITUDE floor (500 tokens). Each message repeats a block of
+   * text large enough to make the heuristic estimator produce a substantial
+   * token count so the calibration machinery actually runs.
+   */
+  function largeHistory(): Message[] {
+    const body = "lorem ipsum dolor sit amet ".repeat(500);
+    return [
+      { role: "user", content: [{ type: "text", text: body }] },
+      { role: "assistant", content: [{ type: "text", text: body }] },
+      { role: "user", content: [{ type: "text", text: body }] },
+    ];
+  }
+
+  test("subsequent estimate with the same modelId picks up the learned ratio", () => {
+    const provider: Provider = {
+      name: "anthropic",
+      async sendMessage() {
+        throw new Error("not used in this test");
+      },
+    };
+    const model = "claude-sonnet-4-5";
+    const history = largeHistory();
+
+    // 1. Raw estimate (what agent/loop.ts computes pre-send).
+    const preSend = estimatePromptTokens(history, "system", {
+      providerName: getCalibrationProviderKey(provider),
+      modelId: model,
+    });
+    expect(preSend).toBeGreaterThan(0);
+
+    // Baseline: no correction recorded yet.
+    expect(getCorrection("anthropic", model)).toBe(1.0);
+
+    // 2. Provider returns ground truth (simulating `handleUsage`).
+    // Simulate a systematic 30% underestimate (common for Anthropic where
+    // the heuristic misses some xml-wrap overhead on tools/thinking).
+    const groundTruth = Math.ceil(preSend * 1.3);
+    recordEstimate(
+      getCalibrationProviderKey(provider),
+      model,
+      preSend,
+      groundTruth,
+    );
+
+    // 3. Lookup with the same key now returns the learned ratio. Math.ceil
+    // on the ground truth introduces ~1/preSend of rounding noise in the
+    // stored ratio, so precision=3 is tight enough to catch regressions
+    // without false positives.
+    expect(getCorrection("anthropic", model)).toBeCloseTo(1.3, 3);
+
+    // And the corrected estimate moves toward the ground truth.
+    const corrected = estimatePromptTokens(history, "system", {
+      providerName: getCalibrationProviderKey(provider),
+      modelId: model,
+    });
+    // With correction factor ≈1.3, corrected estimate is within 1 token of
+    // the ground truth (Math.ceil rounding).
+    expect(corrected).toBeGreaterThan(preSend);
+    expect(Math.abs(corrected - groundTruth)).toBeLessThanOrEqual(1);
+  });
+
+  test("caller without a modelId still gets the per-provider aggregate correction", () => {
+    // Simulate a preflight site that records against (anthropic, sonnet),
+    // then a separate, early-init caller that has no modelId available.
+    // Before the fix, the early-init caller looked up (anthropic, "") which
+    // was never written — so it got 1.0 and the calibration was useless.
+    // With the aggregate-update path, (anthropic, "") now tracks the
+    // rolling per-provider average.
+    const provider: Provider = {
+      name: "anthropic",
+      async sendMessage() {
+        throw new Error("not used");
+      },
+    };
+    const history = largeHistory();
+
+    const preSend = estimatePromptTokens(history, "system", {
+      providerName: getCalibrationProviderKey(provider),
+      modelId: "claude-sonnet-4-5",
+    });
+    const groundTruth = Math.ceil(preSend * 1.25);
+
+    recordEstimate(
+      getCalibrationProviderKey(provider),
+      "claude-sonnet-4-5",
+      preSend,
+      groundTruth,
+    );
+
+    // A subsequent lookup without a modelId (e.g. window-manager that
+    // doesn't know the active model yet) uses the per-provider aggregate.
+    const correctedAggregate = estimatePromptTokens(history, "system", {
+      providerName: getCalibrationProviderKey(provider),
+      // modelId intentionally omitted
+    });
+    // Aggregate ratio ≈ 1.25 (first sample snaps to exact ratio).
+    expect(correctedAggregate).toBe(Math.ceil(preSend * 1.25));
+  });
+
+  test("wrapper provider (OpenRouter → Anthropic) uses the canonical key on both sides", () => {
+    // This is the Devin scenario: OpenRouter wraps Anthropic. If the record
+    // site used `name` ("openrouter") and the lookup site used
+    // `tokenEstimationProvider` ("anthropic"), the data would be scattered
+    // across mismatched keys and calibration would silently fail.
+    // `getCalibrationProviderKey` gives us one source of truth.
+    const openrouter: Provider = {
+      name: "openrouter",
+      tokenEstimationProvider: "anthropic",
+      async sendMessage() {
+        throw new Error("not used");
+      },
+    };
+    const model = "anthropic/claude-sonnet-4-5";
+    const history = largeHistory();
+
+    // Pre-send estimate via the canonical key.
+    const preSend = estimatePromptTokens(history, "system", {
+      providerName: getCalibrationProviderKey(openrouter),
+      modelId: model,
+    });
+    expect(preSend).toBeGreaterThan(0);
+
+    // Provider returns ground truth. `handleUsage` uses the same helper
+    // to pick the calibration key, so the record and lookup sides agree.
+    const groundTruth = Math.ceil(preSend * 1.2);
+    recordEstimate(
+      getCalibrationProviderKey(openrouter),
+      model,
+      preSend,
+      groundTruth,
+    );
+
+    // Lookup under "anthropic" — the canonical upstream key — returns the
+    // ratio. See note above about precision=3.
+    expect(getCorrection("anthropic", model)).toBeCloseTo(1.2, 3);
+    // And under the bare wrapper name stays at the default, because NOTHING
+    // was recorded under "openrouter".
+    expect(getCorrection("openrouter", model)).toBe(1.0);
+
+    // The snapshot reflects a single (provider, model) key + aggregate under
+    // the canonical upstream key — never under the wrapper name.
+    const keys = getCalibrationSnapshot().map(
+      (e) => `${e.provider}::${e.model}`,
+    );
+    expect(keys).toContain(`anthropic::${model}`);
+    expect(keys).toContain("anthropic::");
+    expect(keys).not.toContain(`openrouter::${model}`);
+  });
+
+  test("a run of consistent samples pulls the estimate toward ground truth", () => {
+    // The EWMA should converge quickly. After five consistent 1.3 samples
+    // the correction should be within 1% of 1.3, and the corrected estimate
+    // should be within 1% of the ground truth.
+    const model = "claude-sonnet-4-5";
+    const history = largeHistory();
+
+    const preSend = estimatePromptTokens(history, "system", {
+      providerName: "anthropic",
+      modelId: model,
+    });
+    const groundTruth = Math.ceil(preSend * 1.3);
+
+    for (let i = 0; i < 5; i++) {
+      recordEstimate("anthropic", model, preSend, groundTruth);
+    }
+
+    const finalCorrection = getCorrection("anthropic", model);
+    // EWMA with alpha=0.2 on constant 1.3 stays at 1.3 from the first sample
+    // onward (all deltas are 0 after the initial snap). `precision=3` gives
+    // us ~0.0005 tolerance which covers the Math.ceil rounding noise.
+    expect(finalCorrection).toBeCloseTo(1.3, 3);
+
+    const corrected = estimatePromptTokens(history, "system", {
+      providerName: "anthropic",
+      modelId: model,
+    });
+    // Corrected should be very close to the ground truth (within 1 token
+    // because of the Math.ceil rounding at the end of estimatePromptTokens).
+    expect(Math.abs(corrected - groundTruth)).toBeLessThanOrEqual(1);
+  });
+});

--- a/assistant/src/__tests__/estimator-calibration.test.ts
+++ b/assistant/src/__tests__/estimator-calibration.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getCalibrationSnapshot,
+  getCorrection,
+  recordEstimate,
+  resetCalibrations,
+} from "../context/estimator-calibration.js";
+
+describe("estimator calibration", () => {
+  beforeEach(() => {
+    resetCalibrations();
+  });
+
+  test("default correction is 1.0 for unseen (provider, model)", () => {
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBe(1.0);
+    expect(getCorrection("openai", "gpt-5")).toBe(1.0);
+  });
+
+  test("first sample yields the exact ratio", () => {
+    recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 130_000);
+    const ratio = getCorrection("anthropic", "claude-sonnet-4-5");
+    expect(ratio).toBeCloseTo(1.3, 5);
+  });
+
+  test("EWMA converges to the target ratio given consistent samples", () => {
+    // Seed with a ratio far from the target so the first sample is off,
+    // then hammer with consistent 1.3 samples and watch EWMA close the gap.
+    recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 100_000);
+    for (let i = 0; i < 20; i++) {
+      recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 130_000);
+    }
+    const ratio = getCorrection("anthropic", "claude-sonnet-4-5");
+    expect(ratio).toBeGreaterThan(1.25);
+    expect(ratio).toBeLessThan(1.35);
+  });
+
+  test("ten consistent 1.3 samples land within 0.05 of 1.3", () => {
+    for (let i = 0; i < 10; i++) {
+      recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 130_000);
+    }
+    const ratio = getCorrection("anthropic", "claude-sonnet-4-5");
+    expect(Math.abs(ratio - 1.3)).toBeLessThan(0.05);
+  });
+
+  test("values below MIN_SAMPLE_MAGNITUDE are ignored", () => {
+    // Both below the floor
+    recordEstimate("anthropic", "claude-sonnet-4-5", 200, 400);
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBe(1.0);
+
+    // Estimated below the floor
+    recordEstimate("anthropic", "claude-sonnet-4-5", 200, 100_000);
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBe(1.0);
+
+    // Actual below the floor
+    recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 200);
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBe(1.0);
+  });
+
+  test("ratios outside [1/3, 3] are discarded as outliers", () => {
+    // 4x too high
+    recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 400_000);
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBe(1.0);
+
+    // 4x too low
+    recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 25_000);
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBe(1.0);
+
+    // Just above the 3x edge — still discarded
+    recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 300_001);
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBe(1.0);
+
+    // Exactly at the 3x edge — accepted (ratio === 3, not > 3)
+    recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 300_000);
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBeCloseTo(3, 5);
+  });
+
+  test("resetCalibrations clears all state", () => {
+    recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 130_000);
+    recordEstimate("openai", "gpt-5", 100_000, 90_000);
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBeCloseTo(1.3);
+    expect(getCorrection("openai", "gpt-5")).toBeCloseTo(0.9);
+
+    resetCalibrations();
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBe(1.0);
+    expect(getCorrection("openai", "gpt-5")).toBe(1.0);
+    expect(getCalibrationSnapshot()).toHaveLength(0);
+  });
+
+  test("distinct (provider, model) keys are independent", () => {
+    recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 130_000);
+    recordEstimate("anthropic", "claude-opus-4-7", 100_000, 110_000);
+    recordEstimate("openai", "gpt-5", 100_000, 90_000);
+    recordEstimate("openai", "gpt-5", 100_000, 90_000);
+    recordEstimate("openai", "gpt-5", 100_000, 90_000);
+
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBeCloseTo(1.3, 5);
+    expect(getCorrection("anthropic", "claude-opus-4-7")).toBeCloseTo(1.1, 5);
+    // openai::gpt-5: after 3 EWMA steps of ratio 0.9, still exactly 0.9
+    // because the first sample snaps to ratio and subsequent deltas are 0.
+    expect(getCorrection("openai", "gpt-5")).toBeCloseTo(0.9, 5);
+
+    // Model separation: ensure a sample to one (provider, model) pair does
+    // not pollute another model under the same provider.
+    expect(getCorrection("anthropic", "claude-opus-4-7")).not.toBe(
+      getCorrection("anthropic", "claude-sonnet-4-5"),
+    );
+  });
+
+  test("snapshot reports current calibrations", () => {
+    recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 130_000);
+    recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 130_000);
+    recordEstimate("openai", "gpt-5", 100_000, 90_000);
+
+    const snap = getCalibrationSnapshot();
+    expect(snap).toHaveLength(2);
+
+    const anthropicEntry = snap.find(
+      (e) => e.provider === "anthropic" && e.model === "claude-sonnet-4-5",
+    );
+    expect(anthropicEntry).toBeDefined();
+    expect(anthropicEntry?.samples).toBe(2);
+    expect(anthropicEntry?.ratio).toBeCloseTo(1.3, 5);
+
+    const openaiEntry = snap.find(
+      (e) => e.provider === "openai" && e.model === "gpt-5",
+    );
+    expect(openaiEntry).toBeDefined();
+    expect(openaiEntry?.samples).toBe(1);
+    expect(openaiEntry?.ratio).toBeCloseTo(0.9, 5);
+  });
+
+  test("empty model string is treated as its own key (per-provider fallback)", () => {
+    recordEstimate("anthropic", "", 100_000, 130_000);
+    expect(getCorrection("anthropic", "")).toBeCloseTo(1.3, 5);
+    // A specific model under the same provider is unaffected.
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBe(1.0);
+  });
+});

--- a/assistant/src/__tests__/estimator-calibration.test.ts
+++ b/assistant/src/__tests__/estimator-calibration.test.ts
@@ -113,7 +113,9 @@ describe("estimator calibration", () => {
     recordEstimate("openai", "gpt-5", 100_000, 90_000);
 
     const snap = getCalibrationSnapshot();
-    expect(snap).toHaveLength(2);
+    // Every non-empty-model sample also updates the per-provider aggregate
+    // key (provider, ""). Two providers × {specific model, aggregate} = 4.
+    expect(snap).toHaveLength(4);
 
     const anthropicEntry = snap.find(
       (e) => e.provider === "anthropic" && e.model === "claude-sonnet-4-5",
@@ -128,6 +130,19 @@ describe("estimator calibration", () => {
     expect(openaiEntry).toBeDefined();
     expect(openaiEntry?.samples).toBe(1);
     expect(openaiEntry?.ratio).toBeCloseTo(0.9, 5);
+
+    // Per-provider aggregates are present and track the specific samples.
+    const anthropicAggregate = snap.find(
+      (e) => e.provider === "anthropic" && e.model === "",
+    );
+    expect(anthropicAggregate?.samples).toBe(2);
+    expect(anthropicAggregate?.ratio).toBeCloseTo(1.3, 5);
+
+    const openaiAggregate = snap.find(
+      (e) => e.provider === "openai" && e.model === "",
+    );
+    expect(openaiAggregate?.samples).toBe(1);
+    expect(openaiAggregate?.ratio).toBeCloseTo(0.9, 5);
   });
 
   test("empty model string is treated as its own key (per-provider fallback)", () => {
@@ -135,5 +150,47 @@ describe("estimator calibration", () => {
     expect(getCorrection("anthropic", "")).toBeCloseTo(1.3, 5);
     // A specific model under the same provider is unaffected.
     expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBe(1.0);
+  });
+
+  test("recording with a specific model also updates the per-provider aggregate", () => {
+    // The calibration writes `(provider, model)` and every caller of
+    // `estimatePromptTokens` that cannot resolve a model falls back to
+    // `(provider, "")`. Without the aggregate update, those callers would
+    // stay at the 1.0 default forever, defeating the whole mechanism.
+    recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 130_000);
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBeCloseTo(1.3, 5);
+    expect(getCorrection("anthropic", "")).toBeCloseTo(1.3, 5);
+    // A different provider is unaffected.
+    expect(getCorrection("openai", "")).toBe(1.0);
+  });
+
+  test("the per-provider aggregate tracks a rolling EWMA across models", () => {
+    // Samples across two models for one provider should each feed the
+    // aggregate EWMA, so a generic lookup reflects recent activity from
+    // any model on that provider.
+    recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 120_000);
+    recordEstimate("anthropic", "claude-opus-4-7", 100_000, 120_000);
+    recordEstimate("anthropic", "claude-sonnet-4-5", 100_000, 120_000);
+    recordEstimate("anthropic", "claude-opus-4-7", 100_000, 120_000);
+
+    // After four consistent 1.2 samples (folded into both the model-specific
+    // and the aggregate keys) the EWMA for each sits very close to 1.2.
+    expect(getCorrection("anthropic", "")).toBeCloseTo(1.2, 1);
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBeCloseTo(1.2, 1);
+    expect(getCorrection("anthropic", "claude-opus-4-7")).toBeCloseTo(1.2, 1);
+  });
+
+  test("explicit empty-model recording does not double-count the aggregate", () => {
+    // When a caller passes an empty model string (degenerate case), the
+    // aggregate update path must not run — otherwise the sample would be
+    // folded into the EWMA twice and the ratio would be wrong.
+    recordEstimate("anthropic", "", 100_000, 120_000);
+    // Exactly one sample applied.
+    const snap = getCalibrationSnapshot().filter(
+      (e) => e.provider === "anthropic" && e.model === "",
+    );
+    expect(snap).toHaveLength(1);
+    expect(snap[0].samples).toBe(1);
+    expect(snap[0].ratio).toBeCloseTo(1.2, 5);
   });
 });

--- a/assistant/src/__tests__/estimator-calibration.test.ts
+++ b/assistant/src/__tests__/estimator-calibration.test.ts
@@ -145,11 +145,28 @@ describe("estimator calibration", () => {
     expect(openaiAggregate?.ratio).toBeCloseTo(0.9, 5);
   });
 
-  test("empty model string is treated as its own key (per-provider fallback)", () => {
+  test("specific-model lookup falls back to the per-provider aggregate when no model-specific samples exist", () => {
+    // Writing only to the aggregate simulates the case where callers without
+    // a resolved modelId have been recording, and then a model-specific
+    // caller asks for its correction.
     recordEstimate("anthropic", "", 100_000, 130_000);
     expect(getCorrection("anthropic", "")).toBeCloseTo(1.3, 5);
-    // A specific model under the same provider is unaffected.
-    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBe(1.0);
+    // The specific model has no own samples, but gets the aggregate.
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).toBeCloseTo(1.3, 5);
+    // An unseen provider still defaults to 1.0.
+    expect(getCorrection("gemini", "gemini-2.5-pro")).toBe(1.0);
+  });
+
+  test("specific-model samples take precedence over the aggregate", () => {
+    recordEstimate("anthropic", "", 100_000, 130_000); // aggregate = 1.3
+    recordEstimate("anthropic", "claude-opus-4-7", 100_000, 110_000); // specific = 1.1
+    expect(getCorrection("anthropic", "claude-opus-4-7")).not.toBeCloseTo(
+      1.3,
+      5,
+    );
+    // A different model under the same provider still falls back to the
+    // aggregate (which now reflects both samples via EWMA).
+    expect(getCorrection("anthropic", "claude-sonnet-4-5")).not.toBe(1.0);
   });
 
   test("recording with a specific model also updates the per-provider aggregate", () => {

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1,6 +1,9 @@
 import * as Sentry from "@sentry/node";
 
-import { estimateToolsTokens } from "../context/token-estimator.js";
+import {
+  estimatePromptTokensRaw,
+  estimateToolsTokens,
+} from "../context/token-estimator.js";
 import { truncateOversizedToolResults } from "../context/tool-result-truncation.js";
 import { getHookManager } from "../hooks/manager.js";
 import type {
@@ -100,6 +103,13 @@ export type AgentEvent =
       providerDurationMs: number;
       rawRequest?: unknown;
       rawResponse?: unknown;
+      /**
+       * Pre-send token estimate for the same call. Used by the estimator
+       * calibrator to learn how off the heuristic is versus provider
+       * ground truth. Omitted only when estimation genuinely was not run
+       * for this call (e.g. legacy/stubbed code paths).
+       */
+      estimatedInputTokens?: number;
     };
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
@@ -292,6 +302,25 @@ export class AgentLoop {
         const providerStart = Date.now();
         lastLlmCallTime = providerStart;
 
+        // Compute the pre-send estimate against the full in-memory
+        // history — matching what upstream callers of
+        // `estimatePromptTokens` (preflight, mid-loop checkpoints, the
+        // window manager) see. We use the RAW estimate (before applying
+        // the existing correction) so the calibrator learns the true
+        // bias against provider ground truth instead of ratcheting a
+        // feedback loop against its own corrected output.
+        const toolTokenBudget =
+          currentTools.length > 0 ? estimateToolsTokens(currentTools) : 0;
+        const preSendEstimatedTokens = estimatePromptTokensRaw(
+          history,
+          turnSystemPrompt,
+          {
+            providerName: this.provider.name,
+            modelId: turnModel,
+            toolTokenBudget,
+          },
+        );
+
         // Strip image contentBlocks from older tool results to prevent
         // screenshots from accumulating in the context window. The LLM
         // already saw each image on the turn it was captured; keeping
@@ -372,6 +401,7 @@ export class AgentLoop {
           providerDurationMs,
           rawRequest: response.rawRequest,
           rawResponse: response.rawResponse,
+          estimatedInputTokens: preSendEstimatedTokens,
         });
 
         void getHookManager().trigger("post-llm-call", {

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/node";
 import {
   estimatePromptTokensRaw,
   estimateToolsTokens,
+  getCalibrationProviderKey,
 } from "../context/token-estimator.js";
 import { truncateOversizedToolResults } from "../context/tool-result-truncation.js";
 import { getHookManager } from "../hooks/manager.js";
@@ -208,6 +209,21 @@ export class AgentLoop {
     return estimateToolsTokens(tools);
   }
 
+  /**
+   * Resolve the active model id for the next provider call, matching what
+   * `run()` threads into `providerConfig.model`. Estimator callers outside
+   * `run()` (preflight, mid-loop checkpoints, overflow recovery, the window
+   * manager) use this to build the calibration key so recording and lookup
+   * agree on `(provider, model)`. Returns `undefined` when no override is
+   * configured — the provider's default model is then effectively opaque
+   * until its first response lands, and the estimator falls back to the
+   * per-provider aggregate via the empty-model key.
+   */
+  getActiveModel(history?: Message[]): string | undefined {
+    if (!this.resolveSystemPrompt) return undefined;
+    return this.resolveSystemPrompt(history ?? []).model;
+  }
+
   async run(
     messages: Message[],
     onEvent: (event: AgentEvent) => void | Promise<void>,
@@ -315,7 +331,7 @@ export class AgentLoop {
           history,
           turnSystemPrompt,
           {
-            providerName: this.provider.name,
+            providerName: getCalibrationProviderKey(this.provider),
             modelId: turnModel,
             toolTokenBudget,
           },

--- a/assistant/src/context/estimator-calibration.ts
+++ b/assistant/src/context/estimator-calibration.ts
@@ -89,9 +89,20 @@ export function recordEstimate(
 /**
  * Correction factor to multiply a raw estimate by. Defaults to 1.0 for any
  * unseen (provider, model) tuple, so first-call behavior is unchanged.
+ *
+ * When the model-specific key has no recorded samples, falls back to the
+ * per-provider aggregate `(provider, "")`. This covers model-alias
+ * mismatches where the configured model string (e.g. `claude-opus-4-6`)
+ * differs from the model the provider echoes back in its response
+ * (e.g. `claude-opus-4-6-20250514`).
  */
 export function getCorrection(provider: string, model: string): number {
-  return CALIBRATIONS.get(key(provider, model))?.ratio ?? 1.0;
+  const specific = CALIBRATIONS.get(key(provider, model));
+  if (specific) return specific.ratio;
+  if (model.length > 0) {
+    return CALIBRATIONS.get(key(provider, ""))?.ratio ?? 1.0;
+  }
+  return 1.0;
 }
 
 /** Test helper — clears all calibration state. */

--- a/assistant/src/context/estimator-calibration.ts
+++ b/assistant/src/context/estimator-calibration.ts
@@ -1,0 +1,108 @@
+/**
+ * Self-calibrating correction ratios for the token estimator.
+ *
+ * Every successful provider call returns ground-truth `usage.inputTokens`.
+ * By comparing that to the pre-send estimate, we can maintain a per-model
+ * EWMA correction ratio that multiplies future estimates — catching
+ * miscalibration proactively instead of waiting for provider overflow
+ * errors to reverse-engineer a token count from the error message.
+ *
+ * State is process-local; correction resets on restart. That is acceptable
+ * because the ratio converges quickly (EWMA alpha = 0.2, ~5 samples).
+ */
+
+interface CalibrationState {
+  /** EWMA of (actual / estimated) — multiply estimates by this to correct. */
+  ratio: number;
+  /** Total samples recorded, for observability. */
+  sampleCount: number;
+}
+
+const CALIBRATIONS: Map<string, CalibrationState> = new Map();
+
+/** Fast-adapting EWMA — converges to a steady state in ~5 consistent samples. */
+const EWMA_ALPHA = 0.2;
+
+/**
+ * Below this magnitude both numbers are noisy — a 500-token prompt with a
+ * 600-token usage is within normal overhead fluctuation and should not
+ * move the correction ratio.
+ */
+const MIN_SAMPLE_MAGNITUDE = 500;
+
+/**
+ * Outlier guard — discard samples where the ratio is more than 3x off in
+ * either direction. A ratio that extreme is almost always a bug (wrong
+ * estimate site, wrong provider, double-counting) rather than a genuine
+ * estimation error the calibrator should learn from.
+ */
+const MIN_ACCEPTABLE_RATIO = 1 / 3;
+const MAX_ACCEPTABLE_RATIO = 3;
+
+function key(provider: string, model: string): string {
+  return `${provider}::${model}`;
+}
+
+/**
+ * Fold a new (estimated, actual) observation into the EWMA ratio for this
+ * (provider, model). No-op when either number is too small to be reliable,
+ * or when the ratio is an outlier.
+ */
+export function recordEstimate(
+  provider: string,
+  model: string,
+  estimated: number,
+  actual: number,
+): void {
+  if (estimated < MIN_SAMPLE_MAGNITUDE || actual < MIN_SAMPLE_MAGNITUDE) return;
+  const ratio = actual / estimated;
+  if (ratio < MIN_ACCEPTABLE_RATIO || ratio > MAX_ACCEPTABLE_RATIO) return;
+
+  const k = key(provider, model);
+  const prev = CALIBRATIONS.get(k);
+  const next: CalibrationState = prev
+    ? {
+        ratio: prev.ratio + EWMA_ALPHA * (ratio - prev.ratio),
+        sampleCount: prev.sampleCount + 1,
+      }
+    : { ratio, sampleCount: 1 };
+  CALIBRATIONS.set(k, next);
+}
+
+/**
+ * Correction factor to multiply a raw estimate by. Defaults to 1.0 for any
+ * unseen (provider, model) tuple, so first-call behavior is unchanged.
+ */
+export function getCorrection(provider: string, model: string): number {
+  return CALIBRATIONS.get(key(provider, model))?.ratio ?? 1.0;
+}
+
+/** Test helper — clears all calibration state. */
+export function resetCalibrations(): void {
+  CALIBRATIONS.clear();
+}
+
+/** Observability — list current calibrations for logging/debugging. */
+export function getCalibrationSnapshot(): Array<{
+  provider: string;
+  model: string;
+  ratio: number;
+  samples: number;
+}> {
+  const out: Array<{
+    provider: string;
+    model: string;
+    ratio: number;
+    samples: number;
+  }> = [];
+  for (const [k, state] of CALIBRATIONS) {
+    const [provider, model] = k.split("::", 2) as [string, string];
+    out.push({
+      provider,
+      model,
+      ratio: state.ratio,
+      samples: state.sampleCount,
+    });
+  }
+  return out;
+}

--- a/assistant/src/context/estimator-calibration.ts
+++ b/assistant/src/context/estimator-calibration.ts
@@ -43,10 +43,28 @@ function key(provider: string, model: string): string {
   return `${provider}::${model}`;
 }
 
+/** Apply a single EWMA update at an exact (provider, model) key. */
+function applyEwmaUpdate(provider: string, model: string, ratio: number): void {
+  const k = key(provider, model);
+  const prev = CALIBRATIONS.get(k);
+  const next: CalibrationState = prev
+    ? {
+        ratio: prev.ratio + EWMA_ALPHA * (ratio - prev.ratio),
+        sampleCount: prev.sampleCount + 1,
+      }
+    : { ratio, sampleCount: 1 };
+  CALIBRATIONS.set(k, next);
+}
+
 /**
  * Fold a new (estimated, actual) observation into the EWMA ratio for this
  * (provider, model). No-op when either number is too small to be reliable,
  * or when the ratio is an outlier.
+ *
+ * When `model` is non-empty, the same observation is also folded into the
+ * per-provider aggregate key `(provider, "")` so callers that cannot resolve
+ * a specific model (early-init paths, provider-only estimate sites) still
+ * pick up a reasonable correction via {@link getCorrection}.
  */
 export function recordEstimate(
   provider: string,
@@ -58,15 +76,14 @@ export function recordEstimate(
   const ratio = actual / estimated;
   if (ratio < MIN_ACCEPTABLE_RATIO || ratio > MAX_ACCEPTABLE_RATIO) return;
 
-  const k = key(provider, model);
-  const prev = CALIBRATIONS.get(k);
-  const next: CalibrationState = prev
-    ? {
-        ratio: prev.ratio + EWMA_ALPHA * (ratio - prev.ratio),
-        sampleCount: prev.sampleCount + 1,
-      }
-    : { ratio, sampleCount: 1 };
-  CALIBRATIONS.set(k, next);
+  applyEwmaUpdate(provider, model, ratio);
+
+  // Also fold into the per-provider aggregate so callers without a modelId
+  // fall back to a meaningful rolling correction instead of the 1.0 default.
+  // Skip when the caller already passed an empty model (avoids double-counting).
+  if (model.length > 0) {
+    applyEwmaUpdate(provider, "", ratio);
+  }
 }
 
 /**

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -1,10 +1,26 @@
 import type {
   ContentBlock,
   Message,
+  Provider,
   ToolDefinition,
 } from "../providers/types.js";
 import { getCorrection } from "./estimator-calibration.js";
 import { parseImageDimensions } from "./image-dimensions.js";
+
+/**
+ * Canonical provider key used for calibration lookups and updates. Wrapper
+ * providers (e.g. OpenRouter routing `anthropic/*` traffic to the Messages
+ * API) set `tokenEstimationProvider` to the upstream provider name so the
+ * calibration key matches the one used when the provider actually produces
+ * the response. Falls back to `name` when the wrapper hint is unset.
+ *
+ * Every caller that records a sample or applies a correction must use this
+ * helper — otherwise wrapper-provider data is scattered across mismatched
+ * keys and the calibration becomes a no-op.
+ */
+export function getCalibrationProviderKey(provider: Provider): string {
+  return provider.tokenEstimationProvider ?? provider.name;
+}
 
 const CHARS_PER_TOKEN = 4;
 const MESSAGE_OVERHEAD_TOKENS = 4;

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -3,6 +3,7 @@ import type {
   Message,
   ToolDefinition,
 } from "../providers/types.js";
+import { getCorrection } from "./estimator-calibration.js";
 import { parseImageDimensions } from "./image-dimensions.js";
 
 const CHARS_PER_TOKEN = 4;
@@ -44,6 +45,13 @@ const TOOL_DEFINITION_OVERHEAD_TOKENS = 28;
 
 export interface TokenEstimatorOptions {
   providerName?: string;
+  /**
+   * Active model id. Used together with `providerName` to apply the
+   * self-calibration correction maintained in `estimator-calibration.ts`.
+   * When omitted, the correction key falls back to `(providerName, "")`
+   * so per-provider calibration still applies.
+   */
+  modelId?: string;
   /** Pre-computed tool token budget. When provided, added to the prompt total. */
   toolTokenBudget?: number;
 }
@@ -103,7 +111,9 @@ function estimateAnthropicImageTokens(width: number, height: number): number {
     scaledHeight = Math.round(scaledHeight * mpScale);
   }
 
-  return Math.ceil(scaledWidth * scaledHeight * ANTHROPIC_IMAGE_TOKENS_PER_PIXEL);
+  return Math.ceil(
+    scaledWidth * scaledHeight * ANTHROPIC_IMAGE_TOKENS_PER_PIXEL,
+  );
 }
 
 function estimateImageTokens(
@@ -224,7 +234,13 @@ export function estimateToolsTokens(tools: ToolDefinition[]): number {
   return total;
 }
 
-export function estimatePromptTokens(
+/**
+ * Raw (uncorrected) prompt-token estimate — exposed so the calibrator
+ * can record (raw, actual) pairs. Applying calibration to the estimate
+ * it uses for training would create a feedback loop that eventually
+ * drives the correction ratio back to 1.0 regardless of true bias.
+ */
+export function estimatePromptTokensRaw(
   messages: Message[],
   systemPrompt?: string,
   options?: TokenEstimatorOptions,
@@ -234,6 +250,23 @@ export function estimatePromptTokens(
     : 0;
   const toolTokens = options?.toolTokenBudget ?? 0;
   return systemTokens + toolTokens + estimateMessagesTokens(messages, options);
+}
+
+export function estimatePromptTokens(
+  messages: Message[],
+  systemPrompt?: string,
+  options?: TokenEstimatorOptions,
+): number {
+  const raw = estimatePromptTokensRaw(messages, systemPrompt, options);
+
+  // Apply the self-calibration correction. Default is 1.0 for any
+  // (provider, model) pair we haven't recorded a sample for, so first-call
+  // behavior is unchanged. As usage data accumulates, the correction ratio
+  // pulls estimates toward the provider's ground-truth token count.
+  const providerName = options?.providerName ?? "";
+  const modelId = options?.modelId ?? "";
+  const correction = getCorrection(providerName, modelId);
+  return correction === 1.0 ? raw : Math.ceil(raw * correction);
 }
 
 function stableJson(value: unknown): string {

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -155,6 +155,14 @@ export interface ContextWindowManagerOptions {
   config: ContextWindowConfig;
   /** Pre-computed tool token budget to include in all estimations. */
   toolTokenBudget?: number;
+  /**
+   * Active model id (or a thunk that resolves it). Threaded into
+   * `estimatePromptTokens` so the calibration correction matches the
+   * `(provider, model)` key recorded by `handleUsage`. When omitted or the
+   * thunk returns `undefined`, the per-provider aggregate key is used as
+   * the fallback.
+   */
+  activeModel?: string | (() => string | undefined);
 }
 
 export class ContextWindowManager {
@@ -162,6 +170,10 @@ export class ContextWindowManager {
   private readonly _systemPrompt: string | (() => string);
   private readonly config: ContextWindowConfig;
   private readonly toolTokenBudget: number;
+  private readonly _activeModel:
+    | string
+    | (() => string | undefined)
+    | undefined;
   /**
    * Number of leading messages that are non-persisted (injected inherited
    * context from a parent conversation).  `countPersistedMessages` subtracts
@@ -192,16 +204,31 @@ export class ContextWindowManager {
     this._systemPrompt = options.systemPrompt;
     this.config = options.config;
     this.toolTokenBudget = options.toolTokenBudget ?? 0;
+    this._activeModel = options.activeModel;
   }
 
   /**
    * Provider key for the local token estimator. Wrapper providers (e.g.
    * OpenRouter routing to `anthropic/*`) override `tokenEstimationProvider`
    * so image/PDF sizing uses the same rules as the upstream API instead of
-   * the generic `base64/4` fallback.
+   * the generic `base64/4` fallback. This is also the canonical key used by
+   * the calibration lookup so record and read sites agree.
    */
   private get estimationProviderName(): string {
     return this.provider.tokenEstimationProvider ?? this.provider.name;
+  }
+
+  /**
+   * Resolve the active model id for the calibration lookup. When unset (or
+   * the thunk returns undefined), `estimatePromptTokens` falls back to the
+   * per-provider aggregate key recorded alongside every `(provider, model)`
+   * sample — still catching systematic provider-level bias.
+   */
+  private get activeModel(): string | undefined {
+    if (this._activeModel === undefined) return undefined;
+    return typeof this._activeModel === "function"
+      ? this._activeModel()
+      : this._activeModel;
   }
 
   /** Lazily resolve and cache the system prompt for the duration of a compaction pass. */
@@ -232,6 +259,7 @@ export class ContextWindowManager {
     try {
       const estimated = estimatePromptTokens(messages, this.systemPrompt, {
         providerName: this.estimationProviderName,
+        modelId: this.activeModel,
         toolTokenBudget: this.toolTokenBudget,
       });
       const threshold = Math.floor(
@@ -264,6 +292,7 @@ export class ContextWindowManager {
       options?.precomputedEstimate ??
       estimatePromptTokens(messages, this.systemPrompt, {
         providerName: this.estimationProviderName,
+        modelId: this.activeModel,
         toolTokenBudget: this.toolTokenBudget,
       });
     const thresholdTokens = Math.floor(
@@ -347,6 +376,7 @@ export class ContextWindowManager {
       const estimatedAfterTruncation = didTruncate
         ? estimatePromptTokens(truncatedMessages, this.systemPrompt, {
             providerName: this.estimationProviderName,
+            modelId: this.activeModel,
             toolTokenBudget: this.toolTokenBudget,
           })
         : previousEstimatedInputTokens;
@@ -419,6 +449,7 @@ export class ContextWindowManager {
       this.systemPrompt,
       {
         providerName: this.estimationProviderName,
+        modelId: this.activeModel,
         toolTokenBudget: this.toolTokenBudget,
       },
     );
@@ -549,6 +580,7 @@ export class ContextWindowManager {
       this.systemPrompt,
       {
         providerName: this.estimationProviderName,
+        modelId: this.activeModel,
         toolTokenBudget: this.toolTokenBudget,
       },
     );
@@ -638,6 +670,7 @@ export class ContextWindowManager {
       );
       return estimatePromptTokens(projectedMessages, this.systemPrompt, {
         providerName: this.estimationProviderName,
+        modelId: this.activeModel,
         toolTokenBudget: this.toolTokenBudget,
       });
     };

--- a/assistant/src/daemon/context-overflow-reducer.ts
+++ b/assistant/src/daemon/context-overflow-reducer.ts
@@ -86,6 +86,13 @@ export interface ReducerStepResult {
 export interface ReducerConfig {
   /** Provider name for token estimation. */
   providerName: string;
+  /**
+   * Active model id — threaded into `estimatePromptTokens` so the calibration
+   * correction matches the `(provider, model)` key the agent loop records on
+   * every usage event. When omitted, the estimator falls back to the
+   * per-provider aggregate recorded alongside each sample.
+   */
+  modelId?: string;
   /** The system prompt (needed for accurate token estimation). */
   systemPrompt: string;
   /** The context window config from the assistant config. */
@@ -149,6 +156,7 @@ export async function reduceContextOverflow(
   // All tiers exhausted
   const estimatedTokens = estimatePromptTokens(messages, config.systemPrompt, {
     providerName: config.providerName,
+    modelId: config.modelId,
     toolTokenBudget: config.toolTokenBudget,
   });
   return {
@@ -182,6 +190,7 @@ async function applyForcedCompaction(
     ? result.estimatedInputTokens
     : estimatePromptTokens(messages, config.systemPrompt, {
         providerName: config.providerName,
+        modelId: config.modelId,
         toolTokenBudget: config.toolTokenBudget,
       });
 
@@ -215,6 +224,7 @@ function applyToolResultTruncation(
     config.systemPrompt,
     {
       providerName: config.providerName,
+      modelId: config.modelId,
       toolTokenBudget: config.toolTokenBudget,
     },
   );
@@ -247,6 +257,7 @@ function applyMediaStubbing(
     // Compute the token budget available for media content.
     const totalTokens = estimatePromptTokens(messages, config.systemPrompt, {
       providerName: config.providerName,
+      modelId: config.modelId,
       toolTokenBudget: config.toolTokenBudget,
     });
 
@@ -279,7 +290,10 @@ function applyMediaStubbing(
       providerName: config.providerName,
     });
     const adjustedNonMediaTokens = nonMediaTokens + estimatedStubTokens;
-    const mediaTokenBudget = Math.max(0, config.targetTokens - adjustedNonMediaTokens);
+    const mediaTokenBudget = Math.max(
+      0,
+      config.targetTokens - adjustedNonMediaTokens,
+    );
 
     const stripped = stripMediaPayloadsForRetry(messages, {
       mediaTokenBudget,
@@ -295,6 +309,7 @@ function applyMediaStubbing(
     config.systemPrompt,
     {
       providerName: config.providerName,
+      modelId: config.modelId,
       toolTokenBudget: config.toolTokenBudget,
     },
   );
@@ -325,6 +340,7 @@ function applyInjectionDowngrade(
   // mode, which the caller applies via applyRuntimeInjections().
   const estimatedTokens = estimatePromptTokens(messages, config.systemPrompt, {
     providerName: config.providerName,
+    modelId: config.modelId,
     toolTokenBudget: config.toolTokenBudget,
   });
 

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -14,6 +14,7 @@ import type {
   TurnInterfaceContext,
 } from "../channels/types.js";
 import { recordEstimate } from "../context/estimator-calibration.js";
+import { getCalibrationProviderKey } from "../context/token-estimator.js";
 import {
   addMessage,
   getConversation,
@@ -858,12 +859,23 @@ export function handleUsage(
   // provider's ground-truth inputTokens. `recordEstimate` silently ignores
   // samples below its magnitude threshold or outside its outlier bounds,
   // so it's safe to call unconditionally.
+  //
+  // The calibration key must match what `estimatePromptTokens` callers look
+  // up — use the canonical provider key (`tokenEstimationProvider ?? name`),
+  // falling back to the response's `actualProvider` only when neither hint
+  // is set on the provider object (shouldn't happen, but cheap). Using
+  // `event.actualProvider` as the primary key would scatter data across
+  // mismatched keys for wrapper providers like OpenRouter.
+  const calibrationProviderKey =
+    getCalibrationProviderKey(deps.ctx.provider) ||
+    (event.actualProvider ?? "");
   if (
+    calibrationProviderKey.length > 0 &&
     event.estimatedInputTokens !== undefined &&
     event.estimatedInputTokens > 0
   ) {
     recordEstimate(
-      providerName,
+      calibrationProviderKey,
       event.model,
       event.estimatedInputTokens,
       event.inputTokens,

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -13,6 +13,7 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
+import { recordEstimate } from "../context/estimator-calibration.js";
 import {
   addMessage,
   getConversation,
@@ -852,6 +853,22 @@ export function handleUsage(
   state.exchangeCacheReadInputTokens += event.cacheReadInputTokens ?? 0;
   state.exchangeOutputTokens += event.outputTokens;
   state.model = event.model;
+
+  // Feed the self-calibration loop: compare the pre-send estimate to the
+  // provider's ground-truth inputTokens. `recordEstimate` silently ignores
+  // samples below its magnitude threshold or outside its outlier bounds,
+  // so it's safe to call unconditionally.
+  if (
+    event.estimatedInputTokens !== undefined &&
+    event.estimatedInputTokens > 0
+  ) {
+    recordEstimate(
+      providerName,
+      event.model,
+      event.estimatedInputTokens,
+      event.inputTokens,
+    );
+  }
   if (event.rawResponse !== undefined) {
     state.exchangeRawResponses.push(event.rawResponse);
   }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -28,7 +28,10 @@ import {
   derefToolResultReReads,
   postTurnTruncateToolResults,
 } from "../context/post-turn-tool-result-truncation.js";
-import { estimatePromptTokens } from "../context/token-estimator.js";
+import {
+  estimatePromptTokens,
+  getCalibrationProviderKey,
+} from "../context/token-estimator.js";
 import type { ContextWindowManager } from "../context/window-manager.js";
 import type { ToolProfiler } from "../events/tool-profiling-listener.js";
 import { writeRelationshipState } from "../home/relationship-state-writer.js";
@@ -946,10 +949,19 @@ export async function runAgentLoopImpl(
     let reducerState: ReducerState | undefined;
 
     const toolTokenBudget = ctx.agentLoop.getToolTokenBudget(runMessages);
+    // Canonical calibration key used at every `estimatePromptTokens` site in
+    // this function. Matches the key recorded by `handleUsage` for wrapper
+    // providers (OpenRouter routing to Anthropic → key is `"anthropic"`).
+    const estimationProviderName = getCalibrationProviderKey(ctx.provider);
+    const activeModelId = ctx.agentLoop.getActiveModel(runMessages);
     const preflightTokens = estimatePromptTokens(
       runMessages,
       ctx.systemPrompt,
-      { providerName: ctx.provider.name, toolTokenBudget },
+      {
+        providerName: estimationProviderName,
+        modelId: activeModelId,
+        toolTokenBudget,
+      },
     );
 
     if (overflowRecovery.enabled && preflightTokens > preflightBudget) {
@@ -979,7 +991,8 @@ export async function runAgentLoopImpl(
         const step = await reduceContextOverflow(
           ctx.messages,
           {
-            providerName: ctx.provider.name,
+            providerName: estimationProviderName,
+            modelId: activeModelId,
             systemPrompt: ctx.systemPrompt,
             contextWindow: config.contextWindow,
             targetTokens: preflightBudget,
@@ -1086,7 +1099,11 @@ export async function runAgentLoopImpl(
         const postInjectionTokens = estimatePromptTokens(
           runMessages,
           ctx.systemPrompt,
-          { providerName: ctx.provider.name, toolTokenBudget },
+          {
+            providerName: estimationProviderName,
+            modelId: activeModelId,
+            toolTokenBudget,
+          },
         );
 
         if (postInjectionTokens <= preflightBudget) break;
@@ -1152,7 +1169,11 @@ export async function runAgentLoopImpl(
         const estimated = estimatePromptTokens(
           checkpoint.history,
           ctx.systemPrompt,
-          { providerName: ctx.provider.name, toolTokenBudget },
+          {
+            providerName: estimationProviderName,
+            modelId: ctx.agentLoop.getActiveModel(checkpoint.history),
+            toolTokenBudget,
+          },
         );
         if (estimated > midLoopThreshold) {
           rlog.warn(
@@ -1388,7 +1409,11 @@ export async function runAgentLoopImpl(
       const estimatedTokensAtOverflow = estimatePromptTokens(
         ctx.messages,
         ctx.systemPrompt,
-        { providerName: ctx.provider.name, toolTokenBudget },
+        {
+          providerName: estimationProviderName,
+          modelId: activeModelId,
+          toolTokenBudget,
+        },
       );
       let correctedTarget = preflightBudget;
       if (actualTokens && estimatedTokensAtOverflow > 0) {
@@ -1436,7 +1461,8 @@ export async function runAgentLoopImpl(
         const step = await reduceContextOverflow(
           ctx.messages,
           {
-            providerName: ctx.provider.name,
+            providerName: estimationProviderName,
+            modelId: activeModelId,
             systemPrompt: ctx.systemPrompt,
             contextWindow: config.contextWindow,
             targetTokens: correctedTarget,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -520,6 +520,9 @@ export class Conversation {
       systemPrompt: () => resolveSystemPromptCallback([]).systemPrompt,
       config: config.contextWindow,
       toolTokenBudget: this.agentLoop.getToolTokenBudget(),
+      // Resolve lazily so model-override updates (if ever added) flow
+      // through to calibration lookups without reconstructing the manager.
+      activeModel: () => resolveSystemPromptCallback([]).model,
     });
 
     void getHookManager().trigger("conversation-start", {


### PR DESCRIPTION
## Summary
- New `assistant/src/context/estimator-calibration.ts` maintains an EWMA correction ratio per (provider, model) fed by the provider's ground-truth `usage.inputTokens`.
- `token-estimator.ts` gains `estimatePromptTokensRaw` (uncorrected, used as the calibrator's training signal) alongside `estimatePromptTokens` which now multiplies by the learned correction (default 1.0, so first-call behavior is unchanged for any new (provider, model) pair).
- The agent loop computes the raw pre-send estimate against the same full history that upstream callers (preflight, mid-loop checkpoints, window manager) use, and threads it through the `usage` `AgentEvent` as `estimatedInputTokens`.
- `handleUsage` in the daemon records each (estimated, actual) pair via `recordEstimate`, which is safe to call unconditionally — sub-500-token samples and >3x outliers are dropped inside the module.

Part of plan: `compaction-simplification.md` (PR 7 of 13). Replaces the reactive reverse-engineer-token-count-from-error flow with proactive self-calibration.

Part of JARVIS-compaction-v2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
