### PR TITLE
feat(providers): populate Fireworks capability flags and pricing

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -85,10 +85,30 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
   {
     id: "fireworks",
     displayName: "Fireworks",
+    subtitle:
+      "Open-source models served by Fireworks. Requires a Fireworks API key.",
+    setupMode: "api-key",
+    setupHint: "Enter your Fireworks API key to enable open-source models.",
+    envVar: "FIREWORKS_API_KEY",
+    credentialsGuide: {
+      description: "Sign in to the Fireworks dashboard and create an API key.",
+      url: "https://fireworks.ai/account/api-keys",
+      linkLabel: "Open Fireworks Dashboard",
+    },
     models: [
       {
         id: "accounts/fireworks/models/kimi-k2p5",
         displayName: "Kimi K2.5",
+        contextWindowTokens: 256000,
+        maxOutputTokens: 32768,
+        supportsThinking: false,
+        supportsCaching: false,
+        supportsVision: false,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 0.6,
+          outputPer1mTokens: 2.5,
+        },
       },
     ],
     defaultModel: "accounts/fireworks/models/kimi-k2p5",


### PR DESCRIPTION
## Summary
- Populates provider-level fields for Fireworks.
- Populates capability flags, context window, max output tokens, and pricing for Kimi K2.5.

Part of plan: llm-provider-catalog.md (PR 7 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
