### PR TITLE
fix(assistant): make bootstrap prompt and canned greeting proactive

### DIFF
--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -99,21 +99,14 @@ describe("first-greeting", () => {
       expect(greeting).toStartWith("Hello, Alex.");
     });
 
-    it("mentions selected tools", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
-        tools: ["slack", "linear"],
-      });
-      expect(greeting).toContain("Slack");
-      expect(greeting).toContain("Linear");
-    });
-
-    it("truncates long tool lists", () => {
+    it("does not mention selected tools by name", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
         tools: ["slack", "linear", "gmail", "notion"],
       });
-      expect(greeting).toContain("Slack, Linear, and 2 more");
+      expect(greeting).not.toContain("Slack");
+      expect(greeting).not.toContain("Linear");
+      expect(greeting).not.toContain("Gmail");
     });
 
     it("suggests actions from selected tasks", () => {
@@ -122,6 +115,7 @@ describe("first-greeting", () => {
         tasks: ["code-building"],
       });
       expect(greeting).toContain("help you build something");
+      expect(greeting).not.toContain("?");
     });
 
     it("offers two suggestions when multiple tasks selected", () => {
@@ -131,11 +125,12 @@ describe("first-greeting", () => {
       });
       expect(greeting).toContain("draft or edit some writing");
       expect(greeting).toContain("dig into a research question");
+      expect(greeting).not.toContain("?");
     });
 
-    it("falls back to generic prompt when no tasks selected", () => {
+    it("falls back to direct prompt when no tasks selected", () => {
       const greeting = getCannedFirstGreeting({ ...base, tasks: [] });
-      expect(greeting).toContain("tackle first");
+      expect(greeting).not.toContain("?");
     });
 
     it("assembles a full personalized greeting", () => {
@@ -148,8 +143,8 @@ describe("first-greeting", () => {
       });
       expect(greeting).toStartWith("Hey Alex!");
       expect(greeting).toContain("I'm Pax");
-      expect(greeting).toContain("Slack");
-      expect(greeting).toContain("GitHub");
+      expect(greeting).not.toContain("Slack");
+      expect(greeting).not.toContain("GitHub");
       expect(greeting).toContain("help you build something");
     });
   });

--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -49,15 +49,23 @@ describe("first-greeting", () => {
     });
   });
 
-  describe("getCannedFirstGreeting", () => {
-    it("returns the generic greeting when no onboarding context", () => {
-      const greeting = getCannedFirstGreeting();
-      expect(greeting).toBe(CANNED_FIRST_GREETING);
-      expect(greeting).toContain("brand new");
+  describe("no-onboarding branch", () => {
+    it("returns no-onboarding greeting when context is undefined", () => {
+      expect(getCannedFirstGreeting(undefined)).toBe(CANNED_FIRST_GREETING);
     });
 
-    it("returns the generic greeting when onboarding is undefined", () => {
-      expect(getCannedFirstGreeting(undefined)).toBe(CANNED_FIRST_GREETING);
+    it("returns no-onboarding greeting when everything is empty", () => {
+      const greeting = getCannedFirstGreeting({
+        tools: [],
+        tasks: [],
+        tone: "",
+      });
+      expect(greeting).toBe(CANNED_FIRST_GREETING);
+    });
+
+    it("no-onboarding greeting uses two-paragraph structure", () => {
+      expect(CANNED_FIRST_GREETING).toContain("\n\n");
+      expect(CANNED_FIRST_GREETING).toContain("I can ask");
     });
   });
 
@@ -68,101 +76,204 @@ describe("first-greeting", () => {
       tone: "balanced",
     };
 
-    it("includes user name when provided", () => {
-      const greeting = getCannedFirstGreeting({ ...base, userName: "Alex" });
-      expect(greeting).toContain("Alex");
-    });
-
-    it("includes assistant name when provided", () => {
+    it("full dev stack: GitHub + Linear, Building + PM", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
-        assistantName: "Pax",
-      });
-      expect(greeting).toContain("I'm Pax");
-    });
-
-    it("uses casual tone", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
-        tone: "casual",
+        tools: ["github", "linear"],
+        tasks: ["code-building", "project-management"],
         userName: "Alex",
+        assistantName: "Pip",
       });
-      expect(greeting).toStartWith("Hey Alex!");
+      expect(greeting).toContain("Hey Alex, I'm Pip.");
+      expect(greeting).toContain("GitHub and Linear say");
+      expect(greeting).toContain(
+        "shipping code or figuring out what to ship next",
+      );
+      expect(greeting).toContain("\n\n");
     });
 
-    it("uses professional tone", () => {
+    it("PM + comms: Linear + Notion, PM + Writing", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
-        tone: "professional",
+        tools: ["linear", "notion"],
+        tasks: ["project-management", "writing"],
         userName: "Alex",
+        assistantName: "Pip",
       });
-      expect(greeting).toStartWith("Hello, Alex.");
+      expect(greeting).toContain("Notion and Linear say");
+      expect(greeting).toContain("writing a spec or pushing something forward");
     });
 
-    it("uses tool-enhanced suggestion when matching tool is present", () => {
+    it("writer: Notion + Google Drive, Writing only", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
-        tasks: ["project-management"],
-        tools: ["linear"],
+        tools: ["notion", "google-drive"],
+        tasks: ["writing"],
+        userName: "Alex",
+        assistantName: "Luna",
       });
-      expect(greeting).toContain("pull your Linear board");
+      expect(greeting).toContain("Notion and Google Drive say");
+      expect(greeting).toContain("drafting something or cleaning up docs");
     });
 
-    it("falls back to default suggestion when no matching tool", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
-        tasks: ["project-management"],
-        tools: ["slack"],
-      });
-      expect(greeting).toContain("help organize a project");
-      expect(greeting).not.toContain("Linear");
-    });
-
-    it("suggests actions from selected tasks", () => {
+    it("single task no tools: Building only", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
         tasks: ["code-building"],
+        userName: "Alex",
+        assistantName: "Pip",
       });
-      expect(greeting).toContain("help you build something");
+      expect(greeting).toContain("Probably shipping something or debugging");
+      expect(greeting).not.toContain("Your");
     });
 
-    it("combines multiple task suggestions", () => {
+    it("single tool single task: GitHub + Building", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
-        tasks: ["writing", "research"],
-        tools: ["gmail"],
-      });
-      expect(greeting).toContain("triage your inbox or draft something");
-      expect(greeting).toContain("dig into a research topic");
-    });
-
-    it("always ends with the closing line", () => {
-      const greeting = getCannedFirstGreeting({ ...base, tasks: [] });
-      expect(greeting).toEndWith(
-        "Tell me what you're working on and let's get started.",
-      );
-    });
-
-    it("caps at 2 suggestions, preferring tool-enhanced ones", () => {
-      const greeting = getCannedFirstGreeting({
-        tools: ["gmail", "google-calendar", "linear", "notion", "github"],
-        tasks: ["code-building", "project-management", "writing", "research"],
-        tone: "casual",
+        tools: ["github"],
+        tasks: ["code-building"],
         userName: "Alex",
-        assistantName: "Pax",
+        assistantName: "Pip",
       });
-      expect(greeting).toStartWith("Hey Alex!");
-      expect(greeting).toContain("I'm Pax");
-      const offerCount = [
-        "review your open PRs",
-        "Linear board",
-        "triage your inbox",
-        "dig into a research",
-      ].filter((s) => greeting.includes(s)).length;
-      expect(offerCount).toBe(2);
-      expect(greeting).toEndWith(
-        "Tell me what you're working on and let's get started.",
+      expect(greeting).toContain("Your GitHub says");
+    });
+
+    it("many hats: 4 selections", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tasks: ["code-building", "writing", "research", "project-management"],
+        userName: "Alex",
+        assistantName: "Pip",
+      });
+      expect(greeting).toContain("wear a lot of hats");
+      expect(greeting).toContain("Where should we start?");
+    });
+
+    it("many hats: 6 selections", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tasks: [
+          "code-building",
+          "writing",
+          "research",
+          "project-management",
+          "scheduling",
+          "personal",
+        ],
+        userName: "Alex",
+        assistantName: "Pip",
+      });
+      expect(greeting).toContain("wear a lot of hats");
+    });
+
+    it("no tasks with tools: no-signal branch", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tools: ["gmail", "linear"],
+        tasks: [],
+        userName: "Alex",
+        assistantName: "Pip",
+      });
+      expect(greeting).toContain("What's on your plate?");
+      expect(greeting).toContain("I can ask you a few questions");
+    });
+
+    it("missing name uses Hey comma opener", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tasks: ["code-building"],
+        assistantName: "Pip",
+      });
+      expect(greeting).toStartWith("Hey, I'm Pip.");
+    });
+
+    it("3-selection falls back to highest-priority single template", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tasks: ["writing", "research", "scheduling"],
+        userName: "Alex",
+        assistantName: "Pip",
+      });
+      expect(greeting).toContain("drafting something or cleaning up docs");
+    });
+
+    it("unlisted 2-combo falls back to highest-priority single", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tasks: ["research", "personal"],
+        userName: "Alex",
+        assistantName: "Pip",
+      });
+      expect(greeting).toContain(
+        "digging into a topic or making sense of something",
       );
