### PR TITLE
feat(assistant): wrap compaction as plugin pipeline

### DIFF
--- a/assistant/src/__tests__/compaction-pipeline.test.ts
+++ b/assistant/src/__tests__/compaction-pipeline.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for the `compaction` plugin pipeline (PR 25).
+ *
+ * Covers:
+ * - Default plugin delegates to the manager's `maybeCompact` and returns the
+ *   same `ContextWindowResult` object the manager produced.
+ * - A custom plugin layered on top can short-circuit before the terminal is
+ *   reached and return a different summary, demonstrating that the pipeline
+ *   slot is observable and replaceable without patching the manager.
+ *
+ * The tests drive `runPipeline` directly rather than going through the full
+ * orchestrator — the integration path (conversation-agent-loop) is exercised
+ * by `conversation-agent-loop-overflow.test.ts`, which must continue to pass
+ * as the acceptance criterion for this PR.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import {
+  DEFAULT_COMPACTION_PLUGIN_NAME,
+  defaultCompactionTerminal,
+} from "../plugins/defaults/compaction.js";
+import { runPipeline } from "../plugins/pipeline.js";
+import {
+  type CompactionArgs,
+  type CompactionResult,
+  type Middleware,
+  PluginExecutionError,
+  type TurnContext,
+} from "../plugins/types.js";
+
+type ContextWindowResultShape = {
+  compacted: boolean;
+  summaryText: string;
+  messages: unknown[];
+  previousEstimatedInputTokens: number;
+  estimatedInputTokens: number;
+  maxInputTokens: number;
+  thresholdTokens: number;
+  compactedMessages: number;
+  compactedPersistedMessages: number;
+  summaryCalls: number;
+  summaryInputTokens: number;
+  summaryOutputTokens: number;
+  summaryModel: string;
+  reason?: string;
+};
+
+const trust: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+function makeTurnCtx(manager: {
+  maybeCompact: (...args: unknown[]) => Promise<unknown>;
+}): TurnContext {
+  const base: TurnContext = {
+    requestId: "req-compaction-test",
+    conversationId: "conv-compaction-test",
+    turnIndex: 0,
+    trust,
+  };
+  return {
+    ...base,
+    // The default compaction plugin reads this via lenient cast — see
+    // `plugins/defaults/compaction.ts`.
+    ...({ contextWindowManager: manager } as Partial<TurnContext>),
+  };
+}
+
+function makeResult(
+  overrides: Partial<ContextWindowResultShape> = {},
+): ContextWindowResultShape {
+  return {
+    compacted: true,
+    summaryText: "default-summary",
+    messages: [],
+    previousEstimatedInputTokens: 1000,
+    estimatedInputTokens: 100,
+    maxInputTokens: 100000,
+    thresholdTokens: 80000,
+    compactedMessages: 3,
+    compactedPersistedMessages: 3,
+    summaryCalls: 1,
+    summaryInputTokens: 500,
+    summaryOutputTokens: 120,
+    summaryModel: "default-model",
+    ...overrides,
+  };
+}
+
+describe("compaction pipeline", () => {
+  test("default plugin delegates to the manager and returns its result unchanged", async () => {
+    const observed: {
+      messages: unknown;
+      signal: unknown;
+      options: unknown;
+    }[] = [];
+    const expected = makeResult({
+      summaryText: "manager-summary",
+      compactedMessages: 7,
+    });
+    const manager = {
+      maybeCompact: async (
+        messages: unknown,
+        signal: unknown,
+        options: unknown,
+      ) => {
+        observed.push({ messages, signal, options });
+        return expected;
+      },
+    };
+    const turnCtx = makeTurnCtx(manager);
+    const args: CompactionArgs = {
+      messages: [{ role: "user", content: "hi" }],
+      signal: new AbortController().signal,
+      options: { lastCompactedAt: 42, precomputedEstimate: 1234 },
+    };
+
+    // No middleware registered — the runner invokes the terminal directly.
+    const result = (await runPipeline<CompactionArgs, CompactionResult>(
+      "compaction",
+      [],
+      (innerArgs) => defaultCompactionTerminal(innerArgs, turnCtx),
+      args,
+      turnCtx,
+      30000,
+    )) as ContextWindowResultShape;
+
+    // Terminal forwarded args verbatim to the manager.
+    expect(observed).toHaveLength(1);
+    expect(observed[0]!.messages).toBe(args.messages);
+    expect(observed[0]!.signal).toBe(args.signal);
+    expect(observed[0]!.options).toBe(args.options);
+
+    // Returned result is the manager's object, unmodified — no wrapping
+    // or shape transformation is allowed in the default path.
+    expect(result).toBe(expected);
+    expect(result.summaryText).toBe("manager-summary");
+    expect(result.compactedMessages).toBe(7);
+  });
+
+  test("custom plugin short-circuits to a different summary without touching the manager", async () => {
+    let managerCallCount = 0;
+    const manager = {
+      maybeCompact: async () => {
+        managerCallCount++;
+        return makeResult({ summaryText: "should-not-run" });
+      },
+    };
+    const turnCtx = makeTurnCtx(manager);
+
+    const custom: Middleware<CompactionArgs, CompactionResult> =
+      async function customCompaction(_args, _next, _ctx) {
+        // Short-circuit — omit the `next` call so the terminal never fires.
+        return makeResult({
+          summaryText: "custom-plugin-summary",
+          compactedMessages: 0,
+          summaryCalls: 0,
+          reason: "short-circuited by custom plugin",
+        });
+      };
+
+    const args: CompactionArgs = {
+      messages: [],
+      signal: undefined,
+      options: undefined,
+    };
+
+    const result = (await runPipeline<CompactionArgs, CompactionResult>(
+      "compaction",
+      [custom],
+      (innerArgs) => defaultCompactionTerminal(innerArgs, turnCtx),
+      args,
+      turnCtx,
+      30000,
+    )) as ContextWindowResultShape;
+
+    expect(managerCallCount).toBe(0);
+    expect(result.summaryText).toBe("custom-plugin-summary");
+    expect(result.reason).toBe("short-circuited by custom plugin");
+  });
+
+  test("default terminal surfaces a PluginExecutionError when the manager is missing", async () => {
+    // Build a turn context without the extension field so the default
+    // terminal's lenient read fails — this guards against a future refactor
+    // that removes the handle-attach helper in the orchestrator.
+    const turnCtxWithoutManager: TurnContext = {
+      requestId: "req-missing",
+      conversationId: "conv-missing",
+      turnIndex: 0,
+      trust,
+    };
+    const args: CompactionArgs = {
+      messages: [],
+      signal: undefined,
+      options: undefined,
+    };
+
+    await expect(
+      defaultCompactionTerminal(args, turnCtxWithoutManager),
+    ).rejects.toThrow(PluginExecutionError);
+    await expect(
+      defaultCompactionTerminal(args, turnCtxWithoutManager),
+    ).rejects.toThrow(DEFAULT_COMPACTION_PLUGIN_NAME);
+  });
+});

