### PR TITLE
feat(gateway): add GET/PUT endpoints for global auto-approve thresholds

### DIFF
--- a/gateway/src/__tests__/auto-approve-thresholds.test.ts
+++ b/gateway/src/__tests__/auto-approve-thresholds.test.ts
@@ -1,0 +1,211 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
+import "./test-preload.js";
+
+import {
+  createThresholdsGetHandler,
+  createThresholdsPutHandler,
+} from "../http/routes/auto-approve-thresholds.js";
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(body?: unknown, method = "PUT"): Request {
+  if (body !== undefined) {
+    return new Request("http://localhost/v1/permissions/thresholds", {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+  return new Request("http://localhost/v1/permissions/thresholds", {
+    method,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("auto-approve thresholds", () => {
+  describe("GET handler", () => {
+    test("returns defaults when no row exists", async () => {
+      const handler = createThresholdsGetHandler();
+      const res = await handler(makeRequest(undefined, "GET"));
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({
+        interactive: "low",
+        background: "medium",
+        headless: "none",
+      });
+    });
+
+    test("returns updated values after PUT", async () => {
+      const putHandler = createThresholdsPutHandler();
+      const getHandler = createThresholdsGetHandler();
+
+      // First PUT to set values
+      await putHandler(makeRequest({ interactive: "medium" }));
+
+      // GET should reflect the update
+      const res = await getHandler(makeRequest(undefined, "GET"));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({
+        interactive: "medium",
+        background: "medium",
+        headless: "none",
+      });
+    });
+  });
+
+  describe("PUT handler", () => {
+    test("partial update only changes provided fields", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(makeRequest({ interactive: "medium" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({
+        interactive: "medium",
+        background: "medium",
+        headless: "none",
+      });
+    });
+
+    test("returns 400 for invalid threshold value", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(makeRequest({ interactive: "high" }));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("interactive");
+      expect(data.error).toContain("none, low, medium");
+    });
+
+    test("returns 400 for invalid body (non-JSON)", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const req = new Request("http://localhost/v1/permissions/thresholds", {
+        method: "PUT",
+        body: "not json",
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("valid JSON");
+    });
+
+    test("returns 400 for non-object body", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(makeRequest("just a string"));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("JSON object");
+    });
+
+    test("returns 400 for array body", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(makeRequest([1, 2, 3]));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("JSON object");
+    });
+
+    test("returns 400 for invalid background value", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(makeRequest({ background: "invalid" }));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("background");
+    });
+
+    test("returns 400 for invalid headless value", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(makeRequest({ headless: 42 }));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("headless");
+    });
+
+    test("upserts correctly — first write creates, second write updates", async () => {
+      const handler = createThresholdsPutHandler();
+
+      // First write — creates the row
+      const res1 = await handler(
+        makeRequest({ interactive: "none", background: "low" }),
+      );
+      expect(res1.status).toBe(200);
+      const data1 = await res1.json();
+      expect(data1).toEqual({
+        interactive: "none",
+        background: "low",
+        headless: "none",
+      });
+
+      // Second write — updates the existing row
+      const res2 = await handler(
+        makeRequest({ background: "medium", headless: "low" }),
+      );
+      expect(res2.status).toBe(200);
+      const data2 = await res2.json();
+      expect(data2).toEqual({
+        interactive: "none",
+        background: "medium",
+        headless: "low",
+      });
+    });
+
+    test("updates all fields at once", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(
+        makeRequest({
+          interactive: "medium",
+          background: "none",
+          headless: "low",
+        }),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({
+        interactive: "medium",
+        background: "none",
+        headless: "low",
+      });
+    });
+
+    test("empty object preserves defaults", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(makeRequest({}));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({
+        interactive: "low",
+        background: "medium",
+        headless: "none",
+      });
+    });
+  });
+});

--- a/gateway/src/http/routes/auto-approve-thresholds.ts
+++ b/gateway/src/http/routes/auto-approve-thresholds.ts
@@ -1,0 +1,140 @@
+import { sql } from "drizzle-orm";
+import { getGatewayDb } from "../../db/connection.js";
+import { autoApproveThresholds } from "../../db/schema.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("auto-approve-thresholds");
+
+const VALID_THRESHOLDS = ["none", "low", "medium"] as const;
+type ThresholdValue = (typeof VALID_THRESHOLDS)[number];
+
+const DEFAULTS = {
+  interactive: "low" as ThresholdValue,
+  background: "medium" as ThresholdValue,
+  headless: "none" as ThresholdValue,
+};
+
+function isValidThreshold(value: unknown): value is ThresholdValue {
+  return (
+    typeof value === "string" &&
+    VALID_THRESHOLDS.includes(value as ThresholdValue)
+  );
+}
+
+export function createThresholdsGetHandler() {
+  return async (_req: Request): Promise<Response> => {
+    const db = getGatewayDb();
+    const rows = db.select().from(autoApproveThresholds).all();
+    const row = rows[0];
+
+    if (!row) {
+      return Response.json({ ...DEFAULTS });
+    }
+
+    return Response.json({
+      interactive: row.interactive,
+      background: row.background,
+      headless: row.headless,
+    });
+  };
+}
+
+export function createThresholdsPutHandler() {
+  return async (req: Request): Promise<Response> => {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json(
+        { error: "Request body must be valid JSON" },
+        { status: 400 },
+      );
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return Response.json(
+        { error: "Request body must be a JSON object" },
+        { status: 400 },
+      );
+    }
+
+    const { interactive, background, headless } = body as {
+      interactive?: unknown;
+      background?: unknown;
+      headless?: unknown;
+    };
+
+    const hasInteractive = "interactive" in (body as object);
+    const hasBackground = "background" in (body as object);
+    const hasHeadless = "headless" in (body as object);
+
+    // Validate provided fields
+    if (hasInteractive && !isValidThreshold(interactive)) {
+      return Response.json(
+        {
+          error: `"interactive" must be one of: ${VALID_THRESHOLDS.join(", ")}`,
+        },
+        { status: 400 },
+      );
+    }
+    if (hasBackground && !isValidThreshold(background)) {
+      return Response.json(
+        {
+          error: `"background" must be one of: ${VALID_THRESHOLDS.join(", ")}`,
+        },
+        { status: 400 },
+      );
+    }
+    if (hasHeadless && !isValidThreshold(headless)) {
+      return Response.json(
+        { error: `"headless" must be one of: ${VALID_THRESHOLDS.join(", ")}` },
+        { status: 400 },
+      );
+    }
+
+    const db = getGatewayDb();
+
+    // Read current state to merge with partial updates
+    const existingRows = db.select().from(autoApproveThresholds).all();
+    const existing = existingRows[0];
+
+    const merged = {
+      interactive: hasInteractive
+        ? (interactive as ThresholdValue)
+        : (existing?.interactive ?? DEFAULTS.interactive),
+      background: hasBackground
+        ? (background as ThresholdValue)
+        : (existing?.background ?? DEFAULTS.background),
+      headless: hasHeadless
+        ? (headless as ThresholdValue)
+        : (existing?.headless ?? DEFAULTS.headless),
+    };
+
+    db.insert(autoApproveThresholds)
+      .values({
+        id: 1,
+        interactive: merged.interactive,
+        background: merged.background,
+        headless: merged.headless,
+        updatedAt: sql`datetime('now')`,
+      })
+      .onConflictDoUpdate({
+        target: autoApproveThresholds.id,
+        set: {
+          interactive: merged.interactive,
+          background: merged.background,
+          headless: merged.headless,
+          updatedAt: sql`datetime('now')`,
+        },
+      })
+      .run();
+
+    log.info(merged, "Auto-approve thresholds updated");
+
+    return Response.json({
+      interactive: merged.interactive,
+      background: merged.background,
+      headless: merged.headless,
+    });
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -58,6 +58,10 @@ import {
   createPrivacyConfigGetHandler,
   createPrivacyConfigPatchHandler,
 } from "./http/routes/privacy-config.js";
+import {
+  createThresholdsGetHandler,
+  createThresholdsPutHandler,
+} from "./http/routes/auto-approve-thresholds.js";
 import { createChannelVerificationSessionProxyHandler } from "./http/routes/channel-verification-session-proxy.js";
 import { createCloudOAuthTokenHandler } from "./http/routes/cloud-oauth-token.js";
 import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-control-plane-proxy.js";
@@ -353,6 +357,8 @@ async function main() {
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
   const handlePrivacyConfigGet = createPrivacyConfigGetHandler();
   const handlePrivacyConfigPatch = createPrivacyConfigPatchHandler();
+  const handleThresholdsGet = createThresholdsGetHandler();
+  const handleThresholdsPut = createThresholdsPutHandler();
   const handleTrustRulesList = createTrustRulesListHandler();
   const handleTrustRulesAdd = createTrustRulesAddHandler();
   const handleTrustRulesUpdate = createTrustRulesUpdateHandler();
@@ -1046,6 +1052,36 @@ async function main() {
       auth: "edge-scoped",
       scope: "settings.write",
       handler: (req) => handlePrivacyConfigPatch(req),
+    },
+
+    // ── Auto-approve thresholds (scope-protected) ──
+    {
+      path: "/v1/permissions/thresholds",
+      method: "GET",
+      auth: "edge-scoped",
+      scope: "settings.read",
+      handler: (req) => handleThresholdsGet(req),
+    },
+    {
+      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/?$/,
+      method: "GET",
+      auth: "edge-scoped",
+      scope: "settings.read",
+      handler: (req) => handleThresholdsGet(req),
+    },
+    {
+      path: "/v1/permissions/thresholds",
+      method: "PUT",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req) => handleThresholdsPut(req),
+    },
+    {
+      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/?$/,
+      method: "PUT",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req) => handleThresholdsPut(req),
     },
 
     // ── Log export ──


### PR DESCRIPTION
## Summary
- Add `createThresholdsGetHandler()` and `createThresholdsPutHandler()` in new route file
- Register GET/PUT routes at `/v1/permissions/thresholds` with settings.read/write scopes
- Add tests for default values, partial updates, validation, and upsert behavior

Part of plan: auto-approve-threshold-ui.plan.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
