### PR TITLE
fix(macos-build): auto-clean stale .build on XCFramework path mismatch

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -46,6 +46,7 @@ swift_with_retry() {
     local max_attempts="${SWIFT_RETRY_ATTEMPTS:-3}"
     local attempt=1
     local _pch_cleaned=0
+    local _build_cleaned=0
     local _stderr_log
     _stderr_log=$(mktemp)
     # FIFO for stderr streaming. Process substitutions (2> >(tee ...)) are
@@ -75,6 +76,18 @@ swift_with_retry() {
             find -L "$SCRIPT_DIR/../.build" -type d -name "ModuleCache" -exec rm -rf {} + 2>/dev/null || true
             [ -d "$SPM_MODULE_CACHE" ] && rm -rf "$SPM_MODULE_CACHE"
             _pch_cleaned=1
+            continue
+        fi
+        # Auto-clean stale SPM artifact paths when an XCFramework reference
+        # points at a deleted worktree. SPM bakes absolute paths into
+        # workspace-state.json, debug.yaml, and build.db; with a shared
+        # .build (via worktree symlink), removing the worktree that last
+        # built leaves those entries pointing at a path that no longer
+        # exists, and SPM has no way to re-resolve on its own.
+        if [ "$_build_cleaned" -eq 0 ] && grep -q "XCFramework Info.plist not found" "$_stderr_log" 2>/dev/null; then
+            echo "warning: stale SPM build cache detected (XCFramework path points to missing worktree), cleaning .build and retrying..."
+            rm -rf "$SCRIPT_DIR/../.build"
+            _build_cleaned=1
             continue
         fi
         # Signal 5 (SIGTRAP) is a non-transient crash (e.g. WebKit


### PR DESCRIPTION
## Summary
- Worktrees share \`clients/.build\` via symlink, and SPM bakes absolute paths into its cache files. Deleting a worktree that last built a given artifact leaves the shared cache pointing at a dead path, and every subsequent build fails with \`XCFramework Info.plist not found at .../vellum-assistant-wt-.../...\`.
- \`swift_with_retry\` already handles an analogous issue for stale module caches (PCH path mismatch, duplicate module defs). Extend it to also detect \`XCFramework Info.plist not found\` and \`rm -rf\` the shared \`.build\` once before retrying, so a single transient build failure self-heals instead of requiring a manual cleanup.

## Original prompt
fix 1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
