### PR TITLE
Document and verify macOS host-browser mode end-to-end

### DIFF
--- a/assistant/docs/browser-use-architecture-phase2.md
+++ b/assistant/docs/browser-use-architecture-phase2.md
@@ -2,23 +2,39 @@
 
 ## Overview
 
-Phase 2 of browser automation introduced a three-tier backend selection chain for macOS-originated turns, enabling the assistant to prefer the user's real Chrome session (via the paired extension) over a sandboxed Playwright instance. When the extension is unavailable, the system falls back through cdp-inspect (direct Chrome DevTools Protocol attach) before resorting to the local Playwright browser.
+Phase 2 of browser automation introduced a three-tier backend selection chain for macOS-originated turns, enabling the assistant to prefer the user's real Chrome session over a sandboxed Playwright instance. Two transport paths exist for the top-priority "extension" backend:
 
-This document describes the runtime architecture, backend precedence rules, and the manual QA playbook for verifying correct backend selection.
+1. **Chrome Extension Registry (WebSocket)**: When the user has the Vellum Chrome Extension installed and paired, `host_browser_request` frames route through the `ChromeExtensionRegistry` singleton over a dedicated `/v1/browser-relay` WebSocket.
+2. **macOS Host Browser Proxy (SSE)**: When the macOS desktop client is connected but the Chrome extension is absent, `host_browser_request` frames travel through `assistantEventHub` (SSE). The desktop client receives the frames via its SSE connection, executes CDP commands against the local Chrome, and POSTs results back to `/v1/host-browser-result`.
+
+When neither transport is available, the system falls back through cdp-inspect (direct Chrome DevTools Protocol attach) before resorting to the local Playwright browser.
+
+This document describes the runtime architecture, backend precedence rules, transport matrix, and the manual QA playbook for verifying correct backend selection.
 
 ## Component Inventory
 
-| Component                   | Location                                           | Role                                                                                                                                                                                   |
-| --------------------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **ChromeExtensionRegistry** | `runtime/chrome-extension-registry.ts`             | Tracks active extension WebSocket connections keyed by `(guardianId, clientInstanceId)`. Populated on WS `open`, drained on WS `close`.                                                |
-| **HostBrowserProxy**        | `daemon/host-browser-proxy.ts`                     | Per-conversation proxy that dispatches `host_browser_request` frames and awaits `host_browser_result` responses.                                                                       |
-| **CDP Factory**             | `tools/browser/cdp-client/factory.ts`              | Builds the ordered candidate list and returns a `ScopedCdpClient` with per-invocation failover.                                                                                        |
-| **BrowserSessionManager**   | `browser-session/manager.ts`                       | Routes CDP commands through the selected backend with session tracking.                                                                                                                |
-| **CdpInspectClient**        | `tools/browser/cdp-client/cdp-inspect-client.ts`   | Connects to a host Chrome instance via its remote-debugging WebSocket endpoint.                                                                                                        |
-| **LocalCdpClient**          | `tools/browser/cdp-client/local-cdp-client.ts`     | Drives Playwright's CDPSession against the sacrificial-profile browser.                                                                                                                |
-| **ExtensionCdpClient**      | `tools/browser/cdp-client/extension-cdp-client.ts` | Routes CDP commands through the HostBrowserProxy to the user's real Chrome.                                                                                                            |
-| **conversation-routes.ts**  | `runtime/routes/conversation-routes.ts`            | Wires `resolveHostBrowserSender()` to set `hostBrowserSenderOverride` when the extension is connected. Sets `turnInterfaceContext` from the `interface` field on the incoming message. |
-| **Desktop-auto config**     | `config/schemas/host-browser.ts`                   | `desktopAuto.enabled` (default `true`) and `desktopAuto.cooldownMs` (default 30s) control automatic cdp-inspect on macOS.                                                              |
+| Component                   | Location                                           | Role                                                                                                                                                                              |
+| --------------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ChromeExtensionRegistry** | `runtime/chrome-extension-registry.ts`             | Tracks active extension WebSocket connections keyed by `(guardianId, clientInstanceId)`. Populated on WS `open`, drained on WS `close`.                                           |
+| **HostBrowserProxy**        | `daemon/host-browser-proxy.ts`                     | Per-conversation proxy that dispatches `host_browser_request` frames and awaits `host_browser_result` responses. Wired to either the registry sender or the SSE hub sender.       |
+| **CDP Factory**             | `tools/browser/cdp-client/factory.ts`              | Builds the ordered candidate list and returns a `ScopedCdpClient` with per-invocation failover.                                                                                   |
+| **BrowserSessionManager**   | `browser-session/manager.ts`                       | Routes CDP commands through the selected backend with session tracking.                                                                                                           |
+| **CdpInspectClient**        | `tools/browser/cdp-client/cdp-inspect-client.ts`   | Connects to a host Chrome instance via its remote-debugging WebSocket endpoint.                                                                                                   |
+| **LocalCdpClient**          | `tools/browser/cdp-client/local-cdp-client.ts`     | Drives Playwright's CDPSession against the sacrificial-profile browser.                                                                                                           |
+| **ExtensionCdpClient**      | `tools/browser/cdp-client/extension-cdp-client.ts` | Routes CDP commands through the HostBrowserProxy to the user's real Chrome.                                                                                                       |
+| **conversation-routes.ts**  | `runtime/routes/conversation-routes.ts`            | Wires `resolveHostBrowserSender()` to set `hostBrowserSenderOverride` when the extension is connected. For macOS without extension, provisions the proxy with the SSE hub sender. |
+| **Desktop-auto config**     | `config/schemas/host-browser.ts`                   | `desktopAuto.enabled` (default `true`) and `desktopAuto.cooldownMs` (default 30s) control automatic cdp-inspect on macOS.                                                         |
+
+## Transport Matrix
+
+The following table shows how `host_browser_request` frames are delivered to the client based on the originating interface and extension connectivity:
+
+| Interface          | Extension Connected | Transport                       | Sender                                          | Notes                                                                  |
+| ------------------ | ------------------- | ------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------- |
+| `chrome-extension` | Yes (always)        | WebSocket (`/v1/browser-relay`) | `ChromeExtensionRegistry.send(guardianId, msg)` | The only transport for chrome-extension turns; SSE fallback is invalid |
+| `macos`            | Yes                 | WebSocket (`/v1/browser-relay`) | `ChromeExtensionRegistry.send(guardianId, msg)` | Extension takes priority; browser tools route through user's Chrome    |
+| `macos`            | No                  | SSE (`assistantEventHub`)       | `onEvent` hub publisher                         | macOS host browser proxy mode; desktop client handles CDP locally      |
+| Other              | Any                 | N/A                             | No browser proxy provisioned                    | Falls through to cdp-inspect or local Playwright                       |
 
 ## Wire Diagram
 
