### PR TITLE
feat(meet): bypass Tier 1 regex gate for inbound chat messages

### DIFF
--- a/skills/meet-join/daemon/__tests__/chat-opportunity-detector.test.ts
+++ b/skills/meet-join/daemon/__tests__/chat-opportunity-detector.test.ts
@@ -142,7 +142,7 @@ async function flushPromises(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
-  test("Tier 1 miss does not invoke Tier 2 and does not fire callback", async () => {
+  test("transcript Tier 1 miss does not invoke Tier 2 and does not fire callback", async () => {
     const dispatcher = makeFakeDispatcher();
     const clock = makeClock(1_000);
     const llm = mock(
@@ -172,10 +172,6 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
         "The weather is nice today.",
       ),
     );
-    dispatcher.dispatch(
-      "m1",
-      inboundChat("m1", "2024-01-01T00:00:01.000Z", "hello team"),
-    );
 
     await flushPromises();
 
@@ -185,6 +181,58 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
 
     detector.dispose();
     expect(dispatcher.subscriberCount("m1")).toBe(0);
+  });
+
+  test("inbound chat always invokes Tier 2 regardless of Tier 1 content", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const clock = makeClock(1_000);
+    const llm = mock(
+      async (_prompt: string): Promise<ChatOpportunityDecision> => ({
+        shouldRespond: true,
+        reason: "user addressed the assistant without a keyword",
+      }),
+    );
+    const onOpportunity = mock((_reason: string) => {});
+
+    const detector = new MeetChatOpportunityDetector({
+      meetingId: "m1",
+      assistantDisplayName: "Aria",
+      config: defaultConfig(),
+      callDetectorLLM: llm,
+      onOpportunity,
+      subscribe: dispatcher.subscribe,
+      now: clock.now,
+    });
+    detector.start();
+
+    // Plain "hello team" does NOT match any Tier 1 regex (no assistant
+    // name, no `can you`, no `does anyone`). Before the chat-bypass
+    // change this test would have asserted zero Tier 2 calls; post-
+    // change the detector sends every inbound chat straight to Tier 2.
+    dispatcher.dispatch(
+      "m1",
+      inboundChat("m1", "2024-01-01T00:00:00.000Z", "hello team"),
+    );
+
+    await flushPromises();
+
+    expect(llm).toHaveBeenCalledTimes(1);
+    expect(onOpportunity).toHaveBeenCalledTimes(1);
+    const [reason] = onOpportunity.mock.calls[0] as unknown as [string];
+    expect(reason).toBe("user addressed the assistant without a keyword");
+
+    const stats = detector.getStats();
+    expect(stats.tier1Hits).toBe(1);
+    expect(stats.tier2Calls).toBe(1);
+    expect(stats.tier2PositiveCount).toBe(1);
+    expect(stats.escalationsFired).toBe(1);
+
+    // The Tier 2 prompt should carry the synthetic bypass reason so
+    // operators grepping `tier1:*` in logs still see the trigger.
+    const [prompt] = llm.mock.calls[0] as unknown as [string];
+    expect(prompt).toContain("tier1:chat-always-on");
+
+    detector.dispose();
   });
 
   test("Tier 1 hit + Tier 2 false does not fire callback", async () => {
@@ -556,10 +604,12 @@ describe("MeetChatOpportunityDetector — custom keywords", () => {
     expect(detector.getStats().tier1Hits).toBe(0);
     expect(llm).toHaveBeenCalledTimes(0);
 
-    // The custom pattern should match.
+    // The custom pattern should match. Use a transcript chunk here
+    // (not an inbound chat) because inbound chat bypasses Tier 1
+    // entirely — we want this test to exercise Tier 1 regex matching.
     dispatcher.dispatch(
       "m1",
-      inboundChat(
+      transcriptChunk(
         "m1",
         "2024-01-01T00:00:01.000Z",
         "my favorite is the blue monkey at the zoo",

--- a/skills/meet-join/daemon/chat-opportunity-detector.ts
+++ b/skills/meet-join/daemon/chat-opportunity-detector.ts
@@ -7,18 +7,28 @@
  * Two-tier design:
  *
  *   1. **Tier 1 (regex fast filter)** — synchronous on every final
- *      transcript chunk and every inbound chat message. Default patterns
- *      cover direct assistant-name mentions, `(hey|hi|…) <name>, … ?` style
- *      address-then-question forms, and generic "can you / does anyone
- *      know" requests. A hit feeds Tier 2 with a short trigger reason.
+ *      transcript chunk. Default patterns cover direct assistant-name
+ *      mentions, `(hey|hi|…) <name>, … ?` style address-then-question
+ *      forms, and generic "can you / does anyone know" requests. A hit
+ *      feeds Tier 2 with a short trigger reason.
  *
- *   2. **Tier 2 (LLM confirmation)** — fires on every Tier 1 hit,
- *      subject to a configurable debounce. The prompt includes the
- *      rolling transcript (last N seconds), the most recent 5 chat
- *      messages, the trigger chunk, and the Tier 1 reason, and asks for
- *      strict JSON `{ shouldRespond: boolean, reason: string }`. Positive
- *      verdicts are rate-limited further by an "escalation cooldown" so
- *      a chatty meeting can't fire the callback repeatedly.
+ *      Inbound chat messages intentionally **bypass** Tier 1 and proceed
+ *      straight to Tier 2 with a synthetic `"tier1:chat-always-on"`
+ *      reason. Chat volume is orders of magnitude lower than transcript
+ *      (typically <1/5s even on chatty meetings), so the regex gate's
+ *      cost savings don't pay off there — and users typing in chat
+ *      expect the assistant to read every message rather than be filtered
+ *      by an English-interrogative keyword list. Debounce + escalation
+ *      cooldown remain in effect, so burst bounds are preserved.
+ *
+ *   2. **Tier 2 (LLM confirmation)** — fires on every Tier 1 hit and
+ *      every inbound chat, subject to a configurable debounce. The
+ *      prompt includes the rolling transcript (last N seconds), the
+ *      most recent 5 chat messages, the trigger chunk, and the Tier 1
+ *      reason, and asks for strict JSON `{ shouldRespond: boolean,
+ *      reason: string }`. Positive verdicts are rate-limited further
+ *      by an "escalation cooldown" so a chatty meeting can't fire the
+ *      callback repeatedly.
  *
  * The detector is intentionally inert until wired: it does not itself
  * post to meeting chat, consult any session manager, or share state with
@@ -307,11 +317,15 @@ export class MeetChatOpportunityDetector {
     });
     while (this.chatBuffer.length > CHAT_BUFFER_SIZE) this.chatBuffer.shift();
 
-    const reason = this.tier1Match(raw);
-    if (reason !== null) {
-      this.stats.tier1Hits += 1;
-      void this.maybeRunTier2(reason, raw);
-    }
+    // Every non-empty inbound chat proceeds to Tier 2 unconditionally.
+    // Chat volume is low enough (<1/5s typical) that the debounce +
+    // escalation cooldown are sufficient throttles on their own, and a
+    // keyword gate silently drops natural-but-unkeyworded invitations
+    // like "yo where's that deck" or "wait which one". The synthetic
+    // `tier1:chat-always-on` reason keeps log-grep patterns (`tier1:*`)
+    // working and signals the bypass path in telemetry.
+    this.stats.tier1Hits += 1;
+    void this.maybeRunTier2("tier1:chat-always-on", raw);
   }
 
   // ── Tier 1 ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Every inbound Meet chat message now proceeds straight to Tier 2 LLM confirmation, bypassing the Tier 1 regex fast-filter. Transcript-side Tier 1 is unchanged.
- Chat volume is typically <1 message per 5s, so the existing `tier2DebounceMs` (5s) and `escalationCooldownSec` (30s) already cap call volume without needing a keyword gate. This avoids silently dropping natural-but-unkeyworded invitations like "yo where's that deck" that don't match `\b(can|could|would|will)\s+you\b` etc.
- Synthetic trigger reason `tier1:chat-always-on` preserves `tier1:*` log-grep patterns and makes the bypass explicit in telemetry.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
