### PR TITLE
fix(meet-join): scope orphan reaper to per-instance bot label

### DIFF
--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -59,8 +59,14 @@ export function normalizeAssistantId(assistantId: string): string {
  * Docker mode relocates the workspace via `VELLUM_WORKSPACE_DIR` rather
  * than `BASE_DATA_DIR`, so honoring `BASE_DATA_DIR` here does not affect
  * containerized deployments.
+ *
+ * Exported so other daemon-side consumers (e.g. the meet-join orphan reaper
+ * in `skills/meet-join/daemon/docker-runner.ts`) can derive a per-instance
+ * identifier from the same canonical root. Do not replace with ad-hoc
+ * `process.env.BASE_DATA_DIR` reads — this helper is the single source of
+ * truth for per-instance path resolution.
  */
-function vellumRoot(): string {
+export function vellumRoot(): string {
   const baseDataDir = process.env.BASE_DATA_DIR?.trim();
   if (baseDataDir) return join(baseDataDir, ".vellum");
   return join(homedir(), ".vellum");

--- a/skills/meet-join/daemon/__tests__/docker-runner.test.ts
+++ b/skills/meet-join/daemon/__tests__/docker-runner.test.ts
@@ -20,7 +20,9 @@ import {
   DockerRunner,
   dockerSocketUnreachableMessage,
   extractBoundPorts,
+  getMeetBotInstanceHash,
   HOST_GATEWAY_ALIAS,
+  MEET_BOT_INSTANCE_LABEL,
   MEET_BOT_LABEL,
   MEET_BOT_MEETING_ID_LABEL,
   reapOrphanedMeetBots,
@@ -727,11 +729,13 @@ describe("buildCreateBody labels", () => {
       labels: {
         [MEET_BOT_LABEL]: "true",
         [MEET_BOT_MEETING_ID_LABEL]: "meeting-a",
+        [MEET_BOT_INSTANCE_LABEL]: "abc1234567890def",
       },
     });
     expect(body.Labels).toEqual({
       "vellum.meet.bot": "true",
       "vellum.meet.meetingId": "meeting-a",
+      "vellum.meet.instance": "abc1234567890def",
     });
   });
 });
