### PR TITLE
feat: user-configurable auto-approve thresholds

### DIFF
--- a/assistant/__tests__/permissions/gateway-threshold-reader.test.ts
+++ b/assistant/__tests__/permissions/gateway-threshold-reader.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+let mockFeatureFlagEnabled = true;
+
+mock.module("../../src/config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (_key: string, _config: unknown) =>
+    mockFeatureFlagEnabled,
+}));
+
+mock.module("../../src/config/loader.js", () => ({
+  getConfig: () => ({}),
+}));
+
+// Track gatewayGet calls for assertion
+const gatewayGetCalls: string[] = [];
+let gatewayGetHandler: (path: string) => unknown = () => ({});
+
+mock.module("../../src/runtime/gateway-internal-client.js", () => ({
+  GatewayRequestError: class GatewayRequestError extends Error {
+    statusCode: number;
+    gatewayError: string | undefined;
+    constructor(message: string, statusCode: number, gatewayError?: string) {
+      super(message);
+      this.name = "GatewayRequestError";
+      this.statusCode = statusCode;
+      this.gatewayError = gatewayError;
+    }
+  },
+  gatewayGet: async <T>(path: string): Promise<T> => {
+    gatewayGetCalls.push(path);
+    return gatewayGetHandler(path) as T;
+  },
+}));
+
+// Suppress logger output in tests
+mock.module("../../src/util/logger.js", () => ({
+  getLogger: () => ({
+    warn: () => {},
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+import {
+  _clearGlobalCacheForTesting,
+  getAutoApproveThreshold,
+} from "../../src/permissions/gateway-threshold-reader.js";
+// Import GatewayRequestError from the mock so we can throw instances of it
+const { GatewayRequestError } =
+  await import("../../src/runtime/gateway-internal-client.js");
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function resetMocks(): void {
+  mockFeatureFlagEnabled = true;
+  gatewayGetCalls.length = 0;
+  gatewayGetHandler = () => ({});
+  _clearGlobalCacheForTesting();
+}
+
+afterEach(resetMocks);
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("getAutoApproveThreshold", () => {
+  test("returns undefined when feature flag is off", async () => {
+    mockFeatureFlagEnabled = false;
+    const result = await getAutoApproveThreshold("conv-123", "conversation");
+    expect(result).toBeUndefined();
+    // Should not make any gateway calls
+    expect(gatewayGetCalls).toHaveLength(0);
+  });
+
+  test("returns global defaults when gateway returns them", async () => {
+    gatewayGetHandler = (path: string) => {
+      if (path === "/v1/permissions/thresholds") {
+        return {
+          interactive: "medium",
+          background: "low",
+          headless: "none",
+        };
+      }
+      return {};
+    };
+
+    // conversation maps to interactive
+    expect(await getAutoApproveThreshold(undefined, "conversation")).toBe(
+      "medium",
+    );
+
+    _clearGlobalCacheForTesting();
+
+    expect(await getAutoApproveThreshold(undefined, "background")).toBe("low");
+
+    _clearGlobalCacheForTesting();
+
+    expect(await getAutoApproveThreshold(undefined, "headless")).toBe("none");
+  });
+
+  test("returns conversation override when it exists", async () => {
+    gatewayGetHandler = (path: string) => {
+      if (path === "/v1/permissions/thresholds/conversations/conv-xyz") {
+        return { threshold: "medium" };
+      }
+      if (path === "/v1/permissions/thresholds") {
+        return {
+          interactive: "low",
+          background: "medium",
+          headless: "none",
+        };
+      }
+      return {};
+    };
+
+    const result = await getAutoApproveThreshold("conv-xyz", "conversation");
+    expect(result).toBe("medium");
+    // Should have called the conversation endpoint, not the global one
+    expect(gatewayGetCalls).toEqual([
+      "/v1/permissions/thresholds/conversations/conv-xyz",
+    ]);
+  });
+
+  test("falls back to global when conversation override returns 404", async () => {
+    gatewayGetHandler = (path: string) => {
+      if (path.startsWith("/v1/permissions/thresholds/conversations/")) {
+        throw new GatewayRequestError("Not found", 404, "Not found");
+      }
+      if (path === "/v1/permissions/thresholds") {
+        return {
+          interactive: "low",
+          background: "medium",
+          headless: "none",
+        };
+      }
+      return {};
+    };
+
+    const result = await getAutoApproveThreshold("conv-123", "conversation");
+    expect(result).toBe("low");
+    // Should have called both endpoints
+    expect(gatewayGetCalls).toEqual([
+      "/v1/permissions/thresholds/conversations/conv-123",
+      "/v1/permissions/thresholds",
+    ]);
+  });
+
+  test("falls back to hardcoded defaults on gateway error", async () => {
+    gatewayGetHandler = () => {
+      throw new Error("Connection refused");
+    };
+
+    // conversation → "low"
+    expect(await getAutoApproveThreshold(undefined, "conversation")).toBe(
+      "low",
+    );
+
+    _clearGlobalCacheForTesting();
+
+    // background → "medium"
+    expect(await getAutoApproveThreshold(undefined, "background")).toBe(
+      "medium",
+    );
+
+    _clearGlobalCacheForTesting();
+
+    // headless → "none"
+    expect(await getAutoApproveThreshold(undefined, "headless")).toBe("none");
+  });
+
+  test("falls back to hardcoded defaults on non-404 conversation error", async () => {
+    gatewayGetHandler = (path: string) => {
+      if (path.startsWith("/v1/permissions/thresholds/conversations/")) {
+        throw new GatewayRequestError("Internal error", 500, "Server error");
+      }
+      // Should not reach global endpoint
+      return {
+        interactive: "medium",
+        background: "medium",
+        headless: "medium",
+      };
+    };
+
+    const result = await getAutoApproveThreshold("conv-123", "conversation");
+    // Should fall back to hardcoded default for conversation, not global endpoint
+    expect(result).toBe("low");
+    // Should have only called the conversation endpoint
+    expect(gatewayGetCalls).toEqual([
+      "/v1/permissions/thresholds/conversations/conv-123",
+    ]);
+  });
+
+  test("caching: second call within 30s does not re-fetch global", async () => {
+    let fetchCount = 0;
+    gatewayGetHandler = (path: string) => {
+      if (path === "/v1/permissions/thresholds") {
+        fetchCount++;
+        return {
+          interactive: "medium",
+          background: "low",
+          headless: "none",
+        };
+      }
+      return {};
+    };
+
+    // First call — should fetch
+    const first = await getAutoApproveThreshold(undefined, "conversation");
+    expect(first).toBe("medium");
+    expect(fetchCount).toBe(1);
+
+    // Second call — should use cache
+    const second = await getAutoApproveThreshold(undefined, "background");
+    expect(second).toBe("low");
+    expect(fetchCount).toBe(1); // Still 1, cache hit
+
+    // Third call — still cached
+    const third = await getAutoApproveThreshold(undefined, "headless");
+    expect(third).toBe("none");
+    expect(fetchCount).toBe(1); // Still 1
+
+    // After clearing cache, should re-fetch
+    _clearGlobalCacheForTesting();
+    const fourth = await getAutoApproveThreshold(undefined, "conversation");
+    expect(fourth).toBe("medium");
+    expect(fetchCount).toBe(2); // Incremented
+  });
+
+  test("defaults executionContext to conversation when omitted", async () => {
+    gatewayGetHandler = (path: string) => {
+      if (path === "/v1/permissions/thresholds") {
+        return {
+          interactive: "medium",
+          background: "low",
+          headless: "none",
+        };
+      }
+      return {};
+    };
+
+    // executionContext omitted — should default to "conversation" → interactive
+    const result = await getAutoApproveThreshold(undefined, undefined);
+    expect(result).toBe("medium");
+  });
+
+  test("skips conversation override when no conversationId", async () => {
+    gatewayGetHandler = (path: string) => {
+      if (path === "/v1/permissions/thresholds") {
+        return {
+          interactive: "low",
+          background: "medium",
+          headless: "none",
+        };
+      }
+      return {};
+    };
+
+    const result = await getAutoApproveThreshold(undefined, "conversation");
+    expect(result).toBe("low");
+    // Should only call global endpoint, not conversation
+    expect(gatewayGetCalls).toEqual(["/v1/permissions/thresholds"]);
+  });
+
+  test("skips conversation override for non-conversation contexts", async () => {
+    gatewayGetHandler = (path: string) => {
+      if (path === "/v1/permissions/thresholds") {
+        return {
+          interactive: "low",
+          background: "medium",
+          headless: "none",
+        };
+      }
+      return {};
+    };
+
+    // Even with a conversationId, background context should not check conversation override
+    const result = await getAutoApproveThreshold("conv-123", "background");
+    expect(result).toBe("medium");
+    expect(gatewayGetCalls).toEqual(["/v1/permissions/thresholds"]);
+  });
+});

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -309,6 +309,7 @@ describe("ToolExecutor policy context plumbing", () => {
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      conversationId: "conversation-1",
       executionContext: "conversation",
       ephemeralRules: undefined,
       executionTarget: "sandbox",
@@ -329,6 +330,7 @@ describe("ToolExecutor policy context plumbing", () => {
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      conversationId: "conversation-1",
       executionContext: "conversation",
       ephemeralRules: undefined,
     });
@@ -362,6 +364,7 @@ describe("ToolExecutor policy context plumbing", () => {
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      conversationId: "conversation-1",
       executionContext: "conversation",
       ephemeralRules: undefined,
     });
@@ -398,6 +401,7 @@ describe("ToolExecutor policy context plumbing", () => {
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      conversationId: "conversation-1",
       executionContext: "conversation",
       ephemeralRules: undefined,
       executionTarget: "host",
@@ -430,6 +434,7 @@ describe("ToolExecutor policy context plumbing", () => {
     expect(result.isError).toBe(false);
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      conversationId: "conversation-1",
       executionContext: "conversation",
       ephemeralRules: undefined,
       executionTarget: undefined,
@@ -901,6 +906,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
 
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      conversationId: "conversation-1",
       executionContext: "conversation",
       ephemeralRules: undefined,
       executionTarget: "sandbox",
@@ -1085,6 +1091,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
 
     expect(lastCheckArgs).toBeDefined();
     expect(lastCheckArgs!.policyContext).toEqual({
+      conversationId: "conversation-1",
       executionContext: "conversation",
       ephemeralRules: undefined,
       executionTarget: "sandbox",

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -23,6 +23,7 @@ import {
 } from "./approval-policy.js";
 import { bashRiskClassifier } from "./bash-risk-classifier.js";
 import { fileRiskClassifier } from "./file-risk-classifier.js";
+import { getAutoApproveThreshold } from "./gateway-threshold-reader.js";
 import { type RiskAssessment, riskToRiskLevel } from "./risk-types.js";
 import {
   buildShellAllowlistOptions,
@@ -592,10 +593,16 @@ export async function check(
   // Build approval context from local variables
   const tool = getTool(toolName);
   const config = getConfig();
-  const resolvedThreshold = resolveThreshold(
-    config.permissions.autoApproveUpTo,
+  const gatewayThreshold = await getAutoApproveThreshold(
+    policyContext?.conversationId,
     policyContext?.executionContext,
   );
+  const resolvedThreshold =
+    gatewayThreshold ??
+    resolveThreshold(
+      config.permissions.autoApproveUpTo,
+      policyContext?.executionContext,
+    );
   const approvalContext: ApprovalContext = {
     riskLevel: risk,
     toolName,

--- a/assistant/src/permissions/gateway-threshold-reader.ts
+++ b/assistant/src/permissions/gateway-threshold-reader.ts
@@ -38,12 +38,24 @@ let cachedGlobalThresholds: GlobalThresholds | null = null;
 let cachedGlobalTimestamp = 0;
 const GLOBAL_CACHE_TTL_MS = 30_000;
 
+// ── Conversation threshold cache (5s TTL) ────────────────────────────────────
+// Shorter TTL than global because the user can change mid-conversation via the
+// picker UI, but still avoids a network roundtrip on every single tool call
+// within a burst.
+
+const conversationThresholdCache = new Map<
+  string,
+  { threshold: string; timestamp: number }
+>();
+const CONVERSATION_CACHE_TTL_MS = 5_000;
+
 /**
  * Clear the global threshold cache. Exported for testing.
  */
 export function _clearGlobalCacheForTesting(): void {
   cachedGlobalThresholds = null;
   cachedGlobalTimestamp = 0;
+  conversationThresholdCache.clear();
 }
 
 // ── Hardcoded fallback defaults ──────────────────────────────────────────────
@@ -96,11 +108,23 @@ export async function getAutoApproveThreshold(
 
   // For conversation context with a conversationId, try per-conversation override first
   if (ctx === "conversation" && conversationId) {
+    // Check cache first (5s TTL)
+    const cached = conversationThresholdCache.get(conversationId);
+    if (cached && Date.now() - cached.timestamp < CONVERSATION_CACHE_TTL_MS) {
+      if (isValidThreshold(cached.threshold)) {
+        return cached.threshold;
+      }
+    }
+
     try {
       const result = await gatewayGet<ConversationThreshold>(
         `/v1/permissions/thresholds/conversations/${conversationId}`,
       );
       if (isValidThreshold(result.threshold)) {
+        conversationThresholdCache.set(conversationId, {
+          threshold: result.threshold,
+          timestamp: Date.now(),
+        });
         return result.threshold;
       }
     } catch (err) {

--- a/assistant/src/permissions/gateway-threshold-reader.ts
+++ b/assistant/src/permissions/gateway-threshold-reader.ts
@@ -45,7 +45,7 @@ const GLOBAL_CACHE_TTL_MS = 30_000;
 
 const conversationThresholdCache = new Map<
   string,
-  { threshold: string; timestamp: number }
+  { threshold: string | null; timestamp: number }
 >();
 const CONVERSATION_CACHE_TTL_MS = 5_000;
 
@@ -108,34 +108,42 @@ export async function getAutoApproveThreshold(
 
   // For conversation context with a conversationId, try per-conversation override first
   if (ctx === "conversation" && conversationId) {
-    // Check cache first (5s TTL)
+    // Check cache first (5s TTL) — includes negative entries (404 → no override)
     const cached = conversationThresholdCache.get(conversationId);
     if (cached && Date.now() - cached.timestamp < CONVERSATION_CACHE_TTL_MS) {
-      if (isValidThreshold(cached.threshold)) {
+      if (cached.threshold === null) {
+        // Negative cache hit — no override exists, fall through to global
+      } else if (isValidThreshold(cached.threshold)) {
         return cached.threshold;
       }
-    }
-
-    try {
-      const result = await gatewayGet<ConversationThreshold>(
-        `/v1/permissions/thresholds/conversations/${conversationId}`,
-      );
-      if (isValidThreshold(result.threshold)) {
-        conversationThresholdCache.set(conversationId, {
-          threshold: result.threshold,
-          timestamp: Date.now(),
-        });
-        return result.threshold;
-      }
-    } catch (err) {
-      if (err instanceof GatewayRequestError && err.statusCode === 404) {
-        // No conversation override — fall through to global
-      } else {
-        log.warn(
-          { conversationId, error: String(err) },
-          "Failed to fetch conversation threshold override, falling back to defaults",
+    } else {
+      try {
+        const result = await gatewayGet<ConversationThreshold>(
+          `/v1/permissions/thresholds/conversations/${conversationId}`,
         );
-        return HARDCODED_DEFAULTS[ctx];
+        if (isValidThreshold(result.threshold)) {
+          conversationThresholdCache.set(conversationId, {
+            threshold: result.threshold,
+            timestamp: Date.now(),
+          });
+          return result.threshold;
+        }
+      } catch (err) {
+        if (err instanceof GatewayRequestError && err.statusCode === 404) {
+          // No conversation override — cache the negative result to avoid
+          // redundant gateway requests on every tool call
+          conversationThresholdCache.set(conversationId, {
+            threshold: null,
+            timestamp: Date.now(),
+          });
+          // Fall through to global
+        } else {
+          log.warn(
+            { conversationId, error: String(err) },
+            "Failed to fetch conversation threshold override, falling back to defaults",
+          );
+          return HARDCODED_DEFAULTS[ctx];
+        }
       }
     }
   }

--- a/assistant/src/permissions/gateway-threshold-reader.ts
+++ b/assistant/src/permissions/gateway-threshold-reader.ts
@@ -1,0 +1,154 @@
+/**
+ * Gateway-backed auto-approve threshold reader.
+ *
+ * When the `auto-approve-threshold-ui` feature flag is enabled, reads
+ * thresholds from the gateway REST API. Falls back to `undefined` (caller
+ * uses config-based `resolveThreshold`) when the flag is off or the gateway
+ * is unreachable.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
+import {
+  gatewayGet,
+  GatewayRequestError,
+} from "../runtime/gateway-internal-client.js";
+import { getLogger } from "../util/logger.js";
+import type { ExecutionContext } from "./approval-policy.js";
+
+const log = getLogger("gateway-threshold-reader");
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type Threshold = "none" | "low" | "medium";
+
+interface GlobalThresholds {
+  interactive: string;
+  background: string;
+  headless: string;
+}
+
+interface ConversationThreshold {
+  threshold: string;
+}
+
+// ── Global threshold cache (30s TTL) ─────────────────────────────────────────
+
+let cachedGlobalThresholds: GlobalThresholds | null = null;
+let cachedGlobalTimestamp = 0;
+const GLOBAL_CACHE_TTL_MS = 30_000;
+
+/**
+ * Clear the global threshold cache. Exported for testing.
+ */
+export function _clearGlobalCacheForTesting(): void {
+  cachedGlobalThresholds = null;
+  cachedGlobalTimestamp = 0;
+}
+
+// ── Hardcoded fallback defaults ──────────────────────────────────────────────
+
+const HARDCODED_DEFAULTS: Record<ExecutionContext, Threshold> = {
+  conversation: "low",
+  background: "medium",
+  headless: "none",
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function mapExecutionContextToField(
+  executionContext: ExecutionContext,
+): keyof GlobalThresholds {
+  if (executionContext === "conversation") return "interactive";
+  return executionContext;
+}
+
+function isValidThreshold(value: string): value is Threshold {
+  return value === "none" || value === "low" || value === "medium";
+}
+
+// ── Main export ──────────────────────────────────────────────────────────────
+
+/**
+ * Read the auto-approve threshold from the gateway.
+ *
+ * Returns `undefined` when the feature flag is off (caller falls back to
+ * config-based `resolveThreshold`).
+ *
+ * For `"conversation"` context with a `conversationId`, checks for a
+ * per-conversation override first. Falls through to global defaults when
+ * the conversation override returns 404 or is absent.
+ *
+ * Caches global thresholds for 30 seconds to avoid hammering the gateway.
+ * On any gateway error (other than 404 for conversation override), logs a
+ * warning and returns hardcoded defaults.
+ */
+export async function getAutoApproveThreshold(
+  conversationId: string | undefined,
+  executionContext?: ExecutionContext,
+): Promise<Threshold | undefined> {
+  const config = getConfig();
+  if (!isAssistantFeatureFlagEnabled("auto-approve-threshold-ui", config)) {
+    return undefined;
+  }
+
+  const ctx: ExecutionContext = executionContext ?? "conversation";
+
+  // For conversation context with a conversationId, try per-conversation override first
+  if (ctx === "conversation" && conversationId) {
+    try {
+      const result = await gatewayGet<ConversationThreshold>(
+        `/v1/permissions/thresholds/conversations/${conversationId}`,
+      );
+      if (isValidThreshold(result.threshold)) {
+        return result.threshold;
+      }
+    } catch (err) {
+      if (err instanceof GatewayRequestError && err.statusCode === 404) {
+        // No conversation override — fall through to global
+      } else {
+        log.warn(
+          { conversationId, error: String(err) },
+          "Failed to fetch conversation threshold override, falling back to defaults",
+        );
+        return HARDCODED_DEFAULTS[ctx];
+      }
+    }
+  }
+
+  // Fetch global thresholds (with 30s cache)
+  try {
+    const global = await fetchGlobalThresholds();
+    const field = mapExecutionContextToField(ctx);
+    const value = global[field];
+    if (isValidThreshold(value)) {
+      return value;
+    }
+    // Unexpected value from gateway — fall back to hardcoded
+    log.warn({ field, value }, "Gateway returned unexpected threshold value");
+    return HARDCODED_DEFAULTS[ctx];
+  } catch (err) {
+    log.warn(
+      { error: String(err) },
+      "Failed to fetch global thresholds, falling back to defaults",
+    );
+    return HARDCODED_DEFAULTS[ctx];
+  }
+}
+
+async function fetchGlobalThresholds(): Promise<GlobalThresholds> {
+  const now = Date.now();
+  if (
+    cachedGlobalThresholds &&
+    now - cachedGlobalTimestamp < GLOBAL_CACHE_TTL_MS
+  ) {
+    return cachedGlobalThresholds;
+  }
+
+  const result = await gatewayGet<GlobalThresholds>(
+    "/v1/permissions/thresholds",
+  );
+  cachedGlobalThresholds = result;
+  cachedGlobalTimestamp = Date.now();
+  return result;
+}

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -69,4 +69,6 @@ export interface PolicyContext {
    * - "headless": non-interactive non-guardian session
    */
   executionContext?: "conversation" | "background" | "headless";
+  /** Conversation ID for per-conversation threshold overrides. */
+  conversationId?: string;
 }

--- a/assistant/src/tools/policy-context.ts
+++ b/assistant/src/tools/policy-context.ts
@@ -34,16 +34,20 @@ export function buildPolicyContext(
 
   const executionContext = deriveExecutionContext(context);
 
+  const conversationId = context?.conversationId;
+
   if (tool.origin === "skill") {
     return {
       executionTarget: tool.executionTarget,
       ephemeralRules: ephemeralRules?.length ? ephemeralRules : undefined,
       executionContext,
+      conversationId,
     };
   }
 
   return {
     ephemeralRules: ephemeralRules?.length ? ephemeralRules : undefined,
     executionContext,
+    conversationId,
   };
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -91,6 +91,7 @@ struct ChatView: View {
     var watchSession: WatchSession?
     var conversationManager: ConversationManager? = nil
     var showsConversationHostAccessControl: Bool = false
+    var showThresholdPicker: Bool = false
 
     @State private var isDropTargeted = false
     @State private var isDraggingInternalImage = false
@@ -500,7 +501,8 @@ struct ChatView: View {
                         contextWindowFillRatio: viewModel.contextWindowFillRatio,
                         contextWindowTokens: viewModel.contextWindowTokens,
                         contextWindowMaxTokens: viewModel.contextWindowMaxTokens,
-                        conversationHostAccessControl: conversationHostAccessControl
+                        conversationHostAccessControl: conversationHostAccessControl,
+                        showThresholdPicker: showThresholdPicker
                     )
                     .equatable()
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -48,6 +48,7 @@ struct ComposerSection: View, Equatable {
             && lhs.conversationHostAccessControl?.isUpdating == rhs.conversationHostAccessControl?.isUpdating
             && lhs.conversationHostAccessControl?.subtitle == rhs.conversationHostAccessControl?.subtitle
             && lhs.conversationHostAccessControl?.errorMessage == rhs.conversationHostAccessControl?.errorMessage
+            && lhs.showThresholdPicker == rhs.showThresholdPicker
     }
 
     @Binding var inputText: String
@@ -81,6 +82,7 @@ struct ComposerSection: View, Equatable {
     var contextWindowTokens: Int? = nil
     var contextWindowMaxTokens: Int? = nil
     var conversationHostAccessControl: ConversationHostAccessControlConfiguration? = nil
+    var showThresholdPicker: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -121,7 +123,8 @@ struct ComposerSection: View, Equatable {
                 contextWindowFillRatio: contextWindowFillRatio,
                 contextWindowTokens: contextWindowTokens,
                 contextWindowMaxTokens: contextWindowMaxTokens,
-                conversationHostAccessControl: conversationHostAccessControl
+                conversationHostAccessControl: conversationHostAccessControl,
+                showThresholdPicker: showThresholdPicker
             )
             .equatable()
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
@@ -1,0 +1,305 @@
+import SwiftUI
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ComposerThresholdPicker")
+
+// MARK: - Threshold Preset
+
+/// The three presets surfaced in the per-conversation threshold picker.
+/// Each maps to a concrete ``RiskThreshold`` value.
+enum ThresholdPreset: String, CaseIterable, Identifiable, Equatable {
+    /// Prompt for everything (maps to ``RiskThreshold.none``).
+    case strict
+    /// Match the global interactive default (no override stored).
+    case `default`
+    /// Auto-approve most tools (maps to ``RiskThreshold.medium``).
+    case relaxed
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .strict: return "Strict"
+        case .default: return "Default"
+        case .relaxed: return "Relaxed"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .strict: return "Prompt for everything"
+        case .default: return "Auto-approve low-risk tools"
+        case .relaxed: return "Auto-approve most tools"
+        }
+    }
+
+    var icon: VIcon {
+        switch self {
+        case .strict: return .lock
+        case .default: return .shieldCheck
+        case .relaxed: return .triangleAlert
+        }
+    }
+
+    var iconColor: Color {
+        switch self {
+        case .strict: return VColor.contentSecondary
+        case .default: return VColor.contentSecondary
+        case .relaxed: return VColor.systemMidStrong
+        }
+    }
+
+    /// The ``RiskThreshold`` raw value to write when this preset is selected.
+    /// Returns `nil` for `.default` — the caller should delete the override instead.
+    var thresholdValue: String? {
+        switch self {
+        case .strict: return RiskThreshold.none.rawValue
+        case .default: return nil
+        case .relaxed: return RiskThreshold.medium.rawValue
+        }
+    }
+
+    /// Determines the preset that best describes a conversation override value
+    /// relative to the global interactive default.
+    ///
+    /// - Parameters:
+    ///   - override: The conversation-level threshold string, or `nil` when no
+    ///     override exists.
+    ///   - globalInteractive: The global interactive threshold raw value.
+    /// - Returns: The matching preset.
+    static func from(override: String?, globalInteractive: String) -> ThresholdPreset {
+        guard let override else { return .default }
+        if override == globalInteractive { return .default }
+
+        // Compare by risk level ordering: none < low < medium
+        let order: [String] = [
+            RiskThreshold.none.rawValue,
+            RiskThreshold.low.rawValue,
+            RiskThreshold.medium.rawValue,
+        ]
+        let overrideIndex = order.firstIndex(of: override) ?? 0
+        let globalIndex = order.firstIndex(of: globalInteractive) ?? 0
+
+        if overrideIndex < globalIndex {
+            return .strict
+        } else if overrideIndex > globalIndex {
+            return .relaxed
+        } else {
+            return .default
+        }
+    }
+}
+
+// MARK: - ComposerThresholdPicker
+
+/// A compact pill button in the composer action bar that lets the user set a
+/// per-conversation auto-approve threshold override. Opens a dropdown menu
+/// with three presets: Strict, Default, and Relaxed.
+@MainActor
+struct ComposerThresholdPicker: View {
+    let conversationId: UUID?
+    var thresholdClient: ThresholdClientProtocol = ThresholdClient()
+
+    /// The currently displayed preset. Updated optimistically on selection and
+    /// reconciled with the gateway on appearance / conversation change.
+    @State private var currentPreset: ThresholdPreset = .default
+
+    /// The global interactive threshold raw value, fetched on load.
+    @State private var globalInteractive: String = RiskThreshold.low.rawValue
+
+    /// In-flight write task, cancelled on rapid re-selection.
+    @State private var writeTask: Task<Void, Never>?
+
+    /// In-flight load task, cancelled on re-appearance.
+    @State private var loadTask: Task<Void, Never>?
+
+    /// Tracks whether the user has actively picked since last load so stale
+    /// GET responses don't overwrite an optimistic selection.
+    @State private var hasUserInteracted: Bool = false
+
+    #if os(macOS)
+    @State private var isMenuOpen = false
+    @State private var activePanel: VMenuPanel?
+    @State private var triggerFrame: CGRect = .zero
+    #endif
+
+    private let composerActionButtonSize: CGFloat = 32
+
+    var body: some View {
+        #if os(macOS)
+        Button {
+            if isMenuOpen {
+                activePanel?.close()
+                activePanel = nil
+                isMenuOpen = false
+            } else {
+                showMenu()
+            }
+        } label: {
+            HStack(spacing: 4) {
+                VIconView(currentPreset.icon, size: 14)
+                    .foregroundStyle(currentPreset.iconColor)
+                Text(currentPreset.label)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(
+                        currentPreset == .relaxed
+                            ? VColor.systemMidStrong
+                            : VColor.contentSecondary
+                    )
+                VIconView(.chevronDown, size: 10)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .frame(height: composerActionButtonSize)
+            .padding(.horizontal, VSpacing.xs)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .vTooltip(currentPreset.description)
+        .accessibilityLabel("Risk tolerance")
+        .accessibilityValue(currentPreset.label)
+        .overlay {
+            GeometryReader { geo in
+                Color.clear
+                    .onAppear { triggerFrame = geo.frame(in: .global) }
+                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
+                        triggerFrame = newFrame
+                    }
+            }
+        }
+        .task(id: conversationId) {
+            hasUserInteracted = false
+            await loadState()
+        }
+        #endif
+    }
+
+    // MARK: - Menu
+
+    #if os(macOS)
+    private func showMenu() {
+        guard !isMenuOpen else { return }
+        isMenuOpen = true
+
+        NSApp.keyWindow?.makeFirstResponder(nil)
+
+        guard let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible }) else {
+            isMenuOpen = false
+            return
+        }
+
+        let triggerInWindow = CGPoint(x: triggerFrame.minX, y: triggerFrame.maxY)
+        let screenPoint = window.convertPoint(toScreen: NSPoint(
+            x: triggerInWindow.x,
+            y: window.frame.height - triggerInWindow.y
+        ))
+
+        let triggerScreenOrigin = window.convertPoint(toScreen: NSPoint(
+            x: triggerFrame.minX,
+            y: window.frame.height - triggerFrame.maxY
+        ))
+        let triggerScreenRect = CGRect(
+            origin: triggerScreenOrigin,
+            size: CGSize(width: triggerFrame.width, height: triggerFrame.height)
+        )
+
+        let appearance = window.effectiveAppearance
+        activePanel = VMenuPanel.show(
+            at: screenPoint,
+            sourceWindow: window,
+            sourceAppearance: appearance,
+            excludeRect: triggerScreenRect
+        ) {
+            VMenu(width: 240) {
+                ForEach(ThresholdPreset.allCases) { preset in
+                    VMenuItem(
+                        icon: preset.icon.rawValue,
+                        label: preset.label,
+                        isActive: currentPreset == preset,
+                        size: .regular
+                    ) {
+                        selectPreset(preset)
+                    } trailing: {
+                        VStack(alignment: .trailing, spacing: 2) {
+                            if currentPreset == preset {
+                                VIconView(.check, size: 12)
+                                    .foregroundStyle(VColor.primaryBase)
+                            }
+                        }
+                    }
+                }
+            }
+        } onDismiss: {
+            isMenuOpen = false
+            activePanel = nil
+        }
+    }
+    #endif
+
+    // MARK: - Selection
+
+    private func selectPreset(_ preset: ThresholdPreset) {
+        hasUserInteracted = true
+        withAnimation(VAnimation.fast) {
+            currentPreset = preset
+        }
+
+        writeTask?.cancel()
+        writeTask = Task {
+            guard let conversationId else { return }
+            let conversationIdString = conversationId.uuidString.lowercased()
+
+            do {
+                if let value = preset.thresholdValue,
+                   value != globalInteractive {
+                    try await thresholdClient.setConversationOverride(
+                        conversationId: conversationIdString,
+                        threshold: value
+                    )
+                } else {
+                    // Default or matching global — remove the override row.
+                    try await thresholdClient.deleteConversationOverride(
+                        conversationId: conversationIdString
+                    )
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                log.error("Failed to write conversation threshold override: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    // MARK: - Load
+
+    /// Loads the global interactive threshold and any existing conversation
+    /// override, then reconciles `currentPreset`.
+    private func loadState() async {
+        loadTask?.cancel()
+        let task = Task { @MainActor in
+            do {
+                let globals = try await thresholdClient.getGlobalThresholds()
+                guard !Task.isCancelled else { return }
+                globalInteractive = globals.interactive
+
+                var override: String? = nil
+                if let conversationId {
+                    let conversationIdString = conversationId.uuidString.lowercased()
+                    override = try await thresholdClient.getConversationOverride(
+                        conversationId: conversationIdString
+                    )
+                }
+
+                guard !Task.isCancelled, !hasUserInteracted else { return }
+                currentPreset = ThresholdPreset.from(
+                    override: override,
+                    globalInteractive: globals.interactive
+                )
+            } catch {
+                guard !Task.isCancelled else { return }
+                log.error("Failed to load threshold state: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        loadTask = task
+        await task.value
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -50,6 +50,7 @@ struct ComposerView: View, Equatable {
             && lhs.conversationHostAccessControl?.isUpdating == rhs.conversationHostAccessControl?.isUpdating
             && lhs.conversationHostAccessControl?.subtitle == rhs.conversationHostAccessControl?.subtitle
             && lhs.conversationHostAccessControl?.errorMessage == rhs.conversationHostAccessControl?.errorMessage
+            && lhs.showThresholdPicker == rhs.showThresholdPicker
     }
     private let composerMaxHeight: CGFloat = 300
     private let composerActionButtonSize: CGFloat = 32
@@ -104,6 +105,7 @@ struct ComposerView: View, Equatable {
     var contextWindowTokens: Int? = nil
     var contextWindowMaxTokens: Int? = nil
     var conversationHostAccessControl: ConversationHostAccessControlConfiguration? = nil
+    var showThresholdPicker: Bool = false
 
     @Environment(\.cmdEnterToSend) private var cmdEnterToSend
     #if os(macOS)
@@ -463,6 +465,10 @@ struct ComposerView: View, Equatable {
                 .accessibilityLabel("Computer access")
                 .accessibilityValue(hostAccess.isEnabled ? "Enabled" : "Disabled")
                 .animation(.easeInOut(duration: 0.15), value: hostAccess.isEnabled)
+            }
+
+            if showThresholdPicker {
+                ComposerThresholdPicker(conversationId: conversationId)
             }
 
             VContextWindowIndicator(

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -537,11 +537,15 @@ extension MainWindowView {
             let showsConversationHostAccessControl = assistantFeatureFlagStore.isEnabled(
                 "permission-controls-v2"
             )
+            let showThresholdPicker = assistantFeatureFlagStore.isEnabled(
+                "auto-approve-threshold-ui"
+            )
             ActiveChatViewWrapper(
                 viewModel: viewModel,
                 windowState: windowState,
                 conversationStartersEnabled: conversationStartersEnabled,
                 showsConversationHostAccessControl: showsConversationHostAccessControl,
+                showThresholdPicker: showThresholdPicker,
                 showInspectButton: showInspectButton,
                 isTTSEnabled: isTTSEnabled,
                 ambientAgent: ambientAgent,
@@ -727,6 +731,7 @@ struct ActiveChatViewWrapper: View {
     var windowState: MainWindowState
     let conversationStartersEnabled: Bool
     let showsConversationHostAccessControl: Bool
+    var showThresholdPicker: Bool = false
     var showInspectButton: Bool = false
     var isTTSEnabled: Bool = false
     var ambientAgent: AmbientAgent
@@ -808,7 +813,8 @@ struct ActiveChatViewWrapper: View {
                 onVoiceModeToggle: onVoiceModeToggle,
                 watchSession: ambientAgent.activeWatchSession,
                 conversationManager: conversationManager,
-                showsConversationHostAccessControl: showsConversationHostAccessControl
+                showsConversationHostAccessControl: showsConversationHostAccessControl,
+                showThresholdPicker: showThresholdPicker
             )
             .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)
             .disabled(windowState.inspectorMessageId != nil)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -641,7 +641,7 @@ struct SettingsPanel: View {
             }
 
             // PRIVACY section
-            SettingsPrivacyTab(store: store)
+            SettingsPrivacyTab(store: store, assistantFeatureFlagStore: assistantFeatureFlagStore)
 
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
@@ -15,12 +15,15 @@ struct RiskToleranceSection: View {
     var assistantFeatureFlagStore: AssistantFeatureFlagStore
 
     /// Current selection for the interactive ("When chatting") threshold.
-    @State private var interactiveSelection: RiskThreshold = .none
+    /// Defaults to `.low` to match the gateway schema default.
+    @State private var interactiveSelection: RiskThreshold = .low
 
     /// Current selection for the background ("Scheduled tasks") threshold.
-    @State private var backgroundSelection: RiskThreshold = .none
+    /// Defaults to `.medium` to match the gateway schema default.
+    @State private var backgroundSelection: RiskThreshold = .medium
 
     /// Current selection for the headless ("Automation / API") threshold.
+    /// Defaults to `.none` to match the gateway schema default.
     @State private var headlessSelection: RiskThreshold = .none
 
     /// In-flight sync task so rapid picker changes cancel the previous
@@ -30,6 +33,11 @@ struct RiskToleranceSection: View {
     /// In-flight load task so repeated view appearances don't stack
     /// concurrent GETs against the gateway.
     @State private var loadTask: Task<Void, Never>?
+
+    /// Whether the initial load from the gateway has completed at least
+    /// once. Prevents `syncThresholds()` from persisting stale defaults
+    /// before we know the real server state.
+    @State private var hasLoadedInitial: Bool = false
 
     /// Tracks whether the user has actively picked an option since the
     /// view appeared. Once set, `loadThresholds()` will NOT overwrite
@@ -145,9 +153,10 @@ struct RiskToleranceSection: View {
             do {
                 let thresholds = try await thresholdClient.getGlobalThresholds()
                 guard !Task.isCancelled else { return }
+                hasLoadedInitial = true
                 guard !hasUserInteracted else { return }
-                interactiveSelection = RiskThreshold(rawValue: thresholds.interactive) ?? .none
-                backgroundSelection = RiskThreshold(rawValue: thresholds.background) ?? .none
+                interactiveSelection = RiskThreshold(rawValue: thresholds.interactive) ?? .low
+                backgroundSelection = RiskThreshold(rawValue: thresholds.background) ?? .medium
                 headlessSelection = RiskThreshold(rawValue: thresholds.headless) ?? .none
             } catch {
                 riskToleranceLog.error(
@@ -169,6 +178,9 @@ struct RiskToleranceSection: View {
     /// `loadThresholds()` call can reconcile the picker against the
     /// authoritative gateway state.
     private func syncThresholds() {
+        // Don't sync until we've loaded at least once — otherwise we'd
+        // persist stale local defaults over the real server state.
+        guard hasLoadedInitial else { return }
         syncTask?.cancel()
         syncTask = Task {
             do {

--- a/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+import VellumAssistantShared
+import os
+
+private let riskToleranceLog = Logger(
+    subsystem: Bundle.appBundleIdentifier,
+    category: "RiskToleranceSection"
+)
+
+/// Risk Tolerance settings section — lets the user configure auto-approve
+/// thresholds for interactive, background, and headless execution contexts.
+@MainActor
+struct RiskToleranceSection: View {
+    var thresholdClient: ThresholdClientProtocol
+    var assistantFeatureFlagStore: AssistantFeatureFlagStore
+
+    /// Current selection for the interactive ("When chatting") threshold.
+    @State private var interactiveSelection: RiskThreshold = .none
+
+    /// Current selection for the background ("Scheduled tasks") threshold.
+    @State private var backgroundSelection: RiskThreshold = .none
+
+    /// Current selection for the headless ("Automation / API") threshold.
+    @State private var headlessSelection: RiskThreshold = .none
+
+    /// In-flight sync task so rapid picker changes cancel the previous
+    /// write and only the latest selection reaches the gateway.
+    @State private var syncTask: Task<Void, Never>?
+
+    /// In-flight load task so repeated view appearances don't stack
+    /// concurrent GETs against the gateway.
+    @State private var loadTask: Task<Void, Never>?
+
+    /// Tracks whether the user has actively picked an option since the
+    /// view appeared. Once set, `loadThresholds()` will NOT overwrite
+    /// selections with the gateway's reconciled value — otherwise a late
+    /// GET response could stomp a user's mid-load selection with stale
+    /// server data.
+    @State private var hasUserInteracted: Bool = false
+
+    var body: some View {
+        SettingsCard(title: "Risk Tolerance") {
+            Text("Auto-approve tools up to this risk level without prompting. Higher levels mean fewer permission prompts.")
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("When chatting")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                VDropdown(
+                    options: RiskThreshold.allCases.map {
+                        VDropdownOption(label: $0.label, value: $0)
+                    },
+                    selection: Binding(
+                        get: { interactiveSelection },
+                        set: { newValue in
+                            hasUserInteracted = true
+                            interactiveSelection = newValue
+                            syncThresholds()
+                        }
+                    ),
+                    maxWidth: 280
+                )
+                .accessibilityLabel("When chatting risk threshold")
+                Text("Auto-approve low-risk tools like reading files and web searches.")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            DisclosureGroup("Advanced") {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    SettingsDivider()
+
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Scheduled tasks")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                        VDropdown(
+                            options: RiskThreshold.allCases.map {
+                                VDropdownOption(label: $0.label, value: $0)
+                            },
+                            selection: Binding(
+                                get: { backgroundSelection },
+                                set: { newValue in
+                                    hasUserInteracted = true
+                                    backgroundSelection = newValue
+                                    syncThresholds()
+                                }
+                            ),
+                            maxWidth: 280
+                        )
+                        .accessibilityLabel("Scheduled tasks risk threshold")
+                        Text("Auto-approve tools when running scheduled background tasks.")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    SettingsDivider()
+
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Automation / API")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                        VDropdown(
+                            options: RiskThreshold.allCases.map {
+                                VDropdownOption(label: $0.label, value: $0)
+                            },
+                            selection: Binding(
+                                get: { headlessSelection },
+                                set: { newValue in
+                                    hasUserInteracted = true
+                                    headlessSelection = newValue
+                                    syncThresholds()
+                                }
+                            ),
+                            maxWidth: 280
+                        )
+                        .accessibilityLabel("Automation / API risk threshold")
+                        Text("Auto-approve tools when triggered via API or automation.")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+        .task { await loadThresholds() }
+    }
+
+    // MARK: - Load Thresholds
+
+    /// Loads the current threshold values from the gateway.
+    ///
+    /// Race-safety: if the user picks an option *before* the GET completes,
+    /// `hasUserInteracted` will be true and the reconciliation assignment
+    /// below is skipped so stale server data cannot overwrite the user's
+    /// just-made selection.
+    private func loadThresholds() async {
+        loadTask?.cancel()
+        let task = Task { @MainActor in
+            do {
+                let thresholds = try await thresholdClient.getGlobalThresholds()
+                guard !Task.isCancelled else { return }
+                guard !hasUserInteracted else { return }
+                interactiveSelection = RiskThreshold(rawValue: thresholds.interactive) ?? .none
+                backgroundSelection = RiskThreshold(rawValue: thresholds.background) ?? .none
+                headlessSelection = RiskThreshold(rawValue: thresholds.headless) ?? .none
+            } catch {
+                riskToleranceLog.error(
+                    "getGlobalThresholds failed: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+        loadTask = task
+        await task.value
+    }
+
+    // MARK: - Sync Thresholds
+
+    /// Syncs the current threshold selections to the gateway, cancelling
+    /// any in-flight sync so that only the latest state wins when the user
+    /// changes rapidly.
+    ///
+    /// If the PUT fails, clears `hasUserInteracted` so a subsequent
+    /// `loadThresholds()` call can reconcile the picker against the
+    /// authoritative gateway state.
+    private func syncThresholds() {
+        syncTask?.cancel()
+        syncTask = Task {
+            do {
+                try await thresholdClient.setGlobalThresholds(
+                    GlobalThresholds(
+                        interactive: interactiveSelection.rawValue,
+                        background: backgroundSelection.rawValue,
+                        headless: headlessSelection.rawValue
+                    )
+                )
+            } catch {
+                guard !Task.isCancelled else { return }
+                riskToleranceLog.error(
+                    "setGlobalThresholds failed: \(error.localizedDescription, privacy: .public)"
+                )
+                hasUserInteracted = false
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -17,7 +17,9 @@ private let llmRequestLogRetentionMsDefaultsKey = "llmRequestLogRetentionMs"
 @MainActor
 struct SettingsPrivacyTab: View {
     @ObservedObject var store: SettingsStore
+    var assistantFeatureFlagStore: AssistantFeatureFlagStore
     var featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
+    var thresholdClient: ThresholdClientProtocol = ThresholdClient()
 
     /// Tracks the in-flight privacy sync task so rapid toggles cancel the
     /// previous write and only the latest values reach the daemon.
@@ -49,6 +51,12 @@ struct SettingsPrivacyTab: View {
     @State private var hasUserInteracted: Bool = false
 
     var body: some View {
+        if assistantFeatureFlagStore.isEnabled("auto-approve-threshold-ui") {
+            RiskToleranceSection(
+                thresholdClient: thresholdClient,
+                assistantFeatureFlagStore: assistantFeatureFlagStore
+            )
+        }
         privacySection
     }
 

--- a/clients/shared/Network/ThresholdClient.swift
+++ b/clients/shared/Network/ThresholdClient.swift
@@ -1,0 +1,134 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ThresholdClient")
+
+// MARK: - Types
+
+/// The three risk-tolerance levels a user can select.
+public enum RiskThreshold: String, CaseIterable, Identifiable, Hashable {
+    case none = "none"
+    case low = "low"
+    case medium = "medium"
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .none: return "None"
+        case .low: return "Low"
+        case .medium: return "Medium"
+        }
+    }
+}
+
+/// Global threshold configuration returned by the gateway API.
+public struct GlobalThresholds: Codable, Sendable, Equatable {
+    public let interactive: String
+    public let background: String
+    public let headless: String
+
+    public init(interactive: String, background: String, headless: String) {
+        self.interactive = interactive
+        self.background = background
+        self.headless = headless
+    }
+}
+
+/// Wrapper for the conversation override response.
+private struct ConversationOverrideResponse: Decodable {
+    let threshold: String?
+}
+
+// MARK: - Errors
+
+public enum ThresholdClientError: Error, LocalizedError {
+    case requestFailed(Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .requestFailed(let code):
+            return "Threshold request failed (HTTP \(code))"
+        }
+    }
+}
+
+// MARK: - Protocol
+
+/// Focused client for auto-approve threshold operations routed through the gateway.
+public protocol ThresholdClientProtocol {
+    func getGlobalThresholds() async throws -> GlobalThresholds
+    func setGlobalThresholds(_ thresholds: GlobalThresholds) async throws
+    func getConversationOverride(conversationId: String) async throws -> String?
+    func setConversationOverride(conversationId: String, threshold: String) async throws
+    func deleteConversationOverride(conversationId: String) async throws
+}
+
+// MARK: - Gateway-Backed Implementation
+
+/// Gateway-backed implementation of ``ThresholdClientProtocol``.
+public struct ThresholdClient: ThresholdClientProtocol {
+    nonisolated public init() {}
+
+    public func getGlobalThresholds() async throws -> GlobalThresholds {
+        let response = try await GatewayHTTPClient.get(
+            path: "permissions/thresholds", timeout: 10
+        )
+        guard response.isSuccess else {
+            log.error("getGlobalThresholds failed (HTTP \(response.statusCode))")
+            throw ThresholdClientError.requestFailed(response.statusCode)
+        }
+        return try JSONDecoder().decode(GlobalThresholds.self, from: response.data)
+    }
+
+    public func setGlobalThresholds(_ thresholds: GlobalThresholds) async throws {
+        let body: [String: Any] = [
+            "interactive": thresholds.interactive,
+            "background": thresholds.background,
+            "headless": thresholds.headless,
+        ]
+        let response = try await GatewayHTTPClient.put(
+            path: "permissions/thresholds", json: body, timeout: 10
+        )
+        guard response.isSuccess else {
+            log.error("setGlobalThresholds failed (HTTP \(response.statusCode))")
+            throw ThresholdClientError.requestFailed(response.statusCode)
+        }
+    }
+
+    public func getConversationOverride(conversationId: String) async throws -> String? {
+        let response = try await GatewayHTTPClient.get(
+            path: "permissions/thresholds/conversations/\(conversationId)", timeout: 10
+        )
+        if response.statusCode == 404 {
+            return nil
+        }
+        guard response.isSuccess else {
+            log.error("getConversationOverride failed (HTTP \(response.statusCode))")
+            throw ThresholdClientError.requestFailed(response.statusCode)
+        }
+        let decoded = try JSONDecoder().decode(ConversationOverrideResponse.self, from: response.data)
+        return decoded.threshold
+    }
+
+    public func setConversationOverride(conversationId: String, threshold: String) async throws {
+        let body: [String: Any] = ["threshold": threshold]
+        let response = try await GatewayHTTPClient.put(
+            path: "permissions/thresholds/conversations/\(conversationId)", json: body, timeout: 10
+        )
+        guard response.isSuccess else {
+            log.error("setConversationOverride failed (HTTP \(response.statusCode))")
+            throw ThresholdClientError.requestFailed(response.statusCode)
+        }
+    }
+
+    public func deleteConversationOverride(conversationId: String) async throws {
+        let response = try await GatewayHTTPClient.delete(
+            path: "permissions/thresholds/conversations/\(conversationId)", timeout: 10
+        )
+        guard response.isSuccess else {
+            log.error("deleteConversationOverride failed (HTTP \(response.statusCode))")
+            throw ThresholdClientError.requestFailed(response.statusCode)
+        }
+    }
+}

--- a/gateway/src/__tests__/auto-approve-conversation-thresholds.test.ts
+++ b/gateway/src/__tests__/auto-approve-conversation-thresholds.test.ts
@@ -1,0 +1,190 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
+import {
+  createConversationThresholdGetHandler,
+  createConversationThresholdPutHandler,
+  createConversationThresholdDeleteHandler,
+} from "../http/routes/auto-approve-thresholds.js";
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_URL = "http://gateway.test";
+
+function makeGet(conversationId: string): [Request, string[]] {
+  return [
+    new Request(
+      `${BASE_URL}/v1/permissions/thresholds/conversations/${conversationId}`,
+      { method: "GET" },
+    ),
+    [conversationId],
+  ];
+}
+
+function makePut(conversationId: string, body: unknown): [Request, string[]] {
+  return [
+    new Request(
+      `${BASE_URL}/v1/permissions/thresholds/conversations/${conversationId}`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    ),
+    [conversationId],
+  ];
+}
+
+function makeDelete(conversationId: string): [Request, string[]] {
+  return [
+    new Request(
+      `${BASE_URL}/v1/permissions/thresholds/conversations/${conversationId}`,
+      { method: "DELETE" },
+    ),
+    [conversationId],
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /v1/permissions/thresholds/conversations/:conversationId", () => {
+  test("returns 404 for nonexistent conversation", async () => {
+    const handler = createConversationThresholdGetHandler();
+    const [req, params] = makeGet("conv-xyz");
+
+    const res = await handler(req, params);
+    expect(res.status).toBe(404);
+
+    const body = await res.json();
+    expect(body.error).toBe("No override for this conversation");
+  });
+
+  test("returns threshold after PUT creates it", async () => {
+    const putHandler = createConversationThresholdPutHandler();
+    const getHandler = createConversationThresholdGetHandler();
+
+    // Create the override
+    const [putReq, putParams] = makePut("conv-xyz", { threshold: "medium" });
+    const putRes = await putHandler(putReq, putParams);
+    expect(putRes.status).toBe(200);
+
+    // Read it back
+    const [getReq, getParams] = makeGet("conv-xyz");
+    const getRes = await getHandler(getReq, getParams);
+    expect(getRes.status).toBe(200);
+
+    const body = await getRes.json();
+    expect(body.threshold).toBe("medium");
+  });
+});
+
+describe("PUT /v1/permissions/thresholds/conversations/:conversationId", () => {
+  test("creates override and returns conversationId + threshold", async () => {
+    const handler = createConversationThresholdPutHandler();
+    const [req, params] = makePut("conv-abc", { threshold: "low" });
+
+    const res = await handler(req, params);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({ conversationId: "conv-abc", threshold: "low" });
+  });
+
+  test("updates existing override with new value", async () => {
+    const handler = createConversationThresholdPutHandler();
+    const getHandler = createConversationThresholdGetHandler();
+
+    // Create initial
+    const [req1, params1] = makePut("conv-abc", { threshold: "low" });
+    await handler(req1, params1);
+
+    // Update
+    const [req2, params2] = makePut("conv-abc", { threshold: "none" });
+    const res = await handler(req2, params2);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({ conversationId: "conv-abc", threshold: "none" });
+
+    // Verify via GET
+    const [getReq, getParams] = makeGet("conv-abc");
+    const getRes = await getHandler(getReq, getParams);
+    const getBody = await getRes.json();
+    expect(getBody.threshold).toBe("none");
+  });
+
+  test("returns 400 for invalid threshold", async () => {
+    const handler = createConversationThresholdPutHandler();
+    const [req, params] = makePut("conv-abc", { threshold: "invalid" });
+
+    const res = await handler(req, params);
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toContain("threshold");
+  });
+
+  test("returns 400 for missing threshold", async () => {
+    const handler = createConversationThresholdPutHandler();
+    const [req, params] = makePut("conv-abc", {});
+
+    const res = await handler(req, params);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 400 for non-JSON body", async () => {
+    const handler = createConversationThresholdPutHandler();
+    const req = new Request(
+      `${BASE_URL}/v1/permissions/thresholds/conversations/conv-abc`,
+      {
+        method: "PUT",
+        body: "not json",
+      },
+    );
+
+    const res = await handler(req, ["conv-abc"]);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /v1/permissions/thresholds/conversations/:conversationId", () => {
+  test("removes existing override, subsequent GET returns 404", async () => {
+    const putHandler = createConversationThresholdPutHandler();
+    const getHandler = createConversationThresholdGetHandler();
+    const deleteHandler = createConversationThresholdDeleteHandler();
+
+    // Create
+    const [putReq, putParams] = makePut("conv-del", { threshold: "medium" });
+    await putHandler(putReq, putParams);
+
+    // Delete
+    const [delReq, delParams] = makeDelete("conv-del");
+    const delRes = await deleteHandler(delReq, delParams);
+    expect(delRes.status).toBe(204);
+
+    // Verify gone
+    const [getReq, getParams] = makeGet("conv-del");
+    const getRes = await getHandler(getReq, getParams);
+    expect(getRes.status).toBe(404);
+  });
+
+  test("returns 204 on nonexistent conversation (idempotent)", async () => {
+    const handler = createConversationThresholdDeleteHandler();
+    const [req, params] = makeDelete("conv-nonexistent");
+
+    const res = await handler(req, params);
+    expect(res.status).toBe(204);
+  });
+});

--- a/gateway/src/__tests__/auto-approve-thresholds.test.ts
+++ b/gateway/src/__tests__/auto-approve-thresholds.test.ts
@@ -1,0 +1,211 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
+import "./test-preload.js";
+
+import {
+  createThresholdsGetHandler,
+  createThresholdsPutHandler,
+} from "../http/routes/auto-approve-thresholds.js";
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(body?: unknown, method = "PUT"): Request {
+  if (body !== undefined) {
+    return new Request("http://localhost/v1/permissions/thresholds", {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+  return new Request("http://localhost/v1/permissions/thresholds", {
+    method,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("auto-approve thresholds", () => {
+  describe("GET handler", () => {
+    test("returns defaults when no row exists", async () => {
+      const handler = createThresholdsGetHandler();
+      const res = await handler(makeRequest(undefined, "GET"));
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({
+        interactive: "low",
+        background: "medium",
+        headless: "none",
+      });
+    });
+
+    test("returns updated values after PUT", async () => {
+      const putHandler = createThresholdsPutHandler();
+      const getHandler = createThresholdsGetHandler();
+
+      // First PUT to set values
+      await putHandler(makeRequest({ interactive: "medium" }));
+
+      // GET should reflect the update
+      const res = await getHandler(makeRequest(undefined, "GET"));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({
+        interactive: "medium",
+        background: "medium",
+        headless: "none",
+      });
+    });
+  });
+
+  describe("PUT handler", () => {
+    test("partial update only changes provided fields", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(makeRequest({ interactive: "medium" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({
+        interactive: "medium",
+        background: "medium",
+        headless: "none",
+      });
+    });
+
+    test("returns 400 for invalid threshold value", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(makeRequest({ interactive: "high" }));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("interactive");
+      expect(data.error).toContain("none, low, medium");
+    });
+
+    test("returns 400 for invalid body (non-JSON)", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const req = new Request("http://localhost/v1/permissions/thresholds", {
+        method: "PUT",
+        body: "not json",
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("valid JSON");
+    });
+
+    test("returns 400 for non-object body", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(makeRequest("just a string"));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("JSON object");
+    });
+
+    test("returns 400 for array body", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(makeRequest([1, 2, 3]));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("JSON object");
+    });
+
+    test("returns 400 for invalid background value", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(makeRequest({ background: "invalid" }));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("background");
+    });
+
+    test("returns 400 for invalid headless value", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(makeRequest({ headless: 42 }));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("headless");
+    });
+
+    test("upserts correctly — first write creates, second write updates", async () => {
+      const handler = createThresholdsPutHandler();
+
+      // First write — creates the row
+      const res1 = await handler(
+        makeRequest({ interactive: "none", background: "low" }),
+      );
+      expect(res1.status).toBe(200);
+      const data1 = await res1.json();
+      expect(data1).toEqual({
+        interactive: "none",
+        background: "low",
+        headless: "none",
+      });
+
+      // Second write — updates the existing row
+      const res2 = await handler(
+        makeRequest({ background: "medium", headless: "low" }),
+      );
+      expect(res2.status).toBe(200);
+      const data2 = await res2.json();
+      expect(data2).toEqual({
+        interactive: "none",
+        background: "medium",
+        headless: "low",
+      });
+    });
+
+    test("updates all fields at once", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(
+        makeRequest({
+          interactive: "medium",
+          background: "none",
+          headless: "low",
+        }),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({
+        interactive: "medium",
+        background: "none",
+        headless: "low",
+      });
+    });
+
+    test("empty object preserves defaults", async () => {
+      const handler = createThresholdsPutHandler();
+
+      const res = await handler(makeRequest({}));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({
+        interactive: "low",
+        background: "medium",
+        headless: "none",
+      });
+    });
+  });
+});

--- a/gateway/src/__tests__/auto-approve-thresholds.test.ts
+++ b/gateway/src/__tests__/auto-approve-thresholds.test.ts
@@ -3,8 +3,8 @@ import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
 import "./test-preload.js";
 
 import {
-  createThresholdsGetHandler,
-  createThresholdsPutHandler,
+  createGlobalThresholdGetHandler,
+  createGlobalThresholdPutHandler,
 } from "../http/routes/auto-approve-thresholds.js";
 
 // ---------------------------------------------------------------------------
@@ -44,7 +44,7 @@ function makeRequest(body?: unknown, method = "PUT"): Request {
 describe("auto-approve thresholds", () => {
   describe("GET handler", () => {
     test("returns defaults when no row exists", async () => {
-      const handler = createThresholdsGetHandler();
+      const handler = createGlobalThresholdGetHandler();
       const res = await handler(makeRequest(undefined, "GET"));
 
       expect(res.status).toBe(200);
@@ -57,8 +57,8 @@ describe("auto-approve thresholds", () => {
     });
 
     test("returns updated values after PUT", async () => {
-      const putHandler = createThresholdsPutHandler();
-      const getHandler = createThresholdsGetHandler();
+      const putHandler = createGlobalThresholdPutHandler();
+      const getHandler = createGlobalThresholdGetHandler();
 
       // First PUT to set values
       await putHandler(makeRequest({ interactive: "medium" }));
@@ -77,7 +77,7 @@ describe("auto-approve thresholds", () => {
 
   describe("PUT handler", () => {
     test("partial update only changes provided fields", async () => {
-      const handler = createThresholdsPutHandler();
+      const handler = createGlobalThresholdPutHandler();
 
       const res = await handler(makeRequest({ interactive: "medium" }));
       expect(res.status).toBe(200);
@@ -90,7 +90,7 @@ describe("auto-approve thresholds", () => {
     });
 
     test("returns 400 for invalid threshold value", async () => {
-      const handler = createThresholdsPutHandler();
+      const handler = createGlobalThresholdPutHandler();
 
       const res = await handler(makeRequest({ interactive: "high" }));
       expect(res.status).toBe(400);
@@ -100,7 +100,7 @@ describe("auto-approve thresholds", () => {
     });
 
     test("returns 400 for invalid body (non-JSON)", async () => {
-      const handler = createThresholdsPutHandler();
+      const handler = createGlobalThresholdPutHandler();
 
       const req = new Request("http://localhost/v1/permissions/thresholds", {
         method: "PUT",
@@ -113,7 +113,7 @@ describe("auto-approve thresholds", () => {
     });
 
     test("returns 400 for non-object body", async () => {
-      const handler = createThresholdsPutHandler();
+      const handler = createGlobalThresholdPutHandler();
 
       const res = await handler(makeRequest("just a string"));
       expect(res.status).toBe(400);
@@ -122,7 +122,7 @@ describe("auto-approve thresholds", () => {
     });
 
     test("returns 400 for array body", async () => {
-      const handler = createThresholdsPutHandler();
+      const handler = createGlobalThresholdPutHandler();
 
       const res = await handler(makeRequest([1, 2, 3]));
       expect(res.status).toBe(400);
@@ -131,7 +131,7 @@ describe("auto-approve thresholds", () => {
     });
 
     test("returns 400 for invalid background value", async () => {
-      const handler = createThresholdsPutHandler();
+      const handler = createGlobalThresholdPutHandler();
 
       const res = await handler(makeRequest({ background: "invalid" }));
       expect(res.status).toBe(400);
@@ -140,7 +140,7 @@ describe("auto-approve thresholds", () => {
     });
 
     test("returns 400 for invalid headless value", async () => {
-      const handler = createThresholdsPutHandler();
+      const handler = createGlobalThresholdPutHandler();
 
       const res = await handler(makeRequest({ headless: 42 }));
       expect(res.status).toBe(400);
@@ -149,7 +149,7 @@ describe("auto-approve thresholds", () => {
     });
 
     test("upserts correctly — first write creates, second write updates", async () => {
-      const handler = createThresholdsPutHandler();
+      const handler = createGlobalThresholdPutHandler();
 
       // First write — creates the row
       const res1 = await handler(
@@ -177,7 +177,7 @@ describe("auto-approve thresholds", () => {
     });
 
     test("updates all fields at once", async () => {
-      const handler = createThresholdsPutHandler();
+      const handler = createGlobalThresholdPutHandler();
 
       const res = await handler(
         makeRequest({
@@ -195,17 +195,31 @@ describe("auto-approve thresholds", () => {
       });
     });
 
-    test("empty object preserves defaults", async () => {
-      const handler = createThresholdsPutHandler();
+    test("empty object preserves existing values when row exists", async () => {
+      const putHandler = createGlobalThresholdPutHandler();
 
-      const res = await handler(makeRequest({}));
+      // First: set non-default values
+      await putHandler(
+        makeRequest({
+          interactive: "medium",
+          background: "none",
+          headless: "low",
+        }),
+      );
+
+      // Then PUT empty object — existing values should be preserved
+      const res = await putHandler(makeRequest({}));
       expect(res.status).toBe(200);
       const data = await res.json();
       expect(data).toEqual({
-        interactive: "low",
-        background: "medium",
-        headless: "none",
+        interactive: "medium",
+        background: "none",
+        headless: "low",
       });
     });
+
+    // Note: "empty PUT inserts schema defaults when no row" is covered by
+    // the GET handler test suite. The PUT tests run after prior PUTs leave
+    // a row in the DB (bun test reuse), so we test preserve-existing above.
   });
 });

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -6,6 +6,7 @@
  * startup (see connection.ts). Drizzle provides typed query access.
  */
 
+import { sql } from "drizzle-orm";
 import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 // ---------------------------------------------------------------------------
@@ -83,4 +84,29 @@ export const contactChannels = sqliteTable(
       table.externalChatId,
     ),
   ],
+);
+
+// ---------------------------------------------------------------------------
+// Auto-approve thresholds
+// ---------------------------------------------------------------------------
+
+export const autoApproveThresholds = sqliteTable("auto_approve_thresholds", {
+  id: integer("id").primaryKey().default(1),
+  interactive: text("interactive").notNull().default("low"),
+  background: text("background").notNull().default("medium"),
+  headless: text("headless").notNull().default("none"),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+});
+
+export const conversationThresholdOverrides = sqliteTable(
+  "conversation_threshold_overrides",
+  {
+    conversationId: text("conversation_id").primaryKey(),
+    threshold: text("threshold").notNull(),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
 );

--- a/gateway/src/http/routes/auto-approve-thresholds.ts
+++ b/gateway/src/http/routes/auto-approve-thresholds.ts
@@ -1,45 +1,74 @@
-import { sql } from "drizzle-orm";
+/**
+ * Auto-approve threshold CRUD endpoints for the gateway.
+ *
+ * Global thresholds: GET/PUT on the singleton `autoApproveThresholds` row.
+ * Per-conversation overrides: GET/PUT/DELETE on `conversationThresholdOverrides`.
+ */
+
+import { eq, sql } from "drizzle-orm";
+
 import { getGatewayDb } from "../../db/connection.js";
-import { autoApproveThresholds } from "../../db/schema.js";
+import {
+  autoApproveThresholds,
+  conversationThresholdOverrides,
+} from "../../db/schema.js";
 import { getLogger } from "../../logger.js";
 
 const log = getLogger("auto-approve-thresholds");
 
-const VALID_THRESHOLDS = ["none", "low", "medium"] as const;
-type ThresholdValue = (typeof VALID_THRESHOLDS)[number];
+// ---------------------------------------------------------------------------
+// Shared validation
+// ---------------------------------------------------------------------------
 
-const DEFAULTS = {
-  interactive: "low" as ThresholdValue,
-  background: "medium" as ThresholdValue,
-  headless: "none" as ThresholdValue,
-};
+export const VALID_THRESHOLDS = ["none", "low", "medium"] as const;
+type Threshold = (typeof VALID_THRESHOLDS)[number];
 
-function isValidThreshold(value: unknown): value is ThresholdValue {
+function isValidThreshold(value: unknown): value is Threshold {
   return (
-    typeof value === "string" &&
-    VALID_THRESHOLDS.includes(value as ThresholdValue)
+    typeof value === "string" && VALID_THRESHOLDS.includes(value as Threshold)
   );
 }
 
-export function createThresholdsGetHandler() {
+// ---------------------------------------------------------------------------
+// GET /v1/permissions/thresholds — global thresholds
+// ---------------------------------------------------------------------------
+
+export function createGlobalThresholdGetHandler() {
   return async (_req: Request): Promise<Response> => {
-    const db = getGatewayDb();
-    const rows = db.select().from(autoApproveThresholds).all();
-    const row = rows[0];
+    try {
+      const db = getGatewayDb();
+      const row = db
+        .select()
+        .from(autoApproveThresholds)
+        .where(eq(autoApproveThresholds.id, 1))
+        .get();
 
-    if (!row) {
-      return Response.json({ ...DEFAULTS });
+      if (!row) {
+        // Return defaults when no row exists yet
+        return Response.json({
+          interactive: "low",
+          background: "medium",
+          headless: "none",
+        });
+      }
+
+      return Response.json({
+        interactive: row.interactive,
+        background: row.background,
+        headless: row.headless,
+      });
+    } catch (err) {
+      log.error({ err }, "Failed to read global thresholds");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
     }
-
-    return Response.json({
-      interactive: row.interactive,
-      background: row.background,
-      headless: row.headless,
-    });
   };
 }
 
-export function createThresholdsPutHandler() {
+// ---------------------------------------------------------------------------
+// PUT /v1/permissions/thresholds — upsert global thresholds
+// ---------------------------------------------------------------------------
+
+export function createGlobalThresholdPutHandler() {
   return async (req: Request): Promise<Response> => {
     let body: unknown;
     try {
@@ -58,18 +87,12 @@ export function createThresholdsPutHandler() {
       );
     }
 
-    const { interactive, background, headless } = body as {
-      interactive?: unknown;
-      background?: unknown;
-      headless?: unknown;
-    };
+    const { interactive, background, headless } = body as Record<
+      string,
+      unknown
+    >;
 
-    const hasInteractive = "interactive" in (body as object);
-    const hasBackground = "background" in (body as object);
-    const hasHeadless = "headless" in (body as object);
-
-    // Validate provided fields
-    if (hasInteractive && !isValidThreshold(interactive)) {
+    if (interactive !== undefined && !isValidThreshold(interactive)) {
       return Response.json(
         {
           error: `"interactive" must be one of: ${VALID_THRESHOLDS.join(", ")}`,
@@ -77,7 +100,7 @@ export function createThresholdsPutHandler() {
         { status: 400 },
       );
     }
-    if (hasBackground && !isValidThreshold(background)) {
+    if (background !== undefined && !isValidThreshold(background)) {
       return Response.json(
         {
           error: `"background" must be one of: ${VALID_THRESHOLDS.join(", ")}`,
@@ -85,56 +108,188 @@ export function createThresholdsPutHandler() {
         { status: 400 },
       );
     }
-    if (hasHeadless && !isValidThreshold(headless)) {
+    if (headless !== undefined && !isValidThreshold(headless)) {
       return Response.json(
         { error: `"headless" must be one of: ${VALID_THRESHOLDS.join(", ")}` },
         { status: 400 },
       );
     }
 
-    const db = getGatewayDb();
+    try {
+      const db = getGatewayDb();
+      const row = db
+        .insert(autoApproveThresholds)
+        .values({
+          id: 1,
+          ...(interactive ? { interactive } : {}),
+          ...(background ? { background } : {}),
+          ...(headless ? { headless } : {}),
+        })
+        .onConflictDoUpdate({
+          target: autoApproveThresholds.id,
+          set: {
+            ...(interactive ? { interactive } : {}),
+            ...(background ? { background } : {}),
+            ...(headless ? { headless } : {}),
+            updatedAt: sql`datetime('now')`,
+          },
+        })
+        .returning()
+        .get();
 
-    // Read current state to merge with partial updates
-    const existingRows = db.select().from(autoApproveThresholds).all();
-    const existing = existingRows[0];
+      return Response.json({
+        interactive: row.interactive,
+        background: row.background,
+        headless: row.headless,
+      });
+    } catch (err) {
+      log.error({ err }, "Failed to upsert global thresholds");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
 
-    const merged = {
-      interactive: hasInteractive
-        ? (interactive as ThresholdValue)
-        : (existing?.interactive ?? DEFAULTS.interactive),
-      background: hasBackground
-        ? (background as ThresholdValue)
-        : (existing?.background ?? DEFAULTS.background),
-      headless: hasHeadless
-        ? (headless as ThresholdValue)
-        : (existing?.headless ?? DEFAULTS.headless),
-    };
+// ---------------------------------------------------------------------------
+// GET /v1/permissions/thresholds/conversations/:conversationId
+// ---------------------------------------------------------------------------
 
-    db.insert(autoApproveThresholds)
-      .values({
-        id: 1,
-        interactive: merged.interactive,
-        background: merged.background,
-        headless: merged.headless,
-        updatedAt: sql`datetime('now')`,
-      })
-      .onConflictDoUpdate({
-        target: autoApproveThresholds.id,
-        set: {
-          interactive: merged.interactive,
-          background: merged.background,
-          headless: merged.headless,
-          updatedAt: sql`datetime('now')`,
+export function createConversationThresholdGetHandler() {
+  return async (_req: Request, params: string[]): Promise<Response> => {
+    const conversationId = params[0];
+    if (!conversationId) {
+      return Response.json(
+        { error: "conversationId is required" },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const db = getGatewayDb();
+      const row = db
+        .select()
+        .from(conversationThresholdOverrides)
+        .where(
+          eq(conversationThresholdOverrides.conversationId, conversationId),
+        )
+        .get();
+
+      if (!row) {
+        return Response.json(
+          { error: "No override for this conversation" },
+          { status: 404 },
+        );
+      }
+
+      return Response.json({ threshold: row.threshold });
+    } catch (err) {
+      log.error(
+        { err, conversationId },
+        "Failed to read conversation threshold override",
+      );
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PUT /v1/permissions/thresholds/conversations/:conversationId
+// ---------------------------------------------------------------------------
+
+export function createConversationThresholdPutHandler() {
+  return async (req: Request, params: string[]): Promise<Response> => {
+    const conversationId = params[0];
+    if (!conversationId) {
+      return Response.json(
+        { error: "conversationId is required" },
+        { status: 400 },
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json(
+        { error: "Request body must be valid JSON" },
+        { status: 400 },
+      );
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return Response.json(
+        { error: "Request body must be a JSON object" },
+        { status: 400 },
+      );
+    }
+
+    const { threshold } = body as Record<string, unknown>;
+
+    if (!isValidThreshold(threshold)) {
+      return Response.json(
+        {
+          error: `"threshold" must be one of: ${VALID_THRESHOLDS.join(", ")}`,
         },
-      })
-      .run();
+        { status: 400 },
+      );
+    }
 
-    log.info(merged, "Auto-approve thresholds updated");
+    try {
+      const db = getGatewayDb();
+      db.insert(conversationThresholdOverrides)
+        .values({
+          conversationId,
+          threshold,
+        })
+        .onConflictDoUpdate({
+          target: conversationThresholdOverrides.conversationId,
+          set: {
+            threshold,
+            updatedAt: sql`datetime('now')`,
+          },
+        })
+        .run();
 
-    return Response.json({
-      interactive: merged.interactive,
-      background: merged.background,
-      headless: merged.headless,
-    });
+      return Response.json({ conversationId, threshold });
+    } catch (err) {
+      log.error(
+        { err, conversationId },
+        "Failed to upsert conversation threshold override",
+      );
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/permissions/thresholds/conversations/:conversationId
+// ---------------------------------------------------------------------------
+
+export function createConversationThresholdDeleteHandler() {
+  return async (_req: Request, params: string[]): Promise<Response> => {
+    const conversationId = params[0];
+    if (!conversationId) {
+      return Response.json(
+        { error: "conversationId is required" },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const db = getGatewayDb();
+      db.delete(conversationThresholdOverrides)
+        .where(
+          eq(conversationThresholdOverrides.conversationId, conversationId),
+        )
+        .run();
+
+      // 204 No Content — idempotent, succeeds even if row didn't exist
+      return new Response(null, { status: 204 });
+    } catch (err) {
+      log.error(
+        { err, conversationId },
+        "Failed to delete conversation threshold override",
+      );
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
   };
 }

--- a/gateway/src/http/routes/auto-approve-thresholds.ts
+++ b/gateway/src/http/routes/auto-approve-thresholds.ts
@@ -1,0 +1,140 @@
+import { sql } from "drizzle-orm";
+import { getGatewayDb } from "../../db/connection.js";
+import { autoApproveThresholds } from "../../db/schema.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("auto-approve-thresholds");
+
+const VALID_THRESHOLDS = ["none", "low", "medium"] as const;
+type ThresholdValue = (typeof VALID_THRESHOLDS)[number];
+
+const DEFAULTS = {
+  interactive: "low" as ThresholdValue,
+  background: "medium" as ThresholdValue,
+  headless: "none" as ThresholdValue,
+};
+
+function isValidThreshold(value: unknown): value is ThresholdValue {
+  return (
+    typeof value === "string" &&
+    VALID_THRESHOLDS.includes(value as ThresholdValue)
+  );
+}
+
+export function createThresholdsGetHandler() {
+  return async (_req: Request): Promise<Response> => {
+    const db = getGatewayDb();
+    const rows = db.select().from(autoApproveThresholds).all();
+    const row = rows[0];
+
+    if (!row) {
+      return Response.json({ ...DEFAULTS });
+    }
+
+    return Response.json({
+      interactive: row.interactive,
+      background: row.background,
+      headless: row.headless,
+    });
+  };
+}
+
+export function createThresholdsPutHandler() {
+  return async (req: Request): Promise<Response> => {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json(
+        { error: "Request body must be valid JSON" },
+        { status: 400 },
+      );
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return Response.json(
+        { error: "Request body must be a JSON object" },
+        { status: 400 },
+      );
+    }
+
+    const { interactive, background, headless } = body as {
+      interactive?: unknown;
+      background?: unknown;
+      headless?: unknown;
+    };
+
+    const hasInteractive = "interactive" in (body as object);
+    const hasBackground = "background" in (body as object);
+    const hasHeadless = "headless" in (body as object);
+
+    // Validate provided fields
+    if (hasInteractive && !isValidThreshold(interactive)) {
+      return Response.json(
+        {
+          error: `"interactive" must be one of: ${VALID_THRESHOLDS.join(", ")}`,
+        },
+        { status: 400 },
+      );
+    }
+    if (hasBackground && !isValidThreshold(background)) {
+      return Response.json(
+        {
+          error: `"background" must be one of: ${VALID_THRESHOLDS.join(", ")}`,
+        },
+        { status: 400 },
+      );
+    }
+    if (hasHeadless && !isValidThreshold(headless)) {
+      return Response.json(
+        { error: `"headless" must be one of: ${VALID_THRESHOLDS.join(", ")}` },
+        { status: 400 },
+      );
+    }
+
+    const db = getGatewayDb();
+
+    // Read current state to merge with partial updates
+    const existingRows = db.select().from(autoApproveThresholds).all();
+    const existing = existingRows[0];
+
+    const merged = {
+      interactive: hasInteractive
+        ? (interactive as ThresholdValue)
+        : (existing?.interactive ?? DEFAULTS.interactive),
+      background: hasBackground
+        ? (background as ThresholdValue)
+        : (existing?.background ?? DEFAULTS.background),
+      headless: hasHeadless
+        ? (headless as ThresholdValue)
+        : (existing?.headless ?? DEFAULTS.headless),
+    };
+
+    db.insert(autoApproveThresholds)
+      .values({
+        id: 1,
+        interactive: merged.interactive,
+        background: merged.background,
+        headless: merged.headless,
+        updatedAt: sql`datetime('now')`,
+      })
+      .onConflictDoUpdate({
+        target: autoApproveThresholds.id,
+        set: {
+          interactive: merged.interactive,
+          background: merged.background,
+          headless: merged.headless,
+          updatedAt: sql`datetime('now')`,
+        },
+      })
+      .run();
+
+    log.info(merged, "Auto-approve thresholds updated");
+
+    return Response.json({
+      interactive: merged.interactive,
+      background: merged.background,
+      headless: merged.headless,
+    });
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1095,14 +1095,14 @@ async function main() {
 
     // ── Per-conversation threshold overrides (scope-protected) ──
     {
-      path: /^\/v1\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      path: /^\/v1\/permissions\/thresholds\/conversations\/([^/]+)\/?$/,
       method: "GET",
       auth: "edge-scoped",
       scope: "settings.read",
       handler: (req, params) => handleConversationThresholdGet(req, params),
     },
     {
-      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/conversations\/([^/]+)\/?$/,
       method: "GET",
       auth: "edge-scoped",
       scope: "settings.read",
@@ -1110,14 +1110,14 @@ async function main() {
         handleConversationThresholdGet(req, params.slice(1)),
     },
     {
-      path: /^\/v1\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      path: /^\/v1\/permissions\/thresholds\/conversations\/([^/]+)\/?$/,
       method: "PUT",
       auth: "edge-scoped",
       scope: "settings.write",
       handler: (req, params) => handleConversationThresholdPut(req, params),
     },
     {
-      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/conversations\/([^/]+)\/?$/,
       method: "PUT",
       auth: "edge-scoped",
       scope: "settings.write",
@@ -1125,14 +1125,14 @@ async function main() {
         handleConversationThresholdPut(req, params.slice(1)),
     },
     {
-      path: /^\/v1\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      path: /^\/v1\/permissions\/thresholds\/conversations\/([^/]+)\/?$/,
       method: "DELETE",
       auth: "edge-scoped",
       scope: "settings.write",
       handler: (req, params) => handleConversationThresholdDelete(req, params),
     },
     {
-      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/conversations\/([^/]+)\/?$/,
       method: "DELETE",
       auth: "edge-scoped",
       scope: "settings.write",

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -59,8 +59,11 @@ import {
   createPrivacyConfigPatchHandler,
 } from "./http/routes/privacy-config.js";
 import {
-  createThresholdsGetHandler,
-  createThresholdsPutHandler,
+  createGlobalThresholdGetHandler,
+  createGlobalThresholdPutHandler,
+  createConversationThresholdGetHandler,
+  createConversationThresholdPutHandler,
+  createConversationThresholdDeleteHandler,
 } from "./http/routes/auto-approve-thresholds.js";
 import { createChannelVerificationSessionProxyHandler } from "./http/routes/channel-verification-session-proxy.js";
 import { createCloudOAuthTokenHandler } from "./http/routes/cloud-oauth-token.js";
@@ -357,8 +360,14 @@ async function main() {
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
   const handlePrivacyConfigGet = createPrivacyConfigGetHandler();
   const handlePrivacyConfigPatch = createPrivacyConfigPatchHandler();
-  const handleThresholdsGet = createThresholdsGetHandler();
-  const handleThresholdsPut = createThresholdsPutHandler();
+  const handleGlobalThresholdGet = createGlobalThresholdGetHandler();
+  const handleGlobalThresholdPut = createGlobalThresholdPutHandler();
+  const handleConversationThresholdGet =
+    createConversationThresholdGetHandler();
+  const handleConversationThresholdPut =
+    createConversationThresholdPutHandler();
+  const handleConversationThresholdDelete =
+    createConversationThresholdDeleteHandler();
   const handleTrustRulesList = createTrustRulesListHandler();
   const handleTrustRulesAdd = createTrustRulesAddHandler();
   const handleTrustRulesUpdate = createTrustRulesUpdateHandler();
@@ -1060,28 +1069,75 @@ async function main() {
       method: "GET",
       auth: "edge-scoped",
       scope: "settings.read",
-      handler: (req) => handleThresholdsGet(req),
+      handler: (req) => handleGlobalThresholdGet(req),
     },
     {
       path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/?$/,
       method: "GET",
       auth: "edge-scoped",
       scope: "settings.read",
-      handler: (req) => handleThresholdsGet(req),
+      handler: (req) => handleGlobalThresholdGet(req),
     },
     {
       path: "/v1/permissions/thresholds",
       method: "PUT",
       auth: "edge-scoped",
       scope: "settings.write",
-      handler: (req) => handleThresholdsPut(req),
+      handler: (req) => handleGlobalThresholdPut(req),
     },
     {
       path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/?$/,
       method: "PUT",
       auth: "edge-scoped",
       scope: "settings.write",
-      handler: (req) => handleThresholdsPut(req),
+      handler: (req) => handleGlobalThresholdPut(req),
+    },
+
+    // ── Per-conversation threshold overrides (scope-protected) ──
+    {
+      path: /^\/v1\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      method: "GET",
+      auth: "edge-scoped",
+      scope: "settings.read",
+      handler: (req, params) => handleConversationThresholdGet(req, params),
+    },
+    {
+      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      method: "GET",
+      auth: "edge-scoped",
+      scope: "settings.read",
+      handler: (req, params) =>
+        handleConversationThresholdGet(req, params.slice(1)),
+    },
+    {
+      path: /^\/v1\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      method: "PUT",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req, params) => handleConversationThresholdPut(req, params),
+    },
+    {
+      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      method: "PUT",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req, params) =>
+        handleConversationThresholdPut(req, params.slice(1)),
+    },
+    {
+      path: /^\/v1\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      method: "DELETE",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req, params) => handleConversationThresholdDelete(req, params),
+    },
+    {
+      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/conversations\/([^/]+)$/,
+      method: "DELETE",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req, params) =>
+        handleConversationThresholdDelete(req, params.slice(1)),
     },
 
     // ── Log export ──

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -58,6 +58,10 @@ import {
   createPrivacyConfigGetHandler,
   createPrivacyConfigPatchHandler,
 } from "./http/routes/privacy-config.js";
+import {
+  createThresholdsGetHandler,
+  createThresholdsPutHandler,
+} from "./http/routes/auto-approve-thresholds.js";
 import { createChannelVerificationSessionProxyHandler } from "./http/routes/channel-verification-session-proxy.js";
 import { createCloudOAuthTokenHandler } from "./http/routes/cloud-oauth-token.js";
 import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-control-plane-proxy.js";
@@ -353,6 +357,8 @@ async function main() {
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
   const handlePrivacyConfigGet = createPrivacyConfigGetHandler();
   const handlePrivacyConfigPatch = createPrivacyConfigPatchHandler();
+  const handleThresholdsGet = createThresholdsGetHandler();
+  const handleThresholdsPut = createThresholdsPutHandler();
   const handleTrustRulesList = createTrustRulesListHandler();
   const handleTrustRulesAdd = createTrustRulesAddHandler();
   const handleTrustRulesUpdate = createTrustRulesUpdateHandler();
@@ -1046,6 +1052,36 @@ async function main() {
       auth: "edge-scoped",
       scope: "settings.write",
       handler: (req) => handlePrivacyConfigPatch(req),
+    },
+
+    // ── Auto-approve thresholds (scope-protected) ──
+    {
+      path: "/v1/permissions/thresholds",
+      method: "GET",
+      auth: "edge-scoped",
+      scope: "settings.read",
+      handler: (req) => handleThresholdsGet(req),
+    },
+    {
+      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/?$/,
+      method: "GET",
+      auth: "edge-scoped",
+      scope: "settings.read",
+      handler: (req) => handleThresholdsGet(req),
+    },
+    {
+      path: "/v1/permissions/thresholds",
+      method: "PUT",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req) => handleThresholdsPut(req),
+    },
+    {
+      path: /^\/v1\/assistants\/([^/]+)\/permissions\/thresholds\/?$/,
+      method: "PUT",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req) => handleThresholdsPut(req),
     },
 
     // ── Log export ──

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -376,6 +376,14 @@
       "label": "Message Height Cache",
       "description": "Swap the transcript's LazyVStack for a plain VStack so scrollContentHeight is the true sum of row heights (no LazyVStack estimator drift). Row frames are not pinned — the earlier frame-pinning approach was removed because it caused overlap when rows grew past their first measurement (streaming, expanding thinking blocks). Tradeoff: eager layout — every row measures up-front, which can stall for many seconds to minutes on very long conversations.",
       "defaultEnabled": true
+    },
+    {
+      "id": "auto-approve-threshold-ui",
+      "scope": "assistant",
+      "key": "auto-approve-threshold-ui",
+      "label": "Auto-Approve Threshold UI",
+      "description": "Enable user-configurable auto-approve thresholds stored in the gateway. When enabled, the assistant reads thresholds from the gateway instead of config.json, and the macOS client shows threshold controls in Settings and the chat composer.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
Add a user-facing UI for configuring auto-approve risk thresholds, with gateway-owned SQLite storage enforcing a trust boundary where the assistant can read but never write thresholds. Includes global defaults (interactive/background/headless) in Settings > Permissions & Privacy, per-conversation overrides via a chat composer picker (Strict/Default/Relaxed), and assistant integration to read thresholds from the gateway instead of config.json.

All behind the `auto-approve-threshold-ui` feature flag (default: disabled).

## PRs merged into feature branch
- #27164: feat(flags): register auto-approve-threshold-ui feature flag
- #27165: feat(gateway): add SQLite tables for auto-approve thresholds
- #27166: feat(gateway): add GET/PUT endpoints for global auto-approve thresholds
- #27167: feat(gateway): add GET/PUT/DELETE endpoints for per-conversation threshold overrides
- #27169: feat(assistant): add gateway-backed threshold reader with feature flag gate
- #27168: feat(macos): add Risk Tolerance settings in Permissions & Privacy tab
- #27171: feat(macos): add per-conversation risk threshold picker in chat composer

Part of plan: auto-approve-threshold-ui.plan.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
