### PR TITLE
[ATL-173] Call POST /activate/ when user picks an assistant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -209,6 +209,21 @@ extension AppDelegate {
             assistants: items,
             onConnect: { [weak self] assistantId in
                 LockfileAssistant.setActiveAssistantId(assistantId)
+                // Fire-and-forget: tell the platform this is the active
+                // assistant. Failure is non-fatal — the local lockfile is
+                // the source of truth for which assistant to connect to.
+                if let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
+                    Task {
+                        do {
+                            try await AuthService.shared.activateAssistant(
+                                id: assistantId,
+                                organizationId: orgId
+                            )
+                        } catch {
+                            log.warning("Failed to activate assistant on platform: \(error.localizedDescription)")
+                        }
+                    }
+                }
                 self?.proceedToApp()
             },
             onSignOut: { [weak self] in

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -280,6 +280,17 @@ public final class AuthService {
         return try decodeAssistantResult(response)
     }
 
+    /// Tell the platform this is the user's active assistant. Updates
+    /// `membership.active_assistant` so ID-less flows (e.g. `GET
+    /// /v1/assistants/active/`) resolve to the right assistant.
+    public func activateAssistant(id: String, organizationId: String) async throws {
+        _ = try await performPlatformRequest(
+            path: "v1/assistants/\(id)/activate/",
+            method: "POST",
+            organizationId: organizationId
+        )
+    }
+
     /// List managed assistants visible to the caller in the given organization.
     ///
     /// The backend already scopes the response to platform (cloud-hosted)

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -283,12 +283,28 @@ public final class AuthService {
     /// Tell the platform this is the user's active assistant. Updates
     /// `membership.active_assistant` so ID-less flows (e.g. `GET
     /// /v1/assistants/active/`) resolve to the right assistant.
+    ///
+    /// `performPlatformRequest` only throws on URL/network/missing-token
+    /// failures — it returns 4xx/5xx in the `PlatformResponse`. Callers
+    /// are expected to check `statusCode` explicitly, and we do that here
+    /// so non-2xx responses surface to the caller's `catch` block.
     public func activateAssistant(id: String, organizationId: String) async throws {
-        _ = try await performPlatformRequest(
+        let response = try await performPlatformRequest(
             path: "v1/assistants/\(id)/activate/",
             method: "POST",
             organizationId: organizationId
         )
+
+        if response.statusCode == 401 {
+            throw PlatformAPIError.authenticationRequired
+        }
+        if response.statusCode == 404 {
+            throw PlatformAPIError.notFound
+        }
+        guard (200..<300).contains(response.statusCode) else {
+            let detail = String(data: response.data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: response.statusCode, detail: detail)
+        }
     }
 
     /// List managed assistants visible to the caller in the given organization.

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -295,7 +295,12 @@ public final class AuthService {
             organizationId: organizationId
         )
 
-        if response.statusCode == 401 {
+        if response.statusCode == 401 || response.statusCode == 403 {
+            // Collapsed like the other POSTs on this service (self-hosted
+            // registration, reprovision, retire). The platform's activate
+            // endpoint uses an ownership-filtered queryset — non-owned IDs
+            // come back as 404, so 403 here means session/token/org-access
+            // is bad, not a per-resource permission error.
             throw PlatformAPIError.authenticationRequired
         }
         if response.statusCode == 404 {


### PR DESCRIPTION
Wire `AuthService.activateAssistant(id:organizationId:)` into the picker's `onConnect` handler so the platform's `membership.active_assistant` stays in sync when the user explicitly chooses an assistant.

### How it works

When the user taps **Connect** in the picker:
1. `LockfileAssistant.setActiveAssistantId` — immediate, sync
2. `POST /v1/assistants/{id}/activate/` — async, fire-and-forget
3. `proceedToApp()` — doesn't wait for the activate call

Failure logs a warning but never blocks the user. The local lockfile is the source of truth; the platform call keeps ID-less flows (`GET /v1/assistants/active/`) in sync.

The platform endpoint already exists (`AssistantViewSet.activate` in `django/app/assistant/views.py:1574`).

### Changes

- **`AuthService.swift`** (+11) — new `activateAssistant(id:organizationId:)` method
- **`AppDelegate+AuthLifecycle.swift`** (+15) — fire-and-forget activate call in picker `onConnect`

**+26 lines across 2 files.**

Closes ATL-173.

---

Authored by: David Rose (`david-rose-bot`), @emmiekehoe's assistant
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
