### PR TITLE
refactor(assistant): consolidate TurnContext construction + thread real context through pipelines

### DIFF
--- a/assistant/src/__tests__/compaction-pipeline.test.ts
+++ b/assistant/src/__tests__/compaction-pipeline.test.ts
@@ -55,17 +55,15 @@ const trust: TrustContext = {
 function makeTurnCtx(manager: {
   maybeCompact: (...args: unknown[]) => Promise<unknown>;
 }): TurnContext {
-  const base: TurnContext = {
+  return {
     requestId: "req-compaction-test",
     conversationId: "conv-compaction-test",
     turnIndex: 0,
     trust,
-  };
-  return {
-    ...base,
-    // The default compaction plugin reads this via lenient cast — see
-    // `plugins/defaults/compaction.ts`.
-    ...({ contextWindowManager: manager } as Partial<TurnContext>),
+    // `TurnContext.contextWindowManager` is a typed optional field; the
+    // default compaction plugin reads it directly without a cast.
+    contextWindowManager:
+      manager as unknown as TurnContext["contextWindowManager"],
   };
 }
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -142,12 +142,15 @@ const MAX_EMPTY_RESPONSE_RETRIES = 1;
 
 /**
  * Build a minimal {@link TurnContext} for pipeline invocations inside the
- * agent loop. The loop does not currently own conversation-scoped trust or
- * identity — those live on the orchestrator — so we stamp in placeholders
- * for the few required fields. Later PRs thread full trust context through
- * `AgentLoop.run()` and replace this helper with the real context.
+ * agent loop. Real production call sites thread a full `TurnContext` into
+ * `AgentLoop.run()` (see the `turnContext` parameter on
+ * {@link AgentLoop.run}); this helper is the fallback used only by unit
+ * tests that construct `AgentLoop` directly without an orchestrator.
  *
- * The returned context is still useful for pipeline logging: `requestId`
+ * When the orchestrator-supplied context is present, {@link cloneWithTurnIndex}
+ * is used instead of this helper so the pipeline sees the real
+ * `conversationId`, trust, and `contextWindowManager`. In the fallback path
+ * the returned context is still useful for pipeline logging: `requestId`
  * surfaces in every structured record, and `turnIndex` reflects the
  * current tool-use iteration.
  */
@@ -167,6 +170,29 @@ function buildLoopTurnContext(
       trustClass: "unknown",
     },
   };
+}
+
+/**
+ * Produce a `TurnContext` for a pipeline call inside {@link AgentLoop.run}.
+ *
+ * When the orchestrator supplied a `turnContext`, clone it and overwrite
+ * `requestId` + `turnIndex` with the loop-scoped values so plugin log
+ * records correctly attribute the call to the current tool-use iteration
+ * while preserving the real `conversationId`, trust context, and
+ * `contextWindowManager` the orchestrator assembled for the turn. Without
+ * an orchestrator context (unit tests that instantiate `AgentLoop` with no
+ * `turnContext`), fall back to {@link buildLoopTurnContext}'s synthesized
+ * placeholder.
+ */
+function resolveLoopTurnContext(
+  base: TurnContext | undefined,
+  requestId: string | undefined,
+  turnIndex: number,
+): TurnContext {
+  if (base) {
+    return { ...base, requestId: requestId ?? base.requestId, turnIndex };
+  }
+  return buildLoopTurnContext(requestId, turnIndex);
 }
 
 /**
@@ -211,6 +237,38 @@ export interface ResolvedSystemPrompt {
   model?: string;
 }
 
+/**
+ * Callback shape the loop uses to execute a tool invocation.
+ *
+ * The trailing `turnContext` is optional so in-process tests that wire the
+ * callback without an orchestrator keep working. Production sites (the
+ * `Conversation`'s `createToolExecutor`) forward the supplied context into
+ * `ToolExecutor.execute` so the `toolExecute` pipeline sees the orchestrator's
+ * real conversation identity/trust/contextWindowManager instead of the
+ * synthesized placeholder `ToolExecutor` would otherwise build from the
+ * `ToolContext` alone.
+ */
+export type LoopToolExecutor = (
+  name: string,
+  input: Record<string, unknown>,
+  onOutput?: (chunk: string) => void,
+  toolUseId?: string,
+  turnContext?: TurnContext,
+) => Promise<{
+  content: string;
+  isError: boolean;
+  diff?: {
+    filePath: string;
+    oldContent: string;
+    newContent: string;
+    isNewFile: boolean;
+  };
+  status?: string;
+  contentBlocks?: ContentBlock[];
+  sensitiveBindings?: SensitiveOutputBinding[];
+  yieldToUser?: boolean;
+}>;
+
 export class AgentLoop {
   private provider: Provider;
   private systemPrompt: string;
@@ -220,52 +278,14 @@ export class AgentLoop {
   private resolveSystemPrompt:
     | ((history: Message[]) => ResolvedSystemPrompt)
     | null;
-  private toolExecutor:
-    | ((
-        name: string,
-        input: Record<string, unknown>,
-        onOutput?: (chunk: string) => void,
-        toolUseId?: string,
-      ) => Promise<{
-        content: string;
-        isError: boolean;
-        diff?: {
-          filePath: string;
-          oldContent: string;
-          newContent: string;
-          isNewFile: boolean;
-        };
-        status?: string;
-        contentBlocks?: ContentBlock[];
-        sensitiveBindings?: SensitiveOutputBinding[];
-        yieldToUser?: boolean;
-      }>)
-    | null;
+  private toolExecutor: LoopToolExecutor | null;
 
   constructor(
     provider: Provider,
     systemPrompt: string,
     config?: Partial<AgentLoopConfig>,
     tools?: ToolDefinition[],
-    toolExecutor?: (
-      name: string,
-      input: Record<string, unknown>,
-      onOutput?: (chunk: string) => void,
-      toolUseId?: string,
-    ) => Promise<{
-      content: string;
-      isError: boolean;
-      diff?: {
-        filePath: string;
-        oldContent: string;
-        newContent: string;
-        isNewFile: boolean;
-      };
-      status?: string;
-      contentBlocks?: ContentBlock[];
-      sensitiveBindings?: SensitiveOutputBinding[];
-      yieldToUser?: boolean;
-    }>,
+    toolExecutor?: LoopToolExecutor,
     resolveTools?: (history: Message[]) => ToolDefinition[],
     resolveSystemPrompt?: (history: Message[]) => ResolvedSystemPrompt,
   ) {
@@ -314,6 +334,15 @@ export class AgentLoop {
       checkpoint: CheckpointInfo,
     ) => CheckpointDecision | Promise<CheckpointDecision>,
     callSite?: LLMCallSite,
+    /**
+     * Optional per-turn context supplied by the orchestrator. Every pipeline
+     * invocation inside the loop clones from this value (overwriting only
+     * `turnIndex`/`requestId`) so middleware sees the real conversation
+     * identity, trust class, and `contextWindowManager` rather than the
+     * `"agent-loop"` sentinel used when the loop is instantiated standalone
+     * in unit tests.
+     */
+    turnContext?: TurnContext,
   ): Promise<Message[]> {
     const history = [...messages];
     const initialHistoryLength = messages.length;
@@ -522,15 +551,17 @@ export class AgentLoop {
           },
         };
 
-        // Minimal per-turn context for pipeline logging and plugin
-        // attribution. The agent loop itself does not carry a conversationId
-        // or trust context — those live upstream — so we fill safe defaults.
-        const turnCtx: TurnContext = {
-          requestId: requestId ?? "agent-loop",
-          conversationId: "agent-loop",
-          turnIndex: toolUseTurns,
-          trust: { sourceChannel: "vellum", trustClass: "unknown" },
-        };
+        // Per-turn pipeline context. When the orchestrator threaded a full
+        // `turnContext` into `run()`, use it (overwriting `turnIndex` with
+        // the loop-scoped tool-use iteration) so middleware sees the real
+        // conversation identity, trust, and `contextWindowManager`. The
+        // synthesized fallback is only reached by standalone unit-test
+        // instantiations that never plumb a context through.
+        const turnCtx = resolveLoopTurnContext(
+          turnContext,
+          requestId,
+          toolUseTurns,
+        );
 
         const response: LLMCallResult = await runPipeline<
           LLMCallArgs,
@@ -660,7 +691,11 @@ export class AgentLoop {
           maxEmptyResponseRetries: MAX_EMPTY_RESPONSE_RETRIES,
           priorAssistantHadVisibleText,
         };
-        const emptyResponseCtx = buildLoopTurnContext(requestId, toolUseTurns);
+        const emptyResponseCtx = resolveLoopTurnContext(
+          turnContext,
+          requestId,
+          toolUseTurns,
+        );
         const emptyResponseDecision: EmptyResponseDecision = await runPipeline(
           "emptyResponse",
           getMiddlewaresFor("emptyResponse"),
@@ -773,6 +808,14 @@ export class AgentLoop {
                 });
               },
               toolUse.id,
+              // Forward the loop's resolved `TurnContext` through the
+              // executor callback so `ToolExecutor.execute` can thread the
+              // real orchestrator context into the `toolExecute` pipeline.
+              // Standalone tests that don't wire a `turnContext` into
+              // `AgentLoop.run()` pass `undefined` here and the executor
+              // falls back to the synthesized placeholder — preserving the
+              // existing unit-test behavior.
+              turnCtx,
             );
 
             return { toolUse, result };
