### PR TITLE
feat(assistant): add plugin registry with capability-based versioning

### DIFF
--- a/assistant/src/__tests__/plugin-registry.test.ts
+++ b/assistant/src/__tests__/plugin-registry.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for the plugin registry (PR 13).
+ *
+ * Covers successful registration, required-field and duplicate-name
+ * validation, capability-version negotiation error messaging, injector
+ * ordering, and middleware collection order.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  ASSISTANT_API_VERSIONS,
+  getInjectors,
+  getMiddlewaresFor,
+  getRegisteredPlugins,
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import {
+  type CompactionArgs,
+  type CompactionResult,
+  type Injector,
+  type Middleware,
+  type Plugin,
+  PluginExecutionError,
+} from "../plugins/types.js";
+
+/** Build a minimal, valid plugin with the given name and optional extras. */
+function buildPlugin(
+  name: string,
+  extras: Partial<Omit<Plugin, "manifest">> = {},
+  requiresOverride?: Record<string, string>,
+): Plugin {
+  return {
+    manifest: {
+      name,
+      version: "0.0.1",
+      requires: requiresOverride ?? { pluginRuntime: "v1" },
+    },
+    ...extras,
+  };
+}
+
+describe("plugin registry", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+  });
+
+  test("registers a minimal plugin successfully", () => {
+    const plugin = buildPlugin("alpha");
+    registerPlugin(plugin);
+
+    const registered = getRegisteredPlugins();
+    expect(registered).toHaveLength(1);
+    expect(registered[0]?.manifest.name).toBe("alpha");
+  });
+
+  test("throws on duplicate-name registration", () => {
+    registerPlugin(buildPlugin("alpha"));
+    expect(() => registerPlugin(buildPlugin("alpha"))).toThrow(
+      PluginExecutionError,
+    );
+    expect(() => registerPlugin(buildPlugin("alpha"))).toThrow(
+      "already registered",
+    );
+  });
+
+  test("throws when manifest is missing", () => {
+    // Cast through `unknown` to simulate a JS caller passing a malformed plugin.
+    expect(() => registerPlugin({} as unknown as Plugin)).toThrow(
+      PluginExecutionError,
+    );
+  });
+
+  test("throws when manifest.name is missing", () => {
+    const bad = {
+      manifest: {
+        version: "0.0.1",
+        requires: { pluginRuntime: "v1" },
+      },
+    } as unknown as Plugin;
+    expect(() => registerPlugin(bad)).toThrow(/manifest\.name is required/);
+  });
+
+  test("throws when manifest.version is missing", () => {
+    const bad = {
+      manifest: {
+        name: "missing-version",
+        requires: { pluginRuntime: "v1" },
+      },
+    } as unknown as Plugin;
+    expect(() => registerPlugin(bad)).toThrow(/manifest\.version is required/);
+  });
+
+  test("throws when manifest.requires is missing", () => {
+    const bad = {
+      manifest: { name: "missing-requires", version: "0.0.1" },
+    } as unknown as Plugin;
+    expect(() => registerPlugin(bad)).toThrow(/manifest\.requires is required/);
+  });
+
+  test("throws when requires.pluginRuntime is missing", () => {
+    const plugin = buildPlugin(
+      "no-runtime",
+      {},
+      // Valid shape but no pluginRuntime entry.
+      { memoryApi: "v1" },
+    );
+    expect(() => registerPlugin(plugin)).toThrow(PluginExecutionError);
+    expect(() => registerPlugin(plugin)).toThrow(/pluginRuntime/);
+  });
+
+  test("throws with version-mismatch message when a required version is not exposed", () => {
+    // The assistant seeds memoryApi with ["v1"]. Requesting v2 must fail.
+    const plugin = buildPlugin(
+      "too-new",
+      {},
+      {
+        pluginRuntime: "v1",
+        memoryApi: "v2",
+      },
+    );
+
+    expect(() => registerPlugin(plugin)).toThrow(PluginExecutionError);
+
+    // Sanity-check the assistant actually exposes only v1 for memoryApi so
+    // this test fails loudly if the capability table ever adds v2.
+    expect(ASSISTANT_API_VERSIONS.memoryApi).toEqual(["v1"]);
+
+    try {
+      registerPlugin(plugin);
+      throw new Error("expected registerPlugin to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PluginExecutionError);
+      const msg = (err as PluginExecutionError).message;
+      // Error message must reference plugin name, API, required version,
+      // and the versions the assistant exposes.
+      expect(msg).toContain("too-new");
+      expect(msg).toContain("memoryApi");
+      expect(msg).toContain("v2");
+      expect(msg).toContain("v1");
+      expect((err as PluginExecutionError).pluginName).toBe("too-new");
+    }
+  });
+
+  test("throws with clear message when a required capability is unknown", () => {
+    const plugin = buildPlugin(
+      "asks-for-mystery",
+      {},
+      {
+        pluginRuntime: "v1",
+        thisDoesNotExist: "v1",
+      },
+    );
+    expect(() => registerPlugin(plugin)).toThrow(PluginExecutionError);
+    try {
+      registerPlugin(plugin);
+      throw new Error("expected registerPlugin to throw");
+    } catch (err) {
+      const msg = (err as PluginExecutionError).message;
+      expect(msg).toContain("asks-for-mystery");
+      expect(msg).toContain("thisDoesNotExist");
+      expect(msg).toContain("(none)");
+    }
+  });
+
+  test("getInjectors returns injectors sorted by order ascending", () => {
+    const high: Injector = {
+      name: "high-order",
+      order: 20,
+      async produce() {
+        return null;
+      },
+    };
+    const low: Injector = {
+      name: "low-order",
+      order: 10,
+      async produce() {
+        return null;
+      },
+    };
+
+    // Register the higher-order plugin first so registration order alone
+    // would produce the wrong sequence — the test proves sort-by-order wins.
+    registerPlugin(buildPlugin("high", { injectors: [high] }));
+    registerPlugin(buildPlugin("low", { injectors: [low] }));
+
+    const injectors = getInjectors();
+    expect(injectors.map((i) => i.name)).toEqual(["low-order", "high-order"]);
+  });
+
+  test("getMiddlewaresFor returns middleware in registration order", () => {
+    const firstMw: Middleware<CompactionArgs, CompactionResult> = async (
+      args,
+      next,
+    ) => next(args);
+    const secondMw: Middleware<CompactionArgs, CompactionResult> = async (
+      args,
+      next,
+    ) => next(args);
+
+    registerPlugin(
+      buildPlugin("plugin-first", { middleware: { compaction: firstMw } }),
+    );
+    registerPlugin(
+      buildPlugin("plugin-second", { middleware: { compaction: secondMw } }),
+    );
+
+    const middlewares = getMiddlewaresFor("compaction");
+    expect(middlewares).toHaveLength(2);
+    // Identity comparison proves the middleware instances come back in
+    // registration order — outer→inner composition semantics belong to the
+    // pipeline runner (PR 12), not the registry.
+    expect(middlewares[0]).toBe(firstMw);
+    expect(middlewares[1]).toBe(secondMw);
+  });
+
+  test("getMiddlewaresFor skips plugins without a middleware for the pipeline", () => {
+    const mw: Middleware<CompactionArgs, CompactionResult> = async (
+      args,
+      next,
+    ) => next(args);
+    registerPlugin(buildPlugin("bare"));
+    registerPlugin(buildPlugin("has-mw", { middleware: { compaction: mw } }));
+
+    const middlewares = getMiddlewaresFor("compaction");
+    expect(middlewares).toHaveLength(1);
+    expect(middlewares[0]).toBe(mw);
+  });
+
+  test("getRegisteredPlugins reflects registration order", () => {
+    registerPlugin(buildPlugin("one"));
+    registerPlugin(buildPlugin("two"));
+    registerPlugin(buildPlugin("three"));
+    expect(getRegisteredPlugins().map((p) => p.manifest.name)).toEqual([
+      "one",
+      "two",
+      "three",
+    ]);
+  });
+});

