### PR TITLE
[LUM-1070] Remove unnecessary prechat flow versioning

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingState.swift
@@ -8,9 +8,6 @@ import VellumAssistantShared
 @Observable
 @MainActor
 final class PreChatOnboardingState {
-    /// Bump when the screen order changes so stale persisted indices are reset.
-    private static let currentFlowVersion = 2
-
     var currentScreen: Int = 0 // 0 = tools, 1 = tasks/tone, 2 = names
     var selectedTools: Set<String> = []
     var selectedTasks: Set<String> = []
@@ -40,11 +37,10 @@ final class PreChatOnboardingState {
     private static let toneKey = "\(prefix)toneValue"
     private static let userNameKey = "\(prefix)userName"
     private static let assistantNameKey = "\(prefix)assistantName"
-    private static let flowVersionKey = "\(prefix)flowVersion"
 
     private static let allKeys: [String] = [
         screenKey, toolsKey, tasksKey, toneKey,
-        userNameKey, assistantNameKey, flowVersionKey,
+        userNameKey, assistantNameKey,
     ]
 
     // MARK: - Init (restore from UserDefaults)
@@ -56,14 +52,6 @@ final class PreChatOnboardingState {
         self.userName = ""
 
         let defaults = UserDefaults.standard
-        let storedVersion = defaults.integer(forKey: Self.flowVersionKey)
-
-        guard storedVersion == Self.currentFlowVersion else {
-            // No persisted state or version mismatch — start fresh.
-            // Pre-fill userName from system account.
-            userName = NameExchangeView.defaultUserName()
-            return
-        }
 
         currentScreen = min(defaults.integer(forKey: Self.screenKey), 2)
 
@@ -92,7 +80,6 @@ final class PreChatOnboardingState {
 
     func persist() {
         let defaults = UserDefaults.standard
-        defaults.set(Self.currentFlowVersion, forKey: Self.flowVersionKey)
         defaults.set(currentScreen, forKey: Self.screenKey)
         defaults.set(Array(selectedTools), forKey: Self.toolsKey)
         defaults.set(Array(selectedTasks), forKey: Self.tasksKey)

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingState.swift
@@ -62,7 +62,9 @@ final class PreChatOnboardingState {
             selectedTasks = Set(tasks)
         }
 
-        toneValue = defaults.double(forKey: Self.toneKey)
+        if defaults.object(forKey: Self.toneKey) != nil {
+            toneValue = defaults.double(forKey: Self.toneKey)
+        }
 
         if let name = defaults.string(forKey: Self.userNameKey) {
             userName = name

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/TaskToneSelectionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/TaskToneSelectionView.swift
@@ -123,7 +123,7 @@ struct TaskToneSelectionView: View {
 
             // Footer buttons
             VStack(spacing: VSpacing.sm) {
-                VButton(label: "Continue", style: .primary, isFullWidth: true) {
+                VButton(label: "Continue", style: .primary, isFullWidth: true, isDisabled: selectedTasks.isEmpty) {
                     onContinue()
                 }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/ToolSelectionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/ToolSelectionView.swift
@@ -69,7 +69,8 @@ struct ToolSelectionView: View {
                     ? "Continue"
                     : "Continue \u{00B7} \(selectedTools.count) selected",
                 style: .primary,
-                isFullWidth: true
+                isFullWidth: true,
+                isDisabled: selectedTools.isEmpty
             ) {
                 onContinue()
             }


### PR DESCRIPTION
## Summary
- Remove `currentFlowVersion` and version-check logic from `PreChatOnboardingState`
- Prechat onboarding is only shown to new users, so there's never stale persisted state to migrate — the versioning was dead code

## Test plan
- [ ] Launch app, run through prechat onboarding flow end-to-end
- [ ] Verify selections persist if app is killed mid-flow and relaunched

Closes LUM-1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
