### PR TITLE
feat(meet-join): container-exit watcher to synthesize meet.error on unexpected bot death

### DIFF
--- a/skills/meet-join/daemon/__tests__/docker-runner.test.ts
+++ b/skills/meet-join/daemon/__tests__/docker-runner.test.ts
@@ -344,6 +344,65 @@ describe("DockerRunner.inspect", () => {
   });
 });
 
+describe("DockerRunner.wait", () => {
+  let mock: MockDocker;
+
+  afterEach(async () => {
+    await mock?.close();
+  });
+
+  test("issues POST /containers/<id>/wait and returns the exit code", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 200, body: { StatusCode: 137 } });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    const result = await runner.wait("cid");
+
+    expect(result.StatusCode).toBe(137);
+    expect(mock.captured).toHaveLength(1);
+    expect(mock.captured[0].method).toBe("POST");
+    expect(mock.captured[0].url).toContain("/containers/cid/wait");
+  });
+
+  test("treats 404 (container already removed) as an exit-code-0 observation", async () => {
+    // The session-manager's container-exit watcher races the graceful
+    // `leave()` path — when `leave()` calls `runner.remove()` the engine
+    // can reply to a still-open `wait()` with a 404 rather than the exit
+    // record. The watcher checks `leaveInitiatedByDaemon` before
+    // publishing `meet.error`, but relies on `wait()` resolving (not
+    // throwing) so the promise chain completes. Asserting 0 here
+    // documents the branch `DockerRunner.wait` takes to make that work.
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 404, body: "no such container" });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    const result = await runner.wait("cid");
+    expect(result.StatusCode).toBe(0);
+  });
+
+  test("propagates non-404 errors so the watcher can log + bail", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 500, body: "engine down" });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    await expect(runner.wait("cid")).rejects.toThrow(DockerApiError);
+  });
+
+  test("surfaces engine-reported Error payload in the resolved shape", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({
+      status: 200,
+      body: { StatusCode: 143, Error: { Message: "wait interrupted" } },
+    });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    const result = await runner.wait("cid");
+
+    expect(result.StatusCode).toBe(143);
+    expect(result.Error?.Message).toBe("wait interrupted");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Helper-function unit tests
 // ---------------------------------------------------------------------------

--- a/skills/meet-join/daemon/__tests__/session-manager.test.ts
+++ b/skills/meet-join/daemon/__tests__/session-manager.test.ts
@@ -55,6 +55,16 @@ interface MockRunner {
   remove: ReturnType<typeof mock>;
   inspect: ReturnType<typeof mock>;
   logs: ReturnType<typeof mock>;
+  wait: ReturnType<typeof mock>;
+  /**
+   * Test helper: synchronously resolve the pending `wait(containerId)`
+   * promise with the given exit code. Used to simulate an unexpected bot
+   * container exit (e.g. external `docker kill`) so the session-manager's
+   * container-exit watcher fires. No-op when `containerId` has no
+   * pending-exit hook (wait either was never called or was already
+   * resolved for this containerId).
+   */
+  fireContainerExit(containerId: string, exitCode: number): void;
 }
 
 function makeMockRunner(
@@ -83,16 +93,49 @@ function makeMockRunner(
     ],
   };
 
-  return {
+  // Pending `wait()` resolvers keyed by containerId. `fireContainerExit`
+  // looks up the matching resolver so tests can drive the watcher
+  // deterministically. The default `remove()` mock also resolves any
+  // outstanding wait with StatusCode 0 so tests that exercise the
+  // graceful `leave()` path don't leave a dangling pending promise across
+  // test boundaries. That parallels the real `DockerRunner.wait`'s 404
+  // branch — when the engine reports "container gone" the resolver
+  // returns `{ StatusCode: 0 }`.
+  const pendingWaits = new Map<
+    string,
+    (result: { StatusCode: number }) => void
+  >();
+
+  const runner: MockRunner = {
     run: mock(async () => {
       if (overrides.runError) throw overrides.runError;
       return runResult;
     }),
     stop: mock(async () => {}),
-    remove: mock(async () => {}),
+    remove: mock(async (containerId: string) => {
+      const resolver = pendingWaits.get(containerId);
+      if (resolver) {
+        pendingWaits.delete(containerId);
+        resolver({ StatusCode: 0 });
+      }
+    }),
     inspect: mock(async () => ({ Id: runResult.containerId })),
     logs: mock(async () => ""),
+    wait: mock(
+      (containerId: string) =>
+        new Promise<{ StatusCode: number }>((resolve) => {
+          pendingWaits.set(containerId, resolve);
+        }),
+    ),
+    fireContainerExit: (containerId: string, exitCode: number) => {
+      const resolver = pendingWaits.get(containerId);
+      if (!resolver) return;
+      pendingWaits.delete(containerId);
+      resolver({ StatusCode: exitCode });
+    },
   };
+
+  return runner;
 }
 
 /**
@@ -641,6 +684,151 @@ describe("MeetSessionManager max-minutes timeout", () => {
     } finally {
       globalThis.setTimeout = realSetTimeout;
       globalThis.clearTimeout = realClearTimeout;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Container-exit watcher
+// ---------------------------------------------------------------------------
+
+describe("MeetSessionManager container-exit watcher", () => {
+  function captureHub() {
+    const received: AssistantEvent[] = [];
+    const sub = assistantEventHub.subscribe(
+      { assistantId: DAEMON_INTERNAL_ASSISTANT_ID },
+      (event) => {
+        received.push(event);
+      },
+    );
+    return { received, dispose: () => sub.dispose() };
+  }
+
+  test("synthesizes meet.error and tears the session down when the bot container exits unexpectedly", async () => {
+    const runner = makeMockRunner();
+    const audioIngestFactory = makeFakeAudioIngestFactory();
+    const botLeaveFetch = mock(async () => {});
+    const { received, dispose } = captureHub();
+
+    try {
+      const manager = _createMeetSessionManagerForTests({
+        dockerRunnerFactory: () => runner,
+        getProviderKey: async () => "k",
+        getWorkspaceDir: () => workspaceDir,
+        botLeaveFetch,
+        audioIngestFactory: audioIngestFactory.factory,
+      });
+
+      await manager.join({
+        url: "u",
+        meetingId: "m-exit",
+        conversationId: "c",
+      });
+
+      // Sanity: watcher installed exactly one `wait(containerId)` call for
+      // this meeting's container.
+      expect(runner.wait).toHaveBeenCalledTimes(1);
+      expect(runner.wait.mock.calls[0][0]).toBe("container-123");
+
+      // Pretend some external process (stray daemon reaper, user
+      // `docker kill`, OOM reaper, etc.) terminated the bot container
+      // with exit code 137 (SIGKILL). The `leaveInitiatedByDaemon` flag
+      // is still false because `leave()` was never called, so the watcher
+      // must fire the full unexpected-exit teardown.
+      runner.fireContainerExit("container-123", 137);
+
+      // Let the async teardown settle — the watcher's `.then` handler is
+      // scheduled on the microtask queue, and `handleContainerExit`
+      // itself performs several awaits (cancelAll, storageWriter.stop,
+      // audioIngest.stop, runner.remove).
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
+
+      // Session is gone from the authoritative map and from the router.
+      expect(manager.activeSessions()).toHaveLength(0);
+      expect(manager.getSession("m-exit")).toBeNull();
+      expect(getMeetSessionEventRouter().registeredCount()).toBe(0);
+
+      // meet.error published with an exitCode-bearing detail so the
+      // client can render a useful error state.
+      const errors = received.filter((e) => e.message.type === "meet.error");
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      const detail = (errors[errors.length - 1]!.message as { detail: string })
+        .detail;
+      expect(detail).toContain("bot container exited unexpectedly");
+      expect(detail).toContain("137");
+
+      // The container is already dead — we skip `runner.stop` (would just
+      // 304 or error against a terminated container) but still call
+      // `runner.remove` best-effort so the exited container doesn't
+      // linger in `docker ps -a`.
+      expect(runner.stop).toHaveBeenCalledTimes(0);
+      expect(runner.remove).toHaveBeenCalledTimes(1);
+      // The bot is already dead — skipping the bot HTTP `/leave` avoids
+      // burning 10s on an `ECONNREFUSED` timeout before teardown can
+      // start.
+      expect(botLeaveFetch).toHaveBeenCalledTimes(0);
+
+      // Audio ingest was stopped symmetrically with `leave()` so the
+      // loopback TCP port and streaming STT session don't leak.
+      const ingest = audioIngestFactory.getLastIngest();
+      expect(ingest).not.toBeNull();
+      expect(ingest!.stop).toHaveBeenCalledTimes(1);
+    } finally {
+      dispose();
+    }
+  });
+
+  test("daemon-initiated leave() suppresses the watcher (no duplicate meet.error)", async () => {
+    const runner = makeMockRunner();
+    const audioIngestFactory = makeFakeAudioIngestFactory();
+    const { received, dispose } = captureHub();
+
+    try {
+      const manager = _createMeetSessionManagerForTests({
+        dockerRunnerFactory: () => runner,
+        getProviderKey: async () => "k",
+        getWorkspaceDir: () => workspaceDir,
+        botLeaveFetch: async () => {},
+        audioIngestFactory: audioIngestFactory.factory,
+      });
+
+      await manager.join({
+        url: "u",
+        meetingId: "m-leave-guard",
+        conversationId: "c",
+      });
+
+      // Baseline: no meet.error events yet from join().
+      expect(
+        received.filter((e) => e.message.type === "meet.error"),
+      ).toHaveLength(0);
+
+      // Graceful leave — this path calls `runner.remove` on the
+      // container, which in the mock runner resolves any pending
+      // `wait()` promise with StatusCode 0 (mirroring the real
+      // `DockerRunner.wait`'s 404 branch when the container is gone).
+      // The watcher's `.then` handler then fires, but it must take the
+      // no-op branch because `leave()` set `leaveInitiatedByDaemon`
+      // at the top before any awaits.
+      await manager.leave("m-leave-guard", "user-requested");
+
+      // Give the watcher's microtask chain a chance to run.
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
+
+      // The guard worked: no `meet.error` was published. Only `meet.left`
+      // (from the leave path) should have fired.
+      const errors = received.filter((e) => e.message.type === "meet.error");
+      expect(errors).toHaveLength(0);
+      const leftEvents = received.filter(
+        (e) => e.message.type === "meet.left",
+      );
+      expect(leftEvents).toHaveLength(1);
+    } finally {
+      dispose();
     }
   });
 });

--- a/skills/meet-join/daemon/docker-runner.ts
+++ b/skills/meet-join/daemon/docker-runner.ts
@@ -208,6 +208,24 @@ export interface DockerRunResult {
   boundPorts: BoundPort[];
 }
 
+/**
+ * Result of a successful `wait` call. Mirrors Docker's
+ * `POST /containers/<id>/wait` response body:
+ *
+ * ```
+ *   { "StatusCode": <int>, "Error": { "Message": "<...>" } | null }
+ * ```
+ *
+ * `Error` is only present when the wait itself could not be completed
+ * engine-side; a container that exits with a non-zero code is NOT an error
+ * from the wait endpoint's point of view — the caller reads `StatusCode` to
+ * learn what happened.
+ */
+export interface DockerWaitResult {
+  StatusCode: number;
+  Error?: { Message?: string } | null;
+}
+
 // ---------------------------------------------------------------------------
 // DockerRunner
 // ---------------------------------------------------------------------------
@@ -599,6 +617,37 @@ export class DockerRunner {
       `/${DOCKER_API_VERSION}/containers/${containerId}/json`,
       null,
     );
+  }
+
+  /**
+   * Block until the container exits, then resolve with the engine-reported
+   * exit code. Wraps `POST /containers/<id>/wait` — the engine holds the
+   * HTTP connection open until the container terminates, then replies with
+   * `{ StatusCode, Error? }`.
+   *
+   * Used by the session-manager's container-exit watcher to detect
+   * unexpected bot deaths (e.g. external `docker kill`, OOM reaper, a stray
+   * concurrent daemon reaping the container) so a `meet.error` can be
+   * synthesized and session state torn down — without this hook the
+   * daemon would keep the session pinned in `this.sessions` indefinitely
+   * and all subsequent `meet_*` tool calls would fail against a dead bot.
+   *
+   * A 404 (container removed before `wait` could observe the exit — typical
+   * when our own `remove()` races the watcher on the graceful-leave path)
+   * resolves with `{ StatusCode: 0 }` rather than throwing so the watcher
+   * doesn't need a special-case branch. Any other non-2xx surfaces as a
+   * {@link DockerApiError} so the watcher can log + bail.
+   */
+  async wait(containerId: string): Promise<DockerWaitResult> {
+    const path = `/${DOCKER_API_VERSION}/containers/${containerId}/wait`;
+    try {
+      return await this.request<DockerWaitResult>("POST", path, null);
+    } catch (err) {
+      if (err instanceof DockerApiError && err.status === 404) {
+        return { StatusCode: 0 };
+      }
+      throw err;
+    }
   }
 
   /**

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -110,6 +110,7 @@ import {
   MEET_BOT_MEETING_ID_LABEL,
   reapOrphanedMeetBots,
   type DockerRunResult,
+  type DockerWaitResult,
 } from "./docker-runner.js";
 import {
   meetEventDispatcher,
@@ -406,6 +407,20 @@ interface ActiveSession extends MeetSession {
    * and torn down in `leave()` before the dispatcher is unregistered.
    */
   bargeInWatcher: MeetBargeInWatcherLike;
