### PR TITLE
feat(playground): add endpoint to reset compaction circuit-breaker

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -2895,6 +2895,21 @@ paths:
           required: true
           schema:
             type: string
+  /v1/conversations/{id}/playground/reset-compaction-circuit:
+    post:
+      operationId: conversations_by_id_playground_resetcompactioncircuit_post
+      summary: Clear compaction circuit-breaker state (dev-only playground)
+      tags:
+        - playground
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/conversations/{id}/regenerate:
     post:
       operationId: conversations_by_id_regenerate_post

--- a/assistant/src/runtime/routes/playground/__tests__/guard.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/guard.test.ts
@@ -32,8 +32,14 @@ describe("assertPlaygroundEnabled", () => {
 });
 
 describe("playgroundRouteDefinitions", () => {
-  test("returns an empty array in the scaffold baseline", () => {
-    expect(playgroundRouteDefinitions(makeDeps(true))).toEqual([]);
-    expect(playgroundRouteDefinitions(makeDeps(false))).toEqual([]);
+  test("returns the registered playground routes regardless of flag state", () => {
+    // Route list composition does not depend on the feature flag — per-route
+    // `assertPlaygroundEnabled()` gating runs inside each handler at request
+    // time. Compose-time independence keeps the router identical across
+    // process lifetimes even if the flag is toggled at runtime.
+    const enabled = playgroundRouteDefinitions(makeDeps(true));
+    const disabled = playgroundRouteDefinitions(makeDeps(false));
+    expect(enabled.length).toBeGreaterThan(0);
+    expect(disabled.length).toBe(enabled.length);
   });
 });

--- a/assistant/src/runtime/routes/playground/__tests__/reset-circuit.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/reset-circuit.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must appear before any imports of the modules under test.
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({
+    llm: {
+      default: {
+        contextWindow: {
+          enabled: true,
+          maxInputTokens: 200_000,
+          compactThreshold: 0.8,
+        },
+      },
+    },
+  }),
+}));
+
+mock.module("../../../../context/token-estimator.js", () => ({
+  estimatePromptTokens: () => 1234,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports under test — after mocks.
+// ---------------------------------------------------------------------------
+
+import type { Conversation } from "../../../../daemon/conversation.js";
+import type { ServerMessage } from "../../../../daemon/message-protocol.js";
+import type { RouteContext, RouteDefinition } from "../../../http-router.js";
+import type { PlaygroundRouteDeps } from "../deps.js";
+import { resetCircuitRouteDefinitions } from "../reset-circuit.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+interface FakeConversationState {
+  consecutiveCompactionFailures: number;
+  compactionCircuitOpenUntil: number | null;
+  contextCompactedMessageCount: number;
+  contextCompactedAt: number | null;
+}
+
+interface FakeConversation {
+  conversation: Conversation;
+  sent: ServerMessage[];
+  state: FakeConversationState;
+}
+
+function makeFakeConversation(
+  overrides: Partial<FakeConversationState> = {},
+): FakeConversation {
+  const state: FakeConversationState = {
+    consecutiveCompactionFailures: 0,
+    compactionCircuitOpenUntil: null,
+    contextCompactedMessageCount: 0,
+    contextCompactedAt: null,
+    ...overrides,
+  };
+  const sent: ServerMessage[] = [];
+  const fake = {
+    conversationId: "conv-abc",
+    get consecutiveCompactionFailures(): number {
+      return state.consecutiveCompactionFailures;
+    },
+    set consecutiveCompactionFailures(value: number) {
+      state.consecutiveCompactionFailures = value;
+    },
+    get compactionCircuitOpenUntil(): number | null {
+      return state.compactionCircuitOpenUntil;
+    },
+    set compactionCircuitOpenUntil(value: number | null) {
+      state.compactionCircuitOpenUntil = value;
+    },
+    get contextCompactedMessageCount(): number {
+      return state.contextCompactedMessageCount;
+    },
+    get contextCompactedAt(): number | null {
+      return state.contextCompactedAt;
+    },
+    getMessages: () => [],
+    sendToClient: (msg: ServerMessage) => {
+      sent.push(msg);
+    },
+  } as unknown as Conversation;
+
+  return { conversation: fake, sent, state };
+}
+
+function makeDeps(
+  overrides: Partial<PlaygroundRouteDeps> = {},
+): PlaygroundRouteDeps {
+  return {
+    getConversationById: () => undefined,
+    isPlaygroundEnabled: () => true,
+    ...overrides,
+  };
+}
+
+function makeRouteContext(conversationId: string): RouteContext {
+  const url = new URL(
+    `http://localhost/v1/conversations/${conversationId}/playground/reset-compaction-circuit`,
+  );
+  return {
+    req: new Request(url, { method: "POST" }),
+    url,
+    server: {} as RouteContext["server"],
+    authContext: {
+      subject: "test-user",
+      principalType: "local",
+      assistantId: "self",
+      scopeProfile: "local_v1",
+      scopes: new Set(["local.all" as const]),
+      policyEpoch: 0,
+    },
+    params: { id: conversationId },
+  } as unknown as RouteContext;
+}
+
+function getHandler(deps: PlaygroundRouteDeps): RouteDefinition["handler"] {
+  const routes = resetCircuitRouteDefinitions(deps);
+  expect(routes).toHaveLength(1);
+  return routes[0].handler;
+}
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  return response.json();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("reset-circuit route — metadata", () => {
+  test("registers POST at conversations/:id/playground/reset-compaction-circuit", () => {
+    const routes = resetCircuitRouteDefinitions(makeDeps());
+    expect(routes).toHaveLength(1);
+    const route = routes[0];
+    expect(route.endpoint).toBe(
+      "conversations/:id/playground/reset-compaction-circuit",
+    );
+    expect(route.method).toBe("POST");
+    expect(route.policyKey).toBe("conversations/playground/reset-circuit");
+    expect(route.tags).toContain("playground");
+  });
+});
+
+describe("reset-circuit route — gating", () => {
+  let fake: FakeConversation;
+
+  beforeEach(() => {
+    fake = makeFakeConversation();
+  });
+
+  test("returns 404 when the playground flag is disabled", async () => {
+    const deps = makeDeps({
+      isPlaygroundEnabled: () => false,
+      getConversationById: () => fake.conversation,
+    });
+    const handler = getHandler(deps);
+
+    const response = (await handler(makeRouteContext("conv-abc"))) as Response;
+
+    expect(response.status).toBe(404);
+    const body = (await readJsonBody(response)) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.code).toBe("NOT_FOUND");
+    // State must not be mutated and no event emitted on the disabled path.
+    expect(fake.state.consecutiveCompactionFailures).toBe(0);
+    expect(fake.state.compactionCircuitOpenUntil).toBeNull();
+    expect(fake.sent).toHaveLength(0);
+  });
+
+  test("returns 404 when the conversation is missing", async () => {
+    const deps = makeDeps({
+      getConversationById: () => undefined,
+    });
+    const handler = getHandler(deps);
+
+    const response = (await handler(
+      makeRouteContext("missing-id"),
+    )) as Response;
+
+    expect(response.status).toBe(404);
+    const body = (await readJsonBody(response)) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.code).toBe("NOT_FOUND");
+    expect(body.error.message).toContain("missing-id");
+  });
+});
+
+describe("reset-circuit route — behavior", () => {
+  test("clears an open circuit and emits compaction_circuit_closed exactly once", async () => {
+    const future = Date.now() + 60 * 60 * 1000;
+    const fake = makeFakeConversation({
+      consecutiveCompactionFailures: 2,
+      compactionCircuitOpenUntil: future,
+    });
+    const deps = makeDeps({
+      getConversationById: () => fake.conversation,
+    });
+    const handler = getHandler(deps);
+
+    const response = (await handler(makeRouteContext("conv-abc"))) as Response;
+
+    expect(response.status).toBe(200);
+    expect(fake.state.consecutiveCompactionFailures).toBe(0);
+    expect(fake.state.compactionCircuitOpenUntil).toBeNull();
+    expect(fake.sent).toHaveLength(1);
+    expect(fake.sent[0]).toEqual({
+      type: "compaction_circuit_closed",
+      conversationId: "conv-abc",
+    });
+
+    const body = (await readJsonBody(response)) as Record<string, unknown>;
+    expect(body.consecutiveCompactionFailures).toBe(0);
+    expect(body.compactionCircuitOpenUntil).toBeNull();
+    expect(body.isCircuitOpen).toBe(false);
+    expect(body.estimatedInputTokens).toBe(1234);
+    expect(body.maxInputTokens).toBe(200_000);
+    expect(body.compactThresholdRatio).toBe(0.8);
+    expect(body.thresholdTokens).toBe(160_000);
+    expect(body.messageCount).toBe(0);
+    expect(body.contextCompactedMessageCount).toBe(0);
+    expect(body.contextCompactedAt).toBeNull();
+    expect(body.isCompactionEnabled).toBe(true);
+  });
+
+  test("with the circuit already closed, zeroes the counter without emitting an event", async () => {
+    const fake = makeFakeConversation({
+      consecutiveCompactionFailures: 2,
+      compactionCircuitOpenUntil: null,
+    });
+    const deps = makeDeps({
+      getConversationById: () => fake.conversation,
+    });
+    const handler = getHandler(deps);
+
+    const response = (await handler(makeRouteContext("conv-abc"))) as Response;
+
+    expect(response.status).toBe(200);
+    expect(fake.state.consecutiveCompactionFailures).toBe(0);
+    expect(fake.state.compactionCircuitOpenUntil).toBeNull();
+    // Do not emit compaction_circuit_closed when the breaker was already
+    // closed — the event is reserved for the open→closed transition so the
+    // Swift banner doesn't receive redundant "paused" dismissals.
+    expect(fake.sent).toHaveLength(0);
+
+    const body = (await readJsonBody(response)) as Record<string, unknown>;
+    expect(body.consecutiveCompactionFailures).toBe(0);
+    expect(body.compactionCircuitOpenUntil).toBeNull();
+    expect(body.isCircuitOpen).toBe(false);
+  });
+});

