### PR TITLE
chore(assistant): remove conversation-end hook trigger

### DIFF
--- a/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
@@ -7,9 +7,9 @@
  * `auto-analyze` feature flag and source-type guard).
  *
  * We stub the downstream enqueue helpers and the side-effecting lifecycle
- * deps (hook manager, notifier/skill cleanup, browser-screencast) so the test
- * can invoke `disposeConversation` with a minimal `DisposeContext` and assert
- * on the enqueue bookkeeping alone.
+ * deps (notifier/skill cleanup, browser-screencast) so the test can invoke
+ * `disposeConversation` with a minimal `DisposeContext` and assert on the
+ * enqueue bookkeeping alone.
  *
  * Two recursion guards apply when the source conversation is itself an
  * auto-analysis conversation:
@@ -83,12 +83,6 @@ mock.module("../../memory/auto-analysis-enqueue.js", () => ({
 
 // Stub all side-effecting cleanup helpers that disposeConversation chains
 // into after the enqueue block. We assert on enqueue behavior only.
-mock.module("../../hooks/manager.js", () => ({
-  getHookManager: () => ({
-    trigger: () => undefined,
-  }),
-}));
-
 mock.module("../../tools/browser/browser-screencast.js", () => ({
   unregisterConversationSender: () => {},
 }));
@@ -105,8 +99,7 @@ mock.module("../conversation-skill-tools.js", () => ({
 // Dynamic import after mock.module calls so stubs take effect.
 const { disposeConversation } = await import("../conversation-lifecycle.js");
 type DisposeContext = import("../conversation-lifecycle.js").DisposeContext;
-type TrustClass =
-  import("../../runtime/actor-trust-resolver.js").TrustClass;
+type TrustClass = import("../../runtime/actor-trust-resolver.js").TrustClass;
 
 // ---------------------------------------------------------------------------
 // Fixture builder — minimal DisposeContext satisfying the interface shape.

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -8,7 +8,6 @@ import { createContextSummaryMessage } from "../context/window-manager.js";
 import type { EventBus } from "../events/bus.js";
 import type { AssistantDomainEvents } from "../events/domain-events.js";
 import type { ToolProfiler } from "../events/tool-profiling-listener.js";
-import { getHookManager } from "../hooks/manager.js";
 import { enqueueAutoAnalysisIfEnabled } from "../memory/auto-analysis-enqueue.js";
 import { isAutoAnalysisConversation } from "../memory/auto-analysis-guard.js";
 import {
@@ -355,10 +354,6 @@ export function abortConversation(
 // ── dispose ──────────────────────────────────────────────────────────
 
 export function disposeConversation(ctx: DisposeContext): void {
-  void getHookManager().trigger("conversation-end", {
-    conversationId: ctx.conversationId,
-  });
-
   // Trigger graph extraction for end-of-conversation sweep.
   // Only extract from guardian conversations to preserve the memory trust
   // boundary — untrusted content must not influence future memory retrieval.


### PR DESCRIPTION
## Summary
- Remove conversation-end hook trigger from daemon/conversation-lifecycle.ts
- Remove getHookManager import + clean up test setup

Part of plan: agent-plugin-system.md (PR 7 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
