### PR TITLE
fix(meet-bot): serialize xdotool type + click to prevent mid-type focus shift

### DIFF
--- a/skills/meet-join/bot/__tests__/main.test.ts
+++ b/skills/meet-join/bot/__tests__/main.test.ts
@@ -93,6 +93,14 @@ interface MakeDepsOpts {
   xdotoolClickError?: Error;
   /** Force `xdotoolType` to reject. */
   xdotoolTypeError?: Error;
+  /**
+   * Delay before `xdotoolType` resolves. Used by serialization tests to
+   * simulate the real xdotool's 25ms-per-key wall-clock cost so the
+   * queue behavior is observable in-process.
+   */
+  xdotoolTypeDelayMs?: number;
+  /** Delay before `xdotoolClick` resolves — same rationale as above. */
+  xdotoolClickDelayMs?: number;
   /** Force `startXvfb` to reject. */
   xvfbError?: Error;
   /** Short-circuit `waitForReady` to reject with this error. */
@@ -264,7 +272,11 @@ function makeDeps(opts: MakeDepsOpts = {}): {
         y: clickOpts.y,
         display: clickOpts.display,
       });
+      if (opts.xdotoolClickDelayMs !== undefined) {
+        await new Promise((r) => setTimeout(r, opts.xdotoolClickDelayMs));
+      }
       if (opts.xdotoolClickError) throw opts.xdotoolClickError;
