### PR TITLE
[ATL-173] Wire ReturningUserRouter into ReauthView + hosting picker callback

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -66,14 +66,18 @@ extension AppDelegate {
         }
     }
 
-    func showAuthWindow(reusingWindow existingWindow: NSWindow? = nil) {
-        if let existing = authWindow {
+    func showAuthWindow(
+        reusingWindow existingWindow: NSWindow? = nil,
+        forceOnboarding: Bool = false
+    ) {
+        if let existing = authWindow, !forceOnboarding {
             existing.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             return
         }
 
-        let hasManagedAssistants = LockfileAssistant.loadAll().contains { $0.isManaged && $0.isCurrentEnvironment }
+        let hasManagedAssistants = !forceOnboarding
+            && LockfileAssistant.loadAll().contains { $0.isManaged && $0.isCurrentEnvironment }
         let authView: AnyView
 
         if hasManagedAssistants {
@@ -82,6 +86,9 @@ extension AppDelegate {
                 authManager: authManager,
                 onComplete: { [weak self] in
                     self?.proceedToApp()
+                },
+                onNeedsHostingPicker: { [weak self] in
+                    self?.showAuthWindow(forceOnboarding: true)
                 }
             ))
         } else {
@@ -105,9 +112,14 @@ extension AppDelegate {
 
         let hostingController = NSHostingController(rootView: authView)
 
+        // When forcing the onboarding picker after re-auth, reuse the
+        // current authWindow so the view swaps in-place rather than
+        // closing and re-opening a window.
+        let windowToReuse = existingWindow ?? (forceOnboarding ? authWindow : nil)
+
         let window: NSWindow
-        if let existingWindow {
-            window = existingWindow
+        if let windowToReuse {
+            window = windowToReuse
             window.contentViewController = hostingController
             window.isMovableByWindowBackground = true
             window.backgroundColor = NSColor(VColor.surfaceOverlay)

--- a/clients/macos/vellum-assistant/App/ReturningUserRouter.swift
+++ b/clients/macos/vellum-assistant/App/ReturningUserRouter.swift
@@ -152,6 +152,11 @@ final class ReturningUserRouter {
 
     // MARK: - Helpers
 
+    /// Thrown when the platform fetch exceeds the timeout. Distinct from
+    /// `CancellationError` so callers can tell a timeout apart from a
+    /// parent-task cancellation.
+    private struct PlatformTimeoutError: Error {}
+
     /// Run an async closure with a timeout.
     private func withTimeout<T: Sendable>(
         seconds: UInt64,
@@ -161,7 +166,7 @@ final class ReturningUserRouter {
             group.addTask { try await operation() }
             group.addTask {
                 try await Task.sleep(nanoseconds: seconds * 1_000_000_000)
-                throw CancellationError()
+                throw PlatformTimeoutError()
             }
             let result = try await group.next()!
             group.cancelAll()

--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -8,6 +8,10 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Reaut
 struct ReauthView: View {
     @Bindable var authManager: AuthManager
     var onComplete: () -> Void
+    /// Invoked when `ReturningUserRouter` decides `.showHostingPicker`
+    /// after re-auth (platform returned 0 assistants for this user).
+    /// The host swaps this view for the onboarding hosting picker.
+    var onNeedsHostingPicker: (() -> Void)?
 
     @State private var showContent = false
     @State private var didComplete = false
@@ -117,13 +121,13 @@ struct ReauthView: View {
             // — callers (startAuthenticatedFlow, performLogout) have already
             // resolved the auth state before presenting this view.
             if authManager.isAuthenticated && !didComplete {
-                await completeManagedActivation()
+                await routeAuthenticatedUser()
             }
         }
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
             if isAuthenticated && !didComplete {
                 Task {
-                    await completeManagedActivation()
+                    await routeAuthenticatedUser()
                 }
             }
         }
@@ -151,7 +155,44 @@ struct ReauthView: View {
     private func handleLoginTap() async {
         await authManager.startWorkOSLogin()
         if authManager.isAuthenticated {
-            await completeManagedActivation()
+            await routeAuthenticatedUser()
+        }
+    }
+
+    /// Route through `ReturningUserRouter` so this view and
+    /// `AppDelegate+AuthLifecycle` share one post-auth decision path.
+    ///
+    /// Always takes the async path (no fast-path). `ReauthView` is only
+    /// shown when the lockfile already has a managed current-env entry,
+    /// so `decideFast()` would always return `.autoConnect` — consulting
+    /// the platform is the whole point of routing on re-auth (it catches
+    /// stale lockfile entries where the platform has 0 assistants).
+    @MainActor
+    private func routeAuthenticatedUser() async {
+        guard !didComplete else { return }
+        let router = ReturningUserRouter()
+        do {
+            let decision = try await router.route()
+            guard !didComplete else { return }
+            log.info("ReauthView router decision=\(String(describing: decision), privacy: .public)")
+            switch decision {
+            case .autoConnect:
+                await completeManagedActivation()
+            case .showHostingPicker:
+                if let onNeedsHostingPicker {
+                    log.info("ReauthView → showHostingPicker")
+                    didComplete = true
+                    onNeedsHostingPicker()
+                } else {
+                    // No callback wired — fall back to the old behavior
+                    // so the re-auth flow still terminates.
+                    log.info("ReauthView → showHostingPicker but no callback — falling back to managed activation")
+                    await completeManagedActivation()
+                }
+            }
+        } catch {
+            // CancellationError — view was torn down, nothing to do.
+            log.info("ReauthView router cancelled")
         }
     }
 


### PR DESCRIPTION
Routes `ReauthView` through `ReturningUserRouter.route()` (the async path that consults the platform) instead of calling `completeManagedActivation()` directly. This catches **stale lockfile entries** where the platform returns 0 assistants — the router decides `.showHostingPicker` and the new `onNeedsHostingPicker` callback swaps the reauth view for the onboarding hosting picker in-place.

### Changes

**`ReauthView.swift`** (+39/-3)
- Add optional `onNeedsHostingPicker` callback
- Add `routeAuthenticatedUser()` — uses the async router path (always consults platform, never fast-path, because `decideFast()` would always return `.autoConnect` here and miss stale entries)
- Replace three `completeManagedActivation()` call sites with `routeAuthenticatedUser()`
- Falls back to old `completeManagedActivation()` when no callback is wired

**`AppDelegate+AuthLifecycle.swift`** (+14/-5)
- Add `forceOnboarding` param to `showAuthWindow`
- Wire `onNeedsHostingPicker` → `showAuthWindow(forceOnboarding: true)`
- Reuse `authWindow` for in-place content swap when forcing onboarding

**+61/-8 across 2 files.**

Part of ATL-173.

---

Authored by: David Rose (`david-rose-bot`), @emmiekehoe's assistant
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
