### PR TITLE
fix: guardian auto-approve regression — change autoApproveUpTo default to per-context object

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -675,7 +675,11 @@ describe("AssistantConfigSchema", () => {
     expect(result.permissions).toEqual({
       mode: "workspace",
       hostAccess: false,
-      autoApproveUpTo: "low",
+      autoApproveUpTo: {
+        conversation: "low",
+        background: "medium",
+        headless: "none",
+      },
     });
   });
 
@@ -712,11 +716,15 @@ describe("AssistantConfigSchema", () => {
     }
   });
 
-  test("defaults autoApproveUpTo to low when not specified", () => {
+  test("defaults autoApproveUpTo to per-context object when not specified", () => {
     const result = AssistantConfigSchema.parse({
       permissions: { mode: "workspace" },
     });
-    expect(result.permissions.autoApproveUpTo).toBe("low");
+    expect(result.permissions.autoApproveUpTo).toEqual({
+      conversation: "low",
+      background: "medium",
+      headless: "none",
+    });
   });
 
   test("accepts autoApproveUpTo none", () => {
@@ -2365,7 +2373,11 @@ describe("loadConfig with schema validation", () => {
     expect(config.permissions).toEqual({
       mode: "workspace",
       hostAccess: false,
-      autoApproveUpTo: "low",
+      autoApproveUpTo: {
+        conversation: "low",
+        background: "medium",
+        headless: "none",
+      },
     });
   });
 

--- a/assistant/src/__tests__/permission-mode.test.ts
+++ b/assistant/src/__tests__/permission-mode.test.ts
@@ -40,7 +40,11 @@ describe("PermissionsConfigSchema", () => {
     expect(PermissionsConfigSchema.parse({})).toEqual({
       mode: "workspace",
       hostAccess: false,
-      autoApproveUpTo: "low",
+      autoApproveUpTo: {
+        conversation: "low",
+        background: "medium",
+        headless: "none",
+      },
     });
   });
 
@@ -48,7 +52,11 @@ describe("PermissionsConfigSchema", () => {
     expect(PermissionsConfigSchema.parse({ mode: "strict" })).toEqual({
       mode: "strict",
       hostAccess: false,
-      autoApproveUpTo: "low",
+      autoApproveUpTo: {
+        conversation: "low",
+        background: "medium",
+        headless: "none",
+      },
     });
   });
 
@@ -61,7 +69,11 @@ describe("PermissionsConfigSchema", () => {
     ).toEqual({
       mode: "workspace",
       hostAccess: true,
-      autoApproveUpTo: "low",
+      autoApproveUpTo: {
+        conversation: "low",
+        background: "medium",
+        headless: "none",
+      },
     });
   });
 

--- a/assistant/src/config/schemas/security.ts
+++ b/assistant/src/config/schemas/security.ts
@@ -114,7 +114,7 @@ export const PermissionsConfigSchema = z
             ),
         }),
       ])
-      .default("low")
+      .default({ conversation: "low", background: "medium", headless: "none" })
       .describe(
         "Auto-approve tools at or below this risk level without prompting. " +
           "Accepts a scalar ('none', 'low', 'medium') applied to all contexts, " +


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for bash-risk-approval-policy.md.

**Gap:** Guardian auto-approve regression — Zod default 'low' makes CONTEXT_DEFAULTS dead code
**What was expected:** Background sessions default to 'medium' threshold (matching pre-Phase-3 guardian behavior)
**What was found:** Zod schema default 'low' scalar overrides per-context defaults, breaking Medium-risk guardian auto-approve
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
