### PR TITLE
[ATL-188] fix: add POST /v1/guardian/reset-bootstrap endpoint

### DIFF
--- a/gateway/src/__tests__/guardian-init-lockfile.test.ts
+++ b/gateway/src/__tests__/guardian-init-lockfile.test.ts
@@ -22,6 +22,7 @@ let lockFileExists = false;
 let writtenLockFiles: string[] = [];
 let consumedSecretsContent: string | null = null;
 let writtenConsumedFiles: string[] = [];
+let unlinkedFiles: string[] = [];
 
 mock.module("node:fs", () => ({
   ...actualFs,
@@ -59,6 +60,14 @@ mock.module("node:fs", () => ({
       return;
     }
     return actualFs.writeFileSync(p, data, options);
+  },
+  unlinkSync: (p: string) => {
+    if (typeof p === "string" && p.endsWith("guardian-init.lock")) {
+      unlinkedFiles.push(p);
+      lockFileExists = false;
+      return;
+    }
+    return actualFs.unlinkSync(p);
   },
 }));
 
@@ -99,6 +108,7 @@ afterEach(() => {
   writtenLockFiles = [];
   consumedSecretsContent = null;
   writtenConsumedFiles = [];
+  unlinkedFiles = [];
 });
 
 describe("guardian/init bootstrap secret", () => {
@@ -502,5 +512,136 @@ describe("guardian/init multi-secret consumption tracking", () => {
     } finally {
       delete process.env.GUARDIAN_BOOTSTRAP_SECRET;
     }
+  });
+});
+
+describe("guardian/reset-bootstrap", () => {
+  test("removes lock file and allows re-init on bare-metal", async () => {
+    lockFileExists = true;
+    const handler = createChannelVerificationSessionProxyHandler(makeConfig());
+
+    const res = await handler.handleResetBootstrap("127.0.0.1");
+    expect(res.status).toBe(200);
+    expect(unlinkedFiles.length).toBe(1);
+    expect(unlinkedFiles[0]).toContain("guardian-init.lock");
+    expect(lockFileExists).toBe(false);
+  });
+
+  test("succeeds idempotently when lock file does not exist", async () => {
+    lockFileExists = false;
+    const handler = createChannelVerificationSessionProxyHandler(makeConfig());
+
+    const res = await handler.handleResetBootstrap("127.0.0.1");
+    expect(res.status).toBe(200);
+    expect(unlinkedFiles.length).toBe(0);
+  });
+
+  test("rejects non-loopback clients", async () => {
+    const handler = createChannelVerificationSessionProxyHandler(makeConfig());
+
+    const res = await handler.handleResetBootstrap("192.168.1.100");
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Loopback-only endpoint");
+  });
+
+  test("rejects in Docker mode (bootstrap secret set)", async () => {
+    process.env.GUARDIAN_BOOTSTRAP_SECRET = "docker-secret";
+    try {
+      const handler =
+        createChannelVerificationSessionProxyHandler(makeConfig());
+
+      const res = await handler.handleResetBootstrap("127.0.0.1");
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe("Reset not available in containerized mode");
+    } finally {
+      delete process.env.GUARDIAN_BOOTSTRAP_SECRET;
+    }
+  });
+
+  test("rejects with 409 while init is awaiting upstream", async () => {
+    let resolveInit: (v: Response) => void;
+    fetchMock = mock(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveInit = resolve;
+        }),
+    );
+    const handler = createChannelVerificationSessionProxyHandler(makeConfig());
+
+    // Start an init that will hang until we resolve it
+    const initPromise = handler.handleGuardianInit(
+      new Request("http://localhost:7830/v1/guardian/init", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ platform: "cli", deviceId: "d" }),
+      }),
+      "127.0.0.1",
+    );
+
+    // Reset while init is pending
+    const resetRes = await handler.handleResetBootstrap("127.0.0.1");
+    expect(resetRes.status).toBe(409);
+    const body = await resetRes.json();
+    expect(body.error).toBe("Guardian init is in progress — try again shortly");
+
+    // Let the init finish so it doesn't leak
+    resolveInit!(
+      new Response(JSON.stringify({ accessToken: "t", refreshToken: "r" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    await initPromise;
+  });
+
+  test("resets in-flight flag so init can proceed", async () => {
+    lockFileExists = false;
+    fetchMock = mock(
+      async () =>
+        new Response(JSON.stringify({ accessToken: "t", refreshToken: "r" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const handler = createChannelVerificationSessionProxyHandler(makeConfig());
+
+    // First init succeeds and writes lock
+    await handler.handleGuardianInit(
+      new Request("http://localhost:7830/v1/guardian/init", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ platform: "cli", deviceId: "d" }),
+      }),
+      "127.0.0.1",
+    );
+    expect(lockFileExists).toBe(true);
+
+    // Second init is rejected
+    const blocked = await handler.handleGuardianInit(
+      new Request("http://localhost:7830/v1/guardian/init", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ platform: "cli", deviceId: "d" }),
+      }),
+      "127.0.0.1",
+    );
+    expect(blocked.status).toBe(403);
+
+    // Reset clears the lock
+    const resetRes = await handler.handleResetBootstrap("127.0.0.1");
+    expect(resetRes.status).toBe(200);
+
+    // Init works again
+    const retryRes = await handler.handleGuardianInit(
+      new Request("http://localhost:7830/v1/guardian/init", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ platform: "cli", deviceId: "d" }),
+      }),
+      "127.0.0.1",
+    );
+    expect(retryRes.status).toBe(200);
   });
 });

