### PR TITLE
feat(assistant): convert runtime injection to Injector chain

### DIFF
--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for the plugin-driven runtime-injection chain (PR 21 of the
+ * `agent-plugin-system` plan).
+ *
+ * Covers:
+ *
+ * 1. The seven default injectors registered by `defaultInjectorsPlugin` come
+ *    back from `getInjectors()` in the documented order (workspace-context →
+ *    unified-turn-context → pkb → now-md → subagent-status → slack-messages
+ *    → thread-focus).
+ * 2. A third-party-registered injector at `order: 25` slots between
+ *    `unified-turn-context` (order 20) and `pkb` (order 30), proving the
+ *    extensibility contract.
+ * 3. `composeInjectorChain` concatenates non-null blocks with a blank-line
+ *    separator and yields an empty string when every injector opts out — the
+ *    latter matches pre-PR behavior for the golden-path conversation state
+ *    (all defaults return `null` in this PR).
+ * 4. `applyRuntimeInjections` with an empty `turnContext` chain leaves
+ *    `blocks.injectorChainBlock` undefined, preserving the existing snapshot
+ *    for conversations that don't opt into the chain.
+ * 5. `applyRuntimeInjections` surfaces the composed chain output on
+ *    `blocks.injectorChainBlock` when a third-party injector contributes
+ *    content.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyRuntimeInjections,
+  composeInjectorChain,
+} from "../daemon/conversation-runtime-assembly.js";
+import {
+  DEFAULT_INJECTOR_ORDER,
+  defaultInjectorsPlugin,
+} from "../plugins/defaults/injectors.js";
+import {
+  getInjectors,
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import type {
+  InjectionBlock,
+  Injector,
+  Plugin,
+  TurnContext,
+} from "../plugins/types.js";
+import type { Message } from "../providers/types.js";
+
+/** A fake TurnContext sufficient for driving `composeInjectorChain`. */
+function makeTurnContext(): TurnContext {
+  return {
+    requestId: "req-test-1",
+    conversationId: "conv-test-1",
+    turnIndex: 0,
+    trust: {
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    },
+  };
+}
+
+/** Build a tiny valid plugin wrapping an array of injectors. */
+function wrapInPlugin(name: string, injectors: Injector[]): Plugin {
+  return {
+    manifest: {
+      name,
+      version: "0.0.1",
+      requires: { pluginRuntime: "v1" },
+    },
+    injectors,
+  };
+}
+
+describe("injector chain", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+  });
+
+  test("defaultInjectorsPlugin registers the seven defaults in the documented order", () => {
+    registerPlugin(defaultInjectorsPlugin);
+
+    const names = getInjectors().map((i) => i.name);
+    expect(names).toEqual([
+      "workspace-context",
+      "unified-turn-context",
+      "pkb",
+      "now-md",
+      "subagent-status",
+      "slack-messages",
+      "thread-focus",
+    ]);
+  });
+
+  test("default injector order constants match the registered order values", () => {
+    registerPlugin(defaultInjectorsPlugin);
+
+    const byName = new Map(getInjectors().map((i) => [i.name, i.order]));
+    expect(byName.get("workspace-context")).toBe(
+      DEFAULT_INJECTOR_ORDER.workspaceContext,
+    );
+    expect(byName.get("unified-turn-context")).toBe(
+      DEFAULT_INJECTOR_ORDER.unifiedTurnContext,
+    );
+    expect(byName.get("pkb")).toBe(DEFAULT_INJECTOR_ORDER.pkb);
+    expect(byName.get("now-md")).toBe(DEFAULT_INJECTOR_ORDER.nowMd);
+    expect(byName.get("subagent-status")).toBe(
+      DEFAULT_INJECTOR_ORDER.subagentStatus,
+    );
+    expect(byName.get("slack-messages")).toBe(
+      DEFAULT_INJECTOR_ORDER.slackMessages,
+    );
+    expect(byName.get("thread-focus")).toBe(DEFAULT_INJECTOR_ORDER.threadFocus);
+  });
+
+  test("a third-party injector at order 25 slots between unified-turn-context (20) and pkb (30)", () => {
+    registerPlugin(defaultInjectorsPlugin);
+
+    const middleInjector: Injector = {
+      name: "plugin-25",
+      order: 25,
+      async produce() {
+        return null;
+      },
+    };
+    registerPlugin(wrapInPlugin("third-party", [middleInjector]));
+
+    const names = getInjectors().map((i) => i.name);
+    expect(names).toEqual([
+      "workspace-context", // 10
+      "unified-turn-context", // 20
+      "plugin-25", // 25 — slots in
+      "pkb", // 30
+      "now-md", // 40
+      "subagent-status", // 50
+      "slack-messages", // 60
+      "thread-focus", // 70
+    ]);
+  });
+
+  test("composeInjectorChain returns empty string when every injector opts out", async () => {
+    // The default chain is the golden-path: all seven defaults return `null`
+    // in this PR, so the composed block is an empty string, matching the
+    // pre-PR behavior where no chain existed at all.
+    registerPlugin(defaultInjectorsPlugin);
+
+    const composed = await composeInjectorChain(makeTurnContext());
+    expect(composed).toBe("");
+  });
+
+  test("composeInjectorChain returns empty string when registry is empty", async () => {
+    // No plugins registered — the chain is a no-op and must return an empty
+    // string (not throw, not undefined). Callers rely on this to treat the
+    // chain as purely additive.
+    const composed = await composeInjectorChain(makeTurnContext());
+    expect(composed).toBe("");
+  });
+
+  test("composeInjectorChain concatenates non-null blocks in order with blank-line separators", async () => {
+    const first: Injector = {
+      name: "a",
+      order: 5,
+      async produce(): Promise<InjectionBlock> {
+        return { id: "a", text: "BLOCK_A" };
+      },
+    };
+    const second: Injector = {
+      name: "b",
+      order: 15,
+      async produce(): Promise<InjectionBlock> {
+        return { id: "b", text: "BLOCK_B" };
+      },
+    };
+    const skipped: Injector = {
+      name: "c",
+      order: 25,
+      async produce() {
+        return null;
+      },
+    };
+    // Register the higher-order one first to prove the chain sorts by `order`
+    // rather than registration order.
+    registerPlugin(wrapInPlugin("higher", [second]));
+    registerPlugin(wrapInPlugin("lower", [first]));
+    registerPlugin(wrapInPlugin("opts-out", [skipped]));
+
+    const composed = await composeInjectorChain(makeTurnContext());
+    expect(composed).toBe("BLOCK_A\n\nBLOCK_B");
+  });
+
+  test("composeInjectorChain skips blocks with empty text", async () => {
+    const emitEmpty: Injector = {
+      name: "empty",
+      order: 10,
+      async produce(): Promise<InjectionBlock> {
+        return { id: "empty", text: "" };
+      },
+    };
+    const emitReal: Injector = {
+      name: "real",
+      order: 20,
+      async produce(): Promise<InjectionBlock> {
+        return { id: "real", text: "CONTENT" };
+      },
+    };
+    registerPlugin(wrapInPlugin("plugin", [emitEmpty, emitReal]));
+
+    const composed = await composeInjectorChain(makeTurnContext());
+    expect(composed).toBe("CONTENT");
+  });
+
+  test("applyRuntimeInjections leaves injectorChainBlock undefined when defaults opt out", async () => {
+    // Golden-path snapshot: with only default injectors (all returning
+    // `null`), `applyRuntimeInjections` reports no chain output, so the
+    // historical `blocks` shape is preserved byte-for-byte for any
+    // conversation that doesn't involve third-party injectors.
+    registerPlugin(defaultInjectorsPlugin);
+
+    const runMessages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+    ];
+
+    const result = await applyRuntimeInjections(runMessages, {
+      turnContext: makeTurnContext(),
+    });
+
+    expect(result.blocks.injectorChainBlock).toBeUndefined();
+    // Sanity: the message array is untouched when no options fire (no
+    // hardcoded branches apply, and the chain contributed nothing).
+    expect(result.messages).toEqual(runMessages);
+  });
+
+  test("applyRuntimeInjections surfaces third-party injector output on blocks.injectorChainBlock", async () => {
+    registerPlugin(defaultInjectorsPlugin);
+    registerPlugin(
+      wrapInPlugin("third-party-25", [
+        {
+          name: "plugin-25",
+          order: 25,
+          async produce(): Promise<InjectionBlock> {
+            return { id: "plugin-25", text: "THIRD_PARTY_BLOCK" };
+          },
+        },
+      ]),
+    );
+
+    const runMessages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ];
+
+    const result = await applyRuntimeInjections(runMessages, {
+      turnContext: makeTurnContext(),
+    });
+
+    expect(result.blocks.injectorChainBlock).toBe("THIRD_PARTY_BLOCK");
+  });
+
+  test("applyRuntimeInjections without turnContext skips the chain entirely", async () => {
+    // Backwards compatibility: callers that predate PR 21 don't pass
+    // `turnContext`. The chain must be inert in that case so pre-existing
+    // call sites keep producing identical output.
+    registerPlugin(defaultInjectorsPlugin);
+    registerPlugin(
+      wrapInPlugin("third-party-25", [
+        {
+          name: "plugin-25",
+          order: 25,
+          async produce(): Promise<InjectionBlock> {
+            return { id: "plugin-25", text: "SHOULD_BE_SKIPPED" };
+          },
+        },
+      ]),
+    );
+
+    const runMessages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ];
+
+    const result = await applyRuntimeInjections(runMessages, {});
+
+    expect(result.blocks.injectorChainBlock).toBeUndefined();
+  });
+});

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -27,6 +27,8 @@ import {
   renderSlackTranscript,
 } from "../messaging/providers/slack/render-transcript.js";
 import { isPermissionControlsV2Enabled } from "../permissions/v2-consent-policy.js";
