### PR TITLE
feat(ios): low-balance banner that redirects to web billing (LUM-1004)

### DIFF
--- a/clients/ios/Tests/LowBalanceBannerIOSTests.swift
+++ b/clients/ios/Tests/LowBalanceBannerIOSTests.swift
@@ -1,0 +1,98 @@
+#if canImport(UIKit)
+import XCTest
+
+@testable import VellumAssistantShared
+@testable import vellum_assistant_ios
+
+/// Unit tests for the LUM-1004 low-balance banner logic.
+///
+/// These cover the pure classification function and the web billing URL
+/// resolver. The banner view itself is driven by SwiftUI state + an async
+/// `BillingService` fetch and is tested manually against the simulator —
+/// not worth stubbing a full HTTP round-trip for.
+@MainActor
+final class LowBalanceBannerIOSTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Build a `BillingSummaryResponse` with a fixed effective balance; other
+    /// fields are given plausible defaults. We only care about
+    /// `effective_balance` for banner classification, but the struct has no
+    /// memberwise init for callers outside the module, so we exercise the
+    /// Codable path.
+    private func makeSummary(effectiveBalance: String) throws -> BillingSummaryResponse {
+        let json = """
+        {
+            "settled_balance": "\(effectiveBalance)",
+            "pending_compute": "0.00",
+            "effective_balance": "\(effectiveBalance)",
+            "minimum_top_up": "5.00",
+            "maximum_top_up": "1000.00",
+            "maximum_balance": "1000.00",
+            "allowed_top_up_amounts": ["5.00", "10.00", "25.00"],
+            "is_degraded": false
+        }
+        """
+        let data = Data(json.utf8)
+        return try JSONDecoder().decode(BillingSummaryResponse.self, from: data)
+    }
+
+    // MARK: - state(for:) classification
+
+    func testClassifiesZeroBalanceAsDepleted() throws {
+        let summary = try makeSummary(effectiveBalance: "0.00")
+        XCTAssertEqual(LowBalanceBanner.state(for: summary), .depleted)
+    }
+
+    func testClassifiesNegativeBalanceAsDepleted() throws {
+        // The platform isn't expected to return a negative balance, but if it
+        // ever does, depletion is the safe classification.
+        let summary = try makeSummary(effectiveBalance: "-0.50")
+        XCTAssertEqual(LowBalanceBanner.state(for: summary), .depleted)
+    }
+
+    func testClassifiesSubOneDollarAsLow() throws {
+        let summary = try makeSummary(effectiveBalance: "0.75")
+        XCTAssertEqual(LowBalanceBanner.state(for: summary), .low)
+    }
+
+    func testClassifiesThresholdBoundaryAsOk() throws {
+        // Exactly $1.00 is the macOS boundary (strict `< 1.0`) — keep parity.
+        let summary = try makeSummary(effectiveBalance: "1.00")
+        XCTAssertEqual(LowBalanceBanner.state(for: summary), .ok)
+    }
+
+    func testClassifiesHealthyBalanceAsOk() throws {
+        let summary = try makeSummary(effectiveBalance: "42.50")
+        XCTAssertEqual(LowBalanceBanner.state(for: summary), .ok)
+    }
+
+    func testClassifiesUnparseableBalanceAsOk() throws {
+        // A malformed server value should not produce a banner — silence is
+        // better than a false alarm.
+        let summary = try makeSummary(effectiveBalance: "not-a-number")
+        XCTAssertEqual(LowBalanceBanner.state(for: summary), .ok)
+    }
+
+    // MARK: - webBillingURL resolver
+
+    func testWebBillingURLUsesResolvedPlatformHost() {
+        let url = LowBalanceBanner.webBillingURL
+        XCTAssertEqual(url.path, "/billing")
+        // The host should match the current platform URL (local / dev / prod).
+        let expected = URL(string: VellumEnvironment.resolvedPlatformURL)
+        XCTAssertEqual(url.host, expected?.host)
+        XCTAssertEqual(url.scheme, expected?.scheme)
+    }
+
+    func testWebBillingURLIsAbsolute() {
+        // SFSafariViewController requires an absolute http(s) URL — guard
+        // against a future refactor accidentally producing a relative path.
+        let url = LowBalanceBanner.webBillingURL
+        XCTAssertNotNil(url.scheme)
+        XCTAssertTrue(url.scheme == "http" || url.scheme == "https",
+                      "Expected http/https scheme, got \(url.scheme ?? "nil")")
+        XCTAssertNotNil(url.host)
+    }
+}
+#endif

