### PR TITLE
feat(permissions): add WebRiskClassifier for domain/method-based risk classification

### DIFF
--- a/assistant/src/permissions/web-risk-classifier.test.ts
+++ b/assistant/src/permissions/web-risk-classifier.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+
+import { WebRiskClassifier } from "./web-risk-classifier.js";
+
+// ── Helper ───────────────────────────────────────────────────────────────────
+
+function makeClassifier(): WebRiskClassifier {
+  return new WebRiskClassifier();
+}
+
+// ── web_search ───────────────────────────────────────────────────────────────
+
+describe("web_search", () => {
+  test("always classified as low risk", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "web_search",
+    });
+    expect(result.riskLevel).toBe("low");
+    expect(result.reason).toBe("Web search (read-only)");
+    expect(result.matchType).toBe("registry");
+    expect(result.scopeOptions).toEqual([]);
+  });
+
+  test("low risk even with url provided", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "web_search",
+      url: "https://example.com",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
+});
+
+// ── web_fetch ────────────────────────────────────────────────────────────────
+
+describe("web_fetch", () => {
+  test("default (no private network) is low risk", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "web_fetch",
+    });
+    expect(result.riskLevel).toBe("low");
+    expect(result.reason).toBe("Web fetch (default)");
+    expect(result.matchType).toBe("registry");
+    expect(result.scopeOptions).toEqual([]);
+  });
+
+  test("allowPrivateNetwork=false is low risk", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "web_fetch",
+      allowPrivateNetwork: false,
+    });
+    expect(result.riskLevel).toBe("low");
+    expect(result.reason).toBe("Web fetch (default)");
+  });
+
+  test("allowPrivateNetwork=undefined is low risk", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "web_fetch",
+      allowPrivateNetwork: undefined,
+    });
+    expect(result.riskLevel).toBe("low");
+  });
+
+  test("allowPrivateNetwork=true is high risk", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "web_fetch",
+      allowPrivateNetwork: true,
+    });
+    expect(result.riskLevel).toBe("high");
+    expect(result.reason).toBe("Private network fetch");
+    expect(result.matchType).toBe("registry");
+    expect(result.scopeOptions).toEqual([]);
+  });
+
+  test("private network fetch with url", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "web_fetch",
+      url: "http://192.168.1.1/admin",
+      allowPrivateNetwork: true,
+    });
+    expect(result.riskLevel).toBe("high");
+    expect(result.reason).toBe("Private network fetch");
+  });
+});
+
+// ── network_request ──────────────────────────────────────────────────────────
+
+describe("network_request", () => {
+  test("always classified as medium risk", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "network_request",
+    });
+    expect(result.riskLevel).toBe("medium");
+    expect(result.reason).toBe("Network request (proxied credentials)");
+    expect(result.matchType).toBe("registry");
+    expect(result.scopeOptions).toEqual([]);
+  });
+
+  test("medium risk with url provided", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "network_request",
+      url: "https://api.example.com/data",
+    });
+    expect(result.riskLevel).toBe("medium");
+  });
+
+  test("medium risk regardless of allowPrivateNetwork flag", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "network_request",
+      allowPrivateNetwork: true,
+    });
+    expect(result.riskLevel).toBe("medium");
+    expect(result.reason).toBe("Network request (proxied credentials)");
+  });
+});
+
+// ── Singleton ────────────────────────────────────────────────────────────────
+
+describe("singleton", () => {
+  test("webRiskClassifier is exported and functional", async () => {
+    const { webRiskClassifier } = await import("./web-risk-classifier.js");
+    const result = await webRiskClassifier.classify({
+      toolName: "web_search",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
+});

--- a/assistant/src/permissions/web-risk-classifier.ts
+++ b/assistant/src/permissions/web-risk-classifier.ts
@@ -1,0 +1,81 @@
+/**
+ * Web risk classifier — domain and method-based risk classification.
+ *
+ * Implements RiskClassifier<WebClassifierInput> for web-related tools:
+ * web_search, web_fetch, and network_request. Replicates the exact logic
+ * from checker.ts classifyRiskUncached() lines 472-482.
+ *
+ * - web_search: always Low (read-only)
+ * - web_fetch: High if allowPrivateNetwork, Low otherwise
+ * - network_request: always Medium (proxied credentials)
+ */
+
+import type { RiskAssessment, RiskClassifier } from "./risk-types.js";
+
+// ── Input type ───────────────────────────────────────────────────────────────
+
+/** Input to the web risk classifier. */
+export interface WebClassifierInput {
+  /** Which web tool is being invoked. */
+  toolName: "web_fetch" | "network_request" | "web_search";
+  /** The target URL (informational, not used for classification yet). */
+  url?: string;
+  /** Whether the fetch is allowed to reach private/internal networks. */
+  allowPrivateNetwork?: boolean;
+}
+
+// ── Classifier ───────────────────────────────────────────────────────────────
+
+/**
+ * Web risk classifier implementation.
+ *
+ * Classifies web tool invocations by tool type and flags. This is the
+ * simplest classifier — no registry lookups, no subcommand resolution,
+ * just direct conditional logic matching the original checker.ts behavior.
+ */
+export class WebRiskClassifier implements RiskClassifier<WebClassifierInput> {
+  async classify(input: WebClassifierInput): Promise<RiskAssessment> {
+    const { toolName, allowPrivateNetwork } = input;
+
+    switch (toolName) {
+      case "web_search":
+        return {
+          riskLevel: "low",
+          reason: "Web search (read-only)",
+          scopeOptions: [],
+          matchType: "registry",
+        };
+
+      case "web_fetch":
+        // Private-network fetches are High risk so that blanket allow rules
+        // (including the starter bundle) cannot silently bypass the prompt.
+        if (allowPrivateNetwork === true) {
+          return {
+            riskLevel: "high",
+            reason: "Private network fetch",
+            scopeOptions: [],
+            matchType: "registry",
+          };
+        }
+        return {
+          riskLevel: "low",
+          reason: "Web fetch (default)",
+          scopeOptions: [],
+          matchType: "registry",
+        };
+
+      case "network_request":
+        // Proxy-authenticated network requests are Medium risk — they carry
+        // injected credentials and the user should approve the target host/origin.
+        return {
+          riskLevel: "medium",
+          reason: "Network request (proxied credentials)",
+          scopeOptions: [],
+          matchType: "registry",
+        };
+    }
+  }
+}
+
+/** Singleton classifier instance. */
+export const webRiskClassifier = new WebRiskClassifier();


### PR DESCRIPTION
## Summary
- Add WebRiskClassifier implementing RiskClassifier<WebClassifierInput>
- Classifies web_search (Low), web_fetch (Low/High for private network), network_request (Medium)
- Unit tests covering all branches

Part of plan: risk-extend-classifiers.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