@@ -37,10 +53,12 @@ conversation-routes.ts
     |               |
     |               +-- entry found? --> registrySender (WS to extension)
     |               |                    hostBrowserSenderOverride = registrySender
-    |               |                    provision HostBrowserProxy
+    |               |                    provision HostBrowserProxy(registrySender)
     |               |
     |               +-- entry not found? --> SSE hub sender (default)
     |                                        hostBrowserSenderOverride = undefined
+    |                                        provision HostBrowserProxy(onEvent)
+    |                                        [macOS natively supports host_browser]
     |
     v
 Agent loop invokes browser tool
@@ -50,6 +68,8 @@ getCdpClient(toolContext)
     |-- toolContext.hostBrowserProxy set?
     |       AND hostBrowserProxy.isAvailable()?
     |       --> candidate: extension (priority 1)
+    |       [Transport: WS via registry when extension present,
+    |        SSE via hub when macOS host proxy only]
     |
     |-- transportInterface === "macos"
     |       AND desktopAuto.enabled?
@@ -61,7 +81,7 @@ getCdpClient(toolContext)
     v
 ScopedCdpClient.send(method, params)
     |
-    +-- Try candidate 1 (extension)
+    +-- Try candidate 1 (extension / macOS host proxy)
     |       transport_error? --> failover to candidate 2
     |       cdp_error? --> propagate immediately (no failover)
     |       success? --> sticky for remainder of invocation
@@ -76,11 +96,11 @@ ScopedCdpClient.send(method, params)
 
 ## Backend Precedence (macOS)
 
-| Priority | Backend            | When selected                                                                            | Failover trigger                                                                         |
-| -------- | ------------------ | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| 1        | Extension          | `hostBrowserProxy` present and `isAvailable()` is `true`                                 | Transport error (WebSocket disconnected, send failed)                                    |
-| 2        | cdp-inspect        | Config `enabled: true`, OR macOS + `desktopAuto.enabled` (default) + cooldown not active | Transport error (endpoint unreachable, WS connect failure). Records cooldown on failure. |
-| 3        | Local (Playwright) | Always present as final fallback                                                         | Errors propagate to the tool                                                             |
+| Priority | Backend                      | When selected                                                                                                                                                                   | Transport                  | Failover trigger                                                                         |
+| -------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------- |
+| 1        | Extension / macOS host proxy | `hostBrowserProxy` present and `isAvailable()` is `true`. On macOS, the proxy is always provisioned (SSE sender when no extension, registry-routed when extension is connected) | WS (registry) or SSE (hub) | Transport error (WebSocket disconnected, SSE send failed)                                |
+| 2        | cdp-inspect                  | Config `enabled: true`, OR macOS + `desktopAuto.enabled` (default) + cooldown not active                                                                                        | Direct CDP WebSocket       | Transport error (endpoint unreachable, WS connect failure). Records cooldown on failure. |
+| 3        | Local (Playwright)           | Always present as final fallback                                                                                                                                                | In-process CDP             | Errors propagate to the tool                                                             |
 
 After the first successful CDP command on any backend, that backend becomes **sticky** for the remainder of the tool invocation.
 
@@ -113,6 +133,29 @@ When cdp-inspect fails with a transport error during a desktop-auto attempt:
 - `cdp-factory` log: `CDP factory: candidate succeeded, backend is now sticky` with `candidateKind: "extension"`
 - No `browserManager` launch log (Playwright not started).
 - Extension WebSocket receives `host_browser_request` frames.
+
+### Scenario 1b: macOS Host Browser Proxy (No Extension)
+
+**Setup:**
+
+1. macOS desktop client is running and connected to the assistant via SSE.
+2. No browser extension is installed or connected.
+3. Chrome is running on the desktop machine.
+
+**Test:**
+
+1. Send a message that triggers browser automation (e.g. "navigate to example.com and take a screenshot").
+2. Observe the assistant drives the user's Chrome session via the macOS host browser proxy (the desktop client receives `host_browser_request` frames over SSE and executes CDP commands locally).
+
+**Expected telemetry/log signals:**
+
+- `cdp-factory` log: `CDP factory: built candidate list` with `candidates: [{kind: "extension", ...}, {kind: "cdp-inspect", ...}, {kind: "local", ...}]`
+- `cdp-factory` log: `CDP factory: candidate succeeded, backend is now sticky` with `candidateKind: "extension"`
+- No `browserManager` launch log (Playwright not started).
+- SSE event stream delivers `host_browser_request` frames (not WebSocket relay).
+- `browser_status` output shows `transport: "macos-sse"` in the extension mode details.
+
+**Difference from Scenario 1:** The transport is SSE-based (`assistantEventHub`), not the `/v1/browser-relay` WebSocket. The `hostBrowserSenderOverride` is `undefined` because no registry entry exists. The proxy is provisioned because macOS natively supports `host_browser`.
 
 ### Scenario 2: Extension Absent + cdp-inspect Enabled
 

