### PR TITLE
Scope Ladder v1 — SwiftUI Client Implementation

### DIFF
--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -159,6 +159,8 @@ export interface ConfirmationRequest {
   toolName: string;
   input: Record<string, unknown>;
   riskLevel: string;
+  /** Human-readable reason for the risk classification (e.g. "Modifies remote repository state"). */
+  riskReason?: string;
   executionTarget?: "sandbox" | "host";
   allowlistOptions: Array<{
     label: string;

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -66,6 +66,7 @@ export class PermissionPrompter {
     temporaryOptionsAvailable?: Array<"allow_10m" | "allow_conversation">,
     toolUseId?: string,
     hostAccessEnablePrompt?: boolean,
+    riskReason?: string,
   ): Promise<{
     decision: UserDecision;
     selectedPattern?: string;
@@ -116,6 +117,7 @@ export class PermissionPrompter {
         toolName,
         input: redactSensitiveFields(input),
         riskLevel,
+        riskReason,
         allowlistOptions: allowlistOptions.map((o) => ({
           label: o.label,
           description: o.description,

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -418,6 +418,7 @@ export class PermissionChecker {
           promptOptions.temporaryOptionsAvailable,
           context.toolUseId,
           v2ForcePrompt,
+          riskReason,
         );
 
         const decision =

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -737,7 +737,9 @@ private struct StepDetailRow: View {
     /// when the user taps a risk badge in the expanded view.
     @State private var ruleEditorToolCall: ToolCallData?
 
-    private let trustRuleClient: TrustRuleClientProtocol = TrustRuleClient()
+    /// Shared across all StepDetailRow instances — TrustRuleClient is a stateless
+    /// HTTP client, so a single static instance avoids re-creation on every view rebuild.
+    private static let trustRuleClient: TrustRuleClientProtocol = TrustRuleClient()
 
     private static let coloredOutputCache: NSCache<NSString, StepDetailAttributedStringCacheEntry> = {
         let cache = NSCache<NSString, StepDetailAttributedStringCacheEntry>()
@@ -896,10 +898,10 @@ private struct StepDetailRow: View {
                 currentRiskLevel: tc.riskLevel ?? "medium",
                 riskReason: tc.riskReason ?? "",
                 scopeOptions: Self.scopeOptions(from: tc),
-                workingDir: NSHomeDirectory(),
+                workingDir: Self.workingDir(from: tc),
                 onSave: { rule in
                     Task {
-                        try? await trustRuleClient.addTrustRule(
+                        try? await Self.trustRuleClient.addTrustRule(
                             toolName: rule.toolName,
                             pattern: rule.pattern,
                             scope: rule.scope,
@@ -929,11 +931,20 @@ private struct StepDetailRow: View {
         }
         return options.map { option in
             ScopeOptionItem(
-                label: option.pattern,
-                description: option.label,
+                label: option.label,
+                description: option.pattern,
                 pattern: option.pattern
             )
         }
+    }
+
+    /// Extracts the working directory from the tool call's pending confirmation
+    /// scope options (the first non-"everywhere" scope). Falls back to home directory.
+    private static func workingDir(from toolCall: ToolCallData) -> String {
+        if let scope = toolCall.pendingConfirmation?.scopeOptions.first(where: { $0.scope != "everywhere" })?.scope {
+            return scope
+        }
+        return NSHomeDirectory()
     }
 
     // MARK: - Detail Content

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -940,13 +940,11 @@ private struct StepDetailRow: View {
         }
     }
 
-    /// Extracts the working directory from the tool call's pending confirmation
-    /// scope options (the first non-"everywhere" scope). Falls back to home directory.
+    /// Extracts the working directory for the rule editor modal.
+    /// Uses the persisted `workingDir` from the tool call (set when the confirmation
+    /// arrived), falling back to home directory for auto-approved tools.
     private static func workingDir(from toolCall: ToolCallData) -> String {
-        if let scope = toolCall.pendingConfirmation?.scopeOptions.first(where: { $0.scope != "everywhere" })?.scope {
-            return scope
-        }
-        return NSHomeDirectory()
+        toolCall.workingDir ?? NSHomeDirectory()
     }
 
     // MARK: - Detail Content

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -639,6 +639,7 @@ struct AssistantProgressView: View {
                 if let confirmation = toolCall.pendingConfirmation {
                     ToolConfirmationBubble(
                         confirmation: confirmation,
+                        isV3: MacOSClientFeatureFlagManager.shared.isEnabled("permission-controls-v3"),
                         isKeyboardActive: confirmation.requestId == activeConfirmationRequestId,
                         onAllow: { onConfirmationAllow?(confirmation.requestId) },
                         onDeny: { onConfirmationDeny?(confirmation.requestId) },
@@ -893,7 +894,8 @@ private struct StepDetailRow: View {
         }
         .sheet(item: $ruleEditorToolCall) { tc in
             RuleEditorModal(
-                toolName: tc.friendlyName,
+                toolName: tc.toolName,
+                displayName: tc.friendlyName,
                 command: tc.inputSummary,
                 currentRiskLevel: tc.riskLevel ?? "medium",
                 riskReason: tc.riskReason ?? "",

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -733,6 +733,12 @@ private struct StepDetailRow: View {
     var skillLabel: String?
     var onRehydrate: (() -> Void)?
 
+    /// Drives the Rule Editor Modal sheet presentation. Set to a tool call
+    /// when the user taps a risk badge in the expanded view.
+    @State private var ruleEditorToolCall: ToolCallData?
+
+    private let trustRuleClient: TrustRuleClientProtocol = TrustRuleClient()
+
     private static let coloredOutputCache: NSCache<NSString, StepDetailAttributedStringCacheEntry> = {
         let cache = NSCache<NSString, StepDetailAttributedStringCacheEntry>()
         cache.countLimit = 128
@@ -830,6 +836,14 @@ private struct StepDetailRow: View {
                         .lineLimit(1)
                         .truncationMode(.tail)
 
+                    // Risk badge (expanded view only, gated on permission-controls-v3)
+                    if let risk = toolCall.riskLevel,
+                       MacOSClientFeatureFlagManager.shared.isEnabled("permission-controls-v3") {
+                        RiskBadgeView(riskLevel: risk) {
+                            ruleEditorToolCall = toolCall
+                        }
+                    }
+
                     Spacer()
 
                     // Permission badge + duration + chevron (completed only)
@@ -874,6 +888,51 @@ private struct StepDetailRow: View {
             DispatchQueue.main.async {
                 onRehydrate?()
             }
+        }
+        .sheet(item: $ruleEditorToolCall) { tc in
+            RuleEditorModal(
+                toolName: tc.friendlyName,
+                command: tc.inputSummary,
+                currentRiskLevel: tc.riskLevel ?? "medium",
+                riskReason: tc.riskReason ?? "",
+                scopeOptions: Self.scopeOptions(from: tc),
+                workingDir: NSHomeDirectory(),
+                onSave: { rule in
+                    Task {
+                        try? await trustRuleClient.addTrustRule(
+                            toolName: rule.toolName,
+                            pattern: rule.pattern,
+                            scope: rule.scope,
+                            decision: "allow",
+                            executionTarget: nil
+                        )
+                    }
+                },
+                onDismiss: { ruleEditorToolCall = nil }
+            )
+        }
+    }
+
+    // MARK: - Scope Options
+
+    /// Constructs the scope option items from the tool call's risk scope options.
+    /// Falls back to a single "This exact command" option when none are provided.
+    private static func scopeOptions(from toolCall: ToolCallData) -> [ScopeOptionItem] {
+        guard let options = toolCall.riskScopeOptions, !options.isEmpty else {
+            return [
+                ScopeOptionItem(
+                    label: toolCall.inputSummary,
+                    description: "This exact command",
+                    pattern: toolCall.inputSummary
+                )
+            ]
+        }
+        return options.map { option in
+            ScopeOptionItem(
+                label: option.pattern,
+                description: option.label,
+                pattern: option.pattern
+            )
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
@@ -162,6 +162,7 @@ struct MessageCellView: View, Equatable {
                 if !isConfirmationRenderedInline {
                     ToolConfirmationBubble(
                         confirmation: confirmation,
+                        isV3: MacOSClientFeatureFlagManager.shared.isEnabled("permission-controls-v3"),
                         isKeyboardActive: confirmation.requestId == activePendingRequestId,
                         onAllow: { onConfirmationAllow?(confirmation.requestId) },
                         onDeny: { onConfirmationDeny?(confirmation.requestId) },
@@ -174,6 +175,7 @@ struct MessageCellView: View, Equatable {
                 if !hasPrecedingAssistant {
                     ToolConfirmationBubble(
                         confirmation: confirmation,
+                        isV3: MacOSClientFeatureFlagManager.shared.isEnabled("permission-controls-v3"),
                         onAllow: { onConfirmationAllow?(confirmation.requestId) },
                         onDeny: { onConfirmationDeny?(confirmation.requestId) },
                         onAlwaysAllow: onAlwaysAllow ?? { _, _, _, _ in },

--- a/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// A small colored pill that displays a risk level label.
+///
+/// Color-coded by risk level:
+/// - `"low"` — green (`VColor.systemPositiveStrong`)
+/// - `"medium"` — amber (`VColor.systemMidStrong`)
+/// - `"high"` — red (`VColor.systemNegativeStrong`)
+/// - Any other value — gray (`VColor.contentSecondary`)
+///
+/// When `onTap` is provided the badge renders as a tappable button with a
+/// tooltip; otherwise it is a plain, non-interactive label.
+struct RiskBadgeView: View {
+    let riskLevel: String
+    var onTap: (() -> Void)? = nil
+
+    var body: some View {
+        if let onTap {
+            Button(action: onTap) {
+                badgeContent
+            }
+            .buttonStyle(.plain)
+            .help("Risk level: \(displayLabel). Click to create a rule.")
+        } else {
+            badgeContent
+        }
+    }
+
+    private var badgeContent: some View {
+        Text(displayLabel)
+            .font(VFont.labelDefault)
+            .foregroundStyle(textColor)
+            .padding(EdgeInsets(top: 2, leading: 6, bottom: 2, trailing: 6))
+            .background(backgroundColor)
+            .clipShape(Capsule())
+    }
+
+    // MARK: - Display
+
+    private var displayLabel: String {
+        guard !riskLevel.isEmpty else { return "Unknown" }
+        return riskLevel.prefix(1).uppercased() + riskLevel.dropFirst()
+    }
+
+    // MARK: - Color Mapping
+
+    private var backgroundColor: Color {
+        switch riskLevel.lowercased() {
+        case "low":
+            VColor.systemPositiveStrong
+        case "medium":
+            VColor.systemMidStrong
+        case "high":
+            VColor.systemNegativeStrong
+        default:
+            VColor.contentSecondary
+        }
+    }
+
+    private var textColor: Color {
+        switch riskLevel.lowercased() {
+        case "medium":
+            // Amber background is light — use dark text for contrast.
+            VColor.auxBlack
+        default:
+            VColor.auxWhite
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
@@ -12,7 +12,6 @@ struct ScopeOptionItem: Identifiable, Equatable {
 struct SavedRule {
     let toolName: String
     let pattern: String
-    let riskLevel: String
     let scope: String
 }
 
@@ -22,7 +21,10 @@ struct SavedRule {
 /// Presents five sections: context (read-only), pattern ladder (radio buttons),
 /// risk level picker (segmented control), scope toggle, and a save button.
 struct RuleEditorModal: View {
+    /// Raw tool identifier (e.g. "bash", "host_bash") used for trust rule persistence.
     let toolName: String
+    /// Human-friendly display name (e.g. "Run Command") shown in the context section.
+    let displayName: String
     let command: String
     let currentRiskLevel: String
     let riskReason: String
@@ -32,7 +34,6 @@ struct RuleEditorModal: View {
     let onDismiss: () -> Void
 
     @State private var selectedPatternIndex: Int = 0
-    @State private var selectedRiskLevel: String = "medium"
     @State private var selectedScope: String = "everywhere"
     @State private var isSaving: Bool = false
 
@@ -78,7 +79,6 @@ struct RuleEditorModal: View {
                 VStack(alignment: .leading, spacing: VSpacing.xl) {
                     contextSection
                     patternLadderSection
-                    riskLevelSection
                     scopeSection
                     saveSection
                 }
@@ -87,9 +87,7 @@ struct RuleEditorModal: View {
         }
         .frame(width: 480)
         .background(VColor.surfaceLift)
-        .onAppear {
-            selectedRiskLevel = currentRiskLevel
-        }
+        .onAppear {}
     }
 
     // MARK: - Section 1: Context (read-only)
@@ -107,7 +105,7 @@ struct RuleEditorModal: View {
                     Text("Tool:")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentSecondary)
-                    Text(toolName)
+                    Text(displayName)
                         .font(VFont.bodySmallEmphasised)
                         .foregroundStyle(VColor.contentDefault)
                 }
@@ -192,27 +190,7 @@ struct RuleEditorModal: View {
         .accessibilityValue(selectedPatternIndex == index ? "Selected" : "Not selected")
     }
 
-    // MARK: - Section 3: Risk Level Picker
-
-    @ViewBuilder
-    private var riskLevelSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Risk Level")
-                .font(VFont.bodyMediumEmphasised)
-                .foregroundStyle(VColor.contentDefault)
-                .accessibilityAddTraits(.isHeader)
-
-            Picker("Risk Level", selection: $selectedRiskLevel) {
-                Text("Low").tag("low")
-                Text("Medium").tag("medium")
-                Text("High").tag("high")
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-        }
-    }
-
-    // MARK: - Section 4: Scope
+    // MARK: - Section 3: Scope
 
     @ViewBuilder
     private var scopeSection: some View {
@@ -279,11 +257,12 @@ struct RuleEditorModal: View {
                 guard !isSaving, !scopeOptions.isEmpty else { return }
                 isSaving = true
                 let selectedOption = scopeOptions[selectedPatternIndex]
+                // Resolve "project" to the actual filesystem path for trust matching.
+                let resolvedScope = selectedScope == "project" ? workingDir : selectedScope
                 let rule = SavedRule(
                     toolName: toolName,
                     pattern: selectedOption.pattern,
-                    riskLevel: selectedRiskLevel,
-                    scope: selectedScope
+                    scope: resolvedScope
                 )
                 onSave(rule)
                 onDismiss()

--- a/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
@@ -1,0 +1,293 @@
+import SwiftUI
+
+// MARK: - Helper Types
+
+struct ScopeOptionItem: Identifiable, Equatable {
+    let id = UUID()
+    let label: String
+    let description: String
+    let pattern: String
+}
+
+struct SavedRule {
+    let toolName: String
+    let pattern: String
+    let riskLevel: String
+    let scope: String
+}
+
+// MARK: - RuleEditorModal
+
+/// Modal for creating trust rules from the scope ladder.
+/// Presents five sections: context (read-only), pattern ladder (radio buttons),
+/// risk level picker (segmented control), scope toggle, and a save button.
+struct RuleEditorModal: View {
+    let toolName: String
+    let command: String
+    let currentRiskLevel: String
+    let riskReason: String
+    let scopeOptions: [ScopeOptionItem]
+    let workingDir: String
+    let onSave: (SavedRule) -> Void
+    let onDismiss: () -> Void
+
+    @State private var selectedPatternIndex: Int = 0
+    @State private var selectedRiskLevel: String = "medium"
+    @State private var selectedScope: String = "everywhere"
+    @State private var isSaving: Bool = false
+
+    /// Shortens the working directory path by replacing the home directory prefix with ~.
+    private var displayPath: String {
+        (workingDir as NSString).abbreviatingWithTildeInPath
+    }
+
+    /// Maps a risk level string to a semantic color.
+    private func riskColor(for level: String) -> Color {
+        switch level.lowercased() {
+        case "high":
+            return VColor.systemNegativeStrong
+        case "medium":
+            return VColor.systemMidStrong
+        case "low":
+            return VColor.systemPositiveStrong
+        default:
+            return VColor.contentSecondary
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack {
+                Text("Create Trust Rule")
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+                Spacer(minLength: 0)
+                VButton(
+                    label: "Close",
+                    iconOnly: VIcon.x.rawValue,
+                    style: .ghost,
+                    tintColor: VColor.contentTertiary
+                ) {
+                    onDismiss()
+                }
+            }
+            .padding(EdgeInsets(top: VSpacing.lg, leading: VSpacing.lg, bottom: VSpacing.md, trailing: VSpacing.lg))
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    contextSection
+                    patternLadderSection
+                    riskLevelSection
+                    scopeSection
+                    saveSection
+                }
+                .padding(EdgeInsets(top: 0, leading: VSpacing.lg, bottom: VSpacing.lg, trailing: VSpacing.lg))
+            }
+        }
+        .frame(width: 480)
+        .background(VColor.surfaceLift)
+        .onAppear {
+            selectedRiskLevel = currentRiskLevel
+        }
+    }
+
+    // MARK: - Section 1: Context (read-only)
+
+    @ViewBuilder
+    private var contextSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Context")
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(VColor.contentDefault)
+                .accessibilityAddTraits(.isHeader)
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                HStack(spacing: VSpacing.xs) {
+                    Text("Tool:")
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                    Text(toolName)
+                        .font(VFont.bodySmallEmphasised)
+                        .foregroundStyle(VColor.contentDefault)
+                }
+
+                Text(command)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(VColor.contentDefault)
+                    .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(VColor.surfaceBase)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+
+                HStack(spacing: VSpacing.xs) {
+                    Text("Risk:")
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                    Text(currentRiskLevel.capitalized)
+                        .font(VFont.bodySmallEmphasised)
+                        .foregroundStyle(riskColor(for: currentRiskLevel))
+                }
+
+                if !riskReason.isEmpty {
+                    Text(riskReason)
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Section 2: Pattern Ladder
+
+    @ViewBuilder
+    private var patternLadderSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Pattern")
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(VColor.contentDefault)
+                .accessibilityAddTraits(.isHeader)
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                ForEach(Array(scopeOptions.enumerated()), id: \.element.id) { index, option in
+                    patternRow(option: option, index: index)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func patternRow(option: ScopeOptionItem, index: Int) -> some View {
+        Button {
+            selectedPatternIndex = index
+        } label: {
+            HStack(alignment: .top, spacing: VSpacing.sm) {
+                Image(systemName: selectedPatternIndex == index ? "circle.inset.filled" : "circle")
+                    .foregroundStyle(selectedPatternIndex == index ? VColor.primaryBase : VColor.contentTertiary)
+                    .font(.system(size: 14))
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(option.label)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(VColor.contentDefault)
+                    Text(option.description)
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                }
+            }
+            .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.sm, bottom: VSpacing.sm, trailing: VSpacing.sm))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                selectedPatternIndex == index
+                    ? VColor.surfaceActive
+                    : Color.clear
+            )
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(option.label): \(option.description)")
+        .accessibilityAddTraits(selectedPatternIndex == index ? [.isSelected] : [])
+        .accessibilityValue(selectedPatternIndex == index ? "Selected" : "Not selected")
+    }
+
+    // MARK: - Section 3: Risk Level Picker
+
+    @ViewBuilder
+    private var riskLevelSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Risk Level")
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(VColor.contentDefault)
+                .accessibilityAddTraits(.isHeader)
+
+            Picker("Risk Level", selection: $selectedRiskLevel) {
+                Text("Low").tag("low")
+                Text("Medium").tag("medium")
+                Text("High").tag("high")
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+        }
+    }
+
+    // MARK: - Section 4: Scope
+
+    @ViewBuilder
+    private var scopeSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Scope")
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(VColor.contentDefault)
+                .accessibilityAddTraits(.isHeader)
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                scopeRadioButton(
+                    label: "Everywhere",
+                    value: "everywhere"
+                )
+                scopeRadioButton(
+                    label: "In \(displayPath)",
+                    value: "project"
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func scopeRadioButton(label: String, value: String) -> some View {
+        Button {
+            selectedScope = value
+        } label: {
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: selectedScope == value ? "circle.inset.filled" : "circle")
+                    .foregroundStyle(selectedScope == value ? VColor.primaryBase : VColor.contentTertiary)
+                    .font(.system(size: 14))
+                    .accessibilityHidden(true)
+                Text(label)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+            }
+            .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                selectedScope == value
+                    ? VColor.surfaceActive
+                    : Color.clear
+            )
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(selectedScope == value ? [.isSelected] : [])
+        .accessibilityValue(selectedScope == value ? "Selected" : "Not selected")
+    }
+
+    // MARK: - Section 5: Save
+
+    @ViewBuilder
+    private var saveSection: some View {
+        HStack {
+            Spacer(minLength: 0)
+            VButton(
+                label: "Save Rule",
+                style: .primary,
+                isDisabled: isSaving || scopeOptions.isEmpty
+            ) {
+                guard !isSaving, !scopeOptions.isEmpty else { return }
+                isSaving = true
+                let selectedOption = scopeOptions[selectedPatternIndex]
+                let rule = SavedRule(
+                    toolName: toolName,
+                    pattern: selectedOption.pattern,
+                    riskLevel: selectedRiskLevel,
+                    scope: selectedScope
+                )
+                onSave(rule)
+                onDismiss()
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionChatPreview.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionChatPreview.swift
@@ -51,6 +51,7 @@ struct HomePermissionChatPreview: View {
             // branch (guardian, surfaces, retry, etc.).
             ToolConfirmationBubble(
                 confirmation: confirmation,
+                isV3: MacOSClientFeatureFlagManager.shared.isEnabled("permission-controls-v3"),
                 onAllow: onAllow,
                 onDeny: onDeny,
                 onAlwaysAllow: onAlwaysAllow,

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -1176,6 +1176,7 @@ final class ChatActionHandler {
             toolName: msg.toolName,
             input: msg.input,
             riskLevel: msg.riskLevel,
+            riskReason: msg.riskReason,
             diff: msg.diff,
             allowlistOptions: msg.allowlistOptions,
             scopeOptions: msg.scopeOptions,

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -1190,6 +1190,12 @@ final class ChatActionHandler {
            let msgIdx = vm.messages.firstIndex(where: { $0.id == assistantId }),
            let tcIdx = vm.messages[msgIdx].toolCalls.firstIndex(where: { $0.toolUseId == toolUseId }) {
             vm.messages[msgIdx].toolCalls[tcIdx].pendingConfirmation = confirmation
+            // Persist the working directory from scope options so it survives after
+            // pendingConfirmation is cleared on decision.
+            if vm.messages[msgIdx].toolCalls[tcIdx].workingDir == nil {
+                vm.messages[msgIdx].toolCalls[tcIdx].workingDir = confirmation.scopeOptions
+                    .first(where: { $0.scope != "everywhere" })?.scope
+            }
         }
         let confirmMsg = ChatMessage(
             role: .assistant,

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -834,6 +834,12 @@ public struct ToolCallData: Identifiable, Equatable {
     public var buildingStatus: String?
     /// Non-technical reason for the tool call, extracted from the `reason` field of tool input.
     public var reasonDescription: String?
+    /// Risk level classification from the permission checker ("low", "medium", "high", "unknown").
+    public var riskLevel: String?
+    /// Human-readable reason for the risk classification.
+    public var riskReason: String?
+    /// Scope options ladder for the rule editor (pattern + label pairs, narrowest to broadest).
+    public var riskScopeOptions: [ToolResultRiskScopeOption]?
     /// Accumulated streaming output from tool_output_chunk events (plain text only).
     /// Capped at 5000 characters (keeps the tail when exceeded).
     public var partialOutput: String = ""
@@ -876,6 +882,7 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.confirmationDecision == rhs.confirmationDecision
             && lhs.confirmationLabel == rhs.confirmationLabel
             && lhs.pendingConfirmation == rhs.pendingConfirmation
+            && lhs.riskLevel == rhs.riskLevel
     }
 
     public init(id: UUID = UUID(), toolName: String, inputSummary: String, inputFull: String? = nil, inputRawValue: String? = nil, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageDataList: [String]? = nil, startedAt: Date? = nil, completedAt: Date? = nil) {

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -37,6 +37,8 @@ public struct ToolConfirmationData: Equatable {
     public let toolName: String
     public let input: [String: AnyCodable]
     public let riskLevel: String
+    /// Human-readable reason for the risk classification (v3 prompt).
+    public let riskReason: String?
     public let diff: ConfirmationRequestDiff?
     public let allowlistOptions: [ConfirmationRequestAllowlistOption]
     public let scopeOptions: [ConfirmationRequestScopeOption]
@@ -545,11 +547,12 @@ public struct ToolConfirmationData: Equatable {
         )
     }
 
-    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestDiff? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption] = [], scopeOptions: [ConfirmationRequestScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, temporaryOptionsAvailable: [String] = [], toolUseId: String? = nil, state: ToolConfirmationState = .pending) {
+    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, riskReason: String? = nil, diff: ConfirmationRequestDiff? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption] = [], scopeOptions: [ConfirmationRequestScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, temporaryOptionsAvailable: [String] = [], toolUseId: String? = nil, state: ToolConfirmationState = .pending) {
         self.requestId = requestId
         self.toolName = toolName
         self.input = input
         self.riskLevel = riskLevel
+        self.riskReason = riskReason
         self.diff = diff
         self.allowlistOptions = allowlistOptions
         self.scopeOptions = scopeOptions

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -843,6 +843,9 @@ public struct ToolCallData: Identifiable, Equatable {
     public var riskReason: String?
     /// Scope options ladder for the rule editor (pattern + label pairs, narrowest to broadest).
     public var riskScopeOptions: [ToolResultRiskScopeOption]?
+    /// Working directory for this tool call (extracted from confirmation scope options).
+    /// Persists after pendingConfirmation is cleared so the rule editor modal can use it.
+    public var workingDir: String?
     /// Accumulated streaming output from tool_output_chunk events (plain text only).
     /// Capped at 5000 characters (keeps the tail when exceeded).
     public var partialOutput: String = ""
@@ -1838,6 +1841,7 @@ public struct ChatMessage: Identifiable, Equatable {
             hasher.combine(tc.completedAt)
             hasher.combine(tc.confirmationDecision)
             hasher.combine(tc.confirmationLabel)
+            hasher.combine(tc.riskLevel)
         }
         return hasher.finalize()
     }

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -439,6 +439,9 @@ extension ChatViewModel {
             // Keep cachedImages for display, nil out raw base64 to save memory
             messages[msgIndex].toolCalls[tcIndex].cachedImages = decoded
             messages[msgIndex].toolCalls[tcIndex].imageDataList = decoded.isEmpty ? msg.imageDataList : nil
+            messages[msgIndex].toolCalls[tcIndex].riskLevel = msg.riskLevel
+            messages[msgIndex].toolCalls[tcIndex].riskReason = msg.riskReason
+            messages[msgIndex].toolCalls[tcIndex].riskScopeOptions = msg.riskScopeOptions
             if let status = msg.status, !status.isEmpty {
                 messages[msgIndex].toolCalls[tcIndex].buildingStatus = status
             }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -14,6 +14,13 @@ public struct ToolConfirmationBubble: View {
     /// highlights. When `false` the monitor is removed and keyboard-only state
     /// is cleared so a lower stacked bubble doesn't steal input.
     public let isKeyboardActive: Bool
+    /// When `true`, renders the simplified v3 permission prompt: flat Allow/Deny
+    /// buttons (no split button or duration options), inline risk badge, risk
+    /// reason text, and a post-decision nudge for unknown risk.
+    public let isV3: Bool
+    /// Called when the user taps the post-decision "Create a rule" nudge.
+    /// The caller is responsible for presenting the rule editor.
+    public let onCreateRule: (() -> Void)?
 
     @State private var showDiff = false
     @State private var showTechnicalDetails = false
@@ -25,13 +32,24 @@ public struct ToolConfirmationBubble: View {
     @State private var keyMonitor: Any?
     #endif
 
-    public init(confirmation: ToolConfirmationData, isKeyboardActive: Bool = true, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAlwaysAllow: @escaping (String, String, String, String) -> Void, onTemporaryAllow: ((String, String) -> Void)? = nil) {
+    public init(
+        confirmation: ToolConfirmationData,
+        isKeyboardActive: Bool = true,
+        isV3: Bool = false,
+        onAllow: @escaping () -> Void,
+        onDeny: @escaping () -> Void,
+        onAlwaysAllow: @escaping (String, String, String, String) -> Void,
+        onTemporaryAllow: ((String, String) -> Void)? = nil,
+        onCreateRule: (() -> Void)? = nil
+    ) {
         self.confirmation = confirmation
         self.isKeyboardActive = isKeyboardActive
+        self.isV3 = isV3
         self.onAllow = onAllow
         self.onDeny = onDeny
         self.onAlwaysAllow = onAlwaysAllow
         self.onTemporaryAllow = onTemporaryAllow
+        self.onCreateRule = onCreateRule
     }
 
     private var hasRuleOptions: Bool {
@@ -82,6 +100,9 @@ public struct ToolConfirmationBubble: View {
 
         switch confirmation.state {
         case .approved:
+            if isV3 {
+                return "\(confirmation.toolCategory) allowed"
+            }
             switch confirmation.approvedDecision {
             case "allow_10m":
                 return "\(confirmation.toolCategory) allowed for 10 minutes"
@@ -97,6 +118,11 @@ public struct ToolConfirmationBubble: View {
         case .pending:
             return ""
         }
+    }
+
+    /// Whether to show the post-decision "Create a rule" nudge (v3 only, unknown risk).
+    private var showPostDecisionNudge: Bool {
+        isV3 && isDecided && confirmation.riskLevel.lowercased() == "unknown" && onCreateRule != nil
     }
 
     public var body: some View {
@@ -209,25 +235,41 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private var pendingContent: some View {
-        let actions = topLevelActions
+        let actions = isV3 ? v3TopLevelActions : topLevelActions
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             // Adaptive layout: horizontal when wide, vertical when narrow
             if useCompactConfirmationLayout {
-                confirmationDescription
+                if isV3 {
+                    v3ConfirmationDescription
+                } else {
+                    confirmationDescription
+                }
                 HStack {
                     Spacer()
-                    confirmationActions
+                    if isV3 {
+                        v3ConfirmationActions
+                    } else {
+                        confirmationActions
+                    }
                 }
             } else {
                 HStack(alignment: .top, spacing: VSpacing.sm) {
-                    confirmationDescription
+                    if isV3 {
+                        v3ConfirmationDescription
+                    } else {
+                        confirmationDescription
+                    }
                     Spacer(minLength: VSpacing.md)
-                    confirmationActions
+                    if isV3 {
+                        v3ConfirmationActions
+                    } else {
+                        confirmationActions
+                    }
                 }
             }
 
-            // First-time educational banner for command confirmations
-            if isCommandTool && !hasSeenCommandExplanation {
+            // First-time educational banner for command confirmations (hidden in v3)
+            if !isV3 && isCommandTool && !hasSeenCommandExplanation {
                 commandExplanationBanner
             }
 
@@ -393,7 +435,7 @@ public struct ToolConfirmationBubble: View {
         }
     }
 
-    // MARK: - Button Row
+    // MARK: - Button Row (legacy v2)
 
     private var topLevelActions: [ToolConfirmationKeyboardModel.Action] {
         var actions: [ToolConfirmationKeyboardModel.Action] = []
@@ -406,7 +448,7 @@ public struct ToolConfirmationBubble: View {
         return actions
     }
 
-    // MARK: - Allow Split Button
+    // MARK: - Allow Split Button (legacy v2)
 
     private var isPrimaryAllowKeyboardSelected: Bool {
         guard let selected = keyboardModel?.selectedAction else { return false }
@@ -573,7 +615,7 @@ public struct ToolConfirmationBubble: View {
                         if scopes.isEmpty {
                             Button(option.label) {
                                 markCommandExplanationSeen()
-    
+
                                 onAlwaysAllow(confirmation.requestId, option.pattern, "everywhere", alwaysAllowDecision)
                             }
                         } else {
@@ -582,7 +624,7 @@ public struct ToolConfirmationBubble: View {
                                     ForEach(Array(scopes.enumerated()), id: \.element.scope) { _, scopeOption in
                                         Button(scopeOption.label) {
                                             markCommandExplanationSeen()
-                
+
                                             onAlwaysAllow(confirmation.requestId, option.pattern, scopeOption.scope, alwaysAllowDecision)
                                         }
                                     }
@@ -610,13 +652,101 @@ public struct ToolConfirmationBubble: View {
                         ForEach(Array(scopes.enumerated()), id: \.element.scope) { _, scopeOption in
                             Button(scopeOption.label) {
                                 markCommandExplanationSeen()
-    
+
                                 onAlwaysAllow(confirmation.requestId, option.pattern, scopeOption.scope, alwaysAllowDecision)
                             }
                         }
                     }
                 }
             }
+        }
+    }
+
+    // MARK: - v3 Simplified Prompt
+
+    private var v3TopLevelActions: [ToolConfirmationKeyboardModel.Action] {
+        [.allowOnce, .dontAllow]
+    }
+
+    /// v3 description: tool name with inline risk badge and optional risk reason.
+    @ViewBuilder
+    private var v3ConfirmationDescription: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            HStack(spacing: VSpacing.sm) {
+                Text(confirmation.humanDescription)
+                    .font(VFont.bodyMediumEmphasised)
+                    .foregroundStyle(VColor.contentDefault)
+                    .fixedSize(horizontal: false, vertical: true)
+                v3RiskBadge
+            }
+            if let reason = confirmation.riskReason, !reason.isEmpty {
+                Text(reason)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    /// Inline risk level badge for v3 prompts.
+    @ViewBuilder
+    private var v3RiskBadge: some View {
+        let level = confirmation.riskLevel
+        let label = level.isEmpty ? "Unknown" : level.prefix(1).uppercased() + level.dropFirst()
+        Text(label)
+            .font(VFont.labelDefault)
+            .foregroundStyle(v3RiskBadgeTextColor)
+            .padding(EdgeInsets(top: 2, leading: 6, bottom: 2, trailing: 6))
+            .background(v3RiskBadgeBackgroundColor)
+            .clipShape(Capsule())
+    }
+
+    private var v3RiskBadgeBackgroundColor: Color {
+        switch confirmation.riskLevel.lowercased() {
+        case "low": VColor.systemPositiveStrong
+        case "medium": VColor.systemMidStrong
+        case "high": VColor.systemNegativeStrong
+        default: VColor.contentSecondary
+        }
+    }
+
+    private var v3RiskBadgeTextColor: Color {
+        switch confirmation.riskLevel.lowercased() {
+        case "medium": VColor.auxBlack
+        default: VColor.auxWhite
+        }
+    }
+
+    /// v3 simplified actions: flat Allow + Deny buttons, no split button or duration.
+    private var v3ConfirmationActions: some View {
+        HStack(spacing: VSpacing.sm) {
+            VButton(label: "Allow", style: .primary, size: .compact) {
+                markCommandExplanationSeen()
+                // In v3, "Allow" sends the selected allowlist pattern + scope
+                // through the always-allow path when patterns are available,
+                // otherwise falls back to a simple allow.
+                if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
+                    let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
+                    onAlwaysAllow(confirmation.requestId, option.pattern, scope, "allow")
+                } else {
+                    onAllow()
+                }
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .strokeBorder(VColor.primaryBase, lineWidth: keyboardModel?.selectedAction == .allowOnce ? 2 : 0)
+                    .allowsHitTesting(false)
+            )
+
+            VButton(label: "Deny", style: .danger, size: .compact) {
+                markCommandExplanationSeen()
+                onDeny()
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .strokeBorder(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
+                    .allowsHitTesting(false)
+            )
         }
     }
 
@@ -692,7 +822,17 @@ public struct ToolConfirmationBubble: View {
         markCommandExplanationSeen()
         switch action {
         case .allowOnce:
-            onAllow()
+            if isV3 {
+                // v3: route through the allowlist pattern path if available
+                if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
+                    let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
+                    onAlwaysAllow(confirmation.requestId, option.pattern, scope, "allow")
+                } else {
+                    onAllow()
+                }
+            } else {
+                onAllow()
+            }
         case .allow10m:
             onTemporaryAllow?(confirmation.requestId, "allow_10m")
         case .allowConversation:
@@ -714,10 +854,36 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private var collapsedContent: some View {
-        ApprovalStatusRow(
-            outcome: collapsedOutcome,
-            label: collapsedLabel
-        )
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            ApprovalStatusRow(
+                outcome: collapsedOutcome,
+                label: collapsedLabel
+            )
+
+            // Post-decision nudge: offer to create a rule for unknown-risk actions (v3).
+            if showPostDecisionNudge {
+                postDecisionNudge
+            }
+        }
+    }
+
+    /// Post-decision link prompting the user to create a trust rule for actions
+    /// that the classifier could not confidently assess (v3, unknown risk only).
+    @ViewBuilder
+    private var postDecisionNudge: some View {
+        Button {
+            onCreateRule?()
+        } label: {
+            HStack(spacing: VSpacing.xxs) {
+                VIconView(.plus, size: 12)
+                    .foregroundStyle(VColor.primaryBase)
+                Text("Create a rule for this")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.primaryBase)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Create a rule for this action")
     }
 
     private var collapsedOutcome: ApprovalOutcome {

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4825,8 +4825,14 @@ public struct ToolResult: Codable, Sendable {
     public let imageDataList: [String]?
     /// The tool_use block ID for client-side correlation.
     public let toolUseId: String?
+    /// Risk level from the classifier ("low", "medium", "high", "unknown").
+    public let riskLevel: String?
+    /// Human-readable reason for the risk classification.
+    public let riskReason: String?
+    /// Scope options ladder for the rule editor modal (narrowest to broadest).
+    public let riskScopeOptions: [ToolResultRiskScopeOption]?
 
-    public init(type: String, toolName: String, result: String, isError: Bool? = nil, diff: ToolResultDiff? = nil, status: String? = nil, conversationId: String? = nil, imageDataList: [String]? = nil, toolUseId: String? = nil) {
+    public init(type: String, toolName: String, result: String, isError: Bool? = nil, diff: ToolResultDiff? = nil, status: String? = nil, conversationId: String? = nil, imageDataList: [String]? = nil, toolUseId: String? = nil, riskLevel: String? = nil, riskReason: String? = nil, riskScopeOptions: [ToolResultRiskScopeOption]? = nil) {
         self.type = type
         self.toolName = toolName
         self.result = result
@@ -4836,6 +4842,9 @@ public struct ToolResult: Codable, Sendable {
         self.conversationId = conversationId
         self.imageDataList = imageDataList
         self.toolUseId = toolUseId
+        self.riskLevel = riskLevel
+        self.riskReason = riskReason
+        self.riskScopeOptions = riskScopeOptions
     }
 }
 
@@ -4850,6 +4859,15 @@ public struct ToolResultDiff: Codable, Sendable {
         self.oldContent = oldContent
         self.newContent = newContent
         self.isNewFile = isNewFile
+    }
+}
+
+public struct ToolResultRiskScopeOption: Codable, Sendable, Equatable {
+    public let pattern: String
+    public let label: String
+    public init(pattern: String, label: String) {
+        self.pattern = pattern
+        self.label = label
     }
 }
 

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -770,6 +770,8 @@ public struct ConfirmationRequest: Codable, Sendable {
     public let toolName: String
     public let input: [String: AnyCodable]
     public let riskLevel: String
+    /// Human-readable reason for the risk classification (e.g. "Modifies remote repository state").
+    public let riskReason: String?
     public let executionTarget: String?
     public let allowlistOptions: [ConfirmationRequestAllowlistOption]
     public let scopeOptions: [ConfirmationRequestScopeOption]
@@ -783,12 +785,13 @@ public struct ConfirmationRequest: Codable, Sendable {
     /// The tool_use block ID for client-side correlation with specific tool calls.
     public let toolUseId: String?
 
-    public init(type: String, requestId: String, toolName: String, input: [String: AnyCodable], riskLevel: String, executionTarget: String? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption], scopeOptions: [ConfirmationRequestScopeOption], diff: ConfirmationRequestDiff? = nil, sandboxed: Bool? = nil, conversationId: String? = nil, persistentDecisionsAllowed: Bool? = nil, temporaryOptionsAvailable: [String]? = nil, toolUseId: String? = nil) {
+    public init(type: String, requestId: String, toolName: String, input: [String: AnyCodable], riskLevel: String, riskReason: String? = nil, executionTarget: String? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption], scopeOptions: [ConfirmationRequestScopeOption], diff: ConfirmationRequestDiff? = nil, sandboxed: Bool? = nil, conversationId: String? = nil, persistentDecisionsAllowed: Bool? = nil, temporaryOptionsAvailable: [String]? = nil, toolUseId: String? = nil) {
         self.type = type
         self.requestId = requestId
         self.toolName = toolName
         self.input = input
         self.riskLevel = riskLevel
+        self.riskReason = riskReason
         self.executionTarget = executionTarget
         self.allowlistOptions = allowlistOptions
         self.scopeOptions = scopeOptions


### PR DESCRIPTION
## Summary
Implements the three new SwiftUI client surfaces for Scope Ladder v1, all behind the `permission-controls-v3` feature flag:
- **Risk badge** on expanded tool call results (colored pill: green/amber/red/gray)
- **Simplified permission prompt** (Allow/Deny only, no duration axis)
- **Rule Editor Modal** (pattern ladder, risk picker, scope toggle, save)

## PRs merged into feature branch
- #27456: feat(client): add riskLevel, riskReason, riskScopeOptions to ToolResult model
- #27455: feat(client): add RiskBadgeView colored pill component
- #27457: feat(client): add RuleEditorModal for creating trust rules from scope ladder
- #27458: feat(client): show risk badge on expanded tool calls and open Rule Editor Modal
- #27460: feat(client): simplified Allow/Deny prompt, post-decision nudge, and kill explainer banner

Part of plan: scope-ladder-v1-swiftui.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
