### PR TITLE
fix(ios): preserve center alignment in OnboardingView ZStack (LUM-1084 follow-up)

### DIFF
--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -23,7 +23,7 @@ struct OnboardingView: View {
     @State private var managedBootstrapError: String?
 
     var body: some View {
-        ZStack(alignment: .topLeading) {
+        ZStack {
             if isBootstrappingManaged {
                 managedBootstrapView
                     .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
@@ -49,7 +49,11 @@ struct OnboardingView: View {
                         .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
                 }
             }
-
+        }
+        .overlay(alignment: .topLeading) {
+            // Scope the cancel affordance to an overlay so the ZStack's default
+            // center alignment is preserved for ReadyStep and managedBootstrapView
+            // (bare VStacks that would otherwise render top-leading).
             if isReplay {
                 Button("Cancel") {
                     isCompleted = true


### PR DESCRIPTION
## Summary
Follow-up to [#27296](https://github.com/vellum-ai/vellum-assistant/pull/27296) addressing Codex P2 feedback on [OnboardingView.swift:26](https://github.com/vellum-ai/vellum-assistant/pull/27296#discussion_r3120798225).

The previous PR changed `ZStack { ... }` to `ZStack(alignment: .topLeading) { ... }` to anchor the replay-mode Cancel button. That alignment change also affects `ReadyStep` and `managedBootstrapView` — bare `VStack`s without a fill background — which would render in the top-leading corner during the normal (non-replay) onboarding flow. `LoginView` was unaffected because its inner `ZStack` + `ignoresSafeArea()` background expands to fill the frame.

## Fix
- Restore the default (center) `ZStack` alignment.
- Move the Cancel button into an `.overlay(alignment: .topLeading) { ... }` modifier so it's the only view anchored to the corner.

## Testing
- Normal onboarding flow: login → bootstrap → "You're All Set!" — ReadyStep content centered as before.
- Replay mode (Developer settings → Replay Onboarding): Cancel button appears top-leading, content still centered.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
