### PR TITLE
feat(macos): wire Reset Circuit section

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/ResetCircuitSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/ResetCircuitSection.swift
@@ -1,25 +1,48 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Stub for the Reset Circuit subsection of the Compaction Playground tab.
+/// Reset Circuit subsection of the Compaction Playground tab.
 ///
-/// A Wave-3 follow-up PR replaces this file wholesale with UI that drives
-/// `CompactionPlaygroundClient.resetCircuit(conversationId:)`. The parameter
-/// list is fixed so the replacement PR does not need to touch the tab
-/// composition file.
+/// Drives `CompactionPlaygroundClient.resetCircuit(conversationId:)` to clear
+/// the consecutive-failure count and any open circuit on the active
+/// conversation. The daemon emits a `compaction_circuit_closed` event on
+/// success, which dismisses any active circuit-breaker toast in the UI.
+/// No local state display — the StateDisplaySection polls separately; this
+/// section only triggers the action.
 struct ResetCircuitSection: View {
     let conversationId: String?
     let client: CompactionPlaygroundClient
     let showToast: (String, ToastInfo.Style) -> Void
 
+    @State private var isRunning = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Reset Circuit")
+            Text("Reset Circuit Breaker")
                 .font(VFont.titleSmall)
                 .foregroundStyle(VColor.contentDefault)
-            Text("Coming soon in a follow-up PR.")
+            Text("Clear consecutive-failure count and any open circuit on the active conversation.")
                 .font(VFont.bodySmallDefault)
                 .foregroundStyle(VColor.contentSecondary)
+            VButton(
+                label: "Reset Circuit Breaker",
+                style: .outlined,
+                isDisabled: conversationId == nil || isRunning
+            ) {
+                Task {
+                    guard let id = conversationId else { return }
+                    isRunning = true
+                    defer { isRunning = false }
+                    do {
+                        try await client.resetCircuit(conversationId: id)
+                        showToast("Circuit breaker cleared.", .success)
+                    } catch CompactionPlaygroundError.notAvailable {
+                        showToast("Playground endpoints disabled — enable the compaction-playground flag.", .error)
+                    } catch {
+                        showToast("Reset failed: \(error.localizedDescription)", .error)
+                    }
+                }
+            }
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- Replace the stub Reset Circuit section with a single button that calls `CompactionPlaygroundClient.resetCircuit` and toasts success/failure
- 404-flag-off surfaces a distinctive toast

Part of plan: compaction-playground-macos.md (PR 13 of 17)
Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
