### PR TITLE
fix(onboarding): ghost-style chevron + persistent Continue locally CTA

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingLocalModeDisclosure.swift
@@ -49,7 +49,7 @@ internal struct OnboardingLocalModeDisclosure: View {
                 VButton(
                     label: isExpanded ? "Collapse" : "Expand",
                     iconOnly: isExpanded ? VIcon.chevronUp.rawValue : VIcon.chevronDown.rawValue,
-                    style: .outlined,
+                    style: .ghost,
                     size: .pill,
                     iconColor: VColor.contentSecondary
                 ) {
@@ -58,30 +58,30 @@ internal struct OnboardingLocalModeDisclosure: View {
             }
 
             if isExpanded {
-                VStack(alignment: .leading, spacing: 0) {
-                    Spacer().frame(height: VSpacing.sm)
-
-                    VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        ForEach(tradeoffs, id: \.self) { item in
-                            tradeoffRow(item)
-                        }
-                    }
-                    .accessibilityElement(children: .contain)
-                    .accessibilityLabel(Text("Local Mode details"))
-
-                    Spacer().frame(height: VSpacing.sm)
-
-                    VButton(
-                        label: secondaryCTA,
-                        style: .outlined,
-                        size: .pillRegular,
-                        isFullWidth: true,
-                        isDisabled: isDisabled
-                    ) {
-                        onUseLocalMode()
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    ForEach(tradeoffs, id: \.self) { item in
+                        tradeoffRow(item)
                     }
                 }
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel(Text("Local Mode details"))
+                .padding(.top, VSpacing.md)
                 .transition(.opacity.combined(with: .offset(y: -4)))
+            }
+
+            // Secondary CTA stays rendered in both states — users who
+            // already know they want local mode can pick it without
+            // expanding the details first.
+            Spacer().frame(height: VSpacing.md)
+
+            VButton(
+                label: secondaryCTA,
+                style: .outlined,
+                size: .pillRegular,
+                isFullWidth: true,
+                isDisabled: isDisabled
+            ) {
+                onUseLocalMode()
             }
         }
         .padding(EdgeInsets(


### PR DESCRIPTION
## Summary
- Chevron expand/collapse button switches from `.outlined` to `.ghost` so it renders as a bare glyph instead of a small outlined circle.
- `Continue locally` now renders in both collapsed and expanded states — users who already want local mode can commit without expanding the details first. The tradeoffs list stays gated on `isExpanded` and inserts between the header and the CTA.

## Test plan
- [x] `swift build` green
- [ ] Collapsed: chevron has no circular outline, and `Continue locally` sits at the bottom of the card
- [ ] Tap chevron → tradeoffs reveal above the CTA; chevron flips to up, still no outline
- [ ] CTA at the bottom remains in the same position across both states

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
