### PR TITLE
fix(meet-join): register bot ingress route so hex tokens don't hit JWT auth

### DIFF
--- a/skills/meet-join/__tests__/register.test.ts
+++ b/skills/meet-join/__tests__/register.test.ts
@@ -22,6 +22,11 @@ import { afterAll, describe, expect, mock, test } from "bun:test";
 // Module-scope state so each test can tweak inputs without re-installing mocks.
 let flagEnabled = true;
 let captured: Array<{ name: string }> | null = null;
+const capturedRoutes: Array<{
+  pattern: RegExp;
+  methods: string[];
+  handler: (req: Request, match: RegExpMatchArray) => Promise<Response>;
+}> = [];
 
 mock.module("../../../assistant/src/tools/registry.js", () => ({
   registerExternalTools: (
@@ -37,6 +42,30 @@ mock.module("../../../assistant/src/tools/registry.js", () => ({
         ? toolsOrProvider()
         : toolsOrProvider;
     captured = tools.map((t) => ({ name: t.name }));
+  },
+}));
+
+mock.module("../../../assistant/src/runtime/skill-route-registry.js", () => ({
+  registerSkillRoute: (route: {
+    pattern: RegExp;
+    methods: string[];
+    handler: (req: Request, match: RegExpMatchArray) => Promise<Response>;
+  }) => {
+    capturedRoutes.push(route);
+  },
+}));
+
+// Stub the meet-internal route module so we can (a) assert the exact
+// meetingId passed to the handler after URL decoding, and (b) avoid
+// pulling in the real handler's transitive imports (session router,
+// http-errors) during test boot. We re-declare the path regex here so
+// register.ts still gets a usable value at the original export name.
+let lastHandlerMeetingId: string | null = null;
+mock.module("../routes/meet-internal.js", () => ({
+  MEET_INTERNAL_EVENTS_PATH_RE: /^\/v1\/internal\/meet\/([^/]+)\/events$/,
+  handleMeetInternalEvents: async (_req: Request, meetingId: string) => {
+    lastHandlerMeetingId = meetingId;
+    return new Response(null, { status: 204 });
   },
 }));
 
@@ -146,5 +175,29 @@ describe("meet-join register", () => {
     // accept the drift.
     const meetTools = registeredNames.filter((n) => n.startsWith("meet_"));
     expect(new Set(meetTools).size).toBe(EXPECTED_TOOL_NAMES.length);
+  });
+
+  test("registers the meet-internal POST route for bot ingress", () => {
+    // Without this registration the bot's POST /v1/internal/meet/:id/events
+    // request falls through to the daemon's JWT middleware, which rejects
+    // the bot's opaque hex bearer token with
+    // "malformed_token: expected 3 dot-separated parts".
+    const route = capturedRoutes.find((r) =>
+      r.pattern.test("/v1/internal/meet/abc123/events"),
+    );
+    expect(route).toBeDefined();
+    expect(route?.methods).toEqual(["POST"]);
+    const match = "/v1/internal/meet/abc123/events".match(route!.pattern);
+    expect(match?.[1]).toBe("abc123");
+  });
+
+  test("meet-internal route handler URL-decodes the meetingId capture", async () => {
+    const path = "/v1/internal/meet/abc%20123/events";
+    const route = capturedRoutes.find((r) => r.pattern.test(path));
+    expect(route).toBeDefined();
+    const match = path.match(route!.pattern)!;
+    const req = new Request(`http://host${path}`, { method: "POST" });
+    await route!.handler(req, match);
+    expect(lastHandlerMeetingId).toBe("abc 123");
   });
 });

--- a/skills/meet-join/register.ts
+++ b/skills/meet-join/register.ts
@@ -34,7 +34,12 @@
 
 import { isAssistantFeatureFlagEnabled } from "../../assistant/src/config/assistant-feature-flags.js";
 import { getConfig } from "../../assistant/src/config/loader.js";
+import { registerSkillRoute } from "../../assistant/src/runtime/skill-route-registry.js";
 import { registerExternalTools } from "../../assistant/src/tools/registry.js";
+import {
+  handleMeetInternalEvents,
+  MEET_INTERNAL_EVENTS_PATH_RE,
+} from "./routes/meet-internal.js";
 import {
   meetDisableAvatarTool,
   meetEnableAvatarTool,
@@ -43,6 +48,19 @@ import { MEET_FLAG_KEY, meetJoinTool } from "./tools/meet-join-tool.js";
 import { meetLeaveTool } from "./tools/meet-leave-tool.js";
 import { meetSendChatTool } from "./tools/meet-send-chat-tool.js";
 import { meetCancelSpeakTool, meetSpeakTool } from "./tools/meet-speak-tool.js";
+
+// Route registration is unconditional — the handler authenticates against
+// the per-meeting bearer token resolver, which returns null when no session
+// is active. With the meet flag off, no sessions exist, so every request
+// gets a 401 from the handler itself rather than silently falling through
+// to the daemon's JWT middleware (which would reject the bot's opaque
+// bearer token as a malformed JWT).
+registerSkillRoute({
+  pattern: MEET_INTERNAL_EVENTS_PATH_RE,
+  methods: ["POST"],
+  handler: (req, match) =>
+    handleMeetInternalEvents(req, decodeURIComponent(match[1]!)),
+});
 
 registerExternalTools(() => {
   try {


### PR DESCRIPTION
## Summary

The meet-bot's ingress calls back to the daemon were all failing with:
```
401 "Invalid token: malformed_token: expected 3 dot-separated parts"
```

The handler at `skills/meet-join/routes/meet-internal.ts` was supposed to receive these requests *before* JWT auth — it does a constant-time hex comparison against a per-session bearer token. But the `registerSkillRoute()` call that wires it into `http-server.ts`'s skill-route pre-check was missing. Every bot request fell through to the JWT middleware, which split the hex string on `.`, got one part, and 401'd.

Visible symptom: `meet_join` times out at 120s with the bot container still "running" — the container joined the Meet fine but every event batch it shipped got rejected.

## Changes

- `skills/meet-join/register.ts`: call `registerSkillRoute({ pattern, methods: ["POST"], handler })` at module import time. The handler wrapper `decodeURIComponent`s the path capture group so URL-encoded meeting ids round-trip correctly.
- `skills/meet-join/__tests__/register.test.ts`: added two assertions — route registered with the right pattern/method, and the wrapper URL-decodes the captured meeting id before invoking the handler.

## Why unconditional registration (not gated on the `meet` flag)

The handler already returns 401 when no session is active (via `resolveBotApiToken(meetingId) === null`). When the `meet` flag is off, no sessions exist, so the handler rejects every request on its own. Gating the registration on the flag would add a redundant null-check path and require a daemon restart to pick up flag changes (flag reads already require one).

## Test plan

- [x] `bun test ../skills/meet-join/__tests__/register.test.ts` (3 pass)
- [x] `bun test ../skills/meet-join/routes/__tests__/meet-internal.test.ts` (15 pass — no regression on the handler)
- [x] `bunx tsc --noEmit` from `assistant/` (clean)
- [ ] Manual: `meet_join` against a real Meet URL now completes instead of timing out at 120s

## Root cause provenance

Latent since commit `8b2abbcfe3` ("refactor: remove all ../skills imports from assistant module"), which introduced `registerSkillRoute()` but did not call it for the meet-internal route. The hardcoded route handling previously lived in `http-server.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
