### PR TITLE
feat(permissions): add ArgSchema types and shared parseArgs() utility

### DIFF
--- a/assistant/src/permissions/arg-parser.test.ts
+++ b/assistant/src/permissions/arg-parser.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseArgs } from "./arg-parser.js";
+
+describe("parseArgs", () => {
+  test("boolean flags", () => {
+    const result = parseArgs(["-v", "-f"], {});
+    expect(result.flags.get("-v")).toBe(true);
+    expect(result.flags.get("-f")).toBe(true);
+    expect(result.positionals).toEqual([]);
+    expect(result.pathArgs).toEqual([]);
+    expect(result.sawDoubleDash).toBe(false);
+  });
+
+  test("value-consuming flags", () => {
+    const result = parseArgs(["-o", "out.txt", "in.txt"], {
+      valueFlags: ["-o"],
+    });
+    expect(result.flags.get("-o")).toBe("out.txt");
+    expect(result.positionals).toEqual(["in.txt"]);
+    // Default positionals mode is "paths", so in.txt is a path.
+    expect(result.pathArgs).toEqual(["in.txt"]);
+  });
+
+  test("path flags", () => {
+    const result = parseArgs(["-t", "/tmp/dir", "file.txt"], {
+      valueFlags: ["-t"],
+      pathFlags: { "-t": true },
+    });
+    expect(result.flags.get("-t")).toBe("/tmp/dir");
+    expect(result.positionals).toEqual(["file.txt"]);
+    // /tmp/dir from pathFlag + file.txt from default positional "paths" mode.
+    expect(result.pathArgs).toEqual(["/tmp/dir", "file.txt"]);
+  });
+
+  test("-- terminator", () => {
+    const result = parseArgs(["--", "-notaflag"], {});
+    expect(result.sawDoubleDash).toBe(true);
+    expect(result.positionals).toEqual(["-notaflag"]);
+    expect(result.pathArgs).toEqual(["-notaflag"]);
+    expect(result.flags.size).toBe(0);
+  });
+
+  test("respectsDoubleDash: false", () => {
+    const result = parseArgs(["--", "-notaflag"], {
+      respectsDoubleDash: false,
+    });
+    // `--` is treated as a boolean flag, not a terminator.
+    expect(result.sawDoubleDash).toBe(false);
+    expect(result.flags.get("--")).toBe(true);
+    expect(result.flags.get("-notaflag")).toBe(true);
+    expect(result.positionals).toEqual([]);
+  });
+
+  test("positionals 'paths' (default) — all positionals in pathArgs", () => {
+    const result = parseArgs(["a.txt", "b.txt"], {});
+    expect(result.positionals).toEqual(["a.txt", "b.txt"]);
+    expect(result.pathArgs).toEqual(["a.txt", "b.txt"]);
+  });
+
+  test("positionals 'paths' (explicit) — all positionals in pathArgs", () => {
+    const result = parseArgs(["a.txt", "b.txt"], { positionals: "paths" });
+    expect(result.positionals).toEqual(["a.txt", "b.txt"]);
+    expect(result.pathArgs).toEqual(["a.txt", "b.txt"]);
+  });
+
+  test("positionals 'none' — no positionals in pathArgs", () => {
+    const result = parseArgs(["a.txt", "b.txt"], { positionals: "none" });
+    expect(result.positionals).toEqual(["a.txt", "b.txt"]);
+    expect(result.pathArgs).toEqual([]);
+  });
+
+  test("mixed positionals (array) with rest descriptor", () => {
+    const result = parseArgs(["pattern", "file1.txt", "file2.txt"], {
+      positionals: [{ role: "pattern" }, { role: "path", rest: true }],
+    });
+    expect(result.positionals).toEqual(["pattern", "file1.txt", "file2.txt"]);
+    // "pattern" has role "pattern" → not a path.
+    // "file1.txt" at index 1 has role "path" with rest → path.
+    // "file2.txt" at index 2 exceeds array but rest descriptor applies → path.
+    expect(result.pathArgs).toEqual(["file1.txt", "file2.txt"]);
+  });
+
+  test("positional array without rest — excess positionals default to path", () => {
+    const result = parseArgs(["script", "extra1", "extra2"], {
+      positionals: [{ role: "script" }],
+    });
+    expect(result.positionals).toEqual(["script", "extra1", "extra2"]);
+    // "script" → role "script" → not a path.
+    // "extra1", "extra2" → no descriptor, no rest → conservative default → path.
+    expect(result.pathArgs).toEqual(["extra1", "extra2"]);
+  });
+
+  test("empty args", () => {
+    const result = parseArgs([], {});
+    expect(result.flags.size).toBe(0);
+    expect(result.positionals).toEqual([]);
+    expect(result.pathArgs).toEqual([]);
+    expect(result.sawDoubleDash).toBe(false);
+  });
+
+  test("value-consuming flag at end of args with no next token — treated as boolean", () => {
+    const result = parseArgs(["-o"], { valueFlags: ["-o"] });
+    expect(result.flags.get("-o")).toBe(true);
+    expect(result.positionals).toEqual([]);
+    expect(result.pathArgs).toEqual([]);
+  });
+
+  test("positionals after -- are still classified by positional descriptors", () => {
+    const result = parseArgs(["--", "pattern", "file.txt"], {
+      positionals: [{ role: "pattern" }, { role: "path" }],
+    });
+    expect(result.sawDoubleDash).toBe(true);
+    expect(result.positionals).toEqual(["pattern", "file.txt"]);
+    // "pattern" at index 0 → role "pattern" → not a path.
+    // "file.txt" at index 1 → role "path" → path.
+    expect(result.pathArgs).toEqual(["file.txt"]);
+  });
+
+  test("value flag value is not added to pathArgs unless flag is in pathFlags", () => {
+    const result = parseArgs(["-o", "/some/path"], {
+      valueFlags: ["-o"],
+      positionals: "none",
+    });
+    expect(result.flags.get("-o")).toBe("/some/path");
+    // -o is not in pathFlags, so the value is not a path.
+    expect(result.pathArgs).toEqual([]);
+  });
+
+  test("multiple path flags accumulate in pathArgs", () => {
+    const result = parseArgs(["-I", "/include1", "-I", "/include2", "src.c"], {
+      valueFlags: ["-I"],
+      pathFlags: { "-I": true },
+    });
+    expect(result.flags.get("-I")).toBe("/include2"); // last value wins in Map
+    expect(result.positionals).toEqual(["src.c"]);
+    expect(result.pathArgs).toEqual(["/include1", "/include2", "src.c"]);
+  });
+});

