### PR TITLE
fix(teleport): await post-hatch provisioning before starting bundle import

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -154,6 +154,17 @@ struct AssistantTransferSection: View {
                 throw TransferError.importFailed(message: "Failed to save managed assistant configuration to lockfile.")
             }
 
+            // Wait for post-hatch runtime provisioning (assistant_api_key,
+            // platform_assistant_id, webhook_secret, actor token) to complete
+            // before the import starts rearranging the workspace — otherwise
+            // Django's POST /v1/secrets can race with the atomic workspace
+            // swap, return 500, and fail-closed-revoke the just-issued
+            // assistant API key.
+            currentStep = "Finalizing cloud assistant..."
+            try await ManagedAssistantBootstrapService.shared.awaitAssistantProvisioned(
+                assistantId: platformAssistant.id
+            )
+
             // Step 3 — Import bundle to managed assistant
             currentStep = "Uploading data to cloud..."
             try await importBundleToManaged(bundleData: bundleData)

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -410,6 +410,18 @@ struct TeleportSection: View {
             throw TeleportError.importFailed(message: "Failed to save managed assistant configuration to lockfile.")
         }
 
+        // Wait for post-hatch runtime provisioning (assistant_api_key,
+        // platform_assistant_id, webhook_secret, actor token) to complete
+        // before the import starts rearranging the workspace — otherwise
+        // Django's POST /v1/secrets can race with the atomic workspace
+        // swap, return 500, and fail-closed-revoke the just-issued
+        // assistant API key (leaving the managed proxy rejecting the
+        // pod's key as "Invalid or revoked API key" on the first message).
+        phase = .transferring(step: "Finalizing cloud assistant...")
+        try await ManagedAssistantBootstrapService.shared.awaitAssistantProvisioned(
+            assistantId: platformAssistant.id
+        )
+
         // Step 5 — Import bundle to managed assistant
         phase = .transferring(step: "Importing data to cloud...")
         try await importBundleToManaged(bundleData: bundleData, bundleKey: bundleKey)


### PR DESCRIPTION
## Summary
- Teleport (and the analogous AssistantTransferSection transfer) kicked off the streaming bundle import immediately after `hatchAssistant` returned, without waiting for Django's background post-hatch provisioning to push `vellum:assistant_api_key` (and friends) into the managed pod and flip the platform status to ACTIVE. That let the provisioning POST race against the atomic workspace swap, and when the POST hit an ENOENT on a mid-rename `data/credentials/` dir the pod returned 500, triggering the platform's fail-closed revocation of the just-issued key.
- Fix: after hatch + lockfile persistence and before the import, call `ManagedAssistantBootstrapService.shared.awaitAssistantProvisioned(assistantId:)` — the same gate the onboarding flow uses. Status flips to ACTIVE only when the assistant API key and actor token are both in place, so the import runs against a stable, fully-provisioned pod.
- Applied in `TeleportSection.teleportLocalToPlatform` and `AssistantTransferSection.transferLocalToManaged`. Docker teleport is intentionally untouched.

## Test plan
- [ ] Teleport local → platform: brief "Finalizing cloud assistant..." phase after hatch, then "Importing data to cloud...", then first message succeeds through the managed proxy.
- [ ] Confirm no "Invalid or revoked API key" errors after the first message.
- [ ] Confirm no shadow `Local: {managed_id}` assistants created on the platform as a side effect of failed recovery.
- [ ] If the managed pod fails to provision within 60s, teleport surfaces the timeout error rather than proceeding into a broken import.

## Original prompt
Add `awaitAssistantProvisioned` between hatch and import in the teleport flow so post-hatch provisioning completes before the streaming import starts rearranging the workspace. Without this wait, Django's post-hatch POST to `/v1/secrets` on the pod can race with the atomic swap, hit ENOENT on a mid-rename `data/credentials/` directory, return 500, and trigger the platform's fail-closed revocation — leaving the pod with a revoked `vellum:assistant_api_key` that the managed proxy rejects as "Invalid or revoked API key" on the first message.

Evidence (feedback bundle):
- `os-log.txt`: teleport complete 09:40:26, first message 09:40:34.952, MANAGED_KEY_INVALID at 09:40:35.763.
- `debug-state.json`: ProviderError: Anthropic API error (403): {"detail":"Invalid or revoked API key."} — platform-side error format, confirming the managed proxy rejected the pod's key.
- grep confirmed `awaitAssistantProvisioned` was only wired in `OnboardingFlowView.swift:403`; `TeleportSection.swift:389` went straight from hatch to import.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
