### PR TITLE
feat(home): HomeDetailPanel single "Go to Thread" action, drop primary/secondary

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift
@@ -5,33 +5,28 @@ import VellumAssistantShared
 ///
 /// Matches Figma nodes 3216:63021 (email editor) and 3216:63117 (invoice
 /// preview) — a 601pt solid-white chrome with its own 16pt-rounded card
-/// border, a header that hosts an optional icon chip + title + up to two
-/// trailing actions + optional dismiss, and a scrolling content area
-/// below a hairline divider.
+/// border, a header that hosts an optional icon chip + title + a single
+/// trailing "Go to Thread" action + optional dismiss, and a scrolling
+/// content area below a hairline divider.
 ///
 /// The chrome is intentionally solid (not glass) so the panel reads as a
 /// distinct work surface next to the floating glass recap cards on the
-/// Home page. Header action buttons use `VButton.Size.regular` (32pt
-/// tall, 8pt corners, 10pt horizontal padding) which matches the mock's
-/// `rounded-[8px] h-[32px] px-[10px]` spec exactly — a deliberate break
-/// from the fully-pill buttons used inside the recap cards.
+/// Home page. The header "Go to Thread" button uses `VButton.Size.regular`
+/// (32pt tall, 8pt corners, 10pt horizontal padding) with the `.outlined`
+/// style — a deliberate break from the fully-pill buttons used inside the
+/// recap cards.
 struct HomeDetailPanel<Content: View>: View {
     /// Default panel width from the Figma source (601pt). Callers almost
     /// always want this; exposed as a static so split-view hosts can size
     /// the trailing column without hard-coding a magic number.
     static var defaultWidth: CGFloat { 601 }
 
-    /// Describes one of the trailing header buttons (primary / secondary).
-    struct Action {
-        let label: String
-        var style: VButton.Style = .primary
-        let action: () -> Void
-    }
-
     let icon: VIcon?
     let title: String
-    var primaryAction: Action?   = nil
-    var secondaryAction: Action? = nil
+    /// Tap handler for the trailing "Go to Thread" button in the header.
+    /// Pass `nil` to hide the button (e.g. previews that don't surface a
+    /// thread affordance).
+    var onGoToThread: (() -> Void)? = nil
     var onDismiss: (() -> Void)? = nil
     /// When `true` (default), the content area is wrapped in a vertical
     /// `ScrollView` so tall content like invoice images scrolls naturally.
@@ -74,8 +69,8 @@ struct HomeDetailPanel<Content: View>: View {
 
     // MARK: - Header
 
-    /// Header row: optional icon chip + title on the leading edge, and up
-    /// to two action buttons + optional dismiss on the trailing edge.
+    /// Header row: optional icon chip + title on the leading edge, and a
+    /// single "Go to Thread" action + optional dismiss on the trailing edge.
     private var header: some View {
         HStack(spacing: VSpacing.sm) {
             HStack(spacing: VSpacing.sm) {
@@ -99,21 +94,12 @@ struct HomeDetailPanel<Content: View>: View {
             Spacer(minLength: 0)
 
             HStack(spacing: VSpacing.sm) {
-                if let primaryAction {
+                if let onGoToThread {
                     VButton(
-                        label: primaryAction.label,
-                        style: primaryAction.style,
+                        label: "Go to Thread",
+                        style: .outlined,
                         size: .regular,
-                        action: primaryAction.action
-                    )
-                }
-
-                if let secondaryAction {
-                    VButton(
-                        label: secondaryAction.label,
-                        style: secondaryAction.style,
-                        size: .regular,
-                        action: secondaryAction.action
+                        action: onGoToThread
                     )
                 }
 

--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -409,14 +409,13 @@ struct HomeGallerySection: View {
 
                 GallerySectionHeader(
                     title: "HomeDetailPanel",
-                    description: "Reusable white right-side panel container with standardized header (icon + title + primary/secondary actions + dismiss)."
+                    description: "Reusable white right-side panel container with a standardized header (icon + title + \"Go to Thread\" action + dismiss)."
                 )
 
                 HomeDetailPanel(
                     icon: .file,
                     title: "Panel title",
-                    primaryAction: .init(label: "Primary", action: {}),
-                    secondaryAction: .init(label: "Secondary", style: .danger, action: {}),
+                    onGoToThread: {},
                     onDismiss: {}
                 ) {
                     Text("Detail content goes here.")
@@ -455,8 +454,7 @@ struct HomeGallerySection: View {
                 HomeDetailPanel(
                     icon: .file,
                     title: "Authorise Payment to Slack",
-                    primaryAction: .init(label: "Authorise", action: {}),
-                    secondaryAction: .init(label: "Deny", style: .danger, action: {}),
+                    onGoToThread: {},
                     onDismiss: {}
                 ) {
                     HomeInvoicePreview(image: nil, placeholderCaption: "Sample invoice")
@@ -635,6 +633,7 @@ private struct HomeEmailEditorDemo: View {
         HomeDetailPanel(
             icon: nil,
             title: "Thread Name Here",
+            onGoToThread: {},
             onDismiss: {},
             scrollable: false
         ) {
@@ -721,6 +720,7 @@ private struct HomeSplitLayoutDemo: View {
             HomeDetailPanel(
                 icon: nil,
                 title: "Thread Name Here",
+                onGoToThread: {},
                 onDismiss: {},
                 scrollable: false
             ) {
@@ -737,8 +737,7 @@ private struct HomeSplitLayoutDemo: View {
             HomeDetailPanel(
                 icon: .file,
                 title: "Authorise Payment to Slack",
-                primaryAction: .init(label: "Authorise", action: {}),
-                secondaryAction: .init(label: "Deny", style: .danger, action: {}),
+                onGoToThread: {},
                 onDismiss: {}
             ) {
                 HomeInvoicePreview(image: nil, placeholderCaption: "Sample invoice")


### PR DESCRIPTION
## Summary
- Replace `HomeDetailPanel.primaryAction` + `secondaryAction` (and the nested `Action` struct) with a single `onGoToThread: (() -> Void)?` closure.
- Header now renders one `VButton(label: "Go to Thread", style: .outlined, size: .regular)` — same 32pt pill treatment as before, minus the primary fill.
- `onDismiss` behavior unchanged; still rendered as the trailing iconOnly × pill.
- Update all 5 `HomeGallerySection` call sites to the new API (generic panel, email editor, invoice preview, and the two `HomeSplitLayout` variants). Drop the Primary/Secondary and Authorise/Deny variants since they're no longer a supported shape.

Part of plan: home-figma-redesign.md (detail panel follow-up)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
