### PR TITLE
feat(gateway): async job pattern for URL-body migration imports

### DIFF
--- a/gateway/src/http/routes/migration-proxy.ts
+++ b/gateway/src/http/routes/migration-proxy.ts
@@ -337,6 +337,22 @@ async function runUpstreamImport(args: {
     }
 
     if (response.status >= 200 && response.status < 300) {
+      // Daemon returns HTTP 200 for some logical-failure shapes — notably
+      // `{ success: false, reason: "validation_failed", errors: [...] }`
+      // for bundles that failed manifest / hash validation. Callers that
+      // gate on `status === "complete"` would otherwise report success
+      // for an import that actually failed. Inspect the body before
+      // declaring victory.
+      if (isLogicalFailureBody(parsed)) {
+        const errorMessage =
+          extractErrorMessage(parsed) ?? "Import reported failure";
+        markJobFailed(jobId, response.status, errorMessage, parsed);
+        log.warn(
+          { jobId, status: response.status, duration, error: errorMessage },
+          "Migration import async: daemon returned 2xx with success=false body",
+        );
+        return;
+      }
       markJobComplete(jobId, response.status, parsed);
       log.info(
         { jobId, status: response.status, duration },
@@ -397,6 +413,19 @@ function markJobFailed(
   job.error = error;
   if (result !== undefined) job.result = result;
   job.completedAt = Date.now();
+}
+
+/**
+ * The daemon's migration import handler returns HTTP 200 for some logical
+ * failures — specifically `{ success: false, reason: "validation_failed",
+ * errors: [...] }` when the bundle's manifest / hash checks fail. Those
+ * are semantic failures, NOT HTTP-level errors. Detect them so the async
+ * job ends up in the `failed` state rather than `complete`.
+ */
+function isLogicalFailureBody(body: unknown): boolean {
+  if (!body || typeof body !== "object") return false;
+  const record = body as Record<string, unknown>;
+  return record.success === false;
 }
 
 function extractErrorMessage(body: unknown): string | null {

--- a/gateway/src/http/routes/migration-proxy.ts
+++ b/gateway/src/http/routes/migration-proxy.ts
@@ -4,7 +4,29 @@
  * Follows the same forwarding pattern as upgrade-broadcast-proxy.ts:
  * strips hop-by-hop headers, replaces the client's edge JWT with a
  * minted service token, and proxies the request to the daemon.
+ *
+ * The import handler has two shapes:
+ *
+ *   1. Raw bytes (octet-stream / multipart) — proxied synchronously. The
+ *      caller's connection stays open for the full import duration. Used
+ *      by docker teleport, local .vbundle restore, and any client that
+ *      uploads the bundle body directly. Unchanged.
+ *
+ *   2. JSON `{ url }` body — run asynchronously. The gateway generates a
+ *      jobId, kicks off the upstream daemon call on an unawaited promise,
+ *      and returns `202 Accepted` with `{ job_id, status: "pending" }`
+ *      immediately. Callers poll `GET /v1/migrations/import/:jobId/status`
+ *      for progress. This keeps the external caller's request short
+ *      regardless of bundle size — critical for 8 GB imports where any
+ *      LB/ingress timeout along the caller path would otherwise cause
+ *      504s while the daemon keeps working.
+ *
+ *      The gateway → daemon hop remains synchronous: the background task
+ *      just holds the daemon request open until the import completes,
+ *      then records the outcome in the job map for the caller to poll.
  */
+
+import { randomUUID } from "node:crypto";
 
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
@@ -16,6 +38,20 @@ const log = getLogger("migration-proxy");
 
 /** Timeout for migration requests (60 minutes) — exports/imports can be large (up to 8 GB bundles). */
 const MIGRATION_TIMEOUT_MS = 3_600_000;
+
+/**
+ * How long a finished (or failed) import job is kept in memory before it's
+ * pruned. 30 minutes is long enough for a typical caller-side polling loop
+ * to read the terminal state a few times, short enough to bound memory use
+ * even under heavy job churn.
+ */
+const COMPLETED_JOB_TTL_MS = 30 * 60 * 1000;
+
+/**
+ * How often the pruner sweeps the job map. Not timing-critical — jobs that
+ * survive a bit past their TTL are fine.
+ */
+const JOB_PRUNE_INTERVAL_MS = 60 * 1000;
 
 export function createMigrationExportProxyHandler(config: GatewayConfig) {
   return async function handleMigrationExport(req: Request): Promise<Response> {
@@ -90,75 +126,412 @@ export function createMigrationExportProxyHandler(config: GatewayConfig) {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Async import job bookkeeping
+// ---------------------------------------------------------------------------
+
+/**
+ * Terminal job state mirrors the shape macOS clients already poll on the
+ * platform's `/v1/migrations/import/:jobId/status/` endpoint, so a caller
+ * library that already knows how to poll there can talk to the gateway
+ * with no changes.
+ */
+export type ImportJobStatus = "pending" | "processing" | "complete" | "failed";
+
+interface ImportJob {
+  jobId: string;
+  status: ImportJobStatus;
+  /** Wall-clock ms when the job was created. Used for idle-pruning. */
+  startedAt: number;
+  /** Wall-clock ms when the job reached a terminal state. */
+  completedAt?: number;
+  /** Upstream HTTP status on success. */
+  upstreamStatus?: number;
+  /** Parsed JSON body the daemon returned on success. */
+  result?: unknown;
+  /** Terminal-state error message (fetch failure, non-2xx, body parse). */
+  error?: string;
+}
+
+/**
+ * Singleton job map. Module-level so the proxy handler and the status
+ * handler share it. The gateway is a single Bun process; no external
+ * coordination needed.
+ */
+const jobs = new Map<string, ImportJob>();
+let prunerStarted = false;
+
+function ensurePrunerRunning(): void {
+  if (prunerStarted) return;
+  prunerStarted = true;
+  // Unref'd timer so it doesn't keep the process alive during shutdown.
+  const timer = setInterval(() => {
+    const now = Date.now();
+    for (const [id, job] of jobs) {
+      if (job.completedAt && now - job.completedAt > COMPLETED_JOB_TTL_MS) {
+        jobs.delete(id);
+      }
+    }
+  }, JOB_PRUNE_INTERVAL_MS);
+  if (typeof timer.unref === "function") timer.unref();
+}
+
+/** Test-only: reset the job map between test runs. */
+export function _resetImportJobsForTests(): void {
+  jobs.clear();
+}
+
+/** Test-only: read-only snapshot of the current jobs. */
+export function _getImportJobsForTests(): ReadonlyMap<string, ImportJob> {
+  return jobs;
+}
+
+// ---------------------------------------------------------------------------
+// Import proxy — dispatches on Content-Type
+// ---------------------------------------------------------------------------
+
 export function createMigrationImportProxyHandler(config: GatewayConfig) {
   return async function handleMigrationImport(req: Request): Promise<Response> {
-    const start = performance.now();
-    const bodyBuffer = await req.arrayBuffer();
-
-    const upstream = `${config.assistantRuntimeBaseUrl}/v1/migrations/import`;
-
-    const reqHeaders = stripHopByHop(new Headers(req.headers));
-    reqHeaders.delete("host");
-    reqHeaders.delete("authorization");
-
-    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
-    reqHeaders.set("content-length", String(bodyBuffer.byteLength));
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort(
-        new DOMException(
-          "The operation was aborted due to timeout",
-          "TimeoutError",
-        ),
-      );
-    }, MIGRATION_TIMEOUT_MS);
-
-    let response: Response;
-    try {
-      response = await fetchImpl(upstream, {
-        method: "POST",
-        headers: reqHeaders,
-        body: bodyBuffer,
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-    } catch (err) {
-      clearTimeout(timeoutId);
-      const duration = Math.round(performance.now() - start);
-      if (err instanceof DOMException && err.name === "TimeoutError") {
-        log.error({ duration }, "Migration import proxy upstream timed out");
-        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
-      }
-      log.error(
-        { err, duration },
-        "Migration import proxy upstream connection failed",
-      );
-      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    const contentType = req.headers.get("content-type") ?? "";
+    if (contentType.toLowerCase().includes("application/json")) {
+      return handleAsyncJsonImport(req, config);
     }
+    return handleSyncBytesImport(req, config);
+  };
+}
 
-    const resHeaders = stripHopByHop(new Headers(response.headers));
+/**
+ * Async path: called by the external caller for URL-based imports. Returns
+ * 202 immediately with a job_id; the upstream daemon call runs in the
+ * background and the job map is updated when it completes.
+ */
+async function handleAsyncJsonImport(
+  req: Request,
+  config: GatewayConfig,
+): Promise<Response> {
+  ensurePrunerRunning();
+
+  let bodyText: string;
+  try {
+    bodyText = await req.text();
+  } catch (err) {
+    log.warn({ err }, "Migration import proxy failed to read JSON body");
+    return Response.json(
+      { error: "Bad Request", message: "Failed to read request body" },
+      { status: 400 },
+    );
+  }
+
+  // The gateway doesn't validate the URL or re-serialize — that's the
+  // daemon's job. We just need enough of the headers and the raw body to
+  // proxy the request. Log a preview of the path/host if the body parses
+  // so ops has something to grep on.
+  let previewHost: string | undefined;
+  try {
+    const parsed = JSON.parse(bodyText) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "url" in parsed &&
+      typeof (parsed as { url: unknown }).url === "string"
+    ) {
+      try {
+        previewHost = new URL((parsed as { url: string }).url).host;
+      } catch {
+        // Malformed URL — daemon will 400 on it; log without the host.
+      }
+    }
+  } catch {
+    // Malformed JSON — daemon will 400 on it; let the error body flow
+    // through when the daemon responds.
+  }
+
+  const jobId = randomUUID();
+  const job: ImportJob = {
+    jobId,
+    status: "pending",
+    startedAt: Date.now(),
+  };
+  jobs.set(jobId, job);
+
+  const reqHeaders = stripHopByHop(new Headers(req.headers));
+  reqHeaders.delete("host");
+  reqHeaders.delete("authorization");
+  reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
+  reqHeaders.set("content-type", "application/json");
+  reqHeaders.set("content-length", String(Buffer.byteLength(bodyText)));
+
+  const upstream = `${config.assistantRuntimeBaseUrl}/v1/migrations/import`;
+
+  log.info(
+    { jobId, previewHost },
+    "Migration import proxy: kicking off async URL import",
+  );
+
+  // Fire-and-forget the upstream call. Errors are captured in the job map
+  // so the caller's next poll surfaces them.
+  void runUpstreamImport({
+    jobId,
+    upstream,
+    reqHeaders,
+    bodyText,
+  });
+
+  return Response.json(
+    { job_id: jobId, status: "pending" satisfies ImportJobStatus },
+    { status: 202 },
+  );
+}
+
+/** Helper that holds the daemon request open for the full import duration. */
+async function runUpstreamImport(args: {
+  jobId: string;
+  upstream: string;
+  reqHeaders: Headers;
+  bodyText: string;
+}): Promise<void> {
+  const { jobId, upstream, reqHeaders, bodyText } = args;
+  const start = performance.now();
+
+  const job = jobs.get(jobId);
+  if (job) job.status = "processing";
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort(
+      new DOMException(
+        "The operation was aborted due to timeout",
+        "TimeoutError",
+      ),
+    );
+  }, MIGRATION_TIMEOUT_MS);
+
+  try {
+    const response = await fetchImpl(upstream, {
+      method: "POST",
+      headers: reqHeaders,
+      body: bodyText,
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+
     const duration = Math.round(performance.now() - start);
 
-    if (response.status >= 400) {
-      const body = await response.text();
-      log.warn(
-        { status: response.status, duration },
-        "Migration import proxy upstream error",
+    // The daemon always returns JSON for this path (success OR structured
+    // failure shapes). Parse and record; treat a parse failure as a job
+    // failure since the caller can't meaningfully poll on bytes.
+    let parsed: unknown;
+    try {
+      parsed = await response.json();
+    } catch (err) {
+      markJobFailed(
+        jobId,
+        response.status,
+        `Invalid JSON from daemon: ${errMessage(err)}`,
       );
-      return new Response(body, {
-        status: response.status,
-        headers: resHeaders,
-      });
+      log.error(
+        { jobId, status: response.status, duration, err },
+        "Migration import async: failed to parse daemon JSON response",
+      );
+      return;
     }
 
-    log.info(
-      { status: response.status, duration },
-      "Migration import proxy completed",
+    if (response.status >= 200 && response.status < 300) {
+      markJobComplete(jobId, response.status, parsed);
+      log.info(
+        { jobId, status: response.status, duration },
+        "Migration import async: completed",
+      );
+      return;
+    }
+
+    // Non-2xx: the daemon's JSON body is the caller-visible failure. Pull
+    // a `reason` / `message` out of it for the `error` field if present,
+    // keep the whole body under `result` so nothing is lost.
+    const errorMessage =
+      extractErrorMessage(parsed) ?? `HTTP ${response.status}`;
+    markJobFailed(jobId, response.status, errorMessage, parsed);
+    log.warn(
+      { jobId, status: response.status, duration, error: errorMessage },
+      "Migration import async: daemon returned non-2xx",
     );
-    return new Response(response.body, {
+  } catch (err) {
+    clearTimeout(timeoutId);
+    const duration = Math.round(performance.now() - start);
+    const isTimeout =
+      err instanceof DOMException && err.name === "TimeoutError";
+    const message = isTimeout
+      ? `Gateway → daemon request timed out after ${MIGRATION_TIMEOUT_MS}ms`
+      : `Gateway → daemon request failed: ${errMessage(err)}`;
+    markJobFailed(jobId, undefined, message);
+    log.error(
+      { jobId, duration, err },
+      "Migration import async: upstream connection failed",
+    );
+  }
+}
+
+function markJobComplete(
+  jobId: string,
+  upstreamStatus: number,
+  result: unknown,
+): void {
+  const job = jobs.get(jobId);
+  if (!job) return;
+  job.status = "complete";
+  job.upstreamStatus = upstreamStatus;
+  job.result = result;
+  job.completedAt = Date.now();
+}
+
+function markJobFailed(
+  jobId: string,
+  upstreamStatus: number | undefined,
+  error: string,
+  result?: unknown,
+): void {
+  const job = jobs.get(jobId);
+  if (!job) return;
+  job.status = "failed";
+  job.upstreamStatus = upstreamStatus;
+  job.error = error;
+  if (result !== undefined) job.result = result;
+  job.completedAt = Date.now();
+}
+
+function extractErrorMessage(body: unknown): string | null {
+  if (!body || typeof body !== "object") return null;
+  const record = body as Record<string, unknown>;
+  if (typeof record.message === "string") return record.message;
+  if (typeof record.error === "string") return record.error;
+  if (typeof record.reason === "string") return record.reason;
+  return null;
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Sync path: raw-bytes imports (octet-stream / multipart). Unchanged from
+ * the previous implementation — the request body IS the bundle, so there's
+ * no benefit to running it async (the caller's upload has to stay open
+ * anyway).
+ */
+async function handleSyncBytesImport(
+  req: Request,
+  config: GatewayConfig,
+): Promise<Response> {
+  const start = performance.now();
+  const bodyBuffer = await req.arrayBuffer();
+
+  const upstream = `${config.assistantRuntimeBaseUrl}/v1/migrations/import`;
+
+  const reqHeaders = stripHopByHop(new Headers(req.headers));
+  reqHeaders.delete("host");
+  reqHeaders.delete("authorization");
+
+  reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
+  reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort(
+      new DOMException(
+        "The operation was aborted due to timeout",
+        "TimeoutError",
+      ),
+    );
+  }, MIGRATION_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(upstream, {
+      method: "POST",
+      headers: reqHeaders,
+      body: bodyBuffer,
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+  } catch (err) {
+    clearTimeout(timeoutId);
+    const duration = Math.round(performance.now() - start);
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      log.error({ duration }, "Migration import proxy upstream timed out");
+      return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+    }
+    log.error(
+      { err, duration },
+      "Migration import proxy upstream connection failed",
+    );
+    return Response.json({ error: "Bad Gateway" }, { status: 502 });
+  }
+
+  const resHeaders = stripHopByHop(new Headers(response.headers));
+  const duration = Math.round(performance.now() - start);
+
+  if (response.status >= 400) {
+    const body = await response.text();
+    log.warn(
+      { status: response.status, duration },
+      "Migration import proxy upstream error",
+    );
+    return new Response(body, {
       status: response.status,
       headers: resHeaders,
     });
+  }
+
+  log.info(
+    { status: response.status, duration },
+    "Migration import proxy completed",
+  );
+  return new Response(response.body, {
+    status: response.status,
+    headers: resHeaders,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Status polling
+// ---------------------------------------------------------------------------
+
+/**
+ * GET `/v1/migrations/import/:jobId/status` handler.
+ *
+ * Returns the job's current status on 200, or 404 if the jobId is unknown
+ * (never issued, or pruned after the TTL). The response shape deliberately
+ * mirrors the platform's existing `/v1/migrations/import/:jobId/status/`
+ * endpoint so `PlatformMigrationClient.pollImportStatus` works against
+ * either surface with no changes.
+ */
+export function createMigrationImportStatusProxyHandler(
+  _config: GatewayConfig,
+) {
+  return async function handleMigrationImportStatus(
+    _req: Request,
+    jobId: string,
+  ): Promise<Response> {
+    const job = jobs.get(jobId);
+    if (!job) {
+      return Response.json(
+        { error: "Not Found", message: `Unknown import job: ${jobId}` },
+        { status: 404 },
+      );
+    }
+
+    const body: {
+      status: ImportJobStatus;
+      job_id: string;
+      error?: string;
+      result?: unknown;
+    } = {
+      status: job.status,
+      job_id: job.jobId,
+    };
+    if (job.error !== undefined) body.error = job.error;
+    if (job.result !== undefined) body.result = job.result;
+
+    return Response.json(body, { status: 200 });
   };
 }

--- a/gateway/src/http/routes/migration-proxy.ts
+++ b/gateway/src/http/routes/migration-proxy.ts
@@ -307,13 +307,19 @@ async function runUpstreamImport(args: {
   }, MIGRATION_TIMEOUT_MS);
 
   try {
+    // NOTE: `fetch` resolves on headers, not on full body delivery. Keep
+    // the abort timer alive across `response.json()` so a partial-body
+    // stall on the upstream side still aborts and we transition the job
+    // to `failed` — otherwise a mid-body drop would leave the job pinned
+    // at `processing` indefinitely and pollers would spin forever.
+    // The timer is cleared in the `finally` below, which fires after the
+    // body has been fully consumed (or the abort has fired).
     const response = await fetchImpl(upstream, {
       method: "POST",
       headers: reqHeaders,
       body: bodyText,
       signal: controller.signal,
     });
-    clearTimeout(timeoutId);
 
     const duration = Math.round(performance.now() - start);
 
@@ -327,7 +333,7 @@ async function runUpstreamImport(args: {
       markJobFailed(
         jobId,
         response.status,
-        `Invalid JSON from daemon: ${errMessage(err)}`,
+        `Invalid JSON from assistant: ${errMessage(err)}`,
       );
       log.error(
         { jobId, status: response.status, duration, err },
@@ -372,18 +378,19 @@ async function runUpstreamImport(args: {
       "Migration import async: daemon returned non-2xx",
     );
   } catch (err) {
-    clearTimeout(timeoutId);
     const duration = Math.round(performance.now() - start);
     const isTimeout =
       err instanceof DOMException && err.name === "TimeoutError";
     const message = isTimeout
-      ? `Gateway → daemon request timed out after ${MIGRATION_TIMEOUT_MS}ms`
-      : `Gateway → daemon request failed: ${errMessage(err)}`;
+      ? `Gateway → assistant request timed out after ${MIGRATION_TIMEOUT_MS}ms`
+      : `Gateway → assistant request failed: ${errMessage(err)}`;
     markJobFailed(jobId, undefined, message);
     log.error(
       { jobId, duration, err },
       "Migration import async: upstream connection failed",
     );
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -892,7 +892,12 @@ async function main() {
       path: /^\/v1\/migrations\/import\/([^/]+)\/status\/?$/,
       method: "GET",
       auth: "edge-scoped",
-      scope: "settings.write",
+      // Read-only polling endpoint — read scope, not write. Matches the
+      // convention used for other GET endpoints in this router (OAuth
+      // providers GET, OAuth apps GET, privacy config GET) so a token
+      // profile with `settings.read` only (e.g. the `ui_page_v1`
+      // profile) can still poll import progress.
+      scope: "settings.read",
       handler: (req, params) =>
         migrationImportStatusProxy(req, params[0] ?? ""),
     },

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -73,6 +73,7 @@ import { createUpgradeBroadcastProxyHandler } from "./http/routes/upgrade-broadc
 import {
   createMigrationExportProxyHandler,
   createMigrationImportProxyHandler,
+  createMigrationImportStatusProxyHandler,
 } from "./http/routes/migration-proxy.js";
 import { createMigrationRollbackProxyHandler } from "./http/routes/migration-rollback-proxy.js";
 import { createWorkspaceCommitProxyHandler } from "./http/routes/workspace-commit-proxy.js";
@@ -342,6 +343,8 @@ async function main() {
   const upgradeBroadcastProxy = createUpgradeBroadcastProxyHandler(config);
   const migrationExportProxy = createMigrationExportProxyHandler(config);
   const migrationImportProxy = createMigrationImportProxyHandler(config);
+  const migrationImportStatusProxy =
+    createMigrationImportStatusProxyHandler(config);
   const migrationRollbackProxy = createMigrationRollbackProxyHandler(config);
   const workspaceCommitProxy = createWorkspaceCommitProxyHandler(config);
   const brainGraphProxy = createBrainGraphProxyHandler(config);
@@ -873,6 +876,18 @@ async function main() {
       auth: "edge-scoped",
       scope: "settings.write",
       handler: (req) => migrationImportProxy(req),
+    },
+    {
+      // Async-job status endpoint for URL-based imports. The gateway keeps
+      // an in-memory job map keyed by the jobId it handed back in the
+      // 202 response; this lets callers poll for progress without holding
+      // an HTTP connection open for the full import duration.
+      path: /^\/v1\/migrations\/import\/([^/]+)\/status$/,
+      method: "GET",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req, params) =>
+        migrationImportStatusProxy(req, params[0] ?? ""),
     },
 
     // ── Workspace commit ──

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -882,7 +882,14 @@ async function main() {
       // an in-memory job map keyed by the jobId it handed back in the
       // 202 response; this lets callers poll for progress without holding
       // an HTTP connection open for the full import duration.
-      path: /^\/v1\/migrations\/import\/([^/]+)\/status$/,
+      //
+      // Trailing slash is optional to preserve compatibility with existing
+      // pollers. PlatformMigrationClient.pollImportStatus (macOS) and
+      // cli/src/lib/platform-client.ts both hit `.../status/` against the
+      // platform API today; other callers may follow the bare-path
+      // convention (`.../status`). Regex routes in the gateway router are
+      // NOT trailing-slash-normalized, so the optionality is encoded here.
+      path: /^\/v1\/migrations\/import\/([^/]+)\/status\/?$/,
       method: "GET",
       auth: "edge-scoped",
       scope: "settings.write",

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -3202,10 +3202,10 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Import workspace backup",
           description:
-            "Proxies a migration import request to the assistant daemon. Two request shapes are accepted:\n" +
+            "Proxies a migration import request to the assistant. Two request shapes are accepted:\n" +
             "\n" +
             "  - `application/octet-stream`: raw .vbundle body. The request is proxied synchronously and the caller's connection stays open for the full import duration (returns 200 on success).\n" +
-            '  - `application/json` with `{ "url": "<signed GCS URL>" }`: the gateway generates a jobId, kicks off the upstream daemon call in the background, and returns `202 Accepted` with `{ job_id, status: "pending" }` immediately. Callers poll `GET /v1/migrations/import/{jobId}/status` for progress.\n' +
+            '  - `application/json` with `{ "url": "<signed GCS URL>" }`: the gateway generates a jobId, kicks off the upstream assistant call in the background, and returns `202 Accepted` with `{ job_id, status: "pending" }` immediately. Callers poll `GET /v1/migrations/import/{jobId}/status` for progress.\n' +
             "\n" +
             "Authenticated with an edge JWT. Synchronous-path timeout is 60 minutes to accommodate large 8 GB backups; the async path returns immediately.",
           operationId: "migrationImport",

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -3202,7 +3202,12 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Import workspace backup",
           description:
-            "Proxies a migration import request to the assistant daemon. Accepts a binary .vbundle backup body and restores the workspace from it. Authenticated with an edge JWT. Timeout is 120 seconds to accommodate large backups.",
+            "Proxies a migration import request to the assistant daemon. Two request shapes are accepted:\n" +
+            "\n" +
+            "  - `application/octet-stream`: raw .vbundle body. The request is proxied synchronously and the caller's connection stays open for the full import duration (returns 200 on success).\n" +
+            '  - `application/json` with `{ "url": "<signed GCS URL>" }`: the gateway generates a jobId, kicks off the upstream daemon call in the background, and returns `202 Accepted` with `{ job_id, status: "pending" }` immediately. Callers poll `GET /v1/migrations/import/{jobId}/status` for progress.\n' +
+            "\n" +
+            "Authenticated with an edge JWT. Synchronous-path timeout is 60 minutes to accommodate large 8 GB backups; the async path returns immediately.",
           operationId: "migrationImport",
           security: [{ BearerAuth: [] }],
           requestBody: {
@@ -3211,15 +3216,96 @@ export function buildSchema(): Record<string, unknown> {
               "application/octet-stream": {
                 schema: { type: "string", format: "binary" },
               },
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["url"],
+                  properties: {
+                    url: {
+                      type: "string",
+                      format: "uri",
+                      description:
+                        "Signed GCS URL pointing at a .vbundle archive.",
+                    },
+                  },
+                },
+              },
             },
           },
           responses: {
-            "200": { description: "Backup imported successfully" },
+            "200": {
+              description:
+                "Backup imported successfully (synchronous byte path).",
+            },
+            "202": {
+              description:
+                "Import accepted for async processing (JSON URL path). Poll `/v1/migrations/import/{jobId}/status` for progress.",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["job_id", "status"],
+                    properties: {
+                      job_id: { type: "string" },
+                      status: { type: "string", enum: ["pending"] },
+                    },
+                  },
+                },
+              },
+            },
             "401": {
               description: "Unauthorized — missing or invalid bearer token",
             },
             "502": { description: "Failed to reach assistant daemon" },
             "504": { description: "Assistant daemon request timed out" },
+          },
+        },
+      },
+      "/v1/migrations/import/{jobId}/status": {
+        get: {
+          summary: "Poll async import job status",
+          description:
+            "Returns the current status of an async `.vbundle` import kicked off by `POST /v1/migrations/import` with a JSON `{url}` body. Finished jobs remain queryable for 30 minutes before being pruned.",
+          operationId: "migrationImportStatus",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              in: "path",
+              name: "jobId",
+              required: true,
+              schema: { type: "string" },
+              description:
+                "The `job_id` returned by the 202 response from `POST /v1/migrations/import`.",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Current job status.",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["job_id", "status"],
+                    properties: {
+                      job_id: { type: "string" },
+                      status: {
+                        type: "string",
+                        enum: ["pending", "processing", "complete", "failed"],
+                      },
+                      error: { type: "string" },
+                      result: {},
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "404": {
+              description:
+                "Unknown job — never issued, or pruned after 30-minute TTL.",
+            },
           },
         },
       },


### PR DESCRIPTION
## Summary

- \`POST /v1/migrations/import\` now dispatches on \`Content-Type\`: \`application/json\` (URL-body imports) returns **202 Accepted + \`{ job_id, status: \"pending\" }\`** immediately and runs the upstream daemon call in the background. Raw-bytes paths (octet-stream / multipart for docker teleport and local .vbundle restore) keep their synchronous proxy behavior unchanged.
- Added \`GET /v1/migrations/import/{jobId}/status\` at the gateway, backed by an in-memory job map. Response shape matches the platform API's async-import status endpoint so \`PlatformMigrationClient.pollImportStatus\` works against either surface. Finished jobs are pruned 30 minutes after reaching a terminal state.
- Gateway → daemon hop stays synchronous — the background task holds that request open for the full import duration and records the outcome for the caller to poll. OpenAPI schema updated.

## Original prompt

this should respond with a 200 immediatly to the external caller. The call between the gateway and assistant can be syncronous but not the call to the gateway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
