### PR TITLE
feat(flags): rename `auto-approve-threshold-ui` → `permission-controls-v3`

### DIFF
--- a/assistant/src/permissions/gateway-threshold-reader.ts
+++ b/assistant/src/permissions/gateway-threshold-reader.ts
@@ -1,7 +1,7 @@
 /**
  * Gateway-backed auto-approve threshold reader.
  *
- * When the `auto-approve-threshold-ui` feature flag is enabled, reads
+ * When the `permission-controls-v3` feature flag is enabled, reads
  * thresholds from the gateway REST API. Falls back to `undefined` (caller
  * uses config-based `resolveThreshold`) when the flag is off or the gateway
  * is unreachable.
@@ -105,7 +105,7 @@ export async function getAutoApproveThreshold(
   executionContext?: ExecutionContext,
 ): Promise<Threshold | undefined> {
   const config = getConfig();
-  if (!isAssistantFeatureFlagEnabled("auto-approve-threshold-ui", config)) {
+  if (!isAssistantFeatureFlagEnabled("permission-controls-v3", config)) {
     return undefined;
   }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -538,7 +538,7 @@ extension MainWindowView {
                 "permission-controls-v2"
             )
             let showThresholdPicker = assistantFeatureFlagStore.isEnabled(
-                "auto-approve-threshold-ui"
+                "permission-controls-v3"
             )
             ActiveChatViewWrapper(
                 viewModel: viewModel,

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -51,7 +51,7 @@ struct SettingsPrivacyTab: View {
     @State private var hasUserInteracted: Bool = false
 
     var body: some View {
-        if assistantFeatureFlagStore.isEnabled("auto-approve-threshold-ui") {
+        if assistantFeatureFlagStore.isEnabled("permission-controls-v3") {
             RiskToleranceSection(
                 thresholdClient: thresholdClient,
                 assistantFeatureFlagStore: assistantFeatureFlagStore

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -378,11 +378,11 @@
       "defaultEnabled": true
     },
     {
-      "id": "auto-approve-threshold-ui",
+      "id": "permission-controls-v3",
       "scope": "assistant",
-      "key": "auto-approve-threshold-ui",
-      "label": "Auto-Approve Threshold UI",
-      "description": "Enable user-configurable auto-approve thresholds stored in the gateway. When enabled, the assistant reads thresholds from the gateway instead of config.json, and the macOS client shows threshold controls in Settings and the chat composer.",
+      "key": "permission-controls-v3",
+      "label": "Permission Controls v3",
+      "description": "Enables permission controls v3: gateway-backed auto-approve thresholds, risk badges on tool results, simplified Allow/Deny permission prompt, and rule editor modal.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary
- Rename feature flag id/key from `auto-approve-threshold-ui` to `permission-controls-v3` across all three registry JSON files
- Update flag check in `gateway-threshold-reader.ts` and both Swift client files
- Update label and description to reflect expanded scope (risk badges, simplified prompt, rule editor)

Part of plan: scope-ladder-v1-assistant.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
