### PR TITLE
fix(memory): add ORDER BY to slack meta candidate pagination

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1078,6 +1078,7 @@ export function selectSlackMetaCandidateMetadata(
         like(messages.metadata, '%"slackMeta"%'),
       ),
     )
+    .orderBy(asc(messages.createdAt))
     .limit(limit)
     .offset(offset)
     .all();


### PR DESCRIPTION
Addresses Codex P2 and Devin feedback on #27357: selectSlackMetaCandidateMetadata() now orders by messages.createdAt ascending before applying limit/offset, so iterating with increasing offsets never skips or double-counts rows. Matches the pattern used elsewhere in the memory module.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
