### PR TITLE
fix(assistant): register default plugins at module load; fix CI

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -216,6 +216,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/handlers/config-model.ts", // masked provider key display
       "providers/speech-to-text/resolve.ts", // STT provider API key lookup
       "daemon/lifecycle.ts", // CES client injection into secure-keys at startup
+      "daemon/external-plugins-bootstrap.ts", // reads credentials at plugin init (manifest.requiresCredential) via the CES-mediated getSecureKeyAsync path
       "inbound/platform-callback-registration.ts", // managed credential lookup for platform base URL, assistant ID, and API key
       "tts/providers/elevenlabs-provider.ts", // ElevenLabs TTS API key lookup
       "tts/providers/deepgram-provider.ts", // Deepgram TTS API key lookup

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -95,3 +95,26 @@ export function resetPluginRegistryAndRegisterDefaults(): void {
   resetPluginRegistryForTests();
   registerDefaultPlugins();
 }
+
+// Module-load side effect: register every first-party default plugin so
+// downstream consumers (production bootstrap AND tests that skip
+// `bootstrapPlugins()`) observe a fully-populated registry by default.
+// Idempotent via swallowed duplicate-name errors so repeat imports,
+// test resets followed by re-imports, etc. don't throw.
+//
+// This preserves the G3.2/R3 plan intent: default plugins are the innermost
+// layer, and user plugins registered later via `loadUserPlugins()` wrap
+// them uniformly across all 14 pipelines. Because `loadUserPlugins()` runs
+// inside `bootstrapPlugins()` — strictly AFTER all static side-effect
+// imports have executed — the onion ordering (defaults inner, user
+// middleware outer) holds in production. Test harnesses that skip
+// `bootstrapPlugins()` inherit the defaults automatically, fixing the
+// persistence / emptyResponse / toolError pipeline terminals that throw
+// under strict-fail semantics.
+//
+// Note: pipeline-unit tests that call `resetPluginRegistryForTests()` in
+// `beforeEach` are unaffected because this side-effect runs exactly once,
+// at module load, and the reset helper only clears the registry — it
+// doesn't re-run the module body. Those tests that need defaults back
+// should call `resetPluginRegistryAndRegisterDefaults()` instead.
+registerDefaultPlugins();

--- a/assistant/src/plugins/pipeline.ts
+++ b/assistant/src/plugins/pipeline.ts
@@ -34,6 +34,17 @@ import {
   type TurnContext,
 } from "./types.js";
 
+// Side-effect import: register every first-party default plugin at module
+// load so downstream consumers (production bootstrap AND tests that skip
+// `bootstrapPlugins()`) observe a fully-populated registry by default.
+// Every code path that calls `runPipeline` imports this module, so by the
+// time the first pipeline runs the defaults are already in place. User
+// plugins load via `loadUserPlugins()` inside `bootstrapPlugins()` (which
+// runs AFTER all static side-effect imports), so the onion ordering
+// (defaults inner, user middleware outer) across all 14 pipelines is
+// preserved in production.
+import "./defaults/index.js";
+
 const moduleLogger = getLogger("plugin-pipeline");
 
 // ─── Default timeouts ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Register every first-party default plugin at module-load via side-effect in plugins/defaults/index.ts. Previously all defaults registered only inside bootstrapPlugins(), so test files that don't call bootstrapPlugins saw an empty registry and hit pipeline terminals (persistence, toolError, emptyResponse) that throw under strict-fail semantics.
- Add side-effect import of plugins/defaults/index.ts from plugins/pipeline.ts so every code path that reaches runPipeline (production AND all tests) loads the module-load registration transitively.
- User plugins still load via loadUserPlugins() AFTER defaults, so onion ordering stays consistent (user middleware wraps defaults uniformly across all 14 pipelines).
- Add daemon/external-plugins-bootstrap.ts to credential-security-invariants.test.ts allowlist: it reads credentials for plugin init via getSecureKeyAsync.

Part of plan: agent-plugin-system.md (CI fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
