### PR TITLE
refactor(providers): source LLM env-var names from catalog

### DIFF
--- a/assistant/src/providers/__tests__/provider-env-vars.test.ts
+++ b/assistant/src/providers/__tests__/provider-env-vars.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+import { getLlmProviderEnvVar } from "../provider-env-vars.js";
+
+describe("getLlmProviderEnvVar", () => {
+  test("returns ANTHROPIC_API_KEY for anthropic", () => {
+    expect(getLlmProviderEnvVar("anthropic")).toBe("ANTHROPIC_API_KEY");
+  });
+
+  test("returns OPENAI_API_KEY for openai", () => {
+    expect(getLlmProviderEnvVar("openai")).toBe("OPENAI_API_KEY");
+  });
+
+  test("returns GEMINI_API_KEY for gemini", () => {
+    expect(getLlmProviderEnvVar("gemini")).toBe("GEMINI_API_KEY");
+  });
+
+  test("returns FIREWORKS_API_KEY for fireworks", () => {
+    expect(getLlmProviderEnvVar("fireworks")).toBe("FIREWORKS_API_KEY");
+  });
+
+  test("returns OPENROUTER_API_KEY for openrouter", () => {
+    expect(getLlmProviderEnvVar("openrouter")).toBe("OPENROUTER_API_KEY");
+  });
+
+  test("returns undefined for ollama (keyless provider)", () => {
+    expect(getLlmProviderEnvVar("ollama")).toBeUndefined();
+  });
+
+  test("returns undefined for unknown provider", () => {
+    expect(getLlmProviderEnvVar("unknown-provider")).toBeUndefined();
+  });
+});

--- a/assistant/src/providers/provider-env-vars.ts
+++ b/assistant/src/providers/provider-env-vars.ts
@@ -1,0 +1,19 @@
+/**
+ * LLM provider env-var lookup helper.
+ *
+ * Resolves the `<PROVIDER>_API_KEY` environment variable name for an LLM
+ * provider by consulting the single source of truth (`PROVIDER_CATALOG`)
+ * rather than the legacy `meta/provider-env-vars.json` / duplicated
+ * `shared/provider-env-vars.ts` map.
+ *
+ * Returns `undefined` for:
+ *   - keyless providers (e.g. Ollama, which has no `envVar` in the catalog)
+ *   - unknown provider IDs
+ *   - search providers (brave, perplexity) — those live outside the LLM
+ *     catalog and remain sourced from `meta/provider-env-vars.json`.
+ */
+import { PROVIDER_CATALOG } from "./model-catalog.js";
+
+export function getLlmProviderEnvVar(providerId: string): string | undefined {
+  return PROVIDER_CATALOG.find((p) => p.id === providerId)?.envVar;
+}

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -26,7 +26,7 @@ import type {
 
 import { getIsContainerized } from "../config/env-registry.js";
 import type { CesClient } from "../credential-execution/client.js";
-import { PROVIDER_ENV_VAR_NAMES } from "../shared/provider-env-vars.js";
+import { getLlmProviderEnvVar } from "../providers/provider-env-vars.js";
 import { getLogger } from "../util/logger.js";
 import { createCesCredentialBackend } from "./ces-credential-client.js";
 import { CesRpcCredentialBackend } from "./ces-rpc-credential-backend.js";
@@ -511,14 +511,12 @@ export async function bulkSetSecureKeysAsync(
 // ---------------------------------------------------------------------------
 
 /**
- * Env var names keyed by provider.
- * Ollama is intentionally omitted — it doesn't require an API key.
- */
-const PROVIDER_ENV_VARS: Record<string, string> = PROVIDER_ENV_VAR_NAMES;
-
-/**
  * Retrieve a provider API key, checking secure storage first and falling
  * back to the corresponding `<PROVIDER>_API_KEY` environment variable.
+ *
+ * Env var names come from `PROVIDER_CATALOG` via `getLlmProviderEnvVar`;
+ * keyless providers (e.g. Ollama) return `undefined` and fall through to a
+ * stored-only lookup.
  *
  * Use this instead of raw `getSecureKeyAsync` when looking up provider
  * API keys so that env-var-only setups continue to work.
@@ -528,7 +526,7 @@ export async function getProviderKeyAsync(
 ): Promise<string | undefined> {
   const stored = await getSecureKeyAsync(provider);
   if (stored) return stored;
-  const envVar = PROVIDER_ENV_VARS[provider];
+  const envVar = getLlmProviderEnvVar(provider);
   return envVar ? process.env[envVar] : undefined;
 }
 


### PR DESCRIPTION
## Summary
- New `getLlmProviderEnvVar` helper reads env var names from `PROVIDER_CATALOG` instead of `meta/provider-env-vars.json`.
- Every daemon/CLI consumer that needed an LLM-provider env var now calls the helper.
- Search-provider consumers (brave, perplexity) still use `meta/provider-env-vars.json`.
- `meta/provider-env-vars.json` itself is unchanged; entry removal lands in the follow-up PR.

Part of plan: llm-provider-catalog.md (PR 15 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
