### PR TITLE
feat(macos): wire Force Compact section in Compaction Playground tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/ForceCompactSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/ForceCompactSection.swift
@@ -1,28 +1,107 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Stub for the Force Compact subsection of the Compaction Playground tab.
+/// Force Compact subsection of the Compaction Playground tab.
 ///
-/// A Wave-3 follow-up PR replaces this file wholesale with the real UI that
-/// calls `CompactionPlaygroundClient.forceCompact(conversationId:)`. The
-/// parameter list is fixed so the replacement PR does not need to touch the
-/// tab composition file.
+/// Triggers `CompactionPlaygroundClient.forceCompact(conversationId:)` on the
+/// active conversation and renders before/after token counts, messages removed,
+/// and a `summaryFailed` indicator. A 404 from the flat `/playground/*` route
+/// surface (``CompactionPlaygroundError/notAvailable``) is surfaced with a
+/// distinctive "playground endpoints disabled" message so the dev can tell
+/// "flag off" apart from other failures.
 struct ForceCompactSection: View {
     let conversationId: String?
     let client: CompactionPlaygroundClient
     let showToast: (String, ToastInfo.Style) -> Void
+
+    @State private var isRunning = false
+    @State private var lastResult: CompactionForceResponse?
+    @State private var lastError: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text("Force Compact")
                 .font(VFont.titleSmall)
                 .foregroundStyle(VColor.contentDefault)
-            Text("Coming soon in a follow-up PR.")
+
+            Text("Trigger compaction on the active conversation immediately.")
                 .font(VFont.bodySmallDefault)
                 .foregroundStyle(VColor.contentSecondary)
+
+            VButton(
+                label: isRunning ? "Force Compacting..." : "Force Compact Now",
+                style: .outlined,
+                isDisabled: conversationId == nil || isRunning
+            ) {
+                runForceCompact()
+            }
+
+            if isRunning {
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Compacting...")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+            }
+
+            if let result = lastResult {
+                resultPanel(result)
+            } else if let error = lastError {
+                Text(error)
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+            }
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard()
+    }
+
+    @ViewBuilder
+    private func resultPanel(_ result: CompactionForceResponse) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Compacted: \(result.compacted ? "yes" : "no")")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(result.compacted ? VColor.systemPositiveStrong : VColor.systemNegativeStrong)
+
+            Text("Tokens: \(result.previousTokens) → \(result.newTokens)")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentSecondary)
+
+            Text("Messages removed: \(result.messagesRemoved)")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentSecondary)
+
+            if result.summaryFailed == true {
+                Text("Summary failed")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+            }
+        }
+    }
+
+    private func runForceCompact() {
+        Task {
+            guard let id = conversationId else { return }
+            isRunning = true
+            lastError = nil
+            defer { isRunning = false }
+            do {
+                let result = try await client.forceCompact(conversationId: id)
+                lastResult = result
+                showToast("Compaction completed.", .success)
+            } catch CompactionPlaygroundError.notAvailable {
+                let message = "Playground endpoints disabled — enable the compaction-playground flag."
+                lastError = message
+                lastResult = nil
+                showToast(message, .error)
+            } catch {
+                lastError = error.localizedDescription
+                lastResult = nil
+                showToast("Compaction failed: \(error.localizedDescription)", .error)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Replace the stub Force Compact section with a working button that calls `CompactionPlaygroundClient.forceCompact` against the active conversation
- Surface before/after token counts, messages removed, and `summaryFailed` flag in a result panel
- Distinguish 404-flag-off ("playground endpoints disabled") from other errors via `CompactionPlaygroundError.notAvailable`

Part of plan: compaction-playground-macos.md (PR 10 of 17)
Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
