### PR TITLE
feat(playground): add GET /v1/conversations/:id/playground/compaction-state

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -2895,6 +2895,21 @@ paths:
           required: true
           schema:
             type: string
+  /v1/conversations/{id}/playground/compaction-state:
+    get:
+      operationId: conversations_by_id_playground_compactionstate_get
+      summary: Read current compaction state for a conversation
+      tags:
+        - playground
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/conversations/{id}/playground/reset-compaction-circuit:
     post:
       operationId: conversations_by_id_playground_resetcompactioncircuit_post

--- a/assistant/src/runtime/routes/playground/__tests__/state.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/state.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({
+    llm: {
+      default: {
+        contextWindow: {
+          enabled: true,
+          maxInputTokens: 200_000,
+          compactThreshold: 0.8,
+        },
+      },
+    },
+  }),
+}));
+
+// estimatePromptTokens has no external dependencies beyond its `messages`
+// argument, but we mock it so the assertions here do not depend on the
+// estimator's internal tuning.
+mock.module("../../../../context/token-estimator.js", () => ({
+  estimatePromptTokens: (messages: unknown[]): number => messages.length * 10,
+}));
+
+import type { Conversation } from "../../../../daemon/conversation.js";
+import type { PlaygroundRouteDeps } from "../deps.js";
+import { playgroundRouteDefinitions } from "../index.js";
+import { buildCompactionStateResponse } from "../state.js";
+
+function makeDeps(
+  overrides: Partial<PlaygroundRouteDeps> = {},
+): PlaygroundRouteDeps {
+  return {
+    getConversationById: () => undefined,
+    isPlaygroundEnabled: () => true,
+    ...overrides,
+  };
+}
+
+interface FakeConversationOverrides {
+  messages?: unknown[];
+  contextCompactedMessageCount?: number;
+  contextCompactedAt?: number | null;
+  consecutiveCompactionFailures?: number;
+  compactionCircuitOpenUntil?: number | null;
+}
+
+function makeFakeConversation(
+  overrides: FakeConversationOverrides = {},
+): Conversation {
+  const messages = overrides.messages ?? [];
+  return {
+    getMessages: () => messages,
+    contextCompactedMessageCount: overrides.contextCompactedMessageCount ?? 0,
+    contextCompactedAt: overrides.contextCompactedAt ?? null,
+    consecutiveCompactionFailures: overrides.consecutiveCompactionFailures ?? 0,
+    compactionCircuitOpenUntil: overrides.compactionCircuitOpenUntil ?? null,
+  } as unknown as Conversation;
+}
+
+function findStateRoute() {
+  const routes = playgroundRouteDefinitions(makeDeps());
+  const route = routes.find(
+    (r) =>
+      r.endpoint === "conversations/:id/playground/compaction-state" &&
+      r.method === "GET",
+  );
+  if (!route) throw new Error("compaction-state route not registered");
+  return route;
+}
+
+async function invokeRoute(
+  deps: PlaygroundRouteDeps,
+  id = "conv-abc",
+): Promise<Response> {
+  const routes = playgroundRouteDefinitions(deps);
+  const route = routes.find(
+    (r) =>
+      r.endpoint === "conversations/:id/playground/compaction-state" &&
+      r.method === "GET",
+  );
+  if (!route) throw new Error("compaction-state route not registered");
+  // The handler only reads `params` from RouteContext — cast a minimal stub.
+  return Promise.resolve(
+    route.handler({
+      params: { id },
+    } as unknown as Parameters<typeof route.handler>[0]),
+  );
+}
+
+describe("GET conversations/:id/playground/compaction-state", () => {
+  test("registers the expected route definition", () => {
+    const route = findStateRoute();
+    expect(route.policyKey).toBe("conversations/playground/state");
+    expect(route.tags).toEqual(["playground"]);
+  });
+
+  test("returns 404 when the playground flag is disabled", async () => {
+    const deps = makeDeps({ isPlaygroundEnabled: () => false });
+    const res = await invokeRoute(deps);
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  test("returns 404 when the conversation does not exist", async () => {
+    const deps = makeDeps({
+      getConversationById: () => undefined,
+    });
+    const res = await invokeRoute(deps, "missing-id");
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.code).toBe("NOT_FOUND");
+    expect(body.error.message).toContain("missing-id");
+  });
+
+  test("fresh conversation with no messages returns a baseline payload", async () => {
+    const conversation = makeFakeConversation();
+    const deps = makeDeps({
+      getConversationById: () => conversation,
+    });
+    const res = await invokeRoute(deps);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ReturnType<
+      typeof buildCompactionStateResponse
+    >;
+    expect(body.messageCount).toBe(0);
+    expect(body.estimatedInputTokens).toBe(0);
+    expect(body.maxInputTokens).toBe(200_000);
+    expect(body.compactThresholdRatio).toBe(0.8);
+    expect(body.thresholdTokens).toBe(160_000);
+    expect(body.contextCompactedMessageCount).toBe(0);
+    expect(body.contextCompactedAt).toBeNull();
+    expect(body.consecutiveCompactionFailures).toBe(0);
+    expect(body.compactionCircuitOpenUntil).toBeNull();
+    expect(body.isCircuitOpen).toBe(false);
+    expect(body.isCompactionEnabled).toBe(true);
+  });
+
+  test("open circuit breaker sets isCircuitOpen: true", async () => {
+    const future = Date.now() + 5_000;
+    const conversation = makeFakeConversation({
+      compactionCircuitOpenUntil: future,
+      consecutiveCompactionFailures: 3,
+    });
+    const deps = makeDeps({
+      getConversationById: () => conversation,
+    });
+    const res = await invokeRoute(deps);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ReturnType<
+      typeof buildCompactionStateResponse
+    >;
+    expect(body.compactionCircuitOpenUntil).toBe(future);
+    expect(body.consecutiveCompactionFailures).toBe(3);
+    expect(body.isCircuitOpen).toBe(true);
+  });
+
+  test("elapsed circuit-breaker deadline leaves isCircuitOpen: false", async () => {
+    const past = Date.now() - 1_000;
+    const conversation = makeFakeConversation({
+      compactionCircuitOpenUntil: past,
+    });
+    const deps = makeDeps({
+      getConversationById: () => conversation,
+    });
+    const res = await invokeRoute(deps);
+    const body = (await res.json()) as ReturnType<
+      typeof buildCompactionStateResponse
+    >;
+    expect(body.compactionCircuitOpenUntil).toBe(past);
+    expect(body.isCircuitOpen).toBe(false);
+  });
+
+  test("full response shape matches the canonical CompactionStateResponse keys", async () => {
+    const conversation = makeFakeConversation({
+      messages: [{ role: "user" }, { role: "assistant" }],
+      contextCompactedMessageCount: 2,
+      contextCompactedAt: 1_700_000_000_000,
+      consecutiveCompactionFailures: 1,
+      compactionCircuitOpenUntil: null,
+    });
+    const deps = makeDeps({
+      getConversationById: () => conversation,
+    });
+    const res = await invokeRoute(deps);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(Object.keys(body).sort()).toEqual(
+      [
+        "estimatedInputTokens",
+        "maxInputTokens",
+        "compactThresholdRatio",
+        "thresholdTokens",
+        "messageCount",
+        "contextCompactedMessageCount",
+        "contextCompactedAt",
+        "consecutiveCompactionFailures",
+        "compactionCircuitOpenUntil",
+        "isCircuitOpen",
+        "isCompactionEnabled",
+      ].sort(),
+    );
+    expect(body.messageCount).toBe(2);
+    expect(body.estimatedInputTokens).toBe(20);
+    expect(body.contextCompactedAt).toBe(1_700_000_000_000);
+    expect(body.contextCompactedMessageCount).toBe(2);
+  });
+});
+
+describe("buildCompactionStateResponse", () => {
+  test("is exported for reuse by PR 7 / PR 8 consolidations", () => {
+    const conversation = makeFakeConversation();
+    const snapshot = buildCompactionStateResponse(conversation);
+    expect(typeof snapshot.estimatedInputTokens).toBe("number");
+    expect(typeof snapshot.isCircuitOpen).toBe("boolean");
+  });
+});

--- a/assistant/src/runtime/routes/playground/index.ts
+++ b/assistant/src/runtime/routes/playground/index.ts
@@ -2,6 +2,7 @@ import type { RouteDefinition } from "../../http-router.js";
 import type { PlaygroundRouteDeps } from "./deps.js";
 import { forceCompactRouteDefinitions } from "./force-compact.js";
 import { resetCircuitRouteDefinitions } from "./reset-circuit.js";
+import { stateRouteDefinitions } from "./state.js";
 
 export type { PlaygroundRouteDeps };
 export { assertPlaygroundEnabled } from "./guard.js";
@@ -15,5 +16,6 @@ export function playgroundRouteDefinitions(
   return [
     ...forceCompactRouteDefinitions(deps),
     ...resetCircuitRouteDefinitions(deps),
+    ...stateRouteDefinitions(deps),
   ];
 }

--- a/assistant/src/runtime/routes/playground/state.ts
+++ b/assistant/src/runtime/routes/playground/state.ts
@@ -1,0 +1,82 @@
+/**
+ * GET /v1/conversations/:id/playground/compaction-state
+ *
+ * Read-only view of compaction-relevant state for a conversation. Returns the
+ * token estimate, the configured maxInputTokens / compactThreshold, the
+ * derived threshold token count, current message count, compaction-progress
+ * counters, and circuit-breaker status.
+ *
+ * The endpoint is gated by the `compaction-playground` feature flag via the
+ * shared `assertPlaygroundEnabled` guard — when disabled the whole surface is
+ * invisible in production.
+ */
+
+import { getConfig } from "../../../config/loader.js";
+import { estimatePromptTokens } from "../../../context/token-estimator.js";
+import type { Conversation } from "../../../daemon/conversation.js";
+import { httpError } from "../../http-errors.js";
+import type { RouteDefinition } from "../../http-router.js";
+import { assertPlaygroundEnabled, type PlaygroundRouteDeps } from "./index.js";
+
+/**
+ * Build the `CompactionStateResponse` payload used by:
+ *  - GET ...playground/compaction-state (this file)
+ *  - POST ...playground/inject-compaction-failures (PR 7)
+ *  - POST ...playground/reset-compaction-circuit (PR 8)
+ *
+ * Exported so follow-up cleanup PRs can replace inline copies in PR 7 / PR 8
+ * with this canonical implementation.
+ */
+export function buildCompactionStateResponse(conversation: Conversation) {
+  const messages = conversation.getMessages();
+  const estimatedInputTokens = estimatePromptTokens(messages);
+  const cfg = getConfig().llm.default.contextWindow;
+  const maxInputTokens = cfg.maxInputTokens;
+  const compactThresholdRatio = cfg.compactThreshold;
+  const thresholdTokens = Math.floor(maxInputTokens * compactThresholdRatio);
+  const compactionCircuitOpenUntil = conversation.compactionCircuitOpenUntil;
+  return {
+    estimatedInputTokens,
+    maxInputTokens,
+    compactThresholdRatio,
+    thresholdTokens,
+    messageCount: messages.length,
+    contextCompactedMessageCount: conversation.contextCompactedMessageCount,
+    contextCompactedAt: conversation.contextCompactedAt,
+    consecutiveCompactionFailures: conversation.consecutiveCompactionFailures,
+    compactionCircuitOpenUntil,
+    isCircuitOpen:
+      compactionCircuitOpenUntil !== null &&
+      Date.now() < compactionCircuitOpenUntil,
+    isCompactionEnabled: cfg.enabled,
+  };
+}
+
+export function stateRouteDefinitions(
+  deps: PlaygroundRouteDeps,
+): RouteDefinition[] {
+  return [
+    {
+      endpoint: "conversations/:id/playground/compaction-state",
+      method: "GET",
+      policyKey: "conversations/playground/state",
+      summary: "Read current compaction state for a conversation",
+      tags: ["playground"],
+      handler: ({ params }) => {
+        const gate = assertPlaygroundEnabled(deps);
+        if (gate) return gate;
+
+        const conversation = deps.getConversationById(params.id);
+        if (!conversation) {
+          return httpError(
+            "NOT_FOUND",
+            `Conversation ${params.id} not found`,
+            404,
+          );
+        }
+
+        return Response.json(buildCompactionStateResponse(conversation));
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add state-read playground endpoint returning tokens, threshold, message counts, and circuit-breaker fields for a conversation
- Export canonical `buildCompactionStateResponse` helper (PR 7 and PR 8 hold local copies that can be consolidated in cleanup)

Part of plan: compaction-playground-macos.md (PR 9 of 17)
Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
