### PR TITLE
fix(migrations): gate vellum metadata restore on actual workspace clear

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -273,6 +273,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
     }
   }
 
+  let workspaceWasCleared = false;
   if (hasWorkspaceEntries && workspaceDir && existsSync(workspaceDir)) {
     try {
       // Clear workspace contents selectively, preserving skip dirs
@@ -296,6 +297,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
           rmSync(entryPath, { recursive: true, force: true });
         }
       }
+      workspaceWasCleared = true;
     } catch (err) {
       return {
         ok: false,
@@ -526,15 +528,19 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
     });
   }
 
-  // If the bundle did not carry a metadata.json entry but the target had
-  // `vellum:*` entries before Step 1b cleared them, write a minimal
-  // metadata file with just those preserved entries so the gateway can
-  // still locate the platform API key.
+  // If Step 1b actually cleared the workspace AND the bundle did not
+  // carry a metadata.json entry, the target's vellum:* entries were
+  // wiped along with the `data/credentials/` directory. Restore them by
+  // writing a minimal file containing just the preserved entries so the
+  // gateway can still locate the platform API key. When Step 1b did NOT
+  // run (e.g. workspaceDir unset) the live metadata.json is still on
+  // disk untouched — we must not rewrite it here or we would drop the
+  // non-vellum entries the caller chose to keep.
   const bundleHadMetadata = manifest.files.some(
     (f) => f.path === CREDENTIAL_METADATA_ARCHIVE_PATH,
   );
   if (
-    hasWorkspaceEntries &&
+    workspaceWasCleared &&
     !bundleHadMetadata &&
     liveCredentialMetadataJson &&
     credentialMetadataDiskPath


### PR DESCRIPTION
## Summary
- Follow-up to #27157. Codex flagged that the fallback rewrite (when the bundle omits `workspace/data/credentials/metadata.json` but the target had live `vellum:*` entries) was gated only on `hasWorkspaceEntries`. If the caller did not provide `workspaceDir` Step 1b never ran, so the target's live metadata.json was still intact on disk — but the fallback would overwrite it with a vellum-only synthesized payload, dropping non-vellum entries the caller intended to keep.
- Track whether Step 1b actually cleared the workspace (`workspaceWasCleared`) and gate the restore on that explicit signal instead of the pre-condition. No-clear imports now leave the existing metadata.json untouched.
- Existing tests still pass (99/99) since they exercise the `workspaceDir`-provided path.

## Original prompt
Address Codex feedback on PR #27157: the bundle-without-metadata fallback rewrites the live metadata.json even when Step 1b never ran, so non-vellum entries are dropped on no-clear imports.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