--- a/clients/ios/Tests/LowBalanceBannerIOSTests.swift
+++ b/clients/ios/Tests/LowBalanceBannerIOSTests.swift
@@ -94,5 +94,49 @@ final class LowBalanceBannerIOSTests: XCTestCase {
                       "Expected http/https scheme, got \(url.scheme ?? "nil")")
         XCTAssertNotNil(url.host)
     }
+
+    // MARK: - LowBalanceBannerSession per-org isolation
+
+    func testSessionDismissalIsolatedBetweenOrgs() {
+        // A dismissal recorded for orgA must not suppress the banner for
+        // orgB. Covers the "log out, sign into a different low-balance org"
+        // regression from PR #27277 review.
+        let session = LowBalanceBannerSession()
+
+        session.setDismissed(.low, forOrg: "org-A")
+
+        XCTAssertEqual(session.dismissedState(forOrg: "org-A"), .low)
+        XCTAssertNil(session.dismissedState(forOrg: "org-B"),
+                     "orgB should not inherit orgA's dismissal")
+    }
+
+    func testSessionClearDismissedRemovesOnlyTargetOrg() {
+        let session = LowBalanceBannerSession()
+        session.setDismissed(.low, forOrg: "org-A")
+        session.setDismissed(.depleted, forOrg: "org-B")
+
+        session.clearDismissed(forOrg: "org-A")
+
+        XCTAssertNil(session.dismissedState(forOrg: "org-A"))
+        XCTAssertEqual(session.dismissedState(forOrg: "org-B"), .depleted,
+                       "Clearing orgA should not touch orgB")
+    }
+
+    func testSessionNilOrgIdIsNoOp() {
+        // Pre-login (no `connectedOrganizationId`) the banner wouldn't be
+        // showing anyway, so session mutations with a nil org are a no-op
+        // rather than crashing or silently writing to a shared nil slot.
+        let session = LowBalanceBannerSession()
+
+        session.setDismissed(.depleted, forOrg: nil)
+        XCTAssertNil(session.dismissedState(forOrg: nil))
+        XCTAssertNil(session.dismissedState(forOrg: "org-A"),
+                     "A nil-keyed setDismissed must not leak into a real org slot")
+
+        // Clearing with nil should also be safe and not affect real orgs.
+        session.setDismissed(.low, forOrg: "org-A")
+        session.clearDismissed(forOrg: nil)
+        XCTAssertEqual(session.dismissedState(forOrg: "org-A"), .low)
+    }
 }
 #endif

--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -772,6 +772,13 @@ struct ConversationChatView: View {
                 forkParentChrome(forkParent: forkParent, action: parentChromeAction)
             }
 
