### PR TITLE
feat(permissions): move allowlist scope options into risk classifiers

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -23,7 +23,7 @@ import {
 } from "./approval-policy.js";
 import { bashRiskClassifier } from "./bash-risk-classifier.js";
 import { fileRiskClassifier } from "./file-risk-classifier.js";
-import { riskToRiskLevel } from "./risk-types.js";
+import { type RiskAssessment, riskToRiskLevel } from "./risk-types.js";
 import {
   buildShellAllowlistOptions,
   buildShellCommandCandidates,
@@ -60,6 +60,24 @@ const RISK_CACHE_MAX = 256;
 const riskCache = new Map<string, RiskClassification>();
 let riskCacheInvalidationHookRegistered = false;
 
+// ── Assessment cache ─────────────────────────────────────────────────────────
+// Stores the full RiskAssessment from classifier-backed tools so that
+// generateAllowlistOptions() can read classifier-produced allowlistOptions
+// without re-classifying. Keyed on (toolName, inputHash) — a simpler key
+// than the full risk cache since generateAllowlistOptions() does not receive
+// workingDir or manifestOverride. Cleared alongside the risk cache.
+const assessmentCache = new Map<string, RiskAssessment>();
+
+function assessmentCacheKey(
+  toolName: string,
+  input: Record<string, unknown>,
+): string {
+  const { reason: _reason, activity: _activity, ...cacheableInput } = input;
+  const inputJson = JSON.stringify(cacheableInput);
+  const hash = createHash("sha256").update(inputJson).digest("hex");
+  return `${toolName}\0${hash}`;
+}
+
 function riskCacheKey(
   toolName: string,
   input: Record<string, unknown>,
@@ -84,6 +102,7 @@ function riskCacheKey(
 /** Clear the risk classification cache. Called when trust rules change. */
 function clearRiskCache(): void {
   riskCache.clear();
+  assessmentCache.clear();
 }
 
 function ensureRiskCacheInvalidationHook(): void {
@@ -377,6 +396,7 @@ export async function classifyRisk(
 
   // ── Bash/host_bash: delegate to the registry-driven BashRiskClassifier ────
   let result: RiskClassification;
+  let classifierAssessment: RiskAssessment | undefined;
   if (toolName === "bash" || toolName === "host_bash") {
     const command = ((input.command as string) ?? "").trim();
     if (!command) {
@@ -386,6 +406,7 @@ export async function classifyRisk(
         command,
         toolName: toolName as "bash" | "host_bash",
       });
+      classifierAssessment = assessment;
       result = {
         level: riskToRiskLevel(assessment.riskLevel),
         reason: assessment.reason,
@@ -416,6 +437,7 @@ export async function classifyRisk(
       filePath,
       workingDir: isHostTool ? "/" : (workingDir ?? process.cwd()),
     });
+    classifierAssessment = assessment;
     result = {
       level: riskToRiskLevel(assessment.riskLevel),
       reason: assessment.reason,
@@ -428,6 +450,7 @@ export async function classifyRisk(
       url: getStringField(input, "url"),
       allowPrivateNetwork: input.allow_private_network === true,
     });
+    classifierAssessment = assessment;
     result = {
       level: riskToRiskLevel(assessment.riskLevel),
       reason: assessment.reason,
@@ -446,6 +469,7 @@ export async function classifyRisk(
         | "delete_managed_skill",
       skillSelector: getStringField(input, "skill"),
     });
+    classifierAssessment = assessment;
     result = {
       level: riskToRiskLevel(assessment.riskLevel),
       reason: assessment.reason,
@@ -480,6 +504,17 @@ export async function classifyRisk(
       if (oldest !== undefined) riskCache.delete(oldest);
     }
     riskCache.set(cacheKey, result);
+  }
+
+  // Store the full assessment in a separate cache keyed on (toolName, input)
+  // so generateAllowlistOptions() can retrieve classifier-produced options.
+  if (classifierAssessment) {
+    const aKey = assessmentCacheKey(toolName, input);
+    if (assessmentCache.size >= RISK_CACHE_MAX) {
+      const oldest = assessmentCache.keys().next().value;
+      if (oldest !== undefined) assessmentCache.delete(oldest);
+    }
+    assessmentCache.set(aKey, classifierAssessment);
   }
 
   return result;
@@ -838,6 +873,22 @@ export async function generateAllowlistOptions(
 ): Promise<AllowlistOption[]> {
   signal?.throwIfAborted();
 
+  // Check if a classifier already produced allowlist options during
+  // classifyRisk(). If so, return those directly — avoids duplicate
+  // computation and keeps scope option generation unified with risk
+  // classification.
+  const aKey = assessmentCacheKey(toolName, input);
+  const cachedAssessment = assessmentCache.get(aKey);
+  if (
+    cachedAssessment?.allowlistOptions &&
+    cachedAssessment.allowlistOptions.length > 0
+  ) {
+    return cachedAssessment.allowlistOptions;
+  }
+
+  // Fall back to the per-tool strategy function for tools that don't have
+  // classifier-produced options (e.g. bash tools use the shell identity
+  // strategy, or when the cache was missed).
   if (Object.hasOwn(ALLOWLIST_STRATEGIES, toolName)) {
     return ALLOWLIST_STRATEGIES[toolName](toolName, input);
   }

--- a/assistant/src/permissions/file-risk-classifier.test.ts
+++ b/assistant/src/permissions/file-risk-classifier.test.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { describe, expect, mock, test } from "bun:test";
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
@@ -448,6 +448,88 @@ describe("FileRiskClassifier", () => {
       } finally {
         skillSourcePaths.delete(resolve(absPath));
       }
+    });
+  });
+
+  // ── Allowlist options ─────────────────────────────────────────────────────
+
+  describe("allowlistOptions", () => {
+    test("file_read produces exact file + ancestor dirs + wildcard", async () => {
+      const filePath = "/home/user/project/src/index.ts";
+      const result = await classifyInput({
+        toolName: "file_read",
+        filePath,
+        workingDir: "/",
+      });
+      const opts = result.allowlistOptions!;
+      expect(opts).toBeDefined();
+      expect(opts.length).toBeGreaterThanOrEqual(2);
+
+      // First option is exact file
+      expect(opts[0]).toEqual({
+        label: filePath,
+        description: "This file only",
+        pattern: `file_read:${filePath}`,
+      });
+
+      // Ancestor directory wildcards
+      let dir = dirname(filePath);
+      let i = 1;
+      const maxLevels = 3;
+      let levels = 0;
+      while (dir && dir !== "/" && dir !== "." && levels < maxLevels) {
+        const dirName = dir.split("/").pop() || dir;
+        expect(opts[i]).toEqual({
+          label: `${dir}/**`,
+          description: `Anything in ${dirName}/`,
+          pattern: `file_read:${dir}/**`,
+        });
+        const parent = dirname(dir);
+        if (parent === dir || dir === homedir()) break;
+        dir = parent;
+        i++;
+        levels++;
+      }
+
+      // Last option is the tool wildcard
+      expect(opts[opts.length - 1]).toEqual({
+        label: "file_read:*",
+        description: "All file reads",
+        pattern: "file_read:*",
+      });
+    });
+
+    test("file_write produces options for the given path", async () => {
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "/tmp/output.txt",
+        workingDir: "/",
+      });
+      const opts = result.allowlistOptions!;
+      expect(opts).toBeDefined();
+      expect(opts[0].pattern).toBe("file_write:/tmp/output.txt");
+      expect(opts[opts.length - 1].pattern).toBe("file_write:*");
+      expect(opts[opts.length - 1].description).toBe("All file writes");
+    });
+
+    test("host_file_read produces options", async () => {
+      const result = await classifyInput({
+        toolName: "host_file_read",
+        filePath: "/etc/config.json",
+        workingDir: "/",
+      });
+      const opts = result.allowlistOptions!;
+      expect(opts).toBeDefined();
+      expect(opts[0].pattern).toBe("host_file_read:/etc/config.json");
+      expect(opts[opts.length - 1].description).toBe("All host file reads");
+    });
+
+    test("empty filePath produces empty allowlistOptions", async () => {
+      const result = await classifyInput({
+        toolName: "file_read",
+        filePath: "",
+      });
+      expect(result.allowlistOptions).toEqual([]);
     });
   });
 });

