### PR TITLE
feat(assistant): wire plugin bootstrap into daemon startup

### DIFF
--- a/assistant/src/__tests__/plugin-bootstrap.test.ts
+++ b/assistant/src/__tests__/plugin-bootstrap.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for plugin bootstrap (PR 14).
+ *
+ * Covers:
+ * - A noop `init()` fires with a valid `PluginInitContext` that exposes every
+ *   documented field.
+ * - `requiresCredential` entries are resolved through the credential store
+ *   helper and arrive in `ctx.credentials`.
+ * - Version-mismatch registration fails with an error that names the plugin
+ *   (the registry enforces this at `registerPlugin` time, so bootstrap never
+ *   sees the malformed plugin).
+ * - Shutdown hook walks plugins in reverse registration order.
+ *
+ * Uses `mock.module` to stub `security/secure-keys.js` so credential
+ * resolution doesn't hit the real backend. `resetPluginRegistryForTests()`
+ * isolates registry state between cases.
+ */
+
+import { existsSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Mock credential store before importing the bootstrap module so the
+// module-under-test captures the stubbed binding.
+const getSecureKeyAsyncMock = mock(
+  async (_account: string): Promise<string | undefined> => undefined,
+);
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: getSecureKeyAsyncMock,
+}));
+
+import type { AssistantConfig } from "../config/schema.js";
+import {
+  bootstrapPlugins,
+  type DaemonContext,
+} from "../daemon/external-plugins-bootstrap.js";
+import { runShutdownHooks } from "../daemon/shutdown-registry.js";
+import {
+  ASSISTANT_API_VERSIONS,
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import {
+  type Plugin,
+  PluginExecutionError,
+  type PluginInitContext,
+} from "../plugins/types.js";
+
+// Redirect plugin storage directory creation into a per-process temp tree so
+// the test doesn't touch the developer's real ~/.vellum.
+const TEST_INSTANCE_DIR = join(
+  tmpdir(),
+  `vellum-plugin-bootstrap-test-${process.pid}`,
+);
+process.env.BASE_DATA_DIR = TEST_INSTANCE_DIR;
+
+const fakeConfig = {} as unknown as AssistantConfig;
+const fakeCtx: DaemonContext = {
+  config: fakeConfig,
+  assistantVersion: "9.9.9-test",
+};
+
+function buildPlugin(
+  name: string,
+  extras: Partial<Omit<Plugin, "manifest">> = {},
+  options: {
+    requires?: Record<string, string>;
+    requiresCredential?: string[];
+  } = {},
+): Plugin {
+  return {
+    manifest: {
+      name,
+      version: "0.0.1",
+      requires: options.requires ?? { pluginRuntime: "v1" },
+      ...(options.requiresCredential
+        ? { requiresCredential: options.requiresCredential }
+        : {}),
+    },
+    ...extras,
+  };
+}
+
+describe("plugin bootstrap", () => {
+  beforeEach(async () => {
+    resetPluginRegistryForTests();
+    getSecureKeyAsyncMock.mockReset();
+    getSecureKeyAsyncMock.mockImplementation(async () => undefined);
+    // Clean storage directory between runs so nothing leaks across cases.
+    await rm(TEST_INSTANCE_DIR, { recursive: true, force: true });
+  });
+
+  test("noop plugin: init fires with a fully-populated PluginInitContext", async () => {
+    let received: PluginInitContext | undefined;
+    const plugin: Plugin = buildPlugin("alpha", {
+      async init(ctx) {
+        received = ctx;
+      },
+    });
+    registerPlugin(plugin);
+
+    await bootstrapPlugins(fakeCtx);
+
+    expect(received).toBeDefined();
+    const ctx = received!;
+
+    // Every documented field must be present on the context passed to init.
+    expect(ctx.config).toBeUndefined(); // no `plugins.alpha` block in fake config
+    expect(ctx.credentials).toEqual({});
+    expect(ctx.logger).toBeDefined();
+    expect(typeof (ctx.logger as { info: unknown }).info).toBe("function");
+    // Storage dir lives under vellumRoot()/plugins-data/<name> and must have
+    // been created on disk by bootstrap.
+    expect(ctx.pluginStorageDir).toBe(
+      join(TEST_INSTANCE_DIR, ".vellum", "plugins-data", "alpha"),
+    );
+    expect(existsSync(ctx.pluginStorageDir)).toBe(true);
+    expect(ctx.assistantVersion).toBe("9.9.9-test");
+    // apiVersions must surface the canonical capability table from the
+    // registry so plugins can negotiate at runtime.
+    expect(ctx.apiVersions).toBe(ASSISTANT_API_VERSIONS);
+    expect(ctx.apiVersions.pluginRuntime).toEqual(["v1"]);
+  });
+
+  test("credential resolution: init receives the resolved value under credentials[key]", async () => {
+    getSecureKeyAsyncMock.mockImplementation(async (account: string) => {
+      if (account === "some-key") return "super-secret-value";
+      return undefined;
+    });
+
+    let received: PluginInitContext | undefined;
+    const plugin = buildPlugin(
+      "credentialed",
+      {
+        async init(ctx) {
+          received = ctx;
+        },
+      },
+      { requiresCredential: ["some-key"] },
+    );
+    registerPlugin(plugin);
+
+    await bootstrapPlugins(fakeCtx);
+
+    expect(getSecureKeyAsyncMock).toHaveBeenCalledTimes(1);
+    expect(getSecureKeyAsyncMock).toHaveBeenCalledWith("some-key");
+    expect(received?.credentials).toEqual({ "some-key": "super-secret-value" });
+  });
+
+  test("credential resolution: missing credential fails bootstrap with the plugin named", async () => {
+    getSecureKeyAsyncMock.mockImplementation(async () => undefined);
+
+    registerPlugin(
+      buildPlugin(
+        "missing-cred",
+        { async init() {} },
+        { requiresCredential: ["absent-key"] },
+      ),
+    );
+
+    let caught: unknown;
+    try {
+      await bootstrapPlugins(fakeCtx);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(PluginExecutionError);
+    const msg = (caught as PluginExecutionError).message;
+    expect(msg).toContain("missing-cred");
+    expect(msg).toContain("absent-key");
+  });
+
+  test("version mismatch: registration surfaces a clear error naming the plugin", () => {
+    // The assistant only exposes pluginRuntime@v1 — asking for v99 must fail
+    // registration with the plugin name in the message. The error is raised
+    // at registerPlugin() rather than bootstrap, because the registry is the
+    // single authoritative point of capability validation.
+    const plugin = buildPlugin(
+      "from-the-future",
+      {},
+      { requires: { pluginRuntime: "v99" } },
+    );
+
+    let caught: unknown;
+    try {
+      registerPlugin(plugin);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(PluginExecutionError);
+    const msg = (caught as PluginExecutionError).message;
+    expect(msg).toContain("from-the-future");
+    expect(msg).toContain("pluginRuntime");
+    expect(msg).toContain("v99");
+    expect((caught as PluginExecutionError).pluginName).toBe("from-the-future");
+  });
+
+  test("plugin init throw: bootstrap throws a PluginExecutionError naming the plugin", async () => {
+    registerPlugin(
+      buildPlugin("broken", {
+        async init() {
+          throw new Error("kaboom");
+        },
+      }),
+    );
+
+    let caught: unknown;
+    try {
+      await bootstrapPlugins(fakeCtx);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(PluginExecutionError);
+    const msg = (caught as PluginExecutionError).message;
+    expect(msg).toContain("broken");
+    expect(msg).toContain("kaboom");
+  });
+
+  test("shutdown order: onShutdown fires in reverse registration order", async () => {
+    const callOrder: string[] = [];
+    registerPlugin(
+      buildPlugin("first-registered", {
+        async onShutdown() {
+          callOrder.push("first-registered");
+        },
+      }),
+    );
+    registerPlugin(
+      buildPlugin("second-registered", {
+        async onShutdown() {
+          callOrder.push("second-registered");
+        },
+      }),
+    );
+
+    await bootstrapPlugins(fakeCtx);
+    await runShutdownHooks("test-shutdown");
+
+    // The last plugin to register must shut down first; the first to register
+    // shuts down last. Symmetric tear-down around registration order is the
+    // whole point of the reverse walk.
+    expect(callOrder).toEqual(["second-registered", "first-registered"]);
+  });
+
+  test("empty registry: bootstrap is a no-op", async () => {
+    // Nothing registered. Bootstrap must not throw, and there is no shutdown
+    // hook registered (so downstream shutdown runs are unaffected).
+    await bootstrapPlugins(fakeCtx);
+  });
+});

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -1,0 +1,236 @@
+/**
+ * Plugin bootstrap — runs every registered plugin's `init()` hook once during
+ * daemon startup.
+ *
+ * Plugins register themselves via side-effect imports elsewhere in the boot
+ * sequence (first-party) or at runtime (hot-reload). By the time
+ * {@link bootstrapPlugins} runs, the registry has been fully populated for
+ * this boot cycle. This function:
+ *
+ * 1. Walks {@link getRegisteredPlugins} in registration order.
+ * 2. For each plugin, resolves its `manifest.requiresCredential` entries via
+ *    the credential store helper ({@link getSecureKeyAsync}). In Docker mode
+ *    that helper goes through the CES HTTP API transparently; in local mode
+ *    it hits the encrypted file store / CES RPC backend.
+ * 3. Validates the config block under `plugins.<name>` against
+ *    `manifest.config` if the manifest supplies a parser-like validator
+ *    (Zod schemas with `.parse()` are supported; anything else is passed
+ *    through untouched).
+ * 4. Creates `~/.vellum/plugins-data/<plugin>/` on demand for per-plugin
+ *    writable state and exposes it via {@link PluginInitContext.pluginStorageDir}.
+ * 5. Awaits `plugin.init(ctx)` sequentially. One init failure surfaces as a
+ *    {@link PluginExecutionError} naming the offending plugin and aborts
+ *    bootstrap — later plugins' `init()` never runs and the daemon fails
+ *    startup cleanly rather than coming up in a half-wired state.
+ *
+ * A single shutdown hook is registered via
+ * {@link registerShutdownHook} that walks the plugin list in **reverse
+ * registration order** and awaits each plugin's optional `onShutdown()`.
+ * Per-plugin shutdown failures are logged and swallowed — the hook registry
+ * already swallows hook-level throws, but we log at the plugin level so the
+ * plugin name is attributed.
+ */
+
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import type { AssistantConfig } from "../config/schema.js";
+import {
+  ASSISTANT_API_VERSIONS,
+  getRegisteredPlugins,
+} from "../plugins/registry.js";
+import {
+  type Plugin,
+  PluginExecutionError,
+  type PluginInitContext,
+} from "../plugins/types.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
+import { vellumRoot } from "../util/platform.js";
+import { registerShutdownHook } from "./shutdown-registry.js";
+
+const log = getLogger("plugins-bootstrap");
+
+/**
+ * Minimal context required to bootstrap the plugin layer. Kept intentionally
+ * small so the call site in `lifecycle.ts` can construct it from whatever
+ * state is already available at that point in startup.
+ */
+export interface DaemonContext {
+  config: AssistantConfig;
+  assistantVersion: string;
+}
+
+/**
+ * Resolve one credential value. Returns the raw secret string or throws a
+ * {@link PluginExecutionError} tagged with the plugin name so the caller can
+ * fail startup with clear attribution.
+ */
+async function resolveCredentialOrThrow(
+  pluginName: string,
+  credentialKey: string,
+): Promise<string> {
+  const value = await getSecureKeyAsync(credentialKey);
+  if (value === undefined || value === "") {
+    throw new PluginExecutionError(
+      `plugin ${pluginName} requires credential "${credentialKey}" but the credential store returned no value`,
+      pluginName,
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate a plugin config block. If the manifest supplies a parser-like
+ * validator (Zod schemas expose `.parse()`), use it. Otherwise pass the
+ * config through untouched.
+ */
+function validatePluginConfig(
+  pluginName: string,
+  validator: unknown,
+  raw: unknown,
+): unknown {
+  if (
+    validator != null &&
+    typeof validator === "object" &&
+    "parse" in validator &&
+    typeof (validator as { parse: unknown }).parse === "function"
+  ) {
+    try {
+      return (validator as { parse: (input: unknown) => unknown }).parse(raw);
+    } catch (err) {
+      throw new PluginExecutionError(
+        `plugin ${pluginName} config validation failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        pluginName,
+        { cause: err },
+      );
+    }
+  }
+  return raw;
+}
+
+/**
+ * Read `config.plugins.<name>` defensively. The AssistantConfig schema does
+ * not (yet) declare a `plugins` block, so accessing it goes through
+ * `unknown` casts rather than compile-time field access.
+ */
+function getPluginConfigRaw(
+  config: AssistantConfig,
+  pluginName: string,
+): unknown {
+  const plugins = (config as { plugins?: Record<string, unknown> }).plugins;
+  if (plugins == null || typeof plugins !== "object") return undefined;
+  return plugins[pluginName];
+}
+
+/**
+ * Ensure `~/.vellum/plugins-data/<name>/` exists and return its absolute path.
+ */
+function ensurePluginStorageDir(pluginName: string): string {
+  const dir = join(vellumRoot(), "plugins-data", pluginName);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Run every registered plugin's `init()` hook sequentially and install a
+ * reverse-order shutdown hook. See the module docstring for full semantics.
+ *
+ * Returns once every plugin has finished initialising successfully. Throws a
+ * {@link PluginExecutionError} on the first failure — the error message names
+ * the offending plugin so operators see which `init()` bailed.
+ *
+ * Must be called after the registry is fully populated by this boot cycle
+ * (i.e. after any static side-effect imports of first-party plugins have
+ * run) and before the first conversation is served.
+ */
+export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
+  const plugins = getRegisteredPlugins();
+  if (plugins.length === 0) {
+    // No-op fast path — the registry is empty (no first-party plugins have
+    // been wired yet in this PR). Emit a debug log so the call site is
+    // observable in startup traces and return.
+    log.debug("bootstrapPlugins: registry empty — skipping");
+    return;
+  }
+
+  log.info({ count: plugins.length }, "bootstrapPlugins: initializing plugins");
+
+  for (const plugin of plugins) {
+    const name = plugin.manifest.name;
+
+    // Credential resolution — gather every entry in `requiresCredential`
+    // before calling `init()` so the plugin receives a fully-populated map.
+    const credentials: Record<string, string> = {};
+    const required = plugin.manifest.requiresCredential ?? [];
+    for (const key of required) {
+      credentials[key] = await resolveCredentialOrThrow(name, key);
+    }
+
+    // Per-plugin config block, validated against the manifest's parser-like
+    // validator when one is declared.
+    const rawConfig = getPluginConfigRaw(ctx.config, name);
+    const config = validatePluginConfig(
+      name,
+      plugin.manifest.config,
+      rawConfig,
+    );
+
+    // Per-plugin writable data directory. Created lazily during bootstrap
+    // rather than at registration time so the side effect is isolated to
+    // the boot path.
+    const pluginStorageDir = ensurePluginStorageDir(name);
+
+    const initContext: PluginInitContext = {
+      config,
+      credentials,
+      logger: log.child({ plugin: name }),
+      pluginStorageDir,
+      assistantVersion: ctx.assistantVersion,
+      apiVersions: ASSISTANT_API_VERSIONS,
+    };
+
+    if (plugin.init) {
+      try {
+        await plugin.init(initContext);
+      } catch (err) {
+        throw new PluginExecutionError(
+          `plugin ${name} init() failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          name,
+          { cause: err },
+        );
+      }
+    }
+
+    log.info({ plugin: name }, "plugin initialized");
+  }
+
+  // Shutdown hook — walks plugins in REVERSE registration order. We snapshot
+  // the current plugin list so later registrations (if any) don't end up
+  // being torn down by this hook; subsequent bootstraps (hot-reload) would
+  // register their own hook.
+  const shutdownSnapshot: Plugin[] = [...plugins];
+  registerShutdownHook("plugins", async (reason) => {
+    for (let i = shutdownSnapshot.length - 1; i >= 0; i--) {
+      const plugin = shutdownSnapshot[i]!;
+      const name = plugin.manifest.name;
+      if (!plugin.onShutdown) continue;
+      try {
+        await plugin.onShutdown();
+      } catch (err) {
+        // Swallow — we want every plugin's onShutdown to get a chance to
+        // run even when an earlier one throws. The outer runShutdownHooks
+        // already logs at hook level, but the plugin-name attribution here
+        // is what operators read first.
+        log.warn(
+          { err, plugin: name, reason },
+          "plugin onShutdown failed (continuing with remaining plugins)",
+        );
+      }
+    }
+  });
+}

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -105,6 +105,7 @@ import {
   getInterfacesDir,
   getWorkspaceDir,
 } from "../util/platform.js";
+import { APP_VERSION } from "../version.js";
 import {
   listWorkItems,
   updateWorkItem,
@@ -122,6 +123,7 @@ import {
   cleanupPidFileIfOwner,
   writePid,
 } from "./daemon-control.js";
+import { bootstrapPlugins } from "./external-plugins-bootstrap.js";
 import {
   createGuardianActionCopyGenerator,
   createGuardianFollowUpConversationGenerator,
@@ -695,6 +697,13 @@ export async function runDaemon(): Promise<void> {
         });
       }
     }
+
+    // Bootstrap registered plugins. Runs after the plugin registry is
+    // populated (which happens via static side-effect imports — none exist
+    // in this PR, so the call is a no-op against an empty registry) and
+    // before the DaemonServer starts handling conversations. Credential
+    // resolution + per-plugin storage directory creation happen here.
+    await bootstrapPlugins({ config, assistantVersion: APP_VERSION });
 
     // Start the DaemonServer (conversation manager) before Qdrant so HTTP
     // routes can begin accepting requests while Qdrant initializes.

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -60,7 +60,7 @@ export function normalizeAssistantId(assistantId: string): string {
  * than `BASE_DATA_DIR`, so honoring `BASE_DATA_DIR` here does not affect
  * containerized deployments.
  */
-function vellumRoot(): string {
+export function vellumRoot(): string {
   const baseDataDir = process.env.BASE_DATA_DIR?.trim();
   if (baseDataDir) return join(baseDataDir, ".vellum");
   return join(homedir(), ".vellum");


### PR DESCRIPTION
## Summary
- daemon/external-plugins-bootstrap.ts: bootstrapPlugins() resolves credentials + config, calls init() per plugin sequentially, registers reverse-order shutdown
- Wired into daemon/lifecycle.ts after side-effect plugin imports and before first conversation served
- Tests cover noop init, credential resolution, version mismatch, and reverse-order shutdown

Part of plan: agent-plugin-system.md (PR 14 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
