### PR TITLE
fix(tts-xai): normalize empty language + reverse schema guard

### DIFF
--- a/assistant/src/config/schemas/tts.ts
+++ b/assistant/src/config/schemas/tts.ts
@@ -182,6 +182,7 @@ export const TtsXaiProviderConfigSchema = z
       .string({
         error: "services.tts.providers.xai.language must be a string",
       })
+      .transform((v) => v || "auto")
       .default("auto")
       .describe(
         "BCP-47 language code (e.g. 'en-US') or 'auto' for auto-detection",
@@ -247,6 +248,16 @@ for (const id of VALID_TTS_PROVIDERS) {
     throw new Error(
       `TTS provider "${id}" exists in the catalog but has no schema entry ` +
         `in TtsProvidersSchema. Add a "services.tts.providers.${id}" schema.`,
+    );
+  }
+}
+const catalogKeys = new Set<string>(VALID_TTS_PROVIDERS);
+for (const id of schemaKeys) {
+  if (!catalogKeys.has(id)) {
+    throw new Error(
+      `TTS provider "${id}" has a schema entry in TtsProvidersSchema but ` +
+        `is not registered in the provider catalog. Add it to ` +
+        `provider-catalog.ts or remove it from TtsProvidersSchema.`,
     );
   }
 }


### PR DESCRIPTION
## Summary

Partial address of review feedback on #26872 (schema-only PR 1/3 for xAI TTS).

- **Codex P1**: `language` now normalizes empty strings to the default via `.transform((v) => v || "auto")`, matching the pattern already used by `voiceId`.
- **Devin ANALYSIS**: Added a reverse schema→catalog invariant so a stale entry in `TtsProvidersSchema` (a provider schema without a catalog registration) fails at module load. Previously only catalog ⊆ schema was enforced; now both directions are checked.

## Intentionally skipped

Devin's BUG suggestion to remove `xai` from `TtsProvidersSchema` was **not** applied. It misreads the staged 3-PR plan: PR 1/3's whole purpose is to register the schema ahead of the adapter. `VALID_TTS_PROVIDERS` is catalog-derived, so users cannot select `provider: "xai"` until the catalog/adapter land in PRs 2–3.

Part of plan: xai-tts-provider.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
