### PR TITLE
docs: use 'assistant' over 'daemon' in new circuit-breaker docstrings (JARVIS-576)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -241,7 +241,7 @@ struct CreditsExhaustedBanner: View {
 
 // MARK: - Compaction Circuit Open Banner
 
-/// Inline banner shown when the daemon has paused automatic context
+/// Inline banner shown when the assistant has paused automatic context
 /// compaction after three consecutive summary-LLM failures. Stays visible
 /// while `openUntil` is in the future; auto-dismisses once the cooldown
 /// elapses. A minute-granularity ticker is sufficient — the cooldown is

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -208,7 +208,7 @@ public final class ChatMessageManager {
     public var isCompacting: Bool = false
     public var contextWindowTokens: Int? = nil
     public var contextWindowMaxTokens: Int? = nil
-    /// Timestamp when auto-compaction will resume after the daemon's circuit
+    /// Timestamp when auto-compaction will resume after the assistant's circuit
     /// breaker opened (3 consecutive summary-LLM failures). `nil` when the
     /// breaker is closed. UI surfaces a banner while this is non-nil and in
     /// the future.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -339,7 +339,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         get { messageManager.contextWindowMaxTokens }
         set { messageManager.contextWindowMaxTokens = newValue }
     }
-    /// When non-nil, the daemon has paused automatic context compaction until
+    /// When non-nil, the assistant has paused automatic context compaction until
     /// this timestamp (1-hour cooldown after 3 consecutive summary-LLM
     /// failures). The chat UI surfaces a banner while this is set and the
     /// timestamp is still in the future; the banner auto-dismisses once the


### PR DESCRIPTION
## Summary
Three docstrings introduced by PR #27199 used 'daemon' instead of 'assistant' — CLAUDE.md's User-Facing Terminology rule says to use 'assistant' in user-facing text. Only the newly-introduced docstrings are changed; pre-existing 'daemon' references in the same files are out of scope.

- ChatErrorToastView.swift banner docstring
- ChatMessageManager.swift compactionCircuitOpenUntil docstring
- ChatViewModel.swift compactionCircuitOpenUntil docstring

Part of JARVIS-576.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
