### PR TITLE
Execute host_browser requests on macOS and post results back through HostProxyClient

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -402,6 +402,11 @@ extension AppDelegate {
                     }
                     self.inFlightCuTasks[msg.requestId] = task
 
+                case .hostBrowserRequest(let msg):
+                    self.hostBrowserExecutor.execute(msg)
+                case .hostBrowserCancel(let msg):
+                    self.hostBrowserExecutor.cancel(msg.requestId)
+
                 case .hostBashCancel(let msg):
                     HostToolExecutor.cancelHostBashRequest(msg.requestId)
                 case .hostFileCancel(let msg):

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -53,6 +53,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var hostCuOverlayCancellables = Set<AnyCancellable>()
     /// In-flight CU tasks keyed by request ID, for cancel support.
     var inFlightCuTasks: [String: Task<Void, Never>] = [:]
+    /// Executor for host browser (CDP) requests.
+    let hostBrowserExecutor = HostBrowserExecutor()
     var isStartingSession = false
     var startSessionTask: Task<Void, Never>?
     var voiceInput: VoiceInputManager?

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -497,6 +497,10 @@ public final class EventStreamClient {
             if locallyOwnedConversationIds.contains(msg.conversationId) { return false }
             log.warning("Ignoring host_cu_request for non-local conversation \(msg.conversationId, privacy: .public)")
             return true
+        case .hostBrowserRequest(let msg):
+            if locallyOwnedConversationIds.contains(msg.conversationId) { return false }
+            log.warning("Ignoring host_browser_request for non-local conversation \(msg.conversationId, privacy: .public)")
+            return true
         default:
             return false
         }

--- a/clients/shared/Network/HostBrowserExecutor.swift
+++ b/clients/shared/Network/HostBrowserExecutor.swift
@@ -9,7 +9,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "HostB
 /// Only loopback debugging endpoints are permitted (`localhost`, `127.0.0.1`,
 /// `::1`) to prevent the client from being used as an open proxy to arbitrary
 /// hosts. Non-loopback endpoints are rejected with a structured transport error
-/// so the backend error classifier (PR 1) can trigger failover.
+/// so the backend error classifier can trigger failover.
 ///
 /// Lifecycle:
 /// - `execute(_:using:)` — runs the full attach flow (endpoint discovery,
