### PR TITLE
[ATL-188] fix: retry leaseGuardianToken during local hatch

### DIFF
--- a/cli/src/lib/hatch-local.ts
+++ b/cli/src/lib/hatch-local.ts
@@ -305,10 +305,26 @@ export async function hatchLocal(
   // IP which the daemon rejects as non-loopback.
   emitProgress(6, 7, "Securing connection...");
   const loopbackUrl = `http://127.0.0.1:${resources.gatewayPort}`;
-  try {
-    await leaseGuardianToken(loopbackUrl, instanceName);
-  } catch (err) {
-    console.error(`⚠️  Guardian token lease failed: ${err}`);
+  const maxLeaseAttempts = 3;
+  for (let attempt = 1; attempt <= maxLeaseAttempts; attempt++) {
+    try {
+      await leaseGuardianToken(loopbackUrl, instanceName);
+      break;
+    } catch (err) {
+      if (attempt < maxLeaseAttempts) {
+        const delayMs = 2000 * 2 ** (attempt - 1);
+        console.error(
+          `⚠️  Guardian token lease attempt ${attempt}/${maxLeaseAttempts} failed — retrying in ${delayMs / 1000}s: ${err}`,
+        );
+        await new Promise((r) => setTimeout(r, delayMs));
+      } else {
+        console.error(
+          `⚠️  Guardian token lease failed after ${maxLeaseAttempts} attempts: ${err}\n` +
+            `   The assistant is running but guardian-token.json was not written.\n` +
+            `   If the desktop app loses its stored credentials, re-hatch to recover.`,
+        );
+      }
+    }
   }
 
   // Auto-start ngrok if webhook integrations (e.g. Telegram, Twilio) are configured.

--- a/clients/shared/App/Auth/GuardianTokenFileReader.swift
+++ b/clients/shared/App/Auth/GuardianTokenFileReader.swift
@@ -6,11 +6,12 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Guard
 /// Reads guardian tokens persisted by the CLI at
 /// `$XDG_CONFIG_HOME/vellum{-env}/assistants/<assistantId>/guardian-token.json`.
 ///
-/// During non-local hatches (Docker, GCP, AWS, etc.) the CLI bootstraps the
-/// guardian token via `POST /v1/guardian/init` and writes the result to disk.
-/// The desktop app can import these credentials into `ActorTokenManager`
-/// instead of repeating the HTTP bootstrap (which may fail with 403 when the
-/// daemon is running inside a container).
+/// During hatch, the CLI bootstraps the guardian token via
+/// `POST /v1/guardian/init` and writes the result to disk. The desktop app
+/// can import these credentials into `ActorTokenManager` instead of repeating
+/// the HTTP bootstrap (which may fail with 403 when the daemon is running
+/// inside a container, or when `guardian-init.lock` already exists on
+/// bare-metal).
 public enum GuardianTokenFileReader {
 
     // MARK: - On-Disk Schema


### PR DESCRIPTION
## Summary

The `leaseGuardianToken()` call in `hatch-local.ts` was wrapped in a silent try/catch — if the gateway wasn't ready yet when this ran, `guardian-token.json` was never written and the desktop app had no file-based recovery path on bare-metal.

## Changes

- **`cli/src/lib/hatch-local.ts`**: Replace single try/catch with a 3-attempt retry loop using exponential backoff (2s, 4s). On final failure, log an actionable error message instead of a generic warning.
- **`clients/shared/App/Auth/GuardianTokenFileReader.swift`**: Update doc comment — the file is written during all hatches (including local), not just Docker/cloud.

## Why this matters

This is the root prevention for ATL-188: if the token file is reliably written at hatch time, the macOS app's existing file-import recovery path in `performInitialBootstrap()` actually works on bare-metal. The 60s poll has something to find.

Part of ATL-188

Requested by: David Rose (@emmiekehoe's assistant)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
