### PR TITLE
feat(client): add RiskBadgeView colored pill component

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// A small colored pill that displays a risk level label.
+///
+/// Color-coded by risk level:
+/// - `"low"` — green (`VColor.systemPositiveStrong`)
+/// - `"medium"` — amber (`VColor.systemMidStrong`)
+/// - `"high"` — red (`VColor.systemNegativeStrong`)
+/// - Any other value — gray (`VColor.contentSecondary`)
+///
+/// When `onTap` is provided the badge renders as a tappable button with a
+/// tooltip; otherwise it is a plain, non-interactive label.
+struct RiskBadgeView: View {
+    let riskLevel: String
+    var onTap: (() -> Void)? = nil
+
+    var body: some View {
+        if let onTap {
+            Button(action: onTap) {
+                badgeContent
+            }
+            .buttonStyle(.plain)
+            .help("Risk level: \(displayLabel). Click to create a rule.")
+        } else {
+            badgeContent
+        }
+    }
+
+    private var badgeContent: some View {
+        Text(displayLabel)
+            .font(VFont.labelDefault)
+            .foregroundStyle(textColor)
+            .padding(EdgeInsets(top: 2, leading: 6, bottom: 2, trailing: 6))
+            .background(backgroundColor)
+            .clipShape(Capsule())
+    }
+
+    // MARK: - Display
+
+    private var displayLabel: String {
+        guard !riskLevel.isEmpty else { return "Unknown" }
+        return riskLevel.prefix(1).uppercased() + riskLevel.dropFirst()
+    }
+
+    // MARK: - Color Mapping
+
+    private var backgroundColor: Color {
+        switch riskLevel.lowercased() {
+        case "low":
+            VColor.systemPositiveStrong
+        case "medium":
+            VColor.systemMidStrong
+        case "high":
+            VColor.systemNegativeStrong
+        default:
+            VColor.contentSecondary
+        }
+    }
+
+    private var textColor: Color {
+        switch riskLevel.lowercased() {
+        case "medium":
+            // Amber background is light — use dark text for contrast.
+            VColor.auxBlack
+        default:
+            VColor.auxWhite
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add RiskBadgeView SwiftUI component — small colored pill showing risk level
- Color-coded: green (low), amber (medium), red (high), gray (unknown)
- Interactive when onTap callback provided, plain text otherwise

Part of plan: scope-ladder-v1-swiftui.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
