### PR TITLE
fix(compaction): expand summary echo regex + tighten injection strip

### DIFF
--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -472,6 +472,22 @@ describe("computeSummaryQualitySignals", () => {
     expect(computeSummaryQualitySignals(nowLeak).hadMemoryEcho).toBe(true);
   });
 
+  test("flags tags that sit next to an underscore (word-boundary gap)", () => {
+    // These four tags are all stripped by COMPACTION_ONLY_STRIP_PREFIXES but
+    // the original regex missed them because `\b` does not assert between two
+    // word characters (e.g. the `e_` in `workspace_top_level`), so leakage
+    // telemetry was silently blind to them. Each tag must now flag.
+    const cases = [
+      "<workspace_top_level>\nlisting",
+      "<active_subagents>\nstuff",
+      "<active_workspace>\nstuff",
+      "<active_dynamic_page>\nstuff",
+    ];
+    for (const leaked of cases) {
+      expect(computeSummaryQualitySignals(leaked).hadMemoryEcho).toBe(true);
+    }
+  });
+
   test("does not flag ordinary mentions of the word 'memory'", () => {
     const clean =
       "## Facts\nThe user asked about their memory and remembered their dad's recipe.";

--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -1748,6 +1748,137 @@ describe("stripCompactionOnlyInjections", () => {
     );
     expect(stripped[1].content).toHaveLength(2);
   });
+
+  test("preserves user prose that merely mentions ambiguous tag names", () => {
+    // These are the common-word bare tags whose previous prefix-only match
+    // would false-positive on legitimate user messages discussing XML or
+    // referring to system terminology. Each case should survive stripping
+    // because it is not shaped like a runtime injection (no leading newline
+    // after the tag, or other prose surrounds the tag).
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<memory> is a tag I'd like to add to my parser",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "checking <workspace> usage across the repo, any thoughts?",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "what is <knowledge_base> in this context?",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "<pkb> sounds like a short name — wrong?" },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "when the model hits a <system_reminder>, what happens next?",
+          },
+        ],
+      },
+    ];
+    const stripped = stripCompactionOnlyInjections(messages);
+    expect(stripped).toHaveLength(messages.length);
+    for (let i = 0; i < messages.length; i++) {
+      expect(stripped[i].content).toHaveLength(1);
+      expect((stripped[i].content[0] as { text: string }).text).toBe(
+        (messages[i].content[0] as { text: string }).text,
+      );
+    }
+  });
+
+  test("still strips runtime-shaped wrapped blocks for ambiguous tag names", () => {
+    // Legacy pre-`__injected` history still emits bare-tag blocks with a
+    // newline after the open tag and a matching close tag. Those must
+    // continue to be stripped even though the prefix list no longer names
+    // them — the wrapped-match path covers the legacy shape.
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "<memory>\nlegacy recall blob\n</memory>" },
+          { type: "text", text: "actual user content" },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<workspace>\nRoot: /home\nFiles: a, b\n</workspace>",
+          },
+          { type: "text", text: "more prose" },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<system_reminder>\nread your PKB\n</system_reminder>",
+          },
+          { type: "text", text: "ok" },
+        ],
+      },
+    ];
+    const stripped = stripCompactionOnlyInjections(messages);
+    expect(stripped).toHaveLength(3);
+    for (const msg of stripped) {
+      expect(msg.content).toHaveLength(1);
+    }
+    expect((stripped[0].content[0] as { text: string }).text).toBe(
+      "actual user content",
+    );
+    expect((stripped[1].content[0] as { text: string }).text).toBe(
+      "more prose",
+    );
+    expect((stripped[2].content[0] as { text: string }).text).toBe("ok");
+  });
+
+  test("does not strip a user's inline snippet that is not shaped like an injection", () => {
+    // A user quoting a `<memory>...</memory>` snippet alongside prose in the
+    // SAME text block should survive — the block does not start with
+    // `<memory>\n` (there's surrounding prose) so the wrapped-tag match
+    // does not trigger.
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Here's the XML I'm working with: <memory>x</memory> — what do you think?",
+          },
+        ],
+      },
+    ];
+    const stripped = stripCompactionOnlyInjections(messages);
+    expect(stripped).toHaveLength(1);
+    expect((stripped[0].content[0] as { text: string }).text).toContain(
+      "<memory>x</memory>",
+    );
+  });
 });
 
 describe("summarizer input excludes runtime injections", () => {

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -49,24 +49,25 @@ const SUMMARY_COMPRESSION_PRESSURE_RATIO = 0.6;
  * `conversation-runtime-assembly.ts`. That list governs in-flight turn
  * assembly; this one governs compaction input only. Keep them in sync
  * when new injection types are added.
+ *
+ * Only internal-vocabulary tags are listed here. Tags whose bare form
+ * collides with ordinary English words a user might actually type
+ * (`<memory>`, `<workspace>`, `<knowledge_base>`, `<pkb>`,
+ * `<system_reminder>`) are handled by `COMPACTION_ONLY_WRAPPED_STRIP_TAGS`
+ * below with a tighter match that requires the whole text block to be a
+ * runtime-shaped open/close wrap.
  */
 const COMPACTION_ONLY_STRIP_PREFIXES = [
   "<memory __injected>",
-  "<memory>",
   "<memory_image __injected>",
   "</memory_image>",
   "<memory_context __injected>",
-  "<memory_context>",
   "<turn_context>",
   "<channel_turn_context>",
   "<guardian_context>",
   "<inbound_actor_context>",
   "<interface_turn_context>",
-  "<workspace>",
   "<workspace_top_level>",
-  "<knowledge_base>",
-  "<pkb>",
-  "<system_reminder>",
   "<now_scratchpad>",
   "<NOW.md Always keep this up to date",
   "<active_thread>",
@@ -83,10 +84,40 @@ const COMPACTION_ONLY_STRIP_PREFIXES = [
 ];
 
 /**
- * Remove text blocks whose prefix matches any entry in
- * `COMPACTION_ONLY_STRIP_PREFIXES`. Non-text blocks (images, tool_use,
- * tool_result, etc.) are untouched. Empty messages (every block filtered
- * out) are dropped from the output.
+ * Tags whose bare form (`<tag>`) is common English vocabulary or markup a
+ * user might legitimately type in prose. For these we only strip a text
+ * block if it is shaped exactly like a runtime injection: starts with
+ * `<tag>\n` and ends with `</tag>`. Runtime always emits these blocks with
+ * a newline after the opening tag and a matching closing tag; a user who
+ * mentions `<memory>` in a sentence or inlines `<workspace>...</workspace>`
+ * within other prose will not match this shape.
+ *
+ * Covers both current-format bare emissions and legacy pre-`__injected`
+ * history (e.g. `<memory>...</memory>` from before `<memory __injected>`
+ * was introduced).
+ */
+const COMPACTION_ONLY_WRAPPED_STRIP_TAGS = [
+  "memory",
+  "memory_context",
+  "workspace",
+  "knowledge_base",
+  "pkb",
+  "system_reminder",
+];
+
+function isCompactionInjectedBlock(text: string): boolean {
+  if (COMPACTION_ONLY_STRIP_PREFIXES.some((p) => text.startsWith(p))) {
+    return true;
+  }
+  return COMPACTION_ONLY_WRAPPED_STRIP_TAGS.some(
+    (tag) => text.startsWith(`<${tag}>\n`) && text.endsWith(`</${tag}>`),
+  );
+}
+
+/**
+ * Remove text blocks that look like runtime injections from user messages.
+ * Non-text blocks (images, tool_use, tool_result, etc.) are untouched.
+ * Empty messages (every block filtered out) are dropped from the output.
  *
  * Used only on the `compactableMessages` slice right before it is
  * serialized for the summarization LLM — the caller's original message
@@ -98,9 +129,7 @@ export function stripCompactionOnlyInjections(messages: Message[]): Message[] {
       if (message.role !== "user") return message;
       const nextContent = message.content.filter((block) => {
         if (block.type !== "text") return true;
-        return !COMPACTION_ONLY_STRIP_PREFIXES.some((p) =>
-          block.text.startsWith(p),
-        );
+        return !isCompactionInjectedBlock(block.text);
       });
       if (nextContent.length === message.content.length) return message;
       if (nextContent.length === 0) return null;

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -2322,7 +2322,7 @@ export function collapseRawResponses(
  * worth surfacing via telemetry.
  */
 const SUMMARY_MEMORY_ECHO_PATTERN =
-  /<(?:memory|memory_context|memory_image|turn_context|workspace|knowledge_base|pkb|system_reminder|now_scratchpad|NOW\.md|active_thread|channel_capabilities|transport_hints|system_notice|non_interactive_context|temporal_context|guardian_context|inbound_actor_context|channel_turn_context|interface_turn_context|channel_command_context|voice_call_control)\b/i;
+  /<(?:memory|memory_context|memory_image|turn_context|workspace|workspace_top_level|knowledge_base|pkb|system_reminder|now_scratchpad|NOW\.md|active_thread|active_subagents|active_workspace|active_dynamic_page|channel_capabilities|transport_hints|system_notice|non_interactive_context|temporal_context|guardian_context|inbound_actor_context|channel_turn_context|interface_turn_context|channel_command_context|voice_call_control)\b/i;
 
 /**
  * Compute light-weight quality signals for a compaction summary. Emitted


### PR DESCRIPTION
Addresses review feedback on #27287.

**Devin P2** — `SUMMARY_MEMORY_ECHO_PATTERN` was blind to 4 tags that `COMPACTION_ONLY_STRIP_PREFIXES` strips: `<active_subagents>`, `<active_workspace>`, `<active_dynamic_page>`, `<workspace_top_level>`. The last one failed because `\b` does not assert between `e` and `_` (both word chars). Added all four as explicit alternation items.

**Codex P2** — `stripCompactionOnlyInjections` was using bare-prefix matches for tags that collide with ordinary English / markup a user might legitimately type (`<memory>`, `<workspace>`, `<knowledge_base>`, `<pkb>`, `<system_reminder>`, `<memory_context>`). Split into two lists: internal-vocabulary prefixes matched by `startsWith` as before, and user-authorable tags that require the entire block to be shaped like a runtime injection (`<tag>\n…</tag>`). Runtime emission always matches; user prose almost never does.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
