### PR TITLE
fix(macos/tts): guard Test button against concurrent playTest taps

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TTSServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TTSServiceCard.swift
@@ -106,7 +106,7 @@ struct TTSServiceCard: View {
                     VButton(
                         label: testPlayer.isLoading ? "Testing\u{2026}" : "Test",
                         style: .outlined,
-                        isDisabled: false
+                        isDisabled: testPlayer.isLoading
                     ) {
                         Task { await testPlayer.playTest(text: ttsTestPhrase) }
                     }


### PR DESCRIPTION
## Summary
Addresses Codex P2 + Devin feedback on #26975. Removing the `isLoading` guard let concurrent Test taps spawn racing `playTest` tasks with overlapping audio and an orphaned player.

Restores `isDisabled: testPlayer.isLoading` as a reentrancy guard while keeping the original PR's intent (no gating on unsaved changes or missing keys).

Follow-up to #26975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