--- a/assistant/src/__tests__/host-browser-e2e-cloud.test.ts
+++ b/assistant/src/__tests__/host-browser-e2e-cloud.test.ts
@@ -568,6 +568,313 @@ describe("macOS message ingress with connected extension", () => {
   });
 });
 
+// ── macOS SSE bridge ingress (no extension registry) ────────────────
+//
+// Exercises the cloud-hosted + desktop SSE bridge path for macOS turns
+// WITHOUT relying on the ChromeExtensionRegistry. This validates the
+// native macOS host-browser proxy path where `host_browser_request`
+// frames travel through `assistantEventHub` (SSE) rather than the
+// extension WebSocket.
+//
+// In production, this path is used when:
+//   - The macOS desktop client is connected to the assistant via SSE
+//   - The user does NOT have the Chrome extension installed
+//   - The desktop client receives `host_browser_request` frames via SSE,
+//     executes CDP commands against the local Chrome, and POSTs results
+//     back to `/v1/host-browser-result`
+//
+// The test constructs a HostBrowserProxy wired to a mock SSE sender
+// (simulating the `onEvent` hub publisher) and a mock macOS client that
+// observes the sent frames and returns results via POST.
+
+describe("macOS SSE bridge ingress (no extension registry)", () => {
+  let server: RuntimeHttpServer;
+  let port: number;
+  let runtimeBaseUrl: string;
+
+  beforeEach(async () => {
+    const db = getDb();
+    db.run("DELETE FROM contact_channels");
+    db.run("DELETE FROM contacts");
+    pendingInteractions.clear();
+    __resetChromeExtensionRegistryForTests();
+
+    port = 20200 + Math.floor(Math.random() * 200);
+    runtimeBaseUrl = `http://127.0.0.1:${port}`;
+    server = new RuntimeHttpServer({ port });
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server?.stop();
+    pendingInteractions.clear();
+    __resetChromeExtensionRegistryForTests();
+  });
+
+  /**
+   * Create a HostBrowserProxy wired to a mock SSE sender. The sender
+   * captures `host_browser_request` frames and simulates what the macOS
+   * desktop client does: execute the CDP command locally and POST the
+   * result back to `/v1/host-browser-result`.
+   *
+   * Unlike `createBoundProxy` (which routes through the extension
+   * registry), this helper routes through a direct function call —
+   * simulating the `onEvent` SSE hub publisher path.
+   */
+  function createSseBoundProxy(
+    conversationId: string,
+    token: string,
+  ): {
+    proxy: HostBrowserProxy;
+    conversation: Conversation;
+    sentFrames: Array<{ type: string; [key: string]: unknown }>;
+  } {
+    let proxyRef: HostBrowserProxy | null = null;
+    const conversation = {
+      resolveHostBrowser(
+        requestId: string,
+        response: { content: string; isError: boolean },
+      ) {
+        proxyRef?.resolve(requestId, response);
+      },
+    } as unknown as Conversation;
+
+    const sentFrames: Array<{ type: string; [key: string]: unknown }> = [];
+
+    // The SSE sender simulates what `assistantEventHub.publish` does in
+    // production: it delivers the message to the connected SSE client.
+    // Here we capture the frame and immediately simulate the macOS client
+    // handling it — executing a mock CDP command and POSTing the result
+    // back to the runtime.
+    const sseSender = (msg: ServerMessage) => {
+      const frame = msg as { type: string; [key: string]: unknown };
+      sentFrames.push(frame);
+
+      if (frame.type === "host_browser_request") {
+        const requestId = frame.requestId as string;
+
+        // Register the pending interaction (in production this happens
+        // in makeHubPublisher inside conversation-routes.ts).
+        pendingInteractions.register(requestId, {
+          conversation,
+          conversationId,
+          kind: "host_browser",
+        });
+
+        // Simulate the macOS desktop client processing the CDP command
+        // and POSTing the result back to the runtime.
+        const cdpMethod = frame.cdpMethod as string;
+        let content: string;
+        let isError = false;
+        if (cdpMethod === "Browser.getVersion") {
+          content = JSON.stringify({
+            product: "Chrome/macOS-SSE-Test",
+            protocolVersion: "1.3",
+            revision: "@macos-sse",
+            userAgent: "Mozilla/5.0 (macOS SSE bridge e2e fixture)",
+            jsVersion: "0.0.0-macos-sse",
+          });
+        } else if (cdpMethod === "Runtime.evaluate") {
+          content = JSON.stringify({ result: { value: "complete" } });
+        } else {
+          content = `mock macOS client: unsupported cdpMethod "${cdpMethod}"`;
+          isError = true;
+        }
+
+        // POST result asynchronously (simulating the real macOS client).
+        void fetch(`${runtimeBaseUrl}/v1/host-browser-result`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ requestId, content, isError }),
+        })
+          .then((res) => res.body?.cancel())
+          .catch(() => {});
+      }
+    };
+
+    const proxy = new HostBrowserProxy(sseSender);
+    proxyRef = proxy;
+    return { proxy, conversation, sentFrames };
+  }
+
+  test("happy path: Browser.getVersion round-trips through the SSE bridge without extension registry", async () => {
+    const guardianId = `test-guardian-macos-sse-${crypto.randomUUID()}`;
+    const token = mintActorToken(guardianId);
+
+    const { proxy, sentFrames } = createSseBoundProxy(
+      "conv-macos-sse-happy",
+      token,
+    );
+
+    const result = await proxy.request(
+      { cdpMethod: "Browser.getVersion" },
+      "conv-macos-sse-happy",
+    );
+
+    // The request completed via the SSE bridge path, not the extension registry.
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Chrome/macOS-SSE-Test");
+
+    // The SSE sender received exactly one host_browser_request frame.
+    const requests = sentFrames.filter(
+      (f) => f.type === "host_browser_request",
+    );
+    expect(requests).toHaveLength(1);
+    expect(requests[0].cdpMethod).toBe("Browser.getVersion");
+    expect(requests[0].conversationId).toBe("conv-macos-sse-happy");
+
+    // The extension registry should NOT have been involved — no entries exist.
+    expect(getChromeExtensionRegistry().get(guardianId)).toBeUndefined();
+
+    proxy.dispose();
+  });
+
+  test("abort: SSE-bridged request resolves to 'Aborted' when signal fires", async () => {
+    const guardianId = `test-guardian-macos-sse-abort-${crypto.randomUUID()}`;
+    const _token = mintActorToken(guardianId);
+
+    // Use a CDP handler that hangs forever so we can abort mid-flight.
+    const sentFrames: Array<{ type: string; [key: string]: unknown }> = [];
+    let proxyRef: HostBrowserProxy | null = null;
+    const conversation = {
+      resolveHostBrowser(
+        requestId: string,
+        response: { content: string; isError: boolean },
+      ) {
+        proxyRef?.resolve(requestId, response);
+      },
+    } as unknown as Conversation;
+
+    const hangingSender = (msg: ServerMessage) => {
+      const frame = msg as { type: string; [key: string]: unknown };
+      sentFrames.push(frame);
+      if (frame.type === "host_browser_request") {
+        const requestId = frame.requestId as string;
+        pendingInteractions.register(requestId, {
+          conversation,
+          conversationId: "conv-macos-sse-abort",
+          kind: "host_browser",
+        });
+        // Simulate a macOS client that never responds (hangs).
+      }
+    };
+
+    const proxy = new HostBrowserProxy(hangingSender);
+    proxyRef = proxy;
+
+    const controller = new AbortController();
+    const resultPromise = proxy.request(
+      { cdpMethod: "Browser.getVersion" },
+      "conv-macos-sse-abort",
+      controller.signal,
+    );
+
+    // Wait for the SSE sender to observe the request.
+    await waitFor(() => sentFrames.length === 1);
+
+    controller.abort();
+    const result = await resultPromise;
+
+    expect(result.content).toBe("Aborted");
+    expect(result.isError).toBe(true);
+
+    // The cancel frame should have been sent through the SSE sender.
+    const cancels = sentFrames.filter((f) => f.type === "host_browser_cancel");
+    expect(cancels).toHaveLength(1);
+
+    proxy.dispose();
+  });
+
+  test("timeout: SSE-bridged request surfaces timeout when macOS client never responds", async () => {
+    const guardianId = `test-guardian-macos-sse-timeout-${crypto.randomUUID()}`;
+    const _token = mintActorToken(guardianId);
+
+    const sentFrames: Array<{ type: string; [key: string]: unknown }> = [];
+    let proxyRef: HostBrowserProxy | null = null;
+    const conversation = {
+      resolveHostBrowser(
+        requestId: string,
+        response: { content: string; isError: boolean },
+      ) {
+        proxyRef?.resolve(requestId, response);
+      },
+    } as unknown as Conversation;
+
+    const hangingSender = (msg: ServerMessage) => {
+      const frame = msg as { type: string; [key: string]: unknown };
+      sentFrames.push(frame);
+      if (frame.type === "host_browser_request") {
+        const requestId = frame.requestId as string;
+        pendingInteractions.register(requestId, {
+          conversation,
+          conversationId: "conv-macos-sse-timeout",
+          kind: "host_browser",
+        });
+        // Never respond — simulate unresponsive macOS client.
+      }
+    };
+
+    const proxy = new HostBrowserProxy(hangingSender);
+    proxyRef = proxy;
+
+    const result = await proxy.request(
+      { cdpMethod: "Browser.getVersion", timeout_seconds: 0.05 },
+      "conv-macos-sse-timeout",
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("timed out");
+
+    // The SSE sender received the request frame (confirming the timeout
+    // is from the proxy timer, not a send failure).
+    const requests = sentFrames.filter(
+      (f) => f.type === "host_browser_request",
+    );
+    expect(requests).toHaveLength(1);
+    expect(requests[0].cdpMethod).toBe("Browser.getVersion");
+
+    proxy.dispose();
+  });
+
+  test("multiple sequential commands round-trip through the SSE bridge", async () => {
+    const guardianId = `test-guardian-macos-sse-seq-${crypto.randomUUID()}`;
+    const token = mintActorToken(guardianId);
+
+    const { proxy, sentFrames } = createSseBoundProxy(
+      "conv-macos-sse-seq",
+      token,
+    );
+
+    // First command: Browser.getVersion
+    const result1 = await proxy.request(
+      { cdpMethod: "Browser.getVersion" },
+      "conv-macos-sse-seq",
+    );
+    expect(result1.isError).toBe(false);
+    expect(result1.content).toContain("Chrome/macOS-SSE-Test");
+
+    // Second command: Runtime.evaluate
+    const result2 = await proxy.request(
+      { cdpMethod: "Runtime.evaluate", cdpParams: { expression: "1+1" } },
+      "conv-macos-sse-seq",
+    );
+    expect(result2.isError).toBe(false);
+
+    // Both requests went through the SSE sender.
+    const requests = sentFrames.filter(
+      (f) => f.type === "host_browser_request",
+    );
+    expect(requests).toHaveLength(2);
+    expect(requests[0].cdpMethod).toBe("Browser.getVersion");
+    expect(requests[1].cdpMethod).toBe("Runtime.evaluate");
+
+    proxy.dispose();
+  });
+});
+
 // ── Local wait helpers ──────────────────────────────────────────────
 
 async function waitFor(

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -79,11 +79,20 @@ See `docs/browser-use-architecture-phase2.md` for the full wire diagram and comp
 
 On macOS-originated turns, the CDP factory (`tools/browser/cdp-client/factory.ts`) evaluates three browser backends in strict priority order. Each candidate is tried lazily; if the first command fails with a transport-level error, the factory falls over to the next candidate. CDP protocol errors (the browser understood the command but rejected it) do NOT trigger failover.
 
-| Priority | Backend         | Condition                                                                                                                                                                                           | Source                                                                                                |
-| -------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| 1        | **Extension**   | `hostBrowserProxy` present AND `isAvailable()` returns `true`. On macOS, the proxy is always provisioned (SSE sender when no extension is present, registry-routed when extension is connected)     | SSE sender via `conversation-routes.ts` or `ChromeExtensionRegistry` via `resolveHostBrowserSender()` |
-| 2        | **cdp-inspect** | (a) `hostBrowser.cdpInspect.enabled` is `true` in config, OR (b) `transportInterface === "macos"` AND `desktopAuto.enabled` is `true` (default) AND the cooldown from a prior failure is not active | Config + `desktopAuto` policy in factory                                                              |
-| 3        | **Local**       | Always present as the final fallback                                                                                                                                                                | Playwright sacrificial-profile browser managed by `browserManager`                                    |
+| Priority | Backend                    | Condition                                                                                                                                                                                           | Transport                                                                                              |
+| -------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| 1        | **Extension / host proxy** | `hostBrowserProxy` present AND `isAvailable()` returns `true`. On macOS, the proxy is always provisioned (SSE sender when no extension is present, registry-routed when extension is connected)     | WS via `ChromeExtensionRegistry` (extension present) or SSE via `assistantEventHub` (macOS host proxy) |
+| 2        | **cdp-inspect**            | (a) `hostBrowser.cdpInspect.enabled` is `true` in config, OR (b) `transportInterface === "macos"` AND `desktopAuto.enabled` is `true` (default) AND the cooldown from a prior failure is not active | Direct CDP WebSocket to `localhost:9222`                                                               |
+| 3        | **Local**                  | Always present as the final fallback                                                                                                                                                                | In-process Playwright CDP via `browserManager`                                                         |
+
+**Transport selection for the extension/host-proxy backend:**
+
+The "extension" backend label is a misnomer inherited from the original Phase 2 design where only the Chrome Extension provided host-browser access. In the current architecture, two transports can power this backend:
+
+- **Extension WebSocket**: When the `ChromeExtensionRegistry` has an active entry for the guardian, `resolveHostBrowserSender()` returns a registry-routed sender. `host_browser_request` frames travel over the `/v1/browser-relay` WebSocket to the Chrome extension, which executes CDP commands via `chrome.debugger`.
+- **macOS SSE bridge**: When the macOS desktop client is connected but no extension is present, `resolveHostBrowserSender()` returns the `onEvent` SSE hub sender. `host_browser_request` frames travel through `assistantEventHub` to the desktop client's SSE connection. The desktop client executes CDP commands against the local Chrome and POSTs results back to `/v1/host-browser-result`.
+
+Both transports use the same `HostBrowserProxy` → `ExtensionCdpClient` pipeline. The `browser_status` output distinguishes the transport via the `details.transport` field: `"extension-ws"` or `"macos-sse"`.
 
 **Fallback criteria for cdp-inspect (desktop-auto):**
 
@@ -98,24 +107,24 @@ On macOS-originated turns, the CDP factory (`tools/browser/cdp-client/factory.ts
 
 All CDP-backed browser tools (`browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, `browser_hover`, `browser_scroll`, `browser_press_key`, `browser_select_option`, `browser_wait_for`, `browser_extract`, `browser_fill_credential`, `browser_attach`, `browser_detach`, `browser_close`, `browser_status`) accept an optional `browser_mode` input parameter that overrides the automatic backend selection for that invocation.
 
-| Value            | Behavior                                                                 |
-| ---------------- | ------------------------------------------------------------------------ |
-| `auto` (default) | Existing priority-ordered fallback: extension -> cdp-inspect -> local    |
-| `extension`      | Pin to chrome-extension backend. Fails immediately if proxy unavailable. |
-| `cdp-inspect`    | Pin to CDP inspect/debugger backend. Fails if endpoint unreachable.      |
-| `local`          | Pin to local Playwright-managed browser. No fallback.                    |
-| `cdp-debugger`   | Alias for `cdp-inspect`.                                                 |
-| `playwright`     | Alias for `local`.                                                       |
+| Value            | Behavior                                                                     |
+| ---------------- | ---------------------------------------------------------------------------- |
+| `auto` (default) | Existing priority-ordered fallback: extension -> cdp-inspect -> local        |
+| `extension`      | Pin to extension/host-proxy backend. Fails immediately if proxy unavailable. |
+| `cdp-inspect`    | Pin to CDP inspect/debugger backend. Fails if endpoint unreachable.          |
+| `local`          | Pin to local Playwright-managed browser. No fallback.                        |
+| `cdp-debugger`   | Alias for `cdp-inspect`.                                                     |
+| `playwright`     | Alias for `local`.                                                           |
 
 **Strict pinned-mode semantics**: When `browser_mode` is set to a specific backend (not `auto`), the factory builds exactly one candidate and disables failover. If the pinned backend is unavailable, the tool returns a detailed error including:
 
 - The requested mode
 - An ordered list of attempted backends with exact failure reasons
-- A remediation checklist tailored by backend and failure code (e.g. "Ensure Chrome is running with --remote-debugging-port=9222")
+- A remediation checklist tailored by backend, failure code, and transport (e.g. for macOS SSE: "Verify the Vellum desktop app is running"; for extension: "Ensure Chrome is running with the extension paired")
 
 **Auto-mode fallback logging**: In auto mode, fallback transitions are logged at `warn` level with structured metadata including the full candidate sequence and per-candidate failure reasons. This ensures fallback events are always observable in production logs.
 
-**Test coverage:** Regression tests for `browser_mode` wiring live in `__tests__/headless-browser-mode.test.ts`. E2E regression tests for backend precedence live in `__tests__/host-browser-e2e-cloud.test.ts` (extension path) and `__tests__/conversation-routes-disk-view.test.ts` (macOS fallback path). Unit tests for pinned candidate construction and failover live in `tools/browser/cdp-client/__tests__/factory.test.ts`.
+**Test coverage:** Regression tests for `browser_mode` wiring live in `__tests__/headless-browser-mode.test.ts`. E2E regression tests for backend precedence live in `__tests__/host-browser-e2e-cloud.test.ts` (extension path and macOS SSE bridge path) and `__tests__/conversation-routes-disk-view.test.ts` (macOS fallback path). Unit tests for pinned candidate construction and failover live in `tools/browser/cdp-client/__tests__/factory.test.ts`. Browser status tests covering macOS host-browser diagnostics live in `tools/browser/__tests__/browser-status.test.ts`.
 
 ### Channel approvals (Telegram, Slack)
 

--- a/assistant/src/tools/browser/__tests__/browser-status.test.ts
+++ b/assistant/src/tools/browser/__tests__/browser-status.test.ts
@@ -163,4 +163,172 @@ describe("executeBrowserStatus", () => {
     expect(extension.verified).toBe("active_probe");
     expect(extension.details.restrictedActiveTab).toBe(true);
   });
+
+  // ── macOS host-browser proxy mode tests ─────────────────────────────
+
+  test("macOS: reports host browser proxy as available when proxy is bound and connected", async () => {
+    const result = await executeBrowserStatus(
+      {},
+      makeContext({
+        transportInterface: "macos",
+        hostBrowserProxy: {
+          isAvailable: () => true,
+        } as ToolContext["hostBrowserProxy"],
+      }),
+    );
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content);
+    const extension = payload.modes.find(
+      (m: { mode: string }) => m.mode === BROWSER_STATUS_MODE.EXTENSION,
+    );
+    expect(extension).toBeDefined();
+    expect(extension.available).toBe(true);
+    expect(extension.verified).toBe("active_probe");
+    expect(extension.summary).toContain("macOS host browser proxy");
+    expect(extension.details.transport).toBe("macos-sse");
+  });
+
+  test("macOS: reports proxy unbound with macOS-specific actions when no proxy is present", async () => {
+    const result = await executeBrowserStatus(
+      {},
+      makeContext({
+        transportInterface: "macos",
+      }),
+    );
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content);
+    const extension = payload.modes.find(
+      (m: { mode: string }) => m.mode === BROWSER_STATUS_MODE.EXTENSION,
+    );
+    expect(extension).toBeDefined();
+    expect(extension.available).toBe(false);
+    expect(extension.summary).toContain("macOS host browser proxy");
+    expect(extension.summary).toContain("desktop client");
+    expect(extension.details.transport).toBe("macos-sse");
+    // macOS-specific user actions should mention the desktop app, not the extension
+    expect(
+      extension.userActions.some((a: string) => a.includes("desktop app")),
+    ).toBe(true);
+  });
+
+  test("macOS: reports proxy disconnected with reconnect actions when proxy is bound but not available", async () => {
+    const result = await executeBrowserStatus(
+      {},
+      makeContext({
+        transportInterface: "macos",
+        hostBrowserProxy: {
+          isAvailable: () => false,
+        } as ToolContext["hostBrowserProxy"],
+      }),
+    );
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content);
+    const extension = payload.modes.find(
+      (m: { mode: string }) => m.mode === BROWSER_STATUS_MODE.EXTENSION,
+    );
+    expect(extension).toBeDefined();
+    expect(extension.available).toBe(false);
+    expect(extension.summary).toContain("macOS host browser proxy");
+    expect(extension.summary).toContain("SSE transport");
+    expect(extension.details.transport).toBe("macos-sse");
+    // Should suggest reconnection, not extension install
+    expect(
+      extension.userActions.some((a: string) => a.includes("desktop app")),
+    ).toBe(true);
+  });
+
+  test("macOS: probe failure diagnostics include transport-specific remediation", async () => {
+    probeOutcomes[BROWSER_STATUS_MODE.EXTENSION] = "fail";
+    probeErrors[BROWSER_STATUS_MODE.EXTENSION] = new CdpError(
+      "transport_error",
+      "transport disconnected before response",
+    );
+
+    const result = await executeBrowserStatus(
+      {},
+      makeContext({
+        transportInterface: "macos",
+        hostBrowserProxy: {
+          isAvailable: () => true,
+        } as ToolContext["hostBrowserProxy"],
+      }),
+    );
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content);
+    const extension = payload.modes.find(
+      (m: { mode: string }) => m.mode === BROWSER_STATUS_MODE.EXTENSION,
+    );
+    expect(extension).toBeDefined();
+    expect(extension.available).toBe(false);
+    expect(extension.summary).toContain("macOS host browser proxy");
+    // Should have remediation actions mentioning SSE bridge
+    expect(
+      extension.userActions.some((a: string) => a.includes("SSE bridge")),
+    ).toBe(true);
+  });
+
+  test("recommendation order follows auto candidate precedence for macOS with available extension proxy", async () => {
+    const result = await executeBrowserStatus(
+      {},
+      makeContext({
+        transportInterface: "macos",
+        hostBrowserProxy: {
+          isAvailable: () => true,
+        } as ToolContext["hostBrowserProxy"],
+      }),
+    );
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content);
+    // Extension is the top auto candidate and is available, so it should be recommended
+    expect(payload.recommendedMode).toBe(BROWSER_STATUS_MODE.EXTENSION);
+    expect(payload.autoCandidateOrder[0]).toBe(BROWSER_STATUS_MODE.EXTENSION);
+  });
+
+  test("recommendation falls to cdp-inspect when macOS proxy is unavailable", async () => {
+    // Extension probe fails
+    probeOutcomes[BROWSER_STATUS_MODE.EXTENSION] = "fail";
+    probeErrors[BROWSER_STATUS_MODE.EXTENSION] = new CdpError(
+      "transport_error",
+      "proxy not connected",
+    );
+
+    const result = await executeBrowserStatus(
+      {},
+      makeContext({
+        transportInterface: "macos",
+        // No proxy bound, so extension unavailable
+      }),
+    );
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content);
+    // Extension is unavailable (no proxy), so recommendation should fall to next available
+    expect(payload.recommendedMode).toBe(BROWSER_STATUS_MODE.CDP_INSPECT);
+  });
+
+  test("macOS: restricted chrome:// page probe includes macOS transport details", async () => {
+    probeOutcomes[BROWSER_STATUS_MODE.EXTENSION] = "fail";
+    probeErrors[BROWSER_STATUS_MODE.EXTENSION] = new CdpError(
+      "cdp_error",
+      "Cannot access a chrome:// URL",
+    );
+
+    const result = await executeBrowserStatus(
+      {},
+      makeContext({
+        transportInterface: "macos",
+        hostBrowserProxy: {
+          isAvailable: () => true,
+        } as ToolContext["hostBrowserProxy"],
+      }),
+    );
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content);
+    const extension = payload.modes.find(
+      (m: { mode: string }) => m.mode === BROWSER_STATUS_MODE.EXTENSION,
+    );
+    expect(extension).toBeDefined();
+    expect(extension.available).toBe(true);
+    expect(extension.summary).toContain("macOS host browser proxy");
+    expect(extension.details.transport).toBe("macos-sse");
+  });
 });

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -88,9 +88,9 @@ type StatusCheckMode = BrowserStatusMode;
 const MODE_TRADEOFFS: Record<StatusCheckMode, string[]> = {
   [BROWSER_STATUS_MODE.EXTENSION]: [
     "This is the preferred approach for all things browser-use.",
-    "It requires a one-time install of the Vellum Assistant Chrome Extension.",
+    "On macOS, the host browser proxy is provisioned automatically via the desktop client's SSE bridge — no extension install required.",
+    "When the Chrome extension is also installed, it takes priority for direct WebSocket routing to the user's Chrome session.",
     "More secure than relying on Chrome's native remote debugging functionality.",
-    "Requires the Vellum extension to be paired and actively connected.",
   ],
   [BROWSER_STATUS_MODE.CDP_INSPECT]: [
     "This is the second-best approach for all things browser-use, after the native Vellum Assistant Chrome Extension.",
@@ -190,9 +190,10 @@ export function parseBrowserMode(
 const REMEDIATION_HINTS: Record<string, string[]> = {
   // Extension backend
   "extension:transport_error": [
-    "Ensure the Vellum browser extension is installed and enabled.",
-    "Check that the extension WebSocket connection is active (extension popup → status).",
-    "Try reconnecting the extension or reloading the extension service worker.",
+    "Ensure the Vellum browser extension is installed and enabled, or that the macOS desktop client is running for host browser proxy mode.",
+    "For extension mode: check that the extension WebSocket connection is active (extension popup → status).",
+    "For macOS host browser proxy: verify the desktop client is running and has an active SSE connection to the assistant.",
+    "Try reconnecting the extension or restarting the desktop client.",
   ],
   // cdp-inspect backend — discovery-level failures
   "cdp-inspect:unreachable": [
@@ -2098,6 +2099,43 @@ function extensionSetupActions(): string[] {
   ];
 }
 
+function macOSHostBrowserSetupActions(): string[] {
+  return [
+    "Ensure the Vellum desktop app is running and connected to the assistant.",
+    "Open Google Chrome on the desktop machine so the host browser proxy can attach.",
+    "If the desktop client is not running, launch it and wait for the SSE connection to establish.",
+  ];
+}
+
+function macOSHostBrowserReconnectActions(): string[] {
+  return [
+    "Verify the Vellum desktop app is still running and has an active network connection.",
+    "If the desktop client was recently restarted, send a new message to re-establish the SSE bridge.",
+    "Ensure Chrome is open on the desktop machine for the host browser proxy to target.",
+  ];
+}
+
+function macOSHostBrowserProbeFailureActions(error: CdpError): string[] {
+  const actions: string[] = [
+    "Ensure Google Chrome is running on the desktop machine.",
+  ];
+  const message = error.message.toLowerCase();
+  if (message.includes("timeout") || message.includes("timed out")) {
+    actions.push(
+      "The desktop client may be unresponsive — try restarting the Vellum desktop app.",
+    );
+  }
+  if (message.includes("transport") || message.includes("disconnected")) {
+    actions.push(
+      "The SSE bridge between the assistant and the desktop client appears broken. Send a new message to re-establish the connection.",
+    );
+  }
+  actions.push(
+    "Switch Chrome to a regular http(s) tab (not chrome://...) and retry.",
+  );
+  return dedupeStrings(actions);
+}
+
 function cdpInspectSetupActions(): string[] {
   return [
     "Update Chrome to the latest version by going to chrome://settings/help",
@@ -2247,6 +2285,7 @@ async function checkExtensionModeStatus(
 ): Promise<BrowserStatusModeResult> {
   const proxyBound = Boolean(context.hostBrowserProxy);
   const proxyConnected = context.hostBrowserProxy?.isAvailable() ?? false;
+  const isMacOS = context.transportInterface === "macos";
 
   if (!proxyBound) {
     return {
@@ -2254,13 +2293,17 @@ async function checkExtensionModeStatus(
       available: false,
       verified: "preflight",
       autoCandidate,
-      summary:
-        "Extension mode is unavailable: no host browser proxy is bound to this conversation.",
-      userActions: extensionSetupActions(),
+      summary: isMacOS
+        ? "Extension mode is unavailable: the macOS host browser proxy is not bound to this conversation. Ensure the desktop client is connected."
+        : "Extension mode is unavailable: no host browser proxy is bound to this conversation.",
+      userActions: isMacOS
+        ? macOSHostBrowserSetupActions()
+        : extensionSetupActions(),
       tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.EXTENSION),
       details: {
         proxyBound,
         proxyConnected,
+        transport: isMacOS ? "macos-sse" : "extension-ws",
       },
     };
   }
@@ -2271,13 +2314,17 @@ async function checkExtensionModeStatus(
       available: false,
       verified: "preflight",
       autoCandidate,
-      summary:
-        "Extension mode is unavailable: the extension transport is currently disconnected.",
-      userActions: extensionSetupActions(),
+      summary: isMacOS
+        ? "Extension mode is unavailable: the macOS host browser proxy is bound but the SSE transport is currently disconnected. Verify the desktop client is running and connected."
+        : "Extension mode is unavailable: the extension transport is currently disconnected.",
+      userActions: isMacOS
+        ? macOSHostBrowserReconnectActions()
+        : extensionSetupActions(),
       tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.EXTENSION),
       details: {
         proxyBound,
         proxyConnected,
+        transport: isMacOS ? "macos-sse" : "extension-ws",
       },
     };
   }
@@ -2292,13 +2339,16 @@ async function checkExtensionModeStatus(
       available: true,
       verified: "active_probe",
       autoCandidate,
-      summary: "Extension mode is ready and responded to an active CDP probe.",
+      summary: isMacOS
+        ? "Extension mode is ready via macOS host browser proxy and responded to an active CDP probe."
+        : "Extension mode is ready and responded to an active CDP probe.",
       userActions: [],
       tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.EXTENSION),
       details: {
         proxyBound,
         proxyConnected,
         backendKind: probe.backendKind,
+        transport: isMacOS ? "macos-sse" : "extension-ws",
       },
     };
   }
@@ -2309,8 +2359,9 @@ async function checkExtensionModeStatus(
       available: true,
       verified: "active_probe",
       autoCandidate,
-      summary:
-        "Extension mode transport is connected, but the active Chrome tab is a restricted chrome:// page. Switch to a regular website tab if browser actions fail.",
+      summary: isMacOS
+        ? "Extension mode transport is connected via macOS host browser proxy, but the active Chrome tab is a restricted chrome:// page. Switch to a regular website tab if browser actions fail."
+        : "Extension mode transport is connected, but the active Chrome tab is a restricted chrome:// page. Switch to a regular website tab if browser actions fail.",
       userActions: [
         "Switch Chrome to a regular http(s) tab (not chrome://...) and retry.",
       ],
@@ -2322,6 +2373,7 @@ async function checkExtensionModeStatus(
         errorCode: probe.error.code,
         diagnostic: probe.diagnostic,
         attemptDiagnostics: probe.error.attemptDiagnostics ?? [],
+        transport: isMacOS ? "macos-sse" : "extension-ws",
       },
     };
   }
@@ -2331,11 +2383,12 @@ async function checkExtensionModeStatus(
     available: false,
     verified: "active_probe",
     autoCandidate,
-    summary: `Extension mode probe failed: ${probe.error.message}`,
-    userActions: probeFailureActions(
-      BROWSER_STATUS_MODE.EXTENSION,
-      probe.error,
-    ),
+    summary: isMacOS
+      ? `Extension mode probe failed via macOS host browser proxy: ${probe.error.message}`
+      : `Extension mode probe failed: ${probe.error.message}`,
+    userActions: isMacOS
+      ? macOSHostBrowserProbeFailureActions(probe.error)
+      : probeFailureActions(BROWSER_STATUS_MODE.EXTENSION, probe.error),
     tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.EXTENSION),
     details: {
       proxyBound,
@@ -2343,6 +2396,7 @@ async function checkExtensionModeStatus(
       errorCode: probe.error.code,
       diagnostic: probe.diagnostic,
       attemptDiagnostics: probe.error.attemptDiagnostics ?? [],
+      transport: isMacOS ? "macos-sse" : "extension-ws",
     },
   };
 }


### PR DESCRIPTION
## Summary
- Update browser status UX for macOS host-browser proxy mode with actionable remediation
- Add browser status tests for macOS host-browser availability and diagnostics
- Extend E2E tests for macOS cloud + SSE bridge routing path
- Update architecture docs with transport precedence matrix

Part of plan: host-browser-via-macos-host-proxy.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
