### PR TITLE
feat(macos): add CompactionPlaygroundClient HTTP wrapper

### DIFF
--- a/clients/shared/Network/CompactionPlaygroundClient.swift
+++ b/clients/shared/Network/CompactionPlaygroundClient.swift
@@ -1,0 +1,166 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "CompactionPlaygroundClient")
+
+/// Errors surfaced by ``CompactionPlaygroundClient``.
+///
+/// The 404 mapping distinguishes between "the playground feature is disabled"
+/// (flat `/playground/*` routes returning 404 means the flag is off on the
+/// daemon) and "this specific conversation doesn't exist" (a 404 on a
+/// conversation-scoped route).
+public enum CompactionPlaygroundError: Error {
+    /// The playground feature flag is off — flat `/playground/*` routes
+    /// returned 404.
+    case notAvailable
+    /// The requested conversation was not found.
+    case notFound
+    /// A non-2xx response that does not fit the other cases.
+    case http(statusCode: Int)
+}
+
+/// Focused client for the daemon's compaction-playground HTTP surface.
+///
+/// All paths are gateway-relative and the gateway proxies to the daemon's
+/// `/v1/*` routes. Paths with a `/conversations/<id>/` segment target a
+/// specific conversation; paths without one target the global playground
+/// namespace and surface 404 as ``CompactionPlaygroundError/notAvailable``
+/// (a flag-off indicator).
+public protocol CompactionPlaygroundClientProtocol {
+    func forceCompact(conversationId: String) async throws -> CompactionForceResponse
+    func seedConversation(turns: Int, avgTokensPerTurn: Int?, title: String?) async throws -> SeedConversationResponse
+    func injectFailures(conversationId: String, consecutiveFailures: Int?, circuitOpenForMs: Int?) async throws
+    func resetCircuit(conversationId: String) async throws
+    func getState(conversationId: String) async throws -> CompactionStateResponse
+    func listSeededConversations() async throws -> SeededConversationsListResponse
+    func deleteSeededConversation(id: String) async throws -> DeleteSeededConversationsResponse
+    func deleteAllSeededConversations() async throws -> DeleteSeededConversationsResponse
+}
+
+/// Gateway-backed implementation of ``CompactionPlaygroundClientProtocol``.
+public struct CompactionPlaygroundClient: CompactionPlaygroundClientProtocol {
+    nonisolated public init() {}
+
+    // MARK: - Compaction actions (conversation-scoped)
+
+    public func forceCompact(conversationId: String) async throws -> CompactionForceResponse {
+        let path = "assistants/{assistantId}/conversations/\(conversationId)/playground/compact"
+        let response = try await GatewayHTTPClient.post(path: path, json: [:], timeout: 120)
+        try throwIfUnsuccessful(response, path: path)
+        return try JSONDecoder().decode(CompactionForceResponse.self, from: response.data)
+    }
+
+    public func injectFailures(
+        conversationId: String,
+        consecutiveFailures: Int?,
+        circuitOpenForMs: Int?
+    ) async throws {
+        let path = "assistants/{assistantId}/conversations/\(conversationId)/playground/inject-compaction-failures"
+        let body = InjectFailuresRequest(
+            consecutiveFailures: consecutiveFailures,
+            circuitOpenForMs: circuitOpenForMs
+        )
+        let response = try await GatewayHTTPClient.post(
+            path: path,
+            json: try jsonObject(from: body),
+            timeout: 15
+        )
+        try throwIfUnsuccessful(response, path: path)
+    }
+
+    public func resetCircuit(conversationId: String) async throws {
+        let path = "assistants/{assistantId}/conversations/\(conversationId)/playground/reset-compaction-circuit"
+        let response = try await GatewayHTTPClient.post(path: path, json: [:], timeout: 15)
+        try throwIfUnsuccessful(response, path: path)
+    }
+
+    public func getState(conversationId: String) async throws -> CompactionStateResponse {
+        let path = "assistants/{assistantId}/conversations/\(conversationId)/playground/compaction-state"
+        let response = try await GatewayHTTPClient.get(path: path, timeout: 15)
+        try throwIfUnsuccessful(response, path: path)
+        return try JSONDecoder().decode(CompactionStateResponse.self, from: response.data)
+    }
+
+    // MARK: - Seeded conversations (global playground)
+
+    public func seedConversation(
+        turns: Int,
+        avgTokensPerTurn: Int?,
+        title: String?
+    ) async throws -> SeedConversationResponse {
+        let path = "assistants/{assistantId}/playground/seed-conversation"
+        let body = SeedConversationRequest(
+            turns: turns,
+            avgTokensPerTurn: avgTokensPerTurn,
+            title: title
+        )
+        let response = try await GatewayHTTPClient.post(
+            path: path,
+            json: try jsonObject(from: body),
+            timeout: 60
+        )
+        try throwIfUnsuccessful(response, path: path)
+        return try JSONDecoder().decode(SeedConversationResponse.self, from: response.data)
+    }
+
+    public func listSeededConversations() async throws -> SeededConversationsListResponse {
+        let path = "assistants/{assistantId}/playground/seeded-conversations"
+        let response = try await GatewayHTTPClient.get(path: path, timeout: 15)
+        try throwIfUnsuccessful(response, path: path)
+        return try JSONDecoder().decode(SeededConversationsListResponse.self, from: response.data)
+    }
+
+    public func deleteSeededConversation(id: String) async throws -> DeleteSeededConversationsResponse {
+        let path = "assistants/{assistantId}/playground/seeded-conversations/\(id)"
+        let response = try await GatewayHTTPClient.delete(path: path, timeout: 15)
+        try throwIfUnsuccessful(response, path: path)
+        return try JSONDecoder().decode(DeleteSeededConversationsResponse.self, from: response.data)
+    }
+
+    public func deleteAllSeededConversations() async throws -> DeleteSeededConversationsResponse {
+        let path = "assistants/{assistantId}/playground/seeded-conversations"
+        let response = try await GatewayHTTPClient.delete(path: path, timeout: 30)
+        try throwIfUnsuccessful(response, path: path)
+        return try JSONDecoder().decode(DeleteSeededConversationsResponse.self, from: response.data)
+    }
+
+    // MARK: - Helpers
+
+    /// Serializes a `Codable` request body into the `[String: Any]` shape
+    /// expected by `GatewayHTTPClient.post(path:json:timeout:)`.
+    ///
+    /// Optional properties set to `nil` are omitted from the JSON output by
+    /// `JSONEncoder` (the default behaviour), matching the daemon's expected
+    /// partial-update semantics for the playground requests.
+    private func jsonObject<T: Encodable>(from value: T) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(value)
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return [:]
+        }
+        return object
+    }
+
+    /// Maps non-success responses to ``CompactionPlaygroundError``.
+    ///
+    /// 404 on a path without a `/conversations/` segment indicates the
+    /// playground feature flag is disabled on the daemon — the daemon's
+    /// `/v1/assistants/{id}/playground/*` routes aren't mounted when the flag
+    /// is off. 404 on a conversation-scoped path indicates the conversation
+    /// doesn't exist.
+    private func throwIfUnsuccessful(_ response: GatewayHTTPClient.Response, path: String) throws {
+        guard !response.isSuccess else { return }
+
+        if response.statusCode == 404 {
+            if path.contains("/conversations/") {
+                log.error("compaction playground 404 (not found) for path \(path, privacy: .public)")
+                throw CompactionPlaygroundError.notFound
+            } else {
+                log.error("compaction playground 404 (flag off) for path \(path, privacy: .public)")
+                throw CompactionPlaygroundError.notAvailable
+            }
+        }
+
+        log.error("compaction playground HTTP \(response.statusCode, privacy: .public) for path \(path, privacy: .public)")
+        throw CompactionPlaygroundError.http(statusCode: response.statusCode)
+    }
+}

