### PR TITLE
feat(assistant): wrap tool-error nudging as plugin pipeline

### DIFF
--- a/assistant/src/__tests__/plugin-types.test.ts
+++ b/assistant/src/__tests__/plugin-types.test.ts
@@ -19,6 +19,8 @@ import {
   type PluginInitContext,
   type PluginManifest,
   PluginTimeoutError,
+  type ToolErrorArgs,
+  type ToolErrorDecision,
   type TurnContext,
 } from "../plugins/types.js";
 
@@ -50,6 +52,14 @@ describe("plugin core types", () => {
     const passthrough: Middleware<
       { input: unknown },
       { output: unknown }
+    > = async (args, next, _ctx) => next(args);
+
+    // A few pipelines have concrete args/result types (PR 19 onward refines
+    // placeholders in place). Use purpose-built passthroughs for those slots
+    // so the shape-only test keeps compiling as types get tightened.
+    const toolErrorPassthrough: Middleware<
+      ToolErrorArgs,
+      ToolErrorDecision
     > = async (args, next, _ctx) => next(args);
 
     const injector: Injector = {
@@ -91,7 +101,7 @@ describe("plugin core types", () => {
         titleGenerate: passthrough,
         toolResultTruncate: passthrough,
         emptyResponse: passthrough,
-        toolError: passthrough,
+        toolError: toolErrorPassthrough,
         circuitBreaker: passthrough,
       },
     } satisfies Plugin;

--- a/assistant/src/__tests__/tool-error-pipeline.test.ts
+++ b/assistant/src/__tests__/tool-error-pipeline.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for the `toolError` pipeline (PR 19).
+ *
+ * Covers:
+ * - Default plugin nudges on the first error turn and keeps nudging up to the
+ *   `maxConsecutiveErrorNudges` cap.
+ * - Default plugin suppresses the nudge once the cap is exceeded (the error is
+ *   likely unrecoverable — burning tokens on more nudges is wasteful).
+ * - Default plugin uses the canonical {@link DEFAULT_TOOL_ERROR_NUDGE_TEXT}.
+ * - Default plugin skips when `hasToolError` is false, regardless of the
+ *   consecutive counter (no error this turn → nothing to nudge).
+ * - Swapping in a user plugin that provides its own `toolError` middleware
+ *   changes the nudge text end-to-end through `runPipeline`.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import {
+  DEFAULT_TOOL_ERROR_NUDGE_TEXT,
+  defaultToolErrorPlugin,
+} from "../plugins/defaults/tool-error.js";
+import { runPipeline } from "../plugins/pipeline.js";
+import {
+  getMiddlewaresFor,
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import {
+  type Middleware,
+  type Plugin,
+  type ToolErrorArgs,
+  type ToolErrorDecision,
+  type TurnContext,
+} from "../plugins/types.js";
+
+const trust: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+function makeCtx(): TurnContext {
+  return {
+    requestId: "req-tool-error-test",
+    conversationId: "conv-tool-error-test",
+    turnIndex: 0,
+    trust,
+  };
+}
+
+async function runToolErrorPipeline(
+  args: ToolErrorArgs,
+): Promise<ToolErrorDecision> {
+  return runPipeline<ToolErrorArgs, ToolErrorDecision>(
+    "toolError",
+    getMiddlewaresFor("toolError"),
+    async () => ({ action: "skip" }),
+    args,
+    makeCtx(),
+    500,
+  );
+}
+
+describe("toolError pipeline", () => {
+  describe("default plugin", () => {
+    beforeEach(() => {
+      resetPluginRegistryForTests();
+      registerPlugin(defaultToolErrorPlugin);
+    });
+
+    test("nudges on first error turn with canonical text", async () => {
+      const decision = await runToolErrorPipeline({
+        hasToolError: true,
+        consecutiveErrorTurns: 1,
+        maxConsecutiveErrorNudges: 3,
+      });
+      expect(decision.action).toBe("nudge");
+      if (decision.action === "nudge") {
+        expect(decision.nudgeText).toBe(DEFAULT_TOOL_ERROR_NUDGE_TEXT);
+      }
+    });
+
+    test("keeps nudging up to and including the cap", async () => {
+      // Cap of 3: turns 1, 2, and 3 all nudge. Turn 4 is past the cap.
+      for (let turn = 1; turn <= 3; turn++) {
+        const decision = await runToolErrorPipeline({
+          hasToolError: true,
+          consecutiveErrorTurns: turn,
+          maxConsecutiveErrorNudges: 3,
+        });
+        expect(decision.action).toBe("nudge");
+      }
+    });
+
+    test("suppresses the nudge once the consecutive counter exceeds the cap", async () => {
+      const decision = await runToolErrorPipeline({
+        hasToolError: true,
+        consecutiveErrorTurns: 4,
+        maxConsecutiveErrorNudges: 3,
+      });
+      expect(decision.action).toBe("skip");
+    });
+
+    test("skips when there is no tool error this turn, regardless of counter", async () => {
+      // Counter is non-zero (the previous turn errored) but this turn succeeded,
+      // so nothing to nudge about.
+      const decision = await runToolErrorPipeline({
+        hasToolError: false,
+        consecutiveErrorTurns: 2,
+        maxConsecutiveErrorNudges: 3,
+      });
+      expect(decision.action).toBe("skip");
+    });
+
+    test("honors a caller-supplied cap of zero (never nudges)", async () => {
+      // Some call-sites may want to disable nudging entirely by passing cap = 0.
+      // The decision logic uses `<=`, so counter 0 with cap 0 does nudge; counter
+      // 1 with cap 0 suppresses. The cap is inclusive.
+      const turn1 = await runToolErrorPipeline({
+        hasToolError: true,
+        consecutiveErrorTurns: 1,
+        maxConsecutiveErrorNudges: 0,
+      });
+      expect(turn1.action).toBe("skip");
+    });
+  });
+
+  describe("user-supplied plugin", () => {
+    beforeEach(() => {
+      resetPluginRegistryForTests();
+    });
+
+    test("swapping in a plugin changes the nudge text", async () => {
+      const customText = "<system_notice>Custom error hint.</system_notice>";
+      const customMiddleware: Middleware<
+        ToolErrorArgs,
+        ToolErrorDecision
+      > = async (args) => {
+        if (args.hasToolError) {
+          return { action: "nudge", nudgeText: customText };
+        }
+        return { action: "skip" };
+      };
+      const customPlugin: Plugin = {
+        manifest: {
+          name: "custom-tool-error",
+          version: "0.0.1",
+          requires: { pluginRuntime: "v1", toolErrorApi: "v1" },
+        },
+        middleware: { toolError: customMiddleware },
+      };
+      registerPlugin(customPlugin);
+
+      const decision = await runToolErrorPipeline({
+        hasToolError: true,
+        consecutiveErrorTurns: 1,
+        maxConsecutiveErrorNudges: 3,
+      });
+      expect(decision.action).toBe("nudge");
+      if (decision.action === "nudge") {
+        expect(decision.nudgeText).toBe(customText);
+      }
+    });
+
+    test("swapping in a plugin can suppress nudges even when the default would nudge", async () => {
+      const suppressingMiddleware: Middleware<
+        ToolErrorArgs,
+        ToolErrorDecision
+      > = async () => ({ action: "skip" });
+      const plugin: Plugin = {
+        manifest: {
+          name: "no-nudge",
+          version: "0.0.1",
+          requires: { pluginRuntime: "v1", toolErrorApi: "v1" },
+        },
+        middleware: { toolError: suppressingMiddleware },
+      };
+      registerPlugin(plugin);
+
+      const decision = await runToolErrorPipeline({
+        hasToolError: true,
+        consecutiveErrorTurns: 1,
+        maxConsecutiveErrorNudges: 3,
+      });
+      expect(decision.action).toBe("skip");
+    });
+
+    test("terminal fallback runs when no plugin is registered", async () => {
+      // No registerPlugin call — the registry is empty for this slot. The
+      // terminal we pass to runPipeline returns `skip`, which is what the
+      // caller receives.
+      const decision = await runToolErrorPipeline({
+        hasToolError: true,
+        consecutiveErrorTurns: 1,
+        maxConsecutiveErrorNudges: 3,
+      });
+      expect(decision.action).toBe("skip");
+    });
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -7,6 +7,13 @@ import {
   getCalibrationProviderKey,
 } from "../context/token-estimator.js";
 import { truncateOversizedToolResults } from "../context/tool-result-truncation.js";
+import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
+import { getMiddlewaresFor } from "../plugins/registry.js";
+import type {
+  ToolErrorArgs,
+  ToolErrorDecision,
+  TurnContext,
+} from "../plugins/types.js";
 import type {
   ContentBlock,
   Message,
@@ -123,6 +130,32 @@ const DEFAULT_CONFIG: AgentLoopConfig = {
 
 const MAX_CONSECUTIVE_ERROR_NUDGES = 3;
 const MAX_EMPTY_RESPONSE_RETRIES = 1;
+
+/**
+ * Build a minimal {@link TurnContext} for pipelines invoked from within the
+ * agent loop itself (not the orchestrator). The loop does not have first-class
+ * conversation/trust identity — those live in the surrounding orchestrator
+ * layer in `daemon/conversation-agent-loop.ts`. Later PRs in the
+ * `agent-plugin-system` plan thread those identifiers through. For now, loop-
+ * level pipelines receive the `requestId` the caller supplied (falling back to
+ * a stable synthetic value), a synthetic conversation id, and a placeholder
+ * trust context typed as `unknown` — plugins at this layer generally care
+ * about the per-turn args, not the surrounding identity.
+ */
+function buildLoopTurnContext(
+  requestId: string | undefined,
+  turnIndex: number,
+): TurnContext {
+  return {
+    requestId: requestId ?? "agent-loop",
+    conversationId: "agent-loop-internal",
+    turnIndex,
+    trust: {
+      sourceChannel: "vellum",
+      trustClass: "unknown",
+    },
+  };
+}
 
 /**
  * User-config HTTP status codes that should never page the on-call: billing
@@ -754,20 +787,43 @@ export class AgentLoop {
         // When any tool returned an error, nudge the LLM to retry with
         // corrected parameters instead of ending its turn. Skip the nudge
         // after MAX_CONSECUTIVE_ERROR_NUDGES consecutive error turns
-        // (the error is likely unrecoverable at that point).
+        // (the error is likely unrecoverable at that point). The nudge
+        // decision is delegated to the `toolError` plugin pipeline so user
+        // plugins can change the text, observe the event, or suppress it.
         const hasToolError = toolResults.some(({ result }) => result.isError);
         if (hasToolError) {
           consecutiveErrorTurns++;
         } else {
           consecutiveErrorTurns = 0;
         }
-        if (
-          hasToolError &&
-          consecutiveErrorTurns <= MAX_CONSECUTIVE_ERROR_NUDGES
-        ) {
+        const toolErrorArgs: ToolErrorArgs = {
+          hasToolError,
+          consecutiveErrorTurns,
+          maxConsecutiveErrorNudges: MAX_CONSECUTIVE_ERROR_NUDGES,
+        };
+        const toolErrorCtx: TurnContext = buildLoopTurnContext(
+          requestId,
+          toolUseTurns - 1,
+        );
+        const toolErrorDecision = await runPipeline<
+          ToolErrorArgs,
+          ToolErrorDecision
+        >(
+          "toolError",
+          getMiddlewaresFor("toolError"),
+          // Terminal fallback: fires only when no plugin contributes a
+          // `toolError` middleware. The default plugin's middleware shadows
+          // this with the full decision logic, so production runs never hit
+          // the fallback.
+          async () => ({ action: "skip" }),
+          toolErrorArgs,
+          toolErrorCtx,
+          DEFAULT_TIMEOUTS.toolError,
+        );
+        if (toolErrorDecision.action === "nudge") {
           resultBlocks.push({
             type: "text",
-            text: "<system_notice>One or more tool calls returned an error. If the error looks recoverable (e.g. missing or invalid parameters), fix the parameters and retry. If the error is clearly unrecoverable (e.g. a service is down, a resource does not exist, or a permission is permanently denied), report it to the user.</system_notice>",
+            text: toolErrorDecision.nudgeText,
           });
         }
 

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -35,9 +35,11 @@ import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import type { AssistantConfig } from "../config/schema.js";
+import { defaultToolErrorPlugin } from "../plugins/defaults/tool-error.js";
 import {
   ASSISTANT_API_VERSIONS,
   getRegisteredPlugins,
+  registerPlugin,
 } from "../plugins/registry.js";
 import {
   type Plugin,
@@ -135,6 +137,32 @@ function ensurePluginStorageDir(pluginName: string): string {
 }
 
 /**
+ * Register first-party default plugins with the registry. Called at the top
+ * of {@link bootstrapPlugins} so the defaults are always present regardless
+ * of external registration state. Idempotent: duplicate-registration is
+ * swallowed so repeated bootstraps (hot-reload, test suites that share the
+ * registry) don't throw.
+ */
+function registerFirstPartyPlugins(): void {
+  const defaults: Plugin[] = [defaultToolErrorPlugin];
+  for (const plugin of defaults) {
+    try {
+      registerPlugin(plugin);
+    } catch (err) {
+      // Already registered — ignore. Any other error re-throws with the
+      // original attribution (registerPlugin already tags the plugin name).
+      if (
+        err instanceof PluginExecutionError &&
+        err.message.includes("already registered")
+      ) {
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/**
  * Run every registered plugin's `init()` hook sequentially and install a
  * reverse-order shutdown hook. See the module docstring for full semantics.
  *
@@ -147,6 +175,8 @@ function ensurePluginStorageDir(pluginName: string): string {
  * run) and before the first conversation is served.
  */
 export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
+  registerFirstPartyPlugins();
+
   const plugins = getRegisteredPlugins();
   if (plugins.length === 0) {
     // No-op fast path — the registry is empty (no first-party plugins have

--- a/assistant/src/plugins/defaults/tool-error.ts
+++ b/assistant/src/plugins/defaults/tool-error.ts
@@ -1,0 +1,88 @@
+/**
+ * Default `toolError` pipeline plugin.
+ *
+ * Replicates the inline tool-error-nudge logic that previously lived in
+ * `agent/loop.ts`: when the current turn produced at least one failed tool
+ * result, append a system-notice block to the tool results that coaches the
+ * LLM to either retry with corrected parameters (for recoverable errors) or
+ * report the failure to the user (for unrecoverable ones). After the
+ * consecutive-error-turn counter exceeds the cap the caller supplies, this
+ * default stops nudging — the error is likely not something the LLM can fix
+ * on its own and continuing to nudge only burns tokens.
+ *
+ * Design doc: `.private/plans/agent-plugin-system.md` (PR 19).
+ */
+
+import type {
+  Middleware,
+  Plugin,
+  ToolErrorArgs,
+  ToolErrorDecision,
+} from "../types.js";
+
+/**
+ * Canonical nudge text. Kept as a module-level constant so tests and future
+ * plugins can match it without duplicating the string.
+ */
+export const DEFAULT_TOOL_ERROR_NUDGE_TEXT =
+  "<system_notice>One or more tool calls returned an error. If the error looks recoverable (e.g. missing or invalid parameters), fix the parameters and retry. If the error is clearly unrecoverable (e.g. a service is down, a resource does not exist, or a permission is permanently denied), report it to the user.</system_notice>";
+
+/**
+ * Terminal handler for the `toolError` pipeline. Mirrors the pre-plugin
+ * behavior: nudge iff the current turn had an error AND the consecutive-error
+ * counter is within the cap. Once the cap is breached the caller should stop
+ * appending the nudge (the error is likely unrecoverable and the LLM already
+ * had multiple attempts to correct it).
+ *
+ * Exported so callers (and tests) can reuse the decision logic directly
+ * without going through the pipeline runner.
+ */
+export const defaultToolErrorTerminal = async (
+  args: ToolErrorArgs,
+): Promise<ToolErrorDecision> => {
+  if (
+    args.hasToolError &&
+    args.consecutiveErrorTurns <= args.maxConsecutiveErrorNudges
+  ) {
+    return {
+      action: "nudge",
+      nudgeText: DEFAULT_TOOL_ERROR_NUDGE_TEXT,
+    };
+  }
+  return { action: "skip" };
+};
+
+/**
+ * Default middleware for the `toolError` slot. Acts as the terminal — it
+ * returns a decision directly instead of calling `next`, so the pre-plugin
+ * behavior fires even when no user plugin contributes its own middleware.
+ *
+ * Named explicitly so the pipeline's structured log record carries
+ * `"defaultToolErrorMiddleware"` in `chain` instead of an anonymous entry.
+ */
+const defaultToolErrorMiddleware: Middleware<ToolErrorArgs, ToolErrorDecision> =
+  async function defaultToolErrorMiddleware(args, _next) {
+    return defaultToolErrorTerminal(args);
+  };
+
+/**
+ * Plugin registration for the default `toolError` behavior. Registered by
+ * `daemon/external-plugins-bootstrap.ts` via a side-effect import so the
+ * middleware is available to the pipeline runner from daemon startup.
+ */
+export const defaultToolErrorPlugin: Plugin = {
+  manifest: {
+    name: "default-tool-error",
+    version: "1.0.0",
+    requires: {
+      pluginRuntime: "v1",
+      toolErrorApi: "v1",
+    },
+    provides: {
+      toolError: "v1",
+    },
+  },
+  middleware: {
+    toolError: defaultToolErrorMiddleware,
+  },
+};

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -154,8 +154,36 @@ export type ToolResultTruncateResult = { readonly output: unknown };
 export type EmptyResponseArgs = { readonly input: unknown };
 export type EmptyResponseResult = { readonly output: unknown };
 
-export type ToolErrorArgs = { readonly input: unknown };
-export type ToolErrorResult = { readonly output: unknown };
+/**
+ * Arguments to the `toolError` pipeline — invoked by the agent loop once per
+ * turn that produced tool results, BEFORE the turn's tool-result user message
+ * is pushed into history.
+ *
+ * `hasToolError` is true when at least one tool in the current turn returned
+ * `isError: true`. `consecutiveErrorTurns` is the running count of
+ * back-to-back error turns (reset to 0 on a clean turn, incremented on each
+ * error turn). `maxConsecutiveErrorNudges` is the default cap the agent loop
+ * currently applies; plugins receive it so they can match the default
+ * threshold exactly or compute a relative offset.
+ */
+export type ToolErrorArgs = {
+  readonly hasToolError: boolean;
+  readonly consecutiveErrorTurns: number;
+  readonly maxConsecutiveErrorNudges: number;
+};
+
+/**
+ * Decision returned by the `toolError` pipeline. When `action` is `"nudge"`,
+ * the agent loop appends a text block with `nudgeText` to the turn's tool
+ * results so the next LLM turn sees the nudge. When `action` is `"skip"`, no
+ * nudge is injected and the tool results pass through unchanged.
+ */
+export type ToolErrorDecision =
+  | { readonly action: "nudge"; readonly nudgeText: string }
+  | { readonly action: "skip" };
+
+/** Alias kept so `PipelineMiddlewareMap.toolError` reads result-shaped. */
+export type ToolErrorResult = ToolErrorDecision;
 
 export type CircuitBreakerArgs = { readonly input: unknown };
 export type CircuitBreakerResult = { readonly output: unknown };


### PR DESCRIPTION
## Summary
- Add ToolErrorArgs/Decision types
- Default plugin replicates error-nudge logic with MAX_CONSECUTIVE_ERROR_NUDGES cap
- Swap agent/loop.ts inline error-nudge block to runPipeline

Part of plan: agent-plugin-system.md (PR 19 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
