### PR TITLE
feat(assistant): wrap empty-response handling as plugin pipeline

### DIFF
--- a/assistant/src/__tests__/empty-response-pipeline.test.ts
+++ b/assistant/src/__tests__/empty-response-pipeline.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for the `emptyResponse` plugin pipeline (PR 18).
+ *
+ * Covers:
+ * - Default plugin decision matches the original inline loop logic for the
+ *   canonical cases (empty-after-tools → nudge, visible-text → accept,
+ *   tool-use-blocks-present → accept, retries-exhausted → accept,
+ *   prior-visible-text-in-run → accept).
+ * - Swapping in a custom middleware that returns `action: "accept"` prevents
+ *   the nudge and lets the loop fall through to history append.
+ * - Swapping in a custom middleware that returns `action: "error"` is
+ *   propagated by the pipeline so the loop can surface a clear error.
+ *
+ * The loop's actual side-effects (history append, retry counter bump, log
+ * emission) live in `agent/loop.ts` and are covered by integration tests in
+ * `conversation-agent-loop.test.ts`. This file isolates the pipeline.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import { defaultEmptyResponsePlugin } from "../plugins/defaults/empty-response.js";
+import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
+import {
+  getMiddlewaresFor,
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import type {
+  EmptyResponseArgs,
+  EmptyResponseDecision,
+  Plugin,
+  TurnContext,
+} from "../plugins/types.js";
+import type { ContentBlock } from "../providers/types.js";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const trust: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+function makeCtx(): TurnContext {
+  return {
+    requestId: "req-empty-response",
+    conversationId: "conv-empty-response",
+    turnIndex: 2,
+    trust,
+  };
+}
+
+/**
+ * The nudge text has to match the loop's original inline string verbatim —
+ * clients (and the model) may match on this exact text.
+ */
+const CANONICAL_NUDGE_TEXT =
+  "<system_notice>Your previous response was empty. You must respond to the user with a summary of what you found or did. Do not use any tools — just respond with text.</system_notice>";
+
+const emptyTextBlock: ContentBlock = { type: "text", text: "   " };
+
+function makeArgs(
+  overrides: Partial<EmptyResponseArgs> = {},
+): EmptyResponseArgs {
+  return {
+    responseContent: [],
+    toolUseBlocksLength: 0,
+    toolUseTurns: 1,
+    emptyResponseRetries: 0,
+    maxEmptyResponseRetries: 1,
+    priorAssistantHadVisibleText: false,
+    ...overrides,
+  };
+}
+
+async function runEmpty(
+  args: EmptyResponseArgs,
+): Promise<EmptyResponseDecision> {
+  return runPipeline(
+    "emptyResponse",
+    getMiddlewaresFor("emptyResponse"),
+    async () => ({ action: "accept" }),
+    args,
+    makeCtx(),
+    DEFAULT_TIMEOUTS.emptyResponse,
+  );
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("emptyResponse pipeline — default decisions", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+    registerPlugin(defaultEmptyResponsePlugin);
+  });
+
+  test("empty turn after tool results → nudge with canonical text", async () => {
+    // Whitespace-only text counts as empty (matches inline `trim().length > 0`).
+    const decision = await runEmpty(
+      makeArgs({
+        responseContent: [emptyTextBlock],
+        toolUseBlocksLength: 0,
+        toolUseTurns: 2,
+        emptyResponseRetries: 0,
+        priorAssistantHadVisibleText: false,
+      }),
+    );
+    expect(decision.action).toBe("nudge");
+    expect(decision.nudgeText).toBe(CANONICAL_NUDGE_TEXT);
+  });
+
+  test("turn contains visible text → accept", async () => {
+    const decision = await runEmpty(
+      makeArgs({
+        responseContent: [{ type: "text", text: "here is a summary" }],
+      }),
+    );
+    expect(decision.action).toBe("accept");
+  });
+
+  test("turn contains tool_use blocks → accept (not empty)", async () => {
+    const decision = await runEmpty(
+      makeArgs({
+        responseContent: [
+          {
+            type: "tool_use",
+            id: "tu-1",
+            name: "read",
+            input: { path: "/tmp/x" },
+          } as ContentBlock,
+        ],
+        toolUseBlocksLength: 1,
+      }),
+    );
+    expect(decision.action).toBe("accept");
+  });
+
+  test("retries already exhausted → accept", async () => {
+    const decision = await runEmpty(
+      makeArgs({
+        responseContent: [],
+        toolUseTurns: 3,
+        emptyResponseRetries: 1,
+        maxEmptyResponseRetries: 1,
+      }),
+    );
+    expect(decision.action).toBe("accept");
+  });
+
+  test("prior assistant turn already delivered visible text → accept", async () => {
+    // Model said its piece earlier, ended with a side-effect tool, returned
+    // empty. Nudging would force a verbatim re-send of text the user already
+    // saw. Default must accept.
+    const decision = await runEmpty(
+      makeArgs({
+        responseContent: [],
+        toolUseTurns: 2,
+        priorAssistantHadVisibleText: true,
+      }),
+    );
+    expect(decision.action).toBe("accept");
+  });
+
+  test("no prior tool-use turn (toolUseTurns === 0) → accept", async () => {
+    // Empty first assistant response with no tools is not the pattern the
+    // nudge guards against. Default accepts.
+    const decision = await runEmpty(
+      makeArgs({
+        responseContent: [],
+        toolUseTurns: 0,
+      }),
+    );
+    expect(decision.action).toBe("accept");
+  });
+});
+
+describe("emptyResponse pipeline — custom middleware overrides", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+  });
+
+  test("plugin returning action:accept suppresses the nudge", async () => {
+    // Build a plugin whose middleware short-circuits with accept. Register it
+    // as the ONLY plugin so its decision is authoritative. The loop-side
+    // effect (no nudge appended) is covered by integration tests; here we
+    // assert the pipeline returns what the plugin returned.
+    const acceptPlugin: Plugin = {
+      manifest: {
+        name: "force-accept",
+        version: "1.0.0",
+        requires: { pluginRuntime: "v1" },
+      },
+      middleware: {
+        emptyResponse: async () => ({ action: "accept" }),
+      },
+    };
+    registerPlugin(acceptPlugin);
+
+    const decision = await runEmpty(
+      makeArgs({
+        // Conditions the default would nudge on — but the custom plugin wins.
+        responseContent: [],
+        toolUseTurns: 2,
+        emptyResponseRetries: 0,
+        priorAssistantHadVisibleText: false,
+      }),
+    );
+    expect(decision.action).toBe("accept");
+    // `nudgeText` must not leak from the acceptance branch.
+    expect(decision.nudgeText).toBeUndefined();
+  });
+
+  test("plugin returning action:error is propagated to the caller", async () => {
+    const errorPlugin: Plugin = {
+      manifest: {
+        name: "force-error",
+        version: "1.0.0",
+        requires: { pluginRuntime: "v1" },
+      },
+      middleware: {
+        emptyResponse: async () => ({ action: "error" }),
+      },
+    };
+    registerPlugin(errorPlugin);
+
+    const decision = await runEmpty(makeArgs());
+    expect(decision.action).toBe("error");
+  });
+
+  test("plugin overriding default nudge text changes the returned text", async () => {
+    // Exercises the wrapping semantics: the custom plugin observes the
+    // default's decision via `next(args)` and rewrites only the text. This
+    // is the canonical "plugin wraps default" pattern.
+    const rewriterPlugin: Plugin = {
+      manifest: {
+        name: "rewrite-nudge",
+        version: "1.0.0",
+        requires: { pluginRuntime: "v1" },
+      },
+      middleware: {
+        emptyResponse: async (args, next, ctx) => {
+          const downstream = await next(args);
+          if (downstream.action !== "nudge") return downstream;
+          void ctx; // silence lint
+          return { action: "nudge", nudgeText: "ALTERED_NUDGE" };
+        },
+      },
+    };
+    // Register the custom plugin FIRST so it is the outermost middleware; the
+    // default registers second and acts as the inner decision maker.
+    registerPlugin(rewriterPlugin);
+    registerPlugin(defaultEmptyResponsePlugin);
+
+    const decision = await runEmpty(
+      makeArgs({
+        responseContent: [],
+        toolUseTurns: 2,
+        priorAssistantHadVisibleText: false,
+      }),
+    );
+    expect(decision.action).toBe("nudge");
+    expect(decision.nudgeText).toBe("ALTERED_NUDGE");
+  });
+});

