### PR TITLE
feat(assistant): wrap LLM call as plugin pipeline

### DIFF
--- a/assistant/src/__tests__/llm-call-pipeline.test.ts
+++ b/assistant/src/__tests__/llm-call-pipeline.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Unit tests for the `llmCall` pipeline wrapping (PR 15).
+ *
+ * Exercises the three behaviors the plan calls out:
+ *
+ * 1. The default `llmCall` pipeline delegates to `provider.sendMessage(...)`
+ *    and returns its response unchanged.
+ * 2. A spy middleware registered for `llmCall` observes the full argument
+ *    payload before the provider is called.
+ * 3. A short-circuit middleware synthesizes a `ProviderResponse` and prevents
+ *    the real `provider.sendMessage` from running.
+ */
+
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+
+import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import { defaultLlmCallPlugin } from "../plugins/defaults/llm-call.js";
+import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
+import {
+  getMiddlewaresFor,
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import type {
+  LLMCallArgs,
+  LLMCallResult,
+  Middleware,
+  Plugin,
+  TurnContext,
+} from "../plugins/types.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  ToolDefinition,
+} from "../providers/types.js";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const trust: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+function makeCtx(overrides: Partial<TurnContext> = {}): TurnContext {
+  return {
+    requestId: "req-test",
+    conversationId: "conv-test",
+    turnIndex: 0,
+    trust,
+    ...overrides,
+  };
+}
+
+function makeResponse(
+  overrides: Partial<ProviderResponse> = {},
+): ProviderResponse {
+  return {
+    content: [{ type: "text", text: "hello from provider" }],
+    model: "fake-model",
+    usage: {
+      inputTokens: 10,
+      outputTokens: 5,
+    },
+    stopReason: "end_turn",
+    ...overrides,
+  };
+}
+
+type FakeProviderCall = {
+  messages: Message[];
+  tools?: ToolDefinition[];
+  systemPrompt?: string;
+};
+
+function makeFakeProvider(
+  response: ProviderResponse = makeResponse(),
+): Provider & { calls: FakeProviderCall[] } {
+  const calls: FakeProviderCall[] = [];
+  return {
+    name: "fake-provider",
+    calls,
+    async sendMessage(messages, tools, systemPrompt, _options) {
+      calls.push({ messages, tools, systemPrompt });
+      return response;
+    },
+  };
+}
+
+function makeArgs(
+  provider: Provider,
+  overrides: Partial<LLMCallArgs> = {},
+): LLMCallArgs {
+  return {
+    provider,
+    messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+    tools: undefined,
+    systemPrompt: "you are a helpful assistant",
+    options: { config: {} },
+    ...overrides,
+  };
+}
+
+// The terminal passed into `runPipeline` matches the one in `agent/loop.ts`:
+// it delegates straight to `args.provider.sendMessage(...)` with no
+// transformation. Keeping it identical here means the test exercises the
+// exact call shape the real loop uses.
+const terminal = (args: LLMCallArgs): Promise<LLMCallResult> =>
+  args.provider.sendMessage(
+    args.messages,
+    args.tools,
+    args.systemPrompt,
+    args.options,
+  );
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("llmCall pipeline", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+  });
+
+  // Clear the registry on the way out too so later test files in the same
+  // `bun test` run don't inherit `llmCall` middleware from our final test.
+  // Bun runs files sequentially within a process; `beforeEach` only clears
+  // at the start of each case, leaving whatever the final test registered
+  // in place for the next file.
+  afterAll(() => {
+    resetPluginRegistryForTests();
+  });
+
+  test("default pipeline invokes provider.sendMessage and returns its response", async () => {
+    registerPlugin(defaultLlmCallPlugin);
+
+    const expected = makeResponse({ model: "expected-model" });
+    const provider = makeFakeProvider(expected);
+    const args = makeArgs(provider);
+
+    const result = await runPipeline<LLMCallArgs, LLMCallResult>(
+      "llmCall",
+      getMiddlewaresFor("llmCall"),
+      terminal,
+      args,
+      makeCtx(),
+      DEFAULT_TIMEOUTS.llmCall,
+    );
+
+    expect(result).toBe(expected);
+    expect(provider.calls).toHaveLength(1);
+    expect(provider.calls[0]!.messages).toBe(args.messages);
+    expect(provider.calls[0]!.systemPrompt).toBe("you are a helpful assistant");
+  });
+
+  test("spy middleware records the full invocation arguments", async () => {
+    const observed: LLMCallArgs[] = [];
+    const spyPlugin: Plugin = {
+      manifest: {
+        name: "spy-llm",
+        version: "0.0.1",
+        requires: { pluginRuntime: "v1" },
+      },
+      middleware: {
+        llmCall: async (args, next, _ctx) => {
+          observed.push(args);
+          return next(args);
+        },
+      },
+    };
+
+    registerPlugin(spyPlugin);
+    registerPlugin(defaultLlmCallPlugin);
+
+    const provider = makeFakeProvider();
+    const tools: ToolDefinition[] = [
+      {
+        name: "echo",
+        description: "echoes its input",
+        input_schema: { type: "object" },
+      },
+    ];
+    const args = makeArgs(provider, { tools });
+
+    await runPipeline<LLMCallArgs, LLMCallResult>(
+      "llmCall",
+      getMiddlewaresFor("llmCall"),
+      terminal,
+      args,
+      makeCtx(),
+      DEFAULT_TIMEOUTS.llmCall,
+    );
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0]!.provider).toBe(provider);
+    expect(observed[0]!.messages).toBe(args.messages);
+    expect(observed[0]!.tools).toBe(tools);
+    expect(observed[0]!.systemPrompt).toBe("you are a helpful assistant");
+    expect(provider.calls).toHaveLength(1);
+  });
+
+  test("short-circuit middleware prevents the real provider call", async () => {
+    const synthetic = makeResponse({
+      model: "synthetic-model",
+      content: [{ type: "text", text: "synthesized" }],
+    });
+
+    const shortCircuit: Middleware<LLMCallArgs, LLMCallResult> = async (
+      _args,
+      _next,
+      _ctx,
+    ) => synthetic;
+
+    const shortCircuitPlugin: Plugin = {
+      manifest: {
+        name: "short-circuit-llm",
+        version: "0.0.1",
+        requires: { pluginRuntime: "v1" },
+      },
+      middleware: { llmCall: shortCircuit },
+    };
+
+    registerPlugin(shortCircuitPlugin);
+    registerPlugin(defaultLlmCallPlugin);
+
+    const provider = makeFakeProvider();
+    const args = makeArgs(provider);
+
+    const result = await runPipeline<LLMCallArgs, LLMCallResult>(
+      "llmCall",
+      getMiddlewaresFor("llmCall"),
+      terminal,
+      args,
+      makeCtx(),
+      DEFAULT_TIMEOUTS.llmCall,
+    );
+
+    expect(result).toBe(synthetic);
+    // The short-circuit middleware never calls `next`, so the terminal and
+    // every downstream middleware (including the default) are skipped and
+    // the provider is never contacted.
+    expect(provider.calls).toHaveLength(0);
+  });
+});

