### PR TITLE
feat(home): hover-only Dismiss affordance; drop primary-action from HomeRecapRow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -357,53 +357,43 @@ struct HomeGallerySection: View {
 
                 VCard(background: VColor.surfaceBase) {
                     VStack(spacing: VSpacing.xs) {
-                        // Heartbeat: danger tint, no action.
-                        // Note: plan referenced `Danger._500` / `Danger._900`, which do
-                        // not exist in this codebase; using the closest semantic pair
-                        // `systemNegativeStrong` / `systemNegativeWeak` (see
-                        // HomeRecapRow docs + ColorTokens.swift).
+                        // Heartbeat (nudge): danger/red tint.
                         HomeRecapRow(
                             icon: .heart,
                             iconForeground: VColor.systemNegativeStrong,
                             iconBackground: VColor.systemNegativeWeak,
                             title: "Heartbeat – all systems healthy",
+                            onDismiss: {},
                             onTap: {}
                         )
 
-                        // Permission: blue/primary tint, with action.
-                        // Note: plan referenced a blue/primary scale; the codebase
-                        // has no semantic blue pair, so using `funBlue` for the
-                        // glyph and `surfaceLift` for the subtle tinted background.
+                        // Permission (action): info/blue tint.
                         HomeRecapRow(
                             icon: .arrowLeft,
-                            iconForeground: VColor.funBlue,
-                            iconBackground: VColor.surfaceLift,
+                            iconForeground: VColor.systemInfoStrong,
+                            iconBackground: VColor.systemInfoWeak,
                             title: "I need your permission on authorising a transaction to NBA",
-                            actionLabel: "Action",
-                            onAction: {},
+                            onDismiss: {},
                             onTap: {}
                         )
 
-                        // Digest: emerald tint, with action.
-                        // Note: plan referenced `Forest._500` / `Forest._900`, which
-                        // do not exist; using the closest semantic pair
-                        // `systemPositiveStrong` / `systemPositiveWeak`.
+                        // Digest: emerald/positive tint.
                         HomeRecapRow(
                             icon: .bell,
                             iconForeground: VColor.systemPositiveStrong,
                             iconBackground: VColor.systemPositiveWeak,
                             title: "Last, while you were away, I ran the email clean job and deleted 26 emails…",
-                            actionLabel: "Action",
-                            onAction: {},
+                            onDismiss: {},
                             onTap: {}
                         )
 
-                        // Passive digest: emerald tint, no action.
+                        // Thread (schedule): amber/mid tint.
                         HomeRecapRow(
-                            icon: .bell,
-                            iconForeground: VColor.systemPositiveStrong,
-                            iconBackground: VColor.systemPositiveWeak,
+                            icon: .calendar,
+                            iconForeground: VColor.systemMidStrong,
+                            iconBackground: VColor.systemMidWeak,
                             title: "There's also 4 low priority updates if you want to have a look.",
+                            onDismiss: {},
                             onTap: {}
                         )
                     }

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -143,8 +143,7 @@ struct HomePageView<DetailPanel: View>: View {
                                     iconForeground: iconForeground(for: item),
                                     iconBackground: iconBackground(for: item),
                                     title: item.title,
-                                    actionLabel: actionLabel(for: item),
-                                    onAction: actionLabel(for: item) == nil ? nil : { openItem(item) },
+                                    onDismiss: { dismissItem(item) },
                                     onTap: { openItem(item) }
                                 )
                             }
@@ -292,15 +291,6 @@ struct HomePageView<DetailPanel: View>: View {
         }
     }
 
-    /// Trailing Action button label for a recap row, or nil to hide the
-    /// button entirely. Currently always `nil` — rows are tap-to-open
-    /// across every type. The inline Action affordance is intentionally
-    /// withheld until product signs off on which item shapes should
-    /// surface one; until then the entire row is the hit target.
-    private func actionLabel(for item: FeedItem) -> String? {
-        return nil
-    }
-
     // MARK: - Actions
 
     /// Opens the feed item in a new conversation. The daemon interprets
@@ -315,6 +305,15 @@ struct HomePageView<DetailPanel: View>: View {
             ) {
                 onFeedConversationOpened(conversationId)
             }
