### PR TITLE
fix(macos): gate sidebar skeleton on restoration completion, not timer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift
@@ -129,7 +129,8 @@ final class ConversationSelectionStore {
     // MARK: - Restoration State
 
     /// Flag to suppress lastActiveConversationIdString writes during initialization and conversation restoration.
-    @ObservationIgnored var isRestoringConversations = false
+    /// Observable so views can react to restoration completing (e.g. dismiss loading skeletons).
+    var isRestoringConversations = false
 
     private(set) var restoreRecentConversations: Bool {
         get { UserDefaults.standard.object(forKey: "restoreRecentConversations") as? Bool ?? true }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Lifecycle.swift
@@ -38,6 +38,17 @@ extension MainWindowView {
                     }
                 }
             }
+            .onChange(of: conversationManager.selectionStore.isRestoringConversations) { _, isRestoring in
+                // Dismiss the skeleton when restoration completes, covering the
+                // zero-conversations case (list stays empty but restoration is done)
+                // and the managed-assistant case where the HTTP fetch exceeds the
+                // timer-based fallback.
+                if !isRestoring && showDaemonLoading {
+                    withAnimation(VAnimation.standard) {
+                        showDaemonLoading = false
+                    }
+                }
+            }
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
                 conversationManager.markActiveConversationSeenIfNeeded()
             }
@@ -157,10 +168,15 @@ extension MainWindowView {
     }
 
     func handleDaemonConnectionChange(_ connected: Bool) {
-        // Fallback for fresh users with 0 conversations: dismiss skeleton after a
-        // short delay once the daemon is connected. Only applies during initial load.
+        // Absolute safety-net fallback: dismiss the skeleton after 30s if no
+        // data-driven path has dismissed it. The primary dismissal paths are
+        // the .onChange observers on listStore.conversations.isEmpty (populated
+        // list) and selectionStore.isRestoringConversations (restoration
+        // complete, including the zero-conversations case). This timer only
+        // fires if restoration never completes — e.g. daemon hangs or fetch
+        // fails past its own retries.
         guard connected, showDaemonLoading else { return }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 30) {
             guard showDaemonLoading else { return }
             withAnimation(VAnimation.standard) {
                 showDaemonLoading = false


### PR DESCRIPTION
## Problem

On app launch, the sidebar loading skeleton is dismissed 1.5s after daemon connection via a hardcoded timer in `handleDaemonConnectionChange`, regardless of whether the conversation list has actually loaded.

For managed/platform assistants where the conversation list HTTP fetch takes longer than 1.5s (cold pod, platform proxy latency), this causes the skeleton to disappear before conversations arrive — leaving an empty sidebar until the user starts a new conversation (which triggers a `conversation_list_invalidated` SSE refetch as a side effect).

## Root Cause

Two competing skeleton dismissal paths:
1. **Data-driven** (correct): `.onChange(of: listStore.conversations.isEmpty)` — dismisses when conversations actually arrive
2. **Timer-driven** (broken): `handleDaemonConnectionChange` — dismisses 1.5s after `isConnected`, racing against the fetch and usually winning for managed assistants

## Fix

- **Remove `@ObservationIgnored`** from `isRestoringConversations` on `ConversationSelectionStore` so SwiftUI can observe it
- **Add `.onChange(of: isRestoringConversations)`** — dismisses the skeleton when `ConversationRestorer` finishes loading the conversation list (whether populated or empty)
- **Change the 1.5s timer to a 30s absolute safety-net fallback** — only fires if restoration never completes (daemon hang, fetch failure past retries)

The existing `.onChange(of: listStore.conversations.isEmpty)` path is retained as belt-and-suspenders for populated lists.

## Files Changed

- `ConversationSelectionStore.swift` — remove `@ObservationIgnored` from `isRestoringConversations`
- `MainWindowView+Lifecycle.swift` — add restoration observer, extend fallback timer

2 files, +21/-4 lines.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
