### PR TITLE
feat(meta): add llm-provider-catalog.json with parity test

### DIFF
--- a/assistant/src/__tests__/llm-catalog-parity.test.ts
+++ b/assistant/src/__tests__/llm-catalog-parity.test.ts
@@ -1,0 +1,174 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
+
+/**
+ * Parity guard: daemon LLM provider catalog vs client LLM catalog JSON.
+ *
+ * The daemon maintains its canonical provider catalog in
+ * `assistant/src/providers/model-catalog.ts`.
+ * The client-facing metadata lives in `meta/llm-provider-catalog.json` and is
+ * bundled into native clients at build time (wired up in follow-up PRs).
+ *
+ * These tests enforce exact structural equality between the two catalogs on
+ * every field they share: provider-level metadata, per-model capabilities,
+ * and pricing. CI fails when they drift, forcing the developer to update
+ * whichever side fell behind.
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve repo root (tests run from assistant/) */
+function getRepoRoot(): string {
+  return join(process.cwd(), "..");
+}
+
+interface ClientCatalogCredentialsGuide {
+  description: string;
+  url: string;
+  linkLabel: string;
+}
+
+interface ClientCatalogModel {
+  id: string;
+  displayName: string;
+  contextWindowTokens?: number;
+  maxOutputTokens?: number;
+  supportsThinking?: boolean;
+  supportsCaching?: boolean;
+  supportsVision?: boolean;
+  supportsToolUse?: boolean;
+  pricing?: {
+    inputPer1mTokens: number;
+    outputPer1mTokens: number;
+    cacheWritePer1mTokens?: number;
+    cacheReadPer1mTokens?: number;
+  };
+}
+
+interface ClientCatalogEntry {
+  id: string;
+  displayName: string;
+  subtitle?: string;
+  setupMode?: string;
+  setupHint?: string;
+  envVar?: string;
+  apiKeyPlaceholder?: string;
+  credentialsGuide?: ClientCatalogCredentialsGuide;
+  defaultModel: string;
+  models: ClientCatalogModel[];
+}
+
+interface ClientCatalog {
+  version: number;
+  providers: ClientCatalogEntry[];
+}
+
+function loadClientCatalog(): ClientCatalog {
+  const catalogPath = join(getRepoRoot(), "meta", "llm-provider-catalog.json");
+  const raw = readFileSync(catalogPath, "utf-8");
+  return JSON.parse(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LLM catalog parity: daemon vs client", () => {
+  // -----------------------------------------------------------------------
+  // Structural sanity
+  // -----------------------------------------------------------------------
+
+  test("client catalog JSON has version 1", () => {
+    const json = loadClientCatalog();
+    expect(json.version).toBe(1);
+  });
+
+  test("client catalog provider count matches daemon", () => {
+    const json = loadClientCatalog();
+    expect(json.providers.length).toBe(PROVIDER_CATALOG.length);
+  });
+
+  // -----------------------------------------------------------------------
+  // Provider-level field parity
+  // -----------------------------------------------------------------------
+
+  test("each provider's top-level fields match the daemon catalog", () => {
+    const json = loadClientCatalog();
+
+    for (let i = 0; i < PROVIDER_CATALOG.length; i++) {
+      const daemonEntry = PROVIDER_CATALOG[i]!;
+      const clientEntry = json.providers[i]!;
+
+      expect(clientEntry.id).toBe(daemonEntry.id);
+      expect(clientEntry.displayName).toBe(daemonEntry.displayName);
+      expect(clientEntry.subtitle).toBe(daemonEntry.subtitle);
+      expect(clientEntry.setupMode).toBe(daemonEntry.setupMode);
+      expect(clientEntry.setupHint).toBe(daemonEntry.setupHint);
+      expect(clientEntry.envVar).toBe(daemonEntry.envVar);
+      expect(clientEntry.apiKeyPlaceholder).toBe(daemonEntry.apiKeyPlaceholder);
+      expect(clientEntry.credentialsGuide).toEqual(
+        daemonEntry.credentialsGuide,
+      );
+      expect(clientEntry.defaultModel).toBe(daemonEntry.defaultModel);
+    }
+  });
+
+  test("each provider's model count matches the daemon catalog", () => {
+    const json = loadClientCatalog();
+
+    for (let i = 0; i < PROVIDER_CATALOG.length; i++) {
+      const daemonEntry = PROVIDER_CATALOG[i]!;
+      const clientEntry = json.providers[i]!;
+      expect(clientEntry.models.length).toBe(daemonEntry.models.length);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Per-model field parity
+  // -----------------------------------------------------------------------
+
+  test("each model's fields match the daemon catalog", () => {
+    const json = loadClientCatalog();
+
+    for (let i = 0; i < PROVIDER_CATALOG.length; i++) {
+      const daemonEntry = PROVIDER_CATALOG[i]!;
+      const clientEntry = json.providers[i]!;
+
+      for (let j = 0; j < daemonEntry.models.length; j++) {
+        const daemonModel = daemonEntry.models[j]!;
+        const clientModel = clientEntry.models[j]!;
+
+        expect(clientModel.id).toBe(daemonModel.id);
+        expect(clientModel.displayName).toBe(daemonModel.displayName);
+        expect(clientModel.contextWindowTokens).toBe(
+          daemonModel.contextWindowTokens,
+        );
+        expect(clientModel.maxOutputTokens).toBe(daemonModel.maxOutputTokens);
+        expect(clientModel.supportsThinking).toBe(daemonModel.supportsThinking);
+        expect(clientModel.supportsCaching).toBe(daemonModel.supportsCaching);
+        expect(clientModel.supportsVision).toBe(daemonModel.supportsVision);
+        expect(clientModel.supportsToolUse).toBe(daemonModel.supportsToolUse);
+        expect(clientModel.pricing).toEqual(daemonModel.pricing);
+      }
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Internal consistency
+  // -----------------------------------------------------------------------
+
+  test("every provider's defaultModel exists in its models list", () => {
+    for (const entry of PROVIDER_CATALOG) {
+      const found = entry.models.some((m) => m.id === entry.defaultModel);
+      expect(
+        found,
+        `defaultModel "${entry.defaultModel}" not in models for provider "${entry.id}"`,
+      ).toBe(true);
+    }
+  });
+});

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -1,0 +1,574 @@
+{
+  "version": 1,
+  "providers": [
+    {
+      "id": "anthropic",
+      "displayName": "Anthropic",
+      "subtitle": "Claude models from Anthropic. Requires an Anthropic API key.",
+      "setupMode": "api-key",
+      "setupHint": "Enter your Anthropic API key to enable Claude.",
+      "envVar": "ANTHROPIC_API_KEY",
+      "apiKeyPlaceholder": "sk-ant-api03-...",
+      "credentialsGuide": {
+        "description": "Sign in to the Anthropic Console, navigate to API Keys, and create a new key.",
+        "url": "https://console.anthropic.com/settings/keys",
+        "linkLabel": "Open Anthropic Console"
+      },
+      "defaultModel": "claude-opus-4-7",
+      "models": [
+        {
+          "id": "claude-opus-4-7",
+          "displayName": "Claude Opus 4.7",
+          "contextWindowTokens": 200000,
+          "maxOutputTokens": 32000,
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 15,
+            "outputPer1mTokens": 75,
+            "cacheWritePer1mTokens": 18.75,
+            "cacheReadPer1mTokens": 1.5
+          }
+        },
+        {
+          "id": "claude-opus-4-6",
+          "displayName": "Claude Opus 4.6",
+          "contextWindowTokens": 200000,
+          "maxOutputTokens": 32000,
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 15,
+            "outputPer1mTokens": 75,
+            "cacheWritePer1mTokens": 18.75,
+            "cacheReadPer1mTokens": 1.5
+          }
+        },
+        {
+          "id": "claude-sonnet-4-6",
+          "displayName": "Claude Sonnet 4.6",
+          "contextWindowTokens": 200000,
+          "maxOutputTokens": 64000,
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 3,
+            "outputPer1mTokens": 15,
+            "cacheWritePer1mTokens": 3.75,
+            "cacheReadPer1mTokens": 0.3
+          }
+        },
+        {
+          "id": "claude-haiku-4-5-20251001",
+          "displayName": "Claude Haiku 4.5",
+          "contextWindowTokens": 200000,
+          "maxOutputTokens": 16000,
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1,
+            "outputPer1mTokens": 5,
+            "cacheWritePer1mTokens": 1.25,
+            "cacheReadPer1mTokens": 0.1
+          }
+        }
+      ]
+    },
+    {
+      "id": "openai",
+      "displayName": "OpenAI",
+      "subtitle": "GPT models from OpenAI. Requires an OpenAI API key.",
+      "setupMode": "api-key",
+      "setupHint": "Enter your OpenAI API key to enable GPT.",
+      "envVar": "OPENAI_API_KEY",
+      "apiKeyPlaceholder": "sk-proj-...",
+      "credentialsGuide": {
+        "description": "Log in to the OpenAI platform, go to API Keys, and generate a new secret key.",
+        "url": "https://platform.openai.com/api-keys",
+        "linkLabel": "Open OpenAI Platform"
+      },
+      "defaultModel": "gpt-5.4",
+      "models": [
+        {
+          "id": "gpt-5.4",
+          "displayName": "GPT-5.4",
+          "contextWindowTokens": 400000,
+          "maxOutputTokens": 128000,
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 2.5,
+            "outputPer1mTokens": 10.0,
+            "cacheReadPer1mTokens": 0.25
+          }
+        },
+        {
+          "id": "gpt-5.2",
+          "displayName": "GPT-5.2",
+          "contextWindowTokens": 400000,
+          "maxOutputTokens": 128000,
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 3.0,
+            "outputPer1mTokens": 12.0,
+            "cacheReadPer1mTokens": 0.3
+          }
+        },
+        {
+          "id": "gpt-5.4-mini",
+          "displayName": "GPT-5.4 Mini",
+          "contextWindowTokens": 400000,
+          "maxOutputTokens": 128000,
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.5,
+            "outputPer1mTokens": 2.0,
+            "cacheReadPer1mTokens": 0.05
+          }
+        },
+        {
+          "id": "gpt-5.4-nano",
+          "displayName": "GPT-5.4 Nano",
+          "contextWindowTokens": 400000,
+          "maxOutputTokens": 128000,
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.1,
+            "outputPer1mTokens": 0.4,
+            "cacheReadPer1mTokens": 0.01
+          }
+        }
+      ]
+    },
+    {
+      "id": "gemini",
+      "displayName": "Google Gemini",
+      "subtitle": "Multimodal Gemini models from Google. Requires a Gemini API key.",
+      "setupMode": "api-key",
+      "setupHint": "Enter your Gemini API key to enable Google models.",
+      "envVar": "GEMINI_API_KEY",
+      "apiKeyPlaceholder": "AIza...",
+      "credentialsGuide": {
+        "description": "Visit Google AI Studio, sign in with your Google account, and create an API key.",
+        "url": "https://aistudio.google.com/apikey",
+        "linkLabel": "Open Google AI Studio"
+      },
+      "defaultModel": "gemini-2.5-flash",
+      "models": [
+        {
+          "id": "gemini-2.5-flash",
+          "displayName": "Gemini 2.5 Flash",
+          "contextWindowTokens": 1000000,
+          "maxOutputTokens": 65536,
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.3,
+            "outputPer1mTokens": 2.5,
+            "cacheReadPer1mTokens": 0.075
+          }
+        },
+        {
+          "id": "gemini-2.5-flash-lite",
+          "displayName": "Gemini 2.5 Flash Lite",
+          "contextWindowTokens": 1000000,
+          "maxOutputTokens": 65536,
+          "supportsThinking": false,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.1,
+            "outputPer1mTokens": 0.4,
+            "cacheReadPer1mTokens": 0.025
+          }
+        },
+        {
+          "id": "gemini-2.5-pro",
+          "displayName": "Gemini 2.5 Pro",
+          "contextWindowTokens": 2000000,
+          "maxOutputTokens": 65536,
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1.25,
+            "outputPer1mTokens": 10.0,
+            "cacheReadPer1mTokens": 0.3125
+          }
+        }
+      ]
+    },
+    {
+      "id": "ollama",
+      "displayName": "Ollama",
+      "subtitle": "Run local models via Ollama. No API key required.",
+      "setupMode": "keyless",
+      "setupHint": "Install Ollama locally and pull the models you want to use.",
+      "credentialsGuide": {
+        "description": "Download and install Ollama, then pull models via `ollama pull <model>`.",
+        "url": "https://ollama.com/download",
+        "linkLabel": "Download Ollama"
+      },
+      "defaultModel": "llama3.2",
+      "models": [
+        {
+          "id": "llama3.2",
+          "displayName": "Llama 3.2",
+          "contextWindowTokens": 128000,
+          "maxOutputTokens": 4096,
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true
+        },
+        {
+          "id": "mistral",
+          "displayName": "Mistral",
+          "contextWindowTokens": 32768,
+          "maxOutputTokens": 4096,
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true
+        }
+      ]
+    },
+    {
+      "id": "fireworks",
+      "displayName": "Fireworks",
+      "subtitle": "Open-source models served by Fireworks. Requires a Fireworks API key.",
+      "setupMode": "api-key",
+      "setupHint": "Enter your Fireworks API key to enable open-source models.",
+      "envVar": "FIREWORKS_API_KEY",
+      "apiKeyPlaceholder": "fw_...",
+      "credentialsGuide": {
+        "description": "Sign in to the Fireworks dashboard and create an API key.",
+        "url": "https://fireworks.ai/account/api-keys",
+        "linkLabel": "Open Fireworks Dashboard"
+      },
+      "defaultModel": "accounts/fireworks/models/kimi-k2p5",
+      "models": [
+        {
+          "id": "accounts/fireworks/models/kimi-k2p5",
+          "displayName": "Kimi K2.5",
+          "contextWindowTokens": 256000,
+          "maxOutputTokens": 32768,
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.6,
+            "outputPer1mTokens": 2.5
+          }
+        }
+      ]
+    },
+    {
+      "id": "openrouter",
+      "displayName": "OpenRouter",
+      "subtitle": "Route to many LLM providers via a single OpenRouter API key.",
+      "setupMode": "api-key",
+      "setupHint": "Enter your OpenRouter API key to access multiple models.",
+      "envVar": "OPENROUTER_API_KEY",
+      "apiKeyPlaceholder": "sk-or-v1-...",
+      "credentialsGuide": {
+        "description": "Sign in to OpenRouter and create an API key.",
+        "url": "https://openrouter.ai/keys",
+        "linkLabel": "Open OpenRouter"
+      },
+      "defaultModel": "x-ai/grok-4.20-beta",
+      "models": [
+        {
+          "id": "anthropic/claude-opus-4.7",
+          "displayName": "Claude Opus 4.7",
+          "contextWindowTokens": 200000,
+          "maxOutputTokens": 32000,
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 15,
+            "outputPer1mTokens": 75
+          }
+        },
+        {
+          "id": "anthropic/claude-opus-4.6",
+          "displayName": "Claude Opus 4.6",
+          "contextWindowTokens": 200000,
+          "maxOutputTokens": 32000,
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 15,
+            "outputPer1mTokens": 75
+          }
+        },
+        {
+          "id": "anthropic/claude-sonnet-4.6",
+          "displayName": "Claude Sonnet 4.6",
+          "contextWindowTokens": 200000,
+          "maxOutputTokens": 64000,
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 3,
+            "outputPer1mTokens": 15
+          }
+        },
+        {
+          "id": "anthropic/claude-haiku-4.5",
+          "displayName": "Claude Haiku 4.5",
+          "contextWindowTokens": 200000,
+          "maxOutputTokens": 16000,
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1,
+            "outputPer1mTokens": 5
+          }
+        },
+        {
+          "id": "x-ai/grok-4.20-beta",
+          "displayName": "Grok 4.20 Beta",
+          "contextWindowTokens": 256000,
+          "maxOutputTokens": 16000,
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 3,
+            "outputPer1mTokens": 15
+          }
+        },
+        {
+          "id": "x-ai/grok-4",
+          "displayName": "Grok 4",
+          "contextWindowTokens": 131072,
+          "maxOutputTokens": 16000,
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 3,
+            "outputPer1mTokens": 15
+          }
+        },
+        {
+          "id": "deepseek/deepseek-r1-0528",
+          "displayName": "DeepSeek R1",
+          "contextWindowTokens": 163840,
+          "maxOutputTokens": 32000,
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.55,
+            "outputPer1mTokens": 2.19
+          }
+        },
+        {
+          "id": "deepseek/deepseek-chat-v3-0324",
+          "displayName": "DeepSeek V3",
+          "contextWindowTokens": 163840,
+          "maxOutputTokens": 32000,
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.27,
+            "outputPer1mTokens": 1.1
+          }
+        },
+        {
+          "id": "qwen/qwen3.5-plus-02-15",
+          "displayName": "Qwen 3.5 Plus",
+          "contextWindowTokens": 131072,
+          "maxOutputTokens": 8192,
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.8,
+            "outputPer1mTokens": 2.4
+          }
+        },
+        {
+          "id": "qwen/qwen3.5-397b-a17b",
+          "displayName": "Qwen 3.5 397B",
+          "contextWindowTokens": 131072,
+          "maxOutputTokens": 8192,
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.9,
+            "outputPer1mTokens": 2.7
+          }
+        },
+        {
+          "id": "qwen/qwen3.5-flash-02-23",
+          "displayName": "Qwen 3.5 Flash",
+          "contextWindowTokens": 131072,
+          "maxOutputTokens": 8192,
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.2,
+            "outputPer1mTokens": 0.6
+          }
+        },
+        {
+          "id": "qwen/qwen3-coder-next",
+          "displayName": "Qwen 3 Coder",
+          "contextWindowTokens": 131072,
+          "maxOutputTokens": 8192,
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.5,
+            "outputPer1mTokens": 1.5
+          }
+        },
+        {
+          "id": "moonshotai/kimi-k2.5",
+          "displayName": "Kimi K2.5",
+          "contextWindowTokens": 256000,
+          "maxOutputTokens": 32768,
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.6,
+            "outputPer1mTokens": 2.5
+          }
+        },
+        {
+          "id": "mistralai/mistral-medium-3",
+          "displayName": "Mistral Medium 3",
+          "contextWindowTokens": 131072,
+          "maxOutputTokens": 16000,
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.4,
+            "outputPer1mTokens": 2.0
+          }
+        },
+        {
+          "id": "mistralai/mistral-small-2603",
+          "displayName": "Mistral Small 4",
+          "contextWindowTokens": 131072,
+          "maxOutputTokens": 16000,
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.2,
+            "outputPer1mTokens": 0.6
+          }
+        },
+        {
+          "id": "mistralai/devstral-2512",
+          "displayName": "Devstral 2",
+          "contextWindowTokens": 131072,
+          "maxOutputTokens": 16000,
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.1,
+            "outputPer1mTokens": 0.3
+          }
+        },
+        {
+          "id": "meta-llama/llama-4-maverick",
+          "displayName": "Llama 4 Maverick",
+          "contextWindowTokens": 1000000,
+          "maxOutputTokens": 16000,
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.27,
+            "outputPer1mTokens": 0.85
+          }
+        },
+        {
+          "id": "meta-llama/llama-4-scout",
+          "displayName": "Llama 4 Scout",
+          "contextWindowTokens": 327680,
+          "maxOutputTokens": 16000,
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.11,
+            "outputPer1mTokens": 0.34
+          }
+        },
+        {
+          "id": "amazon/nova-pro-v1",
+          "displayName": "Amazon Nova Pro",
+          "contextWindowTokens": 300000,
+          "maxOutputTokens": 5000,
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.8,
+            "outputPer1mTokens": 3.2
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- New `meta/llm-provider-catalog.json` (v1) projecting the 6 populated providers from the daemon `PROVIDER_CATALOG`.
- New parity test enforces exact field equality between JSON and TS catalog (provider-level fields, per-model capabilities, pricing).
- Not yet bundled into client apps (follow-up PRs wire macOS/iOS build scripts).

Part of plan: llm-provider-catalog.md (PR 12 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
