### PR TITLE
feat(gateway): add SQLite tables for auto-approve thresholds

### DIFF
--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -6,6 +6,7 @@
  * startup (see connection.ts). Drizzle provides typed query access.
  */
 
+import { sql } from "drizzle-orm";
 import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 // ---------------------------------------------------------------------------
@@ -83,4 +84,29 @@ export const contactChannels = sqliteTable(
       table.externalChatId,
     ),
   ],
+);
+
+// ---------------------------------------------------------------------------
+// Auto-approve thresholds
+// ---------------------------------------------------------------------------
+
+export const autoApproveThresholds = sqliteTable("auto_approve_thresholds", {
+  id: integer("id").primaryKey().default(1),
+  interactive: text("interactive").notNull().default("low"),
+  background: text("background").notNull().default("medium"),
+  headless: text("headless").notNull().default("none"),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+});
+
+export const conversationThresholdOverrides = sqliteTable(
+  "conversation_threshold_overrides",
+  {
+    conversationId: text("conversation_id").primaryKey(),
+    threshold: text("threshold").notNull(),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
 );


### PR DESCRIPTION
## Summary
- Add `auto_approve_thresholds` table for global defaults (interactive/background/headless)
- Add `conversation_threshold_overrides` table for per-conversation overrides
- Uses Drizzle ORM declarative schema (auto-migrated via pushSQLiteSchema)

Part of plan: auto-approve-threshold-ui.plan.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