--- a/assistant/src/permissions/file-risk-classifier.ts
+++ b/assistant/src/permissions/file-risk-classifier.ts
@@ -14,7 +14,7 @@
  */
 
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { getConfig } from "../config/loader.js";
 import {
@@ -28,6 +28,7 @@ import {
   getWorkspaceHooksDir,
 } from "../util/platform.js";
 import type { RiskAssessment, RiskClassifier } from "./risk-types.js";
+import type { AllowlistOption } from "./types.js";
 
 // ── Input type ───────────────────────────────────────────────────────────────
 
@@ -80,6 +81,70 @@ function isHooksPath(resolvedPath: string): boolean {
   );
 }
 
+// ── Allowlist option helpers ──────────────────────────────────────────────────
+
+const FILE_TOOL_DISPLAY_NAMES: Record<string, string> = {
+  file_read: "file reads",
+  file_write: "file writes",
+  file_edit: "file edits",
+  host_file_read: "host file reads",
+  host_file_write: "host file writes",
+  host_file_edit: "host file edits",
+};
+
+function friendlyBasename(filePath: string): string {
+  const parts = filePath.split("/");
+  return parts[parts.length - 1] || filePath;
+}
+
+/**
+ * Build allowlist options for a file tool invocation, mirroring the logic
+ * in checker.ts `fileAllowlistStrategy()`. Options go from most specific
+ * (exact file) to broadest (all operations of this tool type).
+ */
+function buildFileAllowlistOptions(
+  toolName: string,
+  filePath: string,
+): AllowlistOption[] {
+  const toolLabel = FILE_TOOL_DISPLAY_NAMES[toolName] ?? toolName;
+  const options: AllowlistOption[] = [];
+
+  // Exact file path
+  options.push({
+    label: filePath,
+    description: "This file only",
+    pattern: `${toolName}:${filePath}`,
+  });
+
+  // Ancestor directory wildcards — walk up from immediate parent, stop at home dir or /
+  const home = homedir();
+  let dir = dirname(filePath);
+  const maxLevels = 3;
+  let levels = 0;
+  while (dir && dir !== "/" && dir !== "." && levels < maxLevels) {
+    const dirName = friendlyBasename(dir);
+    options.push({
+      label: `${dir}/**`,
+      description: `Anything in ${dirName}/`,
+      pattern: `${toolName}:${dir}/**`,
+    });
+    if (dir === home) break;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+    levels++;
+  }
+
+  // All operations of this tool type
+  options.push({
+    label: `${toolName}:*`,
+    description: `All ${toolLabel}`,
+    pattern: `${toolName}:*`,
+  });
+
+  return options;
+}
+
 // ── Classifier ───────────────────────────────────────────────────────────────
 
 /**
@@ -91,6 +156,9 @@ function isHooksPath(resolvedPath: string): boolean {
 export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
   async classify(input: FileClassifierInput): Promise<RiskAssessment> {
     const { toolName, filePath, workingDir } = input;
+    const allowlistOptions = filePath
+      ? buildFileAllowlistOptions(toolName, filePath)
+      : [];
 
     switch (toolName) {
       case "file_read": {
@@ -102,6 +170,7 @@ export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
               reason: "Reads actor token signing key",
               scopeOptions: [],
               matchType: "registry",
+              allowlistOptions,
             };
           }
         }
@@ -110,6 +179,7 @@ export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
           reason: "File read (default)",
           scopeOptions: [],
           matchType: "registry",
+          allowlistOptions,
         };
       }
 
@@ -125,6 +195,7 @@ export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
               reason: "Writes to skill source code",
               scopeOptions: [],
               matchType: "registry",
+              allowlistOptions,
             };
           }
           if (isHooksPath(resolvedPath)) {
@@ -133,6 +204,7 @@ export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
               reason: "Writes to hooks directory",
               scopeOptions: [],
               matchType: "registry",
+              allowlistOptions,
             };
           }
         }
@@ -141,6 +213,7 @@ export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
           reason: `File ${toolName === "file_write" ? "write" : "edit"} (default)`,
           scopeOptions: [],
           matchType: "registry",
+          allowlistOptions,
         };
       }
 
@@ -153,6 +226,7 @@ export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
           reason: "Host file read (default)",
           scopeOptions: [],
           matchType: "registry",
+          allowlistOptions,
         };
       }
 
@@ -170,6 +244,7 @@ export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
               reason: "Writes to skill source code",
               scopeOptions: [],
               matchType: "registry",
+              allowlistOptions,
             };
           }
           if (isHooksPath(resolvedPath)) {
@@ -178,6 +253,7 @@ export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
               reason: "Writes to hooks directory",
               scopeOptions: [],
               matchType: "registry",
+              allowlistOptions,
             };
           }
         }
@@ -187,6 +263,7 @@ export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
           reason: `Host file ${toolName === "host_file_write" ? "write" : "edit"} (default)`,
           scopeOptions: [],
           matchType: "registry",
+          allowlistOptions,
         };
       }
     }

--- a/assistant/src/permissions/risk-types.ts
+++ b/assistant/src/permissions/risk-types.ts
@@ -9,7 +9,7 @@
  * @see /docs/bash-risk-classifier-design.md
  */
 
