### PR TITLE
polish(onboarding): rebalance step-0 layout — calm, centered, never cropped

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -19,11 +19,6 @@ struct OnboardingFlowView: View {
     @State private var completionDelayTask: Task<Void, Never>?
     @State private var isShowingPreChat = false
 
-    private static let appIcon: NSImage? = {
-        guard let path = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png") else { return nil }
-        return NSImage(contentsOfFile: path)
-    }()
-
     private var managedSignInEnabled: Bool {
         MacOSClientFeatureFlagManager.shared.isEnabled("managed-sign-in")
     }
@@ -84,105 +79,101 @@ struct OnboardingFlowView: View {
                     )
             } else if (0...maxOnboardingStep).contains(state.currentStep) {
                 // Onboarding flow: WakeUp → HostingSelector → APIKeyEntry → ImproveExperience (steps 0–3)
-                ScrollView(.vertical, showsIndicators: false) {
-                VStack(spacing: 0) {
-                    if state.currentStep == 0 {
-                        // Step 0 only: compact top inset + app icon. Pre-cards
-                        // this was 80pt + 78pt below the icon; tightened here
-                        // so the WakeUp hero + setup-option cards + footer +
-                        // characters all fit in the 630pt window envelope
-                        // even when the Advanced disclosure is expanded.
-                        Color.clear.frame(height: VSpacing.md)
-
-                        if let nsImage = Self.appIcon {
-                            Image(nsImage: nsImage)
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 80, height: 80)
-                                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                                .shadow(color: VColor.auxBlack.opacity(0.15), radius: 1, x: 0, y: 1)
-                                .padding(.bottom, VSpacing.sm)
-                        }
-                    } else {
-                        // Steps 1–3: top inset only (no icon)
-                        Color.clear.frame(height: VSpacing.xxxl)
-                    }
-
-                    // Step content — Group flattens into parent VStack so
-                    // the inner Spacer flexes with the top Spacer above.
-                    Group {
-                        switch state.currentStep {
-                            case 0:
-                                if managedSignInEnabled && authManager.isAuthenticated {
-                                    // Already authenticated — show a brief loading
-                                    // state while the .task advances to Setup.
-                                    HStack(spacing: VSpacing.sm) {
-                                        ProgressView()
-                                            .controlSize(.small)
-                                            .progressViewStyle(.circular)
-                                    }
-
-                                    Spacer()
-                                } else {
-                                    WakeUpStepView(
-                                        state: state,
-                                        authManager: managedSignInEnabled ? authManager : nil,
-                                        isAdvancing: isAdvancingFromWakeUp,
-                                        managedSignInEnabled: managedSignInEnabled,
-                                        onStartWithAPIKey: {
-                                            guard !isAdvancingFromWakeUp else { return }
-                                            isAdvancingFromWakeUp = true
-                                            state.hasHatched = true
-                                            Task { @MainActor in
-                                                try? await Task.sleep(nanoseconds: 300_000_000)
-                                                guard !Task.isCancelled else { return }
-                                                state.advance()
-                                            }
-                                        },
-                                        onContinueWithVellum: {
-                                            Task {
-                                                await continueWithManagedAssistant()
-                                            }
-                                        }
-                                    )
+                //
+                // Step 0 owns its own full-frame layout (header / flexible
+                // card region / pinned character footer) via WakeUpStepView,
+                // so it renders outside the ScrollView and without the
+                // shared app-icon preamble — this keeps the welcome
+                // illustration from ever being pushed offscreen or clipped.
+                // Steps 1–3 keep the existing scrollable preamble+content
+                // composition.
+                Group {
+                    if state.currentStep == 0, !(managedSignInEnabled && authManager.isAuthenticated) {
+                        WakeUpStepView(
+                            state: state,
+                            authManager: managedSignInEnabled ? authManager : nil,
+                            isAdvancing: isAdvancingFromWakeUp,
+                            managedSignInEnabled: managedSignInEnabled,
+                            onStartWithAPIKey: {
+                                guard !isAdvancingFromWakeUp else { return }
+                                isAdvancingFromWakeUp = true
+                                state.hasHatched = true
+                                Task { @MainActor in
+                                    try? await Task.sleep(nanoseconds: 300_000_000)
+                                    guard !Task.isCancelled else { return }
+                                    state.advance()
                                 }
-                            case 1:
-                                APIKeyStepView(
-                                    state: state,
-                                    isAuthenticated: authManager.isAuthenticated,
-                                    onHatchManaged: {
-                                        Task {
-                                            await performManagedBootstrap()
-                                        }
-                                    }
-                                )
-                            case 2:
-                                APIKeyEntryStepView(state: state)
-                            case 3:
-                                ImproveExperienceStepView(
-                                    state: state,
-                                    skippedAPIKeyEntry: state.skippedAPIKeyEntry,
-                                    onAccepted: state.selectedHostingMode == .vellumCloud ? {
-                                        Task {
-                                            await performManagedBootstrap()
-                                        }
-                                    } : nil
-                                )
-                            default:
-                                EmptyView()
-                        }
-                    }
-                    .transition(
-                        .asymmetric(
-                            insertion: .opacity.combined(with: .offset(y: 12)),
-                            removal: .opacity.combined(with: .offset(y: -8))
+                            },
+                            onContinueWithVellum: {
+                                Task {
+                                    await continueWithManagedAssistant()
+                                }
+                            }
                         )
-                    )
-                    .id(state.currentStep)
+                        .transition(
+                            .asymmetric(
+                                insertion: .opacity.combined(with: .offset(y: 12)),
+                                removal: .opacity.combined(with: .offset(y: -8))
+                            )
+                        )
+                        .id(state.currentStep)
+                    } else {
+                        ScrollView(.vertical, showsIndicators: false) {
+                            VStack(spacing: 0) {
+                                Color.clear.frame(height: VSpacing.xxxl)
+
+                                Group {
+                                    switch state.currentStep {
+                                        case 0:
+                                            // Already-authenticated brief
+                                            // loading state while the .task
+                                            // advances to Setup.
+                                            HStack(spacing: VSpacing.sm) {
+                                                ProgressView()
+                                                    .controlSize(.small)
+                                                    .progressViewStyle(.circular)
+                                            }
+
+                                            Spacer()
+                                        case 1:
+                                            APIKeyStepView(
+                                                state: state,
+                                                isAuthenticated: authManager.isAuthenticated,
+                                                onHatchManaged: {
+                                                    Task {
+                                                        await performManagedBootstrap()
+                                                    }
+                                                }
+                                            )
+                                        case 2:
+                                            APIKeyEntryStepView(state: state)
+                                        case 3:
+                                            ImproveExperienceStepView(
+                                                state: state,
+                                                skippedAPIKeyEntry: state.skippedAPIKeyEntry,
+                                                onAccepted: state.selectedHostingMode == .vellumCloud ? {
+                                                    Task {
+                                                        await performManagedBootstrap()
+                                                    }
+                                                } : nil
+                                            )
+                                        default:
+                                            EmptyView()
+                                    }
+                                }
+                                .transition(
+                                    .asymmetric(
+                                        insertion: .opacity.combined(with: .offset(y: 12)),
+                                        removal: .opacity.combined(with: .offset(y: -8))
+                                    )
+                                )
+                                .id(state.currentStep)
+                            }
+                            .frame(maxWidth: .infinity, minHeight: geometry.size.height, alignment: .top)
+                        }
+                        .scrollBounceBehavior(.basedOnSize)
+                    }
                 }
-                .frame(maxWidth: .infinity, minHeight: geometry.size.height, alignment: .top)
-                }
-                .scrollBounceBehavior(.basedOnSize)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(
                     RadialGradient(

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
@@ -13,7 +13,6 @@ internal struct OnboardingLocalModeDisclosure: View {
 
     var kicker: String = "LOCAL MODE"
     var title: String = "Continue without an account"
-    var tradeoffsKicker: String = "HOW IT WORKS"
     var tradeoffs: [String] = [
         "No account — install and start chatting",
         "Your data stays on your Mac",
@@ -60,29 +59,17 @@ internal struct OnboardingLocalModeDisclosure: View {
 
             if isExpanded {
                 VStack(alignment: .leading, spacing: 0) {
-                    Spacer().frame(height: VSpacing.sm)
+                    Spacer().frame(height: VSpacing.md)
 
-                    VColor.borderBase
-                        .frame(height: 1)
-                        .accessibilityHidden(true)
-
-                    Spacer().frame(height: VSpacing.sm)
-
-                    Text(tradeoffsKicker)
-                        .font(VFont.labelSmall)
-                        .foregroundStyle(VColor.contentTertiary)
-                        .textCase(.uppercase)
-                        .tracking(0.6)
-
-                    Spacer().frame(height: VSpacing.xs)
-
-                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
                         ForEach(tradeoffs, id: \.self) { item in
                             tradeoffRow(item)
                         }
                     }
+                    .accessibilityElement(children: .contain)
+                    .accessibilityLabel(Text("Local Mode details"))
 
-                    Spacer().frame(height: VSpacing.sm)
+                    Spacer().frame(height: VSpacing.md)
 
                     VButton(
                         label: secondaryCTA,
@@ -117,15 +104,15 @@ internal struct OnboardingLocalModeDisclosure: View {
     @ViewBuilder
     private func tradeoffRow(_ text: String) -> some View {
         HStack(alignment: .top, spacing: VSpacing.sm) {
-            Circle()
-                .fill(VColor.contentTertiary)
-                .frame(width: 3, height: 3)
-                .padding(.top, 6)
+            VIconView(.circleCheck, size: 14)
+                .foregroundStyle(VColor.systemPositiveStrong)
                 .accessibilityHidden(true)
             Text(text)
                 .font(VFont.bodySmallDefault)
                 .foregroundStyle(VColor.contentDefault)
                 .fixedSize(horizontal: false, vertical: true)
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(text))
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingVellumCloudCard.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingVellumCloudCard.swift
@@ -10,7 +10,6 @@ struct OnboardingVellumCloudCard: View {
     // MARK: - Configuration
 
     let title: String = "Vellum Cloud"
-    let subtitle: String = "The frictionless experience for serious creators."
     let benefits: [String] = [
         "Always on, even when your Mac sleeps",
         "Instant sync across all your devices",
@@ -47,13 +46,6 @@ struct OnboardingVellumCloudCard: View {
                     shape: .pill
                 )
             }
-
-            Spacer().frame(height: VSpacing.xxs)
-
-            Text(subtitle)
-                .font(VFont.bodySmallDefault)
-                .foregroundStyle(VColor.contentSecondary)
-                .fixedSize(horizontal: false, vertical: true)
 
             Spacer().frame(height: VSpacing.md)
 
@@ -112,7 +104,7 @@ struct OnboardingVellumCloudCard: View {
     private func benefitRow(_ text: String) -> some View {
         HStack(alignment: .top, spacing: VSpacing.sm) {
             VIconView(.circleCheck, size: 14)
-                .foregroundStyle(VColor.contentSecondary)
+                .foregroundStyle(VColor.systemPositiveStrong)
                 .accessibilityHidden(true)
             Text(text)
                 .font(VFont.bodySmallDefault)

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -25,12 +25,20 @@ struct WakeUpStepView: View {
 
     // MARK: - Private State
 
+    @State private var showIcon = false
     @State private var showTitle = false
     @State private var showSubtext = false
     @State private var showCloudCard = false
     @State private var showDisclosure = false
     @State private var showCharacters = false
     @State private var isAdvancedExpanded: Bool = false
+
+    // MARK: - Assets
+
+    private static let appIcon: NSImage? = {
+        guard let path = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png") else { return nil }
+        return NSImage(contentsOfFile: path)
+    }()
 
     private static let welcomeCharacters: NSImage? = {
         guard let url = ResourceBundle.bundle.url(forResource: "welcome-characters", withExtension: "png") else { return nil }
@@ -40,27 +48,73 @@ struct WakeUpStepView: View {
     // MARK: - Body
 
     var body: some View {
-        // Title
-        Text("Welcome to Vellum")
-            .font(VFont.titleLarge)
-            .foregroundStyle(VColor.contentDefault)
-            .opacity(showTitle ? 1 : 0)
-            .offset(y: showTitle ? 0 : 8)
-            .padding(.bottom, VSpacing.xs)
+        // Three-region stack:
+        //   • header   — intrinsic height (app icon + title + subtitle)
+        //   • middle   — flexible; hosts the setup cards, centered when collapsed
+        //   • footer   — intrinsic height (copyright + edge-to-edge characters)
+        //
+        // Two `Spacer(minLength: 0)` bookends around the cards make the cards
+        // float to vertical center inside the middle region when the Advanced
+        // disclosure is collapsed, and compress to zero when it expands — the
+        // middle region then hands every pixel to the cards, letting the
+        // layout "rebalance" without growing the window.
+        VStack(spacing: 0) {
+            header
+                .padding(.horizontal, VSpacing.xl)
 
-        // Subtitle
-        Text("The safest way to create your personal assistant.")
-            .font(VFont.bodyMediumLighter)
-            .foregroundStyle(VColor.contentSecondary)
-            .multilineTextAlignment(.center)
-            .opacity(showSubtext ? 1 : 0)
-            .offset(y: showSubtext ? 0 : 8)
-            .padding(.bottom, VSpacing.md)
+            Spacer(minLength: 0)
 
-        // Setup-option cards (managed path) or single "Get Started" fallback.
-        // The two cards animate in separately (cloud first, then the
-        // disclosure) so the primary option anchors the user's attention
-        // before the secondary one slides in underneath.
+            cards
+                .padding(.horizontal, VSpacing.xl)
+                .layoutPriority(1)
+
+            Spacer(minLength: 0)
+
+            footer
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .animation(VAnimation.standard, value: isAdvancedExpanded)
+        .onAppear(perform: scheduleEntranceAnimations)
+    }
+
+    // MARK: - Header region
+
+    private var header: some View {
+        VStack(spacing: 0) {
+            Color.clear.frame(height: VSpacing.md)
+
+            if let icon = Self.appIcon {
+                Image(nsImage: icon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 80, height: 80)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    .shadow(color: VColor.auxBlack.opacity(0.15), radius: 1, x: 0, y: 1)
+                    .padding(.bottom, VSpacing.sm)
+                    .opacity(showIcon ? 1 : 0)
+                    .offset(y: showIcon ? 0 : 8)
+                    .accessibilityHidden(true)
+            }
+
+            Text("Welcome to Vellum")
+                .font(VFont.titleLarge)
+                .foregroundStyle(VColor.contentDefault)
+                .opacity(showTitle ? 1 : 0)
+                .offset(y: showTitle ? 0 : 8)
+                .padding(.bottom, VSpacing.xs)
+
+            Text("The safest way to create your personal assistant.")
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentSecondary)
+                .multilineTextAlignment(.center)
+                .opacity(showSubtext ? 1 : 0)
+                .offset(y: showSubtext ? 0 : 8)
+        }
+    }
+
+    // MARK: - Cards region
+
+    private var cards: some View {
         VStack(spacing: VSpacing.xs) {
             if managedSignInEnabled {
                 OnboardingVellumCloudCard(
@@ -99,58 +153,66 @@ struct WakeUpStepView: View {
                     .multilineTextAlignment(.center)
             }
         }
-        .frame(maxWidth: .infinity)
-        .padding(.horizontal, VSpacing.xl)
         .disabled(
             isAdvancing
                 || authManager?.isLoading == true
                 || authManager?.isSubmitting == true
         )
-        .onAppear {
-            withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
-                showTitle = true
-            }
-            withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
-                showSubtext = true
-            }
-            withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
-                showCloudCard = true
-            }
-            withAnimation(.easeOut(duration: 0.5).delay(0.65)) {
-                showDisclosure = true
+    }
+
+    // MARK: - Footer region
+
+    private var footer: some View {
+        VStack(spacing: 0) {
+            Text("2026 Vellum Inc.")
+                .font(VFont.labelSmall)
+                .foregroundStyle(VColor.contentTertiary)
+                .padding(.bottom, VSpacing.xs)
+                .opacity(showCharacters ? 1 : 0)
+
+            // Character illustration always renders at its natural aspect
+            // (~4:1 → ~110pt tall at the window's 440pt width) so the
+            // piece is never cropped. The bottom corners hug the macOS
+            // window radius.
+            if let characters = Self.welcomeCharacters {
+                Image(nsImage: characters)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: .infinity)
+                    .clipShape(UnevenRoundedRectangle(
+                        topLeadingRadius: 0,
+                        bottomLeadingRadius: VRadius.window,
+                        bottomTrailingRadius: VRadius.window,
+                        topTrailingRadius: 0
+                    ))
+                    .opacity(showCharacters ? 1 : 0)
+                    .offset(y: showCharacters ? 0 : 30)
+                    .accessibilityHidden(true)
             }
         }
+        .fixedSize(horizontal: false, vertical: true)
+    }
 
-        Spacer(minLength: VSpacing.md)
+    // MARK: - Entrance animations
 
-        Text("2026 Vellum Inc.")
-            .font(VFont.labelSmall)
-            .foregroundStyle(VColor.contentTertiary)
-            .padding(.bottom, VSpacing.xs)
-
-        // Characters peeking up from the bottom. Rendered at the
-        // illustration's natural aspect (4:1 → ~110pt tall at 440pt
-        // window width) so the piece is never cropped. If the Advanced
-        // disclosure is expanded, the step content exceeds the 630pt
-        // window envelope and the outer ScrollView in OnboardingFlowView
-        // engages — deliberate trade so the footer stays intact on the
-        // default collapsed landing view.
-        if let characters = Self.welcomeCharacters {
-            Image(nsImage: characters)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(maxWidth: .infinity)
-                .clipShape(UnevenRoundedRectangle(
-                    topLeadingRadius: 0,
-                    bottomLeadingRadius: VRadius.window,
-                    bottomTrailingRadius: VRadius.window,
-                    topTrailingRadius: 0
-                ))
-                .opacity(showCharacters ? 1 : 0)
-                .offset(y: showCharacters ? 0 : 30)
-                .animation(.easeOut(duration: 0.6).delay(0.8), value: showCharacters)
-                .onAppear { showCharacters = true }
-                .accessibilityHidden(true)
+    private func scheduleEntranceAnimations() {
+        withAnimation(.easeOut(duration: 0.5).delay(0.05)) {
+            showIcon = true
+        }
+        withAnimation(.easeOut(duration: 0.5).delay(0.15)) {
+            showTitle = true
+        }
+        withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
+            showSubtext = true
+        }
+        withAnimation(.easeOut(duration: 0.5).delay(0.45)) {
+            showCloudCard = true
+        }
+        withAnimation(.easeOut(duration: 0.5).delay(0.6)) {
+            showDisclosure = true
+        }
+        withAnimation(.easeOut(duration: 0.6).delay(0.75)) {
+            showCharacters = true
         }
     }
 }


### PR DESCRIPTION
## Summary
Single-commit rebalance of the Welcome step so it feels calm, centered, premium, and never cropped in either the collapsed or expanded Advanced state.

### Layout
- `WakeUpStepView` now owns the full window frame for step 0. Body is a three-region `VStack`:
  - **Header** (intrinsic) — app icon + title + subtitle.
  - **Middle** (flexible) — `cards` region bookended by two `Spacer(minLength: 0)`s. When Local Mode is collapsed the cards vertically center inside the middle region; when it expands, the spacers compress to zero and the cards use every pixel. `.animation(VAnimation.standard, value: isAdvancedExpanded)` rebalances smoothly.
  - **Footer** (intrinsic, pinned) — copyright + characters illustration rendered at its natural 4:1 aspect (`.aspectRatio(.fit)` + `.frame(maxWidth: .infinity)`, no crop, no cap).
- `OnboardingFlowView` now routes step 0 out of the outer `ScrollView` and drops the shared app-icon preamble — step 0 owns both. Steps 1–3 keep their existing scrollable composition.

### Content simplification
- `OnboardingVellumCloudCard`: subtitle line removed.
- `OnboardingLocalModeDisclosure`: divider and `HOW IT WORKS` section label removed. Collapsed still shows only the kicker + title + expand pill. Expanded reveals the bullet list and primary CTA inline — no section chrome between them.

### Visual consistency
- Local Mode bullets swap from the 3pt dot to the same `VIconView(.circleCheck, size: 14)` the Cloud card uses. Both checks tint to `VColor.systemPositiveStrong` (`#277E41`) — matching green success-check treatment on both cards, while Cloud's shadow + `RECOMMENDED` accent chip keep it primary.

### Entrance animation
- Staggered reveal across every region: icon (0.05s) → title (0.15s) → subtitle (0.3s) → cloud card (0.45s) → disclosure (0.6s) → characters (0.75s). Reads as "the surface assembles" rather than "everything slides in together".

## Test plan
- [x] `swift build` from `clients/` green
- [ ] Open onboarding at default 460×630: header anchored at top, cards vertically centered between subtitle and footer, characters illustration uncropped at the bottom
- [ ] Tap `+` on Local Mode: bullets + `Continue locally` reveal inline, layout rebalances (cards expand into the middle region), no scroll, characters still fully visible
- [ ] Tap `×`: layout rebalances back to centered collapsed state
- [ ] Both cards now have green circular check bullets; cloud card still reads as primary
- [ ] Already-authenticated managed path (step 0 loading spinner) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
