### PR TITLE
feat(permissions): add sandboxAutoApprove field to CommandRiskSpec and tag ~50 filesystem commands

### DIFF
--- a/assistant/src/permissions/command-registry.test.ts
+++ b/assistant/src/permissions/command-registry.test.ts
@@ -532,4 +532,186 @@ describe("command-registry", () => {
       expect(trustSubs).toContain("clear");
     });
   });
+
+  // ── sandboxAutoApprove allowlist guard ───────────────────────────────────
+  describe("sandboxAutoApprove allowlist", () => {
+    /** Collect all top-level commands tagged with sandboxAutoApprove: true. */
+    function getSandboxAutoApproveCommands(): string[] {
+      return Object.entries(DEFAULT_COMMAND_REGISTRY)
+        .filter(
+          ([, spec]) => (spec as CommandRiskSpec).sandboxAutoApprove === true,
+        )
+        .map(([name]) => name)
+        .sort();
+    }
+
+    /**
+     * The exact set of commands that should be tagged with sandboxAutoApprove.
+     * This acts as a guard — any addition or removal must be intentional and
+     * update this list.
+     */
+    const EXPECTED_SANDBOX_AUTO_APPROVE = [
+      // Core filesystem (read-only)
+      "ls",
+      "cat",
+      "head",
+      "tail",
+      "less",
+      "more",
+      "wc",
+      "file",
+      "stat",
+      "du",
+      "df",
+      "diff",
+      "tree",
+      "pwd",
+      "realpath",
+      "basename",
+      "dirname",
+      "readlink",
+      // Search / filter / text processing
+      "grep",
+      "rg",
+      "ag",
+      "ack",
+      "sort",
+      "uniq",
+      "cut",
+      "tr",
+      "sed",
+      "awk",
+      // System info / text output
+      "echo",
+      "printf",
+      // Data processing
+      "jq",
+      "yq",
+      // Find
+      "find",
+      "fd",
+      // Write commands
+      "cp",
+      "mv",
+      "mkdir",
+      "touch",
+      "ln",
+      "tee",
+      // Delete commands
+      "rm",
+      "rmdir",
+      // Permissions / ownership
+      "chmod",
+      "chown",
+      // Misc tools
+      "xargs",
+      // Archives
+      "tar",
+      "zip",
+      "unzip",
+      "gzip",
+      "gunzip",
+    ].sort();
+
+    test("sandboxAutoApprove commands match the expected allowlist exactly", () => {
+      const actual = getSandboxAutoApproveCommands();
+      expect(actual).toEqual(EXPECTED_SANDBOX_AUTO_APPROVE);
+    });
+
+    test("network commands are NOT tagged with sandboxAutoApprove", () => {
+      const networkCommands = [
+        "curl",
+        "wget",
+        "http",
+        "ssh",
+        "scp",
+        "rsync",
+        "ping",
+        "dig",
+        "nslookup",
+      ];
+      for (const cmd of networkCommands) {
+        const spec = (
+          DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>
+        )[cmd];
+        expect(spec).toBeDefined();
+        expect(spec.sandboxAutoApprove).not.toBe(true);
+      }
+    });
+
+    test("runtime/language commands are NOT tagged with sandboxAutoApprove", () => {
+      const runtimeCommands = [
+        "node",
+        "deno",
+        "python",
+        "python3",
+        "ruby",
+        "bash",
+        "sh",
+        "zsh",
+      ];
+      for (const cmd of runtimeCommands) {
+        const spec = (
+          DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>
+        )[cmd];
+        expect(spec).toBeDefined();
+        expect(spec.sandboxAutoApprove).not.toBe(true);
+      }
+    });
+
+    test("package manager commands are NOT tagged with sandboxAutoApprove", () => {
+      const packageCommands = [
+        "npm",
+        "npx",
+        "yarn",
+        "pnpm",
+        "bun",
+        "pip",
+        "pip3",
+        "brew",
+        "cargo",
+        "apt-get",
+        "apt",
+        "dnf",
+        "yum",
+        "pacman",
+        "apk",
+      ];
+      for (const cmd of packageCommands) {
+        const spec = (
+          DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>
+        )[cmd];
+        expect(spec).toBeDefined();
+        expect(spec.sandboxAutoApprove).not.toBe(true);
+      }
+    });
+
+    test("system/privilege commands are NOT tagged with sandboxAutoApprove", () => {
+      const systemCommands = [
+        "sudo",
+        "su",
+        "doas",
+        "mount",
+        "umount",
+        "systemctl",
+        "service",
+        "launchctl",
+        "reboot",
+        "shutdown",
+        "kill",
+        "killall",
+        "pkill",
+        "dd",
+        "mkfs",
+        "fdisk",
+      ];
+      for (const cmd of systemCommands) {
+        const spec = (
+          DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>
+        )[cmd];
+        expect(spec).toBeDefined();
+        expect(spec.sandboxAutoApprove).not.toBe(true);
+      }
+    });
+  });
 });

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -31,9 +31,10 @@ const TMP_PATHS = String.raw`^(?:/tmp|/var/tmp|\./|\.\.\/)`;
 
 export const DEFAULT_COMMAND_REGISTRY = {
   // ── Read-only filesystem commands ──────────────────────────────────────────
-  ls: { baseRisk: "low" },
+  ls: { baseRisk: "low", sandboxAutoApprove: true },
   cat: {
     baseRisk: "low",
+    sandboxAutoApprove: true,
     argRules: [
       {
         id: "cat:sensitive",
@@ -43,33 +44,35 @@ export const DEFAULT_COMMAND_REGISTRY = {
       },
     ],
   },
-  head: { baseRisk: "low" },
-  tail: { baseRisk: "low" },
-  less: { baseRisk: "low" },
-  more: { baseRisk: "low" },
-  wc: { baseRisk: "low" },
-  file: { baseRisk: "low" },
-  stat: { baseRisk: "low" },
-  du: { baseRisk: "low" },
-  df: { baseRisk: "low" },
-  diff: { baseRisk: "low" },
-  tree: { baseRisk: "low" },
-  pwd: { baseRisk: "low" },
-  realpath: { baseRisk: "low" },
-  basename: { baseRisk: "low" },
-  dirname: { baseRisk: "low" },
+  head: { baseRisk: "low", sandboxAutoApprove: true },
+  tail: { baseRisk: "low", sandboxAutoApprove: true },
+  less: { baseRisk: "low", sandboxAutoApprove: true },
+  more: { baseRisk: "low", sandboxAutoApprove: true },
+  wc: { baseRisk: "low", sandboxAutoApprove: true },
+  file: { baseRisk: "low", sandboxAutoApprove: true },
+  stat: { baseRisk: "low", sandboxAutoApprove: true },
+  du: { baseRisk: "low", sandboxAutoApprove: true },
+  df: { baseRisk: "low", sandboxAutoApprove: true },
+  diff: { baseRisk: "low", sandboxAutoApprove: true },
+  tree: { baseRisk: "low", sandboxAutoApprove: true },
+  pwd: { baseRisk: "low", sandboxAutoApprove: true },
+  realpath: { baseRisk: "low", sandboxAutoApprove: true },
+  basename: { baseRisk: "low", sandboxAutoApprove: true },
+  dirname: { baseRisk: "low", sandboxAutoApprove: true },
+  readlink: { baseRisk: "low", sandboxAutoApprove: true },
 
   // ── Search / filter / text processing ──────────────────────────────────────
-  grep: { baseRisk: "low" },
-  rg: { baseRisk: "low" },
-  ag: { baseRisk: "low" },
-  ack: { baseRisk: "low" },
-  sort: { baseRisk: "low" },
-  uniq: { baseRisk: "low" },
-  cut: { baseRisk: "low" },
-  tr: { baseRisk: "low" },
+  grep: { baseRisk: "low", sandboxAutoApprove: true },
+  rg: { baseRisk: "low", sandboxAutoApprove: true },
+  ag: { baseRisk: "low", sandboxAutoApprove: true },
+  ack: { baseRisk: "low", sandboxAutoApprove: true },
+  sort: { baseRisk: "low", sandboxAutoApprove: true },
+  uniq: { baseRisk: "low", sandboxAutoApprove: true },
+  cut: { baseRisk: "low", sandboxAutoApprove: true },
+  tr: { baseRisk: "low", sandboxAutoApprove: true },
   sed: {
     baseRisk: "low",
+    sandboxAutoApprove: true,
     argRules: [
       {
         id: "sed:inplace",
@@ -81,13 +84,14 @@ export const DEFAULT_COMMAND_REGISTRY = {
   },
   awk: {
     baseRisk: "medium",
+    sandboxAutoApprove: true,
     complexSyntax: true,
     reason: "Can execute shell commands via system()",
   },
 
   // ── System information (read-only) ─────────────────────────────────────────
-  echo: { baseRisk: "low" },
-  printf: { baseRisk: "low" },
+  echo: { baseRisk: "low", sandboxAutoApprove: true },
+  printf: { baseRisk: "low", sandboxAutoApprove: true },
   whoami: { baseRisk: "low" },
   uname: { baseRisk: "low" },
   uptime: { baseRisk: "low" },
@@ -113,14 +117,15 @@ export const DEFAULT_COMMAND_REGISTRY = {
   hexdump: { baseRisk: "low" },
 
   // ── Data processing ────────────────────────────────────────────────────────
-  jq: { baseRisk: "low" },
-  yq: { baseRisk: "low" },
+  jq: { baseRisk: "low", sandboxAutoApprove: true },
+  yq: { baseRisk: "low", sandboxAutoApprove: true },
 
   // ── Find ───────────────────────────────────────────────────────────────────
   // DIVERGENCE: checker.ts lists `find` as LOW_RISK unconditionally. Our
   // registry adds arg rules for -exec/-execdir/-delete which escalate to high.
   find: {
     baseRisk: "low",
+    sandboxAutoApprove: true,
     complexSyntax: true,
     argRules: [
       {
@@ -137,11 +142,12 @@ export const DEFAULT_COMMAND_REGISTRY = {
       },
     ],
   },
-  fd: { baseRisk: "low" },
+  fd: { baseRisk: "low", sandboxAutoApprove: true },
 
   // ── Write commands ─────────────────────────────────────────────────────────
   cp: {
     baseRisk: "medium",
+    sandboxAutoApprove: true,
     argRules: [
       {
         id: "cp:system",
@@ -153,6 +159,7 @@ export const DEFAULT_COMMAND_REGISTRY = {
   },
   mv: {
     baseRisk: "medium",
+    sandboxAutoApprove: true,
     argRules: [
       {
         id: "mv:system",
@@ -162,15 +169,17 @@ export const DEFAULT_COMMAND_REGISTRY = {
       },
     ],
   },
-  mkdir: { baseRisk: "medium" },
-  touch: { baseRisk: "medium" },
+  mkdir: { baseRisk: "medium", sandboxAutoApprove: true },
+  touch: { baseRisk: "medium", sandboxAutoApprove: true },
+  ln: { baseRisk: "medium", sandboxAutoApprove: true },
   // DIVERGENCE: checker.ts lists `tee` as LOW_RISK. Our registry classifies
   // it as medium because it writes to files.
-  tee: { baseRisk: "medium" },
+  tee: { baseRisk: "medium", sandboxAutoApprove: true },
 
   // ── Delete commands ────────────────────────────────────────────────────────
   rm: {
     baseRisk: "high",
+    sandboxAutoApprove: true,
     argRules: [
       {
         id: "rm:recursive-force",
@@ -204,7 +213,7 @@ export const DEFAULT_COMMAND_REGISTRY = {
       },
     ],
   },
-  rmdir: { baseRisk: "high" },
+  rmdir: { baseRisk: "high", sandboxAutoApprove: true },
 
   // ── Network commands ───────────────────────────────────────────────────────
   curl: {
@@ -584,8 +593,16 @@ export const DEFAULT_COMMAND_REGISTRY = {
     isWrapper: true,
     reason: "Elevates privileges (OpenBSD sudo alternative)",
   },
-  chmod: { baseRisk: "high", reason: "Changes file permissions" },
-  chown: { baseRisk: "high", reason: "Changes file ownership" },
+  chmod: {
+    baseRisk: "high",
+    sandboxAutoApprove: true,
+    reason: "Changes file permissions",
+  },
+  chown: {
+    baseRisk: "high",
+    sandboxAutoApprove: true,
+    reason: "Changes file ownership",
+  },
   chgrp: { baseRisk: "high", reason: "Changes file group" },
   mount: { baseRisk: "high", reason: "Mounts filesystem" },
   umount: { baseRisk: "high", reason: "Unmounts filesystem" },
@@ -723,14 +740,15 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // it as medium because it executes commands with piped arguments.
   xargs: {
     baseRisk: "medium",
+    sandboxAutoApprove: true,
     complexSyntax: true,
     reason: "Executes command with piped arguments",
   },
-  tar: { baseRisk: "medium", complexSyntax: true },
-  zip: { baseRisk: "medium" },
-  unzip: { baseRisk: "medium" },
-  gzip: { baseRisk: "medium" },
-  gunzip: { baseRisk: "medium" },
+  tar: { baseRisk: "medium", sandboxAutoApprove: true, complexSyntax: true },
+  zip: { baseRisk: "medium", sandboxAutoApprove: true },
+  unzip: { baseRisk: "medium", sandboxAutoApprove: true },
+  gzip: { baseRisk: "medium", sandboxAutoApprove: true },
+  gunzip: { baseRisk: "medium", sandboxAutoApprove: true },
 
   // ── Version control tools ──────────────────────────────────────────────────
   gh: {

--- a/assistant/src/permissions/risk-types.ts
+++ b/assistant/src/permissions/risk-types.ts
@@ -158,6 +158,11 @@ export interface CommandRiskSpec {
    * first positional arg (the subcommand name).
    */
   globalValueFlags?: string[];
+  /**
+   * When true, this command auto-approves in the assistant's workspace
+   * without consulting the user's autoApproveUpTo threshold.
+   */
+  sandboxAutoApprove?: boolean;
 }
 
 // ── User rule types ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add sandboxAutoApprove optional boolean field to CommandRiskSpec interface
- Tag ~50 filesystem commands (ls, cat, rm, mkdir, grep, etc.) with sandboxAutoApprove: true
- Add guard tests to lock down the allowlist and verify network/runtime commands are NOT tagged

Part of plan: sandbox-auto-approve-phase1.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
