### PR TITLE
fix(clients): use Bundle.appBundleIdentifier in LLMProviderRegistry logger

### DIFF
--- a/clients/shared/Utilities/LLMProviderRegistry.swift
+++ b/clients/shared/Utilities/LLMProviderRegistry.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os
 
-private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "LLMProviderRegistry")
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "LLMProviderRegistry")
 
 // MARK: - Types
 


### PR DESCRIPTION
Addresses review feedback on #27114.

The `LLMProviderRegistry` Logger was hardcoded to `"com.vellum.vellum-assistant"`, which violates the macOS client convention (see `clients/macos/AGENTS.md`): dev/staging/test builds use different bundle IDs, so the hardcoded string breaks log filtering for those builds. Replace with `Bundle.appBundleIdentifier` — the canonical helper defined in `clients/shared/Utilities/AppBundleIdentifier.swift` and used by every other Logger in the shared/macOS/iOS code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
