### PR TITLE
fix(providers): restore env-var fallback for search providers in getProviderKeyAsync

### DIFF
--- a/assistant/src/providers/__tests__/provider-env-vars.test.ts
+++ b/assistant/src/providers/__tests__/provider-env-vars.test.ts
@@ -1,6 +1,13 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
-import { getLlmProviderEnvVar } from "../provider-env-vars.js";
+import {
+  getAnyProviderEnvVar,
+  getLlmProviderEnvVar,
+  getSearchProviderEnvVar,
+  SEARCH_PROVIDER_ENV_VAR_NAMES,
+} from "../provider-env-vars.js";
 
 describe("getLlmProviderEnvVar", () => {
   test("returns ANTHROPIC_API_KEY for anthropic", () => {
@@ -27,7 +34,69 @@ describe("getLlmProviderEnvVar", () => {
     expect(getLlmProviderEnvVar("ollama")).toBeUndefined();
   });
 
+  test("returns undefined for search providers (out of scope)", () => {
+    expect(getLlmProviderEnvVar("brave")).toBeUndefined();
+    expect(getLlmProviderEnvVar("perplexity")).toBeUndefined();
+  });
+
   test("returns undefined for unknown provider", () => {
     expect(getLlmProviderEnvVar("unknown-provider")).toBeUndefined();
+  });
+});
+
+describe("getSearchProviderEnvVar", () => {
+  test("returns BRAVE_API_KEY for brave", () => {
+    expect(getSearchProviderEnvVar("brave")).toBe("BRAVE_API_KEY");
+  });
+
+  test("returns PERPLEXITY_API_KEY for perplexity", () => {
+    expect(getSearchProviderEnvVar("perplexity")).toBe("PERPLEXITY_API_KEY");
+  });
+
+  test("returns undefined for LLM providers (out of scope)", () => {
+    expect(getSearchProviderEnvVar("anthropic")).toBeUndefined();
+    expect(getSearchProviderEnvVar("openai")).toBeUndefined();
+  });
+
+  test("returns undefined for unknown provider", () => {
+    expect(getSearchProviderEnvVar("unknown-provider")).toBeUndefined();
+  });
+});
+
+describe("getAnyProviderEnvVar", () => {
+  test("returns LLM env var for LLM providers", () => {
+    expect(getAnyProviderEnvVar("anthropic")).toBe("ANTHROPIC_API_KEY");
+    expect(getAnyProviderEnvVar("openai")).toBe("OPENAI_API_KEY");
+  });
+
+  test("returns search env var for search providers", () => {
+    expect(getAnyProviderEnvVar("brave")).toBe("BRAVE_API_KEY");
+    expect(getAnyProviderEnvVar("perplexity")).toBe("PERPLEXITY_API_KEY");
+  });
+
+  test("returns undefined for ollama (keyless LLM provider)", () => {
+    expect(getAnyProviderEnvVar("ollama")).toBeUndefined();
+  });
+
+  test("returns undefined for unknown provider", () => {
+    expect(getAnyProviderEnvVar("unknown")).toBeUndefined();
+  });
+});
+
+describe("SEARCH_PROVIDER_ENV_VAR_NAMES parity with meta/provider-env-vars.json", () => {
+  // The daemon inlines the search-provider env-var map rather than reading
+  // meta/provider-env-vars.json at runtime (compiled binary, no reliable
+  // repo-relative path). This parity check prevents drift: the inline map
+  // must stay in sync with the canonical JSON file consumed by the macOS
+  // client bundle and the CLI cloud-infra flows.
+  test("inline map matches meta/provider-env-vars.json providers", () => {
+    const repoRoot = join(process.cwd(), "..");
+    const metaPath = join(repoRoot, "meta", "provider-env-vars.json");
+    const raw = readFileSync(metaPath, "utf-8");
+    const parsed = JSON.parse(raw) as {
+      version: number;
+      providers: Record<string, string>;
+    };
+    expect(SEARCH_PROVIDER_ENV_VAR_NAMES).toEqual(parsed.providers);
   });
 });

--- a/assistant/src/providers/provider-env-vars.ts
+++ b/assistant/src/providers/provider-env-vars.ts
@@ -1,19 +1,56 @@
 /**
- * LLM provider env-var lookup helper.
+ * Provider env-var lookup helpers.
  *
- * Resolves the `<PROVIDER>_API_KEY` environment variable name for an LLM
- * provider by consulting the single source of truth (`PROVIDER_CATALOG`)
- * rather than the legacy `meta/provider-env-vars.json` map (which is now
- * scoped to search providers only).
+ * Two sources of truth feed these helpers:
  *
- * Returns `undefined` for:
- *   - keyless providers (e.g. Ollama, which has no `envVar` in the catalog)
- *   - unknown provider IDs
- *   - search providers (brave, perplexity) — those live outside the LLM
- *     catalog and remain sourced from `meta/provider-env-vars.json`.
+ *   1. LLM providers — names come from `PROVIDER_CATALOG` in
+ *      `model-catalog.ts`. `getLlmProviderEnvVar` consults the catalog
+ *      directly.
+ *   2. Search providers — names mirror `meta/provider-env-vars.json`
+ *      (the single source of truth for the macOS client bundle). The
+ *      mirror is an inline constant here; parity is enforced by
+ *      `assistant/src/providers/__tests__/provider-env-vars.test.ts`
+ *      to prevent drift. We inline rather than read the JSON at runtime
+ *      because the daemon is compiled to a binary and `meta/` is not
+ *      reliably present at a known path on disk.
+ *
+ * Use `getLlmProviderEnvVar` when you're scoped to LLM providers,
+ * `getSearchProviderEnvVar` when you're scoped to search providers, and
+ * `getAnyProviderEnvVar` (LLM-first, then search) when you accept either
+ * kind — e.g. the generic `getProviderKeyAsync` env-var fallback.
+ *
+ * Each helper returns `undefined` for keyless providers (e.g. Ollama),
+ * unknown IDs, and providers outside the helper's scope.
  */
 import { PROVIDER_CATALOG } from "./model-catalog.js";
 
+/**
+ * Search-provider env var names. Mirrors `meta/provider-env-vars.json`.
+ * Parity with the JSON file is enforced by `provider-env-vars.test.ts`.
+ */
+export const SEARCH_PROVIDER_ENV_VAR_NAMES: Record<string, string> = {
+  brave: "BRAVE_API_KEY",
+  perplexity: "PERPLEXITY_API_KEY",
+};
+
 export function getLlmProviderEnvVar(providerId: string): string | undefined {
   return PROVIDER_CATALOG.find((p) => p.id === providerId)?.envVar;
+}
+
+export function getSearchProviderEnvVar(
+  providerId: string,
+): string | undefined {
+  return SEARCH_PROVIDER_ENV_VAR_NAMES[providerId];
+}
+
+/**
+ * Resolve a provider env-var name from either source — LLM catalog first,
+ * then the search-provider mirror. Returns `undefined` when no provider
+ * scope declares an env var for the given ID (keyless LLM providers like
+ * Ollama, unknown IDs, etc.).
+ */
+export function getAnyProviderEnvVar(providerId: string): string | undefined {
+  return (
+    getLlmProviderEnvVar(providerId) ?? getSearchProviderEnvVar(providerId)
+  );
 }

--- a/assistant/src/security/__tests__/provider-key-env-fallback.test.ts
+++ b/assistant/src/security/__tests__/provider-key-env-fallback.test.ts
@@ -1,0 +1,119 @@
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock logger before importing any code that uses it.
+// ---------------------------------------------------------------------------
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports under test
+// ---------------------------------------------------------------------------
+
+import { _setStorePath } from "../encrypted-store.js";
+import { _resetBackend, getProviderKeyAsync } from "../secure-keys.js";
+
+const TEST_DIR = join(
+  tmpdir(),
+  `vellum-provkey-envfallback-${randomBytes(4).toString("hex")}`,
+);
+const STORE_PATH = join(TEST_DIR, "keys.enc");
+
+/**
+ * Regression test for the env-var fallback in `getProviderKeyAsync`.
+ *
+ * PR #27126 introduced `getLlmProviderEnvVar` which is LLM-scoped only.
+ * After that PR, calls like `getProviderKeyAsync("brave")` and
+ * `getProviderKeyAsync("perplexity")` stopped resolving the env var when
+ * the secure store was empty, breaking web-search for users with
+ * env-var-sourced Brave/Perplexity keys. The fix (this PR) routes the
+ * fallback through `getAnyProviderEnvVar` which consults both the LLM
+ * catalog and the search-provider map.
+ */
+describe("getProviderKeyAsync env-var fallback (regression #27126)", () => {
+  const SAVED_ENV: Record<string, string | undefined> = {};
+  const MANAGED_VARS = [
+    "BRAVE_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+  ];
+
+  beforeEach(() => {
+    // Fresh encrypted store (no saved credentials → forces env-var fallback).
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    _setStorePath(STORE_PATH);
+    _resetBackend();
+
+    // Snapshot env so each test starts clean.
+    for (const name of MANAGED_VARS) {
+      SAVED_ENV[name] = process.env[name];
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    _setStorePath(null);
+    _resetBackend();
+    for (const name of MANAGED_VARS) {
+      const saved = SAVED_ENV[name];
+      if (saved === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = saved;
+      }
+    }
+  });
+
+  afterAll(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  });
+
+  test("returns BRAVE_API_KEY from process.env when secure store is empty", async () => {
+    process.env.BRAVE_API_KEY = "brave-env-test";
+    expect(await getProviderKeyAsync("brave")).toBe("brave-env-test");
+  });
+
+  test("returns PERPLEXITY_API_KEY from process.env when secure store is empty", async () => {
+    process.env.PERPLEXITY_API_KEY = "pplx-env-test";
+    expect(await getProviderKeyAsync("perplexity")).toBe("pplx-env-test");
+  });
+
+  test("returns ANTHROPIC_API_KEY from process.env when secure store is empty (LLM regression)", async () => {
+    process.env.ANTHROPIC_API_KEY = "anthropic-env-test";
+    expect(await getProviderKeyAsync("anthropic")).toBe("anthropic-env-test");
+  });
+
+  test("returns OPENAI_API_KEY from process.env when secure store is empty (LLM regression)", async () => {
+    process.env.OPENAI_API_KEY = "openai-env-test";
+    expect(await getProviderKeyAsync("openai")).toBe("openai-env-test");
+  });
+
+  test("returns undefined for unknown provider even if any env var is set", async () => {
+    process.env.BRAVE_API_KEY = "brave-env-test";
+    expect(await getProviderKeyAsync("unknown-provider")).toBeUndefined();
+  });
+
+  test("returns undefined for keyless ollama even if env has unrelated keys", async () => {
+    process.env.BRAVE_API_KEY = "brave-env-test";
+    expect(await getProviderKeyAsync("ollama")).toBeUndefined();
+  });
+});

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -26,7 +26,7 @@ import type {
 
 import { getIsContainerized } from "../config/env-registry.js";
 import type { CesClient } from "../credential-execution/client.js";
-import { getLlmProviderEnvVar } from "../providers/provider-env-vars.js";
+import { getAnyProviderEnvVar } from "../providers/provider-env-vars.js";
 import { getLogger } from "../util/logger.js";
 import { createCesCredentialBackend } from "./ces-credential-client.js";
 import { CesRpcCredentialBackend } from "./ces-rpc-credential-backend.js";
@@ -514,9 +514,10 @@ export async function bulkSetSecureKeysAsync(
  * Retrieve a provider API key, checking secure storage first and falling
  * back to the corresponding `<PROVIDER>_API_KEY` environment variable.
  *
- * Env var names come from `PROVIDER_CATALOG` via `getLlmProviderEnvVar`;
- * keyless providers (e.g. Ollama) return `undefined` and fall through to a
- * stored-only lookup.
+ * Env var names are resolved via `getAnyProviderEnvVar`, which covers both
+ * LLM providers (sourced from `PROVIDER_CATALOG`) and search providers
+ * (sourced from `SEARCH_PROVIDER_ENV_VAR_NAMES`). Keyless providers (e.g.
+ * Ollama) return `undefined` and fall through to a stored-only lookup.
  *
  * Use this instead of raw `getSecureKeyAsync` when looking up provider
  * API keys so that env-var-only setups continue to work.
@@ -526,7 +527,7 @@ export async function getProviderKeyAsync(
 ): Promise<string | undefined> {
   const stored = await getSecureKeyAsync(provider);
   if (stored) return stored;
-  const envVar = getLlmProviderEnvVar(provider);
+  const envVar = getAnyProviderEnvVar(provider);
   return envVar ? process.env[envVar] : undefined;
 }
 


### PR DESCRIPTION
## Summary
Fixes a regression introduced in PR #27126 (part of llm-provider-catalog plan) where `getProviderKeyAsync` began using `getLlmProviderEnvVar` (LLM-only) to resolve env-var fallback names. As a result, `getProviderKeyAsync('brave')` and `getProviderKeyAsync('perplexity')` always returned undefined when the API key was only in the process env — breaking web-search for users with env-sourced Brave/Perplexity keys.

**Gap:** getProviderKeyAsync lost env-var fallback for search providers
**What was expected:** search providers (brave, perplexity) continue to resolve from process env when secure store is empty
**What was found:** getProviderKeyAsync routed through LLM-only helper; search provider env vars were ignored
**Fix:** Added `getSearchProviderEnvVar` and `getAnyProviderEnvVar` helpers; `getProviderKeyAsync` now uses the combined helper.

Part of plan: llm-provider-catalog.md (fix PR)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
