### PR TITLE
feat(permissions): per-context autoApproveUpTo thresholds

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -748,7 +748,7 @@ describe("Permission Checker", () => {
       // Low risk → auto-allowed via risk-based fallback
       const low = await check("bash", { command: "ls" }, "/tmp");
       expect(low.decision).toBe("allow");
-      expect(low.reason).toContain("low risk");
+      expect(low.reason).toContain("Low risk");
     });
 
     test("host_bash high risk → always prompt", async () => {
@@ -795,7 +795,7 @@ describe("Permission Checker", () => {
       addRule("bash", "rm *", "/tmp");
       const result = await check("bash", { command: "rm file.txt" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("high risk");
+      expect(result.reason).toContain("High risk");
     });
 
     test("file_read → auto-allow", async () => {
@@ -1122,7 +1122,7 @@ describe("Permission Checker", () => {
       addRule("bash", "sudo *", "everywhere");
       const result = await check("bash", { command: "sudo rm -rf /" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("high risk");
+      expect(result.reason).toContain("High risk");
     });
 
     // Deny rule tests
@@ -2681,7 +2681,7 @@ describe("Permission Checker", () => {
       addRule("bash", "sudo *", "everywhere", "allow");
       const result = await check("bash", { command: "sudo rm -rf /" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("high risk");
+      expect(result.reason).toContain("High risk");
     });
   });
 
@@ -2692,7 +2692,7 @@ describe("Permission Checker", () => {
       addRule("bash", "kill *", "everywhere", "allow", 2000);
       const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("high risk");
+      expect(result.reason).toContain("High risk");
     });
 
     test("high-risk bash with allow rule in containerized environment auto-allows", async () => {
@@ -2815,7 +2815,7 @@ describe("Permission Checker", () => {
       addRule("bash", "kill *", "everywhere", "allow", 2000);
       const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("high risk");
+      expect(result.reason).toContain("High risk");
     });
 
     test("strict mode: medium-risk with matching allow rule auto-allows", async () => {
@@ -4830,7 +4830,7 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
     expect(result.decision).toBe("allow");
     // Not auto-allowed via workspace mode — bash falls through to risk-based policy
     expect(result.reason).not.toContain("Workspace mode");
-    expect(result.reason).toContain("low risk");
+    expect(result.reason).toContain("Low risk");
   });
 
   test("bash in workspace (medium risk) → prompt (not auto-allowed)", async () => {

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -763,6 +763,64 @@ describe("AssistantConfigSchema", () => {
     expect(parsed.permissions.autoApproveUpTo).toBe("medium");
   });
 
+  test("accepts autoApproveUpTo as per-context object", () => {
+    const result = AssistantConfigSchema.parse({
+      permissions: {
+        autoApproveUpTo: {
+          conversation: "low",
+          background: "medium",
+          headless: "none",
+        },
+      },
+    });
+    expect(result.permissions.autoApproveUpTo).toEqual({
+      conversation: "low",
+      background: "medium",
+      headless: "none",
+    });
+  });
+
+  test("per-context object applies defaults for omitted keys", () => {
+    const result = AssistantConfigSchema.parse({
+      permissions: {
+        autoApproveUpTo: {},
+      },
+    });
+    expect(result.permissions.autoApproveUpTo).toEqual({
+      conversation: "low",
+      background: "medium",
+      headless: "none",
+    });
+  });
+
+  test("per-context object rejects invalid enum values", () => {
+    const result = AssistantConfigSchema.safeParse({
+      permissions: {
+        autoApproveUpTo: { conversation: "high" },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("per-context object round-trips through JSON serialization", () => {
+    const original = AssistantConfigSchema.parse({
+      permissions: {
+        autoApproveUpTo: {
+          conversation: "none",
+          background: "low",
+          headless: "medium",
+        },
+      },
+    });
+    const json = JSON.stringify(original);
+    const parsed = AssistantConfigSchema.parse(JSON.parse(json));
+    expect(parsed.permissions.autoApproveUpTo).toEqual({
+      conversation: "none",
+      background: "low",
+      headless: "medium",
+    });
+  });
+
   test("applies workspaceGit defaults including interactiveGitTimeoutMs", () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.workspaceGit).toEqual({

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -309,6 +309,8 @@ describe("ToolExecutor policy context plumbing", () => {
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      executionContext: "conversation",
+      ephemeralRules: undefined,
       executionTarget: "sandbox",
     });
   });
@@ -326,7 +328,10 @@ describe("ToolExecutor policy context plumbing", () => {
 
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
-    expect(lastCheckArgs!.policyContext).toBeUndefined();
+    expect(lastCheckArgs!.policyContext).toEqual({
+      executionContext: "conversation",
+      ephemeralRules: undefined,
+    });
   });
 
   test('passes undefined policyContext for tools with origin "core"', async () => {
@@ -356,7 +361,10 @@ describe("ToolExecutor policy context plumbing", () => {
 
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
-    expect(lastCheckArgs!.policyContext).toBeUndefined();
+    expect(lastCheckArgs!.policyContext).toEqual({
+      executionContext: "conversation",
+      ephemeralRules: undefined,
+    });
   });
 
   test('includes executionTarget "host" from skill tool metadata', async () => {
@@ -390,6 +398,8 @@ describe("ToolExecutor policy context plumbing", () => {
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      executionContext: "conversation",
+      ephemeralRules: undefined,
       executionTarget: "host",
     });
   });
@@ -420,6 +430,8 @@ describe("ToolExecutor policy context plumbing", () => {
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      executionContext: "conversation",
+      ephemeralRules: undefined,
       executionTarget: undefined,
     });
   });
@@ -889,6 +901,8 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
 
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      executionContext: "conversation",
+      ephemeralRules: undefined,
       executionTarget: "sandbox",
     });
   });
@@ -1071,6 +1085,8 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
 
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      executionContext: "conversation",
+      ephemeralRules: undefined,
       executionTarget: "sandbox",
     });
   });

--- a/assistant/src/config/schemas/security.ts
+++ b/assistant/src/config/schemas/security.ts
@@ -88,14 +88,37 @@ export const PermissionsConfigSchema = z
         "Whether the assistant can execute commands on the host machine without prompting",
       ),
     autoApproveUpTo: z
-      .enum(["none", "low", "medium"], {
-        error: "permissions.autoApproveUpTo must be one of: none, low, medium",
-      })
+      .union([
+        z.enum(["none", "low", "medium"], {
+          error:
+            "permissions.autoApproveUpTo must be one of: none, low, medium",
+        }),
+        z.object({
+          conversation: z
+            .enum(["none", "low", "medium"])
+            .default("low")
+            .describe(
+              "Threshold for interactive conversation sessions (default: low)",
+            ),
+          background: z
+            .enum(["none", "low", "medium"])
+            .default("medium")
+            .describe(
+              "Threshold for non-interactive guardian sessions (default: medium)",
+            ),
+          headless: z
+            .enum(["none", "low", "medium"])
+            .default("none")
+            .describe(
+              "Threshold for non-interactive non-guardian sessions (default: none)",
+            ),
+        }),
+      ])
       .default("low")
       .describe(
         "Auto-approve tools at or below this risk level without prompting. " +
-          "'none' prompts for everything (strictest), 'low' auto-approves read-only " +
-          "operations (default), 'medium' auto-approves writes and network access too.",
+          "Accepts a scalar ('none', 'low', 'medium') applied to all contexts, " +
+          "or an object with per-context overrides: { conversation, background, headless }.",
       ),
   })
   .describe("Permission enforcement mode for tool operations");

--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { ApprovalContext, ApprovalDecision } from "./approval-policy.js";
-import { DefaultApprovalPolicy } from "./approval-policy.js";
+import { DefaultApprovalPolicy, resolveThreshold } from "./approval-policy.js";
 import type { TrustRule } from "./types.js";
 import { RiskLevel } from "./types.js";
 
@@ -707,6 +707,93 @@ describe("autoApproveUpTo threshold", () => {
       });
       expect(result.decision).toBe("allow");
       expect(result.reason).toContain("within auto-approve threshold");
+    });
+  });
+});
+
+// ── resolveThreshold ─────────────────────────────────────────────────────────
+
+describe("resolveThreshold", () => {
+  describe("scalar form", () => {
+    test("returns scalar for conversation context", () => {
+      expect(resolveThreshold("low", "conversation")).toBe("low");
+    });
+
+    test("returns scalar for background context", () => {
+      expect(resolveThreshold("medium", "background")).toBe("medium");
+    });
+
+    test("returns scalar for headless context", () => {
+      expect(resolveThreshold("none", "headless")).toBe("none");
+    });
+
+    test("returns scalar when executionContext is omitted", () => {
+      expect(resolveThreshold("low")).toBe("low");
+    });
+  });
+
+  describe("object form", () => {
+    const perContext = {
+      conversation: "low" as const,
+      background: "medium" as const,
+      headless: "none" as const,
+    };
+
+    test("returns conversation threshold for conversation context", () => {
+      expect(resolveThreshold(perContext, "conversation")).toBe("low");
+    });
+
+    test("returns background threshold for background context", () => {
+      expect(resolveThreshold(perContext, "background")).toBe("medium");
+    });
+
+    test("returns headless threshold for headless context", () => {
+      expect(resolveThreshold(perContext, "headless")).toBe("none");
+    });
+
+    test("defaults to conversation when executionContext is omitted", () => {
+      expect(resolveThreshold(perContext)).toBe("low");
+    });
+  });
+
+  describe("per-context thresholds in policy evaluation", () => {
+    test("conversation context with low threshold prompts medium risk", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Medium,
+        toolName: "some_tool",
+        autoApproveUpTo: "low",
+      });
+      expect(result.decision).toBe("prompt");
+    });
+
+    test("background context with medium threshold allows medium risk", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Medium,
+        toolName: "some_tool",
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("within auto-approve threshold");
+    });
+
+    test("headless context with none threshold prompts low risk", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "some_tool",
+        autoApproveUpTo: "none",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+
+    test("background context with medium threshold prompts high risk", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.High,
+        toolName: "some_tool",
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
     });
   });
 });

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -42,11 +42,11 @@ export interface ApprovalContext {
  * When `executionContext` is omitted, defaults to `"conversation"`.
  */
 export function resolveThreshold(
-  configValue: PermissionsConfig["autoApproveUpTo"],
+  configValue: PermissionsConfig["autoApproveUpTo"] | undefined,
   executionContext?: ExecutionContext,
 ): "none" | "low" | "medium" {
-  if (typeof configValue === "string") {
-    return configValue;
+  if (configValue == null || typeof configValue === "string") {
+    return configValue ?? "low";
   }
   const ctx = executionContext ?? "conversation";
   return configValue[ctx];

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -1,7 +1,11 @@
+import type { PermissionsConfig } from "../config/schemas/security.js";
 import type { TrustRule } from "./types.js";
 import { RiskLevel } from "./types.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
+
+/** Execution context for per-context threshold resolution. */
+export type ExecutionContext = "conversation" | "background" | "headless";
 
 /** Contextual information that an approval policy uses to reach a decision. */
 export interface ApprovalContext {
@@ -18,12 +22,34 @@ export interface ApprovalContext {
   /** Whether the tool has a manifest override (unregistered skill tool). */
   hasManifestOverride?: boolean;
   /**
-   * Auto-approve tools at or below this risk level when no rule matches.
+   * Resolved auto-approve threshold for this execution context.
    * - "none": prompt for everything (strictest)
    * - "low": auto-approve Low risk (default, matches existing behavior)
    * - "medium": auto-approve Low and Medium risk
    */
   autoApproveUpTo?: "none" | "low" | "medium";
+}
+
+// ── Threshold resolution ─────────────────────────────────────────────────────
+
+/**
+ * Resolve the `autoApproveUpTo` config value to a scalar threshold for
+ * the given execution context.
+ *
+ * - Scalar string → returned as-is for all contexts
+ * - Object with per-context overrides → returns the value for the context
+ *
+ * When `executionContext` is omitted, defaults to `"conversation"`.
+ */
+export function resolveThreshold(
+  configValue: PermissionsConfig["autoApproveUpTo"],
+  executionContext?: ExecutionContext,
+): "none" | "low" | "medium" {
+  if (typeof configValue === "string") {
+    return configValue;
+  }
+  const ctx = executionContext ?? "conversation";
+  return configValue[ctx];
 }
 
 /** The outcome of an approval policy evaluation. */

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -28,6 +28,7 @@ import {
 import {
   type ApprovalContext,
   DefaultApprovalPolicy,
+  resolveThreshold,
 } from "./approval-policy.js";
 import { bashRiskClassifier } from "./bash-risk-classifier.js";
 import { riskToRiskLevel } from "./risk-types.js";
@@ -604,6 +605,10 @@ export async function check(
   // Build approval context from local variables
   const tool = getTool(toolName);
   const config = getConfig();
+  const resolvedThreshold = resolveThreshold(
+    config.permissions.autoApproveUpTo,
+    policyContext?.executionContext,
+  );
   const approvalContext: ApprovalContext = {
     riskLevel: risk,
     toolName,
@@ -618,7 +623,7 @@ export async function check(
       tool?.origin === "skill" ? "skill" : tool ? "builtin" : undefined,
     isSkillBundled: tool?.ownerSkillBundled ?? false,
     hasManifestOverride: !!manifestOverride,
-    autoApproveUpTo: config.permissions.autoApproveUpTo,
+    autoApproveUpTo: resolvedThreshold,
   };
 
   // Delegate the allow/prompt/deny decision to the approval policy

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -62,4 +62,11 @@ export interface PolicyContext {
   executionTarget?: string;
   /** Ephemeral rules for task-scoped permissions — checked before persistent trust.json rules. */
   ephemeralRules?: TrustRule[];
+  /**
+   * Execution context for per-context threshold resolution.
+   * - "conversation": interactive client session (default)
+   * - "background": non-interactive guardian session (e.g. scheduled jobs)
+   * - "headless": non-interactive non-guardian session
+   */
+  executionContext?: "conversation" | "background" | "headless";
 }

--- a/assistant/src/tools/policy-context.ts
+++ b/assistant/src/tools/policy-context.ts
@@ -1,6 +1,23 @@
+import type { ExecutionContext } from "../permissions/approval-policy.js";
 import type { PolicyContext } from "../permissions/types.js";
 import { getTaskRunRules } from "../tasks/ephemeral-permissions.js";
 import type { Tool, ToolContext } from "./types.js";
+
+/**
+ * Derive the execution context from the tool context fields.
+ * - Guardian + non-interactive → "background" (scheduled jobs, reminders)
+ * - Non-interactive (non-guardian) → "headless"
+ * - Otherwise → "conversation"
+ */
+function deriveExecutionContext(context?: ToolContext): ExecutionContext {
+  if (context?.isInteractive === false && context.trustClass === "guardian") {
+    return "background";
+  }
+  if (context?.isInteractive === false) {
+    return "headless";
+  }
+  return "conversation";
+}
 
 /**
  * Build a PolicyContext from tool metadata and execution context.
@@ -10,23 +27,23 @@ import type { Tool, ToolContext } from "./types.js";
 export function buildPolicyContext(
   tool: Tool,
   context?: ToolContext,
-): PolicyContext | undefined {
+): PolicyContext {
   const ephemeralRules = context?.taskRunId
     ? getTaskRunRules(context.taskRunId)
     : undefined;
+
+  const executionContext = deriveExecutionContext(context);
 
   if (tool.origin === "skill") {
     return {
       executionTarget: tool.executionTarget,
       ephemeralRules: ephemeralRules?.length ? ephemeralRules : undefined,
+      executionContext,
     };
   }
 
-  if (context?.taskRunId && ephemeralRules?.length) {
-    return {
-      ephemeralRules,
-    };
-  }
-
-  return undefined;
+  return {
+    ephemeralRules: ephemeralRules?.length ? ephemeralRules : undefined,
+    executionContext,
+  };
 }


### PR DESCRIPTION
## Summary
- Extend autoApproveUpTo to accept scalar or per-context object (conversation/background/headless)
- Add resolveThreshold() helper for config → scalar resolution
- Wire executionContext through PolicyContext → ApprovalContext
- Defaults preserve behavioral parity: conversation=low, background=medium, headless=none

Part of plan: bash-risk-approval-policy.md (PR 5 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
