### PR TITLE
fix(managed): close onboarding + reconcile gaps for vellum identity fields

### DIFF
--- a/assistant/src/runtime/routes/__tests__/migration-vellum-metadata-reconcile.test.ts
+++ b/assistant/src/runtime/routes/__tests__/migration-vellum-metadata-reconcile.test.ts
@@ -2,19 +2,23 @@
  * Tests for the post-import vellum metadata reconciliation helper.
  *
  * After every bundle import, `reconcileVellumMetadataFromCes` walks the
- * four platform-identity fields the gateway requires and, for each one
- * that CES already holds a value for, ensures `metadata.json` lists a
- * matching entry. This closes the race where Django's post-hatch
- * provisioning writes its CES value successfully but its metadata upsert
- * gets clobbered by the import's in-place clear or atomic swap.
+ * platform-identity fields the gateway requires and, for each one that
+ * CES already holds a value for, ensures `metadata.json` lists a
+ * matching entry. This closes the race where a provisioning write to
+ * CES completes successfully but its metadata upsert gets clobbered by
+ * the import's in-place clear or atomic swap. The reconciled set covers
+ * both the Django-provisioned fields (assistant_api_key,
+ * platform_assistant_id, platform_base_url, webhook_secret) and the
+ * client-injected identity fields (platform_organization_id,
+ * platform_user_id).
  *
  * We test the reconcile logic in isolation by mocking the secure-keys
  * and metadata-store modules — the real migration handler wires the
  * same imports, so the behavior under test matches production.
  *
  * Covered:
- * - CES has all 4 fields + metadata empty → all 4 upserted.
- * - CES has all 4 + metadata has 2 → only the missing 2 upserted.
+ * - CES has all 6 fields + metadata empty → all 6 upserted.
+ * - CES has all 6 + metadata has 2 → only the missing 4 upserted.
  * - CES has no values → nothing upserted.
  * - CES has values + metadata already has them → no-op (no duplicate
  *   upserts).
@@ -39,6 +43,8 @@ const VELLUM_FIELDS = [
   "platform_base_url",
   "assistant_api_key",
   "platform_assistant_id",
+  "platform_organization_id",
+  "platform_user_id",
   "webhook_secret",
 ] as const;
 
@@ -118,30 +124,31 @@ afterEach(() => {
   upsertCalls.length = 0;
 });
 
