### PR TITLE
feat(home): HomeDocumentPreview fits available space, no scroll needed

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDocumentPreview.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDocumentPreview.swift
@@ -39,8 +39,12 @@ struct HomeDocumentPreview: View {
     var body: some View {
         VStack(spacing: 0) {
             preview
-                .frame(maxWidth: .infinity, alignment: .top)
                 .padding(VSpacing.lg)
+                // Flex to fill the full remaining vertical space between the
+                // panel chrome and the footer so the preview fits naturally
+                // without a scroll view. Pair with `HomeDetailPanel(scrollable: false, …)`.
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                .layoutPriority(1)
 
             if !actions.isEmpty {
                 VColor.borderBase
@@ -67,10 +71,13 @@ struct HomeDocumentPreview: View {
     @ViewBuilder
     private var preview: some View {
         if let image {
+            // `.aspectRatio(contentMode: .fit)` respects BOTH dimensions of
+            // the enclosing frame — the image scales down to whichever is
+            // the tighter constraint so it never overflows.
             Image(nsImage: image)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
-                .frame(maxWidth: .infinity, alignment: .top)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             VStack(spacing: VSpacing.sm) {
                 VIconView(.file, size: 32)
@@ -80,7 +87,7 @@ struct HomeDocumentPreview: View {
                     .foregroundStyle(VColor.contentTertiary)
                     .multilineTextAlignment(.center)
             }
-            .frame(maxWidth: .infinity, minHeight: 400, alignment: .center)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.xl, style: .continuous)
                     .fill(VColor.surfaceOverlay)

--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -455,7 +455,8 @@ struct HomeGallerySection: View {
                     icon: .file,
                     title: "Porsche-preview-2.4S.png",
                     onGoToThread: {},
-                    onDismiss: {}
+                    onDismiss: {},
+                    scrollable: false
                 ) {
                     HomeDocumentPreview(
                         image: nil,
@@ -784,7 +785,8 @@ private struct HomeSplitLayoutDemo: View {
                 icon: .file,
                 title: "Porsche-preview-2.4S.png",
                 onGoToThread: {},
-                onDismiss: {}
+                onDismiss: {},
+                scrollable: false
             ) {
                 HomeDocumentPreview(
                     image: nil,


### PR DESCRIPTION
- Preview area now flexes to fill the full remaining vertical space between the `HomeDetailPanel` header and the footer actions (`layoutPriority(1)` + `maxHeight: .infinity`).
- Image's `.aspectRatio(contentMode: .fit)` now respects BOTH the width and the height of its frame, so it scales to whichever is tighter — never overflows.
- Placeholder no longer pins at `minHeight: 400`; it expands to fill the available space.
- Gallery demos that host a `HomeDocumentPreview` (main section + `HomeSplitLayoutDemo` `.document` variant) now pass `scrollable: false` to `HomeDetailPanel` so the content isn't wrapped in a `ScrollView`, matching the fit-naturally behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
