### PR TITLE
feat(home-feed): emit feed event on heartbeat completion [JARVIS-579]

### DIFF
--- a/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
@@ -107,7 +107,7 @@ describe("heartbeat feed events", () => {
     const items = readFeedItems();
     const heartbeatItem = items.find((i) => i.title === "Heartbeat");
     expect(heartbeatItem).toBeDefined();
-    expect(heartbeatItem!.summary).toBe("All systems healthy.");
+    expect(heartbeatItem!.summary).toBe("Heartbeat check completed.");
     expect(heartbeatItem!.priority).toBe(30);
     expect(heartbeatItem!.urgency).toBeUndefined();
     expect(heartbeatItem!.source).toBe("assistant");

--- a/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
@@ -1,0 +1,159 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Stub the in-process SSE hub so the writer's publish path is a
+// no-op in these tests.
+const publishSpy = mock<(event: unknown) => Promise<void>>(async () => {});
+
+mock.module("../../runtime/assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    publish: publishSpy,
+    subscribe: () => () => {},
+  },
+}));
+
+// Stub workspace prompt reads so the heartbeat service doesn't try to
+// read real workspace files.
+mock.module("../../util/platform.js", () => ({
+  getWorkspaceDir: () => workspaceDir,
+  getWorkspacePromptPath: (name: string) => join(workspaceDir, name),
+  vellumRoot: () => workspaceDir,
+}));
+
+// Stub config so heartbeat is enabled.
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({
+    heartbeat: {
+      enabled: true,
+      intervalMs: 60_000,
+      activeHoursStart: null,
+      activeHoursEnd: null,
+    },
+  }),
+}));
+
+// Stub conversation bootstrap.
+const lastConversationId = "conv-heartbeat-test";
+mock.module("../../memory/conversation-bootstrap.js", () => ({
+  bootstrapConversation: () => ({ id: lastConversationId }),
+}));
+
+// Stub prompt helpers.
+mock.module("../../prompts/persona-resolver.js", () => ({
+  GUARDIAN_PERSONA_TEMPLATE: "",
+  resolveGuardianPersona: () => null,
+}));
+mock.module("../../prompts/system-prompt.js", () => ({
+  isTemplateContent: () => false,
+}));
+
+const { getHomeFeedPath } = await import("../../home/feed-writer.js");
+const { HeartbeatService } = await import("../heartbeat-service.js");
+
+interface OnDiskItem {
+  id: string;
+  type: string;
+  source?: string;
+  title: string;
+  summary: string;
+  priority: number;
+  status: string;
+  author: string;
+  urgency?: string;
+}
+
+function readFeedItems(): OnDiskItem[] {
+  const raw = JSON.parse(readFileSync(getHomeFeedPath(), "utf-8"));
+  return raw.items as OnDiskItem[];
+}
+
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-hb-feed-"));
+  origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  publishSpy.mockClear();
+});
+
+afterEach(() => {
+  if (origWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = origWorkspaceDir;
+  }
+  try {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+describe("heartbeat feed events", () => {
+  test("successful heartbeat emits feed event with priority 30 and no urgency", async () => {
+    const service = new HeartbeatService({
+      processMessage: async () => ({ messageId: "msg-1" }),
+      alerter: () => {},
+    });
+
+    await service.runOnce({ force: true });
+
+    // Give the fire-and-forget emitFeedEvent time to flush.
+    await new Promise((r) => setTimeout(r, 100));
+
+    const items = readFeedItems();
+    const heartbeatItem = items.find((i) => i.title === "Heartbeat");
+    expect(heartbeatItem).toBeDefined();
+    expect(heartbeatItem!.summary).toBe("All systems healthy.");
+    expect(heartbeatItem!.priority).toBe(30);
+    expect(heartbeatItem!.urgency).toBeUndefined();
+    expect(heartbeatItem!.source).toBe("assistant");
+  });
+
+  test("failed heartbeat emits feed event with priority 55 and urgency medium", async () => {
+    const service = new HeartbeatService({
+      processMessage: async () => {
+        throw new Error("LLM call failed");
+      },
+      alerter: () => {},
+    });
+
+    await service.runOnce({ force: true });
+
+    // Give the fire-and-forget emitFeedEvent time to flush.
+    await new Promise((r) => setTimeout(r, 100));
+
+    const items = readFeedItems();
+    const heartbeatItem = items.find((i) => i.title === "Heartbeat");
+    expect(heartbeatItem).toBeDefined();
+    expect(heartbeatItem!.summary).toBe(
+      "Heartbeat check failed. Check logs for details.",
+    );
+    expect(heartbeatItem!.priority).toBe(55);
+    expect(heartbeatItem!.urgency).toBe("medium");
+    expect(heartbeatItem!.source).toBe("assistant");
+  });
+
+  test("dedupKey uses date for daily dedup", async () => {
+    const service = new HeartbeatService({
+      processMessage: async () => ({ messageId: "msg-1" }),
+      alerter: () => {},
+    });
+
+    // Run twice — same day should dedup to one item.
+    await service.runOnce({ force: true });
+    await new Promise((r) => setTimeout(r, 100));
+    await service.runOnce({ force: true });
+    await new Promise((r) => setTimeout(r, 100));
+
+    const items = readFeedItems();
+    const heartbeatItems = items.filter((i) => i.title === "Heartbeat");
+    expect(heartbeatItems).toHaveLength(1);
+
+    const today = new Date().toISOString().split("T")[0];
+    expect(heartbeatItems[0]!.id).toBe(`emit:assistant:heartbeat:${today}`);
+  });
+});

--- a/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
@@ -20,6 +20,7 @@ mock.module("../../util/platform.js", () => ({
   getWorkspaceDir: () => workspaceDir,
   getWorkspacePromptPath: (name: string) => join(workspaceDir, name),
   vellumRoot: () => workspaceDir,
+  getDataDir: () => join(workspaceDir, "data"),
 }));
 
 // Stub config so heartbeat is enabled.

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { HeartbeatAlert } from "../daemon/message-protocol.js";
+import { emitFeedEvent } from "../home/emit-feed-event.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import {
   GUARDIAN_PERSONA_TEMPLATE,
@@ -396,6 +397,19 @@ export class HeartbeatService {
       }
 
       log.info({ conversationId: conversation.id }, "Heartbeat completed");
+
+      void emitFeedEvent({
+        source: "assistant",
+        title: "Heartbeat",
+        summary: "All systems healthy.",
+        dedupKey: `heartbeat:${new Date().toISOString().split("T")[0]}`,
+        priority: 30,
+      }).catch((err) => {
+        log.warn(
+          { err, conversationId: conversation.id },
+          "Failed to emit heartbeat feed event",
+        );
+      });
     } catch (err) {
       log.error({ err }, "Heartbeat failed");
       try {
@@ -407,6 +421,15 @@ export class HeartbeatService {
       } catch (alertErr) {
         log.error({ alertErr }, "Failed to broadcast heartbeat alert");
       }
+
+      void emitFeedEvent({
+        source: "assistant",
+        title: "Heartbeat",
+        summary: "Heartbeat check failed. Check logs for details.",
+        dedupKey: `heartbeat:${new Date().toISOString().split("T")[0]}`,
+        priority: 55,
+        urgency: "medium",
+      }).catch(() => {});
     }
   }
 

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -401,7 +401,7 @@ export class HeartbeatService {
       void emitFeedEvent({
         source: "assistant",
         title: "Heartbeat",
-        summary: "All systems healthy.",
+        summary: "Heartbeat check completed.",
         dedupKey: `heartbeat:${new Date().toISOString().split("T")[0]}`,
         priority: 30,
       }).catch((err) => {


### PR DESCRIPTION
## Summary
- Add emitFeedEvent calls in heartbeat-service.ts for both success and failure paths
- Success: priority 30, daily dedupKey, 'All systems healthy.'
- Failure: priority 55, urgency medium, daily dedupKey
- Add tests verifying both paths and dedup behavior

Part of plan: wire-feed-event-sources.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
