### PR TITLE
[ATL-188] fix: skip 60s token file poll on bare-metal hatch

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -293,25 +293,30 @@ extension AppDelegate {
                 return
             }
 
-            // The token file doesn't exist yet — the launcher/CLI may still be
-            // writing it. Poll for up to ~60s before falling back to HTTP bootstrap.
-            let maxAttempts = 30
-            let delay: UInt64 = 2_000_000_000 // 2 seconds per poll
-            for attempt in 1...maxAttempts {
-                guard !Task.isCancelled else { return }
-                try? await Task.sleep(nanoseconds: delay)
-                guard !Task.isCancelled else { return }
+            // On remote hatches (Docker, cloud, managed) the CLI/launcher
+            // writes guardian-token.json asynchronously — poll for it. On
+            // bare-metal the file is written synchronously at hatch time, so
+            // if the first check missed it the file isn't coming.
+            let assistant = LockfileAssistant.loadByName(assistantId)
+            let shouldPoll = assistant?.isRemote ?? false
 
-                if GuardianTokenFileReader.importIfAvailable(assistantId: assistantId) {
-                    log.info("Imported guardian token from file after \(attempt) poll(s)")
-                    return
+            if shouldPoll {
+                let maxAttempts = 30
+                let delay: UInt64 = 2_000_000_000 // 2 seconds per poll
+                for attempt in 1...maxAttempts {
+                    guard !Task.isCancelled else { return }
+                    try? await Task.sleep(nanoseconds: delay)
+                    guard !Task.isCancelled else { return }
+
+                    if GuardianTokenFileReader.importIfAvailable(assistantId: assistantId) {
+                        log.info("Imported guardian token from file after \(attempt) poll(s)")
+                        return
+                    }
                 }
+                log.warning("Guardian token file not found after \(maxAttempts) polls — falling back to /v1/guardian/init")
+            } else {
+                log.info("Local hatch — skipping token file poll, falling back to /v1/guardian/init")
             }
-
-            // Token file never appeared — fall back to HTTP bootstrap via
-            // /v1/guardian/init. This path generates its own random bootstrap
-            // secret which may fail if the runtime already consumed the real one.
-            log.warning("Guardian token file not found after \(maxAttempts) polls — falling back to /v1/guardian/init")
         } else {
             log.info("performInitialBootstrap: skipFileImport=true — driving HTTP reprovision path directly")
         }


### PR DESCRIPTION
## Summary

On bare-metal, `guardian-token.json` is written synchronously at hatch time (especially after #27176 adds retry). If the first `importIfAvailable` check misses it, the file is not coming — polling for 60s is wasted time before the HTTP fallback kicks in.

## Changes

- **`clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift`**: Wrap the 30-attempt / 60s poll in an `isRemote` check. Docker/cloud/managed hatches (where the CLI/launcher writes the file asynchronously) still poll. Bare-metal skips straight to `/v1/guardian/init`.

## Why this matters

On a wedged bare-metal install, this removes a 60s dead wait before the recovery path (PR #27214) can actually run. The user clicks Re-pair and gets action in seconds instead of staring at nothing for a minute.

Part of ATL-188

Requested by: David Rose (@emmiekehoe's assistant)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
