### PR TITLE
fix(meet): meet_speak surfaces bot-unreachable errors instead of silent fake-success

### DIFF
--- a/skills/meet-join/daemon/__tests__/tts-bridge.test.ts
+++ b/skills/meet-join/daemon/__tests__/tts-bridge.test.ts
@@ -373,6 +373,12 @@ describe("MeetTtsBridge.speak", () => {
         providerFactory: () => provider,
         spawn,
         newStreamId: () => "stream-cancel",
+        // Disable the fast-fail window: this test cancels mid-stream
+        // and then awaits `completion` to observe the typed cancel
+        // sentinel. With a non-zero window `speak()` would block until
+        // the stream settles (or the window expires) and the test's
+        // cancel would race against a stream that's already completed.
+        speakFastFailWindowMs: 0,
       },
     );
 
@@ -410,6 +416,66 @@ describe("MeetTtsBridge.speak", () => {
     expect(del.authorization).toBe(`Bearer ${TOKEN}`);
 
     // Active stream map is empty after cancel settles.
+    expect(bridge.activeStreamCount()).toBe(0);
+  });
+
+  test("speak() throws MEET_TTS_BOT_UNREACHABLE when the POST connect-fails inside the fast-fail window", async () => {
+    // Regression: before the fast-fail window was added, `speak()` returned
+    // a valid-looking `streamId` as soon as the POST was scheduled — even
+    // if the bot container had died between join and speak. The agent
+    // saw `{streamId}` come back, recorded the tool call as successful,
+    // and moved on; the actual `ECONNREFUSED` surfaced ~1s later as a
+    // fire-and-forget `.catch` that only published a `meet.speaking_ended`
+    // event. The user heard silence and had no tool-side signal that
+    // anything failed.
+    //
+    // We pin the new contract here: if the POST rejects on connect
+    // within {@link SPEAK_FAST_FAIL_WINDOW_MS}, `speak()` rethrows the
+    // {@link MeetTtsError} instead of returning a streamId. Callers
+    // (meet_speak tool) then surface `isError: true` to the model,
+    // which can replan.
+    const provider = makeCannedProvider({
+      chunks: [new Uint8Array([0xaa, 0xbb])],
+    });
+    const { spawn } = makeSpawnMock();
+
+    // Point at a loopback port that nothing is listening on. Docker
+    // Desktop allocates ephemerals in the 40000–65000 range for
+    // published meet-bot ports, so picking a very low non-privileged
+    // port guarantees `ECONNREFUSED` without colliding with a real
+    // listener. The OS returns the refusal synchronously enough that
+    // it easily lands within the default 1500ms fast-fail window.
+    const bridge = new MeetTtsBridge(
+      {
+        meetingId: MEETING_ID,
+        botBaseUrl: "http://127.0.0.1:1",
+        botApiToken: TOKEN,
+      },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-unreachable",
+        // Short window keeps the test fast while still exercising the
+        // race (0 would skip the fast-fail path entirely and regress
+        // to the pre-fix silent-success behavior).
+        speakFastFailWindowMs: 500,
+      },
+    );
+
+    const caught = await bridge
+      .speak({ text: "will refuse" })
+      .then(() => null)
+      .catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(MeetTtsError);
+    expect((caught as MeetTtsError).code).toBe("MEET_TTS_BOT_UNREACHABLE");
+
+    // Stream map is empty after the failed speak — the `.finally`
+    // hanging off `settled` deletes the record even though the caller
+    // never received `completion`.
+    //
+    // The post-throw cleanup is async (ffmpeg exit → synthesis settle
+    // → delete) so give it a beat to drain before asserting.
+    await new Promise((r) => setTimeout(r, 50));
     expect(bridge.activeStreamCount()).toBe(0);
   });
 
@@ -564,6 +630,10 @@ describe("MeetTtsBridge abort reason classification", () => {
         providerFactory: () => provider,
         spawn,
         newStreamId: () => "stream-ffmpeg-crash",
+        // Disable fast-fail: this test triggers a mid-stream ffmpeg
+        // error via `transcodeChild.emit("error", ...)` AFTER speak()
+        // returns, and asserts the rejection flows through `completion`.
+        speakFastFailWindowMs: 0,
       },
     );
 
@@ -632,6 +702,9 @@ describe("MeetTtsBridge abort reason classification", () => {
         providerFactory: () => rejectingProvider,
         spawn,
         newStreamId: () => "stream-provider-reject",
+        // Disable fast-fail: this test relies on `completion` being
+        // the sole path for the provider's mid-stream rejection.
+        speakFastFailWindowMs: 0,
       },
     );
 
