### PR TITLE
feat(playground): add endpoint to mutate compaction circuit-breaker state

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -2910,6 +2910,37 @@ paths:
           required: true
           schema:
             type: string
+  /v1/conversations/{id}/playground/inject-compaction-failures:
+    post:
+      operationId: conversations_by_id_playground_injectcompactionfailures_post
+      summary: Directly mutate compaction circuit-breaker state (dev-only playground)
+      tags:
+        - playground
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                consecutiveFailures:
+                  type: integer
+                  minimum: 0
+                  maximum: 10
+                circuitOpenForMs:
+                  type: integer
+                  minimum: 0
+                  maximum: 86400000
+              additionalProperties: false
   /v1/conversations/{id}/playground/reset-compaction-circuit:
     post:
       operationId: conversations_by_id_playground_resetcompactioncircuit_post

--- a/assistant/src/runtime/routes/playground/__tests__/guard.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/guard.test.ts
@@ -44,4 +44,16 @@ describe("playgroundRouteDefinitions", () => {
       0,
     );
   });
+
+  test("registers the inject-failures playground route", () => {
+    const routes = playgroundRouteDefinitions(makeDeps(true));
+    expect(
+      routes.some(
+        (r) =>
+          r.endpoint ===
+            "conversations/:id/playground/inject-compaction-failures" &&
+          r.method === "POST",
+      ),
+    ).toBe(true);
+  });
 });