--- a/assistant/src/__tests__/plugin-types.test.ts
+++ b/assistant/src/__tests__/plugin-types.test.ts
@@ -13,6 +13,8 @@ import { describe, expect, test } from "bun:test";
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
 import {
   type Injector,
+  type LLMCallArgs,
+  type LLMCallResult,
   type Middleware,
   type Plugin,
   PluginExecutionError,
@@ -52,6 +54,15 @@ describe("plugin core types", () => {
       { output: unknown }
     > = async (args, next, _ctx) => next(args);
 
+    // `llmCall` has concrete arg/result types (upgraded from the initial
+    // `{ input }/{ output }` placeholder in PR 15) so it gets its own
+    // passthrough rather than sharing the generic one above.
+    const llmCallPassthrough: Middleware<LLMCallArgs, LLMCallResult> = async (
+      args,
+      next,
+      _ctx,
+    ) => next(args);
+
     const injector: Injector = {
       name: "sample-injector",
       order: 10,
@@ -80,7 +91,7 @@ describe("plugin core types", () => {
       injectors: [injector],
       middleware: {
         turn: passthrough,
-        llmCall: passthrough,
+        llmCall: llmCallPassthrough,
         toolExecute: passthrough,
         memoryRetrieval: passthrough,
         historyRepair: passthrough,

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -7,6 +7,13 @@ import {
   getCalibrationProviderKey,
 } from "../context/token-estimator.js";
 import { truncateOversizedToolResults } from "../context/tool-result-truncation.js";
+import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
+import { getMiddlewaresFor } from "../plugins/registry.js";
+import type {
+  LLMCallArgs,
+  LLMCallResult,
+  TurnContext,
+} from "../plugins/types.js";
 import type {
   ContentBlock,
   Message,
@@ -394,11 +401,22 @@ export class AgentLoop {
           stripOldImageBlocks(history),
         );
 
-        const response = await this.provider.sendMessage(
-          providerHistory,
-          currentTools.length > 0 ? currentTools : undefined,
-          turnSystemPrompt,
-          {
+        // Wrap the provider call in the `llmCall` pipeline so middleware
+        // contributed by plugins may observe, rewrite, short-circuit, or
+        // post-process every LLM request. The default plugin registered at
+        // bootstrap (`defaultLlmCallPlugin`) acts as the passthrough terminal
+        // and simply delegates back to `provider.sendMessage(...)`. Timeout
+        // is `null` (`DEFAULT_TIMEOUTS.llmCall`) — the provider layer already
+        // enforces its own HTTP-level budgets.
+        //
+        // The `onEvent` wrapping is kept inside `args.options` so substitution
+        // and streaming behavior exactly match the pre-pipeline call site.
+        const llmCallArgs: LLMCallArgs = {
+          provider: this.provider,
+          messages: providerHistory,
+          tools: currentTools.length > 0 ? currentTools : undefined,
+          systemPrompt: turnSystemPrompt,
+          options: {
             config: providerConfig,
             onEvent: (event) => {
               if (event.type === "text_delta") {
@@ -449,6 +467,34 @@ export class AgentLoop {
             },
             signal,
           },
+        };
+
+        // Minimal per-turn context for pipeline logging and plugin
+        // attribution. The agent loop itself does not carry a conversationId
+        // or trust context — those live upstream — so we fill safe defaults.
+        const turnCtx: TurnContext = {
+          requestId: requestId ?? "agent-loop",
+          conversationId: "agent-loop",
+          turnIndex: toolUseTurns,
+          trust: { sourceChannel: "vellum", trustClass: "unknown" },
+        };
+
+        const response: LLMCallResult = await runPipeline<
+          LLMCallArgs,
+          LLMCallResult
+        >(
+          "llmCall",
+          getMiddlewaresFor("llmCall"),
+          (args) =>
+            args.provider.sendMessage(
+              args.messages,
+              args.tools,
+              args.systemPrompt,
+              args.options,
+            ),
+          llmCallArgs,
+          turnCtx,
+          DEFAULT_TIMEOUTS.llmCall,
         );
 
         const providerDurationMs = Date.now() - providerStart;

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -35,9 +35,11 @@ import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import type { AssistantConfig } from "../config/schema.js";
+import { defaultLlmCallPlugin } from "../plugins/defaults/llm-call.js";
 import {
   ASSISTANT_API_VERSIONS,
   getRegisteredPlugins,
+  registerPlugin,
 } from "../plugins/registry.js";
 import {
   type Plugin,
@@ -48,6 +50,18 @@ import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { vellumRoot } from "../util/platform.js";
 import { registerShutdownHook } from "./shutdown-registry.js";
+
+// ─── First-party default plugins ─────────────────────────────────────────────
+//
+// Register default plugins at module load so the registry is populated before
+// `bootstrapPlugins()` runs. Each wrapped pipeline has a corresponding default
+// plugin whose middleware is the passthrough terminal — the plugin system
+// always needs a terminal to fall through to when no other plugin intercepts.
+//
+// Idempotency: this module is imported once via ES module semantics, so the
+// registry never sees duplicate registration. Test environments call
+// `resetPluginRegistryForTests()` and re-register explicitly.
+registerPlugin(defaultLlmCallPlugin);
 
 const log = getLogger("plugins-bootstrap");
 

--- a/assistant/src/plugins/defaults/llm-call.ts
+++ b/assistant/src/plugins/defaults/llm-call.ts
@@ -1,0 +1,50 @@
+/**
+ * Default `llmCall` plugin — the passthrough terminal that delegates to
+ * {@link Provider.sendMessage}.
+ *
+ * The plugin system wraps every LLM request in the `llmCall` pipeline. This
+ * default ensures the pipeline always has a terminal to fall through to when
+ * no other plugin short-circuits or overrides it: it reconstitutes the
+ * provider call from {@link LLMCallArgs} and returns the raw
+ * {@link ProviderResponse} unchanged.
+ *
+ * Registered from `daemon/external-plugins-bootstrap.ts` via a side-effect
+ * import so the plugin is present in the registry before
+ * {@link bootstrapPlugins} walks it.
+ *
+ * Design doc: `.private/plans/agent-plugin-system.md` (PR 15).
+ */
+
+import type { LLMCallArgs, LLMCallResult, Plugin } from "../types.js";
+
+/**
+ * The default LLM-call plugin. Its sole contribution is the `llmCall`
+ * middleware, which calls `args.provider.sendMessage(...)` with the exact
+ * fields `args` carries and returns the provider response as-is.
+ *
+ * Manifest declares `provides.llmCall: "v1"` so other plugins can negotiate
+ * against the pipeline surface and `requires.pluginRuntime: "v1"` to satisfy
+ * the registry's mandatory capability check.
+ */
+export const defaultLlmCallPlugin: Plugin = {
+  manifest: {
+    name: "default-llm-call",
+    version: "1.0.0",
+    provides: { llmCall: "v1" },
+    requires: { pluginRuntime: "v1" },
+  },
+  middleware: {
+    llmCall: async function defaultLlmCall(
+      args: LLMCallArgs,
+      _next,
+      _ctx,
+    ): Promise<LLMCallResult> {
+      return args.provider.sendMessage(
+        args.messages,
+        args.tools,
+        args.systemPrompt,
+        args.options,
+      );
+    },
+  },
+};

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -17,6 +17,13 @@
  */
 
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+} from "../providers/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 
 // ─── Manifest ────────────────────────────────────────────────────────────────
@@ -121,8 +128,28 @@ export type PipelineName =
 export type TurnArgs = { readonly input: unknown };
 export type TurnResult = { readonly output: unknown };
 
-export type LLMCallArgs = { readonly input: unknown };
-export type LLMCallResult = { readonly output: unknown };
+/**
+ * Pipeline arguments for `llmCall` — mirrors the inputs to
+ * {@link Provider.sendMessage}. The terminal handler (the default plugin)
+ * delegates straight to `args.provider.sendMessage(args.messages, args.tools,
+ * args.systemPrompt, args.options)`; middleware may observe or rewrite any
+ * field before that call, short-circuit with a synthetic {@link LLMCallResult},
+ * or post-process the response on the way out.
+ *
+ * `provider` is passed in `args` (rather than resolved from the runtime) so
+ * middleware can swap it deterministically per-call. `options` carries the
+ * full `SendMessageOptions` bag — `config`, `onEvent`, and `signal` — so
+ * middleware can substitute streaming handlers or cancellation signals
+ * without reconstructing them.
+ */
+export type LLMCallArgs = {
+  readonly provider: Provider;
+  readonly messages: Message[];
+  readonly tools?: ToolDefinition[];
+  readonly systemPrompt?: string;
+  readonly options?: SendMessageOptions;
+};
+export type LLMCallResult = ProviderResponse;
 
 export type ToolExecuteArgs = { readonly input: unknown };
 export type ToolExecuteResult = { readonly output: unknown };


### PR DESCRIPTION
## Summary
- Refine LLMCallArgs/Result in plugins/types.ts
- Add defaultLlmCallPlugin delegating to provider.sendMessage
- Swap agent/loop.ts call site to runPipeline("llmCall", ...)
- Register default in external-plugins-bootstrap.ts

Part of plan: agent-plugin-system.md (PR 15 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