--- a/assistant/src/__tests__/plugin-types.test.ts
+++ b/assistant/src/__tests__/plugin-types.test.ts
@@ -12,6 +12,8 @@ import { describe, expect, test } from "bun:test";
 
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
 import {
+  type CompactionArgs,
+  type CompactionResult,
   type Injector,
   type Middleware,
   type Plugin,
@@ -52,6 +54,16 @@ describe("plugin core types", () => {
       { output: unknown }
     > = async (args, next, _ctx) => next(args);
 
+    // Slot-specific passthrough for the `compaction` pipeline — PR 25
+    // narrowed its args/result away from the generic `{ input: unknown }`
+    // placeholder, so the generic `passthrough` no longer satisfies its
+    // middleware signature. This dedicated middleware keeps the shape-only
+    // assertion for the slot without forcing every other slot to narrow.
+    const compactionPassthrough: Middleware<
+      CompactionArgs,
+      CompactionResult
+    > = async (args, next, _ctx) => next(args);
+
     const injector: Injector = {
       name: "sample-injector",
       order: 10,
@@ -85,7 +97,7 @@ describe("plugin core types", () => {
         memoryRetrieval: passthrough,
         historyRepair: passthrough,
         tokenEstimate: passthrough,
-        compaction: passthrough,
+        compaction: compactionPassthrough,
         overflowReduce: passthrough,
         persistence: passthrough,
         titleGenerate: passthrough,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -68,6 +68,14 @@ import type { ConversationGraphMemory } from "../memory/graph/conversation-graph
 import { recordMemoryRecallLog } from "../memory/memory-recall-log-store.js";
 import { PKB_WORKSPACE_SCOPE } from "../memory/pkb/types.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
+import { defaultCompactionTerminal } from "../plugins/defaults/compaction.js";
+import { runPipeline } from "../plugins/pipeline.js";
+import { getMiddlewaresFor } from "../plugins/registry.js";
+import type {
+  CompactionArgs,
+  CompactionResult,
+  TurnContext,
+} from "../plugins/types.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
 import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
@@ -247,6 +255,57 @@ export function trackCompactionOutcome(
       });
     }
   }
+}
+
+// ── Plugin pipeline helpers ──────────────────────────────────────────
+//
+// Turn-level {@link TurnContext} builder threaded into every `runPipeline`
+// call. `TurnContext` intentionally stays slim at the type level — we attach
+// the `contextWindowManager` handle via a lenient extension field that the
+// default-compaction plugin reads with a cast. Custom plugins don't need the
+// handle (they replace the terminal behavior) so widening `TurnContext` would
+// pay no benefit.
+
+/**
+ * Synthetic fallback trust context used when the orchestrator fires a pipeline
+ * before the per-turn trust snapshot has been captured (e.g. invocations that
+ * bypass `processMessage` / `drainQueue`). We bias to `unknown` rather than
+ * `guardian` so a missing snapshot cannot accidentally grant elevated trust
+ * to a custom plugin reading `ctx.trust`.
+ */
+const FALLBACK_TURN_TRUST: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "unknown",
+};
+
+/**
+ * Build the {@link TurnContext} passed to {@link runPipeline}. Pulls trust
+ * context from the per-turn snapshot when present, otherwise from the
+ * conversation-level context, otherwise the synthetic fallback above. The
+ * contextWindowManager handle is attached as an extension so the default
+ * compaction plugin can read it without widening `TurnContext`.
+ */
+function buildPluginTurnContext(
+  ctx: AgentLoopConversationContext,
+  requestId: string,
+): TurnContext {
+  const trust =
+    ctx.currentTurnTrustContext ?? ctx.trustContext ?? FALLBACK_TURN_TRUST;
+  const base: TurnContext = {
+    requestId,
+    conversationId: ctx.conversationId,
+    turnIndex: ctx.turnCount,
+    trust,
+  };
+  return {
+    ...base,
+    // Extension fields — read via lenient casts by default plugins. Kept off
+    // the declared `TurnContext` shape so plugin-facing code isn't tempted to
+    // depend on orchestrator-internal handles.
+    ...({
+      contextWindowManager: ctx.contextWindowManager,
+    } as Partial<TurnContext>),
+  };
 }
 
 // ── Context Interface ────────────────────────────────────────────────
@@ -577,16 +636,24 @@ export async function runAgentLoopImpl(
       );
     }
     const compacted = autoCompactAllowed
