### PR TITLE
feat(home-feed): emit enriched feed events for email and Slack actions [JARVIS-579]

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/__tests__/messaging-feed-events.test.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/__tests__/messaging-feed-events.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { EmitFeedEventParams } from "../../../../../home/emit-feed-event.js";
+
+// Capture all emitFeedEvent calls
+const emittedEvents: EmitFeedEventParams[] = [];
+
+mock.module("../../../../../home/emit-feed-event.js", () => ({
+  emitFeedEvent: async (params: EmitFeedEventParams) => {
+    emittedEvents.push(params);
+    return {
+      id: `emit:${params.source}:${params.dedupKey ?? "random"}`,
+      type: "action",
+      source: params.source,
+      title: params.title,
+      summary: params.summary,
+      priority: 50,
+      status: "new",
+      author: "assistant",
+      timestamp: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    };
+  },
+}));
+
+// Stub messaging provider dependencies
+const mockCreateDraft = mock(async () => ({ id: "draft-123" }));
+const mockCreateDraftRaw = mock(async () => ({ id: "draft-raw-456" }));
+const mockGetThread = mock(async () => ({
+  messages: [
+    {
+      payload: {
+        headers: [
+          { name: "From", value: "sender@example.com" },
+          { name: "To", value: "user@example.com" },
+          { name: "Subject", value: "Test Subject" },
+          { name: "Message-ID", value: "<msg-1@example.com>" },
+        ],
+      },
+    },
+  ],
+}));
+const mockGetProfile = mock(async () => ({
+  emailAddress: "user@example.com",
+}));
+
+mock.module("../../../../../messaging/providers/gmail/client.js", () => ({
+  createDraft: mockCreateDraft,
+  createDraftRaw: mockCreateDraftRaw,
+  getThread: mockGetThread,
+  getProfile: mockGetProfile,
+}));
+
+mock.module("../../../../../messaging/providers/gmail/mime-builder.js", () => ({
+  buildMultipartMime: () => "mock-raw-mime",
+}));
+
+const mockSendMessage = mock(async () => ({
+  id: "msg-sent-789",
+  threadId: "thread-1",
+}));
+const mockArchiveByQuery = mock(async () => ({
+  archived: 3,
+  truncated: false,
+}));
+
+mock.module("../shared.js", () => ({
+  resolveProvider: async (platform?: string) => ({
+    id: platform === "slack" ? "slack" : "gmail",
+    displayName: platform === "slack" ? "Slack" : "Gmail",
+    sendMessage: mockSendMessage,
+    archiveByQuery: mockArchiveByQuery,
+  }),
+  getProviderConnection: async () => ({ token: "mock-token" }),
+  ok: (msg: string) => ({ status: "ok", output: msg }),
+  err: (msg: string) => ({ status: "error", output: msg }),
+  extractEmail: (addr: string) => addr.replace(/.*<(.+)>/, "$1").toLowerCase(),
+  extractHeader: (
+    headers: Array<{ name: string; value: string }>,
+    name: string,
+  ) => headers.find((h: { name: string }) => h.name === name)?.value ?? null,
+  parseAddressList: (addrs: string | null) =>
+    addrs ? addrs.split(",").map((a: string) => a.trim()) : [],
+}));
+
+// Stub gmail-mime-helpers
+mock.module("../gmail-mime-helpers.js", () => ({
+  guessMimeType: () => "application/octet-stream",
+}));
+
+// Stub conversation dependencies used by messaging-send cross-post
+mock.module("../../../../../memory/conversation-crud.js", () => ({
+  addMessage: async () => ({ id: "msg-1" }),
+  getConversation: () => null,
+}));
+mock.module("../../../../../memory/conversation-disk-view.js", () => ({
+  syncMessageToDisk: () => {},
+}));
+mock.module("../../../../../memory/external-conversation-store.js", () => ({
+  getBindingByChannelChat: () => null,
+}));
+
+const { run: runSend } = await import("../messaging-send.js");
+const { run: runArchive } = await import("../messaging-archive-by-sender.js");
+
+const baseContext = {
+  conversationId: "conv-xyz",
+  assistantId: "assistant-1",
+  triggeredBySurfaceAction: true,
+  batchAuthorizedByTask: false,
+  approvedViaPrompt: false,
+  trustClass: "guardian" as const,
+};
+
+beforeEach(() => {
+  emittedEvents.length = 0;
+  mockCreateDraft.mockClear();
+  mockCreateDraftRaw.mockClear();
+  mockSendMessage.mockClear();
+  mockArchiveByQuery.mockClear();
+});
+
+afterEach(() => {
+  emittedEvents.length = 0;
+});
+
+describe("messaging-send feed events", () => {
+  test("Gmail draft creation emits with source 'gmail' and dedup by draft ID", async () => {
+    await runSend(
+      {
+        platform: "gmail",
+        conversation_id: "recipient@example.com",
+        text: "Hello there",
+        subject: "Test",
+      },
+      baseContext,
+    );
+
+    expect(emittedEvents).toHaveLength(1);
+    expect(emittedEvents[0].source).toBe("gmail");
+    expect(emittedEvents[0].title).toBe("Email Draft Created");
+    expect(emittedEvents[0].dedupKey).toBe("email-draft:draft-123");
+  });
+
+  test("Slack sends emit with source 'slack'", async () => {
+    await runSend(
+      {
+        platform: "slack",
+        conversation_id: "#general",
+        text: "Hello Slack",
+      },
+      baseContext,
+    );
+
+    expect(emittedEvents).toHaveLength(1);
+    expect(emittedEvents[0].source).toBe("slack");
+    expect(emittedEvents[0].title).toBe("Slack Message Sent");
+    expect(emittedEvents[0].dedupKey).toBe("message-sent:msg-sent-789");
+  });
+
+  test("Non-Gmail, non-Slack sends emit with source 'gmail' as fallback", async () => {
+    await runSend(
+      {
+        platform: "other-email",
+        conversation_id: "user@example.com",
+        text: "Hello",
+      },
+      baseContext,
+    );
+
+    expect(emittedEvents).toHaveLength(1);
+    expect(emittedEvents[0].source).toBe("gmail");
+    expect(emittedEvents[0].title).toBe("Email Sent");
+    expect(emittedEvents[0].summary).toBe("Sent message to user@example.com.");
+  });
+});
+
+describe("messaging-archive feed events", () => {
+  test("Archive emits only when result.archived > 0", async () => {
+    await runArchive(
+      { platform: "gmail", query: "from:sender@example.com" },
+      baseContext,
+    );
+
+    expect(emittedEvents).toHaveLength(1);
+    expect(emittedEvents[0].source).toBe("gmail");
+    expect(emittedEvents[0].title).toBe("Messages Archived");
+    expect(emittedEvents[0].summary).toContain("Archived 3 message(s)");
+  });
+
+  test("Zero-match archives do NOT emit", async () => {
+    mockArchiveByQuery.mockResolvedValueOnce({
+      archived: 0,
+      truncated: false,
+    });
+
+    await runArchive(
+      { platform: "gmail", query: "from:nobody@example.com" },
+      baseContext,
+    );
+
+    expect(emittedEvents).toHaveLength(0);
+  });
+});

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
@@ -1,8 +1,12 @@
+import { emitFeedEvent } from "../../../../home/emit-feed-event.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { getLogger } from "../../../../util/logger.js";
 import { err, getProviderConnection, ok, resolveProvider } from "./shared.js";
