### PR TITLE
fix(cli): add missing <key> arg to image-generation recovery hint

### DIFF
--- a/assistant/src/cli/commands/image-generation.ts
+++ b/assistant/src/cli/commands/image-generation.ts
@@ -174,7 +174,7 @@ Examples:
       const hint =
         imageGenMode === "managed"
           ? "Managed proxy is not available. Please log in to Vellum or switch to your-own mode:\n  Run 'assistant auth login' to authenticate, or set services.image-generation.mode to 'your-own' in config."
-          : "No Gemini API key configured. Add your Gemini API key:\n  Run 'assistant keys set gemini' or configure it in Settings > Models & Services.";
+          : "No Gemini API key configured. Add your Gemini API key:\n  Run 'assistant keys set gemini <key>' or configure it in Settings > Models & Services.";
 
       if (jsonOutput) {
         process.stdout.write(JSON.stringify({ ok: false, error: hint }) + "\n");


### PR DESCRIPTION
Same fix as PR #27033 applied to tts.ts, now applied to image-generation.ts. The recovery hint told users to run 'assistant keys set gemini' without the required key argument.

Follow-up to #27033.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
