### PR TITLE
feat(macos): add Compaction Playground settings tab with stub subsections

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -13,6 +13,7 @@ enum SettingsTab: String {
     case schedules = "Schedules"
     case debug = "Debug"
     case developer = "Developer"
+    case compactionPlayground = "Compaction Playground"
 
     var icon: VIcon {
         switch self {
@@ -27,6 +28,7 @@ enum SettingsTab: String {
         case .schedules: return .calendar
         case .debug: return .bug
         case .developer: return .terminal
+        case .compactionPlayground: return .flask
         }
     }
 
@@ -139,6 +141,7 @@ struct SettingsPanel: View {
     @State private var isBillingEnabled: Bool = false
     @State private var isSchedulesEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
+    @State private var isCompactionPlaygroundEnabled: Bool = false
     @State private var isSoundsEnabled: Bool = true
     @State private var isEmbeddingProviderEnabled: Bool = false
     @State private var isEmailChannelEnabled: Bool = false
@@ -150,6 +153,7 @@ struct SettingsPanel: View {
     private static let schedulesFeatureFlagKey = "settings-schedules"
     private static let billingFeatureFlagKey = "settings-billing"
     private static let developerFeatureFlagKey = "settings-developer-nav"
+    private static let compactionPlaygroundFeatureFlagKey = "compaction-playground"
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let emailChannelFeatureFlagKey = "email-channel"
     private static let soundsFeatureFlagKey = "sounds"
@@ -391,6 +395,17 @@ struct SettingsPanel: View {
                     selectedTab = .developer
                 }
             }
+            if isDeveloperEnabled && isCompactionPlaygroundEnabled && DevModeManager.shared.isDevMode {
+                VColor.surfaceBase
+                    .frame(height: 1)
+                    .padding(.vertical, SidebarLayoutMetrics.dividerVerticalPadding)
+                    .padding(.trailing, VSpacing.md)
+                VNavItem(icon: SettingsTab.compactionPlayground.icon.rawValue,
+                         label: "Compaction Playground",
+                         isActive: selectedTab == .compactionPlayground) {
+                    selectedTab = .compactionPlayground
+                }
+            }
         }
         .padding(.top, VSpacing.lg)
         .padding(.bottom, VSpacing.xl)
@@ -449,6 +464,13 @@ struct SettingsPanel: View {
             SettingsDebugTab(store: store)
         case .developer:
             SettingsDeveloperTab(store: store, connectionManager: connectionManager, authManager: authManager, onClose: onClose)
+        case .compactionPlayground:
+            SettingsCompactionPlaygroundTab(
+                store: store,
+                conversationManager: conversationManager,
+                showToast: showToast,
+                onClose: onClose
+            )
         }
     }
 
@@ -676,6 +698,9 @@ struct SettingsPanel: View {
                 if let developerFlag = flags.first(where: { $0.key == Self.developerFeatureFlagKey }) {
                     isDeveloperEnabled = developerFlag.enabled
                 }
+                if let playgroundFlag = flags.first(where: { $0.key == Self.compactionPlaygroundFeatureFlagKey }) {
+                    isCompactionPlaygroundEnabled = playgroundFlag.enabled
+                }
                 if let embeddingProviderFlag = flags.first(where: { $0.key == Self.embeddingProviderFeatureFlagKey }) {
                     isEmbeddingProviderEnabled = embeddingProviderFlag.enabled
                 }
@@ -701,6 +726,9 @@ struct SettingsPanel: View {
 
         if let developerEnabled = resolved[Self.developerFeatureFlagKey] {
             isDeveloperEnabled = developerEnabled
+        }
+        if let playgroundEnabled = resolved[Self.compactionPlaygroundFeatureFlagKey] {
+            isCompactionPlaygroundEnabled = playgroundEnabled
         }
         if let embeddingProviderEnabled = resolved[Self.embeddingProviderFeatureFlagKey] {
             isEmbeddingProviderEnabled = embeddingProviderEnabled

--- a/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/EventLogSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/EventLogSection.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Stub for the Event Log subsection of the Compaction Playground tab.
+///
+/// A Wave-3 follow-up PR replaces this file wholesale with UI that subscribes
+/// to the compaction event stream scoped to `conversationId`. The parameter
+/// list is fixed so the replacement PR does not need to touch the tab
+/// composition file.
+struct EventLogSection: View {
+    let conversationId: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Event Log")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+            Text("Coming soon in a follow-up PR.")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentSecondary)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/ForceCompactSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/ForceCompactSection.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Stub for the Force Compact subsection of the Compaction Playground tab.
+///
+/// A Wave-3 follow-up PR replaces this file wholesale with the real UI that
+/// calls `CompactionPlaygroundClient.forceCompact(conversationId:)`. The
+/// parameter list is fixed so the replacement PR does not need to touch the
+/// tab composition file.
+struct ForceCompactSection: View {
+    let conversationId: String?
+    let client: CompactionPlaygroundClient
+    let showToast: (String, ToastInfo.Style) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Force Compact")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+            Text("Coming soon in a follow-up PR.")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentSecondary)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/InjectFailuresSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/InjectFailuresSection.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Stub for the Inject Failures subsection of the Compaction Playground tab.
+///
+/// A Wave-3 follow-up PR replaces this file wholesale with UI that drives
+/// `CompactionPlaygroundClient.injectFailures(conversationId:consecutiveFailures:circuitOpenForMs:)`.
+/// The parameter list is fixed so the replacement PR does not need to touch
+/// the tab composition file.
+struct InjectFailuresSection: View {
+    let conversationId: String?
+    let client: CompactionPlaygroundClient
+    let showToast: (String, ToastInfo.Style) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Inject Failures")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+            Text("Coming soon in a follow-up PR.")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentSecondary)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/ResetCircuitSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/ResetCircuitSection.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Stub for the Reset Circuit subsection of the Compaction Playground tab.
+///
+/// A Wave-3 follow-up PR replaces this file wholesale with UI that drives
+/// `CompactionPlaygroundClient.resetCircuit(conversationId:)`. The parameter
+/// list is fixed so the replacement PR does not need to touch the tab
+/// composition file.
+struct ResetCircuitSection: View {
+    let conversationId: String?
+    let client: CompactionPlaygroundClient
+    let showToast: (String, ToastInfo.Style) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Reset Circuit")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+            Text("Coming soon in a follow-up PR.")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentSecondary)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/SeedHistorySection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/SeedHistorySection.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Stub for the Seed History subsection of the Compaction Playground tab.
+///
+/// A Wave-3 follow-up PR replaces this file wholesale with UI that drives
+/// `CompactionPlaygroundClient.seedConversation(...)` and (optionally) deep
+/// links into the newly seeded conversation via `conversationManager` +
+/// `onClose`. The parameter list is fixed so the replacement PR does not
+/// need to touch the tab composition file.
+struct SeedHistorySection: View {
+    let conversationId: String?
+    let client: CompactionPlaygroundClient
+    let conversationManager: ConversationManager
+    let showToast: (String, ToastInfo.Style) -> Void
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Seed History")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+            Text("Coming soon in a follow-up PR.")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentSecondary)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/SeededConversationsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/SeededConversationsSection.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Stub for the Seeded Conversations subsection of the Compaction Playground tab.
+///
+/// Unlike the other subsections, this one is not scoped to a single
+/// conversation — it lists/deletes all seeded conversations via
+/// `CompactionPlaygroundClient.listSeededConversations()` /
+/// `deleteSeededConversation(id:)` / `deleteAllSeededConversations()`.
+/// A Wave-3 follow-up PR replaces this file wholesale with the real UI;
+/// the parameter list is fixed so the replacement PR does not need to touch
+/// the tab composition file.
+struct SeededConversationsSection: View {
+    let client: CompactionPlaygroundClient
+    let conversationManager: ConversationManager
+    let showToast: (String, ToastInfo.Style) -> Void
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Seeded Conversations")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+            Text("Coming soon in a follow-up PR.")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentSecondary)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/StateDisplaySection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/StateDisplaySection.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Stub for the State Display subsection of the Compaction Playground tab.
+///
+/// A Wave-3 follow-up PR replaces this file wholesale with UI that polls
+/// `CompactionPlaygroundClient.getState(conversationId:)` and renders the
+/// current compaction state (token counts, circuit status, last attempt).
+/// The parameter list is fixed so the replacement PR does not need to touch
+/// the tab composition file.
+struct StateDisplaySection: View {
+    let conversationId: String?
+    let client: CompactionPlaygroundClient
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("State Display")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+            Text("Coming soon in a follow-up PR.")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentSecondary)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsCompactionPlaygroundTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsCompactionPlaygroundTab.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Developer-only Settings tab for the Compaction Playground.
+///
+/// Composes seven stub subsections — one per playground capability — so each
+/// Wave-3 PR can replace exactly one subsection file without touching this
+/// composition file or any sibling stub. The header surfaces the conversation
+/// the playground operates on (read from `ConversationManager.activeConversation`)
+/// so developers know which conversation a compact/seed/inject action will hit.
+@MainActor
+struct SettingsCompactionPlaygroundTab: View {
+    @ObservedObject var store: SettingsStore
+    var conversationManager: ConversationManager
+    var showToast: (String, ToastInfo.Style) -> Void
+    var onClose: () -> Void
+
+    private let client = CompactionPlaygroundClient()
+
+    @State private var activeConversationId: String?
+    @State private var activeConversationTitle: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                headerCard
+
+                ForceCompactSection(
+                    conversationId: activeConversationId,
+                    client: client,
+                    showToast: showToast
+                )
+                SeedHistorySection(
+                    conversationId: activeConversationId,
+                    client: client,
+                    conversationManager: conversationManager,
+                    showToast: showToast,
+                    onClose: onClose
+                )
+                SeededConversationsSection(
+                    client: client,
+                    conversationManager: conversationManager,
+                    showToast: showToast,
+                    onClose: onClose
+                )
+                InjectFailuresSection(
+                    conversationId: activeConversationId,
+                    client: client,
+                    showToast: showToast
+                )
+                ResetCircuitSection(
+                    conversationId: activeConversationId,
+                    client: client,
+                    showToast: showToast
+                )
+                StateDisplaySection(
+                    conversationId: activeConversationId,
+                    client: client
+                )
+                EventLogSection(
+                    conversationId: activeConversationId
+                )
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .onAppear(perform: refreshActiveConversation)
+        .onChange(of: conversationManager.activeConversationId) { _, _ in
+            refreshActiveConversation()
+        }
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var headerCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Compaction Playground")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+
+            if let id = activeConversationId {
+                let title = activeConversationTitle ?? "Untitled"
+                let truncated = truncatedId(id)
+                Text("Operating on: \(title) (\(truncated))")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            } else {
+                Text("Open a conversation in the main window, then return here to run playground actions.")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard()
+    }
+
+    // MARK: - Helpers
+
+    private func refreshActiveConversation() {
+        let active = conversationManager.activeConversation
+        activeConversationId = active?.conversationId
+        activeConversationTitle = active?.title
+    }
+
+    private func truncatedId(_ id: String) -> String {
+        guard id.count > 8 else { return id }
+        return String(id.prefix(8)) + "…"
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SettingsTab.compactionPlayground` case and sidebar nav entry gated on dev mode + developer flag + `compaction-playground` flag
- Create `SettingsCompactionPlaygroundTab` composing seven subsection stubs so Wave-3 UI PRs can each replace one file with zero cross-PR conflict
- Header shows active-conversation context or empty state; `CompactionPlaygroundClient` (PR 3) is instantiated and threaded to sections

Part of plan: compaction-playground-macos.md (PR 4 of 17)
Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
