### PR TITLE
fix(permissions): handle --flag=value syntax in parseArgs and add missing rm test

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -3037,6 +3037,18 @@ describe("Permission Checker", () => {
           expect(result.reason).toContain("sandbox auto-approve");
         }),
       );
+
+      test(
+        "rm -rf / → falls through to threshold (path outside workspace)",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "rm -rf /" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.reason).not.toContain("sandbox auto-approve");
+        }),
+      );
     });
   });
 

--- a/assistant/src/permissions/arg-parser.test.ts
+++ b/assistant/src/permissions/arg-parser.test.ts
@@ -136,4 +136,26 @@ describe("parseArgs", () => {
     expect(result.positionals).toEqual(["src.c"]);
     expect(result.pathArgs).toEqual(["/include1", "/include2", "src.c"]);
   });
+
+  test("--flag=value syntax with path flag", () => {
+    const result = parseArgs(["--target-directory=/tmp/dir", "file.txt"], {
+      valueFlags: ["--target-directory"],
+      pathFlags: { "--target-directory": true },
+    });
+    expect(result.flags.get("--target-directory")).toBe("/tmp/dir");
+    expect(result.positionals).toEqual(["file.txt"]);
+    // /tmp/dir from pathFlag + file.txt from default positional "paths" mode.
+    expect(result.pathArgs).toEqual(["/tmp/dir", "file.txt"]);
+  });
+
+  test("--flag=value syntax with non-path value flag", () => {
+    const result = parseArgs(["--output=out.txt", "in.txt"], {
+      valueFlags: ["--output"],
+    });
+    expect(result.flags.get("--output")).toBe("out.txt");
+    expect(result.positionals).toEqual(["in.txt"]);
+    // --output is not in pathFlags, so out.txt is not a path arg.
+    // in.txt is a positional with default "paths" mode → path.
+    expect(result.pathArgs).toEqual(["in.txt"]);
+  });
 });

--- a/assistant/src/permissions/arg-parser.ts
+++ b/assistant/src/permissions/arg-parser.ts
@@ -55,6 +55,24 @@ export function parseArgs(args: string[], schema: ArgSchema): ParsedArgs {
       continue;
     }
 
+    // --flag=value form: split on the first `=` and check if the flag
+    // name is a value-consuming flag. This handles e.g.
+    // `--target-directory=/tmp/` or `--output=out.txt`.
+    if (token.startsWith("-") && token.includes("=")) {
+      const eqIndex = token.indexOf("=");
+      const flagName = token.slice(0, eqIndex);
+      const flagValue = token.slice(eqIndex + 1);
+
+      if (valueFlagSet.has(flagName)) {
+        flags.set(flagName, flagValue);
+        if (pathFlagSet.has(flagName)) {
+          pathArgs.push(flagValue);
+        }
+        i++;
+        continue;
+      }
+    }
+
     // Boolean flag (starts with `-` but not a value-consuming flag).
     if (token.startsWith("-")) {
       flags.set(token, true);


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for sandbox-auto-approve-phase2.md.

**Gap 1:** parseArgs now handles --flag=value syntax, extracting the value and checking it against pathFlags. This prevents commands like `cp --target-directory=/tmp/ file.txt` from bypassing workspace containment checks.

**Gap 2:** Added missing `rm -rf /` non-containerized test case that was specified in the plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
