### PR TITLE
refactor(macos): source defaults in APIKeyStepView from LLMProviderRegistry

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -333,8 +333,8 @@ struct APIKeyStepView: View {
 
         if isAuthenticated {
             // Authenticated user: skip API key entry, advance to consent step
-            state.selectedProvider = "anthropic"
-            state.selectedModel = "claude-opus-4-7"
+            state.selectedProvider = LLMProviderRegistry.defaultProvider?.id ?? "anthropic"
+            state.selectedModel = LLMProviderRegistry.defaultProvider?.defaultModel ?? ""
             state.skippedAPIKeyEntry = true
             state.advance(by: 2)
         } else {


### PR DESCRIPTION
## Summary
Fixes a gap left by PR 10: `APIKeyStepView.swift:337` still hardcoded `"claude-opus-4-7"` and `"anthropic"` in `handleContinue()`. Both now route through `LLMProviderRegistry.defaultProvider`.

**Gap:** Hardcoded claude-opus-4-7 literal in APIKeyStepView.swift
**Fix:** Route selectedProvider and selectedModel defaults through the registry.

Part of plan: llm-provider-catalog.md (fix PR)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
