### PR TITLE
build(macos): bundle llm-provider-catalog.json

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1058,6 +1058,10 @@ STT_PROVIDER_CATALOG="$SCRIPT_DIR/../../meta/stt-provider-catalog.json"
 if [ -f "$STT_PROVIDER_CATALOG" ]; then
     cp "$STT_PROVIDER_CATALOG" "$RESOURCES_DIR/stt-provider-catalog.json"
 fi
+LLM_PROVIDER_CATALOG="$SCRIPT_DIR/../../meta/llm-provider-catalog.json"
+if [ -f "$LLM_PROVIDER_CATALOG" ]; then
+    cp "$LLM_PROVIDER_CATALOG" "$RESOURCES_DIR/llm-provider-catalog.json"
+fi
 # Bundle Dockerfiles into Contents/Resources/dockerfiles/ for debug builds
 # so that the CLI's findRepoRoot() can locate them when running from a
 # packaged DMG.  This enables `vellum hatch --remote docker` to work


### PR DESCRIPTION
## Summary
- macOS build script now copies `meta/llm-provider-catalog.json` into the app bundle's Resources, alongside the existing STT/TTS catalogs.
- `LLMProviderRegistry` will start loading the bundled JSON instead of falling back to the hardcoded registry.

Part of plan: llm-provider-catalog.md (PR 13 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
