### PR TITLE
fix(assistant): self-register default plugins + fix conversation-queue DB fixture

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -2418,7 +2418,12 @@ describe("Conversation attachment event payloads", () => {
       model: "mock",
       providerDurationMs: 100,
     });
-    run.onEvent({ type: "message_complete", message: assistantMsg });
+    // Await the message_complete dispatch so the async persistence pipeline
+    // (which sets `state.lastAssistantMessageId`) finishes before the mock
+    // resolves `agentLoop.run()` and downstream post-processing runs. The
+    // real agent loop in `agent/loop.ts` awaits onEvent before returning,
+    // so awaiting here keeps the mock faithful to production semantics.
+    await run.onEvent({ type: "message_complete", message: assistantMsg });
     run.resolve([...run.messages, assistantMsg]);
 
     await p1;
@@ -2592,7 +2597,10 @@ describe("Regression: cancel semantics and error channel split", () => {
       model: "mock",
       providerDurationMs: 100,
     });
-    run.onEvent({ type: "message_complete", message: assistantMsg });
+    // Await the message_complete dispatch so the async persistence pipeline
+    // finishes before the mock resolves `agentLoop.run()`. See the matching
+    // comment in "message_complete includes assistant attachments".
+    await run.onEvent({ type: "message_complete", message: assistantMsg });
     run.resolve([...run.messages, assistantMsg]);
     await p1;
 

--- a/assistant/src/plugins/defaults/circuit-breaker.ts
+++ b/assistant/src/plugins/defaults/circuit-breaker.ts
@@ -32,7 +32,8 @@
  * container; the key is attached to the log record via the pipeline runner.
  */
 
-import type { Plugin } from "../types.js";
+import { registerPlugin } from "../registry.js";
+import { type Plugin, PluginExecutionError } from "../types.js";
 
 /**
  * Consecutive failures required to trip the breaker. Matches the legacy
@@ -121,3 +122,25 @@ export const defaultCircuitBreakerPlugin: Plugin = {
     },
   },
 };
+
+// Module-load side effect: register this default at import time so
+// downstream consumers (including tests that skip `bootstrapPlugins()`)
+// observe a populated registry by default. Idempotent via the swallowed
+// duplicate-name check. Kept local to this module (rather than iterating
+// an array in `defaults/index.ts`) so the registration only references
+// the already-initialized `defaultCircuitBreakerPlugin` identifier —
+// avoiding a TDZ crash when tests `mock.module(...)` a dependency of any
+// other default plugin and directly import this file.
+try {
+  registerPlugin(defaultCircuitBreakerPlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both index.ts and the direct
+    // file are imported in the same process
+  } else {
+    throw err;
+  }
+}

--- a/assistant/src/plugins/defaults/compaction.ts
+++ b/assistant/src/plugins/defaults/compaction.ts
@@ -25,6 +25,7 @@ import type {
   ContextWindowResult,
 } from "../../context/window-manager.js";
 import type { Message } from "../../providers/types.js";
+import { registerPlugin } from "../registry.js";
 import {
   type CompactionArgs,
   type CompactionResult,
@@ -120,3 +121,25 @@ export const defaultCompactionPlugin: Plugin = {
     compaction: defaultCompactionMiddleware,
   },
 };
+
+// Module-load side effect: register this default at import time so
+// downstream consumers (including tests that skip `bootstrapPlugins()`)
+// observe a populated registry by default. Idempotent via the swallowed
+// duplicate-name check. Kept local to this module (rather than iterating
+// an array in `defaults/index.ts`) so the registration only references
+// the already-initialized `defaultCompactionPlugin` identifier —
+// avoiding a TDZ crash when tests `mock.module(...)` a dependency of any
+// other default plugin and directly import this file.
+try {
+  registerPlugin(defaultCompactionPlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both index.ts and the direct
+    // file are imported in the same process
+  } else {
+    throw err;
+  }
+}

--- a/assistant/src/plugins/defaults/empty-response.ts
+++ b/assistant/src/plugins/defaults/empty-response.ts
@@ -27,7 +27,8 @@
  * declared in one place only.
  */
 
