### PR TITLE
fix: add feed events to toolGrantRequestResolver [JARVIS-579]

### DIFF
--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -921,6 +921,14 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
         }
       }
 
+      void emitFeedEvent({
+        source: "assistant",
+        title: "Tool Grant Denied",
+        summary: `Denied grant request for ${request.toolName ?? "unknown tool"}.`,
+        dedupKey: `guardian-grant:${request.id}`,
+        urgency: "medium",
+      });
+
       return { ok: true, applied: true };
     }
 
@@ -1018,6 +1026,14 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
         );
       }
     }
+
+    void emitFeedEvent({
+      source: "assistant",
+      title: "Tool Grant Approved",
+      summary: `Approved grant request for ${request.toolName ?? "unknown tool"}.`,
+      dedupKey: `guardian-grant:${request.id}`,
+      urgency: undefined,
+    });
 
     return { ok: true, applied: true, grantMinted: false };
   },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for wire-feed-event-sources.md.

**Gap:** toolGrantRequestResolver missing feed events
**What was expected:** All guardian resolvers should emit feed events
**What was found:** Only pendingInteractionResolver and accessRequestResolver emit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
