### PR TITLE
feat(assistant): wrap overflow reduction as plugin pipeline

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -18,6 +18,8 @@ import type {
   CheckpointInfo,
 } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import { registerDefaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
+import { resetPluginRegistryForTests } from "../plugins/registry.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 
 // ── Module mocks (must precede imports of the module under test) ─────
@@ -554,6 +556,12 @@ beforeEach(() => {
   mockOverflowAction = "fail_gracefully";
   mockApplyRuntimeInjections = (msgs) => msgs;
   recordUsageMock.mockClear();
+  // Reset the plugin registry and re-register the default overflow-reduce
+  // plugin so the pipeline dispatches to it — the orchestrator routes the
+  // preflight reducer through `runPipeline("overflowReduce", …)` which
+  // needs the default in place to reach the mocked `reduceContextOverflow`.
+  resetPluginRegistryForTests();
+  registerDefaultOverflowReducePlugin();
 });
 
 describe("session-agent-loop overflow recovery (JARVIS-110)", () => {

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -6,6 +6,8 @@ import type {
   CheckpointInfo,
 } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import { registerDefaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
+import { resetPluginRegistryForTests } from "../plugins/registry.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 
 // ── Module mocks (must precede imports of the module under test) ─────
@@ -503,6 +505,11 @@ beforeEach(() => {
     () => {},
   );
   applyRuntimeInjectionsMock.mockClear();
+  // Orchestrator overflow reduction runs through the plugin pipeline; reset
+  // and re-register the default plugin so the pipeline dispatches to the
+  // mocked `reduceContextOverflow` that these tests rely on.
+  resetPluginRegistryForTests();
+  registerDefaultOverflowReducePlugin();
 });
 
 describe("session-agent-loop", () => {

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { AgentEvent } from "../agent/loop.js";
 import type { UserMessageAttachment } from "../daemon/message-protocol.js";
+import { registerDefaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
+import { resetPluginRegistryForTests } from "../plugins/registry.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 import { ProviderError } from "../util/errors.js";
 
@@ -440,6 +442,13 @@ describe("provider ordering error retry", () => {
     firstRunErrorMode = "ordering";
     maybeCompactCalls = [];
     forceCompactionEnabled = false;
+    // Orchestrator overflow reduction runs through the plugin pipeline;
+    // ensure the default plugin is registered so the pipeline has a
+    // middleware to dispatch to (the `context-overflow-reducer` module
+    // itself is mocked above, so the default plugin's delegate goes
+    // through the mocked implementation).
+    resetPluginRegistryForTests();
+    registerDefaultOverflowReducePlugin();
   });
 
   test("simulated strict provider error triggers exactly one retry", async () => {

--- a/assistant/src/__tests__/overflow-reduce-pipeline.test.ts
+++ b/assistant/src/__tests__/overflow-reduce-pipeline.test.ts
@@ -1,0 +1,547 @@
+/**
+ * Unit tests for the default `overflowReduce` plugin (PR 23).
+ *
+ * Two goals:
+ *   1. The default middleware produces results **identical** to the historical
+ *      inline tier loop for a golden set of over-budget histories. We exercise
+ *      this by running the same inputs through two paths — the pipeline and a
+ *      faithful re-implementation of the pre-PR-23 inline loop — and asserting
+ *      the final `(messages, runMessages, injectionMode, reducerState,
+ *      reducerCompacted, attempts)` tuple matches byte-for-byte.
+ *   2. A user-registered spy middleware observes **every** reduction attempt
+ *      when wrapped around the default. This covers the onion-composition
+ *      contract: the spy sees each call from the outside and can count
+ *      iterations without changing reducer behavior.
+ *
+ * The test creates its own plugin registry via
+ * `resetPluginRegistryForTests()` and re-registers the default before each
+ * case so the registry is deterministic across runs.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { estimatePromptTokens } from "../context/token-estimator.js";
+import type {
+  ContextWindowCompactOptions,
+  ContextWindowResult,
+} from "../context/window-manager.js";
+import { createContextSummaryMessage } from "../context/window-manager.js";
+import {
+  createInitialReducerState,
+  reduceContextOverflow,
+  type ReducerState,
+} from "../daemon/context-overflow-reducer.js";
+import type {
+  InjectionMode,
+  TrustContext,
+} from "../daemon/conversation-runtime-assembly.js";
+import { defaultOverflowReduceMiddleware } from "../plugins/defaults/overflow-reduce.js";
+import { registerDefaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
+import { runPipeline } from "../plugins/pipeline.js";
+import {
+  getMiddlewaresFor,
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import type {
+  Middleware,
+  OverflowReduceArgs,
+  OverflowReduceResult,
+  Plugin,
+  TurnContext,
+} from "../plugins/types.js";
+import type { Message } from "../providers/types.js";
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+function msg(role: "user" | "assistant", text: string): Message {
+  return { role, content: [{ type: "text", text }] };
+}
+
+function toolUseMsg(id: string, name: string): Message {
+  return {
+    role: "assistant",
+    content: [{ type: "tool_use", id, name, input: { path: "/tmp/test" } }],
+  };
+}
+
+function toolResultMsg(toolUseId: string, content: string): Message {
+  return {
+    role: "user",
+    content: [{ type: "tool_result", tool_use_id: toolUseId, content }],
+  };
+}
+
+const SYSTEM_PROMPT = "You are a helpful assistant.";
+
+const CONTEXT_WINDOW = {
+  enabled: true,
+  maxInputTokens: 2000,
+  targetBudgetRatio: 0.65,
+  compactThreshold: 0.6,
+  summaryBudgetRatio: 0.05,
+  overflowRecovery: {
+    enabled: true,
+    safetyMarginRatio: 0.05,
+    maxAttempts: 3,
+    interactiveLatestTurnCompression: "summarize" as const,
+    nonInteractiveLatestTurnCompression: "truncate" as const,
+  },
+};
+
+const TRUST: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+function makeTurnContext(overrides: Partial<TurnContext> = {}): TurnContext {
+  return {
+    requestId: "req-overflow-test",
+    conversationId: "conv-overflow-test",
+    turnIndex: 0,
+    trust: TRUST,
+    ...overrides,
+  };
+}
+
+/**
+ * Minimal compaction stub — always compacts to a one-message summary so the
+ * reducer's forced-compaction tier succeeds. Mirrors `makeCompactFn` from
+ * `context-overflow-reducer.test.ts` so the two test suites exercise the
+ * reducer under comparable conditions.
+ */
+function makeCompactFn(
+  summaryText = "## Goals\n- compacted summary",
+): (
+  messages: Message[],
+  signal: AbortSignal | undefined,
+  options: ContextWindowCompactOptions,
+) => Promise<ContextWindowResult> {
+  return async (messages, _signal, _options) => {
+    const summaryMsg = createContextSummaryMessage(summaryText);
+    const compactedMessages = [summaryMsg];
+    const estimatedInputTokens = estimatePromptTokens(
+      compactedMessages,
+      SYSTEM_PROMPT,
+      { providerName: "mock" },
+    );
+    return {
+      messages: compactedMessages,
+      compacted: true,
+      previousEstimatedInputTokens: estimatePromptTokens(
+        messages,
+        SYSTEM_PROMPT,
+        { providerName: "mock" },
+      ),
+      estimatedInputTokens,
+      maxInputTokens: 2000,
+      thresholdTokens: 1200,
+      compactedMessages: messages.length,
+      compactedPersistedMessages: messages.length,
+      summaryCalls: 1,
+      summaryInputTokens: 100,
+      summaryOutputTokens: 50,
+      summaryModel: "mock-model",
+      summaryText,
+    };
+  };
+}
+
+/**
+ * Faithful re-implementation of the pre-PR-23 inline tier loop — lives in
+ * this test file rather than the production module so we have an immutable
+ * baseline the default middleware can be diffed against. If either
+ * implementation drifts, the golden-output cases below fail.
+ *
+ * The function intentionally avoids any side effects on external state — no
+ * circuit-breaker tracking, no activity emission, no `applyCompactionResult`.
+ * The production orchestrator still runs those through callbacks; this
+ * baseline only needs the *message mutation* behavior so we can compare
+ * reducer output.
+ */
+async function runInlineBaseline(args: {
+  readonly messages: Message[];
+  readonly runMessages: Message[];
+  readonly systemPrompt: string;
+  readonly providerName: string;
+  readonly preflightBudget: number;
+  readonly toolTokenBudget?: number;
+  readonly maxAttempts: number;
+  readonly abortSignal?: AbortSignal;
+  readonly compactFn: (
+    messages: Message[],
+    signal: AbortSignal | undefined,
+    options: ContextWindowCompactOptions,
+  ) => Promise<ContextWindowResult>;
+  readonly contextWindow: typeof CONTEXT_WINDOW;
+  readonly reinjectForMode: (
+    reducedMessages: Message[],
+    mode: InjectionMode,
+    didCompact: boolean,
+  ) => Promise<Message[]>;
+  readonly estimatePostInjection: (runMsgs: Message[]) => number;
+}): Promise<{
+  messages: Message[];
+  runMessages: Message[];
+  injectionMode: InjectionMode;
+  reducerState: ReducerState;
+  reducerCompacted: boolean;
+  attempts: number;
+}> {
+  let messages = args.messages;
+  let runMessages = args.runMessages;
+  let injectionMode: InjectionMode = "full";
+  let reducerState: ReducerState = createInitialReducerState();
+  let reducerCompacted = false;
+  let attempts = 0;
+
+  while (attempts < args.maxAttempts && !reducerState.exhausted) {
+    attempts++;
+    const step = await reduceContextOverflow(
+      messages,
+      {
+        providerName: args.providerName,
+        systemPrompt: args.systemPrompt,
+        contextWindow: args.contextWindow,
+        targetTokens: args.preflightBudget,
+        toolTokenBudget: args.toolTokenBudget,
+      },
+      reducerState,
+      args.compactFn,
+      args.abortSignal,
+    );
+
+    reducerState = step.state;
+    messages = step.messages;
+    injectionMode = step.state.injectionMode;
+
+    if (step.compactionResult?.compacted) {
+      reducerCompacted = true;
+    }
+
+    runMessages = await args.reinjectForMode(
+      messages,
+      injectionMode,
+      reducerCompacted,
+    );
+
+    const postInjectionTokens = args.estimatePostInjection(runMessages);
+    if (postInjectionTokens <= args.preflightBudget) break;
+  }
+
+  return {
+    messages,
+    runMessages,
+    injectionMode,
+    reducerState,
+    reducerCompacted,
+    attempts,
+  };
+}
+
+function buildArgs(messages: Message[]): {
+  args: OverflowReduceArgs;
+  reinjectCalls: Array<{ mode: InjectionMode; didCompact: boolean }>;
+  compactionResults: ContextWindowResult[];
+  rawCompactFn: (
+    messages: Message[],
+    signal: AbortSignal | undefined,
+    options: ContextWindowCompactOptions,
+  ) => Promise<ContextWindowResult>;
+} {
+  const reinjectCalls: Array<{ mode: InjectionMode; didCompact: boolean }> = [];
+  const compactionResults: ContextWindowResult[] = [];
+  const compactFn = makeCompactFn();
+
+  // Identity reinject: the test harness does not exercise the full
+  // `applyRuntimeInjections` pipeline; it simply tracks how many times the
+  // orchestrator would have been asked to rebuild `runMessages` so the spy
+  // middleware can attribute each iteration. Returns the reducer's latest
+  // `messages` untouched — real orchestrator code re-injects runtime blocks.
+  const reinjectForMode = async (
+    reducedMessages: Message[],
+    mode: InjectionMode,
+    didCompact: boolean,
+  ): Promise<Message[]> => {
+    reinjectCalls.push({ mode, didCompact });
+    return reducedMessages;
+  };
+
+  const estimatePostInjection = (runMsgs: Message[]): number =>
+    estimatePromptTokens(runMsgs, SYSTEM_PROMPT, {
+      providerName: "mock",
+    });
+
+  const args: OverflowReduceArgs = {
+    messages,
+    runMessages: messages,
+    systemPrompt: SYSTEM_PROMPT,
+    providerName: "mock",
+    contextWindow: CONTEXT_WINDOW,
+    preflightBudget: 1000,
+    toolTokenBudget: 0,
+    maxAttempts: CONTEXT_WINDOW.overflowRecovery.maxAttempts,
+    // `OverflowReduceArgs.compactFn` types `options` as `unknown` to avoid
+    // leaking the `ContextWindowCompactOptions` shape into the plugin
+    // surface. The test helper produces a real `ContextWindowCompactOptions`
+    // signature, so we trampoline through a widened wrapper.
+    compactFn: (msgs, signal, opts) =>
+      compactFn(msgs, signal, opts as ContextWindowCompactOptions),
+    emitActivityState: () => {
+      /* no-op — the orchestrator owns activity emission */
+    },
+    onCompactionResult: (result) => {
+      compactionResults.push(result);
+    },
+    reinjectForMode,
+    estimatePostInjection,
+  };
+
+  return { args, reinjectCalls, compactionResults, rawCompactFn: compactFn };
+}
+
+// ── Test suite ──────────────────────────────────────────────────────────────
+
+describe("overflow-reduce pipeline", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+    registerDefaultOverflowReducePlugin();
+  });
+
+  describe("default middleware matches historical inline loop", () => {
+    test("large tool-result history — identical reduced output", async () => {
+      const longToolResult = "r".repeat(8000);
+      const goldenHistory: Message[] = [
+        msg("user", "Start"),
+        toolUseMsg("tu_1", "read_file"),
+        toolResultMsg("tu_1", longToolResult),
+        msg("assistant", "Result"),
+        msg("user", "Next"),
+      ];
+
+      const pipelineBuild = buildArgs(goldenHistory);
+      const inlineBuild = buildArgs(goldenHistory);
+
+      // Run both paths against the SAME fixture. `buildArgs` gives each
+      // call its own `compactFn` instance so nothing leaks between runs.
+      const pipelineResult = await runPipeline<
+        OverflowReduceArgs,
+        OverflowReduceResult
+      >(
+        "overflowReduce",
+        getMiddlewaresFor("overflowReduce"),
+        // Sentinel terminal — the default middleware doesn't call next,
+        // so this must never fire. Assert that invariant here.
+        async () => {
+          throw new Error("terminal unexpectedly reached");
+        },
+        pipelineBuild.args,
+        makeTurnContext(),
+        30000,
+      );
+
+      const inlineResult = await runInlineBaseline({
+        messages: goldenHistory,
+        runMessages: goldenHistory,
+        systemPrompt: SYSTEM_PROMPT,
+        providerName: "mock",
+        preflightBudget: inlineBuild.args.preflightBudget,
+        toolTokenBudget: inlineBuild.args.toolTokenBudget,
+        maxAttempts: inlineBuild.args.maxAttempts,
+        compactFn: inlineBuild.rawCompactFn,
+        contextWindow: CONTEXT_WINDOW,
+        reinjectForMode: inlineBuild.args.reinjectForMode,
+        estimatePostInjection: inlineBuild.args.estimatePostInjection,
+      });
+
+      // Byte-for-byte match across every field the orchestrator relies on.
+      expect(pipelineResult.messages).toEqual(inlineResult.messages);
+      expect(pipelineResult.runMessages).toEqual(inlineResult.runMessages);
+      expect(pipelineResult.injectionMode).toBe(inlineResult.injectionMode);
+      expect(pipelineResult.reducerState).toEqual(inlineResult.reducerState);
+      expect(pipelineResult.reducerCompacted).toBe(
+        inlineResult.reducerCompacted,
+      );
+      expect(pipelineResult.attempts).toBe(inlineResult.attempts);
+    });
+
+    test("small conversation that fits after first reduction — single attempt", async () => {
+      // A history that's already within budget so the first `applyForcedCompaction`
+      // brings us under — the loop must exit without iterating further.
+      const smallHistory: Message[] = [
+        msg("user", "Hello"),
+        msg("assistant", "Hi there — how can I help?"),
+      ];
+
+      const pipelineBuild = buildArgs(smallHistory);
+      const inlineBuild = buildArgs(smallHistory);
+
+      const pipelineResult = await runPipeline<
+        OverflowReduceArgs,
+        OverflowReduceResult
+      >(
+        "overflowReduce",
+        getMiddlewaresFor("overflowReduce"),
+        async () => {
+          throw new Error("terminal unexpectedly reached");
+        },
+        pipelineBuild.args,
+        makeTurnContext(),
+        30000,
+      );
+      const inlineResult = await runInlineBaseline({
+        messages: smallHistory,
+        runMessages: smallHistory,
+        systemPrompt: SYSTEM_PROMPT,
+        providerName: "mock",
+        preflightBudget: inlineBuild.args.preflightBudget,
+        toolTokenBudget: inlineBuild.args.toolTokenBudget,
+        maxAttempts: inlineBuild.args.maxAttempts,
+        compactFn: inlineBuild.rawCompactFn,
+        contextWindow: CONTEXT_WINDOW,
+        reinjectForMode: inlineBuild.args.reinjectForMode,
+        estimatePostInjection: inlineBuild.args.estimatePostInjection,
+      });
+
+      expect(pipelineResult.attempts).toBe(inlineResult.attempts);
+      expect(pipelineResult.attempts).toBeGreaterThanOrEqual(1);
+      expect(pipelineResult.messages).toEqual(inlineResult.messages);
+      expect(pipelineResult.reducerCompacted).toBe(
+        inlineResult.reducerCompacted,
+      );
+    });
+  });
+
+  describe("spy middleware observes each reduction attempt", () => {
+    test("spy sees one invocation when the default converges in one step", async () => {
+      const history: Message[] = [msg("user", "Hello"), msg("assistant", "Hi")];
+
+      // Spy tracks the args passed into its layer. It must forward via
+      // `next` so the default still fires.
+      const spyCalls: Array<{
+        hadMessages: number;
+        budget: number;
+        attempts: number;
+      }> = [];
+      const spy: Middleware<OverflowReduceArgs, OverflowReduceResult> =
+        async function spyMiddleware(args, next, _ctx) {
+          spyCalls.push({
+            hadMessages: args.messages.length,
+            budget: args.preflightBudget,
+            attempts: 0, // populated after next() from the result
+          });
+          const result = await next(args);
+          spyCalls[spyCalls.length - 1]!.attempts = result.attempts;
+          return result;
+        };
+      const spyPlugin: Plugin = {
+        manifest: {
+          name: "spy-overflow",
+          version: "0.0.1",
+          requires: { pluginRuntime: "v1", overflowReduceApi: "v1" },
+        },
+        middleware: { overflowReduce: spy },
+      };
+      // Register spy first so it wraps the default (registration order =
+      // outer→inner). The default therefore runs as the spy's downstream.
+      resetPluginRegistryForTests();
+      registerPlugin(spyPlugin);
+      registerDefaultOverflowReducePlugin();
+
+      const { args } = buildArgs(history);
+      const result = await runPipeline<
+        OverflowReduceArgs,
+        OverflowReduceResult
+      >(
+        "overflowReduce",
+        getMiddlewaresFor("overflowReduce"),
+        async () => {
+          throw new Error("terminal unexpectedly reached");
+        },
+        args,
+        makeTurnContext(),
+        30000,
+      );
+
+      // Spy was called exactly once — the pipeline invokes each middleware
+      // once per pipeline call, not once per reducer iteration. Iteration
+      // count shows up in the result.attempts field.
+      expect(spyCalls).toHaveLength(1);
+      expect(spyCalls[0]?.hadMessages).toBe(2);
+      expect(spyCalls[0]?.budget).toBe(1000);
+      expect(spyCalls[0]?.attempts).toBe(result.attempts);
+      expect(result.attempts).toBeGreaterThanOrEqual(1);
+    });
+
+    test("spy can short-circuit the default by not calling next", async () => {
+      const history: Message[] = [msg("user", "Hi")];
+
+      const shortCircuit: Middleware<OverflowReduceArgs, OverflowReduceResult> =
+        async function shortCircuitMiddleware(args, _next, _ctx) {
+          // Returns a synthetic "no-op" result — the default is never invoked.
+          return {
+            messages: args.messages,
+            runMessages: args.runMessages,
+            injectionMode: "minimal",
+            reducerState: {
+              appliedTiers: ["injection_downgrade"],
+              injectionMode: "minimal",
+              exhausted: true,
+            },
+            reducerCompacted: false,
+            attempts: 0,
+          };
+        };
+      resetPluginRegistryForTests();
+      registerPlugin({
+        manifest: {
+          name: "short-circuit-overflow",
+          version: "0.0.1",
+          requires: { pluginRuntime: "v1", overflowReduceApi: "v1" },
+        },
+        middleware: { overflowReduce: shortCircuit },
+      });
+      registerDefaultOverflowReducePlugin();
+
+      const { args, compactionResults, reinjectCalls } = buildArgs(history);
+      const result = await runPipeline<
+        OverflowReduceArgs,
+        OverflowReduceResult
+      >(
+        "overflowReduce",
+        getMiddlewaresFor("overflowReduce"),
+        async () => {
+          throw new Error("terminal unexpectedly reached");
+        },
+        args,
+        makeTurnContext(),
+        30000,
+      );
+
+      // Because the outer middleware short-circuited, the default never
+      // ran — no compactFn invocations, no reinject callbacks.
+      expect(result.injectionMode).toBe("minimal");
+      expect(result.attempts).toBe(0);
+      expect(compactionResults).toHaveLength(0);
+      expect(reinjectCalls).toHaveLength(0);
+    });
+  });
+
+  describe("direct middleware invocation", () => {
+    test("default middleware without the pipeline runner still executes the tier loop", async () => {
+      const history: Message[] = [msg("user", "Hi")];
+      const { args } = buildArgs(history);
+
+      const result = await defaultOverflowReduceMiddleware(
+        args,
+        async () => {
+          throw new Error("next should not be invoked by the default");
+        },
+        makeTurnContext(),
+      );
+
+      expect(result.attempts).toBeGreaterThanOrEqual(1);
+      expect(result.reducerState.appliedTiers.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/assistant/src/__tests__/plugin-types.test.ts
+++ b/assistant/src/__tests__/plugin-types.test.ts
@@ -14,6 +14,8 @@ import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
 import {
   type Injector,
   type Middleware,
+  type OverflowReduceArgs,
+  type OverflowReduceResult,
   type Plugin,
   PluginExecutionError,
   type PluginInitContext,
@@ -52,6 +54,27 @@ describe("plugin core types", () => {
       { output: unknown }
     > = async (args, next, _ctx) => next(args);
 
+    // Typed passthrough for the pipelines whose args/result shapes have
+    // landed as concrete types in M2 PRs. Uses `satisfies` to keep each
+    // pipeline's signature in sync with its declared slot in
+    // `PipelineMiddlewareMap`. As more pipelines migrate away from the
+    // `{ input: unknown }` placeholder, add their typed passthroughs here.
+    const overflowReducePassthrough: Middleware<
+      OverflowReduceArgs,
+      OverflowReduceResult
+    > = async (args, _next, _ctx) => ({
+      messages: args.messages,
+      runMessages: args.runMessages,
+      injectionMode: "full",
+      reducerState: {
+        appliedTiers: [],
+        injectionMode: "full",
+        exhausted: true,
+      },
+      reducerCompacted: false,
+      attempts: 0,
+    });
+
     const injector: Injector = {
       name: "sample-injector",
       order: 10,
@@ -86,7 +109,7 @@ describe("plugin core types", () => {
         historyRepair: passthrough,
         tokenEstimate: passthrough,
         compaction: passthrough,
-        overflowReduce: passthrough,
+        overflowReduce: overflowReducePassthrough,
         persistence: passthrough,
         titleGenerate: passthrough,
         toolResultTruncate: passthrough,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -68,6 +68,12 @@ import type { ConversationGraphMemory } from "../memory/graph/conversation-graph
 import { recordMemoryRecallLog } from "../memory/memory-recall-log-store.js";
 import { PKB_WORKSPACE_SCOPE } from "../memory/pkb/types.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
+import { runPipeline } from "../plugins/pipeline.js";
+import { getMiddlewaresFor } from "../plugins/registry.js";
+import type {
+  OverflowReduceArgs,
+  OverflowReduceResult,
+} from "../plugins/types.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
 import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
@@ -1052,106 +1058,150 @@ export async function runAgentLoopImpl(
         "Preflight budget exceeded — running overflow reducer before provider call",
       );
 
-      reducerState = createInitialReducerState();
-      let preflightAttempts = 0;
-
-      while (
-        preflightAttempts < overflowRecovery.maxAttempts &&
-        !reducerState.exhausted
-      ) {
-        preflightAttempts++;
-        ctx.emitActivityState(
-          "thinking",
-          "context_compacting",
-          "assistant_turn",
-          reqId,
-        );
-        const step = await reduceContextOverflow(
-          ctx.messages,
-          {
-            providerName: estimationProviderName,
-            systemPrompt: ctx.systemPrompt,
-            contextWindow: config.llm.default.contextWindow,
-            targetTokens: preflightBudget,
-            toolTokenBudget,
-          },
-          reducerState,
-          (msgs, signal, opts) =>
-            ctx.contextWindowManager.maybeCompact(msgs, signal!, opts),
-          abortController.signal,
-        );
-
-        reducerState = step.state;
-        ctx.messages = step.messages;
-        currentInjectionMode = step.state.injectionMode;
-
-        // Track circuit-breaker state whenever the reducer invoked compaction.
-        // The reducer's forced_compaction tier uses force:true, so it bypasses
-        // the open-circuit check, but we still want failure tracking to detect
-        // a run of broken summaries and clear the counter on success. Only
-        // track when the summary LLM actually ran — `summaryFailed === undefined`
-        // indicates an early return (no eligible messages, truncation-only
-        // path, etc.) that shouldn't influence the breaker.
-        if (
-          step.compactionResult &&
-          step.compactionResult.summaryFailed !== undefined
-        ) {
-          trackCompactionOutcome(
-            ctx,
-            step.compactionResult.summaryFailed,
-            onEvent,
+      // Overflow reduction runs through the plugin pipeline. The default
+      // middleware (`default-overflow-reduce`, registered at bootstrap)
+      // contains the historical tier loop — forced compaction → tool-result
+      // truncation → media stubbing → injection downgrade — plus the
+      // re-inject/re-estimate convergence check. The callbacks below are
+      // the orchestrator-specific side effects that the plugin coordinates
+      // per iteration (activity emission, compaction application, runtime
+      // injection reassembly, token re-estimation). Registered plugins that
+      // wrap the `overflowReduce` slot see each iteration through their own
+      // middleware `next` callback.
+      const overflowArgs: OverflowReduceArgs = {
+        messages: ctx.messages,
+        runMessages,
+        systemPrompt: ctx.systemPrompt,
+        providerName: estimationProviderName,
+        contextWindow: config.llm.default.contextWindow,
+        preflightBudget,
+        toolTokenBudget,
+        maxAttempts: overflowRecovery.maxAttempts,
+        abortSignal: abortController.signal,
+        compactFn: (msgs, signal, opts) =>
+          ctx.contextWindowManager.maybeCompact(
+            msgs,
+            signal!,
+            opts as Parameters<ContextWindowManager["maybeCompact"]>[2],
+          ),
+        emitActivityState: () => {
+          ctx.emitActivityState(
+            "thinking",
+            "context_compacting",
+            "assistant_turn",
+            reqId,
           );
-        }
+        },
+        onCompactionResult: (result) => {
+          // Track circuit-breaker state whenever the reducer invoked
+          // compaction. The reducer's forced_compaction tier uses
+          // force:true, so it bypasses the open-circuit check, but we
+          // still want failure tracking to detect a run of broken
+          // summaries and clear the counter on success. Only track when
+          // the summary LLM actually ran — `summaryFailed === undefined`
+          // indicates an early return (no eligible messages,
+          // truncation-only path, etc.) that shouldn't influence the
+          // breaker.
+          if (result.summaryFailed !== undefined) {
+            trackCompactionOutcome(ctx, result.summaryFailed, onEvent);
+          }
+          if (result.compacted) {
+            applyCompactionResult(ctx, result, onEvent, reqId);
+            shouldInjectWorkspace = true;
+          }
+        },
+        reinjectForMode: async (reducedMessages, mode, didCompact) => {
+          // Mirror the pre-PR-23 behavior: `ctx.messages` must track the
+          // reducer's latest output before re-injection runs, because other
+          // sites consulted through `injectionOpts` (`workspaceTopLevelContext`,
+          // slack history, etc.) depend on it and `applyCompactionResult`
+          // only updates `ctx.messages` on a compaction tier. Assigning here
+          // keeps non-compaction tiers (tool-result truncation, media
+          // stubbing, injection downgrade) observable to downstream
+          // injection assembly on the same turn.
+          ctx.messages = reducedMessages;
 
-        if (step.compactionResult?.compacted) {
-          applyCompactionResult(ctx, step.compactionResult, onEvent, reqId);
-          shouldInjectWorkspace = true;
-          reducerCompacted = true;
-        }
-
-        // Re-inject with potentially downgraded injection mode.
-        // When compaction ran it strips existing NOW.md / PKB blocks, so we
-        // must re-inject the current content. Otherwise rely on the deduplicated
-        // value from injectionOpts to avoid duplicate injection.
-        const injection = await applyRuntimeInjections(ctx.messages, {
-          ...injectionOpts,
-          ...(step.compactionResult?.compacted && {
-            pkbContext: currentPkbContent,
-          }),
-          ...(step.compactionResult?.compacted && {
-            nowScratchpad: currentNowContent,
-          }),
-          workspaceTopLevelContext: shouldInjectWorkspace
-            ? ctx.workspaceTopLevelContext
-            : null,
-          // Once the reducer has compacted `ctx.messages`, the captured
-          // `slackChronologicalMessages` snapshot (built from the full
-          // persisted transcript) would overwrite the compacted history
-          // and undo compaction. Suppress the override from here on.
-          slackChronologicalMessages: reducerCompacted
-            ? null
-            : injectionOpts.slackChronologicalMessages,
-          mode: currentInjectionMode,
-        });
-        runMessages = injection.messages;
-        if (isTrustedActor && currentInjectionMode !== "minimal") {
-          const memResult = ctx.graphMemory.reinjectCachedMemory(runMessages);
-          runMessages = memResult.runMessages;
-        }
-
-        // Re-estimate with injections included — step.estimatedTokens was
-        // computed on bare history (ctx.messages) and doesn't account for
-        // tokens added by runtime injections.
-        const postInjectionTokens = estimatePromptTokens(
-          runMessages,
-          ctx.systemPrompt,
-          {
+          // When compaction ran it strips existing NOW.md / PKB blocks,
+          // so we must re-inject the current content. Otherwise rely on
+          // the deduplicated value from injectionOpts to avoid duplicate
+          // injection.
+          const injection = await applyRuntimeInjections(reducedMessages, {
+            ...injectionOpts,
+            ...(didCompact && { pkbContext: currentPkbContent }),
+            ...(didCompact && { nowScratchpad: currentNowContent }),
+            workspaceTopLevelContext: shouldInjectWorkspace
+              ? ctx.workspaceTopLevelContext
+              : null,
+            // Once the reducer has compacted `ctx.messages`, the captured
+            // `slackChronologicalMessages` snapshot (built from the full
+            // persisted transcript) would overwrite the compacted history
+            // and undo compaction. Suppress the override from here on.
+            slackChronologicalMessages: didCompact
+              ? null
+              : injectionOpts.slackChronologicalMessages,
+            mode,
+          });
+          let next = injection.messages;
+          if (isTrustedActor && mode !== "minimal") {
+            const memResult = ctx.graphMemory.reinjectCachedMemory(next);
+            next = memResult.runMessages;
+          }
+          return next;
+        },
+        estimatePostInjection: (runMsgs) =>
+          estimatePromptTokens(runMsgs, ctx.systemPrompt, {
             providerName: estimationProviderName,
             toolTokenBudget,
-          },
-        );
+          }),
+      };
 
-        if (postInjectionTokens <= preflightBudget) break;
+      const overflowResult = await runPipeline<
+        OverflowReduceArgs,
+        OverflowReduceResult
+      >(
+        "overflowReduce",
+        getMiddlewaresFor("overflowReduce"),
+        // Terminal — only reached when every registered middleware calls
+        // `next` and delegates past the innermost layer. The default plugin
+        // is a terminal itself (it doesn't call `next`), so in practice
+        // this fallback fires only when the default has been explicitly
+        // deregistered (tests) and no user plugin replaces it. In that
+        // case the safest behavior is to return the history untouched —
+        // the subsequent provider call will then surface the overflow as
+        // a normal `context_too_large` error, which the convergence loop
+        // below handles.
+        async (args) => ({
+          messages: args.messages,
+          runMessages: args.runMessages,
+          injectionMode: "full" as const,
+          reducerState: {
+            appliedTiers: [],
+            injectionMode: "full",
+            exhausted: true,
+          },
+          reducerCompacted: false,
+          attempts: 0,
+        }),
+        overflowArgs,
+        {
+          requestId: reqId,
+          conversationId: ctx.conversationId,
+          turnIndex: ctx.turnCount,
+          trust: ctx.currentTurnTrustContext ??
+            ctx.trustContext ?? {
+              sourceChannel: "vellum",
+              trustClass: "guardian",
+            },
+        },
+        30000,
+      );
+
+      ctx.messages = overflowResult.messages;
+      runMessages = overflowResult.runMessages;
+      currentInjectionMode = overflowResult.injectionMode;
+      reducerState = overflowResult.reducerState;
+      if (overflowResult.reducerCompacted) {
+        reducerCompacted = true;
       }
     }
 

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -35,6 +35,7 @@ import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import type { AssistantConfig } from "../config/schema.js";
+import { registerDefaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
 import {
   ASSISTANT_API_VERSIONS,
   getRegisteredPlugins,
@@ -132,6 +133,24 @@ function ensurePluginStorageDir(pluginName: string): string {
   const dir = join(vellumRoot(), "plugins-data", pluginName);
   mkdirSync(dir, { recursive: true });
   return dir;
+}
+
+/**
+ * Register every first-party default plugin in the canonical order the
+ * registry should compose them. Call once at daemon startup immediately
+ * before {@link bootstrapPlugins} so the registry is populated before
+ * bootstrap walks it.
+ *
+ * Kept separate from `bootstrapPlugins` so the bootstrap-plumbing tests can
+ * continue to assert against a clean, empty-registry baseline without being
+ * coupled to the specific set of first-party plugins the daemon ships with
+ * today. Middleware composition order follows registration order — defaults
+ * register first so they run innermost and any externally-registered plugin
+ * wrapping the same slot observes the historical behavior as the terminal
+ * step.
+ */
+export function registerFirstPartyDefaults(): void {
+  registerDefaultOverflowReducePlugin();
 }
 
 /**

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -123,7 +123,10 @@ import {
   cleanupPidFileIfOwner,
   writePid,
 } from "./daemon-control.js";
-import { bootstrapPlugins } from "./external-plugins-bootstrap.js";
+import {
+  bootstrapPlugins,
+  registerFirstPartyDefaults,
+} from "./external-plugins-bootstrap.js";
 import {
   createGuardianActionCopyGenerator,
   createGuardianFollowUpConversationGenerator,
@@ -698,11 +701,17 @@ export async function runDaemon(): Promise<void> {
       }
     }
 
-    // Bootstrap registered plugins. Runs after the plugin registry is
-    // populated (which happens via static side-effect imports — none exist
-    // in this PR, so the call is a no-op against an empty registry) and
-    // before the DaemonServer starts handling conversations. Credential
-    // resolution + per-plugin storage directory creation happen here.
+    // Register every first-party default plugin before bootstrapping so the
+    // registry is populated by the time `bootstrapPlugins` walks it. The
+    // helper is a pure registration call — no async work, no I/O — which
+    // keeps the boot sequence observable and lets tests register additional
+    // plugins between this and the bootstrap call.
+    registerFirstPartyDefaults();
+
+    // Bootstrap registered plugins. Credential resolution and per-plugin
+    // storage directory creation happen here. Runs before the DaemonServer
+    // starts handling conversations so `init()` failures surface during
+    // startup rather than mid-turn.
     await bootstrapPlugins({ config, assistantVersion: APP_VERSION });
 
     // Start the DaemonServer (conversation manager) before Qdrant so HTTP

--- a/assistant/src/plugins/defaults/overflow-reduce.ts
+++ b/assistant/src/plugins/defaults/overflow-reduce.ts
@@ -1,0 +1,142 @@
+/**
+ * Default `overflowReduce` plugin — extracted verbatim from the inline
+ * preflight reducer loop that previously lived in
+ * `daemon/conversation-agent-loop.ts` (the `while (preflightAttempts < …)`
+ * block around lines 1045–1156 before PR 23).
+ *
+ * The plugin owns the reducer tier-loop (forced compaction, tool-result
+ * truncation, media stubbing, injection downgrade) and the post-step
+ * re-injection / re-estimation dance. Orchestrator-specific coupling
+ * (activity emission, circuit-breaker tracking, compaction-result
+ * application, runtime injection reassembly) is threaded in through the
+ * callbacks carried on {@link OverflowReduceArgs}; the plugin itself has no
+ * access to the agent-loop context object.
+ *
+ * Internal calls to `ContextWindowManager` remain direct — pipeline layering
+ * ends at the top of the reducer, not within the forced-compaction tier.
+ * The supplied `compactFn` delegates straight into the context window
+ * manager, so only the tier-loop orchestration goes through the pipeline
+ * runner.
+ */
+
+import type { ContextWindowCompactOptions } from "../../context/window-manager.js";
+import {
+  createInitialReducerState,
+  reduceContextOverflow,
+  type ReducerState,
+} from "../../daemon/context-overflow-reducer.js";
+import { registerPlugin } from "../registry.js";
+import type {
+  Middleware,
+  OverflowReduceArgs,
+  OverflowReduceResult,
+  Plugin,
+} from "../types.js";
+
+/**
+ * Default middleware — implements the historical tier-loop semantics.
+ *
+ * The middleware intentionally ignores `next`. Overflow reduction is a
+ * *terminal* behavior: there is no downstream implementation to defer to
+ * when a user-supplied middleware short-circuits. Later plugins may still
+ * wrap this one (outer middleware can observe each reduction iteration via
+ * their own `next` callback) but the default never delegates to a
+ * hypothetical base handler — the inline loop was the base.
+ */
+export const defaultOverflowReduceMiddleware: Middleware<
+  OverflowReduceArgs,
+  OverflowReduceResult
+> = async function defaultOverflowReduceMiddleware(args, _next, _ctx) {
+  let messages = args.messages;
+  let runMessages = args.runMessages;
+  let injectionMode: "full" | "minimal" = "full";
+  let reducerState: ReducerState = createInitialReducerState();
+  let reducerCompacted = false;
+  let attempts = 0;
+
+  while (attempts < args.maxAttempts && !reducerState.exhausted) {
+    attempts++;
+    args.emitActivityState();
+
+    const step = await reduceContextOverflow(
+      messages,
+      {
+        providerName: args.providerName,
+        systemPrompt: args.systemPrompt,
+        contextWindow: args.contextWindow,
+        targetTokens: args.preflightBudget,
+        toolTokenBudget: args.toolTokenBudget,
+      },
+      reducerState,
+      (msgs, signal, opts: ContextWindowCompactOptions) =>
+        args.compactFn(msgs, signal, opts),
+      args.abortSignal,
+    );
+
+    reducerState = step.state;
+    messages = step.messages;
+    injectionMode = step.state.injectionMode;
+
+    // Let the orchestrator apply compaction side effects (circuit-breaker
+    // tracking, event emission, ctx mutation) before we re-inject.
+    if (step.compactionResult) {
+      args.onCompactionResult(step.compactionResult);
+      if (step.compactionResult.compacted) {
+        reducerCompacted = true;
+      }
+    }
+
+    // Rebuild runMessages via the orchestrator-supplied helper (which
+    // re-runs `applyRuntimeInjections` with potentially downgraded mode
+    // and freshly re-hydrated PKB/NOW blocks after compaction). We pass
+    // the current reduced `messages` explicitly so the orchestrator never
+    // has to read from mutable shared state to rebuild runMessages — a
+    // tier that doesn't trigger compaction (tool-result truncation, media
+    // stubbing) won't update `ctx.messages` on its own.
+    runMessages = await args.reinjectForMode(
+      messages,
+      injectionMode,
+      reducerCompacted,
+    );
+
+    // Re-estimate with injections included — `step.estimatedTokens` was
+    // computed on bare history and doesn't account for tokens added by
+    // runtime injections.
+    const postInjectionTokens = args.estimatePostInjection(runMessages);
+    if (postInjectionTokens <= args.preflightBudget) break;
+  }
+
+  return {
+    messages,
+    runMessages,
+    injectionMode,
+    reducerState,
+    reducerCompacted,
+    attempts,
+  };
+};
+
+/**
+ * The default plugin registered at bootstrap. No `init`/`onShutdown` —
+ * registering the middleware is the only behavior.
+ */
+export const defaultOverflowReducePlugin: Plugin = {
+  manifest: {
+    name: "default-overflow-reduce",
+    version: "1.0.0",
+    requires: { pluginRuntime: "v1", overflowReduceApi: "v1" },
+  },
+  middleware: {
+    overflowReduce: defaultOverflowReduceMiddleware,
+  },
+};
+
+/**
+ * Register the default plugin with the global registry. Idempotent-safe
+ * only via `resetPluginRegistryForTests` — registration itself throws on
+ * duplicates, so callers must guard repeat calls during daemon re-init or
+ * test setup.
+ */
+export function registerDefaultOverflowReducePlugin(): void {
+  registerPlugin(defaultOverflowReducePlugin);
+}

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -16,7 +16,14 @@
  * Design doc: `.private/plans/agent-plugin-system.md`.
  */
 
-import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import type { ContextWindowConfig } from "../config/schemas/inference.js";
+import type { ContextWindowResult } from "../context/window-manager.js";
+import type { ReducerState } from "../daemon/context-overflow-reducer.js";
+import type {
+  InjectionMode,
+  TrustContext,
+} from "../daemon/conversation-runtime-assembly.js";
+import type { Message } from "../providers/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 
 // ─── Manifest ────────────────────────────────────────────────────────────────
@@ -139,8 +146,101 @@ export type TokenEstimateResult = { readonly output: unknown };
 export type CompactionArgs = { readonly input: unknown };
 export type CompactionResult = { readonly output: unknown };
 
-export type OverflowReduceArgs = { readonly input: unknown };
-export type OverflowReduceResult = { readonly output: unknown };
+/**
+ * Input to the `overflowReduce` pipeline. Captures everything the reducer
+ * tier loop needs, including the message history, reducer configuration,
+ * and side-effect callbacks that bridge the pipeline back to the orchestrator's
+ * mutable per-turn state (context-window manager, activity emitter, runtime
+ * injection reassembly, memory reinjection).
+ *
+ * The callbacks are supplied by the orchestrator because the reducer loop
+ * needs to coordinate with state that lives on the `AgentLoopConversationContext`
+ * (message mutation, compaction event emission, circuit breaker tracking,
+ * injection block reassembly). Keeping them as explicit callbacks — rather
+ * than pulling the whole context into the pipeline — preserves the rule that
+ * `TurnContext` stays minimal and pipeline-agnostic.
+ */
+export interface OverflowReduceArgs {
+  /** Bare persisted message history (mutable copy — the default middleware
+   *  applies reducer results in-place via the `applyMessages` callback). */
+  readonly messages: Message[];
+  /** Current run-time message array with runtime injections applied. */
+  readonly runMessages: Message[];
+  /** System prompt used for post-step token estimation. */
+  readonly systemPrompt: string;
+  /** Provider name used for token estimation (calibration provider key). */
+  readonly providerName: string;
+  /** Context window config (drives compaction behavior). */
+  readonly contextWindow: ContextWindowConfig;
+  /** Token budget the reducer must get below (preflight budget). */
+  readonly preflightBudget: number;
+  /** Tool-token overhead included in every estimation call. */
+  readonly toolTokenBudget?: number;
+  /** Maximum reducer iterations before the loop exits unconditionally. */
+  readonly maxAttempts: number;
+  /** Abort signal threaded through compaction calls. */
+  readonly abortSignal?: AbortSignal;
+  /**
+   * Compaction callback — the reducer never owns the ContextWindowManager
+   * instance. The orchestrator supplies this closure so the default plugin
+   * can delegate the forced-compaction tier without crossing the
+   * pipeline/infra boundary on its own.
+   */
+  readonly compactFn: (
+    messages: Message[],
+    signal: AbortSignal | undefined,
+    options: unknown,
+  ) => Promise<ContextWindowResult>;
+  /**
+   * Invoked before each reducer iteration to emit the `context_compacting`
+   * activity state. The orchestrator owns activity emission because the
+   * signal is trust/channel aware.
+   */
+  readonly emitActivityState: () => void;
+  /**
+   * Invoked after each reducer step that produced a successful compaction.
+   * Handles circuit-breaker tracking, event emission, and context mutation.
+   * The pipeline passes back `didCompact` so the orchestrator can flip its
+   * `reducerCompacted` / `shouldInjectWorkspace` flags and the next
+   * re-injection uses the fresh messages.
+   */
+  readonly onCompactionResult: (result: ContextWindowResult) => void;
+  /**
+   * Invoked after each step to rebuild `runMessages` from the step's
+   * reduced history with the requested injection mode. The orchestrator
+   * owns this helper so the full per-turn injection options object doesn't
+   * leak into the pipeline surface. The plugin passes the current reduced
+   * messages array explicitly so the orchestrator doesn't need to read
+   * mutable shared state. Returns the new `runMessages`.
+   */
+  readonly reinjectForMode: (
+    messages: Message[],
+    mode: InjectionMode,
+    didCompact: boolean,
+  ) => Promise<Message[]>;
+  /**
+   * Invoked after each step to post-estimate the rebuilt `runMessages`.
+   * Pulled out so the orchestrator controls how estimation is performed
+   * (and which fields feed it) without the pipeline reimplementing it.
+   */
+  readonly estimatePostInjection: (runMessages: Message[]) => number;
+}
+
+/** Output of the `overflowReduce` pipeline. */
+export interface OverflowReduceResult {
+  /** Final reduced `ctx.messages` value (mutated in place by the reducer). */
+  readonly messages: Message[];
+  /** Final `runMessages` with re-applied runtime injections. */
+  readonly runMessages: Message[];
+  /** Final injection mode (may be `"minimal"` if the downgrade tier fired). */
+  readonly injectionMode: InjectionMode;
+  /** Accumulated reducer state at exit. */
+  readonly reducerState: ReducerState;
+  /** True if any step successfully compacted history. */
+  readonly reducerCompacted: boolean;
+  /** How many iterations of the tier loop executed. */
+  readonly attempts: number;
+}
 
 export type PersistenceArgs = { readonly input: unknown };
 export type PersistenceResult = { readonly output: unknown };


### PR DESCRIPTION
## Summary
- Add OverflowArgs/Result types
- Default plugin extracts current inline tier loop
- Swap conversation-agent-loop.ts preflight reducer to runPipeline with 30s timeout

Part of plan: agent-plugin-system.md (PR 23 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