-import type { Plugin } from "../types.js";
+import { registerPlugin } from "../registry.js";
+import { type Plugin, PluginExecutionError } from "../types.js";
 
 /**
  * Historic nudge text. Must stay verbatim so an existing plugin that wraps
@@ -78,3 +79,25 @@ export const defaultEmptyResponsePlugin: Plugin = {
     },
   },
 };
+
+// Module-load side effect: register this default at import time so
+// downstream consumers (including tests that skip `bootstrapPlugins()`)
+// observe a populated registry by default. Idempotent via the swallowed
+// duplicate-name check. Kept local to this module (rather than iterating
+// an array in `defaults/index.ts`) so the registration only references
+// the already-initialized `defaultEmptyResponsePlugin` identifier —
+// avoiding a TDZ crash when tests `mock.module(...)` a dependency of any
+// other default plugin and directly import this file.
+try {
+  registerPlugin(defaultEmptyResponsePlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both index.ts and the direct
+    // file are imported in the same process
+  } else {
+    throw err;
+  }
+}

--- a/assistant/src/plugins/defaults/history-repair.ts
+++ b/assistant/src/plugins/defaults/history-repair.ts
@@ -16,11 +16,13 @@
  */
 
 import { repairHistory } from "../../daemon/history-repair.js";
+import { registerPlugin } from "../registry.js";
 import {
   type HistoryRepairArgs,
   type HistoryRepairResult,
   type Middleware,
   type Plugin,
+  PluginExecutionError,
 } from "../types.js";
 
 /**
@@ -48,3 +50,25 @@ export const defaultHistoryRepairPlugin: Plugin = {
     historyRepair: terminal,
   },
 };
+
+// Module-load side effect: register this default at import time so
+// downstream consumers (including tests that skip `bootstrapPlugins()`)
+// observe a populated registry by default. Idempotent via the swallowed
+// duplicate-name check. Kept local to this module (rather than iterating
+// an array in `defaults/index.ts`) so the registration only references
+// the already-initialized `defaultHistoryRepairPlugin` identifier —
+// avoiding a TDZ crash when tests `mock.module(...)` a dependency of any
+// other default plugin and directly import this file.
+try {
+  registerPlugin(defaultHistoryRepairPlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both index.ts and the direct
+    // file are imported in the same process
+  } else {
+    throw err;
+  }
+}

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -15,6 +15,17 @@
  * Keeping the list here — rather than inline in the bootstrap — avoids a
  * circular import between `plugins/registry.ts` and the bootstrap module and
  * keeps the defaults colocated with the other plugin-layer exports.
+ *
+ * Each `defaults/<name>.ts` module self-registers at module load via a
+ * local side effect. That keeps registrations attached to the already-
+ * initialized per-file plugin identifier, so the TDZ trap that bit the
+ * previous top-level `registerDefaultPlugins()` call in this file cannot
+ * recur when `defaults/index.ts` is loaded mid-cycle through the
+ * `memory-retrieval.ts` → … → `pipeline.ts` → `defaults/index.ts`
+ * cycle. The per-file side effects are idempotent — duplicate-name
+ * registrations are swallowed — so {@link registerDefaultPlugins} and
+ * {@link resetPluginRegistryAndRegisterDefaults} remain safe to call
+ * after a registry reset.
  */
 
 import { registerPlugin, resetPluginRegistryForTests } from "../registry.js";
@@ -39,23 +50,36 @@ import { defaultToolResultTruncatePlugin } from "./tool-result-truncate.js";
  * registered at boot. Registration order drives middleware composition order
  * in the pipeline runner, so additions should be appended — not inserted —
  * unless the plan explicitly requires a different position.
+ *
+ * Implemented as a function (rather than a top-level `const` array) to avoid
+ * a TDZ hazard: `memory-retrieval.ts` transitively imports
+ * `plugins/pipeline.ts` (via `daemon/conversation-runtime-assembly.ts` →
+ * … → `agent/loop.ts`), and `pipeline.ts` side-effect-imports this file.
+ * When the first loader of `defaults/index.ts` is anything in that cycle,
+ * `defaults/index.ts` starts evaluating BEFORE `memory-retrieval.ts`
+ * finishes — so a top-level `ALL_DEFAULT_PLUGINS = [...memoryRetrievalPlugin...]`
+ * declaration trips the live-binding TDZ. A function body defers the
+ * reads until call time, by which point every imported plugin identifier
+ * is guaranteed initialized.
  */
