### PR TITLE
fix(permissions): glob-compatible allowlist patterns + feature flag gate

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1768,50 +1768,55 @@ describe("Permission Checker", () => {
       expect(options[options.length - 1].label).toBe("gh *");
     });
 
-    test("shell allowlist for complex command offers exact + program wildcards", async () => {
+    // These tests run with permission-controls-v3 OFF (default config), so
+    // generateAllowlistOptions falls through to shellAllowlistStrategy which
+    // uses buildShellAllowlistOptions (action: key patterns).
+
+    test("shell allowlist for complex command offers exact compound option", async () => {
       const input = { command: 'git add . && git commit -m "fix"' };
       await classifyRisk("bash", input);
       const options = await generateAllowlistOptions("bash", input);
-      // Classifier produces exact match + per-program wildcards for multi-segment commands
-      expect(options[0].description).toBe("This exact command");
+      // buildShellAllowlistOptions: compound commands get "This exact compound command"
+      expect(options[0].description).toBe("This exact compound command");
       expect(options.length).toBeGreaterThanOrEqual(1);
     });
 
-    test("compound command via pipeline yields exact + program wildcard options", async () => {
+    test("compound command via pipeline yields exact + action key options", async () => {
       const input = { command: "git log | grep fix" };
       await classifyRisk("bash", input);
       const options = await generateAllowlistOptions("bash", input);
       expect(options.length).toBeGreaterThanOrEqual(2);
-      expect(options[0].description).toBe("This exact command");
+      // buildShellAllowlistOptions: pipelines get "This exact compound command"
+      expect(options[0].description).toBe("This exact compound command");
       expect(options[0].label).toContain("git log");
-      // Classifier offers per-program wildcards for pipelines
-      expect(options.some((o) => o.label.includes("*"))).toBe(true);
+      // Action keys from the first segment before the pipe
+      expect(options.some((o) => o.pattern.startsWith("action:"))).toBe(true);
     });
 
-    test("compound command via && yields exact + program wildcard options", async () => {
+    test("compound command via && yields exact compound option", async () => {
       const input = { command: "git add . && git push" };
       await classifyRisk("bash", input);
       const options = await generateAllowlistOptions("bash", input);
-      // Classifier produces exact match + per-program wildcards for multi-segment commands
-      expect(options[0].description).toBe("This exact command");
+      // buildShellAllowlistOptions: compound commands get "This exact compound command"
+      expect(options[0].description).toBe("This exact compound command");
       expect(options.length).toBeGreaterThanOrEqual(1);
     });
 
-    test("shell allowlist for single-word command produces classifier scope options", async () => {
+    test("shell allowlist for single-word command produces action key options", async () => {
       const input = { command: "ls -la" };
       await classifyRisk("bash", input);
       const options = await generateAllowlistOptions("bash", input);
       expect(options[0].label).toBe("ls -la");
       expect(options[0].description).toBe("This exact command");
-      // Should have broader "ls *" option
-      expect(options.some((o) => o.label === "ls *")).toBe(true);
+      // Should have broader action key options
+      expect(options.some((o) => o.pattern === "action:ls")).toBe(true);
     });
 
     test("shell allowlist exact option includes full command with setup prefixes", async () => {
       const input = { command: "cd /tmp && rm -rf build" };
       await classifyRisk("bash", input);
       const options = await generateAllowlistOptions("bash", input);
-      // The exact option must use the full command text
+      // buildShellAllowlistOptions: setup prefix + action gets action keys
       expect(options[0].description).toBe("This exact command");
       expect(options[0].label).toContain("rm -rf build");
     });
@@ -5388,14 +5393,14 @@ describe("integration regressions (PR 11)", () => {
       );
     });
 
-    test("compound command prompt offers exact + program wildcards", async () => {
+    test("compound command prompt offers exact compound option", async () => {
       const input = {
         command: 'git add . && git commit -m "fix" && git push',
       };
       await classifyRisk("host_bash", input);
       const options = await generateAllowlistOptions("host_bash", input);
-      // Classifier produces exact match + per-program wildcards
-      expect(options[0].description).toBe("This exact command");
+      // buildShellAllowlistOptions: compound commands get "This exact compound command"
+      expect(options[0].description).toBe("This exact compound command");
       expect(options.length).toBeGreaterThanOrEqual(1);
     });
   });

--- a/assistant/src/__tests__/tool-executor-shell-integration.test.ts
+++ b/assistant/src/__tests__/tool-executor-shell-integration.test.ts
@@ -3,9 +3,9 @@
  *
  * Unlike tool-executor.test.ts, this file does NOT mock ../permissions/checker.js,
  * so generateAllowlistOptions and generateScopeOptions run through the actual
- * implementation (classifier → assessment cache → tree-sitter WASM parser).
- * This validates the full e2e chain from executor to classifier-produced
- * allowlist options.
+ * implementation. With permission-controls-v3 OFF (the default), bash tools use
+ * the legacy shellAllowlistStrategy (buildShellAllowlistOptions → action: key
+ * patterns). With the flag ON, they use classifier-produced scope ladder options.
  */
 import { beforeAll, describe, expect, mock, test } from "bun:test";
 
@@ -193,7 +193,11 @@ beforeAll(async () => {
 });
 
 describe("ToolExecutor → real shell allowlist integration", () => {
-  test("simple command produces classifier-derived scope ladder", async () => {
+  // These tests run with permission-controls-v3 OFF (default), so
+  // generateAllowlistOptions falls through to shellAllowlistStrategy
+  // which uses action: key patterns from buildShellAllowlistOptions.
+
+  test("simple command produces parser-derived action keys", async () => {
     const { prompter, getAllowlist, getScopes } = makeCapturingPrompter();
     const executor = new ToolExecutor(prompter);
 
@@ -207,16 +211,14 @@ describe("ToolExecutor → real shell allowlist integration", () => {
     expect(allowlist).toBeDefined();
     expect(allowlist!.length).toBeGreaterThan(1);
 
-    // Labels are human-readable command patterns
-    const labels = allowlist!.map((o: AllowlistOption) => o.label);
-    expect(labels).toContain("npm install express");
-    expect(labels).toContain("npm install *");
-    expect(labels).toContain("npm *");
-
-    // Patterns are regex anchors produced by the classifier
     const patterns = allowlist!.map((o: AllowlistOption) => o.pattern);
-    expect(patterns[0]).toMatch(/^\^.*\$$/); // Exact match is anchored
-    expect(patterns[patterns.length - 1]).toMatch(/^\^npm\\b$/); // Command-level wildcard
+
+    // Should contain the exact command
+    expect(patterns).toContain("npm install express");
+
+    // Should contain action keys derived by the parser
+    expect(patterns).toContain("action:npm install");
+    expect(patterns).toContain("action:npm");
 
     // Every option should have label, description, and pattern
     for (const opt of allowlist!) {
@@ -237,7 +239,7 @@ describe("ToolExecutor → real shell allowlist integration", () => {
     );
   });
 
-  test("compound command produces exact match and command-level wildcards", async () => {
+  test("compound command produces only exact compound option (no action keys)", async () => {
     const { prompter, getAllowlist } = makeCapturingPrompter();
     const executor = new ToolExecutor(prompter);
 
@@ -250,19 +252,13 @@ describe("ToolExecutor → real shell allowlist integration", () => {
     const allowlist = getAllowlist();
     expect(allowlist).toBeDefined();
 
-    // Compound commands produce exact match + command-level wildcards for each
-    // unique program (git appears in both segments, so only one wildcard)
-    expect(allowlist!.length).toBe(2);
-
-    // First option is the exact compound command
-    expect(allowlist![0].description).toBe("This exact command");
-
-    // Second option is the command-level wildcard
-    expect(allowlist![1].label).toBe("git *");
-    expect(allowlist![1].description).toBe("Any git command");
+    // Compound commands with two non-setup actions get only the exact compound option
+    expect(allowlist!.length).toBe(1);
+    expect(allowlist![0].pattern).toBe('git add . && git commit -m "fix"');
+    expect(allowlist![0].description).toContain("compound");
   });
 
-  test("setup prefix + action produces exact match and per-program wildcards", async () => {
+  test("setup prefix + action produces canonical primary command and action keys", async () => {
     const { prompter, getAllowlist } = makeCapturingPrompter();
     const executor = new ToolExecutor(prompter);
 
@@ -274,17 +270,20 @@ describe("ToolExecutor → real shell allowlist integration", () => {
 
     const allowlist = getAllowlist();
     expect(allowlist).toBeDefined();
+    expect(allowlist!.length).toBeGreaterThan(1);
 
-    // Exact match + command-level wildcards for each unique program (cd, gh)
-    expect(allowlist!.length).toBe(3);
+    const patterns = allowlist!.map((o: AllowlistOption) => o.pattern);
 
-    // First option is the exact compound command
-    expect(allowlist![0].description).toBe("This exact command");
+    // Should contain the full original command as the exact option
+    expect(patterns).toContain("cd /repo && gh pr view 123");
 
-    // Command-level wildcards for each unique program
-    const labels = allowlist!.map((o: AllowlistOption) => o.label);
-    expect(labels).toContain("cd *");
-    expect(labels).toContain("gh *");
+    // Should contain action keys: cd is a setup prefix, so gh is the primary action
+    expect(patterns).toContain("action:gh pr view");
+    expect(patterns).toContain("action:gh pr");
+    expect(patterns).toContain("action:gh");
+
+    // Should NOT contain action keys for the setup prefix (cd)
+    expect(patterns).not.toContain("action:cd");
   });
 
   test("scope options include project directory and everywhere", async () => {
@@ -317,7 +316,7 @@ describe("ToolExecutor → real shell allowlist integration", () => {
     }
   });
 
-  test("host_bash command also produces classifier-derived scope ladder", async () => {
+  test("host_bash command also produces real parser-derived options", async () => {
     const { prompter, getAllowlist } = makeCapturingPrompter();
     const executor = new ToolExecutor(prompter);
 
@@ -331,18 +330,15 @@ describe("ToolExecutor → real shell allowlist integration", () => {
     expect(allowlist).toBeDefined();
     expect(allowlist!.length).toBeGreaterThan(1);
 
-    // Labels are human-readable
-    const labels = allowlist!.map((o: AllowlistOption) => o.label);
-    expect(labels).toContain("git status");
-    expect(labels).toContain("git *");
-
-    // Patterns are regex
     const patterns = allowlist!.map((o: AllowlistOption) => o.pattern);
-    expect(patterns[0]).toMatch(/^\^git status\$$/);
-    expect(patterns[patterns.length - 1]).toMatch(/^\^git\\b$/);
+
+    // Should contain exact command and action keys
+    expect(patterns).toContain("git status");
+    expect(patterns).toContain("action:git status");
+    expect(patterns).toContain("action:git");
   });
 
-  test("pipeline command produces exact match and per-program wildcards", async () => {
+  test("pipeline command produces exact + action-key options", async () => {
     const { prompter, getAllowlist } = makeCapturingPrompter();
     const executor = new ToolExecutor(prompter);
 
@@ -355,15 +351,11 @@ describe("ToolExecutor → real shell allowlist integration", () => {
     const allowlist = getAllowlist();
     expect(allowlist).toBeDefined();
 
-    // Pipelines produce exact match + command-level wildcards for each program
+    // Pipelines now produce exact option + action key options
     expect(allowlist!.length).toBeGreaterThanOrEqual(2);
-
-    // First option is the exact pipeline command
-    expect(allowlist![0].description).toBe("This exact command");
-
-    // Command-level wildcards for each unique program in the pipeline
-    const labels = allowlist!.map((o: AllowlistOption) => o.label);
-    expect(labels).toContain("cat *");
-    expect(labels).toContain("grep *");
+    expect(allowlist![0].pattern).toBe("cat file.txt | grep error");
+    expect(allowlist![0].description).toContain("compound");
+    // Action keys from the first segment before the pipe
+    expect(allowlist!.some((o) => o.pattern.startsWith("action:"))).toBe(true);
   });
 });

--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -1389,8 +1389,16 @@ describe("scopeOptionsToAllowlistOptions", () => {
     // Labels match scopeOptions labels
     for (let i = 0; i < scopeOptions.length; i++) {
       expect(allowlistOptions[i].label).toBe(scopeOptions[i].label);
-      expect(allowlistOptions[i].pattern).toBe(scopeOptions[i].pattern);
     }
+
+    // Patterns are glob-compatible (not regex) for trust rule matching:
+    // - First option: raw command string (exact match)
+    // - Last option: action:<program> format
+    // - Intermediate: label-based glob patterns
+    expect(allowlistOptions[0].pattern).toBe("git push origin main");
+    expect(
+      allowlistOptions[allowlistOptions.length - 1].pattern,
+    ).toBe("action:git");
   });
 
   test("intermediate options get 'Commands matching this pattern' description", async () => {

--- a/assistant/src/permissions/bash-risk-classifier.ts
+++ b/assistant/src/permissions/bash-risk-classifier.ts
@@ -621,11 +621,12 @@ function escapeRegex(s: string): string {
 /**
  * Convert classifier-produced `ScopeOption[]` to `AllowlistOption[]` format.
  *
- * The description follows the same patterns used by `buildShellAllowlistOptions`
- * in shell-identity.ts:
- * - First option (exact match): "This exact command"
- * - Last option (command-level wildcard): "Any <program> command"
- * - Intermediate options: "Commands matching this pattern"
+ * Patterns must be glob-compatible (not regex) because trust rules use
+ * Minimatch for matching against command candidates produced by
+ * `buildCommandCandidates()`. The format:
+ * - First option (exact match): raw command string
+ * - Intermediate options: label as a glob pattern (e.g. "npm install *")
+ * - Command-level wildcards: "action:<program>" prefix matching action key candidates
  */
 export function scopeOptionsToAllowlistOptions(
   scopeOptions: ScopeOption[],
@@ -637,18 +638,28 @@ export function scopeOptionsToAllowlistOptions(
 
   return scopeOptions.map((opt, i): AllowlistOption => {
     let description: string;
+    let pattern: string;
+
     if (i === 0) {
+      // Exact match: raw command string (matches the raw candidate)
       description = "This exact command";
-    } else if (i === scopeOptions.length - 1) {
-      description = `Any ${programName} command`;
+      pattern = opt.label;
+    } else if (
+      opt.label.endsWith(" *") &&
+      !opt.label.slice(0, -2).includes(" ")
+    ) {
+      // Command-level wildcard (label is "<program> *"): use action: prefix
+      // to match action key candidates from buildCommandCandidates()
+      const prog = opt.label.slice(0, -2);
+      description = `Any ${prog} command`;
+      pattern = `action:${prog}`;
     } else {
+      // Intermediate wildcard: use label as a glob pattern
       description = "Commands matching this pattern";
+      pattern = opt.label;
     }
-    return {
-      label: opt.label,
-      description,
-      pattern: opt.pattern,
-    };
+
+    return { label: opt.label, description, pattern };
   });
 }
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -34,6 +34,7 @@ import {
 } from "./risk-types.js";
 import {
   analyzeShellCommand,
+  buildShellAllowlistOptions,
   cachedParse,
   deriveShellActionKeys,
   type ParsedCommand,
@@ -766,6 +767,14 @@ type AllowlistStrategy = (
   input: Record<string, unknown>,
 ) => Promise<AllowlistOption[]> | AllowlistOption[];
 
+function shellAllowlistStrategy(
+  _toolName: string,
+  input: Record<string, unknown>,
+): Promise<AllowlistOption[]> {
+  const command = ((input.command as string) ?? "").trim();
+  return buildShellAllowlistOptions(command);
+}
+
 function fileAllowlistStrategy(
   toolName: string,
   input: Record<string, unknown>,
@@ -935,6 +944,8 @@ function skillLoadAllowlistStrategy(
 }
 
 const ALLOWLIST_STRATEGIES: Record<string, AllowlistStrategy> = {
+  bash: shellAllowlistStrategy,
+  host_bash: shellAllowlistStrategy,
   file_read: fileAllowlistStrategy,
   file_write: fileAllowlistStrategy,
   file_edit: fileAllowlistStrategy,
@@ -955,21 +966,26 @@ export async function generateAllowlistOptions(
 ): Promise<AllowlistOption[]> {
   signal?.throwIfAborted();
 
-  // Check if a classifier already produced allowlist options during
-  // classifyRisk(). If so, return those directly — avoids duplicate
-  // computation and keeps scope option generation unified with risk
-  // classification.
-  const aKey = assessmentCacheKey(toolName, input);
-  const cachedAssessment = assessmentCache.get(aKey);
-  if (
-    cachedAssessment?.allowlistOptions &&
-    cachedAssessment.allowlistOptions.length > 0
-  ) {
-    return cachedAssessment.allowlistOptions;
+  // When permission-controls-v3 is enabled, use classifier-produced options
+  // from the assessment cache (populated by BashRiskClassifier.classify()).
+  // When the flag is off, fall through to the legacy per-tool strategies
+  // (e.g. shellAllowlistStrategy for bash/host_bash) to avoid changing the
+  // allowlist pattern format for users who haven't opted in.
+  const config = getConfig();
+  if (isAssistantFeatureFlagEnabled("permission-controls-v3", config)) {
+    const aKey = assessmentCacheKey(toolName, input);
+    const cachedAssessment = assessmentCache.get(aKey);
+    if (
+      cachedAssessment?.allowlistOptions &&
+      cachedAssessment.allowlistOptions.length > 0
+    ) {
+      return cachedAssessment.allowlistOptions;
+    }
   }
 
-  // Fall back to the per-tool strategy function for tools that don't have
-  // classifier-produced options (e.g. file tools, web tools, skill tools).
+  // Fall back to the per-tool strategy function. For bash/host_bash when the
+  // flag is off, this uses shellAllowlistStrategy (action: key patterns).
+  // For other tools, this is the only path.
   if (Object.hasOwn(ALLOWLIST_STRATEGIES, toolName)) {
     return ALLOWLIST_STRATEGIES[toolName](toolName, input);
   }

--- a/assistant/src/permissions/shell-identity.ts
+++ b/assistant/src/permissions/shell-identity.ts
@@ -4,6 +4,7 @@ import {
   parse,
   type ParsedCommand,
 } from "../tools/terminal/parser.js";
+import type { AllowlistOption } from "./types.js";
 
 export type { ParsedCommand };
 
@@ -223,5 +224,74 @@ export function deriveShellActionKeys(
   }
 
   return { keys, isSimpleAction: true, primarySegment };
+}
+
+/**
+ * Build allowlist options for shell commands using parser-derived identity.
+ *
+ * For simple actions (optional setup prefix + one action), options are:
+ *   1. Exact canonical primary command
+ *   2. Deepest action key (e.g. "action:gh pr view")
+ *   3. Broader action keys (e.g. "action:gh pr", "action:gh")
+ *
+ * For pipelines, the exact command plus action-key-based broader options
+ * are offered. For other complex commands (multi-action chains, semicolons,
+ * etc.), only the exact command is offered.
+ */
+export async function buildShellAllowlistOptions(
+  command: string,
+): Promise<AllowlistOption[]> {
+  const trimmed = command.trim();
+  if (!trimmed) return [];
+
+  const analysis = await analyzeShellCommand(trimmed);
+  const actionResult = deriveShellActionKeys(analysis);
+
+  if (!actionResult.isSimpleAction || !actionResult.primarySegment) {
+    const options: AllowlistOption[] = [
+      {
+        label: trimmed,
+        description: "This exact compound command",
+        pattern: trimmed,
+      },
+    ];
+    // If pipeline action keys were extracted, offer them as broader options
+    for (const actionKey of actionResult.keys) {
+      const keyTokens = actionKey.key.replace(/^action:/, "");
+      options.push({
+        label: `${keyTokens} *`,
+        description: `Any "${keyTokens}" command`,
+        pattern: actionKey.key,
+      });
+    }
+    return options;
+  }
+
+  const options: AllowlistOption[] = [];
+
+  // Full original command text
+  options.push({
+    label: trimmed,
+    description: "This exact command",
+    pattern: trimmed,
+  });
+
+  // Action keys from narrowest to broadest
+  for (const actionKey of actionResult.keys) {
+    const keyTokens = actionKey.key.replace(/^action:/, "");
+    options.push({
+      label: `${keyTokens} *`,
+      description: `Any "${keyTokens}" command`,
+      pattern: actionKey.key,
+    });
+  }
+
+  // Deduplicate by pattern
+  const seen = new Set<string>();
+  return options.filter((o) => {
+    if (seen.has(o.pattern)) return false;
+    seen.add(o.pattern);
+    return true;
+  });
 }
 


### PR DESCRIPTION
## Summary
- **Pattern format fix**: `scopeOptionsToAllowlistOptions` now produces glob-compatible patterns (raw command strings, `action:<program>` keys) instead of regex patterns that would never match trust rule candidates via Minimatch
- **Feature flag gate**: `generateAllowlistOptions` classifier cache path is now gated behind `permission-controls-v3`; when the flag is off, bash/host_bash fall through to the restored `shellAllowlistStrategy` → `buildShellAllowlistOptions` (action: key pattern format)
- **Restored legacy path**: Re-added `buildShellAllowlistOptions` to `shell-identity.ts` and `shellAllowlistStrategy` to `checker.ts` as the flag-off fallback

## Original prompt
Fix two critical issues on the scope-ladder-v1-assistant feature branch:

ISSUE 1 - Pattern format mismatch: scopeOptionsToAllowlistOptions outputs regex patterns as AllowlistOption.pattern, but trust rules use Minimatch (glob). Fixed by producing raw command strings for exact match, label-based globs for intermediate levels, and action:<program> for command-level wildcards.

ISSUE 2 - Missing feature flag gate: The allowlist format change affects what trust rules get created for ALL users. Fixed by gating the classifier cache path in generateAllowlistOptions behind permission-controls-v3, with the legacy shellAllowlistStrategy as the flag-off fallback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
