### PR TITLE
refactor(assistant): remove orphan registerDefaultOverflowReducePlugin helper

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -18,8 +18,11 @@ import type {
   CheckpointInfo,
 } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
-import { registerDefaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
-import { resetPluginRegistryForTests } from "../plugins/registry.js";
+import { defaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 
 // ── Module mocks (must precede imports of the module under test) ─────
@@ -575,7 +578,7 @@ beforeEach(() => {
   // preflight reducer through `runPipeline("overflowReduce", …)` which
   // needs the default in place to reach the mocked `reduceContextOverflow`.
   resetPluginRegistryForTests();
-  registerDefaultOverflowReducePlugin();
+  registerPlugin(defaultOverflowReducePlugin);
 });
 
 describe("session-agent-loop overflow recovery (JARVIS-110)", () => {

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -6,8 +6,11 @@ import type {
   CheckpointInfo,
 } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
-import { registerDefaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
-import { resetPluginRegistryForTests } from "../plugins/registry.js";
+import { defaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 
 // ── Module mocks (must precede imports of the module under test) ─────
@@ -521,7 +524,7 @@ beforeEach(() => {
   // and re-register the default plugin so the pipeline dispatches to the
   // mocked `reduceContextOverflow` that these tests rely on.
   resetPluginRegistryForTests();
-  registerDefaultOverflowReducePlugin();
+  registerPlugin(defaultOverflowReducePlugin);
 });
 
 describe("session-agent-loop", () => {

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -2,8 +2,11 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { AgentEvent } from "../agent/loop.js";
 import type { UserMessageAttachment } from "../daemon/message-protocol.js";
-import { registerDefaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
-import { resetPluginRegistryForTests } from "../plugins/registry.js";
+import { defaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 import { ProviderError } from "../util/errors.js";
 
@@ -455,7 +458,7 @@ describe("provider ordering error retry", () => {
     // itself is mocked above, so the default plugin's delegate goes
     // through the mocked implementation).
     resetPluginRegistryForTests();
-    registerDefaultOverflowReducePlugin();
+    registerPlugin(defaultOverflowReducePlugin);
   });
 
   test("simulated strict provider error triggers exactly one retry", async () => {

--- a/assistant/src/__tests__/overflow-reduce-pipeline.test.ts
+++ b/assistant/src/__tests__/overflow-reduce-pipeline.test.ts
@@ -35,8 +35,10 @@ import type {
   InjectionMode,
   TrustContext,
 } from "../daemon/conversation-runtime-assembly.js";
-import { defaultOverflowReduceMiddleware } from "../plugins/defaults/overflow-reduce.js";
-import { registerDefaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
+import {
+  defaultOverflowReduceMiddleware,
+  defaultOverflowReducePlugin,
+} from "../plugins/defaults/overflow-reduce.js";
 import { runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,
@@ -305,7 +307,7 @@ function buildArgs(messages: Message[]): {
 describe("overflow-reduce pipeline", () => {
   beforeEach(() => {
     resetPluginRegistryForTests();
-    registerDefaultOverflowReducePlugin();
+    registerPlugin(defaultOverflowReducePlugin);
   });
 
   describe("default middleware matches historical inline loop", () => {
@@ -446,7 +448,7 @@ describe("overflow-reduce pipeline", () => {
       // outer→inner). The default therefore runs as the spy's downstream.
       resetPluginRegistryForTests();
       registerPlugin(spyPlugin);
-      registerDefaultOverflowReducePlugin();
+      registerPlugin(defaultOverflowReducePlugin);
 
       const { args } = buildArgs(history);
       const result = await runPipeline<
@@ -501,7 +503,7 @@ describe("overflow-reduce pipeline", () => {
         },
         middleware: { overflowReduce: shortCircuit },
       });
-      registerDefaultOverflowReducePlugin();
+      registerPlugin(defaultOverflowReducePlugin);
 
       const { args, compactionResults, reinjectCalls } = buildArgs(history);
       const result = await runPipeline<

--- a/assistant/src/plugins/defaults/overflow-reduce.ts
+++ b/assistant/src/plugins/defaults/overflow-reduce.ts
@@ -25,7 +25,6 @@ import {
   reduceContextOverflow,
   type ReducerState,
 } from "../../daemon/context-overflow-reducer.js";
-import { registerPlugin } from "../registry.js";
 import type {
   Middleware,
   OverflowReduceArgs,
@@ -130,13 +129,3 @@ export const defaultOverflowReducePlugin: Plugin = {
     overflowReduce: defaultOverflowReduceMiddleware,
   },
 };
-
-/**
- * Register the default plugin with the global registry. Idempotent-safe
- * only via `resetPluginRegistryForTests` — registration itself throws on
- * duplicates, so callers must guard repeat calls during daemon re-init or
- * test setup.
- */
-export function registerDefaultOverflowReducePlugin(): void {
-  registerPlugin(defaultOverflowReducePlugin);
-}


### PR DESCRIPTION
## Summary
- G3.9: drop registerDefaultOverflowReducePlugin() helper — 12 sibling defaults in plugins/defaults/ expose only the plugin object and callers use registerPlugin(defaultFooPlugin) directly.
- Update 4 test files to register the plugin object directly instead of calling the helper.

Part of plan: agent-plugin-system.md (remediation round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
