### PR TITLE
Remove deprecated `globalValueFlags` from `CommandRiskSpec`

### DIFF
--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -225,7 +225,7 @@ function resolveSubcommand(
     return { spec, remainingArgs: args };
   }
 
-  const valueFlagsList = spec.argSchema?.valueFlags ?? spec.globalValueFlags;
+  const valueFlagsList = spec.argSchema?.valueFlags;
   const valueFlags = valueFlagsList ? new Set(valueFlagsList) : undefined;
   const subcommandName = firstPositionalArg(args, valueFlags);
 

--- a/assistant/src/permissions/risk-types.ts
+++ b/assistant/src/permissions/risk-types.ts
@@ -153,14 +153,6 @@ export interface CommandRiskSpec {
   /** Human-readable reason for the base risk (shown when no arg rule matches). */
   reason?: string;
   /**
-   * Global flags that consume the next token as a value (e.g. git -C <path>).
-   * Used by resolveSubcommand to skip past flag-value pairs when locating the
-   * first positional arg (the subcommand name).
-   *
-   * @deprecated Use argSchema.valueFlags instead. Kept for backward compatibility during migration.
-   */
-  globalValueFlags?: string[];
-  /**
    * When true, this command auto-approves in the assistant's workspace
    * without consulting the user's autoApproveUpTo threshold.
    */


### PR DESCRIPTION
## Summary
- Remove the deprecated `globalValueFlags` field from the `CommandRiskSpec` interface in `risk-types.ts`
- Update `resolveSubcommand()` in `bash-risk-classifier.ts` to read only from `argSchema?.valueFlags` (removing dead fallback code)

Part of plan: sandbox-auto-approve-phase2.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
