### PR TITLE
feat(macOS): compute grouped rows from flat feed list

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedGrouping.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedGrouping.swift
@@ -1,0 +1,73 @@
+import Foundation
+import VellumAssistantShared
+
+/// A feed row for display — either a single item, or a digest parent
+/// with low-priority children collapsed beneath it.
+enum HomeFeedGroupedRow: Hashable {
+    case single(FeedItem)
+    case group(parent: FeedItem, children: [FeedItem])
+
+    var id: String {
+        switch self {
+        case .single(let item): return item.id
+        case .group(let parent, _): return parent.id
+        }
+    }
+}
+
+/// Collapses contiguous low-priority digest items into grouped rows.
+///
+/// A run of ≥ ``minimumGroupSize`` consecutive items of type `.digest`
+/// with `priority < lowPriorityThreshold` is emitted as a single
+/// ``HomeFeedGroupedRow/group(parent:children:)`` row: the first item in
+/// the run becomes the parent and the remaining items become children in
+/// original order. Items that don't qualify — non-digest items, digests
+/// at or above the threshold, or runs shorter than `minimumGroupSize` —
+/// pass through as ``HomeFeedGroupedRow/single(_:)``.
+///
+/// Relative input order is preserved across both singles and groups.
+enum HomeFeedGrouping {
+    /// Items with `priority < lowPriorityThreshold` and `type == .digest`
+    /// are eligible to be collapsed into a group.
+    static let lowPriorityThreshold: Int = 30
+
+    /// A run of eligible items must reach this length to be collapsed.
+    static let minimumGroupSize: Int = 3
+
+    /// Collapse contiguous low-priority digest items into a single
+    /// grouped row. A run is eligible when there are ≥ ``minimumGroupSize``
+    /// consecutive items of type `.digest` with
+    /// `priority < lowPriorityThreshold`. The first item in the run
+    /// becomes the parent; remaining items become children in order.
+    /// Non-digest items, and runs shorter than ``minimumGroupSize``,
+    /// pass through as `.single`. Preserves the input's relative order.
+    static func group(_ items: [FeedItem]) -> [HomeFeedGroupedRow] {
+        var rows: [HomeFeedGroupedRow] = []
+        var buffer: [FeedItem] = []
+
+        func flushBuffer() {
+            if buffer.count >= minimumGroupSize {
+                let parent = buffer[0]
+                let children = Array(buffer.dropFirst())
+                rows.append(.group(parent: parent, children: children))
+            } else {
+                for item in buffer {
+                    rows.append(.single(item))
+                }
+            }
+            buffer.removeAll(keepingCapacity: true)
+        }
+
+        for item in items {
+            if item.type == .digest && item.priority < lowPriorityThreshold {
+                buffer.append(item)
+            } else {
+                flushBuffer()
+                rows.append(.single(item))
+            }
+        }
+        flushBuffer()
+
+        return rows
+    }
+}

