### PR TITLE
fix(meet-bot): guard against stale visemes on reused streamId

### DIFF
--- a/skills/meet-join/bot/__tests__/avatar-lipsync.test.ts
+++ b/skills/meet-join/bot/__tests__/avatar-lipsync.test.ts
@@ -441,6 +441,61 @@ describe("TalkingHead renderer lip-sync alignment", () => {
     ]);
   });
 
+  test("resetPlaybackTimestamp drops leftover visemes when streamId is reused with a fresh utteranceId", async () => {
+    // Regression for the reused-streamId leak: `MeetTtsBridge.speak()`
+    // accepts caller-supplied streamIds and only rejects duplicates
+    // while a stream is concurrently active. After a cancel, a caller
+    // can legally start a new speak() with the same streamId — and any
+    // visemes from the prior utterance that were still buffered (their
+    // playback clock had not yet caught up to them) would, under
+    // streamId-only matching, look identical to the new utterance's
+    // visemes and survive the reset. The bridge mints a fresh
+    // `utteranceId` per speak() call to disambiguate; the renderer
+    // requires BOTH ids to match before preserving an event.
+    const nativeMessaging = new FakeNativeMessaging();
+    const renderer = await startRenderer(nativeMessaging);
+
+    // Utterance 1 with streamId="X", utteranceId="u1". A late-arriving
+    // viseme (audio not yet played) is buffered when the speak is
+    // cancelled — it sits in the buffer with both ids tagged.
+    renderer.pushViseme({
+      phoneme: "stale",
+      weight: 0.1,
+      timestamp: 900,
+      streamId: "X",
+      utteranceId: "u1",
+    });
+
+    // Utterance 2 reuses streamId="X" but is a brand-new speak() call
+    // so the bridge mints utteranceId="u2". Synthesis races ahead of
+    // the POST and an early viseme arrives first, tagged with both new
+    // ids.
+    renderer.pushViseme({
+      phoneme: "early",
+      weight: 0.4,
+      timestamp: 50,
+      streamId: "X",
+      utteranceId: "u2",
+    });
+
+    // The /play_audio POST for utterance 2 fires resetPlaybackTimestamp
+    // with the new ids. The "u1" stale viseme must be dropped (this is
+    // the bug being fixed); the "u2" early viseme must survive.
+    renderer.resetPlaybackTimestamp!("X", "u2");
+
+    renderer.notifyPlaybackTimestamp(50);
+    expect(nativeMessaging.pushVisemes().map((v) => v.phoneme)).toEqual([
+      "early",
+    ]);
+    // Even after the clock runs past the stale viseme's timestamp it
+    // must NEVER surface — confirming the reset evicted it rather than
+    // just hid it behind the rewound clock.
+    renderer.notifyPlaybackTimestamp(10_000);
+    expect(nativeMessaging.pushVisemes().map((v) => v.phoneme)).toEqual([
+      "early",
+    ]);
+  });
+
   test("visemes with identical timestamps are forwarded in arrival order", async () => {
     // ElevenLabs' viseme stream can legitimately produce back-to-back
     // events with the same millisecond timestamp. The buffer drain

--- a/skills/meet-join/bot/src/control/http-server.ts
+++ b/skills/meet-join/bot/src/control/http-server.ts
@@ -411,6 +411,16 @@ export function createHttpServer(
     const providedId = c.req.query("stream_id");
     const streamId =
       providedId && providedId.length > 0 ? providedId : randomUUID();
+    // Bridge-internal utterance id paired with the stream id. Allows the
+    // renderer's `resetPlaybackTimestamp` to distinguish a leftover
+    // viseme from a cancelled prior speak() that reused this same
+    // `stream_id` from an early-arriving viseme of the new speak() call.
+    // Optional so older daemons still interoperate.
+    const providedUtteranceId = c.req.query("utterance_id");
+    const utteranceId =
+      providedUtteranceId && providedUtteranceId.length > 0
+        ? providedUtteranceId
+        : undefined;
 
     // Serialize against every in-flight stream, not just one with the same
     // id. The bot owns a single shared pacat stdin (see audio-playback's
@@ -474,7 +484,7 @@ export function createHttpServer(
         rendererAtStreamStart.capabilities.needsVisemes &&
         typeof rendererAtStreamStart.resetPlaybackTimestamp === "function"
       ) {
-        rendererAtStreamStart.resetPlaybackTimestamp(streamId);
+        rendererAtStreamStart.resetPlaybackTimestamp(streamId, utteranceId);
       }
 
       const controller = new AbortController();
@@ -1014,10 +1024,18 @@ function parseVisemeEvent(body: unknown): VisemeEvent | null {
     typeof raw.streamId === "string" && raw.streamId.length > 0
       ? raw.streamId
       : undefined;
+  // `utteranceId` is also optional and follows the same compatibility
+  // policy: older daemons that haven't yet rolled out the utterance-id
+  // tagging just degrade to streamId-only matching on reset.
+  const utteranceId =
+    typeof raw.utteranceId === "string" && raw.utteranceId.length > 0
+      ? raw.utteranceId
+      : undefined;
   return {
     phoneme: raw.phoneme,
     weight: raw.weight,
     timestamp: raw.timestamp,
     ...(streamId !== undefined ? { streamId } : {}),
+    ...(utteranceId !== undefined ? { utteranceId } : {}),
   };
 }

--- a/skills/meet-join/bot/src/media/avatar/talking-head/renderer.ts
+++ b/skills/meet-join/bot/src/media/avatar/talking-head/renderer.ts
@@ -426,13 +426,21 @@ export class TalkingHeadRenderer implements AvatarRenderer {
    * The daemon fires provider synthesis concurrently with the
    * `/play_audio` POST, so some visemes for the incoming utterance can
    * land on `/avatar/viseme` BEFORE the POST that triggers this reset.
-   * Those events are already tagged with the POST's `stream_id`, so we
-   * preserve any buffered viseme whose `streamId === incomingStreamId`
-   * and drop everything else — the original "clear the entire buffer"
-   * behavior threw those early-arriving events away and defeated the
-   * very buffering this method exists to protect.
+   * Those events are already tagged with the POST's `stream_id` AND
+   * the bridge-internal `utterance_id`, so we preserve any buffered
+   * viseme whose `streamId === incomingStreamId` AND
+   * `utteranceId === incomingUtteranceId` and drop everything else.
+   * Matching on `streamId` alone would not be enough: caller-supplied
+   * stream ids can legally be reused across `MeetTtsBridge.speak()`
+   * calls, so a leftover viseme from a cancelled prior utterance and
+   * an early-arriving viseme from the reused-streamId successor would
+   * both pass a `streamId`-only filter. The fresh `utteranceId` minted
+   * per speak() call disambiguates them.
    */
-  resetPlaybackTimestamp(incomingStreamId?: string): void {
+  resetPlaybackTimestamp(
+    incomingStreamId?: string,
+    incomingUtteranceId?: string,
+  ): void {
     if (this.stopped) return;
     this.currentPlaybackTimestamp = Number.NEGATIVE_INFINITY;
     if (incomingStreamId === undefined) {
@@ -443,15 +451,23 @@ export class TalkingHeadRenderer implements AvatarRenderer {
       return;
     }
     // Filter in place so we don't reallocate; visemes already in
-    // arrival order stay that way. Same-streamId visemes belong to the
-    // incoming utterance (synthesis raced ahead of the POST) and must
-    // survive the reset; every other viseme is prior-utterance debris.
+    // arrival order stay that way. Visemes that belong to the incoming
+    // utterance (synthesis raced ahead of the POST) must match BOTH
+    // ids to survive the reset; every other viseme is prior-utterance
+    // debris. When the daemon hasn't sent an `utteranceId` yet (older
+    // build), fall back to `streamId`-only matching — degraded but no
+    // worse than the prior behavior.
     let writeIdx = 0;
     for (let readIdx = 0; readIdx < this.visemeBuffer.length; readIdx++) {
       const v = this.visemeBuffer[readIdx]!;
-      if (v.streamId === incomingStreamId) {
-        this.visemeBuffer[writeIdx++] = v;
+      if (v.streamId !== incomingStreamId) continue;
+      if (
+        incomingUtteranceId !== undefined &&
+        v.utteranceId !== incomingUtteranceId
+      ) {
+        continue;
       }
+      this.visemeBuffer[writeIdx++] = v;
     }
     this.visemeBuffer.length = writeIdx;
   }

--- a/skills/meet-join/bot/src/media/avatar/types.ts
+++ b/skills/meet-join/bot/src/media/avatar/types.ts
@@ -58,6 +58,21 @@ export type VisemeEvent = {
    * dropped on reset, matching the original clear-all behavior.
    */
   streamId?: string;
+  /**
+   * Optional — the bridge-internal utterance id that uniquely identifies
+   * one `MeetTtsBridge.speak()` call. Distinct from `streamId` because
+   * `streamId` can legally be reused across speak() calls (the bridge
+   * accepts caller-supplied ids and only rejects duplicates while a
+   * stream is concurrently active), so a leftover viseme from a
+   * cancelled prior utterance and an early-arriving viseme from the
+   * reused-streamId successor would both match the new POST's
+   * `streamId` and survive `resetPlaybackTimestamp` — leaking stale
+   * mouth shapes into the new utterance. The bridge mints a fresh
+   * `utteranceId` per speak() call so the renderer can require both
+   * `streamId` AND `utteranceId` to match before preserving an event,
+   * which is the minimum signal needed to disambiguate the two cases.
+   */
+  utteranceId?: string;
 };
 
 /**
@@ -155,16 +170,25 @@ export interface AvatarRenderer {
    *
    * Implementations should drop buffered visemes that belonged to the
    * prior utterance so they cannot leak into the fresh stream, but
-   * must preserve visemes tagged with `incomingStreamId` — the daemon
-   * fires synthesis concurrently with the `/play_audio` POST, so some
-   * events from the incoming utterance can land BEFORE the POST that
-   * triggers this reset. `incomingStreamId` is the `stream_id` of the
-   * new POST; visemes whose `streamId` matches it belong to the
-   * incoming utterance and must be kept. Visemes with any other
-   * `streamId` (or no `streamId` at all — the pre-tagging case) are
+   * must preserve visemes tagged with the incoming utterance's
+   * identifiers — the daemon fires synthesis concurrently with the
+   * `/play_audio` POST, so some events from the incoming utterance can
+   * land BEFORE the POST that triggers this reset.
+   *
+   * `incomingStreamId` is the `stream_id` of the new POST.
+   * `incomingUtteranceId` is the bridge-internal utterance id of the
+   * new POST. Visemes whose `streamId` AND `utteranceId` both match
+   * are preserved. Matching on `streamId` alone is unsafe because
+   * caller-supplied stream ids can be reused across speak() calls,
+   * which would let prior-utterance leftovers tagged with the same
+   * `streamId` slip through. Visemes with mismatched ids — or no
+   * `streamId`/`utteranceId` at all (the pre-tagging case) — are
    * dropped.
    */
-  resetPlaybackTimestamp?(incomingStreamId?: string): void;
+  resetPlaybackTimestamp?(
+    incomingStreamId?: string,
+    incomingUtteranceId?: string,
+  ): void;
 }
 
 /**

--- a/skills/meet-join/daemon/__tests__/tts-bridge.test.ts
+++ b/skills/meet-join/daemon/__tests__/tts-bridge.test.ts
@@ -311,6 +311,7 @@ describe("MeetTtsBridge.speak", () => {
         providerFactory: () => provider,
         spawn,
         newStreamId: () => "stream-abc",
+        newUtteranceId: () => "utt-abc",
       },
     );
 
@@ -324,10 +325,15 @@ describe("MeetTtsBridge.speak", () => {
     await result.completion;
 
     // Assert: exactly one POST landed on the fake bot with the right URL,
-    // headers, and body bytes.
+    // headers, and body bytes. The bridge mints a per-speak utterance id
+    // and pairs it with the stream id on the URL so the bot's renderer
+    // can drop leftover visemes from a cancelled prior speak that reused
+    // the same stream id.
     expect(fakeBot.posts).toHaveLength(1);
     const post = fakeBot.posts[0]!;
-    expect(post.url).toBe("/play_audio?stream_id=stream-abc");
+    expect(post.url).toBe(
+      "/play_audio?stream_id=stream-abc&utterance_id=utt-abc",
+    );
     expect(post.authorization).toBe(`Bearer ${TOKEN}`);
     expect(post.contentType).toBe("application/octet-stream");
     expect(Array.from(post.body)).toEqual(Array.from(expected));
@@ -815,6 +821,7 @@ describe("MeetTtsBridge resampling hot-path (real ffmpeg)", () => {
           // window below.
           spawn: realSpawn,
           newStreamId: () => "stream-resample",
+          newUtteranceId: () => "utt-resample",
         },
       );
 
@@ -823,7 +830,9 @@ describe("MeetTtsBridge resampling hot-path (real ffmpeg)", () => {
 
       expect(fakeBot.posts).toHaveLength(1);
       const post = fakeBot.posts[0]!;
-      expect(post.url).toBe("/play_audio?stream_id=stream-resample");
+      expect(post.url).toBe(
+        "/play_audio?stream_id=stream-resample&utterance_id=utt-resample",
+      );
 
       // Expected output: 48 kHz mono s16le = 2 bytes/sample.
       // 500 ms @ 48 kHz = 24_000 samples = 48_000 bytes.

--- a/skills/meet-join/daemon/__tests__/tts-lipsync.test.ts
+++ b/skills/meet-join/daemon/__tests__/tts-lipsync.test.ts
@@ -303,6 +303,7 @@ describe("MeetTtsBridge.onViseme — provider alignment path", () => {
         providerFactory: () => provider,
         spawn,
         newStreamId: () => "stream-align",
+        newUtteranceId: () => "utt-align",
       },
     );
 
@@ -314,12 +315,25 @@ describe("MeetTtsBridge.onViseme — provider alignment path", () => {
 
     // Only the alignment events should have been forwarded; no "amp"
     // fallback entries since the provider advertised alignment support.
-    // The bridge stamps every viseme with the active stream id so the
-    // bot can distinguish prior-utterance debris from events racing
-    // ahead of a fresh `/play_audio` POST.
+    // The bridge stamps every viseme with both the active stream id and
+    // a per-speak utterance id so the bot can distinguish prior-utterance
+    // debris (including from a cancelled prior speak that reused this
+    // stream id) from events racing ahead of a fresh `/play_audio` POST.
     expect(events).toEqual([
-      { phoneme: "a", weight: 0.3, timestamp: 10, streamId: "stream-align" },
-      { phoneme: "e", weight: 0.7, timestamp: 25, streamId: "stream-align" },
+      {
+        phoneme: "a",
+        weight: 0.3,
+        timestamp: 10,
+        streamId: "stream-align",
+        utteranceId: "utt-align",
+      },
+      {
+        phoneme: "e",
+        weight: 0.7,
+        timestamp: 25,
+        streamId: "stream-align",
+        utteranceId: "utt-align",
+      },
     ]);
     expect(events.every((e) => e.phoneme !== "amp")).toBe(true);
   });

--- a/skills/meet-join/daemon/__tests__/voice-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/voice-e2e.test.ts
@@ -535,6 +535,7 @@ describe("Meet voice E2E (bridge + watcher + real assistant-event-hub)", () => {
         providerFactory: () => provider,
         spawn,
         newStreamId: () => "stream-happy",
+        newUtteranceId: () => "utt-happy",
       },
     );
 
@@ -573,7 +574,9 @@ describe("Meet voice E2E (bridge + watcher + real assistant-event-hub)", () => {
 
       // Wait for the bot to actually receive and finish reading the POST.
       const post = await postCompletion;
-      expect(post.url).toBe("/play_audio?stream_id=stream-happy");
+      expect(post.url).toBe(
+        "/play_audio?stream_id=stream-happy&utterance_id=utt-happy",
+      );
       expect(post.authorization).toBe(`Bearer ${TOKEN}`);
       expect(post.contentType).toBe("application/octet-stream");
 

--- a/skills/meet-join/daemon/tts-bridge.ts
+++ b/skills/meet-join/daemon/tts-bridge.ts
@@ -14,7 +14,8 @@
  *      16-bit signed little-endian PCM. Provider chunks are written into
  *      ffmpeg's stdin; ffmpeg's stdout is the body stream consumed by the
  *      outbound HTTP POST.
- *   4. POST `ffmpeg.stdout` to `${botUrl}/play_audio?stream_id=${streamId}`
+ *   4. POST `ffmpeg.stdout` to
+ *      `${botUrl}/play_audio?stream_id=${streamId}&utterance_id=${utteranceId}`
  *      with `Content-Type: application/octet-stream` using chunked transfer.
  *      Because Node/undici require it for streamed upload bodies, the fetch
  *      is called with `duplex: "half"`.
@@ -130,6 +131,17 @@ export interface VisemeEvent {
    * care about.
    */
   streamId?: string;
+  /**
+   * Optional — bridge-internal monotonic utterance id minted fresh on
+   * every {@link MeetTtsBridge.speak} call (independent of `streamId`,
+   * which callers may legally reuse across speaks). Paired with the
+   * `?utterance_id=` query param sent on `/play_audio` so the bot's
+   * renderer can require BOTH `streamId` and `utteranceId` to match
+   * before preserving a buffered viseme on `resetPlaybackTimestamp` —
+   * preventing stale visemes from a cancelled prior speak that reused
+   * this `streamId` from leaking into the new utterance.
+   */
+  utteranceId?: string;
 }
 
 /**
@@ -245,6 +257,14 @@ export interface MeetTtsBridgeDeps {
   spawn?: SpawnFn;
   /** Override the UUID generator used for streamId allocation (tests). */
   newStreamId?: () => string;
+  /**
+   * Override the generator used for the bridge-internal `utteranceId`
+   * allocated on every `speak()` call. Tests inject a deterministic
+   * factory so they can assert the id propagates onto viseme events
+   * and the `/play_audio?utterance_id=` query param. Defaults to
+   * `randomUUID()`.
+   */
+  newUtteranceId?: () => string;
 }
 
 // ---------------------------------------------------------------------------
@@ -361,6 +381,7 @@ export class MeetTtsBridge {
       fetch: deps.fetch ?? ((url, init) => fetch(url, init as RequestInit)),
       spawn: deps.spawn ?? nodeSpawn,
       newStreamId: deps.newStreamId ?? (() => randomUUID()),
+      newUtteranceId: deps.newUtteranceId ?? (() => randomUUID()),
     };
   }
 
@@ -378,6 +399,13 @@ export class MeetTtsBridge {
         `MeetTtsBridge: streamId ${streamId} is already active for meeting ${this.meetingId}`,
       );
     }
+    // Mint a fresh utterance id even when the caller reuses `streamId`
+    // across speaks. The bot's renderer requires both `streamId` and
+    // `utteranceId` to match before preserving a buffered viseme on
+    // reset, so a unique-per-speak `utteranceId` is what disambiguates
+    // a leftover viseme from a cancelled prior speak with the same
+    // `streamId` from an early-arriving viseme of this new speak.
+    const utteranceId = this.deps.newUtteranceId();
 
     // Pre-flight: verify ffmpeg is on PATH before we allocate any streams.
     // The probe result is memoized on the bridge instance, so this only
@@ -490,6 +518,7 @@ export class MeetTtsBridge {
               weight: clamp01(event.weight),
               timestamp: event.timestamp,
               streamId,
+              utteranceId,
             });
           }
         : undefined;