-export const ALL_DEFAULT_PLUGINS: readonly Plugin[] = [
-  defaultLlmCallPlugin,
-  defaultToolExecutePlugin,
-  defaultToolResultTruncatePlugin,
-  defaultEmptyResponsePlugin,
-  defaultToolErrorPlugin,
-  defaultMemoryRetrievalPlugin,
-  defaultInjectorsPlugin,
-  defaultTokenEstimatePlugin,
-  defaultOverflowReducePlugin,
-  defaultHistoryRepairPlugin,
-  defaultCompactionPlugin,
-  defaultCircuitBreakerPlugin,
-  defaultPersistencePlugin,
-  defaultTitleGeneratePlugin,
-];
+export function getAllDefaultPlugins(): readonly Plugin[] {
+  return [
+    defaultLlmCallPlugin,
+    defaultToolExecutePlugin,
+    defaultToolResultTruncatePlugin,
+    defaultEmptyResponsePlugin,
+    defaultToolErrorPlugin,
+    defaultMemoryRetrievalPlugin,
+    defaultInjectorsPlugin,
+    defaultTokenEstimatePlugin,
+    defaultOverflowReducePlugin,
+    defaultHistoryRepairPlugin,
+    defaultCompactionPlugin,
+    defaultCircuitBreakerPlugin,
+    defaultPersistencePlugin,
+    defaultTitleGeneratePlugin,
+  ];
+}
 
 /**
  * Register every first-party default plugin. Idempotent — duplicate-name
@@ -65,7 +89,7 @@ export const ALL_DEFAULT_PLUGINS: readonly Plugin[] = [
  * mismatch) re-throws.
  */
 export function registerDefaultPlugins(): void {
-  for (const plugin of ALL_DEFAULT_PLUGINS) {
+  for (const plugin of getAllDefaultPlugins()) {
     try {
       registerPlugin(plugin);
     } catch (err) {
@@ -96,25 +120,21 @@ export function resetPluginRegistryAndRegisterDefaults(): void {
   registerDefaultPlugins();
 }
 
-// Module-load side effect: register every first-party default plugin so
-// downstream consumers (production bootstrap AND tests that skip
-// `bootstrapPlugins()`) observe a fully-populated registry by default.
-// Idempotent via swallowed duplicate-name errors so repeat imports,
-// test resets followed by re-imports, etc. don't throw.
+// Module-load registration is now performed by each `defaults/<name>.ts`
+// file via its own local side effect. The old `registerDefaultPlugins()`
+// call that used to live at the end of this module walked the plugin
+// array at the module's top level — which TDZ-crashed whenever
+// `defaults/index.ts` was loaded mid-cycle (e.g. through
+// `memory-retrieval.ts` → `conversation-runtime-assembly.ts` →
+// … → `agent/loop.ts` → `plugins/pipeline.ts` → `defaults/index.ts`):
+// the array referenced `defaultMemoryRetrievalPlugin` before its
+// declaration line had evaluated. Moving registration into each
+// per-file module avoids that hazard because each file's local side
+// effect only references its own `defaultXyzPlugin` identifier, which
+// is initialized by the time its side-effect block runs. Registration
+// order is preserved because `defaults/index.ts` imports each default
+// in the canonical order returned by {@link getAllDefaultPlugins}.
 //
-// This preserves the G3.2/R3 plan intent: default plugins are the innermost
-// layer, and user plugins registered later via `loadUserPlugins()` wrap
-// them uniformly across all 14 pipelines. Because `loadUserPlugins()` runs
-// inside `bootstrapPlugins()` — strictly AFTER all static side-effect
-// imports have executed — the onion ordering (defaults inner, user
-// middleware outer) holds in production. Test harnesses that skip
-// `bootstrapPlugins()` inherit the defaults automatically, fixing the
-// persistence / emptyResponse / toolError pipeline terminals that throw
-// under strict-fail semantics.
-//
-// Note: pipeline-unit tests that call `resetPluginRegistryForTests()` in
-// `beforeEach` are unaffected because this side-effect runs exactly once,
-// at module load, and the reset helper only clears the registry — it
-// doesn't re-run the module body. Those tests that need defaults back
-// should call `resetPluginRegistryAndRegisterDefaults()` instead.
-registerDefaultPlugins();
+// {@link registerDefaultPlugins} and
+// {@link resetPluginRegistryAndRegisterDefaults} remain exported as
+// belt-and-braces helpers for tests that clear the registry mid-run.

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -46,12 +46,14 @@ import { getInContextPkbPaths } from "../../daemon/pkb-context-tracker.js";
 import { buildPkbReminder } from "../../daemon/pkb-reminder-builder.js";
 import { searchPkbFiles } from "../../memory/pkb/pkb-search.js";
 import { getLogger } from "../../util/logger.js";
-import type {
-  InjectionBlock,
-  Injector,
-  Plugin,
-  TurnContext,
-  TurnInjectionInputs,
+import { registerPlugin } from "../registry.js";
+import {
+  type InjectionBlock,
+  type Injector,
+  type Plugin,
+  PluginExecutionError,
+  type TurnContext,
+  type TurnInjectionInputs,
 } from "../types.js";
 
 const pkbReminderLog = getLogger("pkb-reminder");
@@ -460,3 +462,25 @@ export const defaultInjectorsPlugin: Plugin = {
     threadFocusInjector,
   ],
 };
+
+// Module-load side effect: register this default at import time so
+// downstream consumers (including tests that skip `bootstrapPlugins()`)
+// observe a populated registry by default. Idempotent via the swallowed
+// duplicate-name check. Kept local to this module (rather than iterating
+// an array in `defaults/index.ts`) so the registration only references
+// the already-initialized `defaultInjectorsPlugin` identifier —
+// avoiding a TDZ crash when tests `mock.module(...)` a dependency of any
+// other default plugin and directly import this file.
+try {
+  registerPlugin(defaultInjectorsPlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both index.ts and the direct
+    // file are imported in the same process
+  } else {
+    throw err;
+  }
+}

--- a/assistant/src/plugins/defaults/llm-call.ts
+++ b/assistant/src/plugins/defaults/llm-call.ts
@@ -15,7 +15,13 @@
  * Design doc: `.private/plans/agent-plugin-system.md` (PR 15).
  */
 
-import type { LLMCallArgs, LLMCallResult, Plugin } from "../types.js";
+import { registerPlugin } from "../registry.js";
+import {
+  type LLMCallArgs,
+  type LLMCallResult,
+  type Plugin,
+  PluginExecutionError,
+} from "../types.js";
 
 /**
  * The default LLM-call plugin. Its sole contribution is the `llmCall`
@@ -48,3 +54,25 @@ export const defaultLlmCallPlugin: Plugin = {
     },
   },
 };
+
+// Module-load side effect: register this default at import time so
+// downstream consumers (including tests that skip `bootstrapPlugins()`)
+// observe a populated registry by default. Idempotent via the swallowed
+// duplicate-name check. Kept local to this module (rather than iterating
+// an array in `defaults/index.ts`) so the registration only references
+// the already-initialized `defaultLlmCallPlugin` identifier —
+// avoiding a TDZ crash when tests `mock.module(...)` a dependency of any
+// other default plugin and directly import this file.
+try {
+  registerPlugin(defaultLlmCallPlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both index.ts and the direct
+    // file are imported in the same process
+  } else {
+    throw err;
+  }
+}

--- a/assistant/src/plugins/defaults/memory-retrieval.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval.ts
@@ -32,11 +32,13 @@ import {
 import type { ServerMessage } from "../../daemon/message-protocol.js";
 import type { ConversationGraphMemory } from "../../memory/graph/conversation-graph-memory.js";
 import type { Message } from "../../providers/types.js";
+import { registerPlugin } from "../registry.js";
 import {
   type MemoryArgs,
   type MemoryResult,
   type Middleware,
   type Plugin,
+  PluginExecutionError,
 } from "../types.js";
 
 /**
@@ -191,3 +193,25 @@ export const defaultMemoryRetrievalPlugin: Plugin = {
     memoryRetrieval: defaultMemoryRetrievalMiddleware,
   },
 };
+
+// Module-load side effect: register this default at import time so
+// downstream consumers (including tests that skip `bootstrapPlugins()`)
+// observe a populated registry by default. Idempotent via the swallowed
+// duplicate-name check. Kept local to this module (rather than iterating
+// an array in `defaults/index.ts`) so the registration only references
+// the already-initialized `defaultMemoryRetrievalPlugin` identifier —
+// avoiding a TDZ crash when tests `mock.module(...)` a dependency of any
+// other default plugin and directly import this file.
+try {
+  registerPlugin(defaultMemoryRetrievalPlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both index.ts and the direct
+    // file are imported in the same process
+  } else {
+    throw err;
+  }
+}

--- a/assistant/src/plugins/defaults/overflow-reduce.ts
+++ b/assistant/src/plugins/defaults/overflow-reduce.ts
@@ -25,11 +25,13 @@ import {
   reduceContextOverflow,
   type ReducerState,
 } from "../../daemon/context-overflow-reducer.js";
-import type {
-  Middleware,
-  OverflowReduceArgs,
-  OverflowReduceResult,
-  Plugin,
+import { registerPlugin } from "../registry.js";
+import {
+  type Middleware,
+  type OverflowReduceArgs,
+  type OverflowReduceResult,
+  type Plugin,
+  PluginExecutionError,
 } from "../types.js";
 
 /**
@@ -129,3 +131,25 @@ export const defaultOverflowReducePlugin: Plugin = {
     overflowReduce: defaultOverflowReduceMiddleware,
   },
 };
+
+// Module-load side effect: register this default at import time so
+// downstream consumers (including tests that skip `bootstrapPlugins()`)
+// observe a populated registry by default. Idempotent via the swallowed
+// duplicate-name check. Kept local to this module (rather than iterating
+// an array in `defaults/index.ts`) so the registration only references
+// the already-initialized `defaultOverflowReducePlugin` identifier —
+// avoiding a TDZ crash when tests `mock.module(...)` a dependency of any
+// other default plugin and directly import this file.
+try {
+  registerPlugin(defaultOverflowReducePlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both index.ts and the direct
+    // file are imported in the same process
+  } else {
+    throw err;
+  }
+}

--- a/assistant/src/plugins/defaults/persistence.ts
+++ b/assistant/src/plugins/defaults/persistence.ts
@@ -23,7 +23,13 @@ import {
   updateMessageMetadata,
 } from "../../memory/conversation-crud.js";
 import { syncMessageToDisk } from "../../memory/conversation-disk-view.js";
-import { type PersistArgs, type PersistResult, type Plugin } from "../types.js";
+import { registerPlugin } from "../registry.js";
+import {
+  type PersistArgs,
+  type PersistResult,
+  type Plugin,
+  PluginExecutionError,
+} from "../types.js";
 
 /**
  * The default persistence plugin. Its sole contribution is the `persistence`
@@ -91,3 +97,25 @@ export const defaultPersistencePlugin: Plugin = {
     },
   },
 };
+
+// Module-load side effect: register this default at import time so
+// downstream consumers (including tests that skip `bootstrapPlugins()`)
+// observe a populated registry by default. Idempotent via the swallowed
+// duplicate-name check. Kept local to this module (rather than iterating
+// an array in `defaults/index.ts`) so the registration only references
+// the already-initialized `defaultPersistencePlugin` identifier —
+// avoiding a TDZ crash when tests `mock.module(...)` a dependency of any
+// other default plugin and directly import this file.
+try {
+  registerPlugin(defaultPersistencePlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both index.ts and the direct
+    // file are imported in the same process
+  } else {
+    throw err;
+  }
+}

--- a/assistant/src/plugins/defaults/title-generate.ts
+++ b/assistant/src/plugins/defaults/title-generate.ts
@@ -18,7 +18,13 @@
  */
 
 import { queueGenerateConversationTitle } from "../../memory/conversation-title-service.js";
-import type { Plugin, TitleArgs, TitleResult } from "../types.js";
+import { registerPlugin } from "../registry.js";
+import {
+  type Plugin,
+  PluginExecutionError,
+  type TitleArgs,
+  type TitleResult,
+} from "../types.js";
 
 /**
  * Invoke the title-generation service with the provided arguments. Used as
@@ -65,3 +71,25 @@ export const defaultTitleGeneratePlugin: Plugin = {
     },
   },
 };
+
+// Module-load side effect: register this default at import time so
+// downstream consumers (including tests that skip `bootstrapPlugins()`)
+// observe a populated registry by default. Idempotent via the swallowed
+// duplicate-name check. Kept local to this module (rather than iterating
+// an array in `defaults/index.ts`) so the registration only references
+// the already-initialized `defaultTitleGeneratePlugin` identifier —
+// avoiding a TDZ crash when tests `mock.module(...)` a dependency of any
+// other default plugin and directly import this file.
+try {
+  registerPlugin(defaultTitleGeneratePlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both index.ts and the direct
+    // file are imported in the same process
+  } else {
+    throw err;
+  }
+}

--- a/assistant/src/plugins/defaults/token-estimate.ts
+++ b/assistant/src/plugins/defaults/token-estimate.ts
@@ -23,7 +23,13 @@ import {
   estimatePromptTokensRaw,
   estimateToolsTokens,
 } from "../../context/token-estimator.js";
-import type { EstimateArgs, EstimateResult, Plugin } from "../types.js";
+import { registerPlugin } from "../registry.js";
+import {
+  type EstimateArgs,
+  type EstimateResult,
+  type Plugin,
+  PluginExecutionError,
+} from "../types.js";
 
 /**
  * Terminal middleware for the `tokenEstimate` pipeline. Computes the tool
@@ -60,3 +66,25 @@ export const defaultTokenEstimatePlugin: Plugin = {
       defaultTokenEstimateTerminal(args),
   },
 };
+
+// Module-load side effect: register this default at import time so
+// downstream consumers (including tests that skip `bootstrapPlugins()`)
+// observe a populated registry by default. Idempotent via the swallowed
+// duplicate-name check. Kept local to this module (rather than iterating
+// an array in `defaults/index.ts`) so the registration only references
+// the already-initialized `defaultTokenEstimatePlugin` identifier —
+// avoiding a TDZ crash when tests `mock.module(...)` a dependency of any
+// other default plugin and directly import this file.
+try {
+  registerPlugin(defaultTokenEstimatePlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both index.ts and the direct
+    // file are imported in the same process
+  } else {
+    throw err;
+  }
+}

--- a/assistant/src/plugins/defaults/tool-error.ts
+++ b/assistant/src/plugins/defaults/tool-error.ts
@@ -13,11 +13,13 @@
  * Design doc: `.private/plans/agent-plugin-system.md` (PR 19).
  */
 
-import type {
-  Middleware,
-  Plugin,
-  ToolErrorArgs,
-  ToolErrorDecision,
+import { registerPlugin } from "../registry.js";
+import {
+  type Middleware,
+  type Plugin,
+  PluginExecutionError,
+  type ToolErrorArgs,
+  type ToolErrorDecision,
 } from "../types.js";
 
 /**
@@ -86,3 +88,25 @@ export const defaultToolErrorPlugin: Plugin = {
     toolError: defaultToolErrorMiddleware,
   },
 };
+
+// Module-load side effect: register this default at import time so
+// downstream consumers (including tests that skip `bootstrapPlugins()`)
+// observe a populated registry by default. Idempotent via the swallowed
+// duplicate-name check. Kept local to this module (rather than iterating
+// an array in `defaults/index.ts`) so the registration only references
+// the already-initialized `defaultToolErrorPlugin` identifier —
+// avoiding a TDZ crash when tests `mock.module(...)` a dependency of any
+// other default plugin and directly import this file.
+try {
+  registerPlugin(defaultToolErrorPlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both index.ts and the direct
+    // file are imported in the same process
+  } else {
+    throw err;
+  }
+}

--- a/assistant/src/plugins/defaults/tool-execute.ts
+++ b/assistant/src/plugins/defaults/tool-execute.ts
@@ -29,11 +29,13 @@
  *   canonical terminator regardless of which third parties load.
  */
 
-import type {
-  Middleware,
-  Plugin,
-  ToolExecuteArgs,
-  ToolExecuteResult,
+import { registerPlugin } from "../registry.js";
+import {
+  type Middleware,
+  type Plugin,
+  PluginExecutionError,
+  type ToolExecuteArgs,
+  type ToolExecuteResult,
 } from "../types.js";
 
 /**
@@ -63,3 +65,25 @@ export const defaultToolExecutePlugin: Plugin = {
     toolExecute: defaultToolExecute,
   },
 };
+
+// Module-load side effect: register this default at import time so
+// downstream consumers (including tests that skip `bootstrapPlugins()`)
+// observe a populated registry by default. Idempotent via the swallowed
+// duplicate-name check. Kept local to this module (rather than iterating
+// an array in `defaults/index.ts`) so the registration only references
+// the already-initialized `defaultToolExecutePlugin` identifier —
+// avoiding a TDZ crash when tests `mock.module(...)` a dependency of any
+// other default plugin and directly import this file.
+try {
+  registerPlugin(defaultToolExecutePlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both index.ts and the direct
+    // file are imported in the same process
+  } else {
+    throw err;
+  }
+}

--- a/assistant/src/plugins/defaults/tool-result-truncate.ts
+++ b/assistant/src/plugins/defaults/tool-result-truncate.ts
@@ -13,11 +13,13 @@
  */
 
 import { truncateToolResultText } from "../../context/tool-result-truncation.js";
-import type {
-  Middleware,
-  Plugin,
-  ToolResultTruncateArgs,
-  ToolResultTruncateResult,
+import { registerPlugin } from "../registry.js";
+import {
+  type Middleware,
+  type Plugin,
+  PluginExecutionError,
+  type ToolResultTruncateArgs,
+  type ToolResultTruncateResult,
 } from "../types.js";
 
 /**
@@ -57,3 +59,25 @@ export const defaultToolResultTruncatePlugin: Plugin = {
     toolResultTruncate: defaultToolResultTruncateMiddleware,
   },
 };
+
+// Module-load side effect: register this default at import time so
+// downstream consumers (including tests that skip `bootstrapPlugins()`)
+// observe a populated registry by default. Idempotent via the swallowed
+// duplicate-name check. Kept local to this module (rather than iterating
+// an array in `defaults/index.ts`) so the registration only references
+// the already-initialized `defaultToolResultTruncatePlugin` identifier —
+// avoiding a TDZ crash when tests `mock.module(...)` a dependency of any
+// other default plugin and directly import this file.
+try {
+  registerPlugin(defaultToolResultTruncatePlugin);
+} catch (err) {
+  if (
+    err instanceof PluginExecutionError &&
+    err.message.includes("already registered")
+  ) {
+    // already registered — expected when both index.ts and the direct
+    // file are imported in the same process
+  } else {
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- TDZ fix: each plugins/defaults/<name>.ts module now registers itself at module-load via a local side effect. Previously, defaults/index.ts ran `registerDefaultPlugins()` at module-top-level, which TDZ-crashed because `memory-retrieval.ts` → `conversation-runtime-assembly.ts` → … → `agent/loop.ts` → `plugins/pipeline.ts` (which side-effect-imports defaults/index.ts) re-entered defaults/index.ts while memory-retrieval.ts was still mid-load — so the `ALL_DEFAULT_PLUGINS` array hit an uninitialized live binding on `defaultMemoryRetrievalPlugin`. Self-registration attaches each call to the already-initialized per-file plugin identifier, and the former top-level array is now a `getAllDefaultPlugins()` function so its reads are deferred until after the cycle resolves.
- conversation-queue.test.ts race fix: two attachment tests were exhibiting a pre-existing race — the test mock invoked `run.onEvent({ type: 'message_complete' })` synchronously (fire-and-forget) and then resolved `agentLoop.run()` immediately, but the async `handleMessageComplete` → persistence pipeline had not yet set `state.lastAssistantMessageId`, so the downstream `resolveAssistantAttachments` received `undefined` and `attachments[0].id` was missing. The real agent loop in `agent/loop.ts` awaits `onEvent(...)` before returning from `run()`; the test now does the same via `await run.onEvent(...)` to preserve production semantics.

Part of plan: agent-plugin-system.md (CI fix 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
