### PR TITLE
feat(assistant): implement requiresFlag gating + clarify manifest.provides docs

### DIFF
--- a/assistant/docs/plugins.md
+++ b/assistant/docs/plugins.md
@@ -95,23 +95,23 @@ time. Its shape (see
 export interface PluginManifest {
   name: string; // kebab-case, unique
   version: string; // semver, informational
-  provides?: Record<string, string>; // capability → version exposed to other plugins
+  provides?: Record<string, string>; // reserved; not consumed at runtime today
   requires: Record<string, string>; // capability → version required from the assistant
   requiresCredential?: string[]; // credential keys resolved before init()
-  requiresFlag?: string[]; // feature flag keys that must be enabled
+  requiresFlag?: string[]; // feature flag keys that must all be enabled
   config?: unknown; // Zod-like parser for plugins.<name>
 }
 ```
 
-| Field                | Required | Purpose                                                                                                                                                                                                                     |
-| -------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`               | yes      | Unique plugin identifier. Duplicate names fail registration. Used as the directory under `~/.vellum/plugins-data/<name>/` and the attribution tag in logs.                                                                  |
-| `version`            | yes      | Plugin's own semver. Informational — the registry does not compare it.                                                                                                                                                      |
-| `provides`           | no       | Capabilities this plugin exposes to other plugins. Reserved for future composition; currently advisory.                                                                                                                     |
-| `requires`           | yes      | Must include `pluginRuntime: "v1"` at minimum. The registry checks every entry against `ASSISTANT_API_VERSIONS` and refuses to register plugins that ask for a capability or version the assistant does not expose.         |
-| `requiresCredential` | no       | Credential keys the plugin needs. The bootstrap resolves them via the credential store before `init()` runs and hands the values to the plugin in `ctx.credentials`. A missing credential fails startup with a clear error. |
-| `requiresFlag`       | no       | Assistant feature-flag keys that must be ON for the plugin to activate. If any flag is OFF, the plugin is skipped at bootstrap.                                                                                             |
-| `config`             | no       | A parser-like validator (Zod schema, or any object with a `.parse(input)` method). If supplied, the bootstrap validates `config.plugins.<name>` through it before passing the result into `init()`.                         |
+| Field                | Required | Purpose                                                                                                                                                                                                                                                                                                        |
+| -------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`               | yes      | Unique plugin identifier. Duplicate names fail registration. Used as the directory under `~/.vellum/plugins-data/<name>/` and the attribution tag in logs.                                                                                                                                                     |
+| `version`            | yes      | Plugin's own semver. Informational — the registry does not compare it.                                                                                                                                                                                                                                         |
+| `provides`           | no       | Reserved for future cross-plugin composition and not currently consumed by the assistant. Plugin authors may set this field, but no runtime code reads it yet — it is declared here so future cross-plugin work can land without a manifest version bump. Do not rely on it for any runtime behavior today.    |
+| `requires`           | yes      | Must include `pluginRuntime: "v1"` at minimum. The registry checks every entry against `ASSISTANT_API_VERSIONS` and refuses to register plugins that ask for a capability or version the assistant does not expose.                                                                                            |
+| `requiresCredential` | no       | Credential keys the plugin needs. The bootstrap resolves them via the credential store before `init()` runs and hands the values to the plugin in `ctx.credentials`. A missing credential fails startup with a clear error.                                                                                    |
+| `requiresFlag`       | no       | Assistant feature-flag keys that must all be ON for the plugin to activate. If any listed flag is disabled at bootstrap, the plugin is skipped entirely: `init()` is not invoked and no tools, routes, skills, or shutdown hooks are registered for it. See [Feature-flag gating](#feature-flag-gating) below. |
+| `config`             | no       | A parser-like validator (Zod schema, or any object with a `.parse(input)` method). If supplied, the bootstrap validates `config.plugins.<name>` through it before passing the result into `init()`.                                                                                                            |
 
 The exposed capability table (`ASSISTANT_API_VERSIONS`) lives in
 [`registry.ts`](../src/plugins/registry.ts). It lists:
@@ -144,6 +144,39 @@ const manifest: PluginManifest = {
   }),
 };
 ```
+
+### Feature-flag gating
+
+`manifest.requiresFlag` lists one or more **assistant-scope** feature-flag
+keys (the same keys declared in
+`meta/feature-flags/feature-flag-registry.json`). The bootstrap checks each
+key against `isAssistantFeatureFlagEnabled` before touching the plugin. If
+**any** listed flag is disabled, the plugin is skipped entirely for the
+duration of this daemon boot:
+
+- `init()` is **not** invoked.
+- `tools`, `routes`, and `skills` are **not** registered.
+- No shutdown hook entry is installed, so a plugin skipped at boot has
+  nothing to tear down on shutdown.
+
+Flag state is resolved once at bootstrap time. Flipping a `requiresFlag`
+key at runtime does not hot-reload the plugin — restart the daemon after
+changing the flag to pick up the new state. An empty `requiresFlag` (or
+the field being absent) means the plugin activates unconditionally.
+
+The skip path emits a single `info`-level log line naming both the plugin
+and the disabled flag, so operators can diagnose "why isn't my plugin
+loading?" at a glance:
+
+```
+plugins-bootstrap skipping plugin my-logger: feature flag my-logger-enabled is disabled
+```
+
+**Cross-repo note:** new flag keys used here must be declared in the
+assistant-scope section of
+`meta/feature-flags/feature-flag-registry.json` (and provisioned in the
+platform's Terraform configuration). See the root `CLAUDE.md`'s "Assistant
+Feature Flags" section for the full procedure.
 
 ## Registration
 
@@ -596,6 +629,14 @@ module graph.
 
 Do not add new HTTP endpoints to implement plugin-to-plugin messaging
 inside a single daemon process.
+
+`manifest.provides` is reserved as the hook for a future cross-plugin
+capability-negotiation protocol but is **not currently consumed by any
+runtime code**. Declaring `provides` today has no behavioral effect —
+plugins must not depend on it for capability discovery or any other
+runtime purpose. The field is intentionally retained on the manifest so
+that adding real consumers later does not require bumping
+`pluginRuntime` or any other capability version.
 
 ## Hot reload
 

--- a/assistant/src/__tests__/plugin-bootstrap.test.ts
+++ b/assistant/src/__tests__/plugin-bootstrap.test.ts
@@ -31,12 +31,17 @@ mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: getSecureKeyAsyncMock,
 }));
 
