### PR TITLE
test(cli): mock process.stdin.isTTY in inference-send & tts-synthesize tests

### DIFF
--- a/assistant/src/cli/commands/__tests__/inference-send.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-send.test.ts
@@ -138,6 +138,14 @@ async function runCommand(
   const stdoutChunks: string[] = [];
   const stderrChunks: string[] = [];
 
+  // Mock isTTY to undefined so the stdin fallback path is reachable even
+  // when tests run from an interactive terminal (where isTTY === true).
+  const originalIsTTY = process.stdin.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", {
+    value: undefined,
+    configurable: true,
+  });
+
   process.stdout.write = ((chunk: unknown) => {
     stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
     return true;
@@ -164,6 +172,10 @@ async function runCommand(
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.stderr.write = originalStderrWrite;
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+    });
   }
 
   const exitCode = process.exitCode ?? 0;

--- a/assistant/src/cli/commands/__tests__/tts-synthesize.test.ts
+++ b/assistant/src/cli/commands/__tests__/tts-synthesize.test.ts
@@ -128,6 +128,14 @@ async function runCommand(
   const stdoutChunks: string[] = [];
   const stderrChunks: string[] = [];
 
+  // Mock isTTY to undefined so the stdin fallback path is reachable even
+  // when tests run from an interactive terminal (where isTTY === true).
+  const originalIsTTY = process.stdin.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", {
+    value: undefined,
+    configurable: true,
+  });
+
   process.stdout.write = ((chunk: unknown) => {
     stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
     return true;
@@ -161,6 +169,10 @@ async function runCommand(
     process.stdout.write = originalStdoutWrite;
     process.stderr.write = originalStderrWrite;
     process.exit = originalExit;
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+    });
   }
 
   const exitCode = process.exitCode ?? 0;


### PR DESCRIPTION
## Summary

Follow-up to #27050. Devin flagged that the new `!process.stdin.isTTY` guards in `inference.ts` and `tts.ts` make the stdin fallback path unreachable when tests run from an interactive terminal (`isTTY === true`), causing `reads message from stdin when no positional args` and `stdin fallback is used when no --text or positional arg is given` to fail locally.

Applied the same isTTY mock pattern used in `cache.test.ts` and `email-send.test.ts`:
- Save original `process.stdin.isTTY`
- Set it to `undefined` via `Object.defineProperty` before running the command
- Restore in `finally`

## Test plan
- [ ] `cd assistant && bun test src/cli/commands/__tests__/inference-send.test.ts`
- [ ] `cd assistant && bun test src/cli/commands/__tests__/tts-synthesize.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
