### PR TITLE
fix(cache): clear NOW.md + knowledge_base metadata on compaction strip

### DIFF
--- a/assistant/src/__tests__/compaction-strip-metadata-clear.test.ts
+++ b/assistant/src/__tests__/compaction-strip-metadata-clear.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+}));
+
+import {
+  addMessage,
+  clearStrippedInjectionMetadataForConversation,
+  createConversation,
+  getMessages,
+} from "../memory/conversation-crud.js";
+import { getDb, initializeDb } from "../memory/db.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+describe("clearStrippedInjectionMetadataForConversation", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("removes all three stripped-block fields and preserves the rest", async () => {
+    const conv = createConversation("Strip metadata test");
+    await addMessage(
+      conv.id,
+      "user",
+      "turn 1",
+      {
+        memoryInjectedBlock: "mem payload",
+        turnContextBlock: "<turn_context>\nctx\n</turn_context>",
+        workspaceBlock: "<workspace>\nws\n</workspace>",
+        nowScratchpadBlock:
+          "<NOW.md Always keep this up to date>\nnow body\n</NOW.md>",
+        pkbContextBlock: "<knowledge_base>\npkb body\n</knowledge_base>",
+        pkbSystemReminderBlock:
+          "<system_reminder>\nreminder body\n</system_reminder>",
+      },
+      { skipIndexing: true },
+    );
+
+    clearStrippedInjectionMetadataForConversation(conv.id);
+
+    const [row] = getMessages(conv.id);
+    const meta = JSON.parse(row.metadata ?? "{}");
+
+    expect(meta.pkbSystemReminderBlock).toBeUndefined();
+    expect(meta.nowScratchpadBlock).toBeUndefined();
+    expect(meta.pkbContextBlock).toBeUndefined();
+
+    // Non-stripped fields must survive — these back blocks that
+    // `stripInjectionsForCompaction` intentionally leaves in-memory.
+    expect(meta.memoryInjectedBlock).toBe("mem payload");
+    expect(meta.turnContextBlock).toBe("<turn_context>\nctx\n</turn_context>");
+    expect(meta.workspaceBlock).toBe("<workspace>\nws\n</workspace>");
+  });
+
+  test("is idempotent — re-running is a no-op on already-cleared rows", async () => {
+    const conv = createConversation("Idempotent clear");
+    await addMessage(
+      conv.id,
+      "user",
+      "turn 1",
+      {
+        memoryInjectedBlock: "keep me",
+        nowScratchpadBlock: "<NOW.md …>body</NOW.md>",
+      },
+      { skipIndexing: true },
+    );
+
+    clearStrippedInjectionMetadataForConversation(conv.id);
+    clearStrippedInjectionMetadataForConversation(conv.id);
+
+    const [row] = getMessages(conv.id);
+    const meta = JSON.parse(row.metadata ?? "{}");
+    expect(meta.nowScratchpadBlock).toBeUndefined();
+    expect(meta.memoryInjectedBlock).toBe("keep me");
+  });
+
+  test("only targets user rows — assistant metadata is untouched", async () => {
+    const conv = createConversation("Role scoping");
+    await addMessage(
+      conv.id,
+      "user",
+      "turn 1",
+      { nowScratchpadBlock: "<NOW.md …>body</NOW.md>" },
+      { skipIndexing: true },
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      "reply",
+      // Assistant rows don't carry these blocks in practice, but guard the
+      // role filter anyway so an accidental drop of the WHERE clause is
+      // surfaced immediately.
+      { nowScratchpadBlock: "should-not-be-cleared" },
+      { skipIndexing: true },
+    );
+
+    clearStrippedInjectionMetadataForConversation(conv.id);
+
+    const rows = getMessages(conv.id);
+    const userMeta = JSON.parse(rows[0].metadata ?? "{}");
+    const assistantMeta = JSON.parse(rows[1].metadata ?? "{}");
+    expect(userMeta.nowScratchpadBlock).toBeUndefined();
+    expect(assistantMeta.nowScratchpadBlock).toBe("should-not-be-cleared");
+  });
+
+  test("post-clear, rehydration does not re-inject NOW.md / knowledge_base", async () => {
+    // Reproduces the divergence described in the Codex P1 feedback:
+    // stripInjectionsForCompaction removes <NOW.md …> and <knowledge_base>
+    // from the in-memory history during compaction. Without this clear,
+    // a subsequent loadFromDb would rehydrate those blocks from stale
+    // metadata — re-injecting exactly what compaction removed.
+    const conv = createConversation("Rehydrate after strip");
+    await addMessage(
+      conv.id,
+      "user",
+      "historical turn",
+      {
+        memoryInjectedBlock: "mem",
+        turnContextBlock: "<turn_context>\nctx\n</turn_context>",
+        workspaceBlock: "<workspace>\nws\n</workspace>",
+        nowScratchpadBlock:
+          "<NOW.md Always keep this up to date>\nnow\n</NOW.md>",
+        pkbContextBlock: "<knowledge_base>\npkb\n</knowledge_base>",
+        pkbSystemReminderBlock: "<system_reminder>\nsr\n</system_reminder>",
+      },
+      { skipIndexing: true },
+    );
+    await addMessage(conv.id, "assistant", "reply", undefined, {
+      skipIndexing: true,
+    });
+    await addMessage(conv.id, "user", "tail turn", undefined, {
+      skipIndexing: true,
+    });
+
+    // Simulate the compaction-strip lifecycle point.
+    clearStrippedInjectionMetadataForConversation(conv.id);
+
+    const rows = getMessages(conv.id);
+    const historicalMeta = JSON.parse(rows[0].metadata ?? "{}");
+
+    // Loading this back with loadFromDb prepends fields only when they
+    // are present on the row. Confirm the stripped fields are gone so
+    // rehydration cannot resurrect them.
+    expect(historicalMeta.nowScratchpadBlock).toBeUndefined();
+    expect(historicalMeta.pkbContextBlock).toBeUndefined();
+    expect(historicalMeta.pkbSystemReminderBlock).toBeUndefined();
+
+    // And the fields that back blocks `stripInjectionsForCompaction`
+    // intentionally preserves (<turn_context>, <workspace>, <memory __injected>)
+    // must still be present so the cache prefix remains stable.
+    expect(historicalMeta.turnContextBlock).toBe(
+      "<turn_context>\nctx\n</turn_context>",
+    );
+    expect(historicalMeta.workspaceBlock).toBe("<workspace>\nws\n</workspace>");
+    expect(historicalMeta.memoryInjectedBlock).toBe("mem");
+  });
+});

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -167,7 +167,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   getMessageById: () => null,
   updateMessageContent: () => {},
   updateMessageMetadata: () => {},