@@ -676,6 +749,9 @@ describe("MeetTtsBridge abort reason classification", () => {
         providerFactory: () => provider,
         spawn,
         newStreamId: () => "stream-cancel-ok",
+        // Disable fast-fail: this test cancels mid-stream and checks
+        // that `completion` rejects with the typed cancel sentinel.
+        speakFastFailWindowMs: 0,
       },
     );
 

--- a/skills/meet-join/daemon/__tests__/voice-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/voice-e2e.test.ts
@@ -536,6 +536,10 @@ describe("Meet voice E2E (bridge + watcher + real assistant-event-hub)", () => {
         spawn,
         newStreamId: () => "stream-happy",
         newUtteranceId: () => "utt-happy",
+        // Disable the fast-fail window: this E2E asserts the watcher
+        // observes `_isBotSpeaking=true` while the POST is in-flight,
+        // which requires `speak()` to return before the stream settles.
+        speakFastFailWindowMs: 0,
       },
     );
 
@@ -630,6 +634,8 @@ describe("Meet voice E2E (bridge + watcher + real assistant-event-hub)", () => {
         providerFactory: () => provider,
         spawn,
         newStreamId: () => "stream-barge",
+        // See fast-fail opt-out note on the happy-path bridge above.
+        speakFastFailWindowMs: 0,
       },
     );
 
@@ -740,6 +746,8 @@ describe("Meet voice E2E (bridge + watcher + real assistant-event-hub)", () => {
         providerFactory: () => provider,
         spawn,
         newStreamId: () => "stream-cough",
+        // See fast-fail opt-out note on the happy-path bridge above.
+        speakFastFailWindowMs: 0,
       },
     );
 

--- a/skills/meet-join/daemon/tts-bridge.ts
+++ b/skills/meet-join/daemon/tts-bridge.ts
@@ -66,6 +66,38 @@ export const BOT_AUDIO_ENCODING = "pcm_s16le";
  */
 export const CANCEL_DELETE_TIMEOUT_MS = 5_000;
 
+/**
+ * Grace window (ms) {@link MeetTtsBridge.speak} waits before returning the
+ * streamId, so a POST that fast-fails on connect surfaces as a thrown error
+ * instead of a silent fake-success.
+ *
+ * Why this exists: `/play_audio` is a long-lived chunked upload, and Bun's
+ * fetch doesn't resolve the outer `Response` until the server consumes the
+ * full body. That means awaiting the fetch itself blocks for the entire
+ * utterance duration — untenable for the tool call. The historical
+ * fire-and-forget pattern had the opposite failure mode: if the bot
+ * container died between join and speak (e.g. Docker Desktop killing the
+ * container, an orphan-reaper sweep, the user stopping it manually), the
+ * POST rejected with `MEET_TTS_BOT_UNREACHABLE` ~1s later — but `speak()`
+ * had already returned a valid-looking `streamId` so the agent recorded the
+ * tool call as successful and moved on. The user heard silence and had no
+ * signal that the tool had failed.
+ *
+ * Racing the POST's completion against this short window lets us catch the
+ * common connect-level failures without paying their cost on the happy
+ * path: a successful POST either resolves within the window (short
+ * utterances) or is still in-flight when the window expires (long
+ * utterances), and in both cases we return cleanly. Only a rejection
+ * within the window triggers the throw.
+ *
+ * 1500ms is chosen to cover the observed 1.0–1.3s ECONNREFUSED path while
+ * leaving room for DNS/TLS variance. Streaming upload errors that surface
+ * later (body mid-stream crash, 5xx after partial upload) are not caught
+ * here — those continue to flow through `completion` and publish
+ * `meet.speaking_ended` events as before.
+ */
+export const SPEAK_FAST_FAIL_WINDOW_MS = 1_500;
+
 // ---------------------------------------------------------------------------
 // Lip-sync tap — viseme channel and amplitude fallback
 // ---------------------------------------------------------------------------
@@ -265,6 +297,16 @@ export interface MeetTtsBridgeDeps {
    * `randomUUID()`.
    */
   newUtteranceId?: () => string;
+  /**
+   * Override the {@link SPEAK_FAST_FAIL_WINDOW_MS} grace window. Tests
+   * that cover mid-stream cancel / body-error semantics pin this to `0`
+   * so `speak()` returns before the POST settles, preserving the
+   * pre-fast-fail contract where `completion` is the sole path for
+   * post-return errors. Production callers should leave this at the
+   * default so connect-level failures (bot container gone) surface
+   * synchronously instead of as silent fake-success.
+   */
+  speakFastFailWindowMs?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -382,6 +424,8 @@ export class MeetTtsBridge {
       spawn: deps.spawn ?? nodeSpawn,
       newStreamId: deps.newStreamId ?? (() => randomUUID()),
       newUtteranceId: deps.newUtteranceId ?? (() => randomUUID()),
+      speakFastFailWindowMs:
+        deps.speakFastFailWindowMs ?? SPEAK_FAST_FAIL_WINDOW_MS,
     };
   }
 
