### PR TITLE
feat(compaction): strip injections + rewrite prompt so summaries actually summarize

### DIFF
--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -343,6 +343,10 @@ describe("forceCompact event emission", () => {
     expect(compactedEvent.summaryInputTokens).toBe(500);
     expect(compactedEvent.summaryOutputTokens).toBe(200);
     expect(compactedEvent.summaryModel).toBe("test-model");
+    // Quality signals derived from the summary text itself.
+    expect(compactedEvent.summaryCharCount).toBe("summary text".length);
+    expect(compactedEvent.summaryHeaderCount).toBe(0);
+    expect(compactedEvent.summaryHadMemoryEcho).toBe(false);
 
     const usageEvents = collected.filter((m) => m.type === "usage_update");
     expect(usageEvents.length).toBe(1);
@@ -429,5 +433,48 @@ describe("forceCompact event emission", () => {
       0,
     );
     expect(collected.filter((m) => m.type === "usage_update").length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeSummaryQualitySignals — imported lazily after mocks are installed so
+// the logger stub and other module replacements take effect first.
+// ---------------------------------------------------------------------------
+
+import { computeSummaryQualitySignals } from "../daemon/conversation-agent-loop.js";
+
+describe("computeSummaryQualitySignals", () => {
+  test("counts `## ` headers at the start of lines", () => {
+    const summary =
+      "Narrative opener.\n\n## What We're Working On\n- x\n\n## Open Threads\n- y";
+    const signals = computeSummaryQualitySignals(summary);
+    expect(signals.headerCount).toBe(2);
+    expect(signals.charCount).toBe(summary.length);
+    expect(signals.hadMemoryEcho).toBe(false);
+  });
+
+  test("reports empty signals for an empty summary", () => {
+    const signals = computeSummaryQualitySignals("");
+    expect(signals.charCount).toBe(0);
+    expect(signals.headerCount).toBe(0);
+    expect(signals.hadMemoryEcho).toBe(false);
+  });
+
+  test("flags summaries that leaked injection tags", () => {
+    const leaked =
+      "## Facts\nThe user had a `<memory __injected>` block in their history";
+    expect(computeSummaryQualitySignals(leaked).hadMemoryEcho).toBe(true);
+
+    const turnCtxLeak = "A <turn_context> fragment snuck through";
+    expect(computeSummaryQualitySignals(turnCtxLeak).hadMemoryEcho).toBe(true);
+
+    const nowLeak = "<NOW.md> scratchpad echo";
+    expect(computeSummaryQualitySignals(nowLeak).hadMemoryEcho).toBe(true);
+  });
+
+  test("does not flag ordinary mentions of the word 'memory'", () => {
+    const clean =
+      "## Facts\nThe user asked about their memory and remembered their dad's recipe.";
+    expect(computeSummaryQualitySignals(clean).hadMemoryEcho).toBe(false);
   });
 });

--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, test } from "bun:test";
 import type { ContextWindowConfig } from "../config/types.js";
 import { estimateTextTokens } from "../context/token-estimator.js";
 import {
+  clampSummaryAtSectionBoundary,
   CONTEXT_SUMMARY_MARKER,
   ContextWindowManager,
   createContextSummaryMessage,
   getSummaryFromContextMessage,
+  stripCompactionOnlyInjections,
 } from "../context/window-manager.js";
 import type {
   ContentBlock,
@@ -320,12 +322,12 @@ describe("ContextWindowManager", () => {
       provider,
       systemPrompt: "system prompt",
       config: makeConfig({
-        maxInputTokens: 620,
-        targetBudgetRatio: 0.59,
-        compactThreshold: 0.5,
+        maxInputTokens: 2000,
+        targetBudgetRatio: 0.4,
+        compactThreshold: 0.35,
       }),
     });
-    const long = "f".repeat(500);
+    const long = "f".repeat(1500);
     const history: Message[] = [
       {
         role: "user",
@@ -1667,5 +1669,174 @@ describe("ContextWindowManager", () => {
     expect(result.compacted).toBe(true);
     expect(result.compactedMessages).toBe(3);
     expect(result.messages).toHaveLength(1);
+  });
+});
+
+describe("stripCompactionOnlyInjections", () => {
+  test("removes memory, turn_context, and workspace text blocks from user messages", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<memory __injected>\nrecall notes\n</memory>",
+          },
+          {
+            type: "text",
+            text: "<turn_context>\nActor: Alice\n</turn_context>",
+          },
+          { type: "text", text: "real user content" },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "assistant reply" }],
+      },
+    ];
+    const stripped = stripCompactionOnlyInjections(messages);
+    expect(stripped).toHaveLength(2);
+    const firstText = (stripped[0].content[0] as { text: string }).text;
+    expect(firstText).toBe("real user content");
+    expect(stripped[0].content).toHaveLength(1);
+  });
+
+  test("drops user messages that become empty after stripping", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "<memory __injected>\nonly memory\n</memory>" },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "real content" }] },
+    ];
+    const stripped = stripCompactionOnlyInjections(messages);
+    expect(stripped).toHaveLength(1);
+    expect((stripped[0].content[0] as { text: string }).text).toBe(
+      "real content",
+    );
+  });
+
+  test("leaves assistant messages and non-text blocks untouched", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "<turn_context>\nnot really injected\n</turn_context>",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "t1",
+            content: "<memory>fake</memory>",
+          },
+          { type: "text", text: "user reply" },
+        ],
+      },
+    ];
+    const stripped = stripCompactionOnlyInjections(messages);
+    expect(stripped).toHaveLength(2);
+    expect((stripped[0].content[0] as { text: string }).text).toContain(
+      "turn_context",
+    );
+    expect(stripped[1].content).toHaveLength(2);
+  });
+});
+
+describe("summarizer input excludes runtime injections", () => {
+  test("maybeCompact does not pass memory/turn_context text to the summarizer", async () => {
+    const seenPrompts: string[] = [];
+    const provider = createProvider((messages) => {
+      for (const msg of messages) {
+        for (const block of msg.content) {
+          if (block.type === "text") seenPrompts.push(block.text);
+        }
+      }
+      return {
+        content: [
+          {
+            type: "text",
+            text: "## Facts Worth Remembering\n- summary produced",
+          },
+        ],
+        model: "mock",
+        usage: { inputTokens: 100, outputTokens: 25 },
+        stopReason: "end_turn",
+      };
+    });
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({
+        maxInputTokens: 2000,
+        targetBudgetRatio: 0.4,
+        compactThreshold: 0.35,
+      }),
+    });
+    const long = "x".repeat(1500);
+    const memoryBlob =
+      "<memory __injected>\nBOB_ATTENDED_STANDUP_YESTERDAY\n</memory>";
+    const turnCtx =
+      "<turn_context>\nACTOR_METADATA_THAT_SHOULD_NOT_LEAK\n</turn_context>";
+    const history: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: memoryBlob },
+          { type: "text", text: turnCtx },
+          { type: "text", text: `u1 ${long}` },
+        ],
+      },
+      message("assistant", `a1 ${long}`),
+      message("user", `u2 ${long}`),
+      message("assistant", `a2 ${long}`),
+      message("user", `u3 ${long}`),
+    ];
+
+    const result = await manager.maybeCompact(history);
+    expect(result.compacted).toBe(true);
+    const joined = seenPrompts.join("\n");
+    expect(joined).not.toContain("BOB_ATTENDED_STANDUP_YESTERDAY");
+    expect(joined).not.toContain("ACTOR_METADATA_THAT_SHOULD_NOT_LEAK");
+    expect(joined).not.toContain("<memory __injected>");
+    expect(joined).not.toContain("<turn_context>");
+    // Real conversation content should survive — at least one of the
+    // middle turns (whose header/body is short enough to fit within the
+    // capped transcript budget) should appear in the summarizer input.
+    expect(joined).toMatch(/u2 |a1 /);
+  });
+});
+
+describe("clampSummaryAtSectionBoundary", () => {
+  test("returns the input unchanged when under the limit", () => {
+    const summary = "## Decisions\nWe decided to ship.";
+    expect(clampSummaryAtSectionBoundary(summary, 1000)).toBe(summary);
+  });
+
+  test("truncates at a `## ` boundary when one exists in the allowed region", () => {
+    const keeper = "## Facts\n" + "a".repeat(200);
+    const dropped = "## Open Threads\n" + "b".repeat(500);
+    const summary = `${keeper}\n${dropped}`;
+    const maxChars = keeper.length + 20;
+    const clamped = clampSummaryAtSectionBoundary(summary, maxChars);
+    expect(clamped.endsWith("...")).toBe(true);
+    expect(clamped).not.toContain("## Open Threads");
+    expect(clamped).toContain("## Facts");
+    // No mid-header cut: nothing that looks like a partial heading.
+    expect(/##\s*$/.test(clamped)).toBe(false);
+  });
+
+  test("falls back to a hard cut when no section boundary is past the midpoint", () => {
+    const body = "no section headers in this output " + "z".repeat(1000);
+    const clamped = clampSummaryAtSectionBoundary(body, 100);
+    expect(clamped.endsWith("...")).toBe(true);
+    expect(clamped.length).toBeLessThanOrEqual(100);
   });
 });

--- a/assistant/src/context/__tests__/compact-prompt.test.ts
+++ b/assistant/src/context/__tests__/compact-prompt.test.ts
@@ -11,9 +11,26 @@ describe("compact.md prompt asset", () => {
     expect(prompt.length).toBeGreaterThan(0);
   });
 
-  test("contains the '## Goals' section header (canary for truncation)", () => {
+  test("contains explicit length target (canary against accidental 'concise' reversion)", () => {
     const prompt = loadCompactPrompt();
-    expect(prompt).toContain("## Goals");
+    expect(prompt).toContain("1500");
+    expect(prompt).toContain("4000");
+    expect(prompt.toLowerCase()).toContain("tokens");
+  });
+
+  test("includes the never-include guidance for injection tags", () => {
+    const prompt = loadCompactPrompt();
+    expect(prompt).toContain("<memory");
+    expect(prompt).toContain("<turn_context>");
+    expect(prompt.toLowerCase()).toContain("never include");
+  });
+
+  test("lists the flexible section headers", () => {
+    const prompt = loadCompactPrompt();
+    expect(prompt).toContain("## What We're Working On");
+    expect(prompt).toContain("## Decisions & Commitments");
+    expect(prompt).toContain("## Facts Worth Remembering");
+    expect(prompt).toContain("## Open Threads");
   });
 });
 
@@ -29,17 +46,18 @@ describe("loadCompactPromptOrFallback", () => {
       throw new Error("compact.md missing");
     });
     expect(result.length).toBeGreaterThan(0);
-    expect(result).toContain("## Goals");
-    expect(result).toContain("## Constraints");
-    expect(result).toContain("## Decisions");
-    expect(result).toContain("## Open Conversations");
-    expect(result).toContain("## Key Artifacts");
-    expect(result).toContain("## Recent Progress");
+    // Fallback must carry the same core guidance as the on-disk prompt so
+    // summary quality doesn't silently collapse when the bundled asset is
+    // missing (partial deploys, filesystem corruption).
+    expect(result).toContain("1500");
+    expect(result).toContain("4000");
+    expect(result).toContain("<memory");
+    expect(result.toLowerCase()).toContain("never include");
   });
 
   test("uses loadCompactPrompt as the default loader", () => {
     const result = loadCompactPromptOrFallback();
     expect(result.length).toBeGreaterThan(0);
-    expect(result).toContain("## Goals");
+    expect(result).toContain("1500");
   });
 });

