### PR TITLE
fix(meet-ext): narrow generation guard to superseding commands

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/content-bridge.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/content-bridge.test.ts
@@ -173,9 +173,16 @@ describe("startContentBridge bot→content fan-out", () => {
       // the first retry fires, a leave arrives — the later message must
       // cancel the stale join so we don't join a session the bot has
       // already decided to leave.
+      //
+      // The join finds no tab (so it queues a retry). The leave finds a
+      // tab and delivers on its first attempt — that way only the join's
+      // retry behavior is under test and leave's own retry cadence can't
+      // leak into the assertion. We assert the invariant directly: the
+      // stale `join` frame must never reach `chrome.tabs.sendMessage`.
+      let tabsAvailable: chrome.tabs.Tab[] = [];
       fake.tabs.query = async (q) => {
         fake.queryCalls.push(q);
-        return [];
+        return tabsAvailable;
       };
       const join: BotToExtensionMessage = {
         type: "join",
@@ -186,20 +193,68 @@ describe("startContentBridge bot→content fan-out", () => {
       const leave: BotToExtensionMessage = { type: "leave", reason: "cancel" };
       port.emitFromBot(join);
       await flushMicrotasks();
-      // One query from the join attempt, no tabs -> sleeping 100ms.
-      const queriesAfterJoin = fake.queryCalls.length;
-      expect(queriesAfterJoin).toBe(1);
-      // Now the leave supersedes. Let it run — its own query will count.
+      // Join queried once, no tabs — it's now sleeping 100ms before retry.
+      expect(fake.queryCalls.length).toBe(1);
+      // Now a tab exists and the leave supersedes the pending join.
+      tabsAvailable = [{ id: 1 } as chrome.tabs.Tab];
       port.emitFromBot(leave);
-      // Wait long enough for the join's first retry (100ms) to fire if
-      // the generation guard weren't in place, plus margin.
+      // Wait past the join's first retry delay (100ms) plus margin.
       await new Promise((resolve) => setTimeout(resolve, 250));
-      // We expect: queriesAfterJoin (1) + 1 for leave's attempt (which also
-      // found no tabs and is itself sleeping). The stale join retry must
-      // not have added another query after the leave bumped the generation.
-      // So total should be exactly 2 (one from join, one from leave's first
-      // attempt) — the join's 100ms retry was skipped.
-      expect(fake.queryCalls.length).toBe(2);
+      const byType = (t: string) =>
+        fake.sendMessageCalls.filter(
+          (c) => (c.msg as { type: string }).type === t,
+        );
+      // The stale join must not have been delivered.
+      expect(byType("join")).toHaveLength(0);
+      // Leave was delivered (this is the positive invariant — without it
+      // the test would pass if the bridge silently dropped everything).
+      expect(byType("leave").length).toBeGreaterThanOrEqual(1);
+    },
+    5_000,
+  );
+
+  test(
+    "two send_chat messages both deliver — neither supersedes the other",
+    async () => {
+      // send_chat is outside any superseding category, so a rapidly-issued
+      // pair must both reach the content script. Guard: before PR 27314's
+      // follow-up, the generation counter was bumped for every message,
+      // which silently aborted the first send_chat while it was sleeping
+      // between retries.
+      let tabsAvailable: chrome.tabs.Tab[] = [];
+      fake.tabs.query = async (q) => {
+        fake.queryCalls.push(q);
+        return tabsAvailable;
+      };
+      const first: BotToExtensionMessage = {
+        type: "send_chat",
+        text: "hello",
+        requestId: "req-1",
+      };
+      const second: BotToExtensionMessage = {
+        type: "send_chat",
+        text: "world",
+        requestId: "req-2",
+      };
+      // First send_chat: no tab yet, queues a retry.
+      port.emitFromBot(first);
+      await flushMicrotasks();
+      expect(fake.queryCalls.length).toBe(1);
+      // Second send_chat arrives before the first retry fires. A tab is
+      // now mounted so both should be able to deliver.
+      tabsAvailable = [{ id: 1 } as chrome.tabs.Tab];
+      port.emitFromBot(second);
+      // Wait past the first's retry delay (100ms) plus margin.
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      const chatDeliveries = fake.sendMessageCalls.filter(
+        (c) => (c.msg as { type: string }).type === "send_chat",
+      );
+      expect(chatDeliveries).toHaveLength(2);
+      const deliveredIds = chatDeliveries.map(
+        (c) => (c.msg as { requestId: string }).requestId,
+      );
+      expect(deliveredIds).toContain("req-1");
+      expect(deliveredIds).toContain("req-2");
     },
     5_000,
   );

--- a/skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts
+++ b/skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts
@@ -95,17 +95,44 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// Monotonic counter bumped on every fan-out. A pending retry loop compares
-// its captured generation against this value after each sleep and aborts
-// when it has been superseded — e.g. a `join` that is still waiting for the
-// content script to mount must not fire if a later `leave` has already
-// been dispatched for the same session.
-let fanOutGeneration = 0;
+// Per-category monotonic counters bumped when a new command enters that
+// category. A pending retry loop captures the counter value(s) for its own
+// categories and aborts when any captured value is stale — i.e. a newer
+// command in the same category has arrived.
+//
+// Categories (see `supersedingCategoriesFor`):
+//   - `lifecycle` (join, leave): newer supersedes older — a pending `join`
+//     retry must not fire once a `leave` has been dispatched for the same
+//     session, and a newer `join`/`leave` cancels any older `join`/`leave`.
+//   - `camera` (camera.enable, camera.disable): newer toggle supersedes
+//     older toggle so a rapid `disable` after `enable` doesn't end with the
+//     stale `enable` winning the race.
+//
+// Messages outside any category (currently `send_chat`) never supersede
+// and are never superseded — two `send_chat`s must both deliver.
+const fanOutGenerations: Record<"lifecycle" | "camera", number> = {
+  lifecycle: 0,
+  camera: 0,
+};
+
+function supersedingCategoriesFor(
+  type: BotToExtensionMessage["type"],
+): Array<keyof typeof fanOutGenerations> {
+  if (type === "join" || type === "leave") return ["lifecycle"];
+  if (type === "camera.enable" || type === "camera.disable") return ["camera"];
+  return [];
+}
 
 async function fanOutToMeetTabs(msg: BotToExtensionMessage): Promise<void> {
-  const myGeneration = ++fanOutGeneration;
+  const categories = supersedingCategoriesFor(msg.type);
+  const captured = categories.map((cat) => ({
+    cat,
+    gen: ++fanOutGenerations[cat],
+  }));
+  const isSuperseded = (): boolean =>
+    captured.some(({ cat, gen }) => fanOutGenerations[cat] !== gen);
   for (let attempt = 0; attempt <= DELIVERY_RETRY_DELAYS_MS.length; attempt++) {
-    if (myGeneration !== fanOutGeneration) {
+    if (isSuperseded()) {
       console.warn(
         `[meet-ext] aborting stale bot->content fan-out type=${msg.type}; superseded by newer message`,
       );


### PR DESCRIPTION
Addresses review feedback on #27314.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
