### PR TITLE
feat(macos): add Risk Tolerance settings in Permissions & Privacy tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -641,7 +641,7 @@ struct SettingsPanel: View {
             }
 
             // PRIVACY section
-            SettingsPrivacyTab(store: store)
+            SettingsPrivacyTab(store: store, assistantFeatureFlagStore: assistantFeatureFlagStore)
 
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+import VellumAssistantShared
+import os
+
+private let riskToleranceLog = Logger(
+    subsystem: Bundle.appBundleIdentifier,
+    category: "RiskToleranceSection"
+)
+
+/// Risk Tolerance settings section — lets the user configure auto-approve
+/// thresholds for interactive, background, and headless execution contexts.
+@MainActor
+struct RiskToleranceSection: View {
+    var thresholdClient: ThresholdClientProtocol
+    var assistantFeatureFlagStore: AssistantFeatureFlagStore
+
+    /// Current selection for the interactive ("When chatting") threshold.
+    @State private var interactiveSelection: RiskThreshold = .none
+
+    /// Current selection for the background ("Scheduled tasks") threshold.
+    @State private var backgroundSelection: RiskThreshold = .none
+
+    /// Current selection for the headless ("Automation / API") threshold.
+    @State private var headlessSelection: RiskThreshold = .none
+
+    /// In-flight sync task so rapid picker changes cancel the previous
+    /// write and only the latest selection reaches the gateway.
+    @State private var syncTask: Task<Void, Never>?
+
+    /// In-flight load task so repeated view appearances don't stack
+    /// concurrent GETs against the gateway.
+    @State private var loadTask: Task<Void, Never>?
+
+    /// Tracks whether the user has actively picked an option since the
+    /// view appeared. Once set, `loadThresholds()` will NOT overwrite
+    /// selections with the gateway's reconciled value — otherwise a late
+    /// GET response could stomp a user's mid-load selection with stale
+    /// server data.
+    @State private var hasUserInteracted: Bool = false
+
+    var body: some View {
+        SettingsCard(title: "Risk Tolerance") {
+            Text("Auto-approve tools up to this risk level without prompting. Higher levels mean fewer permission prompts.")
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("When chatting")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                VDropdown(
+                    options: RiskThreshold.allCases.map {
+                        VDropdownOption(label: $0.label, value: $0)
+                    },
+                    selection: Binding(
+                        get: { interactiveSelection },
+                        set: { newValue in
+                            hasUserInteracted = true
+                            interactiveSelection = newValue
+                            syncThresholds()
+                        }
+                    ),
+                    maxWidth: 280
+                )
+                .accessibilityLabel("When chatting risk threshold")
+                Text("Auto-approve low-risk tools like reading files and web searches.")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            DisclosureGroup("Advanced") {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    SettingsDivider()
+
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Scheduled tasks")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                        VDropdown(
+                            options: RiskThreshold.allCases.map {
+                                VDropdownOption(label: $0.label, value: $0)
+                            },
+                            selection: Binding(
+                                get: { backgroundSelection },
+                                set: { newValue in
+                                    hasUserInteracted = true
+                                    backgroundSelection = newValue
+                                    syncThresholds()
+                                }
+                            ),
+                            maxWidth: 280
+                        )
+                        .accessibilityLabel("Scheduled tasks risk threshold")
+                        Text("Auto-approve tools when running scheduled background tasks.")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    SettingsDivider()
+
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Automation / API")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                        VDropdown(
+                            options: RiskThreshold.allCases.map {
+                                VDropdownOption(label: $0.label, value: $0)
+                            },
+                            selection: Binding(
+                                get: { headlessSelection },
+                                set: { newValue in
+                                    hasUserInteracted = true
+                                    headlessSelection = newValue
+                                    syncThresholds()
+                                }
+                            ),
+                            maxWidth: 280
+                        )
+                        .accessibilityLabel("Automation / API risk threshold")
+                        Text("Auto-approve tools when triggered via API or automation.")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+        .task { await loadThresholds() }
+    }
+
+    // MARK: - Load Thresholds
+
+    /// Loads the current threshold values from the gateway.
+    ///
+    /// Race-safety: if the user picks an option *before* the GET completes,
+    /// `hasUserInteracted` will be true and the reconciliation assignment
+    /// below is skipped so stale server data cannot overwrite the user's
+    /// just-made selection.
+    private func loadThresholds() async {
+        loadTask?.cancel()
+        let task = Task { @MainActor in
+            do {
+                let thresholds = try await thresholdClient.getGlobalThresholds()
+                guard !Task.isCancelled else { return }
+                guard !hasUserInteracted else { return }
+                interactiveSelection = RiskThreshold(rawValue: thresholds.interactive) ?? .none
+                backgroundSelection = RiskThreshold(rawValue: thresholds.background) ?? .none
+                headlessSelection = RiskThreshold(rawValue: thresholds.headless) ?? .none
+            } catch {
+                riskToleranceLog.error(
+                    "getGlobalThresholds failed: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+        loadTask = task
+        await task.value
+    }
+
+    // MARK: - Sync Thresholds
+
+    /// Syncs the current threshold selections to the gateway, cancelling
+    /// any in-flight sync so that only the latest state wins when the user
+    /// changes rapidly.
+    ///
+    /// If the PUT fails, clears `hasUserInteracted` so a subsequent
+    /// `loadThresholds()` call can reconcile the picker against the
+    /// authoritative gateway state.
+    private func syncThresholds() {
+        syncTask?.cancel()
+        syncTask = Task {
+            do {
+                try await thresholdClient.setGlobalThresholds(
+                    GlobalThresholds(
+                        interactive: interactiveSelection.rawValue,
+                        background: backgroundSelection.rawValue,
+                        headless: headlessSelection.rawValue
+                    )
+                )
+            } catch {
+                guard !Task.isCancelled else { return }
+                riskToleranceLog.error(
+                    "setGlobalThresholds failed: \(error.localizedDescription, privacy: .public)"
+                )
+                hasUserInteracted = false
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -17,7 +17,9 @@ private let llmRequestLogRetentionMsDefaultsKey = "llmRequestLogRetentionMs"
 @MainActor
 struct SettingsPrivacyTab: View {
     @ObservedObject var store: SettingsStore
+    var assistantFeatureFlagStore: AssistantFeatureFlagStore
     var featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
+    var thresholdClient: ThresholdClientProtocol = ThresholdClient()
 
     /// Tracks the in-flight privacy sync task so rapid toggles cancel the
     /// previous write and only the latest values reach the daemon.
@@ -49,6 +51,12 @@ struct SettingsPrivacyTab: View {
     @State private var hasUserInteracted: Bool = false
 
     var body: some View {
+        if assistantFeatureFlagStore.isEnabled("auto-approve-threshold-ui") {
+            RiskToleranceSection(
+                thresholdClient: thresholdClient,
+                assistantFeatureFlagStore: assistantFeatureFlagStore
+            )
+        }
         privacySection
     }
 

--- a/clients/shared/Network/ThresholdClient.swift
+++ b/clients/shared/Network/ThresholdClient.swift
@@ -1,0 +1,134 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ThresholdClient")
+
+// MARK: - Types
+
+/// The three risk-tolerance levels a user can select.
+public enum RiskThreshold: String, CaseIterable, Identifiable, Hashable {
+    case none = "none"
+    case low = "low"
+    case medium = "medium"
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .none: return "None"
+        case .low: return "Low"
+        case .medium: return "Medium"
+        }
+    }
+}
+
+/// Global threshold configuration returned by the gateway API.
+public struct GlobalThresholds: Codable, Sendable, Equatable {
+    public let interactive: String
+    public let background: String
+    public let headless: String
+
+    public init(interactive: String, background: String, headless: String) {
+        self.interactive = interactive
+        self.background = background
+        self.headless = headless
+    }
+}
+
+/// Wrapper for the conversation override response.
+private struct ConversationOverrideResponse: Decodable {
+    let threshold: String?
+}
+
+// MARK: - Errors
+
+public enum ThresholdClientError: Error, LocalizedError {
+    case requestFailed(Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .requestFailed(let code):
+            return "Threshold request failed (HTTP \(code))"
+        }
+    }
+}
+
+// MARK: - Protocol
+
+/// Focused client for auto-approve threshold operations routed through the gateway.
+public protocol ThresholdClientProtocol {
+    func getGlobalThresholds() async throws -> GlobalThresholds
+    func setGlobalThresholds(_ thresholds: GlobalThresholds) async throws
+    func getConversationOverride(conversationId: String) async throws -> String?
+    func setConversationOverride(conversationId: String, threshold: String) async throws
+    func deleteConversationOverride(conversationId: String) async throws
+}
+
+// MARK: - Gateway-Backed Implementation
+
+/// Gateway-backed implementation of ``ThresholdClientProtocol``.
+public struct ThresholdClient: ThresholdClientProtocol {
+    nonisolated public init() {}
+
+    public func getGlobalThresholds() async throws -> GlobalThresholds {
+        let response = try await GatewayHTTPClient.get(
+            path: "permissions/thresholds", timeout: 10
+        )
+        guard response.isSuccess else {
+            log.error("getGlobalThresholds failed (HTTP \(response.statusCode))")
+            throw ThresholdClientError.requestFailed(response.statusCode)
+        }
+        return try JSONDecoder().decode(GlobalThresholds.self, from: response.data)
+    }
+
+    public func setGlobalThresholds(_ thresholds: GlobalThresholds) async throws {
+        let body: [String: Any] = [
+            "interactive": thresholds.interactive,
+            "background": thresholds.background,
+            "headless": thresholds.headless,
+        ]
+        let response = try await GatewayHTTPClient.put(
+            path: "permissions/thresholds", json: body, timeout: 10
+        )
+        guard response.isSuccess else {
+            log.error("setGlobalThresholds failed (HTTP \(response.statusCode))")
+            throw ThresholdClientError.requestFailed(response.statusCode)
+        }
+    }
+
+    public func getConversationOverride(conversationId: String) async throws -> String? {
+        let response = try await GatewayHTTPClient.get(
+            path: "permissions/thresholds/conversations/\(conversationId)", timeout: 10
+        )
+        if response.statusCode == 404 {
+            return nil
+        }
+        guard response.isSuccess else {
+            log.error("getConversationOverride failed (HTTP \(response.statusCode))")
+            throw ThresholdClientError.requestFailed(response.statusCode)
+        }
+        let decoded = try JSONDecoder().decode(ConversationOverrideResponse.self, from: response.data)
+        return decoded.threshold
+    }
+
+    public func setConversationOverride(conversationId: String, threshold: String) async throws {
+        let body: [String: Any] = ["threshold": threshold]
+        let response = try await GatewayHTTPClient.put(
+            path: "permissions/thresholds/conversations/\(conversationId)", json: body, timeout: 10
+        )
+        guard response.isSuccess else {
+            log.error("setConversationOverride failed (HTTP \(response.statusCode))")
+            throw ThresholdClientError.requestFailed(response.statusCode)
+        }
+    }
+
+    public func deleteConversationOverride(conversationId: String) async throws {
+        let response = try await GatewayHTTPClient.delete(
+            path: "permissions/thresholds/conversations/\(conversationId)", timeout: 10
+        )
+        guard response.isSuccess else {
+            log.error("deleteConversationOverride failed (HTTP \(response.statusCode))")
+            throw ThresholdClientError.requestFailed(response.statusCode)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ThresholdClient` for gateway threshold API calls
- Add `RiskToleranceSection` SwiftUI view with interactive/background/headless dropdowns
- Integrate into `SettingsPrivacyTab` behind `auto-approve-threshold-ui` feature flag

Part of plan: auto-approve-threshold-ui.plan.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
