### PR TITLE
refactor(macos): source default LLM model from LLMProviderRegistry

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -86,7 +86,7 @@ final class OnboardingState {
     var sshUser: String = ""
     var sshPrivateKey: String = ""
     var customQRCodeImageData: Data = Data()
-    var selectedModel: String = "claude-opus-4-7"
+    var selectedModel: String = LLMProviderRegistry.defaultProvider?.defaultModel ?? ""
     var selectedProvider: String = "anthropic"
     /// When true, the onboarding flow was launched from the developer tab's
     /// "Hatch New Assistant" button. This prevents auto-completing when the user
@@ -232,7 +232,7 @@ final class OnboardingState {
         }
 
         selectedProvider = "anthropic"
-        selectedModel = "claude-opus-4-7"
+        selectedModel = LLMProviderRegistry.defaultProvider?.defaultModel ?? ""
 
         // Reset hosting selection and cloud credentials
         selectedHostingMode = .vellumCloud


### PR DESCRIPTION
## Summary
- Replaces hardcoded "claude-opus-4-7" literals in OnboardingState.swift with `LLMProviderRegistry.defaultProvider.defaultModel`.
- Behavior is unchanged: registry fallback resolves to the same default.

Part of plan: llm-provider-catalog.md (PR 10 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