@@ -116,7 +116,7 @@ public final class HostBrowserExecutor {
         guard Self.allowedLoopbackHosts.contains(host.lowercased()) else {
             return Self.transportError(
                 requestId: request.requestId,
-                code: "LOOPBACK_VALIDATION_FAILED",
+                code: "non_loopback",
                 message: "CDP endpoint host '\(host)' is not a loopback address. Only localhost, 127.0.0.1, and ::1 are permitted."
             )
         }
@@ -131,7 +131,7 @@ public final class HostBrowserExecutor {
         } catch {
             return Self.transportError(
                 requestId: request.requestId,
-                code: "ENDPOINT_UNREACHABLE",
+                code: "unreachable",
                 message: "Failed to connect to Chrome DevTools at \(host):\(port): \(error.localizedDescription)"
             )
         }
@@ -141,7 +141,7 @@ public final class HostBrowserExecutor {
               let wsURL = target["webSocketDebuggerUrl"] as? String else {
             return Self.transportError(
                 requestId: request.requestId,
-                code: "NO_TARGET",
+                code: "unreachable",
                 message: "No debuggable page target found at \(host):\(port). Ensure Chrome is running with --remote-debugging-port=\(port)."
             )
         }
@@ -150,7 +150,7 @@ public final class HostBrowserExecutor {
         guard let wsEndpoint = URL(string: wsURL) else {
             return Self.transportError(
                 requestId: request.requestId,
-                code: "INVALID_WS_URL",
+                code: "transport_error",
                 message: "Chrome returned an invalid WebSocket URL: \(wsURL)"
             )
         }
@@ -173,13 +173,13 @@ public final class HostBrowserExecutor {
             case .timeout:
                 return Self.transportError(
                     requestId: request.requestId,
-                    code: "CDP_TIMEOUT",
+                    code: "timeout",
                     message: "CDP command '\(request.cdpMethod)' timed out after \(timeout)s"
                 )
             case .connectionFailed(let reason):
                 return Self.transportError(
                     requestId: request.requestId,
-                    code: "CDP_CONNECTION_FAILED",
+                    code: "transport_error",
                     message: "WebSocket connection to Chrome DevTools failed: \(reason)"
                 )
             case .protocolError(let code, let message):
@@ -204,7 +204,7 @@ public final class HostBrowserExecutor {
         } catch {
             return Self.transportError(
                 requestId: request.requestId,
-                code: "CDP_UNKNOWN_ERROR",
+                code: "transport_error",
                 message: "Unexpected error executing CDP command: \(error.localizedDescription)"
             )
         }
@@ -265,10 +265,18 @@ public final class HostBrowserExecutor {
             let session = URLSession(configuration: .default)
             let wsTask = session.webSocketTask(with: endpoint)
 
+            // Guard against double-resuming the continuation. The timeout
+            // fires on DispatchQueue.global() while WebSocket callbacks
+            // run on URLSession's delegate queue, so `resumed` is accessed
+            // from multiple threads and must be synchronized.
+            let lock = NSLock()
             var resumed = false
             let resumeOnce: (Result<String, Error>) -> Void = { result in
-                guard !resumed else { return }
-                resumed = true
+                lock.lock()
+                let alreadyResumed = resumed
+                if !alreadyResumed { resumed = true }
+                lock.unlock()
+                guard !alreadyResumed else { return }
                 wsTask.cancel(with: .normalClosure, reason: nil)
                 session.invalidateAndCancel()
                 continuation.resume(with: result)
@@ -347,8 +355,10 @@ public final class HostBrowserExecutor {
     // MARK: - Error Helpers
 
     /// Build a structured transport error payload with `isError: true` so
-    /// PR 1's error classifier can detect transport failures and trigger
-    /// backend failover.
+    /// the backend error classifier can detect transport failures and trigger
+    /// failover. Error codes use the lowercase set recognized by
+    /// `classifyHostBrowserError`: `transport_error`, `unreachable`,
+    /// `timeout`, `non_loopback`.
     static func transportError(
         requestId: String,
         code: String,

--- a/clients/shared/Network/HostBrowserExecutor.swift
+++ b/clients/shared/Network/HostBrowserExecutor.swift
@@ -1,0 +1,378 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "HostBrowserExecutor")
+
+/// Executes `host_browser_request` envelopes by connecting to a local Chrome
+/// DevTools Protocol (CDP) endpoint and sending a single CDP command.
+///
+/// Only loopback debugging endpoints are permitted (`localhost`, `127.0.0.1`,
+/// `::1`) to prevent the client from being used as an open proxy to arbitrary
+/// hosts. Non-loopback endpoints are rejected with a structured transport error
+/// so the backend error classifier (PR 1) can trigger failover.
+///
+/// Lifecycle:
+/// - `execute(_:using:)` — runs the full attach flow (endpoint discovery,
+///   target/session selection, command send, result serialization) and posts
+///   the result back through `HostProxyClient.postBrowserResult`.
+/// - `cancel(_:)` — marks a request as cancelled so in-flight work is aborted
+///   and the result POST is suppressed.
+///
+/// Thread safety: All public entry points are `@MainActor`. In-flight tasks
+/// are tracked in `inFlightTasks` for cancellation support.
+@MainActor
+public final class HostBrowserExecutor {
+
+    /// Default CDP debugging port when no explicit endpoint is provided.
+    private static let defaultCDPPort: Int = 9222
+
+    /// Default timeout for CDP commands when the request does not specify one.
+    private static let defaultTimeoutSeconds: Double = 30
+
+    /// Loopback hosts that are permitted for CDP connections.
+    private static let allowedLoopbackHosts: Set<String> = ["localhost", "127.0.0.1", "::1"]
+
+    /// In-flight execution tasks keyed by request ID, for cancel support.
+    private var inFlightTasks: [String: Task<Void, Never>] = [:]
+
+    /// Request IDs that have been cancelled. Entries are consumed on first
+    /// check and swept after 30 seconds.
+    private var cancelledRequestIds: [String: Date] = [:]
+
+    private let proxyClient: any HostProxyClientProtocol
+
+    public init(proxyClient: any HostProxyClientProtocol = HostProxyClient()) {
+        self.proxyClient = proxyClient
+    }
+
+    // MARK: - Public API
+
+    /// Execute a host browser request: discover the CDP endpoint, send the
+    /// command, and post the result back to the daemon.
+    public func execute(_ request: HostBrowserRequest) {
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.inFlightTasks.removeValue(forKey: request.requestId) }
+
+            // Pre-flight cancellation check
+            if self.consumeCancelled(request.requestId) {
+                log.debug("Host browser skipped (pre-cancelled) — requestId=\(request.requestId, privacy: .public)")
+                return
+            }
+
+            let result = await self.run(request)
+
+            // Suppress stale POST if cancelled during execution
+            if self.consumeCancelled(request.requestId) {
+                log.debug("Host browser result suppressed (cancelled) — requestId=\(request.requestId, privacy: .public)")
+                return
+            }
+
+            guard !Task.isCancelled else {
+                log.debug("Host browser task cancelled — requestId=\(request.requestId, privacy: .public)")
+                return
+            }
+
+            _ = await self.proxyClient.postBrowserResult(result)
+        }
+        inFlightTasks[request.requestId] = task
+    }
+
+    /// Cancel an in-flight host browser request: mark it cancelled and cancel
+    /// the Swift Task so in-flight network calls are interrupted.
+    public func cancel(_ requestId: String) {
+        markCancelled(requestId)
+        if let task = inFlightTasks.removeValue(forKey: requestId) {
+            task.cancel()
+        }
+        log.info("Cancelling host browser — requestId=\(requestId, privacy: .public)")
+    }
+
+    // MARK: - Cancellation Tracking
+
+    private func markCancelled(_ requestId: String) {
+        let now = Date()
+        cancelledRequestIds[requestId] = now
+        // Sweep entries older than 30 seconds
+        cancelledRequestIds = cancelledRequestIds.filter { now.timeIntervalSince($0.value) < 30 }
+    }
+
+    private func consumeCancelled(_ requestId: String) -> Bool {
+        cancelledRequestIds.removeValue(forKey: requestId) != nil
+    }
+
+    // MARK: - Execution
+
+    /// Run the full CDP command flow and return the result payload. This is
+    /// the core logic that does not interact with the proxy client — separated
+    /// for testability.
+    func run(_ request: HostBrowserRequest) async -> HostBrowserResultPayload {
+        // Resolve the CDP endpoint URL from the request. Default to
+        // localhost:9222 when no explicit endpoint is provided.
+        let host = "localhost"
+        let port = Self.defaultCDPPort
+
+        // Validate loopback — only allow connections to localhost / 127.0.0.1 / ::1
+        guard Self.allowedLoopbackHosts.contains(host.lowercased()) else {
+            return Self.transportError(
+                requestId: request.requestId,
+                code: "LOOPBACK_VALIDATION_FAILED",
+                message: "CDP endpoint host '\(host)' is not a loopback address. Only localhost, 127.0.0.1, and ::1 are permitted."
+            )
+        }
+
+        let timeout = request.timeoutSeconds ?? Self.defaultTimeoutSeconds
+
+        // Step 1: Discover available targets via /json/list
+        let targetsURL = URL(string: "http://\(host):\(port)/json/list")!
+        let targets: [[String: Any]]
+        do {
+            targets = try await fetchJSON(url: targetsURL, timeout: timeout)
+        } catch {
+            return Self.transportError(
+                requestId: request.requestId,
+                code: "ENDPOINT_UNREACHABLE",
+                message: "Failed to connect to Chrome DevTools at \(host):\(port): \(error.localizedDescription)"
+            )
+        }
+
+        // Step 2: Select a page target (first with type == "page")
+        guard let target = targets.first(where: { ($0["type"] as? String) == "page" }),
+              let wsURL = target["webSocketDebuggerUrl"] as? String else {
+            return Self.transportError(
+                requestId: request.requestId,
+                code: "NO_TARGET",
+                message: "No debuggable page target found at \(host):\(port). Ensure Chrome is running with --remote-debugging-port=\(port)."
+            )
+        }
+
+        // Step 3: Connect via WebSocket and send the CDP command
+        guard let wsEndpoint = URL(string: wsURL) else {
+            return Self.transportError(
+                requestId: request.requestId,
+                code: "INVALID_WS_URL",
+                message: "Chrome returned an invalid WebSocket URL: \(wsURL)"
+            )
+        }
+
+        do {
+            let result = try await sendCDPCommand(
+                endpoint: wsEndpoint,
+                method: request.cdpMethod,
+                params: request.cdpParams,
+                sessionId: request.cdpSessionId,
+                timeout: timeout
+            )
+            return HostBrowserResultPayload(
+                requestId: request.requestId,
+                content: result,
+                isError: false
+            )
+        } catch let error as CDPError {
+            switch error {
+            case .timeout:
+                return Self.transportError(
+                    requestId: request.requestId,
+                    code: "CDP_TIMEOUT",
+                    message: "CDP command '\(request.cdpMethod)' timed out after \(timeout)s"
+                )
+            case .connectionFailed(let reason):
+                return Self.transportError(
+                    requestId: request.requestId,
+                    code: "CDP_CONNECTION_FAILED",
+                    message: "WebSocket connection to Chrome DevTools failed: \(reason)"
+                )
+            case .protocolError(let code, let message):
+                // CDP protocol errors are command-level errors (not transport
+                // failures), so they are NOT isError=true transport errors.
+                // Return them as successful results containing the error info
+                // so the backend processes them as CDP responses.
+                let errorPayload: [String: Any] = [
+                    "error": [
+                        "code": code,
+                        "message": message
+                    ]
+                ]
+                let jsonData = try? JSONSerialization.data(withJSONObject: errorPayload)
+                let jsonString = jsonData.flatMap { String(data: $0, encoding: .utf8) } ?? "{\"error\":{\"code\":\(code),\"message\":\"\(message)\"}}"
+                return HostBrowserResultPayload(
+                    requestId: request.requestId,
+                    content: jsonString,
+                    isError: false
+                )
+            }
+        } catch {
+            return Self.transportError(
+                requestId: request.requestId,
+                code: "CDP_UNKNOWN_ERROR",
+                message: "Unexpected error executing CDP command: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    // MARK: - CDP Communication
+
+    /// Fetch JSON from a URL with a timeout. Returns an array of dictionaries.
+    private func fetchJSON(url: URL, timeout: TimeInterval) async throws -> [[String: Any]] {
+        var urlRequest = URLRequest(url: url)
+        urlRequest.timeoutInterval = timeout
+
+        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200..<300).contains(httpResponse.statusCode) else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            throw CDPError.connectionFailed("HTTP \(statusCode) from \(url.absoluteString)")
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            throw CDPError.connectionFailed("Invalid JSON response from \(url.absoluteString)")
+        }
+
+        return json
+    }
+
+    /// Send a single CDP command over WebSocket and return the JSON result
+    /// string. Opens the connection, sends the command, waits for the
+    /// matching response (by `id`), and closes the connection.
+    private func sendCDPCommand(
+        endpoint: URL,
+        method: String,
+        params: [String: AnyCodable]?,
+        sessionId: String?,
+        timeout: TimeInterval
+    ) async throws -> String {
+        // Build the CDP JSON-RPC message
+        let commandId = 1
+        var message: [String: Any] = [
+            "id": commandId,
+            "method": method
+        ]
+        if let params {
+            message["params"] = params.mapValues { $0.value as Any }
+        }
+        if let sessionId {
+            message["sessionId"] = sessionId
+        }
+
+        let messageData = try JSONSerialization.data(withJSONObject: message)
+        guard let messageString = String(data: messageData, encoding: .utf8) else {
+            throw CDPError.connectionFailed("Failed to serialize CDP command")
+        }
+
+        // Open WebSocket, send, and wait for response
+        return try await withCheckedThrowingContinuation { continuation in
+            let session = URLSession(configuration: .default)
+            let wsTask = session.webSocketTask(with: endpoint)
+
+            var resumed = false
+            let resumeOnce: (Result<String, Error>) -> Void = { result in
+                guard !resumed else { return }
+                resumed = true
+                wsTask.cancel(with: .normalClosure, reason: nil)
+                session.invalidateAndCancel()
+                continuation.resume(with: result)
+            }
+
+            // Timeout
+            let timeoutWork = DispatchWorkItem {
+                resumeOnce(.failure(CDPError.timeout))
+            }
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: timeoutWork)
+
+            wsTask.resume()
+
+            // Send the command
+            wsTask.send(.string(messageString)) { error in
+                if let error {
+                    timeoutWork.cancel()
+                    resumeOnce(.failure(CDPError.connectionFailed("WebSocket send failed: \(error.localizedDescription)")))
+                    return
+                }
+
+                // Listen for the response
+                func receiveNext() {
+                    wsTask.receive { result in
+                        switch result {
+                        case .success(let wsMessage):
+                            switch wsMessage {
+                            case .string(let text):
+                                // Parse to check if this is our response (matching id)
+                                if let data = text.data(using: .utf8),
+                                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                                   let responseId = json["id"] as? Int,
+                                   responseId == commandId {
+                                    timeoutWork.cancel()
+
+                                    // Check for CDP protocol error
+                                    if let errorObj = json["error"] as? [String: Any] {
+                                        let code = errorObj["code"] as? Int ?? -1
+                                        let message = errorObj["message"] as? String ?? "Unknown CDP error"
+                                        resumeOnce(.failure(CDPError.protocolError(code: code, message: message)))
+                                        return
+                                    }
+
+                                    // Return the result portion as JSON string
+                                    if let resultObj = json["result"] {
+                                        if let resultData = try? JSONSerialization.data(withJSONObject: resultObj),
+                                           let resultString = String(data: resultData, encoding: .utf8) {
+                                            resumeOnce(.success(resultString))
+                                        } else {
+                                            resumeOnce(.success("{}"))
+                                        }
+                                    } else {
+                                        resumeOnce(.success("{}"))
+                                    }
+                                } else {
+                                    // Not our response — keep listening (events, other messages)
+                                    receiveNext()
+                                }
+                            case .data:
+                                // Binary frames are not expected from CDP
+                                receiveNext()
+                            @unknown default:
+                                receiveNext()
+                            }
+                        case .failure(let error):
+                            timeoutWork.cancel()
+                            resumeOnce(.failure(CDPError.connectionFailed("WebSocket receive failed: \(error.localizedDescription)")))
+                        }
+                    }
+                }
+                receiveNext()
+            }
+        }
+    }
+
+    // MARK: - Error Helpers
+
+    /// Build a structured transport error payload with `isError: true` so
+    /// PR 1's error classifier can detect transport failures and trigger
+    /// backend failover.
+    static func transportError(
+        requestId: String,
+        code: String,
+        message: String
+    ) -> HostBrowserResultPayload {
+        let errorJSON: [String: Any] = [
+            "code": code,
+            "message": message
+        ]
+        let jsonData = (try? JSONSerialization.data(withJSONObject: errorJSON)) ?? Data()
+        let content = String(data: jsonData, encoding: .utf8) ?? "{\"code\":\"\(code)\",\"message\":\"\(message)\"}"
+        log.error("Host browser transport error: \(code) — \(message) (requestId=\(requestId, privacy: .public))")
+        return HostBrowserResultPayload(
+            requestId: requestId,
+            content: content,
+            isError: true
+        )
+    }
+
+    // MARK: - Errors
+
+    enum CDPError: Error {
+        case timeout
+        case connectionFailed(String)
+        case protocolError(code: Int, message: String)
+    }
+}

--- a/clients/shared/Tests/EventStreamClientLifecycleTests.swift
+++ b/clients/shared/Tests/EventStreamClientLifecycleTests.swift
@@ -53,4 +53,49 @@ final class EventStreamClientLifecycleTests: XCTestCase {
             _ = client
         }
     }
+
+    // MARK: - Host Tool Ownership Filtering
+
+    /// Verify that `registerConversationId` adds the ID to the locally owned
+    /// set, which is the prerequisite for host tool requests (including
+    /// host_browser_request) to pass the ownership filter.
+    func testRegisterConversationIdAddsToLocallyOwned() {
+        let client = EventStreamClient()
+        XCTAssertFalse(client.locallyOwnedConversationIds.contains("conv-abc"))
+
+        client.registerConversationId("conv-abc")
+
+        XCTAssertTrue(client.locallyOwnedConversationIds.contains("conv-abc"))
+    }
+
+    /// Verify that `cleanupAfterConversationIdResolution` removes the local
+    /// ID and does not leave a stale entry that could match future requests.
+    func testCleanupAfterResolutionRemovesLocalId() {
+        let client = EventStreamClient()
+        client.registerConversationId("local-123")
+
+        client.cleanupAfterConversationIdResolution(localId: "local-123", serverId: "server-456")
+
+        XCTAssertFalse(
+            client.locallyOwnedConversationIds.contains("local-123"),
+            "Local ID should be removed after resolution"
+        )
+    }
+
+    /// Verify that the locally-owned set tracks both local and server IDs
+    /// after a conversation ID resolution, since SSE messages may arrive
+    /// using either ID.
+    func testLocallyOwnedSetContainsServerIdAfterSendMessage() {
+        let client = EventStreamClient()
+        // sendMessage registers the conversation ID as locally owned and
+        // maps the server ID once the POST response arrives. Since we
+        // cannot easily drive a full sendMessage in a unit test (it makes
+        // an HTTP call), verify that registerConversationId is sufficient
+        // and that the set is mutable via the public API.
+        client.registerConversationId("conv-local")
+        client.registerConversationId("conv-server")
+
+        XCTAssertTrue(client.locallyOwnedConversationIds.contains("conv-local"))
+        XCTAssertTrue(client.locallyOwnedConversationIds.contains("conv-server"))
+    }
 }

--- a/clients/shared/Tests/HostBrowserExecutorTests.swift
+++ b/clients/shared/Tests/HostBrowserExecutorTests.swift
@@ -30,7 +30,7 @@ final class HostBrowserExecutorTests: XCTestCase {
     func testTransportErrorFormatsStructuredJSON() {
         let result = HostBrowserExecutor.transportError(
             requestId: "req-1",
-            code: "ENDPOINT_UNREACHABLE",
+            code: "unreachable",
             message: "Connection refused"
         )
 
@@ -43,14 +43,14 @@ final class HostBrowserExecutorTests: XCTestCase {
             XCTFail("Transport error content should be valid JSON")
             return
         }
-        XCTAssertEqual(json["code"] as? String, "ENDPOINT_UNREACHABLE")
+        XCTAssertEqual(json["code"] as? String, "unreachable")
         XCTAssertEqual(json["message"] as? String, "Connection refused")
     }
 
     // MARK: - Executor Run (Unit — No Real Chrome)
 
     /// When Chrome DevTools is not running, the executor should return a
-    /// structured transport error with ENDPOINT_UNREACHABLE.
+    /// structured transport error with `unreachable` code.
     func testRunReturnsEndpointUnreachableWhenChromeNotRunning() async {
         let executor = HostBrowserExecutor()
         let request = makeRequest(requestId: "req-no-chrome", cdpMethod: "Runtime.evaluate")
@@ -65,7 +65,7 @@ final class HostBrowserExecutorTests: XCTestCase {
             XCTFail("Content should be valid JSON")
             return
         }
-        XCTAssertEqual(json["code"] as? String, "ENDPOINT_UNREACHABLE")
+        XCTAssertEqual(json["code"] as? String, "unreachable")
     }
 
     // MARK: - Cancellation

--- a/clients/shared/Tests/HostBrowserExecutorTests.swift
+++ b/clients/shared/Tests/HostBrowserExecutorTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+
+@testable import VellumAssistantShared
+
+// MARK: - Mock HostProxyClient
+
+/// Records calls to `postBrowserResult` so tests can verify the payload
+/// without making real HTTP requests.
+@MainActor
+private final class MockHostProxyClient: HostProxyClientProtocol {
+    var postedBrowserResults: [HostBrowserResultPayload] = []
+
+    func postBashResult(_ result: HostBashResultPayload) async -> Bool { true }
+    func postFileResult(_ result: HostFileResultPayload) async -> Bool { true }
+    func postCuResult(_ result: HostCuResultPayload) async -> Bool { true }
+
+    func postBrowserResult(_ result: HostBrowserResultPayload) async -> Bool {
+        postedBrowserResults.append(result)
+        return true
+    }
+}
+
+// MARK: - Tests
+
+@MainActor
+final class HostBrowserExecutorTests: XCTestCase {
+
+    // MARK: - Transport Error Helpers
+
+    func testTransportErrorFormatsStructuredJSON() {
+        let result = HostBrowserExecutor.transportError(
+            requestId: "req-1",
+            code: "ENDPOINT_UNREACHABLE",
+            message: "Connection refused"
+        )
+
+        XCTAssertEqual(result.requestId, "req-1")
+        XCTAssertTrue(result.isError, "Transport errors must set isError=true for backend failover")
+
+        // Verify the content is valid JSON with code and message
+        guard let data = result.content.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            XCTFail("Transport error content should be valid JSON")
+            return
+        }
+        XCTAssertEqual(json["code"] as? String, "ENDPOINT_UNREACHABLE")
+        XCTAssertEqual(json["message"] as? String, "Connection refused")
+    }
+
+    // MARK: - Executor Run (Unit — No Real Chrome)
+
+    /// When Chrome DevTools is not running, the executor should return a
+    /// structured transport error with ENDPOINT_UNREACHABLE.
+    func testRunReturnsEndpointUnreachableWhenChromeNotRunning() async {
+        let executor = HostBrowserExecutor()
+        let request = makeRequest(requestId: "req-no-chrome", cdpMethod: "Runtime.evaluate")
+
+        let result = await executor.run(request)
+
+        XCTAssertEqual(result.requestId, "req-no-chrome")
+        XCTAssertTrue(result.isError, "Should be a transport error when Chrome is unreachable")
+
+        guard let data = result.content.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            XCTFail("Content should be valid JSON")
+            return
+        }
+        XCTAssertEqual(json["code"] as? String, "ENDPOINT_UNREACHABLE")
+    }
+
+    // MARK: - Cancellation
+
+    func testCancelSuppressesResultPost() async {
+        let mockClient = MockHostProxyClient()
+        let executor = HostBrowserExecutor(proxyClient: mockClient)
+
+        let request = makeRequest(requestId: "req-cancel-test", cdpMethod: "Runtime.evaluate")
+
+        // Cancel before execute — the result POST should be suppressed
+        executor.cancel(request.requestId)
+        executor.execute(request)
+
+        // Give the task time to start and check cancellation
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertTrue(
+            mockClient.postedBrowserResults.isEmpty,
+            "Cancelled requests should not post results"
+        )
+    }
+
+    func testCancelInFlightRequestCancelsTask() async {
+        let mockClient = MockHostProxyClient()
+        let executor = HostBrowserExecutor(proxyClient: mockClient)
+
+        let request = makeRequest(requestId: "req-inflight", cdpMethod: "Runtime.evaluate")
+
+        // Start execution (will try to connect to non-existent Chrome)
+        executor.execute(request)
+
+        // Immediately cancel
+        executor.cancel(request.requestId)
+
+        // Wait for task cleanup
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        // The result should either be suppressed or reflect the cancellation
+        // Since we cancelled immediately, the post should be suppressed
+        let hasPosted = !mockClient.postedBrowserResults.isEmpty
+        if hasPosted {
+            // If a result was posted before cancellation took effect, that's
+            // acceptable — it should be a transport error (not a success)
+            let result = mockClient.postedBrowserResults[0]
+            XCTAssertTrue(result.isError)
+        }
+    }
+
+    // MARK: - Execute Posts Result
+
+    func testExecutePostsResultForUnreachableEndpoint() async {
+        let mockClient = MockHostProxyClient()
+        let executor = HostBrowserExecutor(proxyClient: mockClient)
+
+        let request = makeRequest(requestId: "req-post-test", cdpMethod: "Page.navigate")
+        executor.execute(request)
+
+        // Wait for the execution to complete and post the result
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+
+        XCTAssertFalse(
+            mockClient.postedBrowserResults.isEmpty,
+            "Executor should post a result even when Chrome is unreachable"
+        )
+
+        let result = mockClient.postedBrowserResults[0]
+        XCTAssertEqual(result.requestId, "req-post-test")
+        XCTAssertTrue(result.isError, "Unreachable endpoint should produce a transport error")
+    }
+
+    // MARK: - Helpers
+
+    /// Build a minimal `HostBrowserRequest` for testing. Uses JSON round-trip
+    /// since the struct has no public init (Decodable only).
+    private func makeRequest(
+        requestId: String,
+        cdpMethod: String,
+        cdpParams: [String: Any]? = nil,
+        cdpSessionId: String? = nil,
+        timeoutSeconds: Double? = nil
+    ) -> HostBrowserRequest {
+        var json: [String: Any] = [
+            "type": "host_browser_request",
+            "requestId": requestId,
+            "conversationId": "conv-test-123",
+            "cdpMethod": cdpMethod
+        ]
+        if let cdpParams {
+            json["cdpParams"] = cdpParams
+        }
+        if let cdpSessionId {
+            json["cdpSessionId"] = cdpSessionId
+        }
+        if let timeoutSeconds {
+            json["timeout_seconds"] = timeoutSeconds
+        }
+
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        return try! JSONDecoder().decode(HostBrowserRequest.self, from: data)
+    }
+}


### PR DESCRIPTION
## Summary
- Create HostBrowserExecutor for handling host_browser_request lifecycle with DevTools loopback attach
- Wire AppDelegate to dispatch host_browser_request and host_browser_cancel events
- Extend EventStreamClient ownership filtering to include host_browser_request
- Add unit tests for executor and SSE filtering

Part of plan: host-browser-via-macos-host-proxy.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
