### PR TITLE
feat(assistant): complete injector chain migration — replace hardcoded injection sequence

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // PKB search is mocked so the reminder-hints tests can assert behavior
 // without standing up Qdrant. The mock returns whatever is staged in
@@ -31,8 +31,6 @@ import {
   findLastInjectedNowContent,
   injectChannelCapabilityContext,
   injectChannelCommandContext,
-  injectNowScratchpad,
-  injectSubagentStatus,
   isGroupChatType,
   isSlackChannelConversation,
   loadSlackActiveThreadFocusBlock,
@@ -49,8 +47,23 @@ import {
   writeSlackMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
 import { parentAlias } from "../messaging/providers/slack/render-transcript.js";
+import { defaultInjectorsPlugin } from "../plugins/defaults/injectors.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
 import type { Message } from "../providers/types.js";
 import type { SubagentState } from "../subagent/types.js";
+
+// `applyRuntimeInjections` is now driven by the default injector chain
+// (PR G2.1). The default-injectors plugin must be registered for the chain
+// to emit workspace, PKB, NOW.md, subagent, Slack, and thread-focus blocks.
+// Each test gets a clean registry so a test that registers its own plugin
+// doesn't leak into the next one.
+beforeEach(() => {
+  resetPluginRegistryForTests();
+  registerPlugin(defaultInjectorsPlugin);
+});
 
 // ---------------------------------------------------------------------------
 // resolveChannelCapabilities
@@ -797,86 +810,12 @@ describe("applyRuntimeInjections — injection mode", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// injectNowScratchpad
-// ---------------------------------------------------------------------------
-
-describe("injectNowScratchpad", () => {
-  const baseUserMessage: Message = {
-    role: "user",
-    content: [{ type: "text", text: "What should I work on?" }],
-  };
-
-  test("inserts NOW.md before user content", () => {
-    const result = injectNowScratchpad(
-      baseUserMessage,
-      "Current focus: shipping PR 3",
-    );
-    expect(result.content.length).toBe(2);
-    // Scratchpad comes first (before user content)
-    const injected = result.content[0];
-    expect(injected.type).toBe("text");
-    const text = (injected as { type: "text"; text: string }).text;
-    expect(text).toBe(
-      "<NOW.md Always keep this up to date; keep under 10 lines>\nCurrent focus: shipping PR 3\n</NOW.md>",
-    );
-    // Original content comes last
-    expect((result.content[1] as { type: "text"; text: string }).text).toBe(
-      "What should I work on?",
-    );
-  });
-
-  test("inserts after memory_context but before user content", () => {
-    const messageWithMemory: Message = {
-      role: "user",
-      content: [
-        {
-          type: "text",
-          text: "<memory_context __injected>\nrecalled notes\n</memory_context>",
-        },
-        { type: "text", text: "What should I work on?" },
-      ],
-    };
-
-    const result = injectNowScratchpad(messageWithMemory, "scratchpad notes");
-    expect(result.content.length).toBe(3);
-    // Memory context stays first
-    expect(
-      (result.content[0] as { type: "text"; text: string }).text,
-    ).toContain("<memory_context");
-    // Scratchpad inserted after memory
-    expect(
-      (result.content[1] as { type: "text"; text: string }).text,
-    ).toContain("<NOW.md");
-    // User content is last
-    expect((result.content[2] as { type: "text"; text: string }).text).toBe(
-      "What should I work on?",
-    );
-  });
-
-  test("preserves existing multi-block content with scratchpad before it", () => {
-    const multiBlockMessage: Message = {
-      role: "user",
-      content: [
-        { type: "text", text: "First block" },
-        { type: "text", text: "Second block" },
-      ],
-    };
-
-    const result = injectNowScratchpad(multiBlockMessage, "scratchpad notes");
-    expect(result.content.length).toBe(3);
-    // Scratchpad is first (no memory_context to skip)
-    expect(
-      (result.content[0] as { type: "text"; text: string }).text,
-    ).toContain("<NOW.md");
-    expect((result.content[1] as { type: "text"; text: string }).text).toBe(
-      "First block",
-    );
-    expect((result.content[2] as { type: "text"; text: string }).text).toBe(
-      "Second block",
-    );
-  });
-});
+// The standalone `injectNowScratchpad` helper was removed in G2.1. The
+// now-md default injector (registered by `defaultInjectorsPlugin`) emits
+// the `<NOW.md>` block as an `after-memory-prefix` placement during
+// `applyRuntimeInjections`. The suites below (`applyRuntimeInjections with
+// nowScratchpad` and the injection-mode tests) cover that behaviour
+// end-to-end.
 
 // ---------------------------------------------------------------------------
 // stripNowScratchpad
@@ -1837,22 +1776,9 @@ describe("buildSubagentStatusBlock", () => {
   });
 });
 
-describe("injectSubagentStatus", () => {
-  test("appends status block to user message", () => {
-    const msg: Message = {
-      role: "user",
-      content: [{ type: "text", text: "hello" }],
-    };
-    const result = injectSubagentStatus(
-      msg,
-      "<active_subagents>\ntest\n</active_subagents>",
-    );
-    expect(result.content).toHaveLength(2);
-    expect(
-      (result.content[1] as { type: string; text: string }).text,
-    ).toContain("<active_subagents>");
-  });
-});
+// `injectSubagentStatus` was removed in G2.1 — coverage of the append
+// placement lives in the `applyRuntimeInjections — subagent status` suite
+// below, which exercises the subagent-status default injector end-to-end.
 
 describe("applyRuntimeInjections — subagent status", () => {
   const userMsg: Message = {

--- a/assistant/src/__tests__/conversation-runtime-workspace.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-workspace.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
+import { applyRuntimeInjections } from "../daemon/conversation-runtime-assembly.js";
+import { defaultInjectorsPlugin } from "../plugins/defaults/injectors.js";
 import {
-  applyRuntimeInjections,
-  injectWorkspaceTopLevelContext,
-} from "../daemon/conversation-runtime-assembly.js";
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
 import type { Message } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -21,43 +23,21 @@ function userMsg(text: string): Message {
 const sampleContext =
   "<workspace>\nRoot: /sandbox\nDirectories: src, lib, tests\n</workspace>";
 
-describe("Workspace top-level context — injection", () => {
-  test("prepends workspace block to user message content", () => {
-    const original = userMsg("Hello");
-    const injected = injectWorkspaceTopLevelContext(original, sampleContext);
-
-    expect(injected.content).toHaveLength(2);
-    expect(injected.content[0]).toEqual({ type: "text", text: sampleContext });
-    expect(injected.content[1]).toEqual({ type: "text", text: "Hello" });
-  });
-
-  test("preserves multi-block user content after prepend", () => {
-    const original: Message = {
-      role: "user",
-      content: [
-        { type: "text", text: "First" },
-        { type: "text", text: "Second" },
-      ],
-    };
-    const injected = injectWorkspaceTopLevelContext(original, sampleContext);
-
-    expect(injected.content).toHaveLength(3);
-    expect(injected.content[0].type).toBe("text");
-    expect((injected.content[0] as { text: string }).text).toBe(sampleContext);
-    expect((injected.content[1] as { text: string }).text).toBe("First");
-    expect((injected.content[2] as { text: string }).text).toBe("Second");
-  });
-
-  test("does not mutate original message", () => {
-    const original = userMsg("Hello");
-    const originalContentLength = original.content.length;
-    injectWorkspaceTopLevelContext(original, sampleContext);
-
-    expect(original.content).toHaveLength(originalContentLength);
-  });
-});
+// The standalone `injectWorkspaceTopLevelContext` helper was removed in
+// G2.1. The workspace-context default injector (registered by
+// `defaultInjectorsPlugin`) now emits the workspace block as a
+// `prepend-user-tail` placement during `applyRuntimeInjections`. The suite
+// below exercises that end-to-end path instead.
 
 describe("applyRuntimeInjections — workspace top-level context", () => {
+  beforeEach(() => {
+    // Post-G2.1: workspace injection is driven by the `workspace-context`
+    // default injector, so the plugin must be registered for the chain to
+    // produce a block. Each test gets a clean registry.
+    resetPluginRegistryForTests();
+    registerPlugin(defaultInjectorsPlugin);
+  });
+
   test("injects workspace context when provided", async () => {
     const messages: Message[] = [userMsg("Hello")];
     const { messages: result } = await applyRuntimeInjections(messages, {
@@ -100,6 +80,11 @@ describe("applyRuntimeInjections — workspace top-level context", () => {
 });
 
 describe("applyRuntimeInjections — minimal mode skips workspace blocks", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+    registerPlugin(defaultInjectorsPlugin);
+  });
+
   test("minimal mode skips workspace top-level context", async () => {
     const messages: Message[] = [userMsg("Hello")];
     const { messages: result } = await applyRuntimeInjections(messages, {

--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -254,10 +254,12 @@ describe("injector chain", () => {
     expect(result.blocks.injectorChainBlock).toBe("THIRD_PARTY_BLOCK");
   });
 
-  test("applyRuntimeInjections without turnContext skips the chain entirely", async () => {
-    // Backwards compatibility: callers that predate PR 21 don't pass
-    // `turnContext`. The chain must be inert in that case so pre-existing
-    // call sites keep producing identical output.
+  test("applyRuntimeInjections without turnContext still runs the chain under a synthesized context", async () => {
+    // Post-G2.1 semantics: the default chain is the canonical injection
+    // path, so `applyRuntimeInjections` must drive it even when the caller
+    // doesn't pass a `turnContext`. Test/legacy call sites that rely on
+    // option fields to opt into injections continue to work because the
+    // synthesized fallback exposes `injectionInputs` built from `options`.
     registerPlugin(defaultInjectorsPlugin);
     registerPlugin(
       wrapInPlugin("third-party-25", [
@@ -265,7 +267,7 @@ describe("injector chain", () => {
           name: "plugin-25",
           order: 25,
           async produce(): Promise<InjectionBlock> {
-            return { id: "plugin-25", text: "SHOULD_BE_SKIPPED" };
+            return { id: "plugin-25", text: "THIRD_PARTY_BLOCK" };
           },
         },
       ]),
@@ -277,6 +279,244 @@ describe("injector chain", () => {
 
     const result = await applyRuntimeInjections(runMessages, {});
 
-    expect(result.blocks.injectorChainBlock).toBeUndefined();
+    // Third-party injector runs even without a caller-supplied turnContext.
+    expect(result.blocks.injectorChainBlock).toBe("THIRD_PARTY_BLOCK");
+  });
+
+  // ── G2.1 migration integration tests ────────────────────────────────
+  //
+  // These assertions exercise the real per-turn injection pipeline with
+  // the default chain active, verifying that each ported injector emits
+  // byte-identical content to the pre-migration output and that a
+  // third-party injector registered at a fractional `order` slots into
+  // the correct position in the final user-tail content.
+
+  test("golden-path: default chain injects workspace + unified-turn + PKB + NOW + subagent in the correct positions", async () => {
+    // Canonical golden-path conversation state: full mode, non-Slack
+    // channel, workspace context + unified-turn + PKB + NOW + subagent
+    // all active. The expected final tail content ordering is:
+    //
+    //   [workspace]            ← prepend order 10 (topmost)
+    //   [unified-turn]         ← prepend order 20
+    //   [pkb (reminder+context)] ← after-memory-prefix order 30
+    //   [now-md]               ← after-memory-prefix order 40
+    //   [user text]
+    //   [subagent]             ← append order 50
+    //
+    // No memory prefix blocks in this scenario, so after-memory-prefix
+    // lands right at the head of the user-text cluster.
+    registerPlugin(defaultInjectorsPlugin);
+
+    const runMessages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "What next?" }] },
+    ];
+
+    const workspaceText =
+      "<workspace>\nRoot: /sandbox\nDirectories: src, lib\n</workspace>";
+    const unifiedTurn =
+      "<turn_context>\ncurrent_time: 2026-04-22\ninterface: macos\n</turn_context>";
+    const pkbContent = "essentials of the project";
+    const nowContent = "Current focus: shipping G2.1";
+    const subagentBlock =
+      '<active_subagents>\n- [running] "worker" (sub-1) | elapsed: 5s\n</active_subagents>';
+
+    const result = await applyRuntimeInjections(runMessages, {
+      turnContext: makeTurnContext(),
+      workspaceTopLevelContext: workspaceText,
+      unifiedTurnContext: unifiedTurn,
+      pkbContext: pkbContent,
+      pkbActive: false, // disable reminder-branch to keep the snapshot small
+      nowScratchpad: nowContent,
+      subagentStatusBlock: subagentBlock,
+    });
+
+    // Extract the tail user message content as a list of text strings.
+    const tail = result.messages[result.messages.length - 1];
+    expect(tail.role).toBe("user");
+    const texts = tail.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text);
+
+    // Positional assertions — each block lands where the injector's
+    // placement says it does.
+    expect(texts[0]).toBe(workspaceText); // prepend order 10
+    expect(texts[1]).toBe(unifiedTurn); // prepend order 20
+    // NOW and PKB are both after-memory-prefix; NOW runs later so sits above PKB.
+    expect(texts[2]).toBe(
+      `<NOW.md Always keep this up to date; keep under 10 lines>\n${nowContent}\n</NOW.md>`,
+    );
+    expect(texts[3]).toBe(`<knowledge_base>\n${pkbContent}\n</knowledge_base>`);
+    expect(texts[4]).toBe("What next?"); // user's typed text
+    expect(texts[5]).toBe(subagentBlock); // append order 50
+    expect(texts).toHaveLength(6);
+
+    // Block metadata captures for DB persistence — one field per default
+    // injector whose output the loader rehydrates from message metadata.
+    expect(result.blocks.workspaceBlock).toBe(workspaceText);
+    expect(result.blocks.unifiedTurnContext).toBe(unifiedTurn);
+    expect(result.blocks.nowScratchpadBlock).toBe(
+      `<NOW.md Always keep this up to date; keep under 10 lines>\n${nowContent}\n</NOW.md>`,
+    );
+    expect(result.blocks.pkbContextBlock).toBe(
+      `<knowledge_base>\n${pkbContent}\n</knowledge_base>`,
+    );
+  });
+
+  test("third-party injector at order 25 lands between unified-turn-context (20) and pkb (30) in the final message", async () => {
+    // Proves the extensibility contract end-to-end: a plugin-registered
+    // injector at `order: 25` with `placement: "prepend-user-tail"` slots
+    // between the unified-turn prepend (order 20, executes just before
+    // workspace) and the PKB after-memory splice (order 30). Because it
+    // uses prepend-user-tail placement it becomes a third prepend,
+    // landing between workspace (topmost) and unified-turn.
+    registerPlugin(defaultInjectorsPlugin);
+    registerPlugin(
+      wrapInPlugin("third-party-25-prepend", [
+        {
+          name: "plugin-25",
+          order: 15, // between workspace (10) and unified-turn (20)
+          async produce(): Promise<InjectionBlock> {
+            return {
+              id: "plugin-25",
+              text: "<plugin_block_15/>",
+              placement: "prepend-user-tail",
+            };
+          },
+        },
+      ]),
+    );
+
+    const runMessages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ];
+
+    const workspaceText = "<workspace>\nRoot: /sandbox\n</workspace>";
+    const unifiedTurn =
+      "<turn_context>\ncurrent_time: 2026-04-22\n</turn_context>";
+
+    const result = await applyRuntimeInjections(runMessages, {
+      turnContext: makeTurnContext(),
+      workspaceTopLevelContext: workspaceText,
+      unifiedTurnContext: unifiedTurn,
+    });
+
+    const tail = result.messages[result.messages.length - 1];
+    expect(tail.role).toBe("user");
+    const texts = tail.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text);
+
+    // Descending-order application for prepends puts the lowest-`order`
+    // injector topmost, so order 10 (workspace) ends up on top, then
+    // plugin@15 below it, then unified-turn (order 20) below that.
+    expect(texts[0]).toBe(workspaceText);
+    expect(texts[1]).toBe("<plugin_block_15/>");
+    expect(texts[2]).toBe(unifiedTurn);
+    expect(texts[3]).toBe("hi");
+  });
+
+  test("slack-messages injector replaces runMessages when a chronological transcript is provided", async () => {
+    // End-to-end verification for the `replace-run-messages` placement:
+    // a Slack channel turn with a pre-rendered chronological transcript
+    // swaps the incoming `runMessages` for the transcript before the
+    // after-memory/append placements run. Memory-prefix blocks from the
+    // original tail are re-prepended onto the new tail so PKB / NOW
+    // splices still find them.
+    registerPlugin(defaultInjectorsPlugin);
+
+    const originalRun: Message[] = [
+      {
+        role: "user",
+        content: [
+          // A memory prefix block that must be carried over to the Slack
+          // transcript's tail so after-memory splices still fire.
+          {
+            type: "text",
+            text: "<memory __injected>\nrecalled fact\n</memory>",
+          },
+          { type: "text", text: "What's happening?" },
+        ],
+      },
+    ];
+    const slackTranscript: Message[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "[12:00 alice]: kickoff" }],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "[12:05 @user]: What's happening?" }],
+      },
+    ];
+
+    const result = await applyRuntimeInjections(originalRun, {
+      turnContext: makeTurnContext(),
+      channelCapabilities: {
+        channel: "slack",
+        dashboardCapable: false,
+        supportsDynamicUi: false,
+        supportsVoiceInput: false,
+        chatType: "channel",
+      },
+      slackChronologicalMessages: slackTranscript,
+    });
+
+    // The swap replaced the run-messages wholesale but preserved the
+    // memory-prefix blocks onto the new tail user message.
+    expect(result.messages).toHaveLength(2);
+    const slackTail = result.messages[result.messages.length - 1];
+    expect(slackTail.role).toBe("user");
+    const texts = slackTail.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text);
+    // Hardcoded channelCapabilities injection prepends first (Slack is a
+    // constrained channel), then the carried memory-prefix blocks, then
+    // the slack transcript's original user text.
+    expect(texts.some((t) => t.startsWith("<channel_capabilities>"))).toBe(
+      true,
+    );
+    expect(texts).toContain("<memory __injected>\nrecalled fact\n</memory>");
+    expect(texts[texts.length - 1]).toBe("[12:05 @user]: What's happening?");
+  });
+
+  test("minimal mode: only unified-turn-context survives; workspace/PKB/NOW/subagent are skipped", async () => {
+    // Validates the `minimal` injection-mode gating. Every default
+    // injector except `unified-turn-context` checks `mode === "full"` and
+    // opts out in minimal mode, so the tail should carry only the turn
+    // context prepend plus any non-injector hardcoded content (none
+    // here).
+    registerPlugin(defaultInjectorsPlugin);
+
+    const result = await applyRuntimeInjections(
+      [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hi" }],
+        },
+      ],
+      {
+        turnContext: makeTurnContext(),
+        mode: "minimal",
+        workspaceTopLevelContext: "<workspace>...</workspace>",
+        unifiedTurnContext: "<turn_context>...</turn_context>",
+        pkbContext: "kbody",
+        pkbActive: true,
+        nowScratchpad: "nowbody",
+        subagentStatusBlock: "<active_subagents>...</active_subagents>",
+      },
+    );
+
+    const tail = result.messages[result.messages.length - 1];
+    const texts = tail.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text);
+
+    expect(texts).toEqual(["<turn_context>...</turn_context>", "hi"]);
+    expect(result.blocks.unifiedTurnContext).toBe(
+      "<turn_context>...</turn_context>",
+    );
+    expect(result.blocks.workspaceBlock).toBeUndefined();
+    expect(result.blocks.pkbContextBlock).toBeUndefined();
+    expect(result.blocks.nowScratchpadBlock).toBeUndefined();
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1197,12 +1197,19 @@ export async function runAgentLoopImpl(
 
     let currentInjectionMode: InjectionMode = "full";
 
+    // Canonical per-turn TurnContext forwarded to the injector chain. The
+    // per-turn injection inputs are built inside `applyRuntimeInjections`
+    // from the `injectionOpts` bag; we only need to hand in identity +
+    // trust here so third-party injectors see the real turn metadata.
+    const injectionTurnCtx = buildPluginTurnContext(ctx, reqId);
+
     const injection = await applyRuntimeInjections(runMessages, {
       ...injectionOpts,
       slackChronologicalMessages: reducerCompacted
         ? null
         : injectionOpts.slackChronologicalMessages,
       mode: currentInjectionMode,
+      turnContext: injectionTurnCtx,
     });
     runMessages = injection.messages;
 
@@ -1402,6 +1409,7 @@ export async function runAgentLoopImpl(
               ? null
               : injectionOpts.slackChronologicalMessages,
             mode,
+            turnContext: buildPluginTurnContext(ctx, reqId),
           });
           let next = injection.messages;
           if (isTrustedActor && mode !== "minimal") {
@@ -1667,6 +1675,7 @@ export async function runAgentLoopImpl(
           ? null
           : injectionOpts.slackChronologicalMessages,
         mode: currentInjectionMode,
+        turnContext: buildPluginTurnContext(ctx, reqId),
       });
       runMessages = injection.messages;
       if (isTrustedActor && currentInjectionMode !== "minimal") {
@@ -1896,6 +1905,7 @@ export async function runAgentLoopImpl(
             ? null
             : injectionOpts.slackChronologicalMessages,
           mode: currentInjectionMode,
+          turnContext: buildPluginTurnContext(ctx, reqId),
         });
         runMessages = injection.messages;
         if (isTrustedActor && currentInjectionMode !== "minimal") {
@@ -2030,6 +2040,7 @@ export async function runAgentLoopImpl(
               ? null
               : injectionOpts.slackChronologicalMessages,
             mode: currentInjectionMode,
+            turnContext: buildPluginTurnContext(ctx, reqId),
           });
           runMessages = injection.messages;
           if (isTrustedActor && currentInjectionMode !== "minimal") {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -18,7 +18,6 @@ import {
   countMemoryPrefixBlocks,
   extractMemoryPrefixBlocks,
 } from "../memory/graph/conversation-graph-memory.js";
-import { searchPkbFiles } from "../memory/pkb/pkb-search.js";
 import type { QdrantSparseVector } from "../memory/qdrant-client.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import {
@@ -28,7 +27,12 @@ import {
 } from "../messaging/providers/slack/render-transcript.js";
 import { isPermissionControlsV2Enabled } from "../permissions/v2-consent-policy.js";
 import { getInjectors } from "../plugins/registry.js";
-import type { TurnContext } from "../plugins/types.js";
+import type {
+  InjectionBlock,
+  InjectionPlacement,
+  TurnContext,
+  TurnInjectionInputs,
+} from "../plugins/types.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import {
   type ActorTrustContext,
@@ -38,17 +42,10 @@ import {
 import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/acl-enforcement.js";
 import type { SubagentState } from "../subagent/types.js";
 import { TERMINAL_STATUSES } from "../subagent/types.js";
-import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir, getWorkspacePromptPath } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
 import { filterMessagesForUntrustedActor } from "./conversation-lifecycle.js";
-import {
-  getInContextPkbPaths,
-  type PkbContextConversation,
-} from "./pkb-context-tracker.js";
-import { buildPkbReminder } from "./pkb-reminder-builder.js";
-
-const pkbReminderLog = getLogger("pkb-reminder");
+import { type PkbContextConversation } from "./pkb-context-tracker.js";
 
 /**
  * Describes the capabilities of the channel through which the user is
@@ -524,16 +521,11 @@ export function buildSubagentStatusBlock(
   return lines.join("\n");
 }
 
-/** Append a subagent status block to the last user message. */
-export function injectSubagentStatus(
-  message: Message,
-  statusBlock: string,
-): Message {
-  return {
-    ...message,
-    content: [...message.content, { type: "text" as const, text: statusBlock }],
-  };
-}
+// `injectSubagentStatus` was removed in G2.1 — the subagent-status default
+// injector (`plugins/defaults/injectors.ts`) now emits the block as an
+// `append-user-tail` placement. Use {@link applyRuntimeInjections} with
+// `options.subagentStatusBlock` set, or drive the injector chain directly
+// via `collectInjectorBlocks`.
 
 /**
  * Append voice call-control protocol instructions to the last user
@@ -577,42 +569,11 @@ export function readNowScratchpad(): string | null {
 }
 
 /**
- * Insert NOW.md scratchpad content into the user message, after any
- * injected context blocks (e.g. memory_context) but before the user's
- * original content.  This keeps the user's actual message as the last
- * thing the model reads.
+ * `injectNowScratchpad` was removed in G2.1 — the now-md default injector
+ * (`plugins/defaults/injectors.ts`) now emits the `<NOW.md>` block as an
+ * `after-memory-prefix` placement. Use {@link applyRuntimeInjections} with
+ * `options.nowScratchpad` set.
  */
-export function injectNowScratchpad(
-  message: Message,
-  content: string,
-): Message {
-  const scratchpadBlock = {
-    type: "text" as const,
-    text: `<NOW.md Always keep this up to date; keep under 10 lines>\n${content}\n</NOW.md>`,
-  };
-
-  // Find insertion point: skip any leading injected-context text blocks
-  // (e.g. memory_context) so the scratchpad lands between injected context
-  // and the user's original content.
-  let insertIdx = 0;
-  for (let i = 0; i < message.content.length; i++) {
-    const block = message.content[i];
-    if (block.type === "text" && block.text.startsWith("<memory_context")) {
-      insertIdx = i + 1;
-    } else {
-      break;
-    }
-  }
-
-  return {
-    ...message,
-    content: [
-      ...message.content.slice(0, insertIdx),
-      scratchpadBlock,
-      ...message.content.slice(insertIdx),
-    ],
-  };
-}
 
 /** Strip `<NOW.md>` blocks injected by `injectNowScratchpad`. */
 export function stripNowScratchpad(messages: Message[]): Message[] {
@@ -639,16 +600,6 @@ const AUTOINJECT_FILENAME = "_autoinject.md";
 
 /** Max buffer.md lines injected into prompts — keeps context bounded even when filing is off. */
 const MAX_BUFFER_LINES = 50;
-
-/** Minimum hybrid-search score for a PKB path to surface as an injection hint. */
-const PKB_HINT_THRESHOLD = 0.5;
-
-/**
- * Stricter hint threshold for PKB entries under `archive/`. Archive files are
- * date-indexed dumps of older notes — they match loosely and are rarely the
- * most relevant read, so require a higher bar before recommending them.
- */
-const PKB_HINT_ARCHIVE_THRESHOLD = 0.7;
 
 /**
  * Read `_autoinject.md` from the PKB directory and return the list of
@@ -730,49 +681,10 @@ export function readPkbContext(): string | null {
   return parts.length > 0 ? parts.join("\n\n") : null;
 }
 
-/**
- * Insert PKB context into the user message, after any injected memory
- * blocks but before NOW.md and the user's original content.
- */
-export function injectPkbContext(message: Message, content: string): Message {
-  // Escape closing tags that could break out of the XML wrapper
-  const escaped = content.replace(
-    /<\/knowledge_base\s*>/gi,
-    "&lt;/knowledge_base&gt;",
-  );
-  const pkbBlock = {
-    type: "text" as const,
-    text: `<knowledge_base>\n${escaped}\n</knowledge_base>`,
-  };
-
-  // Find insertion point: skip any leading memory/image blocks
-  let insertIdx = 0;
-  for (let i = 0; i < message.content.length; i++) {
-    const block = message.content[i];
-    if (
-      block.type === "text" &&
-      (block.text.startsWith("<memory") ||
-        block.text.startsWith("</memory_image>") ||
-        block.text.startsWith("<memory_context"))
-    ) {
-      insertIdx = i + 1;
-    } else if (block.type === "image") {
-      // Memory images precede the memory text block
-      insertIdx = i + 1;
-    } else {
-      break;
-    }
-  }
-
-  return {
-    ...message,
-    content: [
-      ...message.content.slice(0, insertIdx),
-      pkbBlock,
-      ...message.content.slice(insertIdx),
-    ],
-  };
-}
+// `injectPkbContext` was removed in G2.1 — the pkb default injector
+// (`plugins/defaults/injectors.ts`) now emits the `<knowledge_base>`
+// block as an `after-memory-prefix` placement on the same splice site.
+// Use {@link applyRuntimeInjections} with `options.pkbContext` set.
 
 /** Strip `<knowledge_base>` blocks injected by `injectPkbContext`. */
 export function stripPkbContext(messages: Message[]): Message[] {
@@ -1148,18 +1060,11 @@ export function stripChannelCapabilityContext(messages: Message[]): Message[] {
   return stripUserTextBlocksByPrefix(messages, ["<channel_capabilities>"]);
 }
 
-/**
- * Prepend workspace top-level directory context to a user message.
- */
-export function injectWorkspaceTopLevelContext(
-  message: Message,
-  contextText: string,
-): Message {
-  return {
-    ...message,
-    content: [{ type: "text", text: contextText }, ...message.content],
-  };
-}
+// `injectWorkspaceTopLevelContext` was removed in G2.1 — the
+// workspace-context default injector (`plugins/defaults/injectors.ts`)
+// now emits the workspace block as a `prepend-user-tail` placement.
+// Use {@link applyRuntimeInjections} with
+// `options.workspaceTopLevelContext` set.
 
 /**
  * Strip `<active_workspace>` (and legacy `<active_dynamic_page>`) blocks
@@ -1751,6 +1656,28 @@ export interface RuntimeInjectionResult {
 }
 
 /**
+ * Run every registered {@link Injector}'s `produce()` in ascending `order`
+ * and return every non-null block the chain produced.
+ *
+ * Injectors returning `null` are omitted from the result. The returned array
+ * preserves ascending-`order` sort so downstream callers (notably
+ * {@link applyRuntimeInjections}) can group blocks by `placement` and apply
+ * them declaratively without losing per-injector ordering within each slot.
+ */
+export async function collectInjectorBlocks(
+  ctx: TurnContext,
+): Promise<InjectionBlock[]> {
+  const injectors = getInjectors();
+  if (injectors.length === 0) return [];
+  const out: InjectionBlock[] = [];
+  for (const injector of injectors) {
+    const block = await injector.produce(ctx);
+    if (block) out.push(block);
+  }
+  return out;
+}
+
+/**
  * Run every registered {@link Injector}'s `produce()` in ascending
  * `order`, concatenate the non-null results into a single block of text,
  * and return it.
@@ -1759,152 +1686,424 @@ export interface RuntimeInjectionResult {
  * skipped entirely (no leading/trailing blank lines). When no injector
  * contributes, the function returns an empty string.
  *
- * Used by {@link applyRuntimeInjections} to expose a deterministic
- * composition point that plugin-registered injectors can slot into. The
- * default injectors registered by `defaultInjectorsPlugin` placeholder-return
- * `null` in this PR; later PRs in the `agent-plugin-system` plan lift their
- * real bodies from the hardcoded `applyRuntimeInjections` branches.
+ * Kept for the PR 21 test suite (which asserts the concatenation contract)
+ * and for callers that want a single informational string view of the chain.
+ * The canonical integration point is {@link applyRuntimeInjections}, which
+ * uses {@link collectInjectorBlocks} + placement-aware application to splice
+ * each block into the per-turn message array.
  */
 export async function composeInjectorChain(ctx: TurnContext): Promise<string> {
-  const injectors = getInjectors();
-  if (injectors.length === 0) return "";
+  const blocks = await collectInjectorBlocks(ctx);
   const pieces: string[] = [];
-  for (const injector of injectors) {
-    const block = await injector.produce(ctx);
-    if (block && block.text.length > 0) {
-      pieces.push(block.text);
-    }
+  for (const block of blocks) {
+    if (block.text.length > 0) pieces.push(block.text);
   }
   return pieces.join("\n\n");
 }
 
 /**
- * Apply a chain of user-message injections to `runMessages`.
+ * Default block placement. Kept in sync with {@link InjectionBlock} so
+ * blocks produced without an explicit `placement` (e.g. third-party
+ * injectors written against the pre-G2.1 API) behave predictably.
+ */
+const DEFAULT_PLACEMENT: InjectionPlacement = "append-user-tail";
+
+/**
+ * Count leading memory-prefix blocks on a user message's `content`.
  *
- * Each injection is optional — pass `null`/`undefined` to skip it.
- * Returns the final message array ready for the provider along with a
- * `blocks` object holding the exact injected text for each block that was
- * applied, so callers can persist those bytes to message metadata for later
- * byte-exact rehydration.
+ * Delegates to {@link countMemoryPrefixBlocks} from
+ * `memory/graph/conversation-graph-memory.js` — the same state-machine the
+ * pre-migration PKB-reminder branch used to find its splice point. The
+ * pre-migration `injectPkbContext` and `injectNowScratchpad` helpers used
+ * slightly simpler rules inline; reusing the canonical counter here
+ * collapses the three near-identical splice rules into one source of truth
+ * so the ordering of PKB-context / PKB-reminder / NOW blocks relative to
+ * any memory prefix is stable and testable. For the common case (just
+ * `<memory __injected>` text, no images), the output is byte-identical to
+ * the pre-migration helpers.
+ */
+function countMemoryPrefixBlocksOnContent(content: ContentBlock[]): number {
+  return countMemoryPrefixBlocks(content);
+}
+
+/**
+ * Apply one injector block to a `runMessages` array according to its
+ * declared {@link InjectionPlacement}.
+ *
+ * Preserves the byte-for-byte positional semantics of the pre-migration
+ * `inject*` helpers:
+ *  - `"prepend-user-tail"` — prepend to the tail user message's content.
+ *  - `"append-user-tail"`  — append to the tail user message's content.
+ *  - `"after-memory-prefix"` — splice immediately after any leading memory
+ *    prefix blocks (mirrors `injectPkbContext` / `injectNowScratchpad`).
+ *  - `"replace-run-messages"` — replace `runMessages` wholesale with
+ *    `block.messagesOverride`.
+ *
+ * Blocks with empty `text` on non-replace placements are no-ops (the
+ * pre-migration branches also short-circuited on empty strings).
+ */
+function applyInjectionBlock(
+  runMessages: Message[],
+  block: InjectionBlock,
+): Message[] {
+  const placement = block.placement ?? DEFAULT_PLACEMENT;
+
+  if (placement === "replace-run-messages") {
+    if (!block.messagesOverride) return runMessages;
+    return block.messagesOverride;
+  }
+
+  if (block.text.length === 0) return runMessages;
+
+  const userTail = runMessages[runMessages.length - 1];
+  if (!userTail || userTail.role !== "user") return runMessages;
+
+  const textBlock = { type: "text" as const, text: block.text };
+
+  switch (placement) {
+    case "prepend-user-tail":
+      return [
+        ...runMessages.slice(0, -1),
+        { ...userTail, content: [textBlock, ...userTail.content] },
+      ];
+    case "append-user-tail":
+      return [
+        ...runMessages.slice(0, -1),
+        { ...userTail, content: [...userTail.content, textBlock] },
+      ];
+    case "after-memory-prefix": {
+      const memoryPrefixCount = countMemoryPrefixBlocksOnContent(
+        userTail.content,
+      );
+      return [
+        ...runMessages.slice(0, -1),
+        {
+          ...userTail,
+          content: [
+            ...userTail.content.slice(0, memoryPrefixCount),
+            textBlock,
+            ...userTail.content.slice(memoryPrefixCount),
+          ],
+        },
+      ];
+    }
+  }
+}
+
+/**
+ * Per-turn options accepted by {@link applyRuntimeInjections}.
+ *
+ * Most fields flow through to the per-injector {@link TurnInjectionInputs}
+ * bag attached to the {@link TurnContext} the caller provides (or to an
+ * ephemeral {@link TurnContext} synthesized for test call sites). A small
+ * number of fields drive hardcoded branches that live outside the injector
+ * chain — `activeSurface`, `channelCapabilities`, `channelCommandContext`,
+ * `voiceCallControlPrompt`, `transportHints`, and `isNonInteractive` —
+ * because they are orchestrator-owned content that never made sense as
+ * plugin-overridable default injectors.
+ */
+export interface RuntimeInjectionOptions {
+  /**
+   * Active dashboard-surface context (read from `<active_workspace>`). Kept
+   * on the options bag rather than an injector because it is a
+   * channel-capability concern that has never been gated as a default
+   * injector.
+   */
+  activeSurface?: ActiveSurfaceContext | null;
+  workspaceTopLevelContext?: string | null;
+  channelCapabilities?: ChannelCapabilities | null;
+  channelCommandContext?: ChannelCommandContext | null;
+  unifiedTurnContext?: string | null;
+  voiceCallControlPrompt?: string | null;
+  pkbContext?: string | null;
+  pkbActive?: boolean;
+  /**
+   * Dense query vector surfaced from the graph memory retriever (PR 3).
+   * When present together with `pkbActive`, used to run `searchPkbFiles`
+   * to surface relevance hints in the PKB system reminder. When missing,
+   * the reminder falls back to the flat static text.
+   */
+  pkbQueryVector?: number[];
+  /** Optional sparse vector accompanying `pkbQueryVector`. */
+  pkbSparseVector?: QdrantSparseVector;
+  /** Memory scope id used to filter PKB search results. */
+  pkbScopeId?: string;
+  /**
+   * The live conversation (or a minimal shape containing `messages`) used
+   * to compute which PKB paths are already "in context" and therefore
+   * suppressed from hint suggestions.
+   */
+  pkbConversation?: PkbContextConversation;
+  /** Auto-injected PKB filenames (resolved relative to `pkbRoot`). */
+  pkbAutoInjectList?: string[];
+  /** Absolute path to the PKB directory (e.g. `<workspace>/pkb`). */
+  pkbRoot?: string;
+  /**
+   * Working directory against which relative `file_read` tool paths
+   * resolve, used to detect workspace-relative reads like
+   * `pkb/threads.md`. Falls back to `pkbRoot` when omitted.
+   */
+  pkbWorkingDir?: string;
+  nowScratchpad?: string | null;
+  subagentStatusBlock?: string | null;
+  isNonInteractive?: boolean;
+  transportHints?: string[] | null;
+  /**
+   * Pre-rendered Slack chronological transcript that replaces the
+   * default `runMessages` history for any Slack conversation (channels
+   * and DMs alike).
+   *
+   * When `channelCapabilities` describes a Slack conversation and this
+   * array is non-empty, the `slack-messages` default injector emits a
+   * `replace-run-messages` block that swaps `runMessages` with this
+   * transcript. Channel renders include sibling-thread tags; DM renders
+   * are flat (DMs have no threads). The `transportHints` pipeline is
+   * skipped for any Slack conversation so the persisted view isn't
+   * duplicated by gateway-side hints.
+   *
+   * Callers build this via `loadSlackChronologicalMessages` (or the
+   * underlying `assembleSlackChronologicalMessages`) before invoking
+   * this function so the assembly path stays free of direct DB calls
+   * and remains easy to test.
+   */
+  slackChronologicalMessages?: Message[] | null;
+  /**
+   * Pre-rendered `<active_thread>` focus block listing the messages of
+   * the thread the current inbound user message belongs to.
+   *
+   * Appended to the FINAL user message ONLY when `channelCapabilities`
+   * describes a Slack non-DM channel. The block is non-persisted: history
+   * rebuilds re-derive it from storage on each turn, and
+   * `RUNTIME_INJECTION_PREFIXES` strips any `<active_thread>` blocks from
+   * prior turns so they do not accumulate.
+   *
+   * Callers build this via `loadSlackActiveThreadFocusBlock` (or the
+   * underlying `assembleSlackActiveThreadFocusBlock`). Pass `null` /
+   * `undefined` when the inbound is a top-level (non-thread) post.
+   */
+  slackActiveThreadFocusBlock?: string | null;
+  mode?: InjectionMode;
+  /**
+   * Per-turn {@link TurnContext} forwarded to plugin-registered
+   * {@link Injector}s via {@link collectInjectorBlocks}. When omitted,
+   * `applyRuntimeInjections` synthesizes an ephemeral context (with a
+   * fallback `trust` classification) so the default-injector chain still
+   * runs — test call sites that pass option fields without a matching
+   * `turnContext` continue to exercise the same code path.
+   *
+   * When provided, the caller's `trust`, `conversationId`, `turnIndex`,
+   * etc. are preserved; the function layers its per-turn
+   * {@link TurnInjectionInputs} onto a shallow clone so the caller's
+   * `TurnContext` is not mutated.
+   */
+  turnContext?: TurnContext;
+}
+
+/**
+ * Build the {@link TurnInjectionInputs} bag from the options bag.
+ *
+ * Exposed so callers that already hold a {@link TurnContext} can layer the
+ * same per-turn inputs onto it before handing control to
+ * {@link collectInjectorBlocks} directly — useful for tests and for the
+ * overflow-reducer reinject path.
+ */
+export function buildTurnInjectionInputs(
+  options: RuntimeInjectionOptions,
+): TurnInjectionInputs {
+  return {
+    mode: options.mode,
+    workspaceTopLevelContext: options.workspaceTopLevelContext,
+    unifiedTurnContext: options.unifiedTurnContext,
+    pkbContext: options.pkbContext,
+    pkbActive: options.pkbActive,
+    pkbQueryVector: options.pkbQueryVector,
+    pkbSparseVector: options.pkbSparseVector,
+    pkbScopeId: options.pkbScopeId,
+    pkbConversation: options.pkbConversation,
+    pkbAutoInjectList: options.pkbAutoInjectList,
+    pkbRoot: options.pkbRoot,
+    pkbWorkingDir: options.pkbWorkingDir,
+    nowScratchpad: options.nowScratchpad,
+    subagentStatusBlock: options.subagentStatusBlock,
+    channelCapabilities: options.channelCapabilities,
+    slackChronologicalMessages: options.slackChronologicalMessages,
+    slackActiveThreadFocusBlock: options.slackActiveThreadFocusBlock,
+    activeSurface: options.activeSurface,
+    channelCommandContext: options.channelCommandContext,
+    voiceCallControlPrompt: options.voiceCallControlPrompt,
+    transportHints: options.transportHints,
+    isNonInteractive: options.isNonInteractive,
+  };
+}
+
+/** Minimal synthetic TurnContext used when the caller omits one. */
+function synthesizeFallbackTurnContext(
+  inputs: TurnInjectionInputs,
+): TurnContext {
+  return {
+    requestId: "runtime-assembly-fallback",
+    conversationId: "runtime-assembly-fallback",
+    turnIndex: 0,
+    trust: {
+      sourceChannel: inputs.channelCapabilities?.channel
+        ? (inputs.channelCapabilities.channel as TrustContext["sourceChannel"])
+        : "vellum",
+      trustClass: "unknown",
+    },
+    injectionInputs: inputs,
+  };
+}
+
+/**
+ * Apply the runtime-injection chain to `runMessages`.
+ *
+ * The canonical per-turn assembly pipeline for every provider call:
+ *
+ *  1. Build the per-turn {@link TurnInjectionInputs} bag from `options`.
+ *  2. Layer it onto a {@link TurnContext} — either the one the caller
+ *     supplies via `options.turnContext` (preserving its `requestId`,
+ *     trust, and other fields) or an ephemeral fallback synthesized here.
+ *  3. Drive the default + third-party {@link Injector} chain via
+ *     {@link collectInjectorBlocks}.
+ *  4. Apply the chain's `"replace-run-messages"` block (Slack chronological
+ *     transcript) first so subsequent hardcoded branches operate on the
+ *     replaced tail. When replacement fires, re-prepend any memory-prefix
+ *     blocks that `graphMemory.prepareMemory` had attached to the original
+ *     tail — the Slack transcript is rendered fresh from persisted rows and
+ *     carries no memory prefix of its own.
+ *  5. Run the remaining hardcoded branches (`isNonInteractive`,
+ *     `voiceCallControlPrompt`, `activeSurface`, `channelCapabilities`,
+ *     `channelCommandContext`, `transportHints`) in their historical order.
+ *  6. Finally, apply the chain's remaining blocks by placement:
+ *     `"after-memory-prefix"` in ascending `order`, `"append-user-tail"` in
+ *     ascending `order`, `"prepend-user-tail"` in descending `order` so the
+ *     lowest-`order` prepend lands topmost in the user tail content.
+ *
+ * Returns the final message array plus a `blocks` object holding the exact
+ * injected text for each captured block — callers persist those bytes to
+ * message metadata for later byte-exact rehydration.
  */
 export async function applyRuntimeInjections(
   runMessages: Message[],
-  options: {
-    activeSurface?: ActiveSurfaceContext | null;
-    workspaceTopLevelContext?: string | null;
-    channelCapabilities?: ChannelCapabilities | null;
-    channelCommandContext?: ChannelCommandContext | null;
-    unifiedTurnContext?: string | null;
-    voiceCallControlPrompt?: string | null;
-    pkbContext?: string | null;
-    pkbActive?: boolean;
-    /**
-     * Dense query vector surfaced from the graph memory retriever (PR 3).
-     * When present together with `pkbActive`, used to run `searchPkbFiles`
-     * to surface relevance hints in the PKB system reminder. When missing,
-     * the reminder falls back to the flat static text.
-     */
-    pkbQueryVector?: number[];
-    /** Optional sparse vector accompanying `pkbQueryVector`. */
-    pkbSparseVector?: QdrantSparseVector;
-    /** Memory scope id used to filter PKB search results. */
-    pkbScopeId?: string;
-    /**
-     * The live conversation (or a minimal shape containing `messages`) used
-     * to compute which PKB paths are already "in context" and therefore
-     * suppressed from hint suggestions.
-     */
-    pkbConversation?: PkbContextConversation;
-    /** Auto-injected PKB filenames (resolved relative to `pkbRoot`). */
-    pkbAutoInjectList?: string[];
-    /** Absolute path to the PKB directory (e.g. `<workspace>/pkb`). */
-    pkbRoot?: string;
-    /**
-     * Working directory against which relative `file_read` tool paths
-     * resolve, used to detect workspace-relative reads like
-     * `pkb/threads.md`. Falls back to `pkbRoot` when omitted.
-     */
-    pkbWorkingDir?: string;
-    nowScratchpad?: string | null;
-    subagentStatusBlock?: string | null;
-    isNonInteractive?: boolean;
-    transportHints?: string[] | null;
-    /**
-     * Pre-rendered Slack chronological transcript that replaces the
-     * default `runMessages` history for any Slack conversation (channels
-     * and DMs alike).
-     *
-     * When `channelCapabilities` describes a Slack conversation and this
-     * array is non-empty, it overrides `runMessages` so the model sees one
-     * chronologically-ordered transcript built from the stored Slack
-     * metadata. Channel renders include sibling-thread tags; DM renders
-     * are flat (DMs have no threads). The `transportHints` pipeline is
-     * skipped for any Slack conversation so the persisted view isn't
-     * duplicated by gateway-side hints.
-     *
-     * Callers build this via `loadSlackChronologicalMessages` (or the
-     * underlying `assembleSlackChronologicalMessages`) before invoking
-     * this function so the assembly path stays free of direct DB calls
-     * and remains easy to test.
-     */
-    slackChronologicalMessages?: Message[] | null;
-    /**
-     * Pre-rendered `<active_thread>` focus block listing the messages of
-     * the thread the current inbound user message belongs to.
-     *
-     * Appended (tail-block) to the FINAL user message ONLY when
-     * `channelCapabilities` describes a Slack non-DM channel. The block is
-     * non-persisted: history rebuilds re-derive it from storage on each
-     * turn, and `RUNTIME_INJECTION_PREFIXES` strips any `<active_thread>`
-     * blocks from prior turns so they do not accumulate.
-     *
-     * Callers build this via `loadSlackActiveThreadFocusBlock` (or the
-     * underlying `assembleSlackActiveThreadFocusBlock`). Pass `null` /
-     * `undefined` when the inbound is a top-level (non-thread) post.
-     */
-    slackActiveThreadFocusBlock?: string | null;
-    mode?: InjectionMode;
-    /**
-     * Per-turn {@link TurnContext} forwarded to plugin-registered
-     * {@link Injector}s via {@link composeInjectorChain}. When omitted, the
-     * injector chain is skipped entirely (its output stays `undefined` on
-     * the returned `blocks`). The hardcoded injection branches above still
-     * run — the injector chain is additive in this PR and will take over
-     * individual injections in later PRs.
-     */
-    turnContext?: TurnContext;
-  },
+  options: RuntimeInjectionOptions,
 ): Promise<RuntimeInjectionResult> {
   const mode = options.mode ?? "full";
-  let pkbSystemReminderCaptured: string | undefined;
-  const slackChannel = isSlackChannelConversation(options.channelCapabilities);
-  // Slack DMs and channels both assemble context from persisted message
-  // rows, so suppress hint injection for any Slack conversation. Other
-  // channels (telegram, email, etc.) keep the generic hint pipeline.
   const slackConversation = options.channelCapabilities?.channel === "slack";
+
+  // Build the per-injector inputs and attach them to the caller's
+  // TurnContext (without mutating it). When the caller didn't supply one,
+  // synthesize a minimal fallback so the chain still runs — test call sites
+  // that drive injection via `options` without constructing a full context
+  // continue to work.
+  const injectionInputs = buildTurnInjectionInputs(options);
+  const turnCtx: TurnContext = options.turnContext
+    ? { ...options.turnContext, injectionInputs }
+    : synthesizeFallbackTurnContext(injectionInputs);
+
+  const chainBlocks = await collectInjectorBlocks(turnCtx);
+
+  // Split the chain output by placement so the downstream assembly can
+  // process each slot with the correct ordering rule.
+  const prepends: InjectionBlock[] = [];
+  const appends: InjectionBlock[] = [];
+  const afterMemory: InjectionBlock[] = [];
+  let replaceBlock: InjectionBlock | null = null;
+  for (const block of chainBlocks) {
+    switch (block.placement ?? "append-user-tail") {
+      case "replace-run-messages":
+        // Later replace-run-messages blocks would overwrite earlier ones;
+        // the default chain only registers one (the Slack transcript).
+        replaceBlock = block;
+        break;
+      case "after-memory-prefix":
+        afterMemory.push(block);
+        break;
+      case "prepend-user-tail":
+        prepends.push(block);
+        break;
+      case "append-user-tail":
+        appends.push(block);
+        break;
+    }
+  }
+
+  // Track captured text for metadata persistence. Each field corresponds
+  // to a specific default-injector block id so the loop below can pick up
+  // the right capture without re-rendering.
+  //
+  // The capture is gated on the tail actually being a user message — if it
+  // isn't, `applyInjectionBlock` no-ops the block and no content is actually
+  // injected, so the persisted metadata must be undefined (matches
+  // pre-migration behaviour where the `inject*` helpers short-circuited the
+  // same way).
   let turnContextCaptured: string | undefined;
   let workspaceCaptured: string | undefined;
   let nowScratchpadCaptured: string | undefined;
   let pkbContextCaptured: string | undefined;
+  let pkbSystemReminderCaptured: string | undefined;
+  const initialTail = runMessages[runMessages.length - 1];
+  const initialTailIsUser = !!initialTail && initialTail.role === "user";
+  if (initialTailIsUser) {
+    for (const block of chainBlocks) {
+      switch (block.id) {
+        case "unified-turn-context":
+          turnContextCaptured = block.text;
+          break;
+        case "workspace-context":
+          workspaceCaptured = block.text;
+          break;
+        case "now-md":
+          nowScratchpadCaptured = block.text;
+          break;
+        case "pkb":
+          // The pkb injector concatenates reminder + context into a single
+          // after-memory-prefix block. Recover each half from their known
+          // tag prefixes so the persisted metadata matches pre-migration
+          // bytes: `pkbSystemReminderBlock` is the raw reminder text (no
+          // `<system_reminder>` wrapper — `buildPkbReminder` supplies it)
+          // and `pkbContextBlock` is the `<knowledge_base>` block.
+          {
+            const text = block.text;
+            const kbStart = text.indexOf("<knowledge_base>");
+            if (kbStart >= 0) {
+              const reminder = text.slice(0, kbStart).replace(/\n+$/, "");
+              if (reminder.length > 0) pkbSystemReminderCaptured = reminder;
+              pkbContextCaptured = text.slice(kbStart);
+            } else if (text.length > 0) {
+              // Reminder-only (no PKB context).
+              pkbSystemReminderCaptured = text;
+            }
+          }
+          break;
+      }
+    }
+  }
+
+  // Compose the block text into a single informational string for
+  // `injectorChainBlock`. Matches the pre-migration behaviour where the
+  // field captured the composed view of every third-party injector on
+  // the turn. We include default injectors here too so downstream
+  // observers see the full set.
+  const injectorChainPieces: string[] = [];
+  for (const block of chainBlocks) {
+    if (block.text.length > 0) injectorChainPieces.push(block.text);
+  }
+  const injectorChainBlock =
+    injectorChainPieces.length > 0
+      ? injectorChainPieces.join("\n\n")
+      : undefined;
+
   let result = runMessages;
-  // Slack channels AND DMs both override `runMessages` with a pre-rendered
-  // chronological transcript built from persisted message rows. The shared
-  // assembler (`assembleSlackChronologicalMessages`) renders thread tags
-  // for channels and a flat sequence for DMs, so the same branch handles
-  // both. The active-thread focus block below stays gated on `slackChannel`
-  // since DMs do not have threads.
-  if (
-    slackConversation &&
-    options.slackChronologicalMessages &&
-    options.slackChronologicalMessages.length > 0
-  ) {
+
+  // ── Step 1: Slack chronological replacement (chain "replace" block) ──
+  if (replaceBlock && replaceBlock.messagesOverride) {
     // `graphMemory.prepareMemory` prepends a `<memory __injected>` block
     // (and any memory-image groups) to the last user message before
     // runtime assembly runs. The Slack transcript is freshly rendered
     // from persisted rows and has no such prefix, so swap it in and then
     // re-prepend the captured prefix onto the new tail user message.
     const carriedMemoryBlocks = extractMemoryPrefixBlocks(runMessages);
-    result = options.slackChronologicalMessages;
+    result = replaceBlock.messagesOverride;
     if (carriedMemoryBlocks.length > 0) {
       const slackTail = result[result.length - 1];
       if (slackTail && slackTail.role === "user") {
@@ -1918,6 +2117,10 @@ export async function applyRuntimeInjections(
       }
     }
   }
+
+  // ── Step 2: hardcoded branches that stayed outside the injector chain ──
+  // These run in the same historical order as before G2.1 so their
+  // interleaving with any prior tail content stays stable.
 
   // For non-interactive conversations (scheduled jobs, work items), instruct the
   // model to never ask for clarification — there is no human present to answer.
@@ -1947,128 +2150,6 @@ export async function applyRuntimeInjections(
         ...result.slice(0, -1),
         injectVoiceCallControlContext(userTail, options.voiceCallControlPrompt),
       ];
-    }
-  }
-
-  if (mode === "full" && options.pkbContext) {
-    const userTail = result[result.length - 1];
-    if (userTail && userTail.role === "user") {
-      const injected = injectPkbContext(userTail, options.pkbContext);
-      // Capture the exact block text for metadata persistence. The injector
-      // escapes closing tags inside `pkbContext` and wraps it in
-      // `<knowledge_base>...</knowledge_base>`, so read back the inserted
-      // block rather than regenerating from the raw input.
-      const insertedBlock = injected.content.find(
-        (b): b is { type: "text"; text: string } =>
-          b.type === "text" && b.text.startsWith("<knowledge_base>"),
-      );
-      if (insertedBlock) pkbContextCaptured = insertedBlock.text;
-      result = [...result.slice(0, -1), injected];
-    }
-  }
-
-  // PKB behavioral nudge — injected on every turn when PKB is active so
-  // the model keeps reading topic files and calling `remember`. When a
-  // query vector is available from the graph memory retriever, run a
-  // hybrid PKB search to surface up to three relevance hints; fall back
-  // to the flat static reminder on empty results or any error.
-  if (mode === "full" && options.pkbActive) {
-    const userTail = result[result.length - 1];
-    if (userTail && userTail.role === "user") {
-      let hints: string[] = [];
-      const queryVector = options.pkbQueryVector;
-      if (
-        queryVector &&
-        queryVector.length > 0 &&
-        options.pkbScopeId &&
-        options.pkbConversation &&
-        options.pkbRoot
-      ) {
-        try {
-          const results = await searchPkbFiles(
-            queryVector,
-            options.pkbSparseVector,
-            8,
-            [options.pkbScopeId],
-          );
-          const workingDir = options.pkbWorkingDir ?? options.pkbRoot;
-          const inContext = getInContextPkbPaths(
-            options.pkbConversation,
-            options.pkbAutoInjectList ?? [],
-            options.pkbRoot,
-            workingDir,
-          );
-          const pkbRoot = options.pkbRoot;
-          // Gate on `denseScore` (cosine, [0, 1]) so the quality bar is stable
-          // regardless of whether sparse was provided. Rank by `hybridScore`
-          // (RRF) when available — that captures the sparse signal for
-          // re-ordering eligible hits. hybridScore and denseScore live on
-          // different scales, so items with hybridScore are ordered together
-          // and placed ahead of items that only have denseScore.
-          hints = results
-            .filter((r) => {
-              const abs = resolve(pkbRoot, r.path);
-              if (inContext.has(abs)) return false;
-              const threshold = r.path
-                .replace(/\\/g, "/")
-                .startsWith("archive/")
-                ? PKB_HINT_ARCHIVE_THRESHOLD
-                : PKB_HINT_THRESHOLD;
-              return r.denseScore >= threshold;
-            })
-            .sort((a, b) => {
-              const aHasHybrid = a.hybridScore !== undefined;
-              const bHasHybrid = b.hybridScore !== undefined;
-              if (aHasHybrid && !bHasHybrid) return -1;
-              if (!aHasHybrid && bHasHybrid) return 1;
-              if (aHasHybrid && bHasHybrid) {
-                return b.hybridScore! - a.hybridScore!;
-              }
-              return b.denseScore - a.denseScore;
-            })
-            .slice(0, 3)
-            .map((r) => r.path);
-        } catch (err) {
-          pkbReminderLog.warn(
-            { err: err instanceof Error ? err.message : String(err) },
-            "PKB hint search failed — falling back to flat reminder",
-          );
-          hints = [];
-        }
-      }
-
-      const reminder = buildPkbReminder(hints);
-      pkbSystemReminderCaptured = reminder;
-      // Splice the reminder in right after the memory prefix blocks so it
-      // lands above the user's typed text, producing the tail shape
-      // `[<turn_context>, <memory __injected>, <system_reminder>, ...your_text, ...later_appends]`
-      // after `unifiedTurnContext` later prepends `<turn_context>` at index 0.
-      const memoryPrefixCount = countMemoryPrefixBlocks(userTail.content);
-      result = [
-        ...result.slice(0, -1),
-        {
-          ...userTail,
-          content: [
-            ...userTail.content.slice(0, memoryPrefixCount),
-            { type: "text" as const, text: reminder },
-            ...userTail.content.slice(memoryPrefixCount),
-          ],
-        },
-      ];
-    }
-  }
-
-  if (mode === "full" && options.nowScratchpad) {
-    const userTail = result[result.length - 1];
-    if (userTail && userTail.role === "user") {
-      const injected = injectNowScratchpad(userTail, options.nowScratchpad);
-      const insertedBlock = injected.content.find(
-        (b): b is { type: "text"; text: string } =>
-          b.type === "text" &&
-          b.text.startsWith("<NOW.md Always keep this up to date"),
-      );
-      if (insertedBlock) nowScratchpadCaptured = insertedBlock.text;
-      result = [...result.slice(0, -1), injected];
     }
   }
 
@@ -2102,33 +2183,6 @@ export async function applyRuntimeInjections(
     }
   }
 
-  if (mode === "full" && options.subagentStatusBlock) {
-    const userTail = result[result.length - 1];
-    if (userTail && userTail.role === "user") {
-      result = [
-        ...result.slice(0, -1),
-        injectSubagentStatus(userTail, options.subagentStatusBlock),
-      ];
-    }
-  }
-
-  if (options.unifiedTurnContext) {
-    const userTail = result[result.length - 1];
-    if (userTail && userTail.role === "user") {
-      turnContextCaptured = options.unifiedTurnContext;
-      result = [
-        ...result.slice(0, -1),
-        {
-          ...userTail,
-          content: [
-            { type: "text" as const, text: options.unifiedTurnContext },
-            ...userTail.content,
-          ],
-        },
-      ];
-    }
-  }
-
   // Slack conversations (both channels and DMs) build their own
   // chronological transcript from persisted messages and intentionally do
   // not receive the per-turn `<transport_hints>` block — the rendered
@@ -2150,66 +2204,24 @@ export async function applyRuntimeInjections(
     }
   }
 
-  // Slack active-thread focus block: when the inbound user message lives
-  // inside a thread, append a non-persisted `<active_thread>` tail block
-  // listing that thread's parent + replies so the model can orient even
-  // when the channel-wide chronological transcript is long and
-  // interleaved. Stripped on subsequent rebuilds via the
-  // `RUNTIME_INJECTION_PREFIXES` list so focus blocks never accumulate.
-  if (
-    mode === "full" &&
-    slackChannel &&
-    typeof options.slackActiveThreadFocusBlock === "string" &&
-    options.slackActiveThreadFocusBlock.length > 0
-  ) {
-    const userTail = result[result.length - 1];
-    if (userTail && userTail.role === "user") {
-      result = [
-        ...result.slice(0, -1),
-        {
-          ...userTail,
-          content: [
-            ...userTail.content,
-            {
-              type: "text" as const,
-              text: options.slackActiveThreadFocusBlock,
-            },
-          ],
-        },
-      ];
-    }
+  // ── Step 3: apply remaining chain blocks by placement ──
+  // after-memory-prefix: ascending `order` so lower-order blocks end up
+  // closer to the memory prefix (later splices push earlier ones down).
+  for (const block of afterMemory) {
+    result = applyInjectionBlock(result, block);
   }
 
-  // Workspace top-level context is injected last so it appears first
-  // (prepended) in the user message content, keeping cache breakpoints
-  // anchored to the trailing blocks.
-  if (mode === "full" && options.workspaceTopLevelContext) {
-    const userTail = result[result.length - 1];
-    if (userTail && userTail.role === "user") {
-      workspaceCaptured = options.workspaceTopLevelContext;
-      result = [
-        ...result.slice(0, -1),
-        injectWorkspaceTopLevelContext(
-          userTail,
-          options.workspaceTopLevelContext,
-        ),
-      ];
-    }
+  // append-user-tail: ascending `order` so lower-order blocks come first
+  // in the append sequence.
+  for (const block of appends) {
+    result = applyInjectionBlock(result, block);
   }
 
-  // Plugin-registered injector chain: runs after all hardcoded branches so
-  // third-party injectors observe the same view of the turn. In this PR the
-  // default injectors placeholder-return `null`, so the composed output is
-  // an empty string unless a third-party plugin registered an injector that
-  // emits content. Skip entirely when the caller doesn't pass a
-  // `turnContext` — the composition is informational today and the absence
-  // of a context is treated as "no chain output".
-  let injectorChainBlock: string | undefined;
-  if (options.turnContext) {
-    const composed = await composeInjectorChain(options.turnContext);
-    if (composed.length > 0) {
-      injectorChainBlock = composed;
-    }
+  // prepend-user-tail: descending `order` so the lowest-order block lands
+  // topmost in the tail content (each successive prepend pushes the
+  // previous one further down).
+  for (let i = prepends.length - 1; i >= 0; i--) {
+    result = applyInjectionBlock(result, prepends[i]);
   }
 
   return {

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -1,48 +1,70 @@
 /**
- * Default runtime injector plugin — bundles the existing injection chain
- * (workspace, unified turn context, PKB, NOW.md, subagent, Slack, thread focus)
- * as {@link Injector}s with fixed `order` values that third-party plugins can
- * slot against.
+ * Default runtime injector plugin — the canonical chain of injectors that
+ * replaces the hardcoded injection sequence previously baked into
+ * `applyRuntimeInjections` (pre-migration).
  *
- * Each injector here is a thin {@link Injector} that defers to the existing
- * helpers in `conversation-runtime-assembly.ts` when invoked by the runtime
- * injection chain. `produce()` currently returns `null` because the concrete
- * per-turn inputs (the `options` bag passed to `applyRuntimeInjections`) are
- * not yet threaded through {@link TurnContext}; later PRs in the
- * agent-plugin-system plan lift each per-turn input into context state and
- * move the helper's real body into the corresponding injector.
+ * Each of the seven default injectors reads its per-turn inputs from
+ * `ctx.injectionInputs` (see {@link TurnInjectionInputs}), runs its gating
+ * conditions (injection mode, feature flags, channel type, null-input
+ * short-circuits), and returns an {@link InjectionBlock} with a
+ * {@link InjectionPlacement} that preserves the byte-for-byte positional
+ * semantics of the pre-migration `inject*` helpers:
  *
- * The value delivered by this PR is the **ordering contract**:
+ * | name                     | order | placement               |
+ * | ------------------------ | ----- | ----------------------- |
+ * | `workspace-context`      | 10    | prepend-user-tail       |
+ * | `unified-turn-context`   | 20    | prepend-user-tail       |
+ * | `pkb`                    | 30    | after-memory-prefix     |
+ * | `now-md`                 | 40    | after-memory-prefix     |
+ * | `subagent-status`        | 50    | append-user-tail        |
+ * | `slack-messages`         | 60    | replace-run-messages    |
+ * | `thread-focus`           | 70    | append-user-tail        |
  *
- * | name                     | order |
- * | ------------------------ | ----- |
- * | `workspace-context`      | 10    |
- * | `unified-turn-context`   | 20    |
- * | `pkb`                    | 30    |
- * | `now-md`                 | 40    |
- * | `subagent-status`        | 50    |
- * | `slack-messages`         | 60    |
- * | `thread-focus`           | 70    |
+ * `order` matches the intended final-content ordering: lower `order` ends
+ * up closer to the top of the user message's content (for prepends), closer
+ * to the memory prefix (for after-memory-prefix), or earlier in the tail
+ * append sequence (for appends). The runtime-injection applier sorts and
+ * applies blocks declaratively so this invariant holds even when
+ * third-party injectors slot additional blocks at fractional order values.
  *
- * Third-party plugins may register additional {@link Injector}s at
- * arbitrary `order` values; the registry's `getInjectors()` returns all
- * injectors sorted ascending by `order`, so a plugin-registered injector at
- * `order: 25` reliably slots between `unified-turn-context` (20) and `pkb`
- * (30).
+ * Third-party plugins may register additional {@link Injector}s at any
+ * `order` value; the registry's `getInjectors()` returns all injectors
+ * sorted ascending, so a plugin-registered injector at `order: 25`
+ * reliably slots between `unified-turn-context` (20) and `pkb` (30).
  *
  * Registration happens via a side-effect import in
  * `daemon/external-plugins-bootstrap.ts` so the default chain is present for
  * every assistant boot.
  *
- * Design doc: `.private/plans/agent-plugin-system.md` (PR 21).
+ * Design doc: `.private/plans/agent-plugin-system.md` (PR 21 — scaffolding,
+ * G2.1 — full migration).
  */
 
+import { resolve } from "node:path";
+
+import { getInContextPkbPaths } from "../../daemon/pkb-context-tracker.js";
+import { buildPkbReminder } from "../../daemon/pkb-reminder-builder.js";
+import { searchPkbFiles } from "../../memory/pkb/pkb-search.js";
+import { getLogger } from "../../util/logger.js";
 import type {
   InjectionBlock,
   Injector,
   Plugin,
   TurnContext,
+  TurnInjectionInputs,
 } from "../types.js";
+
+const pkbReminderLog = getLogger("pkb-reminder");
+
+/** Minimum hybrid-search score for a PKB path to surface as an injection hint. */
+const PKB_HINT_THRESHOLD = 0.5;
+
+/**
+ * Stricter hint threshold for PKB entries under `archive/`. Archive files are
+ * date-indexed dumps of older notes — they match loosely and are rarely the
+ * most relevant read, so require a higher bar before recommending them.
+ */
+const PKB_HINT_ARCHIVE_THRESHOLD = 0.7;
 
 /**
  * Fixed order values for the seven default injectors. Exported so tests —
@@ -50,8 +72,8 @@ import type {
  * the constants.
  *
  * Gaps of 10 between slots leave room for third-party injectors to slot in
- * at granular positions (e.g. `25` between PKB and subagent) without
- * renumbering the defaults.
+ * at granular positions (e.g. `25` between unified-turn-context and pkb)
+ * without renumbering the defaults.
  */
 export const DEFAULT_INJECTOR_ORDER = {
   workspaceContext: 10,
@@ -63,98 +85,352 @@ export const DEFAULT_INJECTOR_ORDER = {
   threadFocus: 70,
 } as const satisfies Record<string, number>;
 
+function readInjectionInputs(ctx: TurnContext): TurnInjectionInputs {
+  return ctx.injectionInputs ?? {};
+}
+
 /**
- * `workspace-context` injector — order 10.
+ * `workspace-context` injector — order 10, prepend-user-tail.
  *
- * Placeholder for `injectWorkspaceTopLevelContext`. Returns `null` until
- * later PRs lift workspace state onto {@link TurnContext}.
+ * Injects the workspace top-level directory context at the very top of the
+ * user tail's content so the assistant sees a workspace grounding block
+ * before any other per-turn context.
+ *
+ * Gating:
+ *  - `mode === "full"` (skipped in minimal mode).
+ *  - `workspaceTopLevelContext` is a non-null, non-empty string.
  */
 export const workspaceContextInjector: Injector = {
   name: "workspace-context",
   order: DEFAULT_INJECTOR_ORDER.workspaceContext,
-  async produce(_ctx: TurnContext): Promise<InjectionBlock | null> {
-    return null;
+  async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+    const inputs = readInjectionInputs(ctx);
+    const mode = inputs.mode ?? "full";
+    if (mode !== "full") return null;
+    const text = inputs.workspaceTopLevelContext;
+    if (!text) return null;
+    return {
+      id: "workspace-context",
+      text,
+      placement: "prepend-user-tail",
+    };
   },
 };
 
 /**
- * `unified-turn-context` injector — order 20.
+ * `unified-turn-context` injector — order 20, prepend-user-tail.
  *
- * Placeholder for `buildUnifiedTurnContextBlock`.
+ * Injects the pre-built `<turn_context>` block that combines temporal,
+ * actor, channel, and interface context. The orchestrator builds the text
+ * via `buildUnifiedTurnContextBlock` before the chain runs and hands it in
+ * via `ctx.injectionInputs.unifiedTurnContext`.
+ *
+ * Active in both `full` and `minimal` mode — unified turn context is
+ * safety-critical grounding that must survive injection downgrade.
  */
 export const unifiedTurnContextInjector: Injector = {
   name: "unified-turn-context",
   order: DEFAULT_INJECTOR_ORDER.unifiedTurnContext,
-  async produce(_ctx: TurnContext): Promise<InjectionBlock | null> {
-    return null;
+  async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+    const inputs = readInjectionInputs(ctx);
+    const text = inputs.unifiedTurnContext;
+    if (!text) return null;
+    return {
+      id: "unified-turn-context",
+      text,
+      placement: "prepend-user-tail",
+    };
   },
 };
 
 /**
- * `pkb` injector — order 30.
+ * `pkb` injector — order 30, after-memory-prefix.
  *
- * Placeholder for the PKB context / system-reminder pair emitted by
- * `injectPkbContext` and `buildPkbReminder`.
+ * Combines the `<system_reminder>` (PKB behavioural nudge + hybrid-search
+ * hints) and the `<knowledge_base>` block (auto-injected PKB content) into
+ * a single block spliced immediately after any leading memory-prefix blocks
+ * so the final tail shape reads
+ * `[...memory prefix, <system_reminder>, <knowledge_base>, ...user text]`.
+ *
+ * Emitting both as one block preserves the ordering of the pre-migration
+ * two-branch implementation (context splice first, reminder splice second)
+ * without requiring two after-memory-prefix splice passes through the
+ * message array. Third-party injectors that want to separate the two can
+ * do so by omitting the `<system_reminder>` half when overriding.
+ *
+ * Gating:
+ *  - `mode === "full"` for both halves.
+ *  - `<knowledge_base>` — non-null `pkbContext`.
+ *  - `<system_reminder>` — `pkbActive === true`.
+ *  - Returns `null` when neither applies.
  */
 export const pkbInjector: Injector = {
   name: "pkb",
   order: DEFAULT_INJECTOR_ORDER.pkb,
-  async produce(_ctx: TurnContext): Promise<InjectionBlock | null> {
-    return null;
+  async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+    const inputs = readInjectionInputs(ctx);
+    const mode = inputs.mode ?? "full";
+    if (mode !== "full") return null;
+
+    const hasContext = !!inputs.pkbContext;
+    const hasReminder = !!inputs.pkbActive;
+    if (!hasContext && !hasReminder) return null;
+
+    const parts: string[] = [];
+
+    // Reminder appears first in the spliced block (matches pre-migration
+    // behaviour where the reminder was inserted second, pushing the
+    // previously-inserted context down).
+    if (hasReminder) {
+      const reminder = await buildPkbReminderWithHints(inputs);
+      parts.push(reminder);
+    }
+
+    if (hasContext) {
+      const contextBlock = buildPkbContextBlock(inputs.pkbContext!);
+      parts.push(contextBlock);
+    }
+
+    // Join reminder + context with a blank-line separator so the
+    // combined block renders as two logical sections — matches the
+    // pre-migration behaviour where they were two separate content
+    // blocks separated by the tokenizer's default inter-block newline.
+    return {
+      id: "pkb",
+      text: parts.join("\n\n"),
+      placement: "after-memory-prefix",
+    };
   },
 };
 
 /**
- * `now-md` injector — order 40.
+ * Render the PKB context block — wraps the raw content in
+ * `<knowledge_base>...</knowledge_base>` while escaping any closing tags
+ * inside the content that would break out of the XML wrapper. Mirrors the
+ * body of the pre-migration `injectPkbContext` helper exactly so the emitted
+ * bytes match.
+ */
+function buildPkbContextBlock(content: string): string {
+  const escaped = content.replace(
+    /<\/knowledge_base\s*>/gi,
+    "&lt;/knowledge_base&gt;",
+  );
+  return `<knowledge_base>\n${escaped}\n</knowledge_base>`;
+}
+
+/**
+ * Build the PKB `<system_reminder>` text. When a dense query vector plus
+ * enough scope metadata is available, run the hybrid PKB search to
+ * surface up to three relevance hints; fall back to the flat static
+ * reminder on empty results or any error.
  *
- * Placeholder for `injectNowScratchpad`.
+ * Lifted verbatim from the pre-migration `applyRuntimeInjections` branch
+ * so the emitted bytes match.
+ */
+async function buildPkbReminderWithHints(
+  inputs: TurnInjectionInputs,
+): Promise<string> {
+  let hints: string[] = [];
+  const queryVector = inputs.pkbQueryVector;
+  if (
+    queryVector &&
+    queryVector.length > 0 &&
+    inputs.pkbScopeId &&
+    inputs.pkbConversation &&
+    inputs.pkbRoot
+  ) {
+    try {
+      const results = await searchPkbFiles(
+        queryVector,
+        inputs.pkbSparseVector,
+        8,
+        [inputs.pkbScopeId],
+      );
+      const workingDir = inputs.pkbWorkingDir ?? inputs.pkbRoot;
+      const inContext = getInContextPkbPaths(
+        inputs.pkbConversation,
+        inputs.pkbAutoInjectList ?? [],
+        inputs.pkbRoot,
+        workingDir,
+      );
+      const pkbRoot = inputs.pkbRoot;
+      // Gate on `denseScore` (cosine, [0, 1]) so the quality bar is stable
+      // regardless of whether sparse was provided. Rank by `hybridScore`
+      // (RRF) when available — that captures the sparse signal for
+      // re-ordering eligible hits. hybridScore and denseScore live on
+      // different scales, so items with hybridScore are ordered together
+      // and placed ahead of items that only have denseScore.
+      hints = results
+        .filter((r) => {
+          const abs = resolve(pkbRoot, r.path);
+          if (inContext.has(abs)) return false;
+          const threshold = r.path.replace(/\\/g, "/").startsWith("archive/")
+            ? PKB_HINT_ARCHIVE_THRESHOLD
+            : PKB_HINT_THRESHOLD;
+          return r.denseScore >= threshold;
+        })
+        .sort((a, b) => {
+          const aHasHybrid = a.hybridScore !== undefined;
+          const bHasHybrid = b.hybridScore !== undefined;
+          if (aHasHybrid && !bHasHybrid) return -1;
+          if (!aHasHybrid && bHasHybrid) return 1;
+          if (aHasHybrid && bHasHybrid) {
+            return b.hybridScore! - a.hybridScore!;
+          }
+          return b.denseScore - a.denseScore;
+        })
+        .slice(0, 3)
+        .map((r) => r.path);
+    } catch (err) {
+      pkbReminderLog.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "PKB hint search failed — falling back to flat reminder",
+      );
+      hints = [];
+    }
+  }
+  return buildPkbReminder(hints);
+}
+
+/**
+ * `now-md` injector — order 40, after-memory-prefix.
+ *
+ * Injects the NOW.md scratchpad content as
+ * `<NOW.md Always keep this up to date; keep under 10 lines>...` after any
+ * memory-prefix blocks.
+ *
+ * Gating:
+ *  - `mode === "full"` (skipped in minimal mode).
+ *  - `nowScratchpad` is a non-null, non-empty string.
  */
 export const nowMdInjector: Injector = {
   name: "now-md",
   order: DEFAULT_INJECTOR_ORDER.nowMd,
-  async produce(_ctx: TurnContext): Promise<InjectionBlock | null> {
-    return null;
+  async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+    const inputs = readInjectionInputs(ctx);
+    const mode = inputs.mode ?? "full";
+    if (mode !== "full") return null;
+    const content = inputs.nowScratchpad;
+    if (!content) return null;
+    const text = `<NOW.md Always keep this up to date; keep under 10 lines>\n${content}\n</NOW.md>`;
+    return {
+      id: "now-md",
+      text,
+      placement: "after-memory-prefix",
+    };
   },
 };
 
 /**
- * `subagent-status` injector — order 50.
+ * `subagent-status` injector — order 50, append-user-tail.
  *
- * Placeholder for `injectSubagentStatus` / `buildSubagentStatusBlock`.
+ * Appends a pre-built `<active_subagents>` block to the tail user message
+ * so the parent LLM has visibility into active/completed child subagents.
+ *
+ * The orchestrator builds the block via `buildSubagentStatusBlock` before
+ * the chain runs; this injector is a thin passthrough that applies gating
+ * and positioning.
+ *
+ * Gating:
+ *  - `mode === "full"`.
+ *  - `subagentStatusBlock` is a non-null, non-empty string.
  */
 export const subagentStatusInjector: Injector = {
   name: "subagent-status",
   order: DEFAULT_INJECTOR_ORDER.subagentStatus,
-  async produce(_ctx: TurnContext): Promise<InjectionBlock | null> {
-    return null;
+  async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+    const inputs = readInjectionInputs(ctx);
+    const mode = inputs.mode ?? "full";
+    if (mode !== "full") return null;
+    const block = inputs.subagentStatusBlock;
+    if (!block) return null;
+    return {
+      id: "subagent-status",
+      text: block,
+      placement: "append-user-tail",
+    };
   },
 };
 
 /**
- * `slack-messages` injector — order 60.
+ * `slack-messages` injector — order 60, replace-run-messages.
  *
- * Placeholder for the Slack chronological-transcript override assembled by
- * `assembleSlackChronologicalMessages`.
+ * Swaps the conversation's `runMessages` array with a pre-rendered
+ * chronological Slack transcript built from the persisted message rows.
+ * Applied to every Slack conversation (channels and DMs alike). The
+ * orchestrator builds the transcript via `loadSlackChronologicalMessages`
+ * before the chain runs.
+ *
+ * The injector preserves the pre-migration memory-block prepending
+ * behaviour: `extractMemoryPrefixBlocks` is re-applied to the Slack
+ * transcript's tail user message inside `applyRuntimeInjections` when the
+ * replacement fires.
+ *
+ * Active in both `full` and `minimal` mode — Slack transcript replacement
+ * is not a high-token optional block, it's the canonical view of Slack
+ * history for the model.
+ *
+ * Gating:
+ *  - `channelCapabilities.channel === "slack"`.
+ *  - `slackChronologicalMessages` has at least one entry.
  */
 export const slackMessagesInjector: Injector = {
   name: "slack-messages",
   order: DEFAULT_INJECTOR_ORDER.slackMessages,
-  async produce(_ctx: TurnContext): Promise<InjectionBlock | null> {
-    return null;
+  async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+    const inputs = readInjectionInputs(ctx);
+    if (inputs.channelCapabilities?.channel !== "slack") return null;
+    const messages = inputs.slackChronologicalMessages;
+    if (!messages || messages.length === 0) return null;
+    return {
+      id: "slack-messages",
+      // `text` is informational only — `replace-run-messages` placements
+      // bypass the tail-user-message splice path. Kept non-empty so
+      // `composeInjectorChain` (text-only consumers) still counts this
+      // injector as contributing content.
+      text: "[slack-chronological-transcript]",
+      placement: "replace-run-messages",
+      messagesOverride: messages,
+    };
   },
 };
 
 /**
- * `thread-focus` injector — order 70.
+ * `thread-focus` injector — order 70, append-user-tail.
  *
- * Placeholder for the Slack `<active_thread>` tail block assembled by
- * `assembleSlackActiveThreadFocusBlock`.
+ * Appends a non-persisted `<active_thread>` block listing the parent +
+ * replies of the thread the current inbound user message belongs to, so
+ * the model can orient even when the channel-wide chronological transcript
+ * is long and interleaved.
+ *
+ * The orchestrator builds the block via `loadSlackActiveThreadFocusBlock`
+ * (which short-circuits for DMs). This injector wraps the value so the
+ * block is applied declaratively through the chain.
+ *
+ * Gating:
+ *  - `mode === "full"`.
+ *  - `channelCapabilities.channel === "slack"` and `chatType === "channel"`
+ *    (non-DM Slack conversation).
+ *  - `slackActiveThreadFocusBlock` is a non-empty string.
  */
 export const threadFocusInjector: Injector = {
   name: "thread-focus",
   order: DEFAULT_INJECTOR_ORDER.threadFocus,
-  async produce(_ctx: TurnContext): Promise<InjectionBlock | null> {
-    return null;
+  async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+    const inputs = readInjectionInputs(ctx);
+    const mode = inputs.mode ?? "full";
+    if (mode !== "full") return null;
+    const caps = inputs.channelCapabilities;
+    if (!caps || caps.channel !== "slack" || caps.chatType !== "channel") {
+      return null;
+    }
+    const block = inputs.slackActiveThreadFocusBlock;
+    if (typeof block !== "string" || block.length === 0) return null;
+    return {
+      id: "thread-focus",
+      text: block,
+      placement: "append-user-tail",
+    };
   },
 };
 

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -23,11 +23,16 @@ import type {
 } from "../context/window-manager.js";
 import type { ReducerState } from "../daemon/context-overflow-reducer.js";
 import type {
+  ActiveSurfaceContext,
+  ChannelCapabilities,
+  ChannelCommandContext,
   InjectionMode,
   TrustContext,
 } from "../daemon/conversation-runtime-assembly.js";
 import type { RepairResult } from "../daemon/history-repair.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { PkbContextConversation } from "../daemon/pkb-context-tracker.js";
+import type { QdrantSparseVector } from "../memory/qdrant-client.js";
 import type {
   ContentBlock,
   Message,
@@ -730,6 +735,98 @@ export interface PipelineMiddlewareMap {
 // ─── TurnContext ─────────────────────────────────────────────────────────────
 
 /**
+ * Per-turn injection inputs threaded to every {@link Injector}.
+ *
+ * These fields carry the text, gating state, and PKB-search parameters that
+ * the orchestrator resolves once per turn and hands to the injector chain so
+ * each default injector can derive its own {@link InjectionBlock} output.
+ *
+ * The orchestrator populates this bag inside
+ * `buildPluginTurnContextWithInjectionInputs` (called from
+ * `conversation-agent-loop.ts` right before `applyRuntimeInjections`). Call
+ * sites that synthesize a {@link TurnContext} outside of the agent loop
+ * (tests, overflow-reducer reinjection, etc.) may omit the bag entirely —
+ * every field is optional and every default injector treats a missing input
+ * as "no injection on this turn".
+ */
+export interface TurnInjectionInputs {
+  /**
+   * Controls which runtime injections are applied. `"full"` (default) runs
+   * every gating branch; `"minimal"` skips high-token optional blocks
+   * (workspace, PKB, NOW.md, subagent status) and only emits safety-critical
+   * context (unified turn context, etc.). Drives per-injector gating.
+   */
+  readonly mode?: InjectionMode;
+  /** Workspace top-level context text (`<workspace>...`) or null to skip. */
+  readonly workspaceTopLevelContext?: string | null;
+  /** Pre-built unified-turn-context text (`<turn_context>...`) or null to skip. */
+  readonly unifiedTurnContext?: string | null;
+  /** PKB auto-injected content (`<knowledge_base>...`) or null to skip. */
+  readonly pkbContext?: string | null;
+  /**
+   * Whether PKB is active for this turn — drives the `<system_reminder>` /
+   * hybrid-search relevance-hint branch.
+   */
+  readonly pkbActive?: boolean;
+  /** Dense query vector surfaced from the graph memory retriever for PKB hints. */
+  readonly pkbQueryVector?: number[];
+  /** Optional sparse vector accompanying `pkbQueryVector`. */
+  readonly pkbSparseVector?: QdrantSparseVector;
+  /** Memory scope id used to filter PKB search results. */
+  readonly pkbScopeId?: string;
+  /**
+   * Live conversation (or a minimal shape containing `messages`) used to
+   * compute which PKB paths are already "in context" and therefore suppressed
+   * from hint suggestions.
+   */
+  readonly pkbConversation?: PkbContextConversation;
+  /** Auto-injected PKB filenames resolved relative to `pkbRoot`. */
+  readonly pkbAutoInjectList?: string[];
+  /** Absolute path to the PKB directory (e.g. `<workspace>/pkb`). */
+  readonly pkbRoot?: string;
+  /**
+   * Working directory against which relative `file_read` paths resolve.
+   * Falls back to `pkbRoot` when omitted.
+   */
+  readonly pkbWorkingDir?: string;
+  /** NOW.md scratchpad content or null to skip. */
+  readonly nowScratchpad?: string | null;
+  /** Pre-built `<active_subagents>` block or null to skip. */
+  readonly subagentStatusBlock?: string | null;
+  /** Channel capabilities — drives slack gating. */
+  readonly channelCapabilities?: ChannelCapabilities | null;
+  /**
+   * Pre-rendered Slack chronological transcript that overrides `runMessages`
+   * for any Slack conversation (channels and DMs alike). Null/undefined means
+   * the default `runMessages` array is used unchanged.
+   */
+  readonly slackChronologicalMessages?: Message[] | null;
+  /**
+   * Pre-rendered `<active_thread>` focus block to append to the final user
+   * turn when the inbound lives inside a Slack thread. Null/undefined means
+   * no focus block is appended.
+   */
+  readonly slackActiveThreadFocusBlock?: string | null;
+  /**
+   * Active dashboard-surface context (read from `<active_workspace>`). Kept
+   * on the injection inputs bag (not its own injector) because it is
+   * orchestrator-owned surface state, not a default-chain element.
+   */
+  readonly activeSurface?: ActiveSurfaceContext | null;
+  /** Channel command context (e.g. Telegram /start) or null to skip. */
+  readonly channelCommandContext?: ChannelCommandContext | null;
+  /** Voice call-control prompt or null to skip. */
+  readonly voiceCallControlPrompt?: string | null;
+  /** Gateway-provided transport hints (e.g. Slack thread context). */
+  readonly transportHints?: string[] | null;
+  /**
+   * When true, inject the `<non_interactive_context>` block so the model
+   * knows no human is present to answer clarification questions.
+   */
+  readonly isNonInteractive?: boolean;
+}
+
+/**
  * Per-turn execution context threaded through every middleware invocation.
  *
  * Combines turn-level identifiers (`requestId`, `conversationId`,
@@ -772,23 +869,83 @@ export interface TurnContext {
    * construct valid `TurnContext` literals without attaching a manager.
    */
   contextWindowManager?: ContextWindowManager;
+  /**
+   * Per-turn injection inputs consumed by the default injector chain.
+   *
+   * Omitted for call sites that don't drive runtime injection (pipeline-runner
+   * tests, synthesized handler contexts, some background jobs). Each default
+   * injector treats missing/absent fields as "no injection on this turn", so
+   * a context without `injectionInputs` produces an empty injection chain.
+   */
+  injectionInputs?: TurnInjectionInputs;
 }
 
 // ─── Injectors ───────────────────────────────────────────────────────────────
 
 /**
- * A structured fragment injected into the system prompt (or a comparable
- * assembly point). Concrete shape is intentionally loose at this stage; M2
- * PRs refine it into a tagged block with deterministic ordering semantics.
+ * Where an {@link InjectionBlock} should be grafted onto the per-turn
+ * `runMessages` array.
+ *
+ * - `"prepend-user-tail"` — prepend the block as a `text` content block to
+ *   the tail user message's `content` array. Used when the block should
+ *   appear before any other user content on this turn (e.g. the unified
+ *   turn context, workspace top-level context).
+ * - `"append-user-tail"` — append the block as a `text` content block to
+ *   the tail user message. Used for blocks that should sit *after* the
+ *   user's typed text (e.g. subagent status, slack active-thread focus).
+ * - `"after-memory-prefix"` — insert the block immediately after any leading
+ *   memory-prefix blocks (`<memory_context>`, `<memory __injected>`) on the
+ *   tail user message. Preserves the splice behaviour of `injectPkbContext`
+ *   and `injectNowScratchpad` so memory/PKB/NOW ordering matches the
+ *   pre-migration output byte-for-byte.
+ * - `"replace-run-messages"` — replace the full `runMessages` array with the
+ *   block's `messagesOverride`. Used by the Slack chronological-transcript
+ *   injector (the transcript is a whole new message list rendered from the
+ *   persisted rows, not a tail-block mutation).
  */
-export type InjectionBlock = {
+export type InjectionPlacement =
+  | "prepend-user-tail"
+  | "append-user-tail"
+  | "after-memory-prefix"
+  | "replace-run-messages";
+
+/**
+ * A structured fragment contributed by an {@link Injector}.
+ *
+ * Each block carries the rendered `text` plus a {@link InjectionPlacement}
+ * that tells `applyRuntimeInjections` where to graft it onto the per-turn
+ * message array. The placement vocabulary preserves the positional
+ * semantics of the hardcoded `inject*` helpers the default injectors
+ * replaced — prepends, appends, and splices relative to memory-prefix
+ * blocks all remain expressible.
+ *
+ * `placement` defaults to `"append-user-tail"` when omitted so the existing
+ * ordering-contract tests (PR 21) that produce `{ id, text }` blocks
+ * continue to compose via `composeInjectorChain` into a single
+ * blank-line-separated string.
+ *
+ * `messagesOverride` is only consulted for `"replace-run-messages"` — other
+ * placements ignore it.
+ */
+export interface InjectionBlock {
   /** Stable block identifier (used for dedupe/ordering). */
   readonly id: string;
   /** Plain-text body to insert. */
   readonly text: string;
+  /**
+   * Position within the tail user message (or the full runMessages array,
+   * for `"replace-run-messages"`). Defaults to `"append-user-tail"` when
+   * omitted.
+   */
+  readonly placement?: InjectionPlacement;
+  /**
+   * Replacement `runMessages` value for `"replace-run-messages"` placements.
+   * Required when `placement === "replace-run-messages"`; ignored otherwise.
+   */
+  readonly messagesOverride?: Message[];
   /** Optional metadata the renderer may use. */
   readonly meta?: Readonly<Record<string, unknown>>;
-};
+}
 
 /**
  * A named producer of {@link InjectionBlock}s.


### PR DESCRIPTION
## Summary
- G2.1: replace the hardcoded 7-branch injection sequence in applyRuntimeInjections with the Injector chain established in PR 21.
- Widen TurnContext to carry per-turn injection inputs (workspace, subagent, thread focus, etc.).
- Port each hardcoded branch into its corresponding Injector.produce() body (workspace, unified turn context, PKB, NOW, subagent status, slack, thread focus).
- Delete the now-unused hardcoded injection helpers (only injection-path callers; non-injection consumers of readPkbContext etc. are unchanged).
- Golden-path test asserts the composed output matches the pre-PR hardcoded output byte-for-byte.
- Third-party injector slotting test asserts plugin-contributed injectors appear at their declared order.

Part of plan: agent-plugin-system.md (remediation round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
