### PR TITLE
fix(pricing): set standard-speed Opus rates to 5/25 everywhere

### DIFF
--- a/assistant/src/__tests__/conversation-usage.test.ts
+++ b/assistant/src/__tests__/conversation-usage.test.ts
@@ -105,8 +105,8 @@ describe("recordUsage", () => {
     expect(events[0].estimatedCostUsd).toBe(
       expectedPricing.estimatedCostUsd ?? null,
     );
-    // Sanity: fast should be 6x standard (claude-opus-4-6 at $15/$75 → $90 * 6 = $540)
-    expect(expectedPricing.estimatedCostUsd).toBe(540);
+    // Sanity: fast should be 6x standard (claude-opus-4-6 at $5/$25 → $30 * 6 = $180)
+    expect(expectedPricing.estimatedCostUsd).toBe(180);
   });
 
   test("stores direct input separately from Anthropic cache usage while keeping live totals combined", () => {

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -19,7 +19,7 @@ describe("resolvePricing", () => {
         1_000_000,
       );
       expect(result.pricingStatus).toBe("priced");
-      expect(result.estimatedCostUsd).toBe(15 + 75);
+      expect(result.estimatedCostUsd).toBe(5 + 25);
     });
 
     test("returns priced for claude-opus-4", () => {
@@ -30,7 +30,7 @@ describe("resolvePricing", () => {
         1_000_000,
       );
       expect(result.pricingStatus).toBe("priced");
-      expect(result.estimatedCostUsd).toBe(15 + 75);
+      expect(result.estimatedCostUsd).toBe(5 + 25);
     });
 
     test("returns priced for claude-sonnet-4", () => {
@@ -180,7 +180,7 @@ describe("resolvePricing", () => {
         1_000_000,
       );
       expect(result.pricingStatus).toBe("priced");
-      expect(result.estimatedCostUsd).toBe(15 + 75);
+      expect(result.estimatedCostUsd).toBe(5 + 25);
     });
 
     test("matches claude-sonnet-4-6 via claude-sonnet-4 prefix", () => {
@@ -202,7 +202,7 @@ describe("resolvePricing", () => {
         1_000_000,
       );
       expect(result.pricingStatus).toBe("priced");
-      expect(result.estimatedCostUsd).toBe(15 + 75);
+      expect(result.estimatedCostUsd).toBe(5 + 25);
     });
 
     test("matches gpt-4o-mini-2024-07-18 via gpt-4o-mini prefix", () => {
@@ -269,8 +269,8 @@ describe("resolvePricingForUsage", () => {
     );
 
     expect(result.pricingStatus).toBe("priced");
-    // 15 (input) + 150 (output) + 0.45 (cache-read) + 3.75 (5m write) + 3.0 (1h write) = 172.2
-    expect(result.estimatedCostUsd).toBeCloseTo(172.2, 10);
+    // 5 (input) + 50 (output) + 0.15 (cache-read) + 1.25 (5m write) + 1.0 (1h write) = 57.4
+    expect(result.estimatedCostUsd).toBeCloseTo(57.4, 10);
   });
 
   test("returns unpriced with null cost for unknown provider", () => {
@@ -313,9 +313,9 @@ describe("fast mode pricing", () => {
       usage,
     );
 
-    // Base: $15 input + $75 output = $90; fast: $90 * 6 = $540
+    // Base: $5 input + $25 output = $30; fast: $30 * 6 = $180
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe((15 + 75) * 6);
+    expect(result.estimatedCostUsd).toBe((5 + 25) * 6);
   });
 
   test("does not apply multiplier when speed is standard", () => {
@@ -335,7 +335,7 @@ describe("fast mode pricing", () => {
     );
 
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(15 + 75);
+    expect(result.estimatedCostUsd).toBe(5 + 25);
   });
 
   test("does not apply multiplier when speed is null", () => {
@@ -355,7 +355,7 @@ describe("fast mode pricing", () => {
     );
 
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(15 + 75);
+    expect(result.estimatedCostUsd).toBe(5 + 25);
   });
 
   test("fast mode multiplier stacks with cache pricing", () => {
@@ -452,7 +452,7 @@ describe("Anthropic models on OpenRouter", () => {
       1_000_000,
     );
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(15 + 75);
+    expect(result.estimatedCostUsd).toBe(5 + 25);
   });
 
   test("prices anthropic/claude-sonnet-4.6 at Sonnet 4 rates via prefix match", () => {
@@ -485,7 +485,7 @@ describe("Anthropic models on OpenRouter", () => {
       1_000_000,
     );
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(15 + 75);
+    expect(result.estimatedCostUsd).toBe(5 + 25);
   });
 
   test("prices dash-form anthropic/claude-opus-4-6 identically to dot form", () => {
@@ -496,7 +496,7 @@ describe("Anthropic models on OpenRouter", () => {
       1_000_000,
     );
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(15 + 75);
+    expect(result.estimatedCostUsd).toBe(5 + 25);
   });
 
   test("prices version-first anthropic/claude-4.7-opus-<date> at Opus 4.7 rates", () => {
@@ -510,7 +510,7 @@ describe("Anthropic models on OpenRouter", () => {
       1_000_000,
     );
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(15 + 75);
+    expect(result.estimatedCostUsd).toBe(5 + 25);
   });
 
   test("prices version-first dash-form anthropic/claude-4-7-opus-<date>", () => {
@@ -521,7 +521,7 @@ describe("Anthropic models on OpenRouter", () => {
       1_000_000,
     );
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe(15 + 75);
+    expect(result.estimatedCostUsd).toBe(5 + 25);
   });
 
   test("prices version-first anthropic/claude-4.6-sonnet", () => {
@@ -600,7 +600,7 @@ describe("Anthropic models on OpenRouter", () => {
 
     // Cache-read tokens are charged at 10% of input rate for Anthropic models.
     expect(openRouter.pricingStatus).toBe("priced");
-    expect(openRouter.estimatedCostUsd).toBeCloseTo(15 * 0.1, 10);
+    expect(openRouter.estimatedCostUsd).toBeCloseTo(5 * 0.1, 10);
     expect(openRouter.estimatedCostUsd).toBe(direct.estimatedCostUsd);
   });
 
@@ -647,7 +647,7 @@ describe("Anthropic models on OpenRouter", () => {
     );
 
     expect(result.pricingStatus).toBe("priced");
-    expect(result.estimatedCostUsd).toBe((15 + 75) * 6);
+    expect(result.estimatedCostUsd).toBe((5 + 25) * 6);
   });
 });
 

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -59,10 +59,10 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: true,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 15,
-          outputPer1mTokens: 75,
-          cacheWritePer1mTokens: 18.75,
-          cacheReadPer1mTokens: 1.5,
+          inputPer1mTokens: 5,
+          outputPer1mTokens: 25,
+          cacheWritePer1mTokens: 6.25,
+          cacheReadPer1mTokens: 0.5,
         },
       },
       {
@@ -75,10 +75,10 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: true,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 15,
-          outputPer1mTokens: 75,
-          cacheWritePer1mTokens: 18.75,
-          cacheReadPer1mTokens: 1.5,
+          inputPer1mTokens: 5,
+          outputPer1mTokens: 25,
+          cacheWritePer1mTokens: 6.25,
+          cacheReadPer1mTokens: 0.5,
         },
       },
       {

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -21,9 +21,9 @@ const ANTHROPIC_FAST_MODE_MULTIPLIER = 6;
  */
 const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
   anthropic: {
-    "claude-opus-4-7": { inputPer1M: 15, outputPer1M: 75 },
-    "claude-opus-4-6": { inputPer1M: 15, outputPer1M: 75 },
-    "claude-opus-4": { inputPer1M: 15, outputPer1M: 75 },
+    "claude-opus-4-7": { inputPer1M: 5, outputPer1M: 25 },
+    "claude-opus-4-6": { inputPer1M: 5, outputPer1M: 25 },
+    "claude-opus-4": { inputPer1M: 5, outputPer1M: 25 },
     "claude-sonnet-4": { inputPer1M: 3, outputPer1M: 15 },
     "claude-haiku-4": { inputPer1M: 1, outputPer1M: 5 },
   },

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -26,10 +26,10 @@
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 15,
-            "outputPer1mTokens": 75,
-            "cacheWritePer1mTokens": 18.75,
-            "cacheReadPer1mTokens": 1.5
+            "inputPer1mTokens": 5,
+            "outputPer1mTokens": 25,
+            "cacheWritePer1mTokens": 6.25,
+            "cacheReadPer1mTokens": 0.5
           }
         },
         {
@@ -42,10 +42,10 @@
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 15,
-            "outputPer1mTokens": 75,
-            "cacheWritePer1mTokens": 18.75,
-            "cacheReadPer1mTokens": 1.5
+            "inputPer1mTokens": 5,
+            "outputPer1mTokens": 25,
+            "cacheWritePer1mTokens": 6.25,
+            "cacheReadPer1mTokens": 0.5
           }
         },
         {


### PR DESCRIPTION
## Summary
- Revert Opus 4.6 / 4.7 standard-speed pricing to 5/25 (cache 6.25/0.5) across the daemon TS catalog, PROVIDER_PRICING catalog, and client JSON. PR #27361 had bumped these to 15/75 (which is the 3× fast-mode rate, applied on top of the runtime 6× multiplier — double-counting fast pricing by 3×). Fast-mode pricing is computed dynamically via `ANTHROPIC_FAST_MODE_MULTIPLIER = 6` at cost-resolution time, so base catalog values must stay at standard-speed rates.
- Updated pricing unit tests and the fast-mode sanity assertion in `conversation-usage.test.ts` (540 → 180) to match the new base rates; fast-mode math remains 6× standard = (5+25)*6 = 180 per 1M+1M tokens.
- `llm-catalog-parity.test.ts` stays green (both sides synced); OpenRouter `anthropic/*` mirrors were already at 5/25 and needed no change.

## Original prompt
> the opus rates for standard speed (not fast mode - which is also opus 4.6 only) should be 5/25 everywhere
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
