### PR TITLE
fix(home): top-bar red dot uses homeStore.hasUnseenChanges

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -458,16 +458,18 @@ struct MainWindowView: View {
                         windowState.showPanel(.home)
                     }
                     .overlay(alignment: .topTrailing) {
-                        // Red dot when the feed has any items and the user
-                        // isn't already looking at the Home panel. Covers
-                        // the "you have something waiting" affordance.
-                        if !feedStore.items.isEmpty && windowState.selection != .panel(.home) {
+                        // Red dot whenever HomeStore has observed a background
+                        // `relationshipStateUpdated` SSE event while the user
+                        // was off the Home panel. Cleared by PanelCoordinator
+                        // via `homeStore.markSeen()` when Home becomes active.
+                        if homeStore.hasUnseenChanges && windowState.selection != .panel(.home) {
                             Circle()
                                 .fill(VColor.systemNegativeStrong)
                                 .frame(width: 8, height: 8)
                                 .offset(x: 2, y: -2)
+                                .transition(.scale.combined(with: .opacity))
                                 .allowsHitTesting(false)
-                                .accessibilityLabel(Text("New items in feed"))
+                                .accessibilityLabel(Text("Unseen changes"))
                         }
                     }
                 }


### PR DESCRIPTION
Revert the top-bar Home red-dot signal from `!feedStore.items.isEmpty` back to `homeStore.hasUnseenChanges` (the original relationship-state-updated SSE signal). The existing `PanelCoordinator.markSeen()` call clears it when Home becomes active.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
