### PR TITLE
feat(assistant): wrap tool-result truncation as plugin pipeline

### DIFF
--- a/assistant/src/__tests__/plugin-bootstrap.test.ts
+++ b/assistant/src/__tests__/plugin-bootstrap.test.ts
@@ -244,9 +244,11 @@ describe("plugin bootstrap", () => {
     expect(callOrder).toEqual(["second-registered", "first-registered"]);
   });
 
-  test("empty registry: bootstrap is a no-op", async () => {
-    // Nothing registered. Bootstrap must not throw, and there is no shutdown
-    // hook registered (so downstream shutdown runs are unaffected).
+  test("empty registry: bootstrap registers first-party defaults only", async () => {
+    // No external plugins registered. Bootstrap must still register the
+    // first-party default plugins (e.g. `default-tool-result-truncate`) so
+    // every wrapped pipeline has a terminal-like middleware — and it must
+    // not throw in the process.
     await bootstrapPlugins(fakeCtx);
   });
 });

--- a/assistant/src/__tests__/plugin-types.test.ts
+++ b/assistant/src/__tests__/plugin-types.test.ts
@@ -19,6 +19,8 @@ import {
   type PluginInitContext,
   type PluginManifest,
   PluginTimeoutError,
+  type ToolResultTruncateArgs,
+  type ToolResultTruncateResult,
   type TurnContext,
 } from "../plugins/types.js";
 
