### PR TITLE
fix(assistant): add workspace migration to remove legacy workspace/hooks/ dir

### DIFF
--- a/assistant/src/__tests__/platform.test.ts
+++ b/assistant/src/__tests__/platform.test.ts
@@ -133,7 +133,6 @@ describe("path characterization", () => {
 
     // Workspace dirs (in our temp location)
     expect(existsSync(wsDir)).toBe(true);
-    expect(existsSync(join(wsDir, "hooks"))).toBe(true);
     expect(existsSync(join(wsDir, "skills"))).toBe(true);
 
     // Data sub-dirs under workspace

--- a/assistant/src/__tests__/workspace-migration-remove-hooks.test.ts
+++ b/assistant/src/__tests__/workspace-migration-remove-hooks.test.ts
@@ -1,0 +1,99 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { removeWorkspaceHooksMigration } from "../workspace/migrations/046-remove-workspace-hooks.js";
+
+let workspaceDir: string;
+let hooksDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-046-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  hooksDir = join(workspaceDir, "hooks");
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+const dirs: string[] = [];
+
+beforeEach(() => {
+  freshWorkspace();
+  dirs.push(workspaceDir);
+});
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("046-remove-workspace-hooks migration", () => {
+  test("has correct migration id", () => {
+    expect(removeWorkspaceHooksMigration.id).toBe("046-remove-workspace-hooks");
+  });
+
+  test("removes a populated hooks directory", () => {
+    mkdirSync(hooksDir, { recursive: true });
+    mkdirSync(join(hooksDir, "my-hook"), { recursive: true });
+    writeFileSync(join(hooksDir, "my-hook", "manifest.json"), "{}");
+    writeFileSync(join(hooksDir, "my-hook", "run.sh"), "#!/bin/sh\n");
+    writeFileSync(join(hooksDir, "README.md"), "hooks live here");
+
+    removeWorkspaceHooksMigration.run(workspaceDir);
+
+    expect(existsSync(hooksDir)).toBe(false);
+  });
+
+  test("removes an empty hooks directory", () => {
+    mkdirSync(hooksDir, { recursive: true });
+
+    removeWorkspaceHooksMigration.run(workspaceDir);
+
+    expect(existsSync(hooksDir)).toBe(false);
+  });
+
+  test("no-op when the hooks directory does not exist", () => {
+    expect(existsSync(hooksDir)).toBe(false);
+
+    removeWorkspaceHooksMigration.run(workspaceDir);
+
+    expect(existsSync(hooksDir)).toBe(false);
+    // The workspace itself must remain intact.
+    expect(existsSync(workspaceDir)).toBe(true);
+  });
+
+  test("idempotent — safe to re-run after the directory is gone", () => {
+    mkdirSync(hooksDir, { recursive: true });
+    writeFileSync(join(hooksDir, "stale.json"), "{}");
+
+    removeWorkspaceHooksMigration.run(workspaceDir);
+    // Second invocation is a no-op and must not throw.
+    removeWorkspaceHooksMigration.run(workspaceDir);
+
+    expect(existsSync(hooksDir)).toBe(false);
+  });
+
+  test("does not touch unrelated workspace entries", () => {
+    mkdirSync(hooksDir, { recursive: true });
+    writeFileSync(join(hooksDir, "stale.json"), "{}");
+    const skillsDir = join(workspaceDir, "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    writeFileSync(join(skillsDir, "keep.md"), "keep me");
+
+    removeWorkspaceHooksMigration.run(workspaceDir);
+
+    expect(existsSync(hooksDir)).toBe(false);
+    expect(existsSync(skillsDir)).toBe(true);
+    expect(existsSync(join(skillsDir, "keep.md"))).toBe(true);
+  });
+
+  describe("down()", () => {
+    test("is a no-op", () => {
+      removeWorkspaceHooksMigration.down(workspaceDir);
+      expect(existsSync(hooksDir)).toBe(false);
+    });
+  });
+});

--- a/assistant/src/backup/__tests__/backup-worker.test.ts
+++ b/assistant/src/backup/__tests__/backup-worker.test.ts
@@ -20,23 +20,13 @@ import {
 import { unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { BackupConfig, BackupDestination } from "../../config/schema.js";
 import { BackupConfigSchema } from "../../config/schema.js";
 import type { StreamExportVBundleResult } from "../../runtime/migrations/vbundle-builder.js";
 import type { BackupDeps } from "../backup-worker.js";
-import {
-  createSnapshotNow,
-  runBackupTick,
-} from "../backup-worker.js";
+import { createSnapshotNow, runBackupTick } from "../backup-worker.js";
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -190,7 +180,6 @@ describe("runBackupTick — gating", () => {
       snapshotLockPath: join(ROOT, ".snapshot.lock"),
       // Explicit plaintext to avoid touching the key file
       trustPath: join(ROOT, "trust.json"),
-      hooksDir: join(ROOT, "hooks"),
     });
 
     expect(result).toBeNull();

--- a/assistant/src/backup/backup-worker.ts
+++ b/assistant/src/backup/backup-worker.ts
@@ -42,14 +42,10 @@ import {
   getDbPath,
   getProtectedDir,
   getWorkspaceDir,
-  getWorkspaceHooksDir,
 } from "../util/platform.js";
 import { ensureBackupKey as realEnsureBackupKey } from "./backup-key.js";
 import type { SnapshotEntry } from "./list-snapshots.js";
-import {
-  pruneLocalSnapshots,
-  writeLocalSnapshot,
-} from "./local-writer.js";
+import { pruneLocalSnapshots, writeLocalSnapshot } from "./local-writer.js";
 import type { OffsiteWriteResult } from "./offsite-writer.js";
 import {
   pruneOffsiteSnapshotsInAll,
@@ -60,10 +56,7 @@ import {
   getLocalBackupsDir,
   resolveOffsiteDestinations,
 } from "./paths.js";
-import {
-  acquireSnapshotLock,
-  getSnapshotLockPath,
-} from "./snapshot-lock.js";
+import { acquireSnapshotLock, getSnapshotLockPath } from "./snapshot-lock.js";
 
 const log = getLogger("backup-worker");
 
@@ -118,8 +111,6 @@ export interface BackupDeps {
   localDir?: string;
   /** Override for the trust.json path (tests). */
   trustPath?: string;
-  /** Override for the hooks directory (tests). */
-  hooksDir?: string;
   /** Override for the backup key file path (tests). */
   backupKeyPath?: string;
   /**
@@ -187,9 +178,7 @@ async function performBackup(
   const ensureKey = deps.ensureBackupKey ?? realEnsureBackupKey;
   const workspaceDir = deps.workspaceDir ?? getWorkspaceDir();
   const localDir = deps.localDir ?? getLocalBackupsDir(config.localDirectory);
-  const trustPath =
-    deps.trustPath ?? join(getProtectedDir(), "trust.json");
-  const hooksDir = deps.hooksDir ?? getWorkspaceHooksDir();
+  const trustPath = deps.trustPath ?? join(getProtectedDir(), "trust.json");
   const backupKeyPath = deps.backupKeyPath ?? getBackupKeyPath();
 
   const startTimestamp = Date.now();
@@ -207,7 +196,6 @@ async function performBackup(
   const result = await streamExport({
     workspaceDir,
     trustPath,
-    hooksDir,
     source: "backup-worker",
     description: "Automated backup snapshot",
     checkpoint: () => {

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -4,7 +4,7 @@
  * A .vbundle is a gzip-compressed tar archive containing:
  * - manifest.json: metadata with schema_version, checksums, and bundle info
  * - workspace/: the entire ~/.vellum/workspace/ directory tree (DB, config,
- *   skills, hooks, prompts, attachments, etc.) — excluding large/regenerable
+ *   skills, prompts, attachments, etc.) — excluding large/regenerable
  *   dirs (embedding-models/, data/qdrant/)
  * - trust/trust.json: trust rules (optional, lives in protected/ outside workspace)
  */
@@ -430,15 +430,6 @@ export interface BuildExportVBundleOptions {
   /** Absolute path to trust.json. If provided and the file exists, it is included in the archive. */
   trustPath?: string;
   /**
-   * Absolute path to the hooks directory. Previously hooks lived outside the
-   * workspace at ~/.vellum/hooks/ and needed explicit inclusion. Now hooks
-   * live under workspace (~/.vellum/workspace/hooks/) and are included in
-   * the workspace walk. Only pass this for backward-compat scenarios where
-   * hooks are still outside the workspace; otherwise omit to avoid double
-   * export. Included in the archive under the "hooks/" prefix.
-   */
-  hooksDir?: string;
-  /**
    * Absolute path to the workspace directory (~/.vellum/workspace/).
    * When provided and exists, the entire directory tree is walked and
    * included in the archive under the "workspace/" prefix, skipping
@@ -479,7 +470,6 @@ export function buildExportVBundle(
     checkpoint,
     trustPath,
     workspaceDir,
-    hooksDir,
     credentials,
   } = options;
 
@@ -513,11 +503,6 @@ export function buildExportVBundle(
     const configJson = new TextDecoder().decode(configEntry.data);
     const sanitized = sanitizeConfigForTransfer(configJson);
     configEntry.data = new TextEncoder().encode(sanitized);
-  }
-
-  // Include hooks directory if it exists (lives at ~/.vellum/hooks/, outside workspace).
-  if (hooksDir && existsSync(hooksDir) && lstatSync(hooksDir).isDirectory()) {
-    files.push(...walkDirectory(hooksDir, "hooks"));
   }
 
   // Include trust rules if the file exists (lives in protected/, outside workspace).
@@ -820,7 +805,6 @@ export async function streamExportVBundle(
     checkpoint,
     trustPath,
     workspaceDir,
-    hooksDir,
     credentials,
   } = options;
 
@@ -843,11 +827,6 @@ export async function streamExportVBundle(
         skipDirs: ["embedding-models", "data/qdrant", "signals", "deprecated"],
       }),
     );
-  }
-
-  // Include hooks directory if it exists
-  if (hooksDir && existsSync(hooksDir) && lstatSync(hooksDir).isDirectory()) {
-    allFileMetadata.push(...walkDirectoryForMetadata(hooksDir, "hooks"));
   }
 
   // Include trust rules if the file exists

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -255,9 +255,6 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
     }
 
     const result = await streamExportVBundle({
-      // hooksDir is intentionally omitted — hooks now live under workspace/hooks/
-      // and are included in the workspace walk. Passing hooksDir separately would
-      // export them twice (once as workspace/hooks/... and again as hooks/...).
       workspaceDir: getWorkspaceDir(),
       source: "runtime-export",
       description,

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -410,7 +410,6 @@ export function ensureDataDir(): void {
     // Workspace dirs
     workspace,
     join(workspace, "signals"),
-    join(workspace, "hooks"),
     join(workspace, "skills"),
     join(workspace, "routes"),
     join(workspace, "embedding-models"),

--- a/assistant/src/workspace/migrations/046-remove-workspace-hooks.ts
+++ b/assistant/src/workspace/migrations/046-remove-workspace-hooks.ts
@@ -1,0 +1,81 @@
+/**
+ * Workspace migration 046: Remove legacy `workspace/hooks/` directory.
+ *
+ * Migration 022 moved `~/.vellum/hooks/` into `~/.vellum/workspace/hooks/`.
+ * With the hook system entirely removed, that directory is dead state — it is
+ * no longer read or written by the assistant. This migration deletes the
+ * directory (and everything under it) so stale hook manifests, config, and
+ * executables do not linger in user workspaces.
+ *
+ * Idempotent: safe to re-run after interruption. A no-op when the directory
+ * is already absent.
+ */
+
+import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migration-046-remove-workspace-hooks");
+
+/**
+ * Count files under `dir` recursively. Best-effort — returns the count we
+ * could successfully stat, and silently skips entries that fail (e.g. a
+ * symlink whose target is missing, a file removed concurrently). This is
+ * only used for log output, so a slightly stale count is acceptable.
+ */
+function countFilesRecursive(dir: string): number {
+  let count = 0;
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    const entryPath = join(dir, entry);
+    try {
+      const s = statSync(entryPath);
+      if (s.isDirectory()) {
+        count += countFilesRecursive(entryPath);
+      } else {
+        count += 1;
+      }
+    } catch {
+      // best-effort
+    }
+  }
+  return count;
+}
+
+export const removeWorkspaceHooksMigration: WorkspaceMigration = {
+  id: "046-remove-workspace-hooks",
+  description:
+    "Remove legacy workspace/hooks/ directory now that the hook system is gone",
+
+  run(workspaceDir: string): void {
+    const hooksDir = join(workspaceDir, "hooks");
+    if (!existsSync(hooksDir)) return;
+
+    const fileCount = countFilesRecursive(hooksDir);
+    try {
+      rmSync(hooksDir, { recursive: true, force: true });
+      log.info(
+        { path: hooksDir, fileCount },
+        "Removed legacy workspace hooks directory",
+      );
+    } catch (err) {
+      log.warn(
+        { err, path: hooksDir },
+        "Failed to remove legacy workspace hooks directory; leaving in place",
+      );
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: the hook system is gone and the directory contained no
+    // data the assistant still consumes. Restoring an empty directory would
+    // just reintroduce dead state.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -43,6 +43,7 @@ import { fixBackfillGoogleGmailSettingsScopeMigration } from "./042-fix-backfill
 import { releaseNotesLatexRenderingMigration } from "./043-release-notes-latex-rendering.js";
 import { bumpStaleProviderStreamTimeoutMigration } from "./044-bump-stale-provider-stream-timeout.js";
 import { releaseNotesMeetAvatarMigration } from "./045-release-notes-meet-avatar.js";
+import { removeWorkspaceHooksMigration } from "./046-remove-workspace-hooks.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -97,4 +98,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   releaseNotesLatexRenderingMigration,
   bumpStaleProviderStreamTimeoutMigration,
   releaseNotesMeetAvatarMigration,
+  removeWorkspaceHooksMigration,
 ];


### PR DESCRIPTION
## Summary
- G3.10: new append-only workspace migration idempotently removes ~/.vellum/workspace/hooks/ (migration 022 moved it there from legacy ~/.vellum/hooks/, but the hook system is gone — directory is dead state).
- Strip getWorkspaceHooksDir from platform.ts if unused.
- Remove dead references in runtime/migrations/vbundle-builder.ts and runtime/routes/migration-routes.ts.
- Migration 022 is left unchanged (append-only invariant).

Part of plan: agent-plugin-system.md (remediation round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
