### PR TITLE
chore(assistant): remove hook triggers from secret-detection-handler

### DIFF
--- a/assistant/src/__tests__/secret-detection-handler.test.ts
+++ b/assistant/src/__tests__/secret-detection-handler.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 
-const triggerMock = mock(async () => {});
 const scanTextMock = mock(() => [
   { type: "api_key", redactedValue: "sk-***redacted***" },
 ]);
@@ -18,12 +17,6 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
-mock.module("../hooks/manager.js", () => ({
-  getHookManager: () => ({
-    trigger: triggerMock,
-  }),
-}));
-
 mock.module("../security/secret-scanner.js", () => ({
   compileCustomPatterns: () => [],
   redactSecrets: (content: string) => content,
@@ -35,7 +28,6 @@ import { SecretDetectionHandler } from "../tools/secret-detection-handler.js";
 describe("SecretDetectionHandler under v2", () => {
   beforeEach(() => {
     _setOverridesForTesting({});
-    triggerMock.mockClear();
     scanTextMock.mockClear();
   });
 
@@ -79,6 +71,5 @@ describe("SecretDetectionHandler under v2", () => {
         decision: "deny",
       }),
     );
-    expect(triggerMock).toHaveBeenCalled();
   });
 });

--- a/assistant/src/tools/secret-detection-handler.ts
+++ b/assistant/src/tools/secret-detection-handler.ts
@@ -1,5 +1,4 @@
 import { getConfig } from "../config/loader.js";
-import { getHookManager } from "../hooks/manager.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { RiskLevel } from "../permissions/types.js";
 import { isPermissionControlsV2Enabled } from "../permissions/v2-consent-policy.js";
@@ -210,7 +209,7 @@ export class SecretDetectionHandler {
       context: ToolContext,
       event: ToolLifecycleEvent,
     ) => void,
-    sanitizeToolInput: (
+    _sanitizeToolInput: (
       toolName: string,
       input: Record<string, unknown>,
     ) => Record<string, unknown>,
@@ -237,15 +236,6 @@ export class SecretDetectionHandler {
       result: blockedResult,
     });
 
-    void getHookManager().trigger("post-tool-execute", {
-      toolName: name,
-      input: sanitizeToolInput(name, input),
-      riskLevel,
-      isError: true,
-      durationMs,
-      conversationId: context.conversationId,
-    });
-
     return { result: blockedResult, earlyReturn: true };
   }
 
@@ -263,7 +253,7 @@ export class SecretDetectionHandler {
       context: ToolContext,
       event: ToolLifecycleEvent,
     ) => void,
-    sanitizeToolInput: (
+    _sanitizeToolInput: (
       toolName: string,
       input: Record<string, unknown>,
     ) => Record<string, unknown>,
@@ -286,15 +276,6 @@ export class SecretDetectionHandler {
         decision: "deny",
         reason: "Secret output blocked without deterministic prompt under v2",
         durationMs,
-      });
-
-      void getHookManager().trigger("post-tool-execute", {
-        toolName: name,
-        input: sanitizeToolInput(name, input),
-        riskLevel,
-        isError: true,
-        durationMs,
-        conversationId: context.conversationId,
       });
 
       return {
@@ -320,15 +301,6 @@ export class SecretDetectionHandler {
         decision: "deny",
         reason: "Non-interactive session: auto-blocked secret output",
         durationMs,
-      });
-
-      void getHookManager().trigger("post-tool-execute", {
-        toolName: name,
-        input: sanitizeToolInput(name, input),
-        riskLevel,
-        isError: true,
-        durationMs,
-        conversationId: context.conversationId,
       });
 
       return {
@@ -387,15 +359,6 @@ export class SecretDetectionHandler {
         decision: response.decision === "always_deny" ? "always_deny" : "deny",
         reason: `User denied output containing secrets: ${types}`,
         durationMs,
-      });
-
-      void getHookManager().trigger("post-tool-execute", {
-        toolName: name,
-        input: sanitizeToolInput(name, input),
-        riskLevel,
-        isError: true,
-        durationMs,
-        conversationId: context.conversationId,
       });
 
       return {


### PR DESCRIPTION
## Summary
- Remove four post-tool-execute hook triggers from secret-detection-handler.ts
- Remove getHookManager import + clean up test setup

Part of plan: agent-plugin-system.md (PR 3 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