+import {
+  _setOverridesForTesting,
+  clearFeatureFlagOverridesCache,
+} from "../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../config/schema.js";
 import {
   bootstrapPlugins,
   type DaemonContext,
 } from "../daemon/external-plugins-bootstrap.js";
 import { runShutdownHooks } from "../daemon/shutdown-registry.js";
+import { RiskLevel } from "../permissions/types.js";
 import {
   ASSISTANT_API_VERSIONS,
   registerPlugin,
@@ -68,6 +73,7 @@ function buildPlugin(
   options: {
     requires?: Record<string, string>;
     requiresCredential?: string[];
+    requiresFlag?: string[];
   } = {},
 ): Plugin {
   return {
@@ -78,6 +84,7 @@ function buildPlugin(
       ...(options.requiresCredential
         ? { requiresCredential: options.requiresCredential }
         : {}),
+      ...(options.requiresFlag ? { requiresFlag: options.requiresFlag } : {}),
     },
     ...extras,
   };
@@ -88,6 +95,10 @@ describe("plugin bootstrap", () => {
     resetPluginRegistryForTests();
     getSecureKeyAsyncMock.mockReset();
     getSecureKeyAsyncMock.mockImplementation(async () => undefined);
+    // Reset feature-flag cache so tests start from a known state. Individual
+    // tests that exercise `requiresFlag` use `_setOverridesForTesting(...)`
+    // to install their own overrides.
+    clearFeatureFlagOverridesCache();
     // Clean storage directory between runs so nothing leaks across cases.
     await rm(TEST_INSTANCE_DIR, { recursive: true, force: true });
   });
@@ -252,5 +263,172 @@ describe("plugin bootstrap", () => {
     // throwing — the surface of defaults is verified in each pipeline's own
     // dedicated test file.
     await bootstrapPlugins(fakeCtx);
+  });
+
+  // ── requiresFlag gating (G2.2) ──────────────────────────────────────────
+  //
+  // Plugins that declare `manifest.requiresFlag: [key1, ...]` must only
+  // activate when ALL listed flag keys resolve to `true` at bootstrap.
+  // "Skipping" a plugin means:
+  //   - init() is not invoked,
+  //   - tools/routes/skills are not registered,
+  //   - no shutdown hook entry is installed (nothing to tear down later).
+  // Plugins without `requiresFlag` are unaffected.
+  //
+  // Uses `_setOverridesForTesting` to control the resolver deterministically
+  // — no disk writes, no gateway IPC, no reliance on registry defaults.
+
+  test("requiresFlag enabled: plugin inits normally", async () => {
+    _setOverridesForTesting({ "plugin-gated-enabled": true });
+
+    let initFired = false;
+    const plugin = buildPlugin(
+      "gated-on",
+      {
+        async init() {
+          initFired = true;
+        },
+      },
+      { requiresFlag: ["plugin-gated-enabled"] },
+    );
+    registerPlugin(plugin);
+
+    await bootstrapPlugins(fakeCtx);
+
+    expect(initFired).toBe(true);
+  });
+
+  test("requiresFlag disabled: init does not fire and no tools/routes/skills are registered", async () => {
+    _setOverridesForTesting({ "plugin-gated-disabled": false });
+
+    let initFired = false;
+    // Attach tool/route/skill contributions alongside init. If gating works,
+    // none of them should land in their respective registries.
+    const plugin = buildPlugin(
+      "gated-off",
+      {
+        async init() {
+          initFired = true;
+        },
+        tools: [
+          {
+            name: "gated-off-tool",
+            description: "should not be registered",
+            category: "plugin-test",
+            defaultRiskLevel: RiskLevel.Low,
+            getDefinition: () => ({
+              name: "gated-off-tool",
+              description: "should not be registered",
+              input_schema: { type: "object", properties: {}, required: [] },
+            }),
+            execute: async () => ({ content: "nope", isError: false }),
+          },
+        ],
+        routes: [
+          {
+            // Unique pattern so we don't collide with any other test's route.
+            pattern: /^\/_plugin\/gated-off\/status$/,
+            methods: ["GET"],
+            handler: async () => new Response("ok"),
+          },
+        ],
+        skills: [
+          {
+            id: "gated-off/skill",
+            name: "gated-off-skill",
+            description: "should not be catalogued",
+            body: "# unused",
+          },
+        ],
+      },
+      { requiresFlag: ["plugin-gated-disabled"] },
+    );
+    registerPlugin(plugin);
+
+    // Grab tool / route / skill introspection helpers lazily so the import
+    // side effect happens after `mock.module` has taken effect.
+    const { getTool } = await import("../tools/registry.js");
+    const { getPluginSkillRefCount } =
+      await import("../plugins/plugin-skill-contributions.js");
+    const { matchSkillRoute } =
+      await import("../runtime/skill-route-registry.js");
+
+    await bootstrapPlugins(fakeCtx);
+
+    // init must not have fired.
+    expect(initFired).toBe(false);
+    // No tool contributed.
+    expect(getTool("gated-off-tool")).toBeUndefined();
+    // No route wired up — `matchSkillRoute` returns null when nothing matches.
+    expect(matchSkillRoute("/_plugin/gated-off/status", "GET")).toBeNull();
+    // No skill catalogued under this plugin's name — ref count stays 0.
+    expect(getPluginSkillRefCount("gated-off")).toBe(0);
+  });
+
+  test("requiresFlag absent: plugin activates unconditionally", async () => {
+    // Deliberately do not set any overrides — the resolver defaults
+    // undeclared keys to `true`, but more importantly a plugin with no
+    // `requiresFlag` key must not consult the resolver at all.
+    let initFired = false;
+    const plugin = buildPlugin("no-flag", {
+      async init() {
+        initFired = true;
+      },
+    });
+    registerPlugin(plugin);
+
+    await bootstrapPlugins(fakeCtx);
+
+    expect(initFired).toBe(true);
+  });
+
+  test("requiresFlag: one disabled flag out of several skips the plugin", async () => {
+    // When ANY listed flag is disabled, the plugin is skipped wholesale —
+    // this prevents sneaky partial activation on AND semantics.
+    _setOverridesForTesting({
+      "plugin-multi-a": true,
+      "plugin-multi-b": false,
+    });
+
+    let initFired = false;
+    const plugin = buildPlugin(
+      "multi-flag",
+      {
+        async init() {
+          initFired = true;
+        },
+      },
+      { requiresFlag: ["plugin-multi-a", "plugin-multi-b"] },
+    );
+    registerPlugin(plugin);
+
+    await bootstrapPlugins(fakeCtx);
+
+    expect(initFired).toBe(false);
+  });
+
+  test("requiresFlag disabled: no shutdown hook entry installed for the skipped plugin", async () => {
+    _setOverridesForTesting({ "plugin-shutdown-flag": false });
+
+    let shutdownFired = false;
+    const plugin = buildPlugin(
+      "shutdown-skipped",
+      {
+        async init() {},
+        async onShutdown() {
+          shutdownFired = true;
+        },
+      },
+      { requiresFlag: ["plugin-shutdown-flag"] },
+    );
+    registerPlugin(plugin);
+
+    await bootstrapPlugins(fakeCtx);
+    await runShutdownHooks("test-shutdown");
+
+    // The shutdown hook is a single registered callback that walks a
+    // snapshot taken at bootstrap. A skipped plugin should never appear in
+    // that snapshot, so its `onShutdown` must never fire.
+    expect(shutdownFired).toBe(false);
   });
 });

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -12,21 +12,26 @@
  *    {@link defaultToolExecutePlugin}). Registration is idempotent so
  *    repeat calls (e.g. during integration tests) do not throw.
  * 2. Walks {@link getRegisteredPlugins} in registration order.
