### PR TITLE
fix(cd): upload zip instead of CRX to Chrome Web Store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,16 +298,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - name: Download extension CRX
-        id: download-crx
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        continue-on-error: true
-        with:
-          name: chrome-extension-crx
-          path: /tmp/chrome-extension
-
-      - name: Download extension zip (fallback)
-        if: steps.download-crx.outcome != 'success'
+      - name: Download extension zip
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: chrome-extension-zip
@@ -323,8 +314,8 @@ jobs:
           CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
         run: |
-          # Prefer signed CRX if available, fall back to zip
-          UPLOAD_FILE=$(ls /tmp/chrome-extension/*.crx 2>/dev/null || ls /tmp/chrome-extension/*.zip)
+          # CWS Items API only accepts zip files, not signed CRX packages
+          UPLOAD_FILE=$(ls /tmp/chrome-extension/*.zip)
           echo "Uploading: $UPLOAD_FILE"
           chrome-webstore-upload upload \
             --source "$UPLOAD_FILE" \


### PR DESCRIPTION
## Summary

- The `publish-chrome-extension` CD job was failing with `PKG_MUST_UPDATE_AS_CRX` because it preferred uploading the signed `.crx` artifact over the `.zip`
- The Chrome Web Store Items API only accepts `.zip` files for upload — `.crx` signing is only useful for self-hosted distribution
- Simplified the download steps to always use the `chrome-extension-zip` artifact instead of the CRX-first-with-zip-fallback approach

## Original prompt

Fix the `publish-chrome-extension` CD job that failed with `PKG_MUST_UPDATE_AS_CRX` — always upload the zip artifact to CWS instead of the CRX.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
