### PR TITLE
feat(ds): add feedNudge/Digest/Thread tokens and wire Home feed to use them

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedFilterBar.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedFilterBar.swift
@@ -93,15 +93,15 @@ private struct HomeFeedFilterChip: View {
         }
     }
 
-    /// Glyph color. The plan referenced raw Danger/Forest 500-scale
-    /// colors that don't exist in this codebase — these semantic
-    /// tokens are the closest equivalents (see ColorTokens.swift).
+    /// Glyph color. `.action` uses the info/blue pair; the other three
+    /// use the dedicated feed-type pairs (pink / teal / amber per Figma).
+    /// See `ColorTokens.swift`.
     private var foreground: Color {
         switch type {
-        case .nudge:   return VColor.systemNegativeStrong
+        case .nudge:   return VColor.feedNudgeStrong
         case .action:  return VColor.systemInfoStrong
-        case .digest:  return VColor.systemPositiveStrong
-        case .thread:  return VColor.systemMidStrong
+        case .digest:  return VColor.feedDigestStrong
+        case .thread:  return VColor.feedThreadStrong
         }
     }
 
@@ -109,10 +109,10 @@ private struct HomeFeedFilterChip: View {
     /// the Figma chip-by-chip color mapping.
     private var background: Color {
         switch type {
-        case .nudge:   return VColor.systemNegativeWeak
+        case .nudge:   return VColor.feedNudgeWeak
         case .action:  return VColor.systemInfoWeak
-        case .digest:  return VColor.systemPositiveWeak
-        case .thread:  return VColor.systemMidWeak
+        case .digest:  return VColor.feedDigestWeak
+        case .thread:  return VColor.feedThreadWeak
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -357,17 +357,17 @@ struct HomeGallerySection: View {
 
                 VCard(background: VColor.surfaceBase) {
                     VStack(spacing: VSpacing.xs) {
-                        // Heartbeat (nudge): danger/red tint.
+                        // Heartbeat (nudge): pink.
                         HomeRecapRow(
                             icon: .heart,
-                            iconForeground: VColor.systemNegativeStrong,
-                            iconBackground: VColor.systemNegativeWeak,
+                            iconForeground: VColor.feedNudgeStrong,
+                            iconBackground: VColor.feedNudgeWeak,
                             title: "Heartbeat – all systems healthy",
                             onDismiss: {},
                             onTap: {}
                         )
 
-                        // Permission (action): info/blue tint.
+                        // Input (action): info/blue.
                         HomeRecapRow(
                             icon: .arrowLeft,
                             iconForeground: VColor.systemInfoStrong,
@@ -377,21 +377,21 @@ struct HomeGallerySection: View {
                             onTap: {}
                         )
 
-                        // Digest: emerald/positive tint.
+                        // Notification (digest): teal.
                         HomeRecapRow(
                             icon: .bell,
-                            iconForeground: VColor.systemPositiveStrong,
-                            iconBackground: VColor.systemPositiveWeak,
+                            iconForeground: VColor.feedDigestStrong,
+                            iconBackground: VColor.feedDigestWeak,
                             title: "Last, while you were away, I ran the email clean job and deleted 26 emails…",
                             onDismiss: {},
                             onTap: {}
                         )
 
-                        // Thread (schedule): amber/mid tint.
+                        // Schedule (thread): amber.
                         HomeRecapRow(
                             icon: .calendar,
-                            iconForeground: VColor.systemMidStrong,
-                            iconBackground: VColor.systemMidWeak,
+                            iconForeground: VColor.feedThreadStrong,
+                            iconBackground: VColor.feedThreadWeak,
                             title: "There's also 4 low priority updates if you want to have a look.",
                             onDismiss: {},
                             onTap: {}

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -254,45 +254,27 @@ struct HomePageView<DetailPanel: View>: View {
         }
     }
 
-    /// Foreground (glyph) color for the recap icon. The plan referenced
-    /// raw Danger/Forest 500-scale colors, which do not exist in this
-    /// codebase — the closest semantic tokens live in `VColor` (see
-    /// `ColorTokens.swift`). No raw hex values are used.
+    /// Foreground (glyph) color for the recap icon. Each feed type maps
+    /// to its dedicated Figma identifier pair (pink / blue / teal /
+    /// amber) — see the `feed*` and `systemInfo*` tokens in
+    /// `ColorTokens.swift`. Rows and filter chips share one source of
+    /// truth so the visual language stays consistent.
     private func iconForeground(for item: FeedItem) -> Color {
         switch item.type {
-        case .nudge:
-            // Plan: Danger._500. Closest existing token.
-            return VColor.systemNegativeStrong
-        case .action:
-            // Aligned with the Input filter chip — info/blue pair
-            // (#467CC8 glyph over #CEDAEC tint in light; #2A3A50 tint
-            // in dark) so Input rows and chip share one tint.
-            return VColor.systemInfoStrong
-        case .digest:
-            // Plan: Forest._500. Closest existing token.
-            return VColor.systemPositiveStrong
-        case .thread:
-            // Aligned with the Schedule filter chip — amber/mid pair
-            // so thread rows and the Schedule chip share one tint.
-            return VColor.systemMidStrong
+        case .nudge:   return VColor.feedNudgeStrong
+        case .action:  return VColor.systemInfoStrong
+        case .digest:  return VColor.feedDigestStrong
+        case .thread:  return VColor.feedThreadStrong
         }
     }
 
     /// Background (circle fill) color for the recap icon.
     private func iconBackground(for item: FeedItem) -> Color {
         switch item.type {
-        case .nudge:
-            // Plan: Danger._900. Closest existing weak-negative tint.
-            return VColor.systemNegativeWeak
-        case .action:
-            // Aligned with the Input filter chip — info/blue pair.
-            return VColor.systemInfoWeak
-        case .digest:
-            // Plan: Forest._900. Closest existing weak-positive tint.
-            return VColor.systemPositiveWeak
-        case .thread:
-            // Aligned with the Schedule filter chip — amber/mid pair.
-            return VColor.systemMidWeak
+        case .nudge:   return VColor.feedNudgeWeak
+        case .action:  return VColor.systemInfoWeak
+        case .digest:  return VColor.feedDigestWeak
+        case .thread:  return VColor.feedThreadWeak
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
@@ -14,11 +14,13 @@ import VellumAssistantShared
 /// `onTap` — SwiftUI resolves the innermost tappable first.
 struct HomeRecapRow: View {
     let icon: VIcon
-    /// Foreground color for the icon glyph. Callers pass semantic tokens
-    /// (e.g. `VColor.systemNegativeStrong`, `VColor.systemInfoStrong`).
+    /// Foreground color for the icon glyph. Callers pass one of the
+    /// feed identifier tokens (e.g. `VColor.feedNudgeStrong`,
+    /// `VColor.feedDigestStrong`, `VColor.feedThreadStrong`, or
+    /// `VColor.systemInfoStrong` for `.action` items).
     let iconForeground: Color
-    /// Tinted background fill for the icon circle (e.g.
-    /// `VColor.systemNegativeWeak`, `VColor.systemInfoWeak`).
+    /// Tinted background fill for the icon circle (paired weak variant
+    /// of the foreground token — e.g. `VColor.feedNudgeWeak`).
     let iconBackground: Color
     let title: String
     let onDismiss: () -> Void

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -85,6 +85,17 @@ public enum VSemanticColorToken: String, CaseIterable {
     case systemInfoStrong
     case systemInfoWeak
 
+    // Home-feed type-identifier colors. Separate from `system*` on purpose —
+    // the feed uses these to label item kinds (Heartbeat / Notification /
+    // Schedule) and the hues must stay decoupled from the alert / success
+    // semantics used elsewhere in the app.
+    case feedNudgeStrong
+    case feedNudgeWeak
+    case feedDigestStrong
+    case feedDigestWeak
+    case feedThreadStrong
+    case feedThreadWeak
+
     case auxWhite
 }
 
@@ -175,6 +186,20 @@ private enum FigmaRawColor {
     static let systemDarkInfoStrong = Color(hex: 0x467CC8)
     static let systemLightInfoWeak = Color(hex: 0xCEDAEC)
     static let systemDarkInfoWeak = Color(hex: 0x2A3A50)
+
+    // Feed type-identifier pairs — strong = glyph, weak = tinted circle.
+    static let feedLightNudgeStrong = Color(hex: 0xDB4B77)
+    static let feedDarkNudgeStrong = Color(hex: 0xDB4B77)
+    static let feedLightNudgeWeak = Color(hex: 0xF0D9E0)
+    static let feedDarkNudgeWeak = Color(hex: 0x432B33)
+    static let feedLightDigestStrong = Color(hex: 0x0E9B8B)
+    static let feedDarkDigestStrong = Color(hex: 0x0E9B8B)
+    static let feedLightDigestWeak = Color(hex: 0xC8E5E2)
+    static let feedDarkDigestWeak = Color(hex: 0x293D3B)
+    static let feedLightThreadStrong = Color(hex: 0xE9C91A)
+    static let feedDarkThreadStrong = Color(hex: 0xE9C91A)
+    static let feedLightThreadWeak = Color(hex: 0xEFE8C4)
+    static let feedDarkThreadWeak = Color(hex: 0x464125)
 }
 
 public enum VColor {
@@ -215,6 +240,13 @@ public enum VColor {
         .systemMidWeak: .init(lightHex: "#FCF3DD", darkHex: "#4B3D1E"),
         .systemInfoStrong: .init(lightHex: "#467CC8", darkHex: "#467CC8"),
         .systemInfoWeak: .init(lightHex: "#CEDAEC", darkHex: "#2A3A50"),
+
+        .feedNudgeStrong: .init(lightHex: "#DB4B77", darkHex: "#DB4B77"),
+        .feedNudgeWeak: .init(lightHex: "#F0D9E0", darkHex: "#432B33"),
+        .feedDigestStrong: .init(lightHex: "#0E9B8B", darkHex: "#0E9B8B"),
+        .feedDigestWeak: .init(lightHex: "#C8E5E2", darkHex: "#293D3B"),
+        .feedThreadStrong: .init(lightHex: "#E9C91A", darkHex: "#E9C91A"),
+        .feedThreadWeak: .init(lightHex: "#EFE8C4", darkHex: "#464125"),
 
         .auxWhite: .init(lightHex: "#FFFFFF", darkHex: "#FFFFFF"),
     ]
@@ -260,6 +292,14 @@ public enum VColor {
     public static let systemMidWeak = adaptiveColor(light: FigmaRawColor.systemLightMidWeak, dark: FigmaRawColor.systemDarkMidWeak)
     public static let systemInfoStrong = adaptiveColor(light: FigmaRawColor.systemLightInfoStrong, dark: FigmaRawColor.systemDarkInfoStrong)
     public static let systemInfoWeak = adaptiveColor(light: FigmaRawColor.systemLightInfoWeak, dark: FigmaRawColor.systemDarkInfoWeak)
+
+    // Home-feed type identifiers — glyph (strong) + tinted circle (weak) pairs for Nudge/Digest/Thread.
+    public static let feedNudgeStrong = adaptiveColor(light: FigmaRawColor.feedLightNudgeStrong, dark: FigmaRawColor.feedDarkNudgeStrong)
+    public static let feedNudgeWeak = adaptiveColor(light: FigmaRawColor.feedLightNudgeWeak, dark: FigmaRawColor.feedDarkNudgeWeak)
+    public static let feedDigestStrong = adaptiveColor(light: FigmaRawColor.feedLightDigestStrong, dark: FigmaRawColor.feedDarkDigestStrong)
+    public static let feedDigestWeak = adaptiveColor(light: FigmaRawColor.feedLightDigestWeak, dark: FigmaRawColor.feedDarkDigestWeak)
+    public static let feedThreadStrong = adaptiveColor(light: FigmaRawColor.feedLightThreadStrong, dark: FigmaRawColor.feedDarkThreadStrong)
+    public static let feedThreadWeak = adaptiveColor(light: FigmaRawColor.feedLightThreadWeak, dark: FigmaRawColor.feedDarkThreadWeak)
 
     // Pending / queued — warm amber for "held, waiting" affordances (queue drawer accent bar,
     // pending badge backgrounds). Opacity is baked in so the token sits softly over surface


### PR DESCRIPTION
## Summary
Add three dedicated Home-feed type-identifier color pairs to `ColorTokens.swift` — pink / teal / gold — and rewire the filter chip + row icon mappings to use them. The Figma spec for Heartbeat (pink), Notification (teal), and Schedule (gold) differs from the app's `systemNegative` (orange-red), `systemPositive` (forest green), and `systemMid` (warm amber) hues, and those tokens carry alert / success / warning semantics that belong elsewhere.

### New tokens (light/dark)
- `feedNudgeStrong` / `feedNudgeWeak` — pink `#DB4B77` / `#F0D9E0` (light) `#432B33` (dark)
- `feedDigestStrong` / `feedDigestWeak` — teal `#0E9B8B` / `#C8E5E2` (light) `#293D3B` (dark)
- `feedThreadStrong` / `feedThreadWeak` — gold `#E9C91A` / `#EFE8C4` (light) `#464125` (dark)

### Consumers rewired
- `HomeFeedFilterBar` chips — `.nudge`/`.digest`/`.thread` now use the new tokens; `.action` still uses `systemInfo`
- `HomePageView.iconForeground/iconBackground` for feed rows — same mapping
- `HomeGallerySection` demo variants refreshed; `HomeRecapRow` docstring updated

### Deliberately left alone
- `RecapCards/RecapPillView.swift` — uses `systemNegative`/`systemMid` for severity semantics (low/medium/high priority pills), not feed type identifiers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
