### PR TITLE
feat(ds): add systemInfo blue tokens and wire .action/Input to use them

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedFilterBar.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedFilterBar.swift
@@ -98,7 +98,7 @@ private struct HomeFeedFilterChip: View {
     private var foreground: Color {
         switch type {
         case .nudge:   return VColor.systemNegativeStrong
-        case .action:  return VColor.primaryBase
+        case .action:  return VColor.systemInfoStrong
         case .digest:  return VColor.systemPositiveStrong
         case .thread:  return VColor.systemMidStrong
         }
@@ -109,7 +109,7 @@ private struct HomeFeedFilterChip: View {
     private var background: Color {
         switch type {
         case .nudge:   return VColor.systemNegativeWeak
-        case .action:  return VColor.surfaceActive
+        case .action:  return VColor.systemInfoWeak
         case .digest:  return VColor.systemPositiveWeak
         case .thread:  return VColor.systemMidWeak
         }

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -260,7 +260,10 @@ struct HomePageView<DetailPanel: View>: View {
             // Plan: Danger._500. Closest existing token.
             return VColor.systemNegativeStrong
         case .action:
-            return VColor.primaryBase
+            // Aligned with the Input filter chip — info/blue pair
+            // (#467CC8 glyph over #CEDAEC tint in light; #2A3A50 tint
+            // in dark) so Input rows and chip share one tint.
+            return VColor.systemInfoStrong
         case .digest:
             // Plan: Forest._500. Closest existing token.
             return VColor.systemPositiveStrong
@@ -278,10 +281,8 @@ struct HomePageView<DetailPanel: View>: View {
             // Plan: Danger._900. Closest existing weak-negative tint.
             return VColor.systemNegativeWeak
         case .action:
-            // Plan called for "a muted surface" paired with a blue/primary
-            // tint. `surfaceActive` is the muted surface token; the glyph
-            // picks up `primaryBase` for the blue/primary accent.
-            return VColor.surfaceActive
+            // Aligned with the Input filter chip — info/blue pair.
+            return VColor.systemInfoWeak
         case .digest:
             // Plan: Forest._900. Closest existing weak-positive tint.
             return VColor.systemPositiveWeak

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -82,6 +82,8 @@ public enum VSemanticColorToken: String, CaseIterable {
     case systemNegativeWeak
     case systemMidStrong
     case systemMidWeak
+    case systemInfoStrong
+    case systemInfoWeak
 
     case auxWhite
 }
@@ -169,6 +171,10 @@ private enum FigmaRawColor {
     static let systemDarkMidStrong = Color(hex: 0xF1B21E)
     static let systemLightMidWeak = Color(hex: 0xFCF3DD)
     static let systemDarkMidWeak = Color(hex: 0x4B3D1E)
+    static let systemLightInfoStrong = Color(hex: 0x467CC8)
+    static let systemDarkInfoStrong = Color(hex: 0x467CC8)
+    static let systemLightInfoWeak = Color(hex: 0xCEDAEC)
+    static let systemDarkInfoWeak = Color(hex: 0x2A3A50)
 }
 
 public enum VColor {
@@ -207,6 +213,8 @@ public enum VColor {
         .systemNegativeWeak: .init(lightHex: "#F7DAC9", darkHex: "#4E281D"),
         .systemMidStrong: .init(lightHex: "#F1B21E", darkHex: "#F1B21E"),
         .systemMidWeak: .init(lightHex: "#FCF3DD", darkHex: "#4B3D1E"),
+        .systemInfoStrong: .init(lightHex: "#467CC8", darkHex: "#467CC8"),
+        .systemInfoWeak: .init(lightHex: "#CEDAEC", darkHex: "#2A3A50"),
 
         .auxWhite: .init(lightHex: "#FFFFFF", darkHex: "#FFFFFF"),
     ]
@@ -250,6 +258,8 @@ public enum VColor {
     public static let systemNegativeWeak = adaptiveColor(light: FigmaRawColor.systemLightNegativeWeak, dark: FigmaRawColor.systemDarkNegativeWeak)
     public static let systemMidStrong = adaptiveColor(light: FigmaRawColor.systemLightMidStrong, dark: FigmaRawColor.systemDarkMidStrong)
     public static let systemMidWeak = adaptiveColor(light: FigmaRawColor.systemLightMidWeak, dark: FigmaRawColor.systemDarkMidWeak)
+    public static let systemInfoStrong = adaptiveColor(light: FigmaRawColor.systemLightInfoStrong, dark: FigmaRawColor.systemDarkInfoStrong)
+    public static let systemInfoWeak = adaptiveColor(light: FigmaRawColor.systemLightInfoWeak, dark: FigmaRawColor.systemDarkInfoWeak)
 
     // Pending / queued — warm amber for "held, waiting" affordances (queue drawer accent bar,
     // pending badge backgrounds). Opacity is baked in so the token sits softly over surface


### PR DESCRIPTION
## Summary
- **New semantic tokens** in `clients/shared/DesignSystem/Tokens/ColorTokens.swift`:
  - `VColor.systemInfoStrong` — `#467CC8` on both light and dark (same pattern as the other Strong tokens)
  - `VColor.systemInfoWeak` — `#CEDAEC` light / `#2A3A50` dark
  - Fourth system-semantic pair alongside Positive, Negative, and Mid — covers the blue tint Figma calls for wherever we need a soft informational blue.
- **Consumer rewires**:
  - `HomeFeedFilterBar` Input chip: `primaryBase` / `surfaceActive` (neutral gray pair) → `systemInfoStrong` / `systemInfoWeak` (blue)
  - `HomePageView.iconForeground(for:)` / `iconBackground(for:)` for `.action` type rows: same swap
- Result: the Input filter chip and `.action` feed rows now render in the designed blue instead of gray, matching Figma `3596:79557`. Row and chip stay visually aligned.

Part of plan: home-figma-redesign.md (design-system follow-up)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
