### PR TITLE
feat(permissions): replace shouldAutoAllowHighRisk with sandboxAutoApprove check in approval policy

### DIFF
--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -136,16 +136,16 @@ describe("allow rule", () => {
     expect(result.matchedRule).toBeUndefined();
   });
 
-  test("allow at High risk — containerized bash → allow (auto-allow), matchedRule present", () => {
+  test("allow at High risk — containerized bash → prompt (no more shouldAutoAllowHighRisk)", () => {
     const result = evaluate({
       riskLevel: RiskLevel.High,
       toolName: "bash",
       matchedRule: allowRule,
       isContainerized: true,
     });
-    expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("auto-allow-high-risk");
-    expect(result.matchedRule).toBe(allowRule);
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("high risk");
+    expect(result.matchedRule).toBeUndefined();
   });
 
   test("allow at High risk — non-bash tool, containerized → prompt, no matchedRule in decision", () => {
@@ -172,6 +172,86 @@ describe("allow rule", () => {
     expect(result.reason).toContain("high risk");
     // Decision is driven by risk-based fallback, not the rule
     expect(result.matchedRule).toBeUndefined();
+  });
+});
+
+// ── Sandbox auto-approve ─────────────────────────────────────────────────────
+
+describe("sandbox auto-approve", () => {
+  test("bash + hasSandboxAutoApprove + containerized → allow", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "bash",
+      hasSandboxAutoApprove: true,
+      isContainerized: true,
+    });
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("sandbox auto-approve");
+  });
+
+  test("bash + hasSandboxAutoApprove + not containerized → falls through", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "bash",
+      hasSandboxAutoApprove: true,
+      isContainerized: false,
+    });
+    // Not containerized, so sandbox auto-approve doesn't fire.
+    // Falls through to risk-based: Low → allow (within default "low" threshold)
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("within auto-approve threshold");
+  });
+
+  test("host_bash + hasSandboxAutoApprove + containerized → falls through", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "host_bash",
+      hasSandboxAutoApprove: true,
+      isContainerized: true,
+    });
+    // host_bash is not "bash", so sandbox auto-approve doesn't fire.
+    // Falls through to risk-based: Low → allow (within default "low" threshold)
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("within auto-approve threshold");
+  });
+
+  test("bash + no hasSandboxAutoApprove + containerized → falls through", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "bash",
+      hasSandboxAutoApprove: false,
+      isContainerized: true,
+    });
+    // hasSandboxAutoApprove is false, so sandbox auto-approve doesn't fire.
+    // Falls through to risk-based: High → prompt
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("high risk");
+  });
+
+  test("sandbox auto-approve fires even for High risk commands", () => {
+    // e.g. rm -rf in a container — should be auto-approved
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "bash",
+      hasSandboxAutoApprove: true,
+      isContainerized: true,
+    });
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("sandbox auto-approve");
+  });
+
+  test("deny rule still blocks sandbox auto-approve commands", () => {
+    const denyRule = makeRule({ decision: "deny" });
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "bash",
+      hasSandboxAutoApprove: true,
+      isContainerized: true,
+      matchedRule: denyRule,
+    });
+    // Deny at step 1 prevents step 3 (sandbox auto-approve)
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toContain("deny rule");
   });
 });
 
@@ -305,7 +385,7 @@ describe("no rule — workspace mode", () => {
     expect(result.reason).toContain("medium risk");
   });
 