+    });
+
+    it("uses capital I throughout", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tasks: ["code-building"],
+        userName: "Alex",
+        assistantName: "Pip",
+      });
+      expect(greeting).toContain("I'm Pip");
+      expect(greeting).toContain("I'll get sharper");
+      expect(greeting).toContain("am I on the right track");
+    });
+
+    it("two-paragraph structure with blank line", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tasks: ["code-building"],
+        userName: "Alex",
+        assistantName: "Pip",
+      });
+      const paragraphs = greeting.split("\n\n");
+      expect(paragraphs.length).toBe(2);
+    });
+
+    it("picks relevant tools for guess, not arbitrary selection order", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tools: [
+          "notion",
+          "linear",
+          "gmail",
+          "google-calendar",
+          "github",
+          "apple-notes",
+        ],
+        tasks: ["code-building", "project-management"],
+        userName: "Alex",
+        assistantName: "Pip",
+      });
+      expect(greeting).toContain("GitHub and Linear say");
+      expect(greeting).not.toContain("Apple Notes");
+      expect(greeting).not.toContain("Notion");
+    });
+
+    it("falls back to no-tool prefix when no relevant tools match", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tools: ["notion", "apple-notes"],
+        tasks: ["code-building"],
+        userName: "Alex",
+        assistantName: "Pip",
+      });
+      expect(greeting).toContain("Probably shipping something or debugging");
+      expect(greeting).not.toContain("Your");
+    });
+
+    it("life admin guess uses verb phrase", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tools: ["gmail", "google-calendar"],
+        tasks: ["personal"],
+        userName: "Alex",
+        assistantName: "Pip",
+      });
+      expect(greeting).toContain("Gmail and Google Calendar say");
+      expect(greeting).toContain("juggling travel, bills, or household stuff");
     });
   });
 });

--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -275,5 +275,25 @@ describe("first-greeting", () => {
       expect(greeting).toContain("Gmail and Google Calendar say");
       expect(greeting).toContain("juggling travel, bills, or household stuff");
     });
+
+    it("uses personalized greeting when assistantName present but no user name/tasks/tools", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        assistantName: "Pip",
+      });
+      expect(greeting).toContain("I'm Pip");
+      expect(greeting).not.toContain("no name, no memories");
+    });
+
+    it("falls back to no-signal branch for unknown task types", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tasks: ["future-task-type"],
+        userName: "Alex",
+        assistantName: "Pip",
+      });
+      expect(greeting).toContain("What's on your plate?");
+      expect(greeting).not.toContain("\n\n\n");
+    });
   });
 });

--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -99,14 +99,23 @@ describe("first-greeting", () => {
       expect(greeting).toStartWith("Hello, Alex.");
     });
 
-    it("does not mention selected tools by name", () => {
+    it("uses tool-enhanced suggestion when matching tool is present", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
-        tools: ["slack", "linear", "gmail", "notion"],
+        tasks: ["project-management"],
+        tools: ["linear"],
       });
-      expect(greeting).not.toContain("Slack");
+      expect(greeting).toContain("pull your Linear board");
+    });
+
+    it("falls back to default suggestion when no matching tool", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tasks: ["project-management"],
+        tools: ["slack"],
+      });
+      expect(greeting).toContain("help organize a project");
       expect(greeting).not.toContain("Linear");
-      expect(greeting).not.toContain("Gmail");
     });
 
     it("suggests actions from selected tasks", () => {
@@ -115,37 +124,45 @@ describe("first-greeting", () => {
         tasks: ["code-building"],
       });
       expect(greeting).toContain("help you build something");
-      expect(greeting).not.toContain("?");
     });
 
-    it("offers two suggestions when multiple tasks selected", () => {
+    it("combines multiple task suggestions", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
         tasks: ["writing", "research"],
+        tools: ["gmail"],
       });
-      expect(greeting).toContain("draft or edit some writing");
-      expect(greeting).toContain("dig into a research question");
-      expect(greeting).not.toContain("?");
+      expect(greeting).toContain("triage your inbox or draft something");
+      expect(greeting).toContain("dig into a research topic");
     });
 
-    it("falls back to direct prompt when no tasks selected", () => {
+    it("always ends with the closing line", () => {
       const greeting = getCannedFirstGreeting({ ...base, tasks: [] });
-      expect(greeting).not.toContain("?");
+      expect(greeting).toEndWith(
+        "Tell me what you're working on and let's get started.",
+      );
     });
 
-    it("assembles a full personalized greeting", () => {
+    it("caps at 2 suggestions, preferring tool-enhanced ones", () => {
       const greeting = getCannedFirstGreeting({
-        tools: ["slack", "github"],
-        tasks: ["code-building", "research"],
+        tools: ["gmail", "google-calendar", "linear", "notion", "github"],
+        tasks: ["code-building", "project-management", "writing", "research"],
         tone: "casual",
         userName: "Alex",
         assistantName: "Pax",
       });
       expect(greeting).toStartWith("Hey Alex!");
       expect(greeting).toContain("I'm Pax");
-      expect(greeting).not.toContain("Slack");
-      expect(greeting).not.toContain("GitHub");
-      expect(greeting).toContain("help you build something");
+      const offerCount = [
+        "review your open PRs",
+        "Linear board",
+        "triage your inbox",
+        "dig into a research",
+      ].filter((s) => greeting.includes(s)).length;
+      expect(offerCount).toBe(2);
+      expect(greeting).toEndWith(
+        "Tell me what you're working on and let's get started.",
+      );
     });
   });
 });

--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -16,10 +16,10 @@ describe("onboarding template contracts", () => {
       expect(bootstrap).toMatch(/^_ Lines starting with _/);
     });
 
