### PR TITLE
feat(compaction): emit compaction_circuit_closed when breaker clears early (JARVIS-576)

### DIFF
--- a/assistant/src/__tests__/compaction-circuit-breaker.test.ts
+++ b/assistant/src/__tests__/compaction-circuit-breaker.test.ts
@@ -337,4 +337,53 @@ describe("compaction circuit breaker", () => {
     expect(state.consecutiveCompactionFailures).toBe(3);
     expect(state.compactionCircuitOpenUntil).toBe(wasOpenUntil);
   });
+
+  test("(h) emits compaction_circuit_closed when a successful compaction clears an open circuit", () => {
+    // Regression: before this fix, the else branch of `trackCompactionOutcome`
+    // silently reset `compactionCircuitOpenUntil` to null but did not notify
+    // the client. The Swift banner set from `compaction_circuit_open` would
+    // stay visible until the original `openUntil` deadline (up to 1h),
+    // misrepresenting the live state. The fix emits
+    // `compaction_circuit_closed` on the open→closed transition so the
+    // banner dismisses immediately.
+    const fixedNow = 1_700_000_000_000;
+    Date.now = () => fixedNow;
+
+    const state = makeState();
+    const { onEvent, events } = collectEvents();
+
+    // Force the circuit into the open state directly — the emitted-event
+    // transition logic is what we're testing, not the tripping path.
+    state.compactionCircuitOpenUntil = fixedNow + 60 * 60 * 1000;
+    state.consecutiveCompactionFailures = 3;
+
+    trackCompactionOutcome(state, false, onEvent);
+
+    expect(state.consecutiveCompactionFailures).toBe(0);
+    expect(state.compactionCircuitOpenUntil).toBeNull();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "compaction_circuit_closed",
+      conversationId: state.conversationId,
+    });
+  });
+
+  test("(h) successful compaction against an already-closed circuit emits no event", () => {
+    // Rationale: emitting `compaction_circuit_closed` on every successful
+    // compaction would spam the client (the breaker is closed in the common
+    // case). Only the open→closed transition is meaningful, because that's
+    // when the client's banner state is stale.
+    const state = makeState();
+    const { onEvent, events } = collectEvents();
+
+    // Circuit is already closed (fresh state) — success must not emit.
+    expect(state.compactionCircuitOpenUntil).toBeNull();
+    trackCompactionOutcome(state, false, onEvent);
+    expect(state.compactionCircuitOpenUntil).toBeNull();
+    expect(events).toHaveLength(0);
+
+    // A second successful outcome while still closed — still no event.
+    trackCompactionOutcome(state, false, onEvent);
+    expect(events).toHaveLength(0);
+  });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -245,8 +245,26 @@ export function trackCompactionOutcome(
       });
     }
   } else {
+    // Capture the open state before we clear it — we only emit the
+    // `compaction_circuit_closed` event on the open→closed transition so
+    // the Swift banner can dismiss immediately once auto-compaction
+    // resumes. Firing on every successful compaction would be noise
+    // (the breaker is closed in the common case), so the transition
+    // gate keeps the event meaningful.
+    const wasOpen = ctx.compactionCircuitOpenUntil !== null;
     ctx.consecutiveCompactionFailures = 0;
     ctx.compactionCircuitOpenUntil = null;
+    if (wasOpen) {
+      // Scope the event to this conversation so clients can gate it via
+      // `belongsToConversation()` — `EventStreamClient` broadcasts every
+      // parsed server message to all subscribers, so without the ID a
+      // breaker recovery here would clear the banner on every open
+      // `ChatViewModel`.
+      onEvent({
+        type: "compaction_circuit_closed",
+        conversationId: ctx.conversationId,
+      });
+    }
   }
 }
 

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -465,6 +465,25 @@ export interface CompactionCircuitOpen {
   openUntil: number;
 }
 
+/**
+ * Emitted when the compaction circuit breaker transitions from open → closed
+ * because a successful compaction reset
+ * `ctx.compactionCircuitOpenUntil`. The Swift client clears its banner state
+ * on receipt so the "auto-compaction paused" indicator dismisses immediately
+ * instead of lingering until the original `openUntil` deadline (up to 1h).
+ *
+ * Only fires on the open→closed transition — successful compactions while
+ * the breaker was already closed would be noise.
+ *
+ * `conversationId` scopes the event so clients can ignore transitions from
+ * other conversations via `belongsToConversation()`, mirroring the rest of
+ * the broadcast-aware events.
+ */
+export interface CompactionCircuitClosed {
+  type: "compaction_circuit_closed";
+  conversationId: string;
+}
+
 export type ConversationErrorCode =
   | "PROVIDER_NETWORK"
   | "PROVIDER_RATE_LIMIT"
@@ -563,6 +582,7 @@ export type _ConversationsServerMessages =
   | UsageResponse
   | ContextCompacted
   | CompactionCircuitOpen
+  | CompactionCircuitClosed
   | ConversationErrorMessage
   | ConversationInfo
   | ConversationTitleUpdated

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -355,6 +355,14 @@ final class ChatActionHandler {
             vm.compactionCircuitOpenUntil = until
             log.warning("Auto-compaction paused until \(until, privacy: .public) — reason: \(event.reason, privacy: .public)")
 
+        case .compactionCircuitClosed(let event):
+            // Auto-compaction is live again — clear the banner state so the UI
+            // dismisses the "paused" banner immediately without waiting for the
+            // original `openUntil` deadline.
+            guard belongsToConversation(event.conversationId) else { return }
+            vm.compactionCircuitOpenUntil = nil
+            log.info("Auto-compaction resumed (circuit breaker closed)")
+
         default:
             break
         }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1126,6 +1126,16 @@ public struct CompactionCircuitOpen: Codable, Sendable {
     }
 }
 
