### PR TITLE
fix(network): dedicated URLSession for BTW streaming (LUM-820, LUM-903)

### DIFF
--- a/clients/shared/Network/BtwClient.swift
+++ b/clients/shared/Network/BtwClient.swift
@@ -39,10 +39,18 @@ public struct BtwClient: BtwClientProtocol {
         ]
         let bodyData = try JSONSerialization.data(withJSONObject: body)
 
+        // Dedicated per-call session so `invalidateAndCancel()` can tear down
+        // the underlying data task on its own terms when the stream ends or
+        // the consumer cancels — avoids a use-after-free race between
+        // `Task.cancel()` and the `AsyncBytes` iterator on `URLSession.shared`.
+        let session = URLSession(configuration: .default)
+        defer { session.invalidateAndCancel() }
+
         let (bytes, response) = try await GatewayHTTPClient.streamPostWithRetry(
             path: "assistants/{assistantId}/btw",
             body: bodyData,
-            timeout: 120
+            timeout: 120,
+            session: session
         )
 
         guard let http = response as? HTTPURLResponse else {

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -478,15 +478,19 @@ public enum GatewayHTTPClient {
     ///   - path: Path segment after `/v1/`.
     ///   - body: Pre-serialized request body data.
     ///   - timeout: Request timeout in seconds. Defaults to 30.
+    ///   - session: The `URLSession` to use. Defaults to `.shared`. Pass a dedicated
+    ///     session when the caller needs to control the lifecycle of the underlying
+    ///     data task (e.g. to safely cancel a stream without a use-after-free
+    ///     in `AsyncBytes`).
     /// - Returns: A tuple of `(URLSession.AsyncBytes, URLResponse)` for streaming consumption.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func streamPost(path: String, body: Data, timeout: TimeInterval = 30) async throws -> (URLSession.AsyncBytes, URLResponse) {
+    public static func streamPost(path: String, body: Data, timeout: TimeInterval = 30, session: URLSession = .shared) async throws -> (URLSession.AsyncBytes, URLResponse) {
         let connection = try resolveConnection()
         var request = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: connection)
         request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
         request.httpBody = body
         logOutgoing(request, quiet: false)
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let (bytes, response) = try await session.bytes(for: request)
         if let http = response as? HTTPURLResponse {
             logResponse(request, http: http, quiet: false)
         }
@@ -504,18 +508,22 @@ public enum GatewayHTTPClient {
     ///   - path: Path segment after `/v1/`.
     ///   - body: Pre-serialized request body data.
     ///   - timeout: Request timeout in seconds. Defaults to 30.
+    ///   - session: The `URLSession` to use. Defaults to `.shared`. Pass a dedicated
+    ///     session when the caller needs to control the lifecycle of the underlying
+    ///     data task (e.g. to safely cancel a stream without a use-after-free
+    ///     in `AsyncBytes`).
     /// - Returns: A tuple of `(URLSession.AsyncBytes, URLResponse)` for streaming consumption.
     /// - Throws: `ClientError` if the request cannot be constructed,
     ///   `URLError(.userAuthenticationRequired)` if credential refresh fails,
     ///   or network errors from `URLSession`.
-    public static func streamPostWithRetry(path: String, body: Data, timeout: TimeInterval = 30) async throws -> (URLSession.AsyncBytes, URLResponse) {
+    public static func streamPostWithRetry(path: String, body: Data, timeout: TimeInterval = 30, session: URLSession = .shared) async throws -> (URLSession.AsyncBytes, URLResponse) {
         let connection = try resolveConnection()
         var request = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: connection)
         request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
         request.httpBody = body
         logOutgoing(request, quiet: false)
 
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let (bytes, response) = try await session.bytes(for: request)
 
         guard let http = response as? HTTPURLResponse else {
             return (bytes, response)
@@ -541,7 +549,7 @@ public enum GatewayHTTPClient {
         retryRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
         retryRequest.httpBody = body
         logOutgoing(retryRequest, quiet: false)
-        let (retryBytes, retryResponse) = try await URLSession.shared.bytes(for: retryRequest)
+        let (retryBytes, retryResponse) = try await session.bytes(for: retryRequest)
         if let retryHttp = retryResponse as? HTTPURLResponse {
             logResponse(retryRequest, http: retryHttp, quiet: false)
         }


### PR DESCRIPTION
## Summary

- Fixes EXC_BAD_ACCESS crashes in BTW streaming (Sentry MACOS-EB, 8 events / 4 users) by adopting the PR #25396 per-call `URLSession` pattern for `streamPost` and `streamPostWithRetry`.
- `BtwClient` now creates a dedicated `URLSession` per `sendMessage` call and invalidates it when the stream finishes (including on error or consumer cancellation).
- `GatewayHTTPClient.streamPost` and `streamPostWithRetry` gain a `session: URLSession = .shared` parameter — default-valued so existing callers are unaffected.

## Why

Running streaming `URLSession.bytes(for:)` on `URLSession.shared` races `Task.cancel()` against the `AsyncBytes` cooperative-pool iterator. When the shared session's internal state is torn down while the iterator is still reading, `CheckedContinuation.resume` hits freed memory and the process crashes with `KERN_INVALID_ADDRESS at 0x28` in `NSURLSession.data` → `__NSCFURLSessionDelegateWrapper` → `_task_onqueue_didFinish`.

The fix in #25396 (EventStreamClient SSE) moved the main event stream to a per-connection session so `invalidateAndCancel()` can tear down the data task on its own terms. This PR ports the same pattern to the remaining streaming paths (`streamPost`, `streamPostWithRetry`) and to their sole caller, `BtwClient`.

## Tickets resolved

- LUM-820 — EXC_BAD_ACCESS in `CheckedContinuation.resume` during `URLSession.data` callback
- LUM-903 — `streamPost`/`streamPostWithRetry` still use `URLSession.shared`

## Deferred to LUM-1001

A separate Devin session is landing `SafeAsyncBytes` — a delegate-based async bytes wrapper that survives concurrent session invalidation. That's a larger change; this PR intentionally stops at the minimal #25396 pattern to unblock users on the crash signal now. The two are compatible: the session parameter added here carries through.

## Testing

- Exercise BTW side-chain (inline \"btw …\" question) in a conversation; confirm streamed response renders normally.
- Cancel a BTW stream mid-flight (navigate away or start a new BTW while one is in flight); confirm no crash.
- Trigger a 401 during BTW (e.g. force a token expiry); confirm the retry path succeeds on the same per-call session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
