### PR TITLE
fix(meet-ext): add generation guard to fanOutToMeetTabs

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/content-bridge.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/content-bridge.test.ts
@@ -167,6 +167,44 @@ describe("startContentBridge bot→content fan-out", () => {
   });
 
   test(
+    "pending join retry aborts when a later leave supersedes it",
+    async () => {
+      // A join fan-out is stuck retrying because no tab exists yet. Before
+      // the first retry fires, a leave arrives — the later message must
+      // cancel the stale join so we don't join a session the bot has
+      // already decided to leave.
+      fake.tabs.query = async (q) => {
+        fake.queryCalls.push(q);
+        return [];
+      };
+      const join: BotToExtensionMessage = {
+        type: "join",
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        displayName: "Bot",
+        consentMessage: "hello",
+      };
+      const leave: BotToExtensionMessage = { type: "leave", reason: "cancel" };
+      port.emitFromBot(join);
+      await flushMicrotasks();
+      // One query from the join attempt, no tabs -> sleeping 100ms.
+      const queriesAfterJoin = fake.queryCalls.length;
+      expect(queriesAfterJoin).toBe(1);
+      // Now the leave supersedes. Let it run — its own query will count.
+      port.emitFromBot(leave);
+      // Wait long enough for the join's first retry (100ms) to fire if
+      // the generation guard weren't in place, plus margin.
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      // We expect: queriesAfterJoin (1) + 1 for leave's attempt (which also
+      // found no tabs and is itself sleeping). The stale join retry must
+      // not have added another query after the leave bumped the generation.
+      // So total should be exactly 2 (one from join, one from leave's first
+      // attempt) — the join's 100ms retry was skipped.
+      expect(fake.queryCalls.length).toBe(2);
+    },
+    5_000,
+  );
+
+  test(
     "join retries when the only tab responds with {ok:false}",
     async () => {
       // Simulate a profile that has exactly one Meet tab open and that tab is

--- a/skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts
+++ b/skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts
@@ -95,8 +95,22 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Monotonic counter bumped on every fan-out. A pending retry loop compares
+// its captured generation against this value after each sleep and aborts
+// when it has been superseded — e.g. a `join` that is still waiting for the
+// content script to mount must not fire if a later `leave` has already
+// been dispatched for the same session.
+let fanOutGeneration = 0;
+
 async function fanOutToMeetTabs(msg: BotToExtensionMessage): Promise<void> {
+  const myGeneration = ++fanOutGeneration;
   for (let attempt = 0; attempt <= DELIVERY_RETRY_DELAYS_MS.length; attempt++) {
+    if (myGeneration !== fanOutGeneration) {
+      console.warn(
+        `[meet-ext] aborting stale bot->content fan-out type=${msg.type}; superseded by newer message`,
+      );
+      return;
+    }
     let tabs: chrome.tabs.Tab[];
     try {
       tabs = await chrome.tabs.query({ url: MEET_TAB_URL_PATTERN });


### PR DESCRIPTION
## Summary

Addresses Codex feedback on #27054: `fanOutToMeetTabs` lacked a cancellation signal, so a \`join\` that was still retrying (waiting for the content script to mount) could fire after a later \`leave\` had already superseded it, causing the bot to enter a meeting it was supposed to skip.

Fix: a module-level monotonic \`fanOutGeneration\` counter is bumped on every fan-out entry. Each retry loop captures its own generation and aborts at the top of each iteration if it has been superseded. This matches "latest message wins" — any newer \`join\`, \`leave\`, etc. cancels stale pending retries.

## Test plan

- [x] Added regression test: pending \`join\` retry aborts when a later \`leave\` supersedes it — verifies the second attempt's \`tabs.query\` never fires.
- [x] Existing fan-out tests still pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
