### PR TITLE
fix(daemon): narrow ModelInfo.allProviders payload to wire contract

### DIFF
--- a/assistant/src/daemon/handlers/config-model.test.ts
+++ b/assistant/src/daemon/handlers/config-model.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+
+import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
+import { projectProviderForWire } from "./config-model.js";
+
+/**
+ * Regression guard for the wire contract declared in
+ * `daemon/message-types/conversations.ts#ModelInfo.allProviders`. The
+ * daemon's `PROVIDER_CATALOG` carries richer metadata (capability flags,
+ * pricing, subtitle, setupMode, setupHint, envVar, credentialsGuide), but
+ * clients source that metadata from the bundled `LLMProviderRegistry`
+ * JSON, so only the legacy fields belong on the wire. The Swift generated
+ * DTO declares the same legacy-only shape and silently discards any
+ * extras — this test keeps the daemon honest about what it sends.
+ */
+describe("projectProviderForWire", () => {
+  const LEGACY_WIRE_KEYS = new Set([
+    "id",
+    "displayName",
+    "models",
+    "defaultModel",
+    "apiKeyUrl",
+    "apiKeyPlaceholder",
+  ]);
+
+  test("drops rich catalog fields (subtitle, setupMode, envVar, credentialsGuide, setupHint)", () => {
+    for (const entry of PROVIDER_CATALOG) {
+      const wire = projectProviderForWire(entry);
+      const keys = Object.keys(wire);
+      for (const key of keys) {
+        expect(LEGACY_WIRE_KEYS.has(key)).toBe(true);
+      }
+      expect(keys).not.toContain("subtitle");
+      expect(keys).not.toContain("setupMode");
+      expect(keys).not.toContain("setupHint");
+      expect(keys).not.toContain("envVar");
+      expect(keys).not.toContain("credentialsGuide");
+    }
+  });
+
+  test("drops rich CatalogModel fields (capability flags, pricing, context windows)", () => {
+    for (const entry of PROVIDER_CATALOG) {
+      const wire = projectProviderForWire(entry);
+      for (const model of wire.models) {
+        expect(Object.keys(model).sort()).toEqual(["displayName", "id"]);
+      }
+    }
+  });
+
+  test("preserves legacy wire fields exactly", () => {
+    const anthropic = PROVIDER_CATALOG.find((p) => p.id === "anthropic");
+    expect(anthropic).toBeDefined();
+    const wire = projectProviderForWire(anthropic!);
+    expect(wire.id).toBe(anthropic!.id);
+    expect(wire.displayName).toBe(anthropic!.displayName);
+    expect(wire.defaultModel).toBe(anthropic!.defaultModel);
+    expect(wire.apiKeyUrl).toBe(anthropic!.apiKeyUrl);
+    expect(wire.apiKeyPlaceholder).toBe(anthropic!.apiKeyPlaceholder);
+    expect(wire.models.length).toBe(anthropic!.models.length);
+  });
+
+  test("omits apiKeyUrl/apiKeyPlaceholder when source entry has none (keyless providers)", () => {
+    const ollama = PROVIDER_CATALOG.find((p) => p.id === "ollama");
+    expect(ollama).toBeDefined();
+    // Sanity-check the fixture: ollama is the keyless provider.
+    expect(ollama!.apiKeyUrl).toBeUndefined();
+    expect(ollama!.apiKeyPlaceholder).toBeUndefined();
+
+    const wire = projectProviderForWire(ollama!);
+    expect("apiKeyUrl" in wire).toBe(false);
+    expect("apiKeyPlaceholder" in wire).toBe(false);
+  });
+
+  test("JSON round-trip exposes only the legacy wire keys", () => {
+    for (const entry of PROVIDER_CATALOG) {
+      const wire = projectProviderForWire(entry);
+      const serialized = JSON.parse(JSON.stringify(wire)) as Record<
+        string,
+        unknown
+      >;
+      for (const key of Object.keys(serialized)) {
+        expect(LEGACY_WIRE_KEYS.has(key)).toBe(true);
+      }
+    }
+  });
+});

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -40,12 +40,49 @@ export const MODEL_TO_PROVIDER: Record<string, string> = Object.fromEntries(
 // Shared business logic (transport-agnostic)
 // ---------------------------------------------------------------------------
 
+/**
+ * Wire-contract shape for a provider entry in `ModelInfo.allProviders`.
+ * Mirrors the legacy fields declared in `message-types/conversations.ts` —
+ * rich provider metadata (capability flags, pricing, subtitle, setupMode,
+ * setupHint, envVar, credentialsGuide) is sourced by clients from the
+ * bundled `LLMProviderRegistry` JSON, so there is no reason to double-send
+ * it over the wire.
+ */
+export interface WireProviderEntry {
+  id: string;
+  displayName: string;
+  models: Array<{ id: string; displayName: string }>;
+  defaultModel: string;
+  apiKeyUrl?: string;
+  apiKeyPlaceholder?: string;
+}
+
 export interface ModelInfo {
   model: string;
   provider: string;
   configuredProviders?: string[];
   availableModels?: Array<{ id: string; displayName: string }>;
-  allProviders?: ProviderCatalogEntry[];
+  allProviders?: WireProviderEntry[];
+}
+
+/**
+ * Project a rich `ProviderCatalogEntry` to the legacy wire-contract fields.
+ * Keeping the wire payload honest avoids contract drift with
+ * `message-types/conversations.ts` and the generated Swift DTO.
+ */
+export function projectProviderForWire(
+  entry: ProviderCatalogEntry,
+): WireProviderEntry {
+  return {
+    id: entry.id,
+    displayName: entry.displayName,
+    models: entry.models.map((m) => ({ id: m.id, displayName: m.displayName })),
+    defaultModel: entry.defaultModel,
+    ...(entry.apiKeyUrl !== undefined && { apiKeyUrl: entry.apiKeyUrl }),
+    ...(entry.apiKeyPlaceholder !== undefined && {
+      apiKeyPlaceholder: entry.apiKeyPlaceholder,
+    }),
+  };
 }
 
 /** Return current model configuration. */
@@ -57,8 +94,10 @@ export async function getModelInfo(): Promise<ModelInfo> {
     model: config.llm.default.model,
     provider,
     configuredProviders: await getConfiguredProviders(),
-    availableModels: PROVIDER_CATALOG.find((p) => p.id === provider)?.models,
-    allProviders: PROVIDER_CATALOG,
+    availableModels: PROVIDER_CATALOG.find(
+      (p) => p.id === provider,
+    )?.models?.map((m) => ({ id: m.id, displayName: m.displayName })),
+    allProviders: PROVIDER_CATALOG.map(projectProviderForWire),
   };
 }
 


### PR DESCRIPTION
## Summary
After the PROVIDER_CATALOG was enriched with capability flags, pricing, subtitle, setupMode, envVar, and credentialsGuide, `handleModelGet` began sending the full catalog over the wire via `allProviders`. The wire contract (both TS and generated Swift DTO) only declared the legacy six fields. Swift decoders ignored the extras silently, but the contract was drifting. Narrow the daemon payload to the declared shape so the wire contract is honest. Clients already source rich metadata from the bundled `LLMProviderRegistry` JSON.

**Gap:** Wire type drift between daemon payload and declared contract
**Fix:** Project PROVIDER_CATALOG to the legacy wire-contract fields before sending.

Part of plan: llm-provider-catalog.md (fix PR)

## Test plan
- [x] `bunx tsc --noEmit` passes in assistant/
- [x] New unit tests for `projectProviderForWire` pass (5 tests, 143 expect calls)
- [x] Swift client code unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
