### PR TITLE
fix(onboarding): prevent double assistant hatch on view recreation

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -8,7 +8,7 @@ This is your first conversation. This document gives you goals and constraints �
 
 1. **Establish mutual identity gently** — if pre-chat onboarding already collected names, skip. If the user skipped pre-chat, do NOT force it. At most pick a default ("I'll go by Pax and call you 'you' for now") and move on. Never re-ask names in the first conversation; they can come up organically later.
 
-2. **Prove value fast** — do something useful before asking for anything. Wow moment within 2-3 exchanges.
+2. **Prove value fast** — your very first response should offer to do something concrete, not ask what the user wants. If you have onboarding context, use the tasks/tools to propose 2-3 specific things you can do right now. If the user opens with a task, skip suggestions and just do it. Wow moment within 2-3 exchanges.
 
 3. **Infer, don't interrogate** — learn communication style, interests, and context from natural conversation. No personality quiz. No dropdown forms. No structured intake.
 
@@ -87,10 +87,27 @@ When saving to SOUL.md, be specific about tone, energy, and conversational style
 
 If an `onboarding` JSON context is present in this conversation, the user already went through a native pre-chat flow. Use it:
 
-- `tools` array -> know which integration offers to surface first, infer work profile
-- `tasks` array -> know what "prove value fast" means for this person
-- `tone` string -> calibrate warmth/formality
 - `userName` / `assistantName` -> write to IDENTITY.md and users/{{USER_PERSONA_FILE}} immediately, skip name exchange
+- `tone` string -> calibrate warmth/formality from the first response
+- `tasks` array -> the most important signal. These are what the user wants help with. Use them to craft your opening suggestions.
+- `tools` array -> infer their work profile. Do NOT offer to connect tools in the first message — save that for later.
+
+**First response with onboarding context:** Lead with a brief, warm intro (one sentence — you know their name, use it). Then offer 2-3 concrete, actionable suggestions based on their `tasks`. These should be things you can do right now, not setup steps. Frame them as offers, not questions.
+
+Examples of good suggestions (calibrate to their actual tasks):
+- tasks includes "writing" -> "I can draft an email, clean up a doc, or write something from scratch"
+- tasks includes "code-building" -> "I can help you build something, review code, or debug a problem"
+- tasks includes "research" -> "I can dig into a topic and give you a summary"
+- tasks includes "scheduling" -> "I can help you plan your day or prep for an upcoming meeting"
+- tasks includes "project-management" -> "I can help break down a project or write up a status update"
+
+Don't list all of them — pick the 2-3 most compelling based on the combination of tasks and tools. End with something like "what sounds good?" or "or just tell me what you need" so the user knows they can go off-script.
+
+**What NOT to do in the first message:**
+- Don't recite back what you know about them ("I see you use Gmail, Linear, Slack...")
+- Don't offer to connect integrations or do setup
+- Don't ask open-ended questions like "what's on your mind?" or "how can I help?"
+- Don't list capabilities abstractly — suggest specific actions
 
 If no onboarding context is present, infer everything fresh from conversation.
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -17,7 +17,8 @@ struct HatchingStepView: View {
     @State private var characterAwake = false
     @State private var pulseScale: CGFloat = 0.9
     @State private var showCharacter = true
-    @State private var hatchStarted = false
+    // hatch guard lives on OnboardingState (state.hatchProcessStarted)
+    // so it survives SwiftUI view recreation
     @State private var isCheckingHealth = false
     private var hatchBody: AvatarBodyShape {
         state.hatchAvatarBodyShape ?? .allCases[0]
@@ -104,8 +105,8 @@ struct HatchingStepView: View {
                 showContent = true
             }
             startPulse()
-            if !hatchStarted {
-                hatchStarted = true
+            if !state.hatchProcessStarted {
+                state.hatchProcessStarted = true
                 startHatching()
             }
 
@@ -343,7 +344,7 @@ struct HatchingStepView: View {
         state.hatchStepLabel = nil
         state.hatchTotalSteps = 1
         state.hatchCurrentStep = 0
-        hatchStarted = false
+        state.hatchProcessStarted = false
         progressStartDate = nil
         segmentStartDate = nil
         segmentStartValue = 0
@@ -399,7 +400,7 @@ struct HatchingStepView: View {
     }
 
     private func retryHatch() {
-        hatchStarted = false
+        state.hatchProcessStarted = false
         if state.isManagedHatch, let onRetryManaged {
             // Non-destructive retry: re-run managed bootstrap from the top.
             // `resetForRetry` would wipe ToS acceptance and API keys, which is

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -227,6 +227,7 @@ struct OnboardingFlowView: View {
                 completionDelayTask?.cancel()
                 didCallComplete = false
                 state.isHatching = false
+                state.hatchProcessStarted = false
                 state.isManagedHatch = false
                 state.hatchCompleted = false
                 state.hatchFailed = false

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -95,6 +95,7 @@ final class OnboardingState {
     var isRehatch: Bool = false
 
     var isHatching: Bool = false
+    var hatchProcessStarted: Bool = false
     var isManagedHatch: Bool = false
     var hasExistingManagedAssistant: Bool = false
     var hatchLogLines: [String] = []
@@ -197,6 +198,7 @@ final class OnboardingState {
     func resetForRetry() {
         // Reset hatch flags
         isHatching = false
+        hatchProcessStarted = false
         isManagedHatch = false
         hasExistingManagedAssistant = false
         hatchFailed = false


### PR DESCRIPTION
## Summary
- Move the hatch deduplication guard from a view-local `@State` variable (`hatchStarted`) on `HatchingStepView` to `OnboardingState.hatchProcessStarted`
- When SwiftUI recreates `HatchingStepView` during the onboarding flow, `@State` resets and `onAppear` fires again, triggering a second CLI hatch — creating two assistants
- The fix ensures the guard survives view lifecycle changes since `OnboardingState` is an `@Observable` model object that persists across view recreations
- Also reset the new flag in `resetForRetry()` and `retryHatch()` so deliberate retries still work

## Test plan
- [x] Build compiles cleanly
- [ ] Manual: retire all assistants, go through onboarding, verify only ONE assistant is created
- [ ] Manual: retry hatch still works after a failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
