### PR TITLE
feat(permissions): add SkillLoadRiskClassifier for skill trust-level classification

### DIFF
--- a/assistant/src/permissions/skill-risk-classifier.test.ts
+++ b/assistant/src/permissions/skill-risk-classifier.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  type SkillClassifierInput,
+  SkillLoadRiskClassifier,
+  skillLoadRiskClassifier,
+} from "./skill-risk-classifier.js";
+
+// ── SkillLoadRiskClassifier ──────────────────────────────────────────────────
+
+describe("SkillLoadRiskClassifier", () => {
+  const classifier = new SkillLoadRiskClassifier();
+
+  test("skill_load is always Low risk", async () => {
+    const result = await classifier.classify({ toolName: "skill_load" });
+    expect(result.riskLevel).toBe("low");
+    expect(result.reason).toBe("Skill load (default)");
+    expect(result.scopeOptions).toEqual([]);
+    expect(result.matchType).toBe("registry");
+  });
+
+  test("scaffold_managed_skill is always High risk", async () => {
+    const result = await classifier.classify({
+      toolName: "scaffold_managed_skill",
+    });
+    expect(result.riskLevel).toBe("high");
+    expect(result.reason).toBe(
+      "Skill scaffold — writes persistent skill source code",
+    );
+    expect(result.scopeOptions).toEqual([]);
+    expect(result.matchType).toBe("registry");
+  });
+
+  test("delete_managed_skill is always High risk", async () => {
+    const result = await classifier.classify({
+      toolName: "delete_managed_skill",
+    });
+    expect(result.riskLevel).toBe("high");
+    expect(result.reason).toBe(
+      "Skill delete — removes persistent skill source code",
+    );
+    expect(result.scopeOptions).toEqual([]);
+    expect(result.matchType).toBe("registry");
+  });
+
+  test("skill_load with skillSelector is still Low risk", async () => {
+    const result = await classifier.classify({
+      toolName: "skill_load",
+      skillSelector: "my-custom-skill",
+    });
+    expect(result.riskLevel).toBe("low");
+    expect(result.reason).toBe("Skill load (default)");
+  });
+
+  test("scaffold_managed_skill with skillSelector is still High risk", async () => {
+    const result = await classifier.classify({
+      toolName: "scaffold_managed_skill",
+      skillSelector: "new-skill",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("delete_managed_skill with skillSelector is still High risk", async () => {
+    const result = await classifier.classify({
+      toolName: "delete_managed_skill",
+      skillSelector: "old-skill",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+});
+
+// ── Singleton export ─────────────────────────────────────────────────────────
+
+describe("singleton", () => {
+  test("skillLoadRiskClassifier is an instance of SkillLoadRiskClassifier", () => {
+    expect(skillLoadRiskClassifier).toBeInstanceOf(SkillLoadRiskClassifier);
+  });
+
+  test("singleton produces same results as fresh instance", async () => {
+    const inputs: SkillClassifierInput[] = [
+      { toolName: "skill_load" },
+      { toolName: "scaffold_managed_skill" },
+      { toolName: "delete_managed_skill" },
+    ];
+
+    const fresh = new SkillLoadRiskClassifier();
+    for (const input of inputs) {
+      const singletonResult = await skillLoadRiskClassifier.classify(input);
+      const freshResult = await fresh.classify(input);
+      expect(singletonResult).toEqual(freshResult);
+    }
+  });
+});

--- a/assistant/src/permissions/skill-risk-classifier.ts
+++ b/assistant/src/permissions/skill-risk-classifier.ts
@@ -1,0 +1,61 @@
+/**
+ * Skill risk classifier — classifies skill tool invocations by risk level.
+ *
+ * Implements RiskClassifier<SkillClassifierInput> with constant risk levels
+ * for each skill tool type:
+ * - skill_load: Low (read-only skill loading)
+ * - scaffold_managed_skill: High (writes persistent skill source code)
+ * - delete_managed_skill: High (removes persistent skill source code)
+ */
+
+import type { RiskAssessment, RiskClassifier } from "./risk-types.js";
+
+// ── Input type ───────────────────────────────────────────────────────────────
+
+/** Input to the skill risk classifier. */
+export interface SkillClassifierInput {
+  /** Which skill tool is being invoked. */
+  toolName: "skill_load" | "scaffold_managed_skill" | "delete_managed_skill";
+  /** Optional skill selector (e.g. skill name or path). */
+  skillSelector?: string;
+}
+
+// ── Classifier ───────────────────────────────────────────────────────────────
+
+/**
+ * Skill risk classifier implementation.
+ *
+ * Classifies skill tool invocations with constant risk levels per tool type.
+ * checker.ts delegates to the singleton `skillLoadRiskClassifier` instance
+ * for all skill tool risk classification.
+ */
+export class SkillLoadRiskClassifier implements RiskClassifier<SkillClassifierInput> {
+  async classify(input: SkillClassifierInput): Promise<RiskAssessment> {
+    switch (input.toolName) {
+      case "skill_load":
+        return {
+          riskLevel: "low",
+          reason: "Skill load (default)",
+          scopeOptions: [],
+          matchType: "registry",
+        };
+      case "scaffold_managed_skill":
+        return {
+          riskLevel: "high",
+          reason: "Skill scaffold — writes persistent skill source code",
+          scopeOptions: [],
+          matchType: "registry",
+        };
+      case "delete_managed_skill":
+        return {
+          riskLevel: "high",
+          reason: "Skill delete — removes persistent skill source code",
+          scopeOptions: [],
+          matchType: "registry",
+        };
+    }
+  }
+}
+
+/** Singleton classifier instance. */
+export const skillLoadRiskClassifier = new SkillLoadRiskClassifier();

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -522,6 +522,12 @@ struct SettingsPanel: View {
                 )
             }
 
+            // TEXT-TO-SPEECH
+            TTSServiceCard(store: store)
+
+            // SPEECH-TO-TEXT
+            STTServiceCard(store: store)
+
             // EMAIL (feature-flagged)
             if isEmailChannelEnabled {
                 EmailServiceCard(store: store)

--- a/clients/macos/vellum-assistant/Features/Settings/STTServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/STTServiceCard.swift
@@ -1,0 +1,213 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Card for the speech-to-text service with Managed/Your Own mode toggle.
+///
+/// Managed mode is disabled (not yet available) — the card always shows the
+/// "Your Own" provider configuration. Extracted from `VoiceSettingsView` to
+/// live alongside other service cards on the Models & Services page.
+@MainActor
+struct STTServiceCard: View {
+    @ObservedObject var store: SettingsStore
+
+    @AppStorage("sttProvider") private var sttProviderRaw: String = ""
+
+    // Draft state — only persisted on Save.
+    @State private var draftSTTProvider: String = ""
+    @State private var sttApiKeyText: String = ""
+    @State private var initialSTTProvider: String = ""
+    @State private var sttProviderHasKey: Bool = false
+    @State private var sttSaving: Bool = false
+    @State private var sttSaveError: String? = nil
+
+    private let sttRegistry = loadSTTProviderRegistry()
+
+    private var selectedSTTProvider: STTProviderCatalogEntry? {
+        sttRegistry.provider(withId: draftSTTProvider) ?? sttRegistry.providers.first
+    }
+
+    private var sttHasChanges: Bool {
+        let providerChanged = draftSTTProvider != initialSTTProvider
+        let hasNewKey = !sttApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return providerChanged || hasNewKey
+    }
+
+    private var sttResetAllowed: Bool {
+        sttProviderHasKey && SettingsStore.sttKeyIsExclusive(for: draftSTTProvider)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            // Header
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Speech-to-Text")
+                        .font(VFont.titleSmall)
+                        .foregroundStyle(VColor.contentEmphasized)
+                    Text("Choose an STT provider for audio transcription.")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+                Spacer()
+                DisabledManagedSegmentControl(
+                    tooltip: "Managed mode is not provided at this time."
+                )
+            }
+
+            Rectangle()
+                .fill(VColor.surfaceBase)
+                .frame(height: 1)
+
+            // "Your Own" content
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                // Provider dropdown
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("Provider")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                    VDropdown(
+                        placeholder: "Select a provider\u{2026}",
+                        selection: $draftSTTProvider,
+                        options: sttRegistry.providers.map { entry in
+                            (label: entry.displayName, value: entry.id)
+                        }
+                    )
+                }
+
+                // API key field
+                sttApiKeyField
+
+                // Credentials guide
+                sttCredentialsGuideView
+
+                // Save + Reset actions
+                ServiceCardActions(
+                    hasChanges: sttHasChanges,
+                    isSaving: sttSaving,
+                    onSave: { saveSTT() },
+                    savingLabel: "Saving...",
+                    onReset: { resetSTTKey() },
+                    showReset: sttResetAllowed
+                )
+
+                if let sttSaveError {
+                    VInlineMessage(sttSaveError, tone: .error)
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard(radius: VRadius.xl)
+        .onAppear {
+            draftSTTProvider = sttProviderRaw
+            initialSTTProvider = sttProviderRaw
+            sttProviderHasKey = sttKeyExists(for: draftSTTProvider)
+        }
+        .onChange(of: draftSTTProvider) { _, _ in
+            sttApiKeyText = ""
+            sttSaveError = nil
+            sttProviderHasKey = sttKeyExists(for: draftSTTProvider)
+        }
+    }
+
+    // MARK: - API Key Field
+
+    private var sttApiKeyField: some View {
+        APIKeyTextField(
+            label: "\(selectedSTTProvider?.displayName ?? "Provider") API Key",
+            hasKey: sttProviderHasKey,
+            text: $sttApiKeyText
+        )
+        .disabled(sttSaving)
+    }
+
+    // MARK: - Credentials Guide
+
+    @ViewBuilder
+    private var sttCredentialsGuideView: some View {
+        if let guide = selectedSTTProvider?.credentialsGuide,
+           let attributed = try? AttributedString(
+               markdown: "\(guide.description) [\(guide.linkLabel)](\(guide.url))"
+           ) {
+            Text(attributed)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+                .tint(VColor.primaryBase)
+                .lineSpacing(1)
+                .environment(\.openURL, OpenURLAction { url in
+                    NSWorkspace.shared.open(url)
+                    return .handled
+                })
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func sttKeyExists(for sttProviderId: String) -> Bool {
+        let keyProvider = SettingsStore.sttApiKeyProviderName(for: sttProviderId)
+        return APIKeyManager.getKey(for: keyProvider) != nil
+    }
+
+    private func resetSTTKey() {
+        store.clearSTTKey(sttProviderId: draftSTTProvider)
+        sttProviderHasKey = false
+        sttApiKeyText = ""
+    }
+
+    // MARK: - Save
+
+    private func saveSTT() {
+        sttSaving = true
+        sttSaveError = nil
+
+        if draftSTTProvider.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           let resolved = selectedSTTProvider?.id {
+            draftSTTProvider = resolved
+        }
+
+        let providerToSave = draftSTTProvider
+        let providerChanged = providerToSave != sttProviderRaw
+        let trimmedKey = sttApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        Task {
+            var providerSaveSucceeded = true
+            var keySaveSucceeded = true
+
+            if providerChanged {
+                providerSaveSucceeded = await store.setSTTProvider(providerToSave).value
+                if providerSaveSucceeded {
+                    sttProviderRaw = providerToSave
+                } else {
+                    sttSaveError = "Could not save speech-to-text provider selection. Please try again."
+                }
+            }
+
+            if !trimmedKey.isEmpty {
+                let keyResult = await store.saveSTTKeyResult(
+                    trimmedKey,
+                    sttProviderId: providerToSave
+                )
+                keySaveSucceeded = keyResult.success
+                if keyResult.success {
+                    sttApiKeyText = ""
+                    sttProviderHasKey = true
+                } else {
+                    sttSaveError = keyResult.error
+                        ?? "Could not save speech-to-text API key. Please try again."
+                }
+            }
+
+            if providerSaveSucceeded {
+                initialSTTProvider = providerToSave
+            }
+
+            if providerSaveSucceeded && keySaveSucceeded {
+                sttSaveError = nil
+            } else if !providerSaveSucceeded && !keySaveSucceeded {
+                sttSaveError = "Could not save speech-to-text settings. Please try again."
+            }
+
+            sttSaving = false
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
@@ -83,6 +83,51 @@ extension ServiceModeCard where Footer == EmptyView {
     }
 }
 
+// MARK: - Disabled Managed Segment Control
+
+/// A segment control that visually matches `VSegmentControl` but has the
+/// "Managed" segment permanently disabled with a tooltip. Used by service
+/// cards where managed mode is not yet available.
+@MainActor
+struct DisabledManagedSegmentControl: View {
+    var tooltip: String = ""
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // Disabled "Managed" segment
+            Text("Managed")
+                .font(VFont.bodySmallDefault)
+                .fixedSize()
+                .foregroundStyle(VColor.contentDisabled)
+                .padding(.horizontal, VSpacing.sm)
+                .frame(maxWidth: .infinity)
+                .frame(height: 24)
+                .contentShape(Rectangle())
+                .help(tooltip)
+
+            // Always-active "Your Own" segment
+            Text("Your Own")
+                .font(VFont.bodySmallDefault)
+                .fixedSize()
+                .foregroundStyle(VColor.contentEmphasized)
+                .padding(.horizontal, VSpacing.sm)
+                .frame(maxWidth: .infinity)
+                .frame(height: 24)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(VColor.contentInset)
+                        .shadow(color: VColor.auxBlack.opacity(0.08), radius: 2, x: 0, y: 1)
+                )
+        }
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.contentBackground)
+        )
+        .frame(width: 220)
+    }
+}
+
 // MARK: - Reusable Action Buttons
 
 /// Reusable save/reset action buttons for service cards.

--- a/clients/macos/vellum-assistant/Features/Settings/TTSServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TTSServiceCard.swift
@@ -1,0 +1,261 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Card for the text-to-speech service with Managed/Your Own mode toggle.
+///
+/// Managed mode is disabled (not yet available) — the card always shows the
+/// "Your Own" provider configuration. Extracted from `VoiceSettingsView` to
+/// live alongside other service cards on the Models & Services page.
+@MainActor
+struct TTSServiceCard: View {
+    @ObservedObject var store: SettingsStore
+
+    @AppStorage("ttsProvider") private var ttsProviderRaw: String = "elevenlabs"
+
+    // Draft state (mirrors Inference card pattern) — only persisted on Save.
+    @State private var draftTTSProvider: String = "elevenlabs"
+    @State private var ttsApiKeyText: String = ""
+    @State private var ttsVoiceIdText: String = ""
+    @State private var initialVoiceId: String = ""
+    @State private var initialTTSProvider: String = "elevenlabs"
+    @State private var ttsProviderHasKey: Bool = false
+    @State private var ttsSaving: Bool = false
+    @State private var ttsSaveError: String? = nil
+    @State private var testPlayer = TTSTestPlayer()
+
+    private let ttsRegistry = loadTTSProviderRegistry()
+
+    private var selectedTTSProvider: TTSProviderCatalogEntry? {
+        ttsRegistry.provider(withId: draftTTSProvider) ?? ttsRegistry.providers.first
+    }
+
+    private var ttsProviderUsesSharedKey: Bool {
+        SettingsStore.ttsKeyIsShared(for: draftTTSProvider)
+    }
+
+    private var ttsHasChanges: Bool {
+        let providerChanged = draftTTSProvider != initialTTSProvider
+        let hasNewKey = !ttsApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let voiceIdChanged = ttsVoiceIdText.trimmingCharacters(in: .whitespacesAndNewlines) != initialVoiceId
+        return providerChanged || hasNewKey || voiceIdChanged
+    }
+
+    private var ttsResetAllowed: Bool {
+        ttsProviderHasKey && SettingsStore.ttsKeyIsExclusive(for: draftTTSProvider)
+    }
+
+    private var ttsTestPhrase: String {
+        let name = AssistantDisplayName.resolve(
+            IdentityInfo.loadFromDiskCache()?.name,
+            fallback: "your assistant"
+        )
+        return "Hey! It's \(name). How does this sound?"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            // Header
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Text-to-Speech")
+                        .font(VFont.titleSmall)
+                        .foregroundStyle(VColor.contentEmphasized)
+                    Text("Choose a TTS provider for voice conversations and read-aloud.")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+                Spacer()
+                DisabledManagedSegmentControl(
+                    tooltip: "Managed mode is not provided at this time."
+                )
+            }
+
+            Rectangle()
+                .fill(VColor.surfaceBase)
+                .frame(height: 1)
+
+            // "Your Own" content
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                // Provider dropdown
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("Provider")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                    VDropdown(
+                        placeholder: "Select a provider\u{2026}",
+                        selection: $draftTTSProvider,
+                        options: ttsRegistry.providers.map { entry in
+                            (label: entry.displayName, value: entry.id)
+                        }
+                    )
+                }
+
+                // Shared-key note
+                ttsSharedKeyNote
+
+                // API key field
+                ttsApiKeyField
+
+                // Voice ID field (provider-specific)
+                ttsVoiceIdField
+
+                // Credentials guide
+                ttsCredentialsGuideView
+
+                HStack(spacing: VSpacing.sm) {
+                    VButton(
+                        label: testPlayer.isLoading ? "Testing\u{2026}" : "Test",
+                        style: .outlined,
+                        isDisabled: false
+                    ) {
+                        Task { await testPlayer.playTest(text: ttsTestPhrase) }
+                    }
+
+                    ServiceCardActions(
+                        hasChanges: ttsHasChanges,
+                        isSaving: ttsSaving,
+                        onSave: { saveTTS() },
+                        savingLabel: "Saving...",
+                        onReset: {
+                            store.clearTTSKey(ttsProviderId: draftTTSProvider)
+                            ttsProviderHasKey = false
+                            ttsApiKeyText = ""
+                        },
+                        showReset: ttsResetAllowed
+                    )
+                }
+
+                if let testError = testPlayer.error {
+                    VInlineMessage(testError, tone: .error)
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard(radius: VRadius.xl)
+        .onDisappear {
+            testPlayer.stop()
+        }
+        .onAppear {
+            draftTTSProvider = ttsProviderRaw
+            initialTTSProvider = ttsProviderRaw
+            ttsProviderHasKey = SettingsStore.ttsCredentialExists(for: ttsProviderRaw)
+            let voiceId = storedVoiceId(for: ttsProviderRaw)
+            ttsVoiceIdText = voiceId
+            initialVoiceId = voiceId
+        }
+        .onChange(of: draftTTSProvider) { _, _ in
+            ttsApiKeyText = ""
+            ttsSaveError = nil
+            ttsProviderHasKey = SettingsStore.ttsCredentialExists(for: draftTTSProvider)
+            let voiceId = storedVoiceId(for: draftTTSProvider)
+            ttsVoiceIdText = voiceId
+            initialVoiceId = voiceId
+        }
+    }
+
+    // MARK: - Shared Key Note
+
+    @ViewBuilder
+    private var ttsSharedKeyNote: some View {
+        if ttsProviderUsesSharedKey {
+            HStack(alignment: .top, spacing: VSpacing.xs) {
+                VIconView(.info, size: 10)
+                    .foregroundStyle(VColor.contentTertiary)
+                Text("This API key is shared with \(selectedTTSProvider?.displayName ?? "the provider") speech-to-text.")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .lineSpacing(1)
+            }
+        }
+    }
+
+    // MARK: - API Key Field
+
+    private var ttsApiKeyField: some View {
+        APIKeyTextField(
+            label: "\(selectedTTSProvider?.displayName ?? "Provider") API Key",
+            hasKey: ttsProviderHasKey,
+            text: $ttsApiKeyText,
+            errorMessage: ttsSaveError
+        )
+        .disabled(ttsSaving)
+    }
+
+    // MARK: - Voice ID Field
+
+    @ViewBuilder
+    private var ttsVoiceIdField: some View {
+        if selectedTTSProvider?.supportsVoiceSelection == true {
+            VTextField(
+                "Voice ID",
+                placeholder: "\(selectedTTSProvider?.displayName ?? "Provider") Voice ID (optional)",
+                text: $ttsVoiceIdText
+            )
+        }
+    }
+
+    // MARK: - Credentials Guide
+
+    @ViewBuilder
+    private var ttsCredentialsGuideView: some View {
+        if let guide = selectedTTSProvider?.credentialsGuide,
+           let attributed = try? AttributedString(
+               markdown: "\(guide.description) [\(guide.linkLabel)](\(guide.url))"
+           ) {
+            Text(attributed)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+                .tint(VColor.primaryBase)
+                .lineSpacing(1)
+                .environment(\.openURL, OpenURLAction { url in
+                    NSWorkspace.shared.open(url)
+                    return .handled
+                })
+        }
+    }
+
+    // MARK: - Save
+
+    private func saveTTS() {
+        ttsSaving = true
+        ttsSaveError = nil
+
+        if draftTTSProvider != ttsProviderRaw {
+            store.setTTSProvider(draftTTSProvider)
+            ttsProviderRaw = draftTTSProvider
+        }
+
+        let trimmedVoiceId = ttsVoiceIdText.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch draftTTSProvider {
+        case "elevenlabs":
+            store.setElevenLabsVoiceId(trimmedVoiceId)
+        case "fish-audio":
+            store.setFishAudioReferenceId(trimmedVoiceId)
+        default:
+            break
+        }
+
+        let trimmedKey = ttsApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedKey.isEmpty {
+            ttsApiKeyText = ""
+            ttsProviderHasKey = true
+            store.saveTTSKey(trimmedKey, ttsProviderId: draftTTSProvider)
+        }
+
+        ttsSaving = false
+        initialTTSProvider = draftTTSProvider
+        initialVoiceId = trimmedVoiceId
+    }
+
+    private func storedVoiceId(for provider: String) -> String {
+        switch provider {
+        case "elevenlabs":
+            return store.elevenLabsVoiceId
+        case "fish-audio":
+            return store.fishAudioReferenceId
+        default:
+            return ""
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -1,82 +1,18 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Voice settings tab — configure push-to-talk activation key,
-/// conversation timeout, text-to-speech provider, and speech-to-text provider.
+/// Voice settings tab — configure push-to-talk activation key and
+/// conversation timeout. Text-to-Speech and Speech-to-Text provider
+/// configuration has moved to the Models & Services tab.
 struct VoiceSettingsView: View {
     @ObservedObject var store: SettingsStore
 
     @AppStorage("activationKey") private var activationKey: String = "fn"
     @AppStorage("voiceConversationTimeoutSeconds") private var conversationTimeoutSeconds: Int = 30
-    @AppStorage("ttsProvider") private var ttsProviderRaw: String = "elevenlabs"
-    @AppStorage("sttProvider") private var sttProviderRaw: String = ""
-
-    // TTS draft-based state (mirrors Inference card pattern)
-    /// Uncommitted provider selection — only persisted on Save.
-    @State private var draftTTSProvider: String = "elevenlabs"
-    /// API key input field text.
-    @State private var ttsApiKeyText: String = ""
-    /// Voice ID / reference ID input text.
-    @State private var ttsVoiceIdText: String = ""
-    /// Baseline voice ID for change detection — set on appear and after save.
-    @State private var initialVoiceId: String = ""
-    /// Baseline provider for change detection.
-    @State private var initialTTSProvider: String = "elevenlabs"
-    /// Whether the current TTS provider has a stored API key.
-    @State private var ttsProviderHasKey: Bool = false
-    /// Save-in-progress indicator.
-    @State private var ttsSaving: Bool = false
-    /// Error message from key save.
-    @State private var ttsSaveError: String? = nil
-    /// One-shot player for the TTS test button.
-    @State private var testPlayer = TTSTestPlayer()
 
     @State private var isRecordingCustomKey: Bool = false
     @State private var recordingMonitors: [Any] = []
     @State private var modifierHoldTimer: Timer? = nil
-
-    // STT draft-based state
-    /// Uncommitted provider selection — persisted only on Save.
-    /// Empty-string sentinel means "no explicit selection" — the UI
-    /// resolves the effective provider from the catalog via
-    /// `selectedSTTProvider` which falls back to the first registry entry.
-    @State private var draftSTTProvider: String = ""
-    /// API key input text (replaces the old Connect/Set Up flow).
-    @State private var sttApiKeyText: String = ""
-    /// Baseline provider for change detection — set on appear and after save.
-    @State private var initialSTTProvider: String = ""
-    /// Whether the current STT provider already has a stored API key.
-    @State private var sttProviderHasKey: Bool = false
-    /// Save-in-progress indicator.
-    @State private var sttSaving: Bool = false
-    /// Error message from key validation / save.
-    @State private var sttSaveError: String? = nil
-
-    /// The shared TTS provider registry loaded from the bundled catalog.
-    private let ttsRegistry = loadTTSProviderRegistry()
-
-    /// The shared STT provider registry loaded from the bundled catalog.
-    private let sttRegistry = loadSTTProviderRegistry()
-
-    /// The currently selected TTS provider entry from the registry, based on
-    /// the draft selection. Falls back to the first provider in the registry
-    /// if the value does not match any known entry (matching iOS behavior).
-    private var selectedTTSProvider: TTSProviderCatalogEntry? {
-        ttsRegistry.provider(withId: draftTTSProvider) ?? ttsRegistry.providers.first
-    }
-
-    /// The currently selected STT provider entry from the registry, based on
-    /// the draft selection. Falls back to the first provider in the registry
-    /// if the value does not match any known entry.
-    private var selectedSTTProvider: STTProviderCatalogEntry? {
-        sttRegistry.provider(withId: draftSTTProvider) ?? sttRegistry.providers.first
-    }
-
-    /// Whether the currently selected TTS provider uses a shared API key
-    /// (e.g. Deepgram TTS shares the `deepgram` key with Deepgram STT).
-    private var ttsProviderUsesSharedKey: Bool {
-        SettingsStore.ttsKeyIsShared(for: draftTTSProvider)
-    }
 
     private var currentActivator: PTTActivator {
         // Read activationKey to establish SwiftUI dependency tracking —
@@ -99,51 +35,54 @@ struct VoiceSettingsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
+            speechServicesInfoBanner
             pttCard
             conversationTimeoutCard
-            ttsProviderCard
-            sttProviderCard
         }
         .onDisappear {
             stopRecordingCustomKey()
-            testPlayer.stop()
-        }
-        .onAppear {
-            // Initialize TTS draft state from persisted values
-            draftTTSProvider = ttsProviderRaw
-            initialTTSProvider = ttsProviderRaw
-            ttsProviderHasKey = SettingsStore.ttsCredentialExists(for: ttsProviderRaw)
-
-            // Load the stored voice ID for the current TTS provider so
-            // the field reflects the daemon-configured value on page load.
-            let voiceId = storedVoiceId(for: ttsProviderRaw)
-            ttsVoiceIdText = voiceId
-            initialVoiceId = voiceId
-
-            // Initialize STT draft state from persisted values
-            draftSTTProvider = sttProviderRaw
-            initialSTTProvider = sttProviderRaw
-            sttProviderHasKey = sttKeyExists(for: draftSTTProvider)
-        }
-        .onChange(of: draftTTSProvider) { _, _ in
-            // Reset API key field and load the stored voice ID for the
-            // newly selected provider so the field shows its current value.
-            ttsApiKeyText = ""
-            ttsSaveError = nil
-            ttsProviderHasKey = SettingsStore.ttsCredentialExists(for: draftTTSProvider)
-            let voiceId = storedVoiceId(for: draftTTSProvider)
-            ttsVoiceIdText = voiceId
-            initialVoiceId = voiceId
-        }
-        .onChange(of: draftSTTProvider) { _, _ in
-            // Clear stale fields when STT provider changes
-            sttApiKeyText = ""
-            sttSaveError = nil
-            sttProviderHasKey = sttKeyExists(for: draftSTTProvider)
         }
         .onChange(of: conversationTimeoutSeconds) {
             VoiceModeManager.conversationTimeoutOverride = conversationTimeoutSeconds
         }
+    }
+
+    // MARK: - Speech Services Info Banner
+
+    private var speechServicesInfoBanner: some View {
+        HStack(spacing: VSpacing.sm) {
+            VIconView(.info, size: 14)
+                .foregroundStyle(VColor.primaryBase)
+
+            Text("Looking to configure Speech-to-Text or Text-to-Speech models?")
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentSecondary)
+
+            Button {
+                NotificationCenter.default.post(
+                    name: .navigateToSettingsTab,
+                    object: SettingsTab.modelsAndServices
+                )
+            } label: {
+                HStack(spacing: VSpacing.xs) {
+                    Text("Go to Models & Services")
+                        .underline()
+                    VIconView(.arrowUpRight, size: 10)
+                }
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.primaryBase)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(VColor.surfaceBase)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.borderBase, lineWidth: 1)
+        )
     }
 
     // MARK: - Push to Talk Card
@@ -371,399 +310,4 @@ struct VoiceSettingsView: View {
         (label: "30 seconds", value: 30),
         (label: "60 seconds", value: 60),
     ]
-
-    // MARK: - Unified TTS Provider Card
-
-    /// Whether the user has made changes worth saving in the TTS card.
-    private var ttsHasChanges: Bool {
-        let providerChanged = draftTTSProvider != initialTTSProvider
-        let hasNewKey = !ttsApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        let voiceIdChanged = ttsVoiceIdText.trimmingCharacters(in: .whitespacesAndNewlines) != initialVoiceId
-        return providerChanged || hasNewKey || voiceIdChanged
-    }
-
-    /// Whether the TTS reset button should be shown for the current provider.
-    ///
-    /// The reset button is only shown when:
-    /// 1. A key already exists for the provider, AND
-    /// 2. The provider owns its key exclusively (not shared with another
-    ///    service like STT).
-    ///
-    /// This prevents accidental clearing of shared credentials — e.g.
-    /// resetting Deepgram TTS must not delete the `deepgram` key that
-    /// STT also depends on.
-    private var ttsResetAllowed: Bool {
-        ttsProviderHasKey && SettingsStore.ttsKeyIsExclusive(for: draftTTSProvider)
-    }
-
-    /// Phrase synthesized when the Test button is tapped. Uses the
-    /// user-facing assistant name from IDENTITY.md — not the container id
-    /// — so the voice speaks the name the user actually chose.
-    private var ttsTestPhrase: String {
-        let name = AssistantDisplayName.resolve(
-            IdentityInfo.loadFromDiskCache()?.name,
-            fallback: "your assistant"
-        )
-        return "Hey! It's \(name). How does this sound?"
-    }
-
-    private var ttsProviderCard: some View {
-        SettingsCard(title: "Text-to-Speech", subtitle: "Choose a TTS provider for voice conversations and read-aloud. The selected provider is used globally across all speech features.") {
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                // Provider dropdown — data-driven from the shared registry
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    Text("Provider")
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentSecondary)
-                    VDropdown(
-                        placeholder: "Select a provider\u{2026}",
-                        selection: $draftTTSProvider,
-                        options: ttsRegistry.providers.map { entry in
-                            (label: entry.displayName, value: entry.id)
-                        }
-                    )
-                }
-
-                // Shared-key explanatory note for providers like Deepgram
-                // that reuse an API key with another service (e.g. STT).
-                ttsSharedKeyNote
-
-                // API key field — always shown so shared-key providers
-                // (e.g. Deepgram TTS) can be configured even when the
-                // sibling STT provider is set to something else.
-                ttsApiKeyField
-
-                // Voice ID / Reference ID field (provider-specific) —
-                // hidden for providers like Deepgram that use a built-in
-                // default model and do not expose voice selection.
-                ttsVoiceIdField
-
-                // Credentials guide — contextual help for obtaining an API key
-                ttsCredentialsGuideView
-
-                HStack(spacing: VSpacing.sm) {
-                    VButton(
-                        label: testPlayer.isLoading ? "Testing\u{2026}" : "Test",
-                        style: .outlined,
-                        isDisabled: false
-                    ) {
-                        Task { await testPlayer.playTest(text: ttsTestPhrase) }
-                    }
-
-                    ServiceCardActions(
-                        hasChanges: ttsHasChanges,
-                        isSaving: ttsSaving,
-                        onSave: { saveTTS() },
-                        savingLabel: "Saving...",
-                        onReset: {
-                            store.clearTTSKey(ttsProviderId: draftTTSProvider)
-                            ttsProviderHasKey = false
-                            ttsApiKeyText = ""
-                        },
-                        showReset: ttsResetAllowed
-                    )
-                }
-
-                if let testError = testPlayer.error {
-                    VInlineMessage(testError, tone: .error)
-                }
-            }
-        }
-    }
-
-    // MARK: - TTS Shared Key Note
-
-    @ViewBuilder
-    private var ttsSharedKeyNote: some View {
-        if ttsProviderUsesSharedKey {
-            HStack(alignment: .top, spacing: VSpacing.xs) {
-                VIconView(.info, size: 10)
-                    .foregroundStyle(VColor.contentTertiary)
-                Text("This API key is shared with \(selectedTTSProvider?.displayName ?? "the provider") speech-to-text.")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .lineSpacing(1)
-            }
-        }
-    }
-
-    // MARK: - TTS API Key Field
-
-    private var ttsApiKeyField: some View {
-        APIKeyTextField(
-            label: "\(selectedTTSProvider?.displayName ?? "Provider") API Key",
-            hasKey: ttsProviderHasKey,
-            text: $ttsApiKeyText,
-            errorMessage: ttsSaveError
-        )
-        .disabled(ttsSaving)
-    }
-
-    // MARK: - TTS Voice ID Field
-
-    @ViewBuilder
-    private var ttsVoiceIdField: some View {
-        if selectedTTSProvider?.supportsVoiceSelection == true {
-            VTextField(
-                "Voice ID",
-                placeholder: "\(selectedTTSProvider?.displayName ?? "Provider") Voice ID (optional)",
-                text: $ttsVoiceIdText
-            )
-        }
-    }
-
-    // MARK: - TTS Credentials Guide
-
-    @ViewBuilder
-    private var ttsCredentialsGuideView: some View {
-        if let guide = selectedTTSProvider?.credentialsGuide,
-           let attributed = try? AttributedString(
-               markdown: "\(guide.description) [\(guide.linkLabel)](\(guide.url))"
-           ) {
-            Text(attributed)
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentTertiary)
-                .tint(VColor.primaryBase)
-                .lineSpacing(1)
-                .environment(\.openURL, OpenURLAction { url in
-                    NSWorkspace.shared.open(url)
-                    return .handled
-                })
-        }
-    }
-
-    // MARK: - TTS Save / Helpers
-
-    /// Persists the TTS provider, API key, and voice ID atomically.
-    private func saveTTS() {
-        ttsSaving = true
-        ttsSaveError = nil
-
-        // Persist provider if changed
-        if draftTTSProvider != ttsProviderRaw {
-            store.setTTSProvider(draftTTSProvider)
-            ttsProviderRaw = draftTTSProvider
-        }
-
-        // Always persist voice ID for the selected provider, even when
-        // empty — sending an empty string clears a previously set voice
-        // ID and reverts to the provider's default voice.
-        let trimmedVoiceId = ttsVoiceIdText.trimmingCharacters(in: .whitespacesAndNewlines)
-        switch draftTTSProvider {
-        case "elevenlabs":
-            store.setElevenLabsVoiceId(trimmedVoiceId)
-        case "fish-audio":
-            store.setFishAudioReferenceId(trimmedVoiceId)
-        default:
-            break
-        }
-
-        // Persist API key if entered. Shared-key providers (e.g. Deepgram)
-        // route through APIKeyManager which stores the key under the
-        // canonical provider name, so both TTS and STT pick it up.
-        let trimmedKey = ttsApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedKey.isEmpty {
-            ttsApiKeyText = ""
-            ttsProviderHasKey = true
-            store.saveTTSKey(trimmedKey, ttsProviderId: draftTTSProvider)
-        }
-
-        ttsSaving = false
-
-        // Update baseline for change detection
-        initialTTSProvider = draftTTSProvider
-        initialVoiceId = trimmedVoiceId
-    }
-
-    /// Returns the stored voice ID / reference ID for the given TTS provider
-    /// from the daemon-synced values on `SettingsStore`.
-    private func storedVoiceId(for provider: String) -> String {
-        switch provider {
-        case "elevenlabs":
-            return store.elevenLabsVoiceId
-        case "fish-audio":
-            return store.fishAudioReferenceId
-        default:
-            return ""
-        }
-    }
-
-    /// Checks whether an API key exists for the given STT provider by
-    /// resolving the provider's `apiKeyProviderName` from the registry.
-    private func sttKeyExists(for sttProviderId: String) -> Bool {
-        let keyProvider = SettingsStore.sttApiKeyProviderName(for: sttProviderId)
-        return APIKeyManager.getKey(for: keyProvider) != nil
-    }
-
-    // MARK: - STT Key Ownership Helpers
-
-    /// Whether the STT reset button should be shown for the current provider.
-    ///
-    /// The reset button is only shown when:
-    /// 1. A key already exists for the provider, AND
-    /// 2. The provider owns its key exclusively (not shared with another
-    ///    service like Inference).
-    ///
-    /// This prevents accidental clearing of shared credentials — e.g.
-    /// resetting `openai-whisper` must not delete the `openai` key that
-    /// Inference also depends on.
-    ///
-    /// Provider-agnostic: adding a third STT provider only requires a
-    /// catalog entry, not a new conditional here.
-    private var sttResetAllowed: Bool {
-        sttProviderHasKey && SettingsStore.sttKeyIsExclusive(for: draftSTTProvider)
-    }
-
-    // MARK: - STT Provider Card
-
-    /// True when the user has made changes worth saving in the STT card.
-    private var sttHasChanges: Bool {
-        let providerChanged = draftSTTProvider != initialSTTProvider
-        let hasNewKey = !sttApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        return providerChanged || hasNewKey
-    }
-
-    private var sttProviderCard: some View {
-        SettingsCard(title: "Speech-to-Text", subtitle: "Choose an STT provider for audio transcription. The selected provider is used globally across all transcription features.") {
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                // Provider dropdown — data-driven from the shared STT registry
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    Text("Provider")
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentSecondary)
-                    VDropdown(
-                        placeholder: "Select a provider\u{2026}",
-                        selection: $draftSTTProvider,
-                        options: sttRegistry.providers.map { entry in
-                            (label: entry.displayName, value: entry.id)
-                        }
-                    )
-                }
-
-                // API key field — label and placeholder adapt to the selected provider
-                sttApiKeyField
-
-                // Credentials guide — contextual help for obtaining an API key
-                sttCredentialsGuideView
-
-                // Save + Reset actions — reset is only shown for
-                // exclusive-key providers to avoid clearing shared
-                // credentials (e.g. `openai` used by both Inference and
-                // Whisper STT).
-                ServiceCardActions(
-                    hasChanges: sttHasChanges,
-                    isSaving: sttSaving,
-                    onSave: { saveSTT() },
-                    savingLabel: "Saving...",
-                    onReset: { resetSTTKey() },
-                    showReset: sttResetAllowed
-                )
-
-                if let sttSaveError {
-                    VInlineMessage(sttSaveError, tone: .error)
-                }
-            }
-        }
-    }
-
-    // MARK: - STT API Key Field
-
-    private var sttApiKeyField: some View {
-        APIKeyTextField(
-            label: "\(selectedSTTProvider?.displayName ?? "Provider") API Key",
-            hasKey: sttProviderHasKey,
-            text: $sttApiKeyText
-        )
-        .disabled(sttSaving)
-    }
-
-    // MARK: - STT Credentials Guide
-
-    @ViewBuilder
-    private var sttCredentialsGuideView: some View {
-        if let guide = selectedSTTProvider?.credentialsGuide,
-           let attributed = try? AttributedString(
-               markdown: "\(guide.description) [\(guide.linkLabel)](\(guide.url))"
-           ) {
-            Text(attributed)
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentTertiary)
-                .tint(VColor.primaryBase)
-                .lineSpacing(1)
-                .environment(\.openURL, OpenURLAction { url in
-                    NSWorkspace.shared.open(url)
-                    return .handled
-                })
-        }
-    }
-
-    // MARK: - STT Reset
-
-    /// Clears the STT API key for the current draft provider and resets the
-    /// associated UI state. Only called for exclusive-key providers — shared
-    /// credentials are never cleared through the STT settings card.
-    private func resetSTTKey() {
-        store.clearSTTKey(sttProviderId: draftSTTProvider)
-        sttProviderHasKey = false
-        sttApiKeyText = ""
-    }
-
-    // MARK: - STT Save
-
-    private func saveSTT() {
-        sttSaving = true
-        sttSaveError = nil
-
-        // Normalize the empty sentinel to the resolved provider so we never
-        // persist an empty string as the STT provider identifier.
-        if draftSTTProvider.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-           let resolved = selectedSTTProvider?.id {
-            draftSTTProvider = resolved
-        }
-
-        let providerToSave = draftSTTProvider
-        let providerChanged = providerToSave != sttProviderRaw
-        let trimmedKey = sttApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        Task {
-            var providerSaveSucceeded = true
-            var keySaveSucceeded = true
-
-            if providerChanged {
-                providerSaveSucceeded = await store.setSTTProvider(providerToSave).value
-                if providerSaveSucceeded {
-                    sttProviderRaw = providerToSave
-                } else {
-                    sttSaveError = "Could not save speech-to-text provider selection. Please try again."
-                }
-            }
-
-            if !trimmedKey.isEmpty {
-                let keyResult = await store.saveSTTKeyResult(
-                    trimmedKey,
-                    sttProviderId: providerToSave
-                )
-                keySaveSucceeded = keyResult.success
-                if keyResult.success {
-                    sttApiKeyText = ""
-                    sttProviderHasKey = true
-                } else {
-                    sttSaveError = keyResult.error
-                        ?? "Could not save speech-to-text API key. Please try again."
-                }
-            }
-
-            if providerSaveSucceeded {
-                initialSTTProvider = providerToSave
-            }
-
-            if providerSaveSucceeded && keySaveSucceeded {
-                sttSaveError = nil
-            } else if !providerSaveSucceeded && !keySaveSucceeded {
-                sttSaveError = "Could not save speech-to-text settings. Please try again."
-            }
-
-            sttSaving = false
-        }
-    }
 }

