### PR TITLE
fix(macos): guard avatar/traits state mutations against late cancellation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -182,6 +182,11 @@ final class AvatarAppearanceManager {
                 params: ["path": "data/avatar/avatar-image.png"],
                 timeout: 10
             )
+            // Short-circuit state mutations if the task was cancelled while
+            // the HTTP request was in flight — otherwise a late-arriving
+            // response from the previous assistant can stale-flash the
+            // avatar after resetForDisconnect() has cleared state.
+            guard !Task.isCancelled else { return }
             if response.isSuccess, !response.data.isEmpty {
                 cachedChatAvatar = nil
                 customAvatarImage = NSImage(data: response.data)
@@ -199,6 +204,7 @@ final class AvatarAppearanceManager {
             log.warning("Transient avatar fetch failure (HTTP \(response.statusCode)) — preserving cached image and scheduling retry")
             scheduleAvatarRetry()
         } catch {
+            guard !Task.isCancelled else { return }
             log.warning("Transport failure fetching avatar — preserving cached image and scheduling retry: \(error.localizedDescription)")
             scheduleAvatarRetry()
         }
@@ -215,6 +221,11 @@ final class AvatarAppearanceManager {
                 params: ["path": "data/avatar/character-traits.json"],
                 timeout: 10
             )
+            // Short-circuit state mutations if the task was cancelled while
+            // the HTTP request was in flight — otherwise a late-arriving
+            // response from the previous assistant can stale-flash the
+            // traits after resetForDisconnect() has cleared state.
+            guard !Task.isCancelled else { return }
             if response.isSuccess, !response.data.isEmpty {
                 guard let components = try? JSONDecoder().decode(AvatarComponents.self, from: response.data) else {
                     return
@@ -249,6 +260,7 @@ final class AvatarAppearanceManager {
             log.warning("Transient traits fetch failure (HTTP \(response.statusCode)) — preserving cached traits and scheduling retry")
             scheduleTraitsRetry()
         } catch {
+            guard !Task.isCancelled else { return }
             log.warning("Transport failure fetching character traits — preserving cached traits and scheduling retry: \(error.localizedDescription)")
             scheduleTraitsRetry()
         }


### PR DESCRIPTION
Addresses Devin feedback on #27059.

The prior cancellation guards protected only the bookkeeping flags (`avatarRetryInFlight`, `avatarRetryTask`). The fetch methods' own state mutations (`customAvatarImage`, `characterBodyShape`, etc.) still landed when a fetch was cancelled mid-flight, so a late-returning response from the previous assistant could stale-flash the avatar/traits after `resetForDisconnect()` had cleared state.

Added `guard !Task.isCancelled` checks immediately after the `await` in `fetchAvatarViaHTTP` and `fetchTraitsViaHTTP` (both the success path and the catch block) so no state writes or retry scheduling happens after cancellation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
