### PR TITLE
fix(providers): align Gemini catalog pricing with pricing.ts

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -222,9 +222,9 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: true,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 0.3,
-          outputPer1mTokens: 2.5,
-          cacheReadPer1mTokens: 0.075,
+          inputPer1mTokens: 0.15,
+          outputPer1mTokens: 0.6,
+          cacheReadPer1mTokens: 0.0375,
         },
       },
       {
@@ -237,9 +237,9 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: true,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 0.1,
-          outputPer1mTokens: 0.4,
-          cacheReadPer1mTokens: 0.025,
+          inputPer1mTokens: 0.02,
+          outputPer1mTokens: 0.1,
+          cacheReadPer1mTokens: 0.005,
         },
       },
       {


### PR DESCRIPTION
## Summary

Address review feedback on #27118: Gemini 2.5 Flash and Flash-Lite catalog entries were populated with **thinking-mode** rates, but `assistant/src/util/pricing.ts` uses **non-thinking** rates for the same models. Align the catalog to match `pricing.ts`.

- `gemini-2.5-flash`: input `0.3 → 0.15`, output `2.5 → 0.6`
- `gemini-2.5-flash-lite`: input `0.1 → 0.02`, output `0.4 → 0.1`
- Cache-read rates scaled at 0.25× input (Google's published ratio): `0.075 → 0.0375`, `0.025 → 0.005`
- `gemini-2.5-pro` already matched `pricing.ts` (1.25/10)

## Test plan

- [x] Lint + format clean (ship hook)
- [ ] No runtime behavior change; just metadata alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