--- a/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for the inject-compaction-failures playground endpoint.
+ *
+ * This endpoint is dev-only (gated by the `compaction-playground` feature
+ * flag) and directly mutates `consecutiveCompactionFailures` and/or
+ * `compactionCircuitOpenUntil` on a live `Conversation`. It is used by the
+ * macOS playground UI and integration tests to drive the circuit breaker
+ * into interesting states without having to wait for three real summary
+ * LLM failures.
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { Conversation } from "../../../../daemon/conversation.js";
+import type { ServerMessage } from "../../../../daemon/message-protocol.js";
+import type { RouteContext } from "../../../http-router.js";
+import type { PlaygroundRouteDeps } from "../deps.js";
+import { injectFailuresRouteDefinitions } from "../inject-failures.js";
+
+interface MockConversation {
+  readonly conversationId: string;
+  consecutiveCompactionFailures: number;
+  compactionCircuitOpenUntil: number | null;
+  contextCompactedMessageCount: number;
+  contextCompactedAt: number | null;
+  sentMessages: ServerMessage[];
+  sendToClient: (msg: ServerMessage) => void;
+  getMessages: () => unknown[];
+}
+
+function makeConversation(id = "conv-playground-test"): MockConversation {
+  const sentMessages: ServerMessage[] = [];
+  return {
+    conversationId: id,
+    consecutiveCompactionFailures: 0,
+    compactionCircuitOpenUntil: null,
+    contextCompactedMessageCount: 0,
+    contextCompactedAt: null,
+    sentMessages,
+    sendToClient: (msg) => sentMessages.push(msg),
+    getMessages: () => [],
+  };
+}
+
+function makeDeps(
+  opts: {
+    enabled?: boolean;
+    conversation?: MockConversation | undefined;
+  } = {},
+): PlaygroundRouteDeps {
+  const enabled = opts.enabled ?? true;
+  const conversation = opts.conversation;
+  return {
+    isPlaygroundEnabled: () => enabled,
+    getConversationById: (id) => {
+      if (!conversation) return undefined;
+      if (conversation.conversationId !== id) return undefined;
+      return conversation as unknown as Conversation;
+    },
+  };
+}
+
+function getInjectRoute(deps: PlaygroundRouteDeps) {
+  const routes = injectFailuresRouteDefinitions(deps);
+  const route = routes.find(
+    (r) =>
+      r.endpoint ===
+        "conversations/:id/playground/inject-compaction-failures" &&
+      r.method === "POST",
+  );
+  if (!route) {
+    throw new Error("inject-failures route not registered");
+  }
+  return route;
+}
+
+async function invoke(
+  route: ReturnType<typeof getInjectRoute>,
+  conversationId: string,
+  body: unknown,
+): Promise<Response> {
+  const url = `http://localhost/v1/conversations/${conversationId}/playground/inject-compaction-failures`;
+  const req = new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return Promise.resolve(
+    route.handler({
+      req,
+      url: new URL(url),
+      params: { id: conversationId },
+    } as unknown as RouteContext),
+  );
+}
+
+describe("POST /v1/conversations/:id/playground/inject-compaction-failures", () => {
+  test("returns 404 when the compaction-playground flag is disabled", async () => {
+    const conversation = makeConversation();
+    const deps = makeDeps({ enabled: false, conversation });
+    const route = getInjectRoute(deps);
+
+    const res = await invoke(route, conversation.conversationId, {});
+    expect(res.status).toBe(404);
+
+    // Flag-gated — the handler must not mutate conversation state or emit
+    // events when the playground is disabled.
+    expect(conversation.sentMessages).toHaveLength(0);
+  });
+
+  test("returns 404 when the conversation is missing", async () => {
+    const deps = makeDeps({ enabled: true, conversation: undefined });
+    const route = getInjectRoute(deps);
+
+    const res = await invoke(route, "missing-conv-id", {});
+    expect(res.status).toBe(404);
+
+    const body = (await res.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  test("mutates both fields and emits compaction_circuit_open when both provided", async () => {
+    const conversation = makeConversation("conv-open");
+    const deps = makeDeps({ enabled: true, conversation });
+    const route = getInjectRoute(deps);
+
+    const beforeNow = Date.now();
+    const res = await invoke(route, conversation.conversationId, {
+      consecutiveFailures: 3,
+      circuitOpenForMs: 60_000,
+    });
+    const afterNow = Date.now();
+    expect(res.status).toBe(200);
+
+    expect(conversation.consecutiveCompactionFailures).toBe(3);
+    expect(conversation.compactionCircuitOpenUntil).not.toBeNull();
+    const openUntil = conversation.compactionCircuitOpenUntil!;
+    expect(openUntil).toBeGreaterThanOrEqual(beforeNow + 60_000);
+    expect(openUntil).toBeLessThanOrEqual(afterNow + 60_000);
+
+    // Exactly one event emitted with the expected shape.
+    expect(conversation.sentMessages).toHaveLength(1);
+    expect(conversation.sentMessages[0]).toEqual({
+      type: "compaction_circuit_open",
+      conversationId: conversation.conversationId,
+      reason: "3_consecutive_failures",
+      openUntil,
+    });
+  });
+
+  test("clears the circuit and emits compaction_circuit_closed on circuitOpenForMs: 0", async () => {
+    const conversation = makeConversation("conv-close");
+    // Start with an open breaker so the endpoint can clear it.
+    conversation.compactionCircuitOpenUntil = Date.now() + 10_000;
+    conversation.consecutiveCompactionFailures = 3;
+
+    const deps = makeDeps({ enabled: true, conversation });
+    const route = getInjectRoute(deps);
+
+    const res = await invoke(route, conversation.conversationId, {
+      circuitOpenForMs: 0,
+    });
+    expect(res.status).toBe(200);
+
+    expect(conversation.compactionCircuitOpenUntil).toBeNull();
+    // consecutiveFailures was not specified in the body, so it must be
+    // unchanged (the endpoint only mutates fields that are explicitly set).
+    expect(conversation.consecutiveCompactionFailures).toBe(3);
+
+    expect(conversation.sentMessages).toHaveLength(1);
+    expect(conversation.sentMessages[0]).toEqual({
+      type: "compaction_circuit_closed",
+      conversationId: conversation.conversationId,
+    });
+  });
+
+  test("rejects out-of-range consecutiveFailures with 400", async () => {
+    const conversation = makeConversation();
+    const deps = makeDeps({ enabled: true, conversation });
+    const route = getInjectRoute(deps);
+
+    const res = await invoke(route, conversation.conversationId, {
+      consecutiveFailures: 99, // above max (10)
+    });
+    expect(res.status).toBe(400);
+
+    // No mutation, no event.
+    expect(conversation.consecutiveCompactionFailures).toBe(0);
+    expect(conversation.sentMessages).toHaveLength(0);
+  });
+
+  test("rejects out-of-range circuitOpenForMs with 400", async () => {
+    const conversation = makeConversation();
+    const deps = makeDeps({ enabled: true, conversation });
+    const route = getInjectRoute(deps);
+
+    const res = await invoke(route, conversation.conversationId, {
+      circuitOpenForMs: 25 * 60 * 60 * 1000, // 25h, above the 24h cap
+    });
+    expect(res.status).toBe(400);
+
+    expect(conversation.compactionCircuitOpenUntil).toBeNull();
+    expect(conversation.sentMessages).toHaveLength(0);
+  });
+
+  test("rejects negative consecutiveFailures with 400", async () => {
+    const conversation = makeConversation();
+    const deps = makeDeps({ enabled: true, conversation });
+    const route = getInjectRoute(deps);
+
+    const res = await invoke(route, conversation.conversationId, {
+      consecutiveFailures: -1,
+    });
+    expect(res.status).toBe(400);
+    expect(conversation.consecutiveCompactionFailures).toBe(0);
+  });
+
+  test("response body includes the full CompactionStateResponse shape", async () => {
+    const conversation = makeConversation("conv-shape");
+    const deps = makeDeps({ enabled: true, conversation });
+    const route = getInjectRoute(deps);
+
+    const res = await invoke(route, conversation.conversationId, {
+      consecutiveFailures: 2,
+    });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    const requiredKeys = [
+      "estimatedInputTokens",
+      "maxInputTokens",
+      "compactThresholdRatio",
+      "thresholdTokens",
+      "messageCount",
+      "contextCompactedMessageCount",
+      "contextCompactedAt",
+      "consecutiveCompactionFailures",
+      "compactionCircuitOpenUntil",
+      "isCircuitOpen",
+      "isCompactionEnabled",
+    ];
+    for (const key of requiredKeys) {
+      expect(body).toHaveProperty(key);
+    }
+    expect(body.consecutiveCompactionFailures).toBe(2);
+    expect(body.isCircuitOpen).toBe(false);
+    expect(body.compactionCircuitOpenUntil).toBeNull();
+    expect(typeof body.estimatedInputTokens).toBe("number");
+    expect(typeof body.maxInputTokens).toBe("number");
+    expect(typeof body.compactThresholdRatio).toBe("number");
+    expect(typeof body.thresholdTokens).toBe("number");
+    expect(typeof body.messageCount).toBe("number");
+    expect(typeof body.isCompactionEnabled).toBe("boolean");
+  });
+});

--- a/assistant/src/runtime/routes/playground/index.ts
+++ b/assistant/src/runtime/routes/playground/index.ts
@@ -1,6 +1,7 @@
 import type { RouteDefinition } from "../../http-router.js";
 import type { PlaygroundRouteDeps } from "./deps.js";
 import { forceCompactRouteDefinitions } from "./force-compact.js";
+import { injectFailuresRouteDefinitions } from "./inject-failures.js";
 import { resetCircuitRouteDefinitions } from "./reset-circuit.js";
 import { stateRouteDefinitions } from "./state.js";
 
@@ -10,11 +11,13 @@ export { assertPlaygroundEnabled } from "./guard.js";
 export function playgroundRouteDefinitions(
   deps: PlaygroundRouteDeps,
 ): RouteDefinition[] {
-  // Subsequent PRs append concrete route builders here (each returns
-  // RouteDefinition[]). Keeping this as a spread list makes later PRs
-  // purely additive with minimal conflict risk across concurrent PRs.
+  // Each playground route file exports its own `*RouteDefinitions(deps)`
+  // factory; this aggregator spreads the arrays together. Later PRs in the
+  // plan append more imports here — keeping it purely additive minimizes
+  // conflicts across concurrent playground PRs.
   return [
     ...forceCompactRouteDefinitions(deps),
+    ...injectFailuresRouteDefinitions(deps),
     ...resetCircuitRouteDefinitions(deps),
     ...stateRouteDefinitions(deps),
   ];

--- a/assistant/src/runtime/routes/playground/inject-failures.ts
+++ b/assistant/src/runtime/routes/playground/inject-failures.ts
@@ -1,0 +1,161 @@
+/**
+ * POST /v1/conversations/:id/playground/inject-compaction-failures
+ * directly mutates the compaction circuit-breaker state on a conversation.
+ *
+ * This is a dev-only playground endpoint gated by the
+ * `compaction-playground` feature flag. It lets integration tests and the
+ * macOS playground UI drive the circuit breaker into interesting states
+ * without having to wait for real consecutive summary-LLM failures.
+ *
+ * When `circuitOpenForMs` is set to a positive number, the endpoint emits a
+ * `compaction_circuit_open` event with reason `3_consecutive_failures`
+ * (matching the event shape produced by `trackCompactionOutcome` in
+ * `conversation-agent-loop.ts`). Passing `circuitOpenForMs: 0` clears the
+ * open-until timestamp and emits `compaction_circuit_closed`, mirroring the
+ * transition event the daemon emits on the open → closed edge.
+ */
+
+import { z } from "zod";
+
+import { getConfig } from "../../../config/loader.js";
+import { estimatePromptTokens } from "../../../context/token-estimator.js";
+import type { Conversation } from "../../../daemon/conversation.js";
+import { httpError } from "../../http-errors.js";
+import type { RouteDefinition } from "../../http-router.js";
+import { assertPlaygroundEnabled } from "./guard.js";
+import type { PlaygroundRouteDeps } from "./index.js";
+
+const InjectBodySchema = z.object({
+  consecutiveFailures: z.number().int().min(0).max(10).optional(),
+  circuitOpenForMs: z
+    .number()
+    .int()
+    .min(0)
+    .max(24 * 60 * 60 * 1000)
+    .optional(),
+});
+
+export function injectFailuresRouteDefinitions(
+  deps: PlaygroundRouteDeps,
+): RouteDefinition[] {
+  return [
+    {
+      endpoint: "conversations/:id/playground/inject-compaction-failures",
+      method: "POST",
+      policyKey: "conversations/playground/inject-failures",
+      summary:
+        "Directly mutate compaction circuit-breaker state (dev-only playground)",
+      tags: ["playground"],
+      requestBody: InjectBodySchema,
+      handler: async ({ req, params }) => {
+        const gate = assertPlaygroundEnabled(deps);
+        if (gate) return gate;
+
+        const conversation = deps.getConversationById(params.id);
+        if (!conversation) {
+          return httpError(
+            "NOT_FOUND",
+            `Conversation ${params.id} not found`,
+            404,
+          );
+        }
+
+        let rawBody: unknown = {};
+        try {
+          const contentLength = req.headers.get("content-length");
+          if (contentLength !== "0" && req.body !== null) {
+            rawBody = await req.json();
+          }
+        } catch {
+          return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+        }
+
+        const parsed = InjectBodySchema.safeParse(rawBody ?? {});
+        if (!parsed.success) {
+          return httpError("BAD_REQUEST", parsed.error.message, 400);
+        }
+        const { consecutiveFailures, circuitOpenForMs } = parsed.data;
+
+        if (consecutiveFailures !== undefined) {
+          conversation.consecutiveCompactionFailures = consecutiveFailures;
+        }
+
+        if (circuitOpenForMs !== undefined) {
+          if (circuitOpenForMs === 0) {
+            conversation.compactionCircuitOpenUntil = null;
+            // Mirror the `compaction_circuit_closed` transition event the
+            // daemon emits when the breaker auto-closes after a successful
+            // compaction, so the Swift banner dismisses immediately.
+            conversation.sendToClient({
+              type: "compaction_circuit_closed",
+              conversationId: conversation.conversationId,
+            });
+          } else {
+            const openUntil = Date.now() + circuitOpenForMs;
+            conversation.compactionCircuitOpenUntil = openUntil;
+            conversation.sendToClient({
+              type: "compaction_circuit_open",
+              conversationId: conversation.conversationId,
+              reason: "3_consecutive_failures",
+              openUntil,
+            });
+          }
+        }
+
+        return Response.json(buildCompactionState(conversation));
+      },
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Local state-builder — shared shape across PR 7/8/9.
+//
+// PR 9 (the state endpoint) will extract a canonical shared implementation of
+// this helper. For now each parallel PR maintains an identical copy so the
+// three file-level diffs stay independent.
+// ---------------------------------------------------------------------------
+
+export interface CompactionStateResponse {
+  estimatedInputTokens: number;
+  maxInputTokens: number;
+  compactThresholdRatio: number;
+  thresholdTokens: number;
+  messageCount: number;
+  contextCompactedMessageCount: number;
+  contextCompactedAt: number | null;
+  consecutiveCompactionFailures: number;
+  compactionCircuitOpenUntil: number | null;
+  isCircuitOpen: boolean;
+  isCompactionEnabled: boolean;
+}
+
+function buildCompactionState(
+  conversation: Conversation,
+): CompactionStateResponse {
+  const ctxConfig = getConfig().llm.default.contextWindow;
+  const maxInputTokens = ctxConfig.maxInputTokens;
+  const compactThresholdRatio = ctxConfig.compactThreshold;
+  const isCompactionEnabled = ctxConfig.enabled;
+  const thresholdTokens = Math.floor(maxInputTokens * compactThresholdRatio);
+
+  const messages = conversation.getMessages();
+  const estimatedInputTokens = estimatePromptTokens(messages);
+  const circuitOpenUntil = conversation.compactionCircuitOpenUntil;
+  const isCircuitOpen =
+    circuitOpenUntil !== null && Date.now() < circuitOpenUntil;
+
+  return {
+    estimatedInputTokens,
+    maxInputTokens,
+    compactThresholdRatio,
+    thresholdTokens,
+    messageCount: messages.length,
+    contextCompactedMessageCount: conversation.contextCompactedMessageCount,
+    contextCompactedAt: conversation.contextCompactedAt,
+    consecutiveCompactionFailures: conversation.consecutiveCompactionFailures,
+    compactionCircuitOpenUntil: circuitOpenUntil,
+    isCircuitOpen,
+    isCompactionEnabled,
+  };
+}


### PR DESCRIPTION
## Summary
- Add inject-failures playground endpoint that directly sets `consecutiveCompactionFailures` and/or `compactionCircuitOpenUntil` on a conversation
- Emits `compaction_circuit_open` / `compaction_circuit_closed` events so existing UI toasts react as in production
- Returns the full `CompactionStateResponse` shape (shared with PRs 8, 9)

Part of plan: compaction-playground-macos.md (PR 7 of 17)
Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