@@ -51,6 +53,16 @@ describe("plugin core types", () => {
       { input: unknown },
       { output: unknown }
     > = async (args, next, _ctx) => next(args);
+
+    // `toolResultTruncate` has a concrete args/result shape (PR 17) so we
+    // need a dedicated passthrough for that slot.
+    const truncatePassthrough: Middleware<
+      ToolResultTruncateArgs,
+      ToolResultTruncateResult
+    > = async (args, _next, _ctx) => ({
+      content: args.content,
+      truncated: false,
+    });
 
     const injector: Injector = {
       name: "sample-injector",
@@ -89,7 +101,7 @@ describe("plugin core types", () => {
         overflowReduce: passthrough,
         persistence: passthrough,
         titleGenerate: passthrough,
-        toolResultTruncate: passthrough,
+        toolResultTruncate: truncatePassthrough,
         emptyResponse: passthrough,
         toolError: passthrough,
         circuitBreaker: passthrough,

--- a/assistant/src/__tests__/tool-result-truncate-pipeline.test.ts
+++ b/assistant/src/__tests__/tool-result-truncate-pipeline.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Tests for the `toolResultTruncate` plugin pipeline (PR 17).
+ *
+ * Covers:
+ * - The default middleware delegates to `truncateToolResultText`, producing
+ *   byte-for-byte identical output to calling the helper directly across
+ *   short, long, and newline-bounded inputs (property-style).
+ * - The pipeline routes through `runPipeline` with the
+ *   `DEFAULT_TIMEOUTS.toolResultTruncate` budget (1s) and returns a
+ *   `{ content, truncated }` pair whose `truncated` flag matches whether
+ *   the content actually changed.
+ * - Plugins registered ahead of the default can short-circuit with their
+ *   own truncation strategy.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  MIN_KEEP_CHARS,
+  truncateToolResultText,
+  TRUNCATION_SUFFIX,
+} from "../context/tool-result-truncation.js";
+import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import { defaultToolResultTruncateMiddleware } from "../plugins/defaults/tool-result-truncate.js";
+import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
+import {
+  getMiddlewaresFor,
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import {
+  type Middleware,
+  type Plugin,
+  type ToolResultTruncateArgs,
+  type ToolResultTruncateResult,
+  type TurnContext,
+} from "../plugins/types.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const trust: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+function makeCtx(overrides: Partial<TurnContext> = {}): TurnContext {
+  return {
+    requestId: "req-test",
+    conversationId: "conv-test",
+    turnIndex: 0,
+    trust,
+    ...overrides,
+  };
+}
+
+/** The default plugin descriptor, inlined so the tests can register it. */
+const defaultPlugin: Plugin = {
+  manifest: {
+    name: "default-tool-result-truncate",
+    version: "1.0.0",
+    requires: {
+      pluginRuntime: "v1",
+      toolResultTruncateApi: "v1",
+    },
+  },
+  middleware: { toolResultTruncate: defaultToolResultTruncateMiddleware },
+};
+
+/**
+ * Terminal fallback used by `runPipeline` when the outermost middleware
+ * calls `next()` past every registered middleware. Mirrors the inline
+ * terminal in `agent/loop.ts` so the unit test faithfully exercises the
+ * production code path.
+ */
+const terminalFallback = async (
+  args: ToolResultTruncateArgs,
+): Promise<ToolResultTruncateResult> => {
+  const truncated = truncateToolResultText(args.content, args.maxChars);
+  return {
+    content: truncated,
+    truncated: truncated !== args.content,
+  };
+};
+
+describe("toolResultTruncate pipeline", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+  });
+
+  // -------------------------------------------------------------------------
+  // Default middleware — isolated (no pipeline runner)
+  // -------------------------------------------------------------------------
+
+  describe("default middleware", () => {
+    test("passes short content through unchanged with truncated=false", async () => {
+      const content = "hello world";
+      const result = await defaultToolResultTruncateMiddleware(
+        { content, maxChars: 100 },
+        async () => {
+          throw new Error("next should not be called by the default terminal");
+        },
+        makeCtx(),
+      );
+      expect(result.content).toBe(content);
+      expect(result.truncated).toBe(false);
+    });
+
+    test("truncates oversize content and reports truncated=true", async () => {
+      const content = "a".repeat(10_000);
+      const maxChars = 5_000;
+      const expected = truncateToolResultText(content, maxChars);
+      const result = await defaultToolResultTruncateMiddleware(
+        { content, maxChars },
+        async () => {
+          throw new Error("next should not be called by the default terminal");
+        },
+        makeCtx(),
+      );
+      expect(result.content).toBe(expected);
+      expect(result.truncated).toBe(true);
+      expect(result.content).toContain(TRUNCATION_SUFFIX);
+    });
+
+    test("snaps to newline boundary identically to truncateToolResultText", async () => {
+      const lines = Array.from(
+        { length: 1_000 },
+        (_, i) => `line ${i}: ${"x".repeat(20)}`,
+      ).join("\n");
+      const maxChars = 5_000;
+      const expected = truncateToolResultText(lines, maxChars);
+      const result = await defaultToolResultTruncateMiddleware(
+        { content: lines, maxChars },
+        async () => {
+          throw new Error("next should not be called by the default terminal");
+        },
+        makeCtx(),
+      );
+      expect(result.content).toBe(expected);
+      expect(result.truncated).toBe(true);
+    });
+
+    test("returns truncated=false when effectiveMax keeps the full text (maxChars < MIN_KEEP_CHARS case)", async () => {
+      const textLength = MIN_KEEP_CHARS - TRUNCATION_SUFFIX.length - 10;
+      const content = "a".repeat(textLength);
+      const maxChars = 100;
+      const expected = truncateToolResultText(content, maxChars);
+      const result = await defaultToolResultTruncateMiddleware(
+        { content, maxChars },
+        async () => {
+          throw new Error("next should not be called by the default terminal");
+        },
+        makeCtx(),
+      );
+      // Helper returns the original text unchanged in this case.
+      expect(expected).toBe(content);
+      expect(result.content).toBe(content);
+      expect(result.truncated).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // End-to-end: default plugin routed through runPipeline
+  // -------------------------------------------------------------------------
+
+  describe("runPipeline with the default plugin registered", () => {
+    async function runDefault(
+      content: string,
+      maxChars: number,
+    ): Promise<ToolResultTruncateResult> {
+      registerPlugin(defaultPlugin);
+      const middlewares = getMiddlewaresFor("toolResultTruncate");
+      return runPipeline<ToolResultTruncateArgs, ToolResultTruncateResult>(
+        "toolResultTruncate",
+        middlewares,
+        terminalFallback,
+        { content, maxChars },
+        makeCtx(),
+        DEFAULT_TIMEOUTS.toolResultTruncate,
+      );
+    }
+
+    test("short content round-trip matches truncateToolResultText", async () => {
+      const content = "quick brown fox";
+      const maxChars = 200;
+      const expected = truncateToolResultText(content, maxChars);
+      const result = await runDefault(content, maxChars);
+      expect(result.content).toBe(expected);
+      expect(result.truncated).toBe(false);
+    });
+
+    test("long content round-trip matches truncateToolResultText", async () => {
+      const content = "z".repeat(50_000);
+      const maxChars = 10_000;
+      const expected = truncateToolResultText(content, maxChars);
+      const result = await runDefault(content, maxChars);
+      expect(result.content).toBe(expected);
+      expect(result.truncated).toBe(true);
+      expect(result.content).toContain(TRUNCATION_SUFFIX);
+    });
+
+    test("newline-bounded content round-trip matches truncateToolResultText", async () => {
+      const lines = Array.from(
+        { length: 500 },
+        (_, i) => `line ${i}: ${"y".repeat(40)}`,
+      ).join("\n");
+      const maxChars = 4_000;
+      const expected = truncateToolResultText(lines, maxChars);
+      const result = await runDefault(lines, maxChars);
+      expect(result.content).toBe(expected);
+      expect(result.truncated).toBe(true);
+    });
+
+    test("property test: default pipeline output equals direct truncateToolResultText across varied inputs", async () => {
+      // Deterministic pseudo-random over a fixed seed — bun's test runner
+      // doesn't ship a property-test library, so we hand-roll a tiny LCG
+      // that produces enough spread for a meaningful regression signal
+      // without introducing a dependency.
+      let seed = 0xc0ffee;
+      const rand = () => {
+        seed = (seed * 1664525 + 1013904223) & 0xffffffff;
+        return (seed >>> 0) / 0x100000000;
+      };
+      const alphabet = "abcdefghijklmnopqrstuvwxyz \n";
+
+      const cases: Array<{ content: string; maxChars: number }> = [];
+      for (let i = 0; i < 40; i++) {
+        // Lengths span short, boundary, and long relative to the maxChars
+        // budget so the property covers pass-through, newline-snap, and
+        // pure tail-drop paths.
+        const length = Math.floor(rand() * 20_000);
+        let content = "";
+        for (let j = 0; j < length; j++) {
+          content += alphabet[Math.floor(rand() * alphabet.length)];
+        }
+        const maxChars = 1_000 + Math.floor(rand() * 9_000);
+        cases.push({ content, maxChars });
+      }
+
+      // Register once outside the loop — registry is reset in `beforeEach`,
+      // so the per-case reset lives in the loop instead.
+      for (const { content, maxChars } of cases) {
+        resetPluginRegistryForTests();
+        registerPlugin(defaultPlugin);
+        const middlewares = getMiddlewaresFor("toolResultTruncate");
+        const result = await runPipeline<
+          ToolResultTruncateArgs,
+          ToolResultTruncateResult
+        >(
+          "toolResultTruncate",
+          middlewares,
+          async () => {
+            throw new Error("terminal should not be reached");
+          },
+          { content, maxChars },
+          makeCtx(),
+          DEFAULT_TIMEOUTS.toolResultTruncate,
+        );
+        const expected = truncateToolResultText(content, maxChars);
+        expect(result.content).toBe(expected);
+        expect(result.truncated).toBe(expected !== content);
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Middleware composition — an outer plugin can intercept / transform
+  // -------------------------------------------------------------------------
+
+  describe("middleware composition", () => {
+    test("an outer plugin can short-circuit the default with its own content", async () => {
+      const shortCircuit: Middleware<
+        ToolResultTruncateArgs,
+        ToolResultTruncateResult
+      > = async (_args, _next, _ctx) => {
+        return { content: "SUMMARY", truncated: true };
+      };
+      registerPlugin({
+        manifest: {
+          name: "short-circuit",
+          version: "1.0.0",
+          requires: {
+            pluginRuntime: "v1",
+            toolResultTruncateApi: "v1",
+          },
+        },
+        middleware: { toolResultTruncate: shortCircuit },
+      });
+      registerPlugin(defaultPlugin);
+
+      const middlewares = getMiddlewaresFor("toolResultTruncate");
+      const result = await runPipeline<
+        ToolResultTruncateArgs,
+        ToolResultTruncateResult
+      >(
+        "toolResultTruncate",
+        middlewares,
+        async () => {
+          throw new Error("terminal should not be reached");
+        },
+        { content: "a".repeat(10_000), maxChars: 5_000 },
+        makeCtx(),
+        DEFAULT_TIMEOUTS.toolResultTruncate,
+      );
+
+      expect(result.content).toBe("SUMMARY");
+      expect(result.truncated).toBe(true);
+    });
+
+    test("an outer plugin can observe and mutate the default's output", async () => {
+      const prefixer: Middleware<
+        ToolResultTruncateArgs,
+        ToolResultTruncateResult
+      > = async (args, next, _ctx) => {
+        const inner = await next(args);
+        return { ...inner, content: `[wrapped] ${inner.content}` };
+      };
+      registerPlugin({
+        manifest: {
+          name: "prefixer",
+          version: "1.0.0",
+          requires: {
+            pluginRuntime: "v1",
+            toolResultTruncateApi: "v1",
+          },
+        },
+        middleware: { toolResultTruncate: prefixer },
+      });
+      registerPlugin(defaultPlugin);
+
+      const middlewares = getMiddlewaresFor("toolResultTruncate");
+      const content = "hello";
+      const result = await runPipeline<
+        ToolResultTruncateArgs,
+        ToolResultTruncateResult
+      >(
+        "toolResultTruncate",
+        middlewares,
+        async () => {
+          throw new Error("terminal should not be reached");
+        },
+        { content, maxChars: 100 },
+        makeCtx(),
+        DEFAULT_TIMEOUTS.toolResultTruncate,
+      );
+
+      expect(result.content).toBe(`[wrapped] ${content}`);
+      expect(result.truncated).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Timeout budget is wired to DEFAULT_TIMEOUTS.toolResultTruncate
+  // -------------------------------------------------------------------------
+
+  test("DEFAULT_TIMEOUTS.toolResultTruncate is the 1s budget promised by the plan", () => {
+    expect(DEFAULT_TIMEOUTS.toolResultTruncate).toBe(1000);
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -6,7 +6,18 @@ import {
   estimateToolsTokens,
   getCalibrationProviderKey,
 } from "../context/token-estimator.js";
-import { truncateOversizedToolResults } from "../context/tool-result-truncation.js";
+import {
+  calculateMaxToolResultChars,
+  truncateToolResultText,
+} from "../context/tool-result-truncation.js";
+import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
+import { getMiddlewaresFor } from "../plugins/registry.js";
+import type {
+  ToolResultTruncateArgs,
+  ToolResultTruncateResult,
+  TurnContext,
+} from "../plugins/types.js";
 import type {
   ContentBlock,
   Message,
@@ -123,6 +134,21 @@ const DEFAULT_CONFIG: AgentLoopConfig = {
 
 const MAX_CONSECUTIVE_ERROR_NUDGES = 3;
 const MAX_EMPTY_RESPONSE_RETRIES = 1;
+
+/**
+ * Fallback trust context used when the agent loop constructs a {@link
+ * TurnContext} for the plugin pipeline. The agent loop itself is invoked
+ * from trust-aware entry points (conversation orchestrator, agent-wake)
+ * that already performed authorization before reaching the loop, so the
+ * loop's own pipeline invocations do not need a live channel identity —
+ * they only need a well-formed `TurnContext` for telemetry and error
+ * attribution. Later PRs in the plugin-system plan plumb the real trust
+ * context through `run()` and replace this constant with a parameter.
+ */
+const AGENT_LOOP_FALLBACK_TRUST: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
 
 /**
  * User-config HTTP status codes that should never page the on-call: billing
@@ -702,12 +728,73 @@ export class AgentLoop {
           }),
         );
 
-        // Pre-emptively truncate oversized tool results to prevent context overflow
-        const { blocks: resultBlocks, truncatedCount } =
-          truncateOversizedToolResults(
-            rawResultBlocks,
-            this.config.maxInputTokens ?? 180_000,
+        // Pre-emptively truncate oversized tool results to prevent context
+        // overflow. The work is delegated to the `toolResultTruncate`
+        // plugin pipeline so downstream plugins can swap in a smarter
+        // truncation strategy (e.g. a summariser) while the default
+        // middleware preserves the historical tail-drop behaviour.
+        const contextWindowTokens = this.config.maxInputTokens ?? 180_000;
+        const maxChars = calculateMaxToolResultChars(contextWindowTokens);
+        const truncateMiddlewares = getMiddlewaresFor("toolResultTruncate");
+        const turnCtx: TurnContext = {
+          requestId: requestId ?? "unknown",
+          conversationId: requestId ?? "unknown",
+          turnIndex: toolUseTurns,
+          trust: AGENT_LOOP_FALLBACK_TRUST,
+        };
+
+        let truncatedCount = 0;
+        const truncatedBlocks: ContentBlock[] = [];
+        for (const block of rawResultBlocks) {
+          if (block.type !== "tool_result") {
+            truncatedBlocks.push(block);
+            continue;
+          }
+          const toolBlock = block as ToolResultContent;
+          if (
+            typeof toolBlock.content !== "string" ||
+            toolBlock.content.length <= maxChars
+          ) {
+            truncatedBlocks.push(block);
+            continue;
+          }
+          const pipelineResult = await runPipeline<
+            ToolResultTruncateArgs,
+            ToolResultTruncateResult
+          >(
+            "toolResultTruncate",
+            truncateMiddlewares,
+            async (args) => {
+              // Terminal fallback — applies the same tail-drop truncation
+              // the loop used before plugins existed. We run it here
+              // (instead of relying purely on the default plugin) so code
+              // paths that exercise `AgentLoop.run` without first calling
+              // `bootstrapPlugins` — e.g. unit tests that construct a
+              // loop directly — retain the pre-plugin behaviour.
+              const truncated = truncateToolResultText(
+                args.content,
+                args.maxChars,
+              );
+              return {
+                content: truncated,
+                truncated: truncated !== args.content,
+              };
+            },
+            { content: toolBlock.content, maxChars },
+            turnCtx,
+            DEFAULT_TIMEOUTS.toolResultTruncate,
           );
+          if (pipelineResult.truncated) {
+            truncatedCount++;
+            truncatedBlocks.push({
+              ...toolBlock,
+              content: pipelineResult.content,
+            });
+          } else {
+            truncatedBlocks.push(block);
+          }
+        }
+        const resultBlocks = truncatedBlocks;
         if (truncatedCount > 0) {
           log.warn(
             `Truncated ${truncatedCount} oversized tool result(s) to prevent context overflow`,

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -35,9 +35,11 @@ import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import type { AssistantConfig } from "../config/schema.js";
+import { defaultToolResultTruncatePlugin } from "../plugins/defaults/tool-result-truncate.js";
 import {
   ASSISTANT_API_VERSIONS,
   getRegisteredPlugins,
+  registerPlugin,
 } from "../plugins/registry.js";
 import {
   type Plugin,
@@ -135,6 +137,26 @@ function ensurePluginStorageDir(pluginName: string): string {
 }
 
 /**
+ * Register the first-party default plugins that ship with the assistant.
+ *
+ * These provide terminal-like implementations of each wrapped pipeline so
+ * the behaviour when no external plugins are installed is identical to the
+ * pre-plugin-era code path. We skip already-registered names so repeated
+ * bootstrap calls (e.g. in tests or hot-reload) do not throw on duplicate
+ * registration.
+ */
+function registerDefaultPlugins(): void {
+  const alreadyRegistered = new Set(
+    getRegisteredPlugins().map((p) => p.manifest.name),
+  );
+  const defaults: Plugin[] = [defaultToolResultTruncatePlugin];
+  for (const plugin of defaults) {
+    if (alreadyRegistered.has(plugin.manifest.name)) continue;
+    registerPlugin(plugin);
+  }
+}
+
+/**
  * Run every registered plugin's `init()` hook sequentially and install a
  * reverse-order shutdown hook. See the module docstring for full semantics.
  *
@@ -147,6 +169,15 @@ function ensurePluginStorageDir(pluginName: string): string {
  * run) and before the first conversation is served.
  */
 export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
+  // First-party default plugins. These must be registered before any
+  // externally-registered plugin so that middleware-composition order has
+  // the default (terminal-like) implementation at the innermost layer.
+  //
+  // Registration is idempotent across repeated bootstraps (e.g. hot-reload)
+  // by skipping already-registered names — `registerPlugin` throws on
+  // duplicates, which we'd otherwise hit on the second call.
+  registerDefaultPlugins();
+
   const plugins = getRegisteredPlugins();
   if (plugins.length === 0) {
     // No-op fast path — the registry is empty (no first-party plugins have

--- a/assistant/src/plugins/defaults/tool-result-truncate.ts
+++ b/assistant/src/plugins/defaults/tool-result-truncate.ts
@@ -1,0 +1,59 @@
+/**
+ * Default `toolResultTruncate` plugin.
+ *
+ * Wraps the pre-existing `truncateToolResultText` helper from
+ * `context/tool-result-truncation.ts` in a plugin middleware so every
+ * tool-result truncation goes through the shared pipeline runner. The
+ * default behavior is byte-for-byte identical to calling
+ * `truncateToolResultText` directly; plugins registered ahead of this one
+ * can short-circuit with their own truncation strategy (e.g. a summariser
+ * that preserves semantics better than a tail-drop).
+ *
+ * Design doc: `.private/plans/agent-plugin-system.md` (PR 17).
+ */
+
+import { truncateToolResultText } from "../../context/tool-result-truncation.js";
+import type {
+  Middleware,
+  Plugin,
+  ToolResultTruncateArgs,
+  ToolResultTruncateResult,
+} from "../types.js";
+
+/**
+ * Default terminal middleware — delegates to `truncateToolResultText` and
+ * reports whether the call actually shortened the input. The `truncated`
+ * flag lets callers warn/telemeter without re-measuring the output.
+ *
+ * Exported so tests can assert identity / default behavior without standing
+ * up the full plugin registry.
+ */
+export const defaultToolResultTruncateMiddleware: Middleware<
+  ToolResultTruncateArgs,
+  ToolResultTruncateResult
+> = async (args, _next, _ctx) => {
+  const truncated = truncateToolResultText(args.content, args.maxChars);
+  return {
+    content: truncated,
+    truncated: truncated !== args.content,
+  };
+};
+
+/**
+ * Plugin descriptor for the default tool-result truncation middleware.
+ * Registered by `daemon/external-plugins-bootstrap.ts` so the registry
+ * always has at least one middleware for the `toolResultTruncate` pipeline.
+ */
+export const defaultToolResultTruncatePlugin: Plugin = {
+  manifest: {
+    name: "default-tool-result-truncate",
+    version: "1.0.0",
+    requires: {
+      pluginRuntime: "v1",
+      toolResultTruncateApi: "v1",
+    },
+  },
+  middleware: {
+    toolResultTruncate: defaultToolResultTruncateMiddleware,
+  },
+};

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -148,8 +148,25 @@ export type PersistenceResult = { readonly output: unknown };
 export type TitleGenerateArgs = { readonly input: unknown };
 export type TitleGenerateResult = { readonly output: unknown };
 
-export type ToolResultTruncateArgs = { readonly input: unknown };
-export type ToolResultTruncateResult = { readonly output: unknown };
+/**
+ * Input to the `toolResultTruncate` pipeline: the raw tool-result text and
+ * the character budget the caller computed from the context-window share
+ * (see `calculateMaxToolResultChars` in `context/tool-result-truncation.ts`).
+ */
+export type ToolResultTruncateArgs = {
+  readonly content: string;
+  readonly maxChars: number;
+};
+
+/**
+ * Output of the `toolResultTruncate` pipeline: the (possibly truncated)
+ * content and a boolean flag indicating whether the pipeline actually
+ * shortened the input. Callers use `truncated` for telemetry / warnings.
+ */
+export type ToolResultTruncateResult = {
+  readonly content: string;
+  readonly truncated: boolean;
+};
 
 export type EmptyResponseArgs = { readonly input: unknown };
 export type EmptyResponseResult = { readonly output: unknown };


### PR DESCRIPTION
## Summary
- Refine TruncateArgs/Result types
- Default plugin delegates to truncateToolResultText
- Swap agent/loop.ts truncation site to runPipeline

Part of plan: agent-plugin-system.md (PR 17 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
