### PR TITLE
feat(meet): 1:1 voice mode — skip Tier 1+2, fire on silence EOU

### DIFF
--- a/skills/meet-join/__tests__/config-schema.test.ts
+++ b/skills/meet-join/__tests__/config-schema.test.ts
@@ -15,6 +15,11 @@ const DEFAULT_PROACTIVE_CHAT = {
   tier2MaxTranscriptSec: 30,
 };
 
+const DEFAULT_VOICE_MODE = {
+  enabled: true,
+  eouDebounceMs: 800,
+};
+
 const DEFAULT_AVATAR = {
   enabled: false,
   renderer: "noop",
@@ -35,6 +40,7 @@ describe("MeetServiceSchema", () => {
       dockerNetwork: "bridge",
       maxMeetingMinutes: 240,
       proactiveChat: DEFAULT_PROACTIVE_CHAT,
+      voiceMode: DEFAULT_VOICE_MODE,
       avatar: DEFAULT_AVATAR,
     });
   });
@@ -67,6 +73,7 @@ describe("MeetServiceSchema", () => {
     expect(parsed).toEqual({
       ...input,
       proactiveChat: DEFAULT_PROACTIVE_CHAT,
+      voiceMode: DEFAULT_VOICE_MODE,
       avatar: DEFAULT_AVATAR,
     });
   });

--- a/skills/meet-join/config-schema.ts
+++ b/skills/meet-join/config-schema.ts
@@ -413,6 +413,36 @@ export const MeetServiceSchema = z
       .describe(
         "Proactive-chat opportunity detector tuning. The detector uses a Tier 1 regex fast filter plus a Tier 2 LLM confirmation before the assistant posts in meeting chat.",
       ),
+    voiceMode: z
+      .object({
+        enabled: z
+          .boolean({
+            error: "services.meet.voiceMode.enabled must be a boolean",
+          })
+          .default(true)
+          .describe(
+            "When on, 1:1 Meet calls (bot + one human) skip the proactive-chat Tier 1 regex and Tier 2 LLM and wake the agent after a short silence debounce on the last final transcript chunk. Group meetings (3+ participants) keep Tier 1 + Tier 2 behavior regardless of this flag.",
+          ),
+        eouDebounceMs: z
+          .number({
+            error: "services.meet.voiceMode.eouDebounceMs must be a number",
+          })
+          .int("services.meet.voiceMode.eouDebounceMs must be an integer")
+          .nonnegative(
+            "services.meet.voiceMode.eouDebounceMs must be non-negative",
+          )
+          .default(800)
+          .describe(
+            "Silence window after the last final transcript chunk before a 1:1 voice wake fires. Approximates end-of-utterance — long enough to ride through mid-sentence pauses, short enough to feel conversational.",
+          ),
+      })
+      .default({
+        enabled: true,
+        eouDebounceMs: 800,
+      })
+      .describe(
+        "1:1 voice-mode tuning. Active only when the live participant count is <= 2 (bot + one human).",
+      ),
     avatar: MeetAvatarSchema,
   })
   .describe(

--- a/skills/meet-join/daemon/__tests__/chat-opportunity-detector.test.ts
+++ b/skills/meet-join/daemon/__tests__/chat-opportunity-detector.test.ts
@@ -13,8 +13,11 @@ import type { MeetBotEvent } from "../../contracts/index.js";
 
 import {
   type ChatOpportunityDecision,
+  type ChatOpportunityEvent,
   MeetChatOpportunityDetector,
   type ProactiveChatConfig,
+  type TimerHandle,
+  type VoiceModeConfig,
 } from "../chat-opportunity-detector.js";
 import type {
   MeetEventSubscriber,
@@ -115,6 +118,21 @@ function inboundChat(
   };
 }
 
+function participantChange(
+  meetingId: string,
+  timestamp: string,
+  joined: { id: string; name: string; isSelf?: boolean }[],
+  left: { id: string; name: string }[] = [],
+): MeetBotEvent {
+  return {
+    type: "participant.change",
+    meetingId,
+    timestamp,
+    joined,
+    left,
+  };
+}
+
 function defaultConfig(
   overrides: Partial<ProactiveChatConfig> = {},
 ): ProactiveChatConfig {
@@ -130,6 +148,58 @@ function defaultConfig(
     escalationCooldownSec: 30,
     tier2MaxTranscriptSec: 30,
     ...overrides,
+  };
+}
+
+function defaultVoiceConfig(
+  overrides: Partial<VoiceModeConfig> = {},
+): VoiceModeConfig {
+  return {
+    enabled: true,
+    eouDebounceMs: 800,
+    ...overrides,
+  };
+}
+
+/**
+ * Manual timer driver for voice-mode EOU tests. Tests register
+ * scheduled callbacks via `setTimer` and can fire them deterministically
+ * with `fireAll()` or cancel via `clearTimer`.
+ */
+function makeManualTimers(): {
+  setTimer: (cb: () => void, ms: number) => TimerHandle;
+  clearTimer: (handle: TimerHandle) => void;
+  fireAll: () => void;
+  pendingCount: () => number;
+} {
+  interface Entry {
+    id: number;
+    cb: () => void;
+    ms: number;
+    cancelled: boolean;
+  }
+  const pending = new Map<number, Entry>();
+  let nextId = 1;
+  return {
+    setTimer(cb, ms) {
+      const id = nextId++;
+      pending.set(id, { id, cb, ms, cancelled: false });
+      return id;
+    },
+    clearTimer(handle) {
+      const entry = pending.get(handle as number);
+      if (entry) entry.cancelled = true;
+      pending.delete(handle as number);
+    },
+    fireAll() {
+      for (const entry of Array.from(pending.values())) {
+        pending.delete(entry.id);
+        if (!entry.cancelled) entry.cb();
+      }
+    },
+    pendingCount() {
+      return pending.size;
+    },
   };
 }
 
@@ -151,12 +221,13 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
         reason: "should not be called",
       }),
     );
-    const onOpportunity = mock((_reason: string) => {});
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
       assistantDisplayName: "Aria",
       config: defaultConfig(),
+      voiceConfig: defaultVoiceConfig(),
       callDetectorLLM: llm,
       onOpportunity,
       subscribe: dispatcher.subscribe,
@@ -192,12 +263,13 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
         reason: "user addressed the assistant without a keyword",
       }),
     );
-    const onOpportunity = mock((_reason: string) => {});
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
       assistantDisplayName: "Aria",
       config: defaultConfig(),
+      voiceConfig: defaultVoiceConfig(),
       callDetectorLLM: llm,
       onOpportunity,
       subscribe: dispatcher.subscribe,
@@ -218,7 +290,9 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
 
     expect(llm).toHaveBeenCalledTimes(1);
     expect(onOpportunity).toHaveBeenCalledTimes(1);
