### PR TITLE
fix(assistant): add plugins field to AssistantConfigSchema

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -328,6 +328,19 @@ export const AssistantConfigSchema = z
       NotificationsConfigSchema.parse({}),
     ),
     ui: UiConfigSchema.default(UiConfigSchema.parse({})),
+    // Per-plugin config blocks keyed by plugin name. The schema is intentionally
+    // permissive — each plugin's manifest supplies its own validator which the
+    // plugin bootstrap (`external-plugins-bootstrap.ts`) runs against the raw
+    // block under `plugins.<name>` before handing the parsed result to the
+    // plugin's `init()`. Keeping this open here means adding a new plugin does
+    // not require a core-schema change, while invalid configs still surface
+    // through the plugin's own validator at bootstrap.
+    plugins: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe(
+        "Per-plugin configuration keyed by plugin name. Validated downstream by each plugin's manifest.config validator at bootstrap.",
+      ),
     collectUsageData: z
       .boolean()
       .default(true)

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -162,17 +162,16 @@ function validatePluginConfig(
 }
 
 /**
- * Read `config.plugins.<name>` defensively. The AssistantConfig schema does
- * not (yet) declare a `plugins` block, so accessing it goes through
- * `unknown` casts rather than compile-time field access.
+ * Read `config.plugins.<name>`. `AssistantConfigSchema` declares `plugins` as
+ * an optional `Record<string, unknown>`, so the field is type-safe at the
+ * schema boundary; per-plugin validation happens downstream via
+ * `plugin.manifest.config` in `validatePluginConfig`.
  */
 function getPluginConfigRaw(
   config: AssistantConfig,
   pluginName: string,
 ): unknown {
-  const plugins = (config as { plugins?: Record<string, unknown> }).plugins;
-  if (plugins == null || typeof plugins !== "object") return undefined;
-  return plugins[pluginName];
+  return config.plugins?.[pluginName];
 }
 
 /**


### PR DESCRIPTION
## Summary
- G3.3: AssistantConfigSchema was silently stripping config.plugins.<name> because no matching field existed. Adds `plugins: z.record(z.string(), z.unknown()).optional()` so per-plugin config reads documented in plugins.md actually work end-to-end.
- Per-plugin schema validation happens downstream via plugin.manifest.config in bootstrapPlugins (unchanged).

Part of plan: agent-plugin-system.md (remediation round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
