### PR TITLE
fix(suggestion): drop assistant-prefill + seed conversationStarters to haiku

### DIFF
--- a/assistant/src/__tests__/suggestion-routes.test.ts
+++ b/assistant/src/__tests__/suggestion-routes.test.ts
@@ -568,4 +568,104 @@ describe("GET /v1/suggestion", () => {
       | undefined;
     expect(options?.config?.callSite).toBe("conversationStarters");
   });
+
+  test("does not send an assistant-role prefill message", async () => {
+    // Regression guard: Anthropic rejects assistant-message prefill
+    // whenever the request triggers extended thinking (e.g. Opus 4.x at
+    // `effort: "xhigh"`). The suggestion generator must only send a
+    // single user-role message so it stays compatible with every
+    // possible `conversationStarters` call-site config.
+    const provider = makeMockProvider("<reply>Sure, works for me</reply>");
+    mockGetConfiguredProvider.mockImplementation(async () => provider);
+    mockGetConversationByKey.mockImplementation(() => ({
+      conversationId: "conv-test",
+    }));
+    mockGetMessages.mockImplementation(() => [
+      {
+        id: "msg-asst-1",
+        conversationId: "conv-test",
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "Want to meet tomorrow?" },
+        ]),
+        createdAt: Date.now(),
+        metadata: null,
+      },
+    ]);
+
+    const url = makeUrl({ conversationKey: "test-key" });
+    const deps = makeDeps();
+    const response = await handleGetSuggestion(url, deps);
+
+    expect(provider.sendMessage).toHaveBeenCalledTimes(1);
+    const callArgs = provider.sendMessage.mock.calls[0] as unknown[];
+    const messages = callArgs[0] as Array<{ role: string }>;
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("user");
+    expect(messages.every((m) => m.role === "user")).toBe(true);
+
+    // Tag-wrapped response is extracted back to just the reply text.
+    const body = (await response.json()) as { suggestion: string | null };
+    expect(body.suggestion).toBe("Sure, works for me");
+  });
+
+  test("handles untagged model response by falling back to raw text", async () => {
+    // Some non-Anthropic models and some Anthropic configs drop the
+    // `<reply>…</reply>` wrapper entirely. The parser must still
+    // produce a usable suggestion from the raw text.
+    const provider = makeMockProvider("Sounds good to me");
+    mockGetConfiguredProvider.mockImplementation(async () => provider);
+    mockGetConversationByKey.mockImplementation(() => ({
+      conversationId: "conv-test",
+    }));
+    mockGetMessages.mockImplementation(() => [
+      {
+        id: "msg-asst-untagged",
+        conversationId: "conv-test",
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "Want to meet tomorrow?" },
+        ]),
+        createdAt: Date.now(),
+        metadata: null,
+      },
+    ]);
+
+    const url = makeUrl({ conversationKey: "test-key" });
+    const deps = makeDeps();
+    const response = await handleGetSuggestion(url, deps);
+
+    const body = (await response.json()) as { suggestion: string | null };
+    expect(body.suggestion).toBe("Sounds good to me");
+  });
+
+  test("extracts reply content when model adds preamble before tag", async () => {
+    // Without assistant-role prefill, nothing stops a chatty model from
+    // adding a preamble. The parser's tag-extraction step must take the
+    // `<reply>…</reply>` span and ignore surrounding commentary.
+    const provider = makeMockProvider(
+      "Here's a good option:\n\n<reply>Let's do it</reply>",
+    );
+    mockGetConfiguredProvider.mockImplementation(async () => provider);
+    mockGetConversationByKey.mockImplementation(() => ({
+      conversationId: "conv-test",
+    }));
+    mockGetMessages.mockImplementation(() => [
+      {
+        id: "msg-asst-preamble",
+        conversationId: "conv-test",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Ready to ship it?" }]),
+        createdAt: Date.now(),
+        metadata: null,
+      },
+    ]);
+
+    const url = makeUrl({ conversationKey: "test-key" });
+    const deps = makeDeps();
+    const response = await handleGetSuggestion(url, deps);
+
+    const body = (await response.json()) as { suggestion: string | null };
+    expect(body.suggestion).toBe("Let's do it");
+  });
 });