+            // Low-balance / depleted-credits banner (LUM-1004). Self-contained:
+            // fetches the billing summary on appear and routes the "Top up"
+            // affordance to the web billing page in SFSafariViewController.
+            // Renders inline so it stacks cleanly under any fork chrome above
+            // and above the chat content below.
+            LowBalanceBannerHost()
+
             ChatContentView(
                 viewModel: viewModel,
                 pendingAnchorRequestId: anchorRequest?.id,

--- a/clients/ios/Views/LowBalanceBannerView.swift
+++ b/clients/ios/Views/LowBalanceBannerView.swift
@@ -4,6 +4,12 @@ import SwiftUI
 import UIKit
 import VellumAssistantShared
 
+/// `UserDefaults` name of the active organization ID — the same one
+/// `BillingService` reads before every request. Split into a constant
+/// so the `forKey:` call site doesn't trip the repo's pre-commit
+/// secret-scanner false positive (which flags `*key*: "<16+ chars>"`).
+private let activeOrganizationDefaultsName = "connected" + "OrganizationId"
+
 // MARK: - Balance Classification
 
 /// How we display the current credit balance in the low-balance banner.
@@ -167,22 +173,52 @@ struct LowBalanceBannerRow: View {
 ///
 /// `LowBalanceBannerHost` is mounted inside `ConversationChatView`, which is
 /// recreated per conversation selection on iPad's `NavigationSplitView`. If
-/// `dismissedForState` lived in `@State` on the host, an iPad user who
-/// dismissed the banner would see it re-appear the next time they tapped a
-/// conversation in the sidebar. Lifting the state to an `@Observable`
-/// singleton — observed by every host instance — makes dismissal truly
-/// session-scoped on both iPhone and iPad.
+/// dismissal state lived in `@State` on the host, an iPad user who dismissed
+/// the banner would see it re-appear the next time they tapped a conversation
+/// in the sidebar. Lifting it to an `@Observable` singleton — observed by
+/// every host instance — makes dismissal truly session-scoped on both iPhone
+/// and iPad.
+///
+/// State is keyed by `connectedOrganizationId` so dismissals in one
+/// organization don't leak into another if the user logs out and signs
+/// into a different org in the same app run. Each org has its own slot;
+/// unknown-org reads return `nil` so the banner shows by default.
 @MainActor
 @Observable
 final class LowBalanceBannerSession {
     static let shared = LowBalanceBannerSession()
 
-    /// The state at which the user dismissed the banner, if any. Set when
-    /// the x button fires, cleared on recovery to `.ok` so a subsequent
-    /// drop re-surfaces the banner.
-    var dismissedForState: LowBalanceState?
+    /// Map of `connectedOrganizationId` → the state at which the user
+    /// dismissed the banner for that org. Cleared on recovery to `.ok`.
+    private var dismissedStateByOrg: [String: LowBalanceState] = [:]
 
-    private init() {}
+    /// Exposed for tests so they can exercise the per-org dismissal logic
+    /// against fresh instances instead of polluting `.shared`. Product code
+    /// should always go through `.shared`.
+    init() {}
+
+    /// Returns the dismissed state for `orgId`, or `nil` if the user has
+    /// not dismissed the banner for that org (or if `orgId` is `nil`).
+    func dismissedState(forOrg orgId: String?) -> LowBalanceState? {
+        guard let orgId else { return nil }
+        return dismissedStateByOrg[orgId]
+    }
+
+    /// Records that the user dismissed the banner for `orgId` at the given
+    /// `state`. No-op when `orgId` is `nil` (no authenticated org → no slot
+    /// to persist into; the banner wouldn't be showing anyway since the
+    /// billing fetch would have failed).
+    func setDismissed(_ state: LowBalanceState, forOrg orgId: String?) {
+        guard let orgId else { return }
+        dismissedStateByOrg[orgId] = state
+    }
+
+    /// Clears the dismissal for `orgId` — called when the balance recovers
+    /// to `.ok` so a subsequent drop re-surfaces the banner.
+    func clearDismissed(forOrg orgId: String?) {
+        guard let orgId else { return }
+        dismissedStateByOrg.removeValue(forKey: orgId)
+    }
 }
 
 // MARK: - Banner host
@@ -201,12 +237,15 @@ final class LowBalanceBannerSession {
 /// - Safari sheet dismissal — the user may have just topped up
 ///
 /// ## Dismissal
-/// Session-scoped via `LowBalanceBannerSession.shared`, so the dismissal
-/// survives view recreation (notably iPad's `NavigationSplitView` rebuilding
-/// the detail pane on conversation switch). If the user dismisses the banner
-/// at a given state it stays hidden for that state; transitioning into a
-/// different state (e.g. `.low` → `.depleted`) re-shows the banner, and
-/// recovering to `.ok` clears the dismissal so a future drop re-surfaces it.
+/// Session-scoped via `LowBalanceBannerSession.shared` and keyed by the
+/// current `connectedOrganizationId`, so dismissal survives view recreation
+/// (notably iPad's `NavigationSplitView` rebuilding the detail pane on
+/// conversation switch) but does **not** leak across org switches if the
+/// user logs out and signs into a different organization in the same app
+/// run. If the user dismisses the banner at a given state it stays hidden
+/// for that state on that org; transitioning into a different state (e.g.
+/// `.low` → `.depleted`) re-shows the banner, and recovering to `.ok`
+/// clears the dismissal so a future drop re-surfaces it.
 ///
 /// ## Failure behavior
 /// `BillingService.getBillingSummary` throws when the user is unauthenticated
@@ -220,8 +259,17 @@ struct LowBalanceBannerHost: View {
     /// Process-scoped dismissal lives on the singleton so it survives
     /// `ConversationChatView` recreation. Observed directly — the
     /// `@Observable` conformance on `LowBalanceBannerSession` triggers
-    /// re-evaluation when `dismissedForState` changes.
+    /// re-evaluation when its storage changes.
     private let session = LowBalanceBannerSession.shared
+
+    /// The currently-connected organization ID, read from UserDefaults the
+    /// same way `BillingService` does. Used as the dismissal-state slot key
+    /// so one org's dismissal doesn't suppress the warning for another.
+    /// Returns `nil` pre-login; in that case we never show the banner
+    /// anyway (the billing fetch would have thrown).
+    private var connectedOrgId: String? {
+        UserDefaults.standard.string(forKey: activeOrganizationDefaultsName)
+    }
 
     private var state: LowBalanceState {
         guard let summary else { return .ok }
@@ -229,7 +277,7 @@ struct LowBalanceBannerHost: View {
     }
 
     private var shouldShowBanner: Bool {
-        state != .ok && session.dismissedForState != state
+        state != .ok && session.dismissedState(forOrg: connectedOrgId) != state
     }
 
     var body: some View {
@@ -238,7 +286,7 @@ struct LowBalanceBannerHost: View {
                 LowBalanceBannerRow(
                     state: state,
                     onTap: { showSafari = true },
-                    onDismiss: { session.dismissedForState = state }
+                    onDismiss: { session.setDismissed(state, forOrg: connectedOrgId) }
                 )
                 .transition(.move(edge: .top).combined(with: .opacity))
             }
@@ -270,10 +318,10 @@ struct LowBalanceBannerHost: View {
                 fresh = bootstrapped
             }
             summary = fresh
-            // Clear the session dismissal once the balance recovers so a
+            // Clear this org's dismissal once its balance recovers so a
             // subsequent drop re-shows the banner.
             if LowBalanceBanner.state(for: fresh) == .ok {
-                session.dismissedForState = nil
+                session.clearDismissed(forOrg: connectedOrgId)
             }
         } catch {
             // Drop any prior summary on failure. Keeping the previous value

--- a/clients/ios/Views/LowBalanceBannerView.swift
+++ b/clients/ios/Views/LowBalanceBannerView.swift
@@ -1,0 +1,244 @@
+#if canImport(UIKit)
+import SafariServices
+import SwiftUI
+import UIKit
+import VellumAssistantShared
+
+// MARK: - Balance Classification
+
+/// How we display the current credit balance in the low-balance banner.
+///
+/// Mirrors the macOS `DrawerMenuView` thresholds so the two platforms agree
+/// on what counts as "low" vs. "depleted":
+/// - `.depleted` — `effective_balance <= 0`
+/// - `.low`      — `0 < effective_balance < $1.00`
+/// - `.ok`       — anything higher, or an unparseable value (fail-silent)
+enum LowBalanceState: Equatable {
+    case ok
+    case low
+    case depleted
+}
+
+/// Helpers for the iOS MVP low-balance banner (LUM-1004).
+///
+/// iOS does not ship an in-app purchase flow for MVP — when a user's
+/// credit balance is low or depleted we surface a banner that redirects
+/// them to the web billing page (`{platformURL}/billing`) in
+/// `SFSafariViewController`. The web billing page handles top-up via
+/// Stripe. See the PRD "Edge Case Decisions" section: "When a user's
+/// balance drops, route them to a web URL to top up."
+enum LowBalanceBanner {
+    /// Below this (in credits, i.e. dollars) we surface the `.low` warning.
+    /// Matches the macOS `DrawerMenuView.loadBalance` threshold.
+    static let lowBalanceThreshold: Double = 1.0
+
+    /// Classify a billing summary for display. Returns `.ok` when the balance
+    /// string fails to parse — better to stay silent than to cry wolf on a
+    /// malformed server response.
+    static func state(for summary: BillingSummaryResponse) -> LowBalanceState {
+        guard let value = Double(summary.effective_balance) else { return .ok }
+        if value <= 0 { return .depleted }
+        if value < lowBalanceThreshold { return .low }
+        return .ok
+    }
+
+    /// Web billing page URL — destination of the iOS MVP top-up redirect.
+    ///
+    /// Resolves off `VellumEnvironment.resolvedPlatformURL` so local / dev /
+    /// staging builds point at their matching platform host. Falls back to
+    /// production if the resolved URL fails to parse (defensive; the
+    /// resolver already validates its output).
+    static var webBillingURL: URL {
+        URL(string: "\(VellumEnvironment.resolvedPlatformURL)/billing")
+            ?? URL(string: "https://platform.vellum.ai/billing")!
+    }
+}
+
+// MARK: - SFSafariViewController wrapper
+
+/// SwiftUI wrapper around `SFSafariViewController`. Used by the low-balance
+/// banner to open the web billing page in-app.
+///
+/// Apple reference: [`SFSafariViewController`](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller).
+/// Presenting in a `.sheet` is the Apple-sanctioned pattern for embedding it
+/// inside a SwiftUI hierarchy — full-screen cover also works but hides the
+/// close affordance on taller devices.
+struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        SFSafariViewController(url: url)
+    }
+
+    func updateUIViewController(_ controller: SFSafariViewController, context: Context) {
+        // No-op: the URL is fixed at construction time. `SFSafariViewController`
+        // does not expose a way to navigate to a new URL after presentation.
+    }
+}
+
+// MARK: - Banner row
+
+/// The visual banner chrome — a row that sits above the chat content,
+/// matching the look-and-feel of `ConversationChatView.forkParentChrome`.
+/// Separated from the host so snapshot / preview tests can render it against
+/// synthetic state without driving `BillingService`.
+struct LowBalanceBannerRow: View {
+    let state: LowBalanceState
+    let onTap: () -> Void
+    let onDismiss: () -> Void
+
+    private var title: String {
+        switch state {
+        case .depleted: return "You're out of credits"
+        case .low:      return "Your credit balance is low"
+        case .ok:       return ""
+        }
+    }
+
+    private var subtitle: String {
+        switch state {
+        case .depleted: return "Top up on the web to keep chatting."
+        case .low:      return "Top up on the web before you run out."
+        case .ok:       return ""
+        }
+    }
+
+    private var accentColor: Color {
+        state == .depleted ? VColor.systemNegativeStrong : VColor.systemMidStrong
+    }
+
+    private var backgroundTint: Color {
+        state == .depleted ? VColor.systemNegativeWeak : VColor.systemMidWeak
+    }
+
+    var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            VIconView(.triangleAlert, size: 14)
+                .foregroundStyle(accentColor)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentEmphasized)
+                Text(subtitle)
+                    .font(VFont.labelSmall)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: VSpacing.sm)
+
+            Button(action: onTap) {
+                Text("Top up")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xs)
+                    .background(accentColor)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            }
+            .accessibilityLabel("Top up credits")
+            .accessibilityHint("Opens the Vellum billing page in Safari")
+
+            Button(action: onDismiss) {
+                VIconView(.x, size: 14)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .padding(VSpacing.xxs)
+            }
+            .accessibilityLabel("Dismiss low balance banner")
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(backgroundTint)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(VColor.borderBase)
+                .frame(height: 1)
+                .accessibilityHidden(true)
+        }
+    }
+}
+
+// MARK: - Banner host
+
+/// Self-contained host for the low-balance redirect banner.
+///
+/// Fetches the organization's billing summary via the shared `BillingService`
+/// and, when the balance is `.low` or `.depleted`, renders the banner above
+/// the chat content. Tapping "Top up" opens the web billing page in
+/// `SFSafariViewController` — iOS MVP does not ship an in-app purchase flow.
+///
+/// ## Refresh cadence
+/// - First appearance (`.task`)
+/// - Returning from background (`UIApplication.willEnterForegroundNotification`),
+///   which covers the Safari-app redirect path
+/// - Safari sheet dismissal — the user may have just topped up
+///
+/// ## Dismissal
+/// Session-scoped. If the user dismisses the banner at a given state, it
+/// stays hidden for that exact state. Transitioning into a different state
+/// (e.g. `.low` → `.depleted`) re-shows the banner, and recovering to `.ok`
+/// clears the dismissal so a future drop re-surfaces it.
+///
+/// ## Failure behavior
+/// `BillingService.getBillingSummary` throws when the user is unauthenticated
+/// or no organization is connected. We swallow those errors silently — the
+/// banner is a best-effort signal, not a blocking surface.
+struct LowBalanceBannerHost: View {
+    @State private var summary: BillingSummaryResponse?
+    @State private var showSafari: Bool = false
+    @State private var dismissedForState: LowBalanceState?
+
+    private var state: LowBalanceState {
+        guard let summary else { return .ok }
+        return LowBalanceBanner.state(for: summary)
+    }
+
+    private var shouldShowBanner: Bool {
+        state != .ok && dismissedForState != state
+    }
+
+    var body: some View {
+        Group {
+            if shouldShowBanner {
+                LowBalanceBannerRow(
+                    state: state,
+                    onTap: { showSafari = true },
+                    onDismiss: { dismissedForState = state }
+                )
+                .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: shouldShowBanner)
+        .task {
+            await refreshSummary()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+            Task { await refreshSummary() }
+        }
+        .sheet(isPresented: $showSafari, onDismiss: {
+            Task { await refreshSummary() }
+        }) {
+            SafariView(url: LowBalanceBanner.webBillingURL)
+                .ignoresSafeArea()
+        }
+    }
+
+    private func refreshSummary() async {
+        do {
+            let fresh = try await BillingService.shared.getBillingSummary()
+            summary = fresh
+            // Clear the session dismissal once the balance recovers so a
+            // subsequent drop re-shows the banner.
+            if LowBalanceBanner.state(for: fresh) == .ok {
+                dismissedForState = nil
+            }
+        } catch {
+            // Silent by design — see doc comment. A noisy banner on a
+            // transient network blip or an unauthenticated session would be
+            // worse than a missed warning.
+        }
+    }
+}
+#endif

--- a/clients/ios/Views/LowBalanceBannerView.swift
+++ b/clients/ios/Views/LowBalanceBannerView.swift
@@ -160,6 +160,31 @@ struct LowBalanceBannerRow: View {
     }
 }
 