-      ? await ctx.contextWindowManager.maybeCompact(
-          ctx.messages,
-          abortController.signal,
+      ? ((await runPipeline<CompactionArgs, CompactionResult>(
+          "compaction",
+          getMiddlewaresFor("compaction"),
+          (args) =>
+            defaultCompactionTerminal(args, buildPluginTurnContext(ctx, reqId)),
           {
-            lastCompactedAt: ctx.contextCompactedAt ?? undefined,
-            precomputedEstimate: compactCheck.estimatedTokens,
-            conversationOriginChannel:
-              getConversationOriginChannel(ctx.conversationId) ?? undefined,
+            messages: ctx.messages,
+            signal: abortController.signal,
+            options: {
+              lastCompactedAt: ctx.contextCompactedAt ?? undefined,
+              precomputedEstimate: compactCheck.estimatedTokens,
+              conversationOriginChannel:
+                getConversationOriginChannel(ctx.conversationId) ?? undefined,
+            },
           },
-        )
+          buildPluginTurnContext(ctx, reqId),
+          30000,
+        )) as Awaited<ReturnType<typeof ctx.contextWindowManager.maybeCompact>>)
       : null;
     // Only track circuit-breaker state when a summary LLM call actually ran.
     // `summaryFailed` is `undefined` on early returns (compaction disabled,
