### PR TITLE
fix(assistant): test-setup regression — resetPluginRegistryForTests now registers defaults

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -18,11 +18,7 @@ import type {
   CheckpointInfo,
 } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
-import { defaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
-import {
-  registerPlugin,
-  resetPluginRegistryForTests,
-} from "../plugins/registry.js";
+import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 
 // ── Module mocks (must precede imports of the module under test) ─────
@@ -573,12 +569,11 @@ beforeEach(() => {
   mockOverflowAction = "fail_gracefully";
   mockApplyRuntimeInjections = (msgs) => msgs;
   recordUsageMock.mockClear();
-  // Reset the plugin registry and re-register the default overflow-reduce
-  // plugin so the pipeline dispatches to it — the orchestrator routes the
-  // preflight reducer through `runPipeline("overflowReduce", …)` which
-  // needs the default in place to reach the mocked `reduceContextOverflow`.
-  resetPluginRegistryForTests();
-  registerPlugin(defaultOverflowReducePlugin);
+  // Reset the plugin registry and re-register every default so the
+  // orchestrator's pipelines (`overflowReduce`, `persistence`, …) dispatch to
+  // the default middleware, which in turn hits the mocked collaborators
+  // (`reduceContextOverflow`, `syncMessageToDisk`, …) these tests install.
+  resetPluginRegistryAndRegisterDefaults();
 });
 
 describe("session-agent-loop overflow recovery (JARVIS-110)", () => {

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -6,11 +6,7 @@ import type {
   CheckpointInfo,
 } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
-import { defaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
-import {
-  registerPlugin,
-  resetPluginRegistryForTests,
-} from "../plugins/registry.js";
+import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 
 // ── Module mocks (must precede imports of the module under test) ─────
@@ -520,11 +516,12 @@ beforeEach(() => {
     () => {},
   );
   applyRuntimeInjectionsMock.mockClear();
-  // Orchestrator overflow reduction runs through the plugin pipeline; reset
-  // and re-register the default plugin so the pipeline dispatches to the
-  // mocked `reduceContextOverflow` that these tests rely on.
-  resetPluginRegistryForTests();
-  registerPlugin(defaultOverflowReducePlugin);
+  // Orchestrator pipelines (overflowReduce, persistence, …) run through the
+  // plugin registry; reset and re-register every default so the pipelines
+  // dispatch to middleware backed by the mocked collaborators these tests
+  // install (`reduceContextOverflow`, `syncMessageToDisk`, etc.) instead of
+  // hitting the bare terminals.
+  resetPluginRegistryAndRegisterDefaults();
 });
 
 describe("session-agent-loop", () => {

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -2,11 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { AgentEvent } from "../agent/loop.js";
 import type { UserMessageAttachment } from "../daemon/message-protocol.js";
-import { defaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
-import {
-  registerPlugin,
-  resetPluginRegistryForTests,
-} from "../plugins/registry.js";
+import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 import { ProviderError } from "../util/errors.js";
 
@@ -452,13 +448,12 @@ describe("provider ordering error retry", () => {
     firstRunErrorMode = "ordering";
     maybeCompactCalls = [];
     forceCompactionEnabled = false;
-    // Orchestrator overflow reduction runs through the plugin pipeline;
-    // ensure the default plugin is registered so the pipeline has a
-    // middleware to dispatch to (the `context-overflow-reducer` module
-    // itself is mocked above, so the default plugin's delegate goes
-    // through the mocked implementation).
-    resetPluginRegistryForTests();
-    registerPlugin(defaultOverflowReducePlugin);
+    // Orchestrator pipelines (`overflowReduce`, `persistence`, …) run through
+    // the plugin registry; re-register every default so each pipeline has a
+    // middleware to dispatch to. The `context-overflow-reducer` module itself
+    // (and other collaborators) are mocked above, so the default plugins'
+    // delegates go through the mocked implementations.
+    resetPluginRegistryAndRegisterDefaults();
   });
 
   test("simulated strict provider error triggers exactly one retry", async () => {

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -7,10 +7,9 @@
  * {@link bootstrapPlugins} runs, the registry has been fully populated for
  * this boot cycle. This function:
  *
- * 1. Registers the canonical first-party default plugins (one per pipeline
- *    that has been wrapped so far — currently only `toolExecute` via
- *    {@link defaultToolExecutePlugin}). Registration is idempotent so
- *    repeat calls (e.g. during integration tests) do not throw.
+ * 1. Registers the canonical first-party default plugins via
+ *    {@link registerDefaultPlugins} (one per pipeline). Registration is
+ *    idempotent so repeat calls (e.g. during integration tests) do not throw.
  * 2. Walks {@link getRegisteredPlugins} in registration order.
  * 3. For each plugin, consults `manifest.requiresFlag` against
  *    {@link isAssistantFeatureFlagEnabled}. If any listed flag is disabled,
@@ -53,20 +52,7 @@ import { join } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../config/schema.js";
-import { defaultCircuitBreakerPlugin } from "../plugins/defaults/circuit-breaker.js";
-import { defaultCompactionPlugin } from "../plugins/defaults/compaction.js";
-import { defaultEmptyResponsePlugin } from "../plugins/defaults/empty-response.js";
-import { defaultHistoryRepairPlugin } from "../plugins/defaults/history-repair.js";
-import { defaultInjectorsPlugin } from "../plugins/defaults/injectors.js";
-import { defaultLlmCallPlugin } from "../plugins/defaults/llm-call.js";
-import { defaultMemoryRetrievalPlugin } from "../plugins/defaults/memory-retrieval.js";
-import { defaultOverflowReducePlugin } from "../plugins/defaults/overflow-reduce.js";
-import { defaultPersistencePlugin } from "../plugins/defaults/persistence.js";
-import { defaultTitleGeneratePlugin } from "../plugins/defaults/title-generate.js";
-import { defaultTokenEstimatePlugin } from "../plugins/defaults/token-estimate.js";
-import { defaultToolErrorPlugin } from "../plugins/defaults/tool-error.js";
-import { defaultToolExecutePlugin } from "../plugins/defaults/tool-execute.js";
-import { defaultToolResultTruncatePlugin } from "../plugins/defaults/tool-result-truncate.js";
+import { registerDefaultPlugins } from "../plugins/defaults/index.js";
 import {
   registerPluginSkills,
   unregisterPluginSkills,
@@ -74,7 +60,6 @@ import {
 import {
   ASSISTANT_API_VERSIONS,
   getRegisteredPlugins,
-  registerPlugin,
 } from "../plugins/registry.js";
 import {
   type Plugin,
@@ -177,50 +162,6 @@ function ensurePluginStorageDir(pluginName: string): string {
   const dir = join(vellumRoot(), "plugins-data", pluginName);
   mkdirSync(dir, { recursive: true });
   return dir;
-}
-
-/**
- * Register every first-party default plugin. Called from `bootstrapPlugins`
- * before enumerating the registry so the defaults are always present when
- * the daemon serves traffic. Each registration is guarded by a
- * `registeredPlugins` lookup via try/catch — the registry throws
- * `PluginExecutionError` on duplicate names, which we treat as "already
- * registered" so repeated bootstrap calls (notably in integration tests
- * that reuse a warmed-up registry) do not fail.
- */
-function registerDefaultPlugins(): void {
-  const defaults = [
-    defaultLlmCallPlugin,
-    defaultToolExecutePlugin,
-    defaultToolResultTruncatePlugin,
-    defaultEmptyResponsePlugin,
-    defaultToolErrorPlugin,
-    defaultMemoryRetrievalPlugin,
-    defaultInjectorsPlugin,
-    defaultTokenEstimatePlugin,
-    defaultOverflowReducePlugin,
-    defaultHistoryRepairPlugin,
-    defaultCompactionPlugin,
-    defaultCircuitBreakerPlugin,
-    defaultPersistencePlugin,
-    defaultTitleGeneratePlugin,
-  ];
-  for (const plugin of defaults) {
-    try {
-      registerPlugin(plugin);
-    } catch (err) {
-      // Duplicate-name registrations surface as PluginExecutionError with a
-      // specific "already registered" substring. Swallow that one case —
-      // every other error (shape failure, version mismatch) re-throws.
-      if (
-        err instanceof PluginExecutionError &&
-        err.message.includes("already registered")
-      ) {
-        continue;
-      }
-      throw err;
-    }
-  }
 }
 
 /**

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -1,0 +1,97 @@
+/**
+ * Aggregate export of the canonical first-party default plugins.
+ *
+ * Each default wraps one of the assistant's built-in pipelines with a
+ * passthrough implementation so the pipeline shape is always explicit at boot
+ * and at test time, even when no third-party plugins are loaded. The list is
+ * the single source of truth consumed by:
+ *
+ * - `daemon/external-plugins-bootstrap.ts` — production/registry boot path;
+ *   calls {@link registerDefaultPlugins} inside `bootstrapPlugins()`.
+ * - integration tests that reset the registry and then need a
+ *   production-parity state (e.g. `conversation-agent-loop.test.ts`); those
+ *   call {@link resetPluginRegistryAndRegisterDefaults}.
+ *
+ * Keeping the list here — rather than inline in the bootstrap — avoids a
+ * circular import between `plugins/registry.ts` and the bootstrap module and
+ * keeps the defaults colocated with the other plugin-layer exports.
+ */
+
+import { registerPlugin, resetPluginRegistryForTests } from "../registry.js";
+import { type Plugin, PluginExecutionError } from "../types.js";
+import { defaultCircuitBreakerPlugin } from "./circuit-breaker.js";
+import { defaultCompactionPlugin } from "./compaction.js";
+import { defaultEmptyResponsePlugin } from "./empty-response.js";
+import { defaultHistoryRepairPlugin } from "./history-repair.js";
+import { defaultInjectorsPlugin } from "./injectors.js";
+import { defaultLlmCallPlugin } from "./llm-call.js";
+import { defaultMemoryRetrievalPlugin } from "./memory-retrieval.js";
+import { defaultOverflowReducePlugin } from "./overflow-reduce.js";
+import { defaultPersistencePlugin } from "./persistence.js";
+import { defaultTitleGeneratePlugin } from "./title-generate.js";
+import { defaultTokenEstimatePlugin } from "./token-estimate.js";
+import { defaultToolErrorPlugin } from "./tool-error.js";
+import { defaultToolExecutePlugin } from "./tool-execute.js";
+import { defaultToolResultTruncatePlugin } from "./tool-result-truncate.js";
+
+/**
+ * Canonical list of first-party default plugins, in the order they should be
+ * registered at boot. Registration order drives middleware composition order
+ * in the pipeline runner, so additions should be appended — not inserted —
+ * unless the plan explicitly requires a different position.
+ */
+export const ALL_DEFAULT_PLUGINS: readonly Plugin[] = [
+  defaultLlmCallPlugin,
+  defaultToolExecutePlugin,
+  defaultToolResultTruncatePlugin,
+  defaultEmptyResponsePlugin,
+  defaultToolErrorPlugin,
+  defaultMemoryRetrievalPlugin,
+  defaultInjectorsPlugin,
+  defaultTokenEstimatePlugin,
+  defaultOverflowReducePlugin,
+  defaultHistoryRepairPlugin,
+  defaultCompactionPlugin,
+  defaultCircuitBreakerPlugin,
+  defaultPersistencePlugin,
+  defaultTitleGeneratePlugin,
+];
+
+/**
+ * Register every first-party default plugin. Idempotent — duplicate-name
+ * registrations (which the registry surfaces as `PluginExecutionError` with
+ * an "already registered" message) are swallowed so repeat bootstrap or test
+ * setup calls do not throw. Every other error (shape failure, version
+ * mismatch) re-throws.
+ */
+export function registerDefaultPlugins(): void {
+  for (const plugin of ALL_DEFAULT_PLUGINS) {
+    try {
+      registerPlugin(plugin);
+    } catch (err) {
+      if (
+        err instanceof PluginExecutionError &&
+        err.message.includes("already registered")
+      ) {
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Test-only helper: clear the plugin registry and re-register every default
+ * so integration tests that exercise the full agent loop have a
+ * production-parity plugin stack. Use this in `beforeEach` of tests that
+ * dispatch through pipelines with a terminal that assumes the default
+ * plugin handles every op (e.g. persistence, overflowReduce).
+ *
+ * Tests that specifically need an empty registry (pipeline-unit tests, the
+ * plugin-registry tests themselves) should continue to call
+ * {@link resetPluginRegistryForTests} directly.
+ */
+export function resetPluginRegistryAndRegisterDefaults(): void {
+  resetPluginRegistryForTests();
+  registerDefaultPlugins();
+}


### PR DESCRIPTION
## Summary
After the plan consolidated every default's registration into registerDefaultPlugins() (inside bootstrapPlugins), tests that called resetPluginRegistryForTests() without then calling bootstrapPlugins ended up with an empty registry. Pipeline terminals (persistenceTerminal, overflowReduce terminal, etc.) throw in that state, producing ~30 test failures across conversation-agent-loop, overflow, and provider-retry-repair tests.

Fix: Option B — extract the canonical default-plugin list and registrar into a new plugins/defaults/index.ts module, and add a sibling test helper resetPluginRegistryAndRegisterDefaults() that resets the registry and then re-registers every default. The three affected integration tests now call that helper (instead of reset + register a single default), giving them a production-parity plugin stack so pipeline dispatch lands on real default middleware backed by the tests' already-mocked collaborators. Daemon bootstrap now imports registerDefaultPlugins() from the new module; the bootstrap's local copy of the list is deleted.

Chose B over A (making reset register defaults by default with an opt-out) because the majority of tests calling resetPluginRegistryForTests (pipeline-unit, plugin-registry, plugin-bootstrap) legitimately want an empty registry. Inverting that semantic would have forced ~24 tests to opt out. B touches only the 3 integration tests that need full defaults and leaves every other test's semantics unchanged. It also avoids any circular-import risk between registry.ts and the defaults list.

All previously-failing tests now pass. Registry tests that want an intentionally-empty registry keep calling resetPluginRegistryForTests() directly — no opt-out needed.

Part of plan: agent-plugin-system.md (remediation round 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
