### PR TITLE
refactor(compaction): extract applyCompactionResult helper and trim redundancy (JARVIS-576)

### DIFF
--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -1,10 +1,12 @@
 /**
  * Tests for compaction event emission.
  *
- * Verifies that forceCompact() emits a `context_compacted` event and a
- * `usage_update` event with `contextWindowTokens` / `contextWindowMaxTokens`
- * after a successful compaction, so the UI indicator refreshes without
- * waiting for the next full turn.
+ * Verifies that forceCompact() emits a `context_compacted` event (carrying
+ * the fresh `estimatedInputTokens` / `maxInputTokens`) after a successful
+ * compaction, so the UI indicator refreshes without waiting for the next full
+ * turn. The `context_compacted` event is the single source of truth for the
+ * indicator — the paired `usage_update` intentionally omits
+ * `contextWindowTokens` to avoid a redundant SwiftUI invalidation.
  */
 import { describe, expect, mock, test } from "bun:test";
 
@@ -304,7 +306,7 @@ function makeConversation(
 // ---------------------------------------------------------------------------
 
 describe("forceCompact event emission", () => {
-  test("emits context_compacted and usage_update with contextWindow when compacted", async () => {
+  test("emits context_compacted and a usage_update without contextWindow when compacted", async () => {
     const collected: ServerMessage[] = [];
     mockCompactResult = {
       messages: [],
@@ -348,8 +350,11 @@ describe("forceCompact event emission", () => {
       ServerMessage,
       { type: "usage_update" }
     >;
-    expect(usageEvent.contextWindowTokens).toBe(80_000);
-    expect(usageEvent.contextWindowMaxTokens).toBe(200_000);
+    // `context_compacted` is now the single source of truth for the UI
+    // indicator after compaction; the paired `usage_update` intentionally
+    // omits contextWindow to avoid a redundant SwiftUI invalidation.
+    expect(usageEvent.contextWindowTokens).toBeUndefined();
+    expect(usageEvent.contextWindowMaxTokens).toBeUndefined();
     expect(usageEvent.inputTokens).toBe(500);
     expect(usageEvent.outputTokens).toBe(200);
     expect(usageEvent.model).toBe("test-model");

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -232,11 +232,6 @@ export function trackCompactionOutcome(
     ) {
       const openUntil = Date.now() + COMPACTION_CIRCUIT_COOLDOWN_MS;
       ctx.compactionCircuitOpenUntil = openUntil;
-      // Scope the event to this conversation so clients can gate it via
-      // `belongsToConversation()` — `EventStreamClient` broadcasts every
-      // parsed server message to all subscribers, so without the ID a
-      // breaker trip here would set the "paused" banner on every open
-      // `ChatViewModel`.
       onEvent({
         type: "compaction_circuit_open",
         conversationId: ctx.conversationId,
@@ -245,21 +240,11 @@ export function trackCompactionOutcome(
       });
     }
   } else {
-    // Capture the open state before we clear it — we only emit the
-    // `compaction_circuit_closed` event on the open→closed transition so
-    // the Swift banner can dismiss immediately once auto-compaction
-    // resumes. Firing on every successful compaction would be noise
-    // (the breaker is closed in the common case), so the transition
-    // gate keeps the event meaningful.
+    // Emit only on open→closed transition; firing on the common closed→closed case would be noise.
     const wasOpen = ctx.compactionCircuitOpenUntil !== null;
     ctx.consecutiveCompactionFailures = 0;
     ctx.compactionCircuitOpenUntil = null;
     if (wasOpen) {
-      // Scope the event to this conversation so clients can gate it via
-      // `belongsToConversation()` — `EventStreamClient` broadcasts every
-      // parsed server message to all subscribers, so without the ID a
-      // breaker recovery here would clear the banner on every open
-      // `ChatViewModel`.
       onEvent({
         type: "compaction_circuit_closed",
         conversationId: ctx.conversationId,
@@ -646,55 +631,7 @@ export async function runAgentLoopImpl(
       trackCompactionOutcome(ctx, compacted.summaryFailed, onEvent);
     }
     if (compacted?.compacted) {
-      ctx.messages = compacted.messages;
-      ctx.contextCompactedMessageCount += compacted.compactedPersistedMessages;
-      ctx.contextCompactedAt = Date.now();
-      // Notify memory graph that compaction happened — triggers full context
-      // reload on the next turn to replenish lost memory context.
-      ctx.graphMemory.onCompacted(compacted.compactedPersistedMessages);
-      updateConversationContextWindow(
-        ctx.conversationId,
-        compacted.summaryText,
-        ctx.contextCompactedMessageCount,
-      );
-      // Fire auto-analysis on compaction so the reflective agent can
-      // crystallize anything worth remembering before the context window
-      // narrows further.
-      enqueueAutoAnalysisOnCompaction(
-        ctx.conversationId,
-        ctx.trustContext?.trustClass,
-      );
-      onEvent({
-        type: "context_compacted",
-        conversationId: ctx.conversationId,
-        previousEstimatedInputTokens: compacted.previousEstimatedInputTokens,
-        estimatedInputTokens: compacted.estimatedInputTokens,
-        maxInputTokens: compacted.maxInputTokens,
-        thresholdTokens: compacted.thresholdTokens,
-        compactedMessages: compacted.compactedMessages,
-        summaryCalls: compacted.summaryCalls,
-        summaryInputTokens: compacted.summaryInputTokens,
-        summaryOutputTokens: compacted.summaryOutputTokens,
-        summaryModel: compacted.summaryModel,
-      });
-      emitUsage(
-        ctx,
-        compacted.summaryInputTokens,
-        compacted.summaryOutputTokens,
-        compacted.summaryModel,
-        onEvent,
-        "context_compactor",
-        reqId,
-        compacted.summaryCacheCreationInputTokens ?? 0,
-        compacted.summaryCacheReadInputTokens ?? 0,
-        collapseRawResponses(compacted.summaryRawResponses),
-        undefined /* providerName */,
-        1 /* llmCallCount */,
-        {
-          tokens: compacted.estimatedInputTokens,
-          maxTokens: compacted.maxInputTokens,
-        },
-      );
+      applyCompactionResult(ctx, compacted, onEvent, reqId);
       shouldInjectWorkspace = true;
       if (compacted.compactedPersistedMessages > 0) {
         compactedThisTurn = true;
@@ -1188,54 +1125,7 @@ export async function runAgentLoopImpl(
         }
 
         if (step.compactionResult?.compacted) {
-          ctx.contextCompactedMessageCount +=
-            step.compactionResult.compactedPersistedMessages;
-          ctx.contextCompactedAt = Date.now();
-          updateConversationContextWindow(
-            ctx.conversationId,
-            step.compactionResult.summaryText,
-            ctx.contextCompactedMessageCount,
-          );
-          // Fire auto-analysis on compaction — see forceCompact() for rationale.
-          enqueueAutoAnalysisOnCompaction(
-            ctx.conversationId,
-            ctx.trustContext?.trustClass,
-          );
-          onEvent({
-            type: "context_compacted",
-            conversationId: ctx.conversationId,
-            previousEstimatedInputTokens:
-              step.compactionResult.previousEstimatedInputTokens,
-            estimatedInputTokens: step.compactionResult.estimatedInputTokens,
-            maxInputTokens: step.compactionResult.maxInputTokens,
-            thresholdTokens: step.compactionResult.thresholdTokens,
-            compactedMessages: step.compactionResult.compactedMessages,
-            summaryCalls: step.compactionResult.summaryCalls,
-            summaryInputTokens: step.compactionResult.summaryInputTokens,
-            summaryOutputTokens: step.compactionResult.summaryOutputTokens,
-            summaryModel: step.compactionResult.summaryModel,
-          });
-          emitUsage(
-            ctx,
-            step.compactionResult.summaryInputTokens,
-            step.compactionResult.summaryOutputTokens,
-            step.compactionResult.summaryModel,
-            onEvent,
-            "context_compactor",
-            reqId,
-            step.compactionResult.summaryCacheCreationInputTokens ?? 0,
-            step.compactionResult.summaryCacheReadInputTokens ?? 0,
-            collapseRawResponses(step.compactionResult.summaryRawResponses),
-            undefined /* providerName */,
-            1 /* llmCallCount */,
-            {
-              tokens: step.compactionResult.estimatedInputTokens,
-              maxTokens: step.compactionResult.maxInputTokens,
-            },
-          );
-          ctx.graphMemory.onCompacted(
-            step.compactionResult.compactedPersistedMessages,
-          );
+          applyCompactionResult(ctx, step.compactionResult, onEvent, reqId);
           shouldInjectWorkspace = true;
           reducerCompacted = true;
         }
@@ -1448,54 +1338,8 @@ export async function runAgentLoopImpl(
         trackCompactionOutcome(ctx, midLoopCompact.summaryFailed, onEvent);
       }
       if (midLoopCompact.compacted) {
-        ctx.messages = midLoopCompact.messages;
+        applyCompactionResult(ctx, midLoopCompact, onEvent, reqId);
         reducerCompacted = true;
-        ctx.contextCompactedMessageCount +=
-          midLoopCompact.compactedPersistedMessages;
-        ctx.contextCompactedAt = Date.now();
-        updateConversationContextWindow(
-          ctx.conversationId,
-          midLoopCompact.summaryText,
-          ctx.contextCompactedMessageCount,
-        );
-        // Fire auto-analysis on compaction — see forceCompact() for rationale.
-        enqueueAutoAnalysisOnCompaction(
-          ctx.conversationId,
-          ctx.trustContext?.trustClass,
-        );
-        onEvent({
-          type: "context_compacted",
-          conversationId: ctx.conversationId,
-          previousEstimatedInputTokens:
-            midLoopCompact.previousEstimatedInputTokens,
-          estimatedInputTokens: midLoopCompact.estimatedInputTokens,
-          maxInputTokens: midLoopCompact.maxInputTokens,
-          thresholdTokens: midLoopCompact.thresholdTokens,
-          compactedMessages: midLoopCompact.compactedMessages,
-          summaryCalls: midLoopCompact.summaryCalls,
-          summaryInputTokens: midLoopCompact.summaryInputTokens,
-          summaryOutputTokens: midLoopCompact.summaryOutputTokens,
-          summaryModel: midLoopCompact.summaryModel,
-        });
-        emitUsage(
-          ctx,
-          midLoopCompact.summaryInputTokens,
-          midLoopCompact.summaryOutputTokens,
-          midLoopCompact.summaryModel,
-          onEvent,
-          "context_compactor",
-          reqId,
-          midLoopCompact.summaryCacheCreationInputTokens ?? 0,
-          midLoopCompact.summaryCacheReadInputTokens ?? 0,
-          collapseRawResponses(midLoopCompact.summaryRawResponses),
-          undefined /* providerName */,
-          1 /* llmCallCount */,
-          {
-            tokens: midLoopCompact.estimatedInputTokens,
-            maxTokens: midLoopCompact.maxInputTokens,
-          },
-        );
-        ctx.graphMemory.onCompacted(midLoopCompact.compactedPersistedMessages);
         shouldInjectWorkspace = true;
       }
 
@@ -1725,54 +1569,7 @@ export async function runAgentLoopImpl(
         }
 
         if (step.compactionResult?.compacted) {
-          ctx.contextCompactedMessageCount +=
-            step.compactionResult.compactedPersistedMessages;
-          ctx.contextCompactedAt = Date.now();
-          updateConversationContextWindow(
-            ctx.conversationId,
-            step.compactionResult.summaryText,
-            ctx.contextCompactedMessageCount,
-          );
-          // Fire auto-analysis on compaction — see forceCompact() for rationale.
-          enqueueAutoAnalysisOnCompaction(
-            ctx.conversationId,
-            ctx.trustContext?.trustClass,
-          );
-          onEvent({
-            type: "context_compacted",
-            conversationId: ctx.conversationId,
-            previousEstimatedInputTokens:
-              step.compactionResult.previousEstimatedInputTokens,
-            estimatedInputTokens: step.compactionResult.estimatedInputTokens,
-            maxInputTokens: step.compactionResult.maxInputTokens,
-            thresholdTokens: step.compactionResult.thresholdTokens,
-            compactedMessages: step.compactionResult.compactedMessages,
-            summaryCalls: step.compactionResult.summaryCalls,
-            summaryInputTokens: step.compactionResult.summaryInputTokens,
-            summaryOutputTokens: step.compactionResult.summaryOutputTokens,
-            summaryModel: step.compactionResult.summaryModel,
-          });
-          emitUsage(
-            ctx,
-            step.compactionResult.summaryInputTokens,
-            step.compactionResult.summaryOutputTokens,
-            step.compactionResult.summaryModel,
-            onEvent,
-            "context_compactor",
-            reqId,
-            step.compactionResult.summaryCacheCreationInputTokens ?? 0,
-            step.compactionResult.summaryCacheReadInputTokens ?? 0,
-            collapseRawResponses(step.compactionResult.summaryRawResponses),
-            undefined /* providerName */,
-            1 /* llmCallCount */,
-            {
-              tokens: step.compactionResult.estimatedInputTokens,
-              maxTokens: step.compactionResult.maxInputTokens,
-            },
-          );
-          ctx.graphMemory.onCompacted(
-            step.compactionResult.compactedPersistedMessages,
-          );
+          applyCompactionResult(ctx, step.compactionResult, onEvent, reqId);
           shouldInjectWorkspace = true;
           reducerCompacted = true;
         }
@@ -1890,56 +1687,8 @@ export async function runAgentLoopImpl(
             );
           }
           if (emergencyCompact.compacted) {
-            ctx.messages = emergencyCompact.messages;
+            applyCompactionResult(ctx, emergencyCompact, onEvent, reqId);
             reducerCompacted = true;
-            ctx.contextCompactedMessageCount +=
-              emergencyCompact.compactedPersistedMessages;
-            ctx.contextCompactedAt = Date.now();
-            updateConversationContextWindow(
-              ctx.conversationId,
-              emergencyCompact.summaryText,
-              ctx.contextCompactedMessageCount,
-            );
-            // Fire auto-analysis on compaction — see forceCompact() for rationale.
-            enqueueAutoAnalysisOnCompaction(
-              ctx.conversationId,
-              ctx.trustContext?.trustClass,
-            );
-            onEvent({
-              type: "context_compacted",
-              conversationId: ctx.conversationId,
-              previousEstimatedInputTokens:
-                emergencyCompact.previousEstimatedInputTokens,
-              estimatedInputTokens: emergencyCompact.estimatedInputTokens,
-              maxInputTokens: emergencyCompact.maxInputTokens,
-              thresholdTokens: emergencyCompact.thresholdTokens,
-              compactedMessages: emergencyCompact.compactedMessages,
-              summaryCalls: emergencyCompact.summaryCalls,
-              summaryInputTokens: emergencyCompact.summaryInputTokens,
-              summaryOutputTokens: emergencyCompact.summaryOutputTokens,
-              summaryModel: emergencyCompact.summaryModel,
-            });
-            emitUsage(
-              ctx,
-              emergencyCompact.summaryInputTokens,
-              emergencyCompact.summaryOutputTokens,
-              emergencyCompact.summaryModel,
-              onEvent,
-              "context_compactor",
-              reqId,
-              emergencyCompact.summaryCacheCreationInputTokens ?? 0,
-              emergencyCompact.summaryCacheReadInputTokens ?? 0,
-              collapseRawResponses(emergencyCompact.summaryRawResponses),
-              undefined /* providerName */,
-              1 /* llmCallCount */,
-              {
-                tokens: emergencyCompact.estimatedInputTokens,
-                maxTokens: emergencyCompact.maxInputTokens,
-              },
-            );
-            ctx.graphMemory.onCompacted(
-              emergencyCompact.compactedPersistedMessages,
-            );
             shouldInjectWorkspace = true;
           }
 
@@ -2445,6 +2194,99 @@ function emitUsage(
     rawResponse,
     llmCallCount,
     contextWindow,
+  );
+}
+
+/**
+ * Minimal context shape consumed by `applyCompactionResult`. Both
+ * `AgentLoopConversationContext` and `Conversation` satisfy this via structural
+ * typing, so the helper can back both the 5 agent-loop auto-compaction sites
+ * and the single `forceCompact` user-initiated site.
+ */
+export interface CompactionApplyContext {
+  readonly conversationId: string;
+  messages: Message[];
+  contextCompactedMessageCount: number;
+  contextCompactedAt: number | null;
+  readonly graphMemory: ConversationGraphMemory;
+  readonly provider: Provider;
+  usageStats: UsageStats;
+  trustContext?: TrustContext;
+}
+
+/**
+ * Applies a successful `ContextWindowResult` to a conversation: updates the
+ * in-memory message buffer and compaction counters, notifies the graph memory
+ * and conversation-summary store, enqueues auto-analysis, emits the
+ * `context_compacted` event, and records a `context_compactor` usage event.
+ *
+ * The emitted `usage_update` intentionally omits `contextWindow` — the
+ * `context_compacted` event already carries the fresh
+ * `estimatedInputTokens` / `maxInputTokens` and is the single source of
+ * truth for the UI indicator after compaction. Emitting both caused a
+ * redundant SwiftUI invalidation on every compaction.
+ */
+export function applyCompactionResult(
+  ctx: CompactionApplyContext,
+  result: {
+    messages: Message[];
+    compactedPersistedMessages: number;
+    previousEstimatedInputTokens: number;
+    estimatedInputTokens: number;
+    maxInputTokens: number;
+    thresholdTokens: number;
+    compactedMessages: number;
+    summaryCalls: number;
+    summaryInputTokens: number;
+    summaryOutputTokens: number;
+    summaryModel: string;
+    summaryText: string;
+    summaryCacheCreationInputTokens?: number;
+    summaryCacheReadInputTokens?: number;
+    summaryRawResponses?: unknown[];
+  },
+  onEvent: (msg: ServerMessage) => void,
+  reqId: string | null,
+): void {
+  ctx.messages = result.messages;
+  ctx.contextCompactedMessageCount += result.compactedPersistedMessages;
+  ctx.contextCompactedAt = Date.now();
+  ctx.graphMemory.onCompacted(result.compactedPersistedMessages);
+  updateConversationContextWindow(
+    ctx.conversationId,
+    result.summaryText,
+    ctx.contextCompactedMessageCount,
+  );
+  enqueueAutoAnalysisOnCompaction(
+    ctx.conversationId,
+    ctx.trustContext?.trustClass,
+  );
+  onEvent({
+    type: "context_compacted",
+    conversationId: ctx.conversationId,
+    previousEstimatedInputTokens: result.previousEstimatedInputTokens,
+    estimatedInputTokens: result.estimatedInputTokens,
+    maxInputTokens: result.maxInputTokens,
+    thresholdTokens: result.thresholdTokens,
+    compactedMessages: result.compactedMessages,
+    summaryCalls: result.summaryCalls,
+    summaryInputTokens: result.summaryInputTokens,
+    summaryOutputTokens: result.summaryOutputTokens,
+    summaryModel: result.summaryModel,
+  });
+  emitUsage(
+    ctx,
+    result.summaryInputTokens,
+    result.summaryOutputTokens,
+    result.summaryModel,
+    onEvent,
+    "context_compactor",
+    reqId,
+    result.summaryCacheCreationInputTokens ?? 0,
+    result.summaryCacheReadInputTokens ?? 0,
+    collapseRawResponses(result.summaryRawResponses),
+    undefined /* providerName */,
+    1 /* llmCallCount */,
   );
 }
 

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -44,11 +44,9 @@ import {
 } from "../events/tool-profiling-listener.js";
 import { registerToolTraceListener } from "../events/tool-trace-listener.js";
 import { getHookManager } from "../hooks/manager.js";
-import { enqueueAutoAnalysisOnCompaction } from "../memory/auto-analysis-enqueue.js";
 import { resolveCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import {
   getConversationOriginChannel,
-  updateConversationContextWindow,
   updateConversationHostAccess,
 } from "../memory/conversation-crud.js";
 import { ConversationGraphMemory } from "../memory/graph/conversation-graph-memory.js";
@@ -76,7 +74,7 @@ import type { AbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
 import type { AssistantAttachmentDraft } from "./assistant-attachments.js";
 import {
-  collapseRawResponses,
+  applyCompactionResult,
   runAgentLoopImpl,
   trackCompactionOutcome,
 } from "./conversation-agent-loop.js";
@@ -122,7 +120,6 @@ import {
   createResolveToolsCallback,
   createToolExecutor,
 } from "./conversation-tool-setup.js";
-import { recordUsage } from "./conversation-usage.js";
 import { refreshWorkspaceTopLevelContextIfNeeded as refreshWorkspaceImpl } from "./conversation-workspace.js";
 import { HostBashProxy } from "./host-bash-proxy.js";
 import { HostBrowserProxy } from "./host-browser-proxy.js";
@@ -1254,63 +1251,7 @@ export class Conversation {
       trackCompactionOutcome(this, result.summaryFailed, this.sendToClient);
     }
     if (result.compacted) {
-      this.messages = result.messages;
-      this.contextCompactedMessageCount += result.compactedPersistedMessages;
-      this.contextCompactedAt = Date.now();
-      updateConversationContextWindow(
-        this.conversationId,
-        result.summaryText,
-        this.contextCompactedMessageCount,
-      );
-      // Fire auto-analysis on compaction so the reflective agent can
-      // crystallize anything worth remembering before the context window
-      // narrows further.
-      enqueueAutoAnalysisOnCompaction(
-        this.conversationId,
-        this.trustContext?.trustClass,
-      );
-      // Notify memory graph that compaction happened — triggers full context
-      // reload on the next turn to replenish lost memory context. Matches
-      // every auto-compaction path in conversation-agent-loop.ts.
-      this.graphMemory.onCompacted(result.compactedPersistedMessages);
-      this.sendToClient({
-        type: "context_compacted",
-        conversationId: this.conversationId,
-        previousEstimatedInputTokens: result.previousEstimatedInputTokens,
-        estimatedInputTokens: result.estimatedInputTokens,
-        maxInputTokens: result.maxInputTokens,
-        thresholdTokens: result.thresholdTokens,
-        compactedMessages: result.compactedMessages,
-        summaryCalls: result.summaryCalls,
-        summaryInputTokens: result.summaryInputTokens,
-        summaryOutputTokens: result.summaryOutputTokens,
-        summaryModel: result.summaryModel,
-      });
-      // Call recordUsage unconditionally — it early-returns on 0/0 tokens
-      // (the truncation-only path), and the client already picks up the
-      // fresh context-window tokens from the `context_compacted` event
-      // emitted above. Matches the agent-loop auto-compaction sites.
-      recordUsage(
-        {
-          conversationId: this.conversationId,
-          providerName: this.provider.name,
-          usageStats: this.usageStats,
-        },
-        result.summaryInputTokens,
-        result.summaryOutputTokens,
-        result.summaryModel,
-        this.sendToClient,
-        "context_compactor",
-        null,
-        result.summaryCacheCreationInputTokens ?? 0,
-        result.summaryCacheReadInputTokens ?? 0,
-        collapseRawResponses(result.summaryRawResponses),
-        result.summaryCalls,
-        {
-          tokens: result.estimatedInputTokens,
-          maxTokens: result.maxInputTokens,
-        },
-      );
+      applyCompactionResult(this, result, this.sendToClient, null);
     }
     return result;
   }

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -426,10 +426,7 @@ export interface UsageResponse {
  * `/compact`). Carries the fresh `estimatedInputTokens` so clients can refresh
  * the context-window indicator without waiting for the next `usage_update`.
  *
- * `conversationId` scopes the event so clients can ignore compactions from
- * other conversations — `EventStreamClient` broadcasts every parsed server
- * message to all subscribers, so without this field a compaction in one
- * conversation would overwrite the indicator on every open `ChatViewModel`.
+ * Scoped per-conversation — see `CompactionCircuitOpen` doc for why.
  */
 export interface ContextCompacted {
   type: "context_compacted";
@@ -475,9 +472,7 @@ export interface CompactionCircuitOpen {
  * Only fires on the open→closed transition — successful compactions while
  * the breaker was already closed would be noise.
  *
- * `conversationId` scopes the event so clients can ignore transitions from
- * other conversations via `belongsToConversation()`, mirroring the rest of
- * the broadcast-aware events.
+ * Scoped per-conversation — see `CompactionCircuitOpen` doc for why.
  */
 export interface CompactionCircuitClosed {
   type: "compaction_circuit_closed";

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -267,8 +267,6 @@ struct CompactionCircuitOpenBanner: View {
         }
         .foregroundStyle(VColor.auxWhite) // Intentional: white on solid accent background.
         .frame(minHeight: 32)
-        // Single EdgeInsets padding per clients/macos/AGENTS.md — stacked
-        // `.padding(...)` modifiers each add layout-engine depth.
         .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.md, bottom: VSpacing.xs, trailing: VSpacing.lg))
         .background(VColor.systemMidStrong)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -335,31 +335,24 @@ final class ChatActionHandler {
             }
 
         case .contextCompacted(let event):
-            // `EventStreamClient` broadcasts every parsed server message to all
-            // subscribers, so we must gate on `conversationId` to avoid
-            // overwriting the context-window indicator on unrelated
-            // `ChatViewModel`s when a compaction happens in another
-            // conversation.
+            // Scoped per-conversation — see CompactionCircuitOpen doc.
             guard belongsToConversation(event.conversationId) else { return }
             vm.contextWindowTokens = event.estimatedInputTokens
             vm.contextWindowMaxTokens = event.maxInputTokens
 
         case .compactionCircuitOpen(let event):
-            // `EventStreamClient` broadcasts every parsed server message to all
-            // subscribers, so we must gate on `conversationId` to avoid setting
-            // the "auto-compaction paused" banner on unrelated `ChatViewModel`s
-            // when a breaker trips in another conversation. `openUntil` is
-            // milliseconds-since-epoch; convert to Date.
+            // `openUntil` is milliseconds-since-epoch; convert to Date.
             guard belongsToConversation(event.conversationId) else { return }
             let until = Date(timeIntervalSince1970: event.openUntil / 1000.0)
             vm.compactionCircuitOpenUntil = until
             log.warning("Auto-compaction paused until \(until, privacy: .public) — reason: \(event.reason, privacy: .public)")
 
         case .compactionCircuitClosed(let event):
-            // Auto-compaction is live again — clear the banner state so the UI
-            // dismisses the "paused" banner immediately without waiting for the
-            // original `openUntil` deadline.
             guard belongsToConversation(event.conversationId) else { return }
+            // Skip the no-op write when the banner already self-dismissed via
+            // the 60s timer; writing nil→nil would still trigger an
+            // `@Observable` invalidation.
+            guard vm.compactionCircuitOpenUntil != nil else { return }
             vm.compactionCircuitOpenUntil = nil
             log.info("Auto-compaction resumed (circuit breaker closed)")
 

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -208,11 +208,6 @@ public final class ChatMessageManager {
     public var isCompacting: Bool = false
     public var contextWindowTokens: Int? = nil
     public var contextWindowMaxTokens: Int? = nil
-    /// Timestamp when auto-compaction will resume after the assistant's circuit
-    /// breaker opened (3 consecutive summary-LLM failures). `nil` when the
-    /// breaker is closed. UI surfaces a banner while this is non-nil and in
-    /// the future.
-    public var compactionCircuitOpenUntil: Date? = nil
     public var pendingQueuedCount: Int = 0
     /// Monotonic counter incremented once per successful main-turn completion
     /// (daemon `message_complete` event that isn't an auxiliary or cancel-ack).

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -344,10 +344,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// failures). The chat UI surfaces a banner while this is set and the
     /// timestamp is still in the future; the banner auto-dismisses once the
     /// cooldown elapses.
-    public var compactionCircuitOpenUntil: Date? {
-        get { messageManager.compactionCircuitOpenUntil }
-        set { messageManager.compactionCircuitOpenUntil = newValue }
-    }
+    public var compactionCircuitOpenUntil: Date? = nil
     public var contextWindowFillRatio: Double? {
         guard let tokens = contextWindowTokens,
               let max = contextWindowMaxTokens,


### PR DESCRIPTION
## Summary
Follow-up /simplify sweep on JARVIS-576 (PR #27223).

- Extract `applyCompactionResult` helper — 6 near-identical post-compaction emit blocks collapse to one.
- Drop `contextWindow` tuple from compaction-origin `emitUsage` calls; `context_compacted` is now the single source of truth for the UI indicator.
- Move `compactionCircuitOpenUntil` off `ChatMessageManager` onto `ChatViewModel` (manager never consumed it).
- `compactionCircuitClosed` handler guards on `!= nil` to skip no-op VM writes.
- Consolidate 5x-duplicated scoping-rationale comment + delete narrating comments.

## Impact

- ~200 lines collapsed into a helper in conversation-agent-loop.ts / conversation.ts.
- Every compaction now fires one token-carrying event (context_compacted) instead of two; halves the per-compaction SwiftUI invalidation count.
- No behavior change for users; drift protection for future compaction-event field additions.

Part of JARVIS-576.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
