### PR TITLE
fix(home): sort imports and regenerate OpenAPI spec

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4309,10 +4309,51 @@ paths:
                       - timeAwayLabel
                       - newCount
                     additionalProperties: false
+                  suggestedPrompts:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        label:
+                          type: string
+                        icon:
+                          type: string
+                        prompt:
+                          type: string
+                        source:
+                          type: string
+                          enum:
+                            - deterministic
+                            - assistant
+                      required:
+                        - id
+                        - label
+                        - prompt
+                        - source
+                      additionalProperties: false
+                  lowPriorityCollapsed:
+                    type: object
+                    properties:
+                      count:
+                        type: integer
+                        minimum: 0
+                        maximum: 9007199254740991
+                      itemIds:
+                        type: array
+                        items:
+                          type: string
+                    required:
+                      - count
+                      - itemIds
+                    additionalProperties: false
                 required:
                   - items
                   - updatedAt
                   - contextBanner
+                  - suggestedPrompts
+                  - lowPriorityCollapsed
                 additionalProperties: false
       parameters:
         - name: timeAwaySeconds

--- a/assistant/src/runtime/routes/home-feed-routes.ts
+++ b/assistant/src/runtime/routes/home-feed-routes.ts
@@ -26,8 +26,8 @@ import {
   type FeedItem,
   feedItemSchema,
   type FeedItemStatus,
-  suggestedPromptSchema,
   lowPriorityCollapsedSchema,
+  suggestedPromptSchema,
 } from "../../home/feed-types.js";
 import { patchFeedItemStatus, readHomeFeed } from "../../home/feed-writer.js";
 import { runRollupProducer } from "../../home/rollup-producer.js";


### PR DESCRIPTION
## Summary
- Fix lint error (import sort) in `home-feed-routes.ts` from the merge conflict resolution in #26911
- Regenerate `openapi.yaml` to include the new `suggestedPrompts` and `lowPriorityCollapsed` response fields

## Test plan
- CI lint job passes
- OpenAPI spec check passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
