### PR TITLE
fix(memory): extend step-7 supersession placeholder to deferredEdges

### DIFF
--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -1066,10 +1066,18 @@ export async function runGraphExtraction(
   );
 
   // 7. Handle supersession (inherit durability before applying diff)
+  // TODO: full supersession is not yet implemented. When it lands, iterate
+  // BOTH `diff.createEdges` (existing → existing) AND `deferredEdges`
+  // (new → existing, the typical supersession case).
+  // Tracked by https://github.com/vellum-ai/vellum-assistant/pull/27057 (Devin).
   for (const edge of diff.createEdges) {
     if (edge.relationship === "supersedes") {
-      // Supersession is handled differently — see supersedeNode in store
-      // For now, just mark it; full supersession is applied after node creation
+      // Placeholder — see TODO above.
+    }
+  }
+  for (const de of deferredEdges) {
+    if (de.relationship === "supersedes") {
+      // Placeholder — see TODO above.
     }
   }
 


### PR DESCRIPTION
Addresses Devin review on #27057: when the real supersession logic lands, it must also inspect `deferredEdges` (where new→existing supersedes edges land), not just `diff.createEdges`. Added placeholder iteration over deferredEdges and a TODO linking back to the review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
