### PR TITLE
refactor(macos): source SettingsStore defaults from LLMProviderRegistry

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -47,7 +47,7 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Model Selection
 
-    @Published var selectedModel: String = "claude-opus-4-7"
+    @Published var selectedModel: String = LLMProviderRegistry.defaultProvider?.defaultModel ?? ""
     @Published var configuredProviders: Set<String> = ["ollama"]
     @Published var selectedImageGenModel: String = "gemini-3.1-flash-image-preview"
 
@@ -532,9 +532,9 @@ public final class SettingsStore: ObservableObject {
         // Service modes use defaults until daemon provides config
         loadServiceModes(config: emptyConfig)
 
-        // Seed provider catalog with shared defaults so the UI has data before
-        // the first daemon fetch completes.
-        providerCatalog = ProviderCatalogEntry.defaultCatalog
+        // Seed provider catalog from `LLMProviderRegistry` so the UI has data
+        // before the first daemon fetch completes.
+        providerCatalog = LLMProviderRegistry.providers.map(ProviderCatalogEntry.init(registryEntry:))
 
         // Resolve lockfile-derived state (gateway URL, assistant topology)
         // on a background thread so that synchronous Data(contentsOf:)

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -258,73 +258,29 @@ public final class ChatMessageManager {
     // MARK: - Model / provider
 
     /// The currently active model ID, updated via `model_info` messages.
-    public var selectedModel: String = "claude-opus-4-7"
+    public var selectedModel: String = LLMProviderRegistry.defaultProvider?.defaultModel ?? ""
     /// Set of provider keys with configured API keys, updated via `model_info` messages.
     public var configuredProviders: Set<String> = ["anthropic"]
     /// Full provider catalog from daemon, updated via `model_info` messages.
-    /// Seeded with inline defaults so the UI has data before the first daemon fetch completes.
-    public var providerCatalog: [ProviderCatalogEntry] = ProviderCatalogEntry.defaultCatalog
+    /// Seeded from `LLMProviderRegistry` so the UI has data before the first daemon fetch completes.
+    public var providerCatalog: [ProviderCatalogEntry] = LLMProviderRegistry.providers.map(ProviderCatalogEntry.init(registryEntry:))
 
 }
 
-// MARK: - Default Provider Catalog
+// MARK: - Registry bridging
 
 extension ProviderCatalogEntry {
-    /// Inline seed data shared by ChatMessageManager and SettingsStore so the
-    /// model picker / model list has data before the first daemon fetch completes.
-    public static let defaultCatalog: [ProviderCatalogEntry] = [
-        ProviderCatalogEntry(id: "anthropic", displayName: "Anthropic", models: [
-            CatalogModel(id: "claude-opus-4-7", displayName: "Claude Opus 4.7"),
-            CatalogModel(id: "claude-opus-4-6", displayName: "Claude Opus 4.6"),
-            CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
-            CatalogModel(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),
-        ], defaultModel: "claude-opus-4-7", apiKeyUrl: "https://console.anthropic.com/settings/keys", apiKeyPlaceholder: "sk-ant-api03-..."),
-        ProviderCatalogEntry(id: "openai", displayName: "OpenAI", models: [
-            CatalogModel(id: "gpt-5.4", displayName: "GPT-5.4"),
-            CatalogModel(id: "gpt-5.2", displayName: "GPT-5.2"),
-            CatalogModel(id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini"),
-            CatalogModel(id: "gpt-5.4-nano", displayName: "GPT-5.4 Nano"),
-        ], defaultModel: "gpt-5.4", apiKeyUrl: "https://platform.openai.com/api-keys", apiKeyPlaceholder: "sk-proj-..."),
-        ProviderCatalogEntry(id: "gemini", displayName: "Google Gemini", models: [
-            CatalogModel(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash"),
-            CatalogModel(id: "gemini-2.5-flash-lite", displayName: "Gemini 2.5 Flash Lite"),
-            CatalogModel(id: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro"),
-        ], defaultModel: "gemini-2.5-flash", apiKeyUrl: "https://aistudio.google.com/apikey", apiKeyPlaceholder: "AIza..."),
-        ProviderCatalogEntry(id: "ollama", displayName: "Ollama", models: [
-            CatalogModel(id: "llama3.2", displayName: "Llama 3.2"),
-            CatalogModel(id: "mistral", displayName: "Mistral"),
-        ], defaultModel: "llama3.2"),
-        ProviderCatalogEntry(id: "fireworks", displayName: "Fireworks", models: [
-            CatalogModel(id: "accounts/fireworks/models/kimi-k2p5", displayName: "Kimi K2.5"),
-        ], defaultModel: "accounts/fireworks/models/kimi-k2p5", apiKeyUrl: "https://fireworks.ai/account/api-keys", apiKeyPlaceholder: "fw_..."),
-        ProviderCatalogEntry(id: "openrouter", displayName: "OpenRouter", models: [
-            // Anthropic
-            CatalogModel(id: "anthropic/claude-opus-4.7", displayName: "Claude Opus 4.7"),
-            CatalogModel(id: "anthropic/claude-opus-4.6", displayName: "Claude Opus 4.6"),
-            CatalogModel(id: "anthropic/claude-sonnet-4.6", displayName: "Claude Sonnet 4.6"),
-            CatalogModel(id: "anthropic/claude-haiku-4.5", displayName: "Claude Haiku 4.5"),
-            // xAI
-            CatalogModel(id: "x-ai/grok-4.20-beta", displayName: "Grok 4.20 Beta"),
-            CatalogModel(id: "x-ai/grok-4", displayName: "Grok 4"),
-            // DeepSeek
-            CatalogModel(id: "deepseek/deepseek-r1-0528", displayName: "DeepSeek R1"),
-            CatalogModel(id: "deepseek/deepseek-chat-v3-0324", displayName: "DeepSeek V3"),
-            // Qwen
-            CatalogModel(id: "qwen/qwen3.5-plus-02-15", displayName: "Qwen 3.5 Plus"),
-            CatalogModel(id: "qwen/qwen3.5-397b-a17b", displayName: "Qwen 3.5 397B"),
-            CatalogModel(id: "qwen/qwen3.5-flash-02-23", displayName: "Qwen 3.5 Flash"),
-            CatalogModel(id: "qwen/qwen3-coder-next", displayName: "Qwen 3 Coder"),
-            // Moonshot
-            CatalogModel(id: "moonshotai/kimi-k2.5", displayName: "Kimi K2.5"),
-            // Mistral
-            CatalogModel(id: "mistralai/mistral-medium-3", displayName: "Mistral Medium 3"),
-            CatalogModel(id: "mistralai/mistral-small-2603", displayName: "Mistral Small 4"),
-            CatalogModel(id: "mistralai/devstral-2512", displayName: "Devstral 2"),
-            // Meta
-            CatalogModel(id: "meta-llama/llama-4-maverick", displayName: "Llama 4 Maverick"),
-            CatalogModel(id: "meta-llama/llama-4-scout", displayName: "Llama 4 Scout"),
-            // Amazon
-            CatalogModel(id: "amazon/nova-pro-v1", displayName: "Amazon Nova Pro"),
-        ], defaultModel: "x-ai/grok-4.20-beta", apiKeyUrl: "https://openrouter.ai/keys", apiKeyPlaceholder: "sk-or-v1-..."),
-    ]
+    /// Bridge a shared `LLMProviderEntry` (registry-sourced) into the wire-protocol
+    /// `ProviderCatalogEntry` shape consumed by existing chat and settings code.
+    /// Used to seed `providerCatalog` fields before the first daemon fetch completes.
+    public init(registryEntry entry: LLMProviderEntry) {
+        self.init(
+            id: entry.id,
+            displayName: entry.displayName,
+            models: entry.models.map { CatalogModel(id: $0.id, displayName: $0.displayName) },
+            defaultModel: entry.defaultModel,
+            apiKeyUrl: entry.credentialsGuide?.url,
+            apiKeyPlaceholder: entry.apiKeyPlaceholder
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Replaces hardcoded "claude-opus-4-7" default in SettingsStore.swift with `LLMProviderRegistry.defaultProvider.defaultModel`.
- Image-generation model literals (gemini-3.*-image-preview) are intentionally left alone — they are outside the LLM catalog scope.
- If `ProviderCatalogEntry.defaultCatalog` existed as a shared Swift constant, removed it in favor of registry-sourced providers.

Part of plan: llm-provider-catalog.md (PR 11 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
