### PR TITLE
feat(home): HomeRecapRow bg switches to surfaceLift on hover

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
@@ -73,7 +73,7 @@ struct HomeRecapRow: View {
         .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.md, bottom: VSpacing.sm, trailing: VSpacing.md))
         .background(
             RoundedRectangle(cornerRadius: VRadius.md, style: .continuous)
-                .fill(VColor.surfaceOverlay)
+                .fill(isHovering ? VColor.surfaceLift : VColor.surfaceOverlay)
         )
         .onHover { isHovering = $0 }
         .accessibilityElement(children: .combine)


### PR DESCRIPTION
One-liner — reuse the `isHovering` state the row already tracks for the Dismiss affordance to tint the row background to `VColor.surfaceLift` on hover (rest state stays `VColor.surfaceOverlay`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
