### PR TITLE
fix(slack): replace OAuth install with manual install flow

### DIFF
--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -20,13 +20,10 @@ You are helping your user connect a Slack bot to the Vellum Assistant via Socket
 | Value         | Type       | Storage method            | Secret? |
 | ------------- | ---------- | ------------------------- | ------- |
 | App Token     | Credential | `credential_store` prompt | **Yes** |
-| Client ID     | Credential | `credential_store` prompt | **Yes** |
-| Client Secret | Credential | `credential_store` prompt | **Yes** |
-| Bot Token     | Credential | OAuth (automatic)         | **Yes** |
-| User Token    | Credential | OAuth (automatic)         | **Yes** |
+| Bot Token     | Credential | `credential_store` prompt | **Yes** |
+| User Token    | Credential | `credential_store` prompt | **Yes** |
 
-- App Token, Client ID, and Client Secret are collected via `credential_store` prompt — never accept them pasted in plaintext chat.
-- Bot Token and User Token are captured automatically via the OAuth install flow.
+- All credentials are collected via `credential_store` prompt — never accept them pasted in plaintext chat.
 
 # Setup Steps
 
@@ -58,7 +55,7 @@ Note: `user_token` is optional. Missing `user_token` is **not** blocking — set
 
 Ask the user what they'd like to name their Slack bot and optionally provide a short description. Then generate the manifest creation URL.
 
-**MANDATORY — you MUST run the script below to build the manifest URL.** Do NOT write your own manifest. Do NOT show YAML or JSON to the user. Do NOT tell the user to paste a manifest. The script contains the complete, correct manifest with all required scopes, event subscriptions, OAuth redirect URL, and socket mode settings. Running it produces a single pre-filled URL that creates the app with everything configured.
+**MANDATORY — you MUST run the script below to build the manifest URL.** Do NOT write your own manifest. Do NOT show YAML or JSON to the user. Do NOT tell the user to paste a manifest. The script contains the complete, correct manifest with all required scopes, event subscriptions, and socket mode settings. Running it produces a single pre-filled URL that creates the app with everything configured.
 
 Run this `bash` command, replacing `<user_name>` and `<user_description>` with the user's chosen values:
 
