### PR TITLE
fix(meet-ext): cancel non-lifecycle retries on meeting transition

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/content-bridge.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/content-bridge.test.ts
@@ -260,6 +260,79 @@ describe("startContentBridge bot→content fan-out", () => {
   );
 
   test(
+    "pending send_chat retry aborts when a later leave arrives",
+    async () => {
+      // A stale send_chat must not deliver into a new meeting's tab after a
+      // lifecycle transition. send_chat carries no meeting identifier to
+      // re-validate on receipt, so once `leave` (or `join`) fires, any
+      // pending send_chat retry from the prior session must be cancelled.
+      let tabsAvailable: chrome.tabs.Tab[] = [];
+      fake.tabs.query = async (q) => {
+        fake.queryCalls.push(q);
+        return tabsAvailable;
+      };
+      const chat: BotToExtensionMessage = {
+        type: "send_chat",
+        text: "stale message",
+        requestId: "req-stale",
+      };
+      const leave: BotToExtensionMessage = { type: "leave", reason: "cancel" };
+      // send_chat finds no tab — queues a retry.
+      port.emitFromBot(chat);
+      await flushMicrotasks();
+      expect(fake.queryCalls.length).toBe(1);
+      // A tab is now available and `leave` fires, bumping the lifecycle
+      // counter and invalidating the pending send_chat retry.
+      tabsAvailable = [{ id: 1 } as chrome.tabs.Tab];
+      port.emitFromBot(leave);
+      // Wait past the first retry delay (100ms) plus margin.
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      const byType = (t: string) =>
+        fake.sendMessageCalls.filter(
+          (c) => (c.msg as { type: string }).type === t,
+        );
+      // The stale send_chat must not have been delivered.
+      expect(byType("send_chat")).toHaveLength(0);
+      // Leave was delivered (positive invariant).
+      expect(byType("leave").length).toBeGreaterThanOrEqual(1);
+    },
+    5_000,
+  );
+
+  test(
+    "pending camera.enable retry aborts when a later join arrives",
+    async () => {
+      // Same meeting-transition protection for camera toggles: a pending
+      // camera.enable retry must not deliver into a new session's tab.
+      let tabsAvailable: chrome.tabs.Tab[] = [];
+      fake.tabs.query = async (q) => {
+        fake.queryCalls.push(q);
+        return tabsAvailable;
+      };
+      const enable: BotToExtensionMessage = { type: "camera.enable" };
+      const join: BotToExtensionMessage = {
+        type: "join",
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        displayName: "Bot",
+        consentMessage: "hello",
+      };
+      port.emitFromBot(enable);
+      await flushMicrotasks();
+      expect(fake.queryCalls.length).toBe(1);
+      tabsAvailable = [{ id: 1 } as chrome.tabs.Tab];
+      port.emitFromBot(join);
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      const byType = (t: string) =>
+        fake.sendMessageCalls.filter(
+          (c) => (c.msg as { type: string }).type === t,
+        );
+      expect(byType("camera.enable")).toHaveLength(0);
+      expect(byType("join").length).toBeGreaterThanOrEqual(1);
+    },
+    5_000,
+  );
+
+  test(
     "join retries when the only tab responds with {ok:false}",
     async () => {
       // Simulate a profile that has exactly one Meet tab open and that tab is

--- a/skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts
+++ b/skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts
@@ -96,38 +96,64 @@ async function sleep(ms: number): Promise<void> {
 }
 
 // Per-category monotonic counters bumped when a new command enters that
-// category. A pending retry loop captures the counter value(s) for its own
-// categories and aborts when any captured value is stale — i.e. a newer
-// command in the same category has arrived.
+// category. A pending retry loop captures the counter value(s) it cares
+// about and aborts when any captured value is stale — i.e. a command that
+// invalidates it has arrived since.
 //
-// Categories (see `supersedingCategoriesFor`):
-//   - `lifecycle` (join, leave): newer supersedes older — a pending `join`
-//     retry must not fire once a `leave` has been dispatched for the same
-//     session, and a newer `join`/`leave` cancels any older `join`/`leave`.
-//   - `camera` (camera.enable, camera.disable): newer toggle supersedes
-//     older toggle so a rapid `disable` after `enable` doesn't end with the
-//     stale `enable` winning the race.
+// Two separate concepts, because "what this message bumps" and "what
+// invalidates this message" are not the same:
 //
-// Messages outside any category (currently `send_chat`) never supersede
-// and are never superseded — two `send_chat`s must both deliver.
+//   - `bumpingCategoriesFor(type)` — counters this message bumps on entry.
+//   - `invalidatingCategoriesFor(type)` — counters this message captures
+//     and watches for staleness.
+//
+// Categories:
+//   - `lifecycle` (join, leave): a meeting transition. On entry it bumps
+//     both `lifecycle` AND `camera` so any pending camera retry is
+//     invalidated. It only captures `lifecycle` for itself — newer
+//     lifecycle supersedes older, but a camera toggle should not cancel a
+//     pending join/leave.
+//   - `camera` (camera.enable, camera.disable): bumps `camera` so a rapid
+//     `disable` after `enable` doesn't end with the stale `enable` winning
+//     the race. Captures both `lifecycle` and `camera` so a meeting
+//     transition during the ~10s retry window aborts a stale toggle.
+//   - no-category messages (currently `send_chat`): bump nothing — two
+//     `send_chat`s must both deliver, they never supersede each other.
+//     But they still capture `lifecycle` so a pending chat retry aborts
+//     if the meeting transitions out from under it — otherwise a stale
+//     `send_chat` (which carries no meeting identifier to re-validate on
+//     receipt) could deliver into the new session's tab.
 const fanOutGenerations: Record<"lifecycle" | "camera", number> = {
   lifecycle: 0,
   camera: 0,
 };
 
-function supersedingCategoriesFor(
+type FanOutCategory = keyof typeof fanOutGenerations;
+
+function bumpingCategoriesFor(
   type: BotToExtensionMessage["type"],
-): Array<keyof typeof fanOutGenerations> {
-  if (type === "join" || type === "leave") return ["lifecycle"];
+): FanOutCategory[] {
+  if (type === "join" || type === "leave") return ["lifecycle", "camera"];
   if (type === "camera.enable" || type === "camera.disable") return ["camera"];
   return [];
 }
 
+function invalidatingCategoriesFor(
+  type: BotToExtensionMessage["type"],
+): FanOutCategory[] {
+  if (type === "join" || type === "leave") return ["lifecycle"];
+  if (type === "camera.enable" || type === "camera.disable")
+    return ["lifecycle", "camera"];
+  return ["lifecycle"];
+}
+
 async function fanOutToMeetTabs(msg: BotToExtensionMessage): Promise<void> {
-  const categories = supersedingCategoriesFor(msg.type);
-  const captured = categories.map((cat) => ({
+  for (const cat of bumpingCategoriesFor(msg.type)) {
+    fanOutGenerations[cat]++;
+  }
+  const captured = invalidatingCategoriesFor(msg.type).map((cat) => ({
     cat,
-    gen: ++fanOutGenerations[cat],
+    gen: fanOutGenerations[cat],
   }));
   const isSuperseded = (): boolean =>
     captured.some(({ cat, gen }) => fanOutGenerations[cat] !== gen);


### PR DESCRIPTION
Addresses Codex P2 feedback on #27353: lifecycle transitions (join/leave) now invalidate pending send_chat and camera.* retries, preventing a stale command from delivering into a new meeting's tab during the ~10s retry window. Same-category supersedes within each category is preserved.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
