### PR TITLE
fix(skills): preserve merged catalog cache on remote fetch failure

### DIFF
--- a/assistant/src/__tests__/catalog-cache.test.ts
+++ b/assistant/src/__tests__/catalog-cache.test.ts
@@ -184,4 +184,34 @@ describe("getCatalog", () => {
     expect(readLocalCatalogCallCount).toBe(1);
     expect(fetchCatalogCallCount).toBe(1); // attempted remote fetch
   });
+
+  test("preserves merged cache when later remote fetch fails", async () => {
+    mockRepoSkillsDir = "/mock/repo/skills";
+    mockLocalCatalog = [
+      { id: "web-search", name: "Local Web Search", description: "Local" },
+    ];
+    mockFetchCatalogResult = [
+      { id: "web-search", name: "Remote Web Search", description: "Remote" },
+      { id: "remote-only", name: "Remote Only", description: "Remote only" },
+    ];
+
+    // Prime the cache with a successful merged fetch.
+    const merged = await getCatalog();
+    expect(merged).toEqual([
+      { id: "web-search", name: "Local Web Search", description: "Local" },
+      { id: "remote-only", name: "Remote Only", description: "Remote only" },
+    ]);
+
+    // Expire TTL and make remote fetch fail.
+    const originalNow = Date.now;
+    Date.now = () => originalNow() + 5 * 60 * 1000 + 1;
+    try {
+      mockFetchCatalogError = new Error("Network timeout");
+      const fallback = await getCatalog();
+      // Must retain remote-only skills rather than regressing to bare local.
+      expect(fallback).toEqual(merged);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
 });

--- a/assistant/src/skills/catalog-cache.ts
+++ b/assistant/src/skills/catalog-cache.ts
@@ -37,6 +37,13 @@ export async function getCatalog(): Promise<CatalogSkill[]> {
       catalog = remote;
     }
   } catch (err) {
+    if (cachedCatalog) {
+      log.warn(
+        { err },
+        "Failed to fetch Vellum catalog, keeping stale merged cache",
+      );
+      return cachedCatalog;
+    }
     if (local.length > 0) {
       log.warn(
         { err },
@@ -44,11 +51,8 @@ export async function getCatalog(): Promise<CatalogSkill[]> {
       );
       catalog = local;
     } else {
-      log.warn(
-        { err },
-        "Failed to fetch Vellum catalog, using stale cache or empty",
-      );
-      return cachedCatalog ?? [];
+      log.warn({ err }, "Failed to fetch Vellum catalog, returning empty");
+      return [];
     }
   }
   cachedCatalog = catalog;


### PR DESCRIPTION
## Summary

Addresses Codex P2 + Devin feedback on #27040. When the remote catalog fetch in \`getCatalog()\` fails and a local catalog is present, the previous branch replaced any stale merged cache with bare \`local\`, evicting remote-only skills until the next successful fetch — making catalog availability flap with network conditions.

Now on remote-fetch failure we prefer the last-known-good merged \`cachedCatalog\` if one exists, and only fall back to bare \`local\` (or empty) when no prior cache has been populated.

## Test plan

- [x] Existing tests still pass (stale-cache fallback, bare-local fallback with no cache).
- [x] New test: prime a merged cache, expire TTL, fail the remote fetch — verify the merged (local + remote-only) cache is retained instead of regressing to bare local.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
