### PR TITLE
fix(meet-ext): apply findInteractable to step 3 name input

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/join.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/join.test.ts
@@ -1002,6 +1002,49 @@ describe("runJoinFlow (content-script port)", () => {
     expect(errorDiagnostics.length).toBe(0);
   });
 
+  test("regression: skips a hidden template name input and fills the real one", async () => {
+    // Step 3 used to run a raw `doc.querySelector(PREJOIN_NAME_INPUT)` with
+    // no interactable filter, so a hidden template copy of the input at the
+    // front of the tree would win the match and absorb the `displayName`
+    // write. React then never saw a value on the real input, and Step 4
+    // timed out waiting for the join button that stayed gated on an empty
+    // name. Parallels the same-flake filter applied to Step 4 in #27317.
+    const { doc } = loadPrejoinDom();
+    removeMediaModal(doc);
+
+    const real = doc.querySelector(
+      selectors.PREJOIN_NAME_INPUT,
+    ) as HTMLInputElement | null;
+    if (!real) throw new Error("fixture missing PREJOIN_NAME_INPUT");
+    const ghost = real.cloneNode(true) as HTMLInputElement;
+    // Mark the ghost demonstrably hidden so `isInteractable` rejects it.
+    // Insert it BEFORE the real input so `querySelector` would pick it.
+    ghost.setAttribute("aria-hidden", "true");
+    ghost.value = "";
+    real.parentElement!.insertBefore(ghost, real);
+
+    insertPostAdmissionToolbar(doc);
+    insertChatSurface(doc);
+    const restore = installGlobalDoc(doc);
+
+    try {
+      await runJoinFlow({
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        displayName: "Vellum Bot",
+        consentMessage: "Hi, Vellum is listening.",
+        meetingId: "mtg-ghost-name",
+        onEvent: () => {},
+        doc,
+      });
+    } finally {
+      restore();
+    }
+
+    // The ghost stays empty, the real input receives the displayName.
+    expect(ghost.value).toBe("");
+    expect(real.value).toBe("Vellum Bot");
+  });
+
   test("regression: a lone Leave button is NOT accepted as the in-meeting signal", async () => {
     // This is the whole-point regression: before PR 4, step 5 waited on
     // `INGAME_LEAVE_BUTTON`, which Meet renders in BOTH the waiting-room and

--- a/skills/meet-join/meet-controller-ext/src/features/join.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/join.ts
@@ -183,6 +183,20 @@ export async function runJoinFlow(opts: RunJoinFlowOptions): Promise<void> {
   // `firstVisible` to observe that the race resolved, then branch on live DOM.
   void firstVisible;
 
+  // Shared predicate used for Step 3 (name input) and Step 4 (admission
+  // buttons). Meet leaves hidden template / transition copies of these nodes
+  // in the tree during the prejoin mount, so `querySelector` alone can hit a
+  // ghost node. Iterate every `querySelectorAll` match and take the first
+  // interactable one instead, mirroring `waitForSelector({ interactable })`.
+  const findInteractable = (sel: string): Element | null => {
+    const nodes = doc.querySelectorAll(sel);
+    for (let i = 0; i < nodes.length; i++) {
+      const el = nodes[i]!;
+      if (isInteractable(el)) return el;
+    }
+    return null;
+  };
+
   // Step 3 — populate the name input if present. Meet doesn't render it for
   // signed-in users, in which case the account's name is used instead.
   //
@@ -192,7 +206,23 @@ export async function runJoinFlow(opts: RunJoinFlowOptions): Promise<void> {
   // pattern for programmatically setting a controlled input in React —
   // without it, Meet's internal state never registers the name change and
   // the join button remains gated as if the field were still empty.
-  const nameInput = doc.querySelector(selectors.PREJOIN_NAME_INPUT);
+  //
+  // Same flake pattern as Step 4: the input can be in the DOM but not yet
+  // interactable when Step 2's `waitForAny` race resolves on a join button
+  // a few frames ahead of the input's own mount. Writing into the ghost
+  // node leaves React's state empty and the real button stays gated on an
+  // empty name — which then makes Step 4 time out. Poll briefly so we pick
+  // up the real input once it becomes interactable, and short-circuit when
+  // no input nodes are in the tree at all (the signed-in variant, where the
+  // budget would otherwise be wasted on an input that will never appear).
+  let nameInput: Element | null = null;
+  const nameDeadline = Date.now() + 2_000;
+  while (Date.now() < nameDeadline) {
+    if (doc.querySelectorAll(selectors.PREJOIN_NAME_INPUT).length === 0) break;
+    nameInput = findInteractable(selectors.PREJOIN_NAME_INPUT);
+    if (nameInput) break;
+    await new Promise((r) => setTimeout(r, 100));
+  }
   if (nameInput) {
     const input = nameInput as HTMLInputElement;
     input.focus();
@@ -216,19 +246,10 @@ export async function runJoinFlow(opts: RunJoinFlowOptions): Promise<void> {
   // here races against that render. Poll with a short budget — the button
   // is visible in the DOM within a few hundred ms of the input event.
   //
-  // Apply the same interactable filter the Step 1/2 waits use: Meet leaves
-  // hidden template copies of the join buttons in the tree during prejoin,
-  // so the first `querySelector` hit can be a ghost node. Iterate every
-  // match and take the first interactable one so this poll stays consistent
-  // with the rest of the join flow.
-  const findInteractable = (sel: string): Element | null => {
-    const nodes = doc.querySelectorAll(sel);
-    for (let i = 0; i < nodes.length; i++) {
-      const el = nodes[i]!;
-      if (isInteractable(el)) return el;
-    }
-    return null;
-  };
+  // Apply the same interactable filter the Step 1/2 waits use (see the
+  // `findInteractable` helper hoisted above Step 3): Meet leaves hidden
+  // template copies of the join buttons in the tree during prejoin, so the
+  // first `querySelector` hit can be a ghost node.
   let admissionBtn: Element | null = null;
   const joinDeadline = Date.now() + 10_000;
   while (Date.now() < joinDeadline) {


### PR DESCRIPTION
Addresses review feedback on #27317.

Step 3 was still running `doc.querySelector(PREJOIN_NAME_INPUT)` with no interactable filter, so a hidden template copy of the input at the front of the tree could absorb the `displayName` write. React then never saw a value on the real input and Step 4's admission poll timed out on the still-gated join button.

Hoists the Step 4 `findInteractable` helper above Step 3 and polls the name input through it with a 2s budget, short-circuiting immediately when no input nodes exist at all (signed-in variant). Mirrors the flake pattern Devin flagged on #27317.

Adds a regression test that inserts an `aria-hidden` template copy in front of the real name input and asserts the real input receives the `displayName` write.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
