### PR TITLE
fix(teleport): inject vellum org-id/user-id into new managed assistants

### DIFF
--- a/clients/macos/vellum-assistant/App/ManagedAssistantIdentityInjection.swift
+++ b/clients/macos/vellum-assistant/App/ManagedAssistantIdentityInjection.swift
@@ -1,0 +1,90 @@
+import Foundation
+import os
+import VellumAssistantShared
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ManagedAssistantIdentityInjection")
+
+/// Client-resolved vellum:* identity fields that must be POSTed to a
+/// newly-hatched managed assistant's `/v1/secrets` after hatch. Django's
+/// post-hatch provisioning covers the assistant_api_key / platform_base_url /
+/// platform_assistant_id / webhook_secret quartet, but the organization id
+/// and user id are only known to the signed-in client — they never appear in
+/// Django's provisioning payload. Normal local bootstrap covers these via
+/// `LocalAssistantBootstrapService.bootstrap()`; teleport-to-platform and the
+/// local→managed transfer flow skip that bootstrap, so they must inject
+/// these fields directly.
+@MainActor
+enum ManagedAssistantIdentityInjection {
+    /// Inject the client-resolvable `vellum:platform_organization_id` and
+    /// `vellum:platform_user_id` into a managed assistant's secret store via
+    /// the platform-routed `assistants/<id>/secrets` endpoint.
+    ///
+    /// The request is routed through `GatewayHTTPClient.withAssistant(_:)` so
+    /// it resolves the platform base URL + session token for `assistantId`
+    /// rather than for whatever assistant is currently active — teleport
+    /// runs while the source (local / docker) assistant is still active, so
+    /// the override is required.
+    ///
+    /// Failures are logged and swallowed: a missing user id is non-fatal
+    /// (`platform_user_id` is only used for telemetry / Sentry tagging), and
+    /// the org id injection is best-effort since the managed assistant will
+    /// still function if the injection misses — it just won't see the
+    /// signed-in user's org / user id until the next explicit set.
+    static func inject(
+        into assistantId: String,
+        organizationId: String
+    ) async {
+        let userId: String?
+        do {
+            let session = try await AuthService.shared.getSession()
+            userId = session.data?.user?.id
+        } catch {
+            log.warning("Failed to resolve user id before identity injection for \(assistantId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            userId = nil
+        }
+
+        await GatewayHTTPClient.withAssistant(assistantId) {
+            await postSecret(
+                assistantId: assistantId,
+                name: "vellum:platform_organization_id",
+                value: organizationId
+            )
+            if let userId, !userId.isEmpty {
+                await postSecret(
+                    assistantId: assistantId,
+                    name: "vellum:platform_user_id",
+                    value: userId
+                )
+            } else {
+                log.info("Skipping platform_user_id injection for \(assistantId, privacy: .public) — no user id available")
+            }
+        }
+    }
+
+    private static func postSecret(
+        assistantId: String,
+        name: String,
+        value: String
+    ) async {
+        let body: [String: Any] = [
+            "type": "credential",
+            "name": name,
+            "value": value,
+        ]
+        do {
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/\(assistantId)/secrets",
+                json: body,
+                timeout: 10
+            )
+            if response.isSuccess {
+                log.info("Injected \(name, privacy: .public) into \(assistantId, privacy: .public)")
+            } else {
+                let bodyPreview = String(data: response.data, encoding: .utf8) ?? "<non-utf8>"
+                log.warning("Non-OK injecting \(name, privacy: .public) into \(assistantId, privacy: .public): status=\(response.statusCode, privacy: .public) body=\(bodyPreview, privacy: .public)")
+            }
+        } catch {
+            log.warning("Failed to inject \(name, privacy: .public) into \(assistantId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -169,6 +169,16 @@ struct AssistantTransferSection: View {
             currentStep = "Uploading data to cloud..."
             try await importBundleToManaged(bundleData: bundleData)
 
+            // Step 3b — Inject client-resolvable vellum identity fields that
+            // Django's post-hatch provisioning doesn't cover (org id, user id).
+            // Normal local bootstrap sets these via `LocalAssistantBootstrapService`;
+            // the transfer flow has to do it here because it skips that bootstrap.
+            let organizationId = try await ManagedAssistantBootstrapService.shared.resolveOrganizationId()
+            await ManagedAssistantIdentityInjection.inject(
+                into: platformAssistant.id,
+                organizationId: organizationId
+            )
+
             // Step 4 — Switch to managed assistant
             currentStep = "Switching to cloud assistant..."
             guard let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.assistantId == platformAssistant.id && $0.isManaged }) else {

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -173,11 +173,22 @@ struct AssistantTransferSection: View {
             // Django's post-hatch provisioning doesn't cover (org id, user id).
             // Normal local bootstrap sets these via `LocalAssistantBootstrapService`;
             // the transfer flow has to do it here because it skips that bootstrap.
-            let organizationId = try await ManagedAssistantBootstrapService.shared.resolveOrganizationId()
-            await ManagedAssistantIdentityInjection.inject(
-                into: platformAssistant.id,
-                organizationId: organizationId
-            )
+            //
+            // Best-effort: if the org id isn't already cached from
+            // `ensureManagedAssistant()` above, skip injection rather than
+            // blocking the transfer on a fresh network lookup — the export
+            // and import have already succeeded, and a failed injection is
+            // recoverable (managed assistant still boots; org/user tagging
+            // just stays blank until the next explicit set).
+            if let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId"),
+               !organizationId.isEmpty {
+                await ManagedAssistantIdentityInjection.inject(
+                    into: platformAssistant.id,
+                    organizationId: organizationId
+                )
+            } else {
+                log.warning("[transfer] Skipping vellum identity injection — no cached organization id for \(platformAssistant.id, privacy: .public)")
+            }
 
             // Step 4 — Switch to managed assistant
             currentStep = "Switching to cloud assistant..."

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -590,6 +590,17 @@ struct TeleportSection: View {
             throw TeleportError.importFailed(message: "Failed to save managed assistant configuration to lockfile.")
         }
 
+        // Wait for post-hatch runtime provisioning (assistant_api_key,
+        // platform_assistant_id, webhook_secret, actor token) to complete
+        // before the import starts rearranging the workspace — Django's
+        // POST /v1/secrets can otherwise race with the atomic workspace
+        // swap, return 500, and fail-closed-revoke the just-issued
+        // assistant API key. Mirrors the wait in `teleportLocalToPlatform`.
+        phase = .transferring(step: "Finalizing cloud assistant...")
+        try await ManagedAssistantBootstrapService.shared.awaitAssistantProvisioned(
+            assistantId: platformAssistant.id
+        )
+
         // Step 5 — Import bundle to managed assistant
         phase = .transferring(step: "Importing data to cloud...")
         try await importBundleToManaged(bundleData: bundleData, bundleKey: bundleKey)

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -426,6 +426,15 @@ struct TeleportSection: View {
         phase = .transferring(step: "Importing data to cloud...")
         try await importBundleToManaged(bundleData: bundleData, bundleKey: bundleKey)
 
+        // Step 5b — Inject client-resolvable vellum identity fields that
+        // Django's post-hatch provisioning doesn't cover (org id, user id).
+        // Normal local bootstrap sets these via `LocalAssistantBootstrapService`;
+        // the teleport flow has to do it here because it skips that bootstrap.
+        await ManagedAssistantIdentityInjection.inject(
+            into: platformAssistant.id,
+            organizationId: organizationId
+        )
+
         // Step 6 — Resolve managed assistant for later switch
         guard let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.assistantId == platformAssistant.id && $0.isManaged }) else {
             throw TeleportError.managedEntryNotFound
@@ -584,6 +593,15 @@ struct TeleportSection: View {
         // Step 5 — Import bundle to managed assistant
         phase = .transferring(step: "Importing data to cloud...")
         try await importBundleToManaged(bundleData: bundleData, bundleKey: bundleKey)
+
+        // Step 5b — Inject client-resolvable vellum identity fields that
+        // Django's post-hatch provisioning doesn't cover (org id, user id).
+        // Normal local bootstrap sets these via `LocalAssistantBootstrapService`;
+        // the teleport flow has to do it here because it skips that bootstrap.
+        await ManagedAssistantIdentityInjection.inject(
+            into: platformAssistant.id,
+            organizationId: organizationId
+        )
 
         // Step 6 — Resolve managed assistant for later switch
         guard let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.assistantId == platformAssistant.id && $0.isManaged }) else {


### PR DESCRIPTION
## Summary
- Django's post-hatch provisioning covers `vellum:assistant_api_key` / `platform_assistant_id` / `platform_base_url` / `webhook_secret` but not `platform_organization_id` / `platform_user_id` (those require the signed-in client session). `LocalAssistantBootstrapService` injects the latter two in the local hatch flow, but teleport-to-platform and the local→managed transfer flow skip that bootstrap, so the freshly hatched managed assistant comes up with blank org id / user id — affecting Sentry tags and any platform-client call that reads those fields.
- Add a `ManagedAssistantIdentityInjection` helper that POSTs the two fields to `assistants/<id>/secrets` via `GatewayHTTPClient.withAssistant(...)`. Call it from both TeleportSection flows (local→platform, docker→platform) after the bundle import, and from `AssistantTransferSection.transferLocalToManaged` before the switch. Failures are logged and swallowed (best-effort, mirroring `LocalAssistantBootstrapService`'s `try?` pattern).

## Original prompt
it looks like after teleport some items in ces like user id, org id and some other vellum ones are not set. Although they are properly ignored it looks like there might be a missing call during teleport that we make during the normal hatch flow to set these things in the newly hatched assistant, can you check on this
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