-import { RiskLevel } from "./types.js";
+import { type AllowlistOption, RiskLevel } from "./types.js";
 
 // ── Risk levels ──────────────────────────────────────────────────────────────
 
@@ -52,6 +52,13 @@ export interface RiskAssessment {
   scopeOptions: ScopeOption[];
   /** How the risk was determined. */
   matchType: "user_rule" | "registry" | "unknown";
+  /**
+   * Allowlist options for the permission prompt "always allow" scope ladder.
+   * Populated by classifiers that unify risk classification and scope option
+   * generation. When present, `generateAllowlistOptions()` returns these
+   * directly instead of calling the per-tool strategy function.
+   */
+  allowlistOptions?: AllowlistOption[];
 }
 
 // ── Classifier interface ─────────────────────────────────────────────────────

--- a/assistant/src/permissions/skill-risk-classifier.test.ts
+++ b/assistant/src/permissions/skill-risk-classifier.test.ts
@@ -1,4 +1,61 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+// Mock skill resolution so we can control version hashes and catalog lookups.
+let mockResolvedSkill: {
+  id: string;
+  directoryPath: string;
+} | null = null;
+let mockVersionHash: string | undefined;
+let mockTransitiveHash: string | undefined;
+let mockInlineExpansions: string[] = [];
+let mockInlineEnabled = false;
+
+mock.module("../config/skills.js", () => ({
+  resolveSkillSelector: (_selector: string) => ({
+    skill: mockResolvedSkill,
+  }),
+  loadSkillCatalog: () =>
+    mockResolvedSkill
+      ? [
+          {
+            id: mockResolvedSkill.id,
+            directoryPath: mockResolvedSkill.directoryPath,
+            inlineCommandExpansions:
+              mockInlineExpansions.length > 0
+                ? mockInlineExpansions
+                : undefined,
+          },
+        ]
+      : [],
+}));
+
+mock.module("../skills/version-hash.js", () => ({
+  computeSkillVersionHash: () => {
+    if (mockVersionHash === undefined) throw new Error("no hash");
+    return mockVersionHash;
+  },
+}));
+
+mock.module("../skills/transitive-version-hash.js", () => ({
+  computeTransitiveSkillVersionHash: () => {
+    if (mockTransitiveHash === undefined) throw new Error("no hash");
+    return mockTransitiveHash;
+  },
+}));
+
+mock.module("../skills/include-graph.js", () => ({
+  indexCatalogById: () => new Map(),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+}));
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => mockInlineEnabled,
+}));
 
 import {
   type SkillClassifierInput,
@@ -6,12 +63,22 @@ import {
   skillLoadRiskClassifier,
 } from "./skill-risk-classifier.js";
 
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+function resetMocks(): void {
+  mockResolvedSkill = null;
+  mockVersionHash = undefined;
+  mockTransitiveHash = undefined;
+  mockInlineExpansions = [];
+  mockInlineEnabled = false;
+}
+
 // ── SkillLoadRiskClassifier ──────────────────────────────────────────────────
 
 describe("SkillLoadRiskClassifier", () => {
-  const classifier = new SkillLoadRiskClassifier();
-
   test("skill_load is always Low risk", async () => {
+    resetMocks();
+    const classifier = new SkillLoadRiskClassifier();
     const result = await classifier.classify({ toolName: "skill_load" });
     expect(result.riskLevel).toBe("low");
     expect(result.reason).toBe("Skill load (default)");
@@ -20,6 +87,8 @@ describe("SkillLoadRiskClassifier", () => {
   });
 
   test("scaffold_managed_skill is always High risk", async () => {
+    resetMocks();
+    const classifier = new SkillLoadRiskClassifier();
     const result = await classifier.classify({
       toolName: "scaffold_managed_skill",
     });
@@ -32,6 +101,8 @@ describe("SkillLoadRiskClassifier", () => {
   });
 
   test("delete_managed_skill is always High risk", async () => {
+    resetMocks();
+    const classifier = new SkillLoadRiskClassifier();
     const result = await classifier.classify({
       toolName: "delete_managed_skill",
     });
@@ -44,6 +115,8 @@ describe("SkillLoadRiskClassifier", () => {
   });
 
   test("skill_load with skillSelector is still Low risk", async () => {
+    resetMocks();
+    const classifier = new SkillLoadRiskClassifier();
     const result = await classifier.classify({
       toolName: "skill_load",
       skillSelector: "my-custom-skill",
@@ -53,6 +126,8 @@ describe("SkillLoadRiskClassifier", () => {
   });
 
   test("scaffold_managed_skill with skillSelector is still High risk", async () => {
+    resetMocks();
+    const classifier = new SkillLoadRiskClassifier();
     const result = await classifier.classify({
       toolName: "scaffold_managed_skill",
       skillSelector: "new-skill",
@@ -61,11 +136,153 @@ describe("SkillLoadRiskClassifier", () => {
   });
 
   test("delete_managed_skill with skillSelector is still High risk", async () => {
+    resetMocks();
+    const classifier = new SkillLoadRiskClassifier();
     const result = await classifier.classify({
       toolName: "delete_managed_skill",
       skillSelector: "old-skill",
     });
     expect(result.riskLevel).toBe("high");
+  });
+});
+
+// ── Allowlist options ────────────────────────────────────────────────────────
+
+describe("allowlistOptions", () => {
+  test("skill_load without selector produces wildcard option", async () => {
+    resetMocks();
+    const classifier = new SkillLoadRiskClassifier();
+    const result = await classifier.classify({ toolName: "skill_load" });
+    expect(result.allowlistOptions).toEqual([
+      {
+        label: "skill_load:*",
+        description: "All skill loads",
+        pattern: "skill_load:*",
+      },
+    ]);
+  });
+
+  test("skill_load with unresolvable selector produces selector-based option", async () => {
+    resetMocks();
+    // mockResolvedSkill is null — skill not found
+    const classifier = new SkillLoadRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "skill_load",
+      skillSelector: "unknown-skill",
+    });
+    expect(result.allowlistOptions).toEqual([
+      {
+        label: "unknown-skill",
+        description: "This skill",
+        pattern: "skill_load:unknown-skill",
+      },
+    ]);
+  });
+
+  test("skill_load with resolved skill + version hash produces version-pinned option", async () => {
+    resetMocks();
+    mockResolvedSkill = { id: "my-skill", directoryPath: "/skills/my-skill" };
+    mockVersionHash = "abc123";
+
+    const classifier = new SkillLoadRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "skill_load",
+      skillSelector: "my-skill",
+    });
+    expect(result.allowlistOptions).toEqual([
+      {
+        label: "my-skill@abc123",
+        description: "This exact version",
+        pattern: "skill_load:my-skill@abc123",
+      },
+    ]);
+  });
+
+  test("skill_load with dynamic skill produces version-pinned + any-version options", async () => {
+    resetMocks();
+    mockResolvedSkill = {
+      id: "dynamic-skill",
+      directoryPath: "/skills/dynamic-skill",
+    };
+    mockVersionHash = "def456";
+    mockTransitiveHash = "trans789";
+    mockInlineExpansions = ["some-command"];
+    mockInlineEnabled = true;
+
+    const classifier = new SkillLoadRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "skill_load",
+      skillSelector: "dynamic-skill",
+    });
+    expect(result.allowlistOptions).toEqual([
+      {
+        label: "dynamic-skill@trans789",
+        description: "This exact version (pinned)",
+        pattern: "skill_load_dynamic:dynamic-skill@trans789",
+      },
+      {
+        label: "dynamic-skill",
+        description: "This skill (any version)",
+        pattern: "skill_load_dynamic:dynamic-skill",
+      },
+    ]);
+  });
+
+  test("scaffold_managed_skill produces skill-specific + wildcard options", async () => {
+    resetMocks();
+    const classifier = new SkillLoadRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "scaffold_managed_skill",
+      skillSelector: "new-skill",
+    });
+    expect(result.allowlistOptions).toEqual([
+      {
+        label: "new-skill",
+        description: "This skill only",
+        pattern: "scaffold_managed_skill:new-skill",
+      },
+      {
+        label: "scaffold_managed_skill:*",
+        description: "All managed skill scaffolds",
+        pattern: "scaffold_managed_skill:*",
+      },
+    ]);
+  });
+
+  test("delete_managed_skill produces skill-specific + wildcard options", async () => {
+    resetMocks();
+    const classifier = new SkillLoadRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "delete_managed_skill",
+      skillSelector: "old-skill",
+    });
+    expect(result.allowlistOptions).toEqual([
+      {
+        label: "old-skill",
+        description: "This skill only",
+        pattern: "delete_managed_skill:old-skill",
+      },
+      {
+        label: "delete_managed_skill:*",
+        description: "All managed skill deletes",
+        pattern: "delete_managed_skill:*",
+      },
+    ]);
+  });
+
+  test("scaffold_managed_skill without selector produces only wildcard", async () => {
+    resetMocks();
+    const classifier = new SkillLoadRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "scaffold_managed_skill",
+    });
+    expect(result.allowlistOptions).toEqual([
+      {
+        label: "scaffold_managed_skill:*",
+        description: "All managed skill scaffolds",
+        pattern: "scaffold_managed_skill:*",
+      },
+    ]);
   });
 });
 
@@ -77,6 +294,7 @@ describe("singleton", () => {
   });
 
   test("singleton produces same results as fresh instance", async () => {
+    resetMocks();
     const inputs: SkillClassifierInput[] = [
       { toolName: "skill_load" },
       { toolName: "scaffold_managed_skill" },

--- a/assistant/src/permissions/skill-risk-classifier.ts
+++ b/assistant/src/permissions/skill-risk-classifier.ts
@@ -8,7 +8,14 @@
  * - delete_managed_skill: High (removes persistent skill source code)
  */
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
+import { loadSkillCatalog, resolveSkillSelector } from "../config/skills.js";
+import { indexCatalogById } from "../skills/include-graph.js";
+import { computeTransitiveSkillVersionHash } from "../skills/transitive-version-hash.js";
+import { computeSkillVersionHash } from "../skills/version-hash.js";
 import type { RiskAssessment, RiskClassifier } from "./risk-types.js";
+import type { AllowlistOption } from "./types.js";
 
 // ── Input type ───────────────────────────────────────────────────────────────
 
@@ -18,6 +25,141 @@ export interface SkillClassifierInput {
   toolName: "skill_load" | "scaffold_managed_skill" | "delete_managed_skill";
   /** Optional skill selector (e.g. skill name or path). */
   skillSelector?: string;
+}
+
+// ── Allowlist option helpers ─────────────────────────────────────────────────
+
+/**
+ * Resolve a skill selector to its id and version hash. The version hash
+ * is always computed from disk so that untrusted input cannot spoof a
+ * pre-approved hash.
+ */
+function resolveSkillIdAndHash(
+  selector: string,
+): { id: string; versionHash?: string } | null {
+  const resolved = resolveSkillSelector(selector);
+  if (!resolved.skill) return null;
+
+  try {
+    const hash = computeSkillVersionHash(resolved.skill.directoryPath);
+    return { id: resolved.skill.id, versionHash: hash };
+  } catch {
+    return { id: resolved.skill.id };
+  }
+}
+
+/**
+ * Check whether a skill (by id) has parsed inline command expansions.
+ */
+function hasInlineExpansions(skillId: string): boolean {
+  const catalog = loadSkillCatalog();
+  const skill = catalog.find((s) => s.id === skillId);
+  return (
+    skill?.inlineCommandExpansions != null &&
+    skill.inlineCommandExpansions.length > 0
+  );
+}
+
+/**
+ * Compute the transitive version hash for a skill, returning `undefined`
+ * when computation fails (missing includes, cycle, etc.).
+ */
+function computeTransitiveHashSafe(skillId: string): string | undefined {
+  try {
+    const catalog = loadSkillCatalog();
+    const index = indexCatalogById(catalog);
+    return computeTransitiveSkillVersionHash(skillId, index);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Build allowlist options for a skill_load invocation, mirroring the logic
+ * in checker.ts `skillLoadAllowlistStrategy()`.
+ */
+function buildSkillLoadAllowlistOptions(
+  rawSelector?: string,
+): AllowlistOption[] {
+  if (!rawSelector) {
+    return [
+      {
+        label: "skill_load:*",
+        description: "All skill loads",
+        pattern: "skill_load:*",
+      },
+    ];
+  }
+
+  const resolved = resolveSkillIdAndHash(rawSelector);
+
+  // Check whether this is a dynamic (inline-command) skill load
+  const config = getConfig();
+  const inlineEnabled = isAssistantFeatureFlagEnabled(
+    "inline-skill-commands",
+    config,
+  );
+
+  if (resolved && inlineEnabled && hasInlineExpansions(resolved.id)) {
+    const transitiveHash = computeTransitiveHashSafe(resolved.id);
+    const options: AllowlistOption[] = [];
+    if (transitiveHash) {
+      options.push({
+        label: `${resolved.id}@${transitiveHash}`,
+        description: "This exact version (pinned)",
+        pattern: `skill_load_dynamic:${resolved.id}@${transitiveHash}`,
+      });
+    }
+    options.push({
+      label: resolved.id,
+      description: "This skill (any version)",
+      pattern: `skill_load_dynamic:${resolved.id}`,
+    });
+    return options;
+  }
+
+  if (resolved && resolved.versionHash) {
+    return [
+      {
+        label: `${resolved.id}@${resolved.versionHash}`,
+        description: "This exact version",
+        pattern: `skill_load:${resolved.id}@${resolved.versionHash}`,
+      },
+    ];
+  }
+  return [
+    {
+      label: rawSelector,
+      description: "This skill",
+      pattern: `skill_load:${rawSelector}`,
+    },
+  ];
+}
+
+/**
+ * Build allowlist options for scaffold/delete managed skill tools,
+ * mirroring the logic in checker.ts `managedSkillAllowlistStrategy()`.
+ */
+function buildManagedSkillAllowlistOptions(
+  toolName: string,
+  skillId?: string,
+): AllowlistOption[] {
+  const toolLabel =
+    toolName === "scaffold_managed_skill" ? "scaffold" : "delete";
+  const options: AllowlistOption[] = [];
+  if (skillId) {
+    options.push({
+      label: skillId,
+      description: "This skill only",
+      pattern: `${toolName}:${skillId}`,
+    });
+  }
+  options.push({
+    label: `${toolName}:*`,
+    description: `All managed skill ${toolLabel}s`,
+    pattern: `${toolName}:*`,
+  });
+  return options;
 }
 
 // ── Classifier ───────────────────────────────────────────────────────────────
@@ -31,13 +173,16 @@ export interface SkillClassifierInput {
  */
 export class SkillLoadRiskClassifier implements RiskClassifier<SkillClassifierInput> {
   async classify(input: SkillClassifierInput): Promise<RiskAssessment> {
-    switch (input.toolName) {
+    const { toolName, skillSelector } = input;
+
+    switch (toolName) {
       case "skill_load":
         return {
           riskLevel: "low",
           reason: "Skill load (default)",
           scopeOptions: [],
           matchType: "registry",
+          allowlistOptions: buildSkillLoadAllowlistOptions(skillSelector),
         };
       case "scaffold_managed_skill":
         return {
@@ -45,6 +190,10 @@ export class SkillLoadRiskClassifier implements RiskClassifier<SkillClassifierIn
           reason: "Skill scaffold — writes persistent skill source code",
           scopeOptions: [],
           matchType: "registry",
+          allowlistOptions: buildManagedSkillAllowlistOptions(
+            toolName,
+            skillSelector,
+          ),
         };
       case "delete_managed_skill":
         return {
@@ -52,6 +201,10 @@ export class SkillLoadRiskClassifier implements RiskClassifier<SkillClassifierIn
           reason: "Skill delete — removes persistent skill source code",
           scopeOptions: [],
           matchType: "registry",
+          allowlistOptions: buildManagedSkillAllowlistOptions(
+            toolName,
+            skillSelector,
+          ),
         };
     }
   }

--- a/assistant/src/permissions/web-risk-classifier.test.ts
+++ b/assistant/src/permissions/web-risk-classifier.test.ts
@@ -123,6 +123,76 @@ describe("network_request", () => {
   });
 });
 
+// ── Allowlist options ────────────────────────────────────────────────────────
+
+describe("allowlistOptions", () => {
+  test("web_fetch with URL produces exact + origin + wildcard options", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "web_fetch",
+      url: "https://example.com/api/data?key=value",
+    });
+    const opts = result.allowlistOptions!;
+    expect(opts).toBeDefined();
+    expect(opts.length).toBe(3);
+
+    // Exact URL
+    expect(opts[0].description).toBe("This exact URL");
+    expect(opts[0].label).toBe("https://example.com/api/data?key=value");
+
+    // Origin wildcard
+    expect(opts[1].description).toBe("Any page on example.com");
+    expect(opts[1].label).toBe("https://example.com/*");
+
+    // All fetches
+    expect(opts[2].description).toBe("All URL fetches");
+    expect(opts[2].label).toBe("web_fetch:*");
+    expect(opts[2].pattern).toBe("**");
+  });
+
+  test("network_request with URL produces exact + origin + wildcard options", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "network_request",
+      url: "https://api.example.com/v1/users",
+    });
+    const opts = result.allowlistOptions!;
+    expect(opts).toBeDefined();
+    expect(opts.length).toBe(3);
+    expect(opts[0].description).toBe("This exact URL");
+    expect(opts[1].description).toBe("Any page on api.example.com");
+    expect(opts[2].description).toBe("All network requests");
+  });
+
+  test("web_search with no URL produces empty allowlistOptions", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "web_search",
+    });
+    expect(result.allowlistOptions).toEqual([]);
+  });
+
+  test("web_fetch with no URL produces empty allowlistOptions", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "web_fetch",
+    });
+    expect(result.allowlistOptions).toEqual([]);
+  });
+
+  test("deduplicates identical patterns", async () => {
+    const classifier = makeClassifier();
+    const result = await classifier.classify({
+      toolName: "web_fetch",
+      url: "https://example.com/",
+    });
+    const opts = result.allowlistOptions!;
+    const patterns = opts.map((o) => o.pattern);
+    const uniquePatterns = new Set(patterns);
+    expect(patterns.length).toBe(uniquePatterns.size);
+  });
+});
+
 // ── Singleton ────────────────────────────────────────────────────────────────
 
 describe("singleton", () => {

--- a/assistant/src/permissions/web-risk-classifier.ts
+++ b/assistant/src/permissions/web-risk-classifier.ts
@@ -11,6 +11,7 @@
  */
 
 import type { RiskAssessment, RiskClassifier } from "./risk-types.js";
+import type { AllowlistOption } from "./types.js";
 
 // ── Input type ───────────────────────────────────────────────────────────────
 
@@ -24,6 +25,111 @@ export interface WebClassifierInput {
   allowPrivateNetwork?: boolean;
 }
 
+// ── Allowlist option helpers ─────────────────────────────────────────────────
+
+const WEB_TOOL_DISPLAY_NAMES: Record<string, string> = {
+  web_fetch: "URL fetches",
+  network_request: "network requests",
+};
+
+function escapeMinimatchLiteral(value: string): string {
+  return value.replace(/([\\*?[\]{}()!+@|])/g, "\\$1");
+}
+
+function friendlyHostname(url: URL): string {
+  return url.hostname.replace(/^www\./, "");
+}
+
+/**
+ * Normalize a URL for allowlist purposes. Mirrors the canonicalization
+ * logic in checker.ts `normalizeWebFetchUrl()`.
+ */
+function normalizeUrl(rawUrl: string): URL | null {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      parsed.hash = "";
+      parsed.username = "";
+      parsed.password = "";
+      try {
+        parsed.pathname = decodeURI(parsed.pathname);
+      } catch {
+        // Keep canonical form when decoding fails.
+      }
+      if (parsed.hostname.endsWith(".")) {
+        parsed.hostname = parsed.hostname.replace(/\.+$/, "");
+      }
+      return parsed;
+    }
+  } catch {
+    // Fall through.
+  }
+
+  try {
+    const parsed = new URL(`https://${trimmed}`);
+    parsed.hash = "";
+    parsed.username = "";
+    parsed.password = "";
+    if (parsed.hostname.endsWith(".")) {
+      parsed.hostname = parsed.hostname.replace(/\.+$/, "");
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build allowlist options for a web tool invocation, mirroring the logic
+ * in checker.ts `urlAllowlistStrategy()`. Options go from most specific
+ * (exact URL) to broadest (all fetches of this tool type).
+ */
+function buildWebAllowlistOptions(
+  toolName: string,
+  rawUrl?: string,
+): AllowlistOption[] {
+  if (!rawUrl) return [];
+
+  const normalized = normalizeUrl(rawUrl);
+  const exact = normalized?.href ?? rawUrl;
+  const toolLabel = WEB_TOOL_DISPLAY_NAMES[toolName] ?? toolName;
+
+  const options: AllowlistOption[] = [];
+  if (exact) {
+    options.push({
+      label: exact,
+      description: "This exact URL",
+      pattern: `${toolName}:${escapeMinimatchLiteral(exact)}`,
+    });
+  }
+  if (normalized) {
+    const host = friendlyHostname(normalized);
+    options.push({
+      label: `${normalized.origin}/*`,
+      description: `Any page on ${host}`,
+      pattern: `${toolName}:${escapeMinimatchLiteral(normalized.origin)}/*`,
+    });
+  }
+  // Use standalone "**" globstar — minimatch only treats ** as globstar when
+  // it is its own path segment, so "${toolName}:*" would fail to match URL
+  // candidates containing "/". The tool field is already filtered separately.
+  options.push({
+    label: `${toolName}:*`,
+    description: `All ${toolLabel}`,
+    pattern: "**",
+  });
+
+  const seen = new Set<string>();
+  return options.filter((o) => {
+    if (seen.has(o.pattern)) return false;
+    seen.add(o.pattern);
+    return true;
+  });
+}
+
 // ── Classifier ───────────────────────────────────────────────────────────────
 
 /**
@@ -35,7 +141,8 @@ export interface WebClassifierInput {
  */
 export class WebRiskClassifier implements RiskClassifier<WebClassifierInput> {
   async classify(input: WebClassifierInput): Promise<RiskAssessment> {
-    const { toolName, allowPrivateNetwork } = input;
+    const { toolName, url, allowPrivateNetwork } = input;
+    const allowlistOptions = buildWebAllowlistOptions(toolName, url);
 
     switch (toolName) {
       case "web_search":
@@ -44,6 +151,7 @@ export class WebRiskClassifier implements RiskClassifier<WebClassifierInput> {
           reason: "Web search (read-only)",
           scopeOptions: [],
           matchType: "registry",
+          allowlistOptions,
         };
 
       case "web_fetch":
@@ -55,6 +163,7 @@ export class WebRiskClassifier implements RiskClassifier<WebClassifierInput> {
             reason: "Private network fetch",
             scopeOptions: [],
             matchType: "registry",
+            allowlistOptions,
           };
         }
         return {
@@ -62,6 +171,7 @@ export class WebRiskClassifier implements RiskClassifier<WebClassifierInput> {
           reason: "Web fetch (default)",
           scopeOptions: [],
           matchType: "registry",
+          allowlistOptions,
         };
 
       case "network_request":
@@ -72,6 +182,7 @@ export class WebRiskClassifier implements RiskClassifier<WebClassifierInput> {
           reason: "Network request (proxied credentials)",
           scopeOptions: [],
           matchType: "registry",
+          allowlistOptions,
         };
     }
   }


### PR DESCRIPTION
## Summary
- Move file/web/skill allowlist option generation into their respective classifiers
- Add assessment cache so generateAllowlistOptions() can reuse classifier-produced options
- Unify risk classification and scope option generation into a single classifier call

Part of plan: risk-extend-classifiers.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
