### PR TITLE
feat(ios): add 'Replay Onboarding' developer tool (LUM-1084)

### DIFF
--- a/clients/ios/Views/LoginView.swift
+++ b/clients/ios/Views/LoginView.swift
@@ -4,6 +4,10 @@ import VellumAssistantShared
 
 struct LoginView: View {
     @Bindable var authManager: AuthManager
+    /// When true, the primary button advances without invoking WorkOS login.
+    /// Used by the developer "Replay Onboarding" tool so re-viewing the screen
+    /// does not kick off a real auth flow for an already-authenticated user.
+    var isReplay: Bool = false
     /// Called after a successful login so the onboarding flow can advance.
     var onContinue: (() -> Void)?
 
@@ -60,19 +64,23 @@ struct LoginView: View {
 
                 VStack(spacing: VSpacing.sm) {
                     Button {
-                        Task {
-                            await authManager.startWorkOSLogin()
-                            if authManager.isAuthenticated {
-                                onContinue?()
+                        if isReplay {
+                            onContinue?()
+                        } else {
+                            Task {
+                                await authManager.startWorkOSLogin()
+                                if authManager.isAuthenticated {
+                                    onContinue?()
+                                }
                             }
                         }
                     } label: {
                         ZStack {
-                            if authManager.isSubmitting {
+                            if authManager.isSubmitting && !isReplay {
                                 ProgressView()
                                     .tint(VColor.contentInset)
                             } else {
-                                Text("Log In")
+                                Text(isReplay ? "Continue" : "Log In")
                                     .font(VFont.bodyLargeEmphasised)
                                     .foregroundStyle(VColor.contentInset)
                             }
@@ -83,7 +91,7 @@ struct LoginView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 10))
                     }
                     .buttonStyle(.plain)
-                    .disabled(authManager.isSubmitting)
+                    .disabled(authManager.isSubmitting && !isReplay)
                 }
                 .padding(.horizontal, VSpacing.lg)
 

--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -13,12 +13,17 @@ struct OnboardingView: View {
     @Binding var isCompleted: Bool
     @Bindable var authManager: AuthManager
     @EnvironmentObject var clientProvider: ClientProvider
+    /// When true, the flow is being re-shown from Developer settings for visual
+    /// review. The login step advances without re-running WorkOS auth and a
+    /// Cancel button is exposed so the dev can exit mid-flow. No persisted
+    /// state (tokens, assistant config, onboarding_completed) is touched.
+    var isReplay: Bool = false
     @State private var currentStep: OnboardingStep = .login
     @State private var isBootstrappingManaged = false
     @State private var managedBootstrapError: String?
 
     var body: some View {
-        ZStack {
+        ZStack(alignment: .topLeading) {
             if isBootstrappingManaged {
                 managedBootstrapView
                     .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
@@ -27,8 +32,15 @@ struct OnboardingView: View {
                 case .login:
                     LoginView(
                         authManager: authManager,
+                        isReplay: isReplay,
                         onContinue: {
-                            Task { await performManagedBootstrap() }
+                            if isReplay {
+                                // Skip bootstrap in replay — the user is already
+                                // authenticated and we must not mutate state.
+                                currentStep = .ready
+                            } else {
+                                Task { await performManagedBootstrap() }
+                            }
                         }
                     )
                     .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
@@ -36,6 +48,16 @@ struct OnboardingView: View {
                     ReadyStep(isCompleted: $isCompleted)
                         .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
                 }
+            }
+
+            if isReplay {
+                Button("Cancel") {
+                    isCompleted = true
+                }
+                .font(VFont.bodyLargeDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.top, VSpacing.sm)
             }
         }
         .animation(.easeInOut, value: currentStep)

--- a/clients/ios/Views/Settings/DeveloperSettingsSection.swift
+++ b/clients/ios/Views/Settings/DeveloperSettingsSection.swift
@@ -30,6 +30,10 @@ private struct DeveloperSettingsSectionContent: View {
     @State private var assistantLoadError: String?
     @State private var showResetConfirmation = false
 
+    // Non-destructive onboarding replay — see `replayOnboardingSection`.
+    @State private var isReplayingOnboarding = false
+    @State private var replayCompleted = false
+
     init(clientProvider: ClientProvider, authManager: AuthManager, conversationStore: IOSConversationStore) {
         self.clientProvider = clientProvider
         self.authManager = authManager
@@ -42,6 +46,19 @@ private struct DeveloperSettingsSectionContent: View {
 
             Section("Connection") {
                 LabeledContent("Status", value: clientProvider.isConnected ? "Connected" : "Disconnected")
+            }
+
+            Section {
+                Button {
+                    replayCompleted = false
+                    isReplayingOnboarding = true
+                } label: {
+                    Label { Text("Replay Onboarding") } icon: { VIconView(.play, size: 14) }
+                }
+            } header: {
+                Text("Preview")
+            } footer: {
+                Text("Walks through the onboarding screens for visual review. Does not touch tokens, assistant config, or any persisted state.")
             }
 
             Section {
@@ -103,6 +120,23 @@ private struct DeveloperSettingsSectionContent: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This will clear all connection credentials and return to onboarding. You will need to log in or pair again.")
+        }
+        .fullScreenCover(isPresented: $isReplayingOnboarding) {
+            // `replayCompleted` is a local state bound into the replay flow; it
+            // flips when the user taps "Get Started" or "Cancel" inside the
+            // replayed OnboardingView and drives sheet dismissal. The app-wide
+            // `onboarding_completed` AppStorage flag is intentionally untouched.
+            OnboardingView(
+                isCompleted: $replayCompleted,
+                authManager: authManager,
+                isReplay: true
+            )
+            .environmentObject(clientProvider)
+            .onChange(of: replayCompleted) { _, completed in
+                if completed {
+                    isReplayingOnboarding = false
+                }
+            }
         }
         .task {
             await loadAssistants()


### PR DESCRIPTION
## Summary
- Adds a non-destructive **Replay Onboarding** button to the iOS Developer settings so devs can walk the managed-login onboarding flow without wiping any persisted state (tokens, assistant config, org ID, preferences).
- `OnboardingView` and `LoginView` gain an `isReplay` flag: in replay, the primary CTA becomes "Continue" (no WorkOS re-auth), the managed bootstrap step is skipped, and a "Cancel" affordance is rendered so the dev can exit mid-flow.
- Presented as a `.fullScreenCover` from `DeveloperSettingsSection` bound to local state, never touching the app-wide `onboarding_completed` AppStorage flag. Mirrors the macOS `replayOnboarding()` pattern from `AppDelegate+WindowsAndSurfaces.swift` while adapting it to SwiftUI + iOS sheet semantics.
- Gated behind `VellumEnvironment.current != .production` via the existing Developer section, so it is never visible in production builds.

## Original prompt
LUM-1084: Add 'Replay Onboarding' developer tool to iOS Settings

Add a non-destructive 'Replay Onboarding' button to the iOS Developer settings that lets devs walk through the onboarding flow without erasing any data.

### What to do:
1. Find the macOS 'Replay Onboarding' implementation in the menu bar code — understand how it re-presents onboarding without clearing state
2. In the iOS app, find SettingsView.swift — the Developer section (gated behind VellumEnvironment.current != .production)
3. Add a 'Replay Onboarding' button in the Developer section, styled distinctly from the destructive 'Reset Connection & Re-onboard'
4. When tapped, present the OnboardingView flow (OnboardingView.swift / LoginView.swift) but in a 'preview' or 'replay' mode — no state clearing, no token wiping
5. After the user completes (or dismisses) the replayed flow, return to normal app state

### Key constraints:
- MUST NOT clear any persisted state (tokens, assistant config, org ID, preferences)
- Developer-only — never visible in production builds
- Reference OnboardingView and LoginView from PR #27244 (LUM-980) for the current onboarding flow
- Look at the macOS pattern first — mirror the approach if possible
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