@@ -389,8 +433,11 @@ export class MeetTtsBridge {
    * Start streaming a synthesized utterance to the bot. Allocates (or uses
    * the caller-supplied) `streamId`, opens the provider's streaming
    * synthesis call, transcodes on the fly via ffmpeg, and POSTs the result
-   * to the bot. Returns the streamId immediately; the POST runs in the
-   * background and its completion can be awaited via `result.completion`.
+   * to the bot. Returns the streamId after a short fast-fail window (see
+   * {@link SPEAK_FAST_FAIL_WINDOW_MS}) — a POST that fails to connect in
+   * that window is thrown back to the caller as a {@link MeetTtsError};
+   * a POST that's still streaming at window-expiry is handed off via
+   * `result.completion` and continues in the background.
    */
   async speak(input: SpeakInput): Promise<SpeakResult> {
     const streamId = input.streamId ?? this.deps.newStreamId();
@@ -607,6 +654,50 @@ export class MeetTtsBridge {
     });
 
     this.streams.set(streamId, { abort, settled });
+
+    // Fast-fail window — block briefly so POSTs that reject on connect
+    // (bot container dead, port closed, DNS miss) surface as a thrown
+    // error from `speak()` instead of the historical silent fake-success.
+    // See {@link SPEAK_FAST_FAIL_WINDOW_MS} for the full rationale; the
+    // short version is that Bun's fetch can't be awaited for connection-
+    // only (the `Response` only resolves when the bot has consumed the
+    // full body) so we race the whole settle against a short deadline.
+    //
+    // Three outcomes:
+    //   - "rejected": settled already rejected — rethrow so the caller's
+    //     `try/catch` sees the same error the fire-and-forget `.catch`
+    //     in `session-manager.speak` would have otherwise published only
+    //     via `meet.speaking_ended`.
+    //   - "resolved": settled completed successfully inside the window
+    //     (short utterance, fast local bot, test harness) — fall through
+    //     to the normal return.
+    //   - "timeout": settled is still in-flight — fall through to the
+    //     normal return; the body is streaming and any later failure is
+    //     still reported via `completion`.
+    if (this.deps.speakFastFailWindowMs > 0) {
+      const fastFailOutcome = await Promise.race([
+        settled.then<"resolved", { kind: "rejected"; err: unknown }>(
+          () => "resolved",
+          (err) => ({ kind: "rejected", err }),
+        ),
+        new Promise<"timeout">((resolve) => {
+          const t = setTimeout(
+            () => resolve("timeout"),
+            this.deps.speakFastFailWindowMs,
+          );
+          t.unref?.();
+        }),
+      ]);
+
+      if (typeof fastFailOutcome === "object") {
+        // Silence the unhandled-rejection warning on `settled` — the
+        // caller never receives `completion` on this path (we're
+        // throwing) so there'd otherwise be nothing attached to consume
+        // the reject.
+        settled.catch(() => {});
+        throw fastFailOutcome.err;
+      }
+    }
 
     return { streamId, completion: settled };
   }


### PR DESCRIPTION
## Summary

- **Root cause**: `MeetTtsBridge.speak()` fired the POST to `/play_audio` in the background and returned a `streamId` before the connection was confirmed. If the bot container had died (observed: clean SIGTERM exit 2.5min into a session), the POST rejected ~1.2s later with ECONNREFUSED but only as a fire-and-forget `.catch` publishing `meet.speaking_ended` — the tool had already reported success, so the agent kept narrating "sent. hear me?" while the user heard nothing.
- **Fix**: Added a 1500ms `SPEAK_FAST_FAIL_WINDOW_MS` grace window that races the POST's settle against a timer. Connect-level rejections inside the window rethrow as `MeetTtsError` so `meet_speak` surfaces `isError: true` to the model. Long POSTs fall through unchanged at window-expiry; mid-stream cancels / ffmpeg crashes / provider rejects still flow through `completion`.
- **Regression test**: new `tts-bridge.test.ts` case pins the new contract against an unreachable port; `voice-e2e.test.ts` and three mid-stream tests opt out of the window via the new `speakFastFailWindowMs: 0` dep so they keep covering their original semantics. All 12 tts-bridge tests pass; no new regressions in the broader daemon suite.

## Original prompt

`/mainline`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
