### PR TITLE
fix(macos): restore anthropic/* OpenRouter entries in fallback catalog

### DIFF
--- a/clients/shared/Utilities/LLMProviderRegistry.swift
+++ b/clients/shared/Utilities/LLMProviderRegistry.swift
@@ -337,6 +337,11 @@ private let fallbackCatalog = LLMProviderCatalog(
             ),
             defaultModel: "x-ai/grok-4.20-beta",
             models: [
+                // Anthropic
+                LLMModelEntry(id: "anthropic/claude-opus-4.7", displayName: "Claude Opus 4.7"),
+                LLMModelEntry(id: "anthropic/claude-opus-4.6", displayName: "Claude Opus 4.6"),
+                LLMModelEntry(id: "anthropic/claude-sonnet-4.6", displayName: "Claude Sonnet 4.6"),
+                LLMModelEntry(id: "anthropic/claude-haiku-4.5", displayName: "Claude Haiku 4.5"),
                 // xAI
                 LLMModelEntry(id: "x-ai/grok-4.20-beta", displayName: "Grok 4.20 Beta"),
                 LLMModelEntry(id: "x-ai/grok-4", displayName: "Grok 4"),


### PR DESCRIPTION
## Summary

Addresses Codex feedback on #27123. The Swift OpenRouter fallback catalog was missing the 4 `anthropic/*` entries that the replaced inline `defaultCatalog` had. OpenRouter+Anthropic users would be missing their active model in pickers during pre-fetch windows (before the remote catalog loads).

Restores:
- `anthropic/claude-opus-4.7`
- `anthropic/claude-opus-4.6`
- `anthropic/claude-sonnet-4.6`
- `anthropic/claude-haiku-4.5`

## Test plan
- [ ] Launch macOS app cold (no cached remote catalog) with OpenRouter selected; verify the 4 `anthropic/*` models appear in the model picker before the remote catalog resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
