### PR TITLE
fix(providers): sync OpenAI entries to client catalog

### DIFF
--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -108,7 +108,7 @@
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 2.5,
-            "outputPer1mTokens": 10.0,
+            "outputPer1mTokens": 15.0,
             "cacheReadPer1mTokens": 0.25
           }
         },
@@ -122,8 +122,8 @@
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 3.0,
-            "outputPer1mTokens": 12.0,
+            "inputPer1mTokens": 1.75,
+            "outputPer1mTokens": 14.0,
             "cacheReadPer1mTokens": 0.3
           }
         },
@@ -138,7 +138,7 @@
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 0.5,
-            "outputPer1mTokens": 2.0,
+            "outputPer1mTokens": 3.0,
             "cacheReadPer1mTokens": 0.05
           }
         },
@@ -152,8 +152,8 @@
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.1,
-            "outputPer1mTokens": 0.4,
+            "inputPer1mTokens": 0.2,
+            "outputPer1mTokens": 1.25,
             "cacheReadPer1mTokens": 0.01
           }
         }


### PR DESCRIPTION
Addresses review feedback on #27332 + fixes parity test OpenAI regression.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