--- a/assistant/src/__tests__/plugin-types.test.ts
+++ b/assistant/src/__tests__/plugin-types.test.ts
@@ -12,6 +12,8 @@ import { describe, expect, test } from "bun:test";
 
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
 import {
+  type EmptyResponseArgs,
+  type EmptyResponseResult,
   type Injector,
   type Middleware,
   type Plugin,
@@ -52,6 +54,13 @@ describe("plugin core types", () => {
       { output: unknown }
     > = async (args, next, _ctx) => next(args);
 
+    // The `emptyResponse` slot has concrete args/result types; use a
+    // dedicated passthrough so the `satisfies Plugin` check stays honest.
+    const emptyResponsePassthrough: Middleware<
+      EmptyResponseArgs,
+      EmptyResponseResult
+    > = async (args, next, _ctx) => next(args);
+
     const injector: Injector = {
       name: "sample-injector",
       order: 10,
@@ -90,7 +99,7 @@ describe("plugin core types", () => {
         persistence: passthrough,
         titleGenerate: passthrough,
         toolResultTruncate: passthrough,
-        emptyResponse: passthrough,
+        emptyResponse: emptyResponsePassthrough,
         toolError: passthrough,
         circuitBreaker: passthrough,
       },

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -7,6 +7,13 @@ import {
   getCalibrationProviderKey,
 } from "../context/token-estimator.js";
 import { truncateOversizedToolResults } from "../context/tool-result-truncation.js";
+import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
+import { getMiddlewaresFor } from "../plugins/registry.js";
+import type {
+  EmptyResponseArgs,
+  EmptyResponseDecision,
+  TurnContext,
+} from "../plugins/types.js";
 import type {
   ContentBlock,
   Message,
@@ -19,7 +26,7 @@ import {
   applyStreamingSubstitution,
   applySubstitutions,
 } from "../tools/sensitive-output-placeholders.js";
-import { ProviderError } from "../util/errors.js";
+import { AssistantError, ErrorCode, ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { isRetryableNetworkError } from "../util/retry.js";
 
@@ -123,6 +130,35 @@ const DEFAULT_CONFIG: AgentLoopConfig = {
 
 const MAX_CONSECUTIVE_ERROR_NUDGES = 3;
 const MAX_EMPTY_RESPONSE_RETRIES = 1;
+
+/**
+ * Build a minimal {@link TurnContext} for pipeline invocations inside the
+ * agent loop. The loop does not currently own conversation-scoped trust or
+ * identity — those live on the orchestrator — so we stamp in placeholders
+ * for the few required fields. Later PRs thread full trust context through
+ * `AgentLoop.run()` and replace this helper with the real context.
+ *
+ * The returned context is still useful for pipeline logging: `requestId`
+ * surfaces in every structured record, and `turnIndex` reflects the
+ * current tool-use iteration.
+ */
+function buildLoopTurnContext(
+  requestId: string | undefined,
+  turnIndex: number,
+): TurnContext {
+  return {
+    requestId: requestId ?? "agent-loop",
+    // Loop-scoped pipelines do not currently carry a conversation ID; the
+    // outer orchestrator owns that dimension. Use a fixed sentinel so log
+    // consumers can filter loop-origin records out of conversation queries.
+    conversationId: "agent-loop",
+    turnIndex,
+    trust: {
+      sourceChannel: "vellum",
+      trustClass: "unknown",
+    },
+  };
+}
 
 /**
  * User-config HTTP status codes that should never page the on-call: billing
@@ -529,6 +565,12 @@ export class AgentLoop {
         // invocations passed in via `messages`) must NOT suppress the
         // nudge — those turns completed long ago and have no bearing on
         // whether the current tool-use chain has delivered text yet.
+        //
+        // The actual decision (nudge vs. accept vs. error) is delegated to
+        // the `emptyResponse` plugin pipeline. The pipeline returns a
+        // decision; the loop carries out the side-effect (pushing the nudge
+        // or surfacing the error). See `plugins/defaults/empty-response.ts`
+        // for the default decision logic.
         const hasVisibleText = response.content.some(
           (block) => block.type === "text" && block.text.trim().length > 0,
         );
@@ -546,13 +588,33 @@ export class AgentLoop {
           }
           return false;
         })();
-        if (
-          !hasVisibleText &&
-          toolUseBlocks.length === 0 &&
-          toolUseTurns > 0 &&
-          !priorAssistantHadVisibleText &&
-          emptyResponseRetries < MAX_EMPTY_RESPONSE_RETRIES
-        ) {
+
+        const emptyResponseArgs: EmptyResponseArgs = {
+          responseContent: response.content,
+          toolUseBlocksLength: toolUseBlocks.length,
+          toolUseTurns,
+          emptyResponseRetries,
+          maxEmptyResponseRetries: MAX_EMPTY_RESPONSE_RETRIES,
+          priorAssistantHadVisibleText,
+        };
+        const emptyResponseCtx = buildLoopTurnContext(requestId, toolUseTurns);
+        const emptyResponseDecision: EmptyResponseDecision = await runPipeline(
+          "emptyResponse",
+          getMiddlewaresFor("emptyResponse"),
+          async () => ({ action: "accept" }),
+          emptyResponseArgs,
+          emptyResponseCtx,
+          DEFAULT_TIMEOUTS.emptyResponse,
+        );
+
+        if (emptyResponseDecision.action === "nudge") {
+          // Fall back to the canonical nudge text if the plugin returned
+          // `action: "nudge"` but forgot `nudgeText`. Keeps a misbehaving
+          // plugin from silently breaking the loop invariant that the
+          // model sees a coherent prompt.
+          const nudgeText =
+            emptyResponseDecision.nudgeText ??
+            "<system_notice>Your previous response was empty. You must respond to the user with a summary of what you found or did. Do not use any tools — just respond with text.</system_notice>";
           emptyResponseRetries++;
           rlog.warn(
             { turn: toolUseTurns, retry: emptyResponseRetries },
@@ -560,16 +622,25 @@ export class AgentLoop {
           );
           history.push({
             role: "user",
-            content: [
-              {
-                type: "text",
-                text: "<system_notice>Your previous response was empty. You must respond to the user with a summary of what you found or did. Do not use any tools — just respond with text.</system_notice>",
-              },
-            ],
+            content: [{ type: "text", text: nudgeText }],
           });
           continue;
         }
 
+        if (emptyResponseDecision.action === "error") {
+          rlog.error(
+            { turn: toolUseTurns, retries: emptyResponseRetries },
+            "emptyResponse pipeline requested error surface",
+          );
+          throw new AssistantError(
+            "Model returned empty response after tool results",
+            ErrorCode.INTERNAL_ERROR,
+          );
+        }
+
+        // action === "accept" — fall through. Preserve the historic log for
+        // the specific "empty turn after tool results, retries exhausted"
+        // case so ops dashboards that grep on this line keep working.
         if (
           !hasVisibleText &&
           toolUseBlocks.length === 0 &&

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -35,9 +35,11 @@ import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import type { AssistantConfig } from "../config/schema.js";
+import { defaultEmptyResponsePlugin } from "../plugins/defaults/empty-response.js";
 import {
   ASSISTANT_API_VERSIONS,
   getRegisteredPlugins,
+  registerPlugin,
 } from "../plugins/registry.js";
 import {
   type Plugin,
@@ -50,6 +52,16 @@ import { vellumRoot } from "../util/platform.js";
 import { registerShutdownHook } from "./shutdown-registry.js";
 
 const log = getLogger("plugins-bootstrap");
+
+// ─── Default plugin registration ─────────────────────────────────────────────
+//
+// First-party defaults register once at module load. Production daemon startup
+// imports this bootstrap module exactly once, so the registration happens
+// before any code path that reads the registry. Test suites that reset the
+// registry between cases (`resetPluginRegistryForTests`) see an empty registry
+// post-reset — tests that need a default plugin should re-register it
+// explicitly (import from `plugins/defaults/*` and call `registerPlugin`).
+registerPlugin(defaultEmptyResponsePlugin);
 
 /**
  * Minimal context required to bootstrap the plugin layer. Kept intentionally

--- a/assistant/src/plugins/defaults/empty-response.ts
+++ b/assistant/src/plugins/defaults/empty-response.ts
@@ -1,0 +1,80 @@
+/**
+ * Default plugin for the `emptyResponse` pipeline.
+ *
+ * Wraps the historic inline empty-response handling from
+ * `agent/loop.ts` (see the comment block around `MAX_EMPTY_RESPONSE_RETRIES`).
+ *
+ * The pipeline is invoked once per assistant turn after an LLM response
+ * lands. The default middleware inspects the turn snapshot and decides:
+ *
+ * 1. `"nudge"`  — the turn produced no visible text, no tool calls, follows
+ *                 at least one prior tool-use turn, no earlier turn in this
+ *                 run() has already delivered visible text, AND the retry
+ *                 counter is below `maxEmptyResponseRetries`. The loop
+ *                 appends `nudgeText` (the historic `<system_notice>…`
+ *                 message) as a `user` turn and re-queries the model.
+ * 2. `"accept"` — every other case. The turn either legitimately ended
+ *                 (model said its piece earlier), is still in progress
+ *                 (tool calls pending), or exhausted its retry budget. The
+ *                 loop pushes the assistant message and continues normally.
+ *
+ * The default never returns `"error"` — that action is an escape hatch for
+ * downstream plugins (e.g. a circuit breaker) that want to surface an
+ * explicit error instead of silently absorbing an empty turn.
+ *
+ * `MAX_EMPTY_RESPONSE_RETRIES` lives in `agent/loop.ts` and is threaded into
+ * the pipeline via `EmptyResponseArgs.maxEmptyResponseRetries` so the cap is
+ * declared in one place only.
+ */
+
+import type { Plugin } from "../types.js";
+
+/**
+ * Historic nudge text. Must stay verbatim so an existing plugin that wraps
+ * the default cannot accidentally see a different string.
+ *
+ * Wire-compat note: this is shown to the LLM, not the user. Edits here
+ * affect model behavior but not end-user UX directly.
+ */
+const NUDGE_TEXT =
+  "<system_notice>Your previous response was empty. You must respond to the user with a summary of what you found or did. Do not use any tools — just respond with text.</system_notice>";
+
+/** Singleton plugin — the registry rejects duplicate registrations by name. */
+export const defaultEmptyResponsePlugin: Plugin = {
+  manifest: {
+    name: "default-empty-response",
+    version: "1.0.0",
+    provides: { emptyResponseApi: "v1" },
+    requires: { pluginRuntime: "v1", emptyResponseApi: "v1" },
+  },
+  middleware: {
+    /**
+     * Terminal decision maker. Middleware wrapping this one may observe the
+     * decision via `next(args)` and override it — e.g. a plugin could force
+     * `"accept"` under a feature-flag, or turn an exhausted-retries case
+     * into `"error"` for louder telemetry.
+     */
+    emptyResponse: async (args, _next, _ctx) => {
+      const hasVisibleText = args.responseContent.some(
+        (block) =>
+          block.type === "text" &&
+          typeof (block as { text?: unknown }).text === "string" &&
+          (block as { text: string }).text.trim().length > 0,
+      );
+
+      const isEmptyTurn =
+        !hasVisibleText &&
+        args.toolUseBlocksLength === 0 &&
+        args.toolUseTurns > 0 &&
+        !args.priorAssistantHadVisibleText;
+
+      if (
+        isEmptyTurn &&
+        args.emptyResponseRetries < args.maxEmptyResponseRetries
+      ) {
+        return { action: "nudge", nudgeText: NUDGE_TEXT };
+      }
+      return { action: "accept" };
+    },
+  },
+};

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -17,6 +17,7 @@
  */
 
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import type { ContentBlock } from "../providers/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 
 // ─── Manifest ────────────────────────────────────────────────────────────────
@@ -151,8 +152,61 @@ export type TitleGenerateResult = { readonly output: unknown };
 export type ToolResultTruncateArgs = { readonly input: unknown };
 export type ToolResultTruncateResult = { readonly output: unknown };
 
-export type EmptyResponseArgs = { readonly input: unknown };
-export type EmptyResponseResult = { readonly output: unknown };
+/**
+ * Snapshot of the just-completed assistant turn plus retry/context counters
+ * the `emptyResponse` pipeline needs to decide whether to nudge, accept, or
+ * surface an error.
+ *
+ * `emptyResponseRetries` is the *current* retry counter — the pipeline may
+ * compare it to `maxEmptyResponseRetries` to implement a retry cap. The loop
+ * increments the counter only after a `"nudge"` decision; the pipeline is
+ * stateless across turns.
+ *
+ * `priorAssistantHadVisibleText` signals that an earlier turn in the current
+ * `run()` invocation already delivered user-visible text. When true, an
+ * empty follow-up is the model correctly ending its turn and nudging would
+ * mislead it into resending text the user already saw.
+ */
+export interface EmptyResponseArgs {
+  /** Content blocks produced by the assistant on this turn. */
+  readonly responseContent: ReadonlyArray<ContentBlock>;
+  /**
+   * Number of `tool_use` blocks in `responseContent`. Mirrors the loop's own
+   * count so middleware doesn't have to recompute it. When > 0 the turn is
+   * not empty — the model issued tool calls.
+   */
+  readonly toolUseBlocksLength: number;
+  /** 0-based index of the tool-use turn being evaluated. */
+  readonly toolUseTurns: number;
+  /** How many empty-response nudges the loop has already issued this run. */
+  readonly emptyResponseRetries: number;
+  /** Upper bound for `emptyResponseRetries`. The default is 1. */
+  readonly maxEmptyResponseRetries: number;
+  /**
+   * Whether ANY prior assistant turn in the current `run()` call carried
+   * visible text. See `agent/loop.ts` for why the whole-run scan matters.
+   */
+  readonly priorAssistantHadVisibleText: boolean;
+}
+
+/**
+ * Decision produced by the `emptyResponse` pipeline.
+ *
+ * - `"nudge"`  — loop appends `nudgeText` as a `user` message and retries.
+ *                `nudgeText` MUST be present; it is what the model will see.
+ * - `"accept"` — loop treats the turn as complete (pushes the assistant
+ *                message to history and exits the tool-use chain normally).
+ * - `"error"`  — loop surfaces a clear error. Reserved for middleware that
+ *                wants to escalate an empty response rather than absorb it.
+ */
+export interface EmptyResponseDecision {
+  readonly action: "nudge" | "accept" | "error";
+  /** Nudge text the loop will push to history. Required when `action === "nudge"`. */
+  readonly nudgeText?: string;
+}
+
+/** Alias so the {@link PipelineMiddlewareMap} entry names its own result shape. */
+export type EmptyResponseResult = EmptyResponseDecision;
 
 export type ToolErrorArgs = { readonly input: unknown };
 export type ToolErrorResult = { readonly output: unknown };


### PR DESCRIPTION
## Summary
- Add EmptyResponseArgs/Decision types
- Default plugin replicates existing nudge logic with MAX_EMPTY_RESPONSE_RETRIES cap
- Swap agent/loop.ts inline nudge block to runPipeline
- Inline push-to-history stays in loop; pipeline only decides nudge/accept/error

Part of plan: agent-plugin-system.md (PR 18 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
