### PR TITLE
fix(hooks): stop disabling hooks in containerized mode

### DIFF
--- a/assistant/src/hooks/manager.ts
+++ b/assistant/src/hooks/manager.ts
@@ -1,6 +1,5 @@
 import { type FSWatcher, watch } from "node:fs";
 
-import { getIsContainerized } from "../config/env-registry.js";
 import { Debouncer } from "../util/debounce.js";
 import { pathExists } from "../util/fs.js";
 import { getLogger } from "../util/logger.js";
@@ -33,10 +32,6 @@ export class HookManager {
   private readonly debouncer = new Debouncer(500);
 
   initialize(): void {
-    if (getIsContainerized()) {
-      log.info("Hooks disabled in containerized mode");
-      return;
-    }
     this.hooks = discoverHooks();
     this.buildEventIndex();
     const enabled = this.hooks.filter((h) => h.enabled).length;
@@ -112,7 +107,6 @@ export class HookManager {
   }
 
   reload(): void {
-    if (getIsContainerized()) return;
     this.hooks = discoverHooks();
     this.buildEventIndex();
     const enabled = this.hooks.filter((h) => h.enabled).length;
@@ -120,7 +114,6 @@ export class HookManager {
   }
 
   watch(): void {
-    if (getIsContainerized()) return;
     const hooksDir = getWorkspaceHooksDir();
     if (!pathExists(hooksDir)) return;
 


### PR DESCRIPTION
## Summary

- Remove the three `getIsContainerized()` early-returns in `HookManager.initialize()`, `reload()`, and `watch()` so hook discovery and dispatch run in Docker deployments.
- `assistant hooks list`/`install`/`enable` never had a matching containerized gate, so the CLI was already telling users their hook was enabled while the daemon silently skipped the event. The runner (`runner.ts`) and workspace hooks dir creation (`platform.ts:ensureDataDir`) already work in containerized mode, so this just removes the one layer that was breaking the contract.
- Surfaced in the Apollo Bot ticket (JARVIS-557): their `hq-init` hook subscribed to `daemon-start` to register cron jobs — they assumed an image upgrade broke the wiring, but the hook had never fired in their containerized deployment.

## Original prompt

put up a fix so hooks aren't disabled in containerized environments
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
