### PR TITLE
feat(home): add HomePermissionChatPreview detail panel body (Figma 3596:79507)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionChatPreview.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionChatPreview.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Pure body content for the Home detail side panel's permission-request
+/// variant — shown when the assistant is blocked on a tool-confirmation
+/// prompt from an active chat. Figma: node `3596:79507` (New App).
+///
+/// Renders a snapshot of the conversation state at the point the
+/// permission request landed:
+///
+///   1. the last user message that triggered the request
+///   2. the assistant's preamble reply explaining what it's about to do
+///   3. the live ``ToolConfirmationBubble`` itself, so the user can
+///      approve or deny right from the detail panel without jumping
+///      back into the conversation
+///
+/// The "Go to Thread" button lives in the enclosing ``HomeDetailPanel``
+/// chrome — this component is pure body content. Visual language
+/// matches the in-chat bubbles by reusing ``MessageBubbleView`` with
+/// stub closures for the non-relevant affordances (regenerate, fork,
+/// surfaces, retry, etc. are all no-ops in a detail-panel context).
+struct HomePermissionChatPreview: View {
+    let userMessage: String
+    let assistantResponse: String
+    let confirmation: ToolConfirmationData
+    let onAllow: () -> Void
+    let onDeny: () -> Void
+    let onAlwaysAllow: (String, String, String, String) -> Void
+    var onTemporaryAllow: ((String, String) -> Void)? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            MessageBubbleView(
+                message: ChatMessage(role: .user, text: userMessage),
+                onConfirmationResponse: nil,
+                onSurfaceAction: nil,
+                onRegenerate: nil
+            )
+
+            MessageBubbleView(
+                message: ChatMessage(role: .assistant, text: assistantResponse),
+                onConfirmationResponse: nil,
+                onSurfaceAction: nil,
+                onRegenerate: nil
+            )
+
+            // Render the confirmation bubble directly (rather than
+            // wrapping it in a MessageBubbleView with .confirmation
+            // attached) so the panel owns the callback wiring without
+            // the extra machinery of MessageBubbleView's confirmation
+            // branch (guardian, surfaces, retry, etc.).
+            ToolConfirmationBubble(
+                confirmation: confirmation,
+                onAllow: onAllow,
+                onDeny: onDeny,
+                onAlwaysAllow: onAlwaysAllow,
+                onTemporaryAllow: onTemporaryAllow
+            )
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -469,6 +469,44 @@ struct HomeGallerySection: View {
                 .frame(height: 520)
             }
 
+            // MARK: - HomePermissionChatPreview
+
+            if filter == nil || filter == "homePermissionChatPreview" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomePermissionChatPreview",
+                    description: "Pure body content for the Home detail panel's permission-request variant — last user message, assistant preamble, and an inline tool confirmation bubble."
+                )
+
+                HomeDetailPanel(
+                    icon: nil,
+                    title: "Permission to access something",
+                    onGoToThread: {},
+                    onDismiss: {}
+                ) {
+                    HomePermissionChatPreview(
+                        userMessage: "Can you send $5,000 to NBA Merchandising for the annual subscription?",
+                        assistantResponse: "Sure — I've drafted the transfer on Stripe. Before I release it, I need your permission to authorize the payment.",
+                        confirmation: ToolConfirmationData(
+                            requestId: "preview-nba-txn",
+                            toolName: "stripe_transfer",
+                            input: [
+                                "amount_usd": .init(5000),
+                                "recipient": .init("NBA Merchandising")
+                            ],
+                            riskLevel: "medium"
+                        ),
+                        onAllow: {},
+                        onDeny: {},
+                        onAlwaysAllow: { _, _, _, _ in }
+                    )
+                }
+                .frame(height: 520)
+            }
+
             // MARK: - HomeSplitLayout
 
             if filter == nil || filter == "homeSplitLayout" {
@@ -667,12 +705,13 @@ private struct HomeEmailEditorDemo: View {
 /// the two columns, not to exercise the real home page.
 private struct HomeSplitLayoutDemo: View {
     private enum Variant: String, CaseIterable, Identifiable {
-        case email, invoice
+        case email, document, permissionChat
         var id: String { rawValue }
         var label: String {
             switch self {
             case .email: return "Email editor"
-            case .invoice: return "Invoice preview"
+            case .document: return "Document preview"
+            case .permissionChat: return "Permission chat"
             }
         }
     }
@@ -740,7 +779,7 @@ private struct HomeSplitLayoutDemo: View {
                     onSend: {}
                 )
             }
-        case .invoice:
+        case .document:
             HomeDetailPanel(
                 icon: .file,
                 title: "Porsche-preview-2.4S.png",
@@ -754,6 +793,30 @@ private struct HomeSplitLayoutDemo: View {
                         .init(label: "Action", style: .outlined, action: {}),
                         .init(label: "Action", style: .primary, action: {})
                     ]
+                )
+            }
+        case .permissionChat:
+            HomeDetailPanel(
+                icon: nil,
+                title: "Permission to access something",
+                onGoToThread: {},
+                onDismiss: {}
+            ) {
+                HomePermissionChatPreview(
+                    userMessage: "Can you send $5,000 to NBA Merchandising for the annual subscription?",
+                    assistantResponse: "Sure — I've drafted the transfer on Stripe. Before I release it, I need your permission to authorize the payment.",
+                    confirmation: ToolConfirmationData(
+                        requestId: "preview-nba-txn",
+                        toolName: "stripe_transfer",
+                        input: [
+                            "amount_usd": .init(5000),
+                            "recipient": .init("NBA Merchandising")
+                        ],
+                        riskLevel: "medium"
+                    ),
+                    onAllow: {},
+                    onDeny: {},
+                    onAlwaysAllow: { _, _, _, _ in }
                 )
             }
         }
