### PR TITLE
fix(onboarding): restore full-aspect welcome characters footer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -128,19 +128,18 @@ struct WakeUpStepView: View {
             .foregroundStyle(VColor.contentTertiary)
             .padding(.bottom, VSpacing.xs)
 
-        // Characters peeking up from the bottom. `scaledToFill` +
-        // `.frame(height: 56)` + `.clipped()` renders the illustration
-        // full-bleed across the 440pt window and crops the top so the
-        // piece peeks rather than floats. Sitting at 56pt tall keeps the
-        // whole step fitting in a 440×630 window even with the Advanced
-        // disclosure expanded.
+        // Characters peeking up from the bottom. Rendered at the
+        // illustration's natural aspect (4:1 → ~110pt tall at 440pt
+        // window width) so the piece is never cropped. If the Advanced
+        // disclosure is expanded, the step content exceeds the 630pt
+        // window envelope and the outer ScrollView in OnboardingFlowView
+        // engages — deliberate trade so the footer stays intact on the
+        // default collapsed landing view.
         if let characters = Self.welcomeCharacters {
             Image(nsImage: characters)
                 .resizable()
-                .scaledToFill()
+                .aspectRatio(contentMode: .fit)
                 .frame(maxWidth: .infinity)
-                .frame(height: 56)
-                .clipped()
                 .clipShape(UnevenRoundedRectangle(
                     topLeadingRadius: 0,
                     bottomLeadingRadius: VRadius.window,


### PR DESCRIPTION
## Summary
Reverts the clipped 56pt character banner back to the original `.aspectRatio(.fit)` render — the illustration peeks up at its natural ~110pt height, uncropped.

Per our Option B discussion: the collapsed landing view fits inside the 440×630 window with plenty of slack, and the Advanced-expanded state (~681pt content) exceeds the envelope by ~50pt. `OnboardingFlowView`'s outer `ScrollView` (with `.scrollBounceBehavior(.basedOnSize)`) engages only in that case, which feels natural — scrolling inside a deliberately-expanded disclosure is expected.

## Test plan
- [x] `swift build` green
- [ ] Launch onboarding at default 460×630: Welcome hero + both cards (collapsed) + characters illustration visible, no scroll, characters render at full ~110pt aspect
- [ ] Tap `+` on Advanced: content grows, ScrollView engages, characters still reachable by scrolling
- [ ] Tap `×`: collapsed layout restored, no scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
