### PR TITLE
docs(assembly): rewrite RuntimeInjectionBlocks + applyRuntimeInjections JSDoc to describe current state

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1715,11 +1715,12 @@ export function findLastInjectedNowContent(messages: Message[]): string | null {
 export type InjectionMode = "full" | "minimal";
 
 /**
- * Per-turn injection bytes captured for later persistence to message
- * metadata. Persisting these lets `loadFromDb` rehydrate historical user
- * messages byte-for-byte after a daemon restart or conversation eviction,
- * which keeps Anthropic's prefix cache anchored to msg[0] instead of
- * invalidating every turn on reload.
+ * Per-turn injection bytes captured so `loadFromDb` can rehydrate historical
+ * user messages byte-for-byte after a daemon restart or conversation
+ * eviction. Persisting the exact injected text onto message metadata keeps
+ * Anthropic's prefix cache anchored to msg[0] instead of invalidating every
+ * turn on reload. Any field left `undefined` means that block was not
+ * injected on this turn.
  */
 export interface RuntimeInjectionBlocks {
   unifiedTurnContext?: string;
@@ -1738,8 +1739,10 @@ export interface RuntimeInjectionResult {
  * Apply a chain of user-message injections to `runMessages`.
  *
  * Each injection is optional — pass `null`/`undefined` to skip it.
- * Returns the final message array ready for the provider, along with a
- * `blocks` object reserved for captured injection bytes (currently empty).
+ * Returns the final message array ready for the provider along with a
+ * `blocks` object holding the exact injected text for each block that was
+ * applied, so callers can persist those bytes to message metadata for later
+ * byte-exact rehydration.
  */
 export async function applyRuntimeInjections(
   runMessages: Message[],


### PR DESCRIPTION
## Summary
- Rewrite the `RuntimeInjectionBlocks` and `applyRuntimeInjections` JSDoc to describe current behavior instead of narrating PR history.
- The `applyRuntimeInjections` docstring previously claimed `blocks` was "currently empty"; follow-up PRs (#27005, #27006, #27288) now populate it with captured injection bytes used for byte-exact rehydration.
- Also addresses the same feedback raised on #27005 and #27006.

Addresses Devin feedback on #27003.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
