### PR TITLE
fix(onboarding): swap Local Mode expand icon to a chevron

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
@@ -47,8 +47,8 @@ internal struct OnboardingLocalModeDisclosure: View {
                 Spacer(minLength: 0)
 
                 VButton(
-                    label: isExpanded ? "Collapse" : "Learn more",
-                    iconOnly: isExpanded ? VIcon.x.rawValue : VIcon.info.rawValue,
+                    label: isExpanded ? "Collapse" : "Expand",
+                    iconOnly: isExpanded ? VIcon.chevronUp.rawValue : VIcon.chevronDown.rawValue,
                     style: .outlined,
                     size: .pill,
                     iconColor: VColor.contentSecondary


### PR DESCRIPTION
## Summary
The collapsed Local Mode pill now uses `VIcon.chevronDown`, and the expanded state uses `VIcon.chevronUp`. Reads as a disclosure affordance (expand/collapse) rather than an action (`+` / `info` / `×` all had different semantic baggage). VoiceOver labels back to `"Expand"` / `"Collapse"` to match.

## Test plan
- [x] `swift build` green
- [ ] Onboarding step 0 collapsed: trailing pill shows a chevron pointing down
- [ ] Tap → reveals the expanded body and the chevron flips to up
- [ ] Tap again → collapses and chevron returns to down

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