+        }
+    }
+
+    /// Dismisses the feed item — store optimistically removes it from
+    /// `items` and PATCHes the daemon with status `.dismissed`. The
+    /// row disappears from the feed without any further UI.
+    private func dismissItem(_ item: FeedItem) {
+        Task {
+            await feedStore.dismiss(itemId: item.id)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
@@ -3,49 +3,28 @@ import VellumAssistantShared
 
 /// Compact row used in the time-bucketed Home feed.
 ///
-/// Layout: a 26pt tinted icon circle + a single-line title + an optional
-/// trailing Action button + a whole-row tap target. The row itself is
-/// intentionally slim (icon pill drives the height) so a list of recaps
-/// reads as a dense time-feed rather than a stack of cards.
+/// Layout: a 26pt tinted icon circle + a single-line title + a trailing
+/// hover-only Dismiss affordance + a whole-row tap target. The row
+/// itself is intentionally slim (icon pill drives the height) so a list
+/// of recaps reads as a dense time-feed rather than a stack of cards.
 ///
-/// The inner Action button is isolated from the outer row Button so its
-/// tap never bubbles up to `onTap` — pressing "Resolve" (or whatever the
-/// caller labels it) only fires `onAction`, not the row's `onTap`.
+/// The Dismiss affordance appears only while the pointer is over the
+/// row (Figma `3596:79329` — hover state). Its tap is isolated from the
+/// outer row Button so clicking "Dismiss" never fires the row's
+/// `onTap` — SwiftUI resolves the innermost tappable first.
 struct HomeRecapRow: View {
     let icon: VIcon
     /// Foreground color for the icon glyph. Callers pass semantic tokens
-    /// (e.g. `VColor.systemNegativeStrong`, `VColor.systemPositiveStrong`).
-    /// The plan referenced raw Danger/Forest 500-scale colors, which do
-    /// not exist in this codebase — semantic tokens are the closest
-    /// equivalent (see `ColorTokens.swift`).
+    /// (e.g. `VColor.systemNegativeStrong`, `VColor.systemInfoStrong`).
     let iconForeground: Color
     /// Tinted background fill for the icon circle (e.g.
-    /// `VColor.systemNegativeWeak`, `VColor.systemPositiveWeak`).
+    /// `VColor.systemNegativeWeak`, `VColor.systemInfoWeak`).
     let iconBackground: Color
     let title: String
-    /// When `nil` (or paired with a nil `onAction`) the trailing button
-    /// is not rendered and the row is still fully tappable.
-    let actionLabel: String?
-    let onAction: (() -> Void)?
+    let onDismiss: () -> Void
     let onTap: () -> Void
 
-    init(
-        icon: VIcon,
-        iconForeground: Color,
-        iconBackground: Color,
-        title: String,
-        actionLabel: String? = nil,
-        onAction: (() -> Void)? = nil,
-        onTap: @escaping () -> Void
-    ) {
-        self.icon = icon
-        self.iconForeground = iconForeground
-        self.iconBackground = iconBackground
-        self.title = title
-        self.actionLabel = actionLabel
-        self.onAction = onAction
-        self.onTap = onTap
-    }
+    @State private var isHovering: Bool = false
 
     var body: some View {
         Button(action: onTap) {
@@ -68,16 +47,23 @@ struct HomeRecapRow: View {
 
                 Spacer(minLength: VSpacing.sm)
 
-                if let actionLabel, let onAction {
-                    // Wrapping the inner button in its own view keeps its
-                    // tap from bubbling to the outer row `Button` —
-                    // SwiftUI resolves the innermost tappable first.
-                    VButton(
-                        label: actionLabel,
-                        style: .outlined,
-                        size: .pillRegular,
-                        action: onAction
-                    )
+                if isHovering {
+                    // Wrapping the dismiss in its own Button keeps the tap
+                    // from bubbling to the outer row Button — SwiftUI
+                    // resolves the innermost tappable first.
+                    Button(action: onDismiss) {
+                        HStack(spacing: VSpacing.xs) {
+                            VIconView(.x, size: 7)
+                                .foregroundStyle(VColor.contentDisabled)
+                            Text("Dismiss")
+                                .font(VFont.bodySmallDefault)
+                                .foregroundStyle(VColor.contentDisabled)
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .pointerCursor()
+                    .accessibilityLabel(Text("Dismiss"))
                 }
             }
             .contentShape(Rectangle())
@@ -89,28 +75,9 @@ struct HomeRecapRow: View {
             RoundedRectangle(cornerRadius: VRadius.md, style: .continuous)
                 .fill(VColor.surfaceOverlay)
         )
+        .onHover { isHovering = $0 }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(title))
-        .modifier(OptionalRecapActionAccessibility(
-            actionLabel: actionLabel,
-            onAction: onAction
-        ))
-    }
-}
-
-/// Adds an `.accessibilityAction(named:)` only when the row has a
-/// non-nil action, so VoiceOver users can fire the inner Action button
-/// without navigating to it.
-private struct OptionalRecapActionAccessibility: ViewModifier {
-    let actionLabel: String?
-    let onAction: (() -> Void)?
-
-    @ViewBuilder
-    func body(content: Content) -> some View {
-        if let actionLabel, let onAction {
-            content.accessibilityAction(named: Text(actionLabel), onAction)
-        } else {
-            content
-        }
+        .accessibilityAction(named: Text("Dismiss"), onDismiss)
     }
 }


### PR DESCRIPTION
## Summary

Figma `3596:79329` (hover state).

- **HomeRecapRow hover state**: trailing `× Dismiss` affordance now renders only while the pointer is over the row (`@State isHovering` + `.onHover`). Tap fires a required `onDismiss` closure; tap is isolated from the outer row tap so dismissing never opens the item. Uses `VColor.contentDisabled` for glyph + text per Figma (`#5A6672` = `contentDisabled` dark).
- **Drop the primary-action concept**: `actionLabel` / `onAction` props, the inline `VButton`, and the `OptionalRecapActionAccessibility` modifier are all gone. We're not doing inline action buttons anymore.
- **HomePageView**: now passes `onDismiss: { dismissItem(item) }` which wraps `feedStore.dismiss(itemId:)` in a `Task`. The dead `actionLabel(for:)` helper is removed.
- **VoiceOver**: `.accessibilityAction(named: "Dismiss", onDismiss)` so the dismiss path is reachable without hover.
- **Gallery**: 4 demo variants updated to the new API — Heartbeat/Permission/Digest all consistent, thread variant now uses `calendar` + mid tokens to match the Schedule filter chip.

Part of plan: home-figma-redesign.md (hover-state follow-up)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
