### PR TITLE
feat(macos): add per-conversation risk threshold picker in chat composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -91,6 +91,7 @@ struct ChatView: View {
     var watchSession: WatchSession?
     var conversationManager: ConversationManager? = nil
     var showsConversationHostAccessControl: Bool = false
+    var showThresholdPicker: Bool = false
 
     @State private var isDropTargeted = false
     @State private var isDraggingInternalImage = false
@@ -500,7 +501,8 @@ struct ChatView: View {
                         contextWindowFillRatio: viewModel.contextWindowFillRatio,
                         contextWindowTokens: viewModel.contextWindowTokens,
                         contextWindowMaxTokens: viewModel.contextWindowMaxTokens,
-                        conversationHostAccessControl: conversationHostAccessControl
+                        conversationHostAccessControl: conversationHostAccessControl,
+                        showThresholdPicker: showThresholdPicker
                     )
                     .equatable()
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -48,6 +48,7 @@ struct ComposerSection: View, Equatable {
             && lhs.conversationHostAccessControl?.isUpdating == rhs.conversationHostAccessControl?.isUpdating
             && lhs.conversationHostAccessControl?.subtitle == rhs.conversationHostAccessControl?.subtitle
             && lhs.conversationHostAccessControl?.errorMessage == rhs.conversationHostAccessControl?.errorMessage
+            && lhs.showThresholdPicker == rhs.showThresholdPicker
     }
 
     @Binding var inputText: String
@@ -81,6 +82,7 @@ struct ComposerSection: View, Equatable {
     var contextWindowTokens: Int? = nil
     var contextWindowMaxTokens: Int? = nil
     var conversationHostAccessControl: ConversationHostAccessControlConfiguration? = nil
+    var showThresholdPicker: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -121,7 +123,8 @@ struct ComposerSection: View, Equatable {
                 contextWindowFillRatio: contextWindowFillRatio,
                 contextWindowTokens: contextWindowTokens,
                 contextWindowMaxTokens: contextWindowMaxTokens,
-                conversationHostAccessControl: conversationHostAccessControl
+                conversationHostAccessControl: conversationHostAccessControl,
+                showThresholdPicker: showThresholdPicker
             )
             .equatable()
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
@@ -1,0 +1,305 @@
+import SwiftUI
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ComposerThresholdPicker")
+
+// MARK: - Threshold Preset
+
+/// The three presets surfaced in the per-conversation threshold picker.
+/// Each maps to a concrete ``RiskThreshold`` value.
+enum ThresholdPreset: String, CaseIterable, Identifiable, Equatable {
+    /// Prompt for everything (maps to ``RiskThreshold.none``).
+    case strict
+    /// Match the global interactive default (no override stored).
+    case `default`
+    /// Auto-approve most tools (maps to ``RiskThreshold.medium``).
+    case relaxed
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .strict: return "Strict"
+        case .default: return "Default"
+        case .relaxed: return "Relaxed"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .strict: return "Prompt for everything"
+        case .default: return "Auto-approve low-risk tools"
+        case .relaxed: return "Auto-approve most tools"
+        }
+    }
+
+    var icon: VIcon {
+        switch self {
+        case .strict: return .lock
+        case .default: return .shieldCheck
+        case .relaxed: return .triangleAlert
+        }
+    }
+
+    var iconColor: Color {
+        switch self {
+        case .strict: return VColor.contentSecondary
+        case .default: return VColor.contentSecondary
+        case .relaxed: return VColor.systemMidStrong
+        }
+    }
+
+    /// The ``RiskThreshold`` raw value to write when this preset is selected.
+    /// Returns `nil` for `.default` — the caller should delete the override instead.
+    var thresholdValue: String? {
+        switch self {
+        case .strict: return RiskThreshold.none.rawValue
+        case .default: return nil
+        case .relaxed: return RiskThreshold.medium.rawValue
+        }
+    }
+
+    /// Determines the preset that best describes a conversation override value
+    /// relative to the global interactive default.
+    ///
+    /// - Parameters:
+    ///   - override: The conversation-level threshold string, or `nil` when no
+    ///     override exists.
+    ///   - globalInteractive: The global interactive threshold raw value.
+    /// - Returns: The matching preset.
+    static func from(override: String?, globalInteractive: String) -> ThresholdPreset {
+        guard let override else { return .default }
+        if override == globalInteractive { return .default }
+
+        // Compare by risk level ordering: none < low < medium
+        let order: [String] = [
+            RiskThreshold.none.rawValue,
+            RiskThreshold.low.rawValue,
+            RiskThreshold.medium.rawValue,
+        ]
+        let overrideIndex = order.firstIndex(of: override) ?? 0
+        let globalIndex = order.firstIndex(of: globalInteractive) ?? 0
+
+        if overrideIndex < globalIndex {
+            return .strict
+        } else if overrideIndex > globalIndex {
+            return .relaxed
+        } else {
+            return .default
+        }
+    }
+}
+
+// MARK: - ComposerThresholdPicker
+
+/// A compact pill button in the composer action bar that lets the user set a
+/// per-conversation auto-approve threshold override. Opens a dropdown menu
+/// with three presets: Strict, Default, and Relaxed.
+@MainActor
+struct ComposerThresholdPicker: View {
+    let conversationId: UUID?
+    var thresholdClient: ThresholdClientProtocol = ThresholdClient()
+
+    /// The currently displayed preset. Updated optimistically on selection and
+    /// reconciled with the gateway on appearance / conversation change.
+    @State private var currentPreset: ThresholdPreset = .default
+
+    /// The global interactive threshold raw value, fetched on load.
+    @State private var globalInteractive: String = RiskThreshold.low.rawValue
+
+    /// In-flight write task, cancelled on rapid re-selection.
+    @State private var writeTask: Task<Void, Never>?
+
+    /// In-flight load task, cancelled on re-appearance.
+    @State private var loadTask: Task<Void, Never>?
+
+    /// Tracks whether the user has actively picked since last load so stale
+    /// GET responses don't overwrite an optimistic selection.
+    @State private var hasUserInteracted: Bool = false
+
+    #if os(macOS)
+    @State private var isMenuOpen = false
+    @State private var activePanel: VMenuPanel?
+    @State private var triggerFrame: CGRect = .zero
+    #endif
+
+    private let composerActionButtonSize: CGFloat = 32
+
+    var body: some View {
+        #if os(macOS)
+        Button {
+            if isMenuOpen {
+                activePanel?.close()
+                activePanel = nil
+                isMenuOpen = false
+            } else {
+                showMenu()
+            }
+        } label: {
+            HStack(spacing: 4) {
+                VIconView(currentPreset.icon, size: 14)
+                    .foregroundStyle(currentPreset.iconColor)
+                Text(currentPreset.label)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(
+                        currentPreset == .relaxed
+                            ? VColor.systemMidStrong
+                            : VColor.contentSecondary
+                    )
+                VIconView(.chevronDown, size: 10)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .frame(height: composerActionButtonSize)
+            .padding(.horizontal, VSpacing.xs)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .vTooltip(currentPreset.description)
+        .accessibilityLabel("Risk tolerance")
+        .accessibilityValue(currentPreset.label)
+        .overlay {
+            GeometryReader { geo in
+                Color.clear
+                    .onAppear { triggerFrame = geo.frame(in: .global) }
+                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
+                        triggerFrame = newFrame
+                    }
+            }
+        }
+        .task(id: conversationId) {
+            hasUserInteracted = false
+            await loadState()
+        }
+        #endif
+    }
+
+    // MARK: - Menu
+
+    #if os(macOS)
+    private func showMenu() {
+        guard !isMenuOpen else { return }
+        isMenuOpen = true
+
+        NSApp.keyWindow?.makeFirstResponder(nil)
+
+        guard let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible }) else {
+            isMenuOpen = false
+            return
+        }
+
+        let triggerInWindow = CGPoint(x: triggerFrame.minX, y: triggerFrame.maxY)
+        let screenPoint = window.convertPoint(toScreen: NSPoint(
+            x: triggerInWindow.x,
+            y: window.frame.height - triggerInWindow.y
+        ))
+
+        let triggerScreenOrigin = window.convertPoint(toScreen: NSPoint(
+            x: triggerFrame.minX,
+            y: window.frame.height - triggerFrame.maxY
+        ))
+        let triggerScreenRect = CGRect(
+            origin: triggerScreenOrigin,
+            size: CGSize(width: triggerFrame.width, height: triggerFrame.height)
+        )
+
+        let appearance = window.effectiveAppearance
+        activePanel = VMenuPanel.show(
+            at: screenPoint,
+            sourceWindow: window,
+            sourceAppearance: appearance,
+            excludeRect: triggerScreenRect
+        ) {
+            VMenu(width: 240) {
+                ForEach(ThresholdPreset.allCases) { preset in
+                    VMenuItem(
+                        icon: preset.icon.rawValue,
+                        label: preset.label,
+                        isActive: currentPreset == preset,
+                        size: .regular
+                    ) {
+                        selectPreset(preset)
+                    } trailing: {
+                        VStack(alignment: .trailing, spacing: 2) {
+                            if currentPreset == preset {
+                                VIconView(.check, size: 12)
+                                    .foregroundStyle(VColor.primaryBase)
+                            }
+                        }
+                    }
+                }
+            }
+        } onDismiss: {
+            isMenuOpen = false
+            activePanel = nil
+        }
+    }
+    #endif
+
+    // MARK: - Selection
+
+    private func selectPreset(_ preset: ThresholdPreset) {
+        hasUserInteracted = true
+        withAnimation(VAnimation.fast) {
+            currentPreset = preset
+        }
+
+        writeTask?.cancel()
+        writeTask = Task {
+            guard let conversationId else { return }
+            let conversationIdString = conversationId.uuidString.lowercased()
+
+            do {
+                if let value = preset.thresholdValue,
+                   value != globalInteractive {
+                    try await thresholdClient.setConversationOverride(
+                        conversationId: conversationIdString,
+                        threshold: value
+                    )
+                } else {
+                    // Default or matching global — remove the override row.
+                    try await thresholdClient.deleteConversationOverride(
+                        conversationId: conversationIdString
+                    )
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                log.error("Failed to write conversation threshold override: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    // MARK: - Load
+
+    /// Loads the global interactive threshold and any existing conversation
+    /// override, then reconciles `currentPreset`.
+    private func loadState() async {
+        loadTask?.cancel()
+        let task = Task { @MainActor in
+            do {
+                let globals = try await thresholdClient.getGlobalThresholds()
+                guard !Task.isCancelled else { return }
+                globalInteractive = globals.interactive
+
+                var override: String? = nil
+                if let conversationId {
+                    let conversationIdString = conversationId.uuidString.lowercased()
+                    override = try await thresholdClient.getConversationOverride(
+                        conversationId: conversationIdString
+                    )
+                }
+
+                guard !Task.isCancelled, !hasUserInteracted else { return }
+                currentPreset = ThresholdPreset.from(
+                    override: override,
+                    globalInteractive: globals.interactive
+                )
+            } catch {
+                guard !Task.isCancelled else { return }
+                log.error("Failed to load threshold state: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        loadTask = task
+        await task.value
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -50,6 +50,7 @@ struct ComposerView: View, Equatable {
             && lhs.conversationHostAccessControl?.isUpdating == rhs.conversationHostAccessControl?.isUpdating
             && lhs.conversationHostAccessControl?.subtitle == rhs.conversationHostAccessControl?.subtitle
             && lhs.conversationHostAccessControl?.errorMessage == rhs.conversationHostAccessControl?.errorMessage
+            && lhs.showThresholdPicker == rhs.showThresholdPicker
     }
     private let composerMaxHeight: CGFloat = 300
     private let composerActionButtonSize: CGFloat = 32
@@ -104,6 +105,7 @@ struct ComposerView: View, Equatable {
     var contextWindowTokens: Int? = nil
     var contextWindowMaxTokens: Int? = nil
     var conversationHostAccessControl: ConversationHostAccessControlConfiguration? = nil
+    var showThresholdPicker: Bool = false
 
     @Environment(\.cmdEnterToSend) private var cmdEnterToSend
     #if os(macOS)
@@ -463,6 +465,10 @@ struct ComposerView: View, Equatable {
                 .accessibilityLabel("Computer access")
                 .accessibilityValue(hostAccess.isEnabled ? "Enabled" : "Disabled")
                 .animation(.easeInOut(duration: 0.15), value: hostAccess.isEnabled)
+            }
+
+            if showThresholdPicker {
+                ComposerThresholdPicker(conversationId: conversationId)
             }
 
             VContextWindowIndicator(

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -537,11 +537,15 @@ extension MainWindowView {
             let showsConversationHostAccessControl = assistantFeatureFlagStore.isEnabled(
                 "permission-controls-v2"
             )
+            let showThresholdPicker = assistantFeatureFlagStore.isEnabled(
+                "auto-approve-threshold-ui"
+            )
             ActiveChatViewWrapper(
                 viewModel: viewModel,
                 windowState: windowState,
                 conversationStartersEnabled: conversationStartersEnabled,
                 showsConversationHostAccessControl: showsConversationHostAccessControl,
+                showThresholdPicker: showThresholdPicker,
                 showInspectButton: showInspectButton,
                 isTTSEnabled: isTTSEnabled,
                 ambientAgent: ambientAgent,
@@ -727,6 +731,7 @@ struct ActiveChatViewWrapper: View {
     var windowState: MainWindowState
     let conversationStartersEnabled: Bool
     let showsConversationHostAccessControl: Bool
+    var showThresholdPicker: Bool = false
     var showInspectButton: Bool = false
     var isTTSEnabled: Bool = false
     var ambientAgent: AmbientAgent
@@ -808,7 +813,8 @@ struct ActiveChatViewWrapper: View {
                 onVoiceModeToggle: onVoiceModeToggle,
                 watchSession: ambientAgent.activeWatchSession,
                 conversationManager: conversationManager,
-                showsConversationHostAccessControl: showsConversationHostAccessControl
+                showsConversationHostAccessControl: showsConversationHostAccessControl,
+                showThresholdPicker: showThresholdPicker
             )
             .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)
             .disabled(windowState.inspectorMessageId != nil)


### PR DESCRIPTION
## Summary
- Add `ComposerThresholdPicker` SwiftUI view with Strict/Default/Relaxed options
- Integrate into `ComposerView` action bar behind feature flag
- Per-conversation overrides write to gateway, default removes override

Part of plan: auto-approve-threshold-ui.plan.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