@@ -540,7 +569,7 @@ export class MeetTtsBridge {
     // fetch body reader, truncating the audio that reaches the bot.
     let httpBodySource: NodeJS.ReadableStream = ffmpeg.stdout;
     if (useAmplitudeFallback) {
-      const tap = this.createAmplitudeTap(abort.signal, streamId);
+      const tap = this.createAmplitudeTap(abort.signal, streamId, utteranceId);
       ffmpeg.stdout.pipe(tap);
       httpBodySource = tap;
     }
@@ -548,7 +577,9 @@ export class MeetTtsBridge {
       httpBodySource as Readable,
     ) as unknown as ReadableStream<Uint8Array>;
 
-    const url = `${this.botBaseUrl}/play_audio?stream_id=${encodeURIComponent(streamId)}`;
+    const url =
+      `${this.botBaseUrl}/play_audio?stream_id=${encodeURIComponent(streamId)}` +
+      `&utterance_id=${encodeURIComponent(utteranceId)}`;
 
     const postSettled = this.runPost({
       url,
@@ -699,7 +730,11 @@ export class MeetTtsBridge {
    * which keeps the calculation self-consistent and spares consumers a
    * ragged-edge weight.
    */
-  private createAmplitudeTap(signal: AbortSignal, streamId: string): Transform {
+  private createAmplitudeTap(
+    signal: AbortSignal,
+    streamId: string,
+    utteranceId: string,
+  ): Transform {
     let totalBytesConsumed = 0;
     let windowBuffer = Buffer.alloc(0);
 
@@ -728,7 +763,13 @@ export class MeetTtsBridge {
         const rms = Math.sqrt(sumOfSquares / AMPLITUDE_SAMPLES_PER_WINDOW);
         const weight = clamp01(rms / AMPLITUDE_MAX_SAMPLE);
 
-        this.emitVisemeEvent({ phoneme: "amp", weight, timestamp, streamId });
+        this.emitVisemeEvent({
+          phoneme: "amp",
+          weight,
+          timestamp,
+          streamId,
+          utteranceId,
+        });
       }
     };
 


### PR DESCRIPTION
Addresses Codex P2 review feedback on #27340.

`MeetTtsBridge.speak()` accepts caller-supplied stream ids and only rejects duplicates while a stream is concurrently active. After a cancel/early cutoff, a caller can legally reuse the same `streamId` on a new `speak()`, but any visemes from the prior utterance that were still buffered (their playback clock hadn't yet caught up) would, under the existing streamId-only matching in `resetPlaybackTimestamp`, look identical to the new utterance's visemes and survive the reset — leaking stale mouth shapes into the new utterance.

The bridge now mints a fresh internal `utteranceId` per `speak()` call (independent of the caller-supplied `streamId`) and tags every viseme + the paired `/play_audio` POST with it. The renderer's `resetPlaybackTimestamp` requires BOTH `streamId` AND `utteranceId` to match before preserving a buffered viseme, so leftovers from a cancelled prior speak with the same `streamId` are dropped.

Backwards-compat: both fields stay optional on the wire. Older daemons that don't tag with `utteranceId` degrade to streamId-only matching (the prior, slightly-leaky behavior), and older bots that don't read the new query param ignore it — neither side errors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
