### PR TITLE
chore(permissions): clean up classifyRiskUncached after classifier extraction

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -451,10 +451,10 @@ export async function classifyRisk(
       reason: assessment.reason,
     };
   }
-  // ── Remaining tools: fall through to classifyRiskUncached ───────────────
+  // ── Remaining tools: fall through to registry-based classification ──────
   else {
     result = {
-      level: await classifyRiskUncached(
+      level: await classifyRiskFromRegistry(
         toolName,
         input,
         workingDir,
@@ -485,7 +485,7 @@ export async function classifyRisk(
   return result;
 }
 
-async function classifyRiskUncached(
+async function classifyRiskFromRegistry(
   toolName: string,
   _input: Record<string, unknown>,
   _workingDir?: string,

--- a/assistant/src/permissions/file-risk-classifier.ts
+++ b/assistant/src/permissions/file-risk-classifier.ts
@@ -85,7 +85,7 @@ function isHooksPath(resolvedPath: string): boolean {
 /**
  * File risk classifier implementation.
  *
- * Replicates the exact risk classification logic from classifyRiskUncached()
+ * Replicates the exact risk classification logic from classifyRiskFromRegistry()
  * in checker.ts for all six file tool types.
  */
 export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
@@ -146,7 +146,7 @@ export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
 
       case "host_file_read": {
         // host_file_read has no special escalation paths — the tool registry
-        // declares it as Medium risk, and classifyRiskUncached falls through
+        // declares it as Medium risk, and classifyRiskFromRegistry falls through
         // to getTool() which returns that default.
         return {
           riskLevel: "medium",

--- a/assistant/src/permissions/web-risk-classifier.ts
+++ b/assistant/src/permissions/web-risk-classifier.ts
@@ -3,7 +3,7 @@
  *
  * Implements RiskClassifier<WebClassifierInput> for web-related tools:
  * web_search, web_fetch, and network_request. Replicates the exact logic
- * from checker.ts classifyRiskUncached() lines 472-482.
+ * from checker.ts classifyRiskFromRegistry().
  *
  * - web_search: always Low (read-only)
  * - web_fetch: High if allowPrivateNetwork, Low otherwise


### PR DESCRIPTION
## Summary
- Rename classifyRiskUncached() to classifyRiskFromRegistry() to reflect its reduced scope
- Remove any unused imports
- Update all internal references

Part of plan: risk-extend-classifiers.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