--- a/assistant/src/context/prompts/compact.md
+++ b/assistant/src/context/prompts/compact.md
@@ -1,12 +1,26 @@
-You compress long assistant conversations into durable working memory.
-Focus on actionable state, not prose.
-Preserve concrete facts: goals, constraints, decisions, pending questions, file paths, commands, errors, and TODOs.
-Remove repetition and stale details that were superseded.
-Thread anchors: when a "Retained Thread References" section is present, each listed reply cites its parent via `→ Mxxxxxx`. If that parent appears in the Transcript, preserve its text verbatim (reactions may be aggregated as "N users reacted"). Omit when the section is absent.
-Return concise markdown using these section headers exactly:
-## Goals
-## Constraints
-## Decisions
-## Open Conversations
-## Key Artifacts
-## Recent Progress
+You are summarizing a long conversation so that the assistant can keep working with it after older messages are dropped. Your summary will REPLACE those messages — the assistant's only access to what was said earlier will be what you write here.
+
+Be thorough. Capture what happened, why it mattered, what's unresolved, and what was felt. Do not compress away emotional tone, relationship context, or nuance. Keep specific details (names, numbers, file paths, commands, URLs, exact phrasings) when they might matter later.
+
+Target length: aim for 1500–4000 tokens. Use the upper end of that range when the conversation is rich in decisions, relationships, emotional content, or threads that are still open. Use the lower end when the conversation is short or a simple task execution.
+
+Open with a 1–2 paragraph narrative describing what the conversation is about and where it currently stands. Then use `## ` section headers. Use these headers when they apply; skip sections that have nothing to say; add your own headers when something important doesn't fit:
+
+- `## What We're Working On` — active tasks, projects, intentions
+- `## Decisions & Commitments` — what was decided, what was promised, by whom
+- `## Facts Worth Remembering` — durable details: names, preferences, constraints, background
+- `## Open Threads` — unresolved questions, pending follow-ups, things the user is still thinking about
+- `## Emotional Arc / Relationship Notes` — tone, feelings expressed, relational context (include when relevant; omit otherwise)
+- `## Artifacts & References` — files, URLs, commands, code snippets, external systems referenced
+
+If an existing summary is provided, update it: merge new information in, prefer the most recent and explicit detail on conflicts, and preserve anything that is still unresolved or still true. Do not restart from scratch.
+
+**Never include in the summary:**
+
+- Content inside `<memory __injected>`, `<memory>`, `<turn_context>`, `<workspace>`, `<knowledge_base>`, `<system_reminder>`, `<now_scratchpad>`, `<NOW.md …>`, `<active_thread>`, `<channel_capabilities>`, `<transport_hints>`, `<system_notice>`, or any other angle-bracket-tagged system blocks. These are system metadata attached to messages, not part of what the user or assistant said. Ignore them entirely.
+- Tool-call boilerplate (retries, failed attempts the assistant recovered from, routine status updates). Summarize the *outcome* instead.
+- Repetitive chit-chat that adds nothing to working memory.
+
+**Thread anchors (Slack only):** if the input includes a "Retained Thread References" section, each listed reply cites its parent via `→ Mxxxxxx`. If that parent message appears in the transcript, preserve its text verbatim in the summary (reactions may be aggregated as "N users reacted"). Omit this entirely when no such section is present.
+
+Return only the summary itself in markdown — no preamble, no meta-commentary about what you're doing.

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -31,6 +31,87 @@ const MIN_COMPACTABLE_PERSISTED_MESSAGES = 2;
 const INTERNAL_CONTEXT_SUMMARY_MESSAGES = new WeakSet<Message>();
 
 /**
+ * When the existing summary is this fraction or more of the per-summary
+ * token budget, inject a "compress older content aggressively" instruction
+ * so incremental-update passes don't let the summary grow unboundedly.
+ */
+const SUMMARY_COMPRESSION_PRESSURE_RATIO = 0.6;
+
+/**
+ * Text-block prefixes that persist in live history (for prefix-caching
+ * stability and model grounding) but pollute the summarizer's view of the
+ * actual conversation. These blocks are system-metadata attached to user
+ * turns — memory injections, turn context, workspace hints, etc. They are
+ * stripped ONLY from the messages fed to the summarization LLM call. Live
+ * history is never mutated, so prefix caching is preserved.
+ *
+ * This list intentionally overlaps with `RUNTIME_INJECTION_PREFIXES` in
+ * `conversation-runtime-assembly.ts`. That list governs in-flight turn
+ * assembly; this one governs compaction input only. Keep them in sync
+ * when new injection types are added.
+ */
+const COMPACTION_ONLY_STRIP_PREFIXES = [
+  "<memory __injected>",
+  "<memory>",
+  "<memory_image __injected>",
+  "</memory_image>",
+  "<memory_context __injected>",
+  "<memory_context>",
+  "<turn_context>",
+  "<channel_turn_context>",
+  "<guardian_context>",
+  "<inbound_actor_context>",
+  "<interface_turn_context>",
+  "<workspace>",
+  "<workspace_top_level>",
+  "<knowledge_base>",
+  "<pkb>",
+  "<system_reminder>",
+  "<now_scratchpad>",
+  "<NOW.md Always keep this up to date",
+  "<active_thread>",
+  "<active_subagents>",
+  "<active_workspace>",
+  "<active_dynamic_page>",
+  "<channel_capabilities>",
+  "<channel_command_context>",
+  "<voice_call_control>",
+  "<transport_hints>",
+  "<system_notice>",
+  "<non_interactive_context>",
+  "<temporal_context>",
+];
+
+/**
+ * Remove text blocks whose prefix matches any entry in
+ * `COMPACTION_ONLY_STRIP_PREFIXES`. Non-text blocks (images, tool_use,
+ * tool_result, etc.) are untouched. Empty messages (every block filtered
+ * out) are dropped from the output.
+ *
+ * Used only on the `compactableMessages` slice right before it is
+ * serialized for the summarization LLM — the caller's original message
+ * array is never mutated.
+ */
+export function stripCompactionOnlyInjections(messages: Message[]): Message[] {
+  return messages
+    .map((message) => {
+      if (message.role !== "user") return message;
+      const nextContent = message.content.filter((block) => {
+        if (block.type !== "text") return true;
+        return !COMPACTION_ONLY_STRIP_PREFIXES.some((p) =>
+          block.text.startsWith(p),
+        );
+      });
+      if (nextContent.length === message.content.length) return message;
+      if (nextContent.length === 0) return null;
+      return { ...message, content: nextContent };
+    })
+    .filter(
+      (message): message is NonNullable<typeof message> => message != null,
+    );
+}
+
+/**
  * Load the compaction summary system prompt from the bundled markdown asset.
  *
  * `resolveBundledDir` handles the compiled-binary case where the caller path
@@ -57,18 +138,27 @@ export function loadCompactPrompt(): string {
  * rather than failing module import at startup.
  */
 const SUMMARY_PROMPT_FALLBACK = [
-  "You compress long assistant conversations into durable working memory.",
-  "Focus on actionable state, not prose.",
-  "Preserve concrete facts: goals, constraints, decisions, pending questions, file paths, commands, errors, and TODOs.",
-  "Remove repetition and stale details that were superseded.",
-  'Thread anchors: when a "Retained Thread References" section is present, each listed reply cites its parent via `→ Mxxxxxx`. If that parent appears in the Transcript, preserve its text verbatim (reactions may be aggregated as "N users reacted"). Omit when the section is absent.',
-  "Return concise markdown using these section headers exactly:",
-  "## Goals",
-  "## Constraints",
-  "## Decisions",
-  "## Open Conversations",
-  "## Key Artifacts",
-  "## Recent Progress",
+  "You are summarizing a long conversation so that the assistant can keep working with it after older messages are dropped. Your summary will REPLACE those messages — the assistant's only access to what was said earlier will be what you write here.",
+  "",
+  "Be thorough. Capture what happened, why it mattered, what's unresolved, and what was felt. Do not compress away emotional tone, relationship context, or nuance. Keep specific details (names, numbers, file paths, commands, URLs, exact phrasings) when they might matter later.",
+  "",
+  "Target length: aim for 1500–4000 tokens. Use the upper end when the conversation is rich in decisions, relationships, emotional content, or threads that are still open. Use the lower end for short or simple task execution.",
+  "",
+  "Open with a 1–2 paragraph narrative describing what the conversation is about and where it currently stands. Then use `## ` section headers. Use these when they apply; skip sections that have nothing to say; add your own headers when something doesn't fit:",
+  "- `## What We're Working On`",
+  "- `## Decisions & Commitments`",
+  "- `## Facts Worth Remembering`",
+  "- `## Open Threads`",
+  "- `## Emotional Arc / Relationship Notes` (include when relevant)",
+  "- `## Artifacts & References`",
+  "",
+  "If an existing summary is provided, update it: merge new information in, prefer the most recent and explicit detail on conflicts, and preserve anything still unresolved or still true. Do not restart from scratch.",
+  "",
+  "Never include in the summary: content inside `<memory __injected>`, `<memory>`, `<turn_context>`, `<workspace>`, `<knowledge_base>`, `<system_reminder>`, `<now_scratchpad>`, `<NOW.md …>`, `<active_thread>`, `<channel_capabilities>`, `<transport_hints>`, `<system_notice>`, or any other angle-bracket-tagged system blocks. Tool-call boilerplate (retries, failed attempts the assistant recovered from, routine status updates) — summarize the outcome instead. Repetitive chit-chat that adds nothing.",
+  "",
+  'Thread anchors (Slack only): if the input includes a "Retained Thread References" section, each listed reply cites its parent via `→ Mxxxxxx`. If that parent appears in the Transcript, preserve its text verbatim. Omit when absent.',
+  "",
+  "Return only the summary itself in markdown — no preamble, no meta-commentary.",
 ].join("\n");
 
 /**
@@ -535,8 +625,14 @@ export class ContextWindowManager {
     const retainedThreadRefs = collectRetainedThreadReferences(
       messages.slice(keepPlan.keepFromIndex),
     );
+    // Strip runtime injections (memory, turn context, workspace hints, etc.)
+    // from the messages fed to the summarizer. These blocks are system
+    // metadata; leaving them in causes the summary to echo rotating memory
+    // content instead of the actual conversation. The caller's live message
+    // array is untouched so prefix caching stays intact.
+    const transcriptSource = stripCompactionOnlyInjections(compactableMessages);
     const transcriptBlocks = this.capTranscriptBlocksToTokenBudget(
-      serializeMessagesToContentBlocks(compactableMessages),
+      serializeMessagesToContentBlocks(transcriptSource),
       existingSummary ?? "No previous summary.",
       retainedThreadRefs,
     );
@@ -882,10 +978,18 @@ export class ContextWindowManager {
      */
     failed: boolean;
   }> {
+    // When the existing summary is already consuming most of its budget,
+    // nudge the model to compress older durable content aggressively so
+    // incremental-update passes don't let the summary grow unboundedly.
+    const existingSummaryTokens = estimateTextTokens(currentSummary);
+    const compressionPressure =
+      existingSummaryTokens >=
+      this.summaryMaxTokens * SUMMARY_COMPRESSION_PRESSURE_RATIO;
     const contentBlocks = buildSummaryContentBlocks(
       currentSummary,
       transcriptBlocks,
       retainedThreadRefs,
+      { compressionPressure },
     );
     const summaryMessage: Message = { role: "user", content: contentBlocks };
     let failed = false;
@@ -942,8 +1046,36 @@ export class ContextWindowManager {
     // Budget in tokens → approximate char limit (4 chars ≈ 1 token).
     const maxChars = this.summaryMaxTokens * 4;
     if (summary.length <= maxChars) return summary;
-    return `${safeStringSlice(summary, 0, maxChars)}...`;
+    return clampSummaryAtSectionBoundary(summary, maxChars);
   }
+}
+
+/**
+ * Truncate a markdown summary that exceeds `maxChars`, preferring a
+ * section boundary (`\n## `) so we never cut a heading mid-text. Falls
+ * back to a hard character slice when no boundary exists in the safe
+ * region (first half of the budget).
+ */
+export function clampSummaryAtSectionBoundary(
+  summary: string,
+  maxChars: number,
+): string {
+  if (summary.length <= maxChars) return summary;
+  const ELLIPSIS = "...";
+  // Hard limit we must stay under, leaving room for the ellipsis suffix.
+  const cutoff = maxChars - ELLIPSIS.length;
+  if (cutoff <= 0) return ELLIPSIS;
+  const head = safeStringSlice(summary, 0, cutoff);
+  // Find the last `## ` heading at a line start. Require it to be past the
+  // midpoint of the allowed region so we don't drop most of the summary
+  // just to hit a boundary — better to cut mid-section late than to keep
+  // almost nothing.
+  const halfway = Math.floor(cutoff / 2);
+  const boundary = head.lastIndexOf("\n## ");
+  if (boundary >= halfway) {
+    return `${head.slice(0, boundary).trimEnd()}\n${ELLIPSIS}`;
+  }
+  return `${head}${ELLIPSIS}`;
 }
 
 function collectUserTurnStartIndexes(messages: Message[]): number[] {
@@ -1092,17 +1224,25 @@ function buildSummaryContentBlocks(
   currentSummary: string,
   transcriptBlocks: ContentBlock[],
   retainedThreadRefs: string[],
+  options: { compressionPressure: boolean } = { compressionPressure: false },
 ): ContentBlock[] {
   const lines = [
     "Update the summary with new transcript data.",
     "If new information conflicts with older notes, keep the most recent and explicit detail.",
     "Keep all unresolved asks and next steps.",
     "For any images included below, describe their visual content in the summary so the information is preserved after compaction.",
+  ];
+  if (options.compressionPressure) {
+    lines.push(
+      "The existing summary is approaching its token budget. Compress older durable content aggressively (drop detail that is no longer load-bearing, merge bullets, tighten prose) while preserving the most recent turns' nuance.",
+    );
+  }
+  lines.push(
     "",
     "### Existing Summary",
     currentSummary.trim().length > 0 ? currentSummary.trim() : "None.",
     "",
-  ];
+  );
   if (retainedThreadRefs.length > 0) {
     lines.push(
       "### Retained Thread References",

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -2261,6 +2261,7 @@ export function applyCompactionResult(
     ctx.conversationId,
     ctx.trustContext?.trustClass,
   );
+  const summarySignals = computeSummaryQualitySignals(result.summaryText);
   onEvent({
     type: "context_compacted",
     conversationId: ctx.conversationId,
@@ -2273,6 +2274,9 @@ export function applyCompactionResult(
     summaryInputTokens: result.summaryInputTokens,
     summaryOutputTokens: result.summaryOutputTokens,
     summaryModel: result.summaryModel,
+    summaryCharCount: summarySignals.charCount,
+    summaryHeaderCount: summarySignals.headerCount,
+    summaryHadMemoryEcho: summarySignals.hadMemoryEcho,
   });
   emitUsage(
     ctx,
@@ -2295,4 +2299,31 @@ export function collapseRawResponses(
 ): unknown | undefined {
   if (!rawResponses || rawResponses.length === 0) return undefined;
   return rawResponses.length === 1 ? rawResponses[0] : rawResponses;
+}
+
+/**
+ * Matches any runtime-injection tag that should never appear inside a
+ * generated summary. If the regex hits, either the compaction strip logic
+ * failed to drop an injected block from the summarizer input, or the
+ * summarizer invented tag-like text on its own — both are quality bugs
+ * worth surfacing via telemetry.
+ */
+const SUMMARY_MEMORY_ECHO_PATTERN =
+  /<(?:memory|memory_context|memory_image|turn_context|workspace|knowledge_base|pkb|system_reminder|now_scratchpad|NOW\.md|active_thread|channel_capabilities|transport_hints|system_notice|non_interactive_context|temporal_context|guardian_context|inbound_actor_context|channel_turn_context|interface_turn_context|channel_command_context|voice_call_control)\b/i;
+
+/**
+ * Compute light-weight quality signals for a compaction summary. Emitted
+ * on every `context_compacted` event so regressions (short outputs,
+ * header collapse, memory-injection leakage) are visible without having
+ * to read the summary text from the DB.
+ */
+export function computeSummaryQualitySignals(summaryText: string): {
+  charCount: number;
+  headerCount: number;
+  hadMemoryEcho: boolean;
+} {
+  const charCount = summaryText.length;
+  const headerCount = (summaryText.match(/^## /gm) ?? []).length;
+  const hadMemoryEcho = SUMMARY_MEMORY_ECHO_PATTERN.test(summaryText);
+  return { charCount, headerCount, hadMemoryEcho };
 }

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -440,6 +440,22 @@ export interface ContextCompacted {
   summaryInputTokens: number;
   summaryOutputTokens: number;
   summaryModel: string;
+  /**
+   * Quality signals for the generated summary. Emitted for every
+   * compaction (including truncation-only paths where the summary text
+   * is unchanged from the prior pass). Consumers can use these to detect
+   * regressions without needing to read the summary text itself.
+   *
+   * - `summaryCharCount`: length of the produced summary text.
+   * - `summaryHeaderCount`: number of `## ` section headers in the summary.
+   * - `summaryHadMemoryEcho`: `true` if the summary contains any runtime
+   *   injection tag (e.g. `<memory`, `<turn_context>`, `<workspace>`).
+   *   Should always be `false` — `true` indicates the compaction strip
+   *   logic failed to remove an injected block from the summarizer input.
+   */
+  summaryCharCount?: number;
+  summaryHeaderCount?: number;
+  summaryHadMemoryEcho?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Strip `<memory __injected>` / `<turn_context>` / `<workspace>` text blocks from the compaction input (live history untouched so prefix caching still works) — this was the main reason summaries were polluted with rotating memory content.
- Rewrite `compact.md` with an explicit 1500-4000 token target, "be thorough" framing, and flexible sections that fit personal, task, and coding conversations. Keep the inline `SUMMARY_PROMPT_FALLBACK` in sync.
- Summary-of-summary guard: if the existing summary is already >=60% of its budget, the prompt tells the model to compress older durable content aggressively so incremental updates don't let the summary grow unboundedly.
- Clamp to a `## ` section boundary so long summaries don't cut mid-header.
- Add `summaryCharCount` / `summaryHeaderCount` / `summaryHadMemoryEcho` to the `context_compacted` event for regression visibility.

## Test plan
- [x] `cd assistant && bun test src/context/__tests__/compact-prompt.test.ts`
- [x] `cd assistant && bun test src/__tests__/context-window-manager.test.ts`
- [x] `cd assistant && bun test src/__tests__/compaction-events.test.ts`
- [x] `cd assistant && bunx tsc --noEmit`
- [x] `cd assistant && bun run lint`
- [ ] Manual smoke: run a long conversation locally, force a compaction, and confirm the persisted `conversations.context_summary` does not contain `<memory` / `<turn_context>` substrings and lands in the 1500-4000 token range.

## Original prompt
> Right now context summarization in the Vellum assistant is pretty terrible. The context_summary ends up being very short and barely containing anything about the conversation so far and containing a bunch of irrelevant stuff (maybe from memory injections?). Can you take a look at how it works right nwo and propose a better alternative?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