@@ -71,13 +68,13 @@ bash {
 
 If a value contains a single quote, escape it as `'\''` (closes the quote, adds an escaped literal quote, reopens the quote).
 
-The command outputs a ready-to-click URL. **Present it as a markdown link** so the full URL renders as a single clickable element — e.g. `[Click here to create your Slack app](URL)`. Do NOT paste the raw URL as plain text — it is too long and will break across lines, preventing the user from clicking it. Tell them: "Click the link, select your workspace, and click **Create**. All permissions, events, Socket Mode, and the OAuth redirect URL are pre-configured."
+The command outputs a ready-to-click URL. **Present it as a markdown link** so the full URL renders as a single clickable element — e.g. `[Click here to create your Slack app](URL)`. Do NOT paste the raw URL as plain text — it is too long and will break across lines, preventing the user from clicking it. Tell them: "Click the link, select your workspace, and click **Create**. All permissions, events, and Socket Mode are pre-configured."
 
 Wait for the user to confirm they've created the app before proceeding.
 
-## Step 2: Collect Credentials & Install via OAuth
+## Step 2: Collect Credentials
 
-Now collect three values from the app's **Basic Information** page, then automate the rest via OAuth.
+Now collect credentials from the Slack app settings.
 
 ### Step 2a: App Token
 
@@ -87,43 +84,25 @@ Then collect it securely:
 
 - Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "app_token"`, `label: "App-Level Token"`, `placeholder: "xapp-..."`, `description: "Paste the App-Level Token you just generated"`
 
-### Step 2b: Client ID
+### Step 2b: Install App to Workspace
 
-Tell the user to scroll to **App Credentials** on the same Basic Information page. The Client ID is displayed there.
+Tell the user: in the left sidebar of your Slack app settings, go to **Install App**, then click **Install to Workspace**. Slack will ask you to authorize — click **Allow**.
 
-- Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "client_id"`, `label: "Client ID"`, `description: "From Basic Information > App Credentials"`
+After installing, the page will show the **Bot User OAuth Token** (starts with `xoxb-`) and optionally a **User OAuth Token** (starts with `xoxp-`).
 
-### Step 2c: Client Secret
+### Step 2c: Bot Token
 
-The Client Secret is right below the Client ID on the same page (the user may need to click "Show" to reveal it).
+Tell the user to copy the **Bot User OAuth Token** from the Install App page.
 
-- Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "client_secret"`, `label: "Client Secret"`, `placeholder: "starts with a long alphanumeric string"`, `description: "From Basic Information > App Credentials (click Show to reveal)"`
+- Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "bot_token"`, `label: "Bot User OAuth Token"`, `placeholder: "xoxb-..."`, `description: "From Install App page — the Bot User OAuth Token"`
 
-### Step 2d: Run OAuth Install
+### Step 2d: User Token (Optional)
 
-Now that all three credentials are stored, trigger the automated OAuth install. This opens the user's browser to Slack's authorization page — they just click **Allow**.
+If a **User OAuth Token** is shown on the same page, collect it for full triage visibility. If it's not shown, skip this step — the bot will work with bot-only visibility.
 
-Tell the user: "Opening your browser now — just click **Allow** to install the app."
+- Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "user_token"`, `label: "User OAuth Token"`, `placeholder: "xoxp-..."`, `description: "From Install App page — the User OAuth Token (optional, for full channel visibility)"`
 
-Then call the OAuth install endpoint via the gateway:
-
-```
-bash {
-  command: "curl -s -X POST ${INTERNAL_GATEWAY_BASE_URL}/v1/integrations/slack/channel/oauth-install -H 'Content-Type: application/json'"
-  activity: "to run the Slack OAuth install flow"
-  timeout: 360000
-}
-```
-
-This endpoint reads the stored Client ID and Client Secret, opens a browser to Slack's OAuth consent screen, and automatically captures the bot token and user token when the user clicks **Allow**. It blocks until the user completes authorization (up to 5 minutes).
-
-Parse the JSON response:
-
-- If `success: true` — bot and user tokens were captured and stored automatically. Continue to Step 3.
-- If `success: false` — show the `error` field and troubleshoot. Common issues:
-  - "Client ID not found" / "Client Secret not found" — re-collect the missing credential via Step 2b/2c.
-  - "OAuth flow failed: OAuth2 loopback callback timed out" — the user didn't complete authorization in time. Re-run Step 2d.
-  - "OAuth flow failed: OAuth2 authorization denied" — the user clicked Cancel or the workspace requires admin approval.
+Tell the user: the user token is optional — it enables the assistant to see messages in all channels you're in, not just channels the bot has been added to. If they'd rather skip it, that's fine.
 
 ## Step 3: Test Your Connection
 
@@ -167,8 +146,8 @@ Identity: skipped"
 
 For `{triage_line}`, use:
 
-- If `hasUserToken` was `true` in the OAuth response: `✅ Triage visibility: full (can read all your channels)`
-- If `hasUserToken` was `false`: `⬜ Triage visibility: bot-only (only channels the bot is a member of) — you can collect a user token anytime to enable full triage`
+- If a user token was collected in Step 2d: `✅ Triage visibility: full (can read all your channels)`
+- If the user skipped the user token: `⬜ Triage visibility: bot-only (only channels the bot is a member of) — you can collect a user token anytime to enable full triage`
 
 ## Troubleshooting
 
@@ -188,21 +167,15 @@ Re-enter the token via credential_store prompt. The handler validates tokens on 
 
 Verify that `message.channels` event subscription is enabled in your Slack app settings under **Event Subscriptions > Subscribe to bot events**. The manifest pre-configures this, but it can be accidentally removed.
 
-### OAuth install failed
+### Bot token not showing after install
 
-If the OAuth flow fails or times out, re-run Step 2d. Ensure:
-
-- The Client ID and Client Secret are correct (re-collect via credential_store if unsure)
-- The Slack app has `http://localhost:17322/oauth/callback` in its OAuth redirect URLs (pre-configured by the manifest)
-- No other process is using port 17322
+If the **Install App** page doesn't show a Bot User OAuth Token after installation, the app may not have bot scopes configured. Verify that **OAuth & Permissions > Scopes > Bot Token Scopes** lists the expected scopes (the manifest pre-configures these). If scopes are missing, the app was likely created without the manifest — start over from Step 1.
 
 ## Implementation Rules
 
 - **Do NOT improvise or write your own manifest.** The `generate-manifest-url.ts` script in Step 1 contains the only correct manifest. If you show raw YAML/JSON or write a manifest from memory, it WILL be missing scopes, event subscriptions, or socket mode settings and setup will fail.
 - **Do NOT skip the script in Step 1.** You must run it to generate the pre-filled URL. The user should never have to paste a manifest — they click a link.
-- App Token, Client ID, and Client Secret collection goes through `credential_store` prompts. Do NOT use `ui_show`, `ui_update`, `assistant credentials reveal`, or other mechanisms. Do NOT ask the user to paste them in chat — always use the secure credential prompt.
-- Bot Token and User Token are captured automatically by the OAuth install flow. Do NOT ask the user to copy-paste these tokens.
-- **Do NOT tell the user to manually copy the bot token.** The OAuth flow captures it automatically.
+- All credential collection goes through `credential_store` prompts. Do NOT use `ui_show`, `ui_update`, `assistant credentials reveal`, or other mechanisms. Do NOT ask the user to paste tokens in chat — always use the secure credential prompt.
 
 ## Clearing Credentials
 

--- a/skills/slack-app-setup/generate-manifest-url.ts
+++ b/skills/slack-app-setup/generate-manifest-url.ts
@@ -4,8 +4,7 @@
  * Usage: bun skills/slack-app-setup/generate-manifest-url.ts <bot-name> [bot-description]
  *
  * The manifest is the single source of truth for all required scopes,
- * event subscriptions, and settings. Keep it in sync with
- * assistant/src/daemon/handlers/slack-channel-oauth-install.ts.
+ * event subscriptions, and settings.
  */
 
 const name = process.argv[2];
@@ -36,7 +35,6 @@ const manifest = {
     },
   },
   oauth_config: {
-    redirect_urls: ["http://localhost:17322/oauth/callback"],
     scopes: {
       bot: [
         "app_mentions:read",


### PR DESCRIPTION
## Summary
- Remove the automated OAuth install flow that redirected to localhost and broke setup
- Replace with manual install via Slack's "Install to Workspace" UI
- User now copies bot token and user token from the Install App page via secure credential prompts
- Remove `redirect_urls` from manifest and drop Client ID / Client Secret collection (no longer needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
