### PR TITLE
fix(macos): treat unresolvable lockfile entry as remote during re-bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -243,6 +243,12 @@ extension AppDelegate {
     /// it. Bootstrap will still skip the (now-wiped) in-memory credentials
     /// and re-import from the file, which is the intended local fallback.
     ///
+    /// If the lockfile entry can't be resolved (malformed/legacy lockfile,
+    /// missing entry), the hatch classification is ambiguous. Default to
+    /// treating it as remote — i.e. delete the file — so we match pre-PR
+    /// behavior and never silently re-arm a stale token on a misclassified
+    /// remote hatch.
+    ///
     /// If the delete is attempted but fails (e.g. filesystem permissions),
     /// the stale file would otherwise be re-imported by
     /// `performInitialBootstrap()`, defeating the fix. In that case pass
@@ -255,7 +261,16 @@ extension AppDelegate {
         var skipFileImport = false
         if let assistantId = LockfileAssistant.loadActiveAssistantId() {
             let assistant = LockfileAssistant.loadByName(assistantId)
-            let isRemoteHatch = assistant?.isRemote ?? false
+            // When the lockfile entry can't be resolved (malformed/legacy
+            // lockfile, missing entry, read failure) default to treating the
+            // hatch as remote. Pre-PR behavior unconditionally deleted the
+            // token file; defaulting ambiguous state to "remote" preserves
+            // that safety so we never silently re-arm a stale token on a
+            // remote hatch we failed to classify.
+            let isRemoteHatch = assistant?.isRemote ?? true
+            if assistant == nil {
+                log.warning("forceReBootstrap: could not resolve lockfile entry for active assistant — treating as remote hatch to preserve delete-on-rebootstrap safety")
+            }
             if isRemoteHatch {
                 let deleted = GuardianTokenFileReader.deleteTokenFile(assistantId: assistantId)
                 if !deleted {


### PR DESCRIPTION
Addresses Codex feedback on #27068.

When `LockfileAssistant.loadByName` returned `nil` (malformed/legacy lockfile, missing entry, read failure), `isRemoteHatch` defaulted to `false`, silently preserving a stale `guardian-token.json`. Previously this path unconditionally deleted the file, so that was a safety regression for remote hatches whose lockfile entry happened to be unresolvable.

Flip the default: when the entry can't be resolved, treat the hatch as remote and delete the token file. Pre-PR behavior always deleted; this restores the same safety for ambiguous state and only preserves the file on a positively-classified local/bare-metal hatch. Also log a warning when lockfile resolution fails so the classification decision is visible.

## Test plan
- [ ] Re-pair with a missing/malformed lockfile entry — confirm `guardian-token.json` is deleted and bootstrap drives a genuine reprovision path (or HTTP fallback) rather than re-importing a stale token.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
