### PR TITLE
fix(slack): harden DM cold-start warm-count validation + ts-bound check

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1051,20 +1051,22 @@ export function getMessages(conversationId: string): MessageRow[] {
 }
 
 /**
- * Count messages whose metadata JSON contains a `slackMeta` envelope, capped
- * at `limit`. Pushes the cap into SQL (`LIKE` + `LIMIT`) so warm Slack DM
- * conversations don't require a full-table scan + JSON parse on every
- * inbound message to confirm the cold-start threshold has been cleared.
- * Returns the number of matching rows up to `limit`; callers compare against
- * the cold-start threshold to decide whether to backfill.
+ * Return raw `metadata` strings for messages whose metadata contains the
+ * literal substring `"slackMeta"`, capped at `limit`. Pushes `LIKE` + `LIMIT`
+ * into SQL so warm Slack DM conversations don't require a full-table scan on
+ * the webhook critical path. The substring match is an indexable prefilter
+ * only — callers must parse and validate each returned string against the
+ * Slack metadata schema, because a malformed row (partial write, legacy
+ * format, unrelated key accidentally containing the literal) can still slip
+ * through the substring match.
  */
-export function countMessagesWithSlackMeta(
+export function selectSlackMetaCandidateMetadata(
   conversationId: string,
   limit: number,
-): number {
+): string[] {
   const db = getDb();
   const rows = db
-    .select({ one: sql`1` })
+    .select({ metadata: messages.metadata })
     .from(messages)
     .where(
       and(
@@ -1074,7 +1076,13 @@ export function countMessagesWithSlackMeta(
     )
     .limit(limit)
     .all();
-  return rows.length;
+  const out: string[] = [];
+  for (const r of rows) {
+    if (typeof r.metadata === "string" && r.metadata.length > 0) {
+      out.push(r.metadata);
+    }
+  }
+  return out;
 }
 
 /**

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -21,9 +21,9 @@ import {
 } from "../../memory/conversation-attention-store.js";
 import {
   addMessage,
-  countMessagesWithSlackMeta,
   getMessageById,
   getMessages,
+  selectSlackMetaCandidateMetadata,
   updateMessageMetadata,
 } from "../../memory/conversation-crud.js";
 import * as deliveryChannels from "../../memory/delivery-channels.js";
@@ -1049,14 +1049,21 @@ export async function handleChannelInbound(
       // longer trigger backfill. Failures are non-fatal — the new message
       // proceeds without backfilled history.
       if (sourceChannel === "slack" && sourceChatType === "im") {
+        // Exclude the just-arrived webhook message from the history window —
+        // the normal inbound persistence path writes it separately, so
+        // including it here would produce duplicate user turns. Only pass a
+        // bound when we actually have a Slack ts (`<secs>.<micros>`): the
+        // fallback path writes `externalMessageId` into `channelTs`, but that
+        // identifier is not guaranteed to be a Slack ts, and Slack's
+        // `conversations.history` rejects anything that isn't a ts string.
+        const boundingTs = isSlackTs(sourceMessageId)
+          ? sourceMessageId
+          : undefined;
         await tryBackfillSlackDmIfCold({
           conversationId: result.conversationId,
           channelId: conversationExternalId,
           account: slackAccount,
-          // Exclude the just-arrived webhook message from the history window —
-          // the normal inbound persistence path writes it separately, so
-          // including it here would produce duplicate user turns.
-          latestTs: slackInbound?.channelTs,
+          latestTs: boundingTs,
         });
       }
 
@@ -1245,16 +1252,62 @@ async function persistSlackReactionAsMessage(params: {
 const SLACK_DM_BACKFILL_WARM_THRESHOLD = 3;
 
 /**
- * Count messages in a conversation whose `metadata` carries a `slackMeta`
- * envelope, capped at the warm threshold. Delegates to the DB helper which
- * pushes both `LIKE` and `LIMIT` into SQL so a warm DM conversation never
- * scans beyond the threshold's worth of rows on the webhook critical path.
+ * Shape-check for a Slack `ts` value. Slack IDs messages by `<seconds>.<micros>`
+ * strings (e.g. `"1700000000.000100"`). The daemon also stores an
+ * `externalMessageId` derived from the gateway's dedupe key which follows a
+ * different format, so any path that feeds a ts to Slack's API
+ * (`conversations.history`'s `latest`, etc.) must shape-check first — Slack
+ * rejects non-ts arguments with `invalid_arguments`, and passing a malformed
+ * bound silently disables the intended history window.
+ */
+function isSlackTs(value: string | null | undefined): value is string {
+  return typeof value === "string" && /^\d+\.\d+$/.test(value);
+}
+
+/**
+ * Over-fetch multiplier applied to the warm threshold when pulling candidate
+ * rows from SQL. A bare `LIKE '%"slackMeta"%'` match can include rows whose
+ * metadata JSON is malformed or carries the literal under an unrelated key,
+ * so we fetch a few extra and re-validate each candidate with Zod. The
+ * threshold is tiny (see `SLACK_DM_BACKFILL_WARM_THRESHOLD`), so 10× is still
+ * a trivial scan while letting a handful of bad rows not starve the count.
+ */
+const SLACK_DM_CANDIDATE_OVERFETCH = 10;
+
+/**
+ * Count messages in a conversation whose `metadata` carries a well-formed
+ * `slackMeta` envelope, capped at the warm threshold. SQL prefilters with
+ * `LIKE` + `LIMIT` so warm DM conversations never scan the full table on the
+ * webhook critical path, and each candidate is then re-validated through
+ * `readSlackMetadata` — a bare substring match would otherwise wrongly count
+ * rows whose metadata is truncated, parses but fails schema validation, or
+ * happens to contain the literal `"slackMeta"` under an unrelated key.
  */
 function countSlackMetaMessages(conversationId: string): number {
-  return countMessagesWithSlackMeta(
+  const candidates = selectSlackMetaCandidateMetadata(
     conversationId,
-    SLACK_DM_BACKFILL_WARM_THRESHOLD,
+    SLACK_DM_BACKFILL_WARM_THRESHOLD * SLACK_DM_CANDIDATE_OVERFETCH,
   );
+  let count = 0;
+  for (const raw of candidates) {
+    let parent: Record<string, unknown> | null = null;
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        parent = parsed as Record<string, unknown>;
+      }
+    } catch {
+      continue;
+    }
+    if (!parent) continue;
+    const inner = parent.slackMeta;
+    if (typeof inner !== "string") continue;
+    if (readSlackMetadata(inner)) {
+      count++;
+      if (count >= SLACK_DM_BACKFILL_WARM_THRESHOLD) return count;
+    }
+  }
+  return count;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #27052. Addresses Codex P1/P2 review feedback.

## Changes

**P1 — warm-count validation.**
The SQL `LIKE '%\"slackMeta\"%'` prefilter added in #27052 matched rows whose metadata was truncated, failed Zod validation, or carried the literal under an unrelated key — producing false positives the previous parse-validated path rejected. Split the helper into a candidate-selector (`selectSlackMetaCandidateMetadata`) + caller-side `readSlackMetadata` validation, with a 10× over-fetch so a handful of malformed rows can't starve the count. Warm threshold stays tiny so the scan stays cheap.

**P2 — Slack ts bound validation.**
`latestTs` was being sourced from `slackInbound?.channelTs`, which itself falls back from `sourceMessageId` to `externalMessageId`. The latter is a gateway-synthesized dedupe key that is not guaranteed to be a Slack ts, and Slack's `conversations.history` rejects non-ts `latest` values. Now shape-check via `isSlackTs()` and only pass `sourceMessageId` when it matches the `<secs>.<micros>` format — otherwise omit the bound rather than break the whole backfill call.

## Test plan
- [ ] Unit: existing `dm-backfill.test.ts` still passes — test fixtures use real Slack ts format, so the bound is preserved.
- [ ] Manual: malformed slackMeta rows no longer short-circuit backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
