### PR TITLE
fix(openrouter): preserve existing provider overrides in OpenAI-compat path

### DIFF
--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -157,7 +157,11 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
     };
     const only = extractOnlyList(config);
     if (only.length > 0) {
-      extras.provider = { only };
+      const existingProvider = (config?.provider ?? {}) as Record<
+        string,
+        unknown
+      >;
+      extras.provider = { ...existingProvider, only };
     }
     return extras;
   }


### PR DESCRIPTION
## Summary

Apply the same merge pattern from PR #27036 to `buildExtraCreateParams` so the OpenAI-compat path no longer clobbers `config.provider` when injecting `only`.

Previously, the Anthropic path was fixed but the OpenAI-compat path still overwrote the entire `provider` object — creating an asymmetry between the two code paths. Now both preserve existing provider overrides (e.g. `allow_fallbacks`, `sort`) while adding the `only` list.

Addresses Devin's feedback on #27036.

## Test plan
- [ ] Manual verification that `config.provider.allow_fallbacks` (or similar) passes through on non-Anthropic OpenRouter models alongside `openrouter.only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