-    const [reason] = onOpportunity.mock.calls[0] as unknown as [string];
+    const [{ reason }] = onOpportunity.mock.calls[0] as unknown as [
+      ChatOpportunityEvent,
+    ];
     expect(reason).toBe("user addressed the assistant without a keyword");
 
     const stats = detector.getStats();
@@ -244,12 +318,13 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
         reason: "user was talking to another human",
       }),
     );
-    const onOpportunity = mock((_reason: string) => {});
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
       assistantDisplayName: "Aria",
       config: defaultConfig(),
+      voiceConfig: defaultVoiceConfig(),
       callDetectorLLM: llm,
       onOpportunity,
       subscribe: dispatcher.subscribe,
@@ -289,12 +364,13 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
         reason: "team is asking for a spec link the assistant can provide",
       }),
     );
-    const onOpportunity = mock((_reason: string) => {});
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
       assistantDisplayName: "Aria",
       config: defaultConfig(),
+      voiceConfig: defaultVoiceConfig(),
       callDetectorLLM: llm,
       onOpportunity,
       subscribe: dispatcher.subscribe,
@@ -315,7 +391,9 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
 
     expect(llm).toHaveBeenCalledTimes(1);
     expect(onOpportunity).toHaveBeenCalledTimes(1);
-    const [reason] = onOpportunity.mock.calls[0] as unknown as [string];
+    const [{ reason }] = onOpportunity.mock.calls[0] as unknown as [
+      ChatOpportunityEvent,
+    ];
     expect(reason).toBe(
       "team is asking for a spec link the assistant can provide",
     );
@@ -339,12 +417,13 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
         reason: "assistant was directly addressed",
       }),
     );
-    const onOpportunity = mock((_reason: string) => {});
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
       assistantDisplayName: "Aria",
       config: defaultConfig(),
+      voiceConfig: defaultVoiceConfig(),
       callDetectorLLM: llm,
       onOpportunity,
       subscribe: dispatcher.subscribe,
@@ -379,12 +458,13 @@ describe("MeetChatOpportunityDetector — debounce + cooldown", () => {
         reason: "not applicable",
       }),
     );
-    const onOpportunity = mock((_reason: string) => {});
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
       assistantDisplayName: "Aria",
       config: defaultConfig({ tier2DebounceMs: 5_000 }),
+      voiceConfig: defaultVoiceConfig(),
       callDetectorLLM: llm,
       onOpportunity,
       subscribe: dispatcher.subscribe,
@@ -443,7 +523,7 @@ describe("MeetChatOpportunityDetector — debounce + cooldown", () => {
         reason: "assistant should respond",
       }),
     );
-    const onOpportunity = mock((_reason: string) => {});
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
@@ -455,6 +535,7 @@ describe("MeetChatOpportunityDetector — debounce + cooldown", () => {
         tier2DebounceMs: 100,
         escalationCooldownSec: 30,
       }),
+      voiceConfig: defaultVoiceConfig(),
       callDetectorLLM: llm,
       onOpportunity,
       subscribe: dispatcher.subscribe,
@@ -518,12 +599,13 @@ describe("MeetChatOpportunityDetector — enabled=false", () => {
         reason: "should not be called",
       }),
     );
-    const onOpportunity = mock((_reason: string) => {});
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
       assistantDisplayName: "Aria",
       config: defaultConfig({ enabled: false }),
+      voiceConfig: defaultVoiceConfig(),
       callDetectorLLM: llm,
       onOpportunity,
       subscribe: dispatcher.subscribe,
@@ -572,7 +654,7 @@ describe("MeetChatOpportunityDetector — custom keywords", () => {
         reason: "custom trigger fired",
       }),
     );
-    const onOpportunity = mock((_reason: string) => {});
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
@@ -581,6 +663,7 @@ describe("MeetChatOpportunityDetector — custom keywords", () => {
         // Only this custom pattern — none of the defaults are present.
         detectorKeywords: ["\\bblue\\s+monkey\\b"],
       }),
+      voiceConfig: defaultVoiceConfig(),
       callDetectorLLM: llm,
       onOpportunity,
       subscribe: dispatcher.subscribe,
