### PR TITLE
Normalize host_browser transport errors so backend failover can trigger correctly

### DIFF
--- a/assistant/src/__tests__/headless-browser-mode.test.ts
+++ b/assistant/src/__tests__/headless-browser-mode.test.ts
@@ -550,6 +550,63 @@ describe("browser_mode wiring through tool execution", () => {
     expect(result.content).toContain("Remediation:");
   });
 
+  // ── Transport-classified host-browser errors produce failover diagnostics ──
+
+  test("pinned extension with transport-classified host_browser error surfaces failover diagnostics", async () => {
+    // Simulate a structured transport error envelope from the host_browser
+    // dispatcher (e.g. { code: "unreachable", message: "..." }) that the
+    // extension-cdp-client now classifies as transport_error.
+    factoryThrowError = new CdpError(
+      "transport_error",
+      "Host browser not reachable",
+      {
+        attemptDiagnostics: [
+          {
+            candidateKind: "extension",
+            inclusionReason: "pinned mode: extension",
+            stage: "send",
+            errorCode: "transport_error",
+            errorMessage: "Host browser not reachable",
+          },
+        ],
+      },
+    );
+
+    const result = await executeBrowserNavigate(
+      { url: "https://example.com", browser_mode: "extension" },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Browser mode "extension" failed');
+    expect(result.content).toContain("extension: FAILED at send");
+    expect(result.content).toContain("Reason: Host browser not reachable");
+    expect(result.content).toContain("Remediation:");
+    expect(result.content).toContain("extension is installed and enabled");
+  });
+
+  test("pinned extension with timeout transport error surfaces failover diagnostics in snapshot", async () => {
+    factoryThrowError = new CdpError("transport_error", "CDP call timed out", {
+      attemptDiagnostics: [
+        {
+          candidateKind: "extension",
+          inclusionReason: "pinned mode: extension",
+          stage: "send",
+          errorCode: "transport_error",
+          errorMessage: "CDP call timed out",
+        },
+      ],
+    });
+
+    const result = await executeBrowserSnapshot(
+      { browser_mode: "extension" },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Browser mode "extension" failed');
+    expect(result.content).toContain("extension: FAILED at send");
+    expect(result.content).toContain("Remediation:");
+  });
+
   // ── Per-conversation sticky backend kind ─────────────────────────
 
   test("auto-mode call after an explicit pin sticks to the pinned kind", async () => {

--- a/assistant/src/tools/browser/cdp-client/__tests__/extension-cdp-client.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/extension-cdp-client.test.ts
@@ -356,4 +356,234 @@ describe("ExtensionCdpClient", () => {
     expect(err.message).toBe("CDP call aborted");
     expect(err.cdpMethod).toBe("Browser.getVersion");
   });
+
+  // ── Structured transport error classification ────────────────────────
+
+  test("structured error with code 'transport_error' is classified as transport_error", async () => {
+    const errorBody = {
+      code: "transport_error",
+      message: "Extension WebSocket disconnected",
+    };
+    const { proxy } = fakeProxy(async () => ({
+      content: JSON.stringify(errorBody),
+      isError: true,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-transport-1");
+
+    let caught: unknown;
+    try {
+      await client.send("Page.navigate", { url: "https://example.com" });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("transport_error");
+    expect(err.message).toBe("Extension WebSocket disconnected");
+    expect(err.cdpMethod).toBe("Page.navigate");
+    expect(err.cdpParams).toEqual({ url: "https://example.com" });
+    expect(err.underlying).toEqual(errorBody);
+  });
+
+  test("structured error with code 'unreachable' is classified as transport_error", async () => {
+    const errorBody = {
+      code: "unreachable",
+      message: "Host browser not reachable",
+    };
+    const { proxy } = fakeProxy(async () => ({
+      content: JSON.stringify(errorBody),
+      isError: true,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-transport-2");
+
+    let caught: unknown;
+    try {
+      await client.send("Runtime.evaluate", { expression: "1+1" });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("transport_error");
+    expect(err.message).toBe("Host browser not reachable");
+    expect(err.underlying).toEqual(errorBody);
+  });
+
+  test("structured error with code 'timeout' is classified as transport_error", async () => {
+    const errorBody = {
+      code: "timeout",
+      message: "CDP call timed out",
+    };
+    const { proxy } = fakeProxy(async () => ({
+      content: JSON.stringify(errorBody),
+      isError: true,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-transport-3");
+
+    let caught: unknown;
+    try {
+      await client.send("Page.captureScreenshot");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("transport_error");
+    expect(err.message).toBe("CDP call timed out");
+    expect(err.underlying).toEqual(errorBody);
+  });
+
+  test("structured error with code 'non_loopback' is classified as transport_error", async () => {
+    const errorBody = {
+      code: "non_loopback",
+      message: "Only loopback addresses are allowed",
+    };
+    const { proxy } = fakeProxy(async () => ({
+      content: JSON.stringify(errorBody),
+      isError: true,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-transport-4");
+
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("transport_error");
+    expect(err.message).toBe("Only loopback addresses are allowed");
+    expect(err.underlying).toEqual(errorBody);
+  });
+
+  // ── Command-level CDP errors remain cdp_error ────────────────────────
+
+  test("structured error with numeric code (CDP JSON-RPC) remains cdp_error", async () => {
+    const errorBody = {
+      code: -32000,
+      message: "Cannot find context with specified id",
+    };
+    const { proxy } = fakeProxy(async () => ({
+      content: JSON.stringify(errorBody),
+      isError: true,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-cdp-1");
+
+    let caught: unknown;
+    try {
+      await client.send("Runtime.evaluate", { expression: "boom" });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("cdp_error");
+    expect(err.message).toBe("Cannot find context with specified id");
+  });
+
+  test("structured error with unknown string code remains cdp_error", async () => {
+    const errorBody = {
+      code: "some_unknown_code",
+      message: "Unrecognized error",
+    };
+    const { proxy } = fakeProxy(async () => ({
+      content: JSON.stringify(errorBody),
+      isError: true,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-cdp-2");
+
+    let caught: unknown;
+    try {
+      await client.send("Page.navigate", { url: "https://example.com" });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("cdp_error");
+    expect(err.message).toBe("Unrecognized error");
+  });
+
+  test("structured error without code field remains cdp_error", async () => {
+    const errorBody = {
+      message: "Something went wrong",
+    };
+    const { proxy } = fakeProxy(async () => ({
+      content: JSON.stringify(errorBody),
+      isError: true,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-cdp-3");
+
+    let caught: unknown;
+    try {
+      await client.send("DOM.getDocument");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("cdp_error");
+    expect(err.message).toBe("Something went wrong");
+  });
+
+  test("structured error with code: null remains cdp_error", async () => {
+    const errorBody = {
+      code: null,
+      message: "Null code error",
+    };
+    const { proxy } = fakeProxy(async () => ({
+      content: JSON.stringify(errorBody),
+      isError: true,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-cdp-4");
+
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("cdp_error");
+  });
+
+  test("plain-text isError content still throws cdp_error (no failover)", async () => {
+    const { proxy } = fakeProxy(async () => ({
+      content: "Connection lost unexpectedly",
+      isError: true,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-cdp-5");
+
+    let caught: unknown;
+    try {
+      await client.send("Page.navigate", { url: "https://example.com" });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("cdp_error");
+    expect(err.message).toBe("Connection lost unexpectedly");
+    expect(err.underlying).toBe("Connection lost unexpectedly");
+  });
 });

--- a/assistant/src/tools/browser/cdp-client/extension-cdp-client.ts
+++ b/assistant/src/tools/browser/cdp-client/extension-cdp-client.ts
@@ -1,9 +1,27 @@
 import type { HostBrowserProxy } from "../../../daemon/host-browser-proxy.js";
 import { getLogger } from "../../../util/logger.js";
+import type { CdpErrorCode } from "./errors.js";
 import { CdpError } from "./errors.js";
 import type { CdpClientKind, ScopedCdpClient } from "./types.js";
 
 const log = getLogger("extension-cdp-client");
+
+/**
+ * Transport-level error codes that the host_browser dispatcher may
+ * embed in a structured `{ code, message }` error envelope. When the
+ * `code` field of a parsed error object matches one of these values,
+ * the error is classified as `transport_error` so the factory's
+ * failover logic can try the next backend candidate.
+ *
+ * Codes that are NOT in this set are treated as CDP command-level
+ * failures (`cdp_error`) and propagate without failover.
+ */
+const TRANSPORT_ERROR_CODES = new Set([
+  "transport_error",
+  "unreachable",
+  "timeout",
+  "non_loopback",
+]);
 
 /**
  * CdpClient backed by HostBrowserProxy. Each `send` becomes a
@@ -102,11 +120,21 @@ export class ExtensionCdpClient implements ScopedCdpClient {
           typeof (parsedError as { message: unknown }).message === "string" &&
           (parsedError as { message: string }).message) ||
         `CDP error for ${method}`;
+
+      // Detect structured transport error envelopes from the
+      // host_browser dispatcher. When the parsed error object
+      // carries a `code` field that matches a known transport-level
+      // code, classify the error as `transport_error` so the
+      // factory can trigger failover to the next backend candidate.
+      // All other structured errors remain `cdp_error` since they
+      // represent command-level CDP failures that would not benefit
+      // from switching transports.
+      const errorCode = classifyHostBrowserError(parsedError);
       log.debug(
-        { method, params, parsedError },
-        "ExtensionCdpClient: CDP error",
+        { method, params, parsedError, classifiedAs: errorCode },
+        "ExtensionCdpClient: host_browser_result error",
       );
-      throw new CdpError("cdp_error", msg, {
+      throw new CdpError(errorCode, msg, {
         cdpMethod: method,
         cdpParams: params,
         underlying: parsedError,
@@ -137,6 +165,26 @@ export class ExtensionCdpClient implements ScopedCdpClient {
     // it here. In-flight requests will be cancelled by the AbortSignal
     // the tool passes in, or by conversation teardown.
   }
+}
+
+/**
+ * Classify a parsed host_browser_result error envelope as either a
+ * transport-level error (`transport_error`) or a command-level CDP
+ * failure (`cdp_error`).
+ *
+ * Structured envelopes from the host_browser dispatcher carry a
+ * `code` string field (e.g. `"transport_error"`, `"unreachable"`,
+ * `"timeout"`, `"non_loopback"`). When the code matches a known
+ * transport-level value, the error is eligible for factory failover.
+ * All other codes (or missing codes) are treated as CDP command
+ * errors that should propagate without failover.
+ */
+function classifyHostBrowserError(parsed: unknown): CdpErrorCode {
+  if (typeof parsed !== "object" || parsed === null) return "cdp_error";
+  if (!("code" in parsed)) return "cdp_error";
+  const code = (parsed as { code: unknown }).code;
+  if (typeof code !== "string") return "cdp_error";
+  return TRANSPORT_ERROR_CODES.has(code) ? "transport_error" : "cdp_error";
 }
 
 export function createExtensionCdpClient(


### PR DESCRIPTION
## Summary
- Extend extension-cdp-client error parsing to detect structured transport error envelopes from host_browser_result and classify them as transport_error for failover
- Preserve cdp_error classification for command-level CDP failures
- Add unit tests for both transport and CDP error branches

Part of plan: host-browser-via-macos-host-proxy.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
