### PR TITLE
fix(onboarding): fit the setup cards inside the original 440x630 envelope

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -94,13 +94,14 @@ extension AppDelegate {
         let hostingController = NSHostingController(rootView: authView)
 
         // ReauthView is a compact sign-in surface; OnboardingFlowView hosts
-        // the full onboarding including the WakeUp cards, welcome hero,
-        // and the characters footer, which together require at least
-        // 440×980 per the view's `.frame(minWidth:minHeight:)`.
+        // the full onboarding including the WakeUp hero, setup-option cards,
+        // footer, and characters illustration. The view was retuned to fit
+        // inside a 440×630 window envelope even with the Advanced disclosure
+        // expanded — matching the pre-cards window size.
         let windowWidth: CGFloat = 460
-        let windowHeight: CGFloat = hasManagedAssistants ? 620 : 980
+        let windowHeight: CGFloat = hasManagedAssistants ? 620 : 630
         let minWidth: CGFloat = hasManagedAssistants ? 420 : 440
-        let minHeight: CGFloat = hasManagedAssistants ? 580 : 980
+        let minHeight: CGFloat = hasManagedAssistants ? 580 : 630
 
         let window: NSWindow
         if let existingWindow {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -87,8 +87,12 @@ struct OnboardingFlowView: View {
                 ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: 0) {
                     if state.currentStep == 0 {
-                        // Step 0 only: top inset + app icon
-                        Color.clear.frame(height: 80)
+                        // Step 0 only: compact top inset + app icon. Pre-cards
+                        // this was 80pt + 78pt below the icon; tightened here
+                        // so the WakeUp hero + setup-option cards + footer +
+                        // characters all fit in the 630pt window envelope
+                        // even when the Advanced disclosure is expanded.
+                        Color.clear.frame(height: VSpacing.md)
 
                         if let nsImage = Self.appIcon {
                             Image(nsImage: nsImage)
@@ -97,7 +101,7 @@ struct OnboardingFlowView: View {
                                 .frame(width: 80, height: 80)
                                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                                 .shadow(color: VColor.auxBlack.opacity(0.15), radius: 1, x: 0, y: 1)
-                                .padding(.bottom, 78)
+                                .padding(.bottom, VSpacing.sm)
                         }
                     } else {
                         // Steps 1–3: top inset only (no icon)
@@ -195,7 +199,7 @@ struct OnboardingFlowView: View {
             }
         }
         }
-        .frame(minWidth: 440, minHeight: 980)
+        .frame(minWidth: 440, minHeight: 630)
         .task {
             if !authManager.isAuthenticated {
                 await authManager.checkSession()

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
@@ -38,7 +38,7 @@ internal struct OnboardingLocalModeDisclosure: View {
                             .textCase(.uppercase)
                             .tracking(0.6)
                         Text(title)
-                            .font(VFont.bodyMediumEmphasised)
+                            .font(VFont.bodySmallEmphasised)
                             .foregroundStyle(VColor.contentDefault)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -61,13 +61,13 @@ internal struct OnboardingLocalModeDisclosure: View {
 
             if isExpanded {
                 VStack(alignment: .leading, spacing: 0) {
-                    Spacer().frame(height: VSpacing.md)
+                    Spacer().frame(height: VSpacing.sm)
 
                     VColor.borderBase
                         .frame(height: 1)
                         .accessibilityHidden(true)
 
-                    Spacer().frame(height: VSpacing.md)
+                    Spacer().frame(height: VSpacing.sm)
 
                     Text(tradeoffsKicker)
                         .font(VFont.labelSmall)
@@ -75,15 +75,15 @@ internal struct OnboardingLocalModeDisclosure: View {
                         .textCase(.uppercase)
                         .tracking(0.6)
 
-                    Spacer().frame(height: VSpacing.sm)
+                    Spacer().frame(height: VSpacing.xs)
 
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
                         ForEach(tradeoffs, id: \.self) { item in
                             tradeoffRow(item)
                         }
                     }
 
-                    Spacer().frame(height: VSpacing.md)
+                    Spacer().frame(height: VSpacing.sm)
 
                     VButton(
                         label: secondaryCTA,
@@ -99,10 +99,10 @@ internal struct OnboardingLocalModeDisclosure: View {
             }
         }
         .padding(EdgeInsets(
-            top: VSpacing.md,
-            leading: VSpacing.lg,
-            bottom: VSpacing.md,
-            trailing: VSpacing.md
+            top: VSpacing.sm,
+            leading: VSpacing.md,
+            bottom: VSpacing.sm,
+            trailing: VSpacing.sm
         ))
         .frame(maxWidth: .infinity)
         .background(
@@ -121,10 +121,10 @@ internal struct OnboardingLocalModeDisclosure: View {
             Circle()
                 .fill(VColor.contentTertiary)
                 .frame(width: 3, height: 3)
-                .padding(.top, 7)
+                .padding(.top, 6)
                 .accessibilityHidden(true)
             Text(text)
-                .font(VFont.bodyMediumDefault)
+                .font(VFont.bodySmallDefault)
                 .foregroundStyle(VColor.contentDefault)
                 .fixedSize(horizontal: false, vertical: true)
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingVellumCloudCard.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingVellumCloudCard.swift
@@ -29,13 +29,13 @@ struct OnboardingVellumCloudCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header: title + RECOMMENDED chip. Uses `titleMedium` so it
-            // sits a notch below the page title (`VFont.titleLarge` on
+            // Header: title + RECOMMENDED chip. Uses `titleSmall` so it
+            // sits a notch below the page title (`VFont.titleMedium` on
             // `WakeUpStepView`) without clashing with the page's sans
             // family.
             HStack(alignment: .top) {
                 Text(title)
-                    .font(VFont.titleMedium)
+                    .font(VFont.titleSmall)
                     .foregroundStyle(VColor.contentEmphasized)
 
                 Spacer(minLength: VSpacing.sm)
@@ -48,17 +48,17 @@ struct OnboardingVellumCloudCard: View {
                 )
             }
 
-            Spacer().frame(height: VSpacing.xs)
+            Spacer().frame(height: VSpacing.xxs)
 
             Text(subtitle)
-                .font(VFont.bodyMediumLighter)
+                .font(VFont.bodySmallDefault)
                 .foregroundStyle(VColor.contentSecondary)
                 .fixedSize(horizontal: false, vertical: true)
 
-            Spacer().frame(height: VSpacing.lg)
+            Spacer().frame(height: VSpacing.md)
 
             // Benefits
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 ForEach(benefits, id: \.self) { benefit in
                     benefitRow(benefit)
                 }
@@ -66,7 +66,7 @@ struct OnboardingVellumCloudCard: View {
             .accessibilityElement(children: .contain)
             .accessibilityLabel(Text("Vellum Cloud benefits"))
 
-            Spacer().frame(height: VSpacing.lg)
+            Spacer().frame(height: VSpacing.md)
 
             // CTA — "Logging in…" wins over "Checking…" when both bits are set,
             // since the user has just submitted credentials and a generic
@@ -88,10 +88,10 @@ struct OnboardingVellumCloudCard: View {
             }
         }
         .padding(EdgeInsets(
-            top: VSpacing.lg,
-            leading: VSpacing.lg,
-            bottom: VSpacing.lg,
-            trailing: VSpacing.lg
+            top: VSpacing.md,
+            leading: VSpacing.md,
+            bottom: VSpacing.md,
+            trailing: VSpacing.md
         ))
         .frame(maxWidth: .infinity)
         .background(
@@ -110,11 +110,11 @@ struct OnboardingVellumCloudCard: View {
     @ViewBuilder
     private func benefitRow(_ text: String) -> some View {
         HStack(alignment: .top, spacing: VSpacing.sm) {
-            VIconView(.circleCheck, size: 16)
+            VIconView(.circleCheck, size: 14)
                 .foregroundStyle(VColor.contentSecondary)
                 .accessibilityHidden(true)
             Text(text)
-                .font(VFont.bodyMediumDefault)
+                .font(VFont.bodySmallDefault)
                 .foregroundStyle(VColor.contentDefault)
                 .fixedSize(horizontal: false, vertical: true)
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -41,7 +41,7 @@ final class OnboardingWindow {
         let hostingController = NSHostingController(rootView: flowView)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 440, height: 980),
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 630),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -54,10 +54,10 @@ final class OnboardingWindow {
         window.backgroundColor = NSColor(VColor.surfaceOverlay)
         window.isReleasedWhenClosed = false
 
-        window.contentMinSize = NSSize(width: 440, height: 980)
+        window.contentMinSize = NSSize(width: 440, height: 630)
 
         let startWidth: CGFloat = 440
-        let startHeight: CGFloat = 980
+        let startHeight: CGFloat = 630
         if let visibleFrame = Self.visibleScreenFrame() {
             let x = visibleFrame.midX - startWidth / 2
             let y = visibleFrame.midY - startHeight / 2

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -41,11 +41,11 @@ struct WakeUpStepView: View {
     var body: some View {
         // Title
         Text("Welcome to Vellum")
-            .font(VFont.titleLarge)
+            .font(VFont.titleMedium)
             .foregroundStyle(VColor.contentDefault)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
-            .padding(.bottom, VSpacing.md)
+            .padding(.bottom, VSpacing.xs)
 
         // Subtitle
         Text("The safest way to create your personal assistant.")
@@ -54,10 +54,10 @@ struct WakeUpStepView: View {
             .multilineTextAlignment(.center)
             .opacity(showSubtext ? 1 : 0)
             .offset(y: showSubtext ? 0 : 8)
-            .padding(.bottom, VSpacing.xl)
+            .padding(.bottom, VSpacing.md)
 
         // Setup-option cards (managed path) or single "Get Started" fallback.
-        VStack(spacing: VSpacing.sm) {
+        VStack(spacing: VSpacing.xs) {
             if managedSignInEnabled {
                 OnboardingVellumCloudCard(
                     isLoading: authManager?.isLoading == true,
@@ -110,21 +110,24 @@ struct WakeUpStepView: View {
             }
         }
 
-        Spacer(minLength: VSpacing.lg)
+        Spacer(minLength: VSpacing.xs)
 
         Text("2026 Vellum Inc.")
-            .font(VFont.bodySmallDefault)
+            .font(VFont.labelSmall)
             .foregroundStyle(VColor.borderElement)
-            .padding(.bottom, VSpacing.sm)
+            .padding(.bottom, VSpacing.xs)
 
         // Characters peeking up from the bottom — single composed image
         // exported from Figma, displayed edge-to-edge at the window bottom.
         // Clip bottom corners to match the macOS window corner radius.
+        // The image is capped to 64pt of height so the hero + cards +
+        // expanded Advanced state can still fit inside the 630pt window
+        // envelope without engaging the ScrollView.
         if let characters = Self.welcomeCharacters {
             Image(nsImage: characters)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
-                .frame(maxWidth: .infinity)
+                .frame(maxWidth: .infinity, maxHeight: 64)
                 .clipShape(UnevenRoundedRectangle(
                     topLeadingRadius: 0,
                     bottomLeadingRadius: VRadius.window,


### PR DESCRIPTION
## Summary
Keeps the onboarding window at its original 440×630 size and compacts the step-0 layout instead — per feedback that the window should not grow just to accommodate the new cards.

### Typography down-shift
- Page title: `VFont.titleLarge` (24pt) → `VFont.titleMedium` (20pt).
- Card title: `VFont.titleMedium` (20pt) → `VFont.titleSmall` (16pt). Sits a step below the page title in the same family.
- Card subtitle + benefit rows: `VFont.bodyMediumLighter/Default` (14pt) → `VFont.bodySmallDefault` (12pt).
- Circle-check icon: 16pt → 14pt.
- Disclosure title: `VFont.bodyMediumEmphasised` → `VFont.bodySmallEmphasised`.
- Trade-off rows: `VFont.bodyMediumDefault` → `VFont.bodySmallDefault`.
- Footer "2026 Vellum Inc.": `VFont.bodySmallDefault` → `VFont.labelSmall`.

### Spacing tighten-up
- Step-0 preamble: 80pt + 80×80 icon + 78pt → `VSpacing.md` + icon + `VSpacing.sm` (saves ~130pt).
- Welcome hero title/subtitle paddings: `.md` / `.xl` → `.xs` / `.md`.
- Card outer padding: `.lg` (16pt) → `.md` (12pt).
- Card inter-section gaps: `.lg` → `.md`. Benefit row spacing: `.sm` → `.xs`.
- Disclosure outer padding: `.md` leading → `.md`; all other edges `.sm`.
- Disclosure expanded body gaps: `.md` / `.sm` → `.sm` / `.xs`.
- Characters image capped at `maxHeight: 64`.
- Trailing Spacer minLength dropped to `.xs`.

### Window sizing reverts
- `OnboardingFlowView` `.frame(minHeight: 980)` → `.frame(minHeight: 630)`.
- `OnboardingWindow` default + minSize: 980 → 630.
- `AppDelegate+AuthLifecycle` onboarding branch: 980 → 630 (reauth branch still 620/580).

## Test plan
- [x] `swift build` from `clients/` green
- [ ] Launch onboarding at default size (460×630): all six elements (title, subtitle, cloud card, advanced row, footer text, characters image) visible with no scroll
- [ ] Expand the Advanced disclosure: layout still fits without scroll
- [ ] Reauth flow (on authenticated machines with managed assistants) still renders at 460×620 / min 420×580 — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
