### PR TITLE
feat(playground): scaffold compaction-playground daemon route group

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -36,6 +36,7 @@ import {
   handleVoiceWebhook,
 } from "../calls/twilio-routes.js";
 import { parseChannelId } from "../channels/types.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import {
   getGatewayInternalBaseUrl,
   hasUngatedHttpAuthDisabled,
@@ -206,6 +207,7 @@ import {
   handlePairingStatus,
   pairingRouteDefinitions,
 } from "./routes/pairing-routes.js";
+import { playgroundRouteDefinitions } from "./routes/playground/index.js";
 import { profilerRouteDefinitions } from "./routes/profiler-routes.js";
 import { recordingRouteDefinitions } from "./routes/recording-routes.js";
 import { scheduleRouteDefinitions } from "./routes/schedule-routes.js";
@@ -1994,6 +1996,15 @@ export class RuntimeHttpServer {
         suggestionCache: this.suggestionCache,
         suggestionInFlight: this.suggestionInFlight,
         getHeartbeatService: this.getHeartbeatService,
+      }),
+      ...playgroundRouteDefinitions({
+        getConversationById: (id) => {
+          const s = this.findConversation?.(id);
+          if (!s || !("abort" in s)) return undefined;
+          return s as import("../daemon/conversation.js").Conversation;
+        },
+        isPlaygroundEnabled: () =>
+          isAssistantFeatureFlagEnabled("compaction-playground", getConfig()),
       }),
       ...globalSearchRouteDefinitions(),
       ...approvalRouteDefinitions(),

--- a/assistant/src/runtime/routes/playground/__tests__/guard.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/guard.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Conversation } from "../../../../daemon/conversation.js";
+import type { PlaygroundRouteDeps } from "../deps.js";
+import { assertPlaygroundEnabled } from "../guard.js";
+import { playgroundRouteDefinitions } from "../index.js";
+
+function makeDeps(enabled: boolean): PlaygroundRouteDeps {
+  return {
+    getConversationById: (_id: string): Conversation | undefined => undefined,
+    isPlaygroundEnabled: () => enabled,
+  };
+}
+
+describe("assertPlaygroundEnabled", () => {
+  test("returns a 404 Response when the flag is disabled", async () => {
+    const result = assertPlaygroundEnabled(makeDeps(false));
+
+    expect(result).toBeInstanceOf(Response);
+    expect(result?.status).toBe(404);
+
+    const body = (await result?.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.code).toBe("NOT_FOUND");
+    expect(body.error.message).toBe("Not found");
+  });
+
+  test("returns null when the flag is enabled", () => {
+    expect(assertPlaygroundEnabled(makeDeps(true))).toBeNull();
+  });
+});
+
+describe("playgroundRouteDefinitions", () => {
+  test("returns an empty array in the scaffold baseline", () => {
+    expect(playgroundRouteDefinitions(makeDeps(true))).toEqual([]);
+    expect(playgroundRouteDefinitions(makeDeps(false))).toEqual([]);
+  });
+});

--- a/assistant/src/runtime/routes/playground/deps.ts
+++ b/assistant/src/runtime/routes/playground/deps.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared dependency contract for every `/v1/.../playground/*` route.
+ *
+ * Each playground route file accepts a `PlaygroundRouteDeps` and calls
+ * `assertPlaygroundEnabled(deps)` before doing any real work, so the route
+ * group is invisible in production regardless of UI gating.
+ *
+ * Later PRs in the compaction-playground plan (PR 6, PR 16, ...) extend this
+ * interface with additional capabilities. The scaffold keeps the surface
+ * intentionally minimal.
+ */
+
+import type { Conversation } from "../../../daemon/conversation.js";
+
+export interface PlaygroundRouteDeps {
+  readonly getConversationById: (id: string) => Conversation | undefined;
+  readonly isPlaygroundEnabled: () => boolean;
+  // Later PRs (PR 6, PR 16) will extend this interface with additional
+  // capabilities. Keep this list minimal for scaffold.
+}

--- a/assistant/src/runtime/routes/playground/guard.ts
+++ b/assistant/src/runtime/routes/playground/guard.ts
@@ -1,0 +1,17 @@
+import { httpError } from "../../http-errors.js";
+import type { PlaygroundRouteDeps } from "./deps.js";
+
+/**
+ * Defense-in-depth guard every playground route calls first. Returns a 404
+ * Response when the `compaction-playground` feature flag is disabled so the
+ * entire /playground/* surface is invisible in production regardless of UI
+ * gating.
+ */
+export function assertPlaygroundEnabled(
+  deps: PlaygroundRouteDeps,
+): Response | null {
+  if (!deps.isPlaygroundEnabled()) {
+    return httpError("NOT_FOUND", "Not found", 404);
+  }
+  return null;
+}

--- a/assistant/src/runtime/routes/playground/index.ts
+++ b/assistant/src/runtime/routes/playground/index.ts
@@ -1,0 +1,14 @@
+import type { RouteDefinition } from "../../http-router.js";
+import type { PlaygroundRouteDeps } from "./deps.js";
+
+export type { PlaygroundRouteDeps };
+export { assertPlaygroundEnabled } from "./guard.js";
+
+export function playgroundRouteDefinitions(
+  _deps: PlaygroundRouteDeps,
+): RouteDefinition[] {
+  // Subsequent PRs append concrete route builders here (each returns
+  // RouteDefinition[]). Keeping this as a spread list makes later PRs
+  // purely additive with minimal conflict risk across concurrent PRs.
+  return [];
+}


### PR DESCRIPTION
## Summary
- Add empty `runtime/routes/playground/` route group wired into the HTTP server
- Export `assertPlaygroundEnabled` guard so every future playground endpoint can 404 when the feature flag is off
- No new endpoints yet — purely scaffolding so PR 5-9 and PR 16 can each append their route file without conflict

Part of plan: compaction-playground-macos.md (PR 2 of 17)
Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
