### PR TITLE
chore(assistant): remove `hooks` CLI command

### DIFF
--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -5,7 +5,6 @@ import { Command } from "commander";
 import { initFeatureFlagOverrides } from "../config/assistant-feature-flags.js";
 import { getConfigReadOnly } from "../config/loader.js";
 import { isEmailEnabled } from "../email/feature-gate.js";
-import { registerHooksCommand } from "../hooks/cli.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { APP_VERSION } from "../version.js";
 import { registerAttachmentCommand } from "./commands/attachment.js";
@@ -88,7 +87,6 @@ Examples:
   registerAuthCommand(program);
   registerAttachmentCommand(program);
   registerAvatarCommand(program);
-  registerHooksCommand(program);
   registerMcpCommand(program);
   if (isEmailEnabled(getConfigReadOnly())) {
     registerDomainCommand(program);


### PR DESCRIPTION
## Summary
- Remove registerHooksCommand import + registration from cli/program.ts

Part of plan: agent-plugin-system.md (PR 9 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
