### PR TITLE
Add `argSchema.valueFlags` to `curl`, `docker run`, and other commands with flag+value arg rules

### DIFF
--- a/assistant/src/permissions/command-registry.test.ts
+++ b/assistant/src/permissions/command-registry.test.ts
@@ -704,6 +704,45 @@ describe("command-registry", () => {
       expect(spec.sandboxAutoApprove).not.toBe(true);
     });
 
+    test("commands with value-consuming argRule flags have matching argSchema.valueFlags", () => {
+      // When an argRule has both `flags` and `valuePattern`, those flags consume
+      // the next token as a value — the valuePattern matches against that value.
+      // The command's argSchema.valueFlags must include those flags so that
+      // parseArgs() correctly pairs flags with their values.
+      const errors: string[] = [];
+
+      function checkSpec(spec: CommandRiskSpec, path: string): void {
+        if (spec.argRules) {
+          for (const rule of spec.argRules) {
+            if (rule.flags && rule.valuePattern) {
+              // This rule's flags consume a value — check argSchema coverage.
+              const schemaValueFlags = new Set(
+                spec.argSchema?.valueFlags ?? [],
+              );
+              for (const flag of rule.flags) {
+                if (!schemaValueFlags.has(flag)) {
+                  errors.push(
+                    `${path}/${rule.id}: flag "${flag}" consumes a value (has valuePattern) ` +
+                      `but is not listed in argSchema.valueFlags`,
+                  );
+                }
+              }
+            }
+          }
+        }
+        if (spec.subcommands) {
+          for (const [sub, subSpec] of Object.entries(spec.subcommands)) {
+            checkSpec(subSpec, `${path} ${sub}`);
+          }
+        }
+      }
+
+      for (const [name, spec] of Object.entries(DEFAULT_COMMAND_REGISTRY)) {
+        checkSpec(spec as CommandRiskSpec, name);
+      }
+      expect(errors).toEqual([]);
+    });
+
     test("system/privilege commands are NOT tagged with sandboxAutoApprove", () => {
       const systemCommands = [
         "sudo",

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -300,6 +300,40 @@ export const DEFAULT_COMMAND_REGISTRY = {
   // ── Network commands ───────────────────────────────────────────────────────
   curl: {
     baseRisk: "medium",
+    argSchema: {
+      valueFlags: [
+        "-d",
+        "--data",
+        "--data-binary",
+        "--data-raw",
+        "--data-urlencode",
+        "-T",
+        "--upload-file",
+        "-o",
+        "--output",
+        "-H",
+        "--header",
+        "-X",
+        "--request",
+        "-u",
+        "--user",
+        "-A",
+        "--user-agent",
+        "-e",
+        "--referer",
+        "-b",
+        "--cookie",
+        "-c",
+        "--cookie-jar",
+        "--connect-timeout",
+        "-m",
+        "--max-time",
+        "--retry",
+        "-w",
+        "--write-out",
+      ],
+      positionals: "none", // positionals are URLs, not paths
+    },
     argRules: [
       {
         id: "curl:upload-data",
@@ -641,6 +675,26 @@ export const DEFAULT_COMMAND_REGISTRY = {
       push: { baseRisk: "high", reason: "Pushes image to registry" },
       run: {
         baseRisk: "high",
+        argSchema: {
+          valueFlags: [
+            "-v",
+            "--volume",
+            "-p",
+            "--publish",
+            "-e",
+            "--env",
+            "--name",
+            "--network",
+            "-w",
+            "--workdir",
+            "--entrypoint",
+            "--mount",
+            "--cpus",
+            "--memory",
+            "--user",
+            "--platform",
+          ],
+        },
         reason: "Runs arbitrary container",
         argRules: [
           {


### PR DESCRIPTION
## Summary
- Add `argSchema` with `valueFlags` to `curl` covering all flags used in its arg rules (`-d`, `--data`, `-T`, `--upload-file`, `-o`, `--output`, etc.) and `positionals: "none"` (positionals are URLs, not filesystem paths)
- Add `argSchema` with `valueFlags` to `docker run` covering volume mount and other value-consuming flags (`-v`, `--volume`, `-p`, `--publish`, `-e`, `--env`, etc.)
- Add guard test validating that commands with flag+value arg rules (flags + valuePattern) have those flags declared in `argSchema.valueFlags`

Part of plan: sandbox-auto-approve-phase2.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
