### PR TITLE
feat(macOS): open scheduled detail panel when tapping thread items

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -42,6 +42,10 @@ struct HomePageView<DetailPanel: View>: View {
     /// Fired when the user taps one of the suggestion pills. The parent
     /// opens a fresh conversation seeded with the suggestion label.
     let onSuggestionSelected: (HomeSuggestion) -> Void
+    /// Fired when the user taps a `.thread` (scheduled) feed item — the
+    /// parent presents the scheduled detail panel instead of opening a
+    /// conversation. All other item types keep the conversation flow.
+    let onScheduledItemSelected: (FeedItem) -> Void
     /// Drives the two-pane split. When false, the home content renders in
     /// its original single-column layout and the `detailPanel` slot is
     /// ignored.
@@ -280,11 +284,21 @@ struct HomePageView<DetailPanel: View>: View {
 
     // MARK: - Actions
 
-    /// Opens the feed item in a new conversation. The daemon interprets
-    /// any unknown action id as an "open" intent and seeds the new
-    /// conversation with the first available action's prompt (or the
+    /// Opens the feed item. For `.thread` (scheduled) items the parent
+    /// presents a detail panel via `onScheduledItemSelected`; for every
+    /// other type we preserve the existing "trigger the `open` action and
+    /// navigate into the resulting conversation" flow. The daemon
+    /// interprets any unknown action id as an "open" intent and seeds the
+    /// new conversation with the first available action's prompt (or the
     /// item summary if there are no actions).
-    private func openItem(_ item: FeedItem) {
+    ///
+    /// Exposed as `internal` (not `private`) so routing tests can drive it
+    /// directly without needing to render the full view tree.
+    func openItem(_ item: FeedItem) {
+        if item.type == .thread {
+            onScheduledItemSelected(item)
+            return
+        }
         Task {
             if let conversationId = await feedStore.triggerAction(
                 itemId: item.id,
@@ -359,7 +373,8 @@ extension HomePageView where DetailPanel == EmptyView {
         onFeedConversationOpened: @escaping (String) -> Void,
         onStartNewChat: @escaping () -> Void,
         onDismissSuggestions: @escaping () -> Void,
-        onSuggestionSelected: @escaping (HomeSuggestion) -> Void
+        onSuggestionSelected: @escaping (HomeSuggestion) -> Void,
+        onScheduledItemSelected: @escaping (FeedItem) -> Void = { _ in }
     ) {
         self.init(
             store: store,
@@ -369,6 +384,7 @@ extension HomePageView where DetailPanel == EmptyView {
             onStartNewChat: onStartNewChat,
             onDismissSuggestions: onDismissSuggestions,
             onSuggestionSelected: onSuggestionSelected,
+            onScheduledItemSelected: onScheduledItemSelected,
             isDetailPanelVisible: false,
             detailPanel: { EmptyView() }
         )

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -112,6 +112,12 @@ struct MainWindowView: View {
     /// as the Home stores) so the panel is wired up the moment the user
     /// lands on Home, without having to refresh.
     @State var meetStatusViewModel: MeetStatusViewModel
+    /// When non-nil, the Home panel splits into a two-pane layout and
+    /// renders ``HomeScheduledDetailPanel`` on the trailing edge for the
+    /// tapped scheduled (`.thread`) feed item. Owned here (rather than
+    /// inside ``HomePageView``) so the selection survives any @ViewBuilder
+    /// rebuild of the Home panel wrapper.
+    @State var selectedScheduledItemId: String? = nil
     init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, assistantFeatureFlagStore: AssistantFeatureFlagStore, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
         self.conversationManager = conversationManager
         self.listStore = conversationManager.listStore

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -160,6 +160,12 @@ extension MainWindowView {
         // "Home" title would double up and steal vertical space from the
         // first scroll viewport. ``HomePageView`` paints its own full
         // background internally, so no outer chrome is needed here.
+        //
+        // Split layout: when a scheduled (`.thread`) feed item is tapped
+        // we stash its id in ``selectedScheduledItemId`` and flip the
+        // two-pane layout on. The trailing pane renders
+        // ``HomeScheduledDetailPanel`` with placeholder metadata — real
+        // schedule fields are a daemon follow-up.
         HomePageView(
             store: homeStore,
             feedStore: feedStore,
@@ -206,6 +212,31 @@ extension MainWindowView {
                 onDismiss()
                 if let id = conversationManager.activeConversationId {
                     windowState.selection = .conversation(id)
+                }
+            },
+            onScheduledItemSelected: { item in
+                selectedScheduledItemId = item.id
+            },
+            isDetailPanelVisible: selectedScheduledItemId != nil,
+            detailPanel: {
+                if selectedScheduledItemId != nil {
+                    let details = HomeScheduledDetails.placeholder
+                    // TODO: replace placeholder data with real schedule
+                    // metadata when the daemon surfaces scheduled-item
+                    // fields on FeedItem (see .private/plans/home-feed-groups.md
+                    // follow-up).
+                    HomeScheduledDetailPanel(
+                        title: "Scheduled Thing",
+                        description: details.description,
+                        rows: details.displayRows().map { row in
+                            HomeScheduledDetailPanel.DetailRow(key: row.key, value: row.value)
+                        },
+                        primaryActionLabel: "Action",
+                        secondaryActionLabel: "Action",
+                        onClose: { selectedScheduledItemId = nil },
+                        onPrimaryAction: { selectedScheduledItemId = nil },
+                        onSecondaryAction: { selectedScheduledItemId = nil }
+                    )
                 }
             }
         )

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -183,6 +183,12 @@ extension MainWindowView {
                     windowState.showToast(message: "Couldn't open the conversation.", style: .error)
                     return
                 }
+                // Codex P2 feedback (#27467): clear scheduled-detail selection
+                // before navigating away so re-entering Home doesn't show a
+                // stale split layout. Belt-and-suspenders with .onDisappear
+                // below in case the Home view stays mounted across this
+                // navigation path.
+                selectedScheduledItemId = nil
                 onDismiss()
                 windowState.selection = .conversation(uuid)
             },
@@ -246,6 +252,11 @@ extension MainWindowView {
         }
         .onDisappear {
             homeStore.isHomeTabVisible = false
+            // Codex P2 feedback (#27467): clear scheduled-detail selection so
+            // re-entering Home doesn't show a stale split layout when the
+            // user leaves Home through routes other than the detail panel's
+            // own close/action buttons (sidebar switch, conversation open, etc.).
+            selectedScheduledItemId = nil
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))

--- a/clients/macos/vellum-assistantTests/Features/Home/HomeScheduledRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Home/HomeScheduledRoutingTests.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Routing tests for ``HomePageView.openItem(_:)`` — verify that tapping a
+/// `.thread` (scheduled) feed item fires `onScheduledItemSelected` and
+/// skips the triggerAction flow, while non-`.thread` types leave the
+/// callback silent and fall through to the existing conversation flow.
+///
+/// ``openItem`` is exposed as `internal` (not `private`) specifically so
+/// these tests can drive the routing branch without needing to render the
+/// full SwiftUI view tree.
+@MainActor
+final class HomeScheduledRoutingTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeItem(
+        id: String = "item-1",
+        type: FeedItemType = .thread,
+        title: String = "Fixture"
+    ) -> FeedItem {
+        let now = Date(timeIntervalSince1970: 1_760_000_000)
+        return FeedItem(
+            id: id,
+            type: type,
+            priority: 50,
+            title: title,
+            summary: "summary",
+            source: nil,
+            timestamp: now,
+            status: .new,
+            expiresAt: nil,
+            minTimeAway: nil,
+            actions: nil,
+            urgency: nil,
+            author: .assistant,
+            createdAt: now
+        )
+    }
+
+    private func makeStores() -> (HomeStore, HomeFeedStore, MockHomeFeedClient) {
+        let (feedStream, _) = AsyncStream<ServerMessage>.makeStream()
+        let (stateStream, _) = AsyncStream<ServerMessage>.makeStream()
+        let feedClient = MockHomeFeedClient(response: nil)
+        let feedStore = HomeFeedStore(client: feedClient, messageStream: feedStream)
+        let stateClient = MockHomeStateClient()
+        let homeStore = HomeStore(client: stateClient, messageStream: stateStream)
+        return (homeStore, feedStore, feedClient)
+    }
+
+    private func makeView(
+        homeStore: HomeStore,
+        feedStore: HomeFeedStore,
+        onScheduledItemSelected: @escaping (FeedItem) -> Void,
+        onFeedConversationOpened: @escaping (String) -> Void = { _ in }
+    ) -> HomePageView<EmptyView> {
+        let (meetStream, _) = AsyncStream<ServerMessage>.makeStream()
+        let meetVM = MeetStatusViewModel(
+            messageStream: meetStream,
+            clock: { Date(timeIntervalSince1970: 1_760_000_000) }
+        )
+        return HomePageView(
+            store: homeStore,
+            feedStore: feedStore,
+            meetStatusViewModel: meetVM,
+            onFeedConversationOpened: onFeedConversationOpened,
+            onStartNewChat: {},
+            onDismissSuggestions: {},
+            onSuggestionSelected: { _ in },
+            onScheduledItemSelected: onScheduledItemSelected
+        )
+    }
+
+    // MARK: - Tests
+
+    func test_openItem_threadType_firesScheduledCallback() async {
+        let (homeStore, feedStore, feedClient) = makeStores()
+        var captured: [FeedItem] = []
+        var conversationOpens = 0
+        let view = makeView(
+            homeStore: homeStore,
+            feedStore: feedStore,
+            onScheduledItemSelected: { item in captured.append(item) },
+            onFeedConversationOpened: { _ in conversationOpens += 1 }
+        )
+
+        let item = makeItem(id: "sched-1", type: .thread)
+        view.openItem(item)
+
+        XCTAssertEqual(captured.map { $0.id }, ["sched-1"],
+                       "scheduled callback should fire exactly once with the tapped item")
+        XCTAssertEqual(feedClient.triggerCallCount, 0,
+                       "thread taps must not round-trip through triggerAction")
+        XCTAssertEqual(conversationOpens, 0,
+                       "thread taps must not attempt to open a conversation")
+    }
+
+    func test_openItem_nonThreadType_skipsScheduledCallback() async {
+        // We only assert the callback SPY — we deliberately avoid asserting
+        // anything about the async `feedStore.triggerAction` path here:
+        // wiring up deterministic waits for the detached Task would
+        // duplicate HomeFeedStoreTests coverage without adding signal for
+        // this routing check. See note on the test class for rationale.
+        let (homeStore, feedStore, _) = makeStores()
+        for nonThreadType in [FeedItemType.nudge, .digest, .action] {
+            var captured: [FeedItem] = []
+            let view = makeView(
+                homeStore: homeStore,
+                feedStore: feedStore,
+                onScheduledItemSelected: { item in captured.append(item) }
+            )
+
+            view.openItem(makeItem(id: "n-\(nonThreadType)", type: nonThreadType))
+
+            XCTAssertTrue(captured.isEmpty,
+                          "\(nonThreadType) taps must not fire the scheduled callback")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Tapping a `.thread` feed item opens `HomeScheduledDetailPanel` in the home split layout instead of starting a conversation.
- Placeholder data from `HomeScheduledDetails.placeholder`; real schedule metadata is a daemon follow-up (TODO in code).
- Convenience init defaults `onScheduledItemSelected` to no-op for existing call sites.

Part of plan: home-feed-groups.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
