### PR TITLE
feat(macOS): render HomeRecapGroupRow for grouped feed items

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -63,11 +63,6 @@ struct HomePageView<DetailPanel: View>: View {
     /// the filter is a transient read-time affordance, not a setting.
     @State private var activeFilter: FeedItemType? = nil
 
-    /// IDs of group rows whose nested children list is currently expanded.
-    /// Deliberately view-local (not persisted): the expanded state is a
-    /// transient read-time affordance matched to the current group identity.
-    @State private var expandedGroupIds: Set<String> = []
-
     /// Editorial column width. Bumped from 600pt to 960pt to match the
     /// Figma redesign — the new three-block layout reads as a wider page,
     /// not a narrow column.
@@ -170,28 +165,15 @@ struct HomePageView<DetailPanel: View>: View {
                                                 title: child.title
                                             )
                                         },
-                                        isExpanded: Binding(
-                                            get: { expandedGroupIds.contains(parent.id) },
-                                            set: { newValue in
-                                                if newValue { expandedGroupIds.insert(parent.id) }
-                                                else { expandedGroupIds.remove(parent.id) }
-                                            }
-                                        ),
-                                        onParentTap: {
-                                            withAnimation(VAnimation.fast) {
-                                                if expandedGroupIds.contains(parent.id) {
-                                                    expandedGroupIds.remove(parent.id)
-                                                } else {
-                                                    expandedGroupIds.insert(parent.id)
-                                                }
-                                            }
-                                            // Preserve tap-to-open-conversation for the grouped parent item.
-                                            // Without this, `HomeFeedGrouping` would hide the first
-                                            // low-priority digest in each run behind an expand-only affordance,
-                                            // making it inaccessible to the conversation-open flow.
-                                            // (Codex P2 review feedback on PR #27466.)
-                                            openItem(parent)
-                                        },
+                                        // Always-expanded matches Figma `3679:21591` which shows the
+                                        // group's children already visible. Keeping expand/collapse as
+                                        // an affordance conflicted with tap-to-open (Devin P1 feedback
+                                        // on PR #27466 cycle 2) — any tap would either navigate away
+                                        // (losing the expand affordance) or block open (making the
+                                        // parent unreachable, Codex P2 cycle 1). Always-expanded keeps
+                                        // both open-tap AND visible children.
+                                        isExpanded: .constant(true),
+                                        onParentTap: { openItem(parent) },
                                         onChildTap: { child in
                                             if let feedChild = children.first(where: { $0.id == child.id }) {
                                                 openItem(feedChild)

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -63,6 +63,11 @@ struct HomePageView<DetailPanel: View>: View {
     /// the filter is a transient read-time affordance, not a setting.
     @State private var activeFilter: FeedItemType? = nil
 
+    /// IDs of group rows whose nested children list is currently expanded.
+    /// Deliberately view-local (not persisted): the expanded state is a
+    /// transient read-time affordance matched to the current group identity.
+    @State private var expandedGroupIds: Set<String> = []
+
     /// Editorial column width. Bumped from 600pt to 960pt to match the
     /// Figma redesign — the new three-block layout reads as a wider page,
     /// not a narrow column.
@@ -139,15 +144,55 @@ struct HomePageView<DetailPanel: View>: View {
                     VStack(alignment: .leading, spacing: VSpacing.md) {
                         HomeFeedGroupHeader(label: bucket.group.label)
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            ForEach(bucket.items, id: \.id) { item in
-                                HomeRecapRow(
-                                    icon: icon(for: item),
-                                    iconForeground: iconForeground(for: item),
-                                    iconBackground: iconBackground(for: item),
-                                    title: item.title,
-                                    onDismiss: { dismissItem(item) },
-                                    onTap: { openItem(item) }
-                                )
+                            ForEach(bucket.rows, id: \.id) { row in
+                                switch row {
+                                case .single(let item):
+                                    HomeRecapRow(
+                                        icon: icon(for: item),
+                                        iconForeground: iconForeground(for: item),
+                                        iconBackground: iconBackground(for: item),
+                                        title: item.title,
+                                        onDismiss: { dismissItem(item) },
+                                        onTap: { openItem(item) }
+                                    )
+                                case .group(let parent, let children):
+                                    HomeRecapGroupRow(
+                                        parentIcon: icon(for: parent),
+                                        parentIconForeground: iconForeground(for: parent),
+                                        parentIconBackground: iconBackground(for: parent),
+                                        parentTitle: parent.title,
+                                        children: children.map { child in
+                                            HomeRecapGroupRow.Child(
+                                                id: child.id,
+                                                icon: icon(for: child),
+                                                iconForeground: iconForeground(for: child),
+                                                iconBackground: iconBackground(for: child),
+                                                title: child.title
+                                            )
+                                        },
+                                        isExpanded: Binding(
+                                            get: { expandedGroupIds.contains(parent.id) },
+                                            set: { newValue in
+                                                if newValue { expandedGroupIds.insert(parent.id) }
+                                                else { expandedGroupIds.remove(parent.id) }
+                                            }
+                                        ),
+                                        onParentTap: {
+                                            withAnimation(VAnimation.fast) {
+                                                if expandedGroupIds.contains(parent.id) {
+                                                    expandedGroupIds.remove(parent.id)
+                                                } else {
+                                                    expandedGroupIds.insert(parent.id)
+                                                }
+                                            }
+                                        },
+                                        onChildTap: { child in
+                                            if let feedChild = children.first(where: { $0.id == child.id }) {
+                                                openItem(feedChild)
+                                            }
+                                        }
+                                    )
+                                }
                             }
                         }
                     }
@@ -202,19 +247,31 @@ struct HomePageView<DetailPanel: View>: View {
     /// Sorts the feed by `priority desc, createdAt desc`, hides
     /// dismissed items (so `dismissItem(_:)` gives immediate feedback
     /// without waiting for a server refresh to rewrite the array),
-    /// applies the active type filter (nil = show all), then delegates
-    /// to `HomeFeedTimeGroup.bucket(_:)` for day-bucketing. Replaces
-    /// the prior `attentionItems` / `activityItems` partitioning.
-    private var groupedFeed: [(group: HomeFeedTimeGroup, items: [FeedItem])] {
+    /// applies the active type filter (nil = show all), buckets via
+    /// `HomeFeedTimeGroup.bucket(_:)`, then collapses contiguous
+    /// low-priority digest runs within each bucket via
+    /// `HomeFeedGrouping.group(_:)`.
+    // Exposed for HomePageViewGroupingTests — kept out of public API via no-op accessor; grouping is a behavior that benefits from direct unit testing.
+    var groupedFeed: [(group: HomeFeedTimeGroup, rows: [HomeFeedGroupedRow])] {
+        groupedFeed(for: activeFilter)
+    }
+
+    /// Pure grouping pipeline exposed for unit tests. Mirrors the logic
+    /// used by ``groupedFeed`` but takes the filter as a parameter so
+    /// tests don't need to manipulate `@State`.
+    func groupedFeed(for filter: FeedItemType?) -> [(group: HomeFeedTimeGroup, rows: [HomeFeedGroupedRow])] {
         let sorted = feedStore.items.sorted { a, b in
             if a.priority != b.priority { return a.priority > b.priority }
             return a.createdAt > b.createdAt
         }
         let filtered = sorted.filter { item in
             item.status != .dismissed
-                && (activeFilter == nil || activeFilter == item.type)
+                && (filter == nil || filter == item.type)
         }
-        return HomeFeedTimeGroup.bucket(filtered)
+        let buckets = HomeFeedTimeGroup.bucket(filtered)
+        return buckets.map { bucket in
+            (group: bucket.group, rows: HomeFeedGrouping.group(bucket.items))
+        }
     }
 
     // MARK: - Suggestions

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -185,6 +185,12 @@ struct HomePageView<DetailPanel: View>: View {
                                                     expandedGroupIds.insert(parent.id)
                                                 }
                                             }
+                                            // Preserve tap-to-open-conversation for the grouped parent item.
+                                            // Without this, `HomeFeedGrouping` would hide the first
+                                            // low-priority digest in each run behind an expand-only affordance,
+                                            // making it inaccessible to the conversation-open flow.
+                                            // (Codex P2 review feedback on PR #27466.)
+                                            openItem(parent)
                                         },
                                         onChildTap: { child in
                                             if let feedChild = children.first(where: { $0.id == child.id }) {

--- a/clients/macos/vellum-assistantTests/Features/Home/HomePageViewGroupingTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Home/HomePageViewGroupingTests.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Unit tests for ``HomePageView/groupedFeed(for:)``.
+///
+/// The grouping pipeline (sort → filter → bucket → group) is wired through
+/// `HomePageView` but its behaviour is pure — no view lifecycle is
+/// required. These tests instantiate the view with in-memory stores and
+/// call the helper directly, so they stay hermetic and don't depend on the
+/// SwiftUI rendering path.
+@MainActor
+final class HomePageViewGroupingTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeItem(
+        id: String,
+        type: FeedItemType = .digest,
+        priority: Int,
+        createdAt: Date = Date(timeIntervalSince1970: 1_760_000_000)
+    ) -> FeedItem {
+        FeedItem(
+            id: id,
+            type: type,
+            priority: priority,
+            title: "t-\(id)",
+            summary: "s-\(id)",
+            source: nil,
+            timestamp: createdAt,
+            status: .new,
+            expiresAt: nil,
+            minTimeAway: nil,
+            actions: nil,
+            urgency: nil,
+            author: .assistant,
+            createdAt: createdAt
+        )
+    }
+
+    private func makeFeedStore(items: [FeedItem]) async -> HomeFeedStore {
+        // `HomeFeedStore.items` has a private setter, so we hydrate it
+        // through the store's public `load()` pipeline against a mock
+        // client pre-seeded with the fixture items.
+        let response = HomeFeedResponse(
+            items: items,
+            updatedAt: Date(timeIntervalSince1970: 1_760_000_100),
+            contextBanner: ContextBanner(
+                greeting: "Hello",
+                timeAwayLabel: "",
+                newCount: 0
+            ),
+            suggestedPrompts: [],
+            lowPriorityCollapsed: LowPriorityCollapsed(count: 0, itemIds: [])
+        )
+        let client = MockHomeFeedClient(response: response)
+        let (stream, _) = AsyncStream<ServerMessage>.makeStream()
+        let store = HomeFeedStore(client: client, messageStream: stream)
+        await store.load()
+        return store
+    }
+
+    private func makeHomeStore() -> HomeStore {
+        let client = MockHomeStateClient()
+        let (stream, _) = AsyncStream<ServerMessage>.makeStream()
+        return HomeStore(client: client, messageStream: stream)
+    }
+
+    private func makeMeetStatus() -> MeetStatusViewModel {
+        let (stream, _) = AsyncStream<ServerMessage>.makeStream()
+        return MeetStatusViewModel(messageStream: stream)
+    }
+
+    /// Constructs a fully-specialized `HomePageView` wired to the supplied
+    /// feed store. All callbacks are no-ops and `detailPanel` resolves to
+    /// `EmptyView` — the tests never exercise the view body, just the
+    /// pure `groupedFeed(for:)` helper.
+    private func makeView(feedStore: HomeFeedStore) -> HomePageView<EmptyView> {
+        HomePageView<EmptyView>(
+            store: makeHomeStore(),
+            feedStore: feedStore,
+            meetStatusViewModel: makeMeetStatus(),
+            onFeedConversationOpened: { _ in },
+            onStartNewChat: {},
+            onDismissSuggestions: {},
+            onSuggestionSelected: { _ in },
+            isDetailPanelVisible: false,
+            detailPanel: { EmptyView() }
+        )
+    }
+
+    // MARK: - Tests
+
+    func test_groupedFeed_collapsesLowPriorityDigests() async {
+        // Five contiguous low-priority digests should collapse into a
+        // single `.group` row with ≥ 3 children. The two normal items
+        // (nudge/action) render as `.single` rows, regardless of bucket.
+        let items: [FeedItem] = [
+            makeItem(id: "nudge",  type: .nudge,  priority: 90),
+            makeItem(id: "action", type: .action, priority: 80),
+            makeItem(id: "d1",     type: .digest, priority: 20),
+            makeItem(id: "d2",     type: .digest, priority: 15),
+            makeItem(id: "d3",     type: .digest, priority: 10),
+            makeItem(id: "d4",     type: .digest, priority: 7),
+            makeItem(id: "d5",     type: .digest, priority: 5),
+        ]
+        let feedStore = await makeFeedStore(items: items)
+        let view = makeView(feedStore: feedStore)
+
+        let buckets = view.groupedFeed(for: nil)
+        let allRows = buckets.flatMap { $0.rows }
+
+        let groupRows = allRows.compactMap { row -> [FeedItem]? in
+            if case .group(_, let children) = row { return children }
+            return nil
+        }
+
+        XCTAssertFalse(groupRows.isEmpty, "Expected at least one .group row for the low-priority digest run")
+        XCTAssertTrue(
+            groupRows.contains(where: { $0.count >= 3 }),
+            "Expected a .group row with ≥ 3 children (digest run had 5 items)"
+        )
+    }
+
+    func test_groupedFeed_respectsTypeFilter() async {
+        // Same fixture as the collapse test. With `filter = .digest` the
+        // digest run is retained and still collapses into a group. With
+        // `filter = .nudge` only the single nudge row survives — no
+        // digest run means no `.group` emission.
+        let items: [FeedItem] = [
+            makeItem(id: "nudge",  type: .nudge,  priority: 90),
+            makeItem(id: "action", type: .action, priority: 80),
+            makeItem(id: "d1",     type: .digest, priority: 20),
+            makeItem(id: "d2",     type: .digest, priority: 15),
+            makeItem(id: "d3",     type: .digest, priority: 10),
+            makeItem(id: "d4",     type: .digest, priority: 7),
+            makeItem(id: "d5",     type: .digest, priority: 5),
+        ]
+        let feedStore = await makeFeedStore(items: items)
+        let view = makeView(feedStore: feedStore)
+
+        let digestOnly = view.groupedFeed(for: .digest).flatMap { $0.rows }
+        XCTAssertTrue(
+            digestOnly.contains(where: {
+                if case .group = $0 { return true } else { return false }
+            }),
+            "Filtering to .digest should still produce a grouped row"
+        )
+
+        let nudgeOnly = view.groupedFeed(for: .nudge).flatMap { $0.rows }
+        XCTAssertFalse(
+            nudgeOnly.contains(where: {
+                if case .group = $0 { return true } else { return false }
+            }),
+            "Filtering to .nudge should emit no grouped rows (digests are filtered out before grouping)"
+        )
+        XCTAssertEqual(nudgeOnly.count, 1, "Only the single nudge should survive the filter")
+    }
+}


### PR DESCRIPTION
## Summary
- HomePageView now renders `HomeRecapGroupRow` for grouped feed rows (3+ low-priority digests) via `HomeFeedGrouping.group(_:)`.
- Expansion state tracked via `@State expandedGroupIds: Set<String>`; `withAnimation(VAnimation.fast)` animates toggle.
- Existing `HomeRecapRow` path preserved for single rows.

Part of plan: home-feed-groups.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
