### PR TITLE
docs(swift): rewrite ProviderEnvVarRegistry docstring to describe current state

### DIFF
--- a/clients/shared/Utilities/ProviderEnvVarRegistry.swift
+++ b/clients/shared/Utilities/ProviderEnvVarRegistry.swift
@@ -7,11 +7,10 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Provi
 ///
 /// The JSON file lives at `meta/provider-env-vars.json` and is the single
 /// source of truth for **search-provider** env var mappings (e.g. Brave,
-/// Perplexity). LLM-provider env vars have moved into the LLM provider
-/// catalog (`meta/llm-provider-catalog.json`, surfaced via
-/// `LLMProviderRegistry`). Callers that need the combined LLM + search
-/// mapping should merge both sources — see `VellumCli.providerEnvVars`
-/// for the canonical combination.
+/// Perplexity). LLM-provider env vars live in the LLM provider catalog
+/// (`meta/llm-provider-catalog.json`, surfaced via `LLMProviderRegistry`).
+/// Callers that need the combined LLM + search mapping should merge both
+/// sources — see `VellumCli.providerEnvVars` for the canonical combination.
 public struct ProviderEnvVarRegistry: Decodable {
     public let version: Int
     /// Provider identifiers (e.g. "brave") mapped to their env var name


### PR DESCRIPTION
Addresses [Devin review feedback on #27131](https://github.com/vellum-ai/vellum-assistant/pull/27131) flagging historical narration in a code comment.

## Summary
- Rewrites the `ProviderEnvVarRegistry` docstring in `clients/shared/Utilities/ProviderEnvVarRegistry.swift` to describe current state only ("LLM-provider env vars live in the LLM provider catalog") instead of narrating the refactor ("have moved into").
- The companion `assistant/src/providers/provider-env-vars.ts` docstring Devin also flagged was already cleaned up by a later PR in the same LLM Provider Catalog stack — no change needed there.

## Why
`clients/AGENTS.md` Comment Quality rule prohibits historical narration in code comments. The comment should describe the code as it is now, not how it got here.

## Test plan
- [x] Comment-only change; no behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