--- a/assistant/src/runtime/routes/playground/index.ts
+++ b/assistant/src/runtime/routes/playground/index.ts
@@ -1,14 +1,15 @@
 import type { RouteDefinition } from "../../http-router.js";
 import type { PlaygroundRouteDeps } from "./deps.js";
+import { resetCircuitRouteDefinitions } from "./reset-circuit.js";
 
 export type { PlaygroundRouteDeps };
 export { assertPlaygroundEnabled } from "./guard.js";
 
 export function playgroundRouteDefinitions(
-  _deps: PlaygroundRouteDeps,
+  deps: PlaygroundRouteDeps,
 ): RouteDefinition[] {
   // Subsequent PRs append concrete route builders here (each returns
   // RouteDefinition[]). Keeping this as a spread list makes later PRs
   // purely additive with minimal conflict risk across concurrent PRs.
-  return [];
+  return [...resetCircuitRouteDefinitions(deps)];
 }

--- a/assistant/src/runtime/routes/playground/reset-circuit.ts
+++ b/assistant/src/runtime/routes/playground/reset-circuit.ts
@@ -1,0 +1,119 @@
+/**
+ * POST /v1/conversations/:id/playground/reset-compaction-circuit
+ *
+ * Dev-only playground endpoint that clears the compaction circuit-breaker
+ * state on a live conversation. Intended for reproducing flows that normally
+ * require three real summary-LLM failures to trigger — without this hatch,
+ * exercising the "auto-compaction paused" banner requires bespoke fault
+ * injection.
+ *
+ * Behavior:
+ *   - `consecutiveCompactionFailures` is always zeroed.
+ *   - `compactionCircuitOpenUntil` is cleared to null only when it was set;
+ *     the `compaction_circuit_closed` event is emitted on the open→closed
+ *     transition so the Swift banner dismisses immediately, mirroring the
+ *     behavior of a successful compaction in `trackCompactionOutcome()`.
+ *     Calling this endpoint while the breaker is already closed is a no-op
+ *     on the event channel — it never emits a redundant close event.
+ *
+ * Guarded by `assertPlaygroundEnabled()` — the route 404s when the
+ * `compaction-playground` feature flag is disabled, so the entire surface
+ * is invisible in production.
+ */
+
+import { getConfig } from "../../../config/loader.js";
+import { estimatePromptTokens } from "../../../context/token-estimator.js";
+import type { Conversation } from "../../../daemon/conversation.js";
+import { httpError } from "../../http-errors.js";
+import type { RouteDefinition } from "../../http-router.js";
+// Import directly from the source modules (not ./index.js) — index.ts imports
+// this file's `resetCircuitRouteDefinitions`, so pulling its re-exports back
+// through the barrel would create a cycle.
+import type { PlaygroundRouteDeps } from "./deps.js";
+import { assertPlaygroundEnabled } from "./guard.js";
+
+export function resetCircuitRouteDefinitions(
+  deps: PlaygroundRouteDeps,
+): RouteDefinition[] {
+  return [
+    {
+      endpoint: "conversations/:id/playground/reset-compaction-circuit",
+      method: "POST",
+      policyKey: "conversations/playground/reset-circuit",
+      summary: "Clear compaction circuit-breaker state (dev-only playground)",
+      tags: ["playground"],
+      handler: ({ params }) => {
+        const gate = assertPlaygroundEnabled(deps);
+        if (gate) return gate;
+
+        const conversation = deps.getConversationById(params.id);
+        if (!conversation) {
+          return httpError(
+            "NOT_FOUND",
+            `Conversation ${params.id} not found`,
+            404,
+          );
+        }
+
+        conversation.consecutiveCompactionFailures = 0;
+        if (conversation.compactionCircuitOpenUntil !== null) {
+          conversation.compactionCircuitOpenUntil = null;
+          // Mirror `trackCompactionOutcome()` — emit only on the open→closed
+          // transition so clients don't receive a redundant close event when
+          // the breaker was already closed.
+          conversation.sendToClient({
+            type: "compaction_circuit_closed",
+            conversationId: conversation.conversationId,
+          });
+        }
+
+        return Response.json(buildCompactionState(conversation));
+      },
+    },
+  ];
+}
+
+/**
+ * Local state-builder with the same shape as the (future) shared
+ * `CompactionStateResponse`. Sibling PRs (7, 9) carry near-identical copies;
+ * PR 9 extracts a consolidated version and this local copy can be deleted at
+ * that cleanup step.
+ */
+function buildCompactionState(conversation: Conversation): {
+  estimatedInputTokens: number;
+  maxInputTokens: number;
+  compactThresholdRatio: number;
+  thresholdTokens: number;
+  messageCount: number;
+  contextCompactedMessageCount: number;
+  contextCompactedAt: number | null;
+  consecutiveCompactionFailures: number;
+  compactionCircuitOpenUntil: number | null;
+  isCircuitOpen: boolean;
+  isCompactionEnabled: boolean;
+} {
+  const config = getConfig();
+  const contextWindow = config.llm.default.contextWindow;
+  const messages = conversation.getMessages();
+  const estimatedInputTokens = estimatePromptTokens(messages);
+  const maxInputTokens = contextWindow.maxInputTokens;
+  const compactThresholdRatio = contextWindow.compactThreshold;
+  const thresholdTokens = Math.floor(maxInputTokens * compactThresholdRatio);
+  const isCircuitOpen =
+    conversation.compactionCircuitOpenUntil !== null &&
+    Date.now() < conversation.compactionCircuitOpenUntil;
+
+  return {
+    estimatedInputTokens,
+    maxInputTokens,
+    compactThresholdRatio,
+    thresholdTokens,
+    messageCount: messages.length,
+    contextCompactedMessageCount: conversation.contextCompactedMessageCount,
+    contextCompactedAt: conversation.contextCompactedAt,
+    consecutiveCompactionFailures: conversation.consecutiveCompactionFailures,
+    compactionCircuitOpenUntil: conversation.compactionCircuitOpenUntil,
+    isCircuitOpen,
+    isCompactionEnabled: contextWindow.enabled,
+  };
+}


### PR DESCRIPTION
## Summary
- Add reset-circuit playground endpoint that clears `consecutiveCompactionFailures` and `compactionCircuitOpenUntil`
- Emits `compaction_circuit_closed` event only when the circuit was actually open (no redundant emissions)
- Returns the full `CompactionStateResponse` shape (shared with PRs 7, 9)

Part of plan: compaction-playground-macos.md (PR 8 of 17)
Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
