### PR TITLE
fix: update workspace-policy test, tag chgrp, clean up test names

### DIFF
--- a/assistant/src/__tests__/workspace-policy.test.ts
+++ b/assistant/src/__tests__/workspace-policy.test.ts
@@ -1,8 +1,9 @@
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
 
+import * as envRegistry from "../config/env-registry.js";
 import {
   isPathWithinWorkspaceRoot,
   isWorkspaceScopedInvocation,
@@ -198,14 +199,31 @@ describe("isWorkspaceScopedInvocation", () => {
   // ── Bash ───────────────────────────────────────────────────────────
 
   describe("bash", () => {
-    test("returns true (container handles isolation)", () => {
+    test("returns false when not containerized", () => {
       expect(
         isWorkspaceScopedInvocation(
           "bash",
           { command: "ls -la" },
           workspaceRoot,
         ),
-      ).toBe(true);
+      ).toBe(false);
+    });
+
+    test("returns true when containerized", () => {
+      const spy = spyOn(envRegistry, "getIsContainerized").mockReturnValue(
+        true,
+      );
+      try {
+        expect(
+          isWorkspaceScopedInvocation(
+            "bash",
+            { command: "ls -la" },
+            workspaceRoot,
+          ),
+        ).toBe(true);
+      } finally {
+        spy.mockRestore();
+      }
     });
   });
 

--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -136,7 +136,7 @@ describe("allow rule", () => {
     expect(result.matchedRule).toBeUndefined();
   });
 
-  test("allow at High risk — containerized bash → prompt (no more shouldAutoAllowHighRisk)", () => {
+  test("allow at High risk — containerized bash without sandboxAutoApprove flag → prompt", () => {
     const result = evaluate({
       riskLevel: RiskLevel.High,
       toolName: "bash",

--- a/assistant/src/permissions/command-registry.test.ts
+++ b/assistant/src/permissions/command-registry.test.ts
@@ -601,6 +601,7 @@ describe("command-registry", () => {
       "rm",
       "rmdir",
       // Permissions / ownership
+      "chgrp",
       "chmod",
       "chown",
       // Misc tools

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -603,7 +603,11 @@ export const DEFAULT_COMMAND_REGISTRY = {
     sandboxAutoApprove: true,
     reason: "Changes file ownership",
   },
-  chgrp: { baseRisk: "high", reason: "Changes file group" },
+  chgrp: {
+    baseRisk: "high",
+    sandboxAutoApprove: true,
+    reason: "Changes file group",
+  },
   mount: { baseRisk: "high", reason: "Mounts filesystem" },
   umount: { baseRisk: "high", reason: "Unmounts filesystem" },
   systemctl: { baseRisk: "high", reason: "Controls system services" },


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for sandbox-auto-approve-phase1.md.

- Fix failing workspace-policy.test.ts: bash test now expects false (non-containerized) and adds containerized test case
- Tag chgrp with sandboxAutoApprove: true for consistency with chmod/chown
- Rename test that referenced deleted shouldAutoAllowHighRisk method
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
