### PR TITLE
fix(macos): clear persisted thinkingDurations on tool resume

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -350,6 +350,7 @@ struct AssistantProgressView: View {
                 cardCompletedAt = nil
                 if let key = cardKey {
                     progressUIState.clearCardCompletedAt(for: key)
+                    progressUIState.clearThinkingDuration(for: key)
                 }
             }
             // Track thinking phase start only when the daemon explicitly

--- a/clients/macos/vellum-assistant/Features/Chat/ProgressCardUIState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ProgressCardUIState.swift
@@ -133,6 +133,13 @@ struct ProgressCardUIState: Equatable, Sendable {
         cardCompletedDates.removeValue(forKey: cardKey)
     }
 
+    /// Clears the persisted thinking duration for a card. Called alongside
+    /// `clearCardCompletedAt` on tool resume so stale wave-1 durations don't
+    /// leak into wave-2 rendering.
+    mutating func clearThinkingDuration(for cardKey: UUID) {
+        thinkingDurations.removeValue(forKey: cardKey)
+    }
+
     /// Marks a group as having been rehydrated.
     mutating func markRehydrated(groupId: UUID) {
         rehydratedGroupIds.insert(groupId)


### PR DESCRIPTION
Addresses review feedback on #27336.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
