### PR TITLE
fix(meet-chat): open panel + match nested composer on runtime send

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/dom/selectors.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/selectors.ts
@@ -113,18 +113,26 @@ export const chatSelectors = {
    * prefix match covers both the bare and decorated forms, mirroring the
    * approach used for `ASK_TO_JOIN_BUTTON`.
    *
-   * We also accept `div[contenteditable="true"]` variants since some Meet
-   * builds render the composer as a contenteditable div rather than a
-   * textarea. Note that `chat.ts` currently writes via `.value`, which is a
-   * textarea-only affordance — if Meet has migrated to contenteditable, the
-   * selector will resolve but `sendChat` will silently no-op. That's a
-   * follow-up (tracked in the PR body) and out of scope for this selector
-   * drift fix.
+   * Three DOM shapes are accepted, in historical order:
+   *
+   *   1. Legacy textarea: `<textarea aria-label="Send a message ...">`.
+   *   2. Flat contenteditable: `<div contenteditable="true"
+   *      aria-label="Send a message ...">`.
+   *   3. Nested contenteditable: `<div aria-label="Send a message ...">
+   *      <div contenteditable="true">...</div></div>`. As of late April 2026
+   *      live Meet renders the composer this way — the aria-label sits on
+   *      the wrapper, the editable target is a child. The third clause
+   *      resolves directly to the focusable child so `xdotool`-type focus
+   *      lands on the right element.
+   *
+   * `chat.ts`'s xdotool-type path only needs `.focus()` on the matched
+   * element; the `.value =` synthetic-setter fallback is textarea-only and
+   * is exercised only by the test harness.
    */
   // TODO(meet-dom): aria-label is localized. Future versions may need to
   // match multiple locales or fall back to role=textbox + placeholder.
   INPUT:
-    'textarea[aria-label^="Send a message"], div[contenteditable="true"][aria-label^="Send a message"]',
+    'textarea[aria-label^="Send a message"], div[contenteditable="true"][aria-label^="Send a message"], [aria-label^="Send a message"] [contenteditable="true"]',
 
   /**
    * Send button adjacent to the chat composer. Prefix match handles Meet's

--- a/skills/meet-join/meet-controller-ext/src/features/chat.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/chat.ts
@@ -45,6 +45,75 @@ import { chatSelectors } from "../dom/selectors.js";
 import { waitForSelector } from "../dom/wait.js";
 
 /**
+ * Build a one-line inventory of the current DOM state that is most useful
+ * when the composer query turns up empty. Embeds:
+ *
+ *   - `chat-panel-button`: whether the toggle exists and its aria-expanded
+ *     / aria-pressed state — answers "is the chat panel actually open?".
+ *   - `aria-labels`: up to 20 `[aria-label]` elements as `TAG[label]` tuples
+ *     so we can spot localization or wording drift ("Send a message" →
+ *     something else) at a glance.
+ *   - `contenteditables`: count + the closest `[aria-label]` for each,
+ *     since the editable target is the thing that needs to be findable.
+ *   - `shadow-roots`: count of elements with an attached `shadowRoot` so
+ *     a shadow-DOM-encapsulated composer shows up as a non-zero count
+ *     here even though `querySelector` returned nothing for it.
+ *
+ * Kept as a helper so the sender/panel-open paths stay readable and the
+ * diagnostic format stays identical across call sites.
+ */
+function describeComposerSearch(): string {
+  const parts: string[] = [];
+
+  const toggle = document.querySelector(chatSelectors.PANEL_BUTTON);
+  if (toggle) {
+    const expanded = toggle.getAttribute("aria-expanded") ?? "<unset>";
+    const pressed = toggle.getAttribute("aria-pressed") ?? "<unset>";
+    parts.push(
+      `chat-panel-button: found (aria-expanded=${expanded}, aria-pressed=${pressed})`,
+    );
+  } else {
+    parts.push("chat-panel-button: <missing>");
+  }
+
+  const ariaLabeled = Array.from(document.querySelectorAll("[aria-label]"));
+  const ariaInventory = ariaLabeled
+    .slice(0, 20)
+    .map((el) => {
+      const label = (el.getAttribute("aria-label") ?? "")
+        .replace(/\s+/g, " ")
+        .slice(0, 60);
+      return `${el.tagName}[${label}]`;
+    })
+    .join(", ");
+  parts.push(
+    `aria-labels(${ariaLabeled.length}): ${ariaInventory || "<none>"}`,
+  );
+
+  const editables = Array.from(document.querySelectorAll("[contenteditable]"));
+  const editableInventory = editables
+    .slice(0, 6)
+    .map((el) => {
+      const nearest = el.closest("[aria-label]");
+      const label = nearest?.getAttribute("aria-label") ?? "<no-aria-ancestor>";
+      return `${el.tagName}<=${label.replace(/\s+/g, " ").slice(0, 40)}`;
+    })
+    .join(", ");
+  parts.push(
+    `contenteditables(${editables.length}): ${editableInventory || "<none>"}`,
+  );
+
+  // Non-zero here means the composer may be inside an encapsulated subtree
+  // that a plain `querySelector` cannot pierce.
+  const shadowHosts = Array.from(document.querySelectorAll("*")).filter(
+    (el) => (el as Element & { shadowRoot: ShadowRoot | null }).shadowRoot,
+  );
+  parts.push(`shadow-roots: ${shadowHosts.length}`);
+
+  return parts.join("; ");
+}
+
+/**
  * How long {@link ensurePanelOpen} waits for the chat message list to mount
  * after clicking the toggle before giving up.
  *
@@ -251,7 +320,7 @@ export async function sendChat(
   );
   if (!input) {
     throw new Error(
-      `sendChat: chat input not found (selector: ${chatSelectors.INPUT})`,
+      `sendChat: chat input not found (selector: ${chatSelectors.INPUT}; ${describeComposerSearch()})`,
     );
   }
 
@@ -459,7 +528,9 @@ export async function postConsentMessage(
  * its own "chat input not found" diagnostic, which the join flow's
  * `try/catch` already handles.
  */
-async function ensurePanelOpen(opts?: EnsurePanelOpenOptions): Promise<void> {
+export async function ensurePanelOpen(
+  opts?: EnsurePanelOpenOptions,
+): Promise<void> {
   // Prefer the composer as the panel-open signal: if it's in the DOM,
   // `sendChat` will succeed regardless of the surrounding chrome.
   // `MESSAGE_LIST` is retained as a fallback so existing tests (which

--- a/skills/meet-join/meet-controller-ext/src/handle-send-chat.ts
+++ b/skills/meet-join/meet-controller-ext/src/handle-send-chat.ts
@@ -18,7 +18,7 @@ import type {
 } from "../../contracts/native-messaging.js";
 
 import { disableCamera, enableCamera } from "./features/camera.js";
-import { sendChat } from "./features/chat.js";
+import { ensurePanelOpen, sendChat } from "./features/chat.js";
 
 /**
  * Execute a {@link BotSendChatCommand} and emit a matching
@@ -46,7 +46,15 @@ export async function handleSendChat(cmd: BotSendChatCommand): Promise<void> {
 
   let reply: ExtensionSendChatResultMessage;
   try {
-    await sendChat(cmd.text, {
+    // Open the chat panel before typing. The runtime `meet_send_chat`
+    // path cannot assume the panel is already open — the consent-post
+    // flow (`postConsentMessage`) opens it at join time, but any failure
+    // in that path leaves the panel collapsed, and every subsequent
+    // runtime send then lands on a missing composer and throws "chat
+    // input not found". Mirroring `postConsentMessage`'s
+    // `ensurePanelOpen + sendChat` sequence here keeps the runtime path
+    // self-sufficient regardless of the consent-post outcome.
+    const opts = {
       onEvent: sendToBot,
       // Pass the live `window` so `sendChat` can compute screen-space
       // coordinates for the send button's `trusted_click`. Mirrors the
@@ -57,7 +65,9 @@ export async function handleSendChat(cmd: BotSendChatCommand): Promise<void> {
         outerHeight: number;
         innerHeight: number;
       },
-    });
+    };
+    await ensurePanelOpen(opts);
+    await sendChat(cmd.text, opts);
     reply = {
       type: "send_chat_result",
       requestId: cmd.requestId,


### PR DESCRIPTION
## Summary
- Add a third selector clause that matches Meet's current nested-contenteditable composer (aria-label on the wrapper, editable on a child), alongside the legacy textarea and flat-contenteditable forms.
- Embed a DOM-state inventory (panel-button state, aria-labels, contenteditables, shadow-roots) in the "chat input not found" error so future selector drift is debuggable from the thrown error alone.
- Open the chat panel before typing on the runtime send path. Previously only the consent-post flow opened the panel; any failure there left every subsequent runtime send landing on a missing composer.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
