### PR TITLE
feat(macos): add live compaction event log

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/EventLogSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CompactionPlayground/EventLogSection.swift
@@ -1,26 +1,129 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Stub for the Event Log subsection of the Compaction Playground tab.
+/// Event Log subsection of the Compaction Playground tab.
 ///
-/// A Wave-3 follow-up PR replaces this file wholesale with UI that subscribes
-/// to the compaction event stream scoped to `conversationId`. The parameter
-/// list is fixed so the replacement PR does not need to touch the tab
-/// composition file.
+/// Renders `ChatViewModel.compactionEventLog` for the active conversation as
+/// a most-recent-first list. The log is populated by the existing
+/// `context_compacting`, `context_compacted`, `compaction_circuit_open`, and
+/// `compaction_circuit_closed` SSE handlers in `ChatActionHandler`, so no
+/// new subscription is needed here.
+///
+/// The buffer trim (50 entries) is centralized in
+/// `ChatViewModel.appendCompactionEvent(_:)` — this view only reads.
 struct EventLogSection: View {
     let conversationId: String?
+    let conversationManager: ConversationManager
+
+    private static let timestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .medium
+        return formatter
+    }()
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Event Log")
+            Text("Compaction Event Log")
                 .font(VFont.titleSmall)
                 .foregroundStyle(VColor.contentDefault)
-            Text("Coming soon in a follow-up PR.")
+
+            Text("Streamed from the active conversation's SSE events.")
                 .font(VFont.bodySmallDefault)
                 .foregroundStyle(VColor.contentSecondary)
