### PR TITLE
fix: strip <no_response/> inline to handle model artifacts

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -446,6 +446,28 @@ describe("channel-reply-delivery", () => {
     expect(deliveryCalls).toHaveLength(0);
   });
 
+  it("suppresses delivery when <no_response/> is wrapped with model artifacts", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/slack",
+      chatId: "chat-silent-artifact",
+      textSegments: ["[04/21/26 21:53]: <no_response/>"],
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(0);
+  });
+
+  it("suppresses delivery for <no_response /> with space before slash and surrounding artifacts", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/slack",
+      chatId: "chat-silent-artifact-space",
+      textSegments: ["[timestamp]: <no_response />"],
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(0);
+  });
+
   it("delivers other segments when <no_response/> is mixed with real text", async () => {
     await deliverRenderedReplyViaCallback({
       callbackUrl: "http://gateway/deliver/slack",

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -55,22 +55,48 @@ function sleep(ms: number): Promise<void> {
 
 const NO_RESPONSE_RE = /^\s*<no_response\s*\/?>\s*$/;
 
-/** Returns true when any segment is a `<no_response/>` sentinel. */
+/**
+ * Inline regex that matches `<no_response/>` anywhere in a string.
+ * Used to strip the sentinel when the model wraps it with other artifacts
+ * (e.g. timestamp prefixes) so suppression still works.
+ */
+const NO_RESPONSE_INLINE_RE = /<no_response\s*\/?>/;
+
+/** Returns true when any segment contains a `<no_response/>` sentinel. */
 function hasNoResponseMarker(textSegments: string[]): boolean {
-  return textSegments.some((s) => NO_RESPONSE_RE.test(s));
+  return textSegments.some(
+    (s) => NO_RESPONSE_RE.test(s) || NO_RESPONSE_INLINE_RE.test(s),
+  );
+}
+
+/**
+ * Strip `<no_response/>` tags from a segment and return the remaining text.
+ * Handles cases where the model wraps the sentinel with artifacts (e.g.
+ * timestamp prefixes like `[04/21/26 21:53]: <no_response/>`).
+ */
+function stripNoResponseTag(segment: string): string {
+  return segment.replace(NO_RESPONSE_INLINE_RE, "").trim();
 }
 
 function toDeliverableTextSegments(
   textSegments: string[],
   fallbackText?: string,
 ): string[] {
-  const nonEmptySegments = textSegments.filter(
-    (segment) => segment.trim().length > 0 && !NO_RESPONSE_RE.test(segment),
-  );
+  const hadNoResponse = hasNoResponseMarker(textSegments);
+  const nonEmptySegments = textSegments
+    .map((segment) => {
+      // Strip <no_response/> tags inline so surrounding artifacts
+      // (e.g. timestamp prefixes) don't defeat suppression.
+      if (NO_RESPONSE_INLINE_RE.test(segment)) {
+        return stripNoResponseTag(segment);
+      }
+      return segment.trim();
+    })
+    .filter((segment) => segment.length > 0);
   if (nonEmptySegments.length > 0) return nonEmptySegments;
-  // If the only text was <no_response/>, treat as intentional silence —
-  // do not fall back to fallbackText.
-  if (hasNoResponseMarker(textSegments)) return [];
+  // If the original segments contained <no_response/>, treat as intentional
+  // silence — do not fall back to fallbackText.
+  if (hadNoResponse) return [];
   if (typeof fallbackText === "string" && fallbackText.trim().length > 0) {
     return [fallbackText];
   }


### PR DESCRIPTION
## Problem

Two related bugs surfaced in Slack delivery:

1. **Timestamp prefixes** — the model occasionally echoes the conversation timestamp format in its output (e.g. `[04/21/26 21:53]: <actual response>`). This is a model behavior issue.

2. **`<no_response/>` leaked to Slack** — because the model prepended a timestamp to `<no_response/>`, the strict full-match regex (`/^\s*<no_response\s*\/?>\s*$/`) failed to detect it, and the raw text `[04/21/26 21:53]: <no_response/>` was delivered as a visible message.

## Fix

Adds an inline regex (`/<no_response\s*\/?>/`) that detects and strips `<no_response/>` anywhere in a text segment — not just when it's the entire content. After stripping, if the remaining text is empty, delivery is suppressed as intended.

This is a defense-in-depth fix. The model behavior (timestamp prefixing) is the primary issue, but the delivery pipeline should be resilient to model output artifacts wrapping the sentinel.

Note: `conversation-routes.ts` already uses an inline regex (`NO_RESPONSE_INLINE_RE`) for the web/API path. This brings the channel delivery path to parity.

## Changes

- **`channel-reply-delivery.ts`**: Added `NO_RESPONSE_INLINE_RE`, `stripNoResponseTag()` helper, and updated `toDeliverableTextSegments()` to strip inline before filtering.
- **`channel-reply-delivery.test.ts`**: Added two test cases covering artifact-wrapped `<no_response/>` scenarios.

## Test plan

- Existing tests pass (pure `<no_response/>`, whitespace-wrapped, mixed with real text)
- New tests verify suppression when wrapped with timestamp prefix and other artifacts

---
*PR authored by Leo (Vellum Assistant) 🦁*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
