### PR TITLE
docs(tests): rewrite vellum-prefix regression comment to describe current state

### DIFF
--- a/assistant/src/runtime/routes/__tests__/migration-import-credential-filter.test.ts
+++ b/assistant/src/runtime/routes/__tests__/migration-import-credential-filter.test.ts
@@ -238,8 +238,8 @@ describe("migration import credential filtering", () => {
       ),
     ).toBe(true);
 
-    // Guard against the historic bug: the legacy "vellum:" prefix must NOT
-    // match the real CES account format.
+    // The raw "vellum:" string is not a valid CES account prefix — only
+    // the full "credential/vellum/" format from credentialKey() is correct.
     expect(
       credentialKey("vellum", "assistant_api_key").startsWith("vellum:"),
     ).toBe(false);


### PR DESCRIPTION
## Summary
- Addresses Devin review on #27161: the comment guarding the \`startsWith(\"vellum:\")\` assertion narrated history rather than describing current code. Rewrite it as a present-tense statement about the real CES account format.

## Original prompt
yes fix this
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
