### PR TITLE
fix(macOS): add missing VellumAssistantShared import to RuleEditorModal

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import VellumAssistantShared
 
 // MARK: - Helper Types
 


### PR DESCRIPTION
## Summary
- Add missing `import VellumAssistantShared` to `RuleEditorModal.swift`, which resolves the `cannot find 'VButton' in scope` build error
- The file uses `VButton`, `VColor`, `VFont`, `VSpacing`, `VRadius`, and `VIcon` from the shared design system but was missing the import

## Original prompt
Fix macOS build errors: `cannot find 'VButton' in scope` and `cannot infer contextual base in reference to member 'primary'` in `RuleEditorModal.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
