### PR TITLE
feat(macOS): add HomeScheduledDetailPanel for scheduled items

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeScheduledDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeScheduledDetailPanel.swift
@@ -1,0 +1,232 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Right-hand detail panel surfaced when a scheduled feed item is selected
+/// on the redesigned Home page.
+///
+/// Matches Figma node `3684:37504` (right-hand panel): a dark surface-lift
+/// card with a 16pt corner, a header (amber calendar chip + title +
+/// outlined close button), a body (description + details card listing
+/// key/value rows), and a footer that pins optional secondary + primary
+/// action buttons above a hairline divider.
+///
+/// The outer shell uses `VColor.surfaceLift` + `VColor.borderHover` to read
+/// as the same "work surface" as `HomeDetailPanel`. Unlike that panel,
+/// scheduled items have no scrolling content and no "Go to Thread"
+/// action — the entire body is a fixed brief summary of the schedule.
+struct HomeScheduledDetailPanel: View {
+    /// One labeled row inside the details card. `key` is rendered on the
+    /// leading edge in `contentTertiary`, `value` on the trailing edge in
+    /// `contentDefault`.
+    struct DetailRow: Identifiable, Hashable {
+        var id: String { key }
+        let key: String
+        let value: String
+    }
+
+    let title: String
+    let description: String
+    let rows: [DetailRow]
+    let primaryActionLabel: String
+    let secondaryActionLabel: String?
+    let onClose: () -> Void
+    let onPrimaryAction: () -> Void
+    let onSecondaryAction: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+
+            Rectangle()
+                .fill(VColor.borderHover)
+                .frame(height: 1)
+                .accessibilityHidden(true)
+
+            bodySection
+
+            Spacer(minLength: VSpacing.lg)
+
+            footer
+        }
+        .frame(minWidth: 480, idealWidth: 600, maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.xl, style: .continuous)
+                .fill(VColor.surfaceLift)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.xl, style: .continuous)
+                .strokeBorder(VColor.borderHover, lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(Text(title))
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .center) {
+            HStack(spacing: VSpacing.sm) {
+                ZStack {
+                    Circle().fill(VColor.feedThreadWeak)
+                    VIconView(.calendar, size: 12)
+                        .foregroundStyle(VColor.feedThreadStrong)
+                }
+                .frame(width: 26, height: 26)
+                .accessibilityHidden(true)
+
+                Text(title)
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentEmphasized)
+                    .accessibilityAddTraits(.isHeader)
+            }
+
+            Spacer(minLength: 0)
+
+            Button(action: onClose) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: VRadius.md, style: .continuous)
+                        .strokeBorder(VColor.borderElement, lineWidth: 1)
+                    VIconView(.x, size: 9)
+                        .foregroundStyle(VColor.contentEmphasized)
+                }
+                .frame(width: 32, height: 32)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .pointerCursor()
+            .accessibilityLabel(Text("Close"))
+        }
+        .padding(VSpacing.lg)
+    }
+
+    // MARK: - Body
+
+    private var bodySection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text(description)
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentDefault)
+                .fixedSize(horizontal: false, vertical: true)
+
+            detailsCard
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.top, VSpacing.lg)
+    }
+
+    private var detailsCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Details")
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(VColor.contentEmphasized)
+
+            ForEach(rows) { row in
+                HStack {
+                    Text(row.key)
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentTertiary)
+                    Spacer()
+                    Text(row.value)
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentDefault)
+                }
+            }
+        }
+        .padding(EdgeInsets(
+            top: VSpacing.md,
+            leading: VSpacing.md,
+            bottom: VSpacing.lg,
+            trailing: VSpacing.md
+        ))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg, style: .continuous)
+                .fill(VColor.surfaceOverlay)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg, style: .continuous)
+                .strokeBorder(VColor.borderHover, lineWidth: 1)
+        )
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        VStack(spacing: 0) {
+            Rectangle()
+                .fill(VColor.borderHover)
+                .frame(height: 1)
+                .accessibilityHidden(true)
+
+            HStack(alignment: .center, spacing: VSpacing.sm) {
+                Spacer()
+
+                if let secondaryActionLabel {
+                    Button(action: { onSecondaryAction?() }) {
+                        Text(secondaryActionLabel)
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentEmphasized)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .frame(height: 32)
+                            .background(
+                                RoundedRectangle(cornerRadius: VRadius.md, style: .continuous)
+                                    .fill(Color.clear)
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.md, style: .continuous)
+                                    .strokeBorder(VColor.borderElement, lineWidth: 1)
+                            )
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .pointerCursor()
+                    .accessibilityLabel(Text(secondaryActionLabel))
+                }
+
+                Button(action: onPrimaryAction) {
+                    Text(primaryActionLabel)
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentInset)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .frame(height: 32)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.md, style: .continuous)
+                                .fill(VColor.contentEmphasized)
+                        )
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .pointerCursor()
+                .accessibilityLabel(Text(primaryActionLabel))
+            }
+            .padding(VSpacing.lg)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    HomeScheduledDetailPanel(
+        title: "Scheduled Thing",
+        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+        rows: [
+            .init(key: "Name", value: "Morning check-in"),
+            .init(key: "Syntax", value: "cron"),
+            .init(key: "Mode", value: "notify"),
+            .init(key: "Schedule", value: "Every day at 9:00 AM (Europe/Ljubljana)"),
+            .init(key: "Enabled", value: "true"),
+            .init(key: "Next Run", value: "Apr 23, 2026 at 9:00 AM GMT+2"),
+        ],
+        primaryActionLabel: "Action",
+        secondaryActionLabel: "Action",
+        onClose: {},
+        onPrimaryAction: {},
+        onSecondaryAction: {}
+    )
+    .frame(width: 601, height: 786)
+    .padding()
+    .background(VColor.surfaceBase)
+}