@@ -957,7 +1000,8 @@ export class AgentLoop {
           consecutiveErrorTurns,
           maxConsecutiveErrorNudges: MAX_CONSECUTIVE_ERROR_NUDGES,
         };
-        const toolErrorCtx: TurnContext = buildLoopTurnContext(
+        const toolErrorCtx: TurnContext = resolveLoopTurnContext(
+          turnContext,
           requestId,
           toolUseTurns - 1,
         );

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -60,24 +60,30 @@ import type { ServerMessage } from "./message-protocol.js";
 const log = getLogger("agent-loop-handlers");
 
 /**
- * Build a minimal {@link TurnContext} from the handler's deps for pipeline
- * logging and plugin attribution. The agent loop does not carry a full
- * `requestId`/`turnIndex`/`trust` envelope in every handler, so we
- * fill safe defaults here — `turnIndex` is not tracked on the handler side
- * (the orchestrator maintains it) and defaults to `0`; `trust` falls back
- * to `{ sourceChannel: "vellum", trustClass: "unknown" }` when
- * `ctx.trustContext` is not populated (e.g. a fresh conversation before
- * the trust resolver runs).
+ * Build a {@link TurnContext} from the handler's deps for pipeline logging
+ * and plugin attribution.
+ *
+ * Reads `turnIndex` from `deps.ctx.turnCount` — the orchestrator-owned
+ * per-turn counter that is stable for the entire duration of a single
+ * `runAgentLoopImpl` invocation. The handlers fire after the orchestrator
+ * has completed its in-turn pipeline work but before `ctx.turnCount++` runs
+ * in the outer `finally` block, so this value always reflects the turn the
+ * handler's event belongs to. Trust pulls from the per-turn snapshot first,
+ * then the conversation-level context, then the canonical `unknown`
+ * fallback so the required field stays populated for edge cases (fresh
+ * conversations before the trust resolver runs, heartbeat turns that never
+ * bind an actor).
  */
 function buildHandlerTurnContext(deps: EventHandlerDeps): TurnContext {
   return {
     requestId: deps.reqId,
     conversationId: deps.ctx.conversationId,
-    turnIndex: 0,
-    trust: deps.ctx.trustContext ?? {
-      sourceChannel: "vellum",
-      trustClass: "unknown",
-    },
+    turnIndex: deps.ctx.turnCount,
+    trust: deps.ctx.currentTurnTrustContext ??
+      deps.ctx.trustContext ?? {
+        sourceChannel: "vellum",
+        trustClass: "unknown",
+      },
   };
 }
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -202,39 +202,6 @@ type GitServiceInitializer = {
   ensureInitialized(): Promise<void>;
 };
 
-/**
- * Build a {@link PluginTurnContext} for plugin pipeline invocations inside
- * `runAgentLoopImpl`. The orchestrator does not itself carry a
- * `TurnContext` — it composes one on demand at each pipeline call site from
- * ambient state.
- *
- * `turnIndex` is approximated by the current persisted message count: at the
- * time the pipeline fires, this reflects the position of the next assistant
- * turn in the conversation, which is the best stable identifier plugins can
- * key against without threading a counter through the orchestrator.
- *
- * When `trustContext` is unavailable (e.g. an internal heartbeat turn that
- * never bound an actor), we synthesize an "unknown" trust shape so the
- * required `TurnContext.trust` field stays populated. Plugins that need a
- * real trust class should guard on `trust.trustClass !== "unknown"`.
- */
-function buildHistoryRepairTurnContext(
-  requestId: string,
-  conversationId: string,
-  turnIndex: number,
-  trustContext: TrustContext | undefined,
-): PluginTurnContext {
-  return {
-    requestId,
-    conversationId,
-    turnIndex,
-    trust: trustContext ?? {
-      sourceChannel: "vellum",
-      trustClass: "unknown",
-    },
-  };
-}
-
 // ── Compaction circuit-breaker pipeline helpers ─────────────────────
 //
 // The circuit-breaker behavior (3 consecutive summary-LLM failures trips a
@@ -270,11 +237,8 @@ function buildCircuitTurnContext(ctx: {
   trustContext?: TrustContext;
   turnCount: number;
 }): PluginTurnContext {
-  const trust: TrustContext = ctx.currentTurnTrustContext ??
-    ctx.trustContext ?? {
-      sourceChannel: "vellum",
-      trustClass: "unknown",
-    };
+  const trust: TrustContext =
+    ctx.currentTurnTrustContext ?? ctx.trustContext ?? FALLBACK_TURN_TRUST;
   return {
     requestId: ctx.currentRequestId ?? "circuit-breaker",
     conversationId: ctx.conversationId,
@@ -388,12 +352,10 @@ export async function trackCompactionOutcome(
 
 // ── Plugin pipeline helpers ──────────────────────────────────────────
 //
-// Turn-level {@link TurnContext} builder threaded into every `runPipeline`
-// call. `TurnContext` intentionally stays slim at the type level — we attach
-// the `contextWindowManager` handle via a lenient extension field that the
-// default-compaction plugin reads with a cast. Custom plugins don't need the
-// handle (they replace the terminal behavior) so widening `TurnContext` would
-// pay no benefit.
+// Canonical {@link PluginTurnContext} builder threaded into every
+// `runPipeline` call inside `runAgentLoopImpl`. The orchestrator composes
+// the context on demand at each call site from ambient state rather than
+// carrying a persistent `TurnContext` instance across the turn.
 
 /**
  * Synthetic fallback trust context used when the orchestrator fires a pipeline
@@ -402,38 +364,47 @@ export async function trackCompactionOutcome(
  * `guardian` so a missing snapshot cannot accidentally grant elevated trust
  * to a custom plugin reading `ctx.trust`.
  */
-const FALLBACK_TURN_TRUST: TrustContext = {
+export const FALLBACK_TURN_TRUST: TrustContext = {
   sourceChannel: "vellum",
   trustClass: "unknown",
 };
 
 /**
- * Build the {@link TurnContext} passed to {@link runPipeline}. Pulls trust
- * context from the per-turn snapshot when present, otherwise from the
- * conversation-level context, otherwise the synthetic fallback above. The
- * contextWindowManager handle is attached as an extension so the default
- * compaction plugin can read it without widening `TurnContext`.
+ * Build the {@link TurnContext} passed to {@link runPipeline}.
+ *
+ * Canonical source of truth for every pipeline call site inside the agent
+ * loop. Every `runPipeline` invocation in `runAgentLoopImpl` (and in the
+ * handlers that share its ambient state) must route through this helper
+ * rather than constructing a `TurnContext` literal inline — this keeps
+ * `turnIndex`, trust resolution, and the `contextWindowManager` attachment
+ * consistent across pipeline slots, which in turn keeps structured logs
+ * filtered by `conversationId`/`turnIndex` coherent across slots.
+ *
+ * Behavior:
+ * - `turnIndex` is always `ctx.turnCount` — the orchestrator-owned
+ *   0-based turn counter. Reading from a single source avoids the
+ *   earlier inconsistency (`ctx.turnCount`, `ctx.messages.length - 1`,
+ *   `ctx.messages.length`, and `0` were all used for the same turn).
+ * - Trust pulls from the per-turn snapshot first, then the conversation-
+ *   level context, then {@link FALLBACK_TURN_TRUST}. The cascade matches
+ *   the one inside the orchestrator's inline injection assembly so
+ *   middleware reads the same trust class the runtime sees.
+ * - `contextWindowManager` is attached unconditionally. Pipelines that
+ *   don't need it can ignore it; the default compaction plugin reads it
+ *   via the typed optional field on `TurnContext`.
  */
-function buildPluginTurnContext(
+export function buildPluginTurnContext(
   ctx: AgentLoopConversationContext,
   requestId: string,
 ): PluginTurnContext {
   const trust =
     ctx.currentTurnTrustContext ?? ctx.trustContext ?? FALLBACK_TURN_TRUST;
-  const base: PluginTurnContext = {
+  return {
     requestId,
     conversationId: ctx.conversationId,
     turnIndex: ctx.turnCount,
     trust,
-  };
-  return {
-    ...base,
-    // Extension fields — read via lenient casts by default plugins. Kept off
-    // the declared `TurnContext` shape so plugin-facing code isn't tempted to
-    // depend on orchestrator-internal handles.
-    ...({
-      contextWindowManager: ctx.contextWindowManager,
-    } as Partial<PluginTurnContext>),
+    contextWindowManager: ctx.contextWindowManager,
   };
 }
 
@@ -731,21 +702,12 @@ export async function runAgentLoopImpl(
     if (
       isReplaceableTitle(getConversation(ctx.conversationId)?.title ?? null)
     ) {
-      // Build a TurnContext for the titleGenerate pipeline. The trust slot
-      // falls back to an `unknown`/`vellum` placeholder when the
-      // conversation has no resolved trust (e.g. reconstructed after
-      // daemon restart); downstream middleware treats that as a
-      // minimum-trust actor, which matches the previous behavior where
-      // no trust was propagated at all.
-      const titlePipelineCtx: PluginTurnContext = {
-        requestId: reqId,
-        conversationId: ctx.conversationId,
-        turnIndex: ctx.messages.length - 1,
-        trust: ctx.trustContext ?? {
-          sourceChannel: "vellum",
-          trustClass: "unknown",
-        },
-      };
+      // TurnContext routed through the canonical builder so the pipeline's
+      // log record reports the same `conversationId`/`turnIndex` shape as
+      // every other slot in this turn. Title generation does not depend on
+      // the context-window manager attached by the builder, but sharing the
+      // builder keeps the invariant enforced in one place.
+      const titlePipelineCtx = buildPluginTurnContext(ctx, reqId);
       const titleArgs = {
         conversationId: ctx.conversationId,
         provider: ctx.provider,
@@ -876,19 +838,12 @@ export async function runAgentLoopImpl(
     // below runs `runDefaultMemoryRetrieval` which reproduces the prior
     // in-lined behavior (PKB/NOW reads + gated graph call).
     const isTrustedActor = resolveTrustClass(ctx.trustContext) === "guardian";
-    const memoryPluginTurnCtx: PluginTurnContext = {
-      requestId: reqId,
-      conversationId: ctx.conversationId,
-      turnIndex: ctx.turnCount,
-      ...(ctx.trustContext
-        ? { trust: ctx.trustContext }
-        : {
-            trust: {
-              sourceChannel: capturedTurnChannelContext.userMessageChannel,
-              trustClass: "unknown" as const,
-            },
-          }),
-    };
+    // Canonical builder — pulls trust from per-turn snapshot, then
+    // conversation-level, then the synthetic fallback. Memory retrieval
+    // does not need the context-window handle the builder attaches, but
+    // keeping every call site on one helper is load-bearing for log
+    // coherence across pipeline slots.
+    const memoryPluginTurnCtx = buildPluginTurnContext(ctx, reqId);
     const memoryArgs: MemoryArgs = {
       conversationId: ctx.conversationId,
       trustContext: ctx.trustContext,
@@ -1330,22 +1285,11 @@ export async function runAgentLoopImpl(
     // to substitute an alternate estimator (e.g. provider-native tokenization)
     // without touching orchestrator code.
     //
-    // `turnIndex` is 0 at the orchestrator level — the per-tool-use turn
-    // index advances inside `agent/loop.ts` and is surfaced through
-    // `CheckpointInfo` to sites that need it. Here it just satisfies the
-    // pipeline's log record. `trust` falls back to the inbound
-    // `vellum`/`unknown` default when the actor hasn't been resolved yet —
-    // the same fallback `resolveTrustClass` uses — because preflight can run
-    // before trust context is available (e.g. regenerate after daemon restart).
-    const pipelineTurnCtx: PluginTurnContext = {
-      requestId: reqId,
-      conversationId: ctx.conversationId,
-      turnIndex: 0,
-      trust: ctx.trustContext ?? {
-        sourceChannel: "vellum",
-        trustClass: "unknown",
-      },
-    };
+    // Routed through the canonical builder — `turnIndex` is `ctx.turnCount`,
+    // trust cascades through per-turn/conversation-level/fallback, and the
+    // context-window handle rides along so any middleware that wants to
+    // reuse the manager (e.g. to compute compaction-aware estimates) can.
+    const pipelineTurnCtx = buildPluginTurnContext(ctx, reqId);
 
     const runTokenEstimatePipeline = (
       history: Message[],
@@ -1493,16 +1437,7 @@ export async function runAgentLoopImpl(
           );
         },
         overflowArgs,
-        {
-          requestId: reqId,
-          conversationId: ctx.conversationId,
-          turnIndex: ctx.turnCount,
-          trust: ctx.currentTurnTrustContext ??
-            ctx.trustContext ?? {
-              sourceChannel: "vellum",
-              trustClass: "unknown",
-            },
-        },
+        buildPluginTurnContext(ctx, reqId),
         DEFAULT_TIMEOUTS.overflowReduce,
       );
 
@@ -1520,12 +1455,6 @@ export async function runAgentLoopImpl(
     // (registered in `external-plugins-bootstrap.ts`) delegates to
     // `repairHistory` unchanged, preserving existing behavior.
     let preRepairMessages = runMessages;
-    const preRunRepairCtx = buildHistoryRepairTurnContext(
-      reqId,
-      ctx.conversationId,
-      ctx.messages.length,
-      ctx.trustContext,
-    );
     const preRunRepair = await runPipeline<
       HistoryRepairArgs,
       HistoryRepairResult
@@ -1534,7 +1463,7 @@ export async function runAgentLoopImpl(
       getMiddlewaresFor("historyRepair"),
       async (args) => defaultHistoryRepairTerminal(args),
       { history: runMessages, provider: ctx.provider.name },
-      preRunRepairCtx,
+      buildPluginTurnContext(ctx, reqId),
       DEFAULT_TIMEOUTS.historyRepair,
     );
     if (
@@ -1618,6 +1547,14 @@ export async function runAgentLoopImpl(
 
     rlog.info({ callSite: turnCallSite }, "Starting agent loop run");
 
+    // Thread the orchestrator's canonical per-turn context into the agent
+    // loop so its internal pipeline invocations (llmCall, emptyResponse,
+    // toolError, toolResultTruncate, toolExecute) see the real
+    // conversation identity / trust / contextWindowManager instead of the
+    // synthesized `"agent-loop"` placeholder. The loop clones this value
+    // and overwrites `turnIndex` with its own tool-use iteration counter.
+    const loopTurnCtx = buildPluginTurnContext(ctx, reqId);
+
     let updatedHistory = await ctx.agentLoop.run(
       runMessages,
       eventHandler,
@@ -1625,6 +1562,7 @@ export async function runAgentLoopImpl(
       reqId,
       onCheckpoint,
       turnCallSite,
+      loopTurnCtx,
     );
 
     rlog.info(
@@ -1752,6 +1690,7 @@ export async function runAgentLoopImpl(
         reqId,
         onCheckpoint,
         turnCallSite,
+        loopTurnCtx,
       );
     }
 
@@ -1797,6 +1736,7 @@ export async function runAgentLoopImpl(
         reqId,
         onCheckpoint,
         turnCallSite,
+        loopTurnCtx,
       );
 
       if (state.orderingErrorDetected) {
@@ -1981,6 +1921,7 @@ export async function runAgentLoopImpl(
           reqId,
           onCheckpoint,
           turnCallSite,
+          loopTurnCtx,
         );
 
         // If the rerun still yields at checkpoint, the turn is still
@@ -2113,6 +2054,7 @@ export async function runAgentLoopImpl(
             reqId,
             onCheckpoint,
             turnCallSite,
+            loopTurnCtx,
           );
         }
         // action === "fail_gracefully" falls through to the final error below

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -159,6 +159,7 @@ export function createToolExecutor(
   input: Record<string, unknown>,
   onOutput?: (chunk: string) => void,
   toolUseId?: string,
+  turnContext?: import("../plugins/types.js").TurnContext,
 ) => Promise<ToolExecutionResult> {
   // Register the conversation's sendToClient for browser screencast surface messages
   registerConversationSender(ctx.conversationId, (msg) =>
@@ -170,6 +171,7 @@ export function createToolExecutor(
     input: Record<string, unknown>,
     onOutput?: (chunk: string) => void,
     toolUseId?: string,
+    turnContext?: import("../plugins/types.js").TurnContext,
   ) => {
     if (isDoordashCommand(name, input)) {
       markDoordashStepInProgress(ctx, input);
@@ -306,7 +308,12 @@ export function createToolExecutor(
         };
       }
 
-      const result = await executor.execute(toolName, toolInput, toolContext);
+      const result = await executor.execute(
+        toolName,
+        toolInput,
+        toolContext,
+        turnContext,
+      );
       if (toolContext.approvedViaPrompt) {
         ctx.approvedViaPromptThisTurn = true;
       }
@@ -319,7 +326,12 @@ export function createToolExecutor(
       return result;
     }
 
-    const result = await executor.execute(name, input, toolContext);
+    const result = await executor.execute(
+      name,
+      input,
+      toolContext,
+      turnContext,
+    );
     if (toolContext.approvedViaPrompt) {
       ctx.approvedViaPromptThisTurn = true;
     }

--- a/assistant/src/plugins/defaults/compaction.ts
+++ b/assistant/src/plugins/defaults/compaction.ts
@@ -10,14 +10,11 @@
  * before the orchestrator consumes it.
  *
  * Lookup: the default middleware reads `ctx.contextWindowManager` from the
- * {@link TurnContext} via a lenient cast. The orchestrator is responsible
- * for attaching that handle to the per-turn context it hands to
- * {@link runPipeline}. `TurnContext` intentionally stays slim at the type
- * level — we avoid widening it to carry orchestrator-only accessors — and
- * use the same lenient-read pattern the pipeline runner already uses for
- * its optional `logger` slot. If the handle is missing, the middleware
- * throws a {@link PluginExecutionError} so the bug surfaces with clear
- * attribution instead of a late `undefined.maybeCompact is not a function`.
+ * {@link TurnContext} as a typed optional field. The orchestrator is
+ * responsible for attaching that handle to the per-turn context it hands to
+ * {@link runPipeline}. If the handle is missing, the middleware throws a
+ * {@link PluginExecutionError} so the bug surfaces with clear attribution
+ * instead of a late `undefined.maybeCompact is not a function`.
  *
  * Design doc: `.private/plans/agent-plugin-system.md` (PR 25).
  */
@@ -50,19 +47,18 @@ export const DEFAULT_COMPACTION_PLUGIN_NAME = "default-compaction";
  * to the default plugin instead of manifesting as a later NPE.
  */
 function extractManager(ctx: TurnContext): ContextWindowManager {
-  const maybe = (ctx as { contextWindowManager?: unknown })
-    .contextWindowManager;
+  const manager = ctx.contextWindowManager;
   if (
-    maybe == null ||
-    typeof maybe !== "object" ||
-    typeof (maybe as { maybeCompact?: unknown }).maybeCompact !== "function"
+    manager == null ||
+    typeof manager !== "object" ||
+    typeof (manager as { maybeCompact?: unknown }).maybeCompact !== "function"
   ) {
     throw new PluginExecutionError(
       "default-compaction: ctx.contextWindowManager is missing — orchestrator must attach it before invoking the compaction pipeline",
       DEFAULT_COMPACTION_PLUGIN_NAME,
     );
   }
-  return maybe as ContextWindowManager;
+  return manager;
 }
 
 /**

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -17,7 +17,10 @@
  */
 
 import type { ContextWindowConfig } from "../config/schemas/inference.js";
-import type { ContextWindowResult } from "../context/window-manager.js";
+import type {
+  ContextWindowManager,
+  ContextWindowResult,
+} from "../context/window-manager.js";
 import type { ReducerState } from "../daemon/context-overflow-reducer.js";
 import type {
   InjectionMode,
@@ -753,6 +756,22 @@ export interface TurnContext {
   pluginName?: string;
   /** Trust classification and channel identity for the inbound actor. */
   trust: TrustContext;
+  /**
+   * Optional handle to the conversation's {@link ContextWindowManager}.
+   *
+   * Attached by the orchestrator when building the per-turn context for
+   * pipeline invocations that need to defer to the real compaction machinery
+   * (notably the default `compaction` plugin). Pipelines that never touch
+   * compaction can ignore this field; the default compaction plugin throws
+   * a {@link PluginExecutionError} if it is missing, which keeps the failure
+   * attributed to the plugin rather than surfacing as a late NPE downstream.
+   *
+   * Declared as an optional typed field so plugin code can read it without a
+   * lenient cast. The optional shape is load-bearing: pipeline runner tests,
+   * synthesized handler contexts, and other non-compaction call sites still
+   * construct valid `TurnContext` literals without attaching a manager.
+   */
+  contextWindowManager?: ContextWindowManager;
 }
 
 // ─── Injectors ───────────────────────────────────────────────────────────────

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -52,6 +52,17 @@ export class ToolExecutor {
     name: string,
     input: Record<string, unknown>,
     context: ToolContext,
+    /**
+     * Optional per-turn context threaded in by the agent loop. Production
+     * sites propagate the orchestrator-built `TurnContext` (real
+     * `conversationId`, trust cascade, attached `contextWindowManager`) so
+     * middleware registered on the `toolExecute` pipeline sees the same
+     * context every other pipeline slot uses. When omitted (CLI/test
+     * invocations that call `ToolExecutor.execute` directly), the executor
+     * synthesizes a fallback context from the {@link ToolContext}, which
+     * keeps pre-threading behavior intact for legacy callers.
+     */
+    turnContext?: TurnContext,
   ): Promise<ToolExecutionResult> {
     // Compute the per-tool timeout budget upfront so the pipeline timeout
     // matches the existing per-tool timeout. `toolExecute` is intentionally
@@ -62,11 +73,12 @@ export class ToolExecutor {
     // happy path (the pipeline race is a cheap backstop).
     const perToolTimeoutMs = computePerToolTimeoutMs(name, input);
 
-    // Build a TurnContext for the pipeline runner. The executor is called
-    // outside the provider loop's TurnContext today, so we synthesize one
-    // from the ToolContext — middleware that needs richer turn state will
-    // be wired as later PRs thread a real TurnContext through.
-    const turnCtx: TurnContext = {
+    // Prefer the orchestrator-supplied `turnContext` so the pipeline sees
+    // the real conversation identity, per-turn trust, and context-window
+    // manager. When absent (CLI / test invocations that bypass the agent
+    // loop), synthesize a minimal context from the `ToolContext` — the
+    // same fallback the executor has used since the pipeline was added.
+    const turnCtx: TurnContext = turnContext ?? {
       requestId: context.requestId ?? "",
       conversationId: context.conversationId,
       turnIndex: 0,


### PR DESCRIPTION
## Summary
- G3.5: single `buildPluginTurnContext` helper used at every pipeline call site; turnIndex reads ctx.turnCount uniformly.
- G3.11: contextWindowManager is now a typed optional field on TurnContext; drop lenient cast in compaction default.
- G2.3: agent/loop.ts receives TurnContext from orchestrator instead of synthesizing { conversationId: "agent-loop", trustClass: "unknown" }.
- G2.4: tools/executor.ts accepts optional TurnContext param; orchestrator passes real context through toolExecutor callback.

Part of plan: agent-plugin-system.md (remediation round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
