### PR TITLE
fix(meet-ext): iterate all waitFor matches + filter admission poll

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/wait.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/wait.test.ts
@@ -80,6 +80,20 @@ describe("waitForSelector interactable filter", () => {
     ).rejects.toThrow(/timeout waiting for #a/);
   });
 
+  test("iterates all matches and returns the first interactable one", async () => {
+    // Regression: `querySelector` only returns the first hit, so a hidden
+    // template node earlier in the tree used to mask a later interactable
+    // sibling. The fix iterates `querySelectorAll`.
+    const doc = buildDoc(
+      `<body>
+        <button class="c" aria-hidden="true">ghost</button>
+        <button class="c" id="real">real</button>
+      </body>`,
+    );
+    const el = await waitForSelector(".c", 100, doc, { interactable: true });
+    expect(el.id).toBe("real");
+  });
+
   test("resolves once a hidden match becomes interactable", async () => {
     const doc = buildDoc(
       `<body><button id="a" aria-hidden="true">pending</button></body>`,

--- a/skills/meet-join/meet-controller-ext/src/dom/wait.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/wait.ts
@@ -43,8 +43,12 @@
  * explicit attributes, inline styles, or the native visibility check. Elements
  * that merely lack positive evidence of being interactable (common in jsdom,
  * where there is no layout) pass through.
+ *
+ * Exported for reuse by callers that need to apply the same filter to their
+ * own imperative `querySelectorAll` loops (e.g. `features/join.ts` step 4
+ * admission polling).
  */
-function isInteractable(el: Element): boolean {
+export function isInteractable(el: Element): boolean {
   const html = el as HTMLElement;
 
   // Ancestor-or-self check: `hidden` / `aria-hidden="true"` on any enclosing
@@ -118,15 +122,26 @@ export function waitForSelector(
   opts: WaitOptions = {},
 ): Promise<Element> {
   const wantInteractable = opts.interactable === true;
-  const accept = (el: Element | null): el is Element =>
-    el !== null && (!wantInteractable || isInteractable(el));
+  // When filtering, scan every match — not just the first — so a hidden
+  // template node earlier in the tree does not mask a later interactable
+  // sibling. `querySelector` only ever returns the first hit, which makes
+  // the filter falsely bail in that case.
+  const findMatch = (): Element | null => {
+    if (!wantInteractable) return doc.querySelector(sel);
+    const all = doc.querySelectorAll(sel);
+    for (let i = 0; i < all.length; i++) {
+      const el = all[i]!;
+      if (isInteractable(el)) return el;
+    }
+    return null;
+  };
 
   return new Promise<Element>((resolve, reject) => {
     // Synchronous check — if it's already there (and interactable, when
     // requested), return immediately. This short-circuits the happy path
     // without touching MutationObserver.
-    const existing = doc.querySelector(sel);
-    if (accept(existing)) {
+    const existing = findMatch();
+    if (existing) {
       resolve(existing);
       return;
     }
@@ -134,8 +149,8 @@ export function waitForSelector(
     let settled = false;
     const observer = new MutationObserver(() => {
       if (settled) return;
-      const match = doc.querySelector(sel);
-      if (accept(match)) {
+      const match = findMatch();
+      if (match) {
         settled = true;
         observer.disconnect();
         clearTimeout(timer);
@@ -175,11 +190,21 @@ export function waitForAny(
   opts: WaitOptions = {},
 ): Promise<{ selector: string; element: Element }> {
   const wantInteractable = opts.interactable === true;
+  // When filtering, iterate every candidate per selector rather than just
+  // the first `querySelector` hit. A hidden template node at the front of
+  // the list would otherwise short-circuit the selector's match check and
+  // mask a later interactable sibling that would have satisfied it.
   const firstMatch = (): { selector: string; element: Element } | null => {
     for (const selector of selectors) {
-      const el = doc.querySelector(selector);
-      if (el && (!wantInteractable || isInteractable(el))) {
-        return { selector, element: el };
+      if (!wantInteractable) {
+        const el = doc.querySelector(selector);
+        if (el) return { selector, element: el };
+        continue;
+      }
+      const all = doc.querySelectorAll(selector);
+      for (let i = 0; i < all.length; i++) {
+        const el = all[i]!;
+        if (isInteractable(el)) return { selector, element: el };
       }
     }
     return null;

--- a/skills/meet-join/meet-controller-ext/src/features/join.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/join.ts
@@ -37,7 +37,7 @@
  */
 import type { ExtensionToBotMessage } from "../../../contracts/native-messaging.js";
 import { selectors } from "../dom/selectors.js";
-import { waitForAny, waitForSelector } from "../dom/wait.js";
+import { isInteractable, waitForAny, waitForSelector } from "../dom/wait.js";
 import { postConsentMessage } from "./chat.js";
 
 /** How long to wait for the prejoin surface to mount. */
@@ -215,12 +215,26 @@ export async function runJoinFlow(opts: RunJoinFlowOptions): Promise<void> {
   // join button after we populate the name input, so a synchronous query
   // here races against that render. Poll with a short budget — the button
   // is visible in the DOM within a few hundred ms of the input event.
+  //
+  // Apply the same interactable filter the Step 1/2 waits use: Meet leaves
+  // hidden template copies of the join buttons in the tree during prejoin,
+  // so the first `querySelector` hit can be a ghost node. Iterate every
+  // match and take the first interactable one so this poll stays consistent
+  // with the rest of the join flow.
+  const findInteractable = (sel: string): Element | null => {
+    const nodes = doc.querySelectorAll(sel);
+    for (let i = 0; i < nodes.length; i++) {
+      const el = nodes[i]!;
+      if (isInteractable(el)) return el;
+    }
+    return null;
+  };
   let admissionBtn: Element | null = null;
   const joinDeadline = Date.now() + 10_000;
   while (Date.now() < joinDeadline) {
     admissionBtn =
-      doc.querySelector(selectors.PREJOIN_JOIN_NOW_BUTTON) ??
-      doc.querySelector(selectors.PREJOIN_ASK_TO_JOIN_BUTTON);
+      findInteractable(selectors.PREJOIN_JOIN_NOW_BUTTON) ??
+      findInteractable(selectors.PREJOIN_ASK_TO_JOIN_BUTTON);
     if (admissionBtn) break;
     await new Promise((r) => setTimeout(r, 200));
   }


### PR DESCRIPTION
## Summary
- `waitForSelector` / `waitForAny` with `interactable: true` now iterate every `querySelectorAll` match instead of stopping at the first hit, so a hidden template node can no longer mask a later interactable sibling (Codex P1 on #27043).
- Step 4 admission-button polling in `features/join.ts` now applies the same interactable filter, keeping the join flow consistent across all waitFor polls (Devin feedback on #27043).
- Added a regression test covering the multi-match case.

Addresses feedback on #27043.

## Test plan
- [ ] `cd skills/meet-join/meet-controller-ext && bun test src/dom/__tests__/wait.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
