### PR TITLE
feat(assistant): allow plugins to contribute skills

### DIFF
--- a/assistant/src/__tests__/plugin-skill-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-skill-contribution.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Tests for plugin-contributed skills (PR 33).
+ *
+ * Covers:
+ * - A plugin declaring `skills: [...]` has its entries registered after
+ *   bootstrap's `init()` succeeds.
+ * - The registered skill is discoverable via `loadSkillCatalog` and
+ *   resolvable via `loadSkillBySelector` (the exact entry points the model's
+ *   `skill_load` / `skill_execute` flow use).
+ * - Shutdown (runShutdownHooks) unregisters the plugin's skills so repeated
+ *   bootstraps don't leak catalog entries.
+ * - Ref-counted register/unregister semantics match the tool registry's
+ *   per-skill-id semantics (PR 13 precedent).
+ *
+ * Strategy mirrors `plugin-bootstrap.test.ts`: stub the credential store so
+ * bootstrap doesn't hit real backends, and `resetPluginRegistryForTests` /
+ * `resetPluginSkillContributionsForTests` between cases for isolation.
+ */
+
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Stub credential store before importing bootstrap so the module captures
+// the fake binding.
+const getSecureKeyAsyncMock = mock(
+  async (_account: string): Promise<string | undefined> => undefined,
+);
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: getSecureKeyAsyncMock,
+}));
+
+import type { AssistantConfig } from "../config/schema.js";
+import { loadSkillBySelector, loadSkillCatalog } from "../config/skills.js";
+import {
+  bootstrapPlugins,
+  type DaemonContext,
+} from "../daemon/external-plugins-bootstrap.js";
+import { runShutdownHooks } from "../daemon/shutdown-registry.js";
+import {
+  getPluginContributedSkillDefinition,
+  getPluginContributedSkillSummaries,
+  getPluginSkillRefCount,
+  registerPluginSkills,
+  resetPluginSkillContributionsForTests,
+  unregisterPluginSkills,
+} from "../plugins/plugin-skill-contributions.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import {
+  type Plugin,
+  PluginExecutionError,
+  type PluginSkillRegistration,
+} from "../plugins/types.js";
+
+// Per-process temp tree so bootstrap's plugin-storage directory creation
+// doesn't touch the developer's real ~/.vellum.
+const TEST_INSTANCE_DIR = join(
+  tmpdir(),
+  `vellum-plugin-skill-test-${process.pid}`,
+);
+process.env.BASE_DATA_DIR = TEST_INSTANCE_DIR;
+
+const fakeConfig = {} as unknown as AssistantConfig;
+const fakeCtx: DaemonContext = {
+  config: fakeConfig,
+  assistantVersion: "9.9.9-test",
+};
+
+/** Build a plugin that contributes one or more skills. */
+function buildSkillPlugin(
+  name: string,
+  skills: PluginSkillRegistration[],
+  extras: Partial<Omit<Plugin, "manifest" | "skills">> = {},
+): Plugin {
+  return {
+    manifest: {
+      name,
+      version: "0.0.1",
+      requires: { pluginRuntime: "v1" },
+    },
+    skills,
+    ...extras,
+  };
+}
+
+describe("plugin skill contributions", () => {
+  beforeEach(async () => {
+    resetPluginRegistryForTests();
+    resetPluginSkillContributionsForTests();
+    getSecureKeyAsyncMock.mockReset();
+    getSecureKeyAsyncMock.mockImplementation(async () => undefined);
+    await rm(TEST_INSTANCE_DIR, { recursive: true, force: true });
+  });
+
+  test("plugin skills are registered after bootstrap and exposed by the catalog", async () => {
+    const skill: PluginSkillRegistration = {
+      id: "plugin-demo-skill",
+      name: "plugin-demo",
+      displayName: "Plugin Demo",
+      description: "A skill contributed by a plugin",
+      body: "# Plugin Demo\n\nThis is the plugin-provided body.",
+      activationHints: ["demo", "plugin"],
+    };
+
+    registerPlugin(buildSkillPlugin("demo-plugin", [skill]));
+    await bootstrapPlugins(fakeCtx);
+
+    // Ref count bumped to exactly 1 so we can tell register and unregister
+    // are balanced downstream.
+    expect(getPluginSkillRefCount("demo-plugin")).toBe(1);
+
+    // In-memory registry query surfaces the summary form.
+    const summaries = getPluginContributedSkillSummaries();
+    const registered = summaries.find((s) => s.id === "plugin-demo-skill");
+    expect(registered).toBeDefined();
+    expect(registered?.source).toBe("plugin");
+    expect(registered?.name).toBe("plugin-demo");
+    expect(registered?.displayName).toBe("Plugin Demo");
+    expect(registered?.activationHints).toEqual(["demo", "plugin"]);
+    // Summary must not carry the body — bodies are definition-only.
+    expect((registered as unknown as { body?: unknown }).body).toBeUndefined();
+
+    // The full definition is retrievable by id.
+    const def = getPluginContributedSkillDefinition("plugin-demo-skill");
+    expect(def).toBeDefined();
+    expect(def?.body).toContain("This is the plugin-provided body");
+  });
+
+  test("catalog and loadSkillBySelector discover plugin-contributed skills (skill_load pathway)", async () => {
+    const skill: PluginSkillRegistration = {
+      id: "catalog-visible-skill",
+      name: "catalog-visible",
+      description: "A plugin skill expected to surface in loadSkillCatalog",
+      body: "# Catalog-Visible Skill\n\nBody content for skill_load.",
+    };
+
+    registerPlugin(buildSkillPlugin("catalog-plugin", [skill]));
+    await bootstrapPlugins(fakeCtx);
+
+    // loadSkillCatalog is the exact entry point `skill_load` consults via
+    // `loadSkillBySelector` -> `resolveSkillSelector`.
+    const catalog = loadSkillCatalog();
+    const found = catalog.find((s) => s.id === "catalog-visible-skill");
+    expect(found).toBeDefined();
+    expect(found?.source).toBe("plugin");
+    expect(found?.description).toBe(skill.description);
+
+    // loadSkillBySelector is what SkillLoadTool.execute calls — it must
+    // return a fully-populated SkillDefinition, including the body.
+    const lookup = loadSkillBySelector("catalog-visible-skill");
+    expect(lookup.error).toBeUndefined();
+    expect(lookup.skill).toBeDefined();
+    expect(lookup.skill?.id).toBe("catalog-visible-skill");
+    expect(lookup.skill?.body).toContain("Body content for skill_load");
+
+    // And name-based resolution (what users type when the model picks a
+    // skill by name) works the same way.
+    const byName = loadSkillBySelector("catalog-visible");
+    expect(byName.skill?.id).toBe("catalog-visible-skill");
+  });
+
+  test("shutdown unregisters plugin skills so the catalog no longer lists them", async () => {
+    const skill: PluginSkillRegistration = {
+      id: "ephemeral-skill",
+      name: "ephemeral",
+      description: "Disappears after shutdown",
+      body: "Only visible while the plugin is alive.",
+    };
+
+    registerPlugin(buildSkillPlugin("ephemeral-plugin", [skill]));
+    await bootstrapPlugins(fakeCtx);
+
+    // Sanity: present before shutdown.
+    expect(loadSkillCatalog().some((s) => s.id === "ephemeral-skill")).toBe(
+      true,
+    );
+    expect(getPluginSkillRefCount("ephemeral-plugin")).toBe(1);
+
+    await runShutdownHooks("test-shutdown");
+
+    // After shutdown, the plugin's skill is gone from both the in-memory
+    // registry and any catalog view that consults it.
+    expect(getPluginSkillRefCount("ephemeral-plugin")).toBe(0);
+    expect(
+      getPluginContributedSkillDefinition("ephemeral-skill"),
+    ).toBeUndefined();
+
+    const catalogAfter = loadSkillCatalog();
+    expect(catalogAfter.some((s) => s.id === "ephemeral-skill")).toBe(false);
+
+    // And the selector lookup the model would use fails closed.
+    const lookup = loadSkillBySelector("ephemeral-skill");
+    expect(lookup.skill).toBeUndefined();
+  });
+
+  test("bootstrap is a no-op for plugins without a skills list", async () => {
+    // A plugin with no `skills` field must not bump ref counts or
+    // populate the catalog at all.
+    registerPlugin({
+      manifest: {
+        name: "no-skills-plugin",
+        version: "0.0.1",
+        requires: { pluginRuntime: "v1" },
+      },
+    });
+
+    await bootstrapPlugins(fakeCtx);
+
+    expect(getPluginSkillRefCount("no-skills-plugin")).toBe(0);
+    expect(getPluginContributedSkillSummaries()).toEqual([]);
+  });
+
+  test("duplicate skill id across plugins fails bootstrap with the plugin named", async () => {
+    const shared: PluginSkillRegistration = {
+      id: "contested-id",
+      name: "contested",
+      description: "First",
+      body: "from first plugin",
+    };
+    const duplicate: PluginSkillRegistration = {
+      id: "contested-id",
+      name: "contested",
+      description: "Second",
+      body: "from second plugin",
+    };
+
+    registerPlugin(buildSkillPlugin("first-plugin", [shared]));
+    registerPlugin(buildSkillPlugin("second-plugin", [duplicate]));
+
+    let caught: unknown;
+    try {
+      await bootstrapPlugins(fakeCtx);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(PluginExecutionError);
+    // The error must identify which plugin tripped the collision so
+    // operators can deploy a fix.
+    const msg = (caught as PluginExecutionError).message;
+    expect(msg).toContain("second-plugin");
+    expect(msg).toContain("contested-id");
+  });
+
+  test("intra-batch duplicate skill id in one plugin is rejected at registration", () => {
+    // Directly exercise the registry (no bootstrap) — a single plugin
+    // declaring the same id twice is a configuration bug and must fail
+    // loudly rather than silently overwrite.
+    expect(() =>
+      registerPluginSkills("dup-plugin", [
+        {
+          id: "dup-id",
+          name: "one",
+          description: "first",
+          body: "A",
+        },
+        {
+          id: "dup-id",
+          name: "two",
+          description: "second",
+          body: "B",
+        },
+      ]),
+    ).toThrow(PluginExecutionError);
+    expect(() =>
+      registerPluginSkills("dup-plugin", [
+        { id: "x", name: "one", description: "a", body: "A" },
+        { id: "x", name: "two", description: "b", body: "B" },
+      ]),
+    ).toThrow(/declared skill "x" more than once/);
+  });
+
+  test("ref-counted unregister: second unregister call after repeated registers drops skills", () => {
+    const registrations: PluginSkillRegistration[] = [
+      {
+        id: "refcount-skill",
+        name: "refcount",
+        description: "Ref-count demo",
+        body: "stays until the counter hits zero",
+      },
+    ];
+
+    registerPluginSkills("refcount-plugin", registrations);
+    // Second call is the "same plugin registered again" pattern (hot
+    // reload). It must bump the counter without re-inserting.
+    registerPluginSkills("refcount-plugin", registrations);
+    expect(getPluginSkillRefCount("refcount-plugin")).toBe(2);
+    expect(getPluginContributedSkillDefinition("refcount-skill")).toBeDefined();
+
+    // One unregister decrements only — skill must still be registered.
+    unregisterPluginSkills("refcount-plugin");
+    expect(getPluginSkillRefCount("refcount-plugin")).toBe(1);
+    expect(getPluginContributedSkillDefinition("refcount-skill")).toBeDefined();
+
+    // Second unregister drops the entry for real.
+    unregisterPluginSkills("refcount-plugin");
+    expect(getPluginSkillRefCount("refcount-plugin")).toBe(0);
+    expect(
+      getPluginContributedSkillDefinition("refcount-skill"),
+    ).toBeUndefined();
+
+    // Third unregister (over-decrement) is a no-op, not a throw — mirrors
+    // the tool-registry behavior so shutdown races don't crash the
+    // daemon.
+    expect(() => unregisterPluginSkills("refcount-plugin")).not.toThrow();
+  });
+
+  test("managed (filesystem) skill with the same id overrides a plugin-contributed skill", async () => {
+    // Plugin skills sit below managed/workspace in the catalog precedence
+    // chain so a user can shadow a plugin-provided skill by dropping a
+    // SKILL.md with the same id under ~/.vellum/workspace/skills. The test
+    // harness configures VELLUM_WORKSPACE_DIR via the bun test preload, so
+    // we can synthesize a filesystem skill for the same id and assert it
+    // wins.
+    const { mkdirSync, writeFileSync, rmSync, existsSync } =
+      await import("node:fs");
+
+    const workspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+    // Skip the filesystem override check when the harness did not provide a
+    // workspace dir — the other tests in this file still cover catalog
+    // visibility, which is the core of PR 33.
+    if (!workspaceDir) {
+      return;
+    }
+
+    const skillsDir = join(workspaceDir, "skills", "shared-id");
+    mkdirSync(skillsDir, { recursive: true });
+    writeFileSync(
+      join(skillsDir, "SKILL.md"),
+      [
+        "---",
+        'name: "filesystem-version"',
+        'description: "User-authored override"',
+        "---",
+        "",
+        "# Filesystem Override",
+      ].join("\n"),
+    );
+
+    const pluginSkill: PluginSkillRegistration = {
+      id: "shared-id",
+      name: "plugin-version",
+      description: "Plugin-provided skill that should be shadowed",
+      body: "plugin body",
+    };
+    registerPlugin(buildSkillPlugin("shadow-plugin", [pluginSkill]));
+
+    try {
+      await bootstrapPlugins(fakeCtx);
+
+      const catalog = loadSkillCatalog();
+      const entry = catalog.find((s) => s.id === "shared-id");
+      // The filesystem SKILL.md wins — source flips to "managed" and the
+      // plugin's metadata is not what we see.
+      expect(entry).toBeDefined();
+      expect(entry?.source).toBe("managed");
+      expect(entry?.name).toBe("filesystem-version");
+    } finally {
+      if (existsSync(skillsDir)) {
+        rmSync(skillsDir, { recursive: true, force: true });
+      }
+    }
+  });
+});

--- a/assistant/src/__tests__/plugin-types.test.ts
+++ b/assistant/src/__tests__/plugin-types.test.ts
@@ -76,7 +76,14 @@ describe("plugin core types", () => {
       },
       tools: [{ name: "sample-tool" }],
       routes: [{ path: "/sample" }],
-      skills: [{ name: "sample-skill" }],
+      skills: [
+        {
+          id: "sample-skill",
+          name: "Sample Skill",
+          description: "Demo plugin-contributed skill",
+          body: "## Sample\n\nPlugin-provided skill body.",
+        },
+      ],
       injectors: [injector],
       middleware: {
         turn: passthrough,

--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -54,8 +54,12 @@ export function resolveSkillStates(
     if (entry && typeof entry.enabled === "boolean") {
       isEnabled = entry.enabled;
     } else {
-      // Default: bundled and managed (user-installed) skills are enabled, others are disabled
-      isEnabled = skill.source === "bundled" || skill.source === "managed";
+      // Default: bundled, managed (user-installed), and plugin-contributed
+      // skills are enabled. Others (workspace, extra) are disabled by default.
+      isEnabled =
+        skill.source === "bundled" ||
+        skill.source === "managed" ||
+        skill.source === "plugin";
     }
 
     if (!isEnabled) {

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -19,6 +19,10 @@ import {
 import { z } from "zod";
 
 import {
+  getPluginContributedSkillDefinition,
+  getPluginContributedSkillSummaries,
+} from "../plugins/plugin-skill-contributions.js";
+import {
   extractAllText,
   getConfiguredProvider,
   userMessage,
@@ -59,7 +63,24 @@ const SkillMetadataSchema = z
   })
   .passthrough();
 
-export type SkillSource = "bundled" | "managed" | "workspace" | "extra";
+/**
+ * Origin of a skill in the merged catalog.
+ *
+ * - `bundled`: ships inside the assistant binary under `bundled-skills/`.
+ * - `managed`: installed into `~/.vellum/workspace/skills/` from our catalog.
+ * - `workspace`: user-authored skill living in a conversation's working dir.
+ * - `extra`: third-party directory roots passed via `loadSkillCatalog`'s
+ *   `extraDirs` argument (primarily for tests).
+ * - `plugin`: contributed at runtime by a loaded plugin via
+ *   `PluginSkillRegistration`. Body is held in-memory by
+ *   `plugins/plugin-skill-contributions.ts`, not on disk.
+ */
+export type SkillSource =
+  | "bundled"
+  | "managed"
+  | "workspace"
+  | "extra"
+  | "plugin";
 
 // ─── Core interfaces ─────────────────────────────────────────────────────────
 
@@ -819,6 +840,37 @@ export function loadSkillCatalog(
     catalog.push(skill);
   }
 
+  // Load plugin-contributed skills. They sit above bundled/extra but below
+  // managed and workspace so that user-authored filesystem skills can
+  // override a plugin-provided skill by declaring the same id under
+  // `~/.vellum/workspace/skills/`. Registration is owned by the plugin
+  // bootstrap — this call is a pure read against the in-memory registry.
+  const pluginSkills = getPluginContributedSkillSummaries();
+  for (const skill of pluginSkills) {
+    if (seenIds.has(skill.id)) {
+      const existingIndex = catalog.findIndex((s) => s.id === skill.id);
+      if (
+        existingIndex !== -1 &&
+        (catalog[existingIndex].source === "bundled" ||
+          catalog[existingIndex].source === "extra")
+      ) {
+        log.info(
+          { id: skill.id, pluginSkill: true },
+          "Plugin skill overrides bundled/extra skill",
+        );
+        catalog[existingIndex] = skill;
+        continue;
+      }
+      log.warn(
+        { id: skill.id },
+        "Skipping duplicate plugin skill id (already present in catalog)",
+      );
+      continue;
+    }
+    seenIds.add(skill.id);
+    catalog.push(skill);
+  }
+
   // Load managed (user) skills, which take precedence over bundled skills with the same ID
   const skillsDir = getSkillsDir();
   const indexedDirectories = getIndexedSkillDirectories(skillsDir);
@@ -829,16 +881,24 @@ export function loadSkillCatalog(
     if (!skill) continue;
 
     if (seenIds.has(skill.id)) {
-      // If the existing entry is bundled, the user skill overrides it
+      // If the existing entry is bundled, extra, or plugin-contributed, the
+      // user skill overrides it. Only another `managed` or `workspace` entry
+      // (already at or above managed precedence) is treated as a true
+      // duplicate.
       const existingIndex = catalog.findIndex((s) => s.id === skill.id);
       if (
         existingIndex !== -1 &&
         (catalog[existingIndex].bundled ||
-          catalog[existingIndex].source === "extra")
+          catalog[existingIndex].source === "extra" ||
+          catalog[existingIndex].source === "plugin")
       ) {
         log.info(
-          { id: skill.id, directory },
-          "User skill overrides bundled skill",
+          {
+            id: skill.id,
+            directory,
+            overriding: catalog[existingIndex].source,
+          },
+          "User skill overrides existing catalog entry",
         );
         catalog[existingIndex] = skillSummaryFromDefinition(skill, "managed");
         continue;
@@ -1018,6 +1078,35 @@ export function listReferenceFiles(directoryPath: string): string | null {
 }
 
 function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
+  // Plugin-contributed skills live in-memory, not on disk. The registry
+  // (see `plugins/plugin-skill-contributions.ts`) stores a pre-built
+  // SkillDefinition we can return directly — no file read, no frontmatter
+  // parse. We still run placeholder / feature-gate substitution on the
+  // body so plugin skills behave the same as filesystem skills from the
+  // model's perspective.
+  if (skill.source === "plugin") {
+    const pluginDef = getPluginContributedSkillDefinition(skill.id);
+    if (!pluginDef) {
+      // The skill was in the catalog when the selector ran but has since
+      // been unregistered (plugin hot-reload, shutdown race). Fail loudly
+      // rather than returning a mystery undefined.
+      return {
+        error: `Plugin-contributed skill "${skill.id}" is no longer registered`,
+      };
+    }
+    // Shallow-clone so mutating the returned `body` below does not touch
+    // the registry's stored copy — the registry must stay the source of
+    // truth across repeated `skill_load` calls.
+    const loaded: SkillDefinition = { ...pluginDef };
+    loaded.body = loaded.body.replaceAll("{baseDir}", loaded.directoryPath);
+    loaded.body = loaded.body.replaceAll(
+      "{workspaceDir}",
+      getWorkspaceDirDisplay(),
+    );
+    loaded.body = applyFeatureGatedSections(loaded.body);
+    return { skill: loaded };
+  }
+
   let loaded: SkillDefinition | null;
   if (skill.bundled) {
     loaded = readBundledSkillFromDirectory(skill.directoryPath);

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -36,6 +36,10 @@ import { join } from "node:path";
 
 import type { AssistantConfig } from "../config/schema.js";
 import {
+  registerPluginSkills,
+  unregisterPluginSkills,
+} from "../plugins/plugin-skill-contributions.js";
+import {
   ASSISTANT_API_VERSIONS,
   getRegisteredPlugins,
 } from "../plugins/registry.js";
@@ -43,6 +47,7 @@ import {
   type Plugin,
   PluginExecutionError,
   type PluginInitContext,
+  type PluginSkillRegistration,
 } from "../plugins/types.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
@@ -206,6 +211,31 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
       }
     }
 
+    // After init succeeds, wire in the plugin's model-visible capabilities.
+    // Skills (PR 33) register into the in-memory plugin-skill catalog so
+    // `skill_load` / `skill_execute` can resolve them alongside filesystem
+    // skills. A registration failure aborts bootstrap with the plugin named
+    // — same strict-fail posture as init() throws.
+    if (plugin.skills && plugin.skills.length > 0) {
+      try {
+        // `plugin.skills` is typed as `PluginSkillRegistration[]` at the
+        // Plugin interface — the type assertion here is a narrowing from
+        // that generic slot into the concrete shape the registry expects.
+        registerPluginSkills(
+          name,
+          plugin.skills as readonly PluginSkillRegistration[],
+        );
+      } catch (err) {
+        throw new PluginExecutionError(
+          `plugin ${name} skill registration failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          name,
+          { cause: err },
+        );
+      }
+    }
+
     log.info({ plugin: name }, "plugin initialized");
   }
 
@@ -213,23 +243,43 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
   // the current plugin list so later registrations (if any) don't end up
   // being torn down by this hook; subsequent bootstraps (hot-reload) would
   // register their own hook.
+  //
+  // For each plugin we:
+  //   1. Call `onShutdown()` (if defined) so user code can clean up first,
+  //      while the skill is still registered and any in-flight `skill_load`
+  //      call is still serviceable.
+  //   2. Unregister the plugin's contributed skills via the ref-counted
+  //      helper. This mirrors the symmetry of registerPluginSkills() —
+  //      every successful registration must get a matching unregister call,
+  //      regardless of whether onShutdown throws.
   const shutdownSnapshot: Plugin[] = [...plugins];
   registerShutdownHook("plugins", async (reason) => {
     for (let i = shutdownSnapshot.length - 1; i >= 0; i--) {
       const plugin = shutdownSnapshot[i]!;
       const name = plugin.manifest.name;
-      if (!plugin.onShutdown) continue;
-      try {
-        await plugin.onShutdown();
-      } catch (err) {
-        // Swallow — we want every plugin's onShutdown to get a chance to
-        // run even when an earlier one throws. The outer runShutdownHooks
-        // already logs at hook level, but the plugin-name attribution here
-        // is what operators read first.
-        log.warn(
-          { err, plugin: name, reason },
-          "plugin onShutdown failed (continuing with remaining plugins)",
-        );
+      if (plugin.onShutdown) {
+        try {
+          await plugin.onShutdown();
+        } catch (err) {
+          // Swallow — we want every plugin's onShutdown to get a chance to
+          // run even when an earlier one throws. The outer runShutdownHooks
+          // already logs at hook level, but the plugin-name attribution here
+          // is what operators read first.
+          log.warn(
+            { err, plugin: name, reason },
+            "plugin onShutdown failed (continuing with remaining plugins)",
+          );
+        }
+      }
+      if (plugin.skills && plugin.skills.length > 0) {
+        try {
+          unregisterPluginSkills(name);
+        } catch (err) {
+          log.warn(
+            { err, plugin: name, reason },
+            "plugin skill unregistration failed (continuing with remaining plugins)",
+          );
+        }
       }
     }
   });

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -326,10 +326,14 @@ export function postInstallSkill(
 
 /** Map the old `source` field to the new `kind` axis. */
 function deriveKind(
-  source: "bundled" | "managed" | "workspace" | "extra" | "catalog",
+  source: "bundled" | "managed" | "workspace" | "extra" | "catalog" | "plugin",
 ): SlimSkillResponse["kind"] {
   if (source === "bundled") return "bundled";
   if (source === "catalog") return "catalog";
+  // Plugin-contributed skills are framework-provided like bundled skills —
+  // expose them under the same "bundled" kind so the UI doesn't invent a
+  // new category that existing clients don't know how to render.
+  if (source === "plugin") return "bundled";
   return "installed"; // managed, workspace, extra
 }
 

--- a/assistant/src/plugins/plugin-skill-contributions.ts
+++ b/assistant/src/plugins/plugin-skill-contributions.ts
@@ -1,0 +1,292 @@
+/**
+ * In-memory registry of plugin-contributed skills.
+ *
+ * Plugins with `manifest.skills` (or {@link Plugin.skills}) declared in their
+ * {@link PluginSkillRegistration} list get their entries indexed here during
+ * bootstrap (PR 14 -> PR 33). {@link loadSkillCatalog} in
+ * `config/skills.ts` merges these entries into the regular catalog so the
+ * model's `skill_load` / `skill_execute` flow can resolve them under
+ * `source: "plugin"`.
+ *
+ * ## Ref-counted lifecycle
+ *
+ * Registration is per-plugin — a plugin declares zero or more skills and the
+ * registry stores them keyed by plugin name. Several tests and hot-reload
+ * flows may call {@link registerPluginSkills} more than once for the same
+ * plugin (same skills, same body). Each call bumps a reference counter;
+ * {@link unregisterPluginSkills} decrements it and only tears the entry down
+ * when the counter reaches zero. This mirrors the ref-counted teardown
+ * semantics of `registerSkillTools` / `unregisterSkillTools` in the tool
+ * registry, so the plugin layer's lifecycle matches the skill layer's.
+ *
+ * Collision rules:
+ *
+ * - A plugin cannot register two skills with the same id in a single call —
+ *   the duplicate is rejected at registration time.
+ * - Two different plugins cannot contribute skills with the same id. The
+ *   second registration throws so the operator notices, rather than silently
+ *   shadowing the first plugin's contribution.
+ * - The catalog merge logic in {@link loadSkillCatalog} decides how plugin
+ *   skills interact with filesystem skills (bundled/managed/workspace) —
+ *   this module just owns the in-memory set.
+ */
+
+import type {
+  SkillDefinition,
+  SkillSummary,
+  SkillToolManifestMeta,
+} from "../config/skills.js";
+import { getLogger } from "../util/logger.js";
+import { PluginExecutionError, type PluginSkillRegistration } from "./types.js";
+
+// This module imports ONLY types from `config/skills.js`. `config/skills.ts`
+// in turn imports values from here to merge plugin-contributed skills into
+// the catalog output. TypeScript / ESM handles the type-only edge of the
+// cycle cleanly; converting any of the imports above to value imports would
+// introduce a runtime cycle and a load-order hazard with `loadSkillCatalog`.
+
+const log = getLogger("plugin-skills");
+
+/**
+ * Virtual directory path prefix for plugin-contributed skills. `SkillSummary`
+ * requires a `directoryPath` — plugin skills aren't on disk, so we synthesize
+ * a stable, recognizable path that encodes the plugin name. Downstream code
+ * that reads from disk (inline-command rendering, reference-file listing,
+ * icon caching) gates on `source` so these paths are never stat'd.
+ */
+const PLUGIN_VIRTUAL_PATH_PREFIX = "<plugin>/";
+
+/**
+ * One stored plugin skill. Keeps the original registration for re-exposure
+ * and a pre-built {@link SkillDefinition} so the catalog / loader paths can
+ * return summary/definition objects without re-synthesizing them on every
+ * lookup.
+ */
+interface StoredPluginSkill {
+  /** Name of the plugin that contributed the skill. */
+  pluginName: string;
+  /** Pre-built definition (includes the body) returned to `skill_load`. */
+  definition: SkillDefinition;
+}
+
+/** All skills contributed by plugins, keyed by skill id. */
+const pluginSkillsById = new Map<string, StoredPluginSkill>();
+
+/**
+ * Ref-count of active registrations per plugin name. Bumped on
+ * {@link registerPluginSkills}, decremented on {@link unregisterPluginSkills}.
+ * Only when the counter hits zero do we actually remove the plugin's
+ * contributed skills from {@link pluginSkillsById}.
+ */
+const pluginRefCount = new Map<string, number>();
+
+/**
+ * Skill-id -> owning plugin name. Maintained alongside
+ * {@link pluginSkillsById} so {@link unregisterPluginSkills} can drop exactly
+ * the entries the plugin owns without scanning the full id map.
+ */
+const pluginSkillIdsByPlugin = new Map<string, Set<string>>();
+
+/**
+ * Build the {@link SkillDefinition} object that {@link loadSkillCatalog} and
+ * {@link loadSkillBySelector} hand back to consumers. Kept in one place so
+ * summary and definition stay in lockstep — any field added to
+ * {@link PluginSkillRegistration} shows up in both.
+ */
+function buildDefinition(
+  pluginName: string,
+  reg: PluginSkillRegistration,
+): SkillDefinition {
+  // Synthetic directory path. Using a non-filesystem prefix keeps the path
+  // recognizable in logs while preventing accidental `fs.existsSync` loops
+  // elsewhere in the catalog (all such loops live behind source !== "plugin"
+  // guards).
+  const directoryPath = `${PLUGIN_VIRTUAL_PATH_PREFIX}${pluginName}/${reg.id}`;
+  const skillFilePath = `${directoryPath}/SKILL.md`;
+
+  // toolManifest stays undefined for plugin skills — plugin tool contributions
+  // flow through `Plugin.tools` (PR 31), not through a synthetic TOOLS.json.
+  const toolManifest: SkillToolManifestMeta | undefined = undefined;
+
+  return {
+    id: reg.id,
+    name: reg.name,
+    displayName: reg.displayName ?? reg.name,
+    description: reg.description,
+    directoryPath,
+    skillFilePath,
+    body: reg.body,
+    emoji: reg.emoji,
+    source: "plugin",
+    toolManifest,
+    includes: reg.includes,
+    featureFlag: reg.featureFlag,
+    activationHints: reg.activationHints,
+    avoidWhen: reg.avoidWhen,
+    // Plugin skills do not support inline command expansion in this PR.
+    inlineCommandExpansions: undefined,
+  };
+}
+
+/**
+ * Register every skill declared by a plugin's `Plugin.skills` list.
+ *
+ * Must be called after the plugin's `init()` completes successfully (see
+ * `external-plugins-bootstrap.ts`). Throws {@link PluginExecutionError} if a
+ * skill id collides with another plugin's skill or with an id already
+ * registered in an earlier successful registration from the same plugin
+ * that hasn't been torn down.
+ *
+ * Ref-count semantics: each call bumps the plugin-level ref counter.
+ * Duplicate registrations of the *same* plugin's skills are accepted and
+ * treated as a no-op past the first call — the second invocation increments
+ * the counter without re-inserting entries.
+ */
+export function registerPluginSkills(
+  pluginName: string,
+  skills: readonly PluginSkillRegistration[],
+): void {
+  const currentCount = pluginRefCount.get(pluginName) ?? 0;
+
+  if (currentCount > 0) {
+    // The plugin already has skills registered — bump the counter without
+    // re-adding. Duplicate register calls for the same plugin are legitimate
+    // (hot-reload, re-bootstrap) so we accept them rather than throw.
+    pluginRefCount.set(pluginName, currentCount + 1);
+    log.debug(
+      { pluginName, refCount: currentCount + 1 },
+      "Bumped plugin-skills ref count (skills kept)",
+    );
+    return;
+  }
+
+  // First-time registration for this plugin — validate and insert.
+  //
+  // We validate intra-batch uniqueness first so a plugin that accidentally
+  // declares the same skill twice gets a clear error at registration,
+  // rather than the second declaration silently overwriting the first
+  // inside the map.
+  const seenInBatch = new Set<string>();
+  for (const reg of skills) {
+    if (seenInBatch.has(reg.id)) {
+      throw new PluginExecutionError(
+        `plugin ${pluginName} declared skill "${reg.id}" more than once`,
+        pluginName,
+      );
+    }
+    seenInBatch.add(reg.id);
+
+    const existing = pluginSkillsById.get(reg.id);
+    if (existing) {
+      throw new PluginExecutionError(
+        `plugin ${pluginName} cannot contribute skill "${reg.id}" — ` +
+          `already registered by plugin "${existing.pluginName}"`,
+        pluginName,
+      );
+    }
+  }
+
+  const ownedIds = new Set<string>();
+  for (const reg of skills) {
+    pluginSkillsById.set(reg.id, {
+      pluginName,
+      definition: buildDefinition(pluginName, reg),
+    });
+    ownedIds.add(reg.id);
+    log.info({ pluginName, skillId: reg.id }, "Plugin skill registered");
+  }
+
+  pluginSkillIdsByPlugin.set(pluginName, ownedIds);
+  pluginRefCount.set(pluginName, 1);
+}
+
+/**
+ * Decrement the ref count for a plugin's skills. When the count hits zero
+ * the plugin's contributed skills are removed from the in-memory catalog.
+ *
+ * Idempotent — calling on a plugin that was never registered is a no-op
+ * (logged at debug level).
+ */
+export function unregisterPluginSkills(pluginName: string): void {
+  const current = pluginRefCount.get(pluginName) ?? 0;
+  if (current === 0) {
+    log.debug(
+      { pluginName },
+      "unregisterPluginSkills called on unregistered plugin (no-op)",
+    );
+    return;
+  }
+
+  if (current > 1) {
+    pluginRefCount.set(pluginName, current - 1);
+    log.info(
+      { pluginName, remaining: current - 1 },
+      "Decremented plugin-skills ref count, skills kept",
+    );
+    return;
+  }
+
+  // Last reference — actually remove the skills.
+  pluginRefCount.delete(pluginName);
+  const ownedIds = pluginSkillIdsByPlugin.get(pluginName);
+  if (ownedIds) {
+    for (const id of ownedIds) {
+      pluginSkillsById.delete(id);
+      log.info({ pluginName, skillId: id }, "Plugin skill unregistered");
+    }
+    pluginSkillIdsByPlugin.delete(pluginName);
+  }
+}
+
+/**
+ * Return a shallow-copied list of {@link SkillSummary} entries for every
+ * plugin-contributed skill. Consumers (the catalog loader) treat the return
+ * value as a read-only snapshot — mutating it does not mutate the registry.
+ */
+export function getPluginContributedSkillSummaries(): SkillSummary[] {
+  const out: SkillSummary[] = [];
+  for (const stored of pluginSkillsById.values()) {
+    // Strip `body` so we hand out a SkillSummary, not a SkillDefinition —
+    // the catalog merge function in config/skills.ts pushes summaries.
+    const { body: _body, ...summary } = stored.definition;
+    out.push(summary);
+  }
+  return out;
+}
+
+/**
+ * Look up the full {@link SkillDefinition} for a plugin-contributed skill by
+ * id. Used by the catalog loader to satisfy `skill_load` without a disk
+ * read.
+ */
+export function getPluginContributedSkillDefinition(
+  skillId: string,
+): SkillDefinition | undefined {
+  return pluginSkillsById.get(skillId)?.definition;
+}
+
+/**
+ * Return the current ref count for a plugin's skills. Exposed for tests.
+ */
+export function getPluginSkillRefCount(pluginName: string): number {
+  return pluginRefCount.get(pluginName) ?? 0;
+}
+
+/**
+ * Clear every registered plugin skill. Test-only — throws when invoked
+ * outside a test environment. Guard mirrors
+ * {@link resetPluginRegistryForTests}.
+ */
+export function resetPluginSkillContributionsForTests(): void {
+  const isTest =
+    process.env.BUN_TEST === "1" || process.env.NODE_ENV === "test";
+  if (!isTest) {
+    throw new PluginExecutionError(
+      "resetPluginSkillContributionsForTests may only be called in test environments",
+      undefined,
+    );
+  }
+  pluginSkillsById.clear();
+  pluginRefCount.clear();
+  pluginSkillIdsByPlugin.clear();
+}

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -248,16 +248,57 @@ export interface Injector {
 }
 
 // ─── Model-visible capability slots (placeholder shapes) ─────────────────────
-// Concrete shapes are defined by the tool/route/skill registries. Typing
-// them as `unknown`-tagged aliases here keeps the Plugin interface decoupled
-// until later PRs wire real registrations.
+// Tool and route shapes stay `unknown` until their respective contribution PRs
+// (31 and 32) land. Skill contributions (PR 33) ship with a concrete shape
+// below so plugins can declare catalog-discoverable skills today.
 
 /** Tool registration contributed by a plugin. Concrete shape TBD. */
 export type PluginToolRegistration = unknown;
 /** HTTP route registration contributed by a plugin. Concrete shape TBD. */
 export type PluginRouteRegistration = unknown;
-/** Skill registration contributed by a plugin. Concrete shape TBD. */
-export type PluginSkillRegistration = unknown;
+
+/**
+ * A skill contributed by a plugin.
+ *
+ * When a plugin declares {@link Plugin.skills}, the bootstrap registers each
+ * entry into an in-memory side catalog that {@link loadSkillCatalog} merges
+ * into its output. The entry is then discoverable by the model's `skill_load`
+ * / `skill_execute` flow under `source: "plugin"` — the same code paths used
+ * for filesystem-backed skills.
+ *
+ * The fields mirror the subset of `SkillSummary` / `SkillDefinition` that
+ * makes sense for an in-memory contribution. Inline commands and reference
+ * files are out of scope for plugin skills in this PR — add them later if a
+ * real plugin needs them.
+ */
+export interface PluginSkillRegistration {
+  /** Stable skill id (kebab-case). Must be unique across the catalog. */
+  id: string;
+  /**
+   * Skill "name" as surfaced to the model. Matches the SKILL.md frontmatter
+   * `name` field for filesystem skills.
+   */
+  name: string;
+  /**
+   * Human-readable display name shown in UI lists. Defaults to `name` when
+   * omitted — matches the filesystem-skill default.
+   */
+  displayName?: string;
+  /** One-line description shown by `skill_load` / UI. */
+  description: string;
+  /** Full skill body returned when `skill_load` fires for this skill. */
+  body: string;
+  /** Optional emoji shown beside the skill in UI surfaces. */
+  emoji?: string;
+  /** Optional assistant feature-flag key — when set and the flag is OFF, the skill is filtered out. */
+  featureFlag?: string;
+  /** Compact routing cues injected into `<available_skills>` to guide selection. */
+  activationHints?: string[];
+  /** Conditions under which this skill should NOT be loaded. */
+  avoidWhen?: string[];
+  /** IDs of child skills that this skill includes (metadata-only, not auto-activated). */
+  includes?: string[];
+}
 
 // ─── Plugin ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Plugins with `skills: SkillDefinition[]` in manifest auto-register via skills registry
- Shutdown unregisters via existing ref-counted semantics
- Tests cover registration + discoverability + cleanup

Part of plan: agent-plugin-system.md (PR 33 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
