### PR TITLE
fix: differentiate heartbeat success/failure dedupKeys [JARVIS-579]

### DIFF
--- a/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
@@ -155,6 +155,6 @@ describe("heartbeat feed events", () => {
     expect(heartbeatItems).toHaveLength(1);
 
     const today = new Date().toISOString().split("T")[0];
-    expect(heartbeatItems[0]!.id).toBe(`emit:assistant:heartbeat:${today}`);
+    expect(heartbeatItems[0]!.id).toBe(`emit:assistant:heartbeat:ok:${today}`);
   });
 });

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -402,7 +402,7 @@ export class HeartbeatService {
         source: "assistant",
         title: "Heartbeat",
         summary: "Heartbeat check completed.",
-        dedupKey: `heartbeat:${new Date().toISOString().split("T")[0]}`,
+        dedupKey: `heartbeat:ok:${new Date().toISOString().split("T")[0]}`,
         priority: 30,
       }).catch((err) => {
         log.warn(
@@ -426,7 +426,7 @@ export class HeartbeatService {
         source: "assistant",
         title: "Heartbeat",
         summary: "Heartbeat check failed. Check logs for details.",
-        dedupKey: `heartbeat:${new Date().toISOString().split("T")[0]}`,
+        dedupKey: `heartbeat:fail:${new Date().toISOString().split("T")[0]}`,
         priority: 55,
         urgency: "medium",
       }).catch(() => {});


### PR DESCRIPTION
## Summary
Fixes gap where success and failure heartbeat feed events shared the same dedupKey, causing a later success to overwrite an earlier failure (or vice versa).

- Success: `heartbeat:ok:YYYY-MM-DD`
- Failure: `heartbeat:fail:YYYY-MM-DD`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
