### PR TITLE
fix(meet-join): use TCP instead of Unix socket for audio ingest

### DIFF
--- a/skills/meet-join/bot/__tests__/audio-capture.test.ts
+++ b/skills/meet-join/bot/__tests__/audio-capture.test.ts
@@ -204,7 +204,8 @@ describe("startAudioCapture — argv + defaults", () => {
     const sock = recordingSocket();
 
     const capture = await startAudioCapture({
-      socketPath: "/tmp/test.sock",
+      daemonHost: "127.0.0.1",
+      daemonPort: 9000,
       spawn: (argv) => {
         spawnedArgv.push([...argv]);
         return proc;
@@ -231,7 +232,8 @@ describe("startAudioCapture — argv + defaults", () => {
     const sock = recordingSocket();
 
     const capture = await startAudioCapture({
-      socketPath: "/tmp/test.sock",
+      daemonHost: "127.0.0.1",
+      daemonPort: 9000,
       sourceDevice: "custom_source.monitor",
       rateHz: 48_000,
       spawn: (argv) => {
@@ -253,21 +255,24 @@ describe("startAudioCapture — argv + defaults", () => {
     await capture.stop();
   });
 
-  test("passes the socketPath verbatim to the connect factory", async () => {
+  test("passes daemonHost and daemonPort verbatim to the connect factory", async () => {
     const { proc } = fakeParec([]);
     const sock = recordingSocket();
-    const seenPaths: string[] = [];
+    const seenTargets: Array<{ host: string; port: number }> = [];
 
     const capture = await startAudioCapture({
-      socketPath: "/var/run/meet/audio-xyz.sock",
+      daemonHost: "host.docker.internal",
+      daemonPort: 42173,
       spawn: () => proc,
-      connect: (path) => {
-        seenPaths.push(path);
+      connect: (host, port) => {
+        seenTargets.push({ host, port });
         return sock;
       },
     });
 
-    expect(seenPaths).toEqual(["/var/run/meet/audio-xyz.sock"]);
+    expect(seenTargets).toEqual([
+      { host: "host.docker.internal", port: 42173 },
+    ]);
     await capture.stop();
   });
 
@@ -278,7 +283,8 @@ describe("startAudioCapture — argv + defaults", () => {
     let thrown: unknown;
     try {
       await startAudioCapture({
-        socketPath: "/tmp/x.sock",
+        daemonHost: "127.0.0.1",
+        daemonPort: 9000,
         frameBytes: 0,
         spawn: () => proc,
         connect: () => sock,
@@ -306,7 +312,8 @@ describe("startAudioCapture — framing", () => {
     const sock = recordingSocket();
 
     const capture = await startAudioCapture({
-      socketPath: "/tmp/t.sock",
+      daemonHost: "127.0.0.1",
+      daemonPort: 9000,
       spawn: () => proc,
       connect: () => sock,
     });
@@ -335,7 +342,8 @@ describe("startAudioCapture — framing", () => {
     const sock = recordingSocket();
 
     const capture = await startAudioCapture({
-      socketPath: "/tmp/t.sock",
+      daemonHost: "127.0.0.1",
+      daemonPort: 9000,
       frameBytes,
       spawn: () => proc,
       connect: () => sock,
@@ -358,7 +366,8 @@ describe("startAudioCapture — framing", () => {
     const sock = recordingSocket();
 
     const capture = await startAudioCapture({
-      socketPath: "/tmp/t.sock",
+      daemonHost: "127.0.0.1",
+      daemonPort: 9000,
       frameBytes,
       spawn: () => proc,
       connect: () => sock,
@@ -389,7 +398,8 @@ describe("startAudioCapture — reconnect", () => {
     const sock = recordingSocket();
 
     const capture = await startAudioCapture({
-      socketPath: "/tmp/t.sock",
+      daemonHost: "127.0.0.1",
+      daemonPort: 9000,
       spawn: (argv) => {
         spawnCalls.push([...argv]);
         const p = procs[spawnIdx++];
@@ -413,7 +423,8 @@ describe("startAudioCapture — reconnect", () => {
     // must reject with an Error mentioning the retry exhaustion.
     let spawnCount = 0;
     const capture = await startAudioCapture({
-      socketPath: "/tmp/t.sock",
+      daemonHost: "127.0.0.1",
+      daemonPort: 9000,
       spawn: () => {
         spawnCount += 1;
         return fakeFailedParec(1);
@@ -445,7 +456,8 @@ describe("startAudioCapture — reconnect", () => {
     const errors: Error[] = [];
     let spawnCount = 0;
     const capture = await startAudioCapture({
-      socketPath: "/tmp/t.sock",
+      daemonHost: "127.0.0.1",
+      daemonPort: 9000,
       onError: (err) => errors.push(err),
       spawn: () => {
         spawnCount += 1;
@@ -478,7 +490,8 @@ describe("startAudioCapture — stop semantics", () => {
     const sock = recordingSocket();
 
     const capture = await startAudioCapture({
-      socketPath: "/tmp/t.sock",
+      daemonHost: "127.0.0.1",
+      daemonPort: 9000,
       spawn: () => proc,
       connect: () => sock,
     });
@@ -498,7 +511,8 @@ describe("startAudioCapture — stop semantics", () => {
     const sock = recordingSocket();
 
     const capture = await startAudioCapture({
-      socketPath: "/tmp/t.sock",
+      daemonHost: "127.0.0.1",
+      daemonPort: 9000,
       spawn: () => proc,
       connect: () => sock,
     });
@@ -521,7 +535,8 @@ describe("startAudioCapture — stop semantics", () => {
     let spawnIdx = 0;
 
     const capture = await startAudioCapture({
-      socketPath: "/tmp/t.sock",
+      daemonHost: "127.0.0.1",
+      daemonPort: 9000,
       spawn: () => procs[spawnIdx++]!,
       connect: () => (connectIdx++ === 0 ? sock1 : sock2),
     });

--- a/skills/meet-join/bot/__tests__/main.test.ts
+++ b/skills/meet-join/bot/__tests__/main.test.ts
@@ -151,7 +151,8 @@ function makeDeps(opts: MakeDepsOpts = {}): {
     consentMessage: "Hi, I'm an AI assistant listening in.",
     daemonUrl: "http://daemon.local:7000",
     botApiToken: "secret",
-    socketDir: "/sockets",
+    daemonAudioHost: "host.docker.internal",
+    daemonAudioPort: 42173,
     skipPulse: true,
     httpPort: 0,
     extensionPath: "/app/ext",
@@ -276,7 +277,11 @@ function makeDeps(opts: MakeDepsOpts = {}): {
       if (opts.xdotoolTypeError) throw opts.xdotoolTypeError;
     },
     startAudioCapture: async (audioOpts) => {
-      calls.push({ kind: "audio.start", socketPath: audioOpts.socketPath });
+      calls.push({
+        kind: "audio.start",
+        daemonHost: audioOpts.daemonHost,
+        daemonPort: audioOpts.daemonPort,
+      });
       return {
         stop: async () => {
           audioStops += 1;
@@ -495,13 +500,14 @@ describe("runBot — boot sequence", () => {
     expect(lifecycleStates).not.toContain("error");
   });
 
-  test("audio capture uses socketDir/audio.sock", async () => {
+  test("audio capture dials DAEMON_AUDIO_HOST:DAEMON_AUDIO_PORT", async () => {
     BotState.__resetForTests();
     const { deps, handles } = makeDeps();
     await bootHappyPath(deps, handles);
 
     const audioCall = handles.calls.find((c) => c.kind === "audio.start");
-    expect(audioCall?.socketPath).toBe("/sockets/audio.sock");
+    expect(audioCall?.daemonHost).toBe("host.docker.internal");
+    expect(audioCall?.daemonPort).toBe(42173);
   });
 });
 

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -120,8 +120,18 @@ interface BotEnv {
   consentMessage: string | undefined;
   daemonUrl: string | undefined;
   botApiToken: string | undefined;
-  /** Directory containing `audio.sock` — defaults to `/sockets`. */
-  socketDir: string;
+  /**
+   * Host to dial for the daemon's audio-ingest TCP port. Defaults to
+   * `host.docker.internal` — the alias Docker sets via `ExtraHosts` so the
+   * bot can reach its parent daemon on the host.
+   */
+  daemonAudioHost: string;
+  /**
+   * TCP port the daemon's audio-ingest server is listening on. Required —
+   * the session manager picks an ephemeral port and threads it through so
+   * multiple bots can coexist without colliding on a fixed port.
+   */
+  daemonAudioPort: number | undefined;
   /** When "1", skip PulseAudio setup — used by the boot smoke test. */
   skipPulse: boolean;
   /** Bind port for the HTTP control surface. Defaults to 3000. */
@@ -194,7 +204,10 @@ function readEnv(env: NodeJS.ProcessEnv = process.env): BotEnv {
     consentMessage: env.CONSENT_MESSAGE,
     daemonUrl: env.DAEMON_URL,
     botApiToken: env.BOT_API_TOKEN,
-    socketDir: env.SOCKET_DIR ?? "/sockets",
+    daemonAudioHost: env.DAEMON_AUDIO_HOST ?? "host.docker.internal",
+    daemonAudioPort: env.DAEMON_AUDIO_PORT
+      ? Number(env.DAEMON_AUDIO_PORT)
+      : undefined,
     skipPulse: env.SKIP_PULSE === "1",
     httpPort: env.HTTP_PORT ? Number(env.HTTP_PORT) : 3000,
     extensionPath: env.EXTENSION_PATH ?? "/app/ext",
@@ -892,9 +905,39 @@ export async function runBot(deps: BotDeps): Promise<void> {
 
     // ---------------------------------------------------------------------
     // Step 7 — audio capture.
+    //
+    // Dials the daemon's audio-ingest TCP port on `host.docker.internal`.
+    // If the port is missing we fail the boot: the bot cannot do useful
+    // work without streaming audio, and a silent no-op would manifest
+    // downstream as the daemon's 120s "bot did not connect" timeout.
     // ---------------------------------------------------------------------
+    if (env.daemonAudioPort === undefined || Number.isNaN(env.daemonAudioPort)) {
+      await shutdown(
+        "error",
+        "DAEMON_AUDIO_PORT env var is missing or not a number",
+      );
+      detachSigterm();
+      detachSigint();
+      deps.exit(1);
+      return;
+    }
     subsystems.audioCapture = await deps.startAudioCapture({
-      socketPath: `${env.socketDir}/audio.sock`,
+      daemonHost: env.daemonAudioHost,
+      daemonPort: env.daemonAudioPort,
+      onError: (err) => {
+        // Exhausted reconnect budget — the daemon is unreachable or the
+        // pipeline is flapping. Shut the bot down so the daemon rolls the
+        // container back instead of waiting out its 120s join timeout.
+        if (shutdownInProgress) return;
+        deps.logError(`meet-bot: audio capture fatal: ${errMsg(err)}`);
+        void shutdown("error", `audio capture failed: ${errMsg(err)}`).then(
+          () => {
+            detachSigterm();
+            detachSigint();
+            deps.exit(1);
+          },
+        );
+      },
     });
     if (shutdownInProgress) return;
 

--- a/skills/meet-join/bot/src/media/audio-capture.ts
+++ b/skills/meet-join/bot/src/media/audio-capture.ts
@@ -3,10 +3,16 @@
  *
  * Spawns `parec` against the `meet_capture.monitor` Pulse source (set up by
  * `pulse-setup.sh` in PR 5), chunks the raw PCM stream into fixed-size
- * frames, and writes those frames into a Unix socket whose server end is
- * opened by the daemon (`MeetAudioIngest`, PR 16) on the host. The socket
- * path is bind-mounted into the container so the bot can connect as a
- * client.
+ * frames, and writes those frames into a TCP socket whose server end is
+ * opened by the daemon (`MeetAudioIngest`) on the host loopback interface.
+ * The bot dials `host.docker.internal:<port>` to reach it.
+ *
+ * TCP (rather than a Unix-domain socket over a bind mount) is required
+ * because Docker Desktop on macOS exposes the socket file through its
+ * VirtioFS/gRPC-FUSE layer but the kernel rejects `connect()` with
+ * `EOPNOTSUPP` — so Unix sockets across the host↔VM mount boundary work
+ * on Linux only. Loopback TCP traverses `host.docker.internal` cleanly on
+ * every platform the bot runs on.
  *
  * Defaults are tuned for Deepgram's realtime STT: s16le mono 16kHz with
  * 20ms frames (320 bytes = 160 samples * 2 bytes). Callers can override the
@@ -66,10 +72,12 @@ const STABILITY_WINDOW_SECONDS = 2;
 
 export interface AudioCaptureOptions {
   /**
-   * Absolute path to the Unix socket the daemon is listening on. The daemon
-   * owns the server end; the bot is the client.
+   * Host to dial for the daemon's audio server. In production the bot reaches
+   * the daemon via `host.docker.internal`; tests pass `127.0.0.1`.
    */
-  socketPath: string;
+  daemonHost: string;
+  /** TCP port the daemon's audio server is listening on. */
+  daemonPort: number;
   /**
    * Pulse source to capture from. Defaults to the monitor of the
    * `meet_capture` null-sink created by `pulse-setup.sh`.
@@ -155,7 +163,7 @@ export interface CapturedSocket {
   ): void;
 }
 
-export type ConnectFactory = (socketPath: string) => CapturedSocket;
+export type ConnectFactory = (host: string, port: number) => CapturedSocket;
 
 /** Default spawn factory — delegates to `Bun.spawn` with the parec flags. */
 function defaultSpawn(argv: readonly string[]): SpawnedParec {
@@ -171,9 +179,9 @@ function defaultSpawn(argv: readonly string[]): SpawnedParec {
   };
 }
 
-/** Default connect factory — a Node `net.createConnection` over a Unix path. */
-function defaultConnect(socketPath: string): CapturedSocket {
-  const sock: NetSocket = netCreateConnection({ path: socketPath });
+/** Default connect factory — a Node `net.createConnection` over loopback TCP. */
+function defaultConnect(host: string, port: number): CapturedSocket {
+  const sock: NetSocket = netCreateConnection({ host, port });
   return {
     write: (chunk) => sock.write(chunk),
     end: () => sock.end(),
@@ -293,7 +301,7 @@ export async function startAudioCapture(
     // 2. Connect to the daemon socket.
     let sock: CapturedSocket;
     try {
-      sock = connect(opts.socketPath);
+      sock = connect(opts.daemonHost, opts.daemonPort);
     } catch (err) {
       // Socket open failed synchronously — kill parec and report.
       try {

--- a/skills/meet-join/daemon/__tests__/audio-ingest.test.ts
+++ b/skills/meet-join/daemon/__tests__/audio-ingest.test.ts
@@ -32,8 +32,8 @@ import {
   BOT_CONNECT_TIMEOUT_MS,
   MeetAudioIngest,
   MeetAudioIngestError,
-  type UnixSocketConnection,
-  type UnixSocketServer,
+  type AudioIngestConnection,
+  type AudioIngestServer,
 } from "../audio-ingest.js";
 import {
   __resetMeetSessionEventRouterForTests,
@@ -99,7 +99,7 @@ class FakeStreamingTranscriber implements StreamingTranscriber {
  * Fake socket connection. Tests drive it by calling `emitData`, `emitClose`
  * and `emitError` to exercise the ingest's inbound handlers.
  */
-class FakeSocketConnection implements UnixSocketConnection {
+class FakeSocketConnection implements AudioIngestConnection {
   readonly dataListeners: Array<(chunk: Buffer) => void> = [];
   readonly closeListeners: Array<() => void> = [];
   readonly errorListeners: Array<(err: Error) => void> = [];
@@ -141,13 +141,18 @@ class FakeSocketConnection implements UnixSocketConnection {
  * Fake unix-socket server. `listen()` returns one of these; tests trigger
  * a bot connection by calling `connectBot()`.
  */
-class FakeUnixSocketServer implements UnixSocketServer {
-  private connectionListeners: Array<(conn: UnixSocketConnection) => void> = [];
+class FakeAudioIngestServer implements AudioIngestServer {
+  readonly port: number;
+  private connectionListeners: Array<(conn: AudioIngestConnection) => void> = [];
   private errorListeners: Array<(err: Error) => void> = [];
   closed = false;
   closedPromiseResolved = false;
 
-  onConnection(listener: (conn: UnixSocketConnection) => void): void {
+  constructor(port = 42000) {
+    this.port = port;
+  }
+
+  onConnection(listener: (conn: AudioIngestConnection) => void): void {
     this.connectionListeners.push(listener);
   }
 
@@ -185,15 +190,15 @@ async function flushMicrotasks(): Promise<void> {
 }
 
 function newIngestSetup(): {
-  server: FakeUnixSocketServer;
+  server: FakeAudioIngestServer;
   session: FakeStreamingTranscriber;
   ingest: MeetAudioIngest;
-  listenCalls: string[];
+  listenCalls: number;
   createTranscriberCalls: number;
 } {
-  const server = new FakeUnixSocketServer();
+  const server = new FakeAudioIngestServer();
   let session: FakeStreamingTranscriber | null = null;
-  const listenCalls: string[] = [];
+  let listenCalls = 0;
   let createTranscriberCalls = 0;
   const ingest = new MeetAudioIngest({
     createTranscriber: async () => {
@@ -201,8 +206,8 @@ function newIngestSetup(): {
       session = new FakeStreamingTranscriber();
       return session;
     },
-    listen: async (path) => {
-      listenCalls.push(path);
+    listen: async () => {
+      listenCalls++;
       return server;
     },
   });
@@ -213,15 +218,17 @@ function newIngestSetup(): {
       return session;
     },
     ingest,
-    listenCalls,
+    get listenCalls() {
+      return listenCalls;
+    },
     get createTranscriberCalls() {
       return createTranscriberCalls;
     },
   } as unknown as {
-    server: FakeUnixSocketServer;
+    server: FakeAudioIngestServer;
     session: FakeStreamingTranscriber;
     ingest: MeetAudioIngest;
-    listenCalls: string[];
+    listenCalls: number;
     createTranscriberCalls: number;
   };
 }
@@ -248,25 +255,23 @@ describe("MeetAudioIngest.start", () => {
   test("opens streaming transcriber, opens socket server, resolves on bot connect", async () => {
     const setup = newIngestSetup();
 
-    const startPromise = setup.ingest.start("m1", "/tmp/fake-audio.sock");
+    // start() now resolves with { port, ready } as soon as the listener
+    // is bound — `ready` is the promise that waits for the bot to dial in.
+    const { port, ready } = await setup.ingest.start("m1");
 
-    // The listen factory was called with the provided path.
-    // The ingest awaits `listen()` before registering its connection
-    // listener, so we need to let microtasks run before connecting.
-    await flushMicrotasks();
-
-    expect(setup.listenCalls).toEqual(["/tmp/fake-audio.sock"]);
+    expect(port).toBe(42000);
+    expect(setup.listenCalls).toBe(1);
     expect(setup.createTranscriberCalls).toBe(1);
 
     // Simulate the bot dialing in.
     setup.server.connectBot();
-    await startPromise;
+    await ready;
 
     expect(setup.session.started).toBe(true);
   });
 
   test("rejects when the transcriber fails to connect (and does not open the socket)", async () => {
-    const listen = mock(async () => new FakeUnixSocketServer());
+    const listen = mock(async () => new FakeAudioIngestServer());
     const createTranscriber = mock(async () => ({
       providerId: "deepgram" as const,
       boundaryId: "daemon-streaming" as const,
@@ -282,7 +287,7 @@ describe("MeetAudioIngest.start", () => {
       listen,
     });
 
-    await expect(ingest.start("m1", "/tmp/x.sock")).rejects.toThrow(
+    await expect(ingest.start("m1")).rejects.toThrow(
       /stt auth failed/,
     );
     expect(listen).toHaveBeenCalledTimes(0);
@@ -306,17 +311,17 @@ describe("MeetAudioIngest.start", () => {
       },
     });
 
-    await expect(ingest.start("m1", "/tmp/x.sock")).rejects.toThrow(
+    await expect(ingest.start("m1")).rejects.toThrow(
       /EADDRINUSE/,
     );
     expect(session).not.toBeNull();
     expect(sessionsStopped).toHaveLength(1);
   });
 
-  test("rejects with MeetAudioIngestError when no streaming provider is configured, cleaning up the socket path", async () => {
-    const unlinkCalls: string[] = [];
-    const closedServers: FakeUnixSocketServer[] = [];
-    const server = new FakeUnixSocketServer();
+  test("rejects with MeetAudioIngestError when no streaming provider is configured, without opening the listen socket", async () => {
+    let listenCalls = 0;
+    const closedServers: FakeAudioIngestServer[] = [];
+    const server = new FakeAudioIngestServer();
     // Wrap close so we can verify the server is not opened (close is never called)
     // on the missing-provider path.
     const origClose = server.close.bind(server);
@@ -333,13 +338,13 @@ describe("MeetAudioIngest.start", () => {
             "and ensure credentials are present.",
         );
       },
-      listen: async (path) => {
-        unlinkCalls.push(path);
+      listen: async () => {
+        listenCalls++;
         return server;
       },
     });
 
-    const rejection = ingest.start("m-missing", "/tmp/missing.sock");
+    const rejection = ingest.start("m-missing");
     await expect(rejection).rejects.toThrow(
       /No streaming-capable STT provider is configured/,
     );
@@ -350,8 +355,8 @@ describe("MeetAudioIngest.start", () => {
       expect(err).toBeInstanceOf(MeetAudioIngestError);
     }
 
-    // listen() was never called — socket path is uncreated and does not leak.
-    expect(unlinkCalls).toHaveLength(0);
+    // listen() was never called — no TCP port was bound.
+    expect(listenCalls).toBe(0);
     expect(closedServers).toHaveLength(0);
 
     // stop() is idempotent and safe to call on a failed-to-start ingest.
@@ -386,7 +391,7 @@ describe("MeetAudioIngest.start", () => {
 
     try {
       const setup = newIngestSetup();
-      const startPromise = setup.ingest.start("m1", "/tmp/timeout.sock");
+      const { ready } = await setup.ingest.start("m1");
 
       // Let microtasks settle so the ingest has called `listen()` and
       // registered its watchdog.
@@ -399,8 +404,8 @@ describe("MeetAudioIngest.start", () => {
       pending[0].cb();
       pending[0].fired = true;
 
-      await expect(startPromise).rejects.toThrow(
-        /bot did not connect to .*timeout\.sock within/,
+      await expect(ready).rejects.toThrow(
+        /bot did not connect to 127\.0\.0\.1:\d+ within/,
       );
     } finally {
       globalThis.setTimeout = realSetTimeout;
@@ -416,11 +421,11 @@ describe("MeetAudioIngest.start", () => {
 describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
   test("forwards PCM bytes from the bot to the transcriber", async () => {
     const setup = newIngestSetup();
-    const startPromise = setup.ingest.start("m-forward", "/tmp/audio.sock");
+    const { ready } = await setup.ingest.start("m-forward");
     await flushMicrotasks();
 
     const conn = setup.server.connectBot();
-    await startPromise;
+    await ready;
 
     const pcm1 = Buffer.from([0x01, 0x02, 0x03]);
     const pcm2 = Buffer.from([0x04, 0x05]);
@@ -445,10 +450,10 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
       dispatchMock("m-partial", e),
     );
 
-    const startPromise = setup.ingest.start("m-partial", "/tmp/partial.sock");
+    const { ready } = await setup.ingest.start("m-partial");
     await flushMicrotasks();
     setup.server.connectBot();
-    await startPromise;
+    await ready;
 
     setup.session.emit({ type: "partial", text: "hello " });
 
@@ -476,10 +481,10 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
     const captured: Array<unknown> = [];
     getMeetSessionEventRouter().register("m-final", (e) => captured.push(e));
 
-    const startPromise = setup.ingest.start("m-final", "/tmp/final.sock");
+    const { ready } = await setup.ingest.start("m-final");
     await flushMicrotasks();
     setup.server.connectBot();
-    await startPromise;
+    await ready;
 
     setup.session.emit({ type: "final", text: "hello world." });
 
@@ -501,10 +506,10 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
     const captured: Array<unknown> = [];
     getMeetSessionEventRouter().register("m-speaker", (e) => captured.push(e));
 
-    const startPromise = setup.ingest.start("m-speaker", "/tmp/speaker.sock");
+    const { ready } = await setup.ingest.start("m-speaker");
     await flushMicrotasks();
     setup.server.connectBot();
-    await startPromise;
+    await ready;
 
     // Partial event with a speaker label + confidence.
     setup.session.emit({
@@ -568,10 +573,10 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
     const captured: Array<unknown> = [];
     getMeetSessionEventRouter().register("m-ignore", (e) => captured.push(e));
 
-    const startPromise = setup.ingest.start("m-ignore", "/tmp/ignore.sock");
+    const { ready } = await setup.ingest.start("m-ignore");
     await flushMicrotasks();
     setup.server.connectBot();
-    await startPromise;
+    await ready;
 
     setup.session.emit({
       type: "error",
@@ -597,10 +602,10 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
 describe("MeetAudioIngest PCM tee", () => {
   test("fans each PCM chunk to every subscriber in addition to the transcriber", async () => {
     const setup = newIngestSetup();
-    const startPromise = setup.ingest.start("m-tee", "/tmp/tee.sock");
+    const { ready } = await setup.ingest.start("m-tee");
     await flushMicrotasks();
     const conn = setup.server.connectBot();
-    await startPromise;
+    await ready;
 
     const a: Uint8Array[] = [];
     const b: Uint8Array[] = [];
@@ -629,10 +634,10 @@ describe("MeetAudioIngest PCM tee", () => {
 
   test("a throwing subscriber is logged + removed and does not break peers", async () => {
     const setup = newIngestSetup();
-    const startPromise = setup.ingest.start("m-throw", "/tmp/throw.sock");
+    const { ready } = await setup.ingest.start("m-throw");
     await flushMicrotasks();
     const conn = setup.server.connectBot();
-    await startPromise;
+    await ready;
 
     let thrown = 0;
     const throwing = () => {
@@ -659,10 +664,10 @@ describe("MeetAudioIngest PCM tee", () => {
     const received: Uint8Array[] = [];
     const unsub = setup.ingest.subscribePcm((c) => received.push(c));
 
-    const startPromise = setup.ingest.start("m-early", "/tmp/early.sock");
+    const { ready } = await setup.ingest.start("m-early");
     await flushMicrotasks();
     const conn = setup.server.connectBot();
-    await startPromise;
+    await ready;
 
     conn.emitData(Buffer.from([0xab]));
     expect(received).toHaveLength(1);
@@ -673,10 +678,10 @@ describe("MeetAudioIngest PCM tee", () => {
 
   test("stop() drops all subscribers", async () => {
     const setup = newIngestSetup();
-    const startPromise = setup.ingest.start("m-stop-subs", "/tmp/stops.sock");
+    const { ready } = await setup.ingest.start("m-stop-subs");
     await flushMicrotasks();
     const conn = setup.server.connectBot();
-    await startPromise;
+    await ready;
 
     const received: Uint8Array[] = [];
     setup.ingest.subscribePcm((c) => received.push(c));
@@ -693,10 +698,10 @@ describe("MeetAudioIngest PCM tee", () => {
 describe("MeetAudioIngest.stop", () => {
   test("destroys connection, stops transcriber, closes server", async () => {
     const setup = newIngestSetup();
-    const startPromise = setup.ingest.start("m-stop", "/tmp/stop.sock");
+    const { ready } = await setup.ingest.start("m-stop");
     await flushMicrotasks();
     const conn = setup.server.connectBot();
-    await startPromise;
+    await ready;
 
     await setup.ingest.stop();
 
@@ -707,10 +712,10 @@ describe("MeetAudioIngest.stop", () => {
 
   test("is idempotent", async () => {
     const setup = newIngestSetup();
-    const startPromise = setup.ingest.start("m-idem", "/tmp/idem.sock");
+    const { ready } = await setup.ingest.start("m-idem");
     await flushMicrotasks();
     setup.server.connectBot();
-    await startPromise;
+    await ready;
 
     await setup.ingest.stop();
     await setup.ingest.stop();
@@ -721,13 +726,9 @@ describe("MeetAudioIngest.stop", () => {
 
   test("drops audio sent after stop", async () => {
     const setup = newIngestSetup();
-    const startPromise = setup.ingest.start(
-      "m-afterstop",
-      "/tmp/afterstop.sock",
-    );
-    await flushMicrotasks();
+    const { ready } = await setup.ingest.start("m-afterstop");
     const conn = setup.server.connectBot();
-    await startPromise;
+    await ready;
 
     await setup.ingest.stop();
     conn.emitData(Buffer.from([0x0a, 0x0b]));
@@ -780,15 +781,17 @@ describe("MeetAudioIngest — default transcriber factory", () => {
 
     // No createTranscriber override — exercises the default factory path.
     const ingest = new MeetAudioIngest({
-      listen: async () => new FakeUnixSocketServer(),
+      listen: async () => new FakeAudioIngestServer(),
       botConnectTimeoutMs: 1_000,
     });
 
     // Kick off start(); we don't need it to resolve, just to call the
     // resolver. Attach a noop rejection handler so the bot-connect timeout
     // doesn't surface as an unhandled rejection when the test finishes.
-    const startPromise = ingest.start("m-diarize", "/tmp/diarize.sock");
-    startPromise.catch(() => {});
+    const { ready } = await ingest.start("m-diarize");
+    // Attach a noop rejection handler so the bot-connect timeout (which we
+    // never satisfy in this test) doesn't surface as an unhandled rejection.
+    ready.catch(() => {});
     await flushMicrotasks();
 
     expect(mockResolveCalls).toHaveLength(1);
@@ -806,13 +809,13 @@ describe("MeetAudioIngest — default transcriber factory", () => {
     mockResolveResult = null;
 
     const ingest = new MeetAudioIngest({
-      listen: async () => new FakeUnixSocketServer(),
+      listen: async () => new FakeAudioIngestServer(),
     });
 
-    await expect(ingest.start("m-null", "/tmp/null.sock")).rejects.toThrow(
+    await expect(ingest.start("m-null")).rejects.toThrow(
       MeetAudioIngestError,
     );
-    await expect(ingest.start("m-null2", "/tmp/null2.sock")).rejects.toThrow(
+    await expect(ingest.start("m-null2")).rejects.toThrow(
       /configured STT provider is unusable/i,
     );
   });

--- a/skills/meet-join/daemon/__tests__/session-manager.test.ts
+++ b/skills/meet-join/daemon/__tests__/session-manager.test.ts
@@ -118,7 +118,10 @@ function makeFakeAudioIngestFactory(): {
     factory: () => {
       const subscribers = new Set<(bytes: Uint8Array) => void>();
       const ingest: FakeAudioIngest = {
-        start: mock(async () => {}),
+        start: mock(async () => ({
+          port: 42173,
+          ready: Promise.resolve(),
+        })),
         stop: mock(async () => {}),
         subscribePcm: mock((cb: (bytes: Uint8Array) => void) => {
           subscribers.add(cb);
@@ -188,8 +191,8 @@ describe("MeetSessionManager.join", () => {
     expect(session.botBaseUrl).toBe("http://127.0.0.1:49200");
     expect(session.joinTimeoutMs).toBeGreaterThan(0);
 
-    // Workspace directories created.
-    expect(existsSync(join(workspaceDir, "meets", "m1", "sockets"))).toBe(true);
+    // Workspace directories created. Audio socket is a loopback TCP port
+    // now — no per-meeting `sockets/` subdir.
     expect(existsSync(join(workspaceDir, "meets", "m1", "out"))).toBe(true);
 
     // Event router registered a handler for this meeting.
@@ -244,9 +247,9 @@ describe("MeetSessionManager.join", () => {
     expect(runOpts.env.SKIP_PULSE).toBe("0");
 
     expect(runOpts.workspaceMounts).toEqual([
-      { target: "/sockets", subpath: "meets/m1/sockets" },
       { target: "/out", subpath: "meets/m1/out" },
     ]);
+    expect(runOpts.env.DAEMON_AUDIO_PORT).toBeDefined();
 
     expect(runOpts.ports).toEqual([
       {
@@ -309,6 +312,7 @@ describe("MeetSessionManager.join", () => {
     const factory = (): MeetAudioIngestLike => ({
       start: mock(async () => {
         await ingestStartPromise;
+        return { port: 42173, ready: Promise.resolve() };
       }),
       stop: mock(async () => {}),
       subscribePcm: mock(() => () => {}),
@@ -668,13 +672,10 @@ describe("MeetSessionManager audio ingest wiring", () => {
     const ingest = audioIngestFactory.getLastIngest();
     expect(ingest).not.toBeNull();
     expect(ingest!.start).toHaveBeenCalledTimes(1);
-    const call = ingest!.start.mock.calls[0] as unknown as [string, string];
-    expect(call).toHaveLength(2);
-    const [meetingId, socketPath] = call;
+    const call = ingest!.start.mock.calls[0] as unknown as [string];
+    expect(call).toHaveLength(1);
+    const [meetingId] = call;
     expect(meetingId).toBe("m-audio");
-    expect(socketPath).toBe(
-      join(workspaceDir, "meets", "m-audio", "sockets", "audio.sock"),
-    );
     // Session manager no longer fetches a Deepgram key — STT resolution
     // lives inside the audio ingest.
     expect(getProviderKey).not.toHaveBeenCalledWith("deepgram");
@@ -732,9 +733,14 @@ describe("MeetSessionManager audio ingest wiring", () => {
       botLeaveFetch: async () => {},
       audioIngestFactory: () => {
         const ingest = audioIngestFactory.factory();
-        ingest.start = mock(async () => {
-          throw new Error("bot-connect timeout");
-        });
+        // Simulate the port-bind succeeding but the bot never connecting:
+        // the session manager spawns the container concurrently with the
+        // bot-connect wait, so a `ready` rejection is the path that needs
+        // container rollback.
+        ingest.start = mock(async () => ({
+          port: 42173,
+          ready: Promise.reject(new Error("bot-connect timeout")),
+        }));
         return ingest;
       },
     });
@@ -1080,6 +1086,7 @@ describe("MeetSessionManager dispatcher sequencing", () => {
             callOrder.push(
               `ingest.start registeredCount=${getMeetSessionEventRouter().registeredCount()} meetingId=${meetingId}`,
             );
+            return { port: 42173, ready: Promise.resolve() };
           },
           stop: async () => {
             callOrder.push("ingest.stop");

--- a/skills/meet-join/daemon/audio-ingest.ts
+++ b/skills/meet-join/daemon/audio-ingest.ts
@@ -34,9 +34,9 @@
  *     without touching real sockets or a real STT provider account.
  */
 
-import { existsSync, unlinkSync } from "node:fs";
 import {
   createServer as netCreateServer,
+  type AddressInfo,
   type Server as NetServer,
   type Socket as NetSocket,
 } from "node:net";
@@ -58,7 +58,16 @@ import { getMeetSessionEventRouter } from "./session-event-router.js";
 const log = getLogger("meet-audio-ingest");
 
 /**
- * Maximum wall-clock time the bot is given to connect to the audio socket
+ * Host the audio-ingest TCP server binds to. Loopback-only: the bot
+ * reaches us via Docker's `host.docker.internal` alias which maps back to
+ * the host's loopback interface, so there is no reason to accept
+ * connections from anywhere else. External listeners would expose the
+ * raw PCM stream to anything else running on the host.
+ */
+export const AUDIO_INGEST_BIND_HOST = "127.0.0.1";
+
+/**
+ * Maximum wall-clock time the bot is given to connect to the audio port
  * after `start()` opens it. Exceeding this rejects `start()` with a clear
  * error so the session manager can abort the join and clean up the
  * container.
@@ -116,9 +125,11 @@ export class MeetAudioIngestError extends Error {
  * keeping the surface small makes the factory override easier to mock in
  * tests without pulling in the full net module types.
  */
-export interface UnixSocketServer {
+export interface AudioIngestServer {
+  /** TCP port the server accepted its bind on. */
+  readonly port: number;
   /** Register a listener for inbound client connections. */
-  onConnection(listener: (socket: UnixSocketConnection) => void): void;
+  onConnection(listener: (socket: AudioIngestConnection) => void): void;
   /** Register a listener for server-level errors. */
   onError(listener: (err: Error) => void): void;
   /**
@@ -134,7 +145,7 @@ export interface UnixSocketServer {
  * Keyed off `node:net`'s `Socket` but intentionally narrower — we only use
  * data/close/error listeners and a destroy method.
  */
-export interface UnixSocketConnection {
+export interface AudioIngestConnection {
   onData(listener: (chunk: Buffer) => void): void;
   onClose(listener: () => void): void;
   onError(listener: (err: Error) => void): void;
@@ -142,12 +153,12 @@ export interface UnixSocketConnection {
 }
 
 /**
- * Factory signature used to open the Unix-socket server. Production code
- * passes the default (node:net) implementation; tests inject a shim.
+ * Factory signature used to open the audio-ingest TCP server. Production
+ * code passes the default (node:net) implementation; tests inject a shim.
+ * The factory binds to an OS-assigned port on loopback and returns the
+ * server handle with the resolved port exposed.
  */
-export type UnixSocketListenFn = (
-  socketPath: string,
-) => Promise<UnixSocketServer>;
+export type AudioIngestListenFn = () => Promise<AudioIngestServer>;
 
 // ---------------------------------------------------------------------------
 // Streaming transcriber factory
@@ -170,8 +181,8 @@ export type StreamingTranscriberFactory = () => Promise<StreamingTranscriber>;
 export interface MeetAudioIngestDeps {
   /** Override for the streaming-transcriber factory (tests). */
   createTranscriber?: StreamingTranscriberFactory;
-  /** Override for the Unix-socket listener factory (tests). */
-  listen?: UnixSocketListenFn;
+  /** Override for the audio-ingest TCP listener factory (tests). */
+  listen?: AudioIngestListenFn;
   /** Override the bot-connect timeout (tests). */
   botConnectTimeoutMs?: number;
   /**
@@ -194,14 +205,12 @@ export type PcmSubscriber = (bytes: Uint8Array) => void;
  */
 export class MeetAudioIngest {
   private readonly createTranscriber: StreamingTranscriberFactory;
-  private readonly listen: UnixSocketListenFn;
+  private readonly listen: AudioIngestListenFn;
   private readonly botConnectTimeoutMs: number;
   private readonly diarize: boolean;
 
-  /** Stored only for teardown — set in `start()`. */
-  private socketPath: string | null = null;
-  private server: UnixSocketServer | null = null;
-  private connection: UnixSocketConnection | null = null;
+  private server: AudioIngestServer | null = null;
+  private connection: AudioIngestConnection | null = null;
   private transcriber: StreamingTranscriber | null = null;
   private meetingId: string | null = null;
   private stopped = false;
@@ -239,39 +248,34 @@ export class MeetAudioIngest {
   }
 
   /**
-   * Open the Unix-socket server the bot will connect to, start a streaming
-   * STT session, and wire PCM frames into it.
+   * Open the audio-ingest TCP server the bot will connect to, start a
+   * streaming STT session, and wire PCM frames into it.
    *
-   * The promise resolves once:
-   *   - the socket server is listening, AND
-   *   - the streaming session has connected.
+   * Returns a two-phase handle:
+   *   - `port` — the OS-assigned loopback port the server is bound to.
+   *     Available as soon as the outer promise resolves, so the caller can
+   *     thread it into the bot container's env before spawning.
+   *   - `ready` — resolves once the bot has actually connected; rejects
+   *     if the bot fails to connect within {@link BOT_CONNECT_TIMEOUT_MS}.
    *
-   * It rejects if either step fails or if the bot has not connected within
-   * {@link BOT_CONNECT_TIMEOUT_MS} of `start()` being called. Rejections
-   * due to missing provider configuration surface as
-   * {@link MeetAudioIngestError}.
+   * The outer promise rejects if the STT session fails to open or the
+   * server cannot bind. Rejections due to missing provider configuration
+   * surface as {@link MeetAudioIngestError}.
+   *
+   * Splitting "port available" from "bot connected" lets the session
+   * manager keep container spawn concurrent with the bot-connect wait
+   * without losing the env-var threading we need to point the bot at a
+   * per-meeting port.
    */
-  async start(meetingId: string, socketPath: string): Promise<void> {
+  async start(
+    meetingId: string,
+  ): Promise<{ port: number; ready: Promise<void> }> {
     if (this.meetingId) {
       throw new Error(
         `MeetAudioIngest: start() called twice (meetingId=${this.meetingId})`,
       );
     }
     this.meetingId = meetingId;
-    this.socketPath = socketPath;
-
-    // Remove any stale socket file left over from a previous run so
-    // `listen()` doesn't fail with EADDRINUSE.
-    if (existsSync(socketPath)) {
-      try {
-        unlinkSync(socketPath);
-      } catch (err) {
-        log.warn(
-          { err, socketPath },
-          "Failed to unlink stale audio socket (continuing)",
-        );
-      }
-    }
 
     // Open the streaming STT session first. We want the socket server
     // to be able to pump audio into an already-connected session as
@@ -281,10 +285,9 @@ export class MeetAudioIngest {
       transcriber = await this.createTranscriber();
     } catch (err) {
       this.meetingId = null;
-      this.socketPath = null;
       throw err;
     }
-    if (this.stopped) return;
+    if (this.stopped) return { port: 0, ready: Promise.resolve() };
     this.transcriber = transcriber;
 
     try {
@@ -294,16 +297,16 @@ export class MeetAudioIngest {
     } catch (err) {
       this.transcriber = null;
       this.meetingId = null;
-      this.socketPath = null;
       throw err;
     }
-    if (this.stopped) return;
+    if (this.stopped) return { port: 0, ready: Promise.resolve() };
 
-    // Open the Unix-socket server. The bot will dial this path from inside
-    // its container as soon as it boots.
-    let server: UnixSocketServer;
+    // Open the TCP server on loopback. The bot dials it via
+    // `host.docker.internal:<port>` once its Chrome extension signals
+    // `lifecycle:joined`.
+    let server: AudioIngestServer;
     try {
-      server = await this.listen(socketPath);
+      server = await this.listen();
     } catch (err) {
       // Streaming session is already up — tear it down before propagating.
       try {
@@ -313,7 +316,6 @@ export class MeetAudioIngest {
       }
       this.transcriber = null;
       this.meetingId = null;
-      this.socketPath = null;
       throw err;
     }
     // If stop() was called concurrently while listen() was in flight, it
@@ -326,28 +328,31 @@ export class MeetAudioIngest {
       } catch (err) {
         log.warn({ err }, "MeetAudioIngest: server close after stop threw");
       }
-      return;
+      return { port: 0, ready: Promise.resolve() };
     }
     this.server = server;
+    const boundPort = server.port;
 
     server.onError((err) => {
       log.error({ err, meetingId }, "MeetAudioIngest: socket server error");
     });
 
     // Wait for the bot to connect, bounded by BOT_CONNECT_TIMEOUT_MS.
-    await new Promise<void>((resolve, reject) => {
+    // Returned to the caller as `ready` so container spawn can run
+    // concurrently with the connect wait.
+    const ready = new Promise<void>((resolve, reject) => {
       let settled = false;
 
       const timer = setTimeout(() => {
         if (settled) return;
         settled = true;
         log.warn(
-          { meetingId, socketPath, timeoutMs: this.botConnectTimeoutMs },
+          { meetingId, port: boundPort, timeoutMs: this.botConnectTimeoutMs },
           "MeetAudioIngest: bot did not connect within timeout",
         );
         reject(
           new Error(
-            `MeetAudioIngest: bot did not connect to ${socketPath} within ${this.botConnectTimeoutMs}ms`,
+            `MeetAudioIngest: bot did not connect to 127.0.0.1:${boundPort} within ${this.botConnectTimeoutMs}ms`,
           ),
         );
       }, this.botConnectTimeoutMs);
@@ -368,19 +373,22 @@ export class MeetAudioIngest {
 
         this.connection = conn;
         this.wireConnection(conn, meetingId);
+        log.info(
+          { meetingId, port: boundPort },
+          "MeetAudioIngest: bot connected",
+        );
         resolve();
       });
     });
 
-    log.info({ meetingId, socketPath }, "MeetAudioIngest: bot connected");
+    return { port: boundPort, ready };
   }
 
   /**
    * Tear down the ingest:
    *   1. Stop forwarding audio.
    *   2. Close the streaming session (provider may flush remaining finals).
-   *   3. Close the socket server.
-   *   4. Unlink the socket file.
+   *   3. Close the TCP server.
    *
    * Idempotent — calling `stop()` twice is a no-op after the first call.
    */
@@ -423,21 +431,6 @@ export class MeetAudioIngest {
       }
     }
 
-    // Unlink the socket file best-effort — the file may already be gone
-    // (e.g. the workspace directory was cleaned up).
-    const socketPath = this.socketPath;
-    this.socketPath = null;
-    if (socketPath && existsSync(socketPath)) {
-      try {
-        unlinkSync(socketPath);
-      } catch (err) {
-        log.warn(
-          { err, socketPath },
-          "MeetAudioIngest: socket unlink threw — file may leak",
-        );
-      }
-    }
-
     // Drop any lingering PCM subscribers so they can't keep a reference to
     // the ingest alive past stop. Subscribers that unsubscribed on their
     // own (e.g. the storage writer on `stop()`) are already gone.
@@ -453,7 +446,7 @@ export class MeetAudioIngest {
    * subscriber. Subscribers that throw are logged and evicted so one
    * misbehaving consumer cannot break peers.
    */
-  private wireConnection(conn: UnixSocketConnection, meetingId: string): void {
+  private wireConnection(conn: AudioIngestConnection, meetingId: string): void {
     conn.onData((chunk) => {
       if (this.stopped) return;
       const transcriber = this.transcriber;
@@ -599,14 +592,17 @@ async function defaultCreateTranscriber(): Promise<StreamingTranscriber> {
 }
 
 /**
- * Default socket-server factory — opens a `node:net` server listening on
- * the Unix-domain path. Each incoming connection is wrapped in a small
- * shim implementing {@link UnixSocketConnection}.
+ * Default audio-ingest listener — opens a `node:net` TCP server bound to
+ * loopback with an OS-assigned port. The port is read back from the
+ * server's address once `listen()` resolves and exposed on the returned
+ * {@link AudioIngestServer} so the session manager can thread it through
+ * to the bot container as the `DAEMON_AUDIO_PORT` env var.
  */
-function defaultListen(socketPath: string): Promise<UnixSocketServer> {
-  return new Promise<UnixSocketServer>((resolve, reject) => {
+function defaultListen(): Promise<AudioIngestServer> {
+  return new Promise<AudioIngestServer>((resolve, reject) => {
     let settled = false;
-    const connectionListeners: Array<(conn: UnixSocketConnection) => void> = [];
+    const connectionListeners: Array<(conn: AudioIngestConnection) => void> =
+      [];
     const errorListeners: Array<(err: Error) => void> = [];
 
     const netServer: NetServer = netCreateServer((socket) => {
@@ -635,11 +631,30 @@ function defaultListen(socketPath: string): Promise<UnixSocketServer> {
       }
     });
 
-    netServer.listen(socketPath, () => {
+    netServer.listen({ host: AUDIO_INGEST_BIND_HOST, port: 0 }, () => {
       if (settled) return;
       settled = true;
 
-      const wrapped: UnixSocketServer = {
+      const address = netServer.address();
+      if (!address || typeof address === "string") {
+        // `netServer.address()` returns `null` only if the server is not
+        // listening, and a `string` only for Unix-domain servers — neither
+        // can occur after a successful TCP `listen()`. Guard anyway so a
+        // future refactor that reintroduces Unix-domain listens (tests,
+        // alternate transports) fails loudly instead of silently passing
+        // `0` as the port.
+        netServer.close();
+        reject(
+          new Error(
+            `MeetAudioIngest: unexpected listen address shape: ${JSON.stringify(address)}`,
+          ),
+        );
+        return;
+      }
+      const port = (address as AddressInfo).port;
+
+      const wrapped: AudioIngestServer = {
+        port,
         onConnection: (listener) => {
           connectionListeners.push(listener);
         },
@@ -658,9 +673,9 @@ function defaultListen(socketPath: string): Promise<UnixSocketServer> {
 
 /**
  * Adapt a raw `node:net` Socket to the narrow
- * {@link UnixSocketConnection} surface consumed by the ingest.
+ * {@link AudioIngestConnection} surface consumed by the ingest.
  */
-function adaptNetSocket(socket: NetSocket): UnixSocketConnection {
+function adaptNetSocket(socket: NetSocket): AudioIngestConnection {
   return {
     onData: (listener) => socket.on("data", listener),
     onClose: (listener) => socket.on("close", listener),

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -416,7 +416,16 @@ interface ActiveSession extends MeetSession {
  * unsubscribe lets callers drop their tap without disturbing peers.
  */
 export interface MeetAudioIngestLike {
-  start(meetingId: string, socketPath: string): Promise<void>;
+  /**
+   * Open the audio-ingest TCP server and streaming STT session.
+   *
+   * Returns `{ port, ready }` as soon as the server is bound — `port` is
+   * the OS-assigned loopback port the session manager threads into the
+   * bot container as `DAEMON_AUDIO_PORT`, and `ready` resolves once the
+   * bot has actually connected (or rejects on timeout). Splitting the two
+   * lets the container spawn run concurrently with the bot-connect wait.
+   */
+  start(meetingId: string): Promise<{ port: number; ready: Promise<void> }>;
   stop(): Promise<void>;
   subscribePcm(cb: (bytes: Uint8Array) => void): () => void;
 }
@@ -940,7 +949,6 @@ class MeetSessionManagerImpl {
     let meet: ReturnType<typeof getMeetConfig>;
     let workspaceDir: string;
     let meetingDir: string;
-    let socketsDir: string;
     let outDir: string;
     let botApiToken: string;
     let ttsKey: string;
@@ -958,9 +966,7 @@ class MeetSessionManagerImpl {
 
       workspaceDir = this.deps.getWorkspaceDir();
       meetingDir = join(workspaceDir, "meets", meetingId);
-      socketsDir = join(meetingDir, "sockets");
       outDir = join(meetingDir, "out");
-      mkdirSync(socketsDir, { recursive: true });
       mkdirSync(outDir, { recursive: true });
 
       botApiToken = generateBotApiToken();
@@ -1045,30 +1051,48 @@ class MeetSessionManagerImpl {
     // of `start()`, which may begin emitting partials immediately.
     registerMeetingDispatcher(meetingId);
 
-    // Audio ingest + container spawn are started concurrently:
-    //   1. The ingest opens its Unix-socket server and a streaming STT
-    //      session (provider resolved from `services.stt.provider` via
-    //      the provider catalog), then waits for the bot to connect
-    //      (bounded by a 30s timeout).
-    //   2. The container is started in parallel; once it boots, the bot
-    //      process inside dials the shared socket.
+    // Audio ingest first, container spawn second:
+    //   1. The ingest opens a streaming STT session (provider resolved
+    //      from `services.stt.provider` via the provider catalog) and
+    //      binds a loopback TCP port. Resolves with `{ port, ready }` as
+    //      soon as the server is listening.
+    //   2. The container is spawned with `DAEMON_AUDIO_PORT=<port>` in
+    //      its env so the bot knows where to dial.
+    //   3. Container spawn and the bot-connect wait (`ready`) run
+    //      concurrently — spawn typically dominates (seconds) while the
+    //      bot's in-browser join flow takes up to 120s.
     //
-    // Starting the ingest first (i.e. before `runner.run()` returns) is
-    // what lets the bot connect as soon as its process comes up. Running
-    // them concurrently keeps the total latency bounded — the join
-    // completes once both steps succeed, or fails fast if either step
-    // rejects (e.g. with a {@link MeetAudioIngestError} when no
-    // streaming-capable STT provider is configured).
-    const audioSocketPath = join(socketsDir, "audio.sock");
+    // The port phase is synchronous-ish (STT handshake + TCP bind,
+    // normally ~200ms), so the concurrency loss vs. the old "kick ingest
+    // + container in parallel" path is negligible. A failure here
+    // (e.g. {@link MeetAudioIngestError} when no streaming-capable STT
+    // provider is configured) fails fast before we spend time spinning up
+    // a container.
     const audioIngest = this.deps.audioIngestFactory();
-    const audioIngestPromise = audioIngest.start(meetingId, audioSocketPath);
-    // Guard the ingest promise immediately so a rejection between here and
-    // the first explicit `await audioIngestPromise` (after `runner.run()`)
+    let audioIngestReady: Promise<void>;
+    let audioPort: number;
+    try {
+      const handle = await audioIngest.start(meetingId);
+      audioPort = handle.port;
+      audioIngestReady = handle.ready;
+    } catch (err) {
+      unregisterMeetingDispatcher(meetingId);
+      this.pendingBotTokens.delete(meetingId);
+      void publishMeetEvent(
+        DAEMON_INTERNAL_ASSISTANT_ID,
+        meetingId,
+        "meet.error",
+        { detail: errorDetail(err) },
+      );
+      throw err;
+    }
+    // Guard the ready promise immediately so a rejection between here and
+    // the first explicit `await audioIngestReady` (after `runner.run()`)
     // does not surface as an unhandled rejection. The global handler in
     // `shutdown-handlers.ts` calls `process.exit(1)` on unhandled
-    // rejections, so without this guard a transient STT failure during
-    // container spawn would crash the entire daemon.
-    audioIngestPromise.catch(() => {});
+    // rejections, so without this guard a transient bot-connect failure
+    // during container spawn would crash the entire daemon.
+    audioIngestReady.catch(() => {});
 
     const env: Record<string, string> = {
       MEET_URL: url,
@@ -1082,7 +1106,14 @@ class MeetSessionManagerImpl {
       CONSENT_MESSAGE: resolvedConsentMessage,
       DAEMON_URL: daemonUrl,
       BOT_API_TOKEN: botApiToken,
-      // STT credentials live on the daemon, not the bot — bot connects via Unix socket.
+      // Loopback TCP port the daemon's audio-ingest server bound. The bot
+      // dials `host.docker.internal:<port>` to stream PCM. Unix sockets
+      // over a bind mount are not usable here — Docker Desktop on macOS
+      // rejects connect() across the host↔VM VirtioFS boundary.
+      DAEMON_AUDIO_PORT: String(audioPort),
+      // STT credentials live on the daemon, not the bot — the bot just
+      // streams raw PCM and the daemon forwards it to the configured
+      // streaming STT provider.
       TTS_API_KEY: ttsKey,
       // Enable the in-container Pulse null-sink by default (set to "1" to
       // disable in dev). Match the meet-bot image expectation.
@@ -1132,12 +1163,8 @@ class MeetSessionManagerImpl {
         // Logical workspace-rooted mounts. DockerRunner resolves each one
         // to either a host-path bind (bare-metal mode) or a named-volume
         // subpath mount (Docker mode) based on the daemon's runtime mode.
-        // Session-manager stays mode-agnostic — the only thing we rely on
-        // is that the directories exist under the daemon's view of the
-        // workspace so the audio-ingest socket path lines up with what the
-        // bot sees inside its container.
+        // Session-manager stays mode-agnostic.
         workspaceMounts: [
-          { target: "/sockets", subpath: `meets/${meetingId}/sockets` },
           { target: "/out", subpath: `meets/${meetingId}/out` },
         ],
         ports: [
@@ -1208,17 +1235,13 @@ class MeetSessionManagerImpl {
       throw new Error(detail);
     }
 
-    // Now that the container is up, wait for the ingest to finish setup
-    // (streaming STT session opened + bot connected via the shared
-    // socket). If the bot never connects within the 30s timeout — or the
-    // ingest fails to open a streaming session (e.g. no STT provider
-    // configured; surfaced as `MeetAudioIngestError`) — the promise
-    // rejects and we roll the container back before re-throwing. The
-    // error's `message` is forwarded to the caller via both the `throw`
-    // and the `meet.error` event, so the user sees a pointer at
-    // `services.stt.provider` when that's the cause.
+    // Now that the container is up, wait for the bot to dial our loopback
+    // TCP port. If it fails to connect within {@link BOT_CONNECT_TIMEOUT_MS}
+    // the promise rejects and we roll the container back before re-throwing.
+    // The error's `message` is forwarded to the caller via both the
+    // `throw` and the `meet.error` event.
     try {
-      await audioIngestPromise;
+      await audioIngestReady;
     } catch (err) {
       log.error(
         { err, meetingId, containerId: runResult.containerId },


### PR DESCRIPTION
## Summary
- Replace the bind-mounted Unix audio socket with a loopback TCP port (`DAEMON_AUDIO_PORT`) because Docker Desktop on macOS returns `EOPNOTSUPP` when a container tries to `connect()` to a Unix socket file exposed through its VirtioFS bind mount, which silently broke \`meet_join\` on bare-metal macOS.
- Split \`MeetAudioIngest.start()\` into \`{ port, ready }\` so the daemon can thread the bound port into the bot env before container spawn, then await the bot-connect wait concurrently with the spawn (preserving the prior concurrency profile).
- Surface \`startAudioCapture\` fatal errors via an \`onError\` shutdown path so a truly unreachable daemon fails fast instead of masquerading as the 120s bot-connect timeout.

## Original prompt
can you debug this? (screenshots of meet_join timing out despite Velissa joining the meeting)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
