### PR TITLE
fix(meet-ext): propagate sendMessage throws so camera JS fallback runs on runtime-disconnect

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/content-camera.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/content-camera.test.ts
@@ -56,6 +56,13 @@ interface InstalledHarness {
   setCameraState: (on: boolean) => void;
   /** Make the toggle's `.click()` a no-op (simulate isTrusted rejection). */
   makeClickNoOp: () => void;
+  /**
+   * Force `chrome.runtime.sendMessage` to throw synchronously on the next
+   * `trusted_click` dispatch (and only that one). Simulates the
+   * "Extension context invalidated" failure mode that MV3 surfaces when
+   * the runtime is disconnected mid-flow.
+   */
+  failNextTrustedClickSend: () => void;
   restore: () => void;
 }
 
@@ -84,22 +91,26 @@ function installHarness(): InstalledHarness {
   });
 
   const sent: unknown[] = [];
+  let failNextTrustedClickSend = false;
   const chrome: FakeChrome = {
     sent,
     runtime: {
       sendMessage: (msg) => {
+        const isTrustedClick =
+          typeof msg === "object" &&
+          msg !== null &&
+          (msg as { type?: unknown }).type === "trusted_click";
+        if (isTrustedClick && failNextTrustedClickSend) {
+          failNextTrustedClickSend = false;
+          throw new Error("Extension context invalidated.");
+        }
         sent.push(msg);
         // Simulate xdotool landing a real click when the extension emits a
         // `trusted_click`: camera.ts emits trusted_click and NO LONGER calls
         // `toggle.click()` itself (that would invert the toggle twice if the
         // isTrusted gate is ever relaxed). Flip the aria-label here so the
         // poll in `enableCamera`/`disableCamera` observes the transition.
-        if (
-          flipOnClick &&
-          typeof msg === "object" &&
-          msg !== null &&
-          (msg as { type?: unknown }).type === "trusted_click"
-        ) {
+        if (flipOnClick && isTrustedClick) {
           const label = camera.getAttribute("aria-label");
           if (label === "Turn off camera") {
             camera.setAttribute("aria-label", "Turn on camera");
@@ -140,6 +151,9 @@ function installHarness(): InstalledHarness {
     },
     makeClickNoOp: () => {
       flipOnClick = false;
+    },
+    failNextTrustedClickSend: () => {
+      failNextTrustedClickSend = true;
     },
     restore: () => {
       for (const [k, v] of Object.entries(originals)) {
@@ -233,6 +247,33 @@ describe("handleCameraToggle", () => {
     const result = results[0]!;
     if (result.type === "camera_result") {
       expect(result.requestId).toBe("req-3");
+      expect(result.ok).toBe(true);
+      expect(result.changed).toBe(true);
+    }
+  });
+
+  test("falls back to JS .click() when chrome.runtime.sendMessage throws on the trusted_click dispatch", async () => {
+    // Regression: handleCameraToggle's sendToBot must let sync throws
+    // (e.g. "Extension context invalidated" when the MV3 runtime is
+    // disconnected) propagate into camera.ts, so the feature's
+    // try/catch can fall through to the JS .click() fallback instead of
+    // treating a silently failed emit as a successful trusted click and
+    // eating the full 5s poll timeout.
+    harness!.setCameraState(false);
+    harness!.failNextTrustedClickSend();
+
+    await handleCameraToggle!({ type: "camera.enable", requestId: "req-5" });
+
+    const sent = harness!.chrome.sent as ExtensionToBotMessage[];
+    // The failed send never landed in `sent` (the fake throws before the
+    // push). JS .click() ran and flipped the label, so we still succeed.
+    expect(sent.filter((e) => e.type === "trusted_click")).toHaveLength(0);
+
+    const results = sent.filter((e) => e.type === "camera_result");
+    expect(results).toHaveLength(1);
+    const result = results[0]!;
+    if (result.type === "camera_result") {
+      expect(result.requestId).toBe("req-5");
       expect(result.ok).toBe(true);
       expect(result.changed).toBe(true);
     }

--- a/skills/meet-join/meet-controller-ext/src/handle-send-chat.ts
+++ b/skills/meet-join/meet-controller-ext/src/handle-send-chat.ts
@@ -92,10 +92,22 @@ export async function handleCameraToggle(
   cmd: BotCameraEnableCommand | BotCameraDisableCommand,
 ): Promise<void> {
   const sendToBot = (event: ExtensionToBotMessage): void => {
-    try {
-      void chrome.runtime.sendMessage(event);
-    } catch (err) {
-      console.warn("[meet-ext] sendMessage failed:", err);
+    // Propagate synchronous throws (e.g. "Extension context invalidated"
+    // when the runtime is disconnected) so camera.ts can catch them and
+    // fall back to the JS `.click()` path. Swallowing them here would
+    // let `trustedClickEmitted=true` stand against a silently failed
+    // dispatch, the JS fallback would be skipped, and the poll would
+    // sit through the full 5s timeout before surfacing a stuck toggle.
+    // Async rejections are best-effort — log them but don't unwind the
+    // caller, since xdotool may well have already landed the click by
+    // the time the reject resolves.
+    const result = chrome.runtime.sendMessage(event) as
+      | Promise<unknown>
+      | undefined;
+    if (result && typeof (result as Promise<unknown>).catch === "function") {
+      (result as Promise<unknown>).catch((err) => {
+        console.warn("[meet-ext] sendMessage failed (async):", err);
+      });
     }
   };
 


### PR DESCRIPTION
Addresses Codex feedback on #26857.

## Problem

`trustedClickEmitted` was set `true` immediately after `opts.onEvent(...)` returned, but the production `onEvent` path (`handleCameraToggle`'s `sendToBot`) wrapped `chrome.runtime.sendMessage` in a silent try/catch. When the MV3 runtime is disconnected ("Extension context invalidated"), the send throws synchronously — but the catch swallowed it, `trustedClickEmitted` became `true` against a dead bridge, the JS `.click()` fallback was skipped, and the poll sat through the full 5s timeout before surfacing the stuck toggle.

## Fix

Let synchronous throws from `chrome.runtime.sendMessage` propagate out of `sendToBot`. `camera.ts` already wraps the `opts.onEvent(...)` call in a try/catch that leaves `trustedClickEmitted=false` on failure, so the existing JS `.click()` fallback runs as intended. Async rejections stay best-effort (logged, not propagated) since xdotool has likely already landed the click by the time the promise rejects.

## Test

Added a regression test in `content-camera.test.ts` that makes `chrome.runtime.sendMessage` throw synchronously on the `trusted_click` dispatch and asserts that the JS `.click()` fallback still flips the camera and surfaces `camera_result(ok=true, changed=true)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