@@ -1299,17 +1366,28 @@ export async function runAgentLoopImpl(
         reqId,
         "Compacting context",
       );
-      const midLoopCompact = await ctx.contextWindowManager.maybeCompact(
-        ctx.messages,
-        abortController.signal,
+      const midLoopCompact = (await runPipeline<
+        CompactionArgs,
+        CompactionResult
+      >(
+        "compaction",
+        getMiddlewaresFor("compaction"),
+        (args) =>
+          defaultCompactionTerminal(args, buildPluginTurnContext(ctx, reqId)),
         {
-          lastCompactedAt: ctx.contextCompactedAt ?? undefined,
-          force: true,
-          targetInputTokensOverride: preflightBudget,
-          conversationOriginChannel:
-            getConversationOriginChannel(ctx.conversationId) ?? undefined,
+          messages: ctx.messages,
+          signal: abortController.signal,
+          options: {
+            lastCompactedAt: ctx.contextCompactedAt ?? undefined,
+            force: true,
+            targetInputTokensOverride: preflightBudget,
+            conversationOriginChannel:
+              getConversationOriginChannel(ctx.conversationId) ?? undefined,
+          },
         },
-      );
+        buildPluginTurnContext(ctx, reqId),
+        30000,
+      )) as Awaited<ReturnType<typeof ctx.contextWindowManager.maybeCompact>>;
       // `force: true` bypasses the cooldown/threshold gates but early returns
       // for "no eligible messages" / "insufficient messages" still leave
       // `summaryFailed` undefined. Only track when the summary LLM actually ran.
@@ -1646,16 +1724,32 @@ export async function runAgentLoopImpl(
             "assistant_turn",
             reqId,
           );
