### PR TITLE
fix(macOS): resolve Swift build errors in RiskBadgeView and ToolConfirmationBubble call sites

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -639,8 +639,8 @@ struct AssistantProgressView: View {
                 if let confirmation = toolCall.pendingConfirmation {
                     ToolConfirmationBubble(
                         confirmation: confirmation,
-                        isV3: MacOSClientFeatureFlagManager.shared.isEnabled("permission-controls-v3"),
                         isKeyboardActive: confirmation.requestId == activeConfirmationRequestId,
+                        isV3: MacOSClientFeatureFlagManager.shared.isEnabled("permission-controls-v3"),
                         onAllow: { onConfirmationAllow?(confirmation.requestId) },
                         onDeny: { onConfirmationDeny?(confirmation.requestId) },
                         onAlwaysAllow: onAlwaysAllow ?? { _, _, _, _ in },

--- a/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
@@ -162,8 +162,8 @@ struct MessageCellView: View, Equatable {
                 if !isConfirmationRenderedInline {
                     ToolConfirmationBubble(
                         confirmation: confirmation,
-                        isV3: MacOSClientFeatureFlagManager.shared.isEnabled("permission-controls-v3"),
                         isKeyboardActive: confirmation.requestId == activePendingRequestId,
+                        isV3: MacOSClientFeatureFlagManager.shared.isEnabled("permission-controls-v3"),
                         onAllow: { onConfirmationAllow?(confirmation.requestId) },
                         onDeny: { onConfirmationDeny?(confirmation.requestId) },
                         onAlwaysAllow: onAlwaysAllow ?? { _, _, _, _ in },

--- a/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import VellumAssistantShared
 
 /// A small colored pill that displays a risk level label.
 ///


### PR DESCRIPTION
## Summary
- Add missing `import VellumAssistantShared` to `RiskBadgeView.swift` so `VColor` design tokens are in scope
- Fix `ToolConfirmationBubble` argument ordering in `MessageCellView.swift` and `AssistantProgressView.swift` — swap `isKeyboardActive` before `isV3` to match the init signature

## Original prompt
Fix Swift build errors: `VColor` not in scope in RiskBadgeView, and argument order mismatch (`isKeyboardActive` must precede `isV3`) in MessageCellView and AssistantProgressView.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