- * 3. For each plugin, resolves its `manifest.requiresCredential` entries via
- *    the credential store helper ({@link getSecureKeyAsync}). In Docker mode
+ * 3. For each plugin, consults `manifest.requiresFlag` against
+ *    {@link isAssistantFeatureFlagEnabled}. If any listed flag is disabled,
+ *    the plugin is skipped wholesale — no `init()`, no tool/route/skill
+ *    contributions, and no entry in the shutdown hook. This is the primary
+ *    mechanism for shipping experimental plugins behind a feature flag.
+ * 4. Resolves the plugin's `manifest.requiresCredential` entries via the
+ *    credential store helper ({@link getSecureKeyAsync}). In Docker mode
  *    that helper goes through the CES HTTP API transparently; in local mode
  *    it hits the encrypted file store / CES RPC backend.
- * 4. Validates the config block under `plugins.<name>` against
+ * 5. Validates the config block under `plugins.<name>` against
  *    `manifest.config` if the manifest supplies a parser-like validator
  *    (Zod schemas with `.parse()` are supported; anything else is passed
  *    through untouched).
- * 5. Creates `~/.vellum/plugins-data/<plugin>/` on demand for per-plugin
+ * 6. Creates `~/.vellum/plugins-data/<plugin>/` on demand for per-plugin
  *    writable state and exposes it via {@link PluginInitContext.pluginStorageDir}.
