### PR TITLE
fix(migrations): prevent 'database disk image is malformed' after teleport

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -409,6 +409,26 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
       dataToWrite = new TextEncoder().encode(sanitized);
     }
 
+    // If we're about to replace a SQLite main database file, remove any
+    // pre-existing `.db-wal`/`.db-shm`/`.db-journal` siblings at the
+    // target. Those auxiliary files are only valid as a pair with the
+    // exact `.db` that wrote them; leaving them alongside a replacement
+    // DB causes SQLite to replay incompatible WAL frames on the first
+    // open and report "database disk image is malformed". The exporter
+    // already checkpointed the source WAL into the main DB before the
+    // bundle was built, so dropping the sibling aux files doesn't lose
+    // data from the source workspace.
+    if (diskPath.endsWith(".db")) {
+      for (const suffix of [".db-wal", ".db-shm", ".db-journal"]) {
+        const auxPath = `${diskPath.slice(0, -".db".length)}${suffix}`;
+        try {
+          rmSync(auxPath, { force: true });
+        } catch {
+          /* best effort — if the aux file doesn't exist we're fine */
+        }
+      }
+    }
+
     // Write the file
     try {
       writeFileSync(diskPath, dataToWrite);

--- a/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
@@ -1143,6 +1143,21 @@ async function promoteLegacyStagedFiles(
 
     await mkdir(dirname(entry.livePath), { recursive: true });
 
+    // If we're replacing a SQLite main database file, remove any sibling
+    // `.db-wal`/`.db-shm`/`.db-journal` from live first. Those
+    // auxiliary files are only valid with the exact `.db` that wrote
+    // them — leaving them alongside the replacement DB causes SQLite to
+    // replay incompatible WAL frames on the first open and report
+    // "database disk image is malformed".
+    if (entry.livePath.endsWith(".db")) {
+      for (const suffix of [".db-wal", ".db-shm", ".db-journal"]) {
+        const auxPath = `${entry.livePath.slice(0, -".db".length)}${suffix}`;
+        await rm(auxPath, { force: true }).catch(() => {
+          /* best effort */
+        });
+      }
+    }
+
     try {
       await rename(entry.tempPath, entry.livePath);
     } catch (err) {
@@ -1286,8 +1301,53 @@ async function planMergeLiveIntoTempDir(
     }
 
     if (existsInTemp) continue;
+
+    // SQLite auxiliary files (WAL / SHM / journal) are only valid as a
+    // pair with the exact `.db` they were written by. If the bundle
+    // replaced the sibling `.db` in this dir, carrying the live `.db-wal`
+    // forward pairs stale WAL frames with a different DB and SQLite
+    // reports "database disk image is malformed" on first open. Drop
+    // them — SQLite recreates a fresh WAL lazily on next connection,
+    // and the export already checkpointed the source WAL into the main
+    // DB before the bundle was built.
+    //
+    // When the bundle does NOT carry a replacement DB (bundle is
+    // config-only etc.), the live `.db` is preserved and the live WAL
+    // stays paired with it.
+    if (
+      isSqliteAuxiliaryFile(entry.name) &&
+      hasSiblingDbInTemp(tempDir, entry.name)
+    ) {
+      continue;
+    }
+
     plan.push({ liveChild, tempChild });
   }
+}
+
+/**
+ * SQLite writes `<name>.db-wal`, `<name>.db-shm`, `<name>.db-journal`
+ * alongside its main `<name>.db` file. These are only consistent with
+ * the exact `.db` they were created for.
+ */
+function isSqliteAuxiliaryFile(name: string): boolean {
+  return (
+    name.endsWith(".db-wal") ||
+    name.endsWith(".db-shm") ||
+    name.endsWith(".db-journal")
+  );
+}
+
+/**
+ * Does the temp dir contain the main `.db` file that owns this auxiliary
+ * file? Given e.g. `assistant.db-wal`, checks for `tempDir/assistant.db`.
+ */
+function hasSiblingDbInTemp(tempDir: string, auxName: string): boolean {
+  const dbName = auxName
+    .replace(/\.db-wal$/, ".db")
+    .replace(/\.db-shm$/, ".db")
+    .replace(/\.db-journal$/, ".db");
+  return existsSync(join(tempDir, dbName));
 }
 
 /**


### PR DESCRIPTION
## Summary

- After teleport, messaging the new assistant surfaced `SqliteError: database disk image is malformed`. Root cause: the bundle's new `data/db/assistant.db` landed alongside the target's OLD `assistant.db-wal` / `assistant.db-shm` (preserved by carry-over / selective-clear because `data/db` is in `WORKSPACE_PRESERVE_PATHS`). SQLite opens the new DB, replays WAL frames that reference pages from a different DB, and reports corruption.
- Streaming importer: `planMergeLiveIntoTempDir` now skips `.db-wal` / `.db-shm` / `.db-journal` files from carry-over when the matching `.db` is already in the temp workspace (i.e., the bundle replaced the DB). When the bundle doesn't carry a DB file, live's WAL still carries over paired with the live DB.
- Buffer-based `commitImport` + streaming legacy-in-place promotion: before writing any `*.db` from the bundle, remove any sibling `.db-wal` / `.db-shm` / `.db-journal` at the target. The exporter checkpoints the source WAL into the main DB before bundling, so dropping these aux files doesn't lose data from the source workspace.

## Original prompt

After teleport and messaging the new assistant I am seeing: database disk image is malformed. Are you sure you are copying only what is needed?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
