### PR TITLE
fix(providers): align OpenAI catalog prices with pricing.ts (#27117 follow-up)

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -143,7 +143,7 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsToolUse: true,
         pricing: {
           inputPer1mTokens: 2.5,
-          outputPer1mTokens: 10.0,
+          outputPer1mTokens: 15.0,
           cacheReadPer1mTokens: 0.25,
         },
       },
@@ -157,8 +157,8 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: true,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 3.0,
-          outputPer1mTokens: 12.0,
+          inputPer1mTokens: 1.75,
+          outputPer1mTokens: 14.0,
           cacheReadPer1mTokens: 0.3,
         },
       },
@@ -173,7 +173,7 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsToolUse: true,
         pricing: {
           inputPer1mTokens: 0.5,
-          outputPer1mTokens: 2.0,
+          outputPer1mTokens: 3.0,
           cacheReadPer1mTokens: 0.05,
         },
       },
@@ -187,8 +187,8 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: true,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 0.1,
-          outputPer1mTokens: 0.4,
+          inputPer1mTokens: 0.2,
+          outputPer1mTokens: 1.25,
           cacheReadPer1mTokens: 0.01,
         },
       },


### PR DESCRIPTION
## Summary
Reconciles the OpenAI entries in `assistant/src/providers/model-catalog.ts` with the authoritative cost-calculation catalog in `assistant/src/util/pricing.ts`. The model catalog is sent to clients via `getModelInfo()` for display, while `pricing.ts` is used to compute actual usage costs — the two had diverged, so users saw one price while the backend billed a different rate.

Per-model changes (catalog → pricing.ts):
- `gpt-5.4`: output 10.0 → 15.0
- `gpt-5.2`: input 3.0 → 1.75, output 12.0 → 14.0
- `gpt-5.4-mini`: output 2.0 → 3.0
- `gpt-5.4-nano`: input 0.1 → 0.2, output 0.4 → 1.25

Cache-read rates are left untouched since `pricing.ts` does not specify them.

Addresses Codex and Devin review feedback on #27117.

## Test plan
- [ ] No behavior change in cost calculation (`pricing.ts` untouched)
- [ ] Clients now display the same rates used for billing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