@@ -845,6 +849,13 @@ function silentLogger() {
 }
 
 describe("reapOrphanedMeetBots", () => {
+  // Shared hash values used across test scenarios. `OWN_HASH` matches the
+  // caller's instance (the bot containers "we" own); `OTHER_HASH` simulates
+  // a sibling daemon instance on the same host (prod/dev/test/local side-
+  // by-side — common on developer machines).
+  const OWN_HASH = "own-instance-hash";
+  const OTHER_HASH = "other-instance-hash";
+
   test("kills containers whose meetingId is not in the active set, keeps the rest", async () => {
     const killCalls: Array<{ id: string; signal: string | undefined }> = [];
     const docker: FakeDocker = {
@@ -854,6 +865,7 @@ describe("reapOrphanedMeetBots", () => {
           Labels: {
             [MEET_BOT_LABEL]: "true",
             [MEET_BOT_MEETING_ID_LABEL]: "meeting-a",
+            [MEET_BOT_INSTANCE_LABEL]: OWN_HASH,
           },
         },
         {
@@ -861,6 +873,7 @@ describe("reapOrphanedMeetBots", () => {
           Labels: {
             [MEET_BOT_LABEL]: "true",
             [MEET_BOT_MEETING_ID_LABEL]: "meeting-b",
+            [MEET_BOT_INSTANCE_LABEL]: OWN_HASH,
           },
         },
       ],
@@ -872,11 +885,13 @@ describe("reapOrphanedMeetBots", () => {
     const result = await reapOrphanedMeetBots({
       docker,
       activeMeetingIds: new Set(["meeting-b"]),
+      instanceHash: OWN_HASH,
       logger: silentLogger(),
     });
 
     expect(result.killed).toEqual(["c-a"]);
     expect(result.kept).toEqual(["c-b"]);
+    expect(result.skippedUnlabeled).toEqual([]);
     // SIGTERM went out synchronously during the sweep. The delayed SIGKILL
     // is scheduled via unref'd setTimeout — we assert only the SIGTERM here.
     expect(killCalls.filter((c) => c.signal === "SIGTERM")).toEqual([
@@ -894,9 +909,10 @@ describe("reapOrphanedMeetBots", () => {
     const result = await reapOrphanedMeetBots({
       docker,
       activeMeetingIds: new Set(),
+      instanceHash: OWN_HASH,
       logger: silentLogger(),
     });
-    expect(result).toEqual({ killed: [], kept: [] });
+    expect(result).toEqual({ killed: [], kept: [], skippedUnlabeled: [] });
   });
 
   test("continues sweeping when one container's kill throws", async () => {
@@ -908,6 +924,7 @@ describe("reapOrphanedMeetBots", () => {
           Labels: {
             [MEET_BOT_LABEL]: "true",
             [MEET_BOT_MEETING_ID_LABEL]: "meeting-a",
+            [MEET_BOT_INSTANCE_LABEL]: OWN_HASH,
           },
         },
         {
@@ -915,6 +932,7 @@ describe("reapOrphanedMeetBots", () => {
           Labels: {
             [MEET_BOT_LABEL]: "true",
             [MEET_BOT_MEETING_ID_LABEL]: "meeting-b",
+            [MEET_BOT_INSTANCE_LABEL]: OWN_HASH,
           },
         },
         {
@@ -922,6 +940,7 @@ describe("reapOrphanedMeetBots", () => {
           Labels: {
             [MEET_BOT_LABEL]: "true",
             [MEET_BOT_MEETING_ID_LABEL]: "meeting-c",
+            [MEET_BOT_INSTANCE_LABEL]: OWN_HASH,
           },
         },
       ],
@@ -935,6 +954,7 @@ describe("reapOrphanedMeetBots", () => {
     const result = await reapOrphanedMeetBots({
       docker,
       activeMeetingIds: new Set(),
+      instanceHash: OWN_HASH,
       logger: silentLogger(),
     });
 
@@ -942,6 +962,7 @@ describe("reapOrphanedMeetBots", () => {
     expect(killed).toEqual(["c-a", "c-c"]);
     expect(result.killed).toEqual(["c-a", "c-c"]);
     expect(result.kept).toEqual([]);
+    expect(result.skippedUnlabeled).toEqual([]);
   });
 
   test("skips containers created at or after createdBefore cutoff", async () => {
@@ -954,6 +975,7 @@ describe("reapOrphanedMeetBots", () => {
           Labels: {
             [MEET_BOT_LABEL]: "true",
             [MEET_BOT_MEETING_ID_LABEL]: "meeting-old",
+            [MEET_BOT_INSTANCE_LABEL]: OWN_HASH,
           },
         },
         {
@@ -962,6 +984,7 @@ describe("reapOrphanedMeetBots", () => {
           Labels: {
             [MEET_BOT_LABEL]: "true",
             [MEET_BOT_MEETING_ID_LABEL]: "meeting-new",
+            [MEET_BOT_INSTANCE_LABEL]: OWN_HASH,
           },
         },
       ],
@@ -973,12 +996,14 @@ describe("reapOrphanedMeetBots", () => {
     const result = await reapOrphanedMeetBots({
       docker,
       activeMeetingIds: new Set(),
+      instanceHash: OWN_HASH,
       createdBefore: 2000,
       logger: silentLogger(),
     });
 
     expect(result.killed).toEqual(["c-old"]);
     expect(result.kept).toEqual(["c-new"]);
+    expect(result.skippedUnlabeled).toEqual([]);
     expect(killCalls.filter((c) => c.signal === "SIGTERM")).toEqual([
       { id: "c-old", signal: "SIGTERM" },
     ]);
@@ -994,6 +1019,7 @@ describe("reapOrphanedMeetBots", () => {
           Labels: {
             [MEET_BOT_LABEL]: "true",
             [MEET_BOT_MEETING_ID_LABEL]: "meeting-a",
+            [MEET_BOT_INSTANCE_LABEL]: OWN_HASH,
           },
         },
         {
@@ -1001,6 +1027,7 @@ describe("reapOrphanedMeetBots", () => {
           Labels: {
             [MEET_BOT_LABEL]: "true",
             [MEET_BOT_MEETING_ID_LABEL]: "meeting-b",
+            [MEET_BOT_INSTANCE_LABEL]: OWN_HASH,
           },
         },
       ],
@@ -1015,11 +1042,13 @@ describe("reapOrphanedMeetBots", () => {
     const result = await reapOrphanedMeetBots({
       docker,
       activeMeetingIds: () => live,
+      instanceHash: OWN_HASH,
       logger: silentLogger(),
     });
 
     expect(result.killed).toEqual(["c-a"]);
     expect(result.kept).toEqual(["c-b"]);
+    expect(result.skippedUnlabeled).toEqual([]);
   });
 
   test("returns empty result and logs a warning if listContainers throws", async () => {
@@ -1034,8 +1063,173 @@ describe("reapOrphanedMeetBots", () => {
     const result = await reapOrphanedMeetBots({
       docker,
       activeMeetingIds: new Set(),
+      instanceHash: OWN_HASH,
       logger: silentLogger(),
     });
-    expect(result).toEqual({ killed: [], kept: [] });
+    expect(result).toEqual({ killed: [], kept: [], skippedUnlabeled: [] });
+  });
+
+  // -------------------------------------------------------------------------
+  // Per-instance label scoping (regression: multi-instance cross-kill)
+  // -------------------------------------------------------------------------
+
+  test("keeps containers from a different instance (different vellum.meet.instance label)", async () => {
+    const killCalls: Array<{ id: string; signal: string | undefined }> = [];
+    const docker: FakeDocker = {
+      listContainers: async () => [
+        {
+          Id: "c-own",
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-own",
+            [MEET_BOT_INSTANCE_LABEL]: OWN_HASH,
+          },
+        },
+        {
+          Id: "c-other",
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-other",
+            [MEET_BOT_INSTANCE_LABEL]: OTHER_HASH,
+          },
+        },
+      ],
+      kill: async (id, signal) => {
+        killCalls.push({ id, signal });
+      },
+    };
+
+    const result = await reapOrphanedMeetBots({
+      docker,
+      activeMeetingIds: new Set(),
+      instanceHash: OWN_HASH,
+      logger: silentLogger(),
+    });
+
+    // c-own is an orphan from this instance → reaped.
+    // c-other belongs to a different daemon instance on the same host →
+    // left alone (neither killed nor listed as skippedUnlabeled).
+    expect(result.killed).toEqual(["c-own"]);
+    expect(result.kept).toEqual(["c-other"]);
+    expect(result.skippedUnlabeled).toEqual([]);
+    expect(killCalls.filter((c) => c.signal === "SIGTERM")).toEqual([
+      { id: "c-own", signal: "SIGTERM" },
+    ]);
+  });
+
+  test("skips containers with no vellum.meet.instance label (pre-upgrade fossils)", async () => {
+    const killCalls: Array<{ id: string; signal: string | undefined }> = [];
+    const docker: FakeDocker = {
+      listContainers: async () => [
+        {
+          Id: "c-prelabel",
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-old",
+            // No MEET_BOT_INSTANCE_LABEL — this container was created by a
+            // daemon version before the instance-scope change shipped.
+          },
+        },
+        {
+          Id: "c-orphan",
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-new",
+            [MEET_BOT_INSTANCE_LABEL]: OWN_HASH,
+          },
+        },
+      ],
+      kill: async (id, signal) => {
+        killCalls.push({ id, signal });
+      },
+    };
+
+    const result = await reapOrphanedMeetBots({
+      docker,
+      activeMeetingIds: new Set(),
+      instanceHash: OWN_HASH,
+      logger: silentLogger(),
+    });
+
+    // Pre-label container goes into `skippedUnlabeled` — observable signal
+    // for users that a manual `docker rm` may be needed, but we never kill
+    // them (they could belong to another installation on the same host).
+    expect(result.skippedUnlabeled).toEqual(["c-prelabel"]);
+    expect(result.killed).toEqual(["c-orphan"]);
+    expect(result.kept).toEqual([]);
+    // Only the same-instance orphan got a SIGTERM.
+    expect(killCalls.filter((c) => c.signal === "SIGTERM")).toEqual([
+      { id: "c-orphan", signal: "SIGTERM" },
+    ]);
+  });
+
+  test("still kills orphans from the same instance when meetingId is not active", async () => {
+    // Regression guard for the pre-label reaper behavior: a same-instance
+    // container whose meetingId is not in the active set is still an orphan
+    // and must be reaped.
+    const killCalls: Array<{ id: string; signal: string | undefined }> = [];
+    const docker: FakeDocker = {
+      listContainers: async () => [
+        {
+          Id: "c-dead",
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-gone",
+            [MEET_BOT_INSTANCE_LABEL]: OWN_HASH,
+          },
+        },
+        {
+          Id: "c-live",
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-alive",
+            [MEET_BOT_INSTANCE_LABEL]: OWN_HASH,
+          },
+        },
+      ],
+      kill: async (id, signal) => {
+        killCalls.push({ id, signal });
+      },
+    };
+
+    const result = await reapOrphanedMeetBots({
+      docker,
+      activeMeetingIds: new Set(["meeting-alive"]),
+      instanceHash: OWN_HASH,
+      logger: silentLogger(),
+    });
+
+    expect(result.killed).toEqual(["c-dead"]);
+    expect(result.kept).toEqual(["c-live"]);
+    expect(result.skippedUnlabeled).toEqual([]);
+    expect(killCalls.filter((c) => c.signal === "SIGTERM")).toEqual([
+      { id: "c-dead", signal: "SIGTERM" },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getMeetBotInstanceHash
+// ---------------------------------------------------------------------------
+
+describe("getMeetBotInstanceHash", () => {
+  test("returns a deterministic 16-char lowercase hex string", () => {
+    const hash = getMeetBotInstanceHash();
+    expect(hash).toMatch(/^[0-9a-f]{16}$/);
+    expect(hash).toBe(getMeetBotInstanceHash());
+  });
+
+  test("changes when BASE_DATA_DIR changes (per-instance scoping)", () => {
+    const prev = process.env.BASE_DATA_DIR;
+    try {
+      process.env.BASE_DATA_DIR = "/tmp/instance-one";
+      const hashOne = getMeetBotInstanceHash();
+      process.env.BASE_DATA_DIR = "/tmp/instance-two";
+      const hashTwo = getMeetBotInstanceHash();
+      expect(hashOne).not.toBe(hashTwo);
+    } finally {
+      if (prev === undefined) delete process.env.BASE_DATA_DIR;
+      else process.env.BASE_DATA_DIR = prev;
+    }
   });
 });

--- a/skills/meet-join/daemon/__tests__/session-manager.test.ts
+++ b/skills/meet-join/daemon/__tests__/session-manager.test.ts
@@ -228,6 +228,7 @@ describe("MeetSessionManager.join", () => {
       }>;
       name: string;
       network: string;
+      labels: Record<string, string>;
     };
     expect(runOpts.image).toBe("vellum-meet-bot:dev");
     expect(runOpts.env.MEET_URL).toBe("https://meet.google.com/xyz-abc-def");
@@ -262,6 +263,15 @@ describe("MeetSessionManager.join", () => {
 
     expect(runOpts.name).toBe("vellum-meet-m1");
     expect(runOpts.network).toBe("bridge");
+
+    // Container labels consumed by the startup orphan reaper. The
+    // `vellum.meet.instance` label scopes the bot to this daemon's data
+    // root so a concurrently-running second daemon (different instance
+    // root) cannot cross-kill this container via its own reaper. See
+    // `docker-runner.ts:reapOrphanedMeetBots` for the full contract.
+    expect(runOpts.labels["vellum.meet.bot"]).toBe("true");
+    expect(runOpts.labels["vellum.meet.meetingId"]).toBe("m1");
+    expect(runOpts.labels["vellum.meet.instance"]).toMatch(/^[0-9a-f]{16}$/);
 
     // activeSessions and getSession both reflect the new record.
     expect(manager.activeSessions()).toHaveLength(1);

--- a/skills/meet-join/daemon/docker-runner.ts
+++ b/skills/meet-join/daemon/docker-runner.ts
@@ -34,12 +34,14 @@
  *     container.
  */
 
+import { createHash } from "node:crypto";
 import { request as httpRequest } from "node:http";
 import { posix as posixPath } from "node:path";
 
 import type { DaemonRuntimeMode } from "../../../assistant/src/runtime/runtime-mode.js";
 import { getDaemonRuntimeMode } from "../../../assistant/src/runtime/runtime-mode.js";
 import { getLogger } from "../../../assistant/src/util/logger.js";
+import { vellumRoot } from "../../../assistant/src/util/platform.js";
 
 const log = getLogger("meet-docker-runner");
 
@@ -156,10 +158,12 @@ export interface DockerRunOptions {
   avatarDevicePath?: string;
   /**
    * Docker labels applied at container-create time. Meet-bot containers
-   * are tagged with `vellum.meet.bot=true` and
-   * `vellum.meet.meetingId=<id>` so the orphan reaper (see
-   * {@link reapOrphanedMeetBots}) can discover and clean them up after a
-   * crashed prior run without misidentifying unrelated containers.
+   * are tagged with `vellum.meet.bot=true`,
+   * `vellum.meet.meetingId=<id>`, and `vellum.meet.instance=<hash>` so
+   * the orphan reaper (see {@link reapOrphanedMeetBots}) can discover
+   * and clean them up after a crashed prior run without misidentifying
+   * unrelated containers or cross-killing bots from a different daemon
+   * instance on the same host.
    */
   labels?: Record<string, string>;
 }
@@ -746,6 +750,37 @@ export const MEET_BOT_LABEL = "vellum.meet.bot";
 export const MEET_BOT_MEETING_ID_LABEL = "vellum.meet.meetingId";
 
 /**
+ * Docker-label key that scopes a meet-bot container to a specific daemon
+ * instance. Value is a short hash derived from {@link vellumRoot} (the
+ * per-instance data directory, resolved via `BASE_DATA_DIR`). The orphan
+ * reaper compares this against the current instance's hash and refuses to
+ * kill any container whose hash differs — so a second concurrent daemon
+ * pointed at a different instance root cannot SIGTERM another instance's
+ * live bots.
+ *
+ * Containers from pre-label versions (missing this label entirely) are
+ * treated as ambiguous ownership and skipped by the reaper — they might
+ * belong to a different installation. Users upgrading across this change
+ * with a stale container still running must `docker rm` it manually once.
+ */
+export const MEET_BOT_INSTANCE_LABEL = "vellum.meet.instance";
+
+/**
+ * Derive the per-instance hash stamped onto meet-bot containers at create
+ * time. Uses SHA-256 truncated to 16 hex chars — plenty of collision
+ * resistance for the small set of instance roots on a single host, and
+ * short enough to stay readable in `docker ps`.
+ *
+ * The hash is over {@link vellumRoot}'s absolute path so the full filesystem
+ * path isn't leaked into Docker metadata. Deterministic for a given instance
+ * root — the stamp-side and the reap-side see the same value as long as the
+ * daemon process sees the same `BASE_DATA_DIR`.
+ */
+export function getMeetBotInstanceHash(): string {
+  return createHash("sha256").update(vellumRoot()).digest("hex").slice(0, 16);
+}
+
+/**
  * Resolve a workspace-relative `subpath` against the absolute `workspaceDir`
  * using POSIX join semantics. Leading slashes in `subpath` are tolerated;
  * POSIX rules are used so the result is portable across test platforms.
@@ -904,7 +939,7 @@ export const REAPER_TERM_KILL_GRACE_MS = 10_000;
  * Sweep orphaned meet-bot containers left behind by a crashed prior run.
  *
  * **Label scheme.** Every meet-bot container created by this daemon is
- * tagged at `/containers/create` time with two Docker labels:
+ * tagged at `/containers/create` time with three Docker labels:
  *
  *   - `vellum.meet.bot=true` — identifies the container as a meet-bot
  *     managed by this codebase (distinguishes from any other containers
@@ -913,6 +948,19 @@ export const REAPER_TERM_KILL_GRACE_MS = 10_000;
  *     so the reaper can match each labeled container against the currently-
  *     active in-process session set and only kill the ones that belong to
  *     no live session.
+ *   - `vellum.meet.instance=<hash>` — scopes the container to a specific
+ *     daemon instance root (see {@link getMeetBotInstanceHash}). The reaper
+ *     refuses to touch containers whose hash differs so a second daemon
+ *     pointed at a different instance root (common on developer machines
+ *     with prod/dev/test/local instances side-by-side) cannot cross-kill
+ *     another instance's live bots.
+ *
+ * **Filter semantics.** The reaper lists candidates filtered at the Docker
+ * API layer by `vellum.meet.bot=true` only — not by the instance label.
+ * This is deliberate: we need to *observe* pre-label containers (from a
+ * version before this change shipped) so we can skip them and log a
+ * breadcrumb, rather than silently hide them behind an API filter. Same-
+ * instance + different-instance + unlabeled branching happens in code.
  *
  * **Kill protocol.** Each orphan receives a `SIGTERM`, then after a
  * {@link REAPER_TERM_KILL_GRACE_MS}-ms grace window the reaper issues a
@@ -928,12 +976,21 @@ export const REAPER_TERM_KILL_GRACE_MS = 10_000;
  *   in-process session. Accepts either a static set or a zero-arg getter;
  *   the getter is consulted per-container so a join that lands mid-sweep
  *   is observed before its container is evaluated.
+ * @param opts.instanceHash The current daemon instance's hash (from
+ *   {@link getMeetBotInstanceHash}). Required — not optional — so callers
+ *   cannot accidentally widen the sweep to all instances on the host.
+ *   Containers whose `vellum.meet.instance` label doesn't match go into
+ *   `kept`; containers missing the label go into `skippedUnlabeled`.
  * @param opts.createdBefore Optional Unix-epoch-seconds cutoff. Containers
  *   with `Created >= createdBefore` are kept unconditionally. Pass the
  *   daemon's start time during the startup sweep so new joins launched
  *   concurrently can never be misidentified as orphans from a prior run.
  * @param opts.logger Structured logger — one INFO line per kill.
- * @returns Summary of which container ids were killed vs kept.
+ * @returns Summary of which container ids were killed, kept, or skipped as
+ *   unlabeled. `skippedUnlabeled` is observability-only — pre-label
+ *   containers are never reaped because they might belong to another
+ *   installation; users upgrading with a stale unlabeled container must
+ *   `docker rm` it manually once.
  */
 /**
  * Structural subset of a pino-style structured logger — the reaper only
@@ -951,32 +1008,63 @@ export interface ReaperLogger {
 export async function reapOrphanedMeetBots(opts: {
   docker: DockerClientForReaper;
   activeMeetingIds: ReadonlySet<string> | (() => ReadonlySet<string>);
+  instanceHash: string;
   createdBefore?: number;
   logger: ReaperLogger;
-}): Promise<{ killed: string[]; kept: string[] }> {
-  const { docker, activeMeetingIds, createdBefore, logger } = opts;
+}): Promise<{ killed: string[]; kept: string[]; skippedUnlabeled: string[] }> {
+  const { docker, activeMeetingIds, instanceHash, createdBefore, logger } =
+    opts;
   const resolveActive =
     typeof activeMeetingIds === "function"
       ? activeMeetingIds
       : () => activeMeetingIds;
   const killed: string[] = [];
   const kept: string[] = [];
+  const skippedUnlabeled: string[] = [];
 
   let containers: ContainerListEntry[];
   try {
+    // List with the bot label only — not the instance label. We need to
+    // observe pre-label containers so we can skip them with a DEBUG
+    // breadcrumb; filtering on instance at the API layer would hide them.
+    // Same-instance vs different-instance vs unlabeled branching happens
+    // in code below.
     containers = await docker.listContainers({
       labels: { [MEET_BOT_LABEL]: "true" },
       all: false,
     });
   } catch (err) {
     logger.warn({ err }, "reapOrphanedMeetBots: listContainers failed");
-    return { killed, kept };
+    return { killed, kept, skippedUnlabeled };
   }
 
   for (const container of containers) {
     const containerId = container.Id;
     const labels = container.Labels ?? {};
     const meetingId = labels[MEET_BOT_MEETING_ID_LABEL];
+    const containerInstance = labels[MEET_BOT_INSTANCE_LABEL];
+
+    // Pre-label containers (from a version before the instance-label
+    // change shipped). Ownership is ambiguous — the container might
+    // belong to another installation on the same host — so the reaper
+    // never touches them. The user can `docker rm` manually if the
+    // container is actually stale.
+    if (containerInstance === undefined) {
+      logger.debug(
+        { containerId, meetingId },
+        "reapOrphanedMeetBots: skipping pre-label container (missing vellum.meet.instance)",
+      );
+      skippedUnlabeled.push(containerId);
+      continue;
+    }
+
+    // Containers from a different daemon instance on the same host. Leave
+    // them alone — the other instance's own reaper (or lifecycle) owns
+    // their cleanup.
+    if (containerInstance !== instanceHash) {
+      kept.push(containerId);
+      continue;
+    }
 
     // Skip containers created after the cutoff — they belong to this
     // daemon's lifetime (or later) and cannot be orphans from a prior run.
@@ -1021,5 +1109,5 @@ export async function reapOrphanedMeetBots(opts: {
     }
   }
 
-  return { killed, kept };
+  return { killed, kept, skippedUnlabeled };
 }

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -106,6 +106,8 @@ import {
 } from "./conversation-bridge.js";
 import {
   DockerRunner,
+  getMeetBotInstanceHash,
+  MEET_BOT_INSTANCE_LABEL,
   MEET_BOT_LABEL,
   MEET_BOT_MEETING_ID_LABEL,
   reapOrphanedMeetBots,
@@ -810,7 +812,8 @@ class MeetSessionManagerImpl {
     // transient docker-engine hiccup never tears down the session-manager
     // singleton. Tests opt out via {@link MeetSessionManagerDeps.disableStartupOrphanReaper}.
     //
-    // Two guards make the sweep race-safe with concurrent joins:
+    // Three guards make the sweep race-safe with concurrent joins and
+    // safe against cross-instance kills:
     //   1. `createdBefore` — Docker's `Created` timestamp for every
     //      container the reaper considers must predate this moment, so any
     //      container spawned by a join that races the sweep is skipped.
@@ -819,6 +822,11 @@ class MeetSessionManagerImpl {
     //      before the session lands in the map) per-container, so a join
     //      that lands mid-sweep is observed before its meeting ID is
     //      evaluated.
+    //   3. `instanceHash` — derived from `vellumRoot()`, the daemon's
+    //      per-instance data root. Multi-instance setups (prod/dev/test/
+    //      local side-by-side) are common; without this guard a second
+    //      daemon's startup reaper would SIGTERM the first daemon's live
+    //      bot containers. Only same-instance bots are reaped.
     if (!this.deps.disableStartupOrphanReaper) {
       const reaperDocker = this.deps.dockerRunnerFactory();
       const daemonStartEpochSeconds = Math.floor(Date.now() / 1000);
@@ -829,6 +837,7 @@ class MeetSessionManagerImpl {
           for (const id of this.pendingBotTokens.keys()) ids.add(id);
           return ids;
         },
+        instanceHash: getMeetBotInstanceHash(),
         createdBefore: daemonStartEpochSeconds,
         logger: log,
       }).catch((err: unknown) => {
@@ -1182,10 +1191,13 @@ class MeetSessionManagerImpl {
         network: meet.dockerNetwork,
         // Labels consumed by the orphan reaper on the next daemon boot.
         // See {@link reapOrphanedMeetBots} in `docker-runner.ts` for the
-        // full label scheme + reaper contract.
+        // full label scheme + reaper contract. The `vellum.meet.instance`
+        // label scopes the bot to this daemon's instance root so a
+        // concurrently-running second daemon cannot reap this container.
         labels: {
           [MEET_BOT_LABEL]: "true",
           [MEET_BOT_MEETING_ID_LABEL]: meetingId,
+          [MEET_BOT_INSTANCE_LABEL]: getMeetBotInstanceHash(),
         },
         // When avatar is enabled, pass through the v4l2loopback device so
         // the bot container can open `/dev/video10` (or whatever override


### PR DESCRIPTION
## Summary
- Add `vellum.meet.instance=<hash of vellumRoot()>` label on every meet-bot container.
- Scope `reapOrphanedMeetBots` to match that label so a second daemon instance can't SIGTERM another instance's live bots.
- Pre-label containers (no instance label) are now skipped rather than reaped.

## Original prompt
Namespace meet-bot container labels per daemon instance so the orphan reaper can't cross-kill another instance's live bots.

We diagnosed an issue where meet-bot containers were being SIGTERM'd externally while the owning daemon was still running and healthy. The strongest suspect was a second daemon process running concurrently against the same host (multi-instance setups — prod, dev, test, local — are common). The startup orphan reaper at `session-manager.ts` listed ALL containers labeled `vellum.meet.bot=true` and killed any whose `meetingId` was not in the caller's `activeMeetingIds` set. Nothing scoped that sweep to the current daemon instance, so a stray or concurrent daemon could mow down another instance's live bots.

This PR:
1. Adds `MEET_BOT_INSTANCE_LABEL = "vellum.meet.instance"` alongside the existing `MEET_BOT_LABEL` and `MEET_BOT_MEETING_ID_LABEL`.
2. Computes a stable per-instance value: `crypto.createHash("sha256").update(vellumRoot()).digest("hex").slice(0, 16)`.
3. Stamps the new label on every meet-bot container in `DockerRunner.run`.
4. Scopes `reapOrphanedMeetBots` to require an `instanceHash` parameter and only touch containers whose `vellum.meet.instance` matches. Pre-label containers (missing the label entirely) are logged at DEBUG and go into a new `skippedUnlabeled` observability bucket — they might belong to another installation. Users upgrading across this change with a stale pre-label container must `docker rm` it manually once.
5. Updates the call site in `session-manager.ts` to pass `instanceHash: getMeetBotInstanceHash()`.

## Test plan
- [x] `bun test skills/meet-join/daemon/__tests__/docker-runner.test.ts` (42 tests pass)
- [x] `bun test skills/meet-join/daemon/__tests__/session-manager.test.ts` (45 tests pass)
- [x] `bunx tsc --noEmit` in `assistant/` (clean)
- [x] New reaper tests:
  - `keeps containers from a different instance (different vellum.meet.instance label)`
  - `skips containers with no vellum.meet.instance label (pre-upgrade fossils)`
  - `still kills orphans from the same instance when meetingId is not active`
- [x] Session-manager test extended to assert `vellum.meet.instance` label is stamped alongside bot + meetingId labels on `run()`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
