### PR TITLE
fix(stt-xai): detach handshake listeners before forceClose

### DIFF
--- a/assistant/src/providers/speech-to-text/xai-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/xai-realtime.test.ts
@@ -497,14 +497,25 @@ describe("XAIRealtimeTranscriber", () => {
     const transcriber = new XAIRealtimeTranscriber(TEST_API_KEY, {
       connectTimeoutMs: 1_000,
     });
-    const { onEvent } = createEventCollector();
+    const { events, onEvent } = createEventCollector();
 
-    // First attempt: transport-level error before open.
+    // First attempt: transport-level error before open. Real WebSocket
+    // implementations commonly chain `error` → `close` on the abandoned
+    // socket, so simulate both to catch the regression where the old
+    // socket's stray close event corrupts `this.closed` and silently
+    // breaks the retry.
+    const firstSocket = mockWs;
     const firstAttempt = transcriber.start(onEvent);
-    mockWs.simulateError(new Error("ECONNREFUSED"));
+    firstSocket.simulateError(new Error("ECONNREFUSED"));
+    firstSocket.simulateClose(1006, "abnormal closure");
     await expect(firstAttempt).rejects.toThrow(/xAI realtime connect error/);
 
-    // Second attempt — instance must be reusable.
+    // The stray close on the abandoned socket must NOT have emitted a
+    // `closed` event or marked the transcriber closed — otherwise the
+    // retry below would silently no-op on sendAudio.
+    expect(events.filter((e) => e.type === "closed")).toHaveLength(0);
+
+    // Second attempt — instance must be reusable AND fully functional.
     mockWs = new MockWebSocket();
     (globalThis as Record<string, unknown>).WebSocket = class {
       constructor(
@@ -519,6 +530,63 @@ describe("XAIRealtimeTranscriber", () => {
     mockWs.simulateOpen();
     mockWs.simulateMessage(CREATED_FRAME);
     await expect(secondAttempt).resolves.toBeUndefined();
+
+    // Confirm the retry session is actually live — sendAudio must reach
+    // the new socket (proves `this.closed` wasn't sticky-corrupted).
+    transcriber.sendAudio(Buffer.from([0x01, 0x02, 0x03]), "audio/pcm");
+    expect(mockWs.sentData).toHaveLength(1);
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Regression: a close event on the abandoned socket fired AFTER a
+  // handshake-phase rejection must not corrupt `this.closed`. Real
+  // WebSocket impls emit `close` asynchronously after `ws.close()` is
+  // called, and commonly chain `error` → `close`; if the handshake
+  // listeners aren't detached before `forceClose()`, the stray event
+  // routes through `handleProviderClose` and flips `this.closed`,
+  // silently breaking subsequent retries.
+  // ─────────────────────────────────────────────────────────────────
+
+  test("stray close on abandoned socket after handshake rejection does not break retry", async () => {
+    const transcriber = new XAIRealtimeTranscriber(TEST_API_KEY, {
+      connectTimeoutMs: 1_000,
+    });
+    const { events, onEvent } = createEventCollector();
+
+    // First attempt: close rejects the handshake.
+    const firstSocket = mockWs;
+    const firstAttempt = transcriber.start(onEvent);
+    firstSocket.simulateClose(4001, "unauthorized");
+    await expect(firstAttempt).rejects.toThrow(
+      /xAI WebSocket closed before handshake/,
+    );
+
+    // Simulate a second close event arriving on the abandoned socket
+    // (as `forceClose()` → `ws.close()` would trigger in a real impl).
+    firstSocket.simulateClose(1006, "abnormal closure");
+
+    // The stray event must be a no-op: no `closed` event emitted, and
+    // no internal state corruption.
+    expect(events.filter((e) => e.type === "closed")).toHaveLength(0);
+
+    // Retry and confirm the session is fully functional.
+    mockWs = new MockWebSocket();
+    (globalThis as Record<string, unknown>).WebSocket = class {
+      constructor(
+        _url: string,
+        _options?: { headers?: Record<string, string> },
+      ) {
+        return mockWs;
+      }
+    };
+
+    const secondAttempt = transcriber.start(onEvent);
+    mockWs.simulateOpen();
+    mockWs.simulateMessage(CREATED_FRAME);
+    await expect(secondAttempt).resolves.toBeUndefined();
+
+    transcriber.sendAudio(Buffer.from([0x01, 0x02, 0x03]), "audio/pcm");
+    expect(mockWs.sentData).toHaveLength(1);
   });
 
   // ─────────────────────────────────────────────────────────────────

--- a/assistant/src/providers/speech-to-text/xai-realtime.ts
+++ b/assistant/src/providers/speech-to-text/xai-realtime.ts
@@ -255,13 +255,17 @@ export class XAIRealtimeTranscriber implements StreamingTranscriber {
     await new Promise<void>((resolve, reject) => {
       let settled = false;
 
-      const handshakeTimer = setTimeout(() => {
-        if (settled) return;
-        settled = true;
-        this.forceClose();
-        reject(new Error("xAI realtime connect timeout"));
-      }, this.connectTimeoutMs);
-
+      // Listener references, captured so we can detach them from the
+      // abandoned socket on every reject/timeout path. Without this,
+      // `forceClose()` → `ws.close()` triggers an asynchronous `close`
+      // event (and real WebSocket impls commonly chain `error` → `close`)
+      // on the old socket. With the listeners still attached, that stray
+      // event routes through the `settled === true` branch into
+      // `handleProviderClose`, which calls `emitClosedAndCleanup()` and
+      // sets `this.closed = true`. A subsequent `start()` then resolves
+      // but `sendAudio` / `stop` / timers all no-op because `this.closed`
+      // is sticky — retry is silently dead. Detaching the handlers
+      // before `forceClose()` closes that window.
       const settleResolve = () => {
         if (settled) return;
         settled = true;
@@ -273,6 +277,9 @@ export class XAIRealtimeTranscriber implements StreamingTranscriber {
         if (settled) return;
         settled = true;
         clearTimeout(handshakeTimer);
+        // Detach listeners BEFORE `forceClose()` so stray close/error
+        // events on the abandoned socket can't flip `this.closed`.
+        detachHandshakeListeners();
         // Null out this.ws (via forceClose) so the instance can be
         // reused for a retry. Without this, a subsequent start() call
         // would throw "start() called twice" even though no session
@@ -288,9 +295,8 @@ export class XAIRealtimeTranscriber implements StreamingTranscriber {
       const onOpen = () => {
         ws.removeEventListener("open", onOpen);
       };
-      ws.addEventListener("open", onOpen);
 
-      ws.addEventListener("message", (ev: { data: unknown }) => {
+      const onMessage = (ev: { data: unknown }) => {
         if (!settled) {
           if (tryParseHandshakeFrame(ev.data)?.type === "transcript.created") {
             settleResolve();
@@ -303,9 +309,9 @@ export class XAIRealtimeTranscriber implements StreamingTranscriber {
           return;
         }
         this.handleProviderMessage(ev.data);
-      });
+      };
 
-      ws.addEventListener("close", (ev: { code: number; reason: string }) => {
+      const onClose = (ev: { code: number; reason: string }) => {
         if (!settled) {
           // 401 / 403 on connect arrive as WebSocket close codes 4001 /
           // 4003 in most runtimes (or 1008 policy-violation in others).
@@ -320,9 +326,9 @@ export class XAIRealtimeTranscriber implements StreamingTranscriber {
           return;
         }
         this.handleProviderClose(ev.code, ev.reason);
-      });
+      };
 
-      ws.addEventListener("error", (ev: unknown) => {
+      const onError = (ev: unknown) => {
         if (!settled) {
           const msg =
             ev instanceof Error
@@ -334,7 +340,26 @@ export class XAIRealtimeTranscriber implements StreamingTranscriber {
           return;
         }
         this.handleProviderError(ev);
-      });
+      };
+
+      const detachHandshakeListeners = () => {
+        ws.removeEventListener("message", onMessage);
+        ws.removeEventListener("close", onClose);
+        ws.removeEventListener("error", onError);
+      };
+
+      const handshakeTimer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        detachHandshakeListeners();
+        this.forceClose();
+        reject(new Error("xAI realtime connect timeout"));
+      }, this.connectTimeoutMs);
+
+      ws.addEventListener("open", onOpen);
+      ws.addEventListener("message", onMessage);
+      ws.addEventListener("close", onClose);
+      ws.addEventListener("error", onError);
     });
 
     this.resetInactivityTimer();


### PR DESCRIPTION
## Summary

Addresses Codex P1 and Devin review feedback on #27081.

After a handshake-phase rejection, `settleReject()` / the handshake timeout call `this.forceClose()`, which nulls `this.ws` and calls `ws.close()`. In real WebSocket implementations, `ws.close()` triggers an asynchronous `close` event (and `error` commonly chains to `close`). With the unified session-lifetime listeners still attached to the abandoned socket, that stray event routed through the `settled === true` branch into `handleProviderClose`, which calls `emitClosedAndCleanup()` and sets `this.closed = true`. `this.closed` is sticky, so a subsequent `start()` resolved but `sendAudio` / `stop` / timers all silently no-op — the retry appeared successful but processed no audio.

## Fix

Capture the message/close/error listener references and detach them from the abandoned socket before `forceClose()` in every reject/timeout path. Once detached, stray events on the old socket have nowhere to route.

## Tests

- Hardened `start() allows retry after connect-phase error rejects` to simulate the real-world `error` → `close` sequence on the abandoned socket, and asserted the retry is fully functional (`sendAudio` reaches the new socket).
- Added regression test `stray close on abandoned socket after handshake rejection does not break retry` that simulates a second close event on the abandoned socket and confirms no `closed` event is emitted and the retry is live.

## Test plan
- [x] Lint + type checks
- [x] New regression test covers the Codex + Devin bug
- [x] Existing tests remain green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
