### PR TITLE
fix(providers): OpenRouter caching flag + align canonical pricing

### DIFF
--- a/assistant/src/__tests__/conversation-usage.test.ts
+++ b/assistant/src/__tests__/conversation-usage.test.ts
@@ -105,8 +105,8 @@ describe("recordUsage", () => {
     expect(events[0].estimatedCostUsd).toBe(
       expectedPricing.estimatedCostUsd ?? null,
     );
-    // Sanity: fast should be 6x standard ($30 * 6 = $180)
-    expect(expectedPricing.estimatedCostUsd).toBe(180);
+    // Sanity: fast should be 6x standard (claude-opus-4-6 at $15/$75 → $90 * 6 = $540)
+    expect(expectedPricing.estimatedCostUsd).toBe(540);
   });
 
   test("stores direct input separately from Anthropic cache usage while keeping live totals combined", () => {

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -19,7 +19,7 @@ describe("resolvePricing", () => {
         1_000_000,
       );
       expect(result.pricingStatus).toBe("priced");
-      expect(result.estimatedCostUsd).toBe(5 + 25);
+      expect(result.estimatedCostUsd).toBe(15 + 75);
     });
 
     test("returns priced for claude-opus-4", () => {
@@ -52,7 +52,7 @@ describe("resolvePricing", () => {
         1_000_000,
       );
       expect(result.pricingStatus).toBe("priced");
-      expect(result.estimatedCostUsd).toBe(0.8 + 4);
+      expect(result.estimatedCostUsd).toBe(1 + 5);
     });
   });
 
