### PR TITLE
feat(flags): add compaction-playground dev-only feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -384,6 +384,14 @@
       "label": "Auto-Approve Threshold UI",
       "description": "Enable user-configurable auto-approve thresholds stored in the gateway. When enabled, the assistant reads thresholds from the gateway instead of config.json, and the macOS client shows threshold controls in Settings and the chat composer.",
       "defaultEnabled": false
+    },
+    {
+      "id": "compaction-playground",
+      "scope": "assistant",
+      "key": "compaction-playground",
+      "label": "Compaction Playground",
+      "description": "Expose the developer-only Compaction Playground tab in macOS Settings and enable the /playground/* HTTP endpoints for exercising compaction conditions. Dev-only; default off.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Register new `compaction-playground` flag in the assistant feature-flag registry (scope: assistant, defaultEnabled: false)
- No consumers yet — subsequent PRs in the plan add daemon endpoints and the macOS Settings tab

## Follow-up
Companion PR required in `vellum-assistant-platform` to add this flag to the LaunchDarkly Terraform configuration. See the 'Assistant Feature Flags' section of the root `CLAUDE.md`.

Part of plan: compaction-playground-macos.md (PR 1 of 17)
Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
