### PR TITLE
fix(ui): add icons to settings dropdowns and show threshold picker in empty state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -32,6 +32,7 @@ struct ChatEmptyStateView: View {
     var onSelectStarter: ((ConversationStarter) -> Void)? = nil
     var onFetchConversationStarters: (() -> Void)? = nil
     var conversationHostAccessControl: ConversationHostAccessControlConfiguration? = nil
+    var showThresholdPicker: Bool = false
 
     @State private var visible = false
     @State private var fallbackPlaceholder: String = placeholderTexts.randomElement()!
@@ -178,7 +179,8 @@ struct ChatEmptyStateView: View {
                 onVoiceModeToggle: onVoiceModeToggle,
                 placeholderText: fallbackPlaceholder,
                 conversationId: conversationId,
-                conversationHostAccessControl: conversationHostAccessControl
+                conversationHostAccessControl: conversationHostAccessControl,
+                showThresholdPicker: showThresholdPicker
             )
             .equatable()
         }
@@ -405,6 +407,7 @@ struct ChatTemporaryChatEmptyStateView: View {
     var onVoiceModeToggle: (() -> Void)? = nil
     var conversationId: UUID?
     var conversationHostAccessControl: ConversationHostAccessControlConfiguration? = nil
+    var showThresholdPicker: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -451,7 +454,8 @@ struct ChatTemporaryChatEmptyStateView: View {
                     onVoiceModeToggle: onVoiceModeToggle,
                     placeholderText: "Ask anything...",
                     conversationId: conversationId,
-                    conversationHostAccessControl: conversationHostAccessControl
+                    conversationHostAccessControl: conversationHostAccessControl,
+                    showThresholdPicker: showThresholdPicker
                 )
                 .equatable()
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -293,7 +293,8 @@ struct ChatView: View {
                         onDictateToggle: onDictateToggle,
                         onVoiceModeToggle: onVoiceModeToggle,
                         conversationId: conversationId,
-                        conversationHostAccessControl: conversationHostAccessControl
+                        conversationHostAccessControl: conversationHostAccessControl,
+                        showThresholdPicker: showThresholdPicker
                     )
                 } else {
                     ChatEmptyStateView(
@@ -321,7 +322,8 @@ struct ChatView: View {
                         conversationStartersLoading: conversationStartersEnabled && viewModel.conversationStartersLoading,
                         onSelectStarter: { starter in viewModel.inputText = starter.prompt },
                         onFetchConversationStarters: { viewModel.fetchConversationStarters() },
-                        conversationHostAccessControl: conversationHostAccessControl
+                        conversationHostAccessControl: conversationHostAccessControl,
+                        showThresholdPicker: showThresholdPicker
                     )
                     .id(conversationId)
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
@@ -59,7 +59,7 @@ struct RiskToleranceSection: View {
                     .foregroundStyle(VColor.contentDefault)
                 VDropdown(
                     options: RiskThreshold.allCases.map {
-                        VDropdownOption(label: $0.label, value: $0)
+                        VDropdownOption(label: $0.label, value: $0, icon: $0.icon)
                     },
                     selection: Binding(
                         get: { interactiveSelection },
@@ -88,7 +88,7 @@ struct RiskToleranceSection: View {
                             .foregroundStyle(VColor.contentDefault)
                         VDropdown(
                             options: RiskThreshold.allCases.map {
-                                VDropdownOption(label: $0.label, value: $0)
+                                VDropdownOption(label: $0.label, value: $0, icon: $0.icon)
                             },
                             selection: Binding(
                                 get: { backgroundSelection },
@@ -118,7 +118,7 @@ struct RiskToleranceSection: View {
                             .foregroundStyle(VColor.contentDefault)
                         VDropdown(
                             options: RiskThreshold.allCases.map {
-                                VDropdownOption(label: $0.label, value: $0)
+                                VDropdownOption(label: $0.label, value: $0, icon: $0.icon)
                             },
                             selection: Binding(
                                 get: { headlessSelection },

--- a/clients/shared/Network/ThresholdClient.swift
+++ b/clients/shared/Network/ThresholdClient.swift
@@ -23,6 +23,15 @@ public enum RiskThreshold: String, CaseIterable, Identifiable, Hashable {
         }
     }
 
+    public var icon: VIcon {
+        switch self {
+        case .none: return .lock
+        case .low: return .shieldCheck
+        case .medium: return .triangleAlert
+        case .high: return .shieldOff
+        }
+    }
+
     public var settingsDescription: String {
         switch self {
         case .none: return "Always ask before acting. No actions are auto-approved."


### PR DESCRIPTION
## Summary
- Add risk threshold icons to Settings dropdown options (Strict -> lock, Default -> shieldCheck, Relaxed -> triangleAlert, Full access -> shieldOff) via VDropdownOption icon parameter and a new `icon` computed property on `RiskThreshold`
- Thread `showThresholdPicker` from ChatView to both `ChatEmptyStateView` and `ChatTemporaryChatEmptyStateView` so the ComposerThresholdPicker appears in empty conversation composers, matching the active conversation behavior

## Original prompt
Two follow-up fixes for the risk tolerance UI (PR #27293, already merged to main):

1. ICONS IN SETTINGS DROPDOWN: The Settings risk tolerance dropdowns (When chatting, Scheduled tasks, Automation/API) currently show plain text options (Strict, Default, Relaxed, Full access). They should show icons matching the composer picker. The VDropdownOption type already supports an optional icon parameter. Switch from the tuple convenience init to VDropdownOption array form with these icons: Strict -> .lock, Default -> .shieldCheck, Relaxed -> .triangleAlert, Full access -> .shieldOff. File: clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift

2. THRESHOLD PICKER IN EMPTY CONVERSATION COMPOSER: The ComposerThresholdPicker only appears in active conversations. It is missing from the ChatEmptyStateView and ChatTemporaryChatEmptyStateView composers because those views never pass showThresholdPicker to ComposerView (it defaults to false). Thread showThresholdPicker through both empty state views the same way ChatView does via PanelCoordinator. Key files: ChatEmptyStateView.swift, ChatView.swift (see how it threads showThresholdPicker to ComposerSection/ComposerView), PanelCoordinator.swift (see how it sets showThresholdPicker from the feature flag).

Create a feature branch from main, make changes in a single commit, open a PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