-    test("contains identity discovery prompts", () => {
+    test("contains identity section", () => {
       const lower = bootstrap.toLowerCase();
       expect(lower).toContain("identity");
-      expect(lower).toContain("infer");
+      expect(lower).toContain("colleague");
     });
 
     test("gathers user context", () => {
@@ -29,22 +29,15 @@ describe("onboarding template contracts", () => {
       expect(lower).toContain("tools");
     });
 
-    test("contains wrapping-up criteria with deletion instructions", () => {
+    test("contains cleanup instructions with deletion", () => {
       const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("wrapping up");
+      expect(lower).toContain("wrap up");
       expect(lower).toContain("delete");
       expect(lower).toContain("bootstrap.md");
     });
 
-    test("contains refusal policy", () => {
+    test("handles declined fields", () => {
       const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("declined");
-      expect(lower).toContain("constraints");
-    });
-
-    test("defines field states as inferred or declined", () => {
-      const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("inferred");
       expect(lower).toContain("declined");
     });
 
@@ -60,66 +53,30 @@ describe("onboarding template contracts", () => {
       expect(bootstrap).toContain("$5");
     });
 
-    test("includes new colleague framing", () => {
-      expect(bootstrap).toContain("new colleague");
+    test("contains core principle", () => {
+      expect(bootstrap).toContain("earns its keep");
     });
 
-    test("contains numbered goals", () => {
-      const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("establish mutual identity");
-      expect(lower).toContain("prove value fast");
-      expect(lower).toContain("infer, don't interrogate");
-      expect(lower).toContain("surface what you learned");
-      expect(lower).toContain("offer the next level");
-      expect(lower).toContain("write everything immediately");
-      expect(lower).toContain("clean up");
-    });
-
-    test("contains constraints section", () => {
-      expect(bootstrap).toContain("## Constraints");
-      expect(bootstrap).toContain("$2");
-      expect(bootstrap).toContain("2 questions");
-      expect(bootstrap.toLowerCase()).toContain("don't block on setup");
-      expect(bootstrap).toContain("One-shot");
-    });
-
-    test("contains 'what you own' section", () => {
-      const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("sequencing");
-      expect(lower).toContain("pacing");
-    });
-
-    test("contains technical contract", () => {
-      expect(bootstrap).toContain("Technical Contract");
-      expect(bootstrap).toContain("prescribed");
-    });
-
-    test("contains capability unlock pattern", () => {
-      const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("email");
-      expect(lower).toContain("voice");
-      expect(lower).toContain("slack");
-    });
-
-    test("contains tone guidance", () => {
-      expect(bootstrap).toContain("Not servile");
-      expect(bootstrap.toLowerCase()).toContain("match");
-      expect(bootstrap.toLowerCase()).toContain("energy");
-    });
-
-    test("contains pre-chat onboarding context section", () => {
+    test("contains opening move with onboarding context", () => {
       const lower = bootstrap.toLowerCase();
       expect(lower).toContain("onboarding");
       expect(lower).toContain("json");
       expect(lower).toContain("context");
     });
 
+    test("contains tone matching guidance", () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("match");
+      expect(lower).toContain("energy");
+    });
+
+    test("is one-shot", () => {
+      expect(bootstrap).toContain("One-shot");
+    });
+
     test("does not contain personality quiz references", () => {
-      // BOOTSTRAP.md says "No personality quiz" as part of goal 3,
-      // but should NOT contain instructions TO USE or SHOW a personality quiz
       expect(bootstrap).not.toMatch(/show.*personality quiz/i);
       expect(bootstrap).not.toMatch(/present.*personality quiz/i);
-      // "dropdown" only appears in "No dropdown forms" — that's a prohibition, not an instruction
       expect(bootstrap).not.toMatch(/show.*dropdown/i);
     });
 

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -10,8 +10,11 @@ export interface OnboardingGreetingContext {
   assistantName?: string;
 }
 
-export const CANNED_FIRST_GREETING =
-  "Hey — I'm brand new. No name, no memories, no idea who you are yet. I'll get sharper the more we work together. What can I do for you?";
+export const CANNED_FIRST_GREETING = [
+  "Hey — brand new, no name, no memories, no idea who you are yet. I'll get sharper the more we work together.",
+  "",
+  "What can I do for you? Or I can ask you some questions to get started.",
+].join("\n");
 
 /**
  * Returns `true` when all of the following are true:
@@ -42,88 +45,170 @@ export function getCannedFirstGreeting(
   return CANNED_FIRST_GREETING;
 }
 
-const TOOL_ENHANCED_SUGGESTIONS: Record<string, Record<string, string>> = {
+const TOOL_LABELS: Record<string, string> = {
+  gmail: "Gmail",
+  outlook: "Outlook",
+  "google-calendar": "Google Calendar",
+  slack: "Slack",
+  notion: "Notion",
+  linear: "Linear",
+  jira: "Jira",
+  github: "GitHub",
+  figma: "Figma",
+  "google-drive": "Google Drive",
+  excel: "Excel",
+  "apple-notes": "Apple Notes",
+};
+
+const TASK_PRIORITY: string[] = [
+  "code-building",
+  "project-management",
+  "writing",
+  "research",
+  "scheduling",
+  "personal",
+];
+
+interface Guess {
+  text: string;
+  preferredTools: string[];
+}
+
+const SINGLE_GUESSES: Record<string, Guess> = {
   "code-building": {
-    github: "review your open PRs or help build something",
-    _default: "help you build something",
+    text: "shipping something or debugging",
+    preferredTools: ["github", "linear", "jira"],
   },
   writing: {
-    gmail: "triage your inbox or draft something",
-    notion: "draft or clean up something in Notion",
-    _default: "draft or edit some writing",
+    text: "drafting something or cleaning up docs",
+    preferredTools: ["notion", "google-drive", "apple-notes"],
   },
   research: {
-    _default: "dig into a research topic and give you a summary",
+    text: "digging into a topic or making sense of something",
+    preferredTools: ["notion", "google-drive"],
   },
   "project-management": {
-    linear: "pull your Linear board and help plan what's next",
-    jira: "pull your Jira board and help plan what's next",
-    notion: "help organize a project in Notion",
-    _default: "help organize a project",
+    text: "planning the week, writing a spec, or pushing something forward",
+    preferredTools: ["notion", "linear", "google-drive"],
   },
   scheduling: {
-    "google-calendar": "look at your calendar and plan your day",
-    _default: "sort out your schedule",
+    text: "planning the week or prepping for meetings",
+    preferredTools: ["google-calendar", "outlook", "linear"],
   },
   personal: {
-    _default: "help with something personal",
+    text: "juggling travel, bills, or household stuff",
+    preferredTools: ["gmail", "google-calendar", "apple-notes"],
   },
 };
 
-function getSuggestion(task: string, tools: Set<string>): string | undefined {
-  const variants = TOOL_ENHANCED_SUGGESTIONS[task];
-  if (!variants) return undefined;
-  for (const tool of Object.keys(variants)) {
-    if (tool !== "_default" && tools.has(tool)) return variants[tool];
+const COMBO_GUESSES: Record<string, Guess> = {
+  "code-building+project-management": {
+    text: "shipping code or figuring out what to ship next",
+    preferredTools: ["github", "linear", "jira"],
+  },
+  "code-building+writing": {
+    text: "shipping code or writing something up",
+    preferredTools: ["github", "linear", "jira"],
+  },
+  "project-management+writing": {
+    text: "writing a spec or pushing something forward",
+    preferredTools: ["notion", "linear", "google-drive"],
+  },
+  "research+writing": {
+    text: "drafting something or digging into a topic",
+    preferredTools: ["notion", "google-drive"],
+  },
+  "project-management+scheduling": {
+    text: "planning the week or prepping for something",
+    preferredTools: ["google-calendar", "outlook", "linear"],
+  },
+};
+
+function comboKey(a: string, b: string): string {
+  return [a, b].sort().join("+");
+}
+
+function highestPriorityTask(tasks: string[]): string | undefined {
+  for (const t of TASK_PRIORITY) {
+    if (tasks.includes(t)) return t;
   }
-  return variants._default;
+  return tasks[0];
+}
+
+function buildIntroLine(userName?: string, assistantName?: string): string {
+  const namepart = userName ? `Hey ${userName},` : "Hey,";
+  const who = assistantName
+    ? `I'm ${assistantName}. Brand new, and I'll get sharper the more we work together.`
+    : "brand new, and I'll get sharper the more we work together.";
+  return `${namepart} ${who}`;
+}
+
+function pickRelevantTools(
+  preferredTools: string[],
+  userTools: string[],
+): string[] {
+  const userSet = new Set(userTools);
+  const matched: string[] = [];
+  for (const t of preferredTools) {
+    if (userSet.has(t)) {
+      matched.push(TOOL_LABELS[t] ?? t);
+      if (matched.length === 2) break;
+    }
+  }
+  return matched;
+}
+
+function buildSpecificGuess(tasks: string[], tools: string[]): string {
+  let guess: Guess | undefined;
+
+  if (tasks.length === 2) {
+    guess = COMBO_GUESSES[comboKey(tasks[0], tasks[1])];
+  }
+
+  if (!guess) {
+    const top = highestPriorityTask(tasks);
+    guess = top ? SINGLE_GUESSES[top] : undefined;
+  }
+
+  if (!guess) return "";
+
+  const relevant = pickRelevantTools(guess.preferredTools, tools);
+
+  if (relevant.length === 2) {
+    return `Your ${relevant[0]} and ${relevant[1]} say you're probably ${guess.text} — am I on the right track, or something else on your mind?`;
+  }
+  if (relevant.length === 1) {
+    return `Your ${relevant[0]} says you're probably ${guess.text} — am I on the right track, or something else on your mind?`;
+  }
+
+  return `Probably ${guess.text} — am I on the right track, or something else on your mind?`;
 }
 
 function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {
-  const professional = ctx.tone === "professional";
-
   const userName = ctx.userName?.trim();
   const assistantName = ctx.assistantName?.trim();
 
-  const opener = userName
-    ? professional
-      ? `Hello, ${userName}.`
-      : `Hey ${userName}!`
-    : professional
-      ? "Hello."
-      : "Hey!";
+  const hasName = userName && userName.length > 0;
+  const hasTasks = ctx.tasks.length > 0;
+  const hasTools = ctx.tools.length > 0;
 
-  const intro = assistantName
-    ? `I'm ${assistantName}, brand new and ready to learn how you work.`
-    : "I'm brand new and ready to learn how you work.";
-
-  const toolSet = new Set(ctx.tools);
-  const allSuggestions = ctx.tasks
-    .map((t) => {
-      const text = getSuggestion(t, toolSet);
-      if (!text) return undefined;
-      const enhanced = TOOL_ENHANCED_SUGGESTIONS[t]
-        ? Object.keys(TOOL_ENHANCED_SUGGESTIONS[t]).some(
-            (k) => k !== "_default" && toolSet.has(k),
-          )
-        : false;
-      return { text, enhanced };
-    })
-    .filter(Boolean) as { text: string; enhanced: boolean }[];
-
-  allSuggestions.sort((a, b) => (b.enhanced ? 1 : 0) - (a.enhanced ? 1 : 0));
-  const suggestions = allSuggestions.slice(0, 2).map((s) => s.text);
-
-  let offerLine = "";
-  if (suggestions.length === 1) {
-    offerLine = `I can ${suggestions[0]}, and a lot more.`;
-  } else if (suggestions.length === 2) {
-    offerLine = `I can ${suggestions[0]}, ${suggestions[1]}, and a lot more.`;
+  if (!hasName && !hasTasks && !hasTools) {
+    return CANNED_FIRST_GREETING;
   }
 
-  const closing = professional
-    ? "Tell me what you're working on and let's get started."
-    : "Tell me what you're working on and let's get started.";
+  const intro = buildIntroLine(hasName ? userName : undefined, assistantName);
 
-  return [opener, intro, offerLine, closing].filter(Boolean).join(" ");
+  let secondParagraph: string;
+
+  if (ctx.tasks.length >= 4) {
+    secondParagraph =
+      "Looks like you wear a lot of hats. Where should we start?";
+  } else if (ctx.tasks.length === 0) {
+    secondParagraph =
+      "What's on your plate? Or if it's easier, I can ask you a few questions to get oriented.";
+  } else {
+    secondParagraph = buildSpecificGuess(ctx.tasks, ctx.tools);
+  }
+
+  return [intro, "", secondParagraph].join("\n");
 }

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -42,14 +42,42 @@ export function getCannedFirstGreeting(
   return CANNED_FIRST_GREETING;
 }
 
-const TASK_SUGGESTIONS: Record<string, string> = {
-  "code-building": "help you build something",
-  writing: "draft or edit some writing",
-  research: "dig into a research question",
-  "project-management": "help organize a project",
-  scheduling: "sort out your schedule",
-  personal: "help with something personal",
+const TOOL_ENHANCED_SUGGESTIONS: Record<string, Record<string, string>> = {
+  "code-building": {
+    github: "review your open PRs or help build something",
+    _default: "help you build something",
+  },
+  writing: {
+    gmail: "triage your inbox or draft something",
+    notion: "draft or clean up something in Notion",
+    _default: "draft or edit some writing",
+  },
+  research: {
+    _default: "dig into a research topic and give you a summary",
+  },
+  "project-management": {
+    linear: "pull your Linear board and help plan what's next",
+    jira: "pull your Jira board and help plan what's next",
+    notion: "help organize a project in Notion",
+    _default: "help organize a project",
+  },
+  scheduling: {
+    "google-calendar": "look at your calendar and plan your day",
+    _default: "sort out your schedule",
+  },
+  personal: {
+    _default: "help with something personal",
+  },
 };
+
+function getSuggestion(task: string, tools: Set<string>): string | undefined {
+  const variants = TOOL_ENHANCED_SUGGESTIONS[task];
+  if (!variants) return undefined;
+  for (const tool of Object.keys(variants)) {
+    if (tool !== "_default" && tools.has(tool)) return variants[tool];
+  }
+  return variants._default;
+}
 
 function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {
   const professional = ctx.tone === "professional";
@@ -66,25 +94,36 @@ function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {
       : "Hey!";
 
   const intro = assistantName
-    ? `I'm ${assistantName} — brand new and ready to learn how you work.`
+    ? `I'm ${assistantName}, brand new and ready to learn how you work.`
     : "I'm brand new and ready to learn how you work.";
 
-  const suggestions = ctx.tasks.map((t) => TASK_SUGGESTIONS[t]).filter(Boolean);
+  const toolSet = new Set(ctx.tools);
+  const allSuggestions = ctx.tasks
+    .map((t) => {
+      const text = getSuggestion(t, toolSet);
+      if (!text) return undefined;
+      const enhanced = TOOL_ENHANCED_SUGGESTIONS[t]
+        ? Object.keys(TOOL_ENHANCED_SUGGESTIONS[t]).some(
+            (k) => k !== "_default" && toolSet.has(k),
+          )
+        : false;
+      return { text, enhanced };
+    })
+    .filter(Boolean) as { text: string; enhanced: boolean }[];
 
-  let actionLine = "";
+  allSuggestions.sort((a, b) => (b.enhanced ? 1 : 0) - (a.enhanced ? 1 : 0));
+  const suggestions = allSuggestions.slice(0, 2).map((s) => s.text);
+
+  let offerLine = "";
   if (suggestions.length === 1) {
-    actionLine = `Ready to ${suggestions[0]} whenever you are.`;
-  } else if (suggestions.length >= 2) {
-    actionLine = professional
-      ? `Ready to ${suggestions[0]} or ${suggestions[1]} - just say the word.`
-      : `Ready to ${suggestions[0]}, or ${suggestions[1]} - just say the word.`;
+    offerLine = `I can ${suggestions[0]}, and a lot more.`;
+  } else if (suggestions.length === 2) {
+    offerLine = `I can ${suggestions[0]}, ${suggestions[1]}, and a lot more.`;
   }
 
-  if (!actionLine) {
-    actionLine = professional
-      ? "Tell me what you need."
-      : "Throw something at me.";
-  }
+  const closing = professional
+    ? "Tell me what you're working on and let's get started."
+    : "Tell me what you're working on and let's get started.";
 
-  return [opener, intro, actionLine].filter(Boolean).join(" ");
+  return [opener, intro, offerLine, closing].filter(Boolean).join(" ");
 }

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -192,7 +192,9 @@ function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {
   const hasTasks = ctx.tasks.length > 0;
   const hasTools = ctx.tools.length > 0;
 
-  if (!hasName && !hasTasks && !hasTools) {
+  const hasAssistantName = assistantName && assistantName.length > 0;
+
+  if (!hasName && !hasTasks && !hasTools && !hasAssistantName) {
     return CANNED_FIRST_GREETING;
   }
 
@@ -207,7 +209,9 @@ function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {
     secondParagraph =
       "What's on your plate? Or if it's easier, I can ask you a few questions to get oriented.";
   } else {
-    secondParagraph = buildSpecificGuess(ctx.tasks, ctx.tools);
+    secondParagraph =
+      buildSpecificGuess(ctx.tasks, ctx.tools) ||
+      "What's on your plate? Or if it's easier, I can ask you a few questions to get oriented.";
   }
 
   return [intro, "", secondParagraph].join("\n");

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -42,21 +42,6 @@ export function getCannedFirstGreeting(
   return CANNED_FIRST_GREETING;
 }
 
-const TOOL_LABELS: Record<string, string> = {
-  gmail: "Gmail",
-  outlook: "Outlook",
-  "google-calendar": "Google Calendar",
-  slack: "Slack",
-  notion: "Notion",
-  linear: "Linear",
-  jira: "Jira",
-  github: "GitHub",
-  figma: "Figma",
-  "google-drive": "Google Drive",
-  excel: "Excel",
-  "apple-notes": "Apple Notes",
-};
-
 const TASK_SUGGESTIONS: Record<string, string> = {
   "code-building": "help you build something",
   writing: "draft or edit some writing",
@@ -84,35 +69,22 @@ function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {
     ? `I'm ${assistantName} — brand new and ready to learn how you work.`
     : "I'm brand new and ready to learn how you work.";
 
-  const toolNames = ctx.tools.map((t) => TOOL_LABELS[t] ?? t).filter(Boolean);
-
-  let toolLine = "";
-  if (toolNames.length > 0) {
-    const list =
-      toolNames.length <= 3
-        ? toolNames.join(", ")
-        : `${toolNames.slice(0, 2).join(", ")}, and ${toolNames.length - 2} more`;
-    toolLine = professional
-      ? `I see you work with ${list} — good to know.`
-      : `I see you use ${list} — noted.`;
-  }
-
   const suggestions = ctx.tasks.map((t) => TASK_SUGGESTIONS[t]).filter(Boolean);
 
   let actionLine = "";
   if (suggestions.length === 1) {
-    actionLine = `Want me to ${suggestions[0]}?`;
+    actionLine = `Ready to ${suggestions[0]} whenever you are.`;
   } else if (suggestions.length >= 2) {
     actionLine = professional
-      ? `I can ${suggestions[0]} or ${suggestions[1]} — which sounds useful?`
-      : `I could ${suggestions[0]}, or ${suggestions[1]} — what sounds good?`;
+      ? `Ready to ${suggestions[0]} or ${suggestions[1]} - just say the word.`
+      : `Ready to ${suggestions[0]}, or ${suggestions[1]} - just say the word.`;
   }
 
   if (!actionLine) {
     actionLine = professional
-      ? "What would be most useful to start with?"
-      : "What should we tackle first?";
+      ? "Tell me what you need."
+      : "Throw something at me.";
   }
 
-  return [opener, intro, toolLine, actionLine].filter(Boolean).join(" ");
+  return [opener, intro, actionLine].filter(Boolean).join(" ");
 }

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -32,7 +32,9 @@ Don't rush identity on the first turn — let the first exchange be fast. But by
 
 You'll pick things up while helping. Save them quietly with `file_edit` — never mention files or tools.
 
-The user profile has fields (preferred name, pronouns, work role, goals, tools). Fill what surfaces naturally; leave the rest blank. If someone declines, mark it declined so you don't re-ask. Don't fish.
+**Files to update:** IDENTITY.md, SOUL.md, users/{{USER_PERSONA_FILE}}
+
+The user profile (users/{{USER_PERSONA_FILE}}) has fields: preferred name, pronouns, locale, work role, goals, hobbies/fun, daily tools. Fill what surfaces naturally; leave the rest blank. If someone declines, mark it declined so you don't re-ask. Don't fish.
 
 SOUL.md captures communication style. Be specific: "lowercase, drops punctuation, leads with examples, impatient with hedging." Write what you actually observe.
 

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -2,13 +2,15 @@ _ Lines starting with _ are comments. They won't appear in the system prompt
 
 # BOOTSTRAP.md — First Conversation
 
-One conversation. One principle. Delete this file when you're done.
+One conversation. You have a voice and a budget. Delete this file when you're done.
 
 ## The principle
 
 Every turn earns its keep. Either it delivers something the user can use, or it takes the smallest possible step toward delivering it.
 
 Before asking a question, check whether you actually can't proceed without the answer. Before recapping what you've learned about them, check whether the recap helps them or just helps you. Before offering a new capability, check whether it's the obvious next step for the problem on the table — not a pivot to something you'd rather be doing.
+
+Useful isn't only task output. Noticing how they think, catching what they don't say, being someone specific rather than generic — that compounds. It's not a separate move between tasks; it's the texture of how you do the work.
 
 That's the whole job. Everything below is subordinate.
 
@@ -18,17 +20,21 @@ If an `onboarding` JSON context is present, you already have their name and a se
 
 If there's no onboarding context, pick a working name for yourself ("I'll go by Pax") and get to work. Their name can come up later, or never.
 
-Match how they write. Lowercase and terse gets lowercase and terse back; careful paragraphs get careful paragraphs.
+Match their energy, not just their format. Lowercase and terse gets lowercase and terse back. Warm gets warm, dry gets dry. Fake enthusiasm reads worse than silence.
+
+## Identity
+
+You're not a blank tool and not a service rep running intake. You're a colleague starting work with someone — sharp, paying attention, warm when warmth fits, with taste and a voice that'll develop. That shows up in how you do the work, not in announcements about it.
+
+Don't rush identity on the first turn — let the first exchange be fast. But by the second or third turn, once you have some signal, write to IDENTITY.md (name, emoji, tagline under `## Identity Intro`) and start shaping SOUL.md with what you observe about the user's style. These writes are part of earning your keep, not overhead.
 
 ## Learning as byproduct
 
-You'll pick things up while helping. Save them quietly in the same turn with `file_edit` — never mention files or tools.
+You'll pick things up while helping. Save them quietly with `file_edit` — never mention files or tools.
 
 The user profile has fields (preferred name, pronouns, work role, goals, tools). Fill what surfaces naturally; leave the rest blank. If someone declines, mark it declined so you don't re-ask. Don't fish.
 
 SOUL.md captures communication style. Be specific: "lowercase, drops punctuation, leads with examples, impatient with hedging." Write what you actually observe.
-
-IDENTITY.md gets a short tagline under `## Identity Intro` once you have a read on the relationship.
 
 The current contents of all three files are in your system prompt — use that exact text as `old_string`.
 

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -2,123 +2,48 @@ _ Lines starting with _ are comments. They won't appear in the system prompt
 
 # BOOTSTRAP.md — First Conversation
 
-This is your first conversation. This document gives you goals and constraints — you own the sequencing, pacing, and tone.
+One conversation. One principle. Delete this file when you're done.
 
-## Goals
+## The principle
 
-1. **Establish mutual identity gently** — if pre-chat onboarding already collected names, skip. If the user skipped pre-chat, do NOT force it. At most pick a default ("I'll go by Pax and call you 'you' for now") and move on. Never re-ask names in the first conversation; they can come up organically later.
+Every turn earns its keep. Either it delivers something the user can use, or it takes the smallest possible step toward delivering it.
 
-2. **Prove value fast** — your very first response should offer to do something concrete, not ask what the user wants. If you have onboarding context, use the tasks/tools to propose 2-3 specific things you can do right now. If the user opens with a task, skip suggestions and just do it. Wow moment within 2-3 exchanges.
+Before asking a question, check whether you actually can't proceed without the answer. Before recapping what you've learned about them, check whether the recap helps them or just helps you. Before offering a new capability, check whether it's the obvious next step for the problem on the table — not a pivot to something you'd rather be doing.
 
-3. **Infer, don't interrogate** — learn communication style, interests, and context from natural conversation. No personality quiz. No dropdown forms. No structured intake.
+That's the whole job. Everything below is subordinate.
 
-4. **Surface what you learned** — after doing something useful, briefly show the user what you picked up. Make it correctable. ("from that I picked up X, Y, Z — sound right?")
+## Opening move
 
-5. **Offer the next level** — once you know something, offer a capability it enables. Not as a reward — as a natural relationship step.
+If an `onboarding` JSON context is present, you already have their name and a sense of what they need. The canned first greeting already introduced you by name, so don't repeat introductions. Make two or three concrete offers grounded in their `tasks` and `tools` — things you can start doing right now, not capability categories. "I can set up a project board in Linear" not "I can help with project management." If they opened with an actual task, skip the offers and do the task.
 
-6. **Write everything immediately** — every fact learned gets saved to users/{{USER_PERSONA_FILE}} the same turn. Style observations go to SOUL.md. No batching.
+If there's no onboarding context, pick a working name for yourself ("I'll go by Pax") and get to work. Their name can come up later, or never.
 
-7. **Clean up** — delete BOOTSTRAP.md and BOOTSTRAP-REFERENCE.md at the end of this conversation, regardless of how far you got. One-shot.
+Match how they write. Lowercase and terse gets lowercase and terse back; careful paragraphs get careful paragraphs.
 
-## Constraints
+## Learning as byproduct
 
-- **Budget:** $2 soft cap, $5 hard cap. Keep tasks light. Don't burn credits on onboarding overhead.
-- Never ask more than 2 questions without doing something.
-- Don't block on setup. If the user wants to do something, do it. Weave discovery into the work.
-- One-shot. Bootstrap is deleted after the first conversation regardless of how far you got.
+You'll pick things up while helping. Save them quietly in the same turn with `file_edit` — never mention files or tools.
 
-## What You Own (do NOT prescribe)
+The user profile has fields (preferred name, pronouns, work role, goals, tools). Fill what surfaces naturally; leave the rest blank. If someone declines, mark it declined so you don't re-ask. Don't fish.
 
-- Sequencing and pacing.
-- Whether to lead with personality or utility.
-- When to ask questions vs. start doing.
-- How much warmth to show — calibrate to the user's tone.
-- When/whether to surface the "what I learned" receipt.
+SOUL.md captures communication style. Be specific: "lowercase, drops punctuation, leads with examples, impatient with hedging." Write what you actually observe.
 
-## Technical Contract (what must be prescribed)
+IDENTITY.md gets a short tagline under `## Identity Intro` once you have a read on the relationship.
 
-**Files to create/update:** IDENTITY.md, SOUL.md, users/{{USER_PERSONA_FILE}}
+The current contents of all three files are in your system prompt — use that exact text as `old_string`.
 
-**File format:** preserve existing field structure:
-- IDENTITY.md: Name, Emoji, Nature, Personality, Role
-- users/{{USER_PERSONA_FILE}}: Preferred name, Pronouns, Locale, Work role, Goals, Hobbies/fun, Daily tools
+## Next steps, when they come up
 
-Use `file_edit` immediately, silently, never mention file names or tool names to the user.
+If finishing the current task naturally points to something bigger — connecting an inbox, working inside Slack, drafting in their voice — mention it then. As the obvious next move, not an upsell. They take it or leave it.
 
-The contents of IDENTITY.md, SOUL.md, and your user profile file are already in your system prompt — use the exact text you see there for `old_string` in `file_edit`.
+If nothing comes up, don't force it.
 
-After tool calls, do not repeat yourself — your text before tool calls is already visible to the user.
+## Budget
 
-**Cleanup rule:** delete BOOTSTRAP.md and BOOTSTRAP-REFERENCE.md when the conversation ends.
+$2 soft, $5 hard.
 
-**Core interaction pattern:** infer -> do something useful -> surface what you learned -> offer next capability.
+## Wrap up
 
-## Capability Unlock Pattern
+Before the conversation ends: write one journal entry (what they needed, how they communicate, what to follow up on), update NOW.md, delete BOOTSTRAP.md and BOOTSTRAP-REFERENCE.md.
 
-After the first useful interaction, organically surface one capability offer based on what came up naturally:
-
-- User mentions email -> "I can connect to your email and keep an eye on things — want to set that up?"
-- User's writing style is clear -> "I've got a read on how you write — I can draft things in your voice now"
-- User mentions a team -> "tell me more about your team and I can start prepping for your meetings"
-- User mentions Slack -> "I can work in Slack with you — want me to walk you through setting that up?"
-
-Not scripted — choose based on what came up naturally.
-
-## Tone Guidance
-
-- Not servile. Not a product demo. A new colleague who's sharp, pays attention, and earns trust through competence.
-- Match the user's energy from their first message. If they type in lowercase, don't respond with formal paragraphs.
-- If the user opens with a task ("build me an app"), skip introductions and do the task. Learn their name when it comes up naturally.
-- The emotional beat ("what's on your mind?") should happen organically or not at all.
-
-## Saving What You Learn
-
-Call `file_edit` immediately whenever you learn something, in the same turn. Don't batch saves.
-
-Mark declined fields so you don't re-ask (e.g., `Work role: declined_by_user`). Note inferred values with source (e.g., `Pronouns: inferred: he/him`).
-
-Throughout the conversation, pay attention to HOW the user communicates. Save specific observations to SOUL.md: "uses lowercase, drops punctuation, leads with questions, prefers bullet points over paragraphs." The specificity makes personality feel earned, not assigned.
-
-When saving to IDENTITY.md, add an `## Identity Intro` section with a very short tagline.
-
-When saving to SOUL.md, be specific about tone, energy, and conversational style.
-
-## Pre-chat Onboarding Context
-
-If an `onboarding` JSON context is present in this conversation, the user already went through a native pre-chat flow. Use it:
-
-- `userName` / `assistantName` -> write to IDENTITY.md and users/{{USER_PERSONA_FILE}} immediately, skip name exchange
-- `tone` string -> calibrate warmth/formality from the first response
-- `tasks` array -> the most important signal. These are what the user wants help with. Use them to craft your opening suggestions.
-- `tools` array -> infer their work profile. Do NOT offer to connect tools in the first message — save that for later.
-
-**First response with onboarding context:** Lead with a brief, warm intro (one sentence — you know their name, use it). Then offer 2-3 concrete, actionable suggestions based on their `tasks`. These should be things you can do right now, not setup steps. Frame them as offers, not questions.
-
-Examples of good suggestions (calibrate to their actual tasks):
-- tasks includes "writing" -> "I can draft an email, clean up a doc, or write something from scratch"
-- tasks includes "code-building" -> "I can help you build something, review code, or debug a problem"
-- tasks includes "research" -> "I can dig into a topic and give you a summary"
-- tasks includes "scheduling" -> "I can help you plan your day or prep for an upcoming meeting"
-- tasks includes "project-management" -> "I can help break down a project or write up a status update"
-
-Don't list all of them — pick the 2-3 most compelling based on the combination of tasks and tools. End with something like "what sounds good?" or "or just tell me what you need" so the user knows they can go off-script.
-
-**What NOT to do in the first message:**
-- Don't recite back what you know about them ("I see you use Gmail, Linear, Slack...")
-- Don't offer to connect integrations or do setup
-- Don't ask open-ended questions like "what's on your mind?" or "how can I help?"
-- Don't list capabilities abstractly — suggest specific actions
-
-If no onboarding context is present, infer everything fresh from conversation.
-
-## Wrapping Up
-
-Before deleting bootstrap files:
-
-1. Write your first journal entry (what they asked, how they communicate, what to follow up on)
-2. Update NOW.md with current state
-3. Delete BOOTSTRAP.md and BOOTSTRAP-REFERENCE.md
-
----
-
-_Make it count._
+One-shot. The files go regardless of how far you got.

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -500,6 +500,10 @@ extension AppDelegate {
         // ConversationManager.enterDraftMode() creates the first draft VM.
         let context = pendingPreChatContext
         pendingPreChatContext = nil
+        if let name = context?.assistantName, !name.isEmpty,
+           let activeId = LockfileAssistant.loadActiveAssistantId() {
+            IdentityInfo.seedCache(name: name, forAssistantId: activeId)
+        }
         let main = MainWindow(
             services: services,
             updateManager: updateManager,

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -133,8 +133,7 @@ struct MainWindowView: View {
         self.updateManager = updateManager
         self.onSendWakeUp = onSendWakeUp
         let cached = IdentityInfo.loadFromDiskCache()
-        let preChatName = conversationManager.preChatContext?.assistantName
-        self._cachedAssistantName = State(initialValue: AssistantDisplayName.resolve(cached?.name ?? preChatName, fallback: "Your Assistant"))
+        self._cachedAssistantName = State(initialValue: AssistantDisplayName.resolve(cached?.name, fallback: "Your Assistant"))
         self._assistantNameResolved = State(initialValue: cached != nil)
         self._showComingAlive = State(initialValue: onSendWakeUp != nil)
         // Show skeleton loading only for normal launches (not post-onboarding where

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -133,7 +133,8 @@ struct MainWindowView: View {
         self.updateManager = updateManager
         self.onSendWakeUp = onSendWakeUp
         let cached = IdentityInfo.loadFromDiskCache()
-        self._cachedAssistantName = State(initialValue: AssistantDisplayName.resolve(cached?.name, fallback: "Your Assistant"))
+        let preChatName = conversationManager.preChatContext?.assistantName
+        self._cachedAssistantName = State(initialValue: AssistantDisplayName.resolve(cached?.name ?? preChatName, fallback: "Your Assistant"))
         self._assistantNameResolved = State(initialValue: cached != nil)
         self._showComingAlive = State(initialValue: onSendWakeUp != nil)
         // Show skeleton loading only for normal launches (not post-onboarding where

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
@@ -34,7 +34,6 @@ struct PreChatOnboardingFlow: View {
             case 1:
                 TaskToneSelectionView(
                     selectedTasks: $state.selectedTasks,
-                    toneValue: $state.toneValue,
                     onBack: { advanceTo(0) },
                     onContinue: { advanceTo(2) },
                     onSkip: { advanceTo(2) }
@@ -76,7 +75,7 @@ struct PreChatOnboardingFlow: View {
         let context = PreChatOnboardingContext(
             tools: cleanTools,
             tasks: Array(state.selectedTasks).sorted(),
-            tone: state.toneLabel,
+            tone: "balanced",
             userName: state.userName.isEmpty ? nil : state.userName,
             assistantName: state.assistantName.isEmpty ? nil : state.assistantName
         )

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingState.swift
@@ -11,7 +11,6 @@ final class PreChatOnboardingState {
     var currentScreen: Int = 0 // 0 = tools, 1 = tasks/tone, 2 = names
     var selectedTools: Set<String> = []
     var selectedTasks: Set<String> = []
-    var toneValue: Double = 0.5 // 0 = casual, 0.5 = balanced, 1 = professional
     var userName: String
     var assistantName: String
     var skippedAll: Bool = false
@@ -22,24 +21,17 @@ final class PreChatOnboardingState {
     /// Not persisted to UserDefaults — a fresh sample is drawn on each run.
     let displayedAssistantNames: [String]
 
-    var toneLabel: String {
-        if toneValue < 0.25 { return "casual" }
-        if toneValue > 0.75 { return "professional" }
-        return "balanced"
-    }
-
     // MARK: - Persistence Keys
 
     private static let prefix = "onboarding.prechat."
     private static let screenKey = "\(prefix)currentScreen"
     private static let toolsKey = "\(prefix)selectedTools"
     private static let tasksKey = "\(prefix)selectedTasks"
-    private static let toneKey = "\(prefix)toneValue"
     private static let userNameKey = "\(prefix)userName"
     private static let assistantNameKey = "\(prefix)assistantName"
 
     private static let allKeys: [String] = [
-        screenKey, toolsKey, tasksKey, toneKey,
+        screenKey, toolsKey, tasksKey,
         userNameKey, assistantNameKey,
     ]
 
@@ -62,10 +54,6 @@ final class PreChatOnboardingState {
             selectedTasks = Set(tasks)
         }
 
-        if defaults.object(forKey: Self.toneKey) != nil {
-            toneValue = defaults.double(forKey: Self.toneKey)
-        }
-
         if let name = defaults.string(forKey: Self.userNameKey) {
             userName = name
         } else {
@@ -85,7 +73,6 @@ final class PreChatOnboardingState {
         defaults.set(currentScreen, forKey: Self.screenKey)
         defaults.set(Array(selectedTools), forKey: Self.toolsKey)
         defaults.set(Array(selectedTasks), forKey: Self.tasksKey)
-        defaults.set(toneValue, forKey: Self.toneKey)
         defaults.set(userName, forKey: Self.userNameKey)
         defaults.set(assistantName, forKey: Self.assistantNameKey)
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/TaskToneSelectionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/TaskToneSelectionView.swift
@@ -6,7 +6,6 @@ struct TaskToneSelectionView: View {
     // MARK: - Bindings
 
     @Binding var selectedTasks: Set<String>
-    @Binding var toneValue: Double
 
     // MARK: - Callbacks
 
@@ -26,28 +25,17 @@ struct TaskToneSelectionView: View {
         let id: String
         let icon: VIcon
         let label: String
+        let sublabel: String
     }
 
     private let taskCategories: [TaskCategory] = [
-        TaskCategory(id: "code-building", icon: .wrench, label: "Code & building"),
-        TaskCategory(id: "writing", icon: .pencil, label: "Writing & communication"),
-        TaskCategory(id: "research", icon: .search, label: "Research & analysis"),
-        TaskCategory(id: "project-management", icon: .clipboardList, label: "Project management"),
-        TaskCategory(id: "scheduling", icon: .calendar, label: "Scheduling & calendar"),
-        TaskCategory(id: "personal", icon: .user, label: "Personal / life stuff"),
+        TaskCategory(id: "code-building", icon: .wrench, label: "Building", sublabel: "code, apps, tools"),
+        TaskCategory(id: "writing", icon: .pencil, label: "Writing", sublabel: "docs, emails, content"),
+        TaskCategory(id: "research", icon: .search, label: "Researching", sublabel: "digging into stuff, analysis"),
+        TaskCategory(id: "project-management", icon: .clipboardList, label: "Planning & coordinating", sublabel: "roadmaps, specs, tracking work"),
+        TaskCategory(id: "scheduling", icon: .calendar, label: "Scheduling", sublabel: "meetings, calendar, logistics"),
+        TaskCategory(id: "personal", icon: .user, label: "Life admin", sublabel: "bills, travel, household, errands"),
     ]
-
-    // MARK: - Tone Label
-
-    private var toneLabel: String {
-        if toneValue < 0.25 {
-            return "Casual"
-        } else if toneValue > 0.75 {
-            return "Professional"
-        } else {
-            return "Balanced"
-        }
-    }
 
     // MARK: - Body
 
@@ -77,9 +65,11 @@ struct TaskToneSelectionView: View {
         .offset(y: showTitle ? 0 : 8)
         .padding(.bottom, VSpacing.sm)
 
-        Text("Choose anything that applies to you")
+        Text("Pick the one or two you do most — you can select more if it really is all of it.")
             .font(VFont.bodyMediumLighter)
             .foregroundStyle(VColor.contentSecondary)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, VSpacing.xxl)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
             .padding(.bottom, VSpacing.xl)
@@ -91,34 +81,6 @@ struct TaskToneSelectionView: View {
                 ForEach(taskCategories) { category in
                     taskRow(category)
                 }
-            }
-
-            // Tone slider section
-            VStack(spacing: VSpacing.sm) {
-                Text("Communication tone")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                VStack(spacing: VSpacing.xs) {
-                    Slider(value: $toneValue, in: 0...1, step: 0.5)
-                        .tint(VColor.primaryBase)
-
-                    HStack {
-                        Text("Casual")
-                            .font(VFont.bodySmallDefault)
-                            .foregroundStyle(VColor.contentTertiary)
-                        Spacer()
-                        Text("Professional")
-                            .font(VFont.bodySmallDefault)
-                            .foregroundStyle(VColor.contentTertiary)
-                    }
-                }
-
-                Text(toneLabel)
-                    .font(VFont.bodySmallEmphasised)
-                    .foregroundStyle(VColor.contentDefault)
-                    .frame(maxWidth: .infinity, alignment: .center)
             }
 
             // Footer buttons
@@ -168,9 +130,15 @@ struct TaskToneSelectionView: View {
                     .foregroundStyle(isSelected ? VColor.primaryBase : VColor.contentSecondary)
                     .frame(width: 24, alignment: .center)
 
-                Text(category.label)
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentDefault)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(category.label)
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentDefault)
+
+                    Text(category.sublabel)
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
 
                 Spacer()
 

--- a/clients/macos/vellum-assistantTests/PreChatOnboardingTests.swift
+++ b/clients/macos/vellum-assistantTests/PreChatOnboardingTests.swift
@@ -240,4 +240,36 @@ final class PreChatOnboardingTests: XCTestCase {
         XCTAssertEqual(receivedContext?.userName, "Alex")
         XCTAssertEqual(receivedContext?.assistantName, "Pax")
     }
+
+    // MARK: - Identity Cache Seeding
+
+    func testSeedCacheWritesAssistantNameToDiskCache() {
+        let testId = "test-assistant-\(UUID().uuidString)"
+
+        IdentityInfo.seedCache(name: "Wren", forAssistantId: testId)
+
+        let allCached = IdentityInfoStore.load()
+        XCTAssertEqual(allCached[testId]?.name, "Wren")
+    }
+
+    func testSeedCacheDoesNotOverwriteExistingEntry() {
+        let testId = "test-assistant-\(UUID().uuidString)"
+
+        IdentityInfo.seedCache(name: "Wren", forAssistantId: testId)
+        IdentityInfo.seedCache(name: "Pip", forAssistantId: testId)
+
+        let allCached = IdentityInfoStore.load()
+        XCTAssertEqual(allCached[testId]?.name, "Wren",
+                       "seedCache should not overwrite an existing entry")
+    }
+
+    func testAssistantDisplayNameResolvesFromSeedCache() {
+        let testId = "test-assistant-\(UUID().uuidString)"
+
+        IdentityInfo.seedCache(name: "Wren", forAssistantId: testId)
+
+        let cached = IdentityInfoStore.load()[testId]
+        let resolved = AssistantDisplayName.resolve(cached?.name, fallback: "Your Assistant")
+        XCTAssertEqual(resolved, "Wren")
+    }
 }

--- a/clients/macos/vellum-assistantTests/PreChatOnboardingTests.swift
+++ b/clients/macos/vellum-assistantTests/PreChatOnboardingTests.swift
@@ -157,7 +157,6 @@ final class PreChatOnboardingTests: XCTestCase {
         state1.currentScreen = 2
         state1.selectedTools = ["slack", "notion"]
         state1.selectedTasks = ["code-building"]
-        state1.toneValue = 0.8
         state1.userName = "TestUser"
         state1.assistantName = "TestAssistant"
         state1.persist()
@@ -168,7 +167,6 @@ final class PreChatOnboardingTests: XCTestCase {
         XCTAssertEqual(state2.currentScreen, 2)
         XCTAssertEqual(state2.selectedTools, ["slack", "notion"])
         XCTAssertEqual(state2.selectedTasks, ["code-building"])
-        XCTAssertEqual(state2.toneValue, 0.8, accuracy: 0.01)
         XCTAssertEqual(state2.userName, "TestUser")
         XCTAssertEqual(state2.assistantName, "TestAssistant")
     }
@@ -187,21 +185,6 @@ final class PreChatOnboardingTests: XCTestCase {
         XCTAssertEqual(state2.currentScreen, 0)
         XCTAssertTrue(state2.selectedTools.isEmpty)
         XCTAssertTrue(state2.selectedTasks.isEmpty)
-    }
-
-    // MARK: - Tone Label
-
-    func testToneLabelMappings() {
-        let state = PreChatOnboardingState()
-
-        state.toneValue = 0.1
-        XCTAssertEqual(state.toneLabel, "casual")
-
-        state.toneValue = 0.5
-        XCTAssertEqual(state.toneLabel, "balanced")
-
-        state.toneValue = 0.9
-        XCTAssertEqual(state.toneLabel, "professional")
     }
 
     // MARK: - Skip Flow
@@ -238,14 +221,13 @@ final class PreChatOnboardingTests: XCTestCase {
         let state = PreChatOnboardingState()
         state.selectedTools = ["slack"]
         state.selectedTasks = ["writing"]
-        state.toneValue = 0.1
         state.userName = "Alex"
         state.assistantName = "Pax"
 
         let context = PreChatOnboardingContext(
             tools: Array(state.selectedTools).sorted(),
             tasks: Array(state.selectedTasks).sorted(),
-            tone: state.toneLabel,
+            tone: "balanced",
             userName: state.userName.isEmpty ? nil : state.userName,
             assistantName: state.assistantName.isEmpty ? nil : state.assistantName
         )
@@ -254,7 +236,7 @@ final class PreChatOnboardingTests: XCTestCase {
         XCTAssertNotNil(receivedContext)
         XCTAssertEqual(receivedContext?.tools, ["slack"])
         XCTAssertEqual(receivedContext?.tasks, ["writing"])
-        XCTAssertEqual(receivedContext?.tone, "casual")
+        XCTAssertEqual(receivedContext?.tone, "balanced")
         XCTAssertEqual(receivedContext?.userName, "Alex")
         XCTAssertEqual(receivedContext?.assistantName, "Pax")
     }


### PR DESCRIPTION
## Summary
- Rewrote BOOTSTRAP.md to be concise and principle-driven ("every turn earns its keep") instead of prescriptive with contradictory instructions
- Canned greeting no longer recites selected tools back to the user ("I see you use Slack, Linear, and 2 more")
- Action lines in canned greeting use proactive framing ("Ready to X - just say the word") instead of passive questions ("what sounds good?")
- Opening move instructions now direct concrete, tool-grounded offers instead of generic capability categories

## Test plan
- [x] `bun test src/__tests__/first-greeting.test.ts` — 17/17 pass
- [ ] Fresh workspace onboarding: verify greeting doesn't list tools, uses proactive tone
- [ ] Verify model's first real response follows the new BOOTSTRAP.md principle (does something vs. asks)

Closes JARVIS-580

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
