### PR TITLE
fix(slack): omit empty description from manifest to fix broken creation link

### DIFF
--- a/skills/slack-app-setup/generate-manifest-url.ts
+++ b/skills/slack-app-setup/generate-manifest-url.ts
@@ -21,7 +21,7 @@ if (!name) {
 const manifest = {
   display_information: {
     name,
-    description: desc,
+    ...(desc ? { description: desc } : {}),
     background_color: "#1a1a2e",
   },
   features: {


### PR DESCRIPTION
## Summary
- Slack manifest creation link broke when no description was provided because `description: ""` fails Slack's validation
- Conditionally include `description` only when a non-empty value is given

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