--- a/assistant/src/plugins/registry.ts
+++ b/assistant/src/plugins/registry.ts
@@ -1,0 +1,223 @@
+/**
+ * Plugin registry with manifest validation and capability-based API versioning.
+ *
+ * Plugins declare the assistant capabilities they need via
+ * `manifest.requires` (a `{ capability: version }` map). The registry checks
+ * each entry against {@link ASSISTANT_API_VERSIONS} — the canonical table of
+ * capability → supported-version-list pairs the assistant exposes — and
+ * refuses to register plugins that ask for a version the assistant does not
+ * support.
+ *
+ * Registration is order-preserving: {@link getRegisteredPlugins},
+ * {@link getMiddlewaresFor}, and (secondarily) {@link getInjectors} all reflect
+ * the order in which {@link registerPlugin} was called, which in turn
+ * determines onion order for middleware composition in the pipeline runner.
+ *
+ * This module does not call `Plugin.init()` — that is the job of the
+ * bootstrap (see PR 14). It also does not wire the registry into the daemon;
+ * later PRs introduce consumers.
+ *
+ * Design doc: `.private/plans/agent-plugin-system.md` (PR 13).
+ */
+
+import {
+  type Injector,
+  type PipelineMiddlewareMap,
+  type PipelineName,
+  type Plugin,
+  PluginExecutionError,
+} from "./types.js";
+
+/**
+ * Capability table declaring which plugin-facing API versions the assistant
+ * runtime exposes. Each capability maps to the list of supported semver-lite
+ * tags (currently a single `"v1"` per capability).
+ *
+ * New capabilities must be added here AND in their corresponding pipeline /
+ * runtime module so plugins can negotiate against them. Removing a version
+ * tag is a breaking change — all consumers in the plugin ecosystem relying on
+ * it will fail to register until they update their `requires` map.
+ *
+ * The `pluginRuntime` capability is the base runtime API every plugin must
+ * negotiate for; the remaining entries mirror {@link PipelineName} and the
+ * top-level context APIs plugins most commonly consume.
+ */
+export const ASSISTANT_API_VERSIONS: Record<string, string[]> = {
+  // Runtime APIs every plugin interacts with at some level.
+  pluginRuntime: ["v1"],
+  memoryApi: ["v1"],
+  compactionApi: ["v1"],
+  persistenceApi: ["v1"],
+
+  // Per-pipeline APIs. One entry per pipeline slot in {@link PipelineName}.
+  llmCallApi: ["v1"],
+  toolExecuteApi: ["v1"],
+  historyRepairApi: ["v1"],
+  tokenEstimateApi: ["v1"],
+  overflowReduceApi: ["v1"],
+  titleGenerateApi: ["v1"],
+  toolResultTruncateApi: ["v1"],
+  emptyResponseApi: ["v1"],
+  toolErrorApi: ["v1"],
+  circuitBreakerApi: ["v1"],
+};
+
+// ─── Internal state ──────────────────────────────────────────────────────────
+
+/**
+ * Registered plugins keyed by `manifest.name`. A `Map` preserves insertion
+ * order, which the registry relies on for middleware composition and
+ * `getRegisteredPlugins()` output.
+ */
+const registeredPlugins = new Map<string, Plugin>();
+
+// ─── Registration ────────────────────────────────────────────────────────────
+
+/**
+ * Validate and register a plugin. Throws {@link PluginExecutionError} if:
+ *
+ * - `manifest`, `manifest.name`, `manifest.version`, or `manifest.requires`
+ *   are missing.
+ * - a plugin with the same name is already registered.
+ * - any entry in `manifest.requires` names an unknown capability or a version
+ *   the assistant does not expose.
+ *
+ * On success the plugin is appended to the registry in the order this
+ * function is called. This function does NOT invoke `plugin.init()` — that
+ * runs in the bootstrap sequence (PR 14).
+ */
+export function registerPlugin(plugin: Plugin): void {
+  // Basic shape / required-field validation. The type system already enforces
+  // most of this at compile time; these runtime checks guard against
+  // JS-level callers and malformed manifests loaded dynamically.
+  if (!plugin || typeof plugin !== "object") {
+    throw new PluginExecutionError(
+      "registerPlugin requires a Plugin object",
+      undefined,
+    );
+  }
+  const manifest = plugin.manifest;
+  if (!manifest || typeof manifest !== "object") {
+    throw new PluginExecutionError("plugin manifest is missing", undefined);
+  }
+  const name = manifest.name;
+  if (typeof name !== "string" || name.length === 0) {
+    throw new PluginExecutionError(
+      "plugin manifest.name is required",
+      undefined,
+    );
+  }
+  if (typeof manifest.version !== "string" || manifest.version.length === 0) {
+    throw new PluginExecutionError(
+      `plugin ${name} manifest.version is required`,
+      name,
+    );
+  }
+  if (!manifest.requires || typeof manifest.requires !== "object") {
+    throw new PluginExecutionError(
+      `plugin ${name} manifest.requires is required`,
+      name,
+    );
+  }
+
+  // Duplicate-name check — plugins must be uniquely addressable in logs,
+  // storage paths, and error messages.
+  if (registeredPlugins.has(name)) {
+    throw new PluginExecutionError(
+      `plugin ${name} is already registered`,
+      name,
+    );
+  }
+
+  // Capability negotiation. Every plugin must negotiate against
+  // `pluginRuntime`; we enforce that by requiring an entry to exist rather
+  // than special-casing it here, so the per-entry mismatch error is uniform.
+  if (!("pluginRuntime" in manifest.requires)) {
+    throw new PluginExecutionError(
+      `plugin ${name} must declare requires.pluginRuntime (e.g. "v1")`,
+      name,
+    );
+  }
+
+  for (const [api, requiredVersion] of Object.entries(manifest.requires)) {
+    const supported = ASSISTANT_API_VERSIONS[api];
+    if (!supported || !supported.includes(requiredVersion)) {
+      const exposed = supported ? supported.join(", ") : "(none)";
+      throw new PluginExecutionError(
+        `plugin ${name} requires ${api}@${requiredVersion}, assistant exposes ${exposed}`,
+        name,
+      );
+    }
+  }
+
+  registeredPlugins.set(name, plugin);
+}
+
+// ─── Queries ─────────────────────────────────────────────────────────────────
+
+/**
+ * All plugins registered so far, in registration order. Consumers must treat
+ * the returned array as a read-only snapshot — mutating it does not mutate
+ * the registry.
+ */
+export function getRegisteredPlugins(): Plugin[] {
+  return Array.from(registeredPlugins.values());
+}
+
+/**
+ * Collect the middleware each registered plugin contributes for the given
+ * pipeline, in registration order. Consumers feed the returned array into the
+ * pipeline runner's `composeMiddleware` helper (PR 12), which applies the
+ * outermost-first convention.
+ *
+ * Plugins that don't declare a middleware for `pipeline` are skipped.
+ */
+export function getMiddlewaresFor<P extends PipelineName>(
+  pipeline: P,
+): PipelineMiddlewareMap[P][] {
+  const out: PipelineMiddlewareMap[P][] = [];
+  for (const plugin of registeredPlugins.values()) {
+    const middleware = plugin.middleware?.[pipeline];
+    if (middleware) {
+      out.push(middleware);
+    }
+  }
+  return out;
+}
+
+/**
+ * Flatten every registered plugin's `injectors` array and sort the result by
+ * `order` ascending. Two injectors with the same `order` retain their relative
+ * registration order (stable sort via `Array.prototype.sort`).
+ */
+export function getInjectors(): Injector[] {
+  const out: Injector[] = [];
+  for (const plugin of registeredPlugins.values()) {
+    if (plugin.injectors && plugin.injectors.length > 0) {
+      out.push(...plugin.injectors);
+    }
+  }
+  out.sort((a, b) => a.order - b.order);
+  return out;
+}
+
+// ─── Test hooks ──────────────────────────────────────────────────────────────
+
+/**
+ * Clear the registry. Test-only — throws when invoked outside a test
+ * environment so application code can never accidentally wipe the registry
+ * at runtime. The guard recognizes `BUN_TEST=1` (set automatically by bun's
+ * test runner) and `NODE_ENV=test` (the Node.js convention used elsewhere
+ * in the codebase).
+ */
+export function resetPluginRegistryForTests(): void {
+  const isTest =
+    process.env.BUN_TEST === "1" || process.env.NODE_ENV === "test";
+  if (!isTest) {
+    throw new PluginExecutionError(
+      "resetPluginRegistryForTests may only be called in test environments",
+      undefined,
+    );
+  }
+  registeredPlugins.clear();
+}


### PR DESCRIPTION
## Summary
- plugins/registry.ts: registerPlugin + capability-version negotiation + injector/middleware collectors
- ASSISTANT_API_VERSIONS seeded with pluginRuntime and per-pipeline API versions
- PluginExecutionError thrown on duplicate name / missing runtime / version mismatch
- Tests cover registration, version mismatch, injector ordering, middleware collection order

Part of plan: agent-plugin-system.md (PR 13 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
