### PR TITLE
fix(meet-join): clamp send-chat timeout at Meet's 2000-char cap

### DIFF
--- a/skills/meet-join/contracts/native-messaging.ts
+++ b/skills/meet-join/contracts/native-messaging.ts
@@ -170,10 +170,18 @@ export type ExtensionTrustedClickMessage = z.infer<
  * message. The bot simply invokes `xdotool type` against whatever is
  * currently focused on the Xvfb display.
  */
+/**
+ * Google Meet's single-message chat cap. Shared across contracts so every
+ * site that sizes timeouts or validates length uses the same number, and
+ * so the daemon can clamp untrusted inputs before deriving a per-request
+ * timeout (see {@link trustedTypeHttpTimeoutMs}).
+ */
+export const MEET_CHAT_MAX_LENGTH = 2000;
+
 export const ExtensionTrustedTypeMessageSchema = z.object({
   type: z.literal("trusted_type"),
   /** Text to type via `xdotool type`. Length-capped to Meet's 2000-char chat limit. */
-  text: z.string().min(1).max(2000),
+  text: z.string().min(1).max(MEET_CHAT_MAX_LENGTH),
   /** Optional per-keystroke delay (ms), passed as `xdotool --delay`. */
   delayMs: z.number().int().min(0).max(500).optional(),
 });

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -77,7 +77,10 @@ import { resolveTtsConfig } from "../../../assistant/src/tts/tts-config-resolver
 import type { TtsProvider } from "../../../assistant/src/tts/types.js";
 import { getLogger } from "../../../assistant/src/util/logger.js";
 import { getWorkspaceDir } from "../../../assistant/src/util/platform.js";
-import { trustedTypeHttpTimeoutMs } from "../contracts/native-messaging.js";
+import {
+  MEET_CHAT_MAX_LENGTH,
+  trustedTypeHttpTimeoutMs,
+} from "../contracts/native-messaging.js";
 import { getMeetConfig } from "../meet-config.js";
 import { MeetAudioIngest } from "./audio-ingest.js";
 import {
@@ -2425,9 +2428,16 @@ async function defaultBotSendChatFetch(
   // even when the extension eventually completes them successfully.
   // Scale per request via the shared helper; floor at the legacy fixed
   // budget so short messages keep the same (already-tight) ceiling.
+  //
+  // Clamp the length used for timeout sizing at Meet's 2000-char chat
+  // cap. The bot's `/send_chat` handler rejects anything longer, so a
+  // pathological oversized payload (e.g. 10k chars) must not inflate
+  // unreachable-bot latency from ~65s to ~265s+ before surfacing
+  // `MeetSessionUnreachableError`.
+  const clampedLength = Math.min(text.length, MEET_CHAT_MAX_LENGTH);
   const timeoutMs = Math.max(
     BOT_SEND_CHAT_HTTP_TIMEOUT_MS,
-    trustedTypeHttpTimeoutMs(text.length),
+    trustedTypeHttpTimeoutMs(clampedLength),
   );
   let response: Response;
   try {


### PR DESCRIPTION
## Summary

Codex P1 on #27079: `defaultBotSendChatFetch` sized `AbortSignal.timeout` from raw `text.length`, so a pathological 10k-char payload would hold the daemon call open for ~265s before surfacing \`MeetSessionUnreachableError\` — vs. ~10s pre-PR and ~65s for a valid 2000-char chat.

The bot's \`/send_chat\` handler already rejects anything beyond Meet's 2000-char cap, so oversized daemon-side lengths are never sendable; clamp the length used for timeout sizing at the same cap. Export \`MEET_CHAT_MAX_LENGTH\` from \`contracts/native-messaging.ts\` (also reused by the Zod schema) and \`Math.min\` against it in the daemon fetcher. Unreachable-bot latency is now ≤ \`trustedTypeHttpTimeoutMs(2000)\` ≈ 65s regardless of input size.

Addressed in follow-up to #27079.

## Test plan

- [ ] Existing send-chat unit/integration tests continue to pass
- [ ] Manual: send an oversized payload and confirm daemon abandons within ~65s when bot is down
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
