### PR TITLE
fix(permissions): pass executionContext in preflight and simulator checks

### DIFF
--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -477,7 +477,9 @@ async function handleToolPermissionSimulate(body: {
       body.toolName,
       manifestOverride,
     );
-    const policyContext = { executionTarget };
+    const executionContext =
+      body.isInteractive === false ? "background" : "conversation";
+    const policyContext = { executionTarget, executionContext } as const;
 
     const { level: riskLevel } = await classifyRisk(
       body.toolName,

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -478,7 +478,7 @@ async function handleToolPermissionSimulate(body: {
       manifestOverride,
     );
     const executionContext =
-      body.isInteractive === false ? "background" : "conversation";
+      body.isInteractive === false ? "headless" : "conversation";
     const policyContext = { executionTarget, executionContext } as const;
 
     const { level: riskLevel } = await classifyRisk(

--- a/assistant/src/runtime/routes/work-items-routes.ts
+++ b/assistant/src/runtime/routes/work-items-routes.ts
@@ -354,10 +354,11 @@ export async function preflightWorkItem(
   }
 
   const workingDir = process.cwd();
+  const policyContext = { executionContext: "background" as const };
   const permissions = await Promise.all(
     requiredTools.map(async (tool) => {
       const { level: risk } = await classifyRisk(tool, {}, workingDir);
-      const result = await check(tool, {}, workingDir);
+      const result = await check(tool, {}, workingDir, policyContext);
       return {
         tool,
         description: getToolDescription(tool),

--- a/assistant/src/runtime/routes/work-items-routes.ts
+++ b/assistant/src/runtime/routes/work-items-routes.ts
@@ -354,7 +354,7 @@ export async function preflightWorkItem(
   }
 
   const workingDir = process.cwd();
-  const policyContext = { executionContext: "background" as const };
+  const policyContext = { executionContext: "headless" as const };
   const permissions = await Promise.all(
     requiredTools.map(async (tool) => {
       const { level: risk } = await classifyRisk(tool, {}, workingDir);


### PR DESCRIPTION
## Summary
- Pass `executionContext: "background"` in work-item preflight so permission checks use background thresholds instead of defaulting to conversation context
- Derive `executionContext` from `isInteractive` in the settings permission simulator so simulated decisions match real runtime behavior under per-context approval levels

## Original prompt
address the feedback within the PR comment at https://github.com/vellum-ai/vellum-assistant/pull/27134#pullrequestreview-4144663162
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
