### PR TITLE
feat(providers): add Kimi K2.6 on OpenRouter

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -482,6 +482,17 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       },
       // Moonshot
       {
+        id: "moonshotai/kimi-k2.6",
+        displayName: "Kimi K2.6",
+        contextWindowTokens: 262144,
+        maxOutputTokens: 32768,
+        supportsThinking: true,
+        supportsCaching: false,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: { inputPer1mTokens: 0.6, outputPer1mTokens: 2.8 },
+      },
+      {
         id: "moonshotai/kimi-k2.5",
         displayName: "Kimi K2.5",
         contextWindowTokens: 256000,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -471,6 +471,20 @@
           }
         },
         {
+          "id": "moonshotai/kimi-k2.6",
+          "displayName": "Kimi K2.6",
+          "contextWindowTokens": 262144,
+          "maxOutputTokens": 32768,
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.6,
+            "outputPer1mTokens": 2.8
+          }
+        },
+        {
           "id": "moonshotai/kimi-k2.5",
           "displayName": "Kimi K2.5",
           "contextWindowTokens": 256000,


### PR DESCRIPTION
## Summary
- Adds `moonshotai/kimi-k2.6` to the OpenRouter provider catalog, listed above K2.5 (newer-first ordering).
- Sets capabilities per the [OpenRouter page](https://openrouter.ai/moonshotai/kimi-k2.6): 262,144-token context, reasoning-enabled, multimodal (vision), tool use; pricing $0.60 / $2.80 per 1M input/output tokens.
- Mirrors the entry in `meta/llm-provider-catalog.json` to satisfy the daemon-vs-client parity guard.

## Original prompt
Add Kimi K2.6 on OpenRouter: https://openrouter.ai/moonshotai/kimi-k2.6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
