### PR TITLE
feat(gateway): add GET/PUT/DELETE endpoints for per-conversation threshold overrides

### DIFF
--- a/gateway/src/__tests__/auto-approve-conversation-thresholds.test.ts
+++ b/gateway/src/__tests__/auto-approve-conversation-thresholds.test.ts
@@ -1,0 +1,190 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
+import {
+  createConversationThresholdGetHandler,
+  createConversationThresholdPutHandler,
+  createConversationThresholdDeleteHandler,
+} from "../http/routes/auto-approve-thresholds.js";
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_URL = "http://gateway.test";
+
+function makeGet(conversationId: string): [Request, string[]] {
+  return [
+    new Request(
+      `${BASE_URL}/v1/permissions/thresholds/conversations/${conversationId}`,
+      { method: "GET" },
+    ),
+    [conversationId],
+  ];
+}
+
+function makePut(conversationId: string, body: unknown): [Request, string[]] {
+  return [
+    new Request(
+      `${BASE_URL}/v1/permissions/thresholds/conversations/${conversationId}`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    ),
+    [conversationId],
+  ];
+}
+
+function makeDelete(conversationId: string): [Request, string[]] {
+  return [
+    new Request(
+      `${BASE_URL}/v1/permissions/thresholds/conversations/${conversationId}`,
+      { method: "DELETE" },
+    ),
+    [conversationId],
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /v1/permissions/thresholds/conversations/:conversationId", () => {
+  test("returns 404 for nonexistent conversation", async () => {
+    const handler = createConversationThresholdGetHandler();
+    const [req, params] = makeGet("conv-xyz");
+
+    const res = await handler(req, params);
+    expect(res.status).toBe(404);
+
+    const body = await res.json();
+    expect(body.error).toBe("No override for this conversation");
+  });
+
+  test("returns threshold after PUT creates it", async () => {
+    const putHandler = createConversationThresholdPutHandler();
+    const getHandler = createConversationThresholdGetHandler();
+
+    // Create the override
+    const [putReq, putParams] = makePut("conv-xyz", { threshold: "medium" });
+    const putRes = await putHandler(putReq, putParams);
+    expect(putRes.status).toBe(200);
+
+    // Read it back
+    const [getReq, getParams] = makeGet("conv-xyz");
+    const getRes = await getHandler(getReq, getParams);
+    expect(getRes.status).toBe(200);
+
+    const body = await getRes.json();
+    expect(body.threshold).toBe("medium");
+  });
+});
+
+describe("PUT /v1/permissions/thresholds/conversations/:conversationId", () => {
+  test("creates override and returns conversationId + threshold", async () => {
+    const handler = createConversationThresholdPutHandler();
+    const [req, params] = makePut("conv-abc", { threshold: "low" });
+
+    const res = await handler(req, params);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({ conversationId: "conv-abc", threshold: "low" });
+  });
+
+  test("updates existing override with new value", async () => {
+    const handler = createConversationThresholdPutHandler();
+    const getHandler = createConversationThresholdGetHandler();
+
+    // Create initial
+    const [req1, params1] = makePut("conv-abc", { threshold: "low" });
+    await handler(req1, params1);
+
+    // Update
+    const [req2, params2] = makePut("conv-abc", { threshold: "none" });
+    const res = await handler(req2, params2);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({ conversationId: "conv-abc", threshold: "none" });
+
+    // Verify via GET
+    const [getReq, getParams] = makeGet("conv-abc");
+    const getRes = await getHandler(getReq, getParams);
+    const getBody = await getRes.json();
+    expect(getBody.threshold).toBe("none");
+  });
+
+  test("returns 400 for invalid threshold", async () => {
+    const handler = createConversationThresholdPutHandler();
+    const [req, params] = makePut("conv-abc", { threshold: "invalid" });
+
+    const res = await handler(req, params);
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toContain("threshold");
+  });
+
+  test("returns 400 for missing threshold", async () => {
+    const handler = createConversationThresholdPutHandler();
+    const [req, params] = makePut("conv-abc", {});
+
+    const res = await handler(req, params);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 400 for non-JSON body", async () => {
+    const handler = createConversationThresholdPutHandler();
+    const req = new Request(
+      `${BASE_URL}/v1/permissions/thresholds/conversations/conv-abc`,
+      {
+        method: "PUT",
+        body: "not json",
+      },
+    );
+
+    const res = await handler(req, ["conv-abc"]);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /v1/permissions/thresholds/conversations/:conversationId", () => {
+  test("removes existing override, subsequent GET returns 404", async () => {
+    const putHandler = createConversationThresholdPutHandler();
+    const getHandler = createConversationThresholdGetHandler();
+    const deleteHandler = createConversationThresholdDeleteHandler();
+
+    // Create
+    const [putReq, putParams] = makePut("conv-del", { threshold: "medium" });
+    await putHandler(putReq, putParams);
+
+    // Delete
+    const [delReq, delParams] = makeDelete("conv-del");
+    const delRes = await deleteHandler(delReq, delParams);
+    expect(delRes.status).toBe(204);
+
+    // Verify gone
+    const [getReq, getParams] = makeGet("conv-del");
+    const getRes = await getHandler(getReq, getParams);
+    expect(getRes.status).toBe(404);
+  });
+
+  test("returns 204 on nonexistent conversation (idempotent)", async () => {
+    const handler = createConversationThresholdDeleteHandler();
+    const [req, params] = makeDelete("conv-nonexistent");
+
+    const res = await handler(req, params);
+    expect(res.status).toBe(204);
+  });
+});

--- a/gateway/src/http/routes/auto-approve-thresholds.ts
+++ b/gateway/src/http/routes/auto-approve-thresholds.ts
@@ -1,0 +1,295 @@
+/**
+ * Auto-approve threshold CRUD endpoints for the gateway.
+ *
+ * Global thresholds: GET/PUT on the singleton `autoApproveThresholds` row.
+ * Per-conversation overrides: GET/PUT/DELETE on `conversationThresholdOverrides`.
+ */
+
+import { eq, sql } from "drizzle-orm";
+
+import { getGatewayDb } from "../../db/connection.js";
+import {
+  autoApproveThresholds,
+  conversationThresholdOverrides,
+} from "../../db/schema.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("auto-approve-thresholds");
+
+// ---------------------------------------------------------------------------
+// Shared validation
+// ---------------------------------------------------------------------------
+
+export const VALID_THRESHOLDS = ["none", "low", "medium"] as const;
+type Threshold = (typeof VALID_THRESHOLDS)[number];
+
+function isValidThreshold(value: unknown): value is Threshold {
+  return (
+    typeof value === "string" && VALID_THRESHOLDS.includes(value as Threshold)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/permissions/thresholds — global thresholds
+// ---------------------------------------------------------------------------
+
+export function createGlobalThresholdGetHandler() {
+  return async (_req: Request): Promise<Response> => {
+    try {
+      const db = getGatewayDb();
+      const row = db
+        .select()
+        .from(autoApproveThresholds)
+        .where(eq(autoApproveThresholds.id, 1))
+        .get();
+
+      if (!row) {
+        // Return defaults when no row exists yet
+        return Response.json({
+          interactive: "low",
+          background: "medium",
+          headless: "none",
+        });
+      }
+
+      return Response.json({
+        interactive: row.interactive,
+        background: row.background,
+        headless: row.headless,
+      });
+    } catch (err) {
+      log.error({ err }, "Failed to read global thresholds");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PUT /v1/permissions/thresholds — upsert global thresholds
+// ---------------------------------------------------------------------------
+
+export function createGlobalThresholdPutHandler() {
+  return async (req: Request): Promise<Response> => {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json(
+        { error: "Request body must be valid JSON" },
+        { status: 400 },
+      );
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return Response.json(
+        { error: "Request body must be a JSON object" },
+        { status: 400 },
+      );
+    }
+
+    const { interactive, background, headless } = body as Record<
+      string,
+      unknown
+    >;
+
+    if (interactive !== undefined && !isValidThreshold(interactive)) {
+      return Response.json(
+        {
+          error: `"interactive" must be one of: ${VALID_THRESHOLDS.join(", ")}`,
+        },
+        { status: 400 },
+      );
+    }
+    if (background !== undefined && !isValidThreshold(background)) {
+      return Response.json(
+        {
+          error: `"background" must be one of: ${VALID_THRESHOLDS.join(", ")}`,
+        },
+        { status: 400 },
+      );
+    }
+    if (headless !== undefined && !isValidThreshold(headless)) {
+      return Response.json(
+        { error: `"headless" must be one of: ${VALID_THRESHOLDS.join(", ")}` },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const db = getGatewayDb();
+      const row = db
+        .insert(autoApproveThresholds)
+        .values({
+          id: 1,
+          ...(interactive ? { interactive } : {}),
+          ...(background ? { background } : {}),
+          ...(headless ? { headless } : {}),
+        })
+        .onConflictDoUpdate({
+          target: autoApproveThresholds.id,
+          set: {
+            ...(interactive ? { interactive } : {}),
+            ...(background ? { background } : {}),
+            ...(headless ? { headless } : {}),
+            updatedAt: sql`datetime('now')`,
+          },
+        })
+        .returning()
+        .get();
+
+      return Response.json({
+        interactive: row.interactive,
+        background: row.background,
+        headless: row.headless,
+      });
+    } catch (err) {
+      log.error({ err }, "Failed to upsert global thresholds");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/permissions/thresholds/conversations/:conversationId
+// ---------------------------------------------------------------------------
+
+export function createConversationThresholdGetHandler() {
+  return async (_req: Request, params: string[]): Promise<Response> => {
+    const conversationId = params[0];
+    if (!conversationId) {
+      return Response.json(
+        { error: "conversationId is required" },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const db = getGatewayDb();
+      const row = db
+        .select()
+        .from(conversationThresholdOverrides)
+        .where(
+          eq(conversationThresholdOverrides.conversationId, conversationId),
+        )
+        .get();
+
+      if (!row) {
+        return Response.json(
+          { error: "No override for this conversation" },
+          { status: 404 },
+        );
+      }
+
+      return Response.json({ threshold: row.threshold });
+    } catch (err) {
+      log.error(
+        { err, conversationId },
+        "Failed to read conversation threshold override",
+      );
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PUT /v1/permissions/thresholds/conversations/:conversationId
+// ---------------------------------------------------------------------------
+
+export function createConversationThresholdPutHandler() {
+  return async (req: Request, params: string[]): Promise<Response> => {
+    const conversationId = params[0];
+    if (!conversationId) {
+      return Response.json(
+        { error: "conversationId is required" },
+        { status: 400 },
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json(
+        { error: "Request body must be valid JSON" },
+        { status: 400 },
+      );
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return Response.json(
+        { error: "Request body must be a JSON object" },
+        { status: 400 },
+      );
+    }
+
+    const { threshold } = body as Record<string, unknown>;
+
+    if (!isValidThreshold(threshold)) {
+      return Response.json(
+        {
+          error: `"threshold" must be one of: ${VALID_THRESHOLDS.join(", ")}`,
+        },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const db = getGatewayDb();
+      db.insert(conversationThresholdOverrides)
+        .values({
+          conversationId,
+          threshold,
+        })
+        .onConflictDoUpdate({
+          target: conversationThresholdOverrides.conversationId,
+          set: {
+            threshold,
+            updatedAt: sql`datetime('now')`,
+          },
+        })
+        .run();
+
+      return Response.json({ conversationId, threshold });
+    } catch (err) {
+      log.error(
+        { err, conversationId },
+        "Failed to upsert conversation threshold override",
+      );
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/permissions/thresholds/conversations/:conversationId
+// ---------------------------------------------------------------------------
+
+export function createConversationThresholdDeleteHandler() {
+  return async (_req: Request, params: string[]): Promise<Response> => {
+    const conversationId = params[0];
+    if (!conversationId) {
+      return Response.json(
+        { error: "conversationId is required" },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const db = getGatewayDb();
+      db.delete(conversationThresholdOverrides)
+        .where(
+          eq(conversationThresholdOverrides.conversationId, conversationId),
+        )
+        .run();
+
+      // 204 No Content — idempotent, succeeds even if row didn't exist
+      return new Response(null, { status: 204 });
+    } catch (err) {
+      log.error(
+        { err, conversationId },
+        "Failed to delete conversation threshold override",
+      );
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -58,6 +58,11 @@ import {
   createPrivacyConfigGetHandler,
   createPrivacyConfigPatchHandler,
 } from "./http/routes/privacy-config.js";
+import {
+  createConversationThresholdGetHandler,
+  createConversationThresholdPutHandler,
+  createConversationThresholdDeleteHandler,
+} from "./http/routes/auto-approve-thresholds.js";
 import { createChannelVerificationSessionProxyHandler } from "./http/routes/channel-verification-session-proxy.js";
 import { createCloudOAuthTokenHandler } from "./http/routes/cloud-oauth-token.js";
 import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-control-plane-proxy.js";
@@ -353,6 +358,12 @@ async function main() {
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
   const handlePrivacyConfigGet = createPrivacyConfigGetHandler();
   const handlePrivacyConfigPatch = createPrivacyConfigPatchHandler();
+  const handleConversationThresholdGet =
+    createConversationThresholdGetHandler();
+  const handleConversationThresholdPut =
+    createConversationThresholdPutHandler();
+  const handleConversationThresholdDelete =
+    createConversationThresholdDeleteHandler();
   const handleTrustRulesList = createTrustRulesListHandler();
   const handleTrustRulesAdd = createTrustRulesAddHandler();
   const handleTrustRulesUpdate = createTrustRulesUpdateHandler();
@@ -1046,6 +1057,53 @@ async function main() {
       auth: "edge-scoped",
       scope: "settings.write",
       handler: (req) => handlePrivacyConfigPatch(req),
+    },
+
+    // ── Per-conversation threshold overrides (scope-protected) ──
+    {
+      path: /^\/v1\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      method: "GET",
+      auth: "edge-scoped",
+      scope: "settings.read",
+      handler: (req, params) => handleConversationThresholdGet(req, params),
+    },
+    {
+      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      method: "GET",
+      auth: "edge-scoped",
+      scope: "settings.read",
+      handler: (req, params) =>
+        handleConversationThresholdGet(req, params.slice(1)),
+    },
+    {
+      path: /^\/v1\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      method: "PUT",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req, params) => handleConversationThresholdPut(req, params),
+    },
+    {
+      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      method: "PUT",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req, params) =>
+        handleConversationThresholdPut(req, params.slice(1)),
+    },
+    {
+      path: /^\/v1\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      method: "DELETE",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req, params) => handleConversationThresholdDelete(req, params),
+    },
+    {
+      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      method: "DELETE",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req, params) =>
+        handleConversationThresholdDelete(req, params.slice(1)),
     },
 
     // ── Log export ──


### PR DESCRIPTION
## Summary
- Add `createConversationThresholdGetHandler()`, `createConversationThresholdPutHandler()`, and `createConversationThresholdDeleteHandler()`
- Register GET/PUT/DELETE routes at `/v1/permissions/thresholds/conversations/:conversationId`
- Add tests for 404 on missing, upsert, idempotent delete, and validation

Part of plan: auto-approve-threshold-ui.plan.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
