### PR TITLE
fix(pricing): align Fireworks kimi-k2p5 output pricing with catalog

### DIFF
--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -51,7 +51,7 @@ const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
   fireworks: {
     "accounts/fireworks/models/kimi-k2p5": {
       inputPer1M: 0.6,
-      outputPer1M: 3.0,
+      outputPer1M: 2.5,
     },
   },
 };


### PR DESCRIPTION
## Summary
- Fireworks `accounts/fireworks/models/kimi-k2p5` output pricing in `pricing.ts` was `3.0` per 1M tokens, while the canonical value in `model-catalog.ts` is `2.5`. This caused inconsistent cost reporting between UI/catalog metadata and runtime cost estimation.
- Align `pricing.ts` to the catalog value (`2.5`).

Addresses Codex feedback on #27120.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