+
+            if let viewModel = conversationManager.activeViewModel {
+                // ChatViewModel is `@Observable`, so reading
+                // `viewModel.compactionEventLog` directly from a SwiftUI body
+                // registers the observation dependency and triggers re-renders
+                // when `appendCompactionEvent` mutates the array.
+                logContent(viewModel: viewModel)
+            } else {
+                emptyState(
+                    "Open a conversation in the main window to see compaction events."
+                )
+            }
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard()
+    }
+
+    // MARK: - Subviews
+
+    @ViewBuilder
+    private func logContent(viewModel: ChatViewModel) -> some View {
+        if viewModel.compactionEventLog.isEmpty {
+            emptyState(
+                "No compaction events yet — trigger one from the sections above."
+            )
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    ForEach(viewModel.compactionEventLog.reversed()) { entry in
+                        row(entry: entry)
+                    }
+                }
+            }
+            .frame(maxHeight: 240)
+
+            HStack {
+                Spacer()
+                VButton(label: "Clear", style: .outlined) {
+                    viewModel.compactionEventLog = []
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func row(entry: CompactionEventLogEntry) -> some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            Text(Self.timestampFormatter.string(from: entry.timestamp))
+                .font(VFont.bodySmallDefault.monospaced())
+                .foregroundStyle(VColor.contentTertiary)
+                .frame(width: 72, alignment: .leading)
+
+            kindPill(entry.kind)
+
+            Text(entry.summary)
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentDefault)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private func kindPill(_ kind: String) -> some View {
+        Text(kind)
+            .font(VFont.labelSmall)
+            .foregroundStyle(VColor.contentDefault)
+            .padding(.horizontal, VSpacing.xs)
+            .padding(.vertical, 2)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(pillColor(for: kind).opacity(0.2))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(pillColor(for: kind), lineWidth: 1)
+            )
+    }
+
+    private func pillColor(for kind: String) -> Color {
+        switch kind {
+        case "compacting": return VColor.contentTertiary
+        case "compacted": return VColor.systemPositiveStrong
+        case "circuit_open": return VColor.systemNegativeStrong
+        case "circuit_closed": return VColor.systemMidStrong
+        default: return VColor.contentTertiary
+        }
+    }
+
+    @ViewBuilder
+    private func emptyState(_ text: String) -> some View {
+        Text(text)
+            .font(VFont.bodySmallDefault)
+            .foregroundStyle(VColor.contentSecondary)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsCompactionPlaygroundTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsCompactionPlaygroundTab.swift
@@ -58,7 +58,8 @@ struct SettingsCompactionPlaygroundTab: View {
                     client: client
                 )
                 EventLogSection(
-                    conversationId: activeConversationId
+                    conversationId: activeConversationId,
+                    conversationManager: conversationManager
                 )
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -339,6 +339,15 @@ final class ChatActionHandler {
             guard belongsToConversation(event.conversationId) else { return }
             vm.contextWindowTokens = event.estimatedInputTokens
             vm.contextWindowMaxTokens = event.maxInputTokens
+            let callWord = event.summaryCalls == 1 ? "call" : "calls"
+            let summary =
+                "\(Self.formatTokens(event.previousEstimatedInputTokens)) → \(Self.formatTokens(event.estimatedInputTokens)) tokens, "
+                + "\(event.compactedMessages) messages (summary: \(event.summaryCalls) \(callWord))"
+            vm.appendCompactionEvent(CompactionEventLogEntry(
+                timestamp: Date(),
+                kind: "compacted",
+                summary: summary
+            ))
 
         case .compactionCircuitOpen(let event):
             // `openUntil` is milliseconds-since-epoch; convert to Date.
@@ -346,6 +355,14 @@ final class ChatActionHandler {
             let until = Date(timeIntervalSince1970: event.openUntil / 1000.0)
             vm.compactionCircuitOpenUntil = until
             log.warning("Auto-compaction paused until \(until, privacy: .public) — reason: \(event.reason, privacy: .public)")
+            let timeFormatter = DateFormatter()
+            timeFormatter.dateStyle = .none
+            timeFormatter.timeStyle = .short
+            vm.appendCompactionEvent(CompactionEventLogEntry(
+                timestamp: Date(),
+                kind: "circuit_open",
+                summary: "Circuit open until \(timeFormatter.string(from: until))"
+            ))
 
         case .compactionCircuitClosed(let event):
             guard belongsToConversation(event.conversationId) else { return }
@@ -355,6 +372,11 @@ final class ChatActionHandler {
             guard vm.compactionCircuitOpenUntil != nil else { return }
             vm.compactionCircuitOpenUntil = nil
             log.info("Auto-compaction resumed (circuit breaker closed)")
+            vm.appendCompactionEvent(CompactionEventLogEntry(
+                timestamp: Date(),
+                kind: "circuit_closed",
+                summary: "Circuit closed"
+            ))
 
         default:
             break
@@ -1414,6 +1436,13 @@ final class ChatActionHandler {
         vm.assistantActivityReason = msg.reason
         vm.assistantStatusText = msg.statusText
         vm.isCompacting = msg.reason == "context_compacting"
+        if msg.reason == "context_compacting" {
+            vm.appendCompactionEvent(CompactionEventLogEntry(
+                timestamp: Date(),
+                kind: "compacting",
+                summary: "Compacting…"
+            ))
+        }
         switch msg.phase {
         case "thinking":
             vm.isThinking = true
@@ -1428,5 +1457,18 @@ final class ChatActionHandler {
         default:
             break
         }
+    }
+
+    // MARK: - Event-Log Formatting
+
+    /// Format a raw token count as a compact string (e.g. `148000 → "148k"`,
+    /// `500 → "500"`). Used by the compaction event-log summary — mirrors the
+    /// compaction formatter on `VContextWindowIndicator` without exporting
+    /// that private helper.
+    fileprivate static func formatTokens(_ count: Int) -> String {
+        if count >= 1000 {
+            return "\(count / 1000)k"
+        }
+        return "\(count)"
     }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -115,6 +115,27 @@ public struct SurfaceClient: SurfaceClientProtocol {
     }
 }
 
+/// Single entry in `ChatViewModel.compactionEventLog`. Populated from the
+/// SSE handlers for `context_compacting`, `context_compacted`,
+/// `compaction_circuit_open`, and `compaction_circuit_closed`, and rendered
+/// by the Compaction Playground's Event Log section.
+public struct CompactionEventLogEntry: Identifiable, Equatable, Sendable {
+    public let id: UUID
+    public let timestamp: Date
+    /// One of `"compacting"`, `"compacted"`, `"circuit_open"`,
+    /// `"circuit_closed"`. Kept as a plain string so future kinds emitted by
+    /// the daemon surface without a type migration in the client.
+    public let kind: String
+    public let summary: String
+
+    public init(timestamp: Date, kind: String, summary: String) {
+        self.id = UUID()
+        self.timestamp = timestamp
+        self.kind = kind
+        self.summary = summary
+    }
+}
+
 /// Facade that owns the three focused sub-managers and forwards all property
 /// accesses to them via computed properties.  Existing call sites require no
 /// changes because the public API surface is identical to the previous monolith.
@@ -345,6 +366,22 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// timestamp is still in the future; the banner auto-dismisses once the
     /// cooldown elapses.
     public var compactionCircuitOpenUntil: Date? = nil
+
+    /// Rolling log of recent compaction lifecycle events, rendered by the
+    /// Compaction Playground's Event Log section. Capped at 50 entries by
+    /// `appendCompactionEvent(_:)`; writes drop the oldest entries first.
+    public var compactionEventLog: [CompactionEventLogEntry] = []
+
+    /// Append a compaction event to `compactionEventLog`, trimming from the
+    /// front to keep the buffer at most 50 entries. Centralizing the trim
+    /// here lets the Playground UI read the array directly without
+    /// re-implementing the cap.
+    public func appendCompactionEvent(_ entry: CompactionEventLogEntry) {
+        compactionEventLog.append(entry)
+        if compactionEventLog.count > 50 {
+            compactionEventLog.removeFirst(compactionEventLog.count - 50)
+        }
+    }
     public var contextWindowFillRatio: Double? {
         guard let tokens = contextWindowTokens,
               let max = contextWindowMaxTokens,


### PR DESCRIPTION
## Summary
- Add `CompactionEventLogEntry` + `compactionEventLog` to `ChatViewModel` (50-cap buffer) and append from existing `context_compacting`, `context_compacted`, `compaction_circuit_open`, `compaction_circuit_closed` handlers in `ChatActionHandler`
- Replace the stub Event Log section with a most-recent-first list showing timestamp, kind pill, and summary, plus a Clear button

Part of plan: compaction-playground-macos.md (PR 15 of 17)
Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
