### PR TITLE
fix(macos): restore sequential avatar/traits fetch to prevent race

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -274,12 +274,11 @@ final class AvatarAppearanceManager {
     @ObservationIgnored private var traitsRetryInFlight = false
     @ObservationIgnored private var avatarRetryTask: Task<Void, Never>?
     @ObservationIgnored private var traitsRetryTask: Task<Void, Never>?
-    /// Tracks the primary (non-retry) fetch Tasks spawned by `reloadAvatar()` so
+    /// Tracks the primary (non-retry) fetch Task spawned by `reloadAvatar()` so
     /// `resetForDisconnect()` can cancel a fetch in flight. Without cancellation,
     /// a late-arriving response from the previous assistant would bypass the
     /// `Task.isCancelled` guards in the fetch methods and stale-flash state.
     @ObservationIgnored private var avatarPrimaryTask: Task<Void, Never>?
-    @ObservationIgnored private var traitsPrimaryTask: Task<Void, Never>?
 
     private func scheduleAvatarRetry() {
         guard !avatarRetryInFlight else { return }
@@ -383,12 +382,9 @@ final class AvatarAppearanceManager {
         cachedFullFallbackName = nil
 
         avatarPrimaryTask?.cancel()
-        traitsPrimaryTask?.cancel()
         avatarPrimaryTask = Task { [weak self] in
             await self?.fetchComponents()
             await self?.fetchAvatarViaHTTP()
-        }
-        traitsPrimaryTask = Task { [weak self] in
             await self?.fetchTraitsViaHTTP()
         }
     }
@@ -452,13 +448,11 @@ final class AvatarAppearanceManager {
         traitsRetryTask?.cancel()
         traitsRetryTask = nil
         traitsRetryInFlight = false
-        // Cancel in-flight primary fetches too; the `Task.isCancelled` guards
+        // Cancel the in-flight primary fetch too; the `Task.isCancelled` guards
         // inside `fetchAvatarViaHTTP`/`fetchTraitsViaHTTP` suppress the state
         // mutation once the surrounding Task is cancelled.
         avatarPrimaryTask?.cancel()
         avatarPrimaryTask = nil
-        traitsPrimaryTask?.cancel()
-        traitsPrimaryTask = nil
         customAvatarImage = nil
         characterBodyShape = nil
         characterEyeStyle = nil


### PR DESCRIPTION
Addresses Codex P2 and Devin feedback on #27368: splitting the avatar/traits fetch into two concurrent Tasks introduced a race where fetchAvatarViaHTTP could overwrite the customAvatarImage=nil that fetchTraitsViaHTTP had just written, showing the static PNG instead of the animated character path. Consolidating fetchComponents -> fetchAvatarViaHTTP -> fetchTraitsViaHTTP back into a single ordered avatarPrimaryTask preserves the old final-write ordering while still allowing cancellation via the retained task handle.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
