### PR TITLE
fix(test): update suggestion-routes test to match no-prefill behavior

### DIFF
--- a/assistant/src/__tests__/suggestion-routes.test.ts
+++ b/assistant/src/__tests__/suggestion-routes.test.ts
@@ -410,7 +410,7 @@ describe("GET /v1/suggestion", () => {
     expect(body.suggestion).toBe("sounds good");
   });
 
-  test("passes prefill message, stop_sequences, and max_tokens", async () => {
+  test("passes stop_sequences, max_tokens, and XML-framed user prompt", async () => {
     const provider = makeMockProvider("on my way");
     mockGetConfiguredProvider.mockImplementation(async () => provider);
     mockGetConversationByKey.mockImplementation(() => ({
@@ -454,9 +454,8 @@ describe("GET /v1/suggestion", () => {
       };
     };
 
-    expect(messages.length).toBe(2);
-    expect(messages[1].role).toBe("assistant");
-    expect(messages[1].content[0].text).toBe("<reply>");
+    expect(messages.length).toBe(1);
+    expect(messages[0].role).toBe("user");
     expect(options.config?.stop_sequences).toEqual(["</reply>"]);
     expect(options.config?.max_tokens).toBe(60);
     expect(messages[0].content[0].text).toContain("<assistant_message>");


### PR DESCRIPTION
## Summary
- PR #27431 dropped the assistant-role prefill from `generateLlmSuggestion`, but the pre-existing `passes prefill message, stop_sequences, and max_tokens` test still asserted `messages.length === 2` and indexed `messages[1]` for prefill content, breaking CI.
- Update the assertions to the new single-user-message shape while keeping coverage for `stop_sequences`, `max_tokens`, and the XML-framed prompt. Prefill-absence is already covered by the separate regression test added in #27431.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24766942659/job/72463386755
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