+  /**
+   * True once the daemon's own `leave()` path has begun tearing the session
+   * down. Used by the container-exit watcher to distinguish a
+   * daemon-initiated shutdown (expected exit, session cleanup already in
+   * flight) from an unexpected external death (e.g. `docker kill`, OOM
+   * reaper, stray concurrent daemon reaping the container). On the
+   * daemon-initiated path the watcher becomes a no-op; on the external
+   * path it synthesizes a `meet.error`, mirror-tears session-scoped
+   * resources, and drops the session so clients don't stay pinned in
+   * "joined" forever. Set at the TOP of `leave()` before any awaits so a
+   * race between the first teardown await and the engine-side exit
+   * notification still flags the watcher correctly.
+   */
+  leaveInitiatedByDaemon: boolean;
 }
 
 /**
@@ -565,7 +580,14 @@ export interface MeetSessionManagerDeps {
   /** Factory for the Docker runner — swapped in tests. */
   dockerRunnerFactory?: () => Pick<
     DockerRunner,
-    "run" | "stop" | "remove" | "inspect" | "logs" | "kill" | "listContainers"
+    | "run"
+    | "stop"
+    | "remove"
+    | "inspect"
+    | "logs"
+    | "kill"
+    | "listContainers"
+    | "wait"
   >;
   /** Override the function that fetches credentials. */
   getProviderKey?: (provider: string) => Promise<string | undefined>;