@@ -620,6 +703,332 @@ describe("MeetChatOpportunityDetector — custom keywords", () => {
     expect(detector.getStats().tier1Hits).toBe(1);
     expect(llm).toHaveBeenCalledTimes(1);
     expect(onOpportunity).toHaveBeenCalledTimes(1);
+
+    detector.dispose();
+  });
+});
+
+describe("MeetChatOpportunityDetector — 1:1 voice mode", () => {
+  test("bypasses Tier 1 and Tier 2 when participantCount === 2", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const clock = makeClock(1_000);
+    const timers = makeManualTimers();
+    const llm = mock(
+      async (_prompt: string): Promise<ChatOpportunityDecision> => ({
+        shouldRespond: true,
+        reason: "LLM should never be consulted in 1:1 voice mode",
+      }),
+    );
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
+
+    const detector = new MeetChatOpportunityDetector({
+      meetingId: "m1",
+      assistantDisplayName: "Aria",
+      config: defaultConfig(),
+      voiceConfig: defaultVoiceConfig(),
+      callDetectorLLM: llm,
+      onOpportunity,
+      subscribe: dispatcher.subscribe,
+      now: clock.now,
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+    detector.start();
+
+    // Seed a 1:1 meeting: bot + one human.
+    dispatcher.dispatch(
+      "m1",
+      participantChange("m1", "2024-01-01T00:00:00.000Z", [
+        { id: "bot", name: "Aria", isSelf: true },
+        { id: "alice", name: "Alice" },
+      ]),
+    );
+
+    // Transcript without any Tier 1 keyword or assistant-name mention.
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk(
+        "m1",
+        "2024-01-01T00:00:01.000Z",
+        "so what's on our agenda this week",
+      ),
+    );
+    await flushPromises();
+
+    // EOU timer is scheduled but hasn't fired yet.
+    expect(llm).toHaveBeenCalledTimes(0);
+    expect(onOpportunity).toHaveBeenCalledTimes(0);
+    expect(timers.pendingCount()).toBe(1);
+
+    // Fire the EOU timer — wake should land without consulting the LLM.
+    timers.fireAll();
+
+    expect(llm).toHaveBeenCalledTimes(0);
+    expect(onOpportunity).toHaveBeenCalledTimes(1);
+    const [event] = onOpportunity.mock.calls[0] as unknown as [
+      ChatOpportunityEvent,
+    ];
+    expect(event.kind).toBe("voice");
+    expect(event.reason).toContain("voice-turn:");
+    expect(event.reason).toContain("so what's on our agenda this week");
+
+    const stats = detector.getStats();
+    expect(stats.tier1Hits).toBe(0);
+    expect(stats.tier2Calls).toBe(0);
+    expect(stats.voiceWakesFired).toBe(1);
+    expect(stats.escalationsFired).toBe(1);
+
+    detector.dispose();
+  });
+
+  test("EOU debounce collapses rapid final chunks into a single wake", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const clock = makeClock(1_000);
+    const timers = makeManualTimers();
+    const llm = mock(
+      async (_prompt: string): Promise<ChatOpportunityDecision> => ({
+        shouldRespond: true,
+        reason: "should not be called",
+      }),
+    );
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
+
+    const detector = new MeetChatOpportunityDetector({
+      meetingId: "m1",
+      assistantDisplayName: "Aria",
+      config: defaultConfig(),
+      voiceConfig: defaultVoiceConfig(),
+      callDetectorLLM: llm,
+      onOpportunity,
+      subscribe: dispatcher.subscribe,
+      now: clock.now,
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+    detector.start();
+
+    dispatcher.dispatch(
+      "m1",
+      participantChange("m1", "2024-01-01T00:00:00.000Z", [
+        { id: "bot", name: "Aria", isSelf: true },
+        { id: "alice", name: "Alice" },
+      ]),
+    );
+
+    // Two quick final chunks before EOU fires. The second reschedules
+    // the timer — there is always exactly one pending timer per meeting.
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk("m1", "2024-01-01T00:00:01.000Z", "wait which one"),
+    );
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk("m1", "2024-01-01T00:00:01.500Z", "the redesign deck"),
+    );
+    expect(timers.pendingCount()).toBe(1);
+
+    timers.fireAll();
+
+    expect(onOpportunity).toHaveBeenCalledTimes(1);
+    // The wake carries the most recent utterance, not the first one.
+    const [event] = onOpportunity.mock.calls[0] as unknown as [
+      ChatOpportunityEvent,
+    ];
+    expect(event.reason).toContain("the redesign deck");
+
+    detector.dispose();
+  });
+
+  test("voice wake respects escalation cooldown", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const clock = makeClock(1_000);
+    const timers = makeManualTimers();
+    const llm = mock(
+      async (_prompt: string): Promise<ChatOpportunityDecision> => ({
+        shouldRespond: true,
+        reason: "should not be called",
+      }),
+    );
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
+
+    const detector = new MeetChatOpportunityDetector({
+      meetingId: "m1",
+      assistantDisplayName: "Aria",
+      // Short escalation cooldown for the test; voice mode itself has no
+      // separate throttle, so the cooldown is the one gate we can trip.
+      config: defaultConfig({ escalationCooldownSec: 30 }),
+      voiceConfig: defaultVoiceConfig(),
+      callDetectorLLM: llm,
+      onOpportunity,
+      subscribe: dispatcher.subscribe,
+      now: clock.now,
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+    detector.start();
+
+    dispatcher.dispatch(
+      "m1",
+      participantChange("m1", "2024-01-01T00:00:00.000Z", [
+        { id: "bot", name: "Aria", isSelf: true },
+        { id: "alice", name: "Alice" },
+      ]),
+    );
+
+    // First utterance + EOU fires.
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk("m1", "2024-01-01T00:00:01.000Z", "how's it going"),
+    );
+    timers.fireAll();
+    expect(onOpportunity).toHaveBeenCalledTimes(1);
+
+    // Second utterance 10s later — still inside the 30s cooldown.
+    clock.advance(10_000);
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk("m1", "2024-01-01T00:00:11.000Z", "anyway"),
+    );
+    timers.fireAll();
+
+    expect(onOpportunity).toHaveBeenCalledTimes(1); // still 1 — suppressed
+    expect(detector.getStats().escalationsSuppressed).toBe(1);
+
+    // Third utterance past the cooldown — fires again.
+    clock.advance(30_000);
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk("m1", "2024-01-01T00:00:41.000Z", "ok back to it"),
+    );
+    timers.fireAll();
+
+    expect(onOpportunity).toHaveBeenCalledTimes(2);
+
+    detector.dispose();
+  });
+
+  test("falls back to Tier 1 + Tier 2 when a third participant joins", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const clock = makeClock(1_000);
+    const timers = makeManualTimers();
+    const llm = mock(
+      async (_prompt: string): Promise<ChatOpportunityDecision> => ({
+        shouldRespond: false,
+        reason: "not addressed to assistant",
+      }),
+    );
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
+
+    const detector = new MeetChatOpportunityDetector({
+      meetingId: "m1",
+      assistantDisplayName: "Aria",
+      config: defaultConfig(),
+      voiceConfig: defaultVoiceConfig(),
+      callDetectorLLM: llm,
+      onOpportunity,
+      subscribe: dispatcher.subscribe,
+      now: clock.now,
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+    detector.start();
+
+    // 1:1 → voice mode.
+    dispatcher.dispatch(
+      "m1",
+      participantChange("m1", "2024-01-01T00:00:00.000Z", [
+        { id: "bot", name: "Aria", isSelf: true },
+        { id: "alice", name: "Alice" },
+      ]),
+    );
+
+    // Third participant joins — should flip to group mode and cancel any
+    // pending voice EOU timer.
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk("m1", "2024-01-01T00:00:01.000Z", "quick thought"),
+    );
+    expect(timers.pendingCount()).toBe(1);
+
+    dispatcher.dispatch(
+      "m1",
+      participantChange("m1", "2024-01-01T00:00:02.000Z", [
+        { id: "bob", name: "Bob" },
+      ]),
+    );
+    expect(timers.pendingCount()).toBe(0); // voice timer cancelled
+
+    // A non-matching transcript in group mode must not call Tier 2.
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk(
+        "m1",
+        "2024-01-01T00:00:03.000Z",
+        "and also another thing",
+      ),
+    );
+    await flushPromises();
+
+    expect(llm).toHaveBeenCalledTimes(0);
+    expect(onOpportunity).toHaveBeenCalledTimes(0);
+
+    detector.dispose();
+  });
+
+  test("voice mode disabled falls back to Tier 1 + Tier 2 even in 1:1", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const clock = makeClock(1_000);
+    const timers = makeManualTimers();
+    const llm = mock(
+      async (_prompt: string): Promise<ChatOpportunityDecision> => ({
+        shouldRespond: true,
+        reason: "tier 2 is the path here",
+      }),
+    );
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
+
+    const detector = new MeetChatOpportunityDetector({
+      meetingId: "m1",
+      assistantDisplayName: "Aria",
+      config: defaultConfig(),
+      voiceConfig: defaultVoiceConfig({ enabled: false }),
+      callDetectorLLM: llm,
+      onOpportunity,
+      subscribe: dispatcher.subscribe,
+      now: clock.now,
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+    detector.start();
+
+    dispatcher.dispatch(
+      "m1",
+      participantChange("m1", "2024-01-01T00:00:00.000Z", [
+        { id: "bot", name: "Aria", isSelf: true },
+        { id: "alice", name: "Alice" },
+      ]),
+    );
+
+    // Matching Tier 1 transcript — must take the Tier 2 path because
+    // voice mode is disabled, not the EOU-debounced voice path.
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk(
+        "m1",
+        "2024-01-01T00:00:01.000Z",
+        "can you share the doc?",
+      ),
+    );
+    await flushPromises();
+
+    // No voice timer scheduled.
+    expect(timers.pendingCount()).toBe(0);
+    expect(llm).toHaveBeenCalledTimes(1);
+    expect(onOpportunity).toHaveBeenCalledTimes(1);
+    const [event] = onOpportunity.mock.calls[0] as unknown as [
+      ChatOpportunityEvent,
+    ];
+    expect(event.kind).toBe("chat");
 
     detector.dispose();
   });

