### PR TITLE
fix(clients): bump SwiftMath 1.7.1 → 1.7.3 to unblock pre-push builds

### DIFF
--- a/clients/Package.resolved
+++ b/clients/Package.resolved
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mgriebling/SwiftMath.git",
       "state" : {
-        "revision" : "606f9be66db6afe0c41c3b064723a57061723db7",
-        "version" : "1.7.1"
+        "revision" : "fa8244ed032f4a1ade4cb0571bf87d2f1a9fd2d7",
+        "version" : "1.7.3"
       }
     },
     {

--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.58.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.8.1"),
         .package(url: "https://github.com/migueldeicaza/SwiftTerm", exact: "1.11.2"),
-        .package(url: "https://github.com/mgriebling/SwiftMath.git", exact: "1.7.1"),
+        .package(url: "https://github.com/mgriebling/SwiftMath.git", exact: "1.7.3"),
     ],
     targets: [
         .target(

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -965,7 +965,7 @@ private struct MathBlockView: View {
             textColor: nsTextColor,
             labelMode: labelMode
         )
-        let (error, image) = mathImage.asImage()
+        let (error, image, _) = mathImage.asImage()
         if let error = error {
             return .failure(error.localizedDescription)
         }

--- a/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
@@ -674,7 +674,7 @@ final class MarkdownSegmentViewTests: XCTestCase {
     func testMathImage_rendersScreenshotLatex() {
         let latex = #"m_\text{ferrite} \propto (\text{ferrite thickness}) \propto \frac{F_\text{required}}{F_\text{available per m}} \propto \frac{1}{\text{margin}}"#
         var math = MathImage(latex: latex, fontSize: 13, textColor: NSColor.black, labelMode: .display)
-        let (error, image) = math.asImage()
+        let (error, image, _) = math.asImage()
         XCTAssertNil(error, "SwiftMath rejected the screenshot LaTeX: \(error.map { String(describing: $0) } ?? "unknown")")
         XCTAssertNotNil(image)
         XCTAssertGreaterThan(image?.size.width ?? 0, 0)


### PR DESCRIPTION
## Summary

- Contributors have been getting `xcodebuild` / `swift build` errors like \"no versions of 'swiftmath' match the requirement 1.7.1\" during pre-push resolution, forcing `SKIP_IOS_BUILD=1` / `SKIP_SWIFT_BUILD=1` workarounds. Root cause: the upstream `mgriebling/SwiftMath` 1.7.1 tag was force-moved (SPM's per-machine bare-clone cache still references the old commit `d1f84f1`, while `Package.resolved` pins the new commit `606f9be`), so SPM's integrity check fails locally.
- Bumps to 1.7.3 (commit `fa8244e`, released 2025-08-03), the latest published patch. `Package.resolved` revision updated in the same commit. Future contributors hitting the stale cache issue should `rm -rf ~/Library/Caches/org.swift.swiftpm/repositories/SwiftMath-*` to force a fresh clone — the bump itself doesn't purge anyone's cache, but it avoids the force-moved-tag landmine by moving forward.
- 1.7.2 introduced a breaking API change: `MathImage.asImage()` now returns `(NSError?, MTImage?, LayoutInfo?)` (3-tuple) instead of `(NSError?, MTImage?)` (2-tuple). Updated the two call sites (one prod, one test) to destructure and ignore the new `LayoutInfo`.

## Original prompt

fix the iOS swiftmath 1.7.1 package resolution failure that's causing pre-push xcodebuild failures on all iOS-touching PRs. Multiple agents in today's swarm reported this error: `xcodebuild` fails with "no versions of 'swiftmath' match the requirement 1.7.1". Investigate the package pin in `clients/Package.swift` (or wherever swiftmath is declared), check what versions are actually published, and either bump the pin to an available version or pin to a commit SHA if the 1.7.1 tag has been moved/deleted. Per CLAUDE.md Swift SPM rules, must use `.package(url: ..., exact: "X.Y.Z")` — no `from:` or range syntax.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