--- a/assistant/src/permissions/arg-parser.ts
+++ b/assistant/src/permissions/arg-parser.ts
@@ -1,0 +1,123 @@
+import type { ArgSchema, ParsedArgs, PositionalDesc } from "./risk-types.js";
+
+/**
+ * Parse a command's arguments according to an {@link ArgSchema}.
+ *
+ * Classifies each token as a flag, positional, or path argument. The
+ * resulting {@link ParsedArgs} is consumed by downstream path-resolution
+ * and sandbox-policy checks.
+ */
+export function parseArgs(args: string[], schema: ArgSchema): ParsedArgs {
+  const valueFlagSet = new Set(schema.valueFlags);
+  const pathFlagSet = new Set(
+    schema.pathFlags ? Object.keys(schema.pathFlags) : [],
+  );
+
+  const flags = new Map<string, string | true>();
+  const positionals: string[] = [];
+  const pathArgs: string[] = [];
+  let sawDoubleDash = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const token = args[i]!;
+
+    // After `--`, everything is positional.
+    if (sawDoubleDash) {
+      positionals.push(token);
+      addIfPath(token, positionals.length - 1, schema.positionals, pathArgs);
+      i++;
+      continue;
+    }
+
+    // Double-dash terminator.
+    if (token === "--" && schema.respectsDoubleDash !== false) {
+      sawDoubleDash = true;
+      i++;
+      continue;
+    }
+
+    // Value-consuming flag: consume next token as the flag's value.
+    if (token.startsWith("-") && valueFlagSet.has(token)) {
+      const nextIndex = i + 1;
+      if (nextIndex < args.length) {
+        const value = args[nextIndex]!;
+        flags.set(token, value);
+        if (pathFlagSet.has(token)) {
+          pathArgs.push(value);
+        }
+        i += 2;
+      } else {
+        // Flag at end of args with no next token — treat as boolean.
+        flags.set(token, true);
+        i++;
+      }
+      continue;
+    }
+
+    // Boolean flag (starts with `-` but not a value-consuming flag).
+    if (token.startsWith("-")) {
+      flags.set(token, true);
+      i++;
+      continue;
+    }
+
+    // Positional argument.
+    positionals.push(token);
+    addIfPath(token, positionals.length - 1, schema.positionals, pathArgs);
+    i++;
+  }
+
+  return { flags, positionals, pathArgs, sawDoubleDash };
+}
+
+/**
+ * Determine whether a positional at the given index is a path and, if so,
+ * add it to `pathArgs`.
+ */
+function addIfPath(
+  token: string,
+  index: number,
+  positionalsDef: ArgSchema["positionals"],
+  pathArgs: string[],
+): void {
+  if (positionalsDef === undefined || positionalsDef === "paths") {
+    // Default: all positionals are paths.
+    pathArgs.push(token);
+    return;
+  }
+
+  if (positionalsDef === "none") {
+    // Explicitly not paths.
+    return;
+  }
+
+  // Array of PositionalDesc — look up by index.
+  const descs: PositionalDesc[] = positionalsDef;
+
+  // Find the applicable descriptor: either the one at this index, or a
+  // previous `rest: true` descriptor that covers all subsequent positions.
+  let desc: PositionalDesc | undefined;
+
+  if (index < descs.length) {
+    desc = descs[index];
+  } else {
+    // Look backwards for the last `rest: true` descriptor.
+    for (let j = descs.length - 1; j >= 0; j--) {
+      if (descs[j]!.rest) {
+        desc = descs[j];
+        break;
+      }
+    }
+  }
+
+  if (desc) {
+    if (desc.role === "path") {
+      pathArgs.push(token);
+    }
+    // Other roles (pattern, script, value, command) → not a path.
+  } else {
+    // No descriptor and no rest — conservative default: treat as path.
+    pathArgs.push(token);
+  }
+}

