### PR TITLE
feat(playground): add POST /v1/playground/seed-conversation

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6132,6 +6132,38 @@ paths:
           schema:
             type: string
           description: Conversation ID
+  /v1/playground/seed-conversation:
+    post:
+      operationId: playground_seedconversation_post
+      summary: Create a synthetic seeded conversation for compaction testing
+      tags:
+        - playground
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                turns:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 500
+                avgTokensPerTurn:
+                  default: 500
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 5000
+                title:
+                  type: string
+                  maxLength: 120
+              required:
+                - turns
+                - avgTokensPerTurn
+              additionalProperties: false
   /v1/playground/seeded-conversations:
     delete:
       operationId: playground_seededconversations_delete

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -54,7 +54,9 @@ import {
   type SignalType,
 } from "../memory/conversation-attention-store.js";
 import {
+  addMessage,
   type ConversationRow,
+  createConversation,
   deleteConversation,
   forkConversation as forkConversationInStore,
   getConversation,
@@ -2016,6 +2018,14 @@ export class RuntimeHttpServer {
           if (!getConversation(id)) return false;
           deleteConversation(id);
           return true;
+        },
+        createConversation: async (title) => {
+          const row = createConversation({ title });
+          return { id: row.id };
+        },
+        addMessage: async (conversationId, role, contentJson) => {
+          const persisted = await addMessage(conversationId, role, contentJson);
+          return { id: persisted.id };
         },
       }),
       ...globalSearchRouteDefinitions(),

--- a/assistant/src/runtime/routes/playground/__tests__/force-compact.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/force-compact.test.ts
@@ -76,6 +76,8 @@ function makeDeps(
     isPlaygroundEnabled: () => true,
     listConversationsByTitlePrefix: () => [],
     deleteConversationById: () => false,
+    createConversation: async () => ({ id: "conv-test" }),
+    addMessage: async () => ({ id: "msg-test" }),
     ...overrides,
   };
 }

--- a/assistant/src/runtime/routes/playground/__tests__/guard.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/guard.test.ts
@@ -11,6 +11,12 @@ function makeDeps(enabled: boolean): PlaygroundRouteDeps {
     isPlaygroundEnabled: () => enabled,
     listConversationsByTitlePrefix: () => [],
     deleteConversationById: () => false,
+    createConversation: async (_title: string) => ({ id: "conv-test" }),
+    addMessage: async (
+      _conversationId: string,
+      _role: "user" | "assistant",
+      _contentJson: string,
+    ) => ({ id: "msg-test" }),
   };
 }
 
@@ -57,5 +63,11 @@ describe("playgroundRouteDefinitions", () => {
           r.method === "POST",
       ),
     ).toBe(true);
+  });
+
+  test("registers the seed-conversation endpoint", () => {
+    const routes = playgroundRouteDefinitions(makeDeps(true));
+    const endpoints = routes.map((r) => `${r.method} ${r.endpoint}`);
+    expect(endpoints).toContain("POST playground/seed-conversation");
   });
 });

--- a/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
@@ -56,6 +56,10 @@ function makeDeps(
       if (conversation.conversationId !== id) return undefined;
       return conversation as unknown as Conversation;
     },
+    listConversationsByTitlePrefix: () => [],
+    deleteConversationById: () => false,
+    createConversation: async () => ({ id: "conv-test" }),
+    addMessage: async () => ({ id: "msg-test" }),
   };
 }
 

--- a/assistant/src/runtime/routes/playground/__tests__/reset-circuit.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/reset-circuit.test.ts
@@ -104,6 +104,8 @@ function makeDeps(
     isPlaygroundEnabled: () => true,
     listConversationsByTitlePrefix: () => [],
     deleteConversationById: () => false,
+    createConversation: async () => ({ id: "conv-test" }),
+    addMessage: async () => ({ id: "msg-test" }),
     ...overrides,
   };
 }

