### PR TITLE
fix(githooks): isolate Swift pre-push build per worktree

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -155,7 +155,15 @@ if [ -n "$SWIFT_CHANGED_FILES" ] && [ "$SKIP_SWIFT_BUILD" != "1" ]; then
         _repo_real="$(cd "$REPO_ROOT" && pwd -P)"
         _cache_slug="$(printf '%s' "$_repo_real" | md5 -q 2>/dev/null || printf '%s' "$_repo_real" | md5sum | cut -d' ' -f1)"
         _module_cache="/tmp/spm-module-cache/${_cache_slug}"
-        if ! (cd "${REPO_ROOT}/clients" && swift build --product vellum-assistant -Xswiftc -module-cache-path -Xswiftc "$_module_cache" 2>&1); then
+        # Per-worktree scratch directory so concurrent pre-push builds across
+        # parallel swarm worktrees don't contend on the shared `clients/.build`
+        # symlink (single `build.db` lock + a ModuleCache that gets polluted
+        # with sibling worktrees' `.pcm` paths). Cold first build per worktree
+        # is the cost; alternative (flock serialization) needs `flock(1)` which
+        # macOS doesn't ship by default.
+        _scratch_path="/tmp/spm-build/${_cache_slug}"
+        mkdir -p "$_scratch_path"
+        if ! (cd "${REPO_ROOT}/clients" && swift build --product vellum-assistant --scratch-path "$_scratch_path" -Xswiftc -module-cache-path -Xswiftc "$_module_cache" 2>&1); then
             echo ""
             echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
             echo -e "${RED}Swift build errors in clients/ — push blocked${NC}"


### PR DESCRIPTION
## Summary

- Add `--scratch-path /tmp/spm-build/<worktree-hash>` to the `swift build` invocation in `.githooks/pre-push` so concurrent pre-push builds across parallel swarm worktrees stop colliding on the shared `clients/.build` symlink (single `build.db` lock + ModuleCache polluted with sibling worktrees' `.pcm` paths).
- Cost: cold first build per new worktree. Alternative (`flock` serialization) needs `flock(1)`, which macOS doesn't ship by default — and serializing 14 parallel agents on a single build would be slower than letting them each cold-build in parallel anyway.
- Module-cache path was already per-worktree via `-Xswiftc -module-cache-path` (Clang's PCM cache); this change closes the SwiftPM-internal half of the contention.

## Original prompt

Fix the Swift build cache contention issue surfaced by today's swarm. Multiple parallel agents (27336, 27344, 27330) had pre-push Swift builds spuriously fail because they share `/tmp/spm-module-cache` and `clients/.build/` across worktrees — `.pcm` files get polluted with sibling worktrees' module paths and `build.db` locks contend. Add per-worktree isolation in `.claude/ship` (or wherever the Swift pre-push hook lives in this repo) by setting per-worktree `SWIFTPM_MODULE_CACHE_PATH` (and `SWIFTPM_PACKAGE_DEPENDENCY_CACHE_DIR` if relevant) so concurrent swarm runs don't collide. Investigate first (`.claude/ship` is a symlink to claude-skills/scripts/ship; the pre-push Swift logic likely lives in `.githooks/pre-push` or `clients/macos/scripts/`). Pick the smallest reasonable fix.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
