### PR TITLE
fix(macOS): drop #Preview blocks and misleading a11y from HomeRecapGroupRow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeRecapGroupRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeRecapGroupRow.swift
@@ -82,8 +82,6 @@ struct HomeRecapGroupRow: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(parentTitle))
         .accessibilityAddTraits(.isButton)
-        .accessibilityValue(Text(isExpanded.wrappedValue ? "Expanded" : "Collapsed"))
-        .accessibilityHint(Text("Double-tap to \(isExpanded.wrappedValue ? "collapse" : "expand") \(children.count) updates"))
     }
 
     // MARK: - Children
@@ -127,73 +125,4 @@ struct HomeRecapGroupRow: View {
         .accessibilityLabel(Text(child.title))
         .accessibilityAddTraits(.isButton)
     }
-}
-
-// MARK: - Previews
-
-private let previewChildren: [HomeRecapGroupRow.Child] = [
-    .init(
-        id: "1",
-        icon: .bell,
-        iconForeground: VColor.feedDigestStrong,
-        iconBackground: VColor.feedDigestWeak,
-        title: "This is the First notification in the group"
-    ),
-    .init(
-        id: "2",
-        icon: .bell,
-        iconForeground: VColor.feedDigestStrong,
-        iconBackground: VColor.feedDigestWeak,
-        title: "This is the Second notification in the group"
-    ),
-    .init(
-        id: "3",
-        icon: .bell,
-        iconForeground: VColor.feedDigestStrong,
-        iconBackground: VColor.feedDigestWeak,
-        title: "This is the Third notification in the group"
-    ),
-    .init(
-        id: "4",
-        icon: .bell,
-        iconForeground: VColor.feedDigestStrong,
-        iconBackground: VColor.feedDigestWeak,
-        title: "This is the Fourth notification in the group"
-    ),
-]
-
-#Preview("Expanded") {
-    VStack {
-        HomeRecapGroupRow(
-            parentIcon: .bell,
-            parentIconForeground: VColor.feedDigestStrong,
-            parentIconBackground: VColor.feedDigestWeak,
-            parentTitle: "There's also 4 low priority updates if you want to have a look.",
-            children: previewChildren,
-            isExpanded: .constant(true),
-            onParentTap: {},
-            onChildTap: { _ in }
-        )
-    }
-    .frame(width: 720)
-    .padding()
-    .background(VColor.surfaceBase)
-}
-
-#Preview("Collapsed") {
-    VStack {
-        HomeRecapGroupRow(
-            parentIcon: .bell,
-            parentIconForeground: VColor.feedDigestStrong,
-            parentIconBackground: VColor.feedDigestWeak,
-            parentTitle: "There's also 4 low priority updates if you want to have a look.",
-            children: previewChildren,
-            isExpanded: .constant(false),
-            onParentTap: {},
-            onChildTap: { _ in }
-        )
-    }
-    .frame(width: 720)
-    .padding()
-    .background(VColor.surfaceBase)
 }

--- a/clients/macos/vellum-assistantTests/Features/Home/HomeRecapGroupRowTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Home/HomeRecapGroupRowTests.swift
@@ -9,8 +9,8 @@ import XCTest
 /// is touched: (1) the stored `children` list round-trips unchanged
 /// through `init`, and (2) both the collapsed and expanded body
 /// branches type-check and build without crashing. Visual fidelity is
-/// covered by the SwiftUI previews; this file exists so a rename or
-/// API drift breaks CI rather than a preview.
+/// covered by the Component Gallery; this file exists so a rename or
+/// API drift breaks CI.
 final class HomeRecapGroupRowTests: XCTestCase {
 
     private func makeChildren() -> [HomeRecapGroupRow.Child] {


### PR DESCRIPTION
## Summary
Fixes plan-review gaps for home-feed-groups.md.

- Removes `#Preview` blocks (mandatory per clients/macos/AGENTS.md:270).
- Drops `.accessibilityValue` / `.accessibilityHint` that described expand/collapse semantics — the only production caller uses always-expanded mode where tapping opens a conversation, so the expand/collapse hint was misleading to VoiceOver users.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
