### PR TITLE
feat(assistant): load user plugins from ~/.vellum/plugins

### DIFF
--- a/assistant/src/__tests__/user-plugin-loader.test.ts
+++ b/assistant/src/__tests__/user-plugin-loader.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the user plugin loader (PR 29).
+ *
+ * Redirects `vellumRoot()` into a per-test temp directory via `BASE_DATA_DIR`
+ * (the canonical multi-instance override read by `util/platform.ts`) so
+ * `loadUserPlugins()` walks an isolated tree that we populate on demand.
+ *
+ * Covers:
+ * - A plugin whose `register.ts` calls `registerPlugin()` at import time
+ *   ends up in the registry after `loadUserPlugins()` resolves.
+ * - A plugin whose `register.ts` throws during import is logged + skipped;
+ *   other plugins in the same directory still load.
+ * - A missing `vellumRoot()/plugins/` directory is a no-op (zero installed
+ *   user plugins is the default shape of a fresh daemon).
+ */
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getRegisteredPlugins,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import { loadUserPlugins } from "../plugins/user-loader.js";
+
+// Isolate every run under its own tempdir so parallel test files (and
+// repeated runs of this file) cannot collide on `~/.vellum/plugins/`.
+// Each describe-scope gets a fresh subdirectory.
+const TEST_INSTANCE_DIR = join(
+  tmpdir(),
+  `vellum-user-plugin-loader-test-${process.pid}-${Date.now()}`,
+);
+process.env.BASE_DATA_DIR = TEST_INSTANCE_DIR;
+
+/** The plugins directory the loader will walk. */
+const PLUGINS_DIR = join(TEST_INSTANCE_DIR, ".vellum", "plugins");
+
+/**
+ * Write a plugin directory with a `register.ts` (TypeScript source, so bun
+ * can import it at test time without a build step) that executes the given
+ * body. The body has access to `registerPlugin` via a relative import back
+ * into the repo's registry module.
+ *
+ * `relativeRegistryImport` points from the synthetic plugin file at
+ * `<TEST_INSTANCE_DIR>/.vellum/plugins/<name>/register.ts` to the real
+ * registry source at `<repo>/assistant/src/plugins/registry.ts`. Using a
+ * relative path (rather than a project-root alias) keeps the test hermetic
+ * and matches how an on-disk user plugin would actually import the
+ * registry's public API in a real install.
+ */
+function writePlugin(name: string, body: string): void {
+  const pluginDir = join(PLUGINS_DIR, name);
+  mkdirSync(pluginDir, { recursive: true });
+  // Resolve the absolute path to the registry module so the synthetic
+  // register.ts can import it. bun happily resolves `.ts` files at runtime
+  // when the test suite itself is running in source mode.
+  const registryPath = join(import.meta.dir, "..", "plugins", "registry.ts");
+  const registerSource = `
+import { registerPlugin } from ${JSON.stringify(registryPath)};
+${body}
+`;
+  writeFileSync(join(pluginDir, "register.ts"), registerSource);
+}
+
+function clearPluginsDir(): void {
+  rmSync(TEST_INSTANCE_DIR, { recursive: true, force: true });
+}
+
+describe("user plugin loader", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+    clearPluginsDir();
+  });
+
+  test("loads a valid plugin whose register.ts calls registerPlugin()", async () => {
+    writePlugin(
+      "my-plugin",
+      `
+registerPlugin({
+  manifest: {
+    name: "my-plugin",
+    version: "0.0.1",
+    requires: { pluginRuntime: "v1" },
+  },
+});
+`,
+    );
+
+    await loadUserPlugins();
+
+    const registered = getRegisteredPlugins();
+    expect(registered).toHaveLength(1);
+    expect(registered[0]?.manifest.name).toBe("my-plugin");
+  });
+
+  test("per-plugin failure is isolated: other plugins still load", async () => {
+    // Plugin A throws at import time. The loader must log and move on so
+    // Plugin B still ends up registered — one bad user plugin cannot brick
+    // the entire user-plugin surface or crash the daemon.
+    writePlugin(
+      "broken-plugin",
+      `
+throw new Error("boom at import time");
+`,
+    );
+    writePlugin(
+      "good-plugin",
+      `
+registerPlugin({
+  manifest: {
+    name: "good-plugin",
+    version: "0.0.1",
+    requires: { pluginRuntime: "v1" },
+  },
+});
+`,
+    );
+
+    await loadUserPlugins();
+
+    const registered = getRegisteredPlugins();
+    const names = registered.map((p) => p.manifest.name);
+    // Order is not guaranteed (filesystem-dependent) — assert membership.
+    expect(names).toContain("good-plugin");
+    expect(names).not.toContain("broken-plugin");
+  });
+
+  test("missing plugins/ directory is a no-op", async () => {
+    // clearPluginsDir() in beforeEach has already removed TEST_INSTANCE_DIR
+    // entirely, so vellumRoot()/plugins/ does not exist. The loader must
+    // complete without throwing and without registering anything.
+    await loadUserPlugins();
+    expect(getRegisteredPlugins()).toHaveLength(0);
+  });
+
+  test("subdirectory without register.{ts,js} is silently skipped", async () => {
+    // Populate a directory that looks like a plugin but lacks a register
+    // file. The loader must skip it without throwing.
+    const stubDir = join(PLUGINS_DIR, "not-a-plugin");
+    mkdirSync(stubDir, { recursive: true });
+    writeFileSync(join(stubDir, "README.md"), "# not actually a plugin\n");
+
+    await loadUserPlugins();
+    expect(getRegisteredPlugins()).toHaveLength(0);
+  });
+});

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -71,6 +71,7 @@ import {
 } from "../notifications/emit-signal.js";
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
+import { loadUserPlugins } from "../plugins/user-loader.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
@@ -698,11 +699,22 @@ export async function runDaemon(): Promise<void> {
       }
     }
 
