### PR TITLE
feat(protocol): include `riskLevel`, `reason`, and `scopeOptions` in tool result messages

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -86,6 +86,16 @@ let checkFnOverride:
 /** Override for generateScopeOptions — when set, returns this value instead of the default. */
 let scopeOptionsOverride: ScopeOption[] | undefined;
 
+/** Override for getCachedAssessment — when set, returns this value. */
+let cachedAssessmentOverride:
+  | {
+      riskLevel: string;
+      reason: string;
+      scopeOptions: Array<{ pattern: string; label: string }>;
+      matchType: string;
+    }
+  | undefined;
+
 /** Spy on addRule to capture calls without replacing the real implementation. */
 let addRuleSpy: ReturnType<typeof spyOn> | undefined;
 
@@ -127,6 +137,7 @@ mock.module("../permissions/checker.js", () => ({
   ],
   generateScopeOptions: () =>
     scopeOptionsOverride ?? [{ label: "/tmp", scope: "/tmp" }],
+  getCachedAssessment: () => cachedAssessmentOverride,
 }));
 
 // Mock every export so downstream test files that dynamically import modules
@@ -196,6 +207,7 @@ describe("ToolExecutor allowedToolNames gating", () => {
     getToolOverride = undefined;
     checkResultOverride = undefined;
     checkFnOverride = undefined;
+    cachedAssessmentOverride = undefined;
     if (addRuleSpy) {
       addRuleSpy.mockRestore();
       addRuleSpy = undefined;
@@ -272,6 +284,7 @@ describe("ToolExecutor policy context plumbing", () => {
     getToolOverride = undefined;
     checkResultOverride = undefined;
     checkFnOverride = undefined;
+    cachedAssessmentOverride = undefined;
     if (addRuleSpy) {
       addRuleSpy.mockRestore();
       addRuleSpy = undefined;
@@ -754,6 +767,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
     getToolOverride = undefined;
     checkResultOverride = undefined;
     checkFnOverride = undefined;
+    cachedAssessmentOverride = undefined;
     if (addRuleSpy) {
       addRuleSpy.mockRestore();
       addRuleSpy = undefined;
@@ -1259,6 +1273,7 @@ describe("ToolExecutor baseline: allow rule auto-allows file_edit guardian perso
     getToolOverride = undefined;
     checkResultOverride = undefined;
     checkFnOverride = undefined;
+    cachedAssessmentOverride = undefined;
     if (addRuleSpy) {
       addRuleSpy.mockRestore();
       addRuleSpy = undefined;
@@ -1376,6 +1391,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     getToolOverride = undefined;
     checkResultOverride = undefined;
     checkFnOverride = undefined;
+    cachedAssessmentOverride = undefined;
     promptCalled = false;
     if (addRuleSpy) {
       addRuleSpy.mockRestore();
@@ -2131,6 +2147,7 @@ describe("ToolExecutor persistent-allow lifecycle", () => {
     getToolOverride = undefined;
     checkResultOverride = undefined;
     checkFnOverride = undefined;
+    cachedAssessmentOverride = undefined;
     if (addRuleSpy) {
       addRuleSpy.mockRestore();
       addRuleSpy = undefined;
@@ -2307,5 +2324,122 @@ describe("integration regressions — prompt payload (PR 11)", () => {
     expect(capturedScopes).toBeDefined();
     expect(capturedScopes!.length).toBeGreaterThan(0);
     expect(capturedScopes![0]).toHaveProperty("scope");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Risk metadata on ToolExecutionResult (PR 5 — scope-ladder-v1)
+// ---------------------------------------------------------------------------
+
+describe("ToolExecutionResult includes risk metadata from classifier assessment", () => {
+  beforeEach(() => {
+    fakeToolResult = { content: "ok", isError: false };
+    lastCheckArgs = undefined;
+    getToolOverride = undefined;
+    checkResultOverride = undefined;
+    checkFnOverride = undefined;
+    cachedAssessmentOverride = undefined;
+    if (addRuleSpy) {
+      addRuleSpy.mockRestore();
+      addRuleSpy = undefined;
+    }
+  });
+
+  test("auto-approved tool result includes risk metadata when classifier assessment exists", async () => {
+    cachedAssessmentOverride = {
+      riskLevel: "medium",
+      reason: "Writes to a file outside the workspace",
+      scopeOptions: [
+        { pattern: "file_write:/tmp/test.txt", label: "This file only" },
+        { pattern: "file_write:/tmp/**", label: "Anything in tmp/" },
+      ],
+      matchType: "registry",
+    };
+
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.riskLevel).toBe("medium");
+    expect(result.riskReason).toBe("Writes to a file outside the workspace");
+    expect(result.riskScopeOptions).toEqual([
+      { pattern: "file_write:/tmp/test.txt", label: "This file only" },
+      { pattern: "file_write:/tmp/**", label: "Anything in tmp/" },
+    ]);
+  });
+
+  test("tool result omits risk metadata when no classifier assessment exists (e.g. MCP tools)", async () => {
+    // cachedAssessmentOverride is undefined (no classifier ran)
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.riskLevel).toBeUndefined();
+    expect(result.riskReason).toBeUndefined();
+    expect(result.riskScopeOptions).toBeUndefined();
+  });
+
+  test("denied tool result includes risk metadata", async () => {
+    checkResultOverride = {
+      decision: "deny",
+      reason: "Blocked by deny rule",
+    };
+    cachedAssessmentOverride = {
+      riskLevel: "high",
+      reason: "Recursive force delete",
+      scopeOptions: [{ pattern: "bash:rm -rf*", label: "rm -rf commands" }],
+      matchType: "registry",
+    };
+
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "bash",
+      { command: "rm -rf /" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.riskLevel).toBe("high");
+    expect(result.riskReason).toBe("Recursive force delete");
+    expect(result.riskScopeOptions).toEqual([
+      { pattern: "bash:rm -rf*", label: "rm -rf commands" },
+    ]);
+  });
+
+  test("prompted-then-approved tool result includes risk metadata", async () => {
+    checkResultOverride = {
+      decision: "prompt",
+      reason: "Medium risk: requires approval",
+    };
+    cachedAssessmentOverride = {
+      riskLevel: "medium",
+      reason: "Package manager installation",
+      scopeOptions: [
+        { pattern: "bash:npm install*", label: "npm install commands" },
+        { pattern: "bash:npm*", label: "All npm commands" },
+      ],
+      matchType: "registry",
+    };
+
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "bash",
+      { command: "npm install lodash" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("ok");
+    expect(result.riskLevel).toBe("medium");
+    expect(result.riskReason).toBe("Package manager installation");
+    expect(result.riskScopeOptions).toHaveLength(2);
   });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -75,6 +75,9 @@ export type AgentEvent =
       };
       status?: string;
       contentBlocks?: ContentBlock[];
+      riskLevel?: string;
+      riskReason?: string;
+      riskScopeOptions?: Array<{ pattern: string; label: string }>;
     }
   | { type: "tool_use_preview_start"; toolUseId: string; toolName: string }
   | {
@@ -195,6 +198,9 @@ export class AgentLoop {
         contentBlocks?: ContentBlock[];
         sensitiveBindings?: SensitiveOutputBinding[];
         yieldToUser?: boolean;
+        riskLevel?: string;
+        riskReason?: string;
+        riskScopeOptions?: Array<{ pattern: string; label: string }>;
       }>)
     | null;
 
@@ -221,6 +227,9 @@ export class AgentLoop {
       contentBlocks?: ContentBlock[];
       sensitiveBindings?: SensitiveOutputBinding[];
       yieldToUser?: boolean;
+      riskLevel?: string;
+      riskReason?: string;
+      riskScopeOptions?: Array<{ pattern: string; label: string }>;
     }>,
     resolveTools?: (history: Message[]) => ToolDefinition[],
     resolveSystemPrompt?: (history: Message[]) => ResolvedSystemPrompt,
@@ -758,6 +767,9 @@ export class AgentLoop {
             diff: result.diff,
             status: result.status,
             contentBlocks: result.contentBlocks,
+            riskLevel: result.riskLevel,
+            riskReason: result.riskReason,
+            riskScopeOptions: result.riskScopeOptions,
           });
         }
 

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -538,6 +538,9 @@ export function handleToolResult(
     imageData: imageDataList?.[0],
     imageDataList,
     toolUseId: event.toolUseId,
+    riskLevel: event.riskLevel,
+    riskReason: event.riskReason,
+    riskScopeOptions: event.riskScopeOptions,
   });
 }
 

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -145,6 +145,12 @@ export interface ToolResult {
   imageDataList?: string[];
   /** The tool_use block ID for client-side correlation. */
   toolUseId?: string;
+  /** Risk level from the classifier ("low" | "medium" | "high" | "unknown"). */
+  riskLevel?: string;
+  /** Human-readable reason for the risk classification. */
+  riskReason?: string;
+  /** Scope options ladder for the rule editor modal (narrowest to broadest). */
+  riskScopeOptions?: Array<{ pattern: string; label: string }>;
 }
 
 export interface ConfirmationRequest {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -975,6 +975,18 @@ export async function generateAllowlistOptions(
   return [{ label: "*", description: "Everything", pattern: "*" }];
 }
 
+/**
+ * Retrieve a cached RiskAssessment for a given tool invocation.
+ * Returns `undefined` when no classifier-backed assessment exists
+ * (e.g. MCP tools, unknown tools that fall through to registry defaults).
+ */
+export function getCachedAssessment(
+  toolName: string,
+  input: Record<string, unknown>,
+): RiskAssessment | undefined {
+  return assessmentCache.get(assessmentCacheKey(toolName, input));
+}
+
 // Directory-based scope only applies to filesystem and shell tools.
 // All other tools auto-use "everywhere" (the client handles this).
 export const SCOPE_AWARE_TOOLS = new Set([

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -112,6 +112,13 @@ export class ToolExecutor {
       // Exception: requireFreshApproval tools always go through the
       // permission check even when a grant was consumed - the grant does
       // not substitute for an interactive human review.
+      let permRiskMeta:
+        | {
+            riskLevel: string;
+            riskReason: string;
+            riskScopeOptions: Array<{ pattern: string; label: string }>;
+          }
+        | undefined;
       if (!gateResult.grantConsumed || context.requireFreshApproval) {
         // Check permissions via the extracted PermissionChecker
         const permResult = await this.permissionChecker.checkPermission(
@@ -128,9 +135,16 @@ export class ToolExecutor {
 
         riskLevel = permResult.riskLevel;
         decision = permResult.decision;
+        permRiskMeta = permResult.riskMeta;
 
         if (!permResult.allowed) {
-          return { content: permResult.content, isError: true };
+          return {
+            content: permResult.content,
+            isError: true,
+            riskLevel: permRiskMeta?.riskLevel,
+            riskReason: permRiskMeta?.riskReason,
+            riskScopeOptions: permRiskMeta?.riskScopeOptions,
+          };
         }
 
         if (permResult.wasPrompted) {
@@ -396,6 +410,18 @@ export class ToolExecutor {
         durationMs,
         conversationId: context.conversationId,
       });
+
+      // Merge risk metadata from the classifier assessment cache onto the
+      // tool result so downstream consumers (AgentEvent → handleToolResult →
+      // ToolResult SSE message) can forward it to the client.
+      if (permRiskMeta) {
+        execResult = {
+          ...execResult,
+          riskLevel: permRiskMeta.riskLevel,
+          riskReason: permRiskMeta.riskReason,
+          riskScopeOptions: permRiskMeta.riskScopeOptions,
+        };
+      }
 
       return execResult;
     } catch (err) {

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -7,6 +7,7 @@ import {
   classifyRisk,
   generateAllowlistOptions,
   generateScopeOptions,
+  getCachedAssessment,
 } from "../permissions/checker.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import { addRule } from "../permissions/trust-store.js";
@@ -35,8 +36,25 @@ export type PermissionDecision =
       decision: string;
       riskLevel: string;
       wasPrompted?: boolean;
+      /** Risk metadata from the classifier assessment cache (when available). */
+      riskMeta?: {
+        riskLevel: string;
+        riskReason: string;
+        riskScopeOptions: Array<{ pattern: string; label: string }>;
+      };
     }
-  | { allowed: false; decision: string; riskLevel: string; content: string };
+  | {
+      allowed: false;
+      decision: string;
+      riskLevel: string;
+      content: string;
+      /** Risk metadata from the classifier assessment cache (when available). */
+      riskMeta?: {
+        riskLevel: string;
+        riskReason: string;
+        riskScopeOptions: Array<{ pattern: string; label: string }>;
+      };
+    };
 
 export class PermissionChecker {
   private prompter: PermissionPrompter;
@@ -111,6 +129,18 @@ export class PermissionChecker {
     );
     const riskLevel: string = risk;
 
+    // Look up the cached assessment to extract risk metadata for the tool result.
+    // This is populated by classifyRisk() for classifier-backed tools (bash, file, web, skill).
+    // For tools without classifiers (e.g. MCP tools), the cache returns undefined.
+    const cachedAssessment = getCachedAssessment(name, input);
+    const riskMeta = cachedAssessment
+      ? {
+          riskLevel: cachedAssessment.riskLevel,
+          riskReason: cachedAssessment.reason,
+          riskScopeOptions: cachedAssessment.scopeOptions,
+        }
+      : undefined;
+
     // Wrap the rest of permission evaluation so that any exception
     // carries the classified risk level back to the caller. Without
     // this, the executor's catch block would fall back to the default
@@ -179,6 +209,7 @@ export class PermissionChecker {
           decision: "denied",
           riskLevel,
           content: result.reason,
+          riskMeta,
         };
       }
 
@@ -199,7 +230,12 @@ export class PermissionChecker {
           { toolName: name, riskLevel },
           "Auto-approving bash tool for platform-hosted guardian session",
         );
-        return { allowed: true, decision: "platform_auto_approve", riskLevel };
+        return {
+          allowed: true,
+          decision: "platform_auto_approve",
+          riskLevel,
+          riskMeta,
+        };
       }
 
       if (result.decision === "prompt") {
@@ -251,6 +287,7 @@ export class PermissionChecker {
             allowed: true,
             decision: "guardian_auto_approve",
             riskLevel,
+            riskMeta,
           };
         }
 
@@ -281,6 +318,7 @@ export class PermissionChecker {
             decision: "denied",
             riskLevel,
             content: `Permission denied: tool "${name}" requires user approval but no interactive client is connected. The tool was not executed. To allow this tool in non-interactive sessions, add a trust rule via permission settings.`,
+            riskMeta,
           };
         }
 
@@ -305,7 +343,12 @@ export class PermissionChecker {
             },
             "Temporary approval override active - auto-approving without prompt",
           );
-          return { allowed: true, decision: "temporary_override", riskLevel };
+          return {
+            allowed: true,
+            decision: "temporary_override",
+            riskLevel,
+            riskMeta,
+          };
         }
 
         const previewDiff = computePreviewDiff(name, input, context.workingDir);
@@ -422,6 +465,7 @@ export class PermissionChecker {
             decision,
             riskLevel,
             content: denialMessage,
+            riskMeta,
           };
         }
 
@@ -471,6 +515,7 @@ export class PermissionChecker {
             decision,
             riskLevel,
             content: denialMessage,
+            riskMeta,
           };
         }
 
@@ -524,11 +569,17 @@ export class PermissionChecker {
           );
         }
 
-        return { allowed: true, decision, riskLevel, wasPrompted: true };
+        return {
+          allowed: true,
+          decision,
+          riskLevel,
+          wasPrompted: true,
+          riskMeta,
+        };
       }
 
       // result.decision === 'allow'
-      return { allowed: true, decision: "allow", riskLevel };
+      return { allowed: true, decision: "allow", riskLevel, riskMeta };
     } catch (err) {
       if (err instanceof Error) {
         (err as Error & { riskLevel?: string }).riskLevel = riskLevel;

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -242,6 +242,12 @@ export interface ToolExecutionResult {
    * the LLM voluntarily end its turn.
    */
   yieldToUser?: boolean;
+  /** Risk level from the classifier (populated during permission check). */
+  riskLevel?: string;
+  /** Human-readable reason for the risk classification. */
+  riskReason?: string;
+  /** Scope options ladder for the rule editor (narrowest to broadest). */
+  riskScopeOptions?: Array<{ pattern: string; label: string }>;
   /**
    * When present, indicates that a CES tool returned an `approval_required`
    * response. The executor uses the approval bridge to prompt the guardian,


### PR DESCRIPTION
## Summary
- Add `getCachedAssessment()` export to checker.ts to read risk data from the assessment cache
- Thread risk metadata (`riskLevel`, `riskReason`, `riskScopeOptions`) through the full tool result pipeline: ToolExecutionResult → AgentEvent → handleToolResult → ToolResult client message
- Include risk data on both auto-approved and denied tool results
- Add test verifying risk metadata appears on tool execution results

Part of plan: scope-ladder-v1-assistant.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
