### PR TITLE
fix(meet-join): emit lifecycle:joined at admission, not after consent post

### DIFF
--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -389,6 +389,14 @@ function publishLifecycle(
     state,
     ...(detail !== undefined ? { detail } : {}),
   };
+  // Log before enqueue so the silent-success path is visible when
+  // debugging join-flow stalls — without this line the only evidence a
+  // lifecycle event even ran through this function was in the daemon
+  // logs, which made it impossible to tell locally whether the extension
+  // ever reached `joined` after an earlier diagnostic.
+  deps.logInfo(
+    `meet-bot: forwarding lifecycle:${state} to daemon${detail ? ` (${detail})` : ""}`,
+  );
   client.enqueue(event);
 }
 

--- a/skills/meet-join/meet-controller-ext/src/__tests__/join.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/join.test.ts
@@ -859,6 +859,108 @@ describe("runJoinFlow (content-script port)", () => {
     expect(diag).toBeDefined();
   });
 
+  test("fires onAdmitted after admission but before consent post", async () => {
+    const { doc } = loadPrejoinDom();
+    removeMediaModal(doc);
+    insertPostAdmissionToolbar(doc);
+    insertChatSurface(doc);
+    const restore = installGlobalDoc(doc);
+
+    // Capture events and the onAdmitted call in the same ordered stream so
+    // the assertion can pin down "admitted precedes any consent-post DOM
+    // activity" — the whole point of this callback.
+    const timeline: Array<{ kind: "event" | "admitted"; data?: unknown }> = [];
+    try {
+      await runJoinFlow({
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        displayName: "Vellum Bot",
+        consentMessage: "Hi, Vellum is listening.",
+        meetingId: "mtg-admitted",
+        onEvent: (e) => timeline.push({ kind: "event", data: e }),
+        onAdmitted: () => timeline.push({ kind: "admitted" }),
+        doc,
+      });
+    } finally {
+      restore();
+    }
+
+    // onAdmitted fired exactly once.
+    const admittedEntries = timeline.filter((e) => e.kind === "admitted");
+    expect(admittedEntries.length).toBe(1);
+
+    // Consent-post emits a `trusted_type` message containing the consent
+    // text. onAdmitted must land before that so the daemon can publish
+    // `meet.joined` without waiting on chat-composer DOM.
+    const admittedIdx = timeline.findIndex((e) => e.kind === "admitted");
+    const trustedTypeIdx = timeline.findIndex(
+      (e) =>
+        e.kind === "event" &&
+        typeof e.data === "object" &&
+        e.data !== null &&
+        (e.data as { type?: string }).type === "trusted_type",
+    );
+    expect(admittedIdx).toBeGreaterThan(-1);
+    if (trustedTypeIdx !== -1) {
+      expect(admittedIdx).toBeLessThan(trustedTypeIdx);
+    }
+  });
+
+  test("fires onAdmitted even when the consent post fails", async () => {
+    const { doc } = loadPrejoinDom();
+    removeMediaModal(doc);
+    insertPostAdmissionToolbar(doc);
+    // Message list present so ensurePanelOpen short-circuits; no composer
+    // so sendChat throws "chat input not found" — the production failure
+    // mode we are trying to de-couple from the join signal.
+    const list = doc.createElement("div");
+    list.setAttribute("role", "list");
+    list.setAttribute("aria-label", "Chat messages");
+    doc.body.appendChild(list);
+    const restore = installGlobalDoc(doc);
+
+    let admittedCalls = 0;
+    try {
+      await runJoinFlow({
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        displayName: "Vellum Bot",
+        consentMessage: "Hi, Vellum is listening.",
+        meetingId: "mtg-admitted-consent-fail",
+        onEvent: () => {},
+        onAdmitted: () => {
+          admittedCalls += 1;
+        },
+        doc,
+      });
+    } finally {
+      restore();
+    }
+
+    expect(admittedCalls).toBe(1);
+  });
+
+  test("does NOT fire onAdmitted when admission times out", async () => {
+    const { doc } = loadPrejoinDom();
+    removeMediaModal(doc);
+    // No post-admission toolbar — step 5 times out.
+
+    let admittedCalls = 0;
+    await expect(
+      runJoinFlow({
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        displayName: "Vellum Bot",
+        consentMessage: "Hi, Vellum is listening.",
+        meetingId: "mtg-admit-timeout",
+        onEvent: () => {},
+        onAdmitted: () => {
+          admittedCalls += 1;
+        },
+        doc,
+      }),
+    ).rejects.toThrow(/in-meeting UI did not appear/i);
+
+    expect(admittedCalls).toBe(0);
+  });
+
   test("resolves step 5 against the committed ingame fixture", async () => {
     // Load the prejoin fixture (for steps 1-4), then splice in the committed
     // ingame fixture's body contents so `INGAME_READY_INDICATOR` (the mic

--- a/skills/meet-join/meet-controller-ext/src/content.ts
+++ b/skills/meet-join/meet-controller-ext/src/content.ts
@@ -325,6 +325,24 @@ async function handleJoin(
     console.warn("[meet-ext] lifecycle(joining) send failed:", err);
   }
 
+  // Tracks whether `onAdmitted` fired. Used to (a) suppress a duplicate
+  // post-await `joined` emit in the happy path and (b) guard the error
+  // catch from emitting `lifecycle:error` once we've already told the
+  // daemon we joined — a late reject from the best-effort consent post
+  // must not walk back the admission signal.
+  let admitted = false;
+  const finalizeAdmission = (): void => {
+    if (generation !== joinGeneration) return;
+    if (admitted) return;
+    admitted = true;
+    activeSession = startMeetingSession({ meetingId, displayName });
+    try {
+      chrome.runtime.sendMessage(lifecycleMessage("joined", meetingId));
+    } catch (err) {
+      console.warn("[meet-ext] lifecycle(joined) send failed:", err);
+    }
+  };
+
   try {
     await runJoinFlow({
       meetingUrl,
@@ -338,6 +356,7 @@ async function handleJoin(
           console.warn("[meet-ext] runJoinFlow event send failed:", err);
         }
       },
+      onAdmitted: finalizeAdmission,
     });
   } catch (err) {
     // A newer leave/join has already bumped the generation and
@@ -345,6 +364,15 @@ async function handleJoin(
     // confusing the daemon with a late `error` for an invocation it
     // no longer cares about.
     if (generation !== joinGeneration) return;
+    // If admission already fired, the daemon is in `joined`. Any late
+    // throw here comes from a post-admission step (currently only step 6
+    // catches internally, but a future addition might not) — downgrade
+    // to a diagnostic rather than emitting `error` and walking the
+    // lifecycle back.
+    if (admitted) {
+      console.warn("[meet-ext] post-admission runJoinFlow threw:", err);
+      return;
+    }
     const detail =
       err instanceof Error ? err.message : String(err ?? "unknown error");
     try {
@@ -355,19 +383,9 @@ async function handleJoin(
     return;
   }
 
-  // If a leave or newer join landed while runJoinFlow was awaiting,
-  // the daemon no longer expects us to install scrapers for this
-  // meeting. Bailing out here avoids both (a) resurrecting a session
-  // after `leave` and (b) clobbering the session that a newer `join`
-  // installed.
-  if (generation !== joinGeneration) return;
-
-  // Join succeeded — install per-meeting scrapers and emit "joined".
-  activeSession = startMeetingSession({ meetingId, displayName });
-  try {
-    chrome.runtime.sendMessage(lifecycleMessage("joined", meetingId));
-  } catch (err) {
-    console.warn("[meet-ext] lifecycle(joined) send failed:", err);
-  }
+  // Defense-in-depth: if runJoinFlow resolved without firing `onAdmitted`,
+  // that's an invariant violation in the flow — install the session and
+  // emit `joined` here so the daemon isn't left hanging.
+  finalizeAdmission();
 }
 

--- a/skills/meet-join/meet-controller-ext/src/features/join.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/join.ts
@@ -95,6 +95,19 @@ export interface RunJoinFlowOptions {
     outerHeight: number;
     innerHeight: number;
   };
+  /**
+   * Fired synchronously the moment the bot is admitted to the meeting
+   * (step 5 succeeds — `INGAME_READY_INDICATOR` is mounted) and BEFORE the
+   * best-effort consent post runs.
+   *
+   * Callers emit `lifecycle:joined` from here so the daemon sees the join
+   * complete independently of the secondary consent / scraper-install
+   * work that follows. Chat-DOM drift in step 6 must not gate the
+   * "joined" signal — the bot is already in the meeting at this point,
+   * and tearing it back out over a missing greeting would be strictly
+   * worse than letting the consent post fail as a diagnostic.
+   */
+  onAdmitted?: () => void;
 }
 
 /**
@@ -322,6 +335,12 @@ export async function runJoinFlow(opts: RunJoinFlowOptions): Promise<void> {
       `meet-ext: in-meeting UI did not appear within ${MEETING_ROOM_TIMEOUT_MS}ms (host may not have admitted the bot): ${msg}`,
     );
   }
+
+  // Bot is in the meeting. Fire the admitted hook before step 6 so the
+  // caller can publish `lifecycle:joined` before the best-effort consent
+  // post runs — chat-DOM drift there must not delay or block the join
+  // completion signal reaching the daemon.
+  opts.onAdmitted?.();
 
   // Step 6 — post the consent notice in chat. Best effort: the bot is
   // already admitted at this point, so a chat-post failure should surface as


### PR DESCRIPTION
## Summary

- Move the `lifecycle:joined` emit to the moment the bot is admitted to the meeting, decoupling it from the best-effort consent post. Chat-DOM drift in step 6 was silently preventing the join signal from ever reaching the daemon, producing a 120s timeout even though Velissa was visible as a participant in the Meet.
- Downgrade post-admission throws from `runJoinFlow` to a diagnostic so a late consent-post failure can't walk the lifecycle back from `joined` to `error`.
- Add a `publishLifecycle` log line so silent-success forwards are visible locally; the prior debugging session was hamstrung by the fact that a dropped lifecycle event looked identical to one that never fired.

Follow-up (separate PR): the chat composer selector in `dom/selectors.ts:127` needs to be refreshed for Meet's "Continuous chat is turned off" mode. This PR unblocks `meet_join` while that remains outstanding — consent post continues to fail as a non-fatal diagnostic.

## Original prompt

it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