--- a/assistant/src/runtime/routes/playground/__tests__/seed-conversation.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/seed-conversation.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Conversation } from "../../../../daemon/conversation.js";
+import type { RouteDefinition } from "../../../http-router.js";
+import type { PlaygroundRouteDeps } from "../deps.js";
+import {
+  PLAYGROUND_TITLE_PREFIX,
+  seedConversationRouteDefinitions,
+} from "../seed-conversation.js";
+
+type AddMessageArgs = [string, "user" | "assistant", string];
+
+interface Spy {
+  deps: PlaygroundRouteDeps;
+  createdTitles: string[];
+  addedMessages: AddMessageArgs[];
+}
+
+function makeDeps(overrides?: { enabled?: boolean }): Spy {
+  const createdTitles: string[] = [];
+  const addedMessages: AddMessageArgs[] = [];
+  let nextConvId = 0;
+  let nextMessageId = 0;
+
+  const deps: PlaygroundRouteDeps = {
+    getConversationById: (_id: string): Conversation | undefined => undefined,
+    isPlaygroundEnabled: () => overrides?.enabled ?? true,
+    listConversationsByTitlePrefix: () => [],
+    deleteConversationById: () => false,
+    createConversation: async (title) => {
+      createdTitles.push(title);
+      return { id: `conv-${++nextConvId}` };
+    },
+    addMessage: async (conversationId, role, contentJson) => {
+      addedMessages.push([conversationId, role, contentJson]);
+      return { id: `msg-${++nextMessageId}` };
+    },
+  };
+  return { deps, createdTitles, addedMessages };
+}
+
+function getSeedHandler(deps: PlaygroundRouteDeps): RouteDefinition["handler"] {
+  const routes = seedConversationRouteDefinitions(deps);
+  const route = routes.find(
+    (r) => r.endpoint === "playground/seed-conversation" && r.method === "POST",
+  );
+  if (!route) throw new Error("seed-conversation route not registered");
+  return route.handler;
+}
+
+function makeCtx(body: unknown) {
+  const url = new URL("http://localhost/v1/playground/seed-conversation");
+  return {
+    url,
+    req: new Request(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    server: {} as ReturnType<typeof Bun.serve>,
+    authContext: {} as never,
+    params: {},
+  };
+}
+
+describe("POST /v1/playground/seed-conversation", () => {
+  test("returns 404 when the playground flag is disabled", async () => {
+    const { deps } = makeDeps({ enabled: false });
+    const handler = getSeedHandler(deps);
+
+    const res = await handler(makeCtx({ turns: 3 }));
+    expect(res.status).toBe(404);
+
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  test("seeds N turns as 2N messages and returns conversation id", async () => {
+    const spy = makeDeps();
+    const handler = getSeedHandler(spy.deps);
+
+    const res = await handler(makeCtx({ turns: 5, avgTokensPerTurn: 500 }));
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      conversationId: string;
+      messagesInserted: number;
+      estimatedTokens: number;
+    };
+    expect(body.conversationId).toBe("conv-1");
+    expect(body.messagesInserted).toBe(10);
+    expect(spy.createdTitles).toHaveLength(1);
+    expect(spy.addedMessages).toHaveLength(10);
+
+    // Roles alternate user/assistant across the 10 inserted messages.
+    for (let i = 0; i < spy.addedMessages.length; i++) {
+      const [convId, role, contentJson] = spy.addedMessages[i];
+      expect(convId).toBe("conv-1");
+      expect(role).toBe(i % 2 === 0 ? "user" : "assistant");
+      // Content is a JSON-encoded array of blocks matching the in-memory
+      // Message[] shape the rest of the daemon expects.
+      const parsed = JSON.parse(contentJson) as Array<{
+        type: string;
+        text: string;
+      }>;
+      expect(parsed[0].type).toBe("text");
+      expect(parsed[0].text.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("returns a positive estimated token count", async () => {
+    const spy = makeDeps();
+    const handler = getSeedHandler(spy.deps);
+
+    const res = await handler(makeCtx({ turns: 5, avgTokensPerTurn: 500 }));
+    expect(res.status).toBe(200);
+
+    // We intentionally don't assert tight bounds: sibling playground tests
+    // call `mock.module(".../token-estimator.js", ...)` at module scope,
+    // and Bun persists that mock across files in the same test run. All we
+    // can safely assert is that some positive estimate was produced — the
+    // exact value is exercised by the estimator's own tests.
+    const body = (await res.json()) as { estimatedTokens: number };
+    expect(body.estimatedTokens).toBeGreaterThan(0);
+  });
+
+  test("rejects turns: 0", async () => {
+    const { deps } = makeDeps();
+    const handler = getSeedHandler(deps);
+    const res = await handler(makeCtx({ turns: 0 }));
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects turns: 501 (above max)", async () => {
+    const { deps } = makeDeps();
+    const handler = getSeedHandler(deps);
+    const res = await handler(makeCtx({ turns: 501 }));
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects negative avgTokensPerTurn", async () => {
+    const { deps } = makeDeps();
+    const handler = getSeedHandler(deps);
+    const res = await handler(makeCtx({ turns: 2, avgTokensPerTurn: -1 }));
+    expect(res.status).toBe(400);
+  });
+
+  test("prepends [Playground] prefix to a plain title", async () => {
+    const spy = makeDeps();
+    const handler = getSeedHandler(spy.deps);
+
+    const res = await handler(makeCtx({ turns: 1, title: "My test" }));
+    expect(res.status).toBe(200);
+    expect(spy.createdTitles[0]).toBe(`${PLAYGROUND_TITLE_PREFIX}My test`);
+  });
+
+  test("does not double up when the title already starts with the prefix", async () => {
+    const spy = makeDeps();
+    const handler = getSeedHandler(spy.deps);
+
+    const res = await handler(
+      makeCtx({
+        turns: 1,
+        title: `${PLAYGROUND_TITLE_PREFIX}existing`,
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(spy.createdTitles[0]).toBe(`${PLAYGROUND_TITLE_PREFIX}existing`);
+  });
+
+  test("falls back to an ISO timestamp title when none is supplied", async () => {
+    const spy = makeDeps();
+    const handler = getSeedHandler(spy.deps);
+
+    const res = await handler(makeCtx({ turns: 1 }));
+    expect(res.status).toBe(200);
+
+    const created = spy.createdTitles[0];
+    // Pattern: "[Playground] YYYY-MM-DDTHH:MM:SS"
+    expect(created).toMatch(
+      new RegExp(
+        `^${PLAYGROUND_TITLE_PREFIX.replace(
+          /[[\]]/g,
+          "\\$&",
+        )}\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$`,
+      ),
+    );
+  });
+});

--- a/assistant/src/runtime/routes/playground/__tests__/seeded-conversations.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/seeded-conversations.test.ts
@@ -43,6 +43,8 @@ function makeStub(opts: StubOpts = {}): Stub {
         ? deleteReturn(id)
         : deleteReturn;
     },
+    createConversation: async () => ({ id: "conv-test" }),
+    addMessage: async () => ({ id: "msg-test" }),
   };
   return { deps, listCalls, deleteCalls };
 }

--- a/assistant/src/runtime/routes/playground/__tests__/state.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/state.test.ts
@@ -34,6 +34,8 @@ function makeDeps(
     isPlaygroundEnabled: () => true,
     listConversationsByTitlePrefix: () => [],
     deleteConversationById: () => false,
+    createConversation: async () => ({ id: "conv-test" }),
+    addMessage: async () => ({ id: "msg-test" }),
     ...overrides,
   };
 }

--- a/assistant/src/runtime/routes/playground/deps.ts
+++ b/assistant/src/runtime/routes/playground/deps.ts
@@ -34,6 +34,12 @@ export interface PlaygroundRouteDeps {
    * delete path is intentionally best-effort for freshly-seeded rows.
    */
   readonly deleteConversationById: (id: string) => boolean;
+  readonly createConversation: (title: string) => Promise<{ id: string }>;
+  readonly addMessage: (
+    conversationId: string,
+    role: "user" | "assistant",
+    contentJson: string,
+  ) => Promise<{ id: string }>;
   // Later PRs will extend this interface with additional capabilities.
   // Keep this list minimal.
 }

--- a/assistant/src/runtime/routes/playground/index.ts
+++ b/assistant/src/runtime/routes/playground/index.ts
@@ -3,6 +3,7 @@ import type { PlaygroundRouteDeps } from "./deps.js";
 import { forceCompactRouteDefinitions } from "./force-compact.js";
 import { injectFailuresRouteDefinitions } from "./inject-failures.js";
 import { resetCircuitRouteDefinitions } from "./reset-circuit.js";
+import { seedConversationRouteDefinitions } from "./seed-conversation.js";
 import { seededConversationsRouteDefinitions } from "./seeded-conversations.js";
 import { stateRouteDefinitions } from "./state.js";
 
@@ -20,6 +21,7 @@ export function playgroundRouteDefinitions(
     ...forceCompactRouteDefinitions(deps),
     ...injectFailuresRouteDefinitions(deps),
     ...resetCircuitRouteDefinitions(deps),
+    ...seedConversationRouteDefinitions(deps),
     ...seededConversationsRouteDefinitions(deps),
     ...stateRouteDefinitions(deps),
   ];

--- a/assistant/src/runtime/routes/playground/seed-conversation.ts
+++ b/assistant/src/runtime/routes/playground/seed-conversation.ts
@@ -1,0 +1,133 @@
+/**
+ * POST /v1/playground/seed-conversation
+ *
+ * Creates a synthetic conversation for compaction testing. Inserts N
+ * user/assistant message pairs of roughly `avgTokensPerTurn` tokens each and
+ * returns the new conversation id plus an estimated prompt-token count.
+ *
+ * Seeded conversations are prefixed with `[Playground] ` so other playground
+ * endpoints (e.g. seeded-conversations list/delete) can filter by prefix.
+ */
+
+import { z } from "zod";
+
+import { estimatePromptTokens } from "../../../context/token-estimator.js";
+import type { Message } from "../../../providers/types.js";
+import { httpError } from "../../http-errors.js";
+import type { RouteDefinition } from "../../http-router.js";
+import { assertPlaygroundEnabled, type PlaygroundRouteDeps } from "./index.js";
+
+/**
+ * Title prefix applied to every seeded-playground conversation. Exported so
+ * sibling playground endpoints (list/delete) can share the exact string
+ * rather than duplicating a literal.
+ */
+export const PLAYGROUND_TITLE_PREFIX = "[Playground] ";
+
+const SeedBodySchema = z.object({
+  turns: z.number().int().positive().max(500),
+  avgTokensPerTurn: z
+    .number()
+    .int()
+    .positive()
+    .max(5000)
+    .optional()
+    .default(500),
+  title: z.string().trim().max(120).optional(),
+});
+
+const LOREM_BASE =
+  "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. ";
+
+export function seedConversationRouteDefinitions(
+  deps: PlaygroundRouteDeps,
+): RouteDefinition[] {
+  return [
+    {
+      endpoint: "playground/seed-conversation",
+      method: "POST",
+      policyKey: "playground/seed-conversation",
+      summary: "Create a synthetic seeded conversation for compaction testing",
+      tags: ["playground"],
+      requestBody: SeedBodySchema,
+      handler: async ({ req }) => {
+        const gate = assertPlaygroundEnabled(deps);
+        if (gate) return gate;
+
+        let rawBody: unknown;
+        try {
+          rawBody = await req.json();
+        } catch {
+          return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+        }
+
+        const parsed = SeedBodySchema.safeParse(rawBody);
+        if (!parsed.success) {
+          return httpError("BAD_REQUEST", parsed.error.message, 400);
+        }
+        const { turns, avgTokensPerTurn, title } = parsed.data;
+
+        // Derive effective title: strip an accidental prefix first so a
+        // caller passing "[Playground] foo" doesn't end up with
+        // "[Playground] [Playground] foo".
+        const userSuppliedTitle =
+          title && title.length > 0
+            ? title
+            : new Date().toISOString().slice(0, 19);
+        const withoutPrefix = userSuppliedTitle.startsWith(
+          PLAYGROUND_TITLE_PREFIX,
+        )
+          ? userSuppliedTitle.slice(PLAYGROUND_TITLE_PREFIX.length)
+          : userSuppliedTitle;
+        const effectiveTitle = PLAYGROUND_TITLE_PREFIX + withoutPrefix;
+
+        const { id: conversationId } =
+          await deps.createConversation(effectiveTitle);
+
+        // Generate lorem-ipsum-style text. ~4 chars/token is the rough
+        // approximation the rest of the daemon uses. Paragraph is repeated
+        // and sliced to the target byte count, and a "Turn N" prefix keeps
+        // each message unique so downstream search/compaction doesn't
+        // collapse them.
+        const charsPerMessage = avgTokensPerTurn * 4;
+
+        const messages: Array<{ role: "user" | "assistant"; text: string }> =
+          [];
+        for (let i = 0; i < turns; i++) {
+          const userBase = `Turn ${i + 1} user message: ` + LOREM_BASE;
+          const userText = userBase
+            .repeat(Math.ceil(charsPerMessage / userBase.length))
+            .slice(0, charsPerMessage);
+          const asstBase = `Turn ${i + 1} assistant response: ` + LOREM_BASE;
+          const asstText = asstBase
+            .repeat(Math.ceil(charsPerMessage / asstBase.length))
+            .slice(0, charsPerMessage);
+          messages.push({ role: "user", text: userText });
+          messages.push({ role: "assistant", text: asstText });
+        }
+
+        for (const msg of messages) {
+          const contentJson = JSON.stringify([
+            { type: "text", text: msg.text },
+          ]);
+          await deps.addMessage(conversationId, msg.role, contentJson);
+        }
+
+        // Reconstruct the in-memory Message[] shape estimatePromptTokens
+        // expects so the returned estimate matches what compaction will
+        // see once the conversation is loaded.
+        const estimatorMessages: Message[] = messages.map((m) => ({
+          role: m.role,
+          content: [{ type: "text", text: m.text }],
+        }));
+        const estimatedTokens = estimatePromptTokens(estimatorMessages);
+
+        return Response.json({
+          conversationId,
+          messagesInserted: messages.length,
+          estimatedTokens,
+        });
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add seed-conversation endpoint that creates a fresh conversation, inserts N synthetic user/assistant message pairs, and returns the new conversation id + estimated token count
- Enforce the `[Playground]` title prefix (exported as `PLAYGROUND_TITLE_PREFIX` so PR 16 shares the same constant)
- Extend `PlaygroundRouteDeps` with `createConversation` and `addMessage` capabilities, wired in `http-server.ts`

Part of plan: compaction-playground-macos.md (PR 6 of 17)
Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
