### PR TITLE
fix: handle `--flag=value` equals syntax in flags-only arg rule matching

### DIFF
--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -427,10 +427,12 @@ export function classifySegment(
         }
 
         // Fallback: scan raw args for combined short flags (e.g. `-rf`)
-        // that parseArgs doesn't split but the rule lists as a literal.
+        // and --flag=value forms (e.g. `--set=managed`) that parseArgs
+        // doesn't split when the flag isn't in argSchema.valueFlags.
+        // matchesArgRule handles both cases via its flag splitting logic.
         if (!flagMatched) {
           for (const arg of allArgs) {
-            if (rule.flags.includes(arg)) {
+            if (matchesArgRule(rule, arg)) {
               flagMatched = true;
               break;
             }


### PR DESCRIPTION
## Summary
- Fix regression where `--flag=value` syntax (e.g. `--set=managed`) was not matched by flags-only arg rules in the refactored `classifySegment()`
- Replace `rule.flags.includes(arg)` with `matchesArgRule(rule, arg)` in the flags-only fallback scan, which correctly splits `--flag=value` into flag and value parts
- This mirrors the flags+valuePattern branch which already uses `matchesArgRule()` for its fallback

## Original prompt
Fix the failing test in CI for PR #27306. The test at cli-command-risk-guard.test.ts:119 expects "high" for "assistant oauth mode google --set=managed" but gets "low". The refactored classifySegment() is not handling --flag=value (equals syntax) correctly when the flag is not listed in argSchema.valueFlags.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
