### PR TITLE
feat(assistant): wrap tool execution as plugin pipeline

### DIFF
--- a/assistant/src/__tests__/plugin-types.test.ts
+++ b/assistant/src/__tests__/plugin-types.test.ts
@@ -19,6 +19,8 @@ import {
   type PluginInitContext,
   type PluginManifest,
   PluginTimeoutError,
+  type ToolExecuteArgs,
+  type ToolExecuteResult,
   type TurnContext,
 } from "../plugins/types.js";
 
@@ -52,6 +54,14 @@ describe("plugin core types", () => {
       { output: unknown }
     > = async (args, next, _ctx) => next(args);
 
+    // `toolExecute` has concrete arg/result types (refined in PR 16) that
+    // diverge from the generic `{ input }/{ output }` placeholder — provide
+    // a dedicated passthrough so the `satisfies` check is accurate.
+    const toolExecutePassthrough: Middleware<
+      ToolExecuteArgs,
+      ToolExecuteResult
+    > = async (args, next, _ctx) => next(args);
+
     const injector: Injector = {
       name: "sample-injector",
       order: 10,
@@ -81,7 +91,7 @@ describe("plugin core types", () => {
       middleware: {
         turn: passthrough,
         llmCall: passthrough,
-        toolExecute: passthrough,
+        toolExecute: toolExecutePassthrough,
         memoryRetrieval: passthrough,
         historyRepair: passthrough,
         tokenEstimate: passthrough,

--- a/assistant/src/__tests__/tool-execute-pipeline.test.ts
+++ b/assistant/src/__tests__/tool-execute-pipeline.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Pipeline wrapper tests for `ToolExecutor.execute` (PR 16).
+ *
+ * Covers:
+ * - The public `execute` method routes through `runPipeline("toolExecute",
+ *   ...)` so `getMiddlewaresFor("toolExecute")` middleware participates.
+ * - The default `toolExecute` plugin (passthrough) preserves the original
+ *   execution path — result and side effects match the unwrapped executor.
+ * - A spy middleware observes the full tool invocation (name, input, ctx).
+ * - A short-circuit middleware intercepts the call and supplies a custom
+ *   result without hitting the real tool.
+ *
+ * These tests reuse the same module mocks as `tool-executor.test.ts` so the
+ * permission check, risk classifier, and tool registry are stubbed; the
+ * focus here is the pipeline wrapper, not the internal execution body.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ToolExecutionResult } from "../tools/types.js";
+
+// ── Config mock ───────────────────────────────────────────────────────
+const mockConfig = {
+  provider: "anthropic",
+  model: "test",
+  maxTokens: 4096,
+  dataDir: "/tmp",
+  timeouts: {
+    shellDefaultTimeoutSec: 120,
+    shellMaxTimeoutSec: 600,
+    permissionTimeoutSec: 300,
+    toolExecutionTimeoutSec: 120,
+  },
+  sandbox: {
+    enabled: false,
+    backend: "native" as const,
+    docker: {
+      image: "vellum-sandbox:latest",
+      cpus: 1,
+      memoryMb: 512,
+      pidsLimit: 256,
+      network: "none" as const,
+    },
+  },
+  rateLimit: { maxRequestsPerMinute: 0 },
+  secretDetection: {
+    enabled: false,
+    action: "warn" as const,
+    entropyThreshold: 4.0,
+  },
+  permissions: {
+    mode: "workspace" as const,
+  },
+};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+// ── Logger mock ──────────────────────────────────────────────────────
+// Bun's `mock.module` persists across test files until explicitly
+// restored, so this mock can leak into `plugin-bootstrap.test.ts`. That
+// file inspects `ctx.logger` (populated via `log.child({ plugin })`), so
+// we return a Proxy whose `.child(...)` yields another Proxy with the
+// same shape — the bootstrap test's `expect(ctx.logger).toBeDefined()`
+// then passes regardless of test-file ordering.
+function makeFakeLoggerProxy(): object {
+  return new Proxy({} as Record<string, unknown>, {
+    get: (_target, prop) => {
+      if (prop === "child") return () => makeFakeLoggerProxy();
+      return () => {};
+    },
+  });
+}
+mock.module("../util/logger.js", () => ({
+  getLogger: (_name?: string) => makeFakeLoggerProxy(),
+  truncateForLog: (value: string) => value,
+}));
+
+// ── Permission checker — always allow so execution reaches the tool ──
+mock.module("../permissions/checker.js", () => ({
+  classifyRisk: async () => ({ level: "low" }),
+  check: async () => ({ decision: "allow", reason: "allowed" }),
+  generateAllowlistOptions: () => [
+    { label: "exact", description: "exact", pattern: "exact" },
+  ],
+  generateScopeOptions: () => [{ label: "/tmp", scope: "/tmp" }],
+}));
+
+// ── Tool usage store stub ────────────────────────────────────────────
+mock.module("../memory/tool-usage-store.js", () => ({
+  recordToolInvocation: () => {},
+  getRecentInvocations: () => [],
+  rotateToolInvocations: () => 0,
+}));
+
+// ── Tool registry: return a stub tool whose execute records the call ─
+let lastToolCall: { name: string; input: Record<string, unknown> } | undefined;
+let fakeToolResult: ToolExecutionResult = {
+  content: "real tool output",
+  isError: false,
+};
+
+mock.module("../tools/registry.js", () => ({
+  getTool: (name: string) => {
+    if (name === "unknown_tool") return undefined;
+    return {
+      name,
+      description: "test tool",
+      category: "test",
+      defaultRiskLevel: "low",
+      getDefinition: () => ({}),
+      execute: async (input: Record<string, unknown>) => {
+        lastToolCall = { name, input };
+        return fakeToolResult;
+      },
+    };
+  },
+  getAllTools: () => [],
+}));
+
+mock.module("../tools/shared/filesystem/path-policy.js", () => ({
+  sandboxPolicy: () => ({ ok: false }),
+  hostPolicy: () => ({ ok: false }),
+}));
+
+mock.module("../tools/terminal/sandbox.js", () => ({
+  wrapCommand: () => ({ command: "", sandboxed: false }),
+}));
+
+// ── Redaction + token manager so the executor's imports resolve ──────
+mock.module("../security/redaction.js", () => ({
+  redactSensitiveFields: (input: Record<string, unknown>) => input,
+}));
+
+mock.module("../security/token-manager.js", () => ({
+  TokenExpiredError: class TokenExpiredError extends Error {},
+}));
+
+// ── Imports — after mock.module so the executor under test picks them up ──
+import { PermissionPrompter } from "../permissions/prompter.js";
+import { defaultToolExecutePlugin } from "../plugins/defaults/tool-execute.js";
+import {
+  getMiddlewaresFor,
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import type {
+  Middleware,
+  Plugin,
+  ToolExecuteArgs,
+  ToolExecuteResult,
+} from "../plugins/types.js";
+import { ToolExecutor } from "../tools/executor.js";
+import type { ToolContext } from "../tools/types.js";
+
+function makeContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    workingDir: "/tmp/project",
+    conversationId: "conversation-pipeline",
+    trustClass: "guardian",
+    ...overrides,
+  };
+}
+
+function makePrompter(): PermissionPrompter {
+  return {
+    prompt: async () => ({ decision: "allow" as const }),
+    resolveConfirmation: () => {},
+    updateSender: () => {},
+    dispose: () => {},
+  } as unknown as PermissionPrompter;
+}
+
+afterAll(() => {
+  mock.restore();
+});
+
+beforeEach(() => {
+  resetPluginRegistryForTests();
+  lastToolCall = undefined;
+  fakeToolResult = { content: "real tool output", isError: false };
+});
+
+describe("ToolExecutor.execute → toolExecute pipeline", () => {
+  test("default pipeline (no plugins) runs the same execution path", async () => {
+    // With no plugins registered, the pipeline has an empty middleware
+    // array and the terminal (executeInternal) runs directly. The
+    // observable result must match the unwrapped behavior.
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("real tool output");
+    expect(lastToolCall).toEqual({
+      name: "file_read",
+      input: { path: "README.md" },
+    });
+  });
+
+  test("default tool-execute plugin: registering the passthrough preserves behavior", async () => {
+    // The default plugin is a passthrough whose middleware forwards to
+    // `next`. Registering it should not change observable behavior —
+    // the terminal still runs and returns the real tool result.
+    registerPlugin(defaultToolExecutePlugin);
+
+    // Sanity: the registry now reports exactly one middleware for the
+    // `toolExecute` slot, named `defaultToolExecute`.
+    const middlewares = getMiddlewaresFor("toolExecute");
+    expect(middlewares).toHaveLength(1);
+    expect(middlewares[0]?.name).toBe("defaultToolExecute");
+
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("real tool output");
+    expect(lastToolCall).toEqual({
+      name: "file_read",
+      input: { path: "README.md" },
+    });
+  });
+
+  test("spy middleware observes the full tool invocation (name, input, ctx)", async () => {
+    let observedArgs: ToolExecuteArgs | undefined;
+    let observedTurnCtx:
+      | { conversationId: string; requestId: string }
+      | undefined;
+
+    const spyMiddleware: Middleware<ToolExecuteArgs, ToolExecuteResult> =
+      async function spy(args, next, ctx) {
+        observedArgs = args;
+        observedTurnCtx = {
+          conversationId: ctx.conversationId,
+          requestId: ctx.requestId,
+        };
+        return next(args);
+      };
+
+    const spyPlugin: Plugin = {
+      manifest: {
+        name: "spy-tool-execute",
+        version: "0.0.1",
+        requires: { pluginRuntime: "v1" },
+      },
+      middleware: { toolExecute: spyMiddleware },
+    };
+    registerPlugin(spyPlugin);
+
+    const executor = new ToolExecutor(makePrompter());
+    const ctx = makeContext({
+      conversationId: "conv-spy",
+      requestId: "req-spy",
+    });
+    const result = await executor.execute(
+      "bash",
+      { command: "echo hi", timeout_seconds: 10 },
+      ctx,
+    );
+
+    // Spy observed the full args
+    expect(observedArgs).toBeDefined();
+    expect(observedArgs!.name).toBe("bash");
+    expect(observedArgs!.input).toEqual({
+      command: "echo hi",
+      timeout_seconds: 10,
+    });
+    expect(observedArgs!.context).toBe(ctx);
+
+    // Spy observed the synthesized TurnContext carrying conversation +
+    // request IDs from the ToolContext.
+    expect(observedTurnCtx).toEqual({
+      conversationId: "conv-spy",
+      requestId: "req-spy",
+    });
+
+    // Terminal still ran — result reflects the real tool output.
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("real tool output");
+    expect(lastToolCall).toEqual({
+      name: "bash",
+      input: { command: "echo hi", timeout_seconds: 10 },
+    });
+  });
+
+  test("short-circuit middleware intercepts and supplies a custom result", async () => {
+    const syntheticResult: ToolExecuteResult = {
+      content: "synthesized by middleware",
+      isError: false,
+    };
+
+    const shortCircuit: Middleware<ToolExecuteArgs, ToolExecuteResult> =
+      async function shortCircuitMw(_args, _next) {
+        // Intentionally omit `next` — the terminal (real tool execution)
+        // must not run.
+        return syntheticResult;
+      };
+
+    const interceptPlugin: Plugin = {
+      manifest: {
+        name: "short-circuit-tool-execute",
+        version: "0.0.1",
+        requires: { pluginRuntime: "v1" },
+      },
+      middleware: { toolExecute: shortCircuit },
+    };
+    registerPlugin(interceptPlugin);
+
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "file_write",
+      { path: "dangerous.txt", content: "should not run" },
+      makeContext(),
+    );
+
+    expect(result).toEqual(syntheticResult);
+    // The real tool execute must NOT have been called.
+    expect(lastToolCall).toBeUndefined();
+  });
+
+  test("multiple middlewares compose in registration order (outer-first)", async () => {
+    const trace: string[] = [];
+
+    const outer: Middleware<ToolExecuteArgs, ToolExecuteResult> =
+      async function outerMw(args, next) {
+        trace.push("outer:before");
+        const result = await next(args);
+        trace.push("outer:after");
+        return result;
+      };
+    const inner: Middleware<ToolExecuteArgs, ToolExecuteResult> =
+      async function innerMw(args, next) {
+        trace.push("inner:before");
+        const result = await next(args);
+        trace.push("inner:after");
+        return result;
+      };
+
+    registerPlugin({
+      manifest: {
+        name: "outer-tool-execute",
+        version: "0.0.1",
+        requires: { pluginRuntime: "v1" },
+      },
+      middleware: { toolExecute: outer },
+    });
+    registerPlugin({
+      manifest: {
+        name: "inner-tool-execute",
+        version: "0.0.1",
+        requires: { pluginRuntime: "v1" },
+      },
+      middleware: { toolExecute: inner },
+    });
+
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    // Outer middleware wraps inner (registration order = onion order),
+    // so the trace is outer:before → inner:before → terminal →
+    // inner:after → outer:after.
+    expect(trace).toEqual([
+      "outer:before",
+      "inner:before",
+      "inner:after",
+      "outer:after",
+    ]);
+  });
+});

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -7,18 +7,22 @@
  * {@link bootstrapPlugins} runs, the registry has been fully populated for
  * this boot cycle. This function:
  *
- * 1. Walks {@link getRegisteredPlugins} in registration order.
- * 2. For each plugin, resolves its `manifest.requiresCredential` entries via
+ * 1. Registers the canonical first-party default plugins (one per pipeline
+ *    that has been wrapped so far — currently only `toolExecute` via
+ *    {@link defaultToolExecutePlugin}). Registration is idempotent so
+ *    repeat calls (e.g. during integration tests) do not throw.
+ * 2. Walks {@link getRegisteredPlugins} in registration order.
+ * 3. For each plugin, resolves its `manifest.requiresCredential` entries via
  *    the credential store helper ({@link getSecureKeyAsync}). In Docker mode
  *    that helper goes through the CES HTTP API transparently; in local mode
  *    it hits the encrypted file store / CES RPC backend.
- * 3. Validates the config block under `plugins.<name>` against
+ * 4. Validates the config block under `plugins.<name>` against
  *    `manifest.config` if the manifest supplies a parser-like validator
  *    (Zod schemas with `.parse()` are supported; anything else is passed
  *    through untouched).
- * 4. Creates `~/.vellum/plugins-data/<plugin>/` on demand for per-plugin
+ * 5. Creates `~/.vellum/plugins-data/<plugin>/` on demand for per-plugin
  *    writable state and exposes it via {@link PluginInitContext.pluginStorageDir}.
- * 5. Awaits `plugin.init(ctx)` sequentially. One init failure surfaces as a
+ * 6. Awaits `plugin.init(ctx)` sequentially. One init failure surfaces as a
  *    {@link PluginExecutionError} naming the offending plugin and aborts
  *    bootstrap — later plugins' `init()` never runs and the daemon fails
  *    startup cleanly rather than coming up in a half-wired state.
@@ -35,9 +39,11 @@ import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import type { AssistantConfig } from "../config/schema.js";
+import { defaultToolExecutePlugin } from "../plugins/defaults/tool-execute.js";
 import {
   ASSISTANT_API_VERSIONS,
   getRegisteredPlugins,
+  registerPlugin,
 } from "../plugins/registry.js";
 import {
   type Plugin,
@@ -135,6 +141,35 @@ function ensurePluginStorageDir(pluginName: string): string {
 }
 
 /**
+ * Register every first-party default plugin. Called from `bootstrapPlugins`
+ * before enumerating the registry so the defaults are always present when
+ * the daemon serves traffic. Each registration is guarded by a
+ * `registeredPlugins` lookup via try/catch — the registry throws
+ * `PluginExecutionError` on duplicate names, which we treat as "already
+ * registered" so repeated bootstrap calls (notably in integration tests
+ * that reuse a warmed-up registry) do not fail.
+ */
+function registerDefaultPlugins(): void {
+  const defaults = [defaultToolExecutePlugin];
+  for (const plugin of defaults) {
+    try {
+      registerPlugin(plugin);
+    } catch (err) {
+      // Duplicate-name registrations surface as PluginExecutionError with a
+      // specific "already registered" substring. Swallow that one case —
+      // every other error (shape failure, version mismatch) re-throws.
+      if (
+        err instanceof PluginExecutionError &&
+        err.message.includes("already registered")
+      ) {
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/**
  * Run every registered plugin's `init()` hook sequentially and install a
  * reverse-order shutdown hook. See the module docstring for full semantics.
  *
@@ -147,6 +182,14 @@ function ensurePluginStorageDir(pluginName: string): string {
  * run) and before the first conversation is served.
  */
 export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
+  // Register first-party default plugins. Each default wraps one of the
+  // assistant's canonical pipelines (`toolExecute`, `llmCall`, ...) with a
+  // passthrough so the pipeline shape is explicit at boot even when no
+  // third-party plugins are loaded. Registration is idempotent via the
+  // already-registered guard so repeated calls (e.g. during integration
+  // tests) do not throw.
+  registerDefaultPlugins();
+
   const plugins = getRegisteredPlugins();
   if (plugins.length === 0) {
     // No-op fast path — the registry is empty (no first-party plugins have

--- a/assistant/src/plugins/defaults/tool-execute.ts
+++ b/assistant/src/plugins/defaults/tool-execute.ts
@@ -1,0 +1,65 @@
+/**
+ * Default `toolExecute` plugin — a no-argument passthrough that preserves
+ * the behavior `ToolExecutor.execute` had before the pipeline wrapper was
+ * introduced.
+ *
+ * Design
+ * ------
+ * The public {@link ToolExecutor.execute} method invokes
+ * {@link runPipeline} with the terminal bound to an internal
+ * `executeInternal` method (the original execute body, refactored to avoid
+ * recursion). Because the terminal IS the original behavior, the default
+ * plugin's `middleware.toolExecute` is a thin passthrough: it forwards to
+ * `next(args)` and returns the downstream result unchanged.
+ *
+ * This matches the convention set by PR 15 (`default-llm-call.ts`) for
+ * `llmCall` — the default plugin makes the pipeline shape explicit without
+ * introducing any behavior of its own. When no third-party plugins are
+ * registered the chain is `[defaultMiddleware] → terminal`, which composes
+ * identically to `[] → terminal`, so the shell-integration tests (which
+ * never register the default) stay unchanged-green.
+ *
+ * Why a dedicated plugin at all?
+ * ------------------------------
+ * - It signals publicly that `toolExecute` is a supported pipeline slot with
+ *   a concrete contract.
+ * - Registration order determines onion order. If a third-party plugin
+ *   wraps `toolExecute`, the runtime should boot with the default present
+ *   (as the innermost passthrough) so the chain visibly contains a
+ *   canonical terminator regardless of which third parties load.
+ */
+
+import type {
+  Middleware,
+  Plugin,
+  ToolExecuteArgs,
+  ToolExecuteResult,
+} from "../types.js";
+
+/**
+ * Passthrough middleware — forwards the call to `next`. Named so the
+ * pipeline runner's `chain` log entry reads `defaultToolExecute` instead of
+ * `anonymous`.
+ */
+const defaultToolExecute: Middleware<ToolExecuteArgs, ToolExecuteResult> =
+  async function defaultToolExecute(args, next) {
+    return next(args);
+  };
+
+/**
+ * The default `toolExecute` plugin. Exported as a module constant so the
+ * daemon bootstrap can register it via a side-effect import. Tests may
+ * import and register it explicitly via `registerPlugin()` to cover the
+ * on-by-default execution path.
+ */
+export const defaultToolExecutePlugin: Plugin = {
+  manifest: {
+    name: "default-tool-execute",
+    version: "1.0.0",
+    provides: { toolExecuteApi: "v1" },
+    requires: { pluginRuntime: "v1", toolExecuteApi: "v1" },
+  },
+  middleware: {
+    toolExecute: defaultToolExecute,
+  },
+};

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -17,6 +17,7 @@
  */
 
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 
 // ─── Manifest ────────────────────────────────────────────────────────────────
@@ -124,8 +125,24 @@ export type TurnResult = { readonly output: unknown };
 export type LLMCallArgs = { readonly input: unknown };
 export type LLMCallResult = { readonly output: unknown };
 
-export type ToolExecuteArgs = { readonly input: unknown };
-export type ToolExecuteResult = { readonly output: unknown };
+/**
+ * Arguments passed to the `toolExecute` pipeline — mirrors the public
+ * {@link ToolExecutor.execute} signature so middleware can observe (and
+ * mutate) the tool name, input payload, and the full {@link ToolContext}
+ * before the terminal runs the actual execution.
+ */
+export interface ToolExecuteArgs {
+  readonly name: string;
+  readonly input: Record<string, unknown>;
+  readonly context: ToolContext;
+}
+
+/**
+ * Result returned from the `toolExecute` pipeline — identical to
+ * {@link ToolExecutionResult} so short-circuit middleware can supply a
+ * synthetic result without invoking the terminal.
+ */
+export type ToolExecuteResult = ToolExecutionResult;
 
 export type MemoryRetrievalArgs = { readonly input: unknown };
 export type MemoryRetrievalResult = { readonly output: unknown };

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -5,6 +5,13 @@ import { bridgeCesApproval } from "../credential-execution/approval-bridge.js";
 import { isCesShellLockdownEnabled } from "../credential-execution/feature-gates.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { RiskLevel } from "../permissions/types.js";
+import { runPipeline } from "../plugins/pipeline.js";
+import { getMiddlewaresFor } from "../plugins/registry.js";
+import type {
+  ToolExecuteArgs,
+  ToolExecuteResult,
+  TurnContext,
+} from "../plugins/types.js";
 import { isUntrustedTrustClass } from "../runtime/actor-trust-resolver.js";
 import { redactSensitiveFields } from "../security/redaction.js";
 import { TokenExpiredError } from "../security/token-manager.js";
@@ -42,6 +49,47 @@ export class ToolExecutor {
   }
 
   async execute(
+    name: string,
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    // Compute the per-tool timeout budget upfront so the pipeline timeout
+    // matches the existing per-tool timeout. `toolExecute` is intentionally
+    // `null` in `DEFAULT_TIMEOUTS` because `ToolExecutor` already enforces
+    // per-tool timeouts inside `executeWithTimeout`; we pass the same
+    // budget to `runPipeline` so a runaway middleware doesn't silently
+    // exceed the tool's configured limit, without double-enforcing on the
+    // happy path (the pipeline race is a cheap backstop).
+    const perToolTimeoutMs = computePerToolTimeoutMs(name, input);
+
+    // Build a TurnContext for the pipeline runner. The executor is called
+    // outside the provider loop's TurnContext today, so we synthesize one
+    // from the ToolContext — middleware that needs richer turn state will
+    // be wired as later PRs thread a real TurnContext through.
+    const turnCtx: TurnContext = {
+      requestId: context.requestId ?? "",
+      conversationId: context.conversationId,
+      turnIndex: 0,
+      trust: {
+        sourceChannel: "vellum",
+        trustClass: context.trustClass,
+      },
+    };
+
+    const middlewares = getMiddlewaresFor("toolExecute");
+    const pipelineArgs: ToolExecuteArgs = { name, input, context };
+
+    return runPipeline<ToolExecuteArgs, ToolExecuteResult>(
+      "toolExecute",
+      middlewares,
+      (args) => this.executeInternal(args.name, args.input, args.context),
+      pipelineArgs,
+      turnCtx,
+      perToolTimeoutMs,
+    );
+  }
+
+  private async executeInternal(
     name: string,
     input: Record<string, unknown>,
     context: ToolContext,
@@ -137,29 +185,11 @@ export class ToolExecutor {
         }
       }
 
-      // Execute the tool - proxy tools delegate to an external resolver
+      // Execute the tool - proxy tools delegate to an external resolver.
+      // Use the shared per-tool timeout helper so the pipeline runner and
+      // the inner execute-with-timeout wrapper agree on the same budget.
       let execResult: ToolExecutionResult;
-      let toolTimeoutMs: number;
-      if (name === "bash" || name === "host_bash") {
-        // Shell tools manage their own timeouts (SIGKILL on expiry).
-        // Compute the same effective timeout so the executor wrapper
-        // doesn't prematurely kill them with the generic toolExecutionTimeoutSec.
-        const { shellDefaultTimeoutSec, shellMaxTimeoutSec } =
-          getConfig().timeouts;
-        const requestedSec =
-          typeof input.timeout_seconds === "number"
-            ? input.timeout_seconds
-            : shellDefaultTimeoutSec;
-        const shellTimeoutSec = Math.max(
-          1,
-          Math.min(requestedSec, shellMaxTimeoutSec),
-        );
-        // Buffer so the shell's own timeout fires first and handles cleanup
-        toolTimeoutMs = (shellTimeoutSec + 5) * 1000;
-      } else {
-        const rawTimeoutSec = getConfig().timeouts.toolExecutionTimeoutSec;
-        toolTimeoutMs = safeTimeoutMs(rawTimeoutSec);
-      }
+      const toolTimeoutMs = computePerToolTimeoutMs(name, input);
 
       const execContext = context;
 
@@ -423,6 +453,44 @@ export { isSideEffectTool } from "./side-effects.js";
 
 // Re-export PermissionChecker for consumers that need direct access
 export { PermissionChecker } from "./permission-checker.js";
+
+/**
+ * Compute the effective per-tool execution timeout in milliseconds.
+ *
+ * Shell tools (`bash`, `host_bash`) manage their own timeouts with SIGKILL
+ * on expiry. We add a 5s buffer so the shell's own deadline fires first and
+ * handles cleanup before the executor wrapper trips. Non-shell tools use
+ * the generic `toolExecutionTimeoutSec` configuration value.
+ *
+ * Called from two sites:
+ * 1. The public `ToolExecutor.execute` wrapper — passes the result to
+ *    `runPipeline` as the pipeline-level timeout so middleware inherits
+ *    the same budget the tool enforces internally.
+ * 2. `executeInternal` — passes the result to `executeWithTimeout` around
+ *    the actual tool invocation.
+ *
+ * Both sites see the same value because `getConfig()` returns a cached
+ * object; there is no observable divergence.
+ */
+function computePerToolTimeoutMs(
+  name: string,
+  input: Record<string, unknown>,
+): number {
+  if (name === "bash" || name === "host_bash") {
+    const { shellDefaultTimeoutSec, shellMaxTimeoutSec } = getConfig().timeouts;
+    const requestedSec =
+      typeof input.timeout_seconds === "number"
+        ? input.timeout_seconds
+        : shellDefaultTimeoutSec;
+    const shellTimeoutSec = Math.max(
+      1,
+      Math.min(requestedSec, shellMaxTimeoutSec),
+    );
+    return (shellTimeoutSec + 5) * 1000;
+  }
+  const rawTimeoutSec = getConfig().timeouts.toolExecutionTimeoutSec;
+  return safeTimeoutMs(rawTimeoutSec);
+}
 
 /**
  * Sanitize tool inputs before they are emitted in lifecycle events.


### PR DESCRIPTION
## Summary
- Refine ToolExecuteArgs/Result types
- Extract execute body into executeInternal; public execute now runs via runPipeline
- Default plugin delegates to executeInternal
- Pipeline timeout inherits from existing per-tool timeout (no double-enforcement)

Part of plan: agent-plugin-system.md (PR 16 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
