### PR TITLE
feat(assistant): add pipeline runner with onion composition

### DIFF
--- a/assistant/src/__tests__/pipeline-runner.test.ts
+++ b/assistant/src/__tests__/pipeline-runner.test.ts
@@ -1,0 +1,457 @@
+/**
+ * Unit tests for `plugins/pipeline.ts`.
+ *
+ * Covers:
+ * - Onion composition order (outer → inner → terminal → inner → outer).
+ * - Short-circuit (middleware that omits `next` — terminal is skipped).
+ * - Error propagation (no internal try/catch — errors flow unchanged).
+ * - Timeout (breached budget rejects with `PluginTimeoutError`).
+ * - Log shape (one structured record per invocation, every field typed).
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import {
+  composeMiddleware,
+  DEFAULT_TIMEOUTS,
+  runPipeline,
+} from "../plugins/pipeline.js";
+import {
+  type Middleware,
+  PluginTimeoutError,
+  type TurnContext,
+} from "../plugins/types.js";
+
+// A minimal fake pino-compatible logger. The pipeline runner detects a
+// `logger` slot on the context (shape `{ info(record, msg?) }`) and falls
+// back to the module logger only when that slot is absent. Tests pass this
+// fake in via `ctx.logger` so the runner emits into our capture buffer
+// instead of real stderr.
+type LogCall = [record: Record<string, unknown>, msg?: string];
+
+function makeFakeLogger(): {
+  calls: LogCall[];
+  info: (record: Record<string, unknown>, msg?: string) => void;
+  warn: () => void;
+  error: () => void;
+  debug: () => void;
+  trace: () => void;
+  fatal: () => void;
+} {
+  const calls: LogCall[] = [];
+  return {
+    calls,
+    info: (record, msg) => {
+      calls.push([record, msg]);
+    },
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+  };
+}
+
+let fakeLogger = makeFakeLogger();
+
+const trust: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+function makeCtx(overrides: Partial<TurnContext> = {}): TurnContext {
+  return {
+    requestId: "req-test",
+    conversationId: "conv-test",
+    turnIndex: 3,
+    trust,
+    // The runner reads `(ctx as { logger?: unknown }).logger` — we cast
+    // through the partial type to attach it without widening TurnContext.
+    ...({ logger: fakeLogger } as Partial<TurnContext>),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fakeLogger = makeFakeLogger();
+});
+
+type Args = { value: number };
+type Result = { value: number };
+
+describe("composeMiddleware", () => {
+  test("invokes layers in outer→inner→terminal→inner→outer order", async () => {
+    const trace: string[] = [];
+
+    const outer: Middleware<Args, Result> = async (args, next) => {
+      trace.push("outer:before");
+      const result = await next(args);
+      trace.push("outer:after");
+      return result;
+    };
+
+    const inner: Middleware<Args, Result> = async (args, next) => {
+      trace.push("inner:before");
+      const result = await next(args);
+      trace.push("inner:after");
+      return result;
+    };
+
+    const terminal = async (args: Args): Promise<Result> => {
+      trace.push("terminal");
+      return { value: args.value * 2 };
+    };
+
+    const composed = composeMiddleware<Args, Result>([outer, inner], terminal);
+    const result = await composed({ value: 7 }, makeCtx());
+
+    expect(result).toEqual({ value: 14 });
+    expect(trace).toEqual([
+      "outer:before",
+      "inner:before",
+      "terminal",
+      "inner:after",
+      "outer:after",
+    ]);
+  });
+
+  test("middleware that omits `next` short-circuits the chain", async () => {
+    const trace: string[] = [];
+
+    const shortCircuit: Middleware<Args, Result> = async (_args, _next) => {
+      trace.push("short-circuit");
+      return { value: 99 };
+    };
+
+    const inner: Middleware<Args, Result> = async (args, next) => {
+      trace.push("inner");
+      return next(args);
+    };
+
+    const terminal = async (_args: Args): Promise<Result> => {
+      trace.push("terminal");
+      return { value: 0 };
+    };
+
+    const composed = composeMiddleware<Args, Result>(
+      [shortCircuit, inner],
+      terminal,
+    );
+    const result = await composed({ value: 1 }, makeCtx());
+
+    expect(result).toEqual({ value: 99 });
+    expect(trace).toEqual(["short-circuit"]);
+  });
+
+  test("empty middleware list reduces to the terminal handler", async () => {
+    const terminal = async (args: Args): Promise<Result> => ({
+      value: args.value + 1,
+    });
+    const composed = composeMiddleware<Args, Result>([], terminal);
+    const result = await composed({ value: 10 }, makeCtx());
+    expect(result).toEqual({ value: 11 });
+  });
+});
+
+describe("runPipeline — error propagation", () => {
+  test("errors thrown by middleware bubble through unchanged", async () => {
+    class Boom extends Error {
+      override readonly name = "Boom";
+    }
+
+    const thrower: Middleware<Args, Result> = async () => {
+      throw new Boom("detonated");
+    };
+
+    const terminal = async (_args: Args): Promise<Result> => {
+      throw new Error("terminal should not run");
+    };
+
+    await expect(
+      runPipeline(
+        "persistence",
+        [thrower],
+        terminal,
+        { value: 1 },
+        makeCtx(),
+        DEFAULT_TIMEOUTS.persistence,
+      ),
+    ).rejects.toBeInstanceOf(Boom);
+  });
+
+  test("errors thrown by the terminal handler bubble through unchanged", async () => {
+    const terminal = async (_args: Args): Promise<Result> => {
+      throw new TypeError("from terminal");
+    };
+
+    await expect(
+      runPipeline(
+        "persistence",
+        [],
+        terminal,
+        { value: 1 },
+        makeCtx(),
+        DEFAULT_TIMEOUTS.persistence,
+      ),
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+});
+
+describe("runPipeline — timeout", () => {
+  test("breached budget rejects with PluginTimeoutError carrying pipeline + plugin name", async () => {
+    const sleeper: Middleware<Args, Result> = async (_args, _next) =>
+      new Promise<Result>((resolve) => {
+        setTimeout(() => resolve({ value: 0 }), 200);
+      });
+
+    const terminal = async (_args: Args): Promise<Result> => ({ value: 0 });
+
+    let caught: unknown;
+    try {
+      await runPipeline(
+        "memoryRetrieval",
+        [sleeper],
+        terminal,
+        { value: 1 },
+        makeCtx({ pluginName: "slow-plugin" }),
+        20,
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(PluginTimeoutError);
+    const tErr = caught as PluginTimeoutError;
+    expect(tErr.pipeline).toBe("memoryRetrieval");
+    expect(tErr.pluginName).toBe("slow-plugin");
+    expect(tErr.elapsedMs).toBeGreaterThanOrEqual(0);
+    expect(tErr.message).toContain("memoryRetrieval");
+    expect(tErr.message).toContain("slow-plugin");
+  });
+
+  test("fast pipeline does not arm the timer redundantly", async () => {
+    const terminal = async (args: Args): Promise<Result> => ({
+      value: args.value,
+    });
+    const result = await runPipeline(
+      "historyRepair",
+      [],
+      terminal,
+      { value: 42 },
+      makeCtx(),
+      DEFAULT_TIMEOUTS.historyRepair,
+    );
+    expect(result).toEqual({ value: 42 });
+  });
+
+  test("null timeout skips the race entirely", async () => {
+    // llmCall has DEFAULT_TIMEOUTS.llmCall === null — runner must not arm a
+    // timer. We verify by completing after an artificial 30ms wait and
+    // confirming success without interference.
+    const sleeper: Middleware<Args, Result> = async (args, next) =>
+      new Promise<Result>((resolve) => {
+        setTimeout(() => resolve(next(args)), 30);
+      });
+    const terminal = async (_args: Args): Promise<Result> => ({ value: 1 });
+    const result = await runPipeline(
+      "llmCall",
+      [sleeper],
+      terminal,
+      { value: 0 },
+      makeCtx(),
+      DEFAULT_TIMEOUTS.llmCall,
+    );
+    expect(result).toEqual({ value: 1 });
+  });
+});
+
+describe("runPipeline — structured log record", () => {
+  test("success emits one record with every documented field present", async () => {
+    const namedOuter: Middleware<Args, Result> = async function outerMw(
+      args,
+      next,
+    ) {
+      return next(args);
+    };
+    const terminal = async (args: Args): Promise<Result> => ({
+      value: args.value,
+    });
+
+    await runPipeline(
+      "compaction",
+      [namedOuter],
+      terminal,
+      { value: 7 },
+      makeCtx(),
+      DEFAULT_TIMEOUTS.compaction,
+    );
+
+    expect(fakeLogger.calls.length).toBe(1);
+    const [record, msg] = fakeLogger.calls[0]!;
+    expect(msg).toBe("plugin.pipeline");
+    expect(record.event).toBe("plugin.pipeline");
+    expect(record.pipeline).toBe("compaction");
+    expect(record.chain).toEqual(["outerMw"]);
+    expect(record.outcome).toBe("success");
+    expect(typeof record.durationMs).toBe("number");
+    expect(record.durationMs).toBeGreaterThanOrEqual(0);
+    expect(record.timeoutMs).toBe(DEFAULT_TIMEOUTS.compaction!);
+    expect(record.requestId).toBe("req-test");
+    expect(record.conversationId).toBe("conv-test");
+    expect(record.turnIndex).toBe(3);
+    // pluginName is only present when ctx carries one.
+    expect(record.pluginName).toBeUndefined();
+    // Error fields absent on success.
+    expect(record.errorName).toBeUndefined();
+    expect(record.errorMessage).toBeUndefined();
+    expect(record.errorStack).toBeUndefined();
+  });
+
+  test("error path records outcome=error + error fields + plugin name", async () => {
+    class Boom extends Error {
+      override readonly name = "BoomError";
+    }
+    const thrower: Middleware<Args, Result> = async () => {
+      throw new Boom("kaboom");
+    };
+    const terminal = async (_args: Args): Promise<Result> => ({ value: 0 });
+
+    await expect(
+      runPipeline(
+        "toolError",
+        [thrower],
+        terminal,
+        { value: 1 },
+        makeCtx({ pluginName: "noisy-plugin" }),
+        DEFAULT_TIMEOUTS.toolError,
+      ),
+    ).rejects.toBeInstanceOf(Boom);
+
+    expect(fakeLogger.calls.length).toBe(1);
+    const [record] = fakeLogger.calls[0]!;
+    expect(record.outcome).toBe("error");
+    expect(record.pipeline).toBe("toolError");
+    expect(record.errorName).toBe("BoomError");
+    expect(record.errorMessage).toBe("kaboom");
+    expect(typeof record.errorStack).toBe("string");
+    expect(record.pluginName).toBe("noisy-plugin");
+    expect(record.timeoutMs).toBe(DEFAULT_TIMEOUTS.toolError!);
+  });
+
+  test("timeout path records outcome=timeout + PluginTimeoutError fields", async () => {
+    const sleeper: Middleware<Args, Result> = async (_args, _next) =>
+      new Promise<Result>((resolve) => {
+        setTimeout(() => resolve({ value: 0 }), 200);
+      });
+    const terminal = async (_args: Args): Promise<Result> => ({ value: 0 });
+
+    await expect(
+      runPipeline(
+        "emptyResponse",
+        [sleeper],
+        terminal,
+        { value: 1 },
+        makeCtx({ pluginName: "slow-plugin" }),
+        15,
+      ),
+    ).rejects.toBeInstanceOf(PluginTimeoutError);
+
+    expect(fakeLogger.calls.length).toBe(1);
+    const [record] = fakeLogger.calls[0]!;
+    expect(record.outcome).toBe("timeout");
+    expect(record.pipeline).toBe("emptyResponse");
+    expect(record.errorName).toBe("PluginTimeoutError");
+    expect(String(record.errorMessage)).toContain("emptyResponse");
+    expect(String(record.errorMessage)).toContain("slow-plugin");
+    expect(record.timeoutMs).toBe(15);
+    expect(record.pluginName).toBe("slow-plugin");
+  });
+
+  test("null timeout omits timeoutMs field from the log record", async () => {
+    const terminal = async (args: Args): Promise<Result> => ({
+      value: args.value,
+    });
+    await runPipeline(
+      "llmCall",
+      [],
+      terminal,
+      { value: 5 },
+      makeCtx(),
+      DEFAULT_TIMEOUTS.llmCall,
+    );
+
+    expect(fakeLogger.calls.length).toBe(1);
+    const [record] = fakeLogger.calls[0]!;
+    expect(record.pipeline).toBe("llmCall");
+    expect(record.outcome).toBe("success");
+    expect(record.timeoutMs).toBeUndefined();
+  });
+
+  test("turnIndex is omitted when unset on the context", async () => {
+    const terminal = async (_args: Args): Promise<Result> => ({ value: 0 });
+    const ctxNoTurn = {
+      requestId: "r",
+      conversationId: "c",
+      turnIndex: undefined as unknown as number,
+      trust,
+      logger: fakeLogger,
+    } as TurnContext;
+    await runPipeline(
+      "persistence",
+      [],
+      terminal,
+      { value: 0 },
+      ctxNoTurn,
+      null,
+    );
+    const [record] = fakeLogger.calls[0]!;
+    expect(record.turnIndex).toBeUndefined();
+  });
+
+  test("chain list has one entry per middleware in registration order", async () => {
+    const a: Middleware<Args, Result> = async function outerA(args, next) {
+      return next(args);
+    };
+    const b: Middleware<Args, Result> = async function middleB(args, next) {
+      return next(args);
+    };
+    const c: Middleware<Args, Result> = async function innerC(args, next) {
+      return next(args);
+    };
+    const terminal = async (args: Args): Promise<Result> => ({
+      value: args.value,
+    });
+    await runPipeline(
+      "tokenEstimate",
+      [a, b, c],
+      terminal,
+      { value: 0 },
+      makeCtx(),
+      DEFAULT_TIMEOUTS.tokenEstimate,
+    );
+    const [record] = fakeLogger.calls[0]!;
+    expect(record.chain).toEqual(["outerA", "middleB", "innerC"]);
+  });
+});
+
+describe("DEFAULT_TIMEOUTS", () => {
+  test("matches the design-doc table exactly", () => {
+    expect(DEFAULT_TIMEOUTS).toEqual({
+      turn: null,
+      llmCall: null,
+      toolExecute: null,
+      memoryRetrieval: 5000,
+      historyRepair: 1000,
+      tokenEstimate: 1000,
+      compaction: 30000,
+      overflowReduce: 30000,
+      persistence: 10000,
+      titleGenerate: 30000,
+      toolResultTruncate: 1000,
+      emptyResponse: 500,
+      toolError: 500,
+      circuitBreaker: 500,
+    });
+  });
+});

--- a/assistant/src/plugins/pipeline.ts
+++ b/assistant/src/plugins/pipeline.ts
@@ -1,0 +1,229 @@
+/**
+ * Plugin pipeline runner.
+ *
+ * A "pipeline" is a named chain of {@link Middleware}s wrapped around a
+ * terminal handler (the original behavior that existed before plugins). The
+ * runner composes the chain in onion order, runs it under an optional
+ * per-pipeline timeout, and emits one structured log record per invocation
+ * covering success, error, and timeout uniformly.
+ *
+ * Design doc: `.private/plans/agent-plugin-system.md` (PR 12 notes).
+ *
+ * Semantics:
+ * - Onion composition — the first element of `middlewares` is the outermost
+ *   wrapper; it sees the request first and the response last. Terminal runs
+ *   in the middle.
+ * - Strict-fail — there is NO `try/catch` around user middleware. Errors,
+ *   including `PluginTimeoutError` from a breached budget, propagate to the
+ *   caller. The `finally` block only handles logging, never error recovery.
+ * - Timeout — when `timeoutMs` is a finite number, the invocation races a
+ *   timer. A timeout rejection is a `PluginTimeoutError` carrying the
+ *   pipeline name, the best-known offending plugin (from `ctx.pluginName`),
+ *   and elapsed ms. When `timeoutMs` is `null`/`undefined`, no timer is
+ *   armed — pipelines like `llmCall` and `toolExecute` rely on downstream
+ *   timeouts instead.
+ */
+
+import type { Logger } from "pino";
+
+import { getLogger } from "../util/logger.js";
+import {
+  type Middleware,
+  type PipelineName,
+  PluginTimeoutError,
+  type TurnContext,
+} from "./types.js";
+
+const moduleLogger = getLogger("plugin-pipeline");
+
+// ─── Default timeouts ───────────────────────────────────────────────────────
+
+/**
+ * Default per-pipeline timeout budgets in milliseconds. A value of `null`
+ * means the runner does NOT arm a timer — the pipeline relies on its
+ * downstream for budgeting (e.g. `llmCall` defers to provider-level HTTP
+ * timeouts; `toolExecute` defers to the per-tool timeout already enforced
+ * by `ToolExecutor`).
+ *
+ * Callers pass the appropriate entry as `runPipeline`'s `timeoutMs` argument.
+ * The design doc locks these numbers in; do not tweak without coordinating
+ * a design update.
+ */
+export const DEFAULT_TIMEOUTS: Record<PipelineName, number | null> = {
+  turn: null,
+  llmCall: null,
+  toolExecute: null,
+  memoryRetrieval: 5000,
+  historyRepair: 1000,
+  tokenEstimate: 1000,
+  compaction: 30000,
+  overflowReduce: 30000,
+  persistence: 10000,
+  titleGenerate: 30000,
+  toolResultTruncate: 1000,
+  emptyResponse: 500,
+  toolError: 500,
+  circuitBreaker: 500,
+};
+
+// ─── Composition ────────────────────────────────────────────────────────────
+
+/**
+ * Compose an ordered list of {@link Middleware}s around a terminal handler
+ * using onion semantics. The first element of `middlewares` is the outermost
+ * layer.
+ *
+ * The returned function accepts `(args, ctx)` and runs the entire chain:
+ * ```
+ *   middlewares[0] → middlewares[1] → ... → terminal → ... → middlewares[1] → middlewares[0]
+ * ```
+ *
+ * Middlewares that never call `next` short-circuit the chain — the terminal
+ * and any deeper middleware are never invoked. Middlewares that throw abort
+ * the chain; the error flows back out through any outer middleware unchanged
+ * (no internal try/catch).
+ */
+export function composeMiddleware<A, R>(
+  middlewares: ReadonlyArray<Middleware<A, R>>,
+  terminal: (args: A) => Promise<R>,
+): (args: A, ctx: TurnContext) => Promise<R> {
+  return (args, ctx) => {
+    // Walk back-to-front, wrapping each middleware around `next`. The last
+    // middleware in the array wraps `terminal`; earlier entries wrap the
+    // accumulated chain so they execute first.
+    let next: (args: A) => Promise<R> = terminal;
+    for (let i = middlewares.length - 1; i >= 0; i--) {
+      const mw = middlewares[i]!;
+      const downstream = next;
+      next = (innerArgs: A) => mw(innerArgs, downstream, ctx);
+    }
+    return next(args);
+  };
+}
+
+// ─── Runner ─────────────────────────────────────────────────────────────────
+
+type PipelineLogRecord = {
+  event: "plugin.pipeline";
+  pipeline: PipelineName;
+  chain: ReadonlyArray<string>;
+  durationMs: number;
+  outcome: "success" | "error" | "timeout";
+  pluginName?: string;
+  errorName?: string;
+  errorMessage?: string;
+  errorStack?: string;
+  timeoutMs?: number;
+  requestId: string;
+  conversationId: string;
+  turnIndex?: number;
+};
+
+/**
+ * Best-effort detection of a pino-compatible logger on the `TurnContext`.
+ *
+ * `TurnContext` intentionally doesn't require a logger slot — most code paths
+ * use the module-level logger. Some callers (notably plugin-scoped pipelines
+ * in later PRs) may attach a child logger via `(ctx as any).logger`. We type
+ * the field loosely to avoid coupling `TurnContext` to pino.
+ */
+function selectLogger(ctx: TurnContext): Logger {
+  const maybe = (ctx as { logger?: unknown }).logger;
+  if (maybe && typeof maybe === "object" && "info" in maybe) {
+    return maybe as Logger;
+  }
+  return moduleLogger;
+}
+
+/**
+ * Execute a named pipeline: compose middleware, run it under an optional
+ * timeout, and emit one structured log record covering success, error, or
+ * timeout uniformly.
+ *
+ * @param name        The pipeline identifier. Used for telemetry and error
+ *                    attribution.
+ * @param middlewares Ordered list of middlewares to wrap around `terminal`.
+ *                    Names for the log `chain` are pulled from `Function.name`
+ *                    (empty strings are kept so length always matches).
+ * @param terminal    The original behavior. Runs when all middlewares call
+ *                    `next`.
+ * @param args        Pipeline-specific input payload.
+ * @param ctx         Per-turn context. May carry an optional `logger` slot;
+ *                    otherwise the module logger is used.
+ * @param timeoutMs   Deadline in milliseconds. `null`/`undefined` disables
+ *                    the timer entirely (inherits downstream timeouts).
+ *
+ * @throws {PluginTimeoutError} When `timeoutMs` is non-null and the chain
+ *         exceeds the budget. `ctx.pluginName` (if set) is attached as the
+ *         offending plugin.
+ * @throws Any error produced by user middleware or the terminal — flows
+ *         through unchanged.
+ */
+export async function runPipeline<A, R>(
+  name: PipelineName,
+  middlewares: ReadonlyArray<Middleware<A, R>>,
+  terminal: (args: A) => Promise<R>,
+  args: A,
+  ctx: TurnContext,
+  timeoutMs?: number | null,
+): Promise<R> {
+  const logger = selectLogger(ctx);
+  const chain = middlewares.map((m) => m.name || "anonymous");
+  const composed = composeMiddleware(middlewares, terminal);
+  const start = performance.now();
+
+  let outcome: "success" | "error" | "timeout" = "success";
+  let thrown: unknown = undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    if (typeof timeoutMs === "number" && Number.isFinite(timeoutMs)) {
+      const budget = timeoutMs;
+      const timeoutPromise = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new PluginTimeoutError(
+              name,
+              ctx.pluginName,
+              Math.round(performance.now() - start),
+            ),
+          );
+        }, budget);
+      });
+      return await Promise.race([composed(args, ctx), timeoutPromise]);
+    }
+    return await composed(args, ctx);
+  } catch (err) {
+    thrown = err;
+    outcome = err instanceof PluginTimeoutError ? "timeout" : "error";
+    throw err;
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    const durationMs = Math.round(performance.now() - start);
+    const record: PipelineLogRecord = {
+      event: "plugin.pipeline",
+      pipeline: name,
+      chain,
+      durationMs,
+      outcome,
+      requestId: ctx.requestId,
+      conversationId: ctx.conversationId,
+    };
+    if (ctx.turnIndex !== undefined) record.turnIndex = ctx.turnIndex;
+    if (ctx.pluginName !== undefined) record.pluginName = ctx.pluginName;
+    if (typeof timeoutMs === "number" && Number.isFinite(timeoutMs)) {
+      record.timeoutMs = timeoutMs;
+    }
+    if (thrown !== undefined) {
+      if (thrown instanceof Error) {
+        record.errorName = thrown.name;
+        record.errorMessage = thrown.message;
+        if (thrown.stack) record.errorStack = thrown.stack;
+      } else {
+        record.errorName = "NonError";
+        record.errorMessage = String(thrown);
+      }
+    }
+    logger.info(record, "plugin.pipeline");
+  }
+}


### PR DESCRIPTION
## Summary
- plugins/pipeline.ts: composeMiddleware + runPipeline with per-pipeline timeouts and structured OTel-compatible logging
- DEFAULT_TIMEOUTS table baked in (llmCall/toolExecute: null, memory 5s, compaction 30s, persistence 10s, ...)
- No try/catch — strict-fail semantics via natural exception propagation
- Tests cover composition order, short-circuit, error propagation, timeout, and log shape

Part of plan: agent-plugin-system.md (PR 12 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
