### PR TITLE
fix(macos): guard progress card rehydration against stale cross-wave state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -106,7 +106,16 @@ struct AssistantProgressView: View {
         }
         let initialThinkingStart: Date?
         let initialThinkingEnd: Date?
-        if let duration = persistedThinkingDuration, let latestEnd = model.latestCompletedAt {
+        // Cross-wave guard: only rehydrate thinking anchors when the model is
+        // actually in the `.complete` phase. If the view is recycled mid-wave
+        // (e.g. wave 2 still running after wave 1 completed), `handlePhaseChange`
+        // never fires for the current init — so the persisted duration from
+        // wave 1 would otherwise get stitched onto wave 2's latest tool end,
+        // synthesizing a bogus thinking row and re-introducing the stale-anchor
+        // regression this PR is meant to prevent.
+        if model.phase == .complete,
+           let duration = persistedThinkingDuration,
+           let latestEnd = model.latestCompletedAt {
             // Reconstruct from persisted duration
             initialThinkingStart = latestEnd
             initialThinkingEnd = latestEnd.addingTimeInterval(duration)
@@ -138,12 +147,28 @@ struct AssistantProgressView: View {
         // is lossless across view recycling. Falling back to `latestCompletedAt`
         // (last tool end) drops any post-tool thinking/latency tail and
         // re-introduces the duration regression the anchor exists to prevent.
+        //
+        // Cross-wave guard: if the view recycles mid-wave-2, the card's
+        // `.complete` → `.toolRunning` transition happened while the view was
+        // unmounted, so `handlePhaseChange` never got a chance to clear the
+        // wave-1 anchor. Unconditionally restoring the persisted value would
+        // re-introduce the exact regression this PR fixes. Only use the
+        // persisted anchor when the current phase is still `.complete`, and
+        // additionally discard it if a tool completed AFTER the anchor (a new
+        // wave finished while the view was unmounted — the stored timestamp
+        // no longer describes the card's final state).
         let persistedCardCompletedAt = cardKeyForInit.flatMap {
             progressUIState.wrappedValue.cardCompletedAt(for: $0)
         }
         let initialCardCompletedAt: Date? = {
-            if let persisted = persistedCardCompletedAt { return persisted }
-            return model.phase == .complete ? model.latestCompletedAt : nil
+            guard model.phase == .complete else { return nil }
+            if let persisted = persistedCardCompletedAt {
+                if let latest = model.latestCompletedAt, persisted < latest {
+                    return latest
+                }
+                return persisted
+            }
+            return model.latestCompletedAt
         }()
         _cardCompletedAt = State(initialValue: initialCardCompletedAt)
     }


### PR DESCRIPTION
## Summary

Follow-up to #27065. Addresses Codex + Devin review feedback on mid-wave view recycling.

The original PR persisted the card's completion anchor across view recycling via `ProgressCardUIState.cardCompletedDates` (and has long done the same for `thinkingDurations`). Both are cleared inside `handlePhaseChange` when tools resume (new wave), but that handler only fires for phase transitions observed by a *mounted* view. If the view is recycled *during* a subsequent wave — after wave 1's `.complete` transition was seen (so the anchor was written) but before the view observed wave 2's `.toolRunning` transition to clear it — the next init unconditionally restores the persisted wave-1 value, and no transition is ever observed to reset it. The header then stays stuck on wave 1's end time (`cardCompletedAt`) or synthesizes a bogus thinking row stitched onto wave 2's latest tool end (`thinkingDurations`), re-introducing the exact regression #27065 was meant to prevent.

**Fix** (`AssistantProgressView.init`): gate both rehydration paths on the current model phase/wave.

- `cardCompletedAt`: require `model.phase == .complete`; additionally discard the persisted anchor and fall back to `model.latestCompletedAt` if a tool completed *after* the anchor (a wave finished while the view was unmounted).
- `thinkingDurations`: require `model.phase == .complete` before reconstructing thinking start/end from the persisted duration. Mid-wave states fall through to the existing seeding logic, which correctly yields `nil` when thinking-after-tools hasn't been signalled for the current wave.

No schema changes. The persisted dictionaries self-heal: the next `.complete` transition that this view observes calls `setCardCompletedAt` / `setThinkingDuration` and overwrites any stale entry.

## Test plan

- [ ] Multi-wave run, recycle the progress card view mid-wave-2 (scroll out + back): header duration and thinking row no longer restore wave-1 state.
- [ ] Single-wave run: rehydration across view recycling still preserves the post-tool thinking tail.
- [ ] Cold rehydration (no persisted state): behaviour unchanged — falls back to `model.latestCompletedAt` when `phase == .complete`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
