### PR TITLE
fix: validate loopback on webSocketDebuggerUrl from /json/list

### DIFF
--- a/clients/shared/Network/HostBrowserExecutor.swift
+++ b/clients/shared/Network/HostBrowserExecutor.swift
@@ -155,6 +155,18 @@ public final class HostBrowserExecutor {
             )
         }
 
+        // Validate that the WebSocket URL also points to a loopback address.
+        // A process on localhost:9222 could return a non-loopback wsURL to
+        // redirect the client to an arbitrary remote host.
+        guard let wsHost = wsEndpoint.host, Self.allowedLoopbackHosts.contains(wsHost.lowercased()) else {
+            let wsHostDisplay = wsEndpoint.host ?? "<none>"
+            return Self.transportError(
+                requestId: request.requestId,
+                code: "non_loopback",
+                message: "WebSocket URL host '\(wsHostDisplay)' is not a loopback address. Only localhost, 127.0.0.1, and ::1 are permitted."
+            )
+        }
+
         do {
             let result = try await sendCDPCommand(
                 endpoint: wsEndpoint,

--- a/clients/shared/Tests/HostBrowserExecutorTests.swift
+++ b/clients/shared/Tests/HostBrowserExecutorTests.swift
@@ -47,6 +47,31 @@ final class HostBrowserExecutorTests: XCTestCase {
         XCTAssertEqual(json["message"] as? String, "Connection refused")
     }
 
+    /// The `non_loopback` error code is used when either the initial HTTP
+    /// endpoint or the WebSocket URL from `/json/list` points to a
+    /// non-loopback host. Verify it produces valid structured JSON.
+    func testTransportErrorNonLoopbackFormatsStructuredJSON() {
+        let result = HostBrowserExecutor.transportError(
+            requestId: "req-ws-loopback",
+            code: "non_loopback",
+            message: "WebSocket URL host 'evil.example.com' is not a loopback address. Only localhost, 127.0.0.1, and ::1 are permitted."
+        )
+
+        XCTAssertEqual(result.requestId, "req-ws-loopback")
+        XCTAssertTrue(result.isError, "non_loopback errors must set isError=true for backend failover")
+
+        guard let data = result.content.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            XCTFail("Transport error content should be valid JSON")
+            return
+        }
+        XCTAssertEqual(json["code"] as? String, "non_loopback")
+        XCTAssertTrue(
+            (json["message"] as? String)?.contains("evil.example.com") == true,
+            "Error message should include the rejected host"
+        )
+    }
+
     // MARK: - Executor Run (Unit — No Real Chrome)
 
     /// When Chrome DevTools is not running, the executor should return a


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for host-browser-via-macos-host-proxy.md.

**Gap:** Missing loopback validation on webSocketDebuggerUrl
**What was expected:** WS URL host should be validated against loopback allowlist
**What was found:** Only the initial HTTP endpoint was validated

## Changes
- After parsing `webSocketDebuggerUrl` from Chrome's `/json/list` response, extract the host and validate it against `allowedLoopbackHosts`. If the WS URL host is not loopback, return a structured transport error with code `non_loopback`.
- Added test for the `non_loopback` transport error code formatting.

## Test plan
- [x] New test verifies `non_loopback` transport error produces valid structured JSON with the rejected host in the message
- [x] Existing tests continue to pass (unreachable endpoint, cancellation)
- [x] Swift build succeeds locally (`swift build` in `clients/`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