--- a/gateway/src/http/routes/channel-verification-session-proxy.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.ts
@@ -5,7 +5,7 @@
  * disabled, so skills and clients can use gateway URLs exclusively.
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { mintServiceToken } from "../../auth/token-exchange.js";
@@ -45,6 +45,7 @@ export function createChannelVerificationSessionProxyHandler(
   config: GatewayConfig,
 ) {
   let guardianInitInFlight = false;
+  let guardianInitPending = false;
   const secretsInFlight = new Set<number>();
 
   async function proxyToRuntime(
@@ -255,6 +256,7 @@ export function createChannelVerificationSessionProxyHandler(
       }
 
       guardianInitInFlight = true;
+      guardianInitPending = true;
       if (providedIndex >= 0) {
         secretsInFlight.add(providedIndex);
       }
@@ -330,6 +332,7 @@ export function createChannelVerificationSessionProxyHandler(
         guardianInitInFlight = false;
         throw err;
       } finally {
+        guardianInitPending = false;
         if (providedIndex >= 0) {
           secretsInFlight.delete(providedIndex);
         }
@@ -338,6 +341,58 @@ export function createChannelVerificationSessionProxyHandler(
 
     async handleGuardianRefresh(req: Request): Promise<Response> {
       return proxyToRuntime(req, "/v1/guardian/refresh", "");
+    },
+
+    async handleResetBootstrap(clientIp?: string): Promise<Response> {
+      if (clientIp && !isLoopbackAddress(clientIp)) {
+        return Response.json(
+          { error: "Loopback-only endpoint" },
+          { status: 403 },
+        );
+      }
+
+      // Docker mode uses secret-based consumption tracking — resetting the
+      // lockfile alone wouldn't help because consumed secrets are tracked
+      // separately. Only bare-metal (no bootstrap secret) uses the simple
+      // lockfile as the sole guard.
+      if (parseBootstrapSecrets().length > 0) {
+        return Response.json(
+          { error: "Reset not available in containerized mode" },
+          { status: 403 },
+        );
+      }
+
+      // Refuse while an init request is awaiting an upstream response —
+      // mintCredentialPair revokes existing device-bound tokens before
+      // minting, so allowing a concurrent init would invalidate whatever
+      // the in-flight one returns.
+      if (guardianInitPending) {
+        return Response.json(
+          { error: "Guardian init is in progress — try again shortly" },
+          { status: 409 },
+        );
+      }
+
+      const lockDir = getGatewaySecurityDir();
+      const lockPath = join(lockDir, "guardian-init.lock");
+
+      try {
+        if (existsSync(lockPath)) {
+          unlinkSync(lockPath);
+          log.info(
+            "Guardian bootstrap lock file removed — re-init is now allowed",
+          );
+        }
+      } catch (err) {
+        log.error({ err }, "Failed to remove guardian-init.lock");
+        return Response.json(
+          { error: "Failed to remove lock file" },
+          { status: 500 },
+        );
+      }
+
+      guardianInitInFlight = false;
+      return Response.json({ ok: true });
     },
   };
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -656,6 +656,13 @@ async function main() {
         channelVerificationSessionProxy.handleGuardianInit(req, getClientIp()),
     },
     {
+      path: "/v1/guardian/reset-bootstrap",
+      method: "POST",
+      auth: "none",
+      handler: (_req, _params, getClientIp) =>
+        channelVerificationSessionProxy.handleResetBootstrap(getClientIp()),
+    },
+    {
       path: "/v1/channel-verification-sessions",
       method: "POST",
       auth: "edge",

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1698,6 +1698,25 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/guardian/reset-bootstrap": {
+        post: {
+          summary: "Reset guardian bootstrap lock",
+          description:
+            "Loopback-only, bare-metal-only endpoint that removes the guardian-init lock file so that /v1/guardian/init can be called again. Used by the desktop app to recover from a lost actor token.",
+          operationId: "guardianResetBootstrap",
+          responses: {
+            "200": { description: "Lock file removed (or already absent)" },
+            "403": {
+              description:
+                "Forbidden — non-loopback origin or containerized mode",
+            },
+            "409": {
+              description: "Guardian init is in progress — try again shortly",
+            },
+            "500": { description: "Failed to remove lock file" },
+          },
+        },
+      },
       "/v1/channel-verification-sessions/revoke": {
         post: {
           summary: "Revoke verification binding",


### PR DESCRIPTION
## Summary

New loopback-only, bare-metal-only gateway endpoint that removes `guardian-init.lock` so that `/v1/guardian/init` can be called again. This gives the desktop app a safe programmatic path to recover from a lost actor token without touching `protected/` files directly (per the AGENTS.md security boundary — gateway owns trust management).

## Changes

- **`gateway/src/http/routes/channel-verification-session-proxy.ts`**: Add `handleResetBootstrap` — deletes the lock file and resets the in-flight guard. Rejects non-loopback clients and containerized mode.
- **`gateway/src/index.ts`**: Register `POST /v1/guardian/reset-bootstrap` with `auth: "none"`.
- **`gateway/src/schema.ts`**: Add OpenAPI schema entry.
- **`gateway/src/__tests__/guardian-init-lockfile.test.ts`**: 5 new tests covering happy path, idempotency, loopback rejection, Docker rejection, and the full reset→re-init flow.

## Review focus

- The only protection is the in-handler loopback IP check (`isLoopbackAddress`) — same pattern as `guardian/init` in bare-metal mode. No bearer token required.
- Docker mode is rejected because it uses secret-based consumption tracking; resetting the lockfile alone wouldn't help.
- The endpoint is idempotent — succeeds even if the lock file is already absent.

Part of ATL-188

Requested by: David Rose (@emmiekehoe's assistant)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
