### PR TITLE
fix(test): align slack skill regression test with current skill wording

### DIFF
--- a/assistant/src/__tests__/slack-app-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/slack-app-setup-skill-regression.test.ts
@@ -19,7 +19,9 @@ describe("slack-app-setup skill regression", () => {
 
   test("forbids plaintext forms and chat-pasted secrets", () => {
     expect(skillContent).toContain("Do NOT use `ui_show`");
-    expect(skillContent).toContain("Do NOT ask the user to paste them in chat");
+    expect(skillContent).toContain(
+      "Do NOT ask the user to paste tokens in chat",
+    );
   });
 
   test("does not instruct the agent to reimplement Slack validation in shell", () => {


### PR DESCRIPTION
## Summary
- The `slack-app-setup-skill-regression` test expected `"Do NOT ask the user to paste them in chat"` but the skill file says `"Do NOT ask the user to paste tokens in chat"` — updated the test assertion to match.

## Test plan
- [x] `slack-app-setup-skill-regression.test.ts` passes locally (3/3 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
