### PR TITLE
chore(assistant): remove dead sanitizeToolInput + skipPreMessageRollback plumbing

### DIFF
--- a/assistant/src/__tests__/permission-checker-host-gate.test.ts
+++ b/assistant/src/__tests__/permission-checker-host-gate.test.ts
@@ -79,10 +79,6 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
 }
 
 const noopEmit = (_event: ToolLifecycleEvent): void => {};
-const noopSanitize = (
-  _name: string,
-  input: Record<string, unknown>,
-): Record<string, unknown> => input;
 const noopDiff = () => undefined;
 const executionTarget: ExecutionTarget = "host";
 
@@ -139,7 +135,6 @@ describe("permission-checker host-access gate (v2)", () => {
             makeContext(),
             executionTarget,
             noopEmit,
-            noopSanitize,
             Date.now(),
             noopDiff,
           );
@@ -173,7 +168,6 @@ describe("permission-checker host-access gate (v2)", () => {
           makeContext(),
           executionTarget,
           noopEmit,
-          noopSanitize,
           Date.now(),
           noopDiff,
         );
@@ -199,7 +193,6 @@ describe("permission-checker host-access gate (v2)", () => {
             makeContext(),
             executionTarget,
             noopEmit,
-            noopSanitize,
             Date.now(),
             noopDiff,
           );
@@ -227,7 +220,6 @@ describe("permission-checker host-access gate (v2)", () => {
             makeContext(),
             "sandbox",
             noopEmit,
-            noopSanitize,
             Date.now(),
             noopDiff,
           );
@@ -258,7 +250,6 @@ describe("permission-checker host-access gate (v2)", () => {
           makeContext({ requireFreshApproval: true }),
           executionTarget,
           noopEmit,
-          noopSanitize,
           Date.now(),
           noopDiff,
         );
@@ -289,7 +280,6 @@ describe("permission-checker host-access gate (v2)", () => {
           makeContext({ requireFreshApproval: true }),
           "sandbox",
           noopEmit,
-          noopSanitize,
           Date.now(),
           noopDiff,
         );
@@ -326,7 +316,6 @@ describe("permission-checker host-access gate (v2)", () => {
           makeContext({ isInteractive: false, trustClass: "guardian" }),
           executionTarget,
           noopEmit,
-          noopSanitize,
           Date.now(),
           noopDiff,
         );
@@ -360,7 +349,6 @@ describe("permission-checker host-access gate (v2)", () => {
           makeContext({ forcePromptSideEffects: true }),
           executionTarget,
           noopEmit,
-          noopSanitize,
           Date.now(),
           noopDiff,
         );
@@ -385,7 +373,6 @@ describe("permission-checker host-access gate (v2)", () => {
           makeContext({ forcePromptSideEffects: true }),
           "sandbox",
           noopEmit,
-          noopSanitize,
           Date.now(),
           noopDiff,
         );
@@ -404,7 +391,6 @@ describe("permission-checker host-access gate (v2)", () => {
           makeContext({ forcePromptSideEffects: true }),
           "sandbox",
           noopEmit,
-          noopSanitize,
           Date.now(),
           noopDiff,
         );
@@ -433,7 +419,6 @@ describe("permission-checker host-access gate (v2)", () => {
         makeContext({ conversationId: "allow-conv" }),
         executionTarget,
         noopEmit,
-        noopSanitize,
         Date.now(),
         noopDiff,
       );
@@ -444,7 +429,6 @@ describe("permission-checker host-access gate (v2)", () => {
         makeContext({ conversationId: "deny-conv" }),
         executionTarget,
         noopEmit,
-        noopSanitize,
         Date.now(),
         noopDiff,
       );
@@ -471,7 +455,6 @@ describe("permission-checker host-access gate (v2)", () => {
         makeContext(),
         executionTarget,
         noopEmit,
-        noopSanitize,
         Date.now(),
         noopDiff,
       );
@@ -493,7 +476,6 @@ describe("permission-checker host-access gate (v2)", () => {
         makeContext(),
         "sandbox",
         noopEmit,
-        noopSanitize,
         Date.now(),
         noopDiff,
       );

--- a/assistant/src/__tests__/secret-detection-handler.test.ts
+++ b/assistant/src/__tests__/secret-detection-handler.test.ts
@@ -55,7 +55,6 @@ describe("SecretDetectionHandler under v2", () => {
       "allow",
       Date.now(),
       emitLifecycleEvent,
-      (_toolName, input) => input,
     );
 
     expect(result.earlyReturn).toBe(true);

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -596,7 +596,6 @@ export async function runAgentLoopImpl(
   userMessageId: string,
   onEvent: (msg: ServerMessage) => void,
   options?: {
-    skipPreMessageRollback?: boolean;
     isInteractive?: boolean;
     isUserMessage?: boolean;
     titleText?: string;

--- a/assistant/src/daemon/conversation-history.ts
+++ b/assistant/src/daemon/conversation-history.ts
@@ -191,10 +191,7 @@ export function consolidateAssistantMessages(
 
     // Clean up Qdrant vectors (fire-and-forget)
     if (allSegmentIds.length > 0) {
-      cleanupQdrantVectors(
-        conversationId,
-        allSegmentIds,
-      ).catch((err) => {
+      cleanupQdrantVectors(conversationId, allSegmentIds).catch((err) => {
         log.warn(
           { err, conversationId },
           "Qdrant cleanup after consolidation failed (non-fatal)",
@@ -326,10 +323,7 @@ export function consolidateAssistantMessages(
 
   // Clean up Qdrant vectors (fire-and-forget)
   if (allSegmentIds.length > 0) {
-    cleanupQdrantVectors(
-      conversationId,
-      allSegmentIds,
-    ).catch((err) => {
+    cleanupQdrantVectors(conversationId, allSegmentIds).catch((err) => {
       log.warn(
         { err, conversationId },
         "Qdrant cleanup after consolidation failed (non-fatal)",
@@ -365,7 +359,6 @@ export interface HistoryConversationContext {
     userMessageId: string,
     onEvent: (msg: ServerMessage) => void,
     options?: {
-      skipPreMessageRollback?: boolean;
       isUserMessage?: boolean;
       titleText?: string;
     },
@@ -534,15 +527,14 @@ export async function regenerate(
   }
 
   // Clean up Qdrant vectors (fire-and-forget).
-  cleanupQdrantVectors(
-    conversation.conversationId,
-    allSegmentIds,
-  ).catch((err) => {
-    log.warn(
-      { err, conversationId: conversation.conversationId },
-      "Qdrant cleanup after regenerate failed (non-fatal)",
-    );
-  });
+  cleanupQdrantVectors(conversation.conversationId, allSegmentIds).catch(
+    (err) => {
+      log.warn(
+        { err, conversationId: conversation.conversationId },
+        "Qdrant cleanup after regenerate failed (non-fatal)",
+      );
+    },
+  );
 
   // Re-extract the user message content for the agent loop.
   // Use all content blocks (text, image, file) so attachments are
@@ -581,7 +573,6 @@ export async function regenerate(
   // observability contract is preserved on those paths too.
   void conversation
     .runAgentLoop(content, existingUserMessageId, onEvent, {
-      skipPreMessageRollback: true,
       isUserMessage: true,
     })
     .catch((err) => {

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -137,7 +137,6 @@ export interface ProcessConversationContext {
     userMessageId: string,
     onEvent: (msg: ServerMessage) => void,
     options?: {
-      skipPreMessageRollback?: boolean;
       isInteractive?: boolean;
       isUserMessage?: boolean;
       titleText?: string;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1455,7 +1455,6 @@ export class Conversation {
     userMessageId: string,
     onEvent: (msg: ServerMessage) => void,
     options?: {
-      skipPreMessageRollback?: boolean;
       isInteractive?: boolean;
       isUserMessage?: boolean;
       titleText?: string;

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -168,7 +168,6 @@ export class ToolExecutor {
           context,
           executionTarget,
           (event) => emitLifecycleEvent(context, event),
-          sanitizeToolInput,
           startTime,
           computePreviewDiff,
         );
@@ -363,7 +362,6 @@ export class ToolExecutor {
         decision,
         startTime,
         emitLifecycleEvent,
-        sanitizeToolInput,
       );
       if (secretResult.earlyReturn) {
         return secretResult.result;

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -57,10 +57,6 @@ export class PermissionChecker {
     context: ToolContext,
     executionTarget: ExecutionTarget,
     emitLifecycleEvent: (event: ToolLifecycleEvent) => void,
-    sanitizeToolInput: (
-      toolName: string,
-      input: Record<string, unknown>,
-    ) => Record<string, unknown>,
     startTime: number,
     computePreviewDiff: (
       toolName: string,

--- a/assistant/src/tools/secret-detection-handler.ts
+++ b/assistant/src/tools/secret-detection-handler.ts
@@ -45,10 +45,6 @@ export class SecretDetectionHandler {
       context: ToolContext,
       event: ToolLifecycleEvent,
     ) => void,
-    sanitizeToolInput: (
-      toolName: string,
-      input: Record<string, unknown>,
-    ) => Record<string, unknown>,
   ): Promise<{ result: ToolExecutionResult; earlyReturn: boolean }> {
     const sdConfig = getConfig().secretDetection;
     if (!sdConfig.enabled || execResult.isError) {
@@ -107,7 +103,6 @@ export class SecretDetectionHandler {
         decision,
         startTime,
         emitLifecycleEvent,
-        sanitizeToolInput,
       );
     }
 
@@ -123,7 +118,6 @@ export class SecretDetectionHandler {
         decision,
         startTime,
         emitLifecycleEvent,
-        sanitizeToolInput,
       );
     }
 
@@ -209,10 +203,6 @@ export class SecretDetectionHandler {
       context: ToolContext,
       event: ToolLifecycleEvent,
     ) => void,
-    _sanitizeToolInput: (
-      toolName: string,
-      input: Record<string, unknown>,
-    ) => Record<string, unknown>,
   ): { result: ToolExecutionResult; earlyReturn: boolean } {
     const types = [...new Set(allMatches.map((m) => m.type))].join(", ");
     const blockedContent = `Tool output blocked: detected ${allMatches.length} potential secret(s) (${types}). Configure secretDetection.action to "redact" or "prompt" to allow output.`;
@@ -253,10 +243,6 @@ export class SecretDetectionHandler {
       context: ToolContext,
       event: ToolLifecycleEvent,
     ) => void,
-    _sanitizeToolInput: (
-      toolName: string,
-      input: Record<string, unknown>,
-    ) => Record<string, unknown>,
   ): Promise<{ result: ToolExecutionResult; earlyReturn: boolean }> {
     const types = [...new Set(allMatches.map((m) => m.type))].join(", ");
 


### PR DESCRIPTION
## Summary
Leftover plumbing from the removed hooks system:
- G3.6: drop `sanitizeToolInput` parameter from PermissionChecker.checkPermission + SecretDetectionHandler.handle(/Block/Prompt) and all ToolExecutor call sites — unused since hooks deletion.
- G3.7: drop `skipPreMessageRollback` option from runAgentLoopImpl and its fan-out through Conversation / conversation-process / conversation-history — rollback logic was deleted with hooks, option was never read.

Part of plan: agent-plugin-system.md (remediation round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