+      calls.push({ kind: "xdotool.click.end" });
     },
     xdotoolType: async (typeOpts) => {
       calls.push({
@@ -274,7 +286,11 @@ function makeDeps(opts: MakeDepsOpts = {}): {
         display: typeOpts.display,
         timeoutMs: typeOpts.timeoutMs,
       });
+      if (opts.xdotoolTypeDelayMs !== undefined) {
+        await new Promise((r) => setTimeout(r, opts.xdotoolTypeDelayMs));
+      }
       if (opts.xdotoolTypeError) throw opts.xdotoolTypeError;
+      calls.push({ kind: "xdotool.type.end" });
     },
     startAudioCapture: async (audioOpts) => {
       calls.push({
@@ -705,6 +721,91 @@ describe("runBot — extension message routing", () => {
     const counts = handles.stopCounts();
     expect(counts.chrome).toBe(0);
     expect(counts.xvfb).toBe(0);
+  });
+
+  test("serializes trusted_type + trusted_click — click waits for type to finish", async () => {
+    // Regression guard for the consent-message truncation bug: when the
+    // extension emits `trusted_type` immediately followed by a
+    // `trusted_click` for the send button, the bot must NOT spawn the
+    // two xdotool processes concurrently. Running them concurrently
+    // lets the click shift focus mid-type and the composer submits a
+    // truncated message (observed in the field as ~30 chars of a
+    // ~90-char consent message).
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps({
+      // Slow type mimics real xdotool's per-keystroke wall-clock cost.
+      xdotoolTypeDelayMs: 40,
+      // Fast click mimics real xdotool click latency.
+      xdotoolClickDelayMs: 2,
+    });
+    await bootHappyPath(deps, handles);
+
+    // Fire type and click back-to-back — same pattern as the
+    // extension's post-panel-open path in `features/chat.ts`.
+    handles.fireExtensionMessage({
+      type: "trusted_type",
+      text: "Hi, I'm Bot, an AI assistant joining to take notes.",
+    });
+    handles.fireExtensionMessage({
+      type: "trusted_click",
+      x: 1598,
+      y: 611,
+    });
+
+    // Wait long enough for both operations to fully complete.
+    await new Promise((r) => setTimeout(r, 120));
+
+    // Extract the sequence of xdotool start/end events.
+    const sequence = handles.calls
+      .filter((c) => c.kind.startsWith("xdotool."))
+      .map((c) => c.kind);
+
+    // The type must start, end, then the click may start.
+    const typeStartIdx = sequence.indexOf("xdotool.type");
+    const typeEndIdx = sequence.indexOf("xdotool.type.end");
+    const clickStartIdx = sequence.indexOf("xdotool.click");
+
+    expect(typeStartIdx).toBeGreaterThanOrEqual(0);
+    expect(typeEndIdx).toBeGreaterThan(typeStartIdx);
+    expect(clickStartIdx).toBeGreaterThan(typeEndIdx);
+  });
+
+  test("queue continues after an xdotool failure — next op still runs", async () => {
+    // If a `trusted_type` fails (e.g. the "Invalid multi-byte sequence"
+    // error we've seen when xdotool can't map a char to a keysym), the
+    // queue must not stall — subsequent clicks/types must continue to
+    // execute so the bot stays usable.
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps({
+      xdotoolTypeError: new Error("xdotool type exit code 1"),
+    });
+    await bootHappyPath(deps, handles);
+
+    handles.fireExtensionMessage({
+      type: "trusted_type",
+      text: "this will fail",
+    });
+    handles.fireExtensionMessage({
+      type: "trusted_click",
+      x: 100,
+      y: 200,
+    });
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Both xdotool invocations must have been attempted despite the
+    // type failure, and the click must have completed.
+    expect(
+      handles.errors.some((m) => m.includes("trusted_type failed")),
+    ).toBe(true);
+    expect(
+      handles.calls.some(
+        (c) => c.kind === "xdotool.click" && c.x === 100 && c.y === 200,
+      ),
+    ).toBe(true);
+    expect(handles.calls.some((c) => c.kind === "xdotool.click.end")).toBe(
+      true,
+    );
   });
 
   test("diagnostic messages go through the logger, not the daemon", async () => {

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -991,6 +991,34 @@ export async function runBot(deps: BotDeps): Promise<void> {
   // -------------------------------------------------------------------------
 
   /**
+   * Single-lane queue for xdotool invocations (`trusted_type` +
+   * `trusted_click`). Every xdotool operation must complete before the
+   * next begins; overlapping invocations corrupt each other via focus
+   * migration. Concrete symptom: a `trusted_type` for a ~90-char
+   * consent message racing a `trusted_click` for the send button
+   * truncates the typed text to ~30 chars — the click lands mid-
+   * typing, the composer submits whatever made it in so far, and the
+   * remaining keystrokes either drop or land on the wrong element.
+   *
+   * The extension tries to gap these via a wall-clock
+   * `trustedTypeDurationMs(text.length)` wait in `features/chat.ts`,
+   * but that timer doesn't survive NMH pipe backpressure, Chrome
+   * service-worker throttling, or a busy Bun event loop — any of which
+   * can push the two xdotool processes into overlap despite the intended
+   * ordering. The queue makes serial execution a property of the bot
+   * process itself, so overlap is impossible regardless of caller-side
+   * timing assumptions.
+   */
+  let xdotoolQueue: Promise<unknown> = Promise.resolve();
+  function enqueueXdotool<T>(op: () => Promise<T>): Promise<T> {
+    // `.catch(() => undefined)` so one failed xdotool invocation doesn't
+    // poison the chain — later type/click ops must still run.
+    const next = xdotoolQueue.catch(() => undefined).then(op);
+    xdotoolQueue = next;
+    return next;
+  }
+
+  /**
    * Route a single validated inbound message from the extension. Lifecycle
    * + telemetry forward to the daemon, diagnostics get logged, and
    * `send_chat_result` completes the pending HTTP request.
@@ -1081,53 +1109,58 @@ export async function runBot(deps: BotDeps): Promise<void> {
         else deps.logInfo(`[ext] ${msg.message}`);
         return;
       case "trusted_click": {
-        // Fire-and-forget: the extension confirms success by observing the
-        // subsequent DOM transition (waitForSelector on the in-meeting UI).
-        // We surface any xdotool failure as a logError so operators see
-        // them even though the extension can't synchronously react.
-        deps
-          .xdotoolClick({
-            x: msg.x,
-            y: msg.y,
-            display: env.xvfbDisplay,
-          })
-          .then(() =>
-            deps.logInfo(
-              `meet-bot: trusted_click dispatched at (${msg.x},${msg.y})`,
-            ),
-          )
-          .catch((err: unknown) => {
-            const detail = err instanceof Error ? err.message : String(err);
-            deps.logError(`meet-bot: trusted_click failed: ${detail}`);
-          });
+        // Serialized through `xdotoolQueue`: a click issued while a
+        // prior `trusted_type` is still in flight would shift focus
+        // mid-type and truncate the typed text. The extension is
+        // fire-and-forget; the extension observes success via the
+        // subsequent DOM transition (waitForSelector on the in-meeting
+        // UI). xdotool failure is surfaced as a logError so operators
+        // see it even though the extension can't synchronously react.
+        enqueueXdotool(() =>
+          deps
+            .xdotoolClick({
+              x: msg.x,
+              y: msg.y,
+              display: env.xvfbDisplay,
+            })
+            .then(() =>
+              deps.logInfo(
+                `meet-bot: trusted_click dispatched at (${msg.x},${msg.y})`,
+              ),
+            )
+            .catch((err: unknown) => {
+              const detail = err instanceof Error ? err.message : String(err);
+              deps.logError(`meet-bot: trusted_click failed: ${detail}`);
+            }),
+        );
         return;
       }
       case "trusted_type": {
-        // Mirror of trusted_click: fire-and-forget, log on success /
-        // failure, never cascade into a bot shutdown. The extension has
-        // already focused the target element; the bot just types into
-        // whatever is focused on the Xvfb display.
-        //
-        // We pass an explicit `timeoutMs` scaled to the message length so
-        // xdotool is not killed mid-type on long chats. `xdotool-type.ts`'s
+        // Serialized through `xdotoolQueue` — see `trusted_click` above.
+        // The extension has already focused the target element; the bot
+        // just types into whatever is focused on the Xvfb display. An
+        // explicit `timeoutMs` is scaled to the message length so xdotool
+        // is not killed mid-type on long chats. `xdotool-type.ts`'s
         // built-in default is a fixed 15s, which truncated any message
         // above ~590 characters at the default 25ms/keystroke delay.
-        deps
-          .xdotoolType({
-            text: msg.text,
-            delayMs: msg.delayMs,
-            display: env.xvfbDisplay,
-            timeoutMs: trustedTypeKillTimeoutMs(msg.text.length, msg.delayMs),
-          })
-          .then(() =>
-            deps.logInfo(
-              `meet-bot: trusted_type dispatched (${msg.text.length} chars)`,
-            ),
-          )
-          .catch((err: unknown) => {
-            const detail = err instanceof Error ? err.message : String(err);
-            deps.logError(`meet-bot: trusted_type failed: ${detail}`);
-          });
+        enqueueXdotool(() =>
+          deps
+            .xdotoolType({
+              text: msg.text,
+              delayMs: msg.delayMs,
+              display: env.xvfbDisplay,
+              timeoutMs: trustedTypeKillTimeoutMs(msg.text.length, msg.delayMs),
+            })
+            .then(() =>
+              deps.logInfo(
+                `meet-bot: trusted_type dispatched (${msg.text.length} chars)`,
+              ),
+            )
+            .catch((err: unknown) => {
+              const detail = err instanceof Error ? err.message : String(err);
+              deps.logError(`meet-bot: trusted_type failed: ${detail}`);
+            }),
+        );
         return;
       }
       case "send_chat_result": {


### PR DESCRIPTION
## Summary
- Consent message was truncating on join — the bot posted a ~30-char fragment instead of the full ~90-char intro. Root cause: \`trusted_type\` (composer typing, ~2.3s wall-clock for 90 chars) and \`trusted_click\` (send button) were both fire-and-forget in \`main.ts\`, so a send-click xdotool process could spawn while the type was still mid-stroke and shift focus. The extension tries to gap them with \`trustedTypeDurationMs(text.length) + 250ms\`, but that fixed buffer doesn't survive NMH pipe backpressure or a busy Bun event loop.
- Fix: single-lane \`xdotoolQueue\` inside the bot that chains every trusted_type / trusted_click through a \`.then\` so each xdotool process exits before the next begins. Failure in one op doesn't poison the queue — subsequent ops still run. Ordering comes from the bot's NMH receive order, which is already correct.
- Regression tests cover the serialization invariant (slow type + fast click → click starts only after type ends) and the failure-recovery path (typed xdotool error → queued click still runs).

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
