### PR TITLE
feat(home): bind top-bar Home button to ⇧⌘H

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -458,6 +458,9 @@ struct MainWindowView: View {
                     VButton(label: "Home", iconOnly: VIcon.house.rawValue, style: .ghost) {
                         windowState.showPanel(.home)
                     }
+                    // ⇧⌘H avoids the system-reserved ⌘H ("Hide application")
+                    // while keeping the mnemonic on the H key.
+                    .keyboardShortcut("h", modifiers: [.command, .shift])
                     .overlay(alignment: .topTrailing) {
                         // Red dot whenever HomeStore has observed a background
                         // `relationshipStateUpdated` SSE event while the user
@@ -473,7 +476,7 @@ struct MainWindowView: View {
                                 .accessibilityLabel(Text("Unseen changes"))
                         }
                     }
-                    .vTooltip("Home")
+                    .vTooltip("Home (\u{21E7}\u{2318}H)")
                 }
 
                 VButton(label: "Search", iconOnly: VIcon.search.rawValue, style: .ghost) {


### PR DESCRIPTION
Wire a keyboard shortcut to the Home top-bar icon.

- `.keyboardShortcut("h", modifiers: [.command, .shift])` — tap-equivalent, fires `windowState.showPanel(.home)`.
- Chose **⇧⌘H** over ⌘H because ⌘H is reserved by macOS for 'Hide application'. Shift-modifier keeps the H mnemonic and has no existing conflicts in the codebase.
- Tooltip now reads 'Home (⇧⌘H)' to surface the shortcut on hover.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
