### PR TITLE
fix(assistant): trust elevation + hardcoded timeouts + overflowReduce strict-fail

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -94,6 +94,7 @@ import type {
   PersistResult,
   TurnContext as PluginTurnContext,
 } from "../plugins/types.js";
+import { PluginExecutionError } from "../plugins/types.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
 import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
@@ -809,7 +810,7 @@ export async function runAgentLoopImpl(
             },
           },
           buildPluginTurnContext(ctx, reqId),
-          30000,
+          DEFAULT_TIMEOUTS.compaction,
         )) as Awaited<ReturnType<typeof ctx.contextWindowManager.maybeCompact>>)
       : null;
     // Only track circuit-breaker state when a summary LLM call actually ran.
@@ -1483,23 +1484,15 @@ export async function runAgentLoopImpl(
         // `next` and delegates past the innermost layer. The default plugin
         // is a terminal itself (it doesn't call `next`), so in practice
         // this fallback fires only when the default has been explicitly
-        // deregistered (tests) and no user plugin replaces it. In that
-        // case the safest behavior is to return the history untouched —
-        // the subsequent provider call will then surface the overflow as
-        // a normal `context_too_large` error, which the convergence loop
-        // below handles.
-        async (args) => ({
-          messages: args.messages,
-          runMessages: args.runMessages,
-          injectionMode: "full" as const,
-          reducerState: {
-            appliedTiers: [],
-            injectionMode: "full",
-            exhausted: true,
-          },
-          reducerCompacted: false,
-          attempts: 0,
-        }),
+        // deregistered (tests) and no user plugin replaces it. Strict-fail
+        // semantics: throw so the missing terminal surfaces as a visible
+        // error instead of silently returning the history untouched.
+        async () => {
+          throw new PluginExecutionError(
+            "overflowReduce pipeline has no terminal handler — every reducer middleware called next() without providing a replacement",
+            "overflowReduce",
+          );
+        },
         overflowArgs,
         {
           requestId: reqId,
@@ -1508,10 +1501,10 @@ export async function runAgentLoopImpl(
           trust: ctx.currentTurnTrustContext ??
             ctx.trustContext ?? {
               sourceChannel: "vellum",
-              trustClass: "guardian",
+              trustClass: "unknown",
             },
         },
-        30000,
+        DEFAULT_TIMEOUTS.overflowReduce,
       );
 
       ctx.messages = overflowResult.messages;
@@ -1701,7 +1694,7 @@ export async function runAgentLoopImpl(
           },
         },
         buildPluginTurnContext(ctx, reqId),
-        30000,
+        DEFAULT_TIMEOUTS.compaction,
       )) as Awaited<ReturnType<typeof ctx.contextWindowManager.maybeCompact>>;
       // `force: true` bypasses the cooldown/threshold gates but early returns
       // for "no eligible messages" / "insufficient messages" still leave
@@ -2065,7 +2058,7 @@ export async function runAgentLoopImpl(
               },
             },
             buildPluginTurnContext(ctx, reqId),
-            30000,
+            DEFAULT_TIMEOUTS.compaction,
           )) as Awaited<
             ReturnType<typeof ctx.contextWindowManager.maybeCompact>
           >;


### PR DESCRIPTION
## Summary
Three gaps from plan review:
- G3.1: change trustClass "guardian" → "unknown" in conversation-agent-loop.ts fallback (matches all other fallbacks)
- G3.4: replace four hardcoded 30000 timeout literals with DEFAULT_TIMEOUTS.compaction / .overflowReduce
- G2.6: overflowReduce terminal now throws PluginExecutionError (strict-fail semantics)

Part of plan: agent-plugin-system.md (remediation round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
