### PR TITLE
fix(home): suggestion pill border, cursor hints, drop inline Action buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedFilterBar.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedFilterBar.swift
@@ -76,6 +76,7 @@ private struct HomeFeedFilterChip: View {
             .contentShape(Circle())
         }
         .buttonStyle(.plain)
+        .pointerCursor()
         .accessibilityLabel(Text("\(accessibilityName) filter, \(isSelected ? "active" : "inactive")"))
         .accessibilityAddTraits(.isButton)
     }

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -292,20 +292,12 @@ struct HomePageView<DetailPanel: View>: View {
     }
 
     /// Trailing Action button label for a recap row, or nil to hide the
-    /// button entirely. Nudges are tap-to-open (no button); actions
-    /// always show a button; digests show a button only if the daemon
-    /// attached explicit actions; threads are tap-to-open.
+    /// button entirely. Currently always `nil` — rows are tap-to-open
+    /// across every type. The inline Action affordance is intentionally
+    /// withheld until product signs off on which item shapes should
+    /// surface one; until then the entire row is the hit target.
     private func actionLabel(for item: FeedItem) -> String? {
-        switch item.type {
-        case .nudge:
-            return nil
-        case .action:
-            return "Action"
-        case .digest:
-            return (item.actions?.isEmpty == false) ? "Action" : nil
-        case .thread:
-            return nil
-        }
+        return nil
     }
 
     // MARK: - Actions

--- a/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
@@ -83,6 +83,7 @@ struct HomeRecapRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .pointerCursor()
         .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.md, bottom: VSpacing.sm, trailing: VSpacing.md))
         .background(
             RoundedRectangle(cornerRadius: VRadius.md, style: .continuous)

--- a/clients/macos/vellum-assistant/Features/Home/HomeSuggestionPillBar.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeSuggestionPillBar.swift
@@ -119,7 +119,7 @@ struct HomeSuggestionPillBar: View {
         .padding(VSpacing.lg)
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.xl, style: .continuous)
-                .stroke(VColor.borderBase, lineWidth: 1)
+                .stroke(VColor.borderDisabled, lineWidth: 1)
         )
     }
 }


### PR DESCRIPTION
## Summary
- Outer suggestion-pill container border: `VColor.borderBase` → `VColor.borderDisabled` (softer)
- Filter-bar chips: add `.pointerCursor()` so the icons feel clickable on hover
- HomeRecapRow: add `.pointerCursor()` on the whole row button (the entire row is the tap target)
- `HomePageView.actionLabel(for:)` now always returns `nil` — rows are tap-to-open across every type. HomeRecapRow already treats `actionLabel` / `onAction` as optional; this just stops the HomePageView mapping from inserting them until product signs off on which item shapes should get an inline Action.

Part of plan: home-figma-redesign.md (tweaks after initial merge of filter bar + suggestedPrompts)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
