### PR TITLE
docs(test): rewrite migration-import test comment to current-state only

### DIFF
--- a/assistant/src/__tests__/migration-import-from-url.test.ts
+++ b/assistant/src/__tests__/migration-import-from-url.test.ts
@@ -14,11 +14,8 @@
  *
  * Memory-ceiling coverage lives at the streaming-importer layer — see
  * `vbundle-streaming-importer.test.ts` ("streamCommitImport — memory
- * ceiling"). The URL handler adds only a fixed HTTP/framing overhead on top
- * of that pipeline, not bundle-size-proportional allocation, so duplicating
- * the RSS check here through an in-process fetch round-trip was flaky under
- * parallel CI workers without catching a failure mode the direct test
- * doesn't already cover.
+ * ceiling"). The URL handler adds only fixed HTTP/framing overhead on top
+ * of that pipeline, not bundle-size-proportional allocation.
  *
  * The raw-bytes ingress path is exercised by a separate test file,
  * `migration-import-commit-http.test.ts`.


### PR DESCRIPTION
Addresses review feedback on #27347.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
