### PR TITLE
fix(meet-chat): structural fallback for chat reader + drift diagnostic

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/chat.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/chat.test.ts
@@ -435,6 +435,192 @@ describe("startChatReader", () => {
   });
 });
 
+describe("startChatReader — structural fallback (live Meet DOM shape)", () => {
+  let reader: { stop: () => void } | null = null;
+  let installed: InstalledDom | null = null;
+
+  /**
+   * Append a chat message shaped like live Meet's current DOM:
+   * `role="listitem"` with NO `data-message-id`, and sender/timestamp/text
+   * carried on plain <span>/<time>/<div> children with no data-*
+   * markers. The fixture-shaped `appendMessage` helper always emits those
+   * attrs, so structural-fallback coverage needs its own builder.
+   *
+   * The list's aria-label is swapped to "In-call messages" (what live Meet
+   * ships today) before the first append so the structural selector in
+   * `chatSelectors.MESSAGE_NODE` also exercises the case-insensitive
+   * aria-label-substring match.
+   */
+  function appendStructuralMessage(
+    sender: string,
+    text: string,
+    opts: { datetime?: string } = {},
+  ): void {
+    const dom = installed!.dom;
+    const document = dom.window.document;
+    let list = document.querySelector(chatSelectors.MESSAGE_LIST);
+    if (!list) {
+      // Panel closed — relying on fixture invariants would call
+      // `ensurePanelOpen()` in production; for this test we just mount a
+      // fresh list under the aside directly.
+      const aside = document.querySelector("aside");
+      const fresh = document.createElement("div");
+      fresh.setAttribute("role", "list");
+      fresh.setAttribute("aria-label", "In-call messages");
+      aside?.insertBefore(fresh, aside.firstChild);
+      list = fresh;
+    } else {
+      // Swap the pre-existing list's label so the structural aria-label
+      // matcher fires against both common Meet shipped values.
+      list.setAttribute("aria-label", "In-call messages");
+    }
+    const node = document.createElement("div");
+    node.setAttribute("role", "listitem");
+    const senderEl = document.createElement("span");
+    senderEl.textContent = sender;
+    const timeEl = document.createElement("time");
+    timeEl.setAttribute("datetime", opts.datetime ?? new Date().toISOString());
+    timeEl.textContent = "12:00 PM";
+    const bubble = document.createElement("div");
+    const textEl = document.createElement("div");
+    textEl.textContent = text;
+    bubble.appendChild(textEl);
+    node.appendChild(senderEl);
+    node.appendChild(timeEl);
+    node.appendChild(bubble);
+    list.appendChild(node);
+  }
+
+  beforeEach(() => {
+    reader = null;
+    installed = installChatDom();
+    // The fixture ships with a data-message-id message from Alice that
+    // would otherwise pollute the "structural fallback engaged" counts
+    // and the event stream. Drop it so each test starts with a list that
+    // only carries the structural-shape messages it explicitly appends.
+    installed.dom.window.document
+      .querySelectorAll(chatSelectors.MESSAGE_NODE)
+      .forEach((el) => el.remove());
+  });
+
+  afterEach(() => {
+    if (reader) {
+      reader.stop();
+      reader = null;
+    }
+    if (installed) {
+      (installed.dom as unknown as { __restore: () => void }).__restore();
+      installed = null;
+    }
+  });
+
+  test("emits chat.inbound for a listitem without data-* markers", async () => {
+    const events: ExtensionToBotMessage[] = [];
+    reader = startChatReader({
+      meetingId: "m-live",
+      selfName: "Bot",
+      onEvent: (ev) => events.push(ev),
+    });
+
+    appendStructuralMessage("Alice", "hello there");
+    await flushMicrotasks();
+
+    const chatEvents = events.filter((e) => e.type === "chat.inbound");
+    expect(chatEvents.length).toBe(1);
+    const ev = chatEvents[0] as Extract<
+      ExtensionToBotMessage,
+      { type: "chat.inbound" }
+    >;
+    expect(ev.fromName).toBe("Alice");
+    expect(ev.text).toBe("hello there");
+    expect(ev.meetingId).toBe("m-live");
+  });
+
+  test("emits a diagnostic when the structural fallback is actually used", async () => {
+    const events: ExtensionToBotMessage[] = [];
+    reader = startChatReader({
+      meetingId: "m-live",
+      selfName: "Bot",
+      onEvent: (ev) => events.push(ev),
+    });
+
+    appendStructuralMessage("Alice", "hello there");
+    await flushMicrotasks();
+
+    const diagnostics = events.filter((e) => e.type === "diagnostic");
+    expect(diagnostics.length).toBe(1);
+    const diag = diagnostics[0] as Extract<
+      ExtensionToBotMessage,
+      { type: "diagnostic" }
+    >;
+    expect(diag.level).toBe("info");
+    expect(diag.message).toContain("structural fallback engaged");
+  });
+
+  test("dedupes structural-shape messages by (sender, text, timestamp)", async () => {
+    const events: ExtensionToBotMessage[] = [];
+    reader = startChatReader({
+      meetingId: "m-live",
+      selfName: "Bot",
+      onEvent: (ev) => events.push(ev),
+    });
+
+    appendStructuralMessage("Alice", "hello there", {
+      datetime: "2026-04-22T07:08:30Z",
+    });
+    appendStructuralMessage("Alice", "hello there", {
+      datetime: "2026-04-22T07:08:30Z",
+    });
+    await flushMicrotasks();
+
+    const chatEvents = events.filter((e) => e.type === "chat.inbound");
+    expect(chatEvents.length).toBe(1);
+  });
+
+  test("name-match self-filter drops the bot's own structural-shape messages", async () => {
+    const events: ExtensionToBotMessage[] = [];
+    reader = startChatReader({
+      meetingId: "m-live",
+      selfName: "Bot",
+      onEvent: (ev) => events.push(ev),
+    });
+
+    appendStructuralMessage("Bot", "hi there — this is me talking");
+    appendStructuralMessage("Alice", "hello there");
+    await flushMicrotasks();
+
+    const chatEvents = events
+      .filter((e) => e.type === "chat.inbound")
+      .map(
+        (e) =>
+          (e as Extract<ExtensionToBotMessage, { type: "chat.inbound" }>)
+            .fromName,
+      );
+    expect(chatEvents).toEqual(["Alice"]);
+  });
+
+  test("emits the 'stopped without emitting' diagnostic on a silent session", async () => {
+    const events: ExtensionToBotMessage[] = [];
+    reader = startChatReader({
+      meetingId: "m-live",
+      selfName: "Bot",
+      onEvent: (ev) => events.push(ev),
+    });
+
+    // No messages appended at all.
+    reader.stop();
+    reader = null;
+
+    const diagnostics = events.filter((e) => e.type === "diagnostic");
+    expect(diagnostics.length).toBe(1);
+    const diag = diagnostics[0] as Extract<
+      ExtensionToBotMessage,
+      { type: "diagnostic" }
+    >;
+    expect(diag.message).toContain("stopped without emitting");
+  });
+});
+
 describe("sendChat", () => {
   let installed: InstalledDom | null = null;
 

--- a/skills/meet-join/meet-controller-ext/src/dom/selectors.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/selectors.ts
@@ -142,20 +142,37 @@ export const chatSelectors = {
   SEND_BUTTON: 'button[aria-label^="Send a message"]',
 
   /**
-   * Container that holds the list of chat messages. Used to detect whether the
-   * chat panel is open (the container is mounted even when no messages exist).
+   * Container that holds the list of chat messages. Two shapes are accepted
+   * (historical → current), joined with a comma so `querySelector` returns
+   * whichever Meet is rendering:
+   *
+   *   1. `[aria-label="Chat messages"]` — the original fixture shape.
+   *   2. `[aria-label="In-call messages"]` — what late-April-2026 Meet
+   *      actually renders in the opened side panel (matches the panel
+   *      header text visible in the UI). The chat reader's `MESSAGE_NODE`
+   *      fallback scopes to any list whose aria-label *contains* "message",
+   *      so this constant stays authoritative for the panel-open probe.
    */
-  MESSAGE_LIST: '[role="list"][aria-label="Chat messages"]',
+  MESSAGE_LIST:
+    '[role="list"][aria-label="Chat messages"], [role="list"][aria-label="In-call messages"]',
 
   /**
-   * Root node for a single rendered chat message. We use a data attribute
-   * rather than a class because Meet's message-list classes change often.
+   * Root node for a single rendered chat message. Two clauses are accepted
+   * so the reader works against both the hand-authored fixture and the
+   * live Meet DOM Google is actually shipping:
+   *
+   *   1. `[role="listitem"][data-message-id]` — the original fixture shape.
+   *      Retained so unit tests keep passing and, if Meet ever exposes a
+   *      stable data-* id, we prefer it for dedup.
+   *   2. `[role="list"][aria-label*="message" i] [role="listitem"]` —
+   *      structural fallback. Scopes to whichever side-panel `role="list"`
+   *      has "message" in its aria-label (covers "Chat messages" and
+   *      "In-call messages"; case-insensitive to ride through any casing
+   *      drift). This is what catches actual inbound chats today —
+   *      `data-message-id` is not emitted by Meet.
    */
-  // TODO(meet-dom): Meet does not currently expose a stable per-message data
-  // attribute. The selector below assumes we either inject a MutationObserver-
-  // driven marker or rely on a recognizable ARIA structure. Verify during
-  // fixture refresh and swap to whatever Meet actually emits.
-  MESSAGE_NODE: 'div[role="listitem"][data-message-id]',
+  MESSAGE_NODE:
+    '[role="listitem"][data-message-id], [role="list"][aria-label*="message" i] [role="listitem"]',
 
   /** Subselectors applied within a MESSAGE_NODE to extract rendered fields. */
   MESSAGE_SENDER: "[data-sender-name]",

--- a/skills/meet-join/meet-controller-ext/src/features/chat.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/chat.ts
@@ -180,45 +180,179 @@ export function startChatReader(opts: ChatReaderOptions): ChatReader {
   // idle — the same failure mode as before this helper went async.
   void ensurePanelOpen();
 
-  // Bot-side dedupe keyed on the rendered `data-message-id`. The in-page
-  // seen set is reset every time the panel close/reopens and the observer
-  // re-attaches, so we keep our own set to survive those cycles.
-  const seenDomIds = new Set<string>();
+  // Dedup across extract() calls. DOM-node identity is the primary key —
+  // a `role="listitem"` is not reinstantiated once the panel is open, so
+  // a WeakSet on the node is sufficient for the common case. A secondary
+  // content-hash set covers re-mounts (panel close → reopen): the node
+  // identity is new, but the rendered sender+text+time triple is stable
+  // enough to suppress a duplicate fire. `data-message-id` is preferred
+  // when Meet exposes it, but it's not present on the live DOM today.
+  const seenNodes = new WeakSet<Element>();
+  const seenContentHashes = new Set<string>();
+
+  let emittedCount = 0;
+  let diagnosticEmitted = false;
+  /**
+   * Fire a one-shot `[ext]` diagnostic the first time we observe a
+   * message list in which the listitem rows do NOT carry the
+   * `data-message-id` attribute that {@link chatSelectors.MESSAGE_NODE}'s
+   * primary clause depends on. That's the exact drift signature this
+   * reader's fallback path exists to handle — the diagnostic gives an
+   * operator enough DOM structure (attrs on the first listitem, nearby
+   * aria-labels) to write a more precise selector next time.
+   *
+   * Fixture tests (which carry `data-message-id` on every listitem) never
+   * trip this branch, so the diagnostic doesn't pollute their event
+   * streams.
+   */
+  const maybeEmitReaderDiagnostic = (): void => {
+    if (diagnosticEmitted) return;
+    const structuralItems = document.querySelectorAll(
+      '[role="list"][aria-label*="message" i] [role="listitem"]',
+    );
+    if (structuralItems.length === 0) return;
+
+    let structuralOnlyItem: Element | null = null;
+    for (const item of Array.from(structuralItems)) {
+      if (!item.hasAttribute("data-message-id")) {
+        structuralOnlyItem = item;
+        break;
+      }
+    }
+    // Fixture-shaped DOMs (every listitem has data-message-id) never emit
+    // the diagnostic — selector drift is the only case that trips it.
+    if (!structuralOnlyItem) return;
+    diagnosticEmitted = true;
+
+    const lists = document.querySelectorAll(chatSelectors.MESSAGE_LIST);
+    const summarizeItem = (el: Element): string => {
+      const attrs = Array.from(el.attributes)
+        .map((a) => `${a.name}${a.value ? `="${a.value.slice(0, 40)}"` : ""}`)
+        .join(" ");
+      const descendantAttrs = Array.from(el.querySelectorAll("[aria-label]"))
+        .slice(0, 4)
+        .map((child) => {
+          const label = (child.getAttribute("aria-label") ?? "")
+            .replace(/\s+/g, " ")
+            .slice(0, 40);
+          return `${child.tagName}[${label}]`;
+        })
+        .join(", ");
+      return `<${el.tagName} ${attrs}>${descendantAttrs ? ` aria-children: ${descendantAttrs}` : ""}`;
+    };
+
+    const listLabels = Array.from(lists)
+      .map((el) => el.getAttribute("aria-label") ?? "<no-label>")
+      .join(", ");
+    const msg =
+      `chat-reader: structural fallback engaged — ` +
+      `lists(${lists.length})=[${listLabels}] ` +
+      `structuralItems=${structuralItems.length} ` +
+      `firstItem=${summarizeItem(structuralOnlyItem)}`;
+    try {
+      opts.onEvent({ type: "diagnostic", level: "info", message: msg });
+    } catch {
+      // Never let a diagnostic emit throw kill the reader.
+    }
+  };
+
+  /**
+   * Best-effort sender + text extraction. Preferred path is the fixture's
+   * data-* attrs; structural fallbacks cover live Meet, which exposes
+   * neither. Returns `null` if the listitem doesn't carry both fields.
+   */
+  const extractFields = (
+    msg: Element,
+  ): { fromName: string; text: string; timestamp: string } | null => {
+    // Preferred: explicit markers on the fixture shape.
+    let fromName = (
+      msg.querySelector(chatSelectors.MESSAGE_SENDER)?.textContent ?? ""
+    ).trim();
+    let text = (
+      msg.querySelector(chatSelectors.MESSAGE_TEXT)?.textContent ?? ""
+    ).trim();
+
+    if (!fromName || !text) {
+      // Fallback: walk the listitem's text-bearing children. Meet renders
+      // a per-message row as <sender, timestamp> followed by one or more
+      // <bubble> text nodes. Collect all direct+nested text while skipping
+      // pure-whitespace nodes and the <time> subtree.
+      const lines: string[] = [];
+      const collect = (node: Element): void => {
+        for (const child of Array.from(node.children)) {
+          const tag = child.tagName;
+          if (tag === "TIME" || tag === "SCRIPT" || tag === "STYLE") continue;
+          if (child.children.length === 0) {
+            const raw = (child.textContent ?? "").trim();
+            if (raw.length > 0) lines.push(raw);
+          } else {
+            collect(child);
+          }
+        }
+      };
+      collect(msg);
+      if (lines.length >= 2) {
+        // Heuristic: first non-empty line is the sender, remaining lines
+        // (joined with newlines) are the message body. Covers the common
+        // Meet rendering of sender+timestamp on one "row" followed by the
+        // message bubble.
+        if (!fromName) fromName = lines[0];
+        if (!text) text = lines.slice(1).join("\n");
+      }
+    }
+
+    if (!fromName || !text) return null;
+
+    const timestamp =
+      msg.querySelector(chatSelectors.MESSAGE_TIMESTAMP)?.getAttribute(
+        "datetime",
+      ) ?? "";
+
+    return { fromName, text, timestamp };
+  };
 
   const extract = (node: Element): void => {
-    const messages = node.matches(chatSelectors.MESSAGE_NODE)
-      ? [node]
-      : Array.from(node.querySelectorAll(chatSelectors.MESSAGE_NODE));
+    // Probe — don't require membership in the current MESSAGE_NODE set; the
+    // structural fallback inside `chatSelectors.MESSAGE_NODE` is a descendant
+    // selector, so `matches()` won't return `true` even when a passed-in
+    // node is actually a listitem. Check both the strict (data-attr) and
+    // structural paths explicitly.
+    const isStructuralListItem =
+      node.getAttribute?.("role") === "listitem" &&
+      node.closest('[role="list"][aria-label*="message" i]') !== null;
+    const messages: Element[] =
+      node.matches?.(chatSelectors.MESSAGE_NODE) || isStructuralListItem
+        ? [node]
+        : Array.from(node.querySelectorAll(chatSelectors.MESSAGE_NODE));
+
     for (const msg of messages) {
-      const domId =
-        msg.getAttribute("data-message-id") ?? msg.getAttribute("id") ?? "";
-      if (!domId) continue;
-      if (seenDomIds.has(domId)) continue;
+      if (seenNodes.has(msg)) continue;
+      seenNodes.add(msg);
 
-      const senderEl = msg.querySelector(chatSelectors.MESSAGE_SENDER);
-      const textEl = msg.querySelector(chatSelectors.MESSAGE_TEXT);
+      const fields = extractFields(msg);
+      if (!fields) continue;
 
-      const fromName = (senderEl?.textContent ?? "").trim();
-      const text = (textEl?.textContent ?? "").trim();
-      if (!fromName || !text) continue;
+      const { fromName, text, timestamp } = fields;
 
       // Authoritative self-flag wins; otherwise match by display name.
+      // Meet's live DOM does not currently emit `data-is-self`, so the
+      // name-match branch is the one that fires in practice.
+      const senderEl = msg.querySelector(chatSelectors.MESSAGE_SENDER);
       const isSelf =
         msg.getAttribute("data-is-self") === "true" ||
         senderEl?.getAttribute("data-is-self") === "true" ||
         fromName === opts.selfName;
-      if (isSelf) {
-        // Record the DOM id anyway so we don't re-inspect the node on the
-        // next mutation.
-        seenDomIds.add(domId);
-        continue;
-      }
+      if (isSelf) continue;
+
+      // Content hash covers panel close → reopen remounts where the DOM
+      // node identity changes but the rendered message is the same.
+      const contentHash = `${fromName}\u0001${timestamp}\u0001${text}`;
+      if (seenContentHashes.has(contentHash)) continue;
+      seenContentHashes.add(contentHash);
 
       // Sender-side id when Meet exposes one; otherwise fall back to the
       // display name (stable enough within a meeting).
       const fromId = senderEl?.getAttribute("data-sender-id") ?? fromName;
-
-      seenDomIds.add(domId);
 
       const event: ExtensionInboundChatMessage = {
         type: "chat.inbound",
@@ -230,6 +364,7 @@ export function startChatReader(opts: ChatReaderOptions): ChatReader {
         fromName,
         text,
       };
+      emittedCount += 1;
       try {
         opts.onEvent(event);
       } catch {
@@ -240,6 +375,7 @@ export function startChatReader(opts: ChatReaderOptions): ChatReader {
 
   // Backfill any messages already in the DOM when the reader attaches —
   // otherwise we'd miss the pre-existing chat history.
+  maybeEmitReaderDiagnostic();
   for (const existing of document.querySelectorAll(
     chatSelectors.MESSAGE_NODE,
   )) {
@@ -247,6 +383,11 @@ export function startChatReader(opts: ChatReaderOptions): ChatReader {
   }
 
   const observer = new MutationObserver((mutations) => {
+    // Re-probe the diagnostic on each mutation batch until it fires — the
+    // chat list mounts asynchronously after `ensurePanelOpen()` clicks the
+    // toggle, and the backfill probe above often runs before the list is
+    // in the DOM.
+    maybeEmitReaderDiagnostic();
     for (const m of mutations) {
       for (const node of m.addedNodes) {
         if (node.nodeType === 1) extract(node as Element);
@@ -261,6 +402,23 @@ export function startChatReader(opts: ChatReaderOptions): ChatReader {
       if (stopped) return;
       stopped = true;
       observer.disconnect();
+      if (emittedCount === 0) {
+        // Trailing diagnostic so an operator reading `docker logs` after a
+        // silent session sees that the reader attached but saw nothing —
+        // typically a selector-drift signal that the primary MESSAGE_NODE
+        // clause no longer matches. Bounded emission (one per reader
+        // lifecycle) keeps the bot log quiet on healthy sessions.
+        try {
+          opts.onEvent({
+            type: "diagnostic",
+            level: "info",
+            message:
+              "chat-reader: stopped without emitting any chat.inbound events",
+          });
+        } catch {
+          // Never let a diagnostic emit throw kill teardown.
+        }
+      }
     },
   };
 }


### PR DESCRIPTION
## Summary
- Live Meet no longer emits \`data-message-id\` / \`data-sender-name\` / \`data-message-text\` on rendered chat rows, so the reader's primary selector \`div[role=\"listitem\"][data-message-id]\` matched nothing and no \`chat.inbound\` events reached the daemon. Verified against a recent session — zero chat event POSTs during the whole session while an inbound message sat visible in the Meet chat panel.
- \`chatSelectors.MESSAGE_NODE\` now has two clauses: the original data-attr form (kept for fixtures / future Meet data markers) and a structural fallback \`[role=\"list\"][aria-label*=\"message\" i] [role=\"listitem\"]\` that scopes to whichever panel list Meet actually renders (\`Chat messages\` or \`In-call messages\`, case-insensitive).
- \`startChatReader\` field extraction falls back to a text-walk heuristic when \`[data-sender-name]\`/\`[data-message-text]\` are missing; dedup moves to \`WeakSet<Element>\` + \`(sender, text, timestamp)\` content hash so the missing \`data-message-id\` no longer guts dedup.
- Emits one \`[ext]\` diagnostic when the structural fallback first engages (with an inventory of the triggering listitem) and a second diagnostic on \`stop()\` if the reader never emitted a single inbound chat. Fixture-shaped tests (every listitem has \`data-message-id\`) never trip the drift diagnostic, so event streams stay clean.

## Original prompt
yeah can you look into this (traced to the reader's MutationObserver never firing a \`chat.inbound\` because the primary selector required a data attribute Meet no longer emits)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
