### PR TITLE
fix(meet): UTF-8 locale for xdotool typing + Deepgram silence keepalives

### DIFF
--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -806,6 +806,66 @@ describe("DeepgramRealtimeTranscriber", () => {
   });
 
   // ─────────────────────────────────────────────────────────────────
+  // KeepAlive
+  // ─────────────────────────────────────────────────────────────────
+
+  test("sends KeepAlive frames at the configured interval while open", async () => {
+    const { transcriber } = await startSession({
+      keepaliveIntervalMs: 30,
+    });
+
+    // Wait long enough for at least two KeepAlives to fire.
+    await new Promise((resolve) => setTimeout(resolve, 95));
+
+    const keepalives = mockWs.sentData.filter(
+      (d) => typeof d === "string" && d === '{"type":"KeepAlive"}',
+    );
+    expect(keepalives.length).toBeGreaterThanOrEqual(2);
+
+    transcriber.stop();
+  });
+
+  test("KeepAlive timer stops firing after stop()", async () => {
+    const { transcriber } = await startSession({
+      keepaliveIntervalMs: 30,
+    });
+
+    // Let one KeepAlive fire so we know the interval is running.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const beforeStop = mockWs.sentData.filter(
+      (d) => typeof d === "string" && d === '{"type":"KeepAlive"}',
+    ).length;
+    expect(beforeStop).toBeGreaterThanOrEqual(1);
+
+    transcriber.stop();
+
+    // Drain the close grace flow.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    // The interval should be cleared — count must not have grown beyond
+    // what was already buffered before stop(). Tolerate one extra fire
+    // racing with stop()'s synchronous clear path, but no more.
+    const afterStop = mockWs.sentData.filter(
+      (d) => typeof d === "string" && d === '{"type":"KeepAlive"}',
+    ).length;
+    expect(afterStop).toBeLessThanOrEqual(beforeStop + 1);
+  });
+
+  test("keepaliveIntervalMs=0 disables the timer entirely", async () => {
+    const { transcriber } = await startSession({
+      keepaliveIntervalMs: 0,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    const keepalives = mockWs.sentData.filter(
+      (d) => typeof d === "string" && d === '{"type":"KeepAlive"}',
+    );
+    expect(keepalives).toHaveLength(0);
+
+    transcriber.stop();
+  });
+
+  // ─────────────────────────────────────────────────────────────────
   // WebSocket URL construction
   // ─────────────────────────────────────────────────────────────────
 

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -54,6 +54,17 @@ const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
 const DEFAULT_INACTIVITY_TIMEOUT_MS = 30_000;
 
 /**
+ * Default interval (ms) for emitting Deepgram `KeepAlive` control frames
+ * during silent stretches. Deepgram's server-side timeout closes the
+ * socket if no real audio content arrives for ~10s; raw silence PCM does
+ * not reset that timer, only an explicit `{"type":"KeepAlive"}` message
+ * does. Sending one every 5s keeps the socket alive through arbitrary
+ * pauses (think: 1:1 voice mode while the user is thinking) without any
+ * meaningful bandwidth cost.
+ */
+const DEFAULT_KEEPALIVE_INTERVAL_MS = 5_000;
+
+/**
  * Maximum WebSocket bufferedAmount (bytes) before sendAudio applies
  * backpressure by dropping frames. This prevents unbounded memory growth
  * if the network or provider cannot keep up with the audio rate.
@@ -87,6 +98,13 @@ export interface DeepgramRealtimeOptions {
   connectTimeoutMs?: number;
   /** Inactivity timeout in milliseconds. Default: 30_000. */
   inactivityTimeoutMs?: number;
+  /**
+   * Interval (ms) between Deepgram `KeepAlive` control frames sent during
+   * silent stretches. Default: 5_000. Set to 0 to disable (not recommended
+   * outside tests — the server-side socket will close after ~10s of
+   * silence).
+   */
+  keepaliveIntervalMs?: number;
   /** Audio sample rate in Hz (default: 16000). Passed through from the client WebSocket connection. */
   sampleRate?: number;
   /**
@@ -222,6 +240,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
   private readonly baseUrl: string;
   private readonly connectTimeoutMs: number;
   private readonly inactivityTimeoutMs: number;
+  private readonly keepaliveIntervalMs: number;
   private readonly sampleRate: number;
   /**
    * Whether speaker diarization is requested. Forwarded to the Deepgram
@@ -248,6 +267,13 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
   /** Close grace timer handle. */
   private closeGraceTimer: ReturnType<typeof setTimeout> | null = null;
 
+  /**
+   * Periodic keepalive timer. Fires every {@link keepaliveIntervalMs} while
+   * the socket is open and emits a Deepgram `KeepAlive` control frame so
+   * silent stretches do not trip Deepgram's server-side inactivity close.
+   */
+  private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+
   constructor(apiKey: string, options: DeepgramRealtimeOptions = {}) {
     this.apiKey = apiKey;
     this.model = options.model ?? DEFAULT_MODEL;
@@ -260,6 +286,8 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
       options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
     this.inactivityTimeoutMs =
       options.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
+    this.keepaliveIntervalMs =
+      options.keepaliveIntervalMs ?? DEFAULT_KEEPALIVE_INTERVAL_MS;
     this.sampleRate = options.sampleRate ?? 16_000;
     this.diarize = options.diarize ?? false;
   }
@@ -329,6 +357,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
     // the active session lifetime.
     this.attachSessionHandlers(ws);
     this.resetInactivityTimer();
+    this.startKeepaliveTimer();
 
     log.info("Deepgram realtime session opened");
   }
@@ -644,6 +673,34 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
       clearTimeout(this.closeGraceTimer);
       this.closeGraceTimer = null;
     }
