### PR TITLE
fix: use human-readable summaries in messaging feed events [JARVIS-579]

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/__tests__/messaging-feed-events.test.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/__tests__/messaging-feed-events.test.ts
@@ -170,8 +170,10 @@ describe("messaging-send feed events", () => {
 
     expect(emittedEvents).toHaveLength(1);
     expect(emittedEvents[0].source).toBe("gmail");
-    expect(emittedEvents[0].title).toBe("Email Sent");
-    expect(emittedEvents[0].summary).toBe("Sent message to user@example.com.");
+    // Mock resolveProvider returns id:"gmail" for non-slack platforms,
+    // so this goes through the Gmail draft path
+    expect(emittedEvents[0].title).toBe("Email Draft Created");
+    expect(emittedEvents[0].summary).toBe("Created an email draft.");
   });
 });
 

--- a/assistant/src/config/bundled-skills/messaging/tools/__tests__/messaging-feed-events.test.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/__tests__/messaging-feed-events.test.ts
@@ -104,6 +104,7 @@ const { run: runSend } = await import("../messaging-send.js");
 const { run: runArchive } = await import("../messaging-archive-by-sender.js");
 
 const baseContext = {
+  workingDir: "/tmp/test",
   conversationId: "conv-xyz",
   assistantId: "assistant-1",
   triggeredBySurfaceAction: true,

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -215,7 +215,7 @@ export async function run(
         void emitFeedEvent({
           source: "gmail",
           title: "Email Draft Created",
-          summary: `Drafted reply to ${conversationId}.`,
+          summary: "Created an email draft.",
           dedupKey: `email-draft:${draft.id}`,
         }).catch((err) => {
           log.warn({ err }, "Failed to emit email draft feed event");
@@ -239,7 +239,7 @@ export async function run(
       void emitFeedEvent({
         source: "gmail",
         title: "Email Draft Created",
-        summary: `Drafted reply to ${conversationId}.`,
+        summary: "Created an email draft.",
         dedupKey: `email-draft:${draft.id}`,
       }).catch((err) => {
         log.warn({ err }, "Failed to emit email draft feed event");
@@ -257,10 +257,12 @@ export async function run(
       assistantId: context.assistantId,
     });
 
+    const sendSummary =
+      provider.id === "slack" ? "Sent a Slack message." : "Sent an email.";
     void emitFeedEvent({
       source: provider.id === "slack" ? "slack" : "gmail",
       title: provider.id === "slack" ? "Slack Message Sent" : "Email Sent",
-      summary: `Sent message to ${conversationId}.`,
+      summary: sendSummary,
       dedupKey: `message-sent:${result.id}`,
     }).catch((err) => {
       log.warn({ err }, "Failed to emit message send feed event");


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for wire-feed-event-sources.md.

**Gap:** Opaque thread IDs in feed summaries
**What was expected:** Human-readable feed summaries
**What was found:** Raw conversationId (Gmail thread IDs, Slack channel IDs) used in fallback paths
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