@@ -1396,6 +1418,7 @@ class MeetSessionManagerImpl {
       ttsBridge,
       ttsLipsyncHandle,
       bargeInWatcher,
+      leaveInitiatedByDaemon: false,
     };
     this.sessions.set(meetingId, session);
     // `this.sessions` is now the authoritative source for the resolver;
@@ -1512,12 +1535,41 @@ class MeetSessionManagerImpl {
       });
     }, joinTimeoutMs);
 
-    // NOTE: a container-exit watcher still belongs here in a future PR —
-    // it would catch `docker stop`-driven exits that never emit a
-    // `lifecycle: left` event and synthesize a `meet.error` so the client
-    // doesn't hang in "joined" forever. Leaving as a follow-up; the
-    // timeout cap + explicit `leave()` path already cover the normal
-    // teardown routes.
+    // Container-exit watcher. Docker's `POST /containers/<id>/wait` holds a
+    // long-lived HTTP connection open until the container terminates and
+    // then replies with the exit code — a far cheaper signal than polling
+    // `docker inspect`. We fire-and-forget the wait: on the happy path the
+    // daemon's own `leave()` sets `leaveInitiatedByDaemon = true` before
+    // the container-remove fires, so when `wait` resolves (either with
+    // the container's real exit code or with `StatusCode: 0` via the 404
+    // branch in `DockerRunner.wait` when `remove()` ran first) the
+    // watcher sees the flag and becomes a no-op.
+    //
+    // The failure path this closes: some external process — a user
+    // `docker kill`, a concurrent stray daemon's reaper sweep, an OOM
+    // killer, a node-level pod eviction — terminates the bot container
+    // without going through our `leave()`. Without this watcher, the
+    // daemon's `this.sessions` keeps the meeting pinned as "joined"
+    // forever; subsequent `meet_speak`/`meet_send_chat` tool calls fail
+    // against a dead bot; the Swift client stays stuck in the "joined"
+    // state with no way to recover. Synthesizing a `meet.error` + tearing
+    // session state here lets the client observe the bot's death and the
+    // daemon reclaim the slot.
+    void runner
+      .wait(runResult.containerId)
+      .then(async (waitResult) => {
+        await this.handleContainerExit(
+          meetingId,
+          runResult.containerId,
+          waitResult,
+        );
+      })
+      .catch((err) => {
+        log.warn(
+          { err, meetingId, containerId: runResult.containerId },
+          "Container-exit watcher errored — cannot observe bot container exit",
+        );
+      });
 
     log.info(
       {
@@ -1544,6 +1596,16 @@ class MeetSessionManagerImpl {
       log.debug({ meetingId, reason }, "leave(): no active session — no-op");
       return;
     }
+
+    // Flag the container-exit watcher BEFORE any awaits. The watcher's
+    // `runner.wait(...)` promise resolves the instant `runner.remove()`
+    // below fires (the engine's 404 branch in `DockerRunner.wait`
+    // converts the "gone" response to `StatusCode: 0`), so without this
+    // flag set first a slow teardown path could still race the engine
+    // and have the watcher fire a duplicate `meet.error` before the
+    // synthetic `lifecycle:left` lands. Single synchronous assignment —
+    // no throw path to guard.
+    session.leaveInitiatedByDaemon = true;
 
     // Stop the consent monitor first — any pending LLM call can finish
     // harmlessly since `decided` is the only write path it has to the
@@ -1748,6 +1810,178 @@ class MeetSessionManagerImpl {
       },
       "Meet session left",
     );
+  }
+
+  /**
+   * Handle an unexpected bot container exit observed by the per-session
+   * container-exit watcher wired up in `join()`. Fires when
+   * `docker.wait(containerId)` resolves — which the Docker Engine does the
+   * moment the container terminates, regardless of cause.
+   *
+   * No-op in two cases:
+   *   1. The daemon's own `leave()` already set `leaveInitiatedByDaemon =
+   *      true` — the watcher is observing the graceful teardown's own
+   *      `runner.remove()`, and `leave()` is still mid-flight handling all
+   *      the cleanup. Firing here would duplicate the `meet.error` publish
+   *      and race the rest of the teardown.
+   *   2. The session is no longer in `this.sessions`. This can happen if
+   *      `leave()` already completed (ran to the `this.sessions.delete()`
+   *      line) before `wait` resolved, or if a rollback path dropped the
+   *      session without ever recording `leaveInitiatedByDaemon` because
+   *      the rollback fires before the watcher is installed. Either way
+   *      there's nothing left to tear down.
+   *
+   * On the real external-exit path we mirror `leave()`'s cleanup with two
+   * deliberate omissions:
+   *   - Skip `botLeaveFetch` — the bot container is already dead, so an
+   *     HTTP call would just hit `ECONNREFUSED` and burn 10s on the
+   *     timeout before we could even start the actual teardown.
+   *   - Skip `runner.stop` — likewise, stopping an already-exited container
+   *     surfaces a 304 or a cryptic engine error. We go straight to
+   *     `runner.remove()` (best-effort) to unregister the corpse so it
+   *     doesn't linger in `docker ps -a`.
+   *
+   * Publishes a `meet.error` with a human-readable `detail` identifying
+   * the unexpected exit so connected clients can render a useful error
+   * state instead of staying pinned in "joined" forever.
+   */
+  private async handleContainerExit(
+    meetingId: string,
+    containerId: string,
+    waitResult: DockerWaitResult,
+  ): Promise<void> {
+    const session = this.sessions.get(meetingId);
+    if (!session) return;
+    if (session.leaveInitiatedByDaemon) return;
+    // Defensive: if this watcher fires for a session whose `containerId`
+    // no longer matches (a subsequent join would replace the map entry —
+    // though the same-meeting-id guard in join() should make that
+    // impossible), treat it like the session-missing branch above.
+    if (session.containerId !== containerId) return;
+
+    const exitCode = waitResult.StatusCode;
+    const engineError = waitResult.Error?.Message ?? null;
+    const detail = engineError
+      ? `bot container exited unexpectedly (exitCode=${exitCode}, error=${engineError})`
+      : `bot container exited unexpectedly (exitCode=${exitCode})`;
+
+    log.info(
+      { meetingId, containerId, exitCode, engineError },
+      "Meet bot container exited unexpectedly — tearing session down",
+    );
+
+    void publishMeetEvent(
+      DAEMON_INTERNAL_ASSISTANT_ID,
+      meetingId,
+      "meet.error",
+      { detail },
+    );
+
+    // Claim the session before any awaits so a concurrent `leave()` call
+    // (e.g. from a tool handler reacting to the `meet.error` we just
+    // published) takes the no-op branch rather than double-tearing.
+    session.leaveInitiatedByDaemon = true;
+
+    // Symmetric teardown with `leave()` — same order, minus bot HTTP + stop.
+    try {
+      session.consentMonitor.stop();
+    } catch (err) {
+      log.warn(
+        { err, meetingId },
+        "MeetConsentMonitor.stop threw during container-exit teardown",
+      );
+    }
+    try {
+      session.chatOpportunityDetector?.dispose();
+    } catch (err) {
+      log.warn(
+        { err, meetingId },
+        "MeetChatOpportunityDetector.dispose threw during container-exit teardown",
+      );
+    }
+    try {
+      session.bargeInWatcher.stop();
+    } catch (err) {
+      log.warn(
+        { err, meetingId },
+        "MeetBargeInWatcher.stop threw during container-exit teardown",
+      );
+    }
+    try {
+      session.ttsLipsyncHandle.stop();
+    } catch (err) {
+      log.warn(
+        { err, meetingId },
+        "TtsLipsyncHandle.stop threw during container-exit teardown",
+      );
+    }
+    try {
+      await session.ttsBridge.cancelAll();
+    } catch (err) {
+      log.warn(
+        { err, meetingId },
+        "MeetTtsBridge.cancelAll threw during container-exit teardown",
+      );
+    }
+
+    if (session.timeoutHandle) {
+      clearTimeout(session.timeoutHandle);
+      session.timeoutHandle = null;
+    }
+    this.sessions.delete(meetingId);
+    this.pendingBotTokens.delete(meetingId);
+
+    try {
+      session.conversationBridge.unsubscribe();
+    } catch (err) {
+      log.warn(
+        { err, meetingId },
+        "MeetConversationBridge.unsubscribe threw during container-exit teardown",
+      );
+    }
+    try {
+      await session.storageWriter.stop();
+    } catch (err) {
+      log.warn(
+        { err, meetingId },
+        "MeetStorageWriter.stop threw during container-exit teardown",
+      );
+    }
+
+    for (const unsubscribe of session.eventUnsubscribes) {
+      try {
+        unsubscribe();
+      } catch (err) {
+        log.warn(
+          { err, meetingId },
+          "Meet event subscriber unsubscribe threw during container-exit teardown",
+        );
+      }
+    }
+    session.eventUnsubscribes = [];
+    unregisterMeetingDispatcher(meetingId);
+
+    // Container is already dead — skip `runner.stop`, but still best-effort
+    // `runner.remove()` so the exited container doesn't linger in
+    // `docker ps -a` forever.
+    const runner = this.deps.dockerRunnerFactory();
+    try {
+      await runner.remove(containerId);
+    } catch (err) {
+      log.warn(
+        { err, meetingId, containerId },
+        "DockerRunner.remove failed during container-exit teardown — container may linger in `docker ps -a`",
+      );
+    }
+
+    try {
+      await session.audioIngest.stop();
+    } catch (err) {
+      log.warn(
+        { err, meetingId },
+        "MeetAudioIngest.stop failed during container-exit teardown — socket or streaming STT session may leak",
+      );
+    }
   }
 
   /** Snapshot of currently-active sessions (excludes internal fields). */


