### PR TITLE
feat(home): make filter bar single-select

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedFilterBar.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedFilterBar.swift
@@ -6,16 +6,16 @@ import VellumAssistantShared
 ///
 /// Layout: a 12pt "Filter:" caption + a row of four 26pt icon-circle
 /// chips — Heartbeat (`.nudge`), Input (`.action`), Notification
-/// (`.digest`), and Schedule (`.thread`). Chips are toggles; tapping
-/// one adds/removes its ``FeedItemType`` from the active filter set.
-/// An empty active set means "show everything" — the parent view is
-/// responsible for applying the filter to its feed.
+/// (`.digest`), and Schedule (`.thread`). Chips are single-select:
+/// tapping a chip makes it the active filter; tapping the active chip
+/// again clears the filter. A nil ``selected`` means "show everything" —
+/// the parent view is responsible for applying the filter to its feed.
 ///
 /// The chip shape + tint mapping is intentionally aligned with
 /// ``HomeRecapRow``'s leading icon, so the filter chips and the row
 /// icons read as a single visual language.
 struct HomeFeedFilterBar: View {
-    let selected: Set<FeedItemType>
+    let selected: FeedItemType?
     let onToggle: (FeedItemType) -> Void
 
     /// Order matches the Figma mock (Heartbeat, Input, Notification,
@@ -35,7 +35,7 @@ struct HomeFeedFilterBar: View {
             ForEach(Self.chipOrder, id: \.self) { type in
                 HomeFeedFilterChip(
                     type: type,
-                    isSelected: selected.contains(type),
+                    isSelected: selected == type,
                     onToggle: { onToggle(type) }
                 )
             }

--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -558,18 +558,18 @@ struct HomeGallerySection: View {
                             .foregroundStyle(VColor.contentSecondary)
 
                         HomeFeedFilterBar(
-                            selected: Set<FeedItemType>(),
+                            selected: nil,
                             onToggle: { _ in }
                         )
 
                         Divider().background(VColor.borderBase)
 
-                        Text("Partial selection (Heartbeat + Notification active)")
+                        Text("Heartbeat selected (single-select)")
                             .font(VFont.bodySmallEmphasised)
                             .foregroundStyle(VColor.contentSecondary)
 
                         HomeFeedFilterBar(
-                            selected: [.nudge, .digest],
+                            selected: .nudge,
                             onToggle: { _ in }
                         )
                     }

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -61,7 +61,7 @@ struct HomePageView<DetailPanel: View>: View {
     /// everything" — a non-empty set is treated as an inclusion filter
     /// in ``groupedFeed``. Deliberately view-local (not persisted):
     /// the filter is a transient read-time affordance, not a setting.
-    @State private var activeFilters: Set<FeedItemType> = []
+    @State private var activeFilter: FeedItemType? = nil
 
     /// Editorial column width. Bumped from 600pt to 960pt to match the
     /// Figma redesign — the new three-block layout reads as a wider page,
@@ -127,9 +127,11 @@ struct HomePageView<DetailPanel: View>: View {
                 }
 
                 HomeFeedFilterBar(
-                    selected: activeFilters,
+                    selected: activeFilter,
                     onToggle: { type in
-                        activeFilters.formSymmetricDifference([type])
+                        // Single-select: tapping the active chip clears
+                        // the filter; tapping a different chip replaces it.
+                        activeFilter = (activeFilter == type) ? nil : type
                     }
                 )
 
@@ -207,7 +209,7 @@ struct HomePageView<DetailPanel: View>: View {
             return a.createdAt > b.createdAt
         }
         let filtered = sorted.filter { item in
-            activeFilters.isEmpty || activeFilters.contains(item.type)
+            activeFilter == nil || activeFilter == item.type
         }
         return HomeFeedTimeGroup.bucket(filtered)
     }


### PR DESCRIPTION
## Summary
- \`HomeFeedFilterBar.selected\`: \`Set<FeedItemType>\` → \`FeedItemType?\` — single-select semantic is now enforced by the type system; callers can't accidentally pass a multi-element selection.
- \`HomePageView\`: \`@State activeFilters: Set → @State activeFilter: FeedItemType?\`. Tap toggles: tapping a different chip replaces the selection; tapping the active chip clears it.
- \`groupedFeed\` filter: \`activeFilter == nil || activeFilter == item.type\`.
- Gallery demo: swap the "Partial selection" multi-select variant for a "Heartbeat selected" single-select variant.

Part of plan: home-figma-redesign.md (filter semantics follow-up)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
