### PR TITLE
docs(permissions): update docs and comments for sandbox auto-approve changes

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1566,7 +1566,7 @@ graph TB
     FIND_RULE -->|"No match"| NO_MATCH{"Fallback logic"}
 
     RISK_CHECK -->|"Low / Medium"| AUTO_ALLOW["decision: allow<br/>Auto-allowed by rule"]
-    RISK_CHECK -->|"High"| HIGH_CHECK{"shouldAutoAllowHighRisk()<br/>(containerized bash?)"}
+    RISK_CHECK -->|"High"| HIGH_CHECK{"sandboxAutoApprove?<br/>(tagged filesystem cmd<br/>in container)"}
     HIGH_CHECK -->|"yes"| AUTO_ALLOW
     HIGH_CHECK -->|"no"| RISK_THRESHOLD{"Risk-based<br/>threshold fallback"}
 
@@ -1711,7 +1711,7 @@ When a permission prompt is sent to the client (via `confirmation_request` SSE e
 | `allowlistOptions` | Suggested patterns for "always allow" rules         |
 | `scopeOptions`     | Suggested scopes for rule persistence               |
 
-The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). High-risk operations with an allow rule in containerized environments are auto-allowed at runtime by `DefaultApprovalPolicy.shouldAutoAllowHighRisk()` without requiring persisted state. All other risk-based decisions use the `autoApproveUpTo` threshold (default: `"low"`) -- tools at or below the threshold are auto-allowed, those above are prompted.
+The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). In containerized environments, commands tagged with `sandboxAutoApprove` in their risk spec are auto-allowed via the approval policy's sandbox auto-approve check; non-allowlisted commands (network tools, runtimes, package managers) use the user's `autoApproveUpTo` threshold. All other risk-based decisions use the `autoApproveUpTo` threshold (default: `"low"`) -- tools at or below the threshold are auto-allowed, those above are prompted.
 
 ### Canonical Paths
 

--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -20,7 +20,7 @@ graph TB
     FIND_RULE -->|"No match"| NO_MATCH{"Fallback logic"}
 
     RISK_CHECK -->|"Low / Medium"| AUTO_ALLOW["decision: allow<br/>Auto-allowed by rule"]
-    RISK_CHECK -->|"High"| HIGH_CHECK{"shouldAutoAllowHighRisk()<br/>(containerized bash?)"}
+    RISK_CHECK -->|"High"| HIGH_CHECK{"sandboxAutoApprove?<br/>(tagged filesystem cmd<br/>in container)"}
     HIGH_CHECK -->|"yes"| AUTO_ALLOW
     HIGH_CHECK -->|"no"| RISK_THRESHOLD{"Risk-based<br/>threshold fallback"}
 
@@ -165,7 +165,7 @@ When a permission prompt is sent to the client (via `confirmation_request` SSE e
 | `allowlistOptions` | Suggested patterns for "always allow" rules         |
 | `scopeOptions`     | Suggested scopes for rule persistence               |
 
-The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). High-risk operations with an allow rule in containerized environments are auto-allowed at runtime by `DefaultApprovalPolicy.shouldAutoAllowHighRisk()` without requiring persisted state. All other risk-based decisions use the `autoApproveUpTo` threshold (default: `"low"`) -- tools at or below the threshold are auto-allowed, those above are prompted.
+The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). In containerized environments, commands tagged with `sandboxAutoApprove` in their risk spec are auto-allowed via the approval policy's sandbox auto-approve check; non-allowlisted commands (network tools, runtimes, package managers) use the user's `autoApproveUpTo` threshold. All other risk-based decisions use the `autoApproveUpTo` threshold (default: `"low"`) -- tools at or below the threshold are auto-allowed, those above are prompted.
 
 ### Canonical Paths
 

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -85,10 +85,11 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   };
 
   // When running inside a container (IS_CONTAINERIZED=true), bash commands
-  // execute in an isolated environment — auto-allow all of them so the user
-  // is never prompted. High-risk operations are handled by
-  // shouldAutoAllowHighRisk() in checker.ts. Outside a container, bash
-  // commands run on the host and go through normal permission checks.
+  // with sandboxAutoApprove tags auto-allow via the approval policy's
+  // sandbox auto-approve check. Non-allowlisted commands (network tools,
+  // runtimes, package managers) go through the user's autoApproveUpTo
+  // threshold. The default allow rule below lets trust rules match
+  // containerized bash; the sandbox auto-approve check handles the rest.
   const bashShellRule: DefaultRuleTemplate | null = getIsContainerized()
     ? {
         id: "default:allow-bash-global",

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -187,7 +187,7 @@ User approval decisions are persisted as trust rules in `~/.vellum/protected/tru
 
 - **Pattern matching**: Minimatch glob patterns for tool commands and file paths.
 - **Execution target binding**: Rules can be scoped to `sandbox` or `host` execution contexts.
-- **Runtime high-risk auto-allow**: High-risk bash commands with an allow rule in containerized environments are auto-allowed at runtime by `DefaultApprovalPolicy.shouldAutoAllowHighRisk()` without requiring persisted state. Other risk-based decisions use the `autoApproveUpTo` threshold (default: `"low"`).
+- **Sandbox auto-approve**: In containerized environments, commands tagged with `sandboxAutoApprove` in their risk spec are auto-allowed via the approval policy's sandbox auto-approve check. Non-allowlisted commands (network tools, runtimes, package managers) use the user's `autoApproveUpTo` threshold (default: `"low"`).
 
 #### Shell command allowlist options
 


### PR DESCRIPTION
## Summary
- Update comment in defaults.ts to reference sandbox auto-approve instead of shouldAutoAllowHighRisk
- Update ARCHITECTURE.md, security.md, and internal-reference.md to describe new sandbox auto-approve mechanism
- Remove all references to the deleted shouldAutoAllowHighRisk method

Part of plan: sandbox-auto-approve-phase1.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
