### PR TITLE
fix(onboarding): swap Local Mode expand icon from + to info

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
@@ -47,8 +47,8 @@ internal struct OnboardingLocalModeDisclosure: View {
                 Spacer(minLength: 0)
 
                 VButton(
-                    label: isExpanded ? "Collapse" : "Expand",
-                    iconOnly: isExpanded ? VIcon.x.rawValue : VIcon.plus.rawValue,
+                    label: isExpanded ? "Collapse" : "Learn more",
+                    iconOnly: isExpanded ? VIcon.x.rawValue : VIcon.info.rawValue,
                     style: .outlined,
                     size: .pill,
                     iconColor: VColor.contentSecondary


### PR DESCRIPTION
## Summary
Collapsed Local Mode disclosure now uses `VIcon.info` (`lucide-info`) instead of `VIcon.plus` — the affordance reads as "there's more to learn about this option" rather than "add something". Expanded state still uses `VIcon.x`. VoiceOver label on the collapsed pill updated from `"Expand"` to `"Learn more"` to match.

## Test plan
- [x] `swift build` green
- [ ] Gallery / onboarding step 0 collapsed: trailing pill shows an info glyph
- [ ] Tap the info pill → expands with `VAnimation.fast`, pill changes to `×`
- [ ] Tap `×` → collapses back to info icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
