### PR TITLE
fix(meet-join): guard decodeURIComponent against malformed meetingId percent-encoding

### DIFF
--- a/skills/meet-join/__tests__/register.test.ts
+++ b/skills/meet-join/__tests__/register.test.ts
@@ -200,4 +200,19 @@ describe("meet-join register", () => {
     await route!.handler(req, match);
     expect(lastHandlerMeetingId).toBe("abc 123");
   });
+
+  test("meet-internal route handler returns 400 on malformed percent-encoding", async () => {
+    // `%` without two trailing hex digits makes decodeURIComponent throw
+    // URIError. Without the try/catch this surfaces pre-auth and the
+    // daemon returns a 500; the handler must intercept and return 400.
+    const path = "/v1/internal/meet/abc%ZZ/events";
+    const route = capturedRoutes.find((r) => r.pattern.test(path));
+    expect(route).toBeDefined();
+    const match = path.match(route!.pattern)!;
+    lastHandlerMeetingId = null;
+    const req = new Request(`http://host${path}`, { method: "POST" });
+    const res = await route!.handler(req, match);
+    expect(res.status).toBe(400);
+    expect(lastHandlerMeetingId).toBeNull();
+  });
 });

--- a/skills/meet-join/register.ts
+++ b/skills/meet-join/register.ts
@@ -58,8 +58,24 @@ import { meetCancelSpeakTool, meetSpeakTool } from "./tools/meet-speak-tool.js";
 registerSkillRoute({
   pattern: MEET_INTERNAL_EVENTS_PATH_RE,
   methods: ["POST"],
-  handler: (req, match) =>
-    handleMeetInternalEvents(req, decodeURIComponent(match[1]!)),
+  handler: (req, match) => {
+    // decodeURIComponent throws URIError on malformed percent-encoding
+    // (e.g. a stray `%` without two hex digits). Without this guard the
+    // error surfaces pre-auth and the daemon returns a 500 — reject with
+    // a 400 instead so malformed bot URLs are observable as client errors.
+    let meetingId: string;
+    try {
+      meetingId = decodeURIComponent(match[1]!);
+    } catch {
+      return Promise.resolve(
+        Response.json(
+          { error: "Invalid meeting id encoding" },
+          { status: 400 },
+        ),
+      );
+    }
+    return handleMeetInternalEvents(req, meetingId);
+  },
 });
 
 registerExternalTools(() => {


### PR DESCRIPTION
## Summary
- Address codex+devin feedback on #27128: `decodeURIComponent` on the bot-ingress path capture could throw URIError on malformed percent-encoding, which surfaces as a 500 pre-auth instead of a controlled 400.
- Wrap the decode in try/catch and return 400, mirroring the canonical pattern in `gateway/src/index.ts:1034-1041`.

## Test plan
- [x] New test asserts `/v1/internal/meet/abc%ZZ/events` returns 400 and does not invoke the handler.

Addresses feedback on #27128.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