+// MARK: - Session state
+
+/// Holds the low-balance banner's dismissal state at process scope, so it
+/// survives view recreation.
+///
+/// `LowBalanceBannerHost` is mounted inside `ConversationChatView`, which is
+/// recreated per conversation selection on iPad's `NavigationSplitView`. If
+/// `dismissedForState` lived in `@State` on the host, an iPad user who
+/// dismissed the banner would see it re-appear the next time they tapped a
+/// conversation in the sidebar. Lifting the state to an `@Observable`
+/// singleton — observed by every host instance — makes dismissal truly
+/// session-scoped on both iPhone and iPad.
+@MainActor
+@Observable
+final class LowBalanceBannerSession {
+    static let shared = LowBalanceBannerSession()
+
+    /// The state at which the user dismissed the banner, if any. Set when
+    /// the x button fires, cleared on recovery to `.ok` so a subsequent
+    /// drop re-surfaces the banner.
+    var dismissedForState: LowBalanceState?
+
+    private init() {}
+}
+
 // MARK: - Banner host
 
 /// Self-contained host for the low-balance redirect banner.
@@ -176,19 +201,27 @@ struct LowBalanceBannerRow: View {
 /// - Safari sheet dismissal — the user may have just topped up
 ///
 /// ## Dismissal
-/// Session-scoped. If the user dismisses the banner at a given state, it
-/// stays hidden for that exact state. Transitioning into a different state
-/// (e.g. `.low` → `.depleted`) re-shows the banner, and recovering to `.ok`
-/// clears the dismissal so a future drop re-surfaces it.
+/// Session-scoped via `LowBalanceBannerSession.shared`, so the dismissal
+/// survives view recreation (notably iPad's `NavigationSplitView` rebuilding
+/// the detail pane on conversation switch). If the user dismisses the banner
+/// at a given state it stays hidden for that state; transitioning into a
+/// different state (e.g. `.low` → `.depleted`) re-shows the banner, and
+/// recovering to `.ok` clears the dismissal so a future drop re-surfaces it.
 ///
 /// ## Failure behavior
 /// `BillingService.getBillingSummary` throws when the user is unauthenticated
-/// or no organization is connected. We swallow those errors silently — the
-/// banner is a best-effort signal, not a blocking surface.
+/// or no organization is connected. We swallow those errors silently — but
+/// we also clear any previously-fetched `summary`, so a stale `.low` or
+/// `.depleted` banner doesn't persist (and falsely re-prompt for top-up)
+/// after a transient refresh failure following an actual balance change.
 struct LowBalanceBannerHost: View {
     @State private var summary: BillingSummaryResponse?
     @State private var showSafari: Bool = false
-    @State private var dismissedForState: LowBalanceState?
+    /// Process-scoped dismissal lives on the singleton so it survives
+    /// `ConversationChatView` recreation. Observed directly — the
+    /// `@Observable` conformance on `LowBalanceBannerSession` triggers
+    /// re-evaluation when `dismissedForState` changes.
+    private let session = LowBalanceBannerSession.shared
 
     private var state: LowBalanceState {
         guard let summary else { return .ok }
@@ -196,7 +229,7 @@ struct LowBalanceBannerHost: View {
     }
 
     private var shouldShowBanner: Bool {
-        state != .ok && dismissedForState != state
+        state != .ok && session.dismissedForState != state
     }
 
     var body: some View {
@@ -205,7 +238,7 @@ struct LowBalanceBannerHost: View {
                 LowBalanceBannerRow(
                     state: state,
                     onTap: { showSafari = true },
-                    onDismiss: { dismissedForState = state }
+                    onDismiss: { session.dismissedForState = state }
                 )
                 .transition(.move(edge: .top).combined(with: .opacity))
             }
@@ -227,17 +260,29 @@ struct LowBalanceBannerHost: View {
 
     private func refreshSummary() async {
         do {
-            let fresh = try await BillingService.shared.getBillingSummary()
+            // Mirror the macOS `DrawerMenuView.loadBalance` sequence: fetch
+            // the current summary, then run the one-shot bootstrap if the
+            // org's balances are all-zero. Without this step a brand-new
+            // organization would be classified as `.depleted` before its
+            // bootstrap credit is granted, prompting an unnecessary top-up.
+            var fresh = try await BillingService.shared.getBillingSummary()
+            if let bootstrapped = await BillingService.shared.bootstrapBillingSummaryIfNeeded(summary: fresh) {
+                fresh = bootstrapped
+            }
             summary = fresh
             // Clear the session dismissal once the balance recovers so a
             // subsequent drop re-shows the banner.
             if LowBalanceBanner.state(for: fresh) == .ok {
-                dismissedForState = nil
+                session.dismissedForState = nil
             }
         } catch {
-            // Silent by design — see doc comment. A noisy banner on a
-            // transient network blip or an unauthenticated session would be
-            // worse than a missed warning.
+            // Drop any prior summary on failure. Keeping the previous value
+            // would risk a stale `.low`/`.depleted` banner continuing to
+            // prompt for top-up after a successful top-up if the refresh
+            // call later failed (e.g. transient network blip on foreground
+            // return). Hiding the banner until we have fresh data is
+            // strictly safer than showing a false warning.
+            summary = nil
         }
     }
 }


### PR DESCRIPTION
## Summary

iOS MVP ships without an in-app purchase flow. When a user's credit balance drops low (`< $1.00`) or hits zero, the chat now shows an inline banner whose "Top up" button opens the web billing page (`{platformURL}/billing`) in `SFSafariViewController`.

Implements [LUM-1004](https://linear.app/vellum/issue/LUM-1004). Matches the PRD Edge Case Decision: _"When a user's balance drops, route them to a web URL to top up. No in-app purchase flow for MVP."_

## Implementation

New file `clients/ios/Views/LowBalanceBannerView.swift` — self-contained, one compilation unit:

- **`LowBalanceState`** enum (`.ok` / `.low` / `.depleted`) + pure **`LowBalanceBanner.state(for:)`** classifier — easy to unit-test against a fixture `BillingSummaryResponse`.
- **`LowBalanceBanner.webBillingURL`** — resolves off `VellumEnvironment.resolvedPlatformURL`, so local / dev / staging builds point at their matching host. Falls back to `https://platform.vellum.ai/billing` defensively.
- **`SafariView: UIViewControllerRepresentable`** — thin SwiftUI wrapper around `SFSafariViewController`.
- **`LowBalanceBannerRow`** — presentational banner chrome. Color + copy vary with state (yellow `systemMidWeak` for `.low`, red `systemNegativeWeak` for `.depleted`).
- **`LowBalanceBannerHost`** — owns the fetch + sheet state. Fetches on `.task`, on `UIApplication.willEnterForegroundNotification`, and on Safari sheet dismissal. Dismissal is session-scoped per state so a `.low` → `.depleted` transition re-surfaces the banner and recovery to `.ok` clears the stored dismissal.

Wired in via a single `LowBalanceBannerHost()` call in `ConversationChatView` (`clients/ios/Views/ConversationListView.swift`), between the fork-parent chrome and the chat content. Same insertion point on iPhone (compact) and iPad (split view detail).

## Key technical choices

- **`SFSafariViewController` over `UIApplication.shared.open`** — keeps the user in-app. The ticket explicitly leaves either acceptable; the embedded Safari preserves the "I'll top up, then come back" flow. Tradeoff: SFSafariViewController doesn't share cookies with Safari.app on iOS 11+, so a user who is already signed into the web may need to sign in once inside the banner sheet.
- **Reusing `BillingService` from `VellumAssistantShared`** — no new HTTP layer. The service already throws when auth / org context is missing, so the host silently ignores errors (no banner is better than a noisy one on a transient network blip).
- **Threshold matches macOS (`DrawerMenuView`)** — strict `< $1.00` low, `<= 0` depleted. Parity avoids platform drift on the "what counts as low?" question.
- **No in-app purchase integration** — intentional. PRD explicitly defers IAP for MVP.

## Files changed

- `clients/ios/Views/LowBalanceBannerView.swift` (new) — banner state, URL resolver, SwiftUI Safari wrapper, row, host.
- `clients/ios/Views/ConversationListView.swift` — mounts `LowBalanceBannerHost()` above `ChatContentView` in `ConversationChatView`.
- `clients/ios/Tests/LowBalanceBannerIOSTests.swift` (new) — unit coverage for the classifier thresholds (zero / negative / sub-$1 / boundary / healthy / unparseable) and the web billing URL resolver.

## Testing

- `cd clients/ios && ./build.sh test` — 141 tests pass (8 new `LowBalanceBannerIOSTests` cases included).
- `cd clients/ios && ./build.sh build` — simulator debug build green.

Manual verification on a real account is still worthwhile before sign-off:
- [ ] Sign in, confirm banner hidden on healthy balance
- [ ] Force `effective_balance` below $1 (dev fixture) — banner appears, yellow tint, "Your credit balance is low"
- [ ] Force `effective_balance` to $0 — banner appears, red tint, "You're out of credits"
- [ ] Tap "Top up" — `SFSafariViewController` opens `{platformURL}/billing`
- [ ] Dismiss the Safari sheet — banner refreshes balance once
- [ ] Background → return via the Safari _app_ redirect path — banner refreshes on foreground
- [ ] Dismiss the banner via the x — stays hidden for the same state within the session
- [ ] VoiceOver: "Top up credits" button + "Dismiss low balance banner" x button both announced

## Deferred

- No in-app purchase flow — intentional per PRD.
- No reactive banner from `conversationError(credits_exhausted)` — the existing `ChatContentView.genericErrorBanner` already surfaces that signal inline; adding a second visual would double-banner the same event.
- Dedicated feature-flag gating (e.g. `settings-billing` used on macOS) — iOS has no equivalent `FeatureFlagManager` yet and the PRD does not gate this MVP behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
