### PR TITLE
docs(compaction): rewrite comments to describe current state only

### DIFF
--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -473,10 +473,10 @@ describe("computeSummaryQualitySignals", () => {
   });
 
   test("flags tags that sit next to an underscore (word-boundary gap)", () => {
-    // These four tags are all stripped by COMPACTION_ONLY_STRIP_PREFIXES but
-    // the original regex missed them because `\b` does not assert between two
-    // word characters (e.g. the `e_` in `workspace_top_level`), so leakage
-    // telemetry was silently blind to them. Each tag must now flag.
+    // These four tags contain underscores, so `\b` only asserts between the
+    // full tag name and `>` (not between two word characters like the `e_` in
+    // `workspace_top_level`). Each tag must be detected as a memory echo when
+    // leaked into a summary.
     const cases = [
       "<workspace_top_level>\nlisting",
       "<active_subagents>\nstuff",

--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -1750,11 +1750,10 @@ describe("stripCompactionOnlyInjections", () => {
   });
 
   test("preserves user prose that merely mentions ambiguous tag names", () => {
-    // These are the common-word bare tags whose previous prefix-only match
-    // would false-positive on legitimate user messages discussing XML or
-    // referring to system terminology. Each case should survive stripping
-    // because it is not shaped like a runtime injection (no leading newline
-    // after the tag, or other prose surrounds the tag).
+    // Common-word bare tags embedded in legitimate user prose (discussions of
+    // XML, system terminology, etc.) must survive stripping because they are
+    // not shaped like a runtime injection — no leading newline after the
+    // open tag, or other prose surrounds the tag.
     const messages: Message[] = [
       {
         role: "user",
@@ -1810,10 +1809,12 @@ describe("stripCompactionOnlyInjections", () => {
   });
 
   test("still strips runtime-shaped wrapped blocks for ambiguous tag names", () => {
-    // Legacy pre-`__injected` history still emits bare-tag blocks with a
-    // newline after the open tag and a matching close tag. Those must
-    // continue to be stripped even though the prefix list no longer names
-    // them — the wrapped-match path covers the legacy shape.
+    // Bare-tag blocks with a newline after the open tag and a matching close
+    // tag (e.g. `<memory>\n...\n</memory>`) match the wrapped-strip path.
+    // This covers both the current runtime emission shape and blocks
+    // persisted before the `__injected` attribute existed — the prefix list
+    // handles `__injected`-attributed tags, and the wrapped matcher handles
+    // the bare-tag wrap shape.
     const messages: Message[] = [
       {
         role: "user",

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -47,15 +47,19 @@ const SUMMARY_COMPRESSION_PRESSURE_RATIO = 0.6;
  *
  * This list intentionally overlaps with `RUNTIME_INJECTION_PREFIXES` in
  * `conversation-runtime-assembly.ts`. That list governs in-flight turn
- * assembly; this one governs compaction input only. Keep them in sync
- * when new injection types are added.
+ * assembly via pure prefix matching; this one governs compaction input.
+ * Keep the two lists in sync when a new injection type is added.
  *
- * Only internal-vocabulary tags are listed here. Tags whose bare form
- * collides with ordinary English words a user might actually type
+ * Compaction strip coverage is two-tier: this prefix list catches
+ * internal-vocabulary tags and any tag carrying the `__injected`
+ * attribute, while `COMPACTION_ONLY_WRAPPED_STRIP_TAGS` below matches
+ * ambiguous bare-tag blocks that are shaped like a runtime-emitted
+ * open/close wrap. A new ambiguous tag added upstream needs to be
+ * evaluated against both tiers — internal-vocabulary names go here,
+ * and names whose bare form collides with ordinary English
  * (`<memory>`, `<workspace>`, `<knowledge_base>`, `<pkb>`,
- * `<system_reminder>`) are handled by `COMPACTION_ONLY_WRAPPED_STRIP_TAGS`
- * below with a tighter match that requires the whole text block to be a
- * runtime-shaped open/close wrap.
+ * `<system_reminder>`) go in the wrapped-strip list so user prose
+ * mentioning the tag is preserved.
  */
 const COMPACTION_ONLY_STRIP_PREFIXES = [
   "<memory __injected>",
@@ -87,14 +91,12 @@ const COMPACTION_ONLY_STRIP_PREFIXES = [
  * Tags whose bare form (`<tag>`) is common English vocabulary or markup a
  * user might legitimately type in prose. For these we only strip a text
  * block if it is shaped exactly like a runtime injection: starts with
- * `<tag>\n` and ends with `</tag>`. Runtime always emits these blocks with
- * a newline after the opening tag and a matching closing tag; a user who
- * mentions `<memory>` in a sentence or inlines `<workspace>...</workspace>`
- * within other prose will not match this shape.
- *
- * Covers both current-format bare emissions and legacy pre-`__injected`
- * history (e.g. `<memory>...</memory>` from before `<memory __injected>`
- * was introduced).
+ * `<tag>\n` and ends with `</tag>`. This bare-tag wrapped shape
+ * (e.g. `<memory>\n...\n</memory>`) appears in persisted history
+ * alongside the `__injected`-attributed variants, which the prefix list
+ * above already catches via `<memory __injected>`. A user who mentions
+ * `<memory>` in a sentence or inlines `<workspace>...</workspace>` within
+ * other prose will not match this shape.
  */
 const COMPACTION_ONLY_WRAPPED_STRIP_TAGS = [
   "memory",


### PR DESCRIPTION
Addresses Devin feedback on #27360: four comments in window-manager.ts, compaction-events.test.ts, and context-window-manager.test.ts were narrating removed code history, violating the assistant/AGENTS.md 'Code comments' rule. Rewritten to describe current matching behavior only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
