### PR TITLE
fix(slack): add assistant_view feature to manifest for assistant:write scope

### DIFF
--- a/skills/slack-app-setup/generate-manifest-url.ts
+++ b/skills/slack-app-setup/generate-manifest-url.ts
@@ -33,6 +33,10 @@ const manifest = {
       display_name: name,
       always_online: true,
     },
+    assistant_view: {
+      assistant_description: desc || name,
+      suggested_prompts: [],
+    },
   },
   oauth_config: {
     scopes: {


### PR DESCRIPTION
## Summary
- Adds `features.assistant_view` to the Slack app manifest so the `assistant:write` bot scope passes Slack's manifest validation
- Without this, the one-click app creation link fails with "errors in the 3rd party manifest file"
- The assistant_view feature also makes the bot appear in Slack's top-bar agents panel

## Test plan
- [x] Tested the generated manifest URL — Slack accepts it and creates the app successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
