### PR TITLE
fix(providers): sync Anthropic Opus direct pricing to client catalog

### DIFF
--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -26,10 +26,10 @@
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 5,
-            "outputPer1mTokens": 25,
-            "cacheWritePer1mTokens": 6.25,
-            "cacheReadPer1mTokens": 0.5
+            "inputPer1mTokens": 15,
+            "outputPer1mTokens": 75,
+            "cacheWritePer1mTokens": 18.75,
+            "cacheReadPer1mTokens": 1.5
           }
         },
         {
@@ -42,10 +42,10 @@
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 5,
-            "outputPer1mTokens": 25,
-            "cacheWritePer1mTokens": 6.25,
-            "cacheReadPer1mTokens": 0.5
+            "inputPer1mTokens": 15,
+            "outputPer1mTokens": 75,
+            "cacheWritePer1mTokens": 18.75,
+            "cacheReadPer1mTokens": 1.5
           }
         },
         {
@@ -68,16 +68,16 @@
           "id": "claude-haiku-4-5-20251001",
           "displayName": "Claude Haiku 4.5",
           "contextWindowTokens": 200000,
-          "maxOutputTokens": 8192,
+          "maxOutputTokens": 16000,
           "supportsThinking": true,
           "supportsCaching": true,
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.8,
-            "outputPer1mTokens": 4,
-            "cacheWritePer1mTokens": 1,
-            "cacheReadPer1mTokens": 0.08
+            "inputPer1mTokens": 1,
+            "outputPer1mTokens": 5,
+            "cacheWritePer1mTokens": 1.25,
+            "cacheReadPer1mTokens": 0.1
           }
         }
       ]


### PR DESCRIPTION
Follow-up to #27361 which bumped daemon Opus pricing but missed client catalog sync. Restores llm-catalog-parity.test.ts green on main.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
