### PR TITLE
fix(compaction): scope context_compacted events to conversation (JARVIS-576)

### DIFF
--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -333,6 +333,7 @@ describe("forceCompact event emission", () => {
       ServerMessage,
       { type: "context_compacted" }
     >;
+    expect(compactedEvent.conversationId).toBe("conv-compact-events");
     expect(compactedEvent.estimatedInputTokens).toBe(80_000);
     expect(compactedEvent.maxInputTokens).toBe(200_000);
     expect(compactedEvent.previousEstimatedInputTokens).toBe(150_000);
@@ -354,7 +355,7 @@ describe("forceCompact event emission", () => {
     expect(usageEvent.model).toBe("test-model");
   });
 
-  test("emits usage_update even when summary LLM was skipped (truncation-only path)", async () => {
+  test("emits context_compacted even when summary LLM was skipped (truncation-only path)", async () => {
     const collected: ServerMessage[] = [];
     mockCompactResult = {
       messages: [],
@@ -375,22 +376,27 @@ describe("forceCompact event emission", () => {
     const conversation = makeConversation(collected, "conv-compact-trunc");
     await conversation.forceCompact();
 
+    // The truncation-only path does not call the summary LLM, so
+    // `recordUsage` early-returns on 0/0 tokens and no `usage_update` is
+    // emitted. The client instead picks up the fresh context-window tokens
+    // from the `context_compacted` event, which carries the post-compaction
+    // `estimatedInputTokens` and `maxInputTokens` alongside `conversationId`.
     const compactedEvents = collected.filter(
       (m) => m.type === "context_compacted",
     );
     expect(compactedEvents.length).toBe(1);
-
-    const usageEvents = collected.filter((m) => m.type === "usage_update");
-    expect(usageEvents.length).toBe(1);
-    const usageEvent = usageEvents[0] as Extract<
+    const compactedEvent = compactedEvents[0] as Extract<
       ServerMessage,
-      { type: "usage_update" }
+      { type: "context_compacted" }
     >;
-    expect(usageEvent.contextWindowTokens).toBe(80_000);
-    expect(usageEvent.contextWindowMaxTokens).toBe(200_000);
-    expect(usageEvent.inputTokens).toBe(0);
-    expect(usageEvent.outputTokens).toBe(0);
-    expect(usageEvent.estimatedCost).toBe(0);
+    expect(compactedEvent.conversationId).toBe("conv-compact-trunc");
+    expect(compactedEvent.estimatedInputTokens).toBe(80_000);
+    expect(compactedEvent.maxInputTokens).toBe(200_000);
+
+    // No usage_update synthesis in the truncation-only path (the previous
+    // synthetic fallback was removed now that context_compacted carries
+    // conversationId and refreshes the indicator on the client).
+    expect(collected.filter((m) => m.type === "usage_update").length).toBe(0);
   });
 
   test("skips emission when compacted is false", async () => {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -648,6 +648,7 @@ export async function runAgentLoopImpl(
       );
       onEvent({
         type: "context_compacted",
+        conversationId: ctx.conversationId,
         previousEstimatedInputTokens: compacted.previousEstimatedInputTokens,
         estimatedInputTokens: compacted.estimatedInputTokens,
         maxInputTokens: compacted.maxInputTokens,
@@ -1184,6 +1185,7 @@ export async function runAgentLoopImpl(
           );
           onEvent({
             type: "context_compacted",
+            conversationId: ctx.conversationId,
             previousEstimatedInputTokens:
               step.compactionResult.previousEstimatedInputTokens,
             estimatedInputTokens: step.compactionResult.estimatedInputTokens,
@@ -1445,6 +1447,7 @@ export async function runAgentLoopImpl(
         );
         onEvent({
           type: "context_compacted",
+          conversationId: ctx.conversationId,
           previousEstimatedInputTokens:
             midLoopCompact.previousEstimatedInputTokens,
           estimatedInputTokens: midLoopCompact.estimatedInputTokens,
@@ -1720,6 +1723,7 @@ export async function runAgentLoopImpl(
           );
           onEvent({
             type: "context_compacted",
+            conversationId: ctx.conversationId,
             previousEstimatedInputTokens:
               step.compactionResult.previousEstimatedInputTokens,
             estimatedInputTokens: step.compactionResult.estimatedInputTokens,
@@ -1886,6 +1890,7 @@ export async function runAgentLoopImpl(
             );
             onEvent({
               type: "context_compacted",
+              conversationId: ctx.conversationId,
               previousEstimatedInputTokens:
                 emergencyCompact.previousEstimatedInputTokens,
               estimatedInputTokens: emergencyCompact.estimatedInputTokens,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1275,6 +1275,7 @@ export class Conversation {
       this.graphMemory.onCompacted(result.compactedPersistedMessages);
       this.sendToClient({
         type: "context_compacted",
+        conversationId: this.conversationId,
         previousEstimatedInputTokens: result.previousEstimatedInputTokens,
         estimatedInputTokens: result.estimatedInputTokens,
         maxInputTokens: result.maxInputTokens,
@@ -1285,46 +1286,31 @@ export class Conversation {
         summaryOutputTokens: result.summaryOutputTokens,
         summaryModel: result.summaryModel,
       });
-      if (result.summaryInputTokens > 0 || result.summaryOutputTokens > 0) {
-        recordUsage(
-          {
-            conversationId: this.conversationId,
-            providerName: this.provider.name,
-            usageStats: this.usageStats,
-          },
-          result.summaryInputTokens,
-          result.summaryOutputTokens,
-          result.summaryModel,
-          this.sendToClient,
-          "context_compactor",
-          null,
-          result.summaryCacheCreationInputTokens ?? 0,
-          result.summaryCacheReadInputTokens ?? 0,
-          collapseRawResponses(result.summaryRawResponses),
-          result.summaryCalls,
-          {
-            tokens: result.estimatedInputTokens,
-            maxTokens: result.maxInputTokens,
-          },
-        );
-      } else {
-        // Truncation-only path — compaction succeeded without a summary LLM
-        // call, so recordUsage's zero-token guard would early-return and the
-        // UI indicator would stay stale. Emit the contextWindow refresh
-        // directly so the client gets the fresh token counts.
-        this.sendToClient({
-          type: "usage_update",
+      // Call recordUsage unconditionally — it early-returns on 0/0 tokens
+      // (the truncation-only path), and the client already picks up the
+      // fresh context-window tokens from the `context_compacted` event
+      // emitted above. Matches the agent-loop auto-compaction sites.
+      recordUsage(
+        {
           conversationId: this.conversationId,
-          inputTokens: 0,
-          outputTokens: 0,
-          totalInputTokens: this.usageStats.inputTokens,
-          totalOutputTokens: this.usageStats.outputTokens,
-          estimatedCost: 0,
-          model: result.summaryModel,
-          contextWindowTokens: result.estimatedInputTokens,
-          contextWindowMaxTokens: result.maxInputTokens,
-        });
-      }
+          providerName: this.provider.name,
+          usageStats: this.usageStats,
+        },
+        result.summaryInputTokens,
+        result.summaryOutputTokens,
+        result.summaryModel,
+        this.sendToClient,
+        "context_compactor",
+        null,
+        result.summaryCacheCreationInputTokens ?? 0,
+        result.summaryCacheReadInputTokens ?? 0,
+        collapseRawResponses(result.summaryRawResponses),
+        result.summaryCalls,
+        {
+          tokens: result.estimatedInputTokens,
+          maxTokens: result.maxInputTokens,
+        },
+      );
     }
     return result;
   }

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -421,8 +421,19 @@ export interface UsageResponse {
   model: string;
 }
 
+/**
+ * Emitted after a compaction turn completes (both auto-compaction and
+ * `/compact`). Carries the fresh `estimatedInputTokens` so clients can refresh
+ * the context-window indicator without waiting for the next `usage_update`.
+ *
+ * `conversationId` scopes the event so clients can ignore compactions from
+ * other conversations — `EventStreamClient` broadcasts every parsed server
+ * message to all subscribers, so without this field a compaction in one
+ * conversation would overwrite the indicator on every open `ChatViewModel`.
+ */
 export interface ContextCompacted {
   type: "context_compacted";
+  conversationId: string;
   previousEstimatedInputTokens: number;
   estimatedInputTokens: number;
   maxInputTokens: number;

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -335,10 +335,12 @@ final class ChatActionHandler {
             }
 
         case .contextCompacted(let event):
-            // `ContextCompacted` has no conversationId field; SSE streams are
-            // per-conversation and the daemon only emits this for the active
-            // conversation, so we apply unconditionally (unlike `usageUpdate`,
-            // which carries a conversationId and must be gated).
+            // `EventStreamClient` broadcasts every parsed server message to all
+            // subscribers, so we must gate on `conversationId` to avoid
+            // overwriting the context-window indicator on unrelated
+            // `ChatViewModel`s when a compaction happens in another
+            // conversation.
+            guard belongsToConversation(event.conversationId) else { return }
             vm.contextWindowTokens = event.estimatedInputTokens
             vm.contextWindowMaxTokens = event.maxInputTokens
 

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1086,6 +1086,7 @@ public struct ContactsResponse: Codable, Sendable {
 
 public struct ContextCompacted: Codable, Sendable {
     public let type: String
+    public let conversationId: String
     public let previousEstimatedInputTokens: Int
     public let estimatedInputTokens: Int
     public let maxInputTokens: Int
@@ -1096,8 +1097,9 @@ public struct ContextCompacted: Codable, Sendable {
     public let summaryOutputTokens: Int
     public let summaryModel: String
 
-    public init(type: String, previousEstimatedInputTokens: Int, estimatedInputTokens: Int, maxInputTokens: Int, thresholdTokens: Int, compactedMessages: Int, summaryCalls: Int, summaryInputTokens: Int, summaryOutputTokens: Int, summaryModel: String) {
+    public init(type: String, conversationId: String, previousEstimatedInputTokens: Int, estimatedInputTokens: Int, maxInputTokens: Int, thresholdTokens: Int, compactedMessages: Int, summaryCalls: Int, summaryInputTokens: Int, summaryOutputTokens: Int, summaryModel: String) {
         self.type = type
+        self.conversationId = conversationId
         self.previousEstimatedInputTokens = previousEstimatedInputTokens
         self.estimatedInputTokens = estimatedInputTokens
         self.maxInputTokens = maxInputTokens

--- a/clients/shared/Tests/ChatActionHandlerContextCompactedTests.swift
+++ b/clients/shared/Tests/ChatActionHandlerContextCompactedTests.swift
@@ -28,6 +28,7 @@ final class ChatActionHandlerContextCompactedTests: XCTestCase {
         let json = """
         {
           "type": "context_compacted",
+          "conversationId": "sess-1",
           "previousEstimatedInputTokens": 180000,
           "estimatedInputTokens": 80000,
           "maxInputTokens": 200000,
@@ -45,6 +46,7 @@ final class ChatActionHandlerContextCompactedTests: XCTestCase {
             XCTFail("Expected .contextCompacted, got \(decoded)")
             return
         }
+        XCTAssertEqual(event.conversationId, "sess-1")
         XCTAssertEqual(event.estimatedInputTokens, 80_000)
         XCTAssertEqual(event.maxInputTokens, 200_000)
         XCTAssertEqual(event.previousEstimatedInputTokens, 180_000)
@@ -61,6 +63,7 @@ final class ChatActionHandlerContextCompactedTests: XCTestCase {
 
         let event = ContextCompacted(
             type: "context_compacted",
+            conversationId: "sess-1",
             previousEstimatedInputTokens: 180_000,
             estimatedInputTokens: 80_000,
             maxInputTokens: 200_000,
@@ -76,5 +79,32 @@ final class ChatActionHandlerContextCompactedTests: XCTestCase {
 
         XCTAssertEqual(viewModel.contextWindowTokens, 80_000, "Post-compaction estimated input tokens should overwrite contextWindowTokens")
         XCTAssertEqual(viewModel.contextWindowMaxTokens, 200_000, "contextWindowMaxTokens should be set from the event's maxInputTokens")
+    }
+
+    /// `EventStreamClient` broadcasts every parsed server message to all
+    /// subscribers, so the handler MUST ignore events whose `conversationId`
+    /// does not match this VM. Otherwise a compaction in one conversation
+    /// would overwrite the context-window indicator on every open chat.
+    func testActionHandlerIgnoresEventsFromOtherConversations() {
+        viewModel.contextWindowTokens = 42_000
+        viewModel.contextWindowMaxTokens = 200_000
+
+        // Event for a different conversation — the VM should not mutate.
+        viewModel.handleServerMessage(.contextCompacted(ContextCompacted(
+            type: "context_compacted",
+            conversationId: "sess-other",
+            previousEstimatedInputTokens: 180_000,
+            estimatedInputTokens: 80_000,
+            maxInputTokens: 200_000,
+            thresholdTokens: 160_000,
+            compactedMessages: 12,
+            summaryCalls: 1,
+            summaryInputTokens: 15_000,
+            summaryOutputTokens: 2_000,
+            summaryModel: "claude-sonnet"
+        )))
+
+        XCTAssertEqual(viewModel.contextWindowTokens, 42_000, "Indicator must not be mutated by compactions from sibling conversations")
+        XCTAssertEqual(viewModel.contextWindowMaxTokens, 200_000)
     }
 }


### PR DESCRIPTION
## Summary
Self-review fix for the JARVIS-576 feature branch.

- context_compacted now carries conversationId (daemon + Swift + tests).
- Swift handler gates on belongsToConversation so cross-conversation compactions don't overwrite sibling ChatViewModel state.
- forceCompact drops the synthetic usage_update fallback since context_compacted (now scoped) covers the indicator refresh in both the summary-LLM and truncation-only paths.

Part of JARVIS-576.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
