### PR TITLE
fix(meet-bot): preserve in-flight utterance visemes on /play_audio reset

### DIFF
--- a/skills/meet-join/bot/__tests__/avatar-lipsync.test.ts
+++ b/skills/meet-join/bot/__tests__/avatar-lipsync.test.ts
@@ -330,20 +330,37 @@ describe("TalkingHead renderer lip-sync alignment", () => {
     // Leave one viseme from utterance 1 still buffered in the future
     // (e.g. a late-declared viseme whose audio had not yet played).
     // It belongs to utterance 1 and must NOT leak into utterance 2.
-    renderer.pushViseme({ phoneme: "stale", weight: 0.1, timestamp: 900 });
+    renderer.pushViseme({
+      phoneme: "stale",
+      weight: 0.1,
+      timestamp: 900,
+      streamId: "u1",
+    });
     expect(nativeMessaging.pushVisemes()).toHaveLength(0);
 
-    // Simulate the HTTP server starting a fresh /play_audio POST: it
-    // rewinds the renderer's clock in lockstep with the handle's
-    // `resetPlaybackClock()`.
+    // Simulate the HTTP server starting a fresh /play_audio POST for
+    // utterance 2: it rewinds the renderer's clock in lockstep with
+    // the handle's `resetPlaybackClock()` and names the incoming
+    // stream so only prior-utterance events (streamId "u1") get
+    // dropped.
     expect(typeof renderer.resetPlaybackTimestamp).toBe("function");
-    renderer.resetPlaybackTimestamp!();
+    renderer.resetPlaybackTimestamp!("u2");
 
     // Utterance 2's visemes arrive with ts values restarting at 0.
     // They must be buffered — the clock was rewound past them — not
     // flushed immediately.
-    renderer.pushViseme({ phoneme: "a", weight: 0.2, timestamp: 100 });
-    renderer.pushViseme({ phoneme: "b", weight: 0.3, timestamp: 200 });
+    renderer.pushViseme({
+      phoneme: "a",
+      weight: 0.2,
+      timestamp: 100,
+      streamId: "u2",
+    });
+    renderer.pushViseme({
+      phoneme: "b",
+      weight: 0.3,
+      timestamp: 200,
+      streamId: "u2",
+    });
     expect(nativeMessaging.pushVisemes()).toHaveLength(0);
 
     // Advance the clock into utterance 2's range. `a` (t=100) should
@@ -362,6 +379,66 @@ describe("TalkingHead renderer lip-sync alignment", () => {
     renderer.notifyPlaybackTimestamp(10_000);
     pushed = nativeMessaging.pushVisemes();
     expect(pushed.map((v) => v.phoneme)).toEqual(["a", "b"]);
+  });
+
+  test("resetPlaybackTimestamp preserves same-streamId visemes that raced ahead of the /play_audio POST", async () => {
+    // The daemon fires provider synthesis concurrently with the
+    // `/play_audio` POST, so `/avatar/viseme` events for the incoming
+    // utterance can land BEFORE the POST that triggers the reset. An
+    // unconditional buffer clear would drop those events — defeating
+    // the buffering this reset exists to protect. The reset must only
+    // evict visemes whose `streamId` differs from the incoming POST's.
+    const nativeMessaging = new FakeNativeMessaging();
+    const renderer = await startRenderer(nativeMessaging);
+
+    // Utterance 1 had a late-arriving viseme still buffered (its audio
+    // hadn't played yet when the utterance ended).
+    renderer.pushViseme({
+      phoneme: "stale",
+      weight: 0.1,
+      timestamp: 900,
+      streamId: "u1",
+    });
+
+    // Synthesis for utterance 2 races ahead of its `/play_audio` POST
+    // and two of its visemes land first. They're tagged with "u2"
+    // because the daemon already knows the streamId it will use.
+    renderer.pushViseme({
+      phoneme: "early_a",
+      weight: 0.4,
+      timestamp: 40,
+      streamId: "u2",
+    });
+    renderer.pushViseme({
+      phoneme: "early_b",
+      weight: 0.5,
+      timestamp: 120,
+      streamId: "u2",
+    });
+    expect(nativeMessaging.pushVisemes()).toHaveLength(0);
+
+    // Now the POST for utterance 2 arrives and the HTTP server calls
+    // resetPlaybackTimestamp("u2"). The two "u2" visemes must SURVIVE
+    // the reset; the "u1" stale viseme must be dropped.
+    renderer.resetPlaybackTimestamp!("u2");
+
+    // Advance the clock — both preserved "u2" visemes should flush,
+    // and the "u1" stale viseme (t=900) must NEVER appear, even after
+    // the clock runs far past its timestamp.
+    renderer.notifyPlaybackTimestamp(40);
+    expect(nativeMessaging.pushVisemes().map((v) => v.phoneme)).toEqual([
+      "early_a",
+    ]);
+    renderer.notifyPlaybackTimestamp(120);
+    expect(nativeMessaging.pushVisemes().map((v) => v.phoneme)).toEqual([
+      "early_a",
+      "early_b",
+    ]);
+    renderer.notifyPlaybackTimestamp(10_000);
+    expect(nativeMessaging.pushVisemes().map((v) => v.phoneme)).toEqual([
+      "early_a",
+      "early_b",
+    ]);
   });
 
   test("visemes with identical timestamps are forwarded in arrival order", async () => {

--- a/skills/meet-join/bot/src/control/http-server.ts
+++ b/skills/meet-join/bot/src/control/http-server.ts
@@ -462,6 +462,11 @@ export function createHttpServer(
       // stream gets a fresh 0-based clock matching the daemon's
       // per-utterance timestamp coordinate system. Reset the viseme-
       // driven renderer's mirror clock in lockstep for the same reason.
+      //
+      // Pass `streamId` through to the renderer reset so visemes from
+      // THIS utterance that raced ahead of the POST (the daemon fires
+      // provider synthesis concurrently with `/play_audio`) survive the
+      // buffer pruning — only prior-utterance events are dropped.
       handle.resetPlaybackClock();
       const rendererAtStreamStart = avatarRenderer;
       if (
@@ -469,7 +474,7 @@ export function createHttpServer(
         rendererAtStreamStart.capabilities.needsVisemes &&
         typeof rendererAtStreamStart.resetPlaybackTimestamp === "function"
       ) {
-        rendererAtStreamStart.resetPlaybackTimestamp();
+        rendererAtStreamStart.resetPlaybackTimestamp(streamId);
       }
 
       const controller = new AbortController();
@@ -1003,9 +1008,16 @@ function parseVisemeEvent(body: unknown): VisemeEvent | null {
   if (typeof raw.timestamp !== "number" || !Number.isFinite(raw.timestamp)) {
     return null;
   }
+  // `streamId` is optional — older daemons don't tag visemes, and we'd
+  // rather degrade to the pre-tagging behavior than reject the event.
+  const streamId =
+    typeof raw.streamId === "string" && raw.streamId.length > 0
+      ? raw.streamId
+      : undefined;
   return {
     phoneme: raw.phoneme,
     weight: raw.weight,
     timestamp: raw.timestamp,
+    ...(streamId !== undefined ? { streamId } : {}),
   };
 }

--- a/skills/meet-join/bot/src/media/avatar/talking-head/renderer.ts
+++ b/skills/meet-join/bot/src/media/avatar/talking-head/renderer.ts
@@ -414,18 +414,46 @@ export class TalkingHeadRenderer implements AvatarRenderer {
 
   /**
    * Reset the internal playback clock back to the "no audio queued yet"
-   * state and drop any visemes still buffered from the prior utterance.
-   * The HTTP server calls this at the start of every new `/play_audio`
-   * stream, in lockstep with `AudioPlaybackHandle.resetPlaybackClock()`.
-   * Without this reset the clock would sit at the end-of-prior-utterance
-   * timestamp and subsequent visemes (daemon-stamped as ms-from-THAT-
-   * utterance-start, restarting at 0) would all satisfy the `timestamp
-   * <= currentPlaybackTimestamp` check and flush immediately on arrival.
+   * state and drop any buffered visemes that do NOT belong to the
+   * incoming utterance. The HTTP server calls this at the start of
+   * every new `/play_audio` stream, in lockstep with
+   * `AudioPlaybackHandle.resetPlaybackClock()`. Without this reset the
+   * clock would sit at the end-of-prior-utterance timestamp and
+   * subsequent visemes (daemon-stamped as ms-from-THAT-utterance-start,
+   * restarting at 0) would all satisfy the `timestamp <=
+   * currentPlaybackTimestamp` check and flush immediately on arrival.
+   *
+   * The daemon fires provider synthesis concurrently with the
+   * `/play_audio` POST, so some visemes for the incoming utterance can
+   * land on `/avatar/viseme` BEFORE the POST that triggers this reset.
+   * Those events are already tagged with the POST's `stream_id`, so we
+   * preserve any buffered viseme whose `streamId === incomingStreamId`
+   * and drop everything else — the original "clear the entire buffer"
+   * behavior threw those early-arriving events away and defeated the
+   * very buffering this method exists to protect.
    */
-  resetPlaybackTimestamp(): void {
+  resetPlaybackTimestamp(incomingStreamId?: string): void {
     if (this.stopped) return;
     this.currentPlaybackTimestamp = Number.NEGATIVE_INFINITY;
-    this.visemeBuffer.length = 0;
+    if (incomingStreamId === undefined) {
+      // Legacy / untagged path (older daemon or test callers): the
+      // original semantics were "clear everything". Preserve them so
+      // non-race-aware call sites keep working identically.
+      this.visemeBuffer.length = 0;
+      return;
+    }
+    // Filter in place so we don't reallocate; visemes already in
+    // arrival order stay that way. Same-streamId visemes belong to the
+    // incoming utterance (synthesis raced ahead of the POST) and must
+    // survive the reset; every other viseme is prior-utterance debris.
+    let writeIdx = 0;
+    for (let readIdx = 0; readIdx < this.visemeBuffer.length; readIdx++) {
+      const v = this.visemeBuffer[readIdx]!;
+      if (v.streamId === incomingStreamId) {
+        this.visemeBuffer[writeIdx++] = v;
+      }
+    }
+    this.visemeBuffer.length = writeIdx;
   }
 
   /**

--- a/skills/meet-join/bot/src/media/avatar/types.ts
+++ b/skills/meet-join/bot/src/media/avatar/types.ts
@@ -44,6 +44,20 @@ export type VisemeEvent = {
   weight: number;
   /** Monotonic timestamp (ms) used to align the viseme with the audio. */
   timestamp: number;
+  /**
+   * Optional — the `stream_id` of the `/play_audio` POST this viseme
+   * belongs to. The daemon stamps every viseme it emits with the same
+   * id it uses for the paired `/play_audio?stream_id=` call so the bot
+   * can distinguish prior-utterance leftovers from new-utterance events
+   * that raced ahead of their POST.
+   *
+   * Only consumed by `resetPlaybackTimestamp` — a new POST preserves
+   * same-streamId buffered visemes and drops everything else. A viseme
+   * with `streamId === undefined` predates this tagging (an older
+   * daemon) and is treated as "belongs to no current stream" — i.e.
+   * dropped on reset, matching the original clear-all behavior.
+   */
+  streamId?: string;
 };
 
 /**
@@ -139,11 +153,18 @@ export interface AvatarRenderer {
    * immediately on arrival — the exact bug `notifyPlaybackTimestamp`
    * exists to prevent.
    *
-   * Implementations should also drop any buffered viseme state that
-   * belonged to the prior utterance so it cannot leak into the fresh
-   * stream.
+   * Implementations should drop buffered visemes that belonged to the
+   * prior utterance so they cannot leak into the fresh stream, but
+   * must preserve visemes tagged with `incomingStreamId` — the daemon
+   * fires synthesis concurrently with the `/play_audio` POST, so some
+   * events from the incoming utterance can land BEFORE the POST that
+   * triggers this reset. `incomingStreamId` is the `stream_id` of the
+   * new POST; visemes whose `streamId` matches it belong to the
+   * incoming utterance and must be kept. Visemes with any other
+   * `streamId` (or no `streamId` at all — the pre-tagging case) are
+   * dropped.
    */
-  resetPlaybackTimestamp?(): void;
+  resetPlaybackTimestamp?(incomingStreamId?: string): void;
 }
 
 /**

--- a/skills/meet-join/daemon/__tests__/tts-lipsync.test.ts
+++ b/skills/meet-join/daemon/__tests__/tts-lipsync.test.ts
@@ -314,9 +314,12 @@ describe("MeetTtsBridge.onViseme — provider alignment path", () => {
 
     // Only the alignment events should have been forwarded; no "amp"
     // fallback entries since the provider advertised alignment support.
+    // The bridge stamps every viseme with the active stream id so the
+    // bot can distinguish prior-utterance debris from events racing
+    // ahead of a fresh `/play_audio` POST.
     expect(events).toEqual([
-      { phoneme: "a", weight: 0.3, timestamp: 10 },
-      { phoneme: "e", weight: 0.7, timestamp: 25 },
+      { phoneme: "a", weight: 0.3, timestamp: 10, streamId: "stream-align" },
+      { phoneme: "e", weight: 0.7, timestamp: 25, streamId: "stream-align" },
     ]);
     expect(events.every((e) => e.phoneme !== "amp")).toBe(true);
   });

--- a/skills/meet-join/daemon/tts-bridge.ts
+++ b/skills/meet-join/daemon/tts-bridge.ts
@@ -117,6 +117,19 @@ export interface VisemeEvent {
   weight: number;
   /** Milliseconds from the start of the synthesized utterance. */
   timestamp: number;
+  /**
+   * Optional — `stream_id` of the paired `/play_audio` POST. The bot
+   * uses this to preserve visemes belonging to the incoming utterance
+   * when it resets its viseme buffer on a new POST: synthesis runs
+   * concurrently with the POST, so same-utterance visemes can arrive
+   * at `/avatar/viseme` BEFORE the POST that they belong to lands.
+   * Without this tag the bot would drop them as "prior utterance"
+   * debris. Always populated by {@link MeetTtsBridge} in production;
+   * kept optional so fakes / historical test fixtures that construct
+   * events directly aren't forced to synthesize a stream id they don't
+   * care about.
+   */
+  streamId?: string;
 }
 
 /**
@@ -476,6 +489,7 @@ export class MeetTtsBridge {
               phoneme: event.phoneme,
               weight: clamp01(event.weight),
               timestamp: event.timestamp,
+              streamId,
             });
           }
         : undefined;
@@ -526,7 +540,7 @@ export class MeetTtsBridge {
     // fetch body reader, truncating the audio that reaches the bot.
     let httpBodySource: NodeJS.ReadableStream = ffmpeg.stdout;
     if (useAmplitudeFallback) {
-      const tap = this.createAmplitudeTap(abort.signal);
+      const tap = this.createAmplitudeTap(abort.signal, streamId);
       ffmpeg.stdout.pipe(tap);
       httpBodySource = tap;
     }
@@ -685,7 +699,7 @@ export class MeetTtsBridge {
    * which keeps the calculation self-consistent and spares consumers a
    * ragged-edge weight.
    */
-  private createAmplitudeTap(signal: AbortSignal): Transform {
+  private createAmplitudeTap(signal: AbortSignal, streamId: string): Transform {
     let totalBytesConsumed = 0;
     let windowBuffer = Buffer.alloc(0);
 
@@ -714,7 +728,7 @@ export class MeetTtsBridge {
         const rms = Math.sqrt(sumOfSquares / AMPLITUDE_SAMPLES_PER_WINDOW);
         const weight = clamp01(rms / AMPLITUDE_MAX_SAMPLE);
 
-        this.emitVisemeEvent({ phoneme: "amp", weight, timestamp });
+        this.emitVisemeEvent({ phoneme: "amp", weight, timestamp, streamId });
       }
     };
 


### PR DESCRIPTION
## Summary

Addresses Codex feedback on #27075: the unconditional `visemeBuffer` clear in `resetPlaybackTimestamp()` dropped visemes belonging to the incoming utterance when synthesis raced ahead of the paired `/play_audio` POST (synthesis and POST fire concurrently from the daemon).

## Fix

Tag every viseme with its paired `stream_id` end-to-end:

- **daemon/tts-bridge.ts**: `VisemeEvent` grows an optional `streamId` field; both emit paths (`onAlignment` and the amplitude tap) stamp it with the active stream id.
- **bot/src/media/avatar/types.ts**: `VisemeEvent.streamId?` mirrors the daemon; `AvatarRenderer.resetPlaybackTimestamp?(incomingStreamId?)` takes the new POST's id.
- **bot/src/media/avatar/talking-head/renderer.ts**: `resetPlaybackTimestamp(incomingStreamId)` now keeps visemes whose `streamId === incomingStreamId` (they belong to the incoming utterance) and drops every other buffered event. No argument preserves the original clear-all semantics for legacy/untagged callers.
- **bot/src/control/http-server.ts**: the `/play_audio` handler passes its `streamId` to `resetPlaybackTimestamp`; `parseVisemeEvent` forwards the optional field.

## Tests

- Updated the existing `resetPlaybackTimestamp` regression test to tag visemes with stream ids so the new filter-based semantics are exercised.
- Added `resetPlaybackTimestamp preserves same-streamId visemes that raced ahead of the /play_audio POST` — asserts that u2-tagged visemes pushed BEFORE the reset survive, while a u1-tagged stale viseme is evicted and never leaks.
- Updated the alignment-path assertion in `tts-lipsync.test.ts` to reflect the `streamId` stamp.

Addresses: https://github.com/vellum-ai/vellum-assistant/pull/27075
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
