### PR TITLE
feat(assistant): add gateway-backed threshold reader with feature flag gate

### DIFF
--- a/assistant/__tests__/permissions/gateway-threshold-reader.test.ts
+++ b/assistant/__tests__/permissions/gateway-threshold-reader.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+let mockFeatureFlagEnabled = true;
+
+mock.module("../../src/config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (_key: string, _config: unknown) =>
+    mockFeatureFlagEnabled,
+}));
+
+mock.module("../../src/config/loader.js", () => ({
+  getConfig: () => ({}),
+}));
+
+// Track gatewayGet calls for assertion
+const gatewayGetCalls: string[] = [];
+let gatewayGetHandler: (path: string) => unknown = () => ({});
+
+mock.module("../../src/runtime/gateway-internal-client.js", () => ({
+  GatewayRequestError: class GatewayRequestError extends Error {
+    statusCode: number;
+    gatewayError: string | undefined;
+    constructor(message: string, statusCode: number, gatewayError?: string) {
+      super(message);
+      this.name = "GatewayRequestError";
+      this.statusCode = statusCode;
+      this.gatewayError = gatewayError;
+    }
+  },
+  gatewayGet: async <T>(path: string): Promise<T> => {
+    gatewayGetCalls.push(path);
+    return gatewayGetHandler(path) as T;
+  },
+}));
+
+// Suppress logger output in tests
+mock.module("../../src/util/logger.js", () => ({
+  getLogger: () => ({
+    warn: () => {},
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+import {
+  _clearGlobalCacheForTesting,
+  getAutoApproveThreshold,
+} from "../../src/permissions/gateway-threshold-reader.js";
+// Import GatewayRequestError from the mock so we can throw instances of it
+const { GatewayRequestError } =
+  await import("../../src/runtime/gateway-internal-client.js");
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function resetMocks(): void {
+  mockFeatureFlagEnabled = true;
+  gatewayGetCalls.length = 0;
+  gatewayGetHandler = () => ({});
+  _clearGlobalCacheForTesting();
+}
+
+afterEach(resetMocks);
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("getAutoApproveThreshold", () => {
+  test("returns undefined when feature flag is off", async () => {
+    mockFeatureFlagEnabled = false;
+    const result = await getAutoApproveThreshold("conv-123", "conversation");
+    expect(result).toBeUndefined();
+    // Should not make any gateway calls
+    expect(gatewayGetCalls).toHaveLength(0);
+  });
+
+  test("returns global defaults when gateway returns them", async () => {
+    gatewayGetHandler = (path: string) => {
+      if (path === "/v1/permissions/thresholds") {
+        return {
+          interactive: "medium",
+          background: "low",
+          headless: "none",
+        };
+      }
+      return {};
+    };
+
+    // conversation maps to interactive
+    expect(await getAutoApproveThreshold(undefined, "conversation")).toBe(
+      "medium",
+    );
+
+    _clearGlobalCacheForTesting();
+
+    expect(await getAutoApproveThreshold(undefined, "background")).toBe("low");
+
+    _clearGlobalCacheForTesting();
+
+    expect(await getAutoApproveThreshold(undefined, "headless")).toBe("none");
+  });
+
+  test("returns conversation override when it exists", async () => {
+    gatewayGetHandler = (path: string) => {
+      if (path === "/v1/permissions/thresholds/conversations/conv-xyz") {
+        return { threshold: "medium" };
+      }
+      if (path === "/v1/permissions/thresholds") {
+        return {
+          interactive: "low",
+          background: "medium",
+          headless: "none",
+        };
+      }
+      return {};
+    };
+
+    const result = await getAutoApproveThreshold("conv-xyz", "conversation");
+    expect(result).toBe("medium");
+    // Should have called the conversation endpoint, not the global one
+    expect(gatewayGetCalls).toEqual([
+      "/v1/permissions/thresholds/conversations/conv-xyz",
+    ]);
+  });
+
+  test("falls back to global when conversation override returns 404", async () => {
+    gatewayGetHandler = (path: string) => {
+      if (path.startsWith("/v1/permissions/thresholds/conversations/")) {
+        throw new GatewayRequestError("Not found", 404, "Not found");
+      }
+      if (path === "/v1/permissions/thresholds") {
+        return {
+          interactive: "low",
+          background: "medium",
+          headless: "none",
+        };
+      }
+      return {};
+    };
+
+    const result = await getAutoApproveThreshold("conv-123", "conversation");
+    expect(result).toBe("low");
+    // Should have called both endpoints
+    expect(gatewayGetCalls).toEqual([
+      "/v1/permissions/thresholds/conversations/conv-123",
+      "/v1/permissions/thresholds",
+    ]);
+  });
+
+  test("falls back to hardcoded defaults on gateway error", async () => {
+    gatewayGetHandler = () => {
+      throw new Error("Connection refused");
+    };
+
+    // conversation → "low"
+    expect(await getAutoApproveThreshold(undefined, "conversation")).toBe(
+      "low",
+    );
+
+    _clearGlobalCacheForTesting();
+
+    // background → "medium"
+    expect(await getAutoApproveThreshold(undefined, "background")).toBe(
+      "medium",
+    );
+
+    _clearGlobalCacheForTesting();
+
+    // headless → "none"
+    expect(await getAutoApproveThreshold(undefined, "headless")).toBe("none");
+  });
+
+  test("falls back to hardcoded defaults on non-404 conversation error", async () => {
+    gatewayGetHandler = (path: string) => {
+      if (path.startsWith("/v1/permissions/thresholds/conversations/")) {
+        throw new GatewayRequestError("Internal error", 500, "Server error");
+      }
+      // Should not reach global endpoint
+      return {
+        interactive: "medium",
+        background: "medium",
+        headless: "medium",
+      };
+    };
+
+    const result = await getAutoApproveThreshold("conv-123", "conversation");
+    // Should fall back to hardcoded default for conversation, not global endpoint
+    expect(result).toBe("low");
+    // Should have only called the conversation endpoint
+    expect(gatewayGetCalls).toEqual([
+      "/v1/permissions/thresholds/conversations/conv-123",
+    ]);
+  });
+
+  test("caching: second call within 30s does not re-fetch global", async () => {
+    let fetchCount = 0;
+    gatewayGetHandler = (path: string) => {
+      if (path === "/v1/permissions/thresholds") {
+        fetchCount++;
+        return {
+          interactive: "medium",
+          background: "low",
+          headless: "none",
+        };
+      }
+      return {};
+    };
+
+    // First call — should fetch
+    const first = await getAutoApproveThreshold(undefined, "conversation");
+    expect(first).toBe("medium");
+    expect(fetchCount).toBe(1);
+
+    // Second call — should use cache
+    const second = await getAutoApproveThreshold(undefined, "background");
+    expect(second).toBe("low");
+    expect(fetchCount).toBe(1); // Still 1, cache hit
+
+    // Third call — still cached
+    const third = await getAutoApproveThreshold(undefined, "headless");
+    expect(third).toBe("none");
+    expect(fetchCount).toBe(1); // Still 1
+
+    // After clearing cache, should re-fetch
+    _clearGlobalCacheForTesting();
+    const fourth = await getAutoApproveThreshold(undefined, "conversation");
+    expect(fourth).toBe("medium");
+    expect(fetchCount).toBe(2); // Incremented
+  });
+
+  test("defaults executionContext to conversation when omitted", async () => {
+    gatewayGetHandler = (path: string) => {
+      if (path === "/v1/permissions/thresholds") {
+        return {
+          interactive: "medium",
+          background: "low",
+          headless: "none",
+        };
+      }
+      return {};
+    };
+
+    // executionContext omitted — should default to "conversation" → interactive
+    const result = await getAutoApproveThreshold(undefined, undefined);
+    expect(result).toBe("medium");
+  });
+
+  test("skips conversation override when no conversationId", async () => {
+    gatewayGetHandler = (path: string) => {
+      if (path === "/v1/permissions/thresholds") {
+        return {
+          interactive: "low",
+          background: "medium",
+          headless: "none",
+        };
+      }
+      return {};
+    };
+
+    const result = await getAutoApproveThreshold(undefined, "conversation");
+    expect(result).toBe("low");
+    // Should only call global endpoint, not conversation
+    expect(gatewayGetCalls).toEqual(["/v1/permissions/thresholds"]);
+  });
+
+  test("skips conversation override for non-conversation contexts", async () => {
+    gatewayGetHandler = (path: string) => {
+      if (path === "/v1/permissions/thresholds") {
+        return {
+          interactive: "low",
+          background: "medium",
+          headless: "none",
+        };
+      }
+      return {};
+    };
+
+    // Even with a conversationId, background context should not check conversation override
+    const result = await getAutoApproveThreshold("conv-123", "background");
+    expect(result).toBe("medium");
+    expect(gatewayGetCalls).toEqual(["/v1/permissions/thresholds"]);
+  });
+});

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -23,6 +23,7 @@ import {
 } from "./approval-policy.js";
 import { bashRiskClassifier } from "./bash-risk-classifier.js";
 import { fileRiskClassifier } from "./file-risk-classifier.js";
+import { getAutoApproveThreshold } from "./gateway-threshold-reader.js";
 import { type RiskAssessment, riskToRiskLevel } from "./risk-types.js";
 import {
   buildShellAllowlistOptions,
@@ -592,10 +593,16 @@ export async function check(
   // Build approval context from local variables
   const tool = getTool(toolName);
   const config = getConfig();
-  const resolvedThreshold = resolveThreshold(
-    config.permissions.autoApproveUpTo,
+  const gatewayThreshold = await getAutoApproveThreshold(
+    policyContext?.conversationId,
     policyContext?.executionContext,
   );
+  const resolvedThreshold =
+    gatewayThreshold ??
+    resolveThreshold(
+      config.permissions.autoApproveUpTo,
+      policyContext?.executionContext,
+    );
   const approvalContext: ApprovalContext = {
     riskLevel: risk,
     toolName,

--- a/assistant/src/permissions/gateway-threshold-reader.ts
+++ b/assistant/src/permissions/gateway-threshold-reader.ts
@@ -1,0 +1,154 @@
+/**
+ * Gateway-backed auto-approve threshold reader.
+ *
+ * When the `auto-approve-threshold-ui` feature flag is enabled, reads
+ * thresholds from the gateway REST API. Falls back to `undefined` (caller
+ * uses config-based `resolveThreshold`) when the flag is off or the gateway
+ * is unreachable.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
+import {
+  gatewayGet,
+  GatewayRequestError,
+} from "../runtime/gateway-internal-client.js";
+import { getLogger } from "../util/logger.js";
+import type { ExecutionContext } from "./approval-policy.js";
+
+const log = getLogger("gateway-threshold-reader");
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type Threshold = "none" | "low" | "medium";
+
+interface GlobalThresholds {
+  interactive: string;
+  background: string;
+  headless: string;
+}
+
+interface ConversationThreshold {
+  threshold: string;
+}
+
+// ── Global threshold cache (30s TTL) ─────────────────────────────────────────
+
+let cachedGlobalThresholds: GlobalThresholds | null = null;
+let cachedGlobalTimestamp = 0;
+const GLOBAL_CACHE_TTL_MS = 30_000;
+
+/**
+ * Clear the global threshold cache. Exported for testing.
+ */
+export function _clearGlobalCacheForTesting(): void {
+  cachedGlobalThresholds = null;
+  cachedGlobalTimestamp = 0;
+}
+
+// ── Hardcoded fallback defaults ──────────────────────────────────────────────
+
+const HARDCODED_DEFAULTS: Record<ExecutionContext, Threshold> = {
+  conversation: "low",
+  background: "medium",
+  headless: "none",
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function mapExecutionContextToField(
+  executionContext: ExecutionContext,
+): keyof GlobalThresholds {
+  if (executionContext === "conversation") return "interactive";
+  return executionContext;
+}
+
+function isValidThreshold(value: string): value is Threshold {
+  return value === "none" || value === "low" || value === "medium";
+}
+
+// ── Main export ──────────────────────────────────────────────────────────────
+
+/**
+ * Read the auto-approve threshold from the gateway.
+ *
+ * Returns `undefined` when the feature flag is off (caller falls back to
+ * config-based `resolveThreshold`).
+ *
+ * For `"conversation"` context with a `conversationId`, checks for a
+ * per-conversation override first. Falls through to global defaults when
+ * the conversation override returns 404 or is absent.
+ *
+ * Caches global thresholds for 30 seconds to avoid hammering the gateway.
+ * On any gateway error (other than 404 for conversation override), logs a
+ * warning and returns hardcoded defaults.
+ */
+export async function getAutoApproveThreshold(
+  conversationId: string | undefined,
+  executionContext?: ExecutionContext,
+): Promise<Threshold | undefined> {
+  const config = getConfig();
+  if (!isAssistantFeatureFlagEnabled("auto-approve-threshold-ui", config)) {
+    return undefined;
+  }
+
+  const ctx: ExecutionContext = executionContext ?? "conversation";
+
+  // For conversation context with a conversationId, try per-conversation override first
+  if (ctx === "conversation" && conversationId) {
+    try {
+      const result = await gatewayGet<ConversationThreshold>(
+        `/v1/permissions/thresholds/conversations/${conversationId}`,
+      );
+      if (isValidThreshold(result.threshold)) {
+        return result.threshold;
+      }
+    } catch (err) {
+      if (err instanceof GatewayRequestError && err.statusCode === 404) {
+        // No conversation override — fall through to global
+      } else {
+        log.warn(
+          { conversationId, error: String(err) },
+          "Failed to fetch conversation threshold override, falling back to defaults",
+        );
+        return HARDCODED_DEFAULTS[ctx];
+      }
+    }
+  }
+
+  // Fetch global thresholds (with 30s cache)
+  try {
+    const global = await fetchGlobalThresholds();
+    const field = mapExecutionContextToField(ctx);
+    const value = global[field];
+    if (isValidThreshold(value)) {
+      return value;
+    }
+    // Unexpected value from gateway — fall back to hardcoded
+    log.warn({ field, value }, "Gateway returned unexpected threshold value");
+    return HARDCODED_DEFAULTS[ctx];
+  } catch (err) {
+    log.warn(
+      { error: String(err) },
+      "Failed to fetch global thresholds, falling back to defaults",
+    );
+    return HARDCODED_DEFAULTS[ctx];
+  }
+}
+
+async function fetchGlobalThresholds(): Promise<GlobalThresholds> {
+  const now = Date.now();
+  if (
+    cachedGlobalThresholds &&
+    now - cachedGlobalTimestamp < GLOBAL_CACHE_TTL_MS
+  ) {
+    return cachedGlobalThresholds;
+  }
+
+  const result = await gatewayGet<GlobalThresholds>(
+    "/v1/permissions/thresholds",
+  );
+  cachedGlobalThresholds = result;
+  cachedGlobalTimestamp = Date.now();
+  return result;
+}

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -69,4 +69,6 @@ export interface PolicyContext {
    * - "headless": non-interactive non-guardian session
    */
   executionContext?: "conversation" | "background" | "headless";
+  /** Conversation ID for per-conversation threshold overrides. */
+  conversationId?: string;
 }

--- a/assistant/src/tools/policy-context.ts
+++ b/assistant/src/tools/policy-context.ts
@@ -34,16 +34,20 @@ export function buildPolicyContext(
 
   const executionContext = deriveExecutionContext(context);
 
+  const conversationId = context?.conversationId;
+
   if (tool.origin === "skill") {
     return {
       executionTarget: tool.executionTarget,
       ephemeralRules: ephemeralRules?.length ? ephemeralRules : undefined,
       executionContext,
+      conversationId,
     };
   }
 
   return {
     ephemeralRules: ephemeralRules?.length ? ephemeralRules : undefined,
     executionContext,
+    conversationId,
   };
 }


### PR DESCRIPTION
## Summary
- Add `getAutoApproveThreshold()` that reads from gateway with 30s TTL cache
- Wire into `checker.ts` to use gateway thresholds when feature flag is enabled
- Falls back to config.json `resolveThreshold()` when flag is off or gateway errors

Part of plan: auto-approve-threshold-ui.plan.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
