### PR TITLE
feat(onboarding): personalized templated greeting from prechat selections

### DIFF
--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -6,6 +6,7 @@ const tempDir = process.env.VELLUM_WORKSPACE_DIR!;
 
 const { isWakeUpGreeting, getCannedFirstGreeting, CANNED_FIRST_GREETING } =
   await import("../daemon/first-greeting.js");
+import type { OnboardingGreetingContext } from "../daemon/first-greeting.js";
 
 describe("first-greeting", () => {
   describe("isWakeUpGreeting", () => {
@@ -49,11 +50,107 @@ describe("first-greeting", () => {
   });
 
   describe("getCannedFirstGreeting", () => {
-    it("returns the expected greeting string", () => {
+    it("returns the generic greeting when no onboarding context", () => {
       const greeting = getCannedFirstGreeting();
       expect(greeting).toBe(CANNED_FIRST_GREETING);
       expect(greeting).toContain("brand new");
-      expect(greeting).toContain("No name, no memories");
+    });
+
+    it("returns the generic greeting when onboarding is undefined", () => {
+      expect(getCannedFirstGreeting(undefined)).toBe(CANNED_FIRST_GREETING);
+    });
+  });
+
+  describe("personalized greeting", () => {
+    const base: OnboardingGreetingContext = {
+      tools: [],
+      tasks: [],
+      tone: "balanced",
+    };
+
+    it("includes user name when provided", () => {
+      const greeting = getCannedFirstGreeting({ ...base, userName: "Alex" });
+      expect(greeting).toContain("Alex");
+    });
+
+    it("includes assistant name when provided", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        assistantName: "Pax",
+      });
+      expect(greeting).toContain("I'm Pax");
+    });
+
+    it("uses casual tone", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tone: "casual",
+        userName: "Alex",
+      });
+      expect(greeting).toStartWith("Hey Alex!");
+    });
+
+    it("uses professional tone", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tone: "professional",
+        userName: "Alex",
+      });
+      expect(greeting).toStartWith("Hello, Alex.");
+    });
+
+    it("mentions selected tools", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tools: ["slack", "linear"],
+      });
+      expect(greeting).toContain("Slack");
+      expect(greeting).toContain("Linear");
+    });
+
+    it("truncates long tool lists", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tools: ["slack", "linear", "gmail", "notion"],
+      });
+      expect(greeting).toContain("Slack, Linear, and 2 more");
+    });
+
+    it("suggests actions from selected tasks", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tasks: ["code-building"],
+      });
+      expect(greeting).toContain("help you build something");
+    });
+
+    it("offers two suggestions when multiple tasks selected", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tasks: ["writing", "research"],
+      });
+      expect(greeting).toContain("draft or edit some writing");
+      expect(greeting).toContain("dig into a research question");
+    });
+
+    it("falls back to generic prompt when no tasks selected", () => {
+      const greeting = getCannedFirstGreeting({ ...base, tasks: [] });
+      expect(greeting).toContain("tackle first");
+    });
+
+    it("assembles a full personalized greeting", () => {
+      const greeting = getCannedFirstGreeting({
+        tools: ["slack", "github"],
+        tasks: ["code-building", "research"],
+        tone: "casual",
+        userName: "Alex",
+        assistantName: "Pax",
+      });
+      expect(greeting).toStartWith("Hey Alex!");
+      expect(greeting).toContain("I'm Pax");
+      expect(greeting).toContain("Slack");
+      expect(greeting).toContain("GitHub");
+      expect(greeting).toContain("help you build something");
     });
   });
 });

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -2,12 +2,14 @@ import { existsSync } from "node:fs";
 
 import { getWorkspacePromptPath } from "../util/platform.js";
 
-/**
- * The canned assistant response for the wake-up greeting on a fresh workspace.
- * Warm, non-presumptuous greeting that communicates "I'm new," "I improve over
- * time," and invites the user to lead with whatever they want — a task, a
- * question, or getting to know each other.
- */
+export interface OnboardingGreetingContext {
+  tools: string[];
+  tasks: string[];
+  tone: string;
+  userName?: string;
+  assistantName?: string;
+}
+
 export const CANNED_FIRST_GREETING =
   "Hey — I'm brand new. No name, no memories, no idea who you are yet. I'll get sharper the more we work together. What can I do for you?";
 
