### PR TITLE
fix(meet-join): set admitted flag only after session+send succeed

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/content.ts
+++ b/skills/meet-join/meet-controller-ext/src/content.ts
@@ -325,22 +325,25 @@ async function handleJoin(
     console.warn("[meet-ext] lifecycle(joining) send failed:", err);
   }
 
-  // Tracks whether `onAdmitted` fired. Used to (a) suppress a duplicate
-  // post-await `joined` emit in the happy path and (b) guard the error
-  // catch from emitting `lifecycle:error` once we've already told the
-  // daemon we joined — a late reject from the best-effort consent post
-  // must not walk back the admission signal.
+  // Tracks whether `onAdmitted` fired and completed. Used to (a) suppress
+  // a duplicate post-await `joined` emit in the happy path and (b) guard
+  // the error catch from emitting `lifecycle:error` once we've already
+  // told the daemon we joined — a late reject from the best-effort
+  // consent post must not walk back the admission signal. Set only after
+  // both `startMeetingSession` and the `joined` send have completed, so a
+  // throw from either step leaves `admitted` false and lets the outer
+  // catch emit `lifecycle:error` rather than swallowing the failure.
   let admitted = false;
   const finalizeAdmission = (): void => {
     if (generation !== joinGeneration) return;
     if (admitted) return;
-    admitted = true;
     activeSession = startMeetingSession({ meetingId, displayName });
     try {
       chrome.runtime.sendMessage(lifecycleMessage("joined", meetingId));
     } catch (err) {
       console.warn("[meet-ext] lifecycle(joined) send failed:", err);
     }
+    admitted = true;
   };
 
   try {


### PR DESCRIPTION
## Summary

Addresses Devin's review feedback on #27153.

**Devin's finding:** In `finalizeAdmission`, `admitted = true` was set *before* `startMeetingSession` and the `joined` `chrome.runtime.sendMessage` ran. If `startMeetingSession` threw (or sendMessage threw synchronously), the outer try/catch in `handleJoin` would see `admitted = true` and follow the post-admission-throw branch — logging `[meet-ext] post-admission runJoinFlow threw:` and returning *without emitting any lifecycle*. The daemon would then sit in `joining` until the 120s join timeout.

**Fix:** move the `admitted = true` assignment to after both `startMeetingSession` and the `sendMessage` call complete. Now a throw from either step leaves `admitted` at `false`, and the outer catch takes the normal error branch — emitting `lifecycle:error` so the daemon transitions out of `joining` immediately.

## Why Codex's suggestion was NOT applied

Codex suggested re-serializing the consent send so that `lifecycle:joined` only emits *after* the consent post. That would effectively revert the core fix in #27153 and reintroduce the original bug: chat-DOM drift in step 6 (the consent post) silently gating the join signal even though the bot was already admitted to the meeting. The race Codex identifies between `joined` and the consent message arriving is real but secondary — if we want shared ordering, it should be implemented via explicit serialization on the daemon/bot side, not by reverting emit-order.

## Test plan

- [x] Static diff review — minimal change, flag flipped to post-work position
- [ ] Existing `join.test.ts` admitted-ordering tests should continue to pass unchanged (flag position is internal to `handleJoin`, not observable from `runJoinFlow`'s `onAdmitted` contract)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
