### PR TITLE
feat(assistant): warm LLM prompt cache after canned first greeting

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -574,10 +574,19 @@ export class Conversation {
 
     const systemPrompt = this.hasSystemPromptOverride
       ? this.systemPrompt
-      : buildSystemPrompt({
-          hasNoClient: this.hasNoClient,
-          onboardingContext: this.getOnboardingContext(),
-        });
+      : (() => {
+          const persona = resolvePersonaContext(
+            this.currentTurnTrustContext,
+            this.currentTurnChannelCapabilities,
+          );
+          return buildSystemPrompt({
+            hasNoClient: this.hasNoClient,
+            userPersona: persona.userPersona,
+            channelPersona: persona.channelPersona,
+            userSlug: persona.userSlug,
+            onboardingContext: this.getOnboardingContext(),
+          });
+        })();
     const tools = buildToolDefinitions();
     const provider = this.provider;
 
@@ -588,7 +597,7 @@ export class Conversation {
 
     provider
       .sendMessage([warmMessage], tools, systemPrompt, {
-        config: { max_tokens: 1 },
+        config: { max_tokens: 1, callSite: "mainAgent" },
         signal: abort.signal,
       })
       .then(() => {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -364,6 +364,7 @@ export class Conversation {
     toolName?: string,
     toolUseId?: string,
   ) => void;
+  private cacheWarmAbort?: AbortController;
 
   constructor(
     conversationId: string,
@@ -557,6 +558,52 @@ export class Conversation {
 
   getOnboardingContext(): OnboardingContext | undefined {
     return this.onboardingContext;
+  }
+
+  // ── Prompt Cache Warming ─────────────────────────────────────────
+
+  /**
+   * Fire-and-forget LLM call with max_tokens=1 to populate the provider's
+   * prompt cache (system prompt + tools). Called after the canned first
+   * greeting so the user's next real message gets a cache hit.
+   */
+  warmPromptCache(): void {
+    this.cacheWarmAbort?.abort();
+    const abort = new AbortController();
+    this.cacheWarmAbort = abort;
+
+    const systemPrompt = this.hasSystemPromptOverride
+      ? this.systemPrompt
+      : buildSystemPrompt({
+          hasNoClient: this.hasNoClient,
+          onboardingContext: this.getOnboardingContext(),
+        });
+    const tools = buildToolDefinitions();
+    const provider = this.provider;
+
+    const warmMessage: Message = {
+      role: "user",
+      content: [{ type: "text", text: "hi" }],
+    };
+
+    provider
+      .sendMessage([warmMessage], tools, systemPrompt, {
+        config: { max_tokens: 1 },
+        signal: abort.signal,
+      })
+      .then(() => {
+        log.info("Prompt cache warmed successfully");
+      })
+      .catch((err) => {
+        if (!abort.signal.aborted) {
+          log.warn({ err }, "Prompt cache warming failed (non-fatal)");
+        }
+      })
+      .finally(() => {
+        if (this.cacheWarmAbort === abort) {
+          this.cacheWarmAbort = undefined;
+        }
+      });
   }
 
   // ── Lifecycle ────────────────────────────────────────────────────
@@ -1425,6 +1472,8 @@ export class Conversation {
     options?: { isInteractive?: boolean; callSite?: LLMCallSite },
     displayContent?: string,
   ): Promise<string> {
+    this.cacheWarmAbort?.abort();
+    this.cacheWarmAbort = undefined;
     return processMessageImpl(
       this as ProcessConversationContext,
       content,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1774,6 +1774,8 @@ export async function handleSendMessage(
           conversation.drainQueue(),
           "canned-greeting queue drain",
         );
+
+        conversation.warmPromptCache();
       }, 0);
 
       log.info(


### PR DESCRIPTION
## Summary
- After the canned first greeting is served on a fresh workspace, fires a background `provider.sendMessage` with `max_tokens=1` to warm the Anthropic prompt cache (system prompt + tools)
- The user's next real message gets a cache hit instead of paying the full cache-write TTFT latency
- The warming call is automatically aborted if a real message arrives before it completes

Closes JARVIS-578

## Test plan
- [ ] Fresh workspace: verify "Prompt cache warmed successfully" appears in daemon logs after the canned greeting
- [ ] First real message after greeting: confirm faster TTFT compared to before (cache hit vs cache write)
- [ ] Send a message before warming completes: verify the warming call is aborted cleanly (no errors)
- [ ] Non-fresh workspace (no BOOTSTRAP.md): verify `warmPromptCache` is never called

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
