### PR TITLE
fix(permissions): upgrade sed base risk from low to medium

### DIFF
--- a/assistant/src/permissions/bash-risk-classifier.test.ts
+++ b/assistant/src/permissions/bash-risk-classifier.test.ts
@@ -279,12 +279,12 @@ describe("arg rule classification", () => {
     expect(result.riskLevel).toBe("medium");
   });
 
-  test("sed without -i → low", async () => {
+  test("sed without -i → medium", async () => {
     const result = await classifier.classify({
       command: "sed 's/foo/bar/g' file.txt",
       toolName: "bash",
     });
-    expect(result.riskLevel).toBe("low");
+    expect(result.riskLevel).toBe("medium");
   });
 });
 

--- a/assistant/src/permissions/command-registry.ts
+++ b/assistant/src/permissions/command-registry.ts
@@ -111,7 +111,8 @@ export const DEFAULT_COMMAND_REGISTRY = {
     argSchema: { positionals: "none" },
   },
   sed: {
-    baseRisk: "low",
+    baseRisk: "medium",
+    reason: "Can write files or execute commands via sed scripts",
     sandboxAutoApprove: true,
     argSchema: {
       positionals: [{ role: "script" }, { role: "path", rest: true }],


### PR DESCRIPTION
## Summary

- Upgrade `sed` base risk from `low` to `medium` in the command registry, restoring the pre-Phase-2 classification that was accidentally downgraded in PR #27016
- GNU sed can write files (`w` command) and execute shell commands (`e` command) without `-i`, so low-risk auto-allow creates a prompt-bypass vulnerability on `host_bash`
- This is consistent with `awk`, which is already classified as `medium` for the same reason ("Can execute shell commands via system()")

Codex finding: https://chatgpt.com/codex/cloud/security/findings/3fd6463635248191a7197ac176ac184c?sev=critical%2Chigh

## Original prompt
Fix security vulnerability: sed classified as low risk enables prompt bypass for host command execution
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