--- a/skills/meet-join/daemon/__tests__/proactive-chat-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/proactive-chat-e2e.test.ts
@@ -75,8 +75,10 @@ import {
 } from "../../../../assistant/src/runtime/agent-wake.js";
 import {
   type ChatOpportunityDecision,
+  type ChatOpportunityEvent,
   MeetChatOpportunityDetector,
   type ProactiveChatConfig,
+  type VoiceModeConfig,
 } from "../chat-opportunity-detector.js";
 import type {
   MeetEventSubscriber,
@@ -260,6 +262,20 @@ function defaultProactiveChatConfig(
   };
 }
 
+function defaultVoiceModeConfig(
+  overrides: Partial<VoiceModeConfig> = {},
+): VoiceModeConfig {
+  // Disable voice mode by default in the proactive-chat e2e suite: these
+  // scenarios exercise the Tier 1 + Tier 2 path explicitly and treat
+  // "Hey AI, …?" as a Tier 1 trigger. Voice mode's 1:1 branch would
+  // otherwise capture the same events before Tier 1 ever ran.
+  return {
+    enabled: false,
+    eouDebounceMs: 800,
+    ...overrides,
+  };
+}
+
 /**
  * Wait a handful of microtasks so async chains (detector → Tier 2 LLM →
  * wake → tool → HTTP fetch) can settle before assertions. Each scenario
@@ -400,6 +416,7 @@ async function standUpSessionManagerPointedAt(
         tier2PositiveCount: 0,
         escalationsFired: 0,
         escalationsSuppressed: 0,
+        voiceWakesFired: 0,
       }),
     }),
     wakeAgent: async () => {},
@@ -481,13 +498,14 @@ describe("proactive-chat E2E — Tier 1 hit → Tier 2 confirms → agent wake �
         meetingId,
         assistantDisplayName: "AI",
         config: defaultProactiveChatConfig(),
+        voiceConfig: defaultVoiceModeConfig(),
         callDetectorLLM: tier2Llm,
-        onOpportunity: (hint: string) => {
+        onOpportunity: ({ reason }: ChatOpportunityEvent) => {
           wakePromises.push(
             wakeAgentForOpportunity(
               {
                 conversationId,
-                hint,
+                hint: reason,
                 source: "meet-chat-opportunity",
               },
               { resolveTarget: async () => target },
@@ -604,6 +622,7 @@ describe("proactive-chat E2E — Tier 1 hit → Tier 2 confirms → agent wake �
         meetingId,
         assistantDisplayName: "AI",
         config: defaultProactiveChatConfig(),
+        voiceConfig: defaultVoiceModeConfig(),
         callDetectorLLM: tier2Llm,
         onOpportunity: () => {
           void wakeSpy();
@@ -678,11 +697,12 @@ describe("proactive-chat E2E — Tier 1 hit → Tier 2 confirms → agent wake �
         meetingId,
         assistantDisplayName: "AI",
         config: defaultProactiveChatConfig(),
+        voiceConfig: defaultVoiceModeConfig(),
         callDetectorLLM: tier2Llm,
-        onOpportunity: (hint: string) => {
+        onOpportunity: ({ reason }: ChatOpportunityEvent) => {
           wakePromises.push(
             wakeAgentForOpportunity(
-              { conversationId, hint, source: "meet-chat-opportunity" },
+              { conversationId, hint: reason, source: "meet-chat-opportunity" },
               { resolveTarget: async () => target },
             ),
           );
@@ -776,11 +796,12 @@ describe("proactive-chat E2E — Tier 1 hit → Tier 2 confirms → agent wake �
           tier2DebounceMs: 0,
           escalationCooldownSec: 30,
         }),
+        voiceConfig: defaultVoiceModeConfig(),
         callDetectorLLM: tier2Llm,
-        onOpportunity: (hint: string) => {
+        onOpportunity: ({ reason }: ChatOpportunityEvent) => {
           wakePromises.push(
             wakeAgentForOpportunity(
-              { conversationId, hint, source: "meet-chat-opportunity" },
+              { conversationId, hint: reason, source: "meet-chat-opportunity" },
               { resolveTarget: async () => target },
             ).then(() => {}),
           );
@@ -848,12 +869,13 @@ describe("proactive-chat E2E — Tier 1 hit → Tier 2 confirms → agent wake �
           reason: "should never be consulted",
         }),
       );
-      const onOpportunity = mock((_reason: string) => {});
+      const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
 
       const detector = new MeetChatOpportunityDetector({
         meetingId,
         assistantDisplayName: "AI",
         config: defaultProactiveChatConfig({ enabled: false }),
+        voiceConfig: defaultVoiceModeConfig(),
         callDetectorLLM: tier2Llm,
         onOpportunity,
         subscribe: dispatcher.subscribe,

--- a/skills/meet-join/daemon/__tests__/session-manager.test.ts
+++ b/skills/meet-join/daemon/__tests__/session-manager.test.ts
@@ -1380,8 +1380,12 @@ describe("MeetSessionManager proactive chat-opportunity detector wiring", () => 
     start: ReturnType<typeof mock>;
     dispose: ReturnType<typeof mock>;
     getStats: ReturnType<typeof mock>;
-    /** Test helper — simulates a Tier 2 positive verdict firing the callback. */
-    fireOpportunity: (hint: string) => void;
+    /**
+     * Test helper — simulates a Tier 2 positive verdict or a 1:1 voice
+     * EOU firing the callback. Defaults to `kind: "chat"` for
+     * backwards compatibility with tests that predate voice mode.
+     */
+    fireOpportunity: (reason: string, kind?: "chat" | "voice") => void;
   }
 
   function makeFakeDetectorFactory(
@@ -1391,6 +1395,7 @@ describe("MeetSessionManager proactive chat-opportunity detector wiring", () => 
       tier2PositiveCount: 1,
       escalationsFired: 1,
       escalationsSuppressed: 0,
+      voiceWakesFired: 0,
     },
   ): {
     factory: (args: MeetChatOpportunityDetectorFactoryArgs) => FakeDetector;
@@ -1407,7 +1412,8 @@ describe("MeetSessionManager proactive chat-opportunity detector wiring", () => 
           start: mock(() => {}),
           dispose: mock(() => {}),
           getStats: mock(() => ({ ...stats })),
-          fireOpportunity: (hint: string) => capturedOnOpportunity(hint),
+          fireOpportunity: (reason: string, kind: "chat" | "voice" = "chat") =>
+            capturedOnOpportunity({ reason, kind }),
         };
         detector = fake;
         return fake;
@@ -1521,6 +1527,55 @@ describe("MeetSessionManager proactive chat-opportunity detector wiring", () => 
     await manager.leave("m-proactive-on", "cleanup");
     // Detector disposed on leave.
     expect(detector.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  test("voice-kind opportunity routes wakeAgent to source=meet-voice-turn", async () => {
+    overrideProactiveChatConfig(preloadWorkspace, true);
+
+    const runner = makeMockRunner();
+    const audioIngestFactory = makeFakeAudioIngestFactory();
+    const detectorFactory = makeFakeDetectorFactory();
+    const wakeAgent = mock(async () => {});
+
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => runner,
+      getProviderKey: async () => "k",
+      getWorkspaceDir: () => workspaceDir,
+      botLeaveFetch: async () => {},
+      audioIngestFactory: audioIngestFactory.factory,
+      chatOpportunityDetectorFactory: detectorFactory.factory,
+      wakeAgent,
+      resolveAssistantDisplayName: () => "Atlas",
+    });
+
+    await manager.join({
+      url: "u",
+      meetingId: "m-voice-kind",
+      conversationId: "conv-voice-1",
+    });
+
+    // voiceConfig is constructed from schema defaults — detector should
+    // receive it alongside the proactive-chat config.
+    const args = detectorFactory.lastArgs();
+    expect(args).not.toBeNull();
+    expect(args!.voiceConfig.enabled).toBe(true);
+    expect(args!.voiceConfig.eouDebounceMs).toBeGreaterThan(0);
+
+    const detector = detectorFactory.lastDetector()!;
+    detector.fireOpportunity("voice-turn: hello there", "voice");
+    await Promise.resolve();
+
+    expect(wakeAgent).toHaveBeenCalledTimes(1);
+    const calls = wakeAgent.mock.calls as unknown as Array<
+      [{ conversationId: string; hint: string; source: string }]
+    >;
+    expect(calls[0]![0]).toEqual({
+      conversationId: "conv-voice-1",
+      hint: "voice-turn: hello there",
+      source: "meet-voice-turn",
+    });
+
+    await manager.leave("m-voice-kind", "cleanup");
   });
 
   test("proactiveChat.enabled=false skips detector construction entirely", async () => {
@@ -1647,6 +1702,7 @@ describe("MeetSessionManager proactive chat-opportunity detector wiring", () => 
       tier2PositiveCount: 2,
       escalationsFired: 1,
       escalationsSuppressed: 1,
+      voiceWakesFired: 0,
     });
 
     const manager = _createMeetSessionManagerForTests({

--- a/skills/meet-join/daemon/chat-opportunity-detector.ts
+++ b/skills/meet-join/daemon/chat-opportunity-detector.ts
@@ -1,49 +1,64 @@
 /**
- * MeetChatOpportunityDetector — watches meeting transcript and chat for
- * moments when the AI assistant chiming in via meeting chat would be
- * appropriate and helpful. Fires `onOpportunity(reason)` on positive
- * verdicts so a downstream orchestrator (PR 7) can decide what to post.
+ * MeetChatOpportunityDetector — watches meeting transcript, chat, and
+ * participant changes for moments when the assistant should respond.
+ * Fires `onOpportunity({ reason, kind })` through the injected callback
+ * so a downstream orchestrator (the session manager) can wake the agent.
  *
- * Two-tier design:
+ * The detector runs in one of two modes per event, keyed on the live
+ * participant count:
  *
- *   1. **Tier 1 (regex fast filter)** — synchronous on every final
- *      transcript chunk. Default patterns cover direct assistant-name
- *      mentions, `(hey|hi|…) <name>, … ?` style address-then-question
- *      forms, and generic "can you / does anyone know" requests. A hit
- *      feeds Tier 2 with a short trigger reason.
+ *   **Group mode (participantCount >= 3)** — the two-tier chat-opportunity
+ *   pipeline:
  *
- *      Inbound chat messages intentionally **bypass** Tier 1 and proceed
- *      straight to Tier 2 with a synthetic `"tier1:chat-always-on"`
- *      reason. Chat volume is orders of magnitude lower than transcript
- *      (typically <1/5s even on chatty meetings), so the regex gate's
- *      cost savings don't pay off there — and users typing in chat
- *      expect the assistant to read every message rather than be filtered
- *      by an English-interrogative keyword list. Debounce + escalation
- *      cooldown remain in effect, so burst bounds are preserved.
+ *     1. **Tier 1 (regex fast filter)** — synchronous on every final
+ *        transcript chunk. Default patterns cover direct assistant-name
+ *        mentions, `(hey|hi|…) <name>, … ?` style address-then-question
+ *        forms, and generic "can you / does anyone know" requests. A hit
+ *        feeds Tier 2 with a short trigger reason.
  *
- *   2. **Tier 2 (LLM confirmation)** — fires on every Tier 1 hit and
- *      every inbound chat, subject to a configurable debounce. The
- *      prompt includes the rolling transcript (last N seconds), the
- *      most recent 5 chat messages, the trigger chunk, and the Tier 1
- *      reason, and asks for strict JSON `{ shouldRespond: boolean,
- *      reason: string }`. Positive verdicts are rate-limited further
- *      by an "escalation cooldown" so a chatty meeting can't fire the
- *      callback repeatedly.
+ *        Inbound chat messages intentionally **bypass** Tier 1 and proceed
+ *        straight to Tier 2 with a synthetic `"tier1:chat-always-on"`
+ *        reason. Chat volume is orders of magnitude lower than transcript
+ *        (typically <1/5s even on chatty meetings), so the regex gate's
+ *        cost savings don't pay off there — and users typing in chat
+ *        expect the assistant to read every message rather than be filtered
+ *        by an English-interrogative keyword list.
  *
- * The detector is intentionally inert until wired: it does not itself
- * post to meeting chat, consult any session manager, or share state with
- * other meetings. PR 7 of the meet-phase-2-chat plan is responsible for
- * plumbing `onOpportunity` into the session manager and actually
- * constructing the chat reply.
+ *     2. **Tier 2 (LLM confirmation)** — fires on every Tier 1 hit and
+ *        every inbound chat, subject to a configurable debounce. The
+ *        prompt includes the rolling transcript (last N seconds), the
+ *        most recent 5 chat messages, the trigger chunk, and the Tier 1
+ *        reason, and asks for strict JSON `{ shouldRespond: boolean,
+ *        reason: string }`.
+ *
+ *     Positive Tier 2 verdicts clear the escalation cooldown and fire
+ *     `onOpportunity({ kind: "chat" })`.
+ *
+ *   **1:1 voice mode (voiceMode.enabled && participantCount === 2)** —
+ *   Tier 1 and Tier 2 are both skipped for transcript: every utterance
+ *   in a 1:1 is addressed to the bot, so there is nothing to filter for,
+ *   and the extra Tier 2 LLM call adds ~500ms of latency per turn. Instead,
+ *   the detector schedules a short silence-debounce timer
+ *   (`voiceMode.eouDebounceMs`, default 800ms) on each final chunk. When
+ *   the timer fires with no newer chunk having arrived, the detector
+ *   treats that as end-of-utterance and fires
+ *   `onOpportunity({ kind: "voice" })`. Inbound chat continues to run
+ *   through the Tier-2-only chat path (which still wakes the agent).
+ *
+ *   The escalation cooldown remains the shared safety rail for both
+ *   modes — one positive wake per `escalationCooldownSec` regardless of
+ *   trigger path.
  *
  * Dependency injection keeps the detector fully testable: the LLM call
- * is reached via a `callDetectorLLM(prompt)` callable, and the router
- * subscription can be overridden with an in-memory shim.
+ * is reached via a `callDetectorLLM(prompt)` callable, the router
+ * subscription can be overridden, and voice-mode timers can be driven
+ * via `deps.setTimer` / `deps.clearTimer` injections.
  */
 
 import type {
   InboundChatEvent,
   MeetBotEvent,
+  ParticipantChangeEvent,
   TranscriptChunkEvent,
 } from "../contracts/index.js";
 
@@ -71,8 +86,21 @@ export type ChatOpportunityLLMAsk = (
   prompt: string,
 ) => Promise<ChatOpportunityDecision>;
 
+/**
+ * Discriminator on the opportunity callback so downstream code can route
+ * chat-opportunity wakes and 1:1 voice-turn wakes to different agent
+ * sources (e.g. different `source` strings on `wakeAgent`).
+ */
+export type ChatOpportunityKind = "chat" | "voice";
+
+/** Payload fired when an opportunity clears the escalation cooldown. */
+export interface ChatOpportunityEvent {
+  reason: string;
+  kind: ChatOpportunityKind;
+}
+
 /** Callback fired when an opportunity clears Tier 2 and cooldown. */
-export type ChatOpportunityCallback = (reason: string) => void;
+export type ChatOpportunityCallback = (event: ChatOpportunityEvent) => void;
 
 /**
  * Configuration block mirrored from `services.meet.proactiveChat`. Carried
@@ -87,14 +115,25 @@ export interface ProactiveChatConfig {
   tier2MaxTranscriptSec: number;
 }
 
-/** Stats snapshot exposed to PR 7 for telemetry/debug surfaces. */
+/** Configuration block mirrored from `services.meet.voiceMode`. */
+export interface VoiceModeConfig {
+  enabled: boolean;
+  eouDebounceMs: number;
+}
+
+/** Stats snapshot exposed to session-manager for telemetry/debug surfaces. */
 export interface ChatOpportunityDetectorStats {
   tier1Hits: number;
   tier2Calls: number;
   tier2PositiveCount: number;
   escalationsFired: number;
   escalationsSuppressed: number;
+  /** Voice-mode wakes that made it past the escalation cooldown. */
+  voiceWakesFired: number;
 }
+
+/** Timer handle type-erased so tests can swap `setTimeout` for a manual driver. */
+export type TimerHandle = unknown;
 
 export interface MeetChatOpportunityDetectorDeps {
   meetingId: string;
@@ -105,6 +144,7 @@ export interface MeetChatOpportunityDetectorDeps {
    */
   assistantDisplayName: string;
   config: ProactiveChatConfig;
+  voiceConfig: VoiceModeConfig;
   callDetectorLLM: ChatOpportunityLLMAsk;
   onOpportunity: ChatOpportunityCallback;
   /** Override the dispatcher subscribe (tests). */
@@ -114,6 +154,13 @@ export interface MeetChatOpportunityDetectorDeps {
   ) => MeetEventUnsubscribe;
   /** Override `Date.now` for deterministic tests. */
   now?: () => number;
+  /**
+   * Override the voice-mode EOU timer scheduler. Defaults to
+   * `setTimeout`. Tests inject a manual driver so they can advance
+   * the debounce window deterministically without real wall-clock waits.
+   */
+  setTimer?: (cb: () => void, ms: number) => TimerHandle;
+  clearTimer?: (handle: TimerHandle) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -177,6 +224,7 @@ export class MeetChatOpportunityDetector {
   private readonly meetingId: string;
   private readonly assistantDisplayName: string;
   private readonly config: ProactiveChatConfig;
+  private readonly voiceConfig: VoiceModeConfig;
   private readonly callDetectorLLM: ChatOpportunityLLMAsk;
   private readonly onOpportunity: ChatOpportunityCallback;
   private readonly subscribe: (
@@ -184,6 +232,8 @@ export class MeetChatOpportunityDetector {
     cb: MeetEventSubscriber,
   ) => MeetEventUnsubscribe;
   private readonly now: () => number;
+  private readonly setTimer: (cb: () => void, ms: number) => TimerHandle;
+  private readonly clearTimer: (handle: TimerHandle) => void;
 
   private unsubscribe: MeetEventUnsubscribe | null = null;
   private disposed = false;
@@ -194,6 +244,15 @@ export class MeetChatOpportunityDetector {
   private readonly transcriptBuffer: TranscriptEntry[] = [];
   private readonly chatBuffer: ChatEntry[] = [];
 
+  /**
+   * Live participant count (bot + humans) as reported by the
+   * `participant.change` stream. The scraper's first poll emits every
+   * currently-visible participant in `joined` including the bot row, so
+   * starting at 0 and tracking deltas produces a correct running count
+   * without needing an explicit seed from the session manager.
+   */
+  private participantCount = 0;
+
   /** Wall-clock ms of the last Tier 2 call (regardless of outcome). */
   private lastTier2CallAt: number | null = null;
   /** Wall-clock ms of the last positive escalation (`shouldRespond: true`). */
@@ -201,22 +260,41 @@ export class MeetChatOpportunityDetector {
   /** In-flight flag so overlapping Tier 1 hits don't race Tier 2 calls. */
   private tier2InFlight = false;
 
+  /**
+   * Active end-of-utterance timer for 1:1 voice mode. Reset on every
+   * new final transcript chunk, fires `onOpportunity` once the debounce
+   * window elapses with no new chunk. Null when no timer is pending.
+   */
+  private voiceEouTimer: TimerHandle | null = null;
+  /** Last voice-mode trigger text — carried into the wake hint when the timer fires. */
+  private voicePendingTriggerText: string | null = null;
+
   private readonly stats: ChatOpportunityDetectorStats = {
     tier1Hits: 0,
     tier2Calls: 0,
     tier2PositiveCount: 0,
     escalationsFired: 0,
     escalationsSuppressed: 0,
+    voiceWakesFired: 0,
   };
 
   constructor(deps: MeetChatOpportunityDetectorDeps) {
     this.meetingId = deps.meetingId;
     this.assistantDisplayName = deps.assistantDisplayName;
     this.config = deps.config;
+    this.voiceConfig = deps.voiceConfig;
     this.callDetectorLLM = deps.callDetectorLLM;
     this.onOpportunity = deps.onOpportunity;
     this.subscribe = deps.subscribe ?? subscribeToMeetingEvents;
     this.now = deps.now ?? Date.now;
+    this.setTimer =
+      deps.setTimer ??
+      ((cb: () => void, ms: number): TimerHandle => setTimeout(cb, ms));
+    this.clearTimer =
+      deps.clearTimer ??
+      ((handle: TimerHandle): void => {
+        clearTimeout(handle as ReturnType<typeof setTimeout>);
+      });
 
     this.patterns = this.config.enabled
       ? this.buildPatterns(
@@ -224,6 +302,20 @@ export class MeetChatOpportunityDetector {
           this.config.detectorKeywords,
         )
       : [];
+  }
+
+  /**
+   * Whether the detector currently considers the meeting a 1:1
+   * (exactly bot + one human, participantCount === 2). The scraper's
+   * first poll emits every currently-visible participant (including
+   * the bot row with `isSelf: true`), so an established 1:1 meeting
+   * ticks through to 2. Any value other than 2 — 0 or 1 (pre-poll /
+   * bot alone) or ≥ 3 (group) — takes the Tier 1 + Tier 2 path, which
+   * is both the safe default when the detector has no participant
+   * information and the correct behavior for multi-party meetings.
+   */
+  private isOneOnOne(): boolean {
+    return this.participantCount === 2;
   }
 
   /**
@@ -246,6 +338,7 @@ export class MeetChatOpportunityDetector {
    */
   dispose(): void {
     this.disposed = true;
+    this.cancelVoiceEouTimer();
     if (this.unsubscribe) {
       try {
         this.unsubscribe();
@@ -267,8 +360,16 @@ export class MeetChatOpportunityDetector {
   // ── Event handling ────────────────────────────────────────────────────────
 
   private onEvent(event: MeetBotEvent): void {
-    if (!this.config.enabled) return;
     try {
+      // Participant changes are tracked regardless of `config.enabled`
+      // so the mode-switch stays correct even when proactive-chat is
+      // off — voice mode is independently gated and benefits from the
+      // same live count.
+      if (event.type === "participant.change") {
+        this.onParticipantChange(event);
+        return;
+      }
+      if (!this.config.enabled) return;
       if (event.type === "transcript.chunk") {
         this.onTranscriptChunk(event);
         return;
@@ -285,6 +386,21 @@ export class MeetChatOpportunityDetector {
     }
   }
 
+  private onParticipantChange(event: ParticipantChangeEvent): void {
+    const wasOneOnOne = this.isOneOnOne();
+    this.participantCount += event.joined.length - event.left.length;
+    if (this.participantCount < 0) this.participantCount = 0;
+
+    // If a third participant just joined, cancel any pending voice EOU
+    // timer — we should not fire a voice wake for an utterance that
+    // happened while the meeting was 1:1 if the mode flipped before
+    // the debounce window elapsed. The next utterance will take the
+    // group-mode (Tier 1 + Tier 2) branch.
+    if (wasOneOnOne && !this.isOneOnOne()) {
+      this.cancelVoiceEouTimer();
+    }
+  }
+
   private onTranscriptChunk(event: TranscriptChunkEvent): void {
     if (!event.isFinal) return;
     const raw = event.text ?? "";
@@ -298,6 +414,15 @@ export class MeetChatOpportunityDetector {
       text: raw,
     });
     this.trimTranscriptBuffer();
+
+    if (this.voiceConfig.enabled && this.isOneOnOne()) {
+      // 1:1 voice mode: skip Tier 1 + Tier 2 entirely. Every utterance
+      // is necessarily addressed to the bot, so both filters are pure
+      // overhead. The EOU silence debounce decides when to fire;
+      // escalation cooldown remains the safety rail.
+      this.scheduleVoiceEouWake(raw);
+      return;
+    }
 
     const reason = this.tier1Match(raw);
     if (reason !== null) {
@@ -440,45 +565,11 @@ export class MeetChatOpportunityDetector {
         return;
       }
       this.stats.tier2PositiveCount += 1;
-
-      // Escalation cooldown — suppress back-to-back fires.
-      const cooldownMs = this.config.escalationCooldownSec * 1_000;
-      const nowAfter = this.now();
-      if (
-        this.lastEscalationAt !== null &&
-        nowAfter - this.lastEscalationAt < cooldownMs
-      ) {
-        this.stats.escalationsSuppressed += 1;
-        log.debug(
-          {
-            event: "chat_opportunity.escalation.suppressed",
-            meetingId: this.meetingId,
-            msSinceLast: nowAfter - this.lastEscalationAt,
-          },
-          "MeetChatOpportunityDetector: escalation suppressed by cooldown",
-        );
-        return;
-      }
-
-      this.lastEscalationAt = nowAfter;
-      this.stats.escalationsFired += 1;
-      log.info(
-        {
-          event: "chat_opportunity.escalation.fired",
-          meetingId: this.meetingId,
-          triggerReason,
-          decisionReason: decision.reason,
-        },
-        "MeetChatOpportunityDetector: firing opportunity callback",
-      );
-      try {
-        this.onOpportunity(decision.reason);
-      } catch (err) {
-        log.error(
-          { err, meetingId: this.meetingId },
-          "MeetChatOpportunityDetector: onOpportunity callback threw",
-        );
-      }
+      this.tryFireOpportunity({
+        reason: decision.reason,
+        kind: "chat",
+        logContext: { triggerReason, decisionReason: decision.reason },
+      });
     } catch (err) {
       // Restore the debounce clock on failure so the next trigger isn't
       // silently suppressed for the remainder of the debounce window.
@@ -516,6 +607,106 @@ export class MeetChatOpportunityDetector {
       "and helpful here? Reply JSON only: " +
       "{ shouldRespond: bool, reason: string }"
     );
+  }
+
+  // ── Shared opportunity fire (escalation cooldown) ─────────────────────────
+
+  /**
+   * Run the escalation cooldown check and, if it passes, invoke
+   * `onOpportunity` with the supplied kind. Shared between the Tier 2
+   * (chat) path and the voice EOU path so both modes are gated by a
+   * single `escalationCooldownSec` window. A wake for either kind
+   * suppresses subsequent wakes of either kind for the cooldown
+   * duration — the rationale is that "she already spoke" is a human-
+   * facing property, not per-channel.
+   */
+  private tryFireOpportunity(opts: {
+    reason: string;
+    kind: ChatOpportunityKind;
+    logContext?: Record<string, unknown>;
+  }): void {
+    const cooldownMs = this.config.escalationCooldownSec * 1_000;
+    const nowAfter = this.now();
+    if (
+      this.lastEscalationAt !== null &&
+      nowAfter - this.lastEscalationAt < cooldownMs
+    ) {
+      this.stats.escalationsSuppressed += 1;
+      log.debug(
+        {
+          event: "chat_opportunity.escalation.suppressed",
+          meetingId: this.meetingId,
+          kind: opts.kind,
+          msSinceLast: nowAfter - this.lastEscalationAt,
+        },
+        "MeetChatOpportunityDetector: escalation suppressed by cooldown",
+      );
+      return;
+    }
+
+    this.lastEscalationAt = nowAfter;
+    this.stats.escalationsFired += 1;
+    if (opts.kind === "voice") this.stats.voiceWakesFired += 1;
+    log.info(
+      {
+        event: "chat_opportunity.escalation.fired",
+        meetingId: this.meetingId,
+        kind: opts.kind,
+        ...opts.logContext,
+      },
+      "MeetChatOpportunityDetector: firing opportunity callback",
+    );
+    try {
+      this.onOpportunity({ reason: opts.reason, kind: opts.kind });
+    } catch (err) {
+      log.error(
+        { err, meetingId: this.meetingId, kind: opts.kind },
+        "MeetChatOpportunityDetector: onOpportunity callback threw",
+      );
+    }
+  }
+
+  // ── Voice EOU (1:1 mode) ──────────────────────────────────────────────────
+
+  /**
+   * Reset the EOU debounce timer on every new final transcript chunk.
+   * If no new chunk arrives within `voiceConfig.eouDebounceMs`, the
+   * timer fires and we treat that as end-of-utterance. The trigger
+   * text is truncated into the opportunity hint so the agent knows
+   * what the user just said without having to re-read the transcript.
+   */
+  private scheduleVoiceEouWake(triggerText: string): void {
+    this.cancelVoiceEouTimer();
+    this.voicePendingTriggerText = triggerText;
+    this.voiceEouTimer = this.setTimer(() => {
+      this.voiceEouTimer = null;
+      this.onVoiceEouFire();
+    }, this.voiceConfig.eouDebounceMs);
+  }
+
+  private cancelVoiceEouTimer(): void {
+    if (this.voiceEouTimer !== null) {
+      this.clearTimer(this.voiceEouTimer);
+      this.voiceEouTimer = null;
+    }
+    this.voicePendingTriggerText = null;
+  }
+
+  private onVoiceEouFire(): void {
+    if (this.disposed) return;
+    const trigger = this.voicePendingTriggerText ?? "";
+    this.voicePendingTriggerText = null;
+    // Double-check the mode at fire time — a third participant may
+    // have joined while the timer was pending. If so, drop rather than
+    // wake under group-meeting assumptions.
+    if (!this.isOneOnOne() || !this.voiceConfig.enabled) return;
+
+    const snippet = trigger.length > 120 ? `${trigger.slice(0, 117)}...` : trigger;
+    this.tryFireOpportunity({
+      reason: `voice-turn: ${snippet}`,
+      kind: "voice",
+      logContext: { triggerText: snippet, participantCount: this.participantCount },
+    });
   }
 
   // ── Buffer maintenance ────────────────────────────────────────────────────

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -88,11 +88,13 @@ import {
   MeetBargeInWatcher,
 } from "./barge-in-watcher.js";
 import {
+  type ChatOpportunityCallback,
   type ChatOpportunityDecision,
   type ChatOpportunityDetectorStats,
   type ChatOpportunityLLMAsk,
   MeetChatOpportunityDetector,
   type ProactiveChatConfig,
+  type VoiceModeConfig,
 } from "./chat-opportunity-detector.js";
 import {
   MeetConsentMonitor,
@@ -554,8 +556,9 @@ export interface MeetChatOpportunityDetectorFactoryArgs {
   conversationId: string;
   assistantDisplayName: string;
   config: ProactiveChatConfig;
+  voiceConfig: VoiceModeConfig;
   callDetectorLLM: ChatOpportunityLLMAsk;
-  onOpportunity: (hint: string) => void;
+  onOpportunity: ChatOpportunityCallback;
 }
 
 export interface MeetSessionManagerDeps {
@@ -1296,6 +1299,7 @@ class MeetSessionManagerImpl {
     // the detector null when disabled means zero lifecycle overhead and
     // no event-handler cost on the dispatcher path.
     const proactiveChatConfig = meet.proactiveChat;
+    const voiceModeConfig = meet.voiceMode;
     const chatOpportunityDetector: MeetChatOpportunityDetectorLike | null =
       proactiveChatConfig.enabled
         ? this.deps.chatOpportunityDetectorFactory({
@@ -1309,17 +1313,27 @@ class MeetSessionManagerImpl {
               escalationCooldownSec: proactiveChatConfig.escalationCooldownSec,
               tier2MaxTranscriptSec: proactiveChatConfig.tier2MaxTranscriptSec,
             },
+            voiceConfig: {
+              enabled: voiceModeConfig.enabled,
+              eouDebounceMs: voiceModeConfig.eouDebounceMs,
+            },
             callDetectorLLM: defaultCallDetectorLLM,
-            onOpportunity: (hint: string) => {
+            onOpportunity: ({ reason, kind }) => {
+              // `kind` distinguishes chat-opportunity wakes (Tier 2
+              // positive verdict) from 1:1 voice-turn wakes. Thread it
+              // through as a distinct `source` so downstream telemetry
+              // and any future agent-side routing can branch on it.
+              const source =
+                kind === "voice" ? "meet-voice-turn" : "meet-chat-opportunity";
               void this.deps
                 .wakeAgent({
                   conversationId,
-                  hint,
-                  source: "meet-chat-opportunity",
+                  hint: reason,
+                  source,
                 })
                 .catch((err) => {
                   log.warn(
-                    { err, meetingId, conversationId },
+                    { err, meetingId, conversationId, kind },
                     "MeetChatOpportunityDetector: wakeAgent rejected — dropping opportunity",
                   );
                 });
@@ -2181,6 +2195,7 @@ function defaultChatOpportunityDetectorFactory(
     meetingId: args.meetingId,
     assistantDisplayName: args.assistantDisplayName,
     config: args.config,
+    voiceConfig: args.voiceConfig,
     callDetectorLLM: args.callDetectorLLM,
     onOpportunity: args.onOpportunity,
   });


### PR DESCRIPTION
## Summary
- When a Meet call has exactly 2 participants (bot + one human), the chat-opportunity detector now skips both the Tier 1 regex gate and the Tier 2 LLM classifier for transcript chunks. Instead it fires `wakeAgent` after an ~800ms silence debounce (EOU) on the last final chunk. Group meetings (3+ participants) keep today's Tier 1 + Tier 2 behavior.
- New `services.meet.voiceMode` config: `enabled` (default true), `eouDebounceMs` (default 800). Mode switch is automatic via `participant.change` event subscription — no manual toggle required.
- `ChatOpportunityCallback` now receives `{ reason, kind: "chat" | "voice" }` so session-manager can route voice-initiated wakes to `source: "meet-voice-turn"` (distinct from `meet-chat-opportunity`). Escalation cooldown is the shared safety rail across both kinds. Group-mode transcript tests still exercise Tier 1 regex matching.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
