### PR TITLE
fix(migrations): reconcile vellum:* metadata from CES after import

### DIFF
--- a/assistant/src/runtime/routes/__tests__/migration-vellum-metadata-reconcile.test.ts
+++ b/assistant/src/runtime/routes/__tests__/migration-vellum-metadata-reconcile.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for the post-import vellum metadata reconciliation helper.
+ *
+ * After every bundle import, `reconcileVellumMetadataFromCes` walks the
+ * four platform-identity fields the gateway requires and, for each one
+ * that CES already holds a value for, ensures `metadata.json` lists a
+ * matching entry. This closes the race where Django's post-hatch
+ * provisioning writes its CES value successfully but its metadata upsert
+ * gets clobbered by the import's in-place clear or atomic swap.
+ *
+ * We test the reconcile logic in isolation by mocking the secure-keys
+ * and metadata-store modules — the real migration handler wires the
+ * same imports, so the behavior under test matches production.
+ *
+ * Covered:
+ * - CES has all 4 fields + metadata empty → all 4 upserted.
+ * - CES has all 4 + metadata has 2 → only the missing 2 upserted.
+ * - CES has no values → nothing upserted.
+ * - CES has values + metadata already has them → no-op (no duplicate
+ *   upserts).
+ * - upsert throws for one field → warning recorded, loop continues.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { credentialKey } from "../../../security/credential-key.js";
+
+type MetadataRecord = {
+  credentialId: string;
+  service: string;
+  field: string;
+  allowedTools: string[];
+  allowedDomains: string[];
+  createdAt: number;
+  updatedAt: number;
+};
+
+const VELLUM_FIELDS = [
+  "platform_base_url",
+  "assistant_api_key",
+  "platform_assistant_id",
+  "webhook_secret",
+] as const;
+
+const upsertCalls: Array<{ service: string; field: string }> = [];
+let metadataStore: Map<string, MetadataRecord> = new Map();
+let cesValues: Map<string, string> = new Map();
+let upsertImpl: (service: string, field: string) => void = (service, field) => {
+  const key = `${service}:${field}`;
+  metadataStore.set(key, {
+    credentialId: `id-${key}`,
+    service,
+    field,
+    allowedTools: [],
+    allowedDomains: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+};
+
+mock.module("../../../security/secure-keys.js", () => ({
+  bulkSetSecureKeysAsync: async () => [],
+  deleteSecureKeyAsync: async () => "ok",
+  getActiveBackendName: () => "test",
+  getMaskedProviderKey: async () => null,
+  getProviderKeyAsync: async () => null,
+  getSecureKeyAsync: async (key: string) => cesValues.get(key) ?? null,
+  getSecureKeyResultAsync: async () => ({ ok: true, value: null }),
+  listSecureKeysAsync: async () => [],
+  onCesClientChanged: () => {},
+  setCesClient: () => {},
+  setCesReconnect: () => {},
+  setSecureKeyAsync: async () => true,
+  _resetBackend: () => {},
+}));
+
+mock.module("../../../tools/credentials/metadata-store.js", () => ({
+  getCredentialMetadata: (service: string, field: string) =>
+    metadataStore.get(`${service}:${field}`),
+  upsertCredentialMetadata: (
+    service: string,
+    field: string,
+    _policy?: unknown,
+  ) => {
+    upsertCalls.push({ service, field });
+    upsertImpl(service, field);
+    return metadataStore.get(`${service}:${field}`);
+  },
+}));
+
+// Import under test AFTER the mocks are set up.
+const { reconcileVellumMetadataFromCes } =
+  (await import("../migration-routes.js")) as unknown as {
+    reconcileVellumMetadataFromCes: (sink: {
+      warnings: string[];
+    }) => Promise<void>;
+  };
+
+beforeEach(() => {
+  upsertCalls.length = 0;
+  metadataStore = new Map();
+  cesValues = new Map();
+  upsertImpl = (service, field) => {
+    const key = `${service}:${field}`;
+    metadataStore.set(key, {
+      credentialId: `id-${key}`,
+      service,
+      field,
+      allowedTools: [],
+      allowedDomains: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  };
+});
+
+afterEach(() => {
+  upsertCalls.length = 0;
+});
+
+function seedAllFourInCes(): void {
+  for (const field of VELLUM_FIELDS) {
+    cesValues.set(credentialKey("vellum", field), `value-for-${field}`);
+  }
+}
+
+describe("reconcileVellumMetadataFromCes", () => {
+  test("CES holds all 4 fields, metadata empty → all 4 upserted", async () => {
+    seedAllFourInCes();
+    const sink = { warnings: [] as string[] };
+
+    await reconcileVellumMetadataFromCes(sink);
+
+    expect(upsertCalls).toHaveLength(4);
+    expect(new Set(upsertCalls.map((c) => c.field))).toEqual(
+      new Set(VELLUM_FIELDS),
+    );
+    expect(sink.warnings).toHaveLength(0);
+  });
+
+  test("CES holds all 4, metadata has 2 → only the missing 2 upserted", async () => {
+    seedAllFourInCes();
+    // Pre-populate metadata for 2 of the 4 fields.
+    for (const field of ["platform_base_url", "assistant_api_key"] as const) {
+      metadataStore.set(`vellum:${field}`, {
+        credentialId: `id-vellum:${field}`,
+        service: "vellum",
+        field,
+        allowedTools: [],
+        allowedDomains: [],
+        createdAt: 1,
+        updatedAt: 1,
+      });
+    }
+
+    const sink = { warnings: [] as string[] };
+    await reconcileVellumMetadataFromCes(sink);
+
+    expect(upsertCalls).toHaveLength(2);
+    expect(new Set(upsertCalls.map((c) => c.field))).toEqual(
+      new Set(["platform_assistant_id", "webhook_secret"]),
+    );
+  });
+
+  test("CES empty → nothing upserted", async () => {
+    const sink = { warnings: [] as string[] };
+    await reconcileVellumMetadataFromCes(sink);
+    expect(upsertCalls).toHaveLength(0);
+    expect(sink.warnings).toHaveLength(0);
+  });
+
+  test("CES has values, metadata already has entries → no duplicate upserts", async () => {
+    seedAllFourInCes();
+    // Seed metadata for all 4.
+    for (const field of VELLUM_FIELDS) {
+      metadataStore.set(`vellum:${field}`, {
+        credentialId: `id-vellum:${field}`,
+        service: "vellum",
+        field,
+        allowedTools: [],
+        allowedDomains: [],
+        createdAt: 1,
+        updatedAt: 1,
+      });
+    }
+
+    const sink = { warnings: [] as string[] };
+    await reconcileVellumMetadataFromCes(sink);
+
+    expect(upsertCalls).toHaveLength(0);
+  });
+
+  test("upsert throws for one field → warning recorded, loop continues", async () => {
+    seedAllFourInCes();
+    let calls = 0;
+    upsertImpl = (service, field) => {
+      calls += 1;
+      if (field === "assistant_api_key") {
+        throw new Error("simulated metadata write failure");
+      }
+      const key = `${service}:${field}`;
+      metadataStore.set(key, {
+        credentialId: `id-${key}`,
+        service,
+        field,
+        allowedTools: [],
+        allowedDomains: [],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    };
+
+    const sink = { warnings: [] as string[] };
+    await reconcileVellumMetadataFromCes(sink);
+
+    // Every field was attempted (loop did not abort).
+    expect(calls).toBe(4);
+    expect(sink.warnings).toHaveLength(1);
+    expect(sink.warnings[0]).toContain("vellum:assistant_api_key");
+  });
+});

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -24,11 +24,17 @@ import { invalidateConfigCache } from "../../config/loader.js";
 import { getDb, resetDb } from "../../memory/db-connection.js";
 import { validateMigrationState } from "../../memory/migrations/validate-migration-state.js";
 import { clearCache as clearTrustCache } from "../../permissions/trust-store.js";
+import { credentialKey } from "../../security/credential-key.js";
 import {
   bulkSetSecureKeysAsync,
+  getSecureKeyAsync,
   getSecureKeyResultAsync,
   listSecureKeysAsync,
 } from "../../security/secure-keys.js";
+import {
+  getCredentialMetadata,
+  upsertCredentialMetadata,
+} from "../../tools/credentials/metadata-store.js";
 import { getLogger } from "../../util/logger.js";
 import {
   getDbPath,
@@ -57,6 +63,53 @@ import { validateVBundle } from "../migrations/vbundle-validator.js";
 
 /** Credentials with this prefix are platform-identity keys and must not be imported. */
 const PLATFORM_CREDENTIAL_PREFIX = "vellum:";
+
+/**
+ * Platform-identity fields that the managed runtime expects to see in CES
+ * (populated by Django's post-hatch provisioning via `POST /v1/secrets`).
+ * After an import we reconcile metadata.json against CES: for every field
+ * where CES already holds a value, make sure metadata has a matching
+ * entry. This closes a race where Django's provisioning POST arrives
+ * during the import — its CES write survives (separate volume), but its
+ * metadata upsert may be clobbered by the in-place clear / atomic swap.
+ */
+const VELLUM_PLATFORM_IDENTITY_FIELDS = [
+  "platform_base_url",
+  "assistant_api_key",
+  "platform_assistant_id",
+  "webhook_secret",
+] as const;
+
+/**
+ * Idempotent post-import reconciliation: for each vellum:* field, if CES
+ * has a value but metadata.json doesn't list it, upsert the entry. Pure
+ * add-only — never deletes anything. Safe to run whether or not Django's
+ * post-hatch provisioning has completed (missing CES values are skipped).
+ *
+ * Exported for direct unit-testing.
+ */
+export async function reconcileVellumMetadataFromCes(warningSink: {
+  warnings: string[];
+}): Promise<void> {
+  for (const field of VELLUM_PLATFORM_IDENTITY_FIELDS) {
+    try {
+      const value = await getSecureKeyAsync(credentialKey("vellum", field));
+      if (!value) continue;
+      if (getCredentialMetadata("vellum", field)) continue;
+      upsertCredentialMetadata("vellum", field, {});
+      log.info(
+        { field },
+        "Reconciled vellum:* metadata entry from CES after import",
+      );
+    } catch (err) {
+      warningSink.warnings.push(
+        `Failed to reconcile vellum:${field} metadata: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+}
 
 const log = getLogger("migration-routes");
 
@@ -490,6 +543,11 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
       );
     }
 
+    // Reconcile vellum:* metadata against CES so the gateway's
+    // readServiceCredentials can still find platform identity values even
+    // if Django's post-hatch provisioning raced with the import.
+    await reconcileVellumMetadataFromCes(result.report);
+
     // Invalidate in-process caches so imported settings.json and trust.json take effect
     invalidateConfigCache();
     clearTrustCache();
@@ -855,6 +913,14 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
   if (credentialImportWarningSink.warnings.length > 0) {
     result.report.warnings.push(...credentialImportWarningSink.warnings);
   }
+
+  // Reconcile vellum:* metadata against CES so the gateway's
+  // readServiceCredentials can still find platform identity values even
+  // if Django's post-hatch provisioning raced with the streaming import
+  // (its metadata upsert may have landed in the backup-dir copy that the
+  // swap pushed aside, while its CES write survived on the separate
+  // volume).
+  await reconcileVellumMetadataFromCes(result.report);
 
   // streamCommitImport already invalidated config + trust caches inside its
   // post-swap cleanup. We only need to check whether the newly-imported DB


### PR DESCRIPTION
## Summary
- Follow-up to #27157. Even with metadata merge in place, the assistant API key can still appear invalid on the new (GCS streaming) teleport path: Django's post-hatch provisioning writes to CES and metadata.json concurrently with the long streaming import, and its metadata upsert can land mid-swap where it gets clobbered. CES still has the raw value (separate volume) but the gateway refuses to look it up because metadata.json is missing entries.
- Add an idempotent post-import reconcile step that walks the four `vellum:*` platform-identity fields and, for each one CES already holds a value for, upserts a matching metadata.json entry. Pure add-only, never deletes. Wired into both the buffer-based `handleMigrationImport` and the streaming `handleMigrationImportFromUrl`.
- Race-free because it runs AFTER the swap and AFTER credentials have been imported. If Django hasn't provisioned yet, CES values are absent and reconcile is a no-op; Django's later POST /v1/secrets will upsert both CES and metadata normally.
- 5 new unit tests: CES-has-all + empty-metadata upserts all 4; partial metadata only upserts the missing; no CES values no-op; pre-populated metadata stays idempotent; upsert failure on one field records a warning and lets the loop continue.

## Original prompt
The user reported the assistant API key is still getting invalidated after teleport despite the metadata merge fix. The old (pre-GCS) flow did not have this issue because the buffer import finished quickly, giving Django's post-hatch provisioning a clean window to write both CES and metadata. The new streaming flow can take many minutes, so Django's metadata upsert routinely races with the atomic swap and loses. Close the race by reconciling metadata against CES after the import completes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