--- a/clients/macos/vellum-assistantTests/Features/Home/HomeFeedGroupingTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Home/HomeFeedGroupingTests.swift
@@ -1,0 +1,160 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Unit tests for ``HomeFeedGrouping/group(_:)``.
+final class HomeFeedGroupingTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeItem(
+        id: String,
+        type: FeedItemType = .digest,
+        priority: Int
+    ) -> FeedItem {
+        let now = Date()
+        return FeedItem(
+            id: id,
+            type: type,
+            priority: priority,
+            title: "t-\(id)",
+            summary: "s-\(id)",
+            source: nil,
+            timestamp: now,
+            status: .new,
+            expiresAt: nil,
+            minTimeAway: nil,
+            actions: nil,
+            urgency: nil,
+            author: .assistant,
+            createdAt: now
+        )
+    }
+
+    // MARK: - Tests
+
+    func test_emptyInput_returnsEmpty() {
+        XCTAssertTrue(HomeFeedGrouping.group([]).isEmpty)
+    }
+
+    func test_allHighPriorityDigests_allSingle() {
+        let items = [
+            makeItem(id: "a", priority: 90),
+            makeItem(id: "b", priority: 80),
+            makeItem(id: "c", priority: 70),
+            makeItem(id: "d", priority: 60),
+        ]
+
+        let rows = HomeFeedGrouping.group(items)
+
+        XCTAssertEqual(rows.count, 4)
+        for (index, row) in rows.enumerated() {
+            guard case .single(let item) = row else {
+                XCTFail("Expected .single at index \(index), got \(row)")
+                return
+            }
+            XCTAssertEqual(item.id, items[index].id)
+        }
+    }
+
+    func test_fourLowPriorityDigests_producesOneGroup() {
+        let items = [
+            makeItem(id: "a", priority: 20),
+            makeItem(id: "b", priority: 15),
+            makeItem(id: "c", priority: 10),
+            makeItem(id: "d", priority: 5),
+        ]
+
+        let rows = HomeFeedGrouping.group(items)
+
+        XCTAssertEqual(rows.count, 1)
+        guard case .group(let parent, let children) = rows[0] else {
+            XCTFail("Expected .group, got \(rows[0])")
+            return
+        }
+        XCTAssertEqual(parent.id, "a")
+        XCTAssertEqual(children.map(\.id), ["b", "c", "d"])
+    }
+
+    func test_mixedTypes_digestsGroupedOthersSingle() {
+        let items = [
+            makeItem(id: "nudge1", type: .nudge, priority: 50),
+            makeItem(id: "d10", type: .digest, priority: 10),
+            makeItem(id: "d9", type: .digest, priority: 9),
+            makeItem(id: "d8", type: .digest, priority: 8),
+            makeItem(id: "action1", type: .action, priority: 50),
+            makeItem(id: "d7", type: .digest, priority: 7),
+        ]
+
+        let rows = HomeFeedGrouping.group(items)
+
+        XCTAssertEqual(rows.count, 4)
+
+        guard case .single(let first) = rows[0] else {
+            XCTFail("Expected .single at index 0, got \(rows[0])")
+            return
+        }
+        XCTAssertEqual(first.id, "nudge1")
+
+        guard case .group(let parent, let children) = rows[1] else {
+            XCTFail("Expected .group at index 1, got \(rows[1])")
+            return
+        }
+        XCTAssertEqual(parent.id, "d10")
+        XCTAssertEqual(children.map(\.id), ["d9", "d8"])
+
+        guard case .single(let third) = rows[2] else {
+            XCTFail("Expected .single at index 2, got \(rows[2])")
+            return
+        }
+        XCTAssertEqual(third.id, "action1")
+
+        guard case .single(let fourth) = rows[3] else {
+            XCTFail("Expected .single at index 3, got \(rows[3])")
+            return
+        }
+        XCTAssertEqual(fourth.id, "d7")
+    }
+
+    func test_runOfTwo_notGrouped() {
+        let items = [
+            makeItem(id: "a", priority: 10),
+            makeItem(id: "b", priority: 5),
+        ]
+
+        let rows = HomeFeedGrouping.group(items)
+
+        XCTAssertEqual(rows.count, 2)
+        guard case .single(let first) = rows[0], case .single(let second) = rows[1] else {
+            XCTFail("Expected two .single rows, got \(rows)")
+            return
+        }
+        XCTAssertEqual(first.id, "a")
+        XCTAssertEqual(second.id, "b")
+    }
+
+    func test_ordersPreserved() {
+        let items = [
+            makeItem(id: "n1", type: .nudge, priority: 80),
+            makeItem(id: "d1", type: .digest, priority: 20),
+            makeItem(id: "d2", type: .digest, priority: 19),
+            makeItem(id: "d3", type: .digest, priority: 18),
+            makeItem(id: "d4", type: .digest, priority: 17),
+            makeItem(id: "a1", type: .action, priority: 60),
+            makeItem(id: "n2", type: .nudge, priority: 40),
+        ]
+
+        let rows = HomeFeedGrouping.group(items)
+
+        // Expected emission order: n1 single, group(d1 -> [d2, d3, d4]), a1 single, n2 single
+        let emittedIDs = rows.map(\.id)
+        XCTAssertEqual(emittedIDs, ["n1", "d1", "a1", "n2"])
+
+        guard case .group(let parent, let children) = rows[1] else {
+            XCTFail("Expected .group at index 1, got \(rows[1])")
+            return
+        }
+        XCTAssertEqual(parent.id, "d1")
+        XCTAssertEqual(children.map(\.id), ["d2", "d3", "d4"])
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `HomeFeedGrouping.group(_:)` which collapses runs of ≥3 low-priority digests (priority < 30) into a single grouped row.
- Introduces `HomeFeedGroupedRow` enum (`.single` / `.group`) + stable id accessor.
- Preserves relative ordering; non-digest items pass through unchanged.

Part of plan: home-feed-groups.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