--- a/assistant/src/permissions/risk-types.ts
+++ b/assistant/src/permissions/risk-types.ts
@@ -163,6 +163,64 @@ export interface CommandRiskSpec {
    * without consulting the user's autoApproveUpTo threshold.
    */
   sandboxAutoApprove?: boolean;
+  /**
+   * Arg-parsing schema for extracting structured argument information.
+   * Used by `parseArgs()` to classify args into flags, positionals, and
+   * path arguments for downstream path-based policy checks.
+   */
+  argSchema?: ArgSchema;
+}
+
+// ── Arg schema types ─────────────────────────────────────────────────────────
+
+/** Describes the role of a positional argument in a command. */
+export interface PositionalDesc {
+  /** The semantic role of this positional argument. */
+  role: "path" | "pattern" | "script" | "value" | "command";
+  /**
+   * When true, this descriptor applies to all subsequent positionals too
+   * (i.e. the remaining args are all of this role).
+   */
+  rest?: boolean;
+}
+
+/**
+ * Schema for parsing a command's arguments into structured data.
+ *
+ * Drives the `parseArgs()` utility to classify each token as a flag,
+ * positional, or path argument.
+ */
+export interface ArgSchema {
+  /** Flags that consume the next token as a value (e.g. `-o`, `--output`). */
+  valueFlags?: string[];
+  /**
+   * Describes how positional arguments should be interpreted:
+   * - `"paths"` (or omitted): all positionals are filesystem paths
+   * - `"none"`: no positionals are filesystem paths
+   * - `PositionalDesc[]`: per-index role descriptors
+   */
+  positionals?: "paths" | "none" | PositionalDesc[];
+  /** Flag names whose consumed values are filesystem paths (e.g. `{ "-t": true }`). */
+  pathFlags?: Record<string, true>;
+  /**
+   * Whether `--` ends flag parsing (everything after is positional).
+   * Defaults to `true` when omitted.
+   */
+  respectsDoubleDash?: boolean;
+}
+
+/**
+ * The result of parsing a command's arguments via `parseArgs()`.
+ */
+export interface ParsedArgs {
+  /** Flag name to value (`true` for boolean flags, string for value-consuming flags). */
+  flags: Map<string, string | true>;
+  /** All positional arguments in order. */
+  positionals: string[];
+  /** Subset of positionals and flag values that are filesystem paths. */
+  pathArgs: string[];
+  /** Whether a `--` double-dash terminator was encountered. */
+  sawDoubleDash: boolean;
 }
 
 // ── User rule types ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add ArgSchema, PositionalDesc, ParsedArgs types to risk-types.ts
- Add argSchema field to CommandRiskSpec
- Implement parseArgs() shared utility for extracting path arguments from command args
- Comprehensive unit tests for all parseArgs() behaviors

Part of plan: sandbox-auto-approve-phase2.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