### PR DESCRIPTION
## Summary

- Add a per-session watcher on the bot container via Docker's `POST /containers/<id>/wait`; on unexpected exit, publish `meet.error`, mirror-tear session-scoped state (same order as `leave()`, minus bot HTTP + `runner.stop`), and drop the session so clients don't stay pinned in "joined" forever.
- Guard against double-fire when the daemon's own `leave()` is the source via a `session.leaveInitiatedByDaemon` flag set before any awaits.
- Resolves TODO at `skills/meet-join/daemon/session-manager.ts:1515-1520`.

## Test plan

- [x] `bun test skills/meet-join/daemon/__tests__/session-manager.test.ts` — 47 tests pass (45 existing + 2 new watcher tests).
- [x] `bun test skills/meet-join/daemon/__tests__/docker-runner.test.ts` — 41 tests pass (37 existing + 4 new `wait` tests).
- [x] `bunx tsc --noEmit` clean.
- [x] `bun run lint` clean.

## Original prompt

--skip-ci --yolo

Resolve the TODO at \`skills/meet-join/daemon/session-manager.ts:1515-1520\` by adding a container-exit watcher that synthesizes a \`meet.error\` event when the meet-bot container dies unexpectedly (while the session is still active), so the daemon doesn't hang in "joined" forever.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
