### PR TITLE
fix(macos): silence MainActor isolation warning in ReturningUserRouter

### DIFF
--- a/clients/macos/vellum-assistant/App/ReturningUserRouter.swift
+++ b/clients/macos/vellum-assistant/App/ReturningUserRouter.swift
@@ -67,7 +67,7 @@ final class ReturningUserRouter {
     // MARK: - Dependencies
 
     private let organizationIdProvider: () -> String?
-    private let authServiceProvider: () -> ManagedAssistantBootstrapAuthServicing?
+    private let authServiceProvider: @MainActor () -> ManagedAssistantBootstrapAuthServicing?
     private let lockfileLoader: () -> [LockfileAssistant]
     private let multiAssistantFlagProvider: () -> Bool
 
@@ -77,7 +77,7 @@ final class ReturningUserRouter {
         organizationIdProvider: @escaping () -> String? = {
             UserDefaults.standard.string(forKey: "connectedOrganizationId")
         },
-        authServiceProvider: @escaping () -> ManagedAssistantBootstrapAuthServicing? = {
+        authServiceProvider: @MainActor @escaping () -> ManagedAssistantBootstrapAuthServicing? = {
             AuthService.shared
         },
         lockfileLoader: @escaping () -> [LockfileAssistant] = {


### PR DESCRIPTION
## Summary
- Annotate `authServiceProvider` closure property and init parameter as `@MainActor` so accessing `AuthService.shared` (which is `@MainActor`-isolated) is valid in the default closure
- This silences the Swift 6 concurrency warning about referencing a main actor-isolated property from a nonisolated context

## Original prompt
help me fix this macos build warning:

ReturningUserRouter.swift:81:25: warning: main actor-isolated class property 'shared' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
