### PR TITLE
fix(macOS): locale-aware formatter + timezone field + assistant terminology in HomeScheduledDetails

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeScheduledDetails.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeScheduledDetails.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Client-side render metadata for a scheduled (`.thread`) feed item.
-/// The daemon doesn't yet surface these fields on `FeedItem`; this
+/// The assistant doesn't yet surface these fields on `FeedItem`; this
 /// struct lets the detail panel render with placeholder data until
 /// the schedule source lands.
 public struct HomeScheduledDetails: Hashable, Sendable {
@@ -11,6 +11,7 @@ public struct HomeScheduledDetails: Hashable, Sendable {
     public let schedule: String
     public let enabled: Bool
     public let nextRun: Date
+    public let nextRunTimeZone: TimeZone
     public let description: String
 
     public init(
@@ -20,6 +21,7 @@ public struct HomeScheduledDetails: Hashable, Sendable {
         schedule: String,
         enabled: Bool,
         nextRun: Date,
+        nextRunTimeZone: TimeZone,
         description: String
     ) {
         self.name = name
@@ -28,37 +30,42 @@ public struct HomeScheduledDetails: Hashable, Sendable {
         self.schedule = schedule
         self.enabled = enabled
         self.nextRun = nextRun
+        self.nextRunTimeZone = nextRunTimeZone
         self.description = description
     }
 
     // MARK: - Display rows
 
-    private static let nextRunFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM d, yyyy 'at' h:mm a zzz"
-        return formatter
-    }()
-
     /// Ordered key/value pairs suitable for rendering in the detail panel.
     /// Order is fixed: Name, Syntax, Mode, Schedule, Enabled, Next Run.
     public func displayRows() -> [(key: String, value: String)] {
-        [
+        // Construct a per-call formatter: `DateFormatter` is not thread-safe
+        // when mutating `timeZone`, and the timezone is per-instance.
+        let formatter = DateFormatter()
+        formatter.locale = .autoupdatingCurrent
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        formatter.timeZone = nextRunTimeZone
+        let nextRunString = formatter.string(from: nextRun)
+
+        return [
             (key: "Name", value: name),
             (key: "Syntax", value: syntax),
             (key: "Mode", value: mode),
             (key: "Schedule", value: schedule),
             (key: "Enabled", value: enabled ? "true" : "false"),
-            (key: "Next Run", value: Self.nextRunFormatter.string(from: nextRun)),
+            (key: "Next Run", value: nextRunString),
         ]
     }
 
     // MARK: - Placeholder
 
-    /// Figma sample values used while the daemon schedule source is
+    /// Figma sample values used while the assistant schedule source is
     /// still under construction.
     public static let placeholder: HomeScheduledDetails = {
+        let timeZone = TimeZone(identifier: "Europe/Ljubljana")!
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "Europe/Ljubljana")!
+        calendar.timeZone = timeZone
         let nextRun = calendar.date(from: DateComponents(
             year: 2026,
             month: 4,
@@ -74,6 +81,7 @@ public struct HomeScheduledDetails: Hashable, Sendable {
             schedule: "Every day at 9:00 AM (Europe/Ljubljana)",
             enabled: true,
             nextRun: nextRun,
+            nextRunTimeZone: timeZone,
             description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
         )
     }()

--- a/clients/macos/vellum-assistantTests/Features/Home/HomeScheduledDetailsTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Home/HomeScheduledDetailsTests.swift
@@ -15,6 +15,7 @@ final class HomeScheduledDetailsTests: XCTestCase {
             schedule: "Every day at 9:00 AM (Europe/Ljubljana)",
             enabled: enabled,
             nextRun: Date(timeIntervalSince1970: 0),
+            nextRunTimeZone: TimeZone(identifier: "Europe/Ljubljana")!,
             description: "Test description."
         )
     }
@@ -47,5 +48,6 @@ final class HomeScheduledDetailsTests: XCTestCase {
 
         XCTAssertEqual(placeholder.name, "Morning check-in")
         XCTAssertEqual(placeholder.schedule, "Every day at 9:00 AM (Europe/Ljubljana)")
+        XCTAssertEqual(placeholder.nextRunTimeZone, TimeZone(identifier: "Europe/Ljubljana"))
     }
 }


### PR DESCRIPTION
## Summary
Fixes plan-review gaps for home-feed-groups.md.

- Renames 'daemon' → 'assistant' in doc comments (clients/AGENTS.md:406).
- Adds `nextRunTimeZone` field and uses a locale-aware DateFormatter (clients/AGENTS.md:32).
- Fixes timezone mismatch between Schedule string and Next Run display.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
