### PR TITLE
refactor(permissions): migrate globalValueFlags into argSchema.valueFlags

### DIFF
--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -444,6 +444,48 @@ describe("subcommand resolution", () => {
     });
     expect(result.riskLevel).toBe("low");
   });
+
+  // ── argSchema.valueFlags migration tests ─────────────────────────────────
+
+  test("git -C /path push → medium (resolves past -C value flag via argSchema.valueFlags)", async () => {
+    const result = await classifier.classify({
+      command: "git -C /path push",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+  });
+
+  test("docker --host unix:///var/run/docker.sock ps → low (resolves past --host value flag via argSchema.valueFlags)", async () => {
+    const result = await classifier.classify({
+      command: "docker --host unix:///var/run/docker.sock ps",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
+
+  test("git -C /some/path status → low (resolves past -C to read-only subcommand via argSchema.valueFlags)", async () => {
+    const result = await classifier.classify({
+      command: "git -C /some/path status",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
+
+  test("npm --cache /tmp/cache list → low (resolves past --cache value flag via argSchema.valueFlags)", async () => {
+    const result = await classifier.classify({
+      command: "npm --cache /tmp/cache list",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
+
+  test("gh -R owner/repo issue list → low (resolves past -R value flag via argSchema.valueFlags)", async () => {
+    const result = await classifier.classify({
+      command: "gh -R owner/repo issue list",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
 });
 
 // ── Wrapper unwrapping ───────────────────────────────────────────────────────

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -226,9 +226,8 @@ function resolveSubcommand(
     return { spec, remainingArgs: args };
   }
 
-  const valueFlags = spec.globalValueFlags
-    ? new Set(spec.globalValueFlags)
-    : undefined;
+  const valueFlagsList = spec.argSchema?.valueFlags ?? spec.globalValueFlags;
+  const valueFlags = valueFlagsList ? new Set(valueFlagsList) : undefined;
   const subcommandName = firstPositionalArg(args, valueFlags);
 
   if (!subcommandName || !spec.subcommands[subcommandName]) {

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -263,15 +263,17 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // Divergences are noted inline.
   git: {
     baseRisk: "medium",
-    globalValueFlags: [
-      "-C",
-      "-c",
-      "--git-dir",
-      "--work-tree",
-      "--namespace",
-      "--super-prefix",
-      "--config-env",
-    ],
+    argSchema: {
+      valueFlags: [
+        "-C",
+        "-c",
+        "--git-dir",
+        "--work-tree",
+        "--namespace",
+        "--super-prefix",
+        "--config-env",
+      ],
+    },
     subcommands: {
       // LOW_RISK_GIT_SUBCOMMANDS from checker.ts:
       status: { baseRisk: "low" },
@@ -366,7 +368,9 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // they download and execute code, with subcommand-level overrides.
   npm: {
     baseRisk: "medium",
-    globalValueFlags: ["--prefix", "--userconfig", "--globalconfig", "--cache"],
+    argSchema: {
+      valueFlags: ["--prefix", "--userconfig", "--globalconfig", "--cache"],
+    },
     subcommands: {
       ls: { baseRisk: "low" },
       list: { baseRisk: "low" },
@@ -540,7 +544,9 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // ── Docker ─────────────────────────────────────────────────────────────────
   docker: {
     baseRisk: "medium",
-    globalValueFlags: ["--host", "-H", "--config", "--context", "--log-level"],
+    argSchema: {
+      valueFlags: ["--host", "-H", "--config", "--context", "--log-level"],
+    },
     subcommands: {
       ps: { baseRisk: "low" },
       images: { baseRisk: "low" },
@@ -757,7 +763,7 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // ── Version control tools ──────────────────────────────────────────────────
   gh: {
     baseRisk: "low",
-    globalValueFlags: ["--repo", "-R"],
+    argSchema: { valueFlags: ["--repo", "-R"] },
     subcommands: {
       pr: {
         baseRisk: "low",

--- a/assistant/src/permissions/risk-types.ts
+++ b/assistant/src/permissions/risk-types.ts
@@ -156,6 +156,8 @@ export interface CommandRiskSpec {
    * Global flags that consume the next token as a value (e.g. git -C <path>).
    * Used by resolveSubcommand to skip past flag-value pairs when locating the
    * first positional arg (the subcommand name).
+   *
+   * @deprecated Use argSchema.valueFlags instead. Kept for backward compatibility during migration.
    */
   globalValueFlags?: string[];
   /**


### PR DESCRIPTION
## Summary
- Migrate globalValueFlags to argSchema.valueFlags for git, npm, docker, gh
- Update resolveSubcommand() to read from argSchema.valueFlags first
- Add deprecation notice to globalValueFlags
- Add subcommand resolution tests for migrated commands

Part of plan: sandbox-auto-approve-phase2.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