- * 6. Awaits `plugin.init(ctx)` sequentially. One init failure surfaces as a
+ * 7. Awaits `plugin.init(ctx)` sequentially. One init failure surfaces as a
  *    {@link PluginExecutionError} naming the offending plugin and aborts
  *    bootstrap — later plugins' `init()` never runs and the daemon fails
  *    startup cleanly rather than coming up in a half-wired state.
- * 6. After a plugin's `init()` succeeds, registers any tools declared on
+ * 8. After a plugin's `init()` succeeds, registers any tools declared on
  *    `plugin.tools` with the global tool registry via
  *    {@link registerPluginTools}. Tool contributions land after `init()` so
  *    a plugin that fails mid-init never leaves partial tool registrations
@@ -34,16 +39,19 @@
  *
  * A single shutdown hook is registered via
  * {@link registerShutdownHook} that walks the plugin list in **reverse
- * registration order**. For each plugin it first unregisters the contributed
- * tools (so `onShutdown()` observes a clean model-visible surface) and then
- * awaits the optional `onShutdown()`. Per-plugin shutdown failures are
- * logged and swallowed — the hook registry already swallows hook-level
- * throws, but we log at the plugin level so the plugin name is attributed.
+ * registration order**. Only plugins that actually initialized (i.e. were
+ * not skipped by the feature-flag gate) appear in that walk. For each such
+ * plugin it first unregisters the contributed tools (so `onShutdown()`
+ * observes a clean model-visible surface) and then awaits the optional
+ * `onShutdown()`. Per-plugin shutdown failures are logged and swallowed —
+ * the hook registry already swallows hook-level throws, but we log at the
+ * plugin level so the plugin name is attributed.
  */
 
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../config/schema.js";
 import { defaultCircuitBreakerPlugin } from "../plugins/defaults/circuit-breaker.js";
 import { defaultCompactionPlugin } from "../plugins/defaults/compaction.js";
@@ -260,8 +268,34 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
 
   log.info({ count: plugins.length }, "bootstrapPlugins: initializing plugins");
 
