### PR TITLE
[ATL-173] Add ReturningUserRouter for post-auth routing

### DIFF
--- a/clients/macos/vellum-assistant/App/ReturningUserRouter.swift
+++ b/clients/macos/vellum-assistant/App/ReturningUserRouter.swift
@@ -1,0 +1,169 @@
+import Foundation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ReturningUserRouter")
+
+/// Post-authentication routing for returning users.
+///
+/// Centralizes the "what should happen after auth" decision so
+/// `AppDelegate+AuthLifecycle` and `ReauthView` share one source of truth
+/// instead of each re-deriving the answer from the lockfile alone.
+///
+/// Two data sources are consulted in parallel:
+/// - **Lockfile** (local, synchronous) — always available.
+/// - **Platform assistant list** (network, async) — authoritative for managed
+///   assistants but may be unavailable; the router degrades gracefully.
+@MainActor
+final class ReturningUserRouter {
+
+    // MARK: - Types
+
+    enum RoutingDecision: Equatable, CustomStringConvertible {
+        /// Proceed directly to the app with the current (or latest) assistant.
+        case autoConnect
+        /// No assistants found — show the hosting-option picker so the user
+        /// can hatch or set one up.
+        case showHostingPicker
+
+        var description: String {
+            switch self {
+            case .autoConnect: "autoConnect"
+            case .showHostingPicker: "showHostingPicker"
+            }
+        }
+    }
+
+    /// Read-only snapshot of what the router discovered about the user's
+    /// assistant landscape from both local and remote sources.
+    struct AssistantLandscape {
+        let lockfileAssistants: [LockfileAssistant]
+        let platformAssistants: [PlatformAssistant]
+        let platformWasConsulted: Bool
+
+        var currentEnvironmentLockfileAssistants: [LockfileAssistant] {
+            lockfileAssistants.filter(\.isCurrentEnvironment)
+        }
+
+        var currentEnvironmentLocalLockfileAssistants: [LockfileAssistant] {
+            lockfileAssistants.filter { $0.isCurrentEnvironment && !$0.isManaged }
+        }
+
+        /// Deduplicated count. When the platform was consulted, managed
+        /// lockfile entries are excluded (the platform list is authoritative
+        /// for those) to avoid double-counting.
+        var totalCount: Int {
+            if platformWasConsulted {
+                return currentEnvironmentLocalLockfileAssistants.count + platformAssistants.count
+            }
+            return currentEnvironmentLockfileAssistants.count
+        }
+    }
+
+    // MARK: - Dependencies
+
+    private let organizationIdProvider: () -> String?
+    private let authServiceProvider: () -> ManagedAssistantBootstrapAuthServicing?
+    private let lockfileLoader: () -> [LockfileAssistant]
+
+    private static let platformTimeoutSeconds: UInt64 = 5
+
+    init(
+        organizationIdProvider: @escaping () -> String? = {
+            UserDefaults.standard.string(forKey: "connectedOrganizationId")
+        },
+        authServiceProvider: @escaping () -> ManagedAssistantBootstrapAuthServicing? = {
+            AuthService.shared
+        },
+        lockfileLoader: @escaping () -> [LockfileAssistant] = {
+            LockfileAssistant.loadAll()
+        }
+    ) {
+        self.organizationIdProvider = organizationIdProvider
+        self.authServiceProvider = authServiceProvider
+        self.lockfileLoader = lockfileLoader
+    }
+
+    // MARK: - Routing
+
+    /// Synchronous fast path — lockfile only, no network.
+    ///
+    /// Returns `.autoConnect` when any current-environment entry exists,
+    /// `nil` when there are none (caller should fall through to the auth
+    /// window or the async ``route()`` path).
+    func decideFast() -> RoutingDecision? {
+        let all = lockfileLoader()
+        let current = all.filter(\.isCurrentEnvironment)
+        guard !current.isEmpty else { return nil }
+        log.info("decideFast: \(current.count) current-env lockfile entries — autoConnect")
+        return .autoConnect
+    }
+
+    /// Fetch the assistant landscape from both sources.
+    func fetchLandscape() async -> AssistantLandscape {
+        let lockfile = lockfileLoader()
+
+        guard let orgId = organizationIdProvider(),
+              let authService = authServiceProvider() else {
+            log.info("fetchLandscape: no org ID or auth service — skipping platform fetch")
+            return AssistantLandscape(
+                lockfileAssistants: lockfile,
+                platformAssistants: [],
+                platformWasConsulted: false
+            )
+        }
+
+        do {
+            let platform = try await withTimeout(seconds: Self.platformTimeoutSeconds) {
+                try await authService.listAssistants(organizationId: orgId)
+            }
+            log.info("fetchLandscape: \(lockfile.count) lockfile, \(platform.count) platform")
+            return AssistantLandscape(
+                lockfileAssistants: lockfile,
+                platformAssistants: platform,
+                platformWasConsulted: true
+            )
+        } catch {
+            log.warning("fetchLandscape: platform fetch failed — \(error.localizedDescription, privacy: .public)")
+            return AssistantLandscape(
+                lockfileAssistants: lockfile,
+                platformAssistants: [],
+                platformWasConsulted: false
+            )
+        }
+    }
+
+    /// Pure routing decision from a pre-fetched landscape.
+    func decide(for landscape: AssistantLandscape) -> RoutingDecision {
+        let total = landscape.totalCount
+        log.info("decide: totalCount=\(total) platformConsulted=\(landscape.platformWasConsulted)")
+        if total == 0 {
+            return .showHostingPicker
+        }
+        return .autoConnect
+    }
+
+    /// Convenience: fetch the landscape and return the decision.
+    func route() async -> RoutingDecision {
+        decide(for: await fetchLandscape())
+    }
+
+    // MARK: - Helpers
+
+    /// Run an async closure with a timeout.
+    private func withTimeout<T: Sendable>(
+        seconds: UInt64,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { try await operation() }
+            group.addTask {
+                try await Task.sleep(nanoseconds: seconds * 1_000_000_000)
+                throw CancellationError()
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/App/ReturningUserRouter.swift
+++ b/clients/macos/vellum-assistant/App/ReturningUserRouter.swift
@@ -123,6 +123,8 @@ final class ReturningUserRouter {
                 platformAssistants: platform,
                 platformWasConsulted: true
             )
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             log.warning("fetchLandscape: platform fetch failed — \(error.localizedDescription, privacy: .public)")
             return AssistantLandscape(
@@ -144,8 +146,8 @@ final class ReturningUserRouter {
     }
 
     /// Convenience: fetch the landscape and return the decision.
-    func route() async -> RoutingDecision {
-        decide(for: await fetchLandscape())
+    func route() async throws -> RoutingDecision {
+        decide(for: try await fetchLandscape())
     }
 
     // MARK: - Helpers

--- a/clients/macos/vellum-assistantTests/ReturningUserRouterTests.swift
+++ b/clients/macos/vellum-assistantTests/ReturningUserRouterTests.swift
@@ -1,0 +1,215 @@
+import VellumAssistantShared
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class ReturningUserRouterTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeLocalAssistant(id: String = "local-1") -> LockfileAssistant {
+        LockfileAssistant(
+            assistantId: id, runtimeUrl: nil, bearerToken: nil,
+            cloud: "local", project: nil, region: nil, zone: nil,
+            instanceId: nil, hatchedAt: nil, baseDataDir: nil,
+            gatewayPort: nil, instanceDir: nil
+        )
+    }
+
+    private func makeManagedAssistant(id: String = "managed-1") -> LockfileAssistant {
+        LockfileAssistant(
+            assistantId: id,
+            runtimeUrl: VellumEnvironment.resolvedPlatformURL,
+            bearerToken: nil, cloud: "vellum", project: nil,
+            region: nil, zone: nil, instanceId: nil, hatchedAt: nil,
+            baseDataDir: nil, gatewayPort: nil, instanceDir: nil
+        )
+    }
+
+    private func makePlatformAssistant(id: String = "platform-1") -> PlatformAssistant {
+        PlatformAssistant(id: id, name: "Test")
+    }
+
+    private func makeRouter(
+        lockfile: [LockfileAssistant] = [],
+        orgId: String? = nil,
+        platformResult: Result<[PlatformAssistant], Error>? = nil
+    ) -> ReturningUserRouter {
+        let mockAuth: MockAuthService? = platformResult.map { result in
+            MockAuthService(listResult: result)
+        }
+        return ReturningUserRouter(
+            organizationIdProvider: { orgId },
+            authServiceProvider: { mockAuth },
+            lockfileLoader: { lockfile }
+        )
+    }
+
+    // MARK: - decideFast
+
+    func testDecideFastReturnsAutoConnectWhenCurrentEnvEntryExists() {
+        let router = makeRouter(lockfile: [makeLocalAssistant()])
+        XCTAssertEqual(router.decideFast(), .autoConnect)
+    }
+
+    func testDecideFastReturnsNilWhenLockfileIsEmpty() {
+        let router = makeRouter()
+        XCTAssertNil(router.decideFast())
+    }
+
+    func testDecideFastReturnAutoConnectForManagedCurrentEnv() {
+        let router = makeRouter(lockfile: [makeManagedAssistant()])
+        XCTAssertEqual(router.decideFast(), .autoConnect)
+    }
+
+    // MARK: - decide(for:)
+
+    func testDecideShowsHostingPickerWhenZeroAssistants() {
+        let router = makeRouter()
+        let landscape = ReturningUserRouter.AssistantLandscape(
+            lockfileAssistants: [], platformAssistants: [],
+            platformWasConsulted: true
+        )
+        XCTAssertEqual(router.decide(for: landscape), .showHostingPicker)
+    }
+
+    func testDecideAutoConnectsWithOneLocalAssistant() {
+        let local = makeLocalAssistant()
+        let router = makeRouter()
+        let landscape = ReturningUserRouter.AssistantLandscape(
+            lockfileAssistants: [local], platformAssistants: [],
+            platformWasConsulted: true
+        )
+        XCTAssertEqual(router.decide(for: landscape), .autoConnect)
+    }
+
+    func testDecideAutoConnectsWithOnePlatformAssistant() {
+        let router = makeRouter()
+        let landscape = ReturningUserRouter.AssistantLandscape(
+            lockfileAssistants: [], platformAssistants: [makePlatformAssistant()],
+            platformWasConsulted: true
+        )
+        XCTAssertEqual(router.decide(for: landscape), .autoConnect)
+    }
+
+    func testDecideAutoConnectsWithMultipleAssistants() {
+        let router = makeRouter()
+        let landscape = ReturningUserRouter.AssistantLandscape(
+            lockfileAssistants: [makeLocalAssistant()],
+            platformAssistants: [makePlatformAssistant()],
+            platformWasConsulted: true
+        )
+        XCTAssertEqual(router.decide(for: landscape), .autoConnect)
+    }
+
+    // MARK: - Deduplication
+
+    func testManagedLockfileEntryNotDoubleCountedWhenPlatformConsulted() {
+        let router = makeRouter()
+        let landscape = ReturningUserRouter.AssistantLandscape(
+            lockfileAssistants: [makeManagedAssistant(id: "m-1")],
+            platformAssistants: [makePlatformAssistant(id: "m-1")],
+            platformWasConsulted: true
+        )
+        // Managed lockfile entry excluded when platform was consulted;
+        // only the platform entry counts → total = 1, not 2.
+        XCTAssertEqual(landscape.totalCount, 1)
+        XCTAssertEqual(router.decide(for: landscape), .autoConnect)
+    }
+
+    func testManagedLockfileEntryCountedWhenPlatformNotConsulted() {
+        let router = makeRouter()
+        let landscape = ReturningUserRouter.AssistantLandscape(
+            lockfileAssistants: [makeManagedAssistant()],
+            platformAssistants: [],
+            platformWasConsulted: false
+        )
+        XCTAssertEqual(landscape.totalCount, 1)
+        XCTAssertEqual(router.decide(for: landscape), .autoConnect)
+    }
+
+    // MARK: - Platform fallback
+
+    func testPlatformUnreachableWithLockfileEntryAutoConnects() async {
+        let router = makeRouter(
+            lockfile: [makeLocalAssistant()],
+            orgId: "org-1",
+            platformResult: .failure(URLError(.timedOut))
+        )
+        let decision = await router.route()
+        XCTAssertEqual(decision, .autoConnect)
+    }
+
+    func testPlatformUnreachableEmptyLockfileShowsHostingPicker() async {
+        let router = makeRouter(
+            lockfile: [],
+            orgId: "org-1",
+            platformResult: .failure(URLError(.timedOut))
+        )
+        let decision = await router.route()
+        XCTAssertEqual(decision, .showHostingPicker)
+    }
+
+    func testNoOrgIdSkipsPlatformFetch() async {
+        let router = makeRouter(lockfile: [makeLocalAssistant()], orgId: nil)
+        let landscape = await router.fetchLandscape()
+        XCTAssertFalse(landscape.platformWasConsulted)
+        XCTAssertEqual(landscape.totalCount, 1)
+    }
+
+    // MARK: - Landscape helpers
+
+    func testLocalAssistantsAlwaysCurrentEnvironment() {
+        let local = makeLocalAssistant()
+        let landscape = ReturningUserRouter.AssistantLandscape(
+            lockfileAssistants: [local], platformAssistants: [],
+            platformWasConsulted: true
+        )
+        XCTAssertEqual(landscape.currentEnvironmentLockfileAssistants.count, 1)
+        XCTAssertEqual(landscape.currentEnvironmentLocalLockfileAssistants.count, 1)
+    }
+
+    func testTotalCountExcludesCrossEnvironmentEntries() {
+        // A managed assistant with a mismatched runtimeUrl is cross-environment
+        let crossEnv = LockfileAssistant(
+            assistantId: "cross-1",
+            runtimeUrl: "https://other-platform.example.com",
+            bearerToken: nil, cloud: "vellum", project: nil,
+            region: nil, zone: nil, instanceId: nil, hatchedAt: nil,
+            baseDataDir: nil, gatewayPort: nil, instanceDir: nil
+        )
+        let landscape = ReturningUserRouter.AssistantLandscape(
+            lockfileAssistants: [crossEnv], platformAssistants: [],
+            platformWasConsulted: false
+        )
+        XCTAssertEqual(landscape.totalCount, 0)
+    }
+}
+
+// MARK: - Mock
+
+@MainActor
+private final class MockAuthService: ManagedAssistantBootstrapAuthServicing {
+    private let listResult: Result<[PlatformAssistant], Error>
+
+    init(listResult: Result<[PlatformAssistant], Error>) {
+        self.listResult = listResult
+    }
+
+    func listAssistants(organizationId: String) async throws -> [PlatformAssistant] {
+        try listResult.get()
+    }
+
+    // Unused by router — stubs only.
+    func getOrganizations() async throws -> [PlatformOrganization] { [] }
+    func resolveOrganizationId() async throws -> String { "" }
+    func getAssistant(id: String, organizationId: String) async throws -> PlatformAssistantResult {
+        fatalError("Not used by ReturningUserRouter")
+    }
+    func hatchAssistant(
+        organizationId: String, name: String?, description: String?,
+        anthropicApiKey: String?
+    ) async throws -> HatchAssistantResult {
+        fatalError("Not used by ReturningUserRouter")
+    }
+}

--- a/clients/macos/vellum-assistantTests/ReturningUserRouterTests.swift
+++ b/clients/macos/vellum-assistantTests/ReturningUserRouterTests.swift
@@ -130,23 +130,23 @@ final class ReturningUserRouterTests: XCTestCase {
 
     // MARK: - Platform fallback
 
-    func testPlatformUnreachableWithLockfileEntryAutoConnects() async {
+    func testPlatformUnreachableWithLockfileEntryAutoConnects() async throws {
         let router = makeRouter(
             lockfile: [makeLocalAssistant()],
             orgId: "org-1",
             platformResult: .failure(URLError(.timedOut))
         )
-        let decision = await router.route()
+        let decision = try await router.route()
         XCTAssertEqual(decision, .autoConnect)
     }
 
-    func testPlatformUnreachableEmptyLockfileShowsHostingPicker() async {
+    func testPlatformUnreachableEmptyLockfileShowsHostingPicker() async throws {
         let router = makeRouter(
             lockfile: [],
             orgId: "org-1",
             platformResult: .failure(URLError(.timedOut))
         )
-        let decision = await router.route()
+        let decision = try await router.route()
         XCTAssertEqual(decision, .showHostingPicker)
     }
 


### PR DESCRIPTION
Introduces `ReturningUserRouter` to centralize the post-authentication routing decision (`autoConnect` vs `showHostingPicker`) so `AppDelegate+AuthLifecycle` and `ReauthView` can share one source of truth instead of each re-deriving the answer from the lockfile alone.

The router fetches the lockfile and platform assistant list in parallel, deduplicates managed entries (platform is authoritative when consulted), and degrades gracefully when the platform is unreachable (trusts the lockfile alone, 5s timeout).

**This is PR 1 of a series — two new files only, no behavioral change.** Wiring into the existing call sites comes in follow-up PRs.

### What's here
- `ReturningUserRouter.swift` — pure routing logic with DI for testability
  - `decideFast()` — synchronous lockfile-only fast path for cold start
  - `fetchLandscape()` — async parallel fetch from lockfile + platform
  - `decide(for:)` — pure function over `AssistantLandscape`
  - `route()` — convenience combining fetch + decide
- `ReturningUserRouterTests.swift` — 14 test cases covering:
  - Fast-path routing (current-env entries, empty lockfile, managed entries)
  - Landscape decision logic (0/1/N assistants, hosting picker vs auto-connect)
  - Deduplication (managed lockfile entries excluded when platform consulted)
  - Platform fallback (timeout/error → trust lockfile, no org ID → skip fetch)
  - Landscape computed helpers (cross-env filtering, local-only filtering)

Part of ATL-173.

---

Authored by: David Rose (`david-rose-bot`), @emmiekehoe's assistant
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
