### PR TITLE
fix(cache): persist workspace/NOW.md/knowledge_base blocks for reload byte-stability

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1011,11 +1011,14 @@ export async function runAgentLoopImpl(
     // reloads (eviction, restart, fork). loadFromDb re-injects from metadata.
     // Only the first call site persists — the overflow-recovery re-entry sites
     // send identical bytes and the tail row may not correspond to
-    // `userMessageId`. Both blocks are written in a single call to avoid
+    // `userMessageId`. All blocks are written in a single call to avoid
     // doubling SQLite SELECT+UPDATE work on every turn.
     if (
       injection.blocks.unifiedTurnContext ||
-      injection.blocks.pkbSystemReminder
+      injection.blocks.pkbSystemReminder ||
+      injection.blocks.workspaceBlock ||
+      injection.blocks.nowScratchpadBlock ||
+      injection.blocks.pkbContextBlock
     ) {
       try {
         const metadataUpdates: Record<string, unknown> = {};
@@ -1026,6 +1029,16 @@ export async function runAgentLoopImpl(
         if (injection.blocks.pkbSystemReminder) {
           metadataUpdates.pkbSystemReminderBlock =
             injection.blocks.pkbSystemReminder;
+        }
+        if (injection.blocks.workspaceBlock) {
+          metadataUpdates.workspaceBlock = injection.blocks.workspaceBlock;
+        }
+        if (injection.blocks.nowScratchpadBlock) {
+          metadataUpdates.nowScratchpadBlock =
+            injection.blocks.nowScratchpadBlock;
+        }
+        if (injection.blocks.pkbContextBlock) {
+          metadataUpdates.pkbContextBlock = injection.blocks.pkbContextBlock;
         }
         updateMessageMetadata(userMessageId, metadataUpdates);
       } catch (err) {

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -208,21 +208,34 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
 
       content = reinjectImageSourcePaths(content, role, m.metadata);
 
-      // Re-inject persisted memory block from metadata so it survives
+      // Re-inject persisted injection blocks from metadata so it survives
       // conversation reloads (eviction, restart, fork).
       if (role === "user" && m.metadata) {
         try {
           const meta = JSON.parse(m.metadata);
           const isTail = index === arr.length - 1;
 
-          // turn_context and system_reminder rehydrate for historical rows
-          // only; the tail gets fresh blocks via applyRuntimeInjections on
-          // the next turn. All three rehydration steps are prepends — the
-          // ordering below (system_reminder first, memory second,
-          // turn_context last) builds the documented shape right-to-left,
-          // since each prepend shifts previously-prepended blocks one slot
-          // right:
-          //   [<turn_context>, <memory __injected>, <system_reminder>, ...original]
+          // All rehydration steps are prepends — the ordering below
+          // (innermost block first, outermost last) builds the documented
+          // shape right-to-left, since each prepend shifts previously-
+          // prepended blocks one slot right:
+          //   [<workspace>, <turn_context>, <NOW.md>, <memory __injected>,
+          //    <system_reminder>, <knowledge_base>, ...original]
+          //
+          // Persisted non-tail rows rehydrate the full set so Anthropic's
+          // prefix cache keeps matching msg[0] across daemon restarts and
+          // conversation eviction. The tail row gets fresh blocks via
+          // applyRuntimeInjections on the next turn, so rehydration for the
+          // tail is limited to blocks that the next turn's injection pipeline
+          // cannot reconstruct (currently just `memoryInjectedBlock`, which
+          // is not always re-injected on the next turn).
+          if (!isTail && typeof meta.pkbContextBlock === "string") {
+            content = [
+              { type: "text" as const, text: meta.pkbContextBlock },
+              ...content,
+            ];
+          }
+
           if (!isTail && typeof meta.pkbSystemReminderBlock === "string") {
             content = [
               { type: "text" as const, text: meta.pkbSystemReminderBlock },
@@ -241,9 +254,23 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
             ];
           }
 
+          if (!isTail && typeof meta.nowScratchpadBlock === "string") {
+            content = [
+              { type: "text" as const, text: meta.nowScratchpadBlock },
+              ...content,
+            ];
+          }
+
           if (!isTail && typeof meta.turnContextBlock === "string") {
             content = [
               { type: "text" as const, text: meta.turnContextBlock },
+              ...content,
+            ];
+          }
+
+          if (!isTail && typeof meta.workspaceBlock === "string") {
+            content = [
+              { type: "text" as const, text: meta.workspaceBlock },
               ...content,
             ];
           }

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1716,12 +1716,17 @@ export type InjectionMode = "full" | "minimal";
 
 /**
  * Per-turn injection bytes captured for later persistence to message
- * metadata. Empty in this PR — later PRs capture `<turn_context>` and
- * `<system_reminder>` bodies so they survive daemon restarts.
+ * metadata. Persisting these lets `loadFromDb` rehydrate historical user
+ * messages byte-for-byte after a daemon restart or conversation eviction,
+ * which keeps Anthropic's prefix cache anchored to msg[0] instead of
+ * invalidating every turn on reload.
  */
 export interface RuntimeInjectionBlocks {
   unifiedTurnContext?: string;
   pkbSystemReminder?: string;
+  workspaceBlock?: string;
+  nowScratchpadBlock?: string;
+  pkbContextBlock?: string;
 }
 
 export interface RuntimeInjectionResult {
@@ -1823,6 +1828,9 @@ export async function applyRuntimeInjections(
   // channels (telegram, email, etc.) keep the generic hint pipeline.
   const slackConversation = options.channelCapabilities?.channel === "slack";
   let turnContextCaptured: string | undefined;
+  let workspaceCaptured: string | undefined;
+  let nowScratchpadCaptured: string | undefined;
+  let pkbContextCaptured: string | undefined;
   let result = runMessages;
   // Slack channels AND DMs both override `runMessages` with a pre-rendered
   // chronological transcript built from persisted message rows. The shared
@@ -1890,10 +1898,17 @@ export async function applyRuntimeInjections(
   if (mode === "full" && options.pkbContext) {
     const userTail = result[result.length - 1];
     if (userTail && userTail.role === "user") {
-      result = [
-        ...result.slice(0, -1),
-        injectPkbContext(userTail, options.pkbContext),
-      ];
+      const injected = injectPkbContext(userTail, options.pkbContext);
+      // Capture the exact block text for metadata persistence. The injector
+      // escapes closing tags inside `pkbContext` and wraps it in
+      // `<knowledge_base>...</knowledge_base>`, so read back the inserted
+      // block rather than regenerating from the raw input.
+      const insertedBlock = injected.content.find(
+        (b): b is { type: "text"; text: string } =>
+          b.type === "text" && b.text.startsWith("<knowledge_base>"),
+      );
+      if (insertedBlock) pkbContextCaptured = insertedBlock.text;
+      result = [...result.slice(0, -1), injected];
     }
   }
 
@@ -1991,10 +2006,14 @@ export async function applyRuntimeInjections(
   if (mode === "full" && options.nowScratchpad) {
     const userTail = result[result.length - 1];
     if (userTail && userTail.role === "user") {
-      result = [
-        ...result.slice(0, -1),
-        injectNowScratchpad(userTail, options.nowScratchpad),
-      ];
+      const injected = injectNowScratchpad(userTail, options.nowScratchpad);
+      const insertedBlock = injected.content.find(
+        (b): b is { type: "text"; text: string } =>
+          b.type === "text" &&
+          b.text.startsWith("<NOW.md Always keep this up to date"),
+      );
+      if (insertedBlock) nowScratchpadCaptured = insertedBlock.text;
+      result = [...result.slice(0, -1), injected];
     }
   }
 
@@ -2112,6 +2131,7 @@ export async function applyRuntimeInjections(
   if (mode === "full" && options.workspaceTopLevelContext) {
     const userTail = result[result.length - 1];
     if (userTail && userTail.role === "user") {
+      workspaceCaptured = options.workspaceTopLevelContext;
       result = [
         ...result.slice(0, -1),
         injectWorkspaceTopLevelContext(
@@ -2127,6 +2147,9 @@ export async function applyRuntimeInjections(
     blocks: {
       unifiedTurnContext: turnContextCaptured,
       pkbSystemReminder: pkbSystemReminderCaptured,
+      workspaceBlock: workspaceCaptured,
+      nowScratchpadBlock: nowScratchpadCaptured,
+      pkbContextBlock: pkbContextCaptured,
     },
   };
 }

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -107,6 +107,9 @@ export const messageMetadataSchema = z
     memoryInjectedBlock: z.string().optional(),
     turnContextBlock: z.string().optional(),
     pkbSystemReminderBlock: z.string().optional(),
+    workspaceBlock: z.string().optional(),
+    nowScratchpadBlock: z.string().optional(),
+    pkbContextBlock: z.string().optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Summary

- The `<workspace>`, `<NOW.md>`, and `<knowledge_base>` runtime-injection blocks are prepended to the tail user message on every turn but were not persisted to message metadata. On conversation reload (daemon restart / eviction / fork), historical user messages lost those three blocks, changing the byte content of `msg[0]` and invalidating Anthropic's 1h prefix cache at the turn-start cache breakpoint.
- Capture the three block bodies in `applyRuntimeInjections`, persist them to the tail user message's metadata alongside the existing `turnContextBlock` / `memoryInjectedBlock` / `pkbSystemReminderBlock`, and rehydrate them on historical rows in `loadFromDb` in the correct prepend order so the reconstructed `msg[0]` matches the shape that was originally sent to the LLM.
- Non-tail rows get all six blocks rehydrated; the tail row still gets fresh blocks from `applyRuntimeInjections` on the next turn, so its metadata is only used after it becomes historical.

## Original prompt

Fix #1 from \`/Users/sidd/.claude/plans/image-1-can-you-magical-meerkat.md\`: Stop stripping \`<workspace>\` / \`<NOW.md>\` / \`<knowledge_base>\` from historical msg[0] on resume so the cache key at msg[0] stays stable across daemon restarts and post-compaction reloads. Touch points: \`assistant/src/daemon/conversation-runtime-assembly.ts:1627-1665\` (strip list) and \`assistant/src/daemon/conversation-lifecycle.ts:213-249\` (rehydration). Preferred approach: persist the full msg[0] content as-sent and don't rebuild from separate sources on resume, OR re-inject the same three blocks when rebuilding historical msg[0] so byte-for-byte equivalence is preserved.

## Test plan

- [ ] Start a new conversation with a PDF attachment, send ~3 tool-use turns
- [ ] Restart the daemon, send one more turn
- [ ] Compare \`cache_creation_input_tokens\` vs \`cache_read_input_tokens\` in \`llm_usage_events\` for the post-restart turn — cache_read should cover \`system + tools + msg[0] through PDF\` instead of dropping to only \`system + tools\`
- [ ] Verify \`msg[0]\` in \`llm_request_logs.request_payload\` is byte-identical before and after the restart
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