--- a/clients/macos/vellum-assistantTests/Features/Home/DetailPanel/HomeScheduledDetailPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Home/DetailPanel/HomeScheduledDetailPanelTests.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Smoke tests for ``HomeScheduledDetailPanel``.
+///
+/// These tests intentionally stay at the view-model / constructor level —
+/// they verify that the value-type `DetailRow` payload round-trips and
+/// that the optional secondary action doesn't crash the body builder.
+final class HomeScheduledDetailPanelTests: XCTestCase {
+
+    func test_init_storesRows() {
+        let rows: [HomeScheduledDetailPanel.DetailRow] = [
+            .init(key: "Name", value: "Morning check-in"),
+            .init(key: "Mode", value: "notify"),
+            .init(key: "Enabled", value: "true"),
+        ]
+
+        let view = HomeScheduledDetailPanel(
+            title: "Scheduled Thing",
+            description: "desc",
+            rows: rows,
+            primaryActionLabel: "Action",
+            secondaryActionLabel: "Action",
+            onClose: {},
+            onPrimaryAction: {},
+            onSecondaryAction: {}
+        )
+
+        XCTAssertEqual(view.rows.count, 3)
+        XCTAssertEqual(view.rows.map(\.key), ["Name", "Mode", "Enabled"])
+        XCTAssertEqual(view.rows.map(\.value), ["Morning check-in", "notify", "true"])
+    }
+
+    func test_secondaryActionOptional() {
+        let rows: [HomeScheduledDetailPanel.DetailRow] = [
+            .init(key: "Name", value: "Morning check-in"),
+        ]
+
+        let withoutSecondary = HomeScheduledDetailPanel(
+            title: "Scheduled Thing",
+            description: "desc",
+            rows: rows,
+            primaryActionLabel: "Action",
+            secondaryActionLabel: nil,
+            onClose: {},
+            onPrimaryAction: {},
+            onSecondaryAction: nil
+        )
+        _ = withoutSecondary.body
+
+        let withSecondary = HomeScheduledDetailPanel(
+            title: "Scheduled Thing",
+            description: "desc",
+            rows: rows,
+            primaryActionLabel: "Action",
+            secondaryActionLabel: "Action",
+            onClose: {},
+            onPrimaryAction: {},
+            onSecondaryAction: {}
+        )
+        _ = withSecondary.body
+    }
+}


### PR DESCRIPTION
## Summary
- New `HomeScheduledDetailPanel` view for scheduled items — header with amber calendar icon + title, description, details card, action buttons.
- All colors/spacing driven by VColor / VSpacing / VRadius tokens.

Part of plan: home-feed-groups.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
