### PR TITLE
chore(assistant): remove daemon lifecycle hook triggers and template install

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -43,8 +43,6 @@ import {
   startFeedScheduler,
 } from "../home/feed-scheduler.js";
 import { backfillRelationshipStateIfMissing } from "../home/relationship-state-writer.js";
-import { getHookManager } from "../hooks/manager.js";
-import { installTemplates } from "../hooks/templates.js";
 import { closeSentry, initSentry, setSentryDeviceId } from "../instrument.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import * as attachmentsStore from "../memory/attachments-store.js";
@@ -340,8 +338,7 @@ export async function runDaemon(): Promise<void> {
 
     seedInterfaceFiles();
 
-    log.info("Daemon startup: installing templates and initializing DB");
-    installTemplates();
+    log.info("Daemon startup: initializing DB");
     ensurePromptFiles();
 
     // DB must be initialized before workspace migrations because some
@@ -1367,13 +1364,6 @@ export async function runDaemon(): Promise<void> {
       log.warn({ err }, "Assistant symlink installation failed — continuing");
     }
 
-    const hookManager = getHookManager();
-    hookManager.watch();
-
-    void hookManager.trigger("daemon-start", {
-      pid: process.pid,
-    });
-
     // Download embedding runtime in background (non-blocking).
     // If download fails, local embeddings gracefully fall back to cloud backends.
     void (async () => {
@@ -1487,7 +1477,6 @@ export async function runDaemon(): Promise<void> {
       workspaceHeartbeat,
       heartbeat,
       filing,
-      hookManager,
       runtimeHttp,
       scheduler,
       feedScheduler,

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -3,7 +3,6 @@ import * as Sentry from "@sentry/node";
 import type { BackupWorkerHandle } from "../backup/backup-worker.js";
 import type { FilingService } from "../filing/filing-service.js";
 import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
-import type { HookManager } from "../hooks/manager.js";
 import type { McpServerManager } from "../mcp/manager.js";
 import { getSqlite, resetDb } from "../memory/db.js";
 import type { QdrantManager } from "../memory/qdrant-manager.js";
@@ -23,7 +22,6 @@ export interface ShutdownDeps {
   workspaceHeartbeat: WorkspaceHeartbeatService;
   heartbeat: HeartbeatService;
   filing: FilingService;
-  hookManager: HookManager;
   runtimeHttp: RuntimeHttpServer | null;
   scheduler: { stop(): void };
   feedScheduler: { stop(): void } | null;
@@ -44,11 +42,9 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     shuttingDown = true;
     log.info("Shutting down daemon...");
 
-    deps.hookManager.stopWatching();
-
     // Force exit if graceful shutdown takes too long.
-    // Set this BEFORE awaiting heartbeat stop and triggering daemon-stop hooks
-    // so it covers all potentially-blocking async shutdown work.
+    // Set this BEFORE awaiting heartbeat stop so it covers all
+    // potentially-blocking async shutdown work.
     //
     // 20s budget: 15s reserved for Meet session teardown
     // (`MeetSessionManager.shutdownAll`), plus ~5s for the remaining
@@ -66,12 +62,6 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     await deps.workspaceHeartbeat.stop();
     await deps.heartbeat.stop();
     await deps.filing.stop();
-
-    try {
-      await deps.hookManager.trigger("daemon-stop", { pid: process.pid });
-    } catch {
-      // Don't let hook failures block shutdown
-    }
 
     // Run registered skill shutdown hooks (e.g. meet-join session teardown)
     // before stopping the server so any HTTP round-trips and SSE emissions


### PR DESCRIPTION
## Summary
- Remove daemon-start and daemon-stop hook triggers
- Remove installTemplates call from lifecycle.ts
- Drop hookManager wiring from shutdown handlers

Part of plan: agent-plugin-system.md (PR 8 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
