### PR TITLE
fix(macos): keep library app open alongside new-conversation draft

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -147,6 +147,13 @@ final class ConversationManager: ConversationRestorerDelegate {
         set { selectionStore.draftViewModel = newValue }
     }
 
+    /// The draft's pre-assigned local UUID, available whenever a draft VM exists.
+    /// Callers use this to install selections like `.appEditing(_, draftLocalId)`
+    /// that survive the draft-to-committed promotion.
+    var draftLocalId: UUID? {
+        selectionStore.draftLocalId
+    }
+
     var pendingAnchorMessageId: UUID? {
         get { selectionStore.pendingAnchorMessageId }
         set { selectionStore.pendingAnchorMessageId = newValue }
@@ -535,6 +542,10 @@ final class ConversationManager: ConversationRestorerDelegate {
             self?.promoteDraft(fromUserSend: true)
         }
         selectionStore.draftViewModel = viewModel
+        // Pre-generate the local UUID so overlay selections like
+        // `.appEditing(_, draftLocalId)` are valid during draft mode and stay
+        // valid across promotion (promoteDraft reuses this id).
+        selectionStore.draftLocalId = UUID()
         selectionStore.performDeactivation()
         activityStore.observeActiveViewModel(viewModel.messageManager)
         log.info("Entered draft mode")
@@ -543,8 +554,11 @@ final class ConversationManager: ConversationRestorerDelegate {
     private func promoteDraft(fromUserSend: Bool) {
         guard let viewModel = selectionStore.draftViewModel else { return }
 
-        let conversation = ConversationModel(title: "Untitled", groupId: ConversationGroup.all.id)
-        let localId = conversation.id
+        // Reuse the draft's pre-assigned local UUID so any selection that
+        // references it (e.g. `.appEditing(_, draftLocalId)`) stays valid
+        // without an extra state transition after promotion.
+        let localId = selectionStore.draftLocalId ?? UUID()
+        let conversation = ConversationModel(id: localId, title: "Untitled", groupId: ConversationGroup.all.id)
         listStore.conversations.insert(conversation, at: 0)
         selectionStore.chatViewModels[conversation.id] = viewModel
         activityStore.observeBusyState(for: conversation.id, messageManager: viewModel.messageManager)
@@ -553,6 +567,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         selectionStore.touchVMAccessOrder(conversation.id)
         selectionStore.scheduleEvictionIfNeeded()
         selectionStore.draftViewModel = nil
+        selectionStore.draftLocalId = nil
 
         if fromUserSend {
             selectionStore.completedConversationCount += 1

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift
@@ -56,6 +56,7 @@ final class ConversationSelectionStore {
         guard conversationId != activeConversationId else { return }
         // Switching to a real conversation discards any draft.
         draftViewModel = nil
+        draftLocalId = nil
         activeConversationId = conversationId
 
         let vm = getOrCreateViewModel(for: conversationId)
@@ -90,6 +91,13 @@ final class ConversationSelectionStore {
     // MARK: - Draft Mode
 
     var draftViewModel: ChatViewModel?
+
+    /// Pre-generated local UUID for the current draft. Assigned alongside
+    /// `draftViewModel` in ``ConversationManager.enterDraftMode`` and reused by
+    /// ``ConversationManager.promoteDraft`` as the final `ConversationModel.id`,
+    /// so selections like `.appEditing(_, draftLocalId)` remain valid across the
+    /// draft-to-committed transition without rewriting state.
+    var draftLocalId: UUID?
 
     // MARK: - Anchor / Highlight
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -40,6 +40,14 @@ extension MainWindowView {
             } else {
                 windowState.selection = .conversation(id)
             }
+        } else if let appId = windowState.activeAppId,
+                  let draftLocalId = conversationManager.draftLocalId {
+            // Draft mode with an app open: keep the app docked next to the new
+            // draft. The draft's pre-assigned UUID is reused when the draft is
+            // promoted on first send, so the selection stays valid throughout.
+            // persistentConversationId is preserved so navigation-back returns
+            // to the prior conversation the user was editing alongside the app.
+            windowState.setAppEditing(appId: appId, conversationId: draftLocalId)
         } else {
             // Draft mode — clear selection so no sidebar conversation is highlighted
             windowState.selection = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -360,6 +360,27 @@ struct MainWindowView: View {
                             windowState.applySelectionCorrection(nil)
                         }
                     }
+                } else if case .appEditing(let appId, let id) = newSelection {
+                    // Validate the app-editing target. Nav history can replay an
+                    // `.appEditing` whose conversationId references an abandoned
+                    // draft (after switching to another conversation cleared
+                    // `draftLocalId`) or an archived conversation. Without this
+                    // guard the dock keeps rendering the previous
+                    // `activeConversationId` while the sidebar highlights
+                    // nothing — a mixed state the user lands in on Back.
+                    let isCommittedAndVisible = listStore.conversations.contains { $0.id == id && !$0.isArchived }
+                    let isCurrentDraft = conversationManager.draftLocalId == id
+                    if isCommittedAndVisible {
+                        // Sync ConversationManager so the chat dock targets
+                        // this conversation even when we arrived here via a
+                        // history replay rather than a sidebar click.
+                        if conversationManager.activeConversationId != id {
+                            conversationManager.selectConversation(id: id)
+                        }
+                    } else if !isCurrentDraft {
+                        // Stale target — drop the dock but keep the app visible.
+                        windowState.applySelectionCorrection(.app(appId))
+                    }
                 }
 
                 // Sync surface and chat dock state when selection changes

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -228,6 +228,16 @@ struct MainWindowView: View {
     }
 
     func enterAppEditing(appId: String) {
+        // Draft mode: dock onto the draft directly using its pre-assigned local
+        // UUID. Going through resolveConversationId here would route to a stale
+        // committed conversation (visibleConversations.first), and calling
+        // selectConversation with the draft id would fail because the draft
+        // isn't in the conversation list until first-message promotion.
+        if conversationManager.activeConversationId == nil,
+           let draftLocalId = conversationManager.draftLocalId {
+            windowState.setAppEditing(appId: appId, conversationId: draftLocalId)
+            return
+        }
         guard let conversationId = resolveConversationId() else {
             // No committed conversation available — createConversation() entered draft
             // mode, which has no UUID until first user send. Fall back to `.app(appId)`


### PR DESCRIPTION
## Summary

When a library app is open side-by-side with a conversation (`.appEditing`), clicking "New Conversation" collapsed the app, and re-opening it afterward routed the chat dock to an unrelated conversation instead of the new draft.

## Implementation

Makes the draft's local UUID a first-class concept so `.appEditing(appId, draftLocalId)` can be a valid selection across the entire draft lifecycle.

- `ConversationSelectionStore` gains `draftLocalId: UUID?`, nil'd in lockstep with `draftViewModel` (including in `performActivation`).
- `ConversationManager.enterDraftMode` pre-generates the UUID.
- `ConversationManager.promoteDraft` reuses that UUID as the new `ConversationModel.id`, so the in-flight selection stays valid across draft-to-committed promotion with no extra state transition.
- `ConversationManager.draftLocalId` is exposed as a read-only computed property for call sites.

## Key Technical Choices

**Draft mode + `.appEditing` compatibility via pre-generated UUID.** `.appEditing` requires a `UUID`, but draft mode leaves `activeConversationId` as nil until first message. Pre-generating a UUID in `enterDraftMode` and reusing it in `promoteDraft` threads the needle without changing `.appEditing`'s signature. Alternatives considered: a new `.appEditingDraft(appId)` case (rejected — duplicates the rendering path and forces every `switch` to update); making the UUID optional (rejected — noisier pattern matches, no payoff); eagerly committing the draft to the conversation list (rejected — diverges from #25407's deliberate "no sidebar row until first message" invariant).

**Two targeted call-site fixes.**
- `startNewConversation`: in draft mode with an active app, install `.appEditing(appId, draftLocalId)` instead of clearing selection. `persistentConversationId` is preserved (unlike the non-app path) so nav-back returns to the prior conversation the user was editing alongside the app.
- `enterAppEditing`: short-circuit to the draft's UUID when `activeConversationId == nil`, before `resolveConversationId`. Going through the resolver would route to `visibleConversations.first` (stale) and calling `selectConversation` on the draft UUID would fail because the draft isn't in the list until promotion.

## Files Changed

- [`ConversationSelectionStore.swift`](clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift) — new `draftLocalId` property; nil alongside `draftViewModel` in `performActivation`.
- [`ConversationManager.swift`](clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift) — expose `draftLocalId`; assign in `enterDraftMode`; reuse in `promoteDraft`.
- [`MainWindowView+Sidebar.swift`](clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift) — new draft-mode branch in `startNewConversation`.
- [`MainWindowView.swift`](clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift) — draft-mode short-circuit in `enterAppEditing`.

## Testing

1. Open a library app and a conversation — side-by-side `.appEditing` works as before.
2. Click **New Conversation** from `.appEditing`: the app stays docked and the chat dock shows the new draft (empty composer ready to type).
3. Type and send a message: the draft promotes to a real conversation using the same UUID, the sidebar row appears, and `.appEditing` stays intact — no flicker, no re-selection.
4. From the post-bug state ("New conversation" empty screen with no app), open the Library and click an app: now gets `.appEditing` with the draft (via the `enterAppEditing` short-circuit), not the previously-selected conversation.
5. Navigate back after step 2/3 — returns to the prior `.appEditing(_, convA)` state (persistentConversationId preserved).
6. Regression checks: switching between existing conversations while an app is open still works (`selectConversation` path unchanged); cold-launch still lands on draft mode; sidebar highlight still matches committed conversations only.

### Existing test failures

`swift test` on the worktree shows 3 pre-existing failures on `main` at v0.6.5 (unrelated to this change): `testExactForkCommandOnUnsavedDraftShowsLocalErrorWithoutAppendingBubble`, `conversationListRestoresAllAndSetsOffset`, `preMigrationItemsSortBelowNewlyArchived`. Verified by running the suite with changes stashed — same 3 failures.

## Related

- [#25570](https://github.com/vellum-ai/vellum-assistant/pull/25570) added the "keep app open on conversation switch" behavior for committed conversations but missed the draft path — this PR closes that gap.
- [#26160](https://github.com/vellum-ai/vellum-assistant/pull/26160) / LUM-968 established that `.appEditing` falls back to `.app(appId)` (no dock) when no committed conversation exists. This PR refines that: when a draft exists, use its UUID instead of giving up on the dock.
- [#25407](https://github.com/vellum-ai/vellum-assistant/pull/25407) made draft mode the cold-launch default, which is what made this bug common enough to notice.

## Deferred Work

Follow-up: [LUM-1091](https://linear.app/vellum/issue/LUM-1091/split-activeappid-from-selection-in-mainwindowstate-decouple-app) — split `activeAppId` from `selection` so the two axes vary independently; once that lands, the draft-UUID scaffolding introduced here can be reverted.


A longer-term architectural refactor — splitting `activeAppId` from `selection` into orthogonal axes so app visibility and conversation identity vary independently — would eliminate the UUID coupling entirely. Out of scope here; the targeted fix respects the existing `.appEditing` contract with no breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

