### PR TITLE
fix(macOS): AGENTS.md compliance in HomeScheduledDetailPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeScheduledDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeScheduledDetailPanel.swift
@@ -110,8 +110,12 @@ struct HomeScheduledDetailPanel: View {
 
             detailsCard
         }
-        .padding(.horizontal, VSpacing.lg)
-        .padding(.top, VSpacing.lg)
+        .padding(EdgeInsets(
+            top: VSpacing.lg,
+            leading: VSpacing.lg,
+            bottom: 0,
+            trailing: VSpacing.lg
+        ))
     }
 
     private var detailsCard: some View {
@@ -166,13 +170,8 @@ struct HomeScheduledDetailPanel: View {
                         Text(secondaryActionLabel)
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.contentEmphasized)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 6)
+                            .padding(EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10))
                             .frame(height: 32)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.md, style: .continuous)
-                                    .fill(Color.clear)
-                            )
                             .overlay(
                                 RoundedRectangle(cornerRadius: VRadius.md, style: .continuous)
                                     .strokeBorder(VColor.borderElement, lineWidth: 1)
@@ -188,8 +187,7 @@ struct HomeScheduledDetailPanel: View {
                     Text(primaryActionLabel)
                         .font(VFont.bodyMediumDefault)
                         .foregroundStyle(VColor.contentInset)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
+                        .padding(EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10))
                         .frame(height: 32)
                         .background(
                             RoundedRectangle(cornerRadius: VRadius.md, style: .continuous)
@@ -204,29 +202,4 @@ struct HomeScheduledDetailPanel: View {
             .padding(VSpacing.lg)
         }
     }
-}
-
-// MARK: - Preview
-
-#Preview {
-    HomeScheduledDetailPanel(
-        title: "Scheduled Thing",
-        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-        rows: [
-            .init(key: "Name", value: "Morning check-in"),
-            .init(key: "Syntax", value: "cron"),
-            .init(key: "Mode", value: "notify"),
-            .init(key: "Schedule", value: "Every day at 9:00 AM (Europe/Ljubljana)"),
-            .init(key: "Enabled", value: "true"),
-            .init(key: "Next Run", value: "Apr 23, 2026 at 9:00 AM GMT+2"),
-        ],
-        primaryActionLabel: "Action",
-        secondaryActionLabel: "Action",
-        onClose: {},
-        onPrimaryAction: {},
-        onSecondaryAction: {}
-    )
-    .frame(width: 601, height: 786)
-    .padding()
-    .background(VColor.surfaceBase)
 }


### PR DESCRIPTION
## Summary
Fixes plan-review gaps for home-feed-groups.md.

- Removes `#Preview` block (mandatory per clients/macos/AGENTS.md:270).
- Removes `.background(...fill(Color.clear))` no-op (AGENTS.md:274).
- Collapses stacked `.padding(.horizontal).padding(.vertical)` into single `.padding(EdgeInsets(...))` (AGENTS.md:271).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