-          const emergencyCompact = await ctx.contextWindowManager.maybeCompact(
-            ctx.messages,
-            abortController.signal,
+          const emergencyCompact = (await runPipeline<
+            CompactionArgs,
+            CompactionResult
+          >(
+            "compaction",
+            getMiddlewaresFor("compaction"),
+            (args) =>
+              defaultCompactionTerminal(
+                args,
+                buildPluginTurnContext(ctx, reqId),
+              ),
             {
-              lastCompactedAt: ctx.contextCompactedAt ?? undefined,
-              force: true,
-              minKeepRecentUserTurns: 0,
-              targetInputTokensOverride: correctedTarget,
+              messages: ctx.messages,
+              signal: abortController.signal,
+              options: {
+                lastCompactedAt: ctx.contextCompactedAt ?? undefined,
+                force: true,
+                minKeepRecentUserTurns: 0,
+                targetInputTokensOverride: correctedTarget,
+              },
             },
-          );
+            buildPluginTurnContext(ctx, reqId),
+            30000,
+          )) as Awaited<
+            ReturnType<typeof ctx.contextWindowManager.maybeCompact>
+          >;
           // Only track when the summary LLM actually ran; `force: true`
           // bypasses the cooldown but not the early-return paths.
           if (emergencyCompact.summaryFailed !== undefined) {

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -35,9 +35,11 @@ import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import type { AssistantConfig } from "../config/schema.js";
+import { defaultCompactionPlugin } from "../plugins/defaults/compaction.js";
 import {
   ASSISTANT_API_VERSIONS,
   getRegisteredPlugins,
+  registerPlugin,
 } from "../plugins/registry.js";
 import {
   type Plugin,
@@ -146,7 +148,34 @@ function ensurePluginStorageDir(pluginName: string): string {
  * (i.e. after any static side-effect imports of first-party plugins have
  * run) and before the first conversation is served.
  */
+/**
+ * Register first-party default plugins. Idempotent — re-registering a plugin
+ * already in the registry is a no-op so the function is safe to call from
+ * multiple boot paths (daemon startup and the inline test harnesses that run
+ * the orchestrator without the full daemon lifecycle).
+ *
+ * The order here determines onion order for middleware composition — earlier
+ * entries wrap later entries. For defaults we keep the set minimal so custom
+ * plugins registered afterward sit *outside* the defaults (closer to the
+ * caller), which is the typical expectation for observer-style middleware.
+ */
+export function registerDefaultPlugins(): void {
+  const alreadyRegistered = new Set(
+    getRegisteredPlugins().map((p) => p.manifest.name),
+  );
+  for (const plugin of [defaultCompactionPlugin]) {
+    if (alreadyRegistered.has(plugin.manifest.name)) continue;
+    registerPlugin(plugin);
+  }
+}
+
 export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
+  // Ensure first-party defaults are registered before we walk the registry.
+  // Calling sites that bootstrap without going through a prior `registerPlugin`
+  // sweep (tests, hot-reload) would otherwise boot with an empty registry and
+  // skip defaults silently.
+  registerDefaultPlugins();
+
   const plugins = getRegisteredPlugins();
   if (plugins.length === 0) {
     // No-op fast path — the registry is empty (no first-party plugins have

--- a/assistant/src/plugins/defaults/compaction.ts
+++ b/assistant/src/plugins/defaults/compaction.ts
@@ -1,0 +1,126 @@
+/**
+ * Default `compaction` plugin.
+ *
+ * Delegates to the orchestrator's existing
+ * {@link import("../../context/window-manager.js").ContextWindowManager}
+ * instance. No behavior change relative to the pre-plugin call site — the
+ * plugin only exists so custom plugins registered in later PRs can observe
+ * arguments, short-circuit to a different summary, or post-process the
+ * {@link import("../../context/window-manager.js").ContextWindowResult}
+ * before the orchestrator consumes it.
+ *
+ * Lookup: the default middleware reads `ctx.contextWindowManager` from the
+ * {@link TurnContext} via a lenient cast. The orchestrator is responsible
+ * for attaching that handle to the per-turn context it hands to
+ * {@link runPipeline}. `TurnContext` intentionally stays slim at the type
+ * level — we avoid widening it to carry orchestrator-only accessors — and
+ * use the same lenient-read pattern the pipeline runner already uses for
+ * its optional `logger` slot. If the handle is missing, the middleware
+ * throws a {@link PluginExecutionError} so the bug surfaces with clear
+ * attribution instead of a late `undefined.maybeCompact is not a function`.
+ *
+ * Design doc: `.private/plans/agent-plugin-system.md` (PR 25).
+ */
+
+import type {
+  ContextWindowCompactOptions,
+  ContextWindowManager,
+  ContextWindowResult,
+} from "../../context/window-manager.js";
+import type { Message } from "../../providers/types.js";
+import {
+  type CompactionArgs,
+  type CompactionResult,
+  type Middleware,
+  type Plugin,
+  PluginExecutionError,
+  type TurnContext,
+} from "../types.js";
+
+/**
+ * Name under which the default plugin registers. Exposed so tests and later
+ * plugins can assert registration order or override the default via
+ * composition.
+ */
+export const DEFAULT_COMPACTION_PLUGIN_NAME = "default-compaction";
+
+/**
+ * Read `contextWindowManager` off the turn context. Throws
+ * {@link PluginExecutionError} when absent so the failure attributes cleanly
+ * to the default plugin instead of manifesting as a later NPE.
+ */
+function extractManager(ctx: TurnContext): ContextWindowManager {
+  const maybe = (ctx as { contextWindowManager?: unknown })
+    .contextWindowManager;
+  if (
+    maybe == null ||
+    typeof maybe !== "object" ||
+    typeof (maybe as { maybeCompact?: unknown }).maybeCompact !== "function"
+  ) {
+    throw new PluginExecutionError(
+      "default-compaction: ctx.contextWindowManager is missing — orchestrator must attach it before invoking the compaction pipeline",
+      DEFAULT_COMPACTION_PLUGIN_NAME,
+    );
+  }
+  return maybe as ContextWindowManager;
+}
+
+/**
+ * Default terminal behavior. Exposed as a standalone function (rather than
+ * inlined in the plugin object) so the orchestrator can pass it directly to
+ * {@link runPipeline} as the terminal handler. Keeping terminal-vs-middleware
+ * separate avoids a wasted `next → terminal` hop when no custom plugin
+ * observes the slot.
+ */
+export async function defaultCompactionTerminal(
+  args: CompactionArgs,
+  ctx: TurnContext,
+): Promise<CompactionResult> {
+  const manager = extractManager(ctx);
+  const messages = args.messages as Message[];
+  const options = args.options as ContextWindowCompactOptions | undefined;
+  const result: ContextWindowResult = await manager.maybeCompact(
+    messages,
+    args.signal,
+    options,
+  );
+  return result;
+}
+
+/**
+ * Middleware wrapper around {@link defaultCompactionTerminal}. Registered via
+ * {@link defaultCompactionPlugin} so tests that compose middleware through the
+ * registry (rather than passing a terminal to `runPipeline` directly) see a
+ * working no-op default. In production the orchestrator passes
+ * {@link defaultCompactionTerminal} as the terminal and this middleware is
+ * never hit.
+ */
+const defaultCompactionMiddleware: Middleware<
+  CompactionArgs,
+  CompactionResult
+> = async function defaultCompaction(args, next, ctx) {
+  // Invoke `next` so any custom plugins layered outside us still run; when
+  // we're the only middleware, `next` is the terminal and returns the real
+  // compaction output.
+  void ctx;
+  return next(args);
+};
+
+/**
+ * Manifest + middleware wiring for the default compaction plugin. The
+ * registration happens in `daemon/external-plugins-bootstrap.ts` before
+ * {@link bootstrapPlugins} fires plugin `init()` hooks.
+ */
+export const defaultCompactionPlugin: Plugin = {
+  manifest: {
+    name: DEFAULT_COMPACTION_PLUGIN_NAME,
+    version: "1.0.0",
+    requires: {
+      pluginRuntime: "v1",
+      compactionApi: "v1",
+    },
+  },
+  middleware: {
+    compaction: defaultCompactionMiddleware,
+  },
+};

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -136,8 +136,32 @@ export type HistoryRepairResult = { readonly output: unknown };
 export type TokenEstimateArgs = { readonly input: unknown };
 export type TokenEstimateResult = { readonly output: unknown };
 
-export type CompactionArgs = { readonly input: unknown };
-export type CompactionResult = { readonly output: unknown };
+/**
+ * Pipeline inputs for the `compaction` slot — the arguments the assistant
+ * would otherwise have passed to {@link ContextWindowManager.maybeCompact}.
+ *
+ * Typed via `unknown`-forwarded aliases to keep this module free of runtime
+ * imports from `context/window-manager.ts` (which would pull the full
+ * compaction machinery into anything that merely imports plugin types).
+ * The default compaction plugin re-casts back to the concrete types before
+ * delegating to the manager.
+ */
+export type CompactionArgs = {
+  /** The message history to consider for compaction. */
+  readonly messages: unknown;
+  /** Abort signal forwarded to the compaction summary call. */
+  readonly signal?: AbortSignal;
+  /** `ContextWindowCompactOptions` — options block forwarded verbatim. */
+  readonly options?: unknown;
+};
+/**
+ * Pipeline result for the `compaction` slot — the full
+ * {@link import("../context/window-manager.js").ContextWindowResult}
+ * object returned by `maybeCompact()`. Kept as `unknown` here for the
+ * same decoupling reason as {@link CompactionArgs}; consumers in
+ * `daemon/conversation-agent-loop.ts` cast back to the concrete shape.
+ */
+export type CompactionResult = unknown;
 
 export type OverflowReduceArgs = { readonly input: unknown };
 export type OverflowReduceResult = { readonly output: unknown };


### PR DESCRIPTION
## Summary
- Add CompactionArgs/Result types
- Default plugin delegates to ContextWindowManager.maybeCompact
- Swap conversation-agent-loop.ts compaction call site to runPipeline with 30s timeout
- Recovery loop around compaction stays in orchestrator

Part of plan: agent-plugin-system.md (PR 25 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
