### PR TITLE
fix(migrations): preserve target vellum:* metadata entries across import

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-metadata-merge-integration.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-metadata-merge-integration.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Integration tests confirming both importers preserve the target's
+ * `vellum:*` credential metadata entries across a bundle import.
+ *
+ * Covers:
+ * - Buffer-based `commitImport`: target has all 4 vellum entries, bundle
+ *   carries non-vellum user entries → target retains its vellum entries
+ *   and gains the bundle's user entries.
+ * - Streaming `streamCommitImport`: same scenario via the atomic-swap
+ *   path.
+ * - Bundle with rogue vellum entries → filtered out on both paths.
+ * - Bundle without a metadata.json entry → target's preserved entries are
+ *   restored on the buffer path.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { buildVBundle } from "../vbundle-builder.js";
+import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
+import { commitImport } from "../vbundle-importer.js";
+import { streamCommitImport } from "../vbundle-streaming-importer.js";
+
+// ---------------------------------------------------------------------------
+// Metadata helpers
+// ---------------------------------------------------------------------------
+
+interface Record {
+  credentialId: string;
+  service: string;
+  field: string;
+  allowedTools: string[];
+  allowedDomains: string[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+const VELLUM_FIELDS = [
+  "platform_base_url",
+  "assistant_api_key",
+  "platform_assistant_id",
+  "webhook_secret",
+] as const;
+
+function record(service: string, field: string, prefix = "id"): Record {
+  const now = Date.now();
+  return {
+    credentialId: `${prefix}-${service}-${field}`,
+    service,
+    field,
+    allowedTools: [],
+    allowedDomains: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function metadataJson(records: Record[]): string {
+  return JSON.stringify({ version: 5, credentials: records });
+}
+
+function vellumRecords(prefix = "target"): Record[] {
+  return VELLUM_FIELDS.map((field) => record("vellum", field, prefix));
+}
+
+function readMetadata(path: string): { credentials: Record[] } {
+  const raw = readFileSync(path, "utf-8");
+  return JSON.parse(raw) as { credentials: Record[] };
+}
+
+function keys(records: Record[]): Set<string> {
+  return new Set(records.map((r) => `${r.service}:${r.field}`));
+}
+
+function encode(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function readableFrom(buf: Uint8Array): Readable {
+  return Readable.from([Buffer.from(buf)]);
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function freshWorkspace(): string {
+  const parent = realpathSync(
+    mkdtempSync(join(tmpdir(), "vbundle-metadata-merge-")),
+  );
+  return join(parent, "workspace");
+}
+
+function seedTargetMetadata(workspaceDir: string, records: Record[]): string {
+  const dir = join(workspaceDir, "data", "credentials");
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "metadata.json");
+  writeFileSync(path, metadataJson(records));
+  return path;
+}
+
+// ---------------------------------------------------------------------------
+// Buffer-based `commitImport` integration
+// ---------------------------------------------------------------------------
+
+describe("commitImport — credential metadata merge", () => {
+  let workspaceDir: string;
+  beforeEach(() => {
+    workspaceDir = freshWorkspace();
+    mkdirSync(workspaceDir, { recursive: true });
+  });
+  afterEach(() => {
+    const parent = join(workspaceDir, "..");
+    try {
+      rmSync(parent, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  test("target vellum:* entries survive; bundle user entries land", () => {
+    const metadataPath = seedTargetMetadata(workspaceDir, vellumRecords());
+
+    const bundleMetadata = metadataJson([
+      record("telegram", "bot_token", "source"),
+      record("slack_channel", "app_token", "source"),
+    ]);
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "workspace/data/credentials/metadata.json",
+          data: encode(bundleMetadata),
+        },
+        // Include at least one other workspace entry so Step 1b fires.
+        { path: "workspace/noop.txt", data: encode("noop") },
+      ],
+    });
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(true);
+    const merged = readMetadata(metadataPath);
+    const mergedKeys = keys(merged.credentials);
+    for (const field of VELLUM_FIELDS) {
+      expect(mergedKeys.has(`vellum:${field}`)).toBe(true);
+    }
+    expect(mergedKeys.has("telegram:bot_token")).toBe(true);
+    expect(mergedKeys.has("slack_channel:app_token")).toBe(true);
+
+    // Preserved vellum entries must carry target's credentialIds.
+    for (const r of merged.credentials) {
+      if (r.service === "vellum") {
+        expect(r.credentialId.startsWith("target-")).toBe(true);
+      }
+    }
+  });
+
+  test("rogue vellum entries in the bundle are dropped", () => {
+    const metadataPath = seedTargetMetadata(workspaceDir, vellumRecords());
+    const bundleMetadata = metadataJson([
+      record("vellum", "assistant_api_key", "source-rogue"),
+      record("vellum", "platform_base_url", "source-rogue"),
+      record("telegram", "bot_token", "source"),
+    ]);
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "workspace/data/credentials/metadata.json",
+          data: encode(bundleMetadata),
+        },
+        { path: "workspace/noop.txt", data: encode("noop") },
+      ],
+    });
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+    expect(result.ok).toBe(true);
+
+    const merged = readMetadata(metadataPath);
+    const vellum = merged.credentials.filter((r) => r.service === "vellum");
+    expect(vellum.length).toBe(4);
+    for (const r of vellum) {
+      expect(r.credentialId.startsWith("target-")).toBe(true);
+    }
+    expect(keys(merged.credentials).has("telegram:bot_token")).toBe(true);
+  });
+
+  test("bundle without metadata.json still leaves target's vellum entries on disk", () => {
+    const metadataPath = seedTargetMetadata(workspaceDir, vellumRecords());
+
+    const { archive } = buildVBundle({
+      files: [{ path: "workspace/noop.txt", data: encode("noop") }],
+    });
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+    expect(result.ok).toBe(true);
+
+    expect(existsSync(metadataPath)).toBe(true);
+    const merged = readMetadata(metadataPath);
+    const mergedKeys = keys(merged.credentials);
+    for (const field of VELLUM_FIELDS) {
+      expect(mergedKeys.has(`vellum:${field}`)).toBe(true);
+    }
+  });
+
+  test("target without existing metadata.json → bundle's file lands verbatim", () => {
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "workspace/data/credentials/metadata.json",
+          data: encode(
+            metadataJson([record("telegram", "bot_token", "source")]),
+          ),
+        },
+        { path: "workspace/noop.txt", data: encode("noop") },
+      ],
+    });
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+    expect(result.ok).toBe(true);
+
+    const merged = readMetadata(
+      join(workspaceDir, "data", "credentials", "metadata.json"),
+    );
+    expect(keys(merged.credentials)).toEqual(new Set(["telegram:bot_token"]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streaming importer integration
+// ---------------------------------------------------------------------------
+
+describe("streamCommitImport — credential metadata merge", () => {
+  let workspaceDir: string;
+  beforeEach(() => {
+    workspaceDir = freshWorkspace();
+    mkdirSync(workspaceDir, { recursive: true });
+  });
+  afterEach(() => {
+    const parent = join(workspaceDir, "..");
+    try {
+      rmSync(parent, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  test("target vellum:* entries survive atomic swap; bundle user entries land", async () => {
+    const metadataPath = seedTargetMetadata(workspaceDir, vellumRecords());
+
+    const bundleMetadata = metadataJson([
+      record("telegram", "bot_token", "source"),
+    ]);
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "workspace/data/credentials/metadata.json",
+          data: encode(bundleMetadata),
+        },
+        { path: "workspace/noop.txt", data: encode("noop") },
+      ],
+    });
+
+    const result = await streamCommitImport({
+      source: readableFrom(archive),
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(true);
+
+    const merged = readMetadata(metadataPath);
+    const mergedKeys = keys(merged.credentials);
+    for (const field of VELLUM_FIELDS) {
+      expect(mergedKeys.has(`vellum:${field}`)).toBe(true);
+    }
+    expect(mergedKeys.has("telegram:bot_token")).toBe(true);
+    for (const r of merged.credentials) {
+      if (r.service === "vellum") {
+        expect(r.credentialId.startsWith("target-")).toBe(true);
+      }
+    }
+  });
+
+  test("rogue vellum entries in bundle are dropped on streaming path", async () => {
+    const metadataPath = seedTargetMetadata(workspaceDir, vellumRecords());
+    const bundleMetadata = metadataJson([
+      record("vellum", "assistant_api_key", "source-rogue"),
+      record("telegram", "bot_token", "source"),
+    ]);
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "workspace/data/credentials/metadata.json",
+          data: encode(bundleMetadata),
+        },
+        { path: "workspace/noop.txt", data: encode("noop") },
+      ],
+    });
+
+    const result = await streamCommitImport({
+      source: readableFrom(archive),
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+    expect(result.ok).toBe(true);
+
+    const merged = readMetadata(metadataPath);
+    for (const r of merged.credentials) {
+      if (r.service === "vellum") {
+        expect(r.credentialId.startsWith("target-")).toBe(true);
+      }
+    }
+    expect(keys(merged.credentials).has("telegram:bot_token")).toBe(true);
+  });
+
+  test("bundle without metadata.json keeps target's vellum entries after swap", async () => {
+    const metadataPath = seedTargetMetadata(workspaceDir, vellumRecords());
+
+    const { archive } = buildVBundle({
+      files: [{ path: "workspace/noop.txt", data: encode("noop") }],
+    });
+
+    const result = await streamCommitImport({
+      source: readableFrom(archive),
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+    expect(result.ok).toBe(true);
+
+    expect(existsSync(metadataPath)).toBe(true);
+    const merged = readMetadata(metadataPath);
+    const mergedKeys = keys(merged.credentials);
+    for (const field of VELLUM_FIELDS) {
+      expect(mergedKeys.has(`vellum:${field}`)).toBe(true);
+    }
+  });
+
+  test("target with no metadata.json → bundle's file lands on disk verbatim", async () => {
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "workspace/data/credentials/metadata.json",
+          data: encode(
+            metadataJson([record("telegram", "bot_token", "source")]),
+          ),
+        },
+        { path: "workspace/noop.txt", data: encode("noop") },
+      ],
+    });
+
+    const result = await streamCommitImport({
+      source: readableFrom(archive),
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+    expect(result.ok).toBe(true);
+
+    const merged = readMetadata(
+      join(workspaceDir, "data", "credentials", "metadata.json"),
+    );
+    expect(keys(merged.credentials)).toEqual(new Set(["telegram:bot_token"]));
+  });
+});

--- a/assistant/src/runtime/migrations/__tests__/vbundle-metadata-merge.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-metadata-merge.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for the credential metadata merge helper used by the bundle
+ * importers. Covers the behaviour the two importers rely on:
+ *
+ * - Bundle without vellum + target with vellum → target's vellum entries
+ *   survive and the bundle's non-vellum entries are kept.
+ * - Bundle with mixed user services → non-vellum entries import, any
+ *   rogue vellum entries in the bundle are dropped.
+ * - Live metadata empty / missing → bundle lands as-is.
+ * - Malformed inputs → no corruption (bundle returned verbatim).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { mergeMetadataPreservingVellum } from "../vbundle-metadata-merge.js";
+
+interface Record {
+  credentialId: string;
+  service: string;
+  field: string;
+  allowedTools: string[];
+  allowedDomains: string[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+function record(
+  overrides: Partial<Record> & Pick<Record, "service" | "field">,
+): Record {
+  const now = Date.now();
+  return {
+    credentialId: `id-${overrides.service}-${overrides.field}`,
+    allowedTools: [],
+    allowedDomains: [],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function file(records: Record[], version = 5): string {
+  return JSON.stringify({ version, credentials: records });
+}
+
+function parse(json: string): { version?: number; credentials: Record[] } {
+  const parsed = JSON.parse(json);
+  return {
+    version: parsed.version,
+    credentials: (parsed.credentials ?? []) as Record[],
+  };
+}
+
+function asKey(r: Record): string {
+  return `${r.service}:${r.field}`;
+}
+
+function keys(records: Record[]): Set<string> {
+  return new Set(records.map(asKey));
+}
+
+const VELLUM_FIELDS = [
+  "platform_base_url",
+  "assistant_api_key",
+  "platform_assistant_id",
+  "webhook_secret",
+] as const;
+
+function vellumRecords(): Record[] {
+  return VELLUM_FIELDS.map((field) =>
+    record({ service: "vellum", field, credentialId: `target-${field}` }),
+  );
+}
+
+describe("mergeMetadataPreservingVellum", () => {
+  test("preserves all four target vellum:* entries when bundle has none", () => {
+    const target = vellumRecords();
+    const bundle = [
+      record({ service: "telegram", field: "bot_token" }),
+      record({ service: "slack_channel", field: "app_token" }),
+    ];
+
+    const merged = parse(
+      mergeMetadataPreservingVellum(file(bundle), file(target)),
+    );
+
+    const mergedKeys = keys(merged.credentials);
+    for (const field of VELLUM_FIELDS) {
+      expect(mergedKeys.has(`vellum:${field}`)).toBe(true);
+    }
+    expect(mergedKeys.has("telegram:bot_token")).toBe(true);
+    expect(mergedKeys.has("slack_channel:app_token")).toBe(true);
+  });
+
+  test("bundle non-vellum entries still import alongside preserved vellum entries", () => {
+    const target = vellumRecords();
+    const bundle = [
+      record({ service: "telegram", field: "bot_token" }),
+      record({ service: "telegram", field: "webhook_secret" }),
+      record({ service: "google", field: "access_token" }),
+    ];
+
+    const merged = parse(
+      mergeMetadataPreservingVellum(file(bundle), file(target)),
+    );
+
+    // 4 vellum + 3 user = 7 total.
+    expect(merged.credentials.length).toBe(7);
+    expect(keys(merged.credentials).size).toBe(7);
+
+    // Target's credentialIds for vellum are preserved (not the bundle's).
+    for (const r of merged.credentials) {
+      if (r.service === "vellum") {
+        expect(r.credentialId.startsWith("target-")).toBe(true);
+      }
+    }
+  });
+
+  test("drops bundle vellum:* entries and preserves target's identity", () => {
+    const target = vellumRecords();
+    // Bundle carries conflicting vellum entries — should be dropped even
+    // though the source would normally be filtered before this helper is
+    // called.
+    const bundle = [
+      record({
+        service: "vellum",
+        field: "assistant_api_key",
+        credentialId: "source-rogue",
+      }),
+      record({
+        service: "vellum",
+        field: "platform_base_url",
+        credentialId: "source-rogue-url",
+      }),
+      record({ service: "telegram", field: "bot_token" }),
+    ];
+
+    const merged = parse(
+      mergeMetadataPreservingVellum(file(bundle), file(target)),
+    );
+
+    const vellumRecordsOut = merged.credentials.filter(
+      (r) => r.service === "vellum",
+    );
+    expect(vellumRecordsOut.length).toBe(4);
+    for (const r of vellumRecordsOut) {
+      expect(r.credentialId.startsWith("target-")).toBe(true);
+    }
+    // Telegram entry still imports.
+    expect(
+      merged.credentials.some(
+        (r) => r.service === "telegram" && r.field === "bot_token",
+      ),
+    ).toBe(true);
+  });
+
+  test("no live metadata → bundle passes through unchanged (no vellum in bundle)", () => {
+    const bundle = [
+      record({ service: "telegram", field: "bot_token" }),
+      record({ service: "slack_channel", field: "app_token" }),
+    ];
+    const merged = parse(mergeMetadataPreservingVellum(file(bundle), null));
+    expect(keys(merged.credentials)).toEqual(
+      new Set(["telegram:bot_token", "slack_channel:app_token"]),
+    );
+  });
+
+  test("no live metadata still strips bundle vellum:* entries", () => {
+    const bundle = [
+      record({ service: "vellum", field: "assistant_api_key" }),
+      record({ service: "telegram", field: "bot_token" }),
+    ];
+    const merged = parse(mergeMetadataPreservingVellum(file(bundle), null));
+    // Bundle's vellum entry is always filtered.
+    expect(merged.credentials.length).toBe(1);
+    expect(merged.credentials[0]?.service).toBe("telegram");
+  });
+
+  test("preserves bundle version field verbatim", () => {
+    const bundle = file([record({ service: "telegram", field: "bot_token" })]);
+    const merged = JSON.parse(
+      mergeMetadataPreservingVellum(bundle, file(vellumRecords())),
+    );
+    expect(merged.version).toBe(5);
+  });
+
+  test("malformed bundle JSON → returned unchanged (never corrupt the file)", () => {
+    const bad = "{not valid json";
+    const live = file(vellumRecords());
+    const result = mergeMetadataPreservingVellum(bad, live);
+    expect(result).toBe(bad);
+  });
+
+  test("malformed live JSON → bundle returned as merged output without preservation", () => {
+    const bundle = file([record({ service: "telegram", field: "bot_token" })]);
+    const merged = parse(mergeMetadataPreservingVellum(bundle, "{bad"));
+    expect(keys(merged.credentials)).toEqual(new Set(["telegram:bot_token"]));
+  });
+
+  test("live metadata with extra non-vellum entries does NOT smuggle them in", () => {
+    const live = file([
+      ...vellumRecords(),
+      record({ service: "telegram", field: "bot_token" }),
+      record({ service: "notion", field: "api_key" }),
+    ]);
+    const bundle = file([
+      record({ service: "slack_channel", field: "app_token" }),
+    ]);
+
+    const merged = parse(mergeMetadataPreservingVellum(bundle, live));
+
+    // Only bundle's non-vellum + target's vellum. Target's user entries
+    // must NOT carry over (they belong to source-style flows, handled by
+    // the bundle).
+    expect(keys(merged.credentials).has("slack_channel:app_token")).toBe(true);
+    expect(keys(merged.credentials).has("telegram:bot_token")).toBe(false);
+    expect(keys(merged.credentials).has("notion:api_key")).toBe(false);
+    for (const field of VELLUM_FIELDS) {
+      expect(keys(merged.credentials).has(`vellum:${field}`)).toBe(true);
+    }
+  });
+});

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -28,6 +28,7 @@ import { sanitizeConfigForTransfer } from "../../config/sanitize-for-transfer.js
 import { isGuardianPersonaCustomized } from "../../prompts/persona-resolver.js";
 import { getLogger } from "../../util/logger.js";
 import type { PathResolver } from "./vbundle-import-analyzer.js";
+import { mergeMetadataPreservingVellum } from "./vbundle-metadata-merge.js";
 import type { ManifestType, VBundleTarEntry } from "./vbundle-validator.js";
 import { validateVBundle } from "./vbundle-validator.js";
 
@@ -45,6 +46,15 @@ export const CONFIG_ARCHIVE_PATHS: ReadonlySet<string> = new Set([
   "workspace/config.json",
   "config/settings.json",
 ]);
+
+/**
+ * Archive path for the credential metadata file. On import, bundle contents
+ * must be merged with the target's live `vellum:*` entries so the gateway's
+ * `readServiceCredentials` can still locate the platform API key after a
+ * local→platform teleport. Both importers consult this constant.
+ */
+export const CREDENTIAL_METADATA_ARCHIVE_PATH =
+  "workspace/data/credentials/metadata.json";
 
 /**
  * Paths inside the workspace directory that must be preserved across an
@@ -240,6 +250,29 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
     (f) => f.path.startsWith("workspace/") && !!pathResolver.resolve(f.path),
   );
 
+  // Capture the target's credential metadata BEFORE the workspace clear
+  // runs. Step 1b wipes `data/credentials/`, so reading live metadata
+  // later (during the per-file write loop) would always miss. The merge
+  // helper needs this content to preserve the target's platform-identity
+  // (`vellum:*`) entries across the overwrite.
+  let liveCredentialMetadataJson: string | null = null;
+  const credentialMetadataDiskPath = pathResolver.resolve(
+    CREDENTIAL_METADATA_ARCHIVE_PATH,
+  );
+  if (credentialMetadataDiskPath && existsSync(credentialMetadataDiskPath)) {
+    try {
+      liveCredentialMetadataJson = readFileSync(
+        credentialMetadataDiskPath,
+        "utf-8",
+      );
+    } catch (err) {
+      log.warn(
+        { err, path: credentialMetadataDiskPath },
+        "Failed to read live credential metadata before import; vellum:* entries may not be preserved",
+      );
+    }
+  }
+
   if (hasWorkspaceEntries && workspaceDir && existsSync(workspaceDir)) {
     try {
       // Clear workspace contents selectively, preserving skip dirs
@@ -409,6 +442,21 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
       dataToWrite = new TextEncoder().encode(sanitized);
     }
 
+    // Preserve target's `vellum:*` metadata entries across the overwrite.
+    // Django's post-hatch provisioning writes these on the target via
+    // POST /v1/secrets; a naive overwrite of the bundle's metadata.json
+    // would wipe them and break the gateway's vellum credential read.
+    // We use the snapshot captured BEFORE the workspace clear because
+    // Step 1b may have already removed the live file.
+    if (fileEntry.path === CREDENTIAL_METADATA_ARCHIVE_PATH) {
+      const bundleJson = new TextDecoder().decode(archiveEntry.data);
+      const merged = mergeMetadataPreservingVellum(
+        bundleJson,
+        liveCredentialMetadataJson,
+      );
+      dataToWrite = new TextEncoder().encode(merged);
+    }
+
     // Write the file
     try {
       writeFileSync(diskPath, dataToWrite);
@@ -456,6 +504,35 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
       sha256: expectedSha256,
       backup_path: backupPath,
     });
+  }
+
+  // If the bundle did not carry a metadata.json entry but the target had
+  // `vellum:*` entries before Step 1b cleared them, write a minimal
+  // metadata file with just those preserved entries so the gateway can
+  // still locate the platform API key.
+  const bundleHadMetadata = manifest.files.some(
+    (f) => f.path === CREDENTIAL_METADATA_ARCHIVE_PATH,
+  );
+  if (
+    hasWorkspaceEntries &&
+    !bundleHadMetadata &&
+    liveCredentialMetadataJson &&
+    credentialMetadataDiskPath
+  ) {
+    const merged = mergeMetadataPreservingVellum(
+      JSON.stringify({ version: 5, credentials: [] }),
+      liveCredentialMetadataJson,
+    );
+    try {
+      mkdirSync(dirname(credentialMetadataDiskPath), { recursive: true });
+      writeFileSync(credentialMetadataDiskPath, merged);
+    } catch (err) {
+      warnings.push(
+        `Failed to restore preserved vellum:* credential metadata: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
   }
 
   // Build final report

--- a/assistant/src/runtime/migrations/vbundle-metadata-merge.ts
+++ b/assistant/src/runtime/migrations/vbundle-metadata-merge.ts
@@ -1,0 +1,124 @@
+/**
+ * Merge helper for `data/credentials/metadata.json` on bundle import.
+ *
+ * The credential metadata file lists the credentials known to the assistant
+ * (service, field, policy, timestamps) and is used by the gateway's
+ * `readServiceCredentials` to decide whether a service is "configured".
+ * The VELLUM spec requires all four `vellum:*` fields (`platform_base_url`,
+ * `assistant_api_key`, `platform_assistant_id`, `webhook_secret`) to be
+ * present in metadata before the gateway will even look up their values in
+ * CES.
+ *
+ * On a local→platform teleport, the bundle carries the SOURCE's metadata
+ * (no `vellum:*` entries, since the source is local), and a naive overwrite
+ * would wipe out the `vellum:*` entries that Django's post-hatch
+ * provisioning just wrote on the TARGET. This module merges bundle and live
+ * metadata with one rule:
+ *
+ *   - Drop `service === "vellum"` entries the bundle tries to ship
+ *     (defense-in-depth — they represent the source's identity, not the
+ *     target's). This mirrors the CES-side filter in migration-routes.ts.
+ *   - Preserve every `service === "vellum"` entry the target already has.
+ *   - Import bundle entries for every other service normally (user OAuth,
+ *     channel credentials).
+ *
+ * Malformed input (missing file, unparseable JSON, unrecognized schema) is
+ * handled by the callers: they should treat "no live metadata" as no
+ * preservation needed, and leave the bundle's file untouched if its schema
+ * can't be merged cleanly.
+ */
+
+const VELLUM_SERVICE = "vellum";
+
+interface MetadataRecord {
+  credentialId: string;
+  service: string;
+  field: string;
+  [key: string]: unknown;
+}
+
+interface MetadataFile {
+  version?: number;
+  credentials?: unknown[];
+  [key: string]: unknown;
+}
+
+function isRecord(value: unknown): value is MetadataRecord {
+  if (typeof value !== "object" || value == null) return false;
+  const r = value as Record<string, unknown>;
+  return (
+    typeof r.credentialId === "string" &&
+    typeof r.service === "string" &&
+    typeof r.field === "string"
+  );
+}
+
+function parseMetadata(json: string | null | undefined): MetadataFile | null {
+  if (!json) return null;
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (typeof parsed !== "object" || parsed == null || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as MetadataFile;
+  } catch {
+    return null;
+  }
+}
+
+function extractVellumRecords(file: MetadataFile | null): MetadataRecord[] {
+  if (!file || !Array.isArray(file.credentials)) return [];
+  return file.credentials
+    .filter(isRecord)
+    .filter((r) => r.service === VELLUM_SERVICE);
+}
+
+/**
+ * Merge the bundle's metadata.json content with any `vellum:*` entries
+ * present in the target's live metadata.json.
+ *
+ * Returns the merged JSON string, preserving the bundle's schema version
+ * and formatting (2-space indent). If the bundle's JSON is unparseable the
+ * original input is returned unchanged — we never want to corrupt the
+ * bundle's file by emitting an empty or restructured payload.
+ *
+ * If the live JSON is unparseable or missing, the bundle's file is returned
+ * verbatim (no preservation possible — nothing to preserve).
+ */
+export function mergeMetadataPreservingVellum(
+  bundleJson: string,
+  liveJson: string | null,
+): string {
+  const bundle = parseMetadata(bundleJson);
+  if (!bundle) return bundleJson;
+
+  const preservedVellum = extractVellumRecords(parseMetadata(liveJson));
+
+  const bundleCredentials = Array.isArray(bundle.credentials)
+    ? bundle.credentials.filter(isRecord)
+    : [];
+
+  // Drop any `service === "vellum"` entries from the bundle (defense-in-depth).
+  const filteredBundle = bundleCredentials.filter(
+    (r) => r.service !== VELLUM_SERVICE,
+  );
+
+  // Union: bundle non-vellum entries + target vellum entries. If the
+  // preserved list happens to collide with a bundle entry on credentialId,
+  // the preserved version wins (it belongs to the target's live identity).
+  const merged = [...filteredBundle, ...preservedVellum];
+
+  const output: MetadataFile = {
+    ...bundle,
+    credentials: merged,
+  };
+
+  return JSON.stringify(output, null, 2);
+}
+
+/** @internal For direct use by tests. */
+export const _internal = {
+  VELLUM_SERVICE,
+  parseMetadata,
+  extractVellumRecords,
+};

--- a/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
@@ -63,6 +63,7 @@ import {
   LEGACY_USER_MD_ARCHIVE_PATH,
   WORKSPACE_PRESERVE_PATHS,
 } from "./vbundle-importer.js";
+import { mergeMetadataPreservingVellum } from "./vbundle-metadata-merge.js";
 import {
   createHashVerifier,
   readAndValidateManifest,
@@ -853,6 +854,48 @@ export async function streamCommitImport(
     log.warn({ err }, "resetDb threw before swap; continuing");
   }
 
+  // Preserve the target's `vellum:*` credential metadata entries across
+  // the swap. Django's post-hatch provisioning on the platform writes
+  // `vellum:platform_base_url` / `assistant_api_key` / `platform_assistant_id`
+  // / `webhook_secret` via POST /v1/secrets, which upserts into the live
+  // workspace's `data/credentials/metadata.json`. Without this merge the
+  // swap would replace that file with the source's copy (which has no
+  // vellum entries on local sources), and the gateway's
+  // `readServiceCredentials` would stop finding the platform API key.
+  //
+  // Executes in the temp workspace only — no effect on the live workspace
+  // — so a failure here leaves pre-swap state untouched. Any filesystem
+  // error is logged and degraded to a warning rather than aborting the
+  // import (credential loss is recoverable via reprovision; an aborted
+  // swap is a larger regression).
+  const liveMetadataPath = join(
+    realWorkspaceDir,
+    "data",
+    "credentials",
+    "metadata.json",
+  );
+  const tempMetadataPath = join(
+    tempWorkspaceDir,
+    "data",
+    "credentials",
+    "metadata.json",
+  );
+  try {
+    await mergeCredentialMetadataIntoTemp(
+      liveMetadataPath,
+      tempMetadataPath,
+      warnings,
+    );
+  } catch (err) {
+    log.warn(
+      { err, liveMetadataPath, tempMetadataPath },
+      "Credential metadata merge failed before swap",
+    );
+    warnings.push(
+      `Credential metadata merge failed: ${errMessage(err)}; vellum:* entries may not survive the import`,
+    );
+  }
+
   // Carry-over: for every path in WORKSPACE_PRESERVE_PATHS, if the bundle
   // did NOT populate it inside the temp workspace but the LIVE workspace
   // has it, move the live copy into the temp workspace at the same
@@ -1163,6 +1206,77 @@ async function promoteLegacyStagedFiles(
         report.action = "created";
       }
     }
+  }
+}
+
+/**
+ * Rewrite the temp workspace's `data/credentials/metadata.json` so the
+ * target's live `vellum:*` entries survive the swap. Exits silently if
+ * there is nothing to merge.
+ *
+ * Four cases:
+ *   - No live metadata, no temp metadata → no-op.
+ *   - Live metadata present, temp metadata missing → if the live metadata
+ *     contains vellum entries, synthesize a minimal v5 metadata file in
+ *     the temp tree containing only those preserved entries. If it has
+ *     none, no-op (no entries to preserve).
+ *   - Live metadata missing, temp metadata present → no-op (nothing to
+ *     preserve; the bundle's copy lands as-is).
+ *   - Both present → run the merge helper and rewrite the temp copy.
+ *
+ * Invoked under a try/catch by the caller; thrown errors surface as
+ * warnings but don't abort the import.
+ */
+async function mergeCredentialMetadataIntoTemp(
+  liveMetadataPath: string,
+  tempMetadataPath: string,
+  warnings: string[],
+): Promise<void> {
+  let liveJson: string | null = null;
+  try {
+    liveJson = await readFile(liveMetadataPath, "utf-8");
+  } catch (err) {
+    if (!isENOENT(err)) throw err;
+  }
+
+  let tempJson: string | null = null;
+  try {
+    tempJson = await readFile(tempMetadataPath, "utf-8");
+  } catch (err) {
+    if (!isENOENT(err)) throw err;
+  }
+
+  if (liveJson == null && tempJson == null) return;
+
+  if (tempJson != null) {
+    const merged = mergeMetadataPreservingVellum(tempJson, liveJson);
+    if (merged !== tempJson) {
+      await writeFile(tempMetadataPath, merged, { mode: 0o600 });
+    }
+    return;
+  }
+
+  // Live-only path: synthesize a v5 file with just the preserved vellum
+  // entries so the gateway can still locate them after the swap.
+  const synthesized = mergeMetadataPreservingVellum(
+    JSON.stringify({ version: 5, credentials: [] }),
+    liveJson,
+  );
+  const parsed = JSON.parse(synthesized) as {
+    credentials?: unknown[];
+  };
+  if (!parsed.credentials || parsed.credentials.length === 0) {
+    // Live file exists but had no vellum entries worth preserving.
+    return;
+  }
+
+  try {
+    await mkdir(dirname(tempMetadataPath), { recursive: true });
+    await writeFile(tempMetadataPath, synthesized, { mode: 0o600 });
+  } catch (err) {
+    warnings.push(
+      `Failed to write preserved vellum:* metadata into temp workspace: ${errMessage(err)}`,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- Bundle import was silently wiping the target's `vellum:*` metadata entries (platform_base_url, assistant_api_key, platform_assistant_id, webhook_secret). The CES values survived (filtered by `PLATFORM_CREDENTIAL_PREFIX` in migration-routes.ts) but the gateway's `readServiceCredentials` requires all four entries in `data/credentials/metadata.json` before it will look them up — so after teleport the platform API key appeared invalid.
- Merge `data/credentials/metadata.json` on import instead of overwriting: drop any `service === "vellum"` entries the bundle carries (defense-in-depth), preserve every `service === "vellum"` entry the target already has, and import bundle entries for every other service normally. Applied in both the buffer-based `commitImport` (captures live metadata before Step 1b wipes the workspace) and the streaming `streamCommitImport` (merges into the temp tree before the swap).
- New unit + integration tests cover: target-vellum + bundle-non-vellum preservation, rogue bundle vellum entries dropped, bundle-without-metadata fallback, malformed-input safety.

## Original prompt
Preserve target's `vellum:*` entries in `data/credentials/metadata.json` during bundle import.

**Problem**: When a local assistant is teleported to the platform, the target's freshly hatched `vellum:*` metadata entries (platform_base_url, assistant_api_key, platform_assistant_id, webhook_secret — written by Django's post-hatch provisioning via `POST /v1/secrets`, which calls `upsertCredentialMetadata` in `assistant/src/runtime/routes/secret-routes.ts`) get overwritten when the bundle import replaces `<workspaceDir>/data/credentials/metadata.json` with the source's copy. The CES values are preserved by the existing `PLATFORM_CREDENTIAL_PREFIX = "vellum:"` filter in `assistant/src/runtime/routes/migration-routes.ts:59`, but the gateway's `readServiceCredentials` in `gateway/src/credential-reader.ts:281-319` requires ALL 4 fields of `VELLUM_CREDENTIAL_SPEC` to be present in metadata.json before it will look up the values.

**Fix**: Merge metadata.json on import. Preserve target's `service === "vellum"` entries from the live metadata.json and re-apply them after the bundle's metadata.json lands. Drop any `service === "vellum"` entries the source tried to ship (mirroring the existing credential-value filter on the CES side). Non-vellum entries from the bundle still get imported normally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
