### PR TITLE
feat(home): move Home nav from sidebar to top-bar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -72,31 +72,6 @@ extension MainWindowView {
 
     var sidebarOuterMargin: CGFloat { 16 }
 
-    /// Small notification-red dot overlaid on the Home sidebar row whenever
-    /// `HomeStore` has observed a background `relationshipStateUpdated` event
-    /// while the user was on some other surface. Hidden when:
-    ///
-    /// - The `home-tab` feature flag is off (Home page not live).
-    /// - `HomeStore.hasUnseenChanges` is false (nothing new, or user has seen it).
-    /// - The user is already sitting on the Home panel.
-    ///
-    /// `home-tab` is a macos-scope flag, resolved via
-    /// `MacOSClientFeatureFlagManager`, not the assistant-scope store.
-    @ViewBuilder
-    var homeUnseenChangesDot: some View {
-        if MacOSClientFeatureFlagManager.shared.isEnabled("home-tab")
-            && homeStore.hasUnseenChanges
-            && windowState.selection != .panel(.home) {
-            Circle()
-                .fill(VColor.systemNegativeStrong)
-                .frame(width: 8, height: 8)
-                .offset(x: 4, y: -4)
-                .transition(.scale.combined(with: .opacity))
-                .allowsHitTesting(false)
-                .accessibilityLabel(Text("Unseen changes"))
-        }
-    }
-
     @ViewBuilder
     var sidebarView: some View {
         VStack(spacing: 0) {
@@ -423,14 +398,7 @@ extension MainWindowView {
             }
 
             // MARK: Nav Items (fixed)
-            if MacOSClientFeatureFlagManager.shared.isEnabled("home-tab") {
-                SidebarNavRow(icon: VIcon.house.rawValue, label: "Home", isActive: windowState.selection == .panel(.home)) {
-                    windowState.showPanel(.home)
-                }
-                .overlay(alignment: .topTrailing) {
-                    homeUnseenChangesDot
-                }
-            }
+            // Home has moved to the top-menu bar (see MainWindowView.topBarView).
             SidebarNavRow(icon: VIcon.brain.rawValue, label: cachedAssistantName, isActive: windowState.selection == .panel(.intelligence)) {
                 windowState.showPanel(.intelligence)
             }
@@ -564,14 +532,7 @@ extension MainWindowView {
                 sidebarSectionDivider()
             }
 
-            if MacOSClientFeatureFlagManager.shared.isEnabled("home-tab") {
-                SidebarNavRow(icon: VIcon.house.rawValue, label: "Home", isActive: windowState.selection == .panel(.home), isExpanded: false) {
-                    windowState.showPanel(.home)
-                }
-                .overlay(alignment: .topTrailing) {
-                    homeUnseenChangesDot
-                }
-            }
+            // Home has moved to the top-menu bar (see MainWindowView.topBarView).
             SidebarNavRow(icon: VIcon.brain.rawValue, label: cachedAssistantName, isActive: windowState.selection == .panel(.intelligence), isExpanded: false) {
                 windowState.showPanel(.intelligence)
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -453,6 +453,25 @@ struct MainWindowView: View {
                     }
                 }
 
+                if MacOSClientFeatureFlagManager.shared.isEnabled("home-tab") {
+                    VButton(label: "Home", iconOnly: VIcon.house.rawValue, style: .ghost, tooltip: "Home") {
+                        windowState.showPanel(.home)
+                    }
+                    .overlay(alignment: .topTrailing) {
+                        // Red dot when the feed has any items and the user
+                        // isn't already looking at the Home panel. Covers
+                        // the "you have something waiting" affordance.
+                        if !feedStore.items.isEmpty && windowState.selection != .panel(.home) {
+                            Circle()
+                                .fill(VColor.systemNegativeStrong)
+                                .frame(width: 8, height: 8)
+                                .offset(x: 2, y: -2)
+                                .allowsHitTesting(false)
+                                .accessibilityLabel(Text("New items in feed"))
+                        }
+                    }
+                }
+
                 VButton(label: "Search", iconOnly: VIcon.search.rawValue, style: .ghost, tooltip: "Search (\u{2318}K)") {
                     AppDelegate.shared?.toggleCommandPalette()
                 }


### PR DESCRIPTION
## Summary
- Insert a new ghost-style Home `VButton` in `MainWindowView.topBarView` between the Sidebar toggle and the Search icon, matching the mock (sidebar → home → search → back/forward).
- Red-dot indicator overlays the top-right of the Home icon when `!feedStore.items.isEmpty && windowState.selection != .panel(.home)` — the "you have something waiting" affordance only shows when there are feed items AND the user isn't already on Home.
- Remove both Home `SidebarNavRow` entries (expanded + collapsed sidebar states) from `MainWindowView+Sidebar.swift`. Home is no longer a sidebar nav item.
- Drop the unused `homeUnseenChangesDot` helper — its only callers were the two removed sidebar rows. New top-bar dot uses `feedStore.items.isEmpty` directly (scoped to the feed, per the request).

Part of plan: home-figma-redesign.md (nav-affordance placement follow-up)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