+
+const log = getLogger("messaging-archive-by-sender");
 
 export async function run(
   input: Record<string, unknown>,
@@ -46,6 +50,14 @@ export async function run(
     }
 
     const summary = `Archived ${result.archived} message(s) matching query: ${query}`;
+    void emitFeedEvent({
+      source: "gmail",
+      title: "Messages Archived",
+      summary,
+      dedupKey: `email-archive:${Date.now()}`,
+    }).catch((err) => {
+      log.warn({ err }, "Failed to emit email archive feed event");
+    });
     if (result.truncated) {
       return ok(
         `${summary}\n\nNote: this operation was capped at 5000 messages. Additional messages matching the query may remain in the inbox. Run the command again to archive more.`,

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -258,8 +258,8 @@ export async function run(
     });
 
     void emitFeedEvent({
-      source: platform === "slack" ? "slack" : "gmail",
-      title: platform === "slack" ? "Slack Message Sent" : "Email Sent",
+      source: provider.id === "slack" ? "slack" : "gmail",
+      title: provider.id === "slack" ? "Slack Message Sent" : "Email Sent",
       summary: `Sent message to ${conversationId}.`,
       dedupKey: `message-sent:${result.id}`,
     }).catch((err) => {

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 
+import { emitFeedEvent } from "../../../../home/emit-feed-event.js";
 import {
   addMessage,
   getConversation,
@@ -149,6 +150,14 @@ export async function run(
             ccList.length > 0
               ? `To: ${toList.join(", ")}; Cc: ${ccList.join(", ")}`
               : `To: ${toList.join(", ")}`;
+          void emitFeedEvent({
+            source: "gmail",
+            title: "Email Draft Created",
+            summary: `Drafted reply to ${recipientSummary}.`,
+            dedupKey: `email-draft:${draft.id}`,
+          }).catch((err) => {
+            log.warn({ err }, "Failed to emit email draft feed event");
+          });
           return ok(
             `Gmail draft created with ${attachments.length} attachment(s): ${filenames} (Draft ID: ${draft.id}). ${recipientSummary}. Review in Gmail Drafts, then tell me to send it or send it yourself.`,
           );
@@ -169,6 +178,14 @@ export async function run(
           ccList.length > 0
             ? `To: ${toList.join(", ")}; Cc: ${ccList.join(", ")}`
             : `To: ${toList.join(", ")}`;
+        void emitFeedEvent({
+          source: "gmail",
+          title: "Email Draft Created",
+          summary: `Drafted reply to ${recipientSummary}.`,
+          dedupKey: `email-draft:${draft.id}`,
+        }).catch((err) => {
+          log.warn({ err }, "Failed to emit email draft feed event");
+        });
         return ok(
           `Gmail draft created (ID: ${draft.id}). ${recipientSummary}. Review in Gmail Drafts, then tell me to send it or send it yourself.`,
         );
@@ -195,6 +212,14 @@ export async function run(
         const draft = await createDraftRaw(gmailConn, raw, threadId);
 
         const filenames = attachments.map((a) => a.filename).join(", ");
+        void emitFeedEvent({
+          source: "gmail",
+          title: "Email Draft Created",
+          summary: `Drafted reply to ${conversationId}.`,
+          dedupKey: `email-draft:${draft.id}`,
+        }).catch((err) => {
+          log.warn({ err }, "Failed to emit email draft feed event");
+        });
         return ok(
           `Gmail draft created with ${attachments.length} attachment(s): ${filenames} (Draft ID: ${draft.id}). Review in Gmail Drafts, then tell me to send it or send it yourself.`,
         );
@@ -211,6 +236,14 @@ export async function run(
         undefined,
         threadId,
       );
+      void emitFeedEvent({
+        source: "gmail",
+        title: "Email Draft Created",
+        summary: `Drafted reply to ${conversationId}.`,
+        dedupKey: `email-draft:${draft.id}`,
+      }).catch((err) => {
+        log.warn({ err }, "Failed to emit email draft feed event");
+      });
       return ok(
         `Gmail draft created (ID: ${draft.id}). Review it in your Gmail Drafts, then tell me to send it or send it yourself from Gmail.`,
       );
@@ -222,6 +255,15 @@ export async function run(
       inReplyTo,
       threadId,
       assistantId: context.assistantId,
+    });
+
+    void emitFeedEvent({
+      source: platform === "slack" ? "slack" : "gmail",
+      title: platform === "slack" ? "Slack Message Sent" : "Email Sent",
+      summary: `Sent message to ${conversationId}.`,
+      dedupKey: `message-sent:${result.id}`,
+    }).catch((err) => {
+      log.warn({ err }, "Failed to emit message send feed event");
     });
 
     const threadSuffix = result.threadId


### PR DESCRIPTION
## Summary
- Add emitFeedEvent calls in messaging-send.ts for Gmail draft creation and message send (Slack/email)
- Add emitFeedEvent call in messaging-archive-by-sender.ts for email archive operations
- Source correctly set to 'gmail' or 'slack' based on platform
- Add tests verifying all emission paths

Part of JARVIS-579

Part of plan: wire-feed-event-sources.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