--- a/risk-classifier-phase2-followups.md
+++ b/risk-classifier-phase2-followups.md
@@ -1,0 +1,74 @@
+# Risk Classifier — Phase 2 Follow-ups
+
+Issues to resolve before starting Phase 3. Ordered by severity.
+
+---
+
+## P1: `resolveSubcommand` only knows git's value flags
+
+`resolveSubcommand` hardcodes git as the only command with global value-consuming flags:
+
+```ts
+const valueFlags = program === "git" ? GIT_VALUE_FLAGS : undefined;
+```
+
+Any CLI that takes global flags before the subcommand will misresolve. `gh --repo owner/repo pr merge` treats `owner/repo` as the first positional, misses the `pr merge` subcommand entirely, and falls back to `gh`'s base risk of `low` — a false negative on a high-risk operation. Same for `docker --host ... rm`, `npm --prefix /path test`, etc.
+
+**Fix:** Add an optional `globalValueFlags?: string[]` field to `CommandRiskSpec`. Populate it for `gh`, `docker`, `npm`, `kubectl`, and any other command with global value-consuming flags. `resolveSubcommand` reads it from the spec instead of the hardcoded check.
+
+---
+
+## P2: Variable expansion escalation uses baseRisk, not current computed risk
+
+Line 433 of `bash-risk-classifier.ts`:
+
+```ts
+const escalated = escalateOne(resolvedSpec.baseRisk);
+```
+
+If arg rules already raised risk above baseRisk, the `$VAR` escalation compares against base rather than the running max. Example: a command with `baseRisk: "low"` that matched a `medium` arg rule, with `$VAR` in args — `escalateOne("low")` = `medium`, which equals the current risk, so no escalation happens. But the dynamic content should arguably push a medium-risk command to high.
+
+**Fix:** `escalateOne` should operate on the *current computed risk* (after arg rule evaluation), not `resolvedSpec.baseRisk`.
+
+---
+
+## P2: Dual scope-option systems will diverge
+
+`checker.ts` still generates permission prompt options via `buildShellAllowlistOptions` (lines 757-763, from `shell-identity.ts`). The classifier now generates its own `scopeOptions` via `generateScopeOptions` in `bash-risk-classifier.ts`. These are two parallel systems producing scope ladders from different logic.
+
+This is acknowledged as future work, but the longer both exist, the more they'll drift. Phase 3 should wire `RiskAssessment.scopeOptions` into the permission prompts and retire `buildShellAllowlistOptions`.
+
+---
+
+## P3: `command -v`/`-V` wrapper special case is ad-hoc
+
+Lines 301-304 hardcode a check for `command -v`/`-V` as a non-exec wrapper mode:
+
+```ts
+const isCommandLookup =
+  programName === "command" &&
+  segment.args.length > 0 &&
+  (segment.args[0] === "-v" || segment.args[0] === "-V");
+```
+
+This works but doesn't generalize. Wrappers can have non-exec modes (`command -v`, `env -0`, `timeout --help`), and `isWrapper` currently assumes wrapping always means "run the inner thing."
+
+**Fix:** Add an optional `nonExecFlags?: string[]` field on wrapper `CommandRiskSpec`s. When the first arg matches a non-exec flag, skip unwrapping and classify the wrapper command standalone. Replaces the hardcoded check and handles future cases cleanly.
+
+---
+
+## P3: `rm` safe-file downgrade silently excludes flags
+
+The `isRmOfKnownSafeFile` downgrade in `classifySegment` only fires when `segment.args.length === 1` (bare filename, no flags). So `rm -f BOOTSTRAP.md` stays high because `-f` makes `args.length === 2`.
+
+This is *correct* behavior (conservative), but surprising — `-f` doesn't make the operation more dangerous. Worth either:
+- Expanding the guard to strip known-benign rm flags (`-f`, `-i`, `-v`) before checking, or
+- Adding an inline comment explaining why flags disqualify the downgrade.
+
+---
+
+## Nits
+
+- **`riskOrd` fallback is dead code.** The `?? 2` on line 50 can never fire since `Risk` is a closed union. Add a `// defensive fallback` comment or remove.
+- **Regex cache never clears.** `compiledPatterns` is module-level. Fine for the static default registry, but if user rules with regex patterns get hot-swapped at runtime, stale entries accumulate. Consider exposing `clearCompiledPatterns()` for tests or a cache-invalidation hook.
+- **`go` base risk inconsistency.** `go` has `baseRisk: "low"` but `npm` has `baseRisk: "medium"`. Both are package managers that can execute arbitrary code. Bare `go` (no subcommand) just prints help, so low is defensible — but worth a comment explaining the asymmetry since `go get` and `go generate` exist.


### PR DESCRIPTION
## Summary
- Add SkillLoadRiskClassifier implementing RiskClassifier<SkillClassifierInput>
- Classifies skill_load (Low), scaffold_managed_skill (High), delete_managed_skill (High)
- Unit tests covering all tool types

Part of plan: risk-extend-classifiers.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