@@ -180,7 +180,7 @@ describe("resolvePricing", () => {
         1_000_000,
       );
       expect(result.pricingStatus).toBe("priced");
-      expect(result.estimatedCostUsd).toBe(5 + 25);
+      expect(result.estimatedCostUsd).toBe(15 + 75);
     });
 
     test("matches claude-sonnet-4-6 via claude-sonnet-4 prefix", () => {
@@ -269,7 +269,8 @@ describe("resolvePricingForUsage", () => {
     );
 
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBeCloseTo(57.4, 10);
+    // 15 (input) + 150 (output) + 0.45 (cache-read) + 3.75 (5m write) + 3.0 (1h write) = 172.2
+    expect(result.estimatedCostUsd).toBeCloseTo(172.2, 10);
   });
 
   test("returns unpriced with null cost for unknown provider", () => {
@@ -306,11 +307,15 @@ describe("fast mode pricing", () => {
       speed: "fast",
     };
 
-    const result = resolvePricingForUsage("anthropic", "claude-opus-4-6", usage);
+    const result = resolvePricingForUsage(
+      "anthropic",
+      "claude-opus-4-6",
+      usage,
+    );
 
-    // Base: $5 input + $25 output = $30; fast: $30 * 6 = $180
+    // Base: $15 input + $75 output = $90; fast: $90 * 6 = $540
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe((5 + 25) * 6);
+    expect(result.estimatedCostUsd).toBe((15 + 75) * 6);
   });
 
   test("does not apply multiplier when speed is standard", () => {
@@ -323,10 +328,14 @@ describe("fast mode pricing", () => {
       speed: "standard",
     };
 
-    const result = resolvePricingForUsage("anthropic", "claude-opus-4-6", usage);
+    const result = resolvePricingForUsage(
+      "anthropic",
+      "claude-opus-4-6",
+      usage,
+    );
 
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(5 + 25);
+    expect(result.estimatedCostUsd).toBe(15 + 75);
   });
 
   test("does not apply multiplier when speed is null", () => {
@@ -339,10 +348,14 @@ describe("fast mode pricing", () => {
       speed: null,
     };
 
-    const result = resolvePricingForUsage("anthropic", "claude-opus-4-6", usage);
+    const result = resolvePricingForUsage(
+      "anthropic",
+      "claude-opus-4-6",
+      usage,
+    );
 
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(5 + 25);
+    expect(result.estimatedCostUsd).toBe(15 + 75);
   });
 
   test("fast mode multiplier stacks with cache pricing", () => {
@@ -374,7 +387,9 @@ describe("fast mode pricing", () => {
     expect(fastResult.pricingStatus).toBe("priced");
     expect(standardResult.pricingStatus).toBe("priced");
     // Fast mode applies 6x to base rates; cache multipliers stack on top
-    expect(fastResult.estimatedCostUsd).toBe(standardResult.estimatedCostUsd! * 6);
+    expect(fastResult.estimatedCostUsd).toBe(
+      standardResult.estimatedCostUsd! * 6,
+    );
   });
 
   test("does not apply fast mode multiplier for non-Anthropic providers", () => {
@@ -437,7 +452,7 @@ describe("Anthropic models on OpenRouter", () => {
       1_000_000,
     );
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(5 + 25);
+    expect(result.estimatedCostUsd).toBe(15 + 75);
   });
 
   test("prices anthropic/claude-sonnet-4.6 at Sonnet 4 rates via prefix match", () => {
@@ -459,7 +474,7 @@ describe("Anthropic models on OpenRouter", () => {
       1_000_000,
     );
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(0.8 + 4);
+    expect(result.estimatedCostUsd).toBe(1 + 5);
   });
 
   test("prices bare claude-opus-4-6 slug returned unprefixed", () => {
@@ -470,7 +485,7 @@ describe("Anthropic models on OpenRouter", () => {
       1_000_000,
     );
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(5 + 25);
+    expect(result.estimatedCostUsd).toBe(15 + 75);
   });
 
   test("prices dash-form anthropic/claude-opus-4-6 identically to dot form", () => {
@@ -481,7 +496,7 @@ describe("Anthropic models on OpenRouter", () => {
       1_000_000,
     );
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(5 + 25);
+    expect(result.estimatedCostUsd).toBe(15 + 75);
   });
 
   test("prices version-first anthropic/claude-4.7-opus-<date> at Opus 4.7 rates", () => {
@@ -495,7 +510,7 @@ describe("Anthropic models on OpenRouter", () => {
       1_000_000,
     );
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(5 + 25);
+    expect(result.estimatedCostUsd).toBe(15 + 75);
   });
 
   test("prices version-first dash-form anthropic/claude-4-7-opus-<date>", () => {
@@ -506,7 +521,7 @@ describe("Anthropic models on OpenRouter", () => {
       1_000_000,
     );
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(5 + 25);
+    expect(result.estimatedCostUsd).toBe(15 + 75);
   });
 
   test("prices version-first anthropic/claude-4.6-sonnet", () => {
@@ -528,7 +543,7 @@ describe("Anthropic models on OpenRouter", () => {
       1_000_000,
     );
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(0.8 + 4);
+    expect(result.estimatedCostUsd).toBe(1 + 5);
   });
 
   test("returns unpriced for unknown anthropic model on OpenRouter", () => {
@@ -542,10 +557,21 @@ describe("Anthropic models on OpenRouter", () => {
     expect(result.estimatedCostUsd).toBeNull();
   });
 
-  test("returns unpriced for non-Anthropic OpenRouter model", () => {
+  test("prices non-Anthropic OpenRouter model from catalog", () => {
     const result = resolvePricing(
       "openrouter",
       "x-ai/grok-4.20-beta",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(3 + 15);
+  });
+
+  test("returns unpriced for unknown non-Anthropic OpenRouter model", () => {
+    const result = resolvePricing(
+      "openrouter",
+      "unknown-provider/some-model",
       1_000_000,
       1_000_000,
     );
@@ -566,11 +592,15 @@ describe("Anthropic models on OpenRouter", () => {
       "anthropic/claude-opus-4.6",
       usage,
     );
-    const direct = resolvePricingForUsage("anthropic", "claude-opus-4-6", usage);
+    const direct = resolvePricingForUsage(
+      "anthropic",
+      "claude-opus-4-6",
+      usage,
+    );
 
     // Cache-read tokens are charged at 10% of input rate for Anthropic models.
     expect(openRouter.pricingStatus).toBe("priced");
-    expect(openRouter.estimatedCostUsd).toBeCloseTo(5 * 0.1, 10);
+    expect(openRouter.estimatedCostUsd).toBeCloseTo(15 * 0.1, 10);
     expect(openRouter.estimatedCostUsd).toBe(direct.estimatedCostUsd);
   });
 
@@ -617,13 +647,15 @@ describe("Anthropic models on OpenRouter", () => {
     );
 
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe((5 + 25) * 6);
+    expect(result.estimatedCostUsd).toBe((15 + 75) * 6);
   });
 });
 
 describe("usesAnthropicPricingRules", () => {
   test("returns true for direct Anthropic", () => {
-    expect(usesAnthropicPricingRules("anthropic", "claude-opus-4-6")).toBe(true);
+    expect(usesAnthropicPricingRules("anthropic", "claude-opus-4-6")).toBe(
+      true,
+    );
   });
 
   test("returns true for anthropic/* on OpenRouter", () => {

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -345,16 +345,24 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     },
     models: [
       // Anthropic
+      // OpenRouter proxies anthropic/* through Anthropic's Messages API, so
+      // prompt caching and cache TTL metadata pass through unchanged and
+      // billing matches Anthropic's direct rates.
       {
         id: "anthropic/claude-opus-4.7",
         displayName: "Claude Opus 4.7",
         contextWindowTokens: 200000,
         maxOutputTokens: 32000,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 15, outputPer1mTokens: 75 },
+        pricing: {
+          inputPer1mTokens: 15,
+          outputPer1mTokens: 75,
+          cacheWritePer1mTokens: 18.75,
+          cacheReadPer1mTokens: 1.5,
+        },
       },
       {
         id: "anthropic/claude-opus-4.6",
@@ -362,10 +370,15 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 200000,
         maxOutputTokens: 32000,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 15, outputPer1mTokens: 75 },
+        pricing: {
+          inputPer1mTokens: 15,
+          outputPer1mTokens: 75,
+          cacheWritePer1mTokens: 18.75,
+          cacheReadPer1mTokens: 1.5,
+        },
       },
       {
         id: "anthropic/claude-sonnet-4.6",
@@ -373,10 +386,15 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 200000,
         maxOutputTokens: 64000,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 3, outputPer1mTokens: 15 },
+        pricing: {
+          inputPer1mTokens: 3,
+          outputPer1mTokens: 15,
+          cacheWritePer1mTokens: 3.75,
+          cacheReadPer1mTokens: 0.3,
+        },
       },
       {
         id: "anthropic/claude-haiku-4.5",
@@ -384,10 +402,15 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 200000,
         maxOutputTokens: 16000,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 1, outputPer1mTokens: 5 },
+        pricing: {
+          inputPer1mTokens: 1,
+          outputPer1mTokens: 5,
+          cacheWritePer1mTokens: 1.25,
+          cacheReadPer1mTokens: 0.1,
+        },
       },
       // xAI
       {

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -21,11 +21,11 @@ const ANTHROPIC_FAST_MODE_MULTIPLIER = 6;
  */
 const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
   anthropic: {
-    "claude-opus-4-7": { inputPer1M: 5, outputPer1M: 25 },
-    "claude-opus-4-6": { inputPer1M: 5, outputPer1M: 25 },
+    "claude-opus-4-7": { inputPer1M: 15, outputPer1M: 75 },
+    "claude-opus-4-6": { inputPer1M: 15, outputPer1M: 75 },
     "claude-opus-4": { inputPer1M: 15, outputPer1M: 75 },
     "claude-sonnet-4": { inputPer1M: 3, outputPer1M: 15 },
-    "claude-haiku-4": { inputPer1M: 0.8, outputPer1M: 4 },
+    "claude-haiku-4": { inputPer1M: 1, outputPer1M: 5 },
   },
   openai: {
     "gpt-5.4": { inputPer1M: 2.5, outputPer1M: 15 },
@@ -53,6 +53,29 @@ const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
       inputPer1M: 0.6,
       outputPer1M: 3.0,
     },
+  },
+  // Non-Anthropic OpenRouter models. Anthropic-on-OpenRouter is handled by a
+  // dedicated branch in resolvePricingForUsage that routes to the Anthropic
+  // catalog (OpenRouter bills those at Anthropic's direct rates). Rates here
+  // mirror the catalog metadata in model-catalog.ts so cost tracking has a
+  // priced value instead of falling back to 'unpriced'.
+  openrouter: {
+    "x-ai/grok-4.20-beta": { inputPer1M: 3, outputPer1M: 15 },
+    "x-ai/grok-4": { inputPer1M: 3, outputPer1M: 15 },
+    "deepseek/deepseek-r1-0528": { inputPer1M: 0.55, outputPer1M: 2.19 },
+    "deepseek/deepseek-chat-v3-0324": { inputPer1M: 0.27, outputPer1M: 1.1 },
+    "qwen/qwen3.5-plus-02-15": { inputPer1M: 0.8, outputPer1M: 2.4 },
+    "qwen/qwen3.5-397b-a17b": { inputPer1M: 0.9, outputPer1M: 2.7 },
+    "qwen/qwen3.5-flash-02-23": { inputPer1M: 0.2, outputPer1M: 0.6 },
+    "qwen/qwen3-coder-next": { inputPer1M: 0.5, outputPer1M: 1.5 },
+    "moonshotai/kimi-k2.6": { inputPer1M: 0.6, outputPer1M: 2.8 },
+    "moonshotai/kimi-k2.5": { inputPer1M: 0.6, outputPer1M: 2.5 },
+    "mistralai/mistral-medium-3": { inputPer1M: 0.4, outputPer1M: 2.0 },
+    "mistralai/mistral-small-2603": { inputPer1M: 0.2, outputPer1M: 0.6 },
+    "mistralai/devstral-2512": { inputPer1M: 0.1, outputPer1M: 0.3 },
+    "meta-llama/llama-4-maverick": { inputPer1M: 0.27, outputPer1M: 0.85 },
+    "meta-llama/llama-4-scout": { inputPer1M: 0.11, outputPer1M: 0.34 },
+    "amazon/nova-pro-v1": { inputPer1M: 0.8, outputPer1M: 3.2 },
   },
 };
 

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -308,12 +308,14 @@
           "contextWindowTokens": 200000,
           "maxOutputTokens": 32000,
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 15,
-            "outputPer1mTokens": 75
+            "outputPer1mTokens": 75,
+            "cacheWritePer1mTokens": 18.75,
+            "cacheReadPer1mTokens": 1.5
           }
         },
         {
@@ -322,12 +324,14 @@
           "contextWindowTokens": 200000,
           "maxOutputTokens": 32000,
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 15,
-            "outputPer1mTokens": 75
+            "outputPer1mTokens": 75,
+            "cacheWritePer1mTokens": 18.75,
+            "cacheReadPer1mTokens": 1.5
           }
         },
         {
@@ -336,12 +340,14 @@
           "contextWindowTokens": 200000,
           "maxOutputTokens": 64000,
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 3,
-            "outputPer1mTokens": 15
+            "outputPer1mTokens": 15,
+            "cacheWritePer1mTokens": 3.75,
+            "cacheReadPer1mTokens": 0.3
           }
         },
         {
@@ -350,12 +356,14 @@
           "contextWindowTokens": 200000,
           "maxOutputTokens": 16000,
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 1,
-            "outputPer1mTokens": 5
+            "outputPer1mTokens": 5,
+            "cacheWritePer1mTokens": 1.25,
+            "cacheReadPer1mTokens": 0.1
           }
         },
         {


### PR DESCRIPTION
## Summary

Addresses review feedback from #27119:

- `supportsCaching` is now `true` for `anthropic/*` OpenRouter models (they proxy through Anthropic's Messages API, preserving prompt caching).
- `pricing.ts` Anthropic rates aligned to canonical values from #27116 (Opus 4.6/4.7 at 15/75, Haiku 4 at 1/5) — fixes the ~3x mismatch vs. the catalog.
- Non-Anthropic OpenRouter models (xAI, DeepSeek, Qwen, Moonshot, Mistral, Meta, Amazon) now have cost-tracking pricing via a new `openrouter` entry in `PROVIDER_PRICING`.

## Test plan

- [x] Updated `pricing.test.ts` expected values for 15/75 and 1/5 rates.
- [x] Updated `conversation-usage.test.ts` fast-mode sanity check ($90 * 6 = $540).
- [x] Refreshed `meta/llm-provider-catalog.json` to keep the daemon↔client parity guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
