### PR TITLE
feat(client): add riskLevel, riskReason, riskScopeOptions to ToolResult model

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -834,6 +834,12 @@ public struct ToolCallData: Identifiable, Equatable {
     public var buildingStatus: String?
     /// Non-technical reason for the tool call, extracted from the `reason` field of tool input.
     public var reasonDescription: String?
+    /// Risk level classification from the permission checker ("low", "medium", "high", "unknown").
+    public var riskLevel: String?
+    /// Human-readable reason for the risk classification.
+    public var riskReason: String?
+    /// Scope options ladder for the rule editor (pattern + label pairs, narrowest to broadest).
+    public var riskScopeOptions: [ToolResultRiskScopeOption]?
     /// Accumulated streaming output from tool_output_chunk events (plain text only).
     /// Capped at 5000 characters (keeps the tail when exceeded).
     public var partialOutput: String = ""
@@ -876,6 +882,7 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.confirmationDecision == rhs.confirmationDecision
             && lhs.confirmationLabel == rhs.confirmationLabel
             && lhs.pendingConfirmation == rhs.pendingConfirmation
+            && lhs.riskLevel == rhs.riskLevel
     }
 
     public init(id: UUID = UUID(), toolName: String, inputSummary: String, inputFull: String? = nil, inputRawValue: String? = nil, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageDataList: [String]? = nil, startedAt: Date? = nil, completedAt: Date? = nil) {

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -439,6 +439,9 @@ extension ChatViewModel {
             // Keep cachedImages for display, nil out raw base64 to save memory
             messages[msgIndex].toolCalls[tcIndex].cachedImages = decoded
             messages[msgIndex].toolCalls[tcIndex].imageDataList = decoded.isEmpty ? msg.imageDataList : nil
+            messages[msgIndex].toolCalls[tcIndex].riskLevel = msg.riskLevel
+            messages[msgIndex].toolCalls[tcIndex].riskReason = msg.riskReason
+            messages[msgIndex].toolCalls[tcIndex].riskScopeOptions = msg.riskScopeOptions
             if let status = msg.status, !status.isEmpty {
                 messages[msgIndex].toolCalls[tcIndex].buildingStatus = status
             }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4825,8 +4825,14 @@ public struct ToolResult: Codable, Sendable {
     public let imageDataList: [String]?
     /// The tool_use block ID for client-side correlation.
     public let toolUseId: String?
+    /// Risk level from the classifier ("low", "medium", "high", "unknown").
+    public let riskLevel: String?
+    /// Human-readable reason for the risk classification.
+    public let riskReason: String?
+    /// Scope options ladder for the rule editor modal (narrowest to broadest).
+    public let riskScopeOptions: [ToolResultRiskScopeOption]?
 
-    public init(type: String, toolName: String, result: String, isError: Bool? = nil, diff: ToolResultDiff? = nil, status: String? = nil, conversationId: String? = nil, imageDataList: [String]? = nil, toolUseId: String? = nil) {
+    public init(type: String, toolName: String, result: String, isError: Bool? = nil, diff: ToolResultDiff? = nil, status: String? = nil, conversationId: String? = nil, imageDataList: [String]? = nil, toolUseId: String? = nil, riskLevel: String? = nil, riskReason: String? = nil, riskScopeOptions: [ToolResultRiskScopeOption]? = nil) {
         self.type = type
         self.toolName = toolName
         self.result = result
@@ -4836,6 +4842,9 @@ public struct ToolResult: Codable, Sendable {
         self.conversationId = conversationId
         self.imageDataList = imageDataList
         self.toolUseId = toolUseId
+        self.riskLevel = riskLevel
+        self.riskReason = riskReason
+        self.riskScopeOptions = riskScopeOptions
     }
 }
 
@@ -4850,6 +4859,15 @@ public struct ToolResultDiff: Codable, Sendable {
         self.oldContent = oldContent
         self.newContent = newContent
         self.isNewFile = isNewFile
+    }
+}
+
+public struct ToolResultRiskScopeOption: Codable, Sendable, Equatable {
+    public let pattern: String
+    public let label: String
+    public init(pattern: String, label: String) {
+        self.pattern = pattern
+        self.label = label
     }
 }
 


### PR DESCRIPTION
## Summary
- Add ToolResultRiskScopeOption struct and riskLevel/riskReason/riskScopeOptions fields to ToolResult
- Propagate risk metadata from SSE ToolResult to ToolCallData in ChatMessage
- Include riskLevel in ToolCallData equality comparison

Part of plan: scope-ladder-v1-swiftui.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