+public struct CompactionCircuitClosed: Codable, Sendable {
+    public let type: String
+    public let conversationId: String
+
+    public init(type: String, conversationId: String) {
+        self.type = type
+        self.conversationId = conversationId
+    }
+}
+
 public struct ConversationSearchMatchingMessage: Codable, Sendable {
     public let messageId: String
     public let role: String

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2609,6 +2609,7 @@ public enum ServerMessage: Decodable, Sendable {
     case contextCompacted(ContextCompacted)
     case usageUpdate(UsageUpdate)
     case compactionCircuitOpen(CompactionCircuitOpen)
+    case compactionCircuitClosed(CompactionCircuitClosed)
     case serviceGroupUpdateStarting(ServiceGroupUpdateStartingMessage)
     case serviceGroupUpdateProgress(ServiceGroupUpdateProgressMessage)
     case serviceGroupUpdateComplete(ServiceGroupUpdateCompleteMessage)
@@ -3098,6 +3099,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "compaction_circuit_open":
             let message = try CompactionCircuitOpen(from: decoder)
             self = .compactionCircuitOpen(message)
+        case "compaction_circuit_closed":
+            let message = try CompactionCircuitClosed(from: decoder)
+            self = .compactionCircuitClosed(message)
         case "service_group_update_starting":
             let message = try ServiceGroupUpdateStartingMessage(from: decoder)
             self = .serviceGroupUpdateStarting(message)

--- a/clients/shared/Tests/ChatActionHandlerCircuitOpenTests.swift
+++ b/clients/shared/Tests/ChatActionHandlerCircuitOpenTests.swift
@@ -104,4 +104,66 @@ final class ChatActionHandlerCircuitOpenTests: XCTestCase {
 
         XCTAssertNil(viewModel.compactionCircuitOpenUntil)
     }
+
+    /// The discriminated-union decoder must route a `compaction_circuit_closed`
+    /// payload into the `.compactionCircuitClosed` case and preserve every
+    /// field. This is the event the daemon emits when a successful compaction
+    /// resets an open circuit, so the UI can dismiss the paused banner
+    /// immediately instead of waiting for the original `openUntil` deadline.
+    func testDecodesCompactionCircuitClosed() throws {
+        let json = Data(
+            """
+            {
+              "type": "compaction_circuit_closed",
+              "conversationId": "sess-1"
+            }
+            """.utf8
+        )
+
+        let message = try decoder.decode(ServerMessage.self, from: json)
+
+        guard case .compactionCircuitClosed(let event) = message else {
+            XCTFail("Expected .compactionCircuitClosed, got \(message)")
+            return
+        }
+
+        XCTAssertEqual(event.type, "compaction_circuit_closed")
+        XCTAssertEqual(event.conversationId, "sess-1")
+    }
+
+    /// Feeding a decoded `compaction_circuit_closed` event through the VM's
+    /// `handleServerMessage` dispatcher must clear `compactionCircuitOpenUntil`
+    /// so the "auto-compaction paused" banner dismisses without waiting for
+    /// the original `openUntil` deadline.
+    func testActionHandlerClearsCompactionCircuitOpenUntilOnClose() {
+        // Start with the banner visible — simulate a prior
+        // `compaction_circuit_open` event having set the state.
+        let openUntilMs: Double = 1_776_960_000_000
+        viewModel.compactionCircuitOpenUntil = Date(timeIntervalSince1970: openUntilMs / 1000.0)
+        XCTAssertNotNil(viewModel.compactionCircuitOpenUntil)
+
+        viewModel.handleServerMessage(.compactionCircuitClosed(CompactionCircuitClosed(
+            type: "compaction_circuit_closed",
+            conversationId: "sess-1"
+        )))
+
+        XCTAssertNil(viewModel.compactionCircuitOpenUntil)
+    }
+
+    /// The close event must also be conversation-scoped. A recovery in a
+    /// different conversation must not clear this VM's banner.
+    func testActionHandlerIgnoresCloseEventsFromOtherConversations() {
+        let openUntilMs: Double = 1_776_960_000_000
+        let until = Date(timeIntervalSince1970: openUntilMs / 1000.0)
+        viewModel.compactionCircuitOpenUntil = until
+        XCTAssertEqual(viewModel.compactionCircuitOpenUntil, until)
+
+        viewModel.handleServerMessage(.compactionCircuitClosed(CompactionCircuitClosed(
+            type: "compaction_circuit_closed",
+            conversationId: "sess-other"
+        )))
+
+        // Banner state preserved — the recovery was for a different VM.
+        XCTAssertEqual(viewModel.compactionCircuitOpenUntil, until)
+    }
 }


### PR DESCRIPTION
## Summary
Round-2 review finding: the circuit-breaker banner stays visible for up to an hour after auto-compaction resumes, because the server cleared its state silently without telling the client.

- Daemon emits `compaction_circuit_closed` only when transitioning from open→closed (not on every successful compaction).
- Swift client clears `vm.compactionCircuitOpenUntil` on receipt; banner auto-dismisses.
- Tests cover both the transition emit and the no-op already-closed case.

Part of JARVIS-576.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