-function seedAllFourInCes(): void {
+function seedAllInCes(): void {
   for (const field of VELLUM_FIELDS) {
     cesValues.set(credentialKey("vellum", field), `value-for-${field}`);
   }
 }
 
 describe("reconcileVellumMetadataFromCes", () => {
-  test("CES holds all 4 fields, metadata empty → all 4 upserted", async () => {
-    seedAllFourInCes();
+  test("CES holds all fields, metadata empty → all upserted", async () => {
+    seedAllInCes();
     const sink = { warnings: [] as string[] };
 
     await reconcileVellumMetadataFromCes(sink);
 
-    expect(upsertCalls).toHaveLength(4);
+    expect(upsertCalls).toHaveLength(VELLUM_FIELDS.length);
     expect(new Set(upsertCalls.map((c) => c.field))).toEqual(
       new Set(VELLUM_FIELDS),
     );
     expect(sink.warnings).toHaveLength(0);
   });
 
-  test("CES holds all 4, metadata has 2 → only the missing 2 upserted", async () => {
-    seedAllFourInCes();
-    // Pre-populate metadata for 2 of the 4 fields.
-    for (const field of ["platform_base_url", "assistant_api_key"] as const) {
+  test("CES holds all, metadata has 2 → only the missing ones upserted", async () => {
+    seedAllInCes();
+    // Pre-populate metadata for 2 of the fields.
+    const prepopulated = ["platform_base_url", "assistant_api_key"] as const;
+    for (const field of prepopulated) {
       metadataStore.set(`vellum:${field}`, {
         credentialId: `id-vellum:${field}`,
         service: "vellum",
@@ -156,10 +163,29 @@ describe("reconcileVellumMetadataFromCes", () => {
     const sink = { warnings: [] as string[] };
     await reconcileVellumMetadataFromCes(sink);
 
-    expect(upsertCalls).toHaveLength(2);
-    expect(new Set(upsertCalls.map((c) => c.field))).toEqual(
-      new Set(["platform_assistant_id", "webhook_secret"]),
+    const expectedMissing = VELLUM_FIELDS.filter(
+      (f) => !(prepopulated as readonly string[]).includes(f),
     );
+    expect(upsertCalls).toHaveLength(expectedMissing.length);
+    expect(new Set(upsertCalls.map((c) => c.field))).toEqual(
+      new Set(expectedMissing),
+    );
+  });
+
+  test("covers both Django-provisioned and client-injected identity fields", async () => {
+    seedAllInCes();
+    const sink = { warnings: [] as string[] };
+    await reconcileVellumMetadataFromCes(sink);
+
+    const reconciled = new Set(upsertCalls.map((c) => c.field));
+    // Django-provisioned quartet.
+    expect(reconciled).toContain("platform_base_url");
+    expect(reconciled).toContain("assistant_api_key");
+    expect(reconciled).toContain("platform_assistant_id");
+    expect(reconciled).toContain("webhook_secret");
+    // Client-injected identity fields (onboarding / teleport / transfer).
+    expect(reconciled).toContain("platform_organization_id");
+    expect(reconciled).toContain("platform_user_id");
   });
 
   test("CES empty → nothing upserted", async () => {
@@ -170,8 +196,7 @@ describe("reconcileVellumMetadataFromCes", () => {
   });
 
   test("CES has values, metadata already has entries → no duplicate upserts", async () => {
-    seedAllFourInCes();
-    // Seed metadata for all 4.
+    seedAllInCes();
     for (const field of VELLUM_FIELDS) {
       metadataStore.set(`vellum:${field}`, {
         credentialId: `id-vellum:${field}`,
@@ -191,7 +216,7 @@ describe("reconcileVellumMetadataFromCes", () => {
   });
 
   test("upsert throws for one field → warning recorded, loop continues", async () => {
-    seedAllFourInCes();
+    seedAllInCes();
     let calls = 0;
     upsertImpl = (service, field) => {
       calls += 1;
@@ -214,7 +239,7 @@ describe("reconcileVellumMetadataFromCes", () => {
     await reconcileVellumMetadataFromCes(sink);
 
     // Every field was attempted (loop did not abort).
-    expect(calls).toBe(4);
+    expect(calls).toBe(VELLUM_FIELDS.length);
     expect(sink.warnings).toHaveLength(1);
     expect(sink.warnings[0]).toContain("vellum:assistant_api_key");
   });

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -73,18 +73,23 @@ import { validateVBundle } from "../migrations/vbundle-validator.js";
 const PLATFORM_CREDENTIAL_PREFIX = credentialKey("vellum", "");
 
 /**
- * Platform-identity fields that the managed runtime expects to see in CES
- * (populated by Django's post-hatch provisioning via `POST /v1/secrets`).
- * After an import we reconcile metadata.json against CES: for every field
- * where CES already holds a value, make sure metadata has a matching
- * entry. This closes a race where Django's provisioning POST arrives
- * during the import — its CES write survives (separate volume), but its
- * metadata upsert may be clobbered by the in-place clear / atomic swap.
+ * Platform-identity fields that the managed runtime expects to see in CES.
+ * Django's post-hatch provisioning populates the first four via
+ * `POST /v1/secrets`; `platform_organization_id` and `platform_user_id` are
+ * populated by the signed-in client after hatch (onboarding, teleport,
+ * local→managed transfer) because Django has no signed-in user session to
+ * resolve them. Either set of writes can race with the import — the CES
+ * write survives (separate volume), but the metadata upsert may be
+ * clobbered by the in-place clear / atomic swap. After every import we
+ * reconcile metadata.json against CES so any field CES already holds a
+ * value for gets a matching metadata entry.
  */
 const VELLUM_PLATFORM_IDENTITY_FIELDS = [
   "platform_base_url",
   "assistant_api_key",
   "platform_assistant_id",
+  "platform_organization_id",
+  "platform_user_id",
   "webhook_secret",
 ] as const;
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -430,6 +430,27 @@ struct OnboardingFlowView: View {
                 ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
                 if response.isSuccess {
                     log.info("Managed assistant \(assistantId, privacy: .public) is ready")
+
+                    // Inject client-resolvable vellum identity fields that
+                    // Django's post-hatch provisioning doesn't cover (org
+                    // id, user id). Local assistants get these via
+                    // `LocalAssistantBootstrapService`; the managed hatch
+                    // path skips that bootstrap, so onboarding has to
+                    // inject them directly. Best-effort: skip when the
+                    // org id isn't cached rather than blocking onboarding
+                    // on a fresh lookup. `ensureManagedAssistant()`
+                    // already resolved and persisted the org id earlier
+                    // in the bootstrap.
+                    if let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId"),
+                       !organizationId.isEmpty {
+                        await ManagedAssistantIdentityInjection.inject(
+                            into: assistantId,
+                            organizationId: organizationId
+                        )
+                    } else {
+                        log.warning("Skipping vellum identity injection — no cached organization id for \(assistantId, privacy: .public)")
+                    }
+
                     state.hatchCurrentStep = 3
                     state.hatchStepLabel = "Ready"
                     state.hatchProgressTarget = 1.0


### PR DESCRIPTION
## Summary

- Call `ManagedAssistantIdentityInjection.inject` from the onboarding hatch flow (`OnboardingFlowView.awaitManagedAssistantReady`). Without this, a fresh managed hatch — the one path #27163 didn't cover — still boots without `platform_organization_id` / `platform_user_id`.
- Extend `VELLUM_PLATFORM_IDENTITY_FIELDS` in `migration-routes.ts` to include `platform_organization_id` and `platform_user_id` so `reconcileVellumMetadataFromCes` can restore their metadata.json entries if the client inject races with the import's workspace clear. Tests updated accordingly.

## Original prompt

I merged in that PR, please also address this other issue
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