+    if (this.keepaliveTimer !== null) {
+      clearInterval(this.keepaliveTimer);
+      this.keepaliveTimer = null;
+    }
+  }
+
+  /**
+   * Start the periodic keepalive timer. Sends a Deepgram `KeepAlive`
+   * control frame every {@link keepaliveIntervalMs}; this is the only
+   * thing that resets Deepgram's server-side inactivity timer when the
+   * stream is carrying silence (raw silence PCM frames do not count).
+   *
+   * Skipped when {@link keepaliveIntervalMs} is 0 (test override) or the
+   * adapter is already closed/stopping.
+   */
+  private startKeepaliveTimer(): void {
+    if (this.closed || this.stopping) return;
+    if (this.keepaliveIntervalMs <= 0) return;
+    this.keepaliveTimer = setInterval(() => {
+      if (this.closed || this.stopping) return;
+      const ws = this.ws;
+      if (!ws || ws.readyState !== WS_OPEN) return;
+      try {
+        ws.send(JSON.stringify({ type: "KeepAlive" }));
+      } catch (err) {
+        log.warn({ err }, "Deepgram KeepAlive send failed");
+      }
+    }, this.keepaliveIntervalMs);
   }
 
   /**

--- a/skills/meet-join/bot/Dockerfile
+++ b/skills/meet-join/bot/Dockerfile
@@ -34,6 +34,15 @@
 
 FROM oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4839c2e4e42a7
 
+# UTF-8 locale for every process in the image. Without this the container
+# defaults to POSIX/C locale and locale-aware tools refuse non-ASCII bytes —
+# `xdotool type` aborts a chat message on the first multi-byte character
+# (curly apostrophe, em-dash, emoji) with `Invalid multi-byte sequence
+# encountered`, leaving the composer holding a truncated message that the
+# subsequent send click then commits. Modern Debian (the base for
+# `oven/bun`) ships `C.UTF-8` without needing the `locales` package.
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
 # System dependencies. Keep this list grouped and sorted so future PRs can
 # add/remove packages cleanly.
 #

--- a/skills/meet-join/bot/__tests__/xdotool-type.test.ts
+++ b/skills/meet-join/bot/__tests__/xdotool-type.test.ts
@@ -89,6 +89,27 @@ describe("xdotoolType", () => {
     expect(fake.calls[0]!.options.env?.DISPLAY).toBe(":99");
   });
 
+  test("forces LANG=C.UTF-8 so xdotool can type non-ASCII characters", async () => {
+    // Without an explicit UTF-8 locale, xdotool runs in POSIX/C and aborts
+    // a chat message on the first multi-byte byte (em-dash, curly
+    // apostrophe, emoji) with "Invalid multi-byte sequence encountered",
+    // leaving a partial string in the composer. Pin the env so that
+    // failure mode can't return if the bot is invoked outside the
+    // container (e.g. local dev) where the host locale may not be UTF-8.
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    const pending = xdotoolType({
+      text: "Hi — I'm the note-taker, don't mind me.",
+      display: ":99",
+      spawn: fake.spawn,
+    });
+    child.__simulateExit(0);
+    await pending;
+
+    expect(fake.calls[0]!.options.env?.LANG).toBe("C.UTF-8");
+  });
+
   test("passes text starting with '-' safely via the '--' end-of-options marker", async () => {
     // Regression: without `--` before the text token, xdotool parses
     // anything starting with `-` as an option flag (e.g. a negative number

--- a/skills/meet-join/bot/src/browser/xdotool-type.ts
+++ b/skills/meet-join/bot/src/browser/xdotool-type.ts
@@ -116,8 +116,19 @@ export async function xdotoolType(opts: XdotoolTypeOptions): Promise<void> {
       else resolve();
     };
 
+    // Force `LANG=C.UTF-8` for the xdotool process. xdotool's text-typing
+    // path uses the inherited locale to decode the argv string, and in the
+    // POSIX/C locale it rejects any non-ASCII byte with `Invalid multi-byte
+    // sequence encountered`, aborting partway through the message. The bot
+    // container's Dockerfile already sets `LANG=C.UTF-8`, but pinning it
+    // here keeps non-container callers (tests, local dev) from re-breaking
+    // the typing path if their host locale drifts.
     const child = spawnFn(binary, args, {
-      env: { ...process.env, DISPLAY: opts.display },
+      env: {
+        ...process.env,
+        DISPLAY: opts.display,
+        LANG: "C.UTF-8",
+      },
     });
 
     let stderr = "";


### PR DESCRIPTION
## Summary
- **Bot container locale**: add `ENV LANG=C.UTF-8 LC_ALL=C.UTF-8` to `skills/meet-join/bot/Dockerfile` and pin `LANG=C.UTF-8` in the `xdotoolType` spawn env. Without this, xdotool runs in POSIX/C locale and aborts on the first multi-byte byte (`Invalid multi-byte sequence encountered`), truncating the composer text and leaving whatever typed so far to be sent on the subsequent click.
- **Deepgram silence keepalives**: send `{"type":"KeepAlive"}` every 5s (configurable via `keepaliveIntervalMs`) from `DeepgramRealtimeTranscriber`. Deepgram's server-side inactivity timer closes the socket after ~10s of no real audio — silence PCM frames don't reset it, only the explicit control frame does. Keeps 1:1 voice-mode STT sessions alive through natural user pauses.
- Tests: 1 new xdotool case asserting `LANG=C.UTF-8` in spawn env (total 10/10 pass); 3 new Deepgram cases covering keepalive emission, stop() clearing the timer, and `keepaliveIntervalMs: 0` disabling it (total 47/47 pass).

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