--- a/clients/shared/Network/CompactionPlaygroundTypes.swift
+++ b/clients/shared/Network/CompactionPlaygroundTypes.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+// MARK: - Compaction Playground Wire Types
+//
+// Codable types mirroring the daemon's compaction-playground HTTP surface.
+// Keys are lowerCamelCase to match the daemon JSON convention — do not add a
+// key-decoding strategy; the wire contract already matches Swift property names.
+
+/// Response from `POST /v1/assistants/{id}/conversations/{id}/playground/compact`.
+public struct CompactionForceResponse: Codable, Sendable {
+    public let compacted: Bool
+    public let previousTokens: Int
+    public let newTokens: Int
+    public let summaryText: String?
+    public let messagesRemoved: Int
+    public let summaryFailed: Bool?
+
+    public init(
+        compacted: Bool,
+        previousTokens: Int,
+        newTokens: Int,
+        summaryText: String?,
+        messagesRemoved: Int,
+        summaryFailed: Bool?
+    ) {
+        self.compacted = compacted
+        self.previousTokens = previousTokens
+        self.newTokens = newTokens
+        self.summaryText = summaryText
+        self.messagesRemoved = messagesRemoved
+        self.summaryFailed = summaryFailed
+    }
+}
+
+/// Request body for `POST /v1/assistants/{id}/playground/seed-conversation`.
+public struct SeedConversationRequest: Codable, Sendable {
+    public let turns: Int
+    public let avgTokensPerTurn: Int?
+    public let title: String?
+
+    public init(turns: Int, avgTokensPerTurn: Int? = nil, title: String? = nil) {
+        self.turns = turns
+        self.avgTokensPerTurn = avgTokensPerTurn
+        self.title = title
+    }
+}
+
+/// Response from `POST /v1/assistants/{id}/playground/seed-conversation`.
+public struct SeedConversationResponse: Codable, Sendable {
+    public let conversationId: String
+    public let messagesInserted: Int
+    public let estimatedTokens: Int
+
+    public init(conversationId: String, messagesInserted: Int, estimatedTokens: Int) {
+        self.conversationId = conversationId
+        self.messagesInserted = messagesInserted
+        self.estimatedTokens = estimatedTokens
+    }
+}
+
+/// Request body for
+/// `POST /v1/assistants/{id}/conversations/{id}/playground/inject-compaction-failures`.
+public struct InjectFailuresRequest: Codable, Sendable {
+    public let consecutiveFailures: Int?
+    public let circuitOpenForMs: Int?
+
+    public init(consecutiveFailures: Int? = nil, circuitOpenForMs: Int? = nil) {
+        self.consecutiveFailures = consecutiveFailures
+        self.circuitOpenForMs = circuitOpenForMs
+    }
+}
+
+/// Response from `GET /v1/assistants/{id}/conversations/{id}/playground/compaction-state`.
+public struct CompactionStateResponse: Codable, Sendable {
+    public let estimatedInputTokens: Int
+    public let maxInputTokens: Int
+    public let compactThresholdRatio: Double
+    public let thresholdTokens: Int
+    public let messageCount: Int
+    public let contextCompactedMessageCount: Int
+    /// Milliseconds since epoch.
+    public let contextCompactedAt: Int?
+    public let consecutiveCompactionFailures: Int
+    /// Milliseconds since epoch.
+    public let compactionCircuitOpenUntil: Int?
+    public let isCircuitOpen: Bool
+    public let isCompactionEnabled: Bool
+
+    public init(
+        estimatedInputTokens: Int,
+        maxInputTokens: Int,
+        compactThresholdRatio: Double,
+        thresholdTokens: Int,
+        messageCount: Int,
+        contextCompactedMessageCount: Int,
+        contextCompactedAt: Int?,
+        consecutiveCompactionFailures: Int,
+        compactionCircuitOpenUntil: Int?,
+        isCircuitOpen: Bool,
+        isCompactionEnabled: Bool
+    ) {
+        self.estimatedInputTokens = estimatedInputTokens
+        self.maxInputTokens = maxInputTokens
+        self.compactThresholdRatio = compactThresholdRatio
+        self.thresholdTokens = thresholdTokens
+        self.messageCount = messageCount
+        self.contextCompactedMessageCount = contextCompactedMessageCount
+        self.contextCompactedAt = contextCompactedAt
+        self.consecutiveCompactionFailures = consecutiveCompactionFailures
+        self.compactionCircuitOpenUntil = compactionCircuitOpenUntil
+        self.isCircuitOpen = isCircuitOpen
+        self.isCompactionEnabled = isCompactionEnabled
+    }
+}
+
+/// One entry in the seeded-conversations list.
+public struct SeededConversationSummary: Codable, Sendable, Identifiable {
+    public let id: String
+    public let title: String
+    public let messageCount: Int
+    /// Milliseconds since epoch.
+    public let createdAt: Int
+
+    public init(id: String, title: String, messageCount: Int, createdAt: Int) {
+        self.id = id
+        self.title = title
+        self.messageCount = messageCount
+        self.createdAt = createdAt
+    }
+}
+
+/// Response from `GET /v1/assistants/{id}/playground/seeded-conversations`.
+public struct SeededConversationsListResponse: Codable, Sendable {
+    public let conversations: [SeededConversationSummary]
+
+    public init(conversations: [SeededConversationSummary]) {
+        self.conversations = conversations
+    }
+}
+
+/// Response from the seeded-conversations DELETE endpoints.
+public struct DeleteSeededConversationsResponse: Codable, Sendable {
+    public let deletedCount: Int
+
+    public init(deletedCount: Int) {
+        self.deletedCount = deletedCount
+    }
+}


### PR DESCRIPTION
## Summary
- Add shared Codable types mirroring the daemon compaction-playground wire contract
- Add `CompactionPlaygroundClient` with methods for force-compact, seed-conversation, inject-failures, reset-circuit, get-state, and seeded-conversations list/delete/delete-all
- No consumers yet — settings tab (PR 4) and UI sections (PR 10-15, 17) will wire the client

Part of plan: compaction-playground-macos.md (PR 3 of 17)
Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