-  clearPkbSystemReminderMetadataForConversation: () => {},
+  clearStrippedInjectionMetadataForConversation: () => {},
 }));
 
 mock.module("../memory/retriever.js", () => ({

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -120,7 +120,7 @@ mock.module("../hooks/manager.js", () => ({
 const updateMessageMetadataMock = mock(
   (_id: string, _updates: Record<string, unknown>) => {},
 );
-const clearPkbSystemReminderMetadataForConversationMock = mock(
+const clearStrippedInjectionMetadataForConversationMock = mock(
   (_conversationId: string) => {},
 );
 mock.module("../memory/conversation-crud.js", () => ({
@@ -128,8 +128,8 @@ mock.module("../memory/conversation-crud.js", () => ({
   setConversationOriginChannelIfUnset: () => {},
   updateConversationUsage: () => {},
   updateMessageMetadata: updateMessageMetadataMock,
-  clearPkbSystemReminderMetadataForConversation:
-    clearPkbSystemReminderMetadataForConversationMock,
+  clearStrippedInjectionMetadataForConversation:
+    clearStrippedInjectionMetadataForConversationMock,
   getMessages: () => [],
   getConversation: () => ({
     id: "conv-1",
@@ -514,8 +514,8 @@ beforeEach(() => {
   rebuildConversationDiskViewFromDbStateMock.mockClear();
   updateMessageMetadataMock.mockClear();
   updateMessageMetadataMock.mockImplementation(() => {});
-  clearPkbSystemReminderMetadataForConversationMock.mockClear();
-  clearPkbSystemReminderMetadataForConversationMock.mockImplementation(
+  clearStrippedInjectionMetadataForConversationMock.mockClear();
+  clearStrippedInjectionMetadataForConversationMock.mockImplementation(
     () => {},
   );
   applyRuntimeInjectionsMock.mockClear();
@@ -2368,14 +2368,14 @@ describe("session-agent-loop", () => {
       // The bulk-clear helper must have been called with the conversation id
       // at least once (one of the three strip sites fired).
       const clearCalls =
-        clearPkbSystemReminderMetadataForConversationMock.mock.calls.filter(
+        clearStrippedInjectionMetadataForConversationMock.mock.calls.filter(
           (call) => call[0] === "test-conv",
         );
       expect(clearCalls.length).toBeGreaterThanOrEqual(1);
     });
 
     test("strip-site clear is non-fatal when the helper throws", async () => {
-      clearPkbSystemReminderMetadataForConversationMock.mockImplementation(
+      clearStrippedInjectionMetadataForConversationMock.mockImplementation(
         () => {
           throw new Error("db write failed");
         },

--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -219,7 +219,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   getLastAssistantTimestampBefore: () => null,
   archiveConversation: () => false,
   unarchiveConversation: () => false,
-  clearPkbSystemReminderMetadataForConversation: () => {},
+  clearStrippedInjectionMetadataForConversation: () => {},
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -48,7 +48,7 @@ import { getApp, listAppFiles, resolveAppDir } from "../memory/app-store.js";
 import { enqueueAutoAnalysisOnCompaction } from "../memory/auto-analysis-enqueue.js";
 import {
   addMessage,
-  clearPkbSystemReminderMetadataForConversation,
+  clearStrippedInjectionMetadataForConversation,
   deleteMessageById,
   getConversation,
   getConversationOriginChannel,
@@ -1318,11 +1318,11 @@ export async function runAgentLoopImpl(
       const rawHistory = stripInjectionsForCompaction(updatedHistory);
       ctx.messages = rawHistory;
       try {
-        clearPkbSystemReminderMetadataForConversation(ctx.conversationId);
+        clearStrippedInjectionMetadataForConversation(ctx.conversationId);
       } catch (err) {
         rlog.warn(
           { err },
-          "Failed to clear pkbSystemReminderBlock metadata after compaction strip (non-fatal)",
+          "Failed to clear stripped-injection metadata after compaction strip (non-fatal)",
         );
       }
 
@@ -1471,11 +1471,11 @@ export async function runAgentLoopImpl(
       if (updatedHistory.length > preRunHistoryLength) {
         ctx.messages = stripInjectionsForCompaction(updatedHistory);
         try {
-          clearPkbSystemReminderMetadataForConversation(ctx.conversationId);
+          clearStrippedInjectionMetadataForConversation(ctx.conversationId);
         } catch (err) {
           rlog.warn(
             { err },
-            "Failed to clear pkbSystemReminderBlock metadata after compaction strip (non-fatal)",
+            "Failed to clear stripped-injection metadata after compaction strip (non-fatal)",
           );
         }
         convergenceStripped = true;
@@ -1648,11 +1648,11 @@ export async function runAgentLoopImpl(
           if (updatedHistory.length > preRunHistoryLength) {
             ctx.messages = stripInjectionsForCompaction(updatedHistory);
             try {
-              clearPkbSystemReminderMetadataForConversation(ctx.conversationId);
+              clearStrippedInjectionMetadataForConversation(ctx.conversationId);
             } catch (err) {
               rlog.warn(
                 { err },
-                "Failed to clear pkbSystemReminderBlock metadata after compaction strip (non-fatal)",
+                "Failed to clear stripped-injection metadata after compaction strip (non-fatal)",
               );
             }
             convergenceStripped = true;

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1519,22 +1519,35 @@ export function updateMessageMetadata(
 }
 
 /**
- * Bulk-remove the `pkbSystemReminderBlock` field from every user-message
- * metadata row in a conversation. Called from compaction-strip sites so
- * post-restart rehydration stays consistent with the in-memory state
- * produced by `stripInjectionsForCompaction` (which removes
- * `<system_reminder>` from live messages but cannot touch the DB).
+ * Bulk-remove the metadata fields that back the blocks stripped by
+ * `stripInjectionsForCompaction` — currently `pkbSystemReminderBlock`
+ * (`<system_reminder>`), `nowScratchpadBlock` (`<NOW.md …>`), and
+ * `pkbContextBlock` (`<knowledge_base>`). Called from compaction-strip
+ * sites so post-restart rehydration stays consistent with the in-memory
+ * state produced by `stripInjectionsForCompaction` (which removes those
+ * tags from live messages but cannot touch the DB). Fields backing
+ * blocks that are intentionally NOT stripped (`turnContextBlock`,
+ * `workspaceBlock`, `memoryInjectedBlock`) are preserved.
  */
-export function clearPkbSystemReminderMetadataForConversation(
+export function clearStrippedInjectionMetadataForConversation(
   conversationId: string,
 ): void {
   rawRun(
     `UPDATE messages
-        SET metadata = json_remove(metadata, '$.pkbSystemReminderBlock')
+        SET metadata = json_remove(
+          metadata,
+          '$.pkbSystemReminderBlock',
+          '$.nowScratchpadBlock',
+          '$.pkbContextBlock'
+        )
       WHERE conversation_id = ?
         AND role = 'user'
         AND metadata IS NOT NULL
-        AND json_extract(metadata, '$.pkbSystemReminderBlock') IS NOT NULL`,
+        AND (
+          json_extract(metadata, '$.pkbSystemReminderBlock') IS NOT NULL
+          OR json_extract(metadata, '$.nowScratchpadBlock') IS NOT NULL
+          OR json_extract(metadata, '$.pkbContextBlock') IS NOT NULL
+        )`,
     conversationId,
   );
 }


### PR DESCRIPTION
Addresses review feedback on #27288.

## Problem

PR #27288 persisted `nowScratchpadBlock` and `pkbContextBlock` into message metadata on tail user messages so `loadFromDb` can rehydrate them byte-for-byte after eviction/restart. But the compaction-strip sites only called `clearPkbSystemReminderMetadataForConversation`. Because `stripInjectionsForCompaction` removes `<NOW.md …>` and `<knowledge_base>` from in-memory history, a later daemon restart/eviction would rehydrate those stripped blocks from stale metadata — re-injecting exactly what compaction removed and diverging post-compaction history from what the provider saw.

## Fix

- Renamed `clearPkbSystemReminderMetadataForConversation` → `clearStrippedInjectionMetadataForConversation` and expanded its SQL to `json_remove` all three fields that back stripped blocks (`pkbSystemReminderBlock`, `nowScratchpadBlock`, `pkbContextBlock`) in a single UPDATE. The non-stripped fields (`turnContextBlock`, `workspaceBlock`, `memoryInjectedBlock`) remain untouched — those blocks are intentionally preserved in-memory, so rehydrating them keeps the cache prefix stable.
- All three strip sites in `conversation-agent-loop.ts` (mid-loop compaction, convergence-loop strip, post-rerun strip) now clear all three fields symmetrically.
- `loadFromDb` needs no guard — symmetric metadata clearing + preserving the rehydrate-if-present pattern is sufficient.

## Tests

New `compaction-strip-metadata-clear.test.ts` uses the real DB to verify:
- All three stripped-block fields are removed
- Non-stripped fields survive
- Idempotent (re-runnable)
- Role-scoped to user rows
- Post-clear metadata cannot rehydrate the stripped blocks (reproducing the divergence)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