@@ -781,6 +844,7 @@ extension HomeGallerySection {
         case "homeDetailPanel": HomeGallerySection(filter: "homeDetailPanel")
         case "homeEmailEditor": HomeGallerySection(filter: "homeEmailEditor")
         case "homeDocumentPreview": HomeGallerySection(filter: "homeDocumentPreview")
+        case "homePermissionChatPreview": HomeGallerySection(filter: "homePermissionChatPreview")
         case "homeSplitLayout": HomeGallerySection(filter: "homeSplitLayout")
         case "homeSuggestionPillBar": HomeGallerySection(filter: "homeSuggestionPillBar")
         case "homeFeedFilterBar": HomeGallerySection(filter: "homeFeedFilterBar")

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -132,6 +132,12 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                     description: "Pure body content showing a document, image, or any file attachment preview in the Home detail panel. Optional right-aligned footer actions."
                 ),
                 GalleryComponent(
+                    "homePermissionChatPreview",
+                    "HomePermissionChatPreview",
+                    keywords: ["permission", "chat", "confirmation", "tool", "preview", "detail"],
+                    description: "Pure body content for the Home detail panel's permission-request variant — last user message, assistant preamble, and an inline tool confirmation bubble."
+                ),
+                GalleryComponent(
                     "homeSplitLayout",
                     "HomeSplitLayout",
                     keywords: ["home", "split", "side by side", "layout"],


### PR DESCRIPTION
## Summary

A new `HomeDetailPanel` body variant for permission requests that land on Home from an active chat. Figma: `3596:79507` (chrome only — the body content is the real task).

Renders:
1. The **last user message** that triggered the tool request
2. The **assistant's preamble reply** explaining what it's about to do
3. The live **`ToolConfirmationBubble`** — user can approve/deny right from the detail panel without jumping to the thread

Reuses `MessageBubbleView` for the two text bubbles (visual parity with the in-chat bubbles) and `ToolConfirmationBubble` directly for the confirmation pill. Callbacks (`onAllow` / `onDeny` / `onAlwaysAllow` / `onTemporaryAllow`) flow through so the parent wires the real permission routes.

## Gallery
- New `homePermissionChatPreview` gallery section with a fully-populated demo (NBA $5,000 Stripe transfer)
- Registered in `ComponentGalleryCategory.home`
- `HomeSplitLayoutDemo` enum grows a `.permissionChat` variant; renamed `.invoice` → `.document` to match the `HomeDocumentPreview` rename from PR #27226

Part of plan: home-figma-redesign.md (detail-panel follow-up)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
