### PR TITLE
fix(macos/math): guard against SwiftMath Bundle.module crash when resource bundle missing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -907,6 +907,33 @@ func clearMathImageCache() {
     mathImageCache.removeAllObjects()
 }
 
+private let mathRenderLog = Logger(subsystem: Bundle.appBundleIdentifier, category: "MathRender")
+
+/// Probes whether SwiftMath's SPM-generated resource bundle is locatable.
+/// `Bundle.module` inside SwiftMath calls `fatalError` when it cannot find
+/// `SwiftMath_SwiftMath.bundle`, which takes the whole app down the first
+/// time a LaTeX block renders. The crash is unrecoverable because the miss
+/// is wired through a `dispatch_once` static initializer — subsequent reads
+/// re-trap on the same uninitialized property. Checking the same candidate
+/// paths SPM uses lets us route to the raw-LaTeX fallback when the bundle
+/// is missing from a broken or stale build instead of crashing.
+private let swiftMathResourceBundleAvailable: Bool = {
+    let bundleName = "SwiftMath_SwiftMath.bundle"
+    let candidates: [URL?] = [
+        Bundle.main.resourceURL,
+        Bundle.main.bundleURL,
+    ]
+    let fm = FileManager.default
+    for candidate in candidates {
+        guard let url = candidate?.appendingPathComponent(bundleName) else { continue }
+        if fm.fileExists(atPath: url.path) {
+            return true
+        }
+    }
+    mathRenderLog.error("SwiftMath resource bundle '\(bundleName, privacy: .public)' not found; falling back to raw LaTeX")
+    return false
+}()
+
 /// Converts an `NSColor` to a stable hex cache-key component. Uses the
 /// sRGB-calibrated components so color-space shifts don't cause cache misses
 /// on logically identical colors. When the color cannot be bridged into sRGB
@@ -947,6 +974,13 @@ private struct MathBlockView: View {
     }
 
     private func resolveRender() -> RenderResult {
+        // SwiftMath's `Bundle.module` fatals if the resource bundle is missing.
+        // Bail to the raw-LaTeX fallback before any SwiftMath API can trigger
+        // that one-time initializer — see `swiftMathResourceBundleAvailable`.
+        guard swiftMathResourceBundleAvailable else {
+            return .failure("math font bundle missing")
+        }
+
         // Font size matches the resolved chat markdown font so inline math
         // visually aligns with surrounding body text. `.regular.pointSize`
         // resolves against the current DM Sans font set (16pt at rest).


### PR DESCRIPTION
## Summary
- SwiftMath's SPM-generated `Bundle.module` fatals when `SwiftMath_SwiftMath.bundle` isn't locatable, taking the whole app down the first time a `MathBlockView` evaluates. The crash originates from a `dispatch_once` static initializer, so it's unrecoverable and re-traps on every subsequent access.
- Added a file-private `swiftMathResourceBundleAvailable` probe that mirrors SPM's candidate-path search (`Bundle.main.resourceURL`, then `Bundle.main.bundleURL`) and checks for the bundle without triggering `Bundle.module`. When the bundle is missing, `MathBlockView.resolveRender()` returns `.failure` up front, which routes to the existing raw-LaTeX error UI instead of calling any SwiftMath API.
- Logs via `os.Logger` when the bundle is absent so we can observe stale/broken builds in the field.

## Original prompt
> The Vellum app just crashed with this report. Can you fix it?

Crash summary (full report truncated for PR length):
- Exception: `EXC_BREAKPOINT (SIGTRAP)` at `libswiftCore` `_assertionFailure`
- Dispatch queue: `com.smartmath.mathfont.threadsafequeue`
- App: `com.vellum.vellum-assistant-dev 0.6.4-local.20260421213149.17a5b89892` on macOS 26.3.2
- Fault stack (Velissa frames):
  ```
  closure #1 in variable initialization expression of static NSBundle.module
  one-time initialization function for module
  NSBundle.module.unsafeMutableAddressor
  BundleManager.registerCGFont(mathFont:)
  BundleManager.onDemandRegistration(mathFont:)
  MathFont.cgFont()
  MTFontV2.init(font:size:)
  MathFont.mtfont(size:)
  MathImage.asImage()
  MathBlockView.resolveRender()
  MathBlockView.body.getter
  ```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
