### PR TITLE
fix(client): use assistantFeatureFlagStore for permission-controls-v3 flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -7,6 +7,8 @@ import Dispatch
 /// Unified container that handles all tool progress states through a single component
 /// that smoothly morphs between phases.
 struct AssistantProgressView: View {
+    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore
+
     let toolCalls: [ToolCallData]
     let isStreaming: Bool
     let hasText: Bool
@@ -640,7 +642,7 @@ struct AssistantProgressView: View {
                     ToolConfirmationBubble(
                         confirmation: confirmation,
                         isKeyboardActive: confirmation.requestId == activeConfirmationRequestId,
-                        isV3: MacOSClientFeatureFlagManager.shared.isEnabled("permission-controls-v3"),
+                        isV3: assistantFeatureFlagStore.isEnabled("permission-controls-v3"),
                         onAllow: { onConfirmationAllow?(confirmation.requestId) },
                         onDeny: { onConfirmationDeny?(confirmation.requestId) },
                         onAlwaysAllow: onAlwaysAllow ?? { _, _, _, _ in },
@@ -725,6 +727,8 @@ private final class StepDetailAttributedStringCacheEntry: NSObject {
 /// Unified row for tool call steps — handles completed, running, and blocked states.
 /// Completed rows are expandable to show technical details, screenshots, and output.
 private struct StepDetailRow: View {
+    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore
+
     let toolCall: ToolCallData
     let phase: ProgressCardPhase
     /// Expansion state lifted to ChatBubble so it survives the
@@ -841,7 +845,7 @@ private struct StepDetailRow: View {
 
                     // Risk badge (expanded view only, gated on permission-controls-v3)
                     if let risk = toolCall.riskLevel,
-                       MacOSClientFeatureFlagManager.shared.isEnabled("permission-controls-v3") {
+                       assistantFeatureFlagStore.isEnabled("permission-controls-v3") {
                         RiskBadgeView(riskLevel: risk) {
                             ruleEditorToolCall = toolCall
                         }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
@@ -7,6 +7,8 @@ import VellumAssistantShared
 /// struct boundary for diffing: when all `let` inputs are equal, SwiftUI can
 /// skip re-evaluating the body during LazySubviewPlacements.updateValue.
 struct MessageCellView: View, Equatable {
+    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore
+
     static func == (lhs: MessageCellView, rhs: MessageCellView) -> Bool {
         lhs.message == rhs.message
             && lhs.showTimestamp == rhs.showTimestamp
@@ -163,7 +165,7 @@ struct MessageCellView: View, Equatable {
                     ToolConfirmationBubble(
                         confirmation: confirmation,
                         isKeyboardActive: confirmation.requestId == activePendingRequestId,
-                        isV3: MacOSClientFeatureFlagManager.shared.isEnabled("permission-controls-v3"),
+                        isV3: assistantFeatureFlagStore.isEnabled("permission-controls-v3"),
                         onAllow: { onConfirmationAllow?(confirmation.requestId) },
                         onDeny: { onConfirmationDeny?(confirmation.requestId) },
                         onAlwaysAllow: onAlwaysAllow ?? { _, _, _, _ in },
@@ -175,7 +177,7 @@ struct MessageCellView: View, Equatable {
                 if !hasPrecedingAssistant {
                     ToolConfirmationBubble(
                         confirmation: confirmation,
-                        isV3: MacOSClientFeatureFlagManager.shared.isEnabled("permission-controls-v3"),
+                        isV3: assistantFeatureFlagStore.isEnabled("permission-controls-v3"),
                         onAllow: { onConfirmationAllow?(confirmation.requestId) },
                         onDeny: { onConfirmationDeny?(confirmation.requestId) },
                         onAlwaysAllow: onAlwaysAllow ?? { _, _, _, _ in },

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionChatPreview.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionChatPreview.swift
@@ -20,6 +20,8 @@ import VellumAssistantShared
 /// stub closures for the non-relevant affordances (regenerate, fork,
 /// surfaces, retry, etc. are all no-ops in a detail-panel context).
 struct HomePermissionChatPreview: View {
+    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore
+
     let userMessage: String
     let assistantResponse: String
     let confirmation: ToolConfirmationData
@@ -51,7 +53,7 @@ struct HomePermissionChatPreview: View {
             // branch (guardian, surfaces, retry, etc.).
             ToolConfirmationBubble(
                 confirmation: confirmation,
-                isV3: MacOSClientFeatureFlagManager.shared.isEnabled("permission-controls-v3"),
+                isV3: assistantFeatureFlagStore.isEnabled("permission-controls-v3"),
                 onAllow: onAllow,
                 onDeny: onDeny,
                 onAlwaysAllow: onAlwaysAllow,

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -322,6 +322,7 @@ struct MainWindowView: View {
 
     var body: some View {
         coreLayoutView
+            .environment(assistantFeatureFlagStore)
             .opacity(showComingAlive ? 0 : 1)
             .overlay {
                 if showComingAlive {


### PR DESCRIPTION
## Summary
- The permission-controls-v3 flag has scope "assistant" in the registry, so MacOSClientFeatureFlagManager (macos-scoped only) never resolves it — the v3 prompt was unreachable
- Inject assistantFeatureFlagStore into SwiftUI environment at MainWindowView level
- Replace all 5 MacOSClientFeatureFlagManager.shared.isEnabled call sites with assistantFeatureFlagStore.isEnabled via @Environment
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
