### PR TITLE
Add shared HostProxyClient support for host-browser result callbacks

### DIFF
--- a/clients/shared/Network/HostProxyClient.swift
+++ b/clients/shared/Network/HostProxyClient.swift
@@ -8,6 +8,7 @@ public protocol HostProxyClientProtocol {
     func postBashResult(_ result: HostBashResultPayload) async -> Bool
     func postFileResult(_ result: HostFileResultPayload) async -> Bool
     func postCuResult(_ result: HostCuResultPayload) async -> Bool
+    func postBrowserResult(_ result: HostBrowserResultPayload) async -> Bool
 }
 
 /// Gateway-backed implementation of ``HostProxyClientProtocol``.
@@ -72,6 +73,25 @@ public struct HostProxyClient: HostProxyClientProtocol {
             return true
         } catch {
             log.error("postCuResult error: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    public func postBrowserResult(_ result: HostBrowserResultPayload) async -> Bool {
+        do {
+            let body = try JSONEncoder().encode(result)
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/host-browser-result",
+                body: body,
+                timeout: 30
+            )
+            guard response.isSuccess else {
+                log.error("postBrowserResult failed (HTTP \(response.statusCode))")
+                return false
+            }
+            return true
+        } catch {
+            log.error("postBrowserResult error: \(error.localizedDescription)")
             return false
         }
     }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -48,6 +48,8 @@ import Foundation
 // │                                 │ decodes only to keep SSE healthy        │
 // │ HostBrowserCancelRequest        │ Hand-maintained alongside               │
 // │                                 │ HostBrowserRequest                      │
+// │ HostBrowserResultPayload        │ Posted back to daemon; hand-maintained  │
+// │                                 │ alongside HostBrowserRequest            │
 // │ SkillSearchResult               │ Client-only result wrapper for search;  │
 // │                                 │ not a wire type                         │
 // │ SkillOperationResult            │ Client-only result wrapper for skill    │
@@ -1716,6 +1718,25 @@ public struct HostBrowserRequest: Decodable, Sendable {
 public struct HostBrowserCancelRequest: Decodable, Sendable {
     public let type: String
     public let requestId: String
+}
+
+/// Payload posted back to the daemon with the result of a host browser execution.
+public struct HostBrowserResultPayload: Codable, Sendable {
+    public let requestId: String
+    public let content: String
+    public let isError: Bool
+
+    public init(requestId: String, content: String, isError: Bool) {
+        self.requestId = requestId
+        self.content = content
+        self.isError = isError
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case requestId
+        case content
+        case isError
+    }
 }
 
 // MARK: - Meet (live meeting state)

--- a/clients/shared/Tests/MessageTypesTests.swift
+++ b/clients/shared/Tests/MessageTypesTests.swift
@@ -133,6 +133,78 @@ final class MessageTypesTests: XCTestCase {
         XCTAssertEqual(cancel.requestId, "req-abc-123")
     }
 
+    // MARK: - HostBrowserResultPayload
+
+    func testDecodes_hostBrowserResultPayload_withAllFields() throws {
+        let json = Data(
+            """
+            {
+              "requestId": "req-browser-001",
+              "content": "CDP command executed successfully",
+              "isError": false
+            }
+            """.utf8
+        )
+
+        let payload = try decoder.decode(HostBrowserResultPayload.self, from: json)
+
+        XCTAssertEqual(payload.requestId, "req-browser-001")
+        XCTAssertEqual(payload.content, "CDP command executed successfully")
+        XCTAssertFalse(payload.isError)
+    }
+
+    func testDecodes_hostBrowserResultPayload_withError() throws {
+        let json = Data(
+            """
+            {
+              "requestId": "req-browser-err",
+              "content": "Target closed unexpectedly",
+              "isError": true
+            }
+            """.utf8
+        )
+
+        let payload = try decoder.decode(HostBrowserResultPayload.self, from: json)
+
+        XCTAssertEqual(payload.requestId, "req-browser-err")
+        XCTAssertEqual(payload.content, "Target closed unexpectedly")
+        XCTAssertTrue(payload.isError)
+    }
+
+    func testRoundTrips_hostBrowserResultPayload() throws {
+        let original = HostBrowserResultPayload(
+            requestId: "req-round-trip",
+            content: "Page.navigate result",
+            isError: false
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try decoder.decode(HostBrowserResultPayload.self, from: encoded)
+
+        XCTAssertEqual(decoded.requestId, original.requestId)
+        XCTAssertEqual(decoded.content, original.content)
+        XCTAssertEqual(decoded.isError, original.isError)
+    }
+
+    func testEncodes_hostBrowserResultPayload_withExpectedKeys() throws {
+        let payload = HostBrowserResultPayload(
+            requestId: "req-keys",
+            content: "ok",
+            isError: false
+        )
+
+        let encoded = try JSONEncoder().encode(payload)
+        let dict = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+
+        // Verify expected JSON keys match the wire shape
+        XCTAssertEqual(Set(dict.keys), Set(["requestId", "content", "isError"]))
+        XCTAssertEqual(dict["requestId"] as? String, "req-keys")
+        XCTAssertEqual(dict["content"] as? String, "ok")
+        XCTAssertEqual(dict["isError"] as? Bool, false)
+    }
+
     // MARK: - open_conversation
 
     func testDecodes_openConversation_withAllFields() throws {


### PR DESCRIPTION
## Summary
- Add HostBrowserResultPayload codable type with requestId/content/isError wire shape
- Extend HostProxyClientProtocol with postBrowserResult method posting to host-browser-result endpoint
- Add decoding/shape tests for the new payload type

Part of plan: host-browser-via-macos-host-proxy.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