-  test("workspace mode, bash, NOT containerized, Low risk, workspace-scoped → falls through (no auto-allow for host bash)", () => {
+  test("workspace mode, bash, NOT containerized, Low risk, workspace-scoped → allow via workspace mode", () => {
     const result = evaluate({
       riskLevel: RiskLevel.Low,
       toolName: "bash",
@@ -313,10 +393,8 @@ describe("no rule — workspace mode", () => {
       isContainerized: false,
       isWorkspaceScoped: true,
     });
-    // Non-containerized bash falls through the workspace check.
-    // Then hits risk-based: Low → allow (within default "low" threshold)
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("low risk");
+    expect(result.reason).toContain("Workspace mode");
   });
 
   test("workspace mode, bash, containerized, Low risk, workspace-scoped → allow via workspace mode", () => {
@@ -474,10 +552,9 @@ describe("edge cases", () => {
     expect(result.decision).toBe("allow");
   });
 
-  test("workspace mode non-containerized bash, Low risk, workspace-scoped → low risk allow (not workspace allow)", () => {
-    // This is the subtle bash host exception. The workspace mode check
-    // specifically skips bash when not containerized, so it falls through
-    // to the risk-based path where Low risk still auto-allows.
+  test("workspace mode non-containerized bash, Low risk, workspace-scoped → workspace allow", () => {
+    // The bash-specific host exception was removed. Non-containerized bash
+    // now auto-allows via workspace mode like any other tool.
     const result = evaluate({
       riskLevel: RiskLevel.Low,
       toolName: "bash",
@@ -486,10 +563,7 @@ describe("edge cases", () => {
       isWorkspaceScoped: true,
     });
     expect(result.decision).toBe("allow");
-    // The reason should be "low risk" not "Workspace mode" — the workspace
-    // auto-allow was bypassed because bash is on the host.
-    expect(result.reason).not.toContain("Workspace mode");
-    expect(result.reason).toContain("low risk");
+    expect(result.reason).toContain("Workspace mode");
   });
 
   test("hasManifestOverride with toolOrigin set to skill — third-party check triggers on origin", () => {

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -21,6 +21,8 @@ export interface ApprovalContext {
   isSkillBundled?: boolean;
   /** Whether the tool has a manifest override (unregistered skill tool). */
   hasManifestOverride?: boolean;
+  /** Whether the command's registry entry has sandboxAutoApprove: true. */
+  hasSandboxAutoApprove?: boolean;
   /**
    * Resolved auto-approve threshold for this execution context.
    * - "none": prompt for everything (strictest)
@@ -106,13 +108,12 @@ export interface ApprovalPolicy {
  *
  * 1. Deny rule → deny
  * 2. Ask rule → prompt
- * 3. Allow rule + non-High → allow
- * 4. Allow rule + High + containerized bash → allow (shouldAutoAllowHighRisk)
- * 5. Allow rule + High + no auto-allow → prompt (fall through)
+ * 3. Sandbox auto-approve: bash + sandboxAutoApprove + containerized → allow
+ * 4. Allow rule + non-High → allow
+ * 5. Allow rule + High → fall through to risk-based
  * 6. No rule + third-party skill tool → prompt
  * 7. No rule + strict mode → prompt
  * 8. No rule + workspace mode + Low + workspace-scoped → allow
- *    (except non-containerized bash — never auto-allow)
  * 9. No rule + Low + bundled skill → allow
  * 10. Risk ≤ autoApproveUpTo threshold → allow
  * 11. Risk > autoApproveUpTo threshold → prompt
@@ -129,6 +130,7 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       toolOrigin,
       isSkillBundled,
       hasManifestOverride,
+      hasSandboxAutoApprove,
     } = context;
 
     // ── 1. Deny rules apply at ALL risk levels ────────────────────────
@@ -149,9 +151,20 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       };
     }
 
-    // ── 3–5. Allow rule handling ──────────────────────────────────────
+    // ── 3. Sandbox auto-approve: bash + allowlisted + containerized → allow ──
+    if (
+      toolName === "bash" &&
+      hasSandboxAutoApprove === true &&
+      isContainerized
+    ) {
+      return {
+        decision: "allow",
+        reason: "Workspace filesystem operation (sandbox auto-approve)",
+      };
+    }
+
+    // ── 4–5. Allow rule handling ──────────────────────────────────────
     if (matchedRule) {
-      // 3. Allow rule + non-High → allow
       if (riskLevel !== RiskLevel.High) {
         return {
           decision: "allow",
@@ -159,19 +172,7 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
           matchedRule,
         };
       }
-
-      // 4. Allow rule + High + containerized bash → allow
-      if (this.shouldAutoAllowHighRisk(toolName, isContainerized)) {
-        return {
-          decision: "allow",
-          reason: `Matched trust rule in auto-allow-high-risk context: ${matchedRule.pattern}`,
-          matchedRule,
-        };
-      }
-
-      // 5. Allow rule + High (no auto-allow) → fall through to risk-based
-      // Note: matchedRule is intentionally omitted from the risk-based
-      // fallback return — the decision is driven by risk, not the rule.
+      // High risk: fall through to risk-based regardless of rule
     }
 
     // ── 6. No rule + third-party skill tool → prompt ──────────────────
@@ -199,15 +200,12 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
     }
 
     // ── 8. No rule + workspace mode + Low + workspace-scoped → allow ──
-    // Exception: non-containerized bash never auto-allows.
     if (
       permissionsMode === "workspace" &&
       !matchedRule &&
       riskLevel === RiskLevel.Low
     ) {
-      if (toolName === "bash" && !isContainerized) {
-        // Fall through to risk-based policy below
-      } else if (isWorkspaceScoped) {
+      if (isWorkspaceScoped) {
         return {
           decision: "allow",
           reason: "Workspace mode: workspace-scoped operation auto-allowed",
@@ -239,19 +237,5 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       decision: "prompt",
       reason: `${riskLevel} risk: above auto-approve threshold`,
     };
-  }
-
-  /**
-   * Determines at runtime whether a high-risk operation should be auto-allowed.
-   * Auto-allows high-risk operations when running in a containerized sandbox.
-   *
-   * Auto-allow cases:
-   * - Containerized bash: all commands are sandboxed, so high-risk is safe.
-   */
-  private shouldAutoAllowHighRisk(
-    toolName: string,
-    isContainerized: boolean,
-  ): boolean {
-    return toolName === "bash" && isContainerized;
   }
 }


### PR DESCRIPTION
## Summary
- Delete shouldAutoAllowHighRisk method from DefaultApprovalPolicy
- Add sandbox auto-approve check: bash + sandboxAutoApprove + containerized → allow
- Remove non-containerized bash exception from workspace mode step 8
- Add hasSandboxAutoApprove field to ApprovalContext
- Update all approval-policy tests for new behavior

Part of plan: sandbox-auto-approve-phase1.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
