### PR TITLE
feat(macOS): add HomeScheduledDetails value type

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeScheduledDetails.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeScheduledDetails.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Client-side render metadata for a scheduled (`.thread`) feed item.
+/// The daemon doesn't yet surface these fields on `FeedItem`; this
+/// struct lets the detail panel render with placeholder data until
+/// the schedule source lands.
+public struct HomeScheduledDetails: Hashable, Sendable {
+    public let name: String
+    public let syntax: String
+    public let mode: String
+    public let schedule: String
+    public let enabled: Bool
+    public let nextRun: Date
+    public let description: String
+
+    public init(
+        name: String,
+        syntax: String,
+        mode: String,
+        schedule: String,
+        enabled: Bool,
+        nextRun: Date,
+        description: String
+    ) {
+        self.name = name
+        self.syntax = syntax
+        self.mode = mode
+        self.schedule = schedule
+        self.enabled = enabled
+        self.nextRun = nextRun
+        self.description = description
+    }
+
+    // MARK: - Display rows
+
+    private static let nextRunFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, yyyy 'at' h:mm a zzz"
+        return formatter
+    }()
+
+    /// Ordered key/value pairs suitable for rendering in the detail panel.
+    /// Order is fixed: Name, Syntax, Mode, Schedule, Enabled, Next Run.
+    public func displayRows() -> [(key: String, value: String)] {
+        [
+            (key: "Name", value: name),
+            (key: "Syntax", value: syntax),
+            (key: "Mode", value: mode),
+            (key: "Schedule", value: schedule),
+            (key: "Enabled", value: enabled ? "true" : "false"),
+            (key: "Next Run", value: Self.nextRunFormatter.string(from: nextRun)),
+        ]
+    }
+
+    // MARK: - Placeholder
+
+    /// Figma sample values used while the daemon schedule source is
+    /// still under construction.
+    public static let placeholder: HomeScheduledDetails = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Europe/Ljubljana")!
+        let nextRun = calendar.date(from: DateComponents(
+            year: 2026,
+            month: 4,
+            day: 23,
+            hour: 9,
+            minute: 0
+        )) ?? Date()
+
+        return HomeScheduledDetails(
+            name: "Morning check-in",
+            syntax: "cron",
+            mode: "notify",
+            schedule: "Every day at 9:00 AM (Europe/Ljubljana)",
+            enabled: true,
+            nextRun: nextRun,
+            description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+        )
+    }()
+}

--- a/clients/macos/vellum-assistantTests/Features/Home/HomeScheduledDetailsTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Home/HomeScheduledDetailsTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Unit tests for ``HomeScheduledDetails``.
+final class HomeScheduledDetailsTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeDetails(enabled: Bool = true) -> HomeScheduledDetails {
+        HomeScheduledDetails(
+            name: "Morning check-in",
+            syntax: "cron",
+            mode: "notify",
+            schedule: "Every day at 9:00 AM (Europe/Ljubljana)",
+            enabled: enabled,
+            nextRun: Date(timeIntervalSince1970: 0),
+            description: "Test description."
+        )
+    }
+
+    // MARK: - displayRows
+
+    func test_displayRows_orderAndCount() {
+        let rows = makeDetails().displayRows()
+
+        XCTAssertEqual(rows.count, 6)
+        XCTAssertEqual(rows[0].key, "Name")
+        XCTAssertEqual(rows[1].key, "Syntax")
+        XCTAssertEqual(rows[2].key, "Mode")
+        XCTAssertEqual(rows[3].key, "Schedule")
+        XCTAssertEqual(rows[4].key, "Enabled")
+        XCTAssertEqual(rows[5].key, "Next Run")
+    }
+
+    func test_displayRows_enabledFalseRendersAsFalse() {
+        let rows = makeDetails(enabled: false).displayRows()
+
+        let enabledRow = rows.first { $0.key == "Enabled" }
+        XCTAssertEqual(enabledRow?.value, "false")
+    }
+
+    // MARK: - placeholder
+
+    func test_placeholderHasFigmaSample() {
+        let placeholder = HomeScheduledDetails.placeholder
+
+        XCTAssertEqual(placeholder.name, "Morning check-in")
+        XCTAssertEqual(placeholder.schedule, "Every day at 9:00 AM (Europe/Ljubljana)")
+    }
+}


### PR DESCRIPTION
## Summary
- New `HomeScheduledDetails` value type with six fields + description for scheduled feed items.
- `displayRows()` returns ordered key/value pairs for the detail panel.
- `placeholder` static matches the Figma sample.

Part of plan: home-feed-groups.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
