### PR TITLE
[ATL-173] Wire ReturningUserRouter into cold-start auth flow

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -18,17 +18,29 @@ extension AppDelegate {
             let hasKey = APIKeyManager.hasAnyKey()
             log.info("[authFlow] isAuthenticated=\(isAuthed) hasAnyKey=\(hasKey)")
             if isAuthed || hasKey {
-                // Verify there is at least one assistant from the current
-                // platform environment before entering the app. After a
-                // retire the lockfile may only contain cross-environment
-                // entries that cannot be connected to — in that case fall
-                // through to onboarding so the user can hatch a new one.
-                let hasConnectable = LockfileAssistant.loadAll().contains { $0.isCurrentEnvironment }
-                if hasConnectable {
-                    log.info("[authFlow] → proceedToApp()")
-                    proceedToApp()
+                // Delegate the post-auth routing decision to
+                // ReturningUserRouter so this call site and ReauthView
+                // share one source of truth.
+                //
+                // The synchronous fast path is the only router call made
+                // here — when the lockfile has a current-environment
+                // entry it returns .autoConnect and the app proceeds
+                // without any network wait. When it returns nil, the
+                // lockfile has zero current-env entries, which means
+                // showAuthWindow will land on OnboardingFlowView
+                // regardless of what the platform says.
+                let router = ReturningUserRouter()
+                if let decision = router.decideFast() {
+                    switch decision {
+                    case .autoConnect:
+                        log.info("[authFlow] router → autoConnect → proceedToApp()")
+                        proceedToApp()
+                    case .showHostingPicker:
+                        log.info("[authFlow] router → showHostingPicker")
+                        showAuthWindow()
+                    }
                 } else {
-                    log.info("[authFlow] Authenticated but no current-environment assistant — showing onboarding")
+                    log.info("[authFlow] router → nil (no current-env entry) — showing auth window")
                     showAuthWindow()
                 }
             } else {

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -22,6 +22,10 @@ extension AppDelegate {
     /// Rejects managed assistants from a different platform environment (e.g.
     /// dev-platform assistants in a production build) and falls back to the
     /// first valid current-environment assistant.
+    ///
+    /// ATL-173: this helper runs *after* `ReturningUserRouter` has already
+    /// decided `.autoConnect`. It resolves *which* assistant to connect to —
+    /// it no longer decides whether to connect at all.
     @discardableResult
     func loadAssistantFromLockfile() -> LockfileAssistant? {
         // Migration: fall back to UserDefaults for users upgrading from


### PR DESCRIPTION
Replaces the raw `LockfileAssistant.loadAll().contains { $0.isCurrentEnvironment }` check in `startAuthenticatedFlow()` with `ReturningUserRouter().decideFast()`, so the cold-start path shares the same routing logic that `ReauthView` will use in a follow-up PR.

**Behavioral change: none.** `decideFast()` checks the same condition (any current-environment lockfile entry exists) via the same `LockfileAssistant.loadAll()` call internally. The `switch` on `RoutingDecision` handles `.showHostingPicker` for forward-compatibility even though `decideFast()` currently only returns `.autoConnect` or `nil`.

Also adds a doc comment to `loadAssistantFromLockfile()` clarifying that it now runs after the router's `.autoConnect` decision — it resolves *which* assistant to connect to, not *whether* to connect.

### Changes
- `AppDelegate+AuthLifecycle.swift` — swap raw lockfile check for router (+16/-10)
- `AppDelegate+ConnectionSetup.swift` — doc comment update (+4/-0)

**+26/-10 across 2 files.**

Part of ATL-173.

---

Authored by: David Rose (`david-rose-bot`), @emmiekehoe's assistant
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
