### PR TITLE
feat(assistant): wrap token estimation as plugin pipeline

### DIFF
--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -56,7 +56,7 @@ mock.module("../providers/registry.js", () => ({
 
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
-    ui: {},    
+    ui: {},
     llm: {
       default: {
         provider: "mock-provider",
@@ -205,6 +205,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getResolvedTools() {
+      return [];
+    }
     getActiveModel() {
       return undefined;
     }
@@ -213,7 +216,9 @@ mock.module("../agent/loop.js", () => ({
       _onEvent: (event: AgentEvent) => void,
       _signal?: AbortSignal,
       _requestId?: string,
-      _onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
+      _onCheckpoint?: (
+        checkpoint: CheckpointInfo,
+      ) => CheckpointDecision | Promise<CheckpointDecision>,
     ): Promise<Message[]> {
       return [];
     }

--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -226,6 +226,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getResolvedTools() {
+      return [];
+    }
     getActiveModel() {
       return undefined;
     }
@@ -234,7 +237,9 @@ mock.module("../agent/loop.js", () => ({
       _onEvent: (event: AgentEvent) => void,
       _signal?: AbortSignal,
       _requestId?: string,
-      _onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
+      _onCheckpoint?: (
+        checkpoint: CheckpointInfo,
+      ) => CheckpointDecision | Promise<CheckpointDecision>,
     ): Promise<Message[]> {
       return [];
     }

--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -25,7 +25,7 @@ mock.module("../providers/registry.js", () => ({
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
-    
+
     llm: {
       default: {
         provider: "mock-provider",
@@ -167,6 +167,9 @@ mock.module("../agent/loop.js", () => ({
     constructor() {}
     getToolTokenBudget() {
       return 0;
+    }
+    getResolvedTools() {
+      return [];
     }
     getActiveModel() {
       return undefined;

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -71,12 +71,23 @@ mock.module("../config/loader.js", () => ({
 // Token estimator — controllable per-test via mockEstimateTokens.
 // Can be a number (constant), a no-arg function, or a function that
 // receives the messages array for dynamic behavior based on content.
+// Both the calibrated entry point (`estimatePromptTokens`, used in the
+// convergence path) and the raw entry point (`estimatePromptTokensRaw`,
+// used by the default `tokenEstimate` plugin pipeline for preflight/mid-
+// loop) are stubbed so either call site can drive the test.
 let mockEstimateTokens: number | ((msgs?: Message[]) => number) = 1000;
 mock.module("../context/token-estimator.js", () => ({
   estimatePromptTokens: (msgs: Message[]) =>
     typeof mockEstimateTokens === "function"
       ? mockEstimateTokens(msgs)
       : mockEstimateTokens,
+  estimatePromptTokensRaw: (msgs: Message[]) =>
+    typeof mockEstimateTokens === "function"
+      ? mockEstimateTokens(msgs)
+      : mockEstimateTokens,
+  // Default plugin multiplies-in tool tokens via this helper; 0 keeps the
+  // stubbed raw value unchanged.
+  estimateToolsTokens: () => 0,
   // Conversation agent loop now calls this helper to canonicalize the
   // provider key shared with the calibration system. The tests here
   // don't exercise that path, so a passthrough mock is fine.
@@ -359,7 +370,9 @@ type AgentLoopRun = (
   onEvent: (event: AgentEvent) => void,
   signal?: AbortSignal,
   requestId?: string,
-  onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
+  onCheckpoint?: (
+    checkpoint: CheckpointInfo,
+  ) => CheckpointDecision | Promise<CheckpointDecision>,
 ) => Promise<Message[]>;
 
 function makeCtx(
@@ -389,6 +402,7 @@ function makeCtx(
     agentLoop: {
       run: agentLoopRun,
       getToolTokenBudget: () => 0,
+      getResolvedTools: () => [],
       // Tests in this file don't exercise calibration, so returning
       // undefined is fine — the estimator falls back to the per-provider
       // aggregate key.
@@ -1369,7 +1383,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
           // Call onCheckpoint — this should trigger the mid-loop budget check
           // which sees 170_000 > 161_500 and returns "yield"
           if (onCheckpoint) {
-            const decision = onCheckpoint({
+            const decision = await onCheckpoint({
               turnIndex: 0,
               toolCount: 1,
               hasToolUse: true,
@@ -1543,7 +1557,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
             });
 
             if (onCheckpoint) {
-              const decision = onCheckpoint({
+              const decision = await onCheckpoint({
                 turnIndex: i,
                 toolCount: 1,
                 hasToolUse: true,
@@ -1727,7 +1741,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
 
       // Always yield at checkpoint — simulates compaction not helping
       if (onCheckpoint) {
-        const decision = onCheckpoint({
+        const decision = await onCheckpoint({
           turnIndex: 0,
           toolCount: 1,
           hasToolUse: true,
@@ -1883,7 +1897,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
 
       // Always yield at checkpoint — simulates reduction not helping enough
       if (onCheckpoint) {
-        const decision = onCheckpoint({
+        const decision = await onCheckpoint({
           turnIndex: 0,
           toolCount: 1,
           hasToolUse: true,

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -57,10 +57,19 @@ mock.module("../config/loader.js", () => ({
 // ── Overflow recovery mocks ──────────────────────────────────────────
 
 // Token estimator returns a small value by default (well within budget)
-// so preflight does not trigger unless the test overrides it.
+// so preflight does not trigger unless the test overrides it. Both the
+// calibrated entry point (`estimatePromptTokens`, used in the convergence
+// path) and the raw entry point (`estimatePromptTokensRaw`, used by the
+// default `tokenEstimate` plugin pipeline for preflight/mid-loop) are
+// stubbed so either call site can drive the test.
 let mockEstimateTokens = 1000;
 mock.module("../context/token-estimator.js", () => ({
   estimatePromptTokens: () => mockEstimateTokens,
+  estimatePromptTokensRaw: () => mockEstimateTokens,
+  // Pass-through: the default plugin computes `toolTokenBudget` via this
+  // helper before delegating to the raw estimator. Return 0 so the mocked
+  // raw estimate is not perturbed.
+  estimateToolsTokens: () => 0,
 }));
 
 // Reducer: by default returns the input untouched and marks exhausted
@@ -353,7 +362,9 @@ type AgentLoopRun = (
   onEvent: (event: AgentEvent) => void,
   signal?: AbortSignal,
   requestId?: string,
-  onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
+  onCheckpoint?: (
+    checkpoint: CheckpointInfo,
+  ) => CheckpointDecision | Promise<CheckpointDecision>,
 ) => Promise<Message[]>;
 
 function makeCtx(
@@ -383,6 +394,7 @@ function makeCtx(
     agentLoop: {
       run: agentLoopRun,
       getToolTokenBudget: () => 0,
+      getResolvedTools: () => [],
       // Tests here don't exercise calibration; returning undefined makes
       // the estimator use the per-provider aggregate key.
       getActiveModel: () => undefined,
@@ -1571,7 +1583,7 @@ describe("session-agent-loop", () => {
           providerDurationMs: 100,
         });
         if (onCheckpoint) {
-          const decision = onCheckpoint({
+          const decision = await onCheckpoint({
             turnIndex: 0,
             toolCount: 1,
             hasToolUse: true,
@@ -1639,7 +1651,7 @@ describe("session-agent-loop", () => {
           providerDurationMs: 100,
         });
         if (onCheckpoint) {
-          onCheckpoint({
+          await onCheckpoint({
             turnIndex: 0,
             toolCount: 1,
             hasToolUse: true,

--- a/assistant/src/__tests__/conversation-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/conversation-confirmation-signals.test.ts
@@ -195,6 +195,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getResolvedTools() {
+      return [];
+    }
     getActiveModel() {
       return undefined;
     }
@@ -203,7 +206,9 @@ mock.module("../agent/loop.js", () => ({
       _onEvent: (event: AgentEvent) => void,
       _signal?: AbortSignal,
       _requestId?: string,
-      _onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
+      _onCheckpoint?: (
+        checkpoint: CheckpointInfo,
+      ) => CheckpointDecision | Promise<CheckpointDecision>,
     ): Promise<Message[]> {
       return [];
     }

--- a/assistant/src/__tests__/conversation-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/conversation-pre-run-repair.test.ts
@@ -23,7 +23,7 @@ mock.module("../providers/registry.js", () => ({
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
-    
+
     llm: {
       default: {
         provider: "mock-provider",
@@ -140,6 +140,9 @@ mock.module("../agent/loop.js", () => ({
     constructor() {}
     getToolTokenBudget() {
       return 0;
+    }
+    getResolvedTools() {
+      return [];
     }
     getActiveModel() {
       return undefined;

--- a/assistant/src/__tests__/conversation-process-callsite.test.ts
+++ b/assistant/src/__tests__/conversation-process-callsite.test.ts
@@ -170,6 +170,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getResolvedTools() {
+      return [];
+    }
     async run(
       messages: Message[],
       onEvent: (event: Record<string, unknown>) => void,

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -76,9 +76,13 @@ mock.module("../config/loader.js", () => ({
 }));
 
 // Token estimator: return a small value (well within budget) so preflight
-// does not trigger in existing tests.
+// does not trigger in existing tests. Stub both the calibrated and raw
+// entry points — the latter backs the default `tokenEstimate` plugin
+// pipeline now used by the orchestrator's preflight / mid-loop checkpoints.
 mock.module("../context/token-estimator.js", () => ({
   estimatePromptTokens: () => 1000,
+  estimatePromptTokensRaw: () => 1000,
+  estimateToolsTokens: () => 0,
 }));
 
 // Overflow recovery module mocks — the convergence loop delegates to these
@@ -255,6 +259,9 @@ mock.module("../agent/loop.js", () => ({
     constructor() {}
     getToolTokenBudget() {
       return 0;
+    }
+    getResolvedTools() {
+      return [];
     }
     getActiveModel() {
       return undefined;

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -55,7 +55,7 @@ mock.module("../providers/registry.js", () => ({
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
-    
+
     llm: {
       default: {
         provider: "mock-provider",
@@ -330,7 +330,9 @@ interface PendingRun {
   reject: (err: Error) => void;
   messages: Message[];
   onEvent: (event: AgentEvent) => void;
-  onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision;
+  onCheckpoint?: (
+    checkpoint: CheckpointInfo,
+  ) => CheckpointDecision | Promise<CheckpointDecision>;
 }
 
 let pendingRuns: PendingRun[] = [];
@@ -341,6 +343,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getResolvedTools() {
+      return [];
+    }
     getActiveModel() {
       return undefined;
     }
@@ -349,7 +354,9 @@ mock.module("../agent/loop.js", () => ({
       onEvent: (event: AgentEvent) => void,
       _signal?: AbortSignal,
       _requestId?: string,
-      onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
+      onCheckpoint?: (
+        checkpoint: CheckpointInfo,
+      ) => CheckpointDecision | Promise<CheckpointDecision>,
     ): Promise<Message[]> {
       return new Promise<Message[]>((resolve, reject) => {
         pendingRuns.push({ resolve, reject, messages, onEvent, onCheckpoint });
@@ -1728,7 +1735,7 @@ describe("Conversation checkpoint handoff", () => {
     // Simulate the agent loop calling it at a turn boundary.
     const run = pendingRuns[0];
     expect(run.onCheckpoint).toBeDefined();
-    const decision = run.onCheckpoint!({
+    const decision = await run.onCheckpoint!({
       turnIndex: 0,
       toolCount: 1,
       hasToolUse: true,
@@ -1771,7 +1778,7 @@ describe("Conversation checkpoint handoff", () => {
     // The pending run should have an onCheckpoint callback
     const run = pendingRuns[0];
     expect(run.onCheckpoint).toBeDefined();
-    const decision = run.onCheckpoint!({
+    const decision = await run.onCheckpoint!({
       turnIndex: 0,
       toolCount: 1,
       hasToolUse: true,
@@ -1813,7 +1820,7 @@ describe("Conversation checkpoint handoff", () => {
     // Simulate the agent loop yielding at the checkpoint (first run is mid-tool-use)
     const run0 = pendingRuns[0];
     expect(run0.onCheckpoint).toBeDefined();
-    const decision = run0.onCheckpoint!({
+    const decision = await run0.onCheckpoint!({
       turnIndex: 0,
       toolCount: 1,
       hasToolUse: true,
@@ -1871,7 +1878,7 @@ describe("Conversation checkpoint handoff", () => {
 
     // Simulate multiple tool-use turns before the checkpoint fires
     // Turn 0 — checkpoint yields because msg-2 is waiting
-    const decision = run.onCheckpoint!({
+    const decision = await run.onCheckpoint!({
       turnIndex: 0,
       toolCount: 1,
       hasToolUse: true,
@@ -1966,7 +1973,7 @@ describe("Conversation checkpoint handoff", () => {
     const runA = pendingRuns[0];
     expect(runA.onCheckpoint).toBeDefined();
     expect(
-      runA.onCheckpoint!({
+      await runA.onCheckpoint!({
         turnIndex: 0,
         toolCount: 1,
         hasToolUse: true,
@@ -1983,7 +1990,7 @@ describe("Conversation checkpoint handoff", () => {
     const runB = pendingRuns[1];
     expect(runB.onCheckpoint).toBeDefined();
     expect(
-      runB.onCheckpoint!({
+      await runB.onCheckpoint!({
         turnIndex: 0,
         toolCount: 1,
         hasToolUse: true,
@@ -1998,7 +2005,7 @@ describe("Conversation checkpoint handoff", () => {
     expect(runC.onCheckpoint).toBeDefined();
     // Only D remains, still should yield
     expect(
-      runC.onCheckpoint!({
+      await runC.onCheckpoint!({
         turnIndex: 0,
         toolCount: 1,
         hasToolUse: true,
@@ -2012,7 +2019,7 @@ describe("Conversation checkpoint handoff", () => {
     const runD = pendingRuns[3];
     expect(runD.onCheckpoint).toBeDefined();
     expect(
-      runD.onCheckpoint!({
+      await runD.onCheckpoint!({
         turnIndex: 0,
         toolCount: 1,
         hasToolUse: true,
@@ -2450,7 +2457,7 @@ describe("Conversation attachment event payloads", () => {
     const run = pendingRuns[0];
     expect(run.onCheckpoint).toBeDefined();
     expect(
-      run.onCheckpoint!({
+      await run.onCheckpoint!({
         turnIndex: 0,
         toolCount: 1,
         hasToolUse: true,

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -30,7 +30,7 @@ mock.module("../providers/registry.js", () => ({
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
-    
+
     llm: {
       default: {
         provider: "mock-provider",
@@ -207,6 +207,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getResolvedTools() {
+      return [];
+    }
     getActiveModel() {
       return undefined;
     }
@@ -215,7 +218,9 @@ mock.module("../agent/loop.js", () => ({
       onEvent: (event: AgentEvent) => void,
       _signal?: AbortSignal,
       _requestId?: string,
-      _onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
+      _onCheckpoint?: (
+        checkpoint: CheckpointInfo,
+      ) => CheckpointDecision | Promise<CheckpointDecision>,
     ): Promise<Message[]> {
       return new Promise<Message[]>((resolve) => {
         pendingRuns.push({ resolve, messages, onEvent });

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -236,6 +236,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getResolvedTools() {
+      return [];
+    }
     getActiveModel() {
       return undefined;
     }
@@ -244,7 +247,9 @@ mock.module("../agent/loop.js", () => ({
       onEvent: (event: AgentEvent) => void,
       _signal?: AbortSignal,
       _requestId?: string,
-      _onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
+      _onCheckpoint?: (
+        checkpoint: CheckpointInfo,
+      ) => CheckpointDecision | Promise<CheckpointDecision>,
     ): Promise<Message[]> {
       agentLoopRunCalled = true;
       const assistantMsg: Message = {

--- a/assistant/src/__tests__/conversation-speed-override.test.ts
+++ b/assistant/src/__tests__/conversation-speed-override.test.ts
@@ -211,6 +211,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getResolvedTools() {
+      return [];
+    }
     getActiveModel() {
       return undefined;
     }
@@ -219,7 +222,9 @@ mock.module("../agent/loop.js", () => ({
       _onEvent: (event: AgentEvent) => void,
       _signal?: AbortSignal,
       _requestId?: string,
-      _onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
+      _onCheckpoint?: (
+        checkpoint: CheckpointInfo,
+      ) => CheckpointDecision | Promise<CheckpointDecision>,
     ): Promise<Message[]> {
       return [];
     }

--- a/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
@@ -24,7 +24,7 @@ mock.module("../providers/registry.js", () => ({
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
-    
+
     llm: {
       default: {
         provider: "mock-provider",
@@ -166,6 +166,9 @@ mock.module("../agent/loop.js", () => ({
     constructor() {}
     getToolTokenBudget() {
       return 0;
+    }
+    getResolvedTools() {
+      return [];
     }
     getActiveModel() {
       return undefined;

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -227,6 +227,9 @@ mock.module("../agent/loop.js", () => ({
     getToolTokenBudget() {
       return 0;
     }
+    getResolvedTools() {
+      return [];
+    }
     getActiveModel() {
       return undefined;
     }

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -31,7 +31,7 @@ mock.module("../providers/registry.js", () => ({
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
-    
+
     llm: {
       default: {
         provider: "mock-provider",
@@ -210,6 +210,9 @@ mock.module("../agent/loop.js", () => ({
     constructor() {}
     getToolTokenBudget() {
       return 0;
+    }
+    getResolvedTools() {
+      return [];
     }
     getActiveModel() {
       return undefined;

--- a/assistant/src/__tests__/plugin-types.test.ts
+++ b/assistant/src/__tests__/plugin-types.test.ts
@@ -12,6 +12,8 @@ import { describe, expect, test } from "bun:test";
 
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
 import {
+  type EstimateArgs,
+  type EstimateResult,
   type Injector,
   type Middleware,
   type Plugin,
@@ -52,6 +54,15 @@ describe("plugin core types", () => {
       { output: unknown }
     > = async (args, next, _ctx) => next(args);
 
+    // `tokenEstimate` has a concrete arg/result shape (refined in the
+    // tokenEstimate-pipeline PR), so its middleware can't share the generic
+    // `{ input, output }` passthrough. A slot-specific passthrough keeps the
+    // shape-only assertion honest across type-refinement PRs.
+    const tokenEstimatePassthrough: Middleware<
+      EstimateArgs,
+      EstimateResult
+    > = async (args, next, _ctx) => next(args);
+
     const injector: Injector = {
       name: "sample-injector",
       order: 10,
@@ -84,7 +95,7 @@ describe("plugin core types", () => {
         toolExecute: passthrough,
         memoryRetrieval: passthrough,
         historyRepair: passthrough,
-        tokenEstimate: passthrough,
+        tokenEstimate: tokenEstimatePassthrough,
         compaction: passthrough,
         overflowReduce: passthrough,
         persistence: passthrough,

--- a/assistant/src/__tests__/token-estimate-pipeline.test.ts
+++ b/assistant/src/__tests__/token-estimate-pipeline.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Tests for the `tokenEstimate` plugin pipeline (PR 22 of the
+ * agent-plugin-system plan).
+ *
+ * Covers:
+ * - The default plugin's terminal middleware matches
+ *   {@link estimatePromptTokensRaw} output exactly across a set of golden
+ *   inputs (empty history, text-only, tools, provider-specific image sizing).
+ * - Running the pipeline end-to-end with the default registered produces
+ *   the same numeric result as calling `estimatePromptTokensRaw` directly.
+ * - A custom plugin that short-circuits the chain can override the default,
+ *   proving the extension point works.
+ *
+ * These tests exercise the registry + runner directly. They do not touch
+ * `bootstrapPlugins` — the default registration path is covered by the
+ * bootstrap suite.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  estimatePromptTokensRaw,
+  estimateToolsTokens,
+} from "../context/token-estimator.js";
+import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import { defaultTokenEstimatePlugin } from "../plugins/defaults/token-estimate.js";
+import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
+import {
+  getMiddlewaresFor,
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import type {
+  EstimateArgs,
+  EstimateResult,
+  Middleware,
+  Plugin,
+  TurnContext,
+} from "../plugins/types.js";
+import type { Message, ToolDefinition } from "../providers/types.js";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+const trust: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+function makeCtx(overrides: Partial<TurnContext> = {}): TurnContext {
+  return {
+    requestId: "req-token-estimate-test",
+    conversationId: "conv-token-estimate-test",
+    turnIndex: 0,
+    trust,
+    ...overrides,
+  };
+}
+
+const EMPTY_HISTORY: Message[] = [];
+
+const TEXT_HISTORY: Message[] = [
+  { role: "user", content: [{ type: "text", text: "hello there" }] },
+  {
+    role: "assistant",
+    content: [
+      { type: "text", text: "hi! how can I help you today?" },
+      { type: "text", text: "a second text block for good measure" },
+    ],
+  },
+];
+
+const TOOL_USE_HISTORY: Message[] = [
+  { role: "user", content: [{ type: "text", text: "what's in the log?" }] },
+  {
+    role: "assistant",
+    content: [
+      {
+        type: "tool_use",
+        id: "tu-1",
+        name: "bash",
+        input: { command: "tail -n 5 server.log" },
+      },
+    ],
+  },
+  {
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: "tu-1",
+        content: "line1\nline2\nline3",
+      },
+    ],
+  },
+];
+
+const SYSTEM_PROMPT = "You are a helpful assistant with a long preamble.";
+
+const SAMPLE_TOOLS: ToolDefinition[] = [
+  {
+    name: "bash",
+    description: "Execute a shell command and return its output.",
+    input_schema: {
+      type: "object",
+      properties: { command: { type: "string" } },
+      required: ["command"],
+    },
+  },
+  {
+    name: "file_read",
+    description: "Read a file from the workspace.",
+    input_schema: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    },
+  },
+];
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function registerDefault(): void {
+  registerPlugin(defaultTokenEstimatePlugin);
+}
+
+function rawEstimate(
+  args: Pick<EstimateArgs, "history" | "systemPrompt" | "providerName"> & {
+    tools: ToolDefinition[];
+  },
+): number {
+  const toolTokenBudget =
+    args.tools.length > 0 ? estimateToolsTokens(args.tools) : 0;
+  return estimatePromptTokensRaw(args.history, args.systemPrompt, {
+    providerName: args.providerName,
+    toolTokenBudget,
+  });
+}
+
+async function runViaPipeline(args: EstimateArgs): Promise<EstimateResult> {
+  return runPipeline<EstimateArgs, EstimateResult>(
+    "tokenEstimate",
+    getMiddlewaresFor("tokenEstimate"),
+    // Terminal is a sentinel — the default plugin's middleware short-circuits
+    // so this should only run when no plugin contributes. We make it throw
+    // to catch any accidental fall-through.
+    async () => {
+      throw new Error(
+        "pipeline terminal reached — no middleware short-circuit",
+      );
+    },
+    args,
+    makeCtx(),
+    DEFAULT_TIMEOUTS.tokenEstimate,
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  resetPluginRegistryForTests();
+});
+
+afterEach(() => {
+  resetPluginRegistryForTests();
+});
+
+describe("tokenEstimate pipeline — default plugin parity", () => {
+  test("default matches estimatePromptTokensRaw on empty history", async () => {
+    registerDefault();
+    const args: EstimateArgs = {
+      history: EMPTY_HISTORY,
+      systemPrompt: undefined,
+      tools: [],
+      providerName: undefined,
+    };
+    const pipelineResult = await runViaPipeline(args);
+    expect(pipelineResult).toBe(rawEstimate(args));
+  });
+
+  test("default matches estimatePromptTokensRaw on text-only history", async () => {
+    registerDefault();
+    const args: EstimateArgs = {
+      history: TEXT_HISTORY,
+      systemPrompt: SYSTEM_PROMPT,
+      tools: [],
+      providerName: "anthropic",
+    };
+    const pipelineResult = await runViaPipeline(args);
+    expect(pipelineResult).toBe(rawEstimate(args));
+    // Sanity: the system prompt adds real token cost, so the number is
+    // strictly larger than the bare-history estimate.
+    expect(pipelineResult).toBeGreaterThan(
+      rawEstimate({
+        history: TEXT_HISTORY,
+        systemPrompt: undefined,
+        tools: [],
+        providerName: "anthropic",
+      }),
+    );
+  });
+
+  test("default matches estimatePromptTokensRaw with tool_use/tool_result blocks", async () => {
+    registerDefault();
+    const args: EstimateArgs = {
+      history: TOOL_USE_HISTORY,
+      systemPrompt: SYSTEM_PROMPT,
+      tools: SAMPLE_TOOLS,
+      providerName: "anthropic",
+    };
+    const pipelineResult = await runViaPipeline(args);
+    expect(pipelineResult).toBe(rawEstimate(args));
+  });
+
+  test("default folds tool definition tokens into the result", async () => {
+    registerDefault();
+    const baseArgs: EstimateArgs = {
+      history: TEXT_HISTORY,
+      systemPrompt: SYSTEM_PROMPT,
+      tools: [],
+      providerName: "anthropic",
+    };
+    const withoutTools = await runViaPipeline(baseArgs);
+    const withTools = await runViaPipeline({
+      ...baseArgs,
+      tools: SAMPLE_TOOLS,
+    });
+    // Tools contribute non-zero overhead; the pipeline result must grow.
+    const toolBudget = estimateToolsTokens(SAMPLE_TOOLS);
+    expect(toolBudget).toBeGreaterThan(0);
+    expect(withTools - withoutTools).toBe(toolBudget);
+  });
+
+  test("provider-specific image sizing flows through the default", async () => {
+    registerDefault();
+    // Two providers see different image token costs for the same content —
+    // the raw estimator is the source of truth, so the pipeline must agree
+    // under both provider names.
+    const imageHistory: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              // Small fake PNG-ish payload; the estimator's fallback path
+              // kicks in when parseImageDimensions fails, which is fine —
+              // the two providers still diverge on overhead.
+              data: "a".repeat(128),
+            },
+          },
+        ],
+      },
+    ];
+    const anthropicArgs: EstimateArgs = {
+      history: imageHistory,
+      systemPrompt: undefined,
+      tools: [],
+      providerName: "anthropic",
+    };
+    const openaiArgs: EstimateArgs = {
+      ...anthropicArgs,
+      providerName: "openai",
+    };
+    const anthropicResult = await runViaPipeline(anthropicArgs);
+    const openaiResult = await runViaPipeline(openaiArgs);
+    expect(anthropicResult).toBe(rawEstimate(anthropicArgs));
+    expect(openaiResult).toBe(rawEstimate(openaiArgs));
+  });
+});
+
+describe("tokenEstimate pipeline — custom override", () => {
+  test("custom plugin short-circuit returns a different value than the default", async () => {
+    // A plugin that completely replaces the default with a fixed value,
+    // proving plugins can substitute provider-native tokenizers (e.g.
+    // `countTokens`) without touching orchestrator code.
+    const FIXED = 424242;
+    const override: Middleware<EstimateArgs, EstimateResult> = async (
+      _args,
+      _next,
+      _ctx,
+    ) => FIXED;
+    const customPlugin: Plugin = {
+      manifest: {
+        name: "custom-token-estimate",
+        version: "1.0.0",
+        requires: { pluginRuntime: "v1", tokenEstimateApi: "v1" },
+      },
+      middleware: { tokenEstimate: override },
+    };
+
+    // Register the custom plugin FIRST so it sits outermost and short-
+    // circuits before the default's terminal runs.
+    registerPlugin(customPlugin);
+    registerDefault();
+
+    const args: EstimateArgs = {
+      history: TEXT_HISTORY,
+      systemPrompt: SYSTEM_PROMPT,
+      tools: SAMPLE_TOOLS,
+      providerName: "anthropic",
+    };
+    const pipelineResult = await runViaPipeline(args);
+    expect(pipelineResult).toBe(FIXED);
+    // And for contrast: the default alone would have given the raw value.
+    expect(pipelineResult).not.toBe(rawEstimate(args));
+  });
+
+  test("wrapper middleware that scales the downstream result composes with the default", async () => {
+    // A plugin that wraps the downstream estimate, doubling it. This
+    // exercises the onion composition: outer middleware sees the raw
+    // default result and returns its own modification.
+    const doubler: Middleware<EstimateArgs, EstimateResult> = async (
+      args,
+      next,
+      _ctx,
+    ) => {
+      const inner = await next(args);
+      return inner * 2;
+    };
+    const wrapperPlugin: Plugin = {
+      manifest: {
+        name: "doubling-token-estimate",
+        version: "1.0.0",
+        requires: { pluginRuntime: "v1", tokenEstimateApi: "v1" },
+      },
+      middleware: { tokenEstimate: doubler },
+    };
+
+    registerPlugin(wrapperPlugin);
+    registerDefault();
+
+    const args: EstimateArgs = {
+      history: TEXT_HISTORY,
+      systemPrompt: SYSTEM_PROMPT,
+      tools: SAMPLE_TOOLS,
+      providerName: "anthropic",
+    };
+    const pipelineResult = await runViaPipeline(args);
+    expect(pipelineResult).toBe(rawEstimate(args) * 2);
+  });
+});
+
+describe("tokenEstimate pipeline — empty registry fallback", () => {
+  test("without any plugin registered, the terminal receives the call", async () => {
+    // `runViaPipeline` uses a throwing terminal, so here we run the
+    // pipeline with an explicit terminal that returns a sentinel to prove
+    // that an empty middleware list falls through.
+    const SENTINEL = 12345;
+    const result = await runPipeline<EstimateArgs, EstimateResult>(
+      "tokenEstimate",
+      getMiddlewaresFor("tokenEstimate"),
+      async () => SENTINEL,
+      {
+        history: TEXT_HISTORY,
+        systemPrompt: SYSTEM_PROMPT,
+        tools: [],
+        providerName: "anthropic",
+      },
+      makeCtx(),
+      DEFAULT_TIMEOUTS.tokenEstimate,
+    );
+    expect(result).toBe(SENTINEL);
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -234,6 +234,21 @@ export class AgentLoop {
   }
 
   /**
+   * Resolve the tool definitions sent to the provider for the given turn.
+   *
+   * Mirrors the logic of {@link getToolTokenBudget} but returns the tool
+   * array itself — callers that need to thread the tool set into a plugin
+   * pipeline (e.g. `tokenEstimate`, where the pipeline's args include
+   * `tools`) use this rather than re-implementing the dynamic-vs-static
+   * resolver fork.
+   */
+  getResolvedTools(history?: Message[]): ToolDefinition[] {
+    return history && this.resolveTools
+      ? this.resolveTools(history)
+      : this.tools;
+  }
+
+  /**
    * Estimate token cost of the tool definitions sent to the provider.
    *
    * When `history` is provided and a dynamic `resolveTools` callback
@@ -242,9 +257,7 @@ export class AgentLoop {
    * without a resolver), falls back to the static `this.tools`.
    */
   getToolTokenBudget(history?: Message[]): number {
-    const tools =
-      history && this.resolveTools ? this.resolveTools(history) : this.tools;
-    return estimateToolsTokens(tools);
+    return estimateToolsTokens(this.getResolvedTools(history));
   }
 
   async run(
@@ -252,7 +265,9 @@ export class AgentLoop {
     onEvent: (event: AgentEvent) => void | Promise<void>,
     signal?: AbortSignal,
     requestId?: string,
-    onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
+    onCheckpoint?: (
+      checkpoint: CheckpointInfo,
+    ) => CheckpointDecision | Promise<CheckpointDecision>,
     callSite?: LLMCallSite,
   ): Promise<Message[]> {
     const history = [...messages];
@@ -774,9 +789,11 @@ export class AgentLoop {
         // Add tool results as a user message and continue the loop
         history.push({ role: "user", content: resultBlocks });
 
-        // Invoke checkpoint callback after tool results are in history
+        // Invoke checkpoint callback after tool results are in history.
+        // The callback may be async — the mid-loop budget check delegates
+        // to the `tokenEstimate` plugin pipeline, which is asynchronous.
         if (onCheckpoint) {
-          const decision = onCheckpoint({
+          const decision = await onCheckpoint({
             turnIndex: toolUseTurns - 1, // 0-based (toolUseTurns was already incremented)
             toolCount: toolUseBlocks.length,
             hasToolUse: true,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -68,6 +68,14 @@ import type { ConversationGraphMemory } from "../memory/graph/conversation-graph
 import { recordMemoryRecallLog } from "../memory/memory-recall-log-store.js";
 import { PKB_WORKSPACE_SCOPE } from "../memory/pkb/types.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
+import { defaultTokenEstimateTerminal } from "../plugins/defaults/token-estimate.js";
+import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
+import { getMiddlewaresFor } from "../plugins/registry.js";
+import type {
+  EstimateArgs,
+  EstimateResult,
+  TurnContext,
+} from "../plugins/types.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
 import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
@@ -1029,18 +1037,53 @@ export async function runAgentLoopImpl(
     let reducerState: ReducerState | undefined;
 
     const toolTokenBudget = ctx.agentLoop.getToolTokenBudget(runMessages);
-    // Canonical calibration key used at every `estimatePromptTokens` site in
-    // this function. Matches the key recorded by `handleUsage` for wrapper
-    // providers (OpenRouter routing to Anthropic → key is `"anthropic"`).
+    // Canonical calibration key — passed to the `tokenEstimate` pipeline for
+    // every preflight/mid-loop estimate, the overflow reducer config, and the
+    // convergence-path `estimatePromptTokens` call. Matches the key recorded
+    // by `handleUsage` for wrapper providers (OpenRouter routing to
+    // Anthropic → key is `"anthropic"`).
     const estimationProviderName = getCalibrationProviderKey(ctx.provider);
-    const preflightTokens = estimatePromptTokens(
-      runMessages,
-      ctx.systemPrompt,
-      {
-        providerName: estimationProviderName,
-        toolTokenBudget,
+
+    // Shared `TurnContext` for every `tokenEstimate` pipeline invocation in
+    // this turn. The pipeline is the extension point for plugins that want
+    // to substitute an alternate estimator (e.g. provider-native tokenization)
+    // without touching orchestrator code.
+    //
+    // `turnIndex` is 0 at the orchestrator level — the per-tool-use turn
+    // index advances inside `agent/loop.ts` and is surfaced through
+    // `CheckpointInfo` to sites that need it. Here it just satisfies the
+    // pipeline's log record. `trust` falls back to the inbound
+    // `vellum`/`unknown` default when the actor hasn't been resolved yet —
+    // the same fallback `resolveTrustClass` uses — because preflight can run
+    // before trust context is available (e.g. regenerate after daemon restart).
+    const pipelineTurnCtx: TurnContext = {
+      requestId: reqId,
+      conversationId: ctx.conversationId,
+      turnIndex: 0,
+      trust: ctx.trustContext ?? {
+        sourceChannel: "vellum",
+        trustClass: "unknown",
       },
-    );
+    };
+
+    const runTokenEstimatePipeline = (
+      history: Message[],
+    ): Promise<EstimateResult> =>
+      runPipeline<EstimateArgs, EstimateResult>(
+        "tokenEstimate",
+        getMiddlewaresFor("tokenEstimate"),
+        defaultTokenEstimateTerminal,
+        {
+          history,
+          systemPrompt: ctx.systemPrompt,
+          tools: ctx.agentLoop.getResolvedTools(history),
+          providerName: estimationProviderName,
+        },
+        pipelineTurnCtx,
+        DEFAULT_TIMEOUTS.tokenEstimate,
+      );
+
+    const preflightTokens = await runTokenEstimatePipeline(runMessages);
 
     if (overflowRecovery.enabled && preflightTokens > preflightBudget) {
       rlog.warn(
@@ -1142,14 +1185,7 @@ export async function runAgentLoopImpl(
         // Re-estimate with injections included — step.estimatedTokens was
         // computed on bare history (ctx.messages) and doesn't account for
         // tokens added by runtime injections.
-        const postInjectionTokens = estimatePromptTokens(
-          runMessages,
-          ctx.systemPrompt,
-          {
-            providerName: estimationProviderName,
-            toolTokenBudget,
-          },
-        );
+        const postInjectionTokens = await runTokenEstimatePipeline(runMessages);
 
         if (postInjectionTokens <= preflightBudget) break;
       }
@@ -1206,7 +1242,9 @@ export async function runAgentLoopImpl(
 
     let yieldedForBudget = false;
 
-    const onCheckpoint = (checkpoint: CheckpointInfo): CheckpointDecision => {
+    const onCheckpoint = async (
+      checkpoint: CheckpointInfo,
+    ): Promise<CheckpointDecision> => {
       state.currentTurnToolNames = [];
 
       if (ctx.canHandoffAtCheckpoint()) {
@@ -1219,14 +1257,7 @@ export async function runAgentLoopImpl(
       // conversation-agent-loop run compaction before the provider rejects.
       if (overflowRecovery.enabled) {
         const midLoopThreshold = preflightBudget * 0.85;
-        const estimated = estimatePromptTokens(
-          checkpoint.history,
-          ctx.systemPrompt,
-          {
-            providerName: estimationProviderName,
-            toolTokenBudget,
-          },
-        );
+        const estimated = await runTokenEstimatePipeline(checkpoint.history);
         if (estimated > midLoopThreshold) {
           rlog.warn(
             { phase: "mid-loop", estimated, threshold: midLoopThreshold },

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -35,9 +35,11 @@ import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import type { AssistantConfig } from "../config/schema.js";
+import { defaultTokenEstimatePlugin } from "../plugins/defaults/token-estimate.js";
 import {
   ASSISTANT_API_VERSIONS,
   getRegisteredPlugins,
+  registerPlugin,
 } from "../plugins/registry.js";
 import {
   type Plugin,
@@ -135,6 +137,27 @@ function ensurePluginStorageDir(pluginName: string): string {
 }
 
 /**
+ * Register first-party default plugins with the registry. Idempotent — skips
+ * any plugin whose name is already registered so repeated daemon boots
+ * (and test-suite `resetPluginRegistryForTests` cycles followed by a
+ * re-bootstrap) do not throw duplicate-name errors.
+ *
+ * Every pipeline wrapped under the agent-plugin-system plan contributes its
+ * default plugin here. The registry's insertion order determines onion order,
+ * so defaults are registered once, up-front, which keeps them at the innermost
+ * layer unless a caller explicitly reorders.
+ */
+function registerDefaultPlugins(): void {
+  const alreadyRegistered = new Set(
+    getRegisteredPlugins().map((p) => p.manifest.name),
+  );
+  for (const plugin of [defaultTokenEstimatePlugin]) {
+    if (alreadyRegistered.has(plugin.manifest.name)) continue;
+    registerPlugin(plugin);
+  }
+}
+
+/**
  * Run every registered plugin's `init()` hook sequentially and install a
  * reverse-order shutdown hook. See the module docstring for full semantics.
  *
@@ -147,6 +170,13 @@ function ensurePluginStorageDir(pluginName: string): string {
  * run) and before the first conversation is served.
  */
 export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
+  // Register first-party defaults up-front. Terminal middlewares for wrapped
+  // pipelines must be in the registry before the first conversation runs;
+  // doing it here (rather than at module-import time in the pipeline call
+  // site) keeps registration observable in the boot path and reusable by
+  // bootstrap tests.
+  registerDefaultPlugins();
+
   const plugins = getRegisteredPlugins();
   if (plugins.length === 0) {
     // No-op fast path — the registry is empty (no first-party plugins have

--- a/assistant/src/plugins/defaults/token-estimate.ts
+++ b/assistant/src/plugins/defaults/token-estimate.ts
@@ -1,0 +1,62 @@
+/**
+ * Default `tokenEstimate` pipeline plugin.
+ *
+ * The `tokenEstimate` pipeline produces the user-facing prompt-token estimate
+ * the orchestrator consults before calling a provider — the value that drives
+ * preflight overflow gating and the mid-loop checkpoint yield decision. This
+ * plugin's terminal middleware delegates to
+ * {@link import("../../context/token-estimator.js").estimatePromptTokensRaw estimatePromptTokensRaw},
+ * so the default output matches the uncalibrated raw estimator.
+ *
+ * The calibration path in `agent/loop.ts` (pre-send raw estimate recorded
+ * alongside provider-reported ground truth) stays outside the pipeline on
+ * purpose: calibration must see the raw estimate so the EWMA learns against
+ * provider truth instead of chasing its own corrected output. Pipelines are
+ * for user-facing estimates only.
+ *
+ * Custom plugins can override by contributing their own `tokenEstimate`
+ * middleware via the registry — e.g. a plugin that calls a provider-native
+ * `countTokens` endpoint and short-circuits the chain by skipping `next`.
+ */
+
+import {
+  estimatePromptTokensRaw,
+  estimateToolsTokens,
+} from "../../context/token-estimator.js";
+import type { EstimateArgs, EstimateResult, Plugin } from "../types.js";
+
+/**
+ * Terminal middleware for the `tokenEstimate` pipeline. Computes the tool
+ * token budget from `args.tools` and delegates to {@link estimatePromptTokensRaw}
+ * with the canonical provider key. Short-circuits the chain by ignoring
+ * `next` — this plugin is the last stop when no other plugin supplies its
+ * own `tokenEstimate` middleware.
+ */
+export const defaultTokenEstimateTerminal = async (
+  args: EstimateArgs,
+): Promise<EstimateResult> => {
+  const toolTokenBudget =
+    args.tools.length > 0 ? estimateToolsTokens(args.tools) : 0;
+  return estimatePromptTokensRaw(args.history, args.systemPrompt, {
+    providerName: args.providerName,
+    toolTokenBudget,
+  });
+};
+
+/**
+ * Default `tokenEstimate` plugin. Registered by
+ * {@link bootstrapPlugins} on daemon startup so the pipeline always has a
+ * terminal handler even when no other plugin contributes one.
+ */
+export const defaultTokenEstimatePlugin: Plugin = {
+  manifest: {
+    name: "default-token-estimate",
+    version: "1.0.0",
+    provides: { tokenEstimate: "v1" },
+    requires: { pluginRuntime: "v1", tokenEstimateApi: "v1" },
+  },
+  middleware: {
+    tokenEstimate: async (args, _next, _ctx) =>
+      defaultTokenEstimateTerminal(args),
+  },
+};

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -17,6 +17,7 @@
  */
 
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import type { Message, ToolDefinition } from "../providers/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 
 // ─── Manifest ────────────────────────────────────────────────────────────────
@@ -133,8 +134,37 @@ export type MemoryRetrievalResult = { readonly output: unknown };
 export type HistoryRepairArgs = { readonly input: unknown };
 export type HistoryRepairResult = { readonly output: unknown };
 
-export type TokenEstimateArgs = { readonly input: unknown };
-export type TokenEstimateResult = { readonly output: unknown };
+/**
+ * Inputs to the `tokenEstimate` pipeline. The default middleware delegates
+ * these straight to {@link estimatePromptTokensRaw}; custom plugins may
+ * substitute an alternate estimator (e.g. provider-native tokenization) by
+ * short-circuiting the pipeline with their own {@link EstimateResult}.
+ *
+ * Fields:
+ * - `history` — current message list to estimate over.
+ * - `systemPrompt` — system prompt string, or `undefined` when absent.
+ * - `tools` — tool definitions visible on this turn. The default plugin
+ *   sums their token budget via `estimateToolsTokens(tools)` and hands the
+ *   result to the raw estimator via `toolTokenBudget`. Plugins that want to
+ *   ignore tool cost can skip that term.
+ * - `providerName` — canonical calibration provider key (the value returned
+ *   by `getCalibrationProviderKey(provider)`). Drives provider-specific
+ *   heuristics inside the raw estimator (e.g. Anthropic image sizing).
+ */
+export type EstimateArgs = {
+  readonly history: Message[];
+  readonly systemPrompt: string | undefined;
+  readonly tools: ToolDefinition[];
+  readonly providerName: string | undefined;
+};
+
+/** Result of the `tokenEstimate` pipeline — total estimated prompt tokens. */
+export type EstimateResult = number;
+
+/** Alias retained for symmetry with the rest of the pipeline-name family. */
+export type TokenEstimateArgs = EstimateArgs;
+/** Alias retained for symmetry with the rest of the pipeline-name family. */
+export type TokenEstimateResult = EstimateResult;
 
 export type CompactionArgs = { readonly input: unknown };
 export type CompactionResult = { readonly output: unknown };


### PR DESCRIPTION
## Summary
- Add EstimateArgs/Result types
- Default plugin delegates to estimatePromptTokensRaw
- Swap preflight + mid-loop checkpoint token-estimate calls to runPipeline
- Calibration path (agent/loop.ts raw estimate) intentionally unchanged

Part of plan: agent-plugin-system.md (PR 22 of 33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
