### PR TITLE
build(ios): bundle llm-provider-catalog.json

### DIFF
--- a/clients/ios/build.sh
+++ b/clients/ios/build.sh
@@ -66,6 +66,7 @@ case "$CMD" in
         echo "Cleaning..."
         rm -rf "$DIST_DIR" "$CLIENTS_DIR/.build"
         rm -f "$SCRIPT_DIR/Resources/tts-provider-catalog.json"
+        rm -f "$SCRIPT_DIR/Resources/llm-provider-catalog.json"
         echo "Done."
         exit 0
         ;;
@@ -86,6 +87,10 @@ esac
 TTS_PROVIDER_CATALOG="$SCRIPT_DIR/../../meta/tts-provider-catalog.json"
 if [ -f "$TTS_PROVIDER_CATALOG" ]; then
     cp "$TTS_PROVIDER_CATALOG" "$SCRIPT_DIR/Resources/tts-provider-catalog.json"
+fi
+LLM_PROVIDER_CATALOG="$SCRIPT_DIR/../../meta/llm-provider-catalog.json"
+if [ -f "$LLM_PROVIDER_CATALOG" ]; then
+    cp "$LLM_PROVIDER_CATALOG" "$SCRIPT_DIR/Resources/llm-provider-catalog.json"
 fi
 
 # ── Generate xcodeproj ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- iOS build script now copies `meta/llm-provider-catalog.json` into `clients/ios/Resources/` before xcodegen runs, so the file is listed in the generated xcodeproj.

Part of plan: llm-provider-catalog.md (PR 14 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
