### PR TITLE
fix(macos): cancel primary avatar/traits fetch tasks on disconnect

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -274,6 +274,12 @@ final class AvatarAppearanceManager {
     @ObservationIgnored private var traitsRetryInFlight = false
     @ObservationIgnored private var avatarRetryTask: Task<Void, Never>?
     @ObservationIgnored private var traitsRetryTask: Task<Void, Never>?
+    /// Tracks the primary (non-retry) fetch Tasks spawned by `reloadAvatar()` so
+    /// `resetForDisconnect()` can cancel a fetch in flight. Without cancellation,
+    /// a late-arriving response from the previous assistant would bypass the
+    /// `Task.isCancelled` guards in the fetch methods and stale-flash state.
+    @ObservationIgnored private var avatarPrimaryTask: Task<Void, Never>?
+    @ObservationIgnored private var traitsPrimaryTask: Task<Void, Never>?
 
     private func scheduleAvatarRetry() {
         guard !avatarRetryInFlight else { return }
@@ -376,9 +382,13 @@ final class AvatarAppearanceManager {
         cachedFullFallbackAvatar = nil
         cachedFullFallbackName = nil
 
-        Task { [weak self] in
+        avatarPrimaryTask?.cancel()
+        traitsPrimaryTask?.cancel()
+        avatarPrimaryTask = Task { [weak self] in
             await self?.fetchComponents()
             await self?.fetchAvatarViaHTTP()
+        }
+        traitsPrimaryTask = Task { [weak self] in
             await self?.fetchTraitsViaHTTP()
         }
     }
@@ -442,6 +452,13 @@ final class AvatarAppearanceManager {
         traitsRetryTask?.cancel()
         traitsRetryTask = nil
         traitsRetryInFlight = false
+        // Cancel in-flight primary fetches too; the `Task.isCancelled` guards
+        // inside `fetchAvatarViaHTTP`/`fetchTraitsViaHTTP` suppress the state
+        // mutation once the surrounding Task is cancelled.
+        avatarPrimaryTask?.cancel()
+        avatarPrimaryTask = nil
+        traitsPrimaryTask?.cancel()
+        traitsPrimaryTask = nil
         customAvatarImage = nil
         characterBodyShape = nil
         characterEyeStyle = nil


### PR DESCRIPTION
Addresses review feedback on #27330.

PR 27330 added `Task.isCancelled` guards in `fetchAvatarViaHTTP` / `fetchTraitsViaHTTP` so late-arriving responses cannot mutate state after disconnect. The guards fired for the retry tasks (`avatarRetryTask`/`traitsRetryTask`) because `resetForDisconnect()` already cancelled those. The *primary* fetch task spawned by `reloadAvatar()` was not tracked or cancelled, so a primary fetch that completed after `resetForDisconnect()` still mutated state unguarded.

Track the primary reload as `avatarPrimaryTask` / `traitsPrimaryTask`, cancel them on each new `reloadAvatar()` call, and cancel + clear them in `resetForDisconnect()`. With the surrounding Task cancelled, the existing `Task.isCancelled` guards inside the fetch methods now suppress the stale-response state mutation for the primary path too.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
