### PR TITLE
feat(macOS): add VNotification feedback component to shared DesignSystem

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -95,6 +95,7 @@ public struct VNotification: View {
         Rectangle()
             .fill(foregroundColor.opacity(dividerOpacity))
             .frame(width: 1, height: 18)
+            .accessibilityHidden(true)
     }
 
     private var textFont: Font {
@@ -145,7 +146,7 @@ public struct VNotification: View {
         switch tone {
         case .positive: return .circleCheck
         case .negative: return .circleX
-        case .warning: return .info
+        case .warning: return .triangleAlert
         case .neutral: return .info
         }
     }

--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -41,13 +41,15 @@ public struct VNotification: View {
                     Text(message)
                         .font(textFont)
                         .foregroundStyle(textColor)
-                        .fixedSize(horizontal: false, vertical: true)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                 }
             } else {
                 Text(message)
                     .font(textFont)
                     .foregroundStyle(textColor)
-                    .fixedSize(horizontal: false, vertical: true)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
 
             Spacer()

--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+/// Compact single-line notification bar with optional action and dismiss. Positioned inline or pinned above content. See FeedbackGallerySection for variants.
+public struct VNotification: View {
+    public enum Tone { case positive, negative, warning, neutral }
+    public enum Style { case weak, strong }
+
+    public let message: String
+    public var tone: Tone
+    public var style: Style
+    public var showsLeadingIcon: Bool
+    public var actionLabel: String?
+    public var onAction: (() -> Void)?
+    public var onDismiss: (() -> Void)?
+
+    public init(
+        _ message: String,
+        tone: Tone = .positive,
+        style: Style = .weak,
+        showsLeadingIcon: Bool = true,
+        actionLabel: String? = nil,
+        onAction: (() -> Void)? = nil,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.message = message
+        self.tone = tone
+        self.style = style
+        self.showsLeadingIcon = showsLeadingIcon
+        self.actionLabel = actionLabel
+        self.onAction = onAction
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        HStack(alignment: .center, spacing: 0) {
+            if showsLeadingIcon {
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(leadingIcon, size: 12)
+                        .foregroundStyle(foregroundColor)
+                        .accessibilityHidden(true)
+                    Text(message)
+                        .font(textFont)
+                        .foregroundStyle(textColor)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            } else {
+                Text(message)
+                    .font(textFont)
+                    .foregroundStyle(textColor)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
+            if hasTrailingCluster {
+                HStack(spacing: VSpacing.sm) {
+                    if let actionLabel, let onAction {
+                        divider
+                        Button(action: onAction) {
+                            Text(actionLabel)
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(foregroundColor)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(actionLabel)
+                    }
+                    if let onDismiss {
+                        divider
+                        Button(action: onDismiss) {
+                            VIconView(.x, size: 10)
+                                .foregroundStyle(foregroundColor)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Dismiss")
+                    }
+                }
+            }
+        }
+        .frame(height: 32)
+        .padding(.horizontal, VSpacing.sm)
+        .background(backgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .accessibilityElement(children: isInteractive ? .contain : .combine)
+    }
+
+    private var hasTrailingCluster: Bool {
+        (actionLabel != nil && onAction != nil) || onDismiss != nil
+    }
+
+    private var isInteractive: Bool {
+        (actionLabel != nil && onAction != nil) || onDismiss != nil
+    }
+
+    private var divider: some View {
+        Rectangle()
+            .fill(foregroundColor.opacity(dividerOpacity))
+            .frame(width: 1, height: 18)
+    }
+
+    private var textFont: Font {
+        switch style {
+        case .weak: return VFont.bodyMediumDefault
+        case .strong: return VFont.bodyMediumLighter
+        }
+    }
+
+    private var textColor: Color {
+        if case .neutral = tone, case .weak = style {
+            return VColor.contentTertiary
+        }
+        return foregroundColor
+    }
+
+    private var backgroundColor: Color {
+        switch (tone, style) {
+        case (.positive, .weak): return VColor.systemPositiveWeak
+        case (.positive, .strong): return VColor.systemPositiveStrong
+        case (.negative, .weak): return VColor.systemNegativeWeak
+        case (.negative, .strong): return VColor.systemNegativeStrong
+        case (.warning, .weak): return VColor.systemMidWeak
+        case (.warning, .strong): return VColor.systemMidStrong
+        case (.neutral, .weak): return VColor.contentBackground
+        case (.neutral, .strong): return VColor.contentSecondary
+        }
+    }
+
+    private var foregroundColor: Color {
+        switch (tone, style) {
+        case (_, .strong): return VColor.contentInset
+        case (.positive, .weak): return VColor.systemPositiveStrong
+        case (.negative, .weak): return VColor.systemNegativeStrong
+        case (.warning, .weak): return VColor.systemMidStrong
+        case (.neutral, .weak): return VColor.contentTertiary
+        }
+    }
+
+    private var dividerOpacity: Double {
+        switch (tone, style) {
+        case (.neutral, .weak): return 0.20
+        default: return 0.30
+        }
+    }
+
+    private var leadingIcon: VIcon {
+        switch tone {
+        case .positive: return .circleCheck
+        case .negative: return .circleX
+        case .warning: return .info
+        case .neutral: return .info
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add reusable VNotification component to clients/shared/DesignSystem/Core/Feedback/
- Supports 4 tones (positive/negative/warning/neutral) × 2 styles (weak/strong), with optional leading icon, action label, and dismiss button
- All colors map to existing VColor semantic tokens — no new tokens needed

Part of plan: v-notification.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