+import { getInjectors } from "../plugins/registry.js";
+import type { TurnContext } from "../plugins/types.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import {
   type ActorTrustContext,
@@ -1728,11 +1730,52 @@ export interface RuntimeInjectionBlocks {
   workspaceBlock?: string;
   nowScratchpadBlock?: string;
   pkbContextBlock?: string;
+  /**
+   * Composed output of every plugin-registered {@link Injector}, concatenated
+   * in ascending `order`. Empty string when every injector opted out (returned
+   * `null`). Today the default injectors (`default-injectors` plugin)
+   * placeholder-return `null`, so this is only non-empty when a third-party
+   * plugin registers an injector that emits content.
+   *
+   * Populated by {@link composeInjectorChain} during
+   * {@link applyRuntimeInjections}. Distinct from the other `blocks` fields
+   * because those track specific hardcoded injections today; this field is
+   * the extensibility seam for {@link Injector} plugins.
+   */
+  injectorChainBlock?: string;
 }
 
 export interface RuntimeInjectionResult {
   messages: Message[];
   blocks: RuntimeInjectionBlocks;
+}
+
+/**
+ * Run every registered {@link Injector}'s `produce()` in ascending
+ * `order`, concatenate the non-null results into a single block of text,
+ * and return it.
+ *
+ * Separator: blank line between blocks. Injectors returning `null` are
+ * skipped entirely (no leading/trailing blank lines). When no injector
+ * contributes, the function returns an empty string.
+ *
+ * Used by {@link applyRuntimeInjections} to expose a deterministic
+ * composition point that plugin-registered injectors can slot into. The
+ * default injectors registered by `defaultInjectorsPlugin` placeholder-return
+ * `null` in this PR; later PRs in the `agent-plugin-system` plan lift their
+ * real bodies from the hardcoded `applyRuntimeInjections` branches.
+ */
+export async function composeInjectorChain(ctx: TurnContext): Promise<string> {
+  const injectors = getInjectors();
+  if (injectors.length === 0) return "";
+  const pieces: string[] = [];
+  for (const injector of injectors) {
+    const block = await injector.produce(ctx);
+    if (block && block.text.length > 0) {
+      pieces.push(block.text);
+    }
+  }
+  return pieces.join("\n\n");
 }
 
 /**
@@ -1821,6 +1864,15 @@ export async function applyRuntimeInjections(
      */
     slackActiveThreadFocusBlock?: string | null;
     mode?: InjectionMode;