+    // Populate the registry with user plugins from `~/.vellum/plugins/*`
+    // AFTER first-party plugins have already registered via their static
+    // side-effect imports. User plugins may fail to load individually; a
+    // failing user plugin is logged and skipped so one bad install can't
+    // prevent the daemon from starting. Ordering is load-bearing:
+    //   first-party registrations → user registrations → bootstrap (init).
+    // Both groups are fully registered before any `init()` runs so plugins
+    // that depend on each other's registration observably see a stable
+    // registry at init time.
+    await loadUserPlugins();
+
     // Bootstrap registered plugins. Runs after the plugin registry is
-    // populated (which happens via static side-effect imports — none exist
-    // in this PR, so the call is a no-op against an empty registry) and
-    // before the DaemonServer starts handling conversations. Credential
-    // resolution + per-plugin storage directory creation happen here.
+    // populated (first-party static side-effect imports + user plugins
+    // loaded above) and before the DaemonServer starts handling
+    // conversations. Credential resolution + per-plugin storage directory
+    // creation happen here.
     await bootstrapPlugins({ config, assistantVersion: APP_VERSION });
 
     // Start the DaemonServer (conversation manager) before Qdrant so HTTP

--- a/assistant/src/plugins/user-loader.ts
+++ b/assistant/src/plugins/user-loader.ts
@@ -1,0 +1,136 @@
+/**
+ * User plugin loader — discovers plugins under `~/.vellum/plugins/*` and
+ * invokes each plugin's registration side effect via a dynamic import.
+ *
+ * A user plugin is a directory under `vellumRoot()/plugins/` that contains a
+ * `register.ts` (or `register.js` after compilation). The file is expected to
+ * call {@link registerPlugin} at import time so the plugin ends up in the
+ * registry before {@link bootstrapPlugins} runs during daemon startup.
+ *
+ * The loader deliberately:
+ *
+ * - Uses {@link vellumRoot} rather than `homedir()` directly so the
+ *   multi-instance invariant in the root CLAUDE.md holds — each instance
+ *   loads its own plugin set from its own `.vellum` directory.
+ * - Prefers `register.js` over `register.ts` when both exist (compiled plugins
+ *   always win; this matches how `bun`/Node consumers resolve modules at
+ *   runtime in the compiled binary).
+ * - Treats any error from the dynamic import as a per-plugin isolation
+ *   boundary: the offending directory is logged with `"Failed to load user
+ *   plugin <dir>: <err>"` and the loader moves on to the next candidate.
+ *   One bad user plugin must not crash the daemon.
+ *
+ * Call order relative to the rest of the plugin system:
+ *
+ *     first-party registrations (static side-effect imports)
+ *       → loadUserPlugins()          ← this module
+ *         → bootstrapPlugins()       (init for everyone registered so far)
+ *
+ * Design doc: `.private/plans/agent-plugin-system.md` (PR 29).
+ */
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { getLogger } from "../util/logger.js";
+import { vellumRoot } from "../util/platform.js";
+
+const log = getLogger("user-plugin-loader");
+
+/**
+ * Scan `vellumRoot()/plugins/` for subdirectories containing a
+ * `register.{ts,js}` file, and dynamic-import each one so the module's
+ * side-effecting {@link registerPlugin} calls populate the registry.
+ *
+ * Invariants:
+ *
+ * - No-ops when `vellumRoot()/plugins/` does not exist — a clean install with
+ *   zero user plugins must not generate errors.
+ * - Per-plugin isolation: a failing import is logged and skipped. The
+ *   function resolves normally even when every plugin fails to load.
+ * - Does not return plugin instances. The registry is the single source of
+ *   truth for who got registered, and the caller inspects it directly.
+ *
+ * Must be called after first-party plugin side-effect imports have run and
+ * before {@link bootstrapPlugins} — see the module docstring for the ordering
+ * contract.
+ */
+export async function loadUserPlugins(): Promise<void> {
+  const pluginsDir = join(vellumRoot(), "plugins");
+  if (!existsSync(pluginsDir)) {
+    log.debug(
+      { pluginsDir },
+      "loadUserPlugins: no plugins directory — skipping",
+    );
+    return;
+  }
+
+  let entries: string[];
+  try {
+    entries = readdirSync(pluginsDir);
+  } catch (err) {
+    // Permissions error, transient FS issue, etc. Log and bail without
+    // crashing startup — the daemon must come up even when the plugins dir
+    // is unreadable.
+    log.warn(
+      { err, pluginsDir },
+      "loadUserPlugins: failed to read plugins directory",
+    );
+    return;
+  }
+
+  for (const entry of entries) {
+    const pluginDir = join(pluginsDir, entry);
+
+    // Only directories are candidates. Plain files (readmes, stray configs)
+    // are silently ignored.
+    let stats;
+    try {
+      stats = statSync(pluginDir);
+    } catch {
+      continue;
+    }
+    if (!stats.isDirectory()) continue;
+
+    // Prefer the compiled `register.js` over the TypeScript source. In the
+    // bun-compiled daemon binary only the compiled file can be imported;
+    // in development both may exist, in which case resolving the compiled
+    // artifact matches how the runtime would behave in production.
+    const jsPath = join(pluginDir, "register.js");
+    const tsPath = join(pluginDir, "register.ts");
+    let registerPath: string | undefined;
+    if (existsSync(jsPath)) {
+      registerPath = jsPath;
+    } else if (existsSync(tsPath)) {
+      registerPath = tsPath;
+    }
+    if (!registerPath) {
+      log.debug(
+        { pluginDir },
+        "loadUserPlugins: no register.{ts,js} — skipping",
+      );
+      continue;
+    }
+
+    // `import()` with a `file://` URL works identically under Node and bun
+    // and sidesteps platform-specific absolute-path quirks on Windows.
+    const moduleUrl = pathToFileURL(registerPath).href;
+    try {
+      await import(moduleUrl);
+      log.info(
+        { pluginDir, registerPath },
+        "loaded user plugin (side-effect import completed)",
+      );
+    } catch (err) {
+      // One plugin's failure must never prevent other plugins from loading
+      // or crash the daemon. Log with the directory name so operators can
+      // find the broken plugin quickly.
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(
+        { err, pluginDir },
+        `Failed to load user plugin ${pluginDir}: ${message}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- plugins/user-loader.ts: dynamic-import register.ts from each plugin subdirectory
- Wrap each import in try/catch, log failures, continue on error
- Wire into daemon/lifecycle.ts between first-party registrations and bootstrapPlugins()
- Uses vellumRoot() for multi-instance correctness

Part of plan: agent-plugin-system.md (PR 29 of 33)