### PR TITLE
fix(macOS): default HomePageView.onScheduledItemSelected to a no-op to unblock test compilation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -45,7 +45,10 @@ struct HomePageView<DetailPanel: View>: View {
     /// Fired when the user taps a `.thread` (scheduled) feed item — the
     /// parent presents the scheduled detail panel instead of opening a
     /// conversation. All other item types keep the conversation flow.
-    let onScheduledItemSelected: (FeedItem) -> Void
+    /// Defaults to a no-op so callers that don't need the scheduled-panel
+    /// flow don't have to supply it (and the memberwise init stays usable
+    /// from tests that only care about the detail-panel split).
+    let onScheduledItemSelected: (FeedItem) -> Void = { _ in }
     /// Drives the two-pane split. When false, the home content renders in
     /// its original single-column layout and the `detailPanel` slot is
     /// ignored.


### PR DESCRIPTION
## Summary
Fixes plan-review gap for home-feed-groups.md.

- `onScheduledItemSelected` now has a no-op default `{ _ in }` on the stored property.
- Unblocks `HomePageViewGroupingTests.makeView` which calls the memberwise init without this argument.
- The convenience init already defaulted the parameter; this aligns the memberwise path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