+  // Plugins that passed `requiresFlag` gating and therefore need the full
+  // init → contribute → shutdown lifecycle. Plugins skipped by the flag gate
+  // are omitted from this list so the shutdown hook below never tears down
+  // capabilities that were never wired up in the first place.
+  const activePlugins: Plugin[] = [];
+
   for (const plugin of plugins) {
     const name = plugin.manifest.name;
+
+    // Feature-flag gating — if any key in `manifest.requiresFlag` is
+    // disabled, skip this plugin entirely. Skipping means: no `init()`, no
+    // tool / route / skill contributions, and no shutdown hook entry. A
+    // later boot with the flag flipped ON picks up the plugin cleanly.
+    const requiredFlags = plugin.manifest.requiresFlag ?? [];
+    let disabledFlag: string | undefined;
+    for (const flagKey of requiredFlags) {
+      if (!isAssistantFeatureFlagEnabled(flagKey, ctx.config)) {
+        disabledFlag = flagKey;
+        break;
+      }
+    }
+    if (disabledFlag !== undefined) {
+      log.info(
+        { plugin: name, flag: disabledFlag },
+        `skipping plugin ${name}: feature flag ${disabledFlag} is disabled`,
+      );
+      continue;
+    }
 
     // Credential resolution — gather every entry in `requiresCredential`
     // before calling `init()` so the plugin receives a fully-populated map.
@@ -359,13 +393,16 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
       }
     }
 
+    activePlugins.push(plugin);
+
     log.info({ plugin: name }, "plugin initialized");
   }
 
   // Shutdown hook — walks plugins in REVERSE registration order. We snapshot
-  // the current plugin list so later registrations (if any) don't end up
-  // being torn down by this hook; subsequent bootstraps (hot-reload) would
-  // register their own hook.
+  // only the plugins that actually initialized so later registrations (if
+  // any) don't end up being torn down by this hook, and plugins skipped by
+  // `requiresFlag` gating do not appear in the tear-down list. Subsequent
+  // bootstraps (hot-reload) would register their own hook.
   //
   // For each plugin we:
   //   1. Call `onShutdown()` (if defined) so user code can clean up first,
@@ -375,7 +412,7 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
   //      helper. This mirrors the symmetry of registerPluginSkills() —
   //      every successful registration must get a matching unregister call,
   //      regardless of whether onShutdown throws.
-  const shutdownSnapshot: Plugin[] = [...plugins];
+  const shutdownSnapshot: Plugin[] = [...activePlugins];
   registerShutdownHook("plugins", async (reason) => {
     for (let i = shutdownSnapshot.length - 1; i >= 0; i--) {
       const plugin = shutdownSnapshot[i]!;

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -46,7 +46,8 @@ import { AssistantError, ErrorCode } from "../util/errors.js";
  * `provides` and `requires` are capability → semantic-version maps. The
  * registry checks each entry in `requires` against the assistant's exposed
  * capability table and refuses to register plugins that ask for a version the
- * assistant does not expose.
+ * assistant does not expose. `provides` is currently declared-but-unused —
+ * see the field docstring below.
  */
 export interface PluginManifest {
   /** Unique plugin identifier (kebab-case). Duplicate names fail registration. */
@@ -54,13 +55,27 @@ export interface PluginManifest {
   /** Plugin version (semver). Informational — the registry compares
    *  capability versions via `requires`, not this field. */
   version: string;
-  /** Capabilities this plugin exposes to other plugins (reserved for future composition). */
+  /**
+   * Capabilities this plugin exposes to other plugins.
+   *
+   * **Reserved for future cross-plugin composition — not currently consumed
+   * by any runtime code.** The field is declared so future cross-plugin work
+   * can land without a manifest version bump, but today nothing reads it and
+   * plugins must not depend on it for capability discovery. See
+   * `assistant/docs/plugins.md` (Cross-plugin communication) for the
+   * rationale.
+   */
   provides?: Record<string, string>;
   /** Capabilities this plugin needs from the assistant runtime. */
   requires: Record<string, string>;
   /** Credential keys the plugin needs resolved before `init()` runs. */
   requiresCredential?: string[];
-  /** Feature flag keys that must be enabled for this plugin to activate. */
+  /**
+   * Assistant feature-flag keys that must all be enabled for this plugin to
+   * activate. Checked by `bootstrapPlugins` via `isAssistantFeatureFlagEnabled`
+   * — if any listed flag is disabled, the plugin is skipped entirely for the
+   * boot (no `init()`, no tool/route/skill contributions, no shutdown hook).
+   */
   requiresFlag?: string[];
   /**
    * Zod-compatible validator (or any parser-like object) for the plugin's


### PR DESCRIPTION
## Summary
- G2.2: bootstrapPlugins now checks manifest.requiresFlag against the assistant feature-flag system. Plugins whose flags are disabled skip init, tool/route/skill contribution, and shutdown hook registration.
- G2.5: manifest.provides documented as reserved for future cross-plugin composition; currently unused. Field retained so future cross-plugin work doesn't require a manifest version bump.
- Tests cover enabled / disabled / absent requiresFlag paths.

Part of plan: agent-plugin-system.md (remediation round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
