### PR TITLE
[ATL-173] Add AssistantPickerView + multi-assistant routing

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -95,8 +95,8 @@ extension AppDelegate {
                 onNeedsHostingPicker: { [weak self] in
                     self?.showAuthWindow(forceOnboarding: true)
                 },
-                onNeedsAssistantPicker: { [weak self] in
-                    self?.showAssistantPicker()
+                onNeedsAssistantPicker: { [weak self] landscape in
+                    self?.showAssistantPicker(landscape: landscape)
                 }
             ))
         } else {
@@ -178,13 +178,21 @@ extension AppDelegate {
         authWindow = window
     }
 
-    /// Show the assistant picker in the auth window. Builds the picker
-    /// items from the lockfile (current-environment entries only) and
-    /// swaps the auth window content in-place.
-    private func showAssistantPicker() {
-        let items = LockfileAssistant.loadAll()
-            .filter(\.isCurrentEnvironment)
+    /// Show the assistant picker in the auth window. Builds picker items
+    /// from both the lockfile and the platform list (via the landscape) so
+    /// platform-only assistants (hatched on another device) are included.
+    private func showAssistantPicker(landscape: ReturningUserRouter.AssistantLandscape) {
+        // Local lockfile entries (current-env only)
+        let localItems = landscape.currentEnvironmentLocalLockfileAssistants
             .map(AssistantPickerItem.from(lockfile:))
+
+        // Platform entries — exclude any already represented in the lockfile
+        let lockfileIds = Set(landscape.currentEnvironmentLockfileAssistants.map(\.assistantId))
+        let platformItems = landscape.platformAssistants
+            .filter { !lockfileIds.contains($0.id) }
+            .map(AssistantPickerItem.from(platform:))
+
+        let items = localItems + platformItems
 
         let pickerView = AssistantPickerView(
             assistants: items,
@@ -195,6 +203,7 @@ extension AppDelegate {
             onSignOut: { [weak self] in
                 Task {
                     await self?.authManager.logout()
+                    self?.showAuthWindow()
                 }
             }
         )

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -182,8 +182,8 @@ extension AppDelegate {
     /// from both the lockfile and the platform list (via the landscape) so
     /// platform-only assistants (hatched on another device) are included.
     private func showAssistantPicker(landscape: ReturningUserRouter.AssistantLandscape) {
-        // Local lockfile entries (current-env only)
-        let localItems = landscape.currentEnvironmentLocalLockfileAssistants
+        // Lockfile entries (current-env, both local and managed)
+        let localItems = landscape.currentEnvironmentLockfileAssistants
             .map(AssistantPickerItem.from(lockfile:))
 
         // Platform entries — exclude any already represented in the lockfile

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -210,6 +210,16 @@ extension AppDelegate {
 
         if let window = authWindow {
             window.contentViewController = NSHostingController(rootView: pickerView)
+            // Ensure the window matches the standard auth size — it may
+            // have been resized or the content swap can leave it undersized.
+            window.contentMinSize = NSSize(width: 420, height: 580)
+            if let visibleFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame {
+                let targetWidth: CGFloat = 460
+                let targetHeight: CGFloat = 620
+                let x = visibleFrame.midX - targetWidth / 2
+                let y = visibleFrame.midY - targetHeight / 2
+                window.setFrame(NSRect(x: x, y: y, width: targetWidth, height: targetHeight), display: true, animate: true)
+            }
         } else {
             showAuthWindow()
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -182,9 +182,20 @@ extension AppDelegate {
     /// from both the lockfile and the platform list (via the landscape) so
     /// platform-only assistants (hatched on another device) are included.
     private func showAssistantPicker(landscape: ReturningUserRouter.AssistantLandscape) {
+        // Index platform names by ID so lockfile items can show real names
+        let platformById = Dictionary(
+            landscape.platformAssistants.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
         // Lockfile entries (current-env, both local and managed)
         let localItems = landscape.currentEnvironmentLockfileAssistants
-            .map(AssistantPickerItem.from(lockfile:))
+            .map { entry in
+                AssistantPickerItem.from(
+                    lockfile: entry,
+                    platformName: platformById[entry.assistantId]?.name
+                )
+            }
 
         // Platform entries — exclude any already represented in the lockfile
         let lockfileIds = Set(landscape.currentEnvironmentLockfileAssistants.map(\.assistantId))

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -38,6 +38,11 @@ extension AppDelegate {
                     case .showHostingPicker:
                         log.info("[authFlow] router → showHostingPicker")
                         showAuthWindow()
+                    case .showAssistantPicker:
+                        // decideFast() never returns this (no flag/platform
+                        // check), but handle it for exhaustiveness.
+                        log.info("[authFlow] router → showAssistantPicker")
+                        showAuthWindow()
                     }
                 } else {
                     log.info("[authFlow] router → nil (no current-env entry) — showing auth window")
@@ -89,6 +94,9 @@ extension AppDelegate {
                 },
                 onNeedsHostingPicker: { [weak self] in
                     self?.showAuthWindow(forceOnboarding: true)
+                },
+                onNeedsAssistantPicker: { [weak self] in
+                    self?.showAssistantPicker()
                 }
             ))
         } else {
@@ -168,6 +176,34 @@ extension AppDelegate {
         NSApp.activate(ignoringOtherApps: true)
 
         authWindow = window
+    }
+
+    /// Show the assistant picker in the auth window. Builds the picker
+    /// items from the lockfile (current-environment entries only) and
+    /// swaps the auth window content in-place.
+    private func showAssistantPicker() {
+        let items = LockfileAssistant.loadAll()
+            .filter(\.isCurrentEnvironment)
+            .map(AssistantPickerItem.from(lockfile:))
+
+        let pickerView = AssistantPickerView(
+            assistants: items,
+            onConnect: { [weak self] assistantId in
+                LockfileAssistant.setActiveAssistantId(assistantId)
+                self?.proceedToApp()
+            },
+            onSignOut: { [weak self] in
+                Task {
+                    await self?.authManager.logout()
+                }
+            }
+        )
+
+        if let window = authWindow {
+            window.contentViewController = NSHostingController(rootView: pickerView)
+        } else {
+            showAuthWindow()
+        }
     }
 
     @objc func performRestart() {

--- a/clients/macos/vellum-assistant/App/ReturningUserRouter.swift
+++ b/clients/macos/vellum-assistant/App/ReturningUserRouter.swift
@@ -25,11 +25,15 @@ final class ReturningUserRouter {
         /// No assistants found — show the hosting-option picker so the user
         /// can hatch or set one up.
         case showHostingPicker
+        /// Multiple assistants (or one with multi-assistant flag) — show the
+        /// assistant picker so the user explicitly chooses which to connect.
+        case showAssistantPicker
 
         var description: String {
             switch self {
             case .autoConnect: "autoConnect"
             case .showHostingPicker: "showHostingPicker"
+            case .showAssistantPicker: "showAssistantPicker"
             }
         }
     }
@@ -65,6 +69,7 @@ final class ReturningUserRouter {
     private let organizationIdProvider: () -> String?
     private let authServiceProvider: () -> ManagedAssistantBootstrapAuthServicing?
     private let lockfileLoader: () -> [LockfileAssistant]
+    private let multiAssistantFlagProvider: () -> Bool
 
     private static let platformTimeoutSeconds: UInt64 = 5
 
@@ -77,11 +82,15 @@ final class ReturningUserRouter {
         },
         lockfileLoader: @escaping () -> [LockfileAssistant] = {
             LockfileAssistant.loadAll()
+        },
+        multiAssistantFlagProvider: @escaping () -> Bool = {
+            MacOSClientFeatureFlagManager.shared.isEnabled("multi-platform-assistant")
         }
     ) {
         self.organizationIdProvider = organizationIdProvider
         self.authServiceProvider = authServiceProvider
         self.lockfileLoader = lockfileLoader
+        self.multiAssistantFlagProvider = multiAssistantFlagProvider
     }
 
     // MARK: - Routing
@@ -138,9 +147,13 @@ final class ReturningUserRouter {
     /// Pure routing decision from a pre-fetched landscape.
     func decide(for landscape: AssistantLandscape) -> RoutingDecision {
         let total = landscape.totalCount
-        log.info("decide: totalCount=\(total) platformConsulted=\(landscape.platformWasConsulted)")
+        let hasMultiFlag = multiAssistantFlagProvider()
+        log.info("decide: totalCount=\(total) multiFlag=\(hasMultiFlag) platformConsulted=\(landscape.platformWasConsulted)")
         if total == 0 {
             return .showHostingPicker
+        }
+        if total > 1 || (total == 1 && hasMultiFlag) {
+            return .showAssistantPicker
         }
         return .autoConnect
     }

--- a/clients/macos/vellum-assistant/App/ReturningUserRouter.swift
+++ b/clients/macos/vellum-assistant/App/ReturningUserRouter.swift
@@ -104,6 +104,10 @@ final class ReturningUserRouter {
         let all = lockfileLoader()
         let current = all.filter(\.isCurrentEnvironment)
         guard !current.isEmpty else { return nil }
+        if current.count > 1 || (current.count == 1 && multiAssistantFlagProvider()) {
+            log.info("decideFast: \(current.count) current-env entries + multiFlag — showAssistantPicker")
+            return .showAssistantPicker
+        }
         log.info("decideFast: \(current.count) current-env lockfile entries — autoConnect")
         return .autoConnect
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/AssistantPickerView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AssistantPickerView.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AssistantPickerView")
+
+/// Shown when the returning-user router decides `.showAssistantPicker` —
+/// the user has multiple assistants (or one with the multi-assistant flag)
+/// and must explicitly choose which to connect.
+@MainActor
+struct AssistantPickerView: View {
+    let assistants: [AssistantPickerItem]
+    let onConnect: (String) -> Void
+    let onSignOut: () -> Void
+
+    @State private var connectingId: String?
+
+    private static let appIcon: NSImage? = {
+        guard let path = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png") else { return nil }
+        return NSImage(contentsOfFile: path)
+    }()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer().frame(height: 60)
+
+            if let nsImage = Self.appIcon {
+                Image(nsImage: nsImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 72, height: 72)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    .padding(.bottom, VSpacing.lg)
+            }
+
+            Text("Choose an Assistant")
+                .font(VFont.displayLarge)
+                .foregroundStyle(VColor.contentDefault)
+                .padding(.bottom, VSpacing.xs)
+
+            Text("Select which assistant to connect to.")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentSecondary)
+                .padding(.bottom, VSpacing.xl)
+
+            VStack(spacing: VSpacing.sm) {
+                ForEach(assistants, id: \.id) { item in
+                    assistantRow(item)
+                }
+            }
+            .frame(maxWidth: 320)
+
+            Spacer()
+
+            VButton(label: "Not you? Sign out", style: .ghost) {
+                onSignOut()
+            }
+            .padding(.bottom, VSpacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            RadialGradient(
+                colors: [VColor.surfaceBase, VColor.surfaceOverlay],
+                center: .center,
+                startRadius: 0,
+                endRadius: 500
+            )
+            .ignoresSafeArea()
+        )
+    }
+
+    @ViewBuilder
+    private func assistantRow(_ item: AssistantPickerItem) -> some View {
+        HStack(spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.displayName)
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+                if let subtitle = item.subtitle {
+                    Text(subtitle)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                }
+            }
+            Spacer()
+            if connectingId == item.id {
+                ProgressView()
+                    .controlSize(.small)
+                    .progressViewStyle(.circular)
+            } else {
+                VButton(label: "Connect", style: .secondary) {
+                    connectingId = item.id
+                    onConnect(item.id)
+                }
+                .disabled(connectingId != nil)
+            }
+        }
+        .padding(VSpacing.md)
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+    }
+}
+
+/// Presentation model for a single row in the assistant picker.
+struct AssistantPickerItem: Identifiable {
+    let id: String
+    let displayName: String
+    let subtitle: String?
+    let isManaged: Bool
+
+    static func from(lockfile: LockfileAssistant) -> AssistantPickerItem {
+        let name = AssistantDisplayName.resolve(
+            IdentityInfo.cached(for: lockfile.assistantId)?.name,
+            lockfile.assistantId
+        )
+        let subtitle = lockfile.isManaged ? "Managed" : "Local"
+        return AssistantPickerItem(
+            id: lockfile.assistantId,
+            displayName: name,
+            subtitle: subtitle,
+            isManaged: lockfile.isManaged
+        )
+    }
+
+    static func from(platform: PlatformAssistant) -> AssistantPickerItem {
+        let name = AssistantDisplayName.resolve(platform.name, platform.id)
+        return AssistantPickerItem(
+            id: platform.id,
+            displayName: name,
+            subtitle: "Managed",
+            isManaged: true
+        )
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/AssistantPickerView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AssistantPickerView.swift
@@ -88,7 +88,7 @@ struct AssistantPickerView: View {
                     .controlSize(.small)
                     .progressViewStyle(.circular)
             } else {
-                VButton(label: "Connect", style: .secondary) {
+                VButton(label: "Connect", style: .outlined) {
                     connectingId = item.id
                     onConnect(item.id)
                 }
@@ -108,6 +108,7 @@ struct AssistantPickerItem: Identifiable {
     let subtitle: String?
     let isManaged: Bool
 
+    @MainActor
     static func from(lockfile: LockfileAssistant) -> AssistantPickerItem {
         let name = AssistantDisplayName.resolve(
             IdentityInfo.cached(for: lockfile.assistantId)?.name,
@@ -122,6 +123,7 @@ struct AssistantPickerItem: Identifiable {
         )
     }
 
+    @MainActor
     static func from(platform: PlatformAssistant) -> AssistantPickerItem {
         let name = AssistantDisplayName.resolve(platform.name, platform.id)
         return AssistantPickerItem(

--- a/clients/macos/vellum-assistant/Features/Onboarding/AssistantPickerView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AssistantPickerView.swift
@@ -108,9 +108,13 @@ struct AssistantPickerItem: Identifiable {
     let subtitle: String?
     let isManaged: Bool
 
+    /// Build a picker item from a lockfile entry. When the platform was
+    /// consulted, pass the matching `PlatformAssistant.name` so we have
+    /// a real display name instead of a raw UUID.
     @MainActor
-    static func from(lockfile: LockfileAssistant) -> AssistantPickerItem {
+    static func from(lockfile: LockfileAssistant, platformName: String? = nil) -> AssistantPickerItem {
         let name = AssistantDisplayName.resolve(
+            platformName,
             IdentityInfo.cached(for: lockfile.assistantId)?.name,
             lockfile.assistantId
         )

--- a/clients/macos/vellum-assistant/Features/Onboarding/AssistantPickerView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AssistantPickerView.swift
@@ -115,8 +115,7 @@ struct AssistantPickerItem: Identifiable {
     static func from(lockfile: LockfileAssistant, platformName: String? = nil) -> AssistantPickerItem {
         let name = AssistantDisplayName.resolve(
             platformName,
-            IdentityInfo.cached(for: lockfile.assistantId)?.name,
-            lockfile.assistantId
+            IdentityInfo.cached(for: lockfile.assistantId)?.name
         )
         let subtitle = lockfile.isManaged ? "Managed" : "Local"
         return AssistantPickerItem(
@@ -129,7 +128,7 @@ struct AssistantPickerItem: Identifiable {
 
     @MainActor
     static func from(platform: PlatformAssistant) -> AssistantPickerItem {
-        let name = AssistantDisplayName.resolve(platform.name, platform.id)
+        let name = AssistantDisplayName.resolve(platform.name)
         return AssistantPickerItem(
             id: platform.id,
             displayName: name,

--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -14,7 +14,9 @@ struct ReauthView: View {
     var onNeedsHostingPicker: (() -> Void)?
     /// Invoked when `ReturningUserRouter` decides `.showAssistantPicker`
     /// (multiple assistants or multi-assistant flag enabled).
-    var onNeedsAssistantPicker: (() -> Void)?
+    /// Receives the landscape so the picker can show platform-only assistants
+    /// that aren't in the local lockfile.
+    var onNeedsAssistantPicker: ((ReturningUserRouter.AssistantLandscape) -> Void)?
 
     @State private var showContent = false
     @State private var didComplete = false
@@ -175,7 +177,8 @@ struct ReauthView: View {
         guard !didComplete else { return }
         let router = ReturningUserRouter()
         do {
-            let decision = try await router.route()
+            let landscape = try await router.fetchLandscape()
+            let decision = router.decide(for: landscape)
             guard !didComplete else { return }
             log.info("ReauthView router decision=\(String(describing: decision), privacy: .public)")
             switch decision {
@@ -194,7 +197,7 @@ struct ReauthView: View {
                 if let onNeedsAssistantPicker {
                     log.info("ReauthView → showAssistantPicker")
                     didComplete = true
-                    onNeedsAssistantPicker()
+                    onNeedsAssistantPicker(landscape)
                 } else {
                     log.info("ReauthView → showAssistantPicker but no callback — falling back to managed activation")
                     await completeManagedActivation()

--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -12,6 +12,9 @@ struct ReauthView: View {
     /// after re-auth (platform returned 0 assistants for this user).
     /// The host swaps this view for the onboarding hosting picker.
     var onNeedsHostingPicker: (() -> Void)?
+    /// Invoked when `ReturningUserRouter` decides `.showAssistantPicker`
+    /// (multiple assistants or multi-assistant flag enabled).
+    var onNeedsAssistantPicker: (() -> Void)?
 
     @State private var showContent = false
     @State private var didComplete = false
@@ -184,9 +187,16 @@ struct ReauthView: View {
                     didComplete = true
                     onNeedsHostingPicker()
                 } else {
-                    // No callback wired — fall back to the old behavior
-                    // so the re-auth flow still terminates.
                     log.info("ReauthView → showHostingPicker but no callback — falling back to managed activation")
+                    await completeManagedActivation()
+                }
+            case .showAssistantPicker:
+                if let onNeedsAssistantPicker {
+                    log.info("ReauthView → showAssistantPicker")
+                    didComplete = true
+                    onNeedsAssistantPicker()
+                } else {
+                    log.info("ReauthView → showAssistantPicker but no callback — falling back to managed activation")
                     await completeManagedActivation()
                 }
             }

--- a/clients/macos/vellum-assistantTests/ReturningUserRouterTests.swift
+++ b/clients/macos/vellum-assistantTests/ReturningUserRouterTests.swift
@@ -64,6 +64,16 @@ final class ReturningUserRouterTests: XCTestCase {
         XCTAssertEqual(router.decideFast(), .autoConnect)
     }
 
+    func testDecideFastShowsPickerForMultipleLockfileEntries() {
+        let router = makeRouter(lockfile: [makeLocalAssistant(), makeManagedAssistant()])
+        XCTAssertEqual(router.decideFast(), .showAssistantPicker)
+    }
+
+    func testDecideFastShowsPickerForSingleEntryWithMultiFlag() {
+        let router = makeRouter(lockfile: [makeLocalAssistant()], multiAssistantFlag: true)
+        XCTAssertEqual(router.decideFast(), .showAssistantPicker)
+    }
+
     // MARK: - decide(for:)
 
     func testDecideShowsHostingPickerWhenZeroAssistants() {

--- a/clients/macos/vellum-assistantTests/ReturningUserRouterTests.swift
+++ b/clients/macos/vellum-assistantTests/ReturningUserRouterTests.swift
@@ -33,7 +33,8 @@ final class ReturningUserRouterTests: XCTestCase {
     private func makeRouter(
         lockfile: [LockfileAssistant] = [],
         orgId: String? = nil,
-        platformResult: Result<[PlatformAssistant], Error>? = nil
+        platformResult: Result<[PlatformAssistant], Error>? = nil,
+        multiAssistantFlag: Bool = false
     ) -> ReturningUserRouter {
         let mockAuth: MockAuthService? = platformResult.map { result in
             MockAuthService(listResult: result)
@@ -41,7 +42,8 @@ final class ReturningUserRouterTests: XCTestCase {
         return ReturningUserRouter(
             organizationIdProvider: { orgId },
             authServiceProvider: { mockAuth },
-            lockfileLoader: { lockfile }
+            lockfileLoader: { lockfile },
+            multiAssistantFlagProvider: { multiAssistantFlag }
         )
     }
 
@@ -92,11 +94,43 @@ final class ReturningUserRouterTests: XCTestCase {
         XCTAssertEqual(router.decide(for: landscape), .autoConnect)
     }
 
-    func testDecideAutoConnectsWithMultipleAssistants() {
-        let router = makeRouter()
+    func testDecideAutoConnectsWithMultipleAssistantsWhenFlagOff() {
+        let router = makeRouter(multiAssistantFlag: false)
         let landscape = ReturningUserRouter.AssistantLandscape(
             lockfileAssistants: [makeLocalAssistant()],
             platformAssistants: [makePlatformAssistant()],
+            platformWasConsulted: true
+        )
+        XCTAssertEqual(router.decide(for: landscape), .showAssistantPicker)
+    }
+
+    // MARK: - Assistant picker routing
+
+    func testDecideShowsPickerForMultipleAssistants() {
+        let router = makeRouter(multiAssistantFlag: false)
+        let landscape = ReturningUserRouter.AssistantLandscape(
+            lockfileAssistants: [makeLocalAssistant(), makeLocalAssistant(id: "local-2")],
+            platformAssistants: [],
+            platformWasConsulted: true
+        )
+        XCTAssertEqual(router.decide(for: landscape), .showAssistantPicker)
+    }
+
+    func testDecideShowsPickerForSingleAssistantWithMultiFlag() {
+        let router = makeRouter(multiAssistantFlag: true)
+        let landscape = ReturningUserRouter.AssistantLandscape(
+            lockfileAssistants: [makeLocalAssistant()],
+            platformAssistants: [],
+            platformWasConsulted: true
+        )
+        XCTAssertEqual(router.decide(for: landscape), .showAssistantPicker)
+    }
+
+    func testDecideAutoConnectsForSingleAssistantWithoutMultiFlag() {
+        let router = makeRouter(multiAssistantFlag: false)
+        let landscape = ReturningUserRouter.AssistantLandscape(
+            lockfileAssistants: [makeLocalAssistant()],
+            platformAssistants: [],
             platformWasConsulted: true
         )
         XCTAssertEqual(router.decide(for: landscape), .autoConnect)


### PR DESCRIPTION
Adds `.showAssistantPicker` to `RoutingDecision`, gated on the `multi-platform-assistant` feature flag:

- **0 assistants** → `.showHostingPicker` (unchanged)
- **1 assistant, no flag** → `.autoConnect` (unchanged)
- **1 assistant + flag** → `.showAssistantPicker` (new)
- **N assistants** → `.showAssistantPicker` (new)

New `AssistantPickerView` shows current-environment assistants with per-row Connect buttons and a "Not you? Sign out" footer. Wired into `showAuthWindow` via `onNeedsAssistantPicker` callback from `ReauthView`, with in-place window content swap.

### Changes

- **`ReturningUserRouter.swift`** (+15/-1) — add `.showAssistantPicker` case, `multiAssistantFlagProvider` DI, update `decide(for:)`
- **`AssistantPickerView.swift`** (new, 134 lines) — picker view + `AssistantPickerItem` presentation model
- **`AppDelegate+AuthLifecycle.swift`** (+36) — add `showAssistantPicker()`, wire callback, handle new case in `decideFast` switch
- **`ReauthView.swift`** (+14/-2) — add `onNeedsAssistantPicker` callback, handle new case in `routeAuthenticatedUser`
- **`ReturningUserRouterTests.swift`** (+42/-4) — 3 new picker routing tests, update helper with `multiAssistantFlag` param

**+234/-7 across 5 files.**

Part of ATL-173.

---

Authored by: David Rose (`david-rose-bot`), @emmiekehoe's assistant
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