--- a/assistant/src/__tests__/workspace-migration-046-seed-conversation-starters-callsite.test.ts
+++ b/assistant/src/__tests__/workspace-migration-046-seed-conversation-starters-callsite.test.ts
@@ -1,0 +1,183 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { seedConversationStartersCallsiteMigration } from "../workspace/migrations/046-seed-conversation-starters-callsite.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-046-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function configPath(): string {
+  return join(workspaceDir, "config.json");
+}
+
+beforeEach(() => {
+  freshWorkspace();
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+});
+
+afterEach(() => {
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("046-seed-conversation-starters-callsite migration", () => {
+  test("has correct migration id", () => {
+    expect(seedConversationStartersCallsiteMigration.id).toBe(
+      "046-seed-conversation-starters-callsite",
+    );
+  });
+
+  test("seeds haiku callsite entry on Anthropic workspace without override", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic", model: "claude-opus-4-7" },
+        callSites: { watchCommentary: { model: "claude-haiku-4-5-20251001" } },
+      },
+    });
+
+    seedConversationStartersCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.conversationStarters).toEqual({
+      model: "claude-haiku-4-5-20251001",
+      effort: "low",
+      thinking: { enabled: false },
+    });
+    // Does not clobber unrelated entries.
+    expect(config.llm.callSites.watchCommentary).toEqual({
+      model: "claude-haiku-4-5-20251001",
+    });
+  });
+
+  test("seeds openrouter-shaped model ID on openrouter workspace", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "openrouter", model: "anthropic/claude-opus-4.7" },
+      },
+    });
+
+    seedConversationStartersCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.conversationStarters).toEqual({
+      model: "anthropic/claude-haiku-4.5",
+      effort: "low",
+      thinking: { enabled: false },
+    });
+  });
+
+  test("skips when conversationStarters already has an explicit override", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        callSites: {
+          conversationStarters: {
+            model: "claude-opus-4-7",
+            effort: "high",
+          },
+        },
+      },
+    });
+
+    seedConversationStartersCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.conversationStarters).toEqual({
+      model: "claude-opus-4-7",
+      effort: "high",
+    });
+  });
+
+  test("skips entirely when non-Anthropic, non-OpenRouter provider is configured", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "openai", model: "gpt-5.4" },
+      },
+    });
+
+    seedConversationStartersCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites?: Record<string, unknown> };
+    };
+    // No callSites object created at all.
+    expect(config.llm.callSites).toBeUndefined();
+  });
+
+  test("skips when VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH is set", () => {
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = "/tmp/overlay.json";
+    writeConfig({
+      llm: { default: { provider: "anthropic" } },
+    });
+
+    seedConversationStartersCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites?: Record<string, unknown> };
+    };
+    expect(config.llm.callSites).toBeUndefined();
+  });
+
+  test("runs on fresh install (no config.json) and writes starter config", () => {
+    expect(existsSync(configPath())).toBe(false);
+
+    seedConversationStartersCallsiteMigration.run(workspaceDir);
+
+    expect(existsSync(configPath())).toBe(true);
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.conversationStarters).toEqual({
+      model: "claude-haiku-4-5-20251001",
+      effort: "low",
+      thinking: { enabled: false },
+    });
+  });
+
+  test("is idempotent — a second run is a no-op", () => {
+    writeConfig({
+      llm: { default: { provider: "anthropic" } },
+    });
+
+    seedConversationStartersCallsiteMigration.run(workspaceDir);
+    const afterFirst = readFileSync(configPath(), "utf-8");
+    seedConversationStartersCallsiteMigration.run(workspaceDir);
+    const afterSecond = readFileSync(configPath(), "utf-8");
+
+    expect(afterSecond).toBe(afterFirst);
+  });
+});

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -2249,11 +2249,15 @@ async function generateLlmSuggestion(
     `Write the user's next reply, focusing on the LAST question or call-to-action in the assistant message. Keep it short (under 15 words), casual, and in the user's voice. Respond in this exact format:\n\n` +
     `<reply>YOUR_REPLY_HERE</reply>`;
 
+  // Single user message only — no assistant-role prefill. Anthropic
+  // rejects assistant prefill whenever the request triggers extended
+  // thinking (e.g. Opus 4.x at `effort: "xhigh"`), and the call-site
+  // config is user-controlled, so we can't statically guarantee a
+  // prefill-safe model. Keep `stop_sequences: ["</reply>"]` as an
+  // early-termination hint; the parser below handles both tagged and
+  // untagged responses so untagged "casual answer" replies still work.
   const response = await provider.sendMessage(
-    [
-      { role: "user", content: [{ type: "text", text: userPrompt }] },
-      { role: "assistant", content: [{ type: "text", text: "<reply>" }] },
-    ],
+    [{ role: "user", content: [{ type: "text", text: userPrompt }] }],
     [], // no tools
     systemPrompt,
     {
@@ -2268,7 +2272,12 @@ async function generateLlmSuggestion(
 
   const textBlock = response.content.find((b) => b.type === "text");
   const raw = textBlock && "text" in textBlock ? textBlock.text : "";
-  const stripped = raw
+  // Prefer the content inside <reply>…</reply> when the model honors the
+  // tag format. If the response has no tags, fall back to the raw text —
+  // a plain "Sure, tomorrow works" without tags is still a valid chip.
+  const tagMatch = raw.match(/<reply>([\s\S]*?)(?:<\/reply>|$)/i);
+  const extracted = tagMatch ? tagMatch[1] : raw;
+  const stripped = extracted
     .replace(/<\/?reply>/gi, "")
     .replace(/^["'`]+|["'`]+$/g, "")
     .trim();

--- a/assistant/src/workspace/migrations/046-seed-conversation-starters-callsite.ts
+++ b/assistant/src/workspace/migrations/046-seed-conversation-starters-callsite.ts
@@ -1,0 +1,108 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Seed a latency-optimized default for the `conversationStarters` LLM
+ * call site.
+ *
+ * `conversationStarters` drives the reply-suggestion chip rendered in the
+ * macOS client after every assistant turn. Migration 040 seeded most
+ * trivial copy-generation call sites to haiku-4.5 but missed this one, so
+ * it falls through to `llm.default` — on workspaces where the default is
+ * a high-effort / extended-thinking configured model (e.g. Opus 4.x at
+ * `effort: "xhigh"`), every turn completion kicks off an expensive
+ * reasoning call that, to add insult to injury, rejects the assistant
+ * message prefill the suggestion generator previously relied on with an
+ * HTTP 400.
+ *
+ * Follows the same contract as `040-seed-latency-callsite-defaults`:
+ *   - Skip entirely when `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` is set
+ *     (platform overlay owns call-site seeds).
+ *   - Skip when the resolved provider is not Anthropic (the seeded
+ *     model IDs are Anthropic-shaped, so mixing with another provider
+ *     would guarantee invalid-model errors).
+ *   - No-op when `llm.callSites.conversationStarters` is already set.
+ *
+ * Idempotent, append-only — existing 040 entries are untouched.
+ */
+export const seedConversationStartersCallsiteMigration: WorkspaceMigration = {
+  id: "046-seed-conversation-starters-callsite",
+  description:
+    "Seed latency-optimized default for conversationStarters LLM call site",
+  run(workspaceDir: string): void {
+    if (process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH) return;
+
+    const configPath = join(workspaceDir, "config.json");
+    const configExisted = existsSync(configPath);
+
+    let config: Record<string, unknown> = {};
+    if (configExisted) {
+      try {
+        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+        config = raw as Record<string, unknown>;
+      } catch {
+        return;
+      }
+    }
+
+    const llm = readObject(config.llm) ?? {};
+    const defaultBlock = readObject(llm.default);
+
+    const explicitProvider = readString(defaultBlock?.provider);
+    if (
+      explicitProvider !== undefined &&
+      explicitProvider !== "anthropic" &&
+      explicitProvider !== "openrouter"
+    ) {
+      return;
+    }
+    const provider = explicitProvider ?? "anthropic";
+    const fastModel = resolveLatencyModel(provider);
+    if (fastModel === undefined) return;
+
+    const callSites = readObject(llm.callSites) ?? {};
+    if (readObject(callSites.conversationStarters) !== null) return;
+
+    callSites.conversationStarters = {
+      model: fastModel,
+      effort: "low",
+      thinking: { enabled: false },
+    };
+
+    llm.callSites = callSites;
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: removing the seeded default would reintroduce the
+    // cost/latency regression and the assistant-prefill 400 that this
+    // migration fixes.
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers — self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const PROVIDER_LATENCY_MODELS: Record<string, string> = {
+  anthropic: "claude-haiku-4-5-20251001",
+  openrouter: "anthropic/claude-haiku-4.5",
+};
+
+function resolveLatencyModel(provider: string): string | undefined {
+  return PROVIDER_LATENCY_MODELS[provider];
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -43,6 +43,7 @@ import { fixBackfillGoogleGmailSettingsScopeMigration } from "./042-fix-backfill
 import { releaseNotesLatexRenderingMigration } from "./043-release-notes-latex-rendering.js";
 import { bumpStaleProviderStreamTimeoutMigration } from "./044-bump-stale-provider-stream-timeout.js";
 import { releaseNotesMeetAvatarMigration } from "./045-release-notes-meet-avatar.js";
+import { seedConversationStartersCallsiteMigration } from "./046-seed-conversation-starters-callsite.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -97,4 +98,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   releaseNotesLatexRenderingMigration,
   bumpStaleProviderStreamTimeoutMigration,
   releaseNotesMeetAvatarMigration,
+  seedConversationStartersCallsiteMigration,
 ];


### PR DESCRIPTION
## Summary
- `generateLlmSuggestion` no longer sends an assistant-role prefill message. Anthropic rejects prefill whenever the request triggers extended thinking (Opus 4.x at high effort), producing the 400 `This model does not support assistant message prefill` that fires after every assistant turn. Now sends a single user message and parses `<reply>…</reply>` out of the response (with a raw-text fallback so untagged replies still work).
- New workspace migration `046-seed-conversation-starters-callsite` backfills `llm.callSites.conversationStarters` with haiku-4.5 / low effort / no thinking for Anthropic and OpenRouter workspaces. Migration 040 missed this call site, so it was falling through to `llm.default` (Opus with xhigh effort) — both the cause of the 400 and an unnecessary ~13s per-turn cost sink.
- Regression tests: suggestion-routes asserts no assistant-role message is ever sent and covers tagged / untagged / preamble-wrapped responses. Migration test covers fresh install, anthropic provider, openrouter provider, explicit override short-circuit, non-Anthropic provider skip, env-overlay skip, and idempotency.

## Original prompt
it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
