### PR TITLE
fix: browser_status reports correct transport when macOS uses extension

### DIFF
--- a/assistant/src/tools/browser/__tests__/browser-status.test.ts
+++ b/assistant/src/tools/browser/__tests__/browser-status.test.ts
@@ -188,6 +188,27 @@ describe("executeBrowserStatus", () => {
     expect(extension.details.transport).toBe("macos-sse");
   });
 
+  test("macOS: reports transport as extension-ws when hostBrowserRegistryRouted is true", async () => {
+    const result = await executeBrowserStatus(
+      {},
+      makeContext({
+        transportInterface: "macos",
+        hostBrowserRegistryRouted: true,
+        hostBrowserProxy: {
+          isAvailable: () => true,
+        } as ToolContext["hostBrowserProxy"],
+      }),
+    );
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content);
+    const extension = payload.modes.find(
+      (m: { mode: string }) => m.mode === BROWSER_STATUS_MODE.EXTENSION,
+    );
+    expect(extension).toBeDefined();
+    expect(extension.available).toBe(true);
+    expect(extension.details.transport).toBe("extension-ws");
+  });
+
   test("macOS: reports proxy unbound with macOS-specific actions when no proxy is present", async () => {
     const result = await executeBrowserStatus(
       {},

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -2303,7 +2303,10 @@ async function checkExtensionModeStatus(
       details: {
         proxyBound,
         proxyConnected,
-        transport: isMacOS ? "macos-sse" : "extension-ws",
+        transport:
+          isMacOS && !context.hostBrowserRegistryRouted
+            ? "macos-sse"
+            : "extension-ws",
       },
     };
   }
@@ -2324,7 +2327,10 @@ async function checkExtensionModeStatus(
       details: {
         proxyBound,
         proxyConnected,
-        transport: isMacOS ? "macos-sse" : "extension-ws",
+        transport:
+          isMacOS && !context.hostBrowserRegistryRouted
+            ? "macos-sse"
+            : "extension-ws",
       },
     };
   }
@@ -2348,7 +2354,10 @@ async function checkExtensionModeStatus(
         proxyBound,
         proxyConnected,
         backendKind: probe.backendKind,
-        transport: isMacOS ? "macos-sse" : "extension-ws",
+        transport:
+          isMacOS && !context.hostBrowserRegistryRouted
+            ? "macos-sse"
+            : "extension-ws",
       },
     };
   }
@@ -2373,7 +2382,10 @@ async function checkExtensionModeStatus(
         errorCode: probe.error.code,
         diagnostic: probe.diagnostic,
         attemptDiagnostics: probe.error.attemptDiagnostics ?? [],
-        transport: isMacOS ? "macos-sse" : "extension-ws",
+        transport:
+          isMacOS && !context.hostBrowserRegistryRouted
+            ? "macos-sse"
+            : "extension-ws",
       },
     };
   }
@@ -2396,7 +2408,10 @@ async function checkExtensionModeStatus(
       errorCode: probe.error.code,
       diagnostic: probe.diagnostic,
       attemptDiagnostics: probe.error.attemptDiagnostics ?? [],
-      transport: isMacOS ? "macos-sse" : "extension-ws",
+      transport:
+        isMacOS && !context.hostBrowserRegistryRouted
+          ? "macos-sse"
+          : "extension-ws",
     },
   };
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for host-browser-via-macos-host-proxy.md.

**Gap:** browser_status reports wrong transport when macOS has extension connected
**What was expected:** transport should be extension-ws when hostBrowserRegistryRouted is true
**What was found:** transport was always macos-sse for macOS turns
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
