### PR TITLE
fix(home): spread real conversation-crud exports in home-feed-routes test mock

### DIFF
--- a/assistant/src/runtime/routes/__tests__/home-feed-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/home-feed-routes.test.ts
@@ -33,7 +33,10 @@ const addedMessages: Array<{
 }> = [];
 let createConversationShouldThrow = false;
 
+const realConversationCrud =
+  await import("../../../memory/conversation-crud.js");
 mock.module("../../../memory/conversation-crud.js", () => ({
+  ...realConversationCrud,
   createConversation: (opts: unknown) => {
     if (createConversationShouldThrow) {
       throw new Error("synthetic createConversation failure");


### PR DESCRIPTION
## Summary
- The `home-feed-routes.test.ts` mock for `conversation-crud.js` only provided `createConversation` and `addMessage`, but transitive imports (e.g. `getMessages`) caused a `SyntaxError: Export named 'getMessages' not found` at module resolution time
- Fixed by spreading the real module's exports (`...realConversationCrud`) into the mock, so only the two overridden functions are stubbed while all other exports remain available

## Test plan
- [x] `bun test src/runtime/routes/__tests__/home-feed-routes.test.ts` passes locally (30/30)
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