@@ -31,11 +33,86 @@ export function isWakeUpGreeting(
   );
 }
 
-/**
- * Returns the canned first-greeting string. Simple getter that exists to keep
- * the call site consistent and allow future flexibility (e.g., locale-aware
- * greetings) without changing the API.
- */
-export function getCannedFirstGreeting(): string {
+export function getCannedFirstGreeting(
+  onboarding?: OnboardingGreetingContext,
+): string {
+  if (onboarding) {
+    return buildPersonalizedGreeting(onboarding);
+  }
   return CANNED_FIRST_GREETING;
+}
+
+const TOOL_LABELS: Record<string, string> = {
+  gmail: "Gmail",
+  outlook: "Outlook",
+  "google-calendar": "Google Calendar",
+  slack: "Slack",
+  notion: "Notion",
+  linear: "Linear",
+  jira: "Jira",
+  github: "GitHub",
+  figma: "Figma",
+  "google-drive": "Google Drive",
+  excel: "Excel",
+  "apple-notes": "Apple Notes",
+};
+
+const TASK_SUGGESTIONS: Record<string, string> = {
+  "code-building": "help you build something",
+  writing: "draft or edit some writing",
+  research: "dig into a research question",
+  "project-management": "help organize a project",
+  scheduling: "sort out your schedule",
+  personal: "help with something personal",
+};
+
+function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {
+  const professional = ctx.tone === "professional";
+
+  const userName = ctx.userName?.trim();
+  const assistantName = ctx.assistantName?.trim();
+
+  const opener = userName
+    ? professional
+      ? `Hello, ${userName}.`
+      : `Hey ${userName}!`
+    : professional
+      ? "Hello."
+      : "Hey!";
+
+  const intro = assistantName
+    ? `I'm ${assistantName} — brand new and ready to learn how you work.`
+    : "I'm brand new and ready to learn how you work.";
+
+  const toolNames = ctx.tools.map((t) => TOOL_LABELS[t] ?? t).filter(Boolean);
+
+  let toolLine = "";
+  if (toolNames.length > 0) {
+    const list =
+      toolNames.length <= 3
+        ? toolNames.join(", ")
+        : `${toolNames.slice(0, 2).join(", ")}, and ${toolNames.length - 2} more`;
+    toolLine = professional
+      ? `I see you work with ${list} — good to know.`
+      : `I see you use ${list} — noted.`;
+  }
+
+  const suggestions = ctx.tasks.map((t) => TASK_SUGGESTIONS[t]).filter(Boolean);
+
+  let actionLine = "";
+  if (suggestions.length === 1) {
+    actionLine = `Want me to ${suggestions[0]}?`;
+  } else if (suggestions.length >= 2) {
+    actionLine = professional
+      ? `I can ${suggestions[0]} or ${suggestions[1]} — which sounds useful?`
+      : `I could ${suggestions[0]}, or ${suggestions[1]} — what sounds good?`;
+  }
+
+  if (!actionLine) {
+    actionLine = professional
+      ? "What would be most useful to start with?"
+      : "What should we tackle first?";
+  }
+
+  return [opener, intro, toolLine, actionLine].filter(Boolean).join(" ");
 }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1705,7 +1705,12 @@ export async function handleSendMessage(
   // On a completely fresh workspace, skip LLM inference for the macOS
   // wake-up greeting and return a pre-written response. This eliminates
   // 10-30s of inference latency on first boot.
-  if (isWakeUpGreeting(trimmedContent, conversation.getMessages().length)) {
+  // When onboarding context is present, skip the canned greeting so the
+  // model can generate a proactive response using the prechat selections.
+  if (
+    !body.onboarding &&
+    isWakeUpGreeting(trimmedContent, conversation.getMessages().length)
+  ) {
     const cannedGreeting = getCannedFirstGreeting();
     if (cannedGreeting) {
       conversation.processing = true;

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1707,48 +1707,46 @@ export async function handleSendMessage(
   // 10-30s of inference latency on first boot.
   // When onboarding context is present, skip the canned greeting so the
   // model can generate a proactive response using the prechat selections.
-  if (
-    !body.onboarding &&
-    isWakeUpGreeting(trimmedContent, conversation.getMessages().length)
-  ) {
-    const cannedGreeting = getCannedFirstGreeting();
-    if (cannedGreeting) {
-      conversation.processing = true;
-      let cleanupDeferred = false;
-      try {
-        const provenance = provenanceFromTrustContext(
-          conversation.trustContext,
-        );
-        const channelMeta = {
-          ...provenance,
-          userMessageChannel: sourceChannel,
-          assistantMessageChannel: sourceChannel,
-          userMessageInterface: sourceInterface,
-          assistantMessageInterface: sourceInterface,
-        };
+  if (isWakeUpGreeting(trimmedContent, conversation.getMessages().length)) {
+    const cannedGreeting = body.onboarding ? null : getCannedFirstGreeting();
 
-        const rawContent = content ?? "";
-        const attachments = hasAttachments
-          ? smDeps.resolveAttachments(attachmentIds)
-          : [];
-        const userMsg = createUserMessage(rawContent, attachments);
-        const persisted = await addMessage(
-          mapping.conversationId,
-          "user",
-          JSON.stringify(userMsg.content),
-          channelMeta,
-        );
-        conversation.getMessages().push(userMsg);
+    conversation.processing = true;
+    let cleanupDeferred = false;
+    try {
+      const provenance = provenanceFromTrustContext(conversation.trustContext);
+      const channelMeta = {
+        ...provenance,
+        userMessageChannel: sourceChannel,
+        assistantMessageChannel: sourceChannel,
+        userMessageInterface: sourceInterface,
+        assistantMessageInterface: sourceInterface,
+      };
 
-        setConversationOriginChannelIfUnset(
-          mapping.conversationId,
-          sourceChannel,
-        );
-        setConversationOriginInterfaceIfUnset(
-          mapping.conversationId,
-          sourceInterface,
-        );
+      const rawContent = content ?? "";
+      const attachments = hasAttachments
+        ? smDeps.resolveAttachments(attachmentIds)
+        : [];
+      const userMsg = createUserMessage(rawContent, attachments);
+      const persisted = await addMessage(
+        mapping.conversationId,
+        "user",
+        JSON.stringify(userMsg.content),
+        channelMeta,
+      );
+      conversation.getMessages().push(userMsg);
 
+      setConversationOriginChannelIfUnset(
+        mapping.conversationId,
+        sourceChannel,
+      );
+      setConversationOriginInterfaceIfUnset(
+        mapping.conversationId,
+        sourceInterface,
+      );
+
+      const conversationId = mapping.conversationId;
+
+      if (cannedGreeting) {
         const assistantMsg = createAssistantMessage(cannedGreeting);
         await addMessage(
           mapping.conversationId,
@@ -1758,7 +1756,6 @@ export async function handleSendMessage(
         );
         conversation.getMessages().push(assistantMsg);
 
-        const conversationId = mapping.conversationId;
         const response = Response.json(
           { accepted: true, messageId: persisted.id, conversationId },
           { status: 202 },
@@ -1790,11 +1787,77 @@ export async function handleSendMessage(
         );
         cleanupDeferred = true;
         return response;
-      } finally {
-        if (!cleanupDeferred && conversation.processing) {
-          conversation.processing = false;
-          silentlyWithLog(conversation.drainQueue(), "error-path queue drain");
-        }
+      }
+
+      // Onboarding context present — user message is persisted above,
+      // now hand off to the agent loop for a personalized greeting.
+      conversation.abortController = new AbortController();
+      conversation.currentRequestId = crypto.randomUUID();
+
+      conversation.setTurnChannelContext({
+        userMessageChannel: sourceChannel,
+        assistantMessageChannel: sourceChannel,
+      });
+      conversation.setTurnInterfaceContext({
+        userMessageInterface: sourceInterface,
+        assistantMessageInterface: sourceInterface,
+      });
+
+      onEvent({
+        type: "user_message_echo",
+        text: rawContent,
+        conversationId,
+        messageId: persisted.id,
+        clientMessageId,
+      });
+
+      const fallbackGreeting = getCannedFirstGreeting();
+      conversation
+        .runAgentLoop(rawContent, persisted.id, onEvent, {
+          isInteractive,
+          isUserMessage: true,
+        })
+        .catch((err) => {
+          log.error(
+            { err, conversationId },
+            "Agent loop failed (onboarding first greeting) — serving canned fallback",
+          );
+          if (fallbackGreeting) {
+            const assistantMsg = createAssistantMessage(fallbackGreeting);
+            addMessage(
+              conversationId,
+              "assistant",
+              JSON.stringify(assistantMsg.content),
+              channelMeta,
+            ).then(() => {
+              conversation.getMessages().push(assistantMsg);
+              onEvent({
+                type: "assistant_text_delta",
+                text: fallbackGreeting,
+              });
+              onEvent({ type: "message_complete", conversationId });
+              conversation.processing = false;
+              silentlyWithLog(
+                conversation.drainQueue(),
+                "onboarding-fallback queue drain",
+              );
+            });
+          }
+        });
+
+      log.info(
+        { conversationId },
+        "Skipped canned greeting — running agent loop with onboarding context",
+      );
+      cleanupDeferred = true;
+      return Response.json(
+        { accepted: true, messageId: persisted.id, conversationId },
+        { status: 202 },
+      );
+    } finally {
+      if (!cleanupDeferred && conversation.processing) {
+        conversation.processing = false;
+        silentlyWithLog(conversation.drainQueue(), "error-path queue drain");
       }
     }
   }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1703,12 +1703,11 @@ export async function handleSendMessage(
 
   // ── Canned first-greeting fast path ──
   // On a completely fresh workspace, skip LLM inference for the macOS
-  // wake-up greeting and return a pre-written response. This eliminates
-  // 10-30s of inference latency on first boot.
-  // When onboarding context is present, skip the canned greeting so the
-  // model can generate a proactive response using the prechat selections.
+  // wake-up greeting and return a pre-written response. When onboarding
+  // context is present the greeting is personalized using the selections;
+  // otherwise a generic greeting is served. Both paths are instant.
   if (isWakeUpGreeting(trimmedContent, conversation.getMessages().length)) {
-    const cannedGreeting = body.onboarding ? null : getCannedFirstGreeting();
+    const cannedGreeting = getCannedFirstGreeting(body.onboarding ?? undefined);
 
     conversation.processing = true;
     let cleanupDeferred = false;
@@ -1746,114 +1745,43 @@ export async function handleSendMessage(
 
       const conversationId = mapping.conversationId;
 
-      if (cannedGreeting) {
-        const assistantMsg = createAssistantMessage(cannedGreeting);
-        await addMessage(
-          mapping.conversationId,
-          "assistant",
-          JSON.stringify(assistantMsg.content),
-          channelMeta,
-        );
-        conversation.getMessages().push(assistantMsg);
-
-        const response = Response.json(
-          { accepted: true, messageId: persisted.id, conversationId },
-          { status: 202 },
-        );
-
-        // Defer event publishing to next tick (same pattern as unknown-slash
-        // fast path) so the HTTP response reaches the client before SSE
-        // events arrive.
-        setTimeout(() => {
-          onEvent({
-            type: "user_message_echo",
-            text: rawContent,
-            conversationId,
-            messageId: persisted.id,
-            clientMessageId,
-          });
-          onEvent({ type: "assistant_text_delta", text: cannedGreeting });
-          onEvent({ type: "message_complete", conversationId });
-          conversation.processing = false;
-          silentlyWithLog(
-            conversation.drainQueue(),
-            "canned-greeting queue drain",
-          );
-        }, 0);
-
-        log.info(
-          { conversationId },
-          "Served canned first greeting — skipped LLM inference",
-        );
-        cleanupDeferred = true;
-        return response;
-      }
-
-      // Onboarding context present — user message is persisted above,
-      // now hand off to the agent loop for a personalized greeting.
-      conversation.abortController = new AbortController();
-      conversation.currentRequestId = crypto.randomUUID();
-
-      conversation.setTurnChannelContext({
-        userMessageChannel: sourceChannel,
-        assistantMessageChannel: sourceChannel,
-      });
-      conversation.setTurnInterfaceContext({
-        userMessageInterface: sourceInterface,
-        assistantMessageInterface: sourceInterface,
-      });
-
-      onEvent({
-        type: "user_message_echo",
-        text: rawContent,
-        conversationId,
-        messageId: persisted.id,
-        clientMessageId,
-      });
-
-      const fallbackGreeting = getCannedFirstGreeting();
-      conversation
-        .runAgentLoop(rawContent, persisted.id, onEvent, {
-          isInteractive,
-          isUserMessage: true,
-        })
-        .catch((err) => {
-          log.error(
-            { err, conversationId },
-            "Agent loop failed (onboarding first greeting) — serving canned fallback",
-          );
-          if (fallbackGreeting) {
-            const assistantMsg = createAssistantMessage(fallbackGreeting);
-            addMessage(
-              conversationId,
-              "assistant",
-              JSON.stringify(assistantMsg.content),
-              channelMeta,
-            ).then(() => {
-              conversation.getMessages().push(assistantMsg);
-              onEvent({
-                type: "assistant_text_delta",
-                text: fallbackGreeting,
-              });
-              onEvent({ type: "message_complete", conversationId });
-              conversation.processing = false;
-              silentlyWithLog(
-                conversation.drainQueue(),
-                "onboarding-fallback queue drain",
-              );
-            });
-          }
-        });
-
-      log.info(
-        { conversationId },
-        "Skipped canned greeting — running agent loop with onboarding context",
+      const assistantMsg = createAssistantMessage(cannedGreeting);
+      await addMessage(
+        mapping.conversationId,
+        "assistant",
+        JSON.stringify(assistantMsg.content),
+        channelMeta,
       );
-      cleanupDeferred = true;
-      return Response.json(
+      conversation.getMessages().push(assistantMsg);
+
+      const response = Response.json(
         { accepted: true, messageId: persisted.id, conversationId },
         { status: 202 },
       );
+
+      setTimeout(() => {
+        onEvent({
+          type: "user_message_echo",
+          text: rawContent,
+          conversationId,
+          messageId: persisted.id,
+          clientMessageId,
+        });
+        onEvent({ type: "assistant_text_delta", text: cannedGreeting });
+        onEvent({ type: "message_complete", conversationId });
+        conversation.processing = false;
+        silentlyWithLog(
+          conversation.drainQueue(),
+          "canned-greeting queue drain",
+        );
+      }, 0);
+
+      log.info(
+        { conversationId, personalized: !!body.onboarding },
+        "Served canned first greeting — skipped LLM inference",
+      );
+      cleanupDeferred = true;
+      return response;
     } finally {
       if (!cleanupDeferred && conversation.processing) {
         conversation.processing = false;


### PR DESCRIPTION
## Summary
- Replace the slow LLM agent loop for first-boot greetings with instant templated personalization
- `getCannedFirstGreeting()` now accepts onboarding context and interpolates user name, assistant name, selected tools, tasks, and tone
- Both onboarding and non-onboarding paths use the same fast canned greeting mechanism — no more 10-20s inference delay
- Tool mentions are neutral ("I see you use Slack, Linear — noted.") to avoid implying OAuth integrations exist

## Example output
**Input**: tools=["slack","github"], tasks=["code-building","research"], tone="casual", userName="Alex", assistantName="Pax"

**Output**: "Hey Alex! I'm Pax — brand new and ready to learn how you work. I see you use Slack, GitHub — noted. I could help you build something, or dig into a research question — what sounds good?"

## Test plan
- [x] `first-greeting.test.ts` passes (18 tests — 10 new for personalization)
- [ ] Manual: retire, go through prechat flow, verify personalized greeting appears instantly
- [ ] Manual: skip prechat flow, verify generic canned greeting still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)