### PR TITLE
fix(meet-join): use chat panel toggle as admission signal to avoid prejoin-lobby aliasing

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/join.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/join.test.ts
@@ -175,24 +175,28 @@ function spyOnClick(doc: Document, sel: string): string[] {
 }
 
 /**
- * Insert the post-admission bottom toolbar buttons — the "Leave call" button
- * AND the mic toggle — into the DOM to simulate admission. We run this
- * *synchronously* before calling {@link runJoinFlow} so the step-5 wait
- * short-circuits on the initial `querySelector` check rather than racing
- * against the observer. The separation-of-concerns test goals here are
- * "does the flow locate the in-meeting UI?" — not "does the observer fire
- * on a late mutation?" — so pre-insertion is the cleaner assertion target.
+ * Insert the post-admission bottom toolbar buttons — the leave button,
+ * mic toggle, AND the chat/participants panel toggles — into the DOM to
+ * simulate admission. We run this *synchronously* before calling
+ * {@link runJoinFlow} so the step-5 wait short-circuits on the initial
+ * `querySelector` check rather than racing against the observer. The
+ * separation-of-concerns test goals here are "does the flow locate the
+ * in-meeting UI?" — not "does the observer fire on a late mutation?" —
+ * so pre-insertion is the cleaner assertion target.
  *
- * The mic toggle is what `runJoinFlow` step 5 actually waits on
- * (`INGAME_READY_INDICATOR`); the leave button is kept alongside it so the
- * post-admission fixture mirrors live Meet (which renders both). Omitting
- * the mic toggle is how {@link insertLeaveButtonOnly} below simulates the
- * original bug: Meet's leave button mounts in the waiting room too, so the
- * bot-side code used to short-circuit step 5 before actual admission.
+ * The chat panel button is what `runJoinFlow` step 5 actually waits on
+ * (`INGAME_READY_INDICATOR`); the other buttons are kept alongside it so
+ * the post-admission fixture mirrors live Meet (which renders all four).
+ * Omitting the panel toggles is how {@link insertLeaveButtonOnly} and
+ * {@link insertLobbyDevicePreviewToolbar} simulate the two historical
+ * short-circuit bugs: the leave button also mounts in the waiting room,
+ * and the mic toggle also mounts on the prejoin device-preview lobby.
  */
 function insertPostAdmissionToolbar(doc: Document): {
   leave: HTMLButtonElement;
   micToggle: HTMLButtonElement;
+  chatPanelButton: HTMLButtonElement;
+  participantsPanelButton: HTMLButtonElement;
 } {
   const leave = doc.createElement("button");
   leave.setAttribute("type", "button");
@@ -206,9 +210,62 @@ function insertPostAdmissionToolbar(doc: Document): {
   micToggle.textContent = "Microphone";
   doc.body.appendChild(micToggle);
 
+  const chatPanelButton = doc.createElement("button");
+  chatPanelButton.setAttribute("type", "button");
+  chatPanelButton.setAttribute("aria-label", "Chat with everyone");
+  chatPanelButton.textContent = "Chat";
+  doc.body.appendChild(chatPanelButton);
+
+  const participantsPanelButton = doc.createElement("button");
+  participantsPanelButton.setAttribute("type", "button");
+  participantsPanelButton.setAttribute("aria-label", "Show everyone");
+  participantsPanelButton.textContent = "People";
+  doc.body.appendChild(participantsPanelButton);
+
   return {
     leave: leave as HTMLButtonElement,
     micToggle: micToggle as HTMLButtonElement,
+    chatPanelButton: chatPanelButton as HTMLButtonElement,
+    participantsPanelButton: participantsPanelButton as HTMLButtonElement,
+  };
+}
+
+/**
+ * Insert a prejoin-lobby device-preview toolbar — a mic toggle and
+ * camera toggle with the same aria-labels Meet uses on the in-meeting
+ * bottom bar — but NOT the chat/participants panel buttons. This
+ * simulates the state just after the bot clicked "Ask to join" but
+ * before Meet has mounted the in-meeting toolbar: the xdotool click is
+ * still queued, so `PREJOIN_NAME_INPUT` may still be in the DOM too.
+ *
+ * Before this aliasing fix, `INGAME_READY_INDICATOR` was the mic toggle
+ * selector and `waitForSelector` resolved synchronously on this DOM —
+ * step 5 returned instantly, `onAdmitted` fired, and step 6 tried to
+ * post the consent message into a DOM that had no chat panel at all.
+ * The symptom in production was a `[ext] consent post failed: chat
+ * input not found` diagnostic emitted while the bot was still on the
+ * lobby screen (aria-labels dump showed `BUTTON[Ask to join without
+ * camera]` and `INPUT[Your name]`).
+ */
+function insertLobbyDevicePreviewToolbar(doc: Document): {
+  micToggle: HTMLButtonElement;
+  cameraToggle: HTMLButtonElement;
+} {
+  const micToggle = doc.createElement("button");
+  micToggle.setAttribute("type", "button");
+  micToggle.setAttribute("aria-label", "Turn off microphone");
+  micToggle.textContent = "Microphone";
+  doc.body.appendChild(micToggle);
+
+  const cameraToggle = doc.createElement("button");
+  cameraToggle.setAttribute("type", "button");
+  cameraToggle.setAttribute("aria-label", "Turn off camera");
+  cameraToggle.textContent = "Camera";
+  doc.body.appendChild(cameraToggle);
+
+  return {
+    micToggle: micToggle as HTMLButtonElement,
+    cameraToggle: cameraToggle as HTMLButtonElement,
   };
 }
 
@@ -832,9 +889,9 @@ describe("runJoinFlow (content-script port)", () => {
     const { doc } = loadPrejoinDom();
     removeMediaModal(doc);
     // Deliberately do NOT insert the post-admission toolbar — the
-    // INGAME_READY_INDICATOR (mic toggle) never mounts, so step 5 should
-    // reject. The beforeEach setTimeout patch collapses the 90s wait to a
-    // single tick so the test runs quickly.
+    // INGAME_READY_INDICATOR (chat/participants panel toggles) never
+    // mounts, so step 5 should reject. The beforeEach setTimeout patch
+    // collapses the 90s wait to a single tick so the test runs quickly.
 
     const events: unknown[] = [];
     await expect(
@@ -963,11 +1020,12 @@ describe("runJoinFlow (content-script port)", () => {
 
   test("resolves step 5 against the committed ingame fixture", async () => {
     // Load the prejoin fixture (for steps 1-4), then splice in the committed
-    // ingame fixture's body contents so `INGAME_READY_INDICATOR` (the mic
-    // toggle) is visible to step 5. This gives us an end-to-end assertion
-    // that the selector chosen in `dom/selectors.ts` actually matches the
-    // real captured post-admission markup — not just the synthesized toolbar
-    // used by the other happy-path tests.
+    // ingame fixture's body contents so `INGAME_READY_INDICATOR` (the
+    // chat/participants panel toggles) is visible to step 5. This gives
+    // us an end-to-end assertion that the selector chosen in
+    // `dom/selectors.ts` actually matches the real captured post-
+    // admission markup — not just the synthesized toolbar used by the
+    // other happy-path tests.
     const { doc } = loadPrejoinDom();
     removeMediaModal(doc);
     spliceIngameFixture(doc);
@@ -988,7 +1046,7 @@ describe("runJoinFlow (content-script port)", () => {
       restore();
     }
 
-    // Sanity-check: the mic toggle came in via the ingame fixture.
+    // Sanity-check: the panel toggles came in via the ingame fixture.
     expect(doc.querySelector(selectors.INGAME_READY_INDICATOR)).not.toBeNull();
 
     // And no error diagnostics fired — step 5 resolved cleanly.
@@ -1068,6 +1126,49 @@ describe("runJoinFlow (content-script port)", () => {
         displayName: "Vellum Bot",
         consentMessage: "Hi, Vellum is listening.",
         meetingId: "mtg-leave-button-alone",
+        onEvent: (e) => events.push(e),
+        doc,
+      }),
+    ).rejects.toThrow(/in-meeting UI did not appear/i);
+
+    // Diagnostic was emitted before the throw.
+    const diag = events.find(
+      (e) =>
+        typeof e === "object" &&
+        e !== null &&
+        (e as { type?: string }).type === "diagnostic" &&
+        (e as { level?: string }).level === "error",
+    );
+    expect(diag).toBeDefined();
+  });
+
+  test("regression: the prejoin lobby's mic toggle is NOT accepted as the in-meeting signal", async () => {
+    // Paired with the waiting-room regression above: before this fix,
+    // `INGAME_READY_INDICATOR` was `MIC_TOGGLE` on the assumption that
+    // the dual `"Turn off microphone"` / `"Turn on microphone"` aria-
+    // label only appears post-admission. In practice Meet renders the
+    // same device-preview toolbar on the prejoin lobby with identical
+    // aria-labels, so `waitForSelector(INGAME_READY_INDICATOR)` resolved
+    // synchronously before the bot even clicked "Ask to join" — step 5
+    // returned instantly, `onAdmitted` fired, and step 6's consent post
+    // failed against the lobby DOM with `chat input not found`.
+    //
+    // We simulate the lobby surface by inserting only the mic + camera
+    // toggles (no chat panel button, no participants panel button) and
+    // assert the join flow now times out at step 5 instead of racing
+    // ahead. The `beforeEach` setTimeout patch collapses the 90s wait
+    // to a single tick so the test runs quickly.
+    const { doc } = loadPrejoinDom();
+    removeMediaModal(doc);
+    insertLobbyDevicePreviewToolbar(doc);
+
+    const events: unknown[] = [];
+    await expect(
+      runJoinFlow({
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        displayName: "Vellum Bot",
+        consentMessage: "Hi, Vellum is listening.",
+        meetingId: "mtg-lobby-mic-toggle-alone",
         onEvent: (e) => events.push(e),
         doc,
       }),

--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/selectors.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/selectors.test.ts
@@ -102,11 +102,14 @@ describe("in-meeting selectors", () => {
     // selector ever stops matching, the join flow's step-5 wait will
     // time out after 90s on every real-world join — fail loud here so
     // the drift is caught during fixture refresh rather than in prod.
+    //
+    // The selector is an OR-list of the chat and participants panel
+    // toggles, so both should be present in a real in-meeting capture.
     const nodes = doc.querySelectorAll(controlSelectors.INGAME_READY_INDICATOR);
-    expect(nodes.length).toBe(1);
-    expect((nodes[0] as HTMLElement).getAttribute("aria-label")).toBe(
-      "Turn off microphone",
-    );
+    const labels = Array.from(nodes)
+      .map((n) => (n as HTMLElement).getAttribute("aria-label"))
+      .sort();
+    expect(labels).toEqual(["Chat with everyone", "Show everyone"]);
   });
 
   test("INGAME_READY_INDICATOR does NOT resolve in the prejoin fixture", () => {

--- a/skills/meet-join/meet-controller-ext/src/dom/selectors.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/selectors.ts
@@ -232,31 +232,45 @@ export const controlSelectors = {
    * Post-admission-only "ready" indicator used as the canonical signal that
    * the bot has actually entered the meeting.
    *
-   * Why this exists: the `LEAVE_BUTTON` selector (`button[aria-label="Leave
-   * call"]`) is ambiguous — Meet renders the same red hang-up button in BOTH
-   * the waiting-room UI AND the in-meeting UI, so `waitForSelector(LEAVE_
-   * BUTTON)` resolves immediately after the user clicks "Ask to join",
-   * BEFORE the host has actually admitted the bot. Callers that used
-   * LEAVE_BUTTON as an admission signal (e.g. the join flow's step 5)
-   * would then race ahead and try to interact with in-meeting surfaces
-   * (chat panel, participant list) that don't exist in the waiting room,
-   * producing spurious "chat input not found"-style failures.
+   * Why this exists: several obvious admission-signal candidates alias onto
+   * earlier join surfaces and would fire before the bot is in-meeting,
+   * racing step 6's consent post against a DOM that doesn't yet have the
+   * chat composer:
    *
-   * We re-use `MIC_TOGGLE` as the signal because the microphone toggle's
-   * dual aria-label (`"Turn off microphone"` / `"Turn on microphone"`) is
-   * a post-admission-only affordance — the waiting-room mic preview
-   * controls use a different labeling scheme and are not rendered by the
-   * bottom-bar toolbar that hosts this button. Matching MIC_TOGGLE
-   * therefore guarantees the bot is inside the meeting (bottom toolbar
-   * is mounted) rather than still on the prejoin surface.
+   *   - `LEAVE_BUTTON` (`button[aria-label="Leave call"]`) renders in BOTH
+   *     the waiting-room UI and the in-meeting UI. Using it makes
+   *     `waitForSelector` resolve the moment the bot clicks "Ask to join",
+   *     before the host has admitted it.
+   *   - `MIC_TOGGLE` (`"Turn off microphone"` / `"Turn on microphone"`)
+   *     renders on the **prejoin lobby** too: Meet shows a fully-wired
+   *     device-preview toolbar with the same dual aria-label on the
+   *     pre-admission screen. `waitForSelector(MIC_TOGGLE)` therefore
+   *     resolves synchronously on the lobby DOM — before the bot has
+   *     even clicked "Ask to join" — and step 5 short-circuits so hard
+   *     that `onAdmitted` fires while the bot is still sitting on the
+   *     lobby. Step 6 then tries to post consent into a DOM that has
+   *     no chat panel button at all, and the `[ext] consent post failed:
+   *     chat input not found` diagnostic is the first sign anything
+   *     went wrong.
    *
-   * This constant is an alias for {@link MIC_TOGGLE}; it exists as a
-   * separate name so the join flow reads clearly ("wait for the in-meeting
-   * UI to be ready") and so future DOM drift can move the signal to a
-   * different post-admission-only element without changing the call site.
+   * We use the chat / participants panel toggles instead. Both are
+   * bottom-toolbar buttons that Meet mounts only once the user is
+   * actually in the meeting — they do not render on the prejoin lobby
+   * (which only shows device-preview controls) or in the waiting room
+   * (which shows only the leave button and an "asking to be let in"
+   * label). Matching either one guarantees the in-meeting toolbar has
+   * mounted and that step 6's `ensurePanelOpen` will find `PANEL_BUTTON`
+   * in the DOM a beat later.
+   *
+   * This lives as a dedicated constant (not an alias for `PANEL_BUTTON`)
+   * so future DOM drift can move the signal to a different post-
+   * admission-only element without changing the join flow's call site,
+   * and so the OR-list can fail over to `"Show everyone"` if Meet ever
+   * renames / hides the chat toggle (e.g. "continuous chat is turned
+   * off" host configurations).
    */
   INGAME_READY_INDICATOR:
-    'button[aria-label="Turn off microphone"], button[aria-label="Turn on microphone"]',
+    'button[aria-label="Chat with everyone"], button[aria-label="Show everyone"]',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

- Root cause: `INGAME_READY_INDICATOR` was `MIC_TOGGLE`, but Meet renders the same mic/camera toggles on the prejoin lobby — `waitForSelector` resolved synchronously on lobby DOM, `onAdmitted` fired prematurely, and step 6's consent post ran against a DOM with no chat panel button. Bot logs confirmed: `chat-panel-button: <missing>` + lobby aria-labels (`INPUT[Your name]`, `BUTTON[Ask to join without camera]`).
- Fix: change `INGAME_READY_INDICATOR` to `'button[aria-label="Chat with everyone"], button[aria-label="Show everyone"]'` — panel toggles only mount on the in-meeting bottom toolbar, not on the prejoin lobby or waiting room.
- Regression test: `insertLobbyDevicePreviewToolbar` fixture mirrors the production lobby DOM (mic/camera toggles, no panel buttons) and asserts step 5 now times out instead of short-circuiting.

## Original prompt

`/mainline`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