+    /**
+     * Per-turn {@link TurnContext} forwarded to plugin-registered
+     * {@link Injector}s via {@link composeInjectorChain}. When omitted, the
+     * injector chain is skipped entirely (its output stays `undefined` on
+     * the returned `blocks`). The hardcoded injection branches above still
+     * run — the injector chain is additive in this PR and will take over
+     * individual injections in later PRs.
+     */
+    turnContext?: TurnContext;
   },
 ): Promise<RuntimeInjectionResult> {
   const mode = options.mode ?? "full";
@@ -2145,6 +2197,21 @@ export async function applyRuntimeInjections(
     }
   }
 
+  // Plugin-registered injector chain: runs after all hardcoded branches so
+  // third-party injectors observe the same view of the turn. In this PR the
+  // default injectors placeholder-return `null`, so the composed output is
+  // an empty string unless a third-party plugin registered an injector that
+  // emits content. Skip entirely when the caller doesn't pass a
+  // `turnContext` — the composition is informational today and the absence
+  // of a context is treated as "no chain output".
+  let injectorChainBlock: string | undefined;
+  if (options.turnContext) {
+    const composed = await composeInjectorChain(options.turnContext);
+    if (composed.length > 0) {
+      injectorChainBlock = composed;
+    }
+  }
+
   return {
     messages: result,
     blocks: {
@@ -2153,6 +2220,7 @@ export async function applyRuntimeInjections(
       workspaceBlock: workspaceCaptured,
       nowScratchpadBlock: nowScratchpadCaptured,
       pkbContextBlock: pkbContextCaptured,
+      injectorChainBlock,
     },
   };
 }

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -35,9 +35,11 @@ import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import type { AssistantConfig } from "../config/schema.js";
+import { defaultInjectorsPlugin } from "../plugins/defaults/injectors.js";
 import {
   ASSISTANT_API_VERSIONS,
   getRegisteredPlugins,
+  registerPlugin,
 } from "../plugins/registry.js";
 import {
   type Plugin,
@@ -48,6 +50,28 @@ import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { vellumRoot } from "../util/platform.js";
 import { registerShutdownHook } from "./shutdown-registry.js";
+
+/**
+ * Register first-party default plugins into the registry.
+ *
+ * Called by {@link bootstrapPlugins} before it walks the registry so every
+ * default plugin's `init()` runs alongside any third-party plugins loaded
+ * via side-effect imports earlier in the boot sequence.
+ *
+ * Idempotent: skips any default plugin already present in the registry (by
+ * manifest name). This lets tests pre-register a stub `default-injectors`
+ * plugin to override the real chain, and keeps re-entry safe when a caller
+ * invokes `bootstrapPlugins` multiple times in the same process (e.g.
+ * hot-reload).
+ */
+function registerDefaultPlugins(): void {
+  const existingNames = new Set(
+    getRegisteredPlugins().map((p) => p.manifest.name),
+  );
+  if (!existingNames.has(defaultInjectorsPlugin.manifest.name)) {
+    registerPlugin(defaultInjectorsPlugin);
+  }
+}
 
 const log = getLogger("plugins-bootstrap");
 
@@ -147,11 +171,18 @@ function ensurePluginStorageDir(pluginName: string): string {
  * run) and before the first conversation is served.
  */
 export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
+  // Register first-party default plugins before walking the registry so the
+  // default injector chain (`defaultInjectorsPlugin`) is present on every
+  // boot. Third-party plugins register themselves via side-effect imports
+  // earlier in the boot sequence; they remain in whatever order they loaded.
+  registerDefaultPlugins();
+
   const plugins = getRegisteredPlugins();
   if (plugins.length === 0) {
-    // No-op fast path — the registry is empty (no first-party plugins have
-    // been wired yet in this PR). Emit a debug log so the call site is
-    // observable in startup traces and return.
+    // No-op fast path — the registry is empty. After this PR the default
+    // injectors are always present, but this branch stays defensive for
+    // tests that call `resetPluginRegistryForTests()` and stub the
+    // default registration.
     log.debug("bootstrapPlugins: registry empty — skipping");
     return;
   }

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -1,0 +1,186 @@
+/**
+ * Default runtime injector plugin — bundles the existing injection chain
+ * (workspace, unified turn context, PKB, NOW.md, subagent, Slack, thread focus)
+ * as {@link Injector}s with fixed `order` values that third-party plugins can
+ * slot against.
+ *
+ * Each injector here is a thin {@link Injector} that defers to the existing
+ * helpers in `conversation-runtime-assembly.ts` when invoked by the runtime
+ * injection chain. `produce()` currently returns `null` because the concrete
+ * per-turn inputs (the `options` bag passed to `applyRuntimeInjections`) are
+ * not yet threaded through {@link TurnContext}; later PRs in the
+ * agent-plugin-system plan lift each per-turn input into context state and
+ * move the helper's real body into the corresponding injector.
+ *
+ * The value delivered by this PR is the **ordering contract**:
+ *
+ * | name                     | order |
+ * | ------------------------ | ----- |
+ * | `workspace-context`      | 10    |
+ * | `unified-turn-context`   | 20    |
+ * | `pkb`                    | 30    |
+ * | `now-md`                 | 40    |
+ * | `subagent-status`        | 50    |
+ * | `slack-messages`         | 60    |
+ * | `thread-focus`           | 70    |
+ *
+ * Third-party plugins may register additional {@link Injector}s at
+ * arbitrary `order` values; the registry's `getInjectors()` returns all
+ * injectors sorted ascending by `order`, so a plugin-registered injector at
+ * `order: 25` reliably slots between `unified-turn-context` (20) and `pkb`
+ * (30).
+ *
+ * Registration happens via a side-effect import in
+ * `daemon/external-plugins-bootstrap.ts` so the default chain is present for
+ * every assistant boot.
+ *
+ * Design doc: `.private/plans/agent-plugin-system.md` (PR 21).
+ */
+
+import type {
+  InjectionBlock,
+  Injector,
+  Plugin,
+  TurnContext,
+} from "../types.js";
+
+/**
+ * Fixed order values for the seven default injectors. Exported so tests —
+ * and any future integration code — can assert ordering without re-deriving
+ * the constants.
+ *
+ * Gaps of 10 between slots leave room for third-party injectors to slot in
+ * at granular positions (e.g. `25` between PKB and subagent) without
+ * renumbering the defaults.
+ */
+export const DEFAULT_INJECTOR_ORDER = {
+  workspaceContext: 10,
+  unifiedTurnContext: 20,
+  pkb: 30,
+  nowMd: 40,
+  subagentStatus: 50,
+  slackMessages: 60,
+  threadFocus: 70,
+} as const satisfies Record<string, number>;
+
+/**
+ * `workspace-context` injector — order 10.
+ *
+ * Placeholder for `injectWorkspaceTopLevelContext`. Returns `null` until
+ * later PRs lift workspace state onto {@link TurnContext}.
+ */
+export const workspaceContextInjector: Injector = {
+  name: "workspace-context",
+  order: DEFAULT_INJECTOR_ORDER.workspaceContext,
+  async produce(_ctx: TurnContext): Promise<InjectionBlock | null> {
+    return null;
+  },
+};
+
+/**
+ * `unified-turn-context` injector — order 20.
+ *
+ * Placeholder for `buildUnifiedTurnContextBlock`.
+ */
+export const unifiedTurnContextInjector: Injector = {
+  name: "unified-turn-context",
+  order: DEFAULT_INJECTOR_ORDER.unifiedTurnContext,
+  async produce(_ctx: TurnContext): Promise<InjectionBlock | null> {
+    return null;
+  },
+};
+
+/**
+ * `pkb` injector — order 30.
+ *
+ * Placeholder for the PKB context / system-reminder pair emitted by
+ * `injectPkbContext` and `buildPkbReminder`.
+ */
+export const pkbInjector: Injector = {
+  name: "pkb",
+  order: DEFAULT_INJECTOR_ORDER.pkb,
+  async produce(_ctx: TurnContext): Promise<InjectionBlock | null> {
+    return null;
+  },
+};
+
+/**
+ * `now-md` injector — order 40.
+ *
+ * Placeholder for `injectNowScratchpad`.
+ */
+export const nowMdInjector: Injector = {
+  name: "now-md",
+  order: DEFAULT_INJECTOR_ORDER.nowMd,
+  async produce(_ctx: TurnContext): Promise<InjectionBlock | null> {
+    return null;
+  },
+};
+
+/**
+ * `subagent-status` injector — order 50.
+ *
+ * Placeholder for `injectSubagentStatus` / `buildSubagentStatusBlock`.
+ */
+export const subagentStatusInjector: Injector = {
+  name: "subagent-status",
+  order: DEFAULT_INJECTOR_ORDER.subagentStatus,
+  async produce(_ctx: TurnContext): Promise<InjectionBlock | null> {
+    return null;
+  },
+};
+
+/**
+ * `slack-messages` injector — order 60.
+ *
+ * Placeholder for the Slack chronological-transcript override assembled by
+ * `assembleSlackChronologicalMessages`.
+ */
+export const slackMessagesInjector: Injector = {
+  name: "slack-messages",
+  order: DEFAULT_INJECTOR_ORDER.slackMessages,
+  async produce(_ctx: TurnContext): Promise<InjectionBlock | null> {
+    return null;
+  },
+};
+
+/**
+ * `thread-focus` injector — order 70.
+ *
+ * Placeholder for the Slack `<active_thread>` tail block assembled by
+ * `assembleSlackActiveThreadFocusBlock`.
+ */
+export const threadFocusInjector: Injector = {
+  name: "thread-focus",
+  order: DEFAULT_INJECTOR_ORDER.threadFocus,
+  async produce(_ctx: TurnContext): Promise<InjectionBlock | null> {
+    return null;
+  },
+};
+
+/**
+ * Bundle every default injector into a single first-party plugin. Registered
+ * at daemon startup via `external-plugins-bootstrap.ts`.
+ *
+ * Using one plugin per injector would inflate the registry and create
+ * spurious registration-order dependencies; a single plugin keeps the
+ * ordering contract entirely in the `order` field.
+ */
+export const defaultInjectorsPlugin: Plugin = {
+  manifest: {
+    name: "default-injectors",
+    version: "1.0.0",
+    requires: {
+      pluginRuntime: "v1",
+    },
+  },
+  injectors: [
+    workspaceContextInjector,
+    unifiedTurnContextInjector,
+    pkbInjector,
+    nowMdInjector,
+    subagentStatusInjector,
+    slackMessagesInjector,
+    threadFocusInjector,
+  ],
+};


### PR DESCRIPTION
## Summary
- Extract workspace/turn/PKB/NOW/subagent/slack/thread-focus into Injectors with fixed order values
- Bundle into defaultInjectorsPlugin
- Replace hardcoded injection sequence with getInjectors() iteration

Part of plan: agent-plugin-system.md (PR 21 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
