### PR TITLE
chore(assistant): remove hook triggers from agent loop

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -7,7 +7,6 @@ import {
   getCalibrationProviderKey,
 } from "../context/token-estimator.js";
 import { truncateOversizedToolResults } from "../context/tool-result-truncation.js";
-import { getHookManager } from "../hooks/manager.js";
 import type {
   ContentBlock,
   Message,
@@ -354,22 +353,6 @@ export class AgentLoop {
           providerConfig.callSite = callSite;
         }
 
-        const preLlmResult = await getHookManager().trigger("pre-llm-call", {
-          systemPrompt: turnSystemPrompt,
-          messages: history,
-          toolCount: currentTools.length,
-        });
-
-        if (preLlmResult.blocked) {
-          onEvent({
-            type: "error",
-            error: new Error(
-              `LLM call blocked by hook "${preLlmResult.blockedBy}"`,
-            ),
-          });
-          break;
-        }
-
         // Rate-limit consecutive LLM calls to prevent spin when tools return instantly
         const minInterval = this.config.minTurnIntervalMs ?? 0;
         if (minInterval > 0 && lastLlmCallTime > 0) {
@@ -482,14 +465,6 @@ export class AgentLoop {
           rawRequest: response.rawRequest,
           rawResponse: response.rawResponse,
           estimatedInputTokens: preSendEstimatedTokens,
-        });
-
-        void getHookManager().trigger("post-llm-call", {
-          model: response.model,
-          inputTokens: response.usage.inputTokens,
-          outputTokens: response.usage.outputTokens,
-          contentBlockCount: response.content.length,
-          durationMs: providerDurationMs,
         });
 
         // Flush any buffered streaming text from the substitution pipeline


### PR DESCRIPTION
## Summary
- Remove pre-llm-call and post-llm-call hook triggers from agent/loop.ts
- Remove getHookManager import

Part of plan: agent-plugin-system.md (PR 1 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
