### PR TITLE
fix(macos): align bootstrap nil-defaults to restore local recovery

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -319,8 +319,20 @@ extension AppDelegate {
             // writes guardian-token.json asynchronously — poll for it. On
             // bare-metal the file is written synchronously at hatch time, so
             // if the first check missed it the file isn't coming.
+            //
+            // When the lockfile entry can't be resolved, default to treating
+            // the hatch as remote (poll) to stay aligned with
+            // `forceReBootstrap()`'s "treat unresolved as remote" default.
+            // A bare-metal run with an unresolvable entry otherwise falls
+            // straight into `/v1/guardian/init`, which is permanently 403'd
+            // after the first hatch — producing a non-recovering loop.
+            // Polling first gives the CLI/launcher a chance to (re)write the
+            // token file before the HTTP fallback is exercised.
             let assistant = LockfileAssistant.loadByName(assistantId)
-            let shouldPoll = assistant?.isRemote ?? false
+            let shouldPoll = assistant?.isRemote ?? true
+            if assistant == nil {
+                log.warning("performInitialBootstrap: could not resolve lockfile entry for active assistant — polling for guardian token file before HTTP fallback")
+            }
 
             if shouldPoll {
                 let maxAttempts = 30


### PR DESCRIPTION
Addresses review feedback on #27344.

PR #27344 flipped `forceReBootstrap`'s nil-default for `isRemoteHatch` to `true` to prevent silently re-arming a stale token on a misclassified remote hatch. However, `performInitialBootstrap` still defaulted `shouldPoll = false` for an unresolvable lockfile entry, so a local user whose lockfile entry couldn't be resolved would:

1. Hit `forceReBootstrap`: treated as remote → token file deleted, `GuardianClient().resetBootstrap()` **not** called.
2. Fall through to `performInitialBootstrap`: treated as local → skips polling and immediately calls `/v1/guardian/init`, which is permanently 403-locked on bare-metal after the first hatch.

Result: a non-recovering bootstrap loop.

## Fix

Option (a) from the review: align `performInitialBootstrap`'s nil-default with `forceReBootstrap`'s — treat an unresolvable entry as remote (`shouldPoll = true`). This preserves the original PR's safety fix (we still never silently re-arm a stale token, because the delete in `forceReBootstrap` happens first on the remote path), and gives the CLI/launcher a chance to (re)write the token file during the poll window before the permanently-403'd HTTP init endpoint is touched.

Chose (a) over (b)/(c) because it is the smallest surface-area change and keeps the two call sites consistent. Option (b) (calling `resetBootstrap()` before the HTTP fallback) adds an extra network call on every nil-resolve; option (c) (re-pair prompt) is heavier UX and unnecessary when polling already gives the provisioner a window to recover.

## Files

- `clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift`: flip nil-coalescing default at line 323 from `false` to `true`; add warning log + rationale comment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
