### PR TITLE
fix(onboarding): show assistant name in sidebar and intelligence panel after hatch

### DIFF
--- a/assistant/src/__tests__/persist-onboarding-artifacts.test.ts
+++ b/assistant/src/__tests__/persist-onboarding-artifacts.test.ts
@@ -145,7 +145,24 @@ describe("persistOnboardingArtifacts", () => {
     expect(content).toBe("# User\n\n- **Name:** NewUser\n");
   });
 
-  test("does not touch existing file without **Name:** field", () => {
+  test("updates old-format Name field in existing IDENTITY.md", () => {
+    writeFileSync(
+      workspacePath("IDENTITY.md"),
+      "# Identity\n\n- Name: OldFormat\n",
+    );
+
+    persistOnboardingArtifacts({
+      tools: [],
+      tasks: [],
+      tone: "casual",
+      assistantName: "NewName",
+    });
+
+    const content = readFileSync(workspacePath("IDENTITY.md"), "utf-8");
+    expect(content).toBe("# Identity\n\n- **Name:** NewName\n");
+  });
+
+  test("does not touch existing file without Name field", () => {
     writeFileSync(
       workspacePath("IDENTITY.md"),
       "# Identity\n\nCustom content here\n",

--- a/assistant/src/__tests__/persist-onboarding-artifacts.test.ts
+++ b/assistant/src/__tests__/persist-onboarding-artifacts.test.ts
@@ -77,7 +77,7 @@ describe("persistOnboardingArtifacts", () => {
     });
 
     const content = readFileSync(workspacePath("IDENTITY.md"), "utf-8");
-    expect(content).toBe("# Identity\n\n- Name: Nova\n");
+    expect(content).toBe("# Identity\n\n- **Name:** Nova\n");
   });
 
   test("seeds USER.md with user name when file does not exist", () => {
@@ -89,7 +89,7 @@ describe("persistOnboardingArtifacts", () => {
     });
 
     const content = readFileSync(workspacePath("USER.md"), "utf-8");
-    expect(content).toBe("# User\n\n- Name: Alex\n");
+    expect(content).toBe("# User\n\n- **Name:** Alex\n");
   });
 
   test("seeds both IDENTITY.md and USER.md when both names are provided", () => {
@@ -102,17 +102,17 @@ describe("persistOnboardingArtifacts", () => {
     });
 
     expect(readFileSync(workspacePath("IDENTITY.md"), "utf-8")).toBe(
-      "# Identity\n\n- Name: Pax\n",
+      "# Identity\n\n- **Name:** Pax\n",
     );
     expect(readFileSync(workspacePath("USER.md"), "utf-8")).toBe(
-      "# User\n\n- Name: Alex\n",
+      "# User\n\n- **Name:** Alex\n",
     );
   });
 
-  test("does not overwrite existing IDENTITY.md", () => {
+  test("updates Name field in existing IDENTITY.md template", () => {
     writeFileSync(
       workspacePath("IDENTITY.md"),
-      "# Identity\n\n- Name: Existing\n",
+      "# Identity\n\n- **Name:** _(not yet chosen)_\n- **Role:** _(not yet established)_\n",
     );
 
     persistOnboardingArtifacts({
@@ -123,11 +123,16 @@ describe("persistOnboardingArtifacts", () => {
     });
 
     const content = readFileSync(workspacePath("IDENTITY.md"), "utf-8");
-    expect(content).toBe("# Identity\n\n- Name: Existing\n");
+    expect(content).toBe(
+      "# Identity\n\n- **Name:** NewName\n- **Role:** _(not yet established)_\n",
+    );
   });
 
-  test("does not overwrite existing USER.md", () => {
-    writeFileSync(workspacePath("USER.md"), "# User\n\n- Name: Existing\n");
+  test("updates Name field in existing USER.md template", () => {
+    writeFileSync(
+      workspacePath("USER.md"),
+      "# User\n\n- **Name:** _(not yet chosen)_\n",
+    );
 
     persistOnboardingArtifacts({
       tools: [],
@@ -137,7 +142,24 @@ describe("persistOnboardingArtifacts", () => {
     });
 
     const content = readFileSync(workspacePath("USER.md"), "utf-8");
-    expect(content).toBe("# User\n\n- Name: Existing\n");
+    expect(content).toBe("# User\n\n- **Name:** NewUser\n");
+  });
+
+  test("does not touch existing file without **Name:** field", () => {
+    writeFileSync(
+      workspacePath("IDENTITY.md"),
+      "# Identity\n\nCustom content here\n",
+    );
+
+    persistOnboardingArtifacts({
+      tools: [],
+      tasks: [],
+      tone: "casual",
+      assistantName: "NewName",
+    });
+
+    const content = readFileSync(workspacePath("IDENTITY.md"), "utf-8");
+    expect(content).toBe("# Identity\n\nCustom content here\n");
   });
 
   test("skips IDENTITY.md when assistantName is missing", () => {
@@ -194,10 +216,10 @@ describe("persistOnboardingArtifacts", () => {
     });
 
     expect(readFileSync(workspacePath("IDENTITY.md"), "utf-8")).toBe(
-      "# Identity\n\n- Name: Nova\n",
+      "# Identity\n\n- **Name:** Nova\n",
     );
     expect(readFileSync(workspacePath("USER.md"), "utf-8")).toBe(
-      "# User\n\n- Name: Alex\n",
+      "# User\n\n- **Name:** Alex\n",
     );
   });
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1293,7 +1293,7 @@ export function persistOnboardingArtifacts(onboarding: {
       if (existsSync(identityPath)) {
         const content = readFileSync(identityPath, "utf-8");
         const updated = content.replace(
-          /^- \*\*Name:\*\*\s*.*$/m,
+          /^- (?:\*\*)?Name:(?:\*\*)?\s*.*$/m,
           `- **Name:** ${assistantName}`,
         );
         if (updated !== content) {
@@ -1321,7 +1321,7 @@ export function persistOnboardingArtifacts(onboarding: {
       if (existsSync(userPath)) {
         const content = readFileSync(userPath, "utf-8");
         const updated = content.replace(
-          /^- \*\*Name:\*\*\s*.*$/m,
+          /^- (?:\*\*)?Name:(?:\*\*)?\s*.*$/m,
           `- **Name:** ${userName}`,
         );
         if (updated !== content) {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1294,7 +1294,7 @@ export function persistOnboardingArtifacts(onboarding: {
         const content = readFileSync(identityPath, "utf-8");
         const updated = content.replace(
           /^- (?:\*\*)?Name:(?:\*\*)?\s*.*$/m,
-          `- **Name:** ${assistantName}`,
+          () => `- **Name:** ${assistantName}`,
         );
         if (updated !== content) {
           writeFileSync(identityPath, updated, "utf-8");
@@ -1322,7 +1322,7 @@ export function persistOnboardingArtifacts(onboarding: {
         const content = readFileSync(userPath, "utf-8");
         const updated = content.replace(
           /^- (?:\*\*)?Name:(?:\*\*)?\s*.*$/m,
-          `- **Name:** ${userName}`,
+          () => `- **Name:** ${userName}`,
         );
         if (updated !== content) {
           writeFileSync(userPath, updated, "utf-8");

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1,7 +1,13 @@
 /**
  * Route handlers for conversation messages and suggestions.
  */
-import { existsSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { join, relative } from "node:path";
 
 import { z } from "zod";
@@ -1283,31 +1289,49 @@ export function persistOnboardingArtifacts(onboarding: {
   const assistantName = onboarding.assistantName?.trim();
   if (assistantName) {
     const identityPath = getWorkspacePromptPath("IDENTITY.md");
-    if (!existsSync(identityPath)) {
-      try {
+    try {
+      if (existsSync(identityPath)) {
+        const content = readFileSync(identityPath, "utf-8");
+        const updated = content.replace(
+          /^- \*\*Name:\*\*\s*.*$/m,
+          `- **Name:** ${assistantName}`,
+        );
+        if (updated !== content) {
+          writeFileSync(identityPath, updated, "utf-8");
+        }
+      } else {
         writeFileSync(
           identityPath,
-          `# Identity\n\n- Name: ${assistantName}\n`,
+          `# Identity\n\n- **Name:** ${assistantName}\n`,
           "utf-8",
         );
-      } catch (err) {
-        log.warn(
-          { err, identityPath },
-          "Failed to seed IDENTITY.md from onboarding",
-        );
       }
+    } catch (err) {
+      log.warn(
+        { err, identityPath },
+        "Failed to seed IDENTITY.md from onboarding",
+      );
     }
   }
 
   const userName = onboarding.userName?.trim();
   if (userName) {
     const userPath = getWorkspacePromptPath("USER.md");
-    if (!existsSync(userPath)) {
-      try {
-        writeFileSync(userPath, `# User\n\n- Name: ${userName}\n`, "utf-8");
-      } catch (err) {
-        log.warn({ err, userPath }, "Failed to seed USER.md from onboarding");
+    try {
+      if (existsSync(userPath)) {
+        const content = readFileSync(userPath, "utf-8");
+        const updated = content.replace(
+          /^- \*\*Name:\*\*\s*.*$/m,
+          `- **Name:** ${userName}`,
+        );
+        if (updated !== content) {
+          writeFileSync(userPath, updated, "utf-8");
+        }
+      } else {
+        writeFileSync(userPath, `# User\n\n- **Name:** ${userName}\n`, "utf-8");
       }
+    } catch (err) {
+      log.warn({ err, userPath }, "Failed to seed USER.md from onboarding");
     }
   }
 
@@ -1501,14 +1525,15 @@ export async function handleSendMessage(
   );
 
   // Store pre-chat onboarding context on the conversation when this is the
-  // very first message (no prior messages loaded). Also persist the
-  // onboarding selections so the Home page shows onboarding-sourced
-  // chips immediately, and seed IDENTITY.md / USER.md so subsequent
-  // turn-boundary recomputes of relationship-state have a stable
-  // persona source beyond the in-memory conversation object.
-  if (body.onboarding && conversation.messages.length === 0) {
-    conversation.setOnboardingContext(body.onboarding);
-    persistOnboardingArtifacts(body.onboarding);
+  // very first message (no prior messages loaded). Artifact persistence
+  // (IDENTITY.md, USER.md, sidecar) is deferred: on the canned greeting
+  // path it runs inside the setTimeout right before warmPromptCache() so
+  // the warmed system prompt includes the identity; on the normal LLM
+  // path it runs immediately before inference starts.
+  const isFirstOnboarding =
+    !!body.onboarding && conversation.messages.length === 0;
+  if (isFirstOnboarding) {
+    conversation.setOnboardingContext(body.onboarding!);
   }
 
   // Resolve guardian context from the AuthContext's actorPrincipalId.
@@ -1775,6 +1800,9 @@ export async function handleSendMessage(
           "canned-greeting queue drain",
         );
 
+        if (isFirstOnboarding) {
+          persistOnboardingArtifacts(body.onboarding!);
+        }
         conversation.warmPromptCache();
       }, 0);
 
@@ -1790,6 +1818,10 @@ export async function handleSendMessage(
         silentlyWithLog(conversation.drainQueue(), "error-path queue drain");
       }
     }
+  }
+
+  if (isFirstOnboarding) {
+    persistOnboardingArtifacts(body.onboarding!);
   }
 
   const attachments = hasAttachments

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -638,7 +638,6 @@ extension AppDelegate {
         // Close and recreate the main window to reset conversation state
         mainWindow?.close()
         mainWindow = nil
-
         // 3. Persist the new assistant selection
         LockfileAssistant.setActiveAssistantId(assistant.assistantId)
         SentryDeviceInfo.updateAssistantTag(assistant.assistantId)

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -365,6 +365,7 @@ extension AppDelegate {
             // Retain the onboarding state so avatar traits generated during
             // hatching can be synced to the assistant after the switch.
             self?.onboardingState = state
+            self?.pendingPreChatContext = state.preChatContext
 
             // Detect the newly hatched assistant by diffing lockfile against snapshot.
             // loadAll() returns newest-first, so the first new ID is the most recently hatched.
@@ -500,16 +501,28 @@ extension AppDelegate {
         // ConversationManager.enterDraftMode() creates the first draft VM.
         let context = pendingPreChatContext
         pendingPreChatContext = nil
-        if let name = context?.assistantName, !name.isEmpty,
-           let activeId = LockfileAssistant.loadActiveAssistantId() {
-            IdentityInfo.seedCache(name: name, forAssistantId: activeId)
+        let onboardingName = onboardingState?.assistantName
+        let resolvedName = AssistantDisplayName.firstUserFacing(from: [
+            context?.assistantName,
+            onboardingName,
+        ])
+        if let resolvedName {
+            var activeId = LockfileAssistant.loadActiveAssistantId()
+            if activeId == nil, let latest = LockfileAssistant.loadLatest() {
+                LockfileAssistant.setActiveAssistantId(latest.assistantId)
+                activeId = latest.assistantId
+            }
+            if let activeId {
+                IdentityInfo.seedCache(name: resolvedName, forAssistantId: activeId)
+            }
         }
         let main = MainWindow(
             services: services,
             updateManager: updateManager,
             assistantFeatureFlagStore: featureFlagStore,
             isFirstLaunch: isFirstLaunch,
-            preChatContext: context
+            preChatContext: context,
+            initialAssistantName: resolvedName
         )
         main.onMicrophoneToggle = { [weak self] in
             self?.voiceInput?.toggleRecording()

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -313,16 +313,20 @@ public final class MainWindow {
         conversationManager.activeViewModel
     }
 
+    private var initialAssistantName: String?
+
     init(
         services: AppServices,
         updateManager: UpdateManager,
         assistantFeatureFlagStore: AssistantFeatureFlagStore,
         isFirstLaunch: Bool = false,
-        preChatContext: PreChatOnboardingContext? = nil
+        preChatContext: PreChatOnboardingContext? = nil,
+        initialAssistantName: String? = nil
     ) {
         self.services = services
         self.updateManager = updateManager
         self.assistantFeatureFlagStore = assistantFeatureFlagStore
+        self.initialAssistantName = initialAssistantName
         self.conversationManager = ConversationManager(
             connectionManager: services.connectionManager,
             eventStreamClient: services.connectionManager.eventStreamClient,
@@ -459,7 +463,7 @@ public final class MainWindow {
             }
         } : nil
 
-        let rootView = MainWindowView(conversationManager: conversationManager, appListManager: appListManager, zoomManager: zoomManager, traceStore: traceStore, usageDashboardStore: usageDashboardStore, connectionManager: connectionManager, eventStreamClient: eventStreamClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, assistantFeatureFlagStore: assistantFeatureFlagStore, documentManager: documentManager, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, updateManager: updateManager, onSendWakeUp: wakeUpCallback)
+        let rootView = MainWindowView(conversationManager: conversationManager, appListManager: appListManager, zoomManager: zoomManager, traceStore: traceStore, usageDashboardStore: usageDashboardStore, connectionManager: connectionManager, eventStreamClient: eventStreamClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, assistantFeatureFlagStore: assistantFeatureFlagStore, documentManager: documentManager, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, updateManager: updateManager, onSendWakeUp: wakeUpCallback, initialAssistantName: initialAssistantName)
         let hostingController = NonDraggableHostingController(rootView: rootView)
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Lifecycle.swift
@@ -125,8 +125,10 @@ extension MainWindowView {
         isAppChatOpen = false
         Task {
             let info = await IdentityInfo.loadAsync()
-            cachedAssistantName = AssistantDisplayName.resolve(info?.name, fallback: "Your Assistant")
-            if info != nil { assistantNameResolved = true }
+            if let name = AssistantDisplayName.firstUserFacing(from: [info?.name]) {
+                cachedAssistantName = name
+                assistantNameResolved = true
+            }
         }
         selectedConversationId = conversationManager.activeConversationId
         if let activeId = conversationManager.activeConversationId {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -112,7 +112,7 @@ struct MainWindowView: View {
     /// as the Home stores) so the panel is wired up the moment the user
     /// lands on Home, without having to refresh.
     @State var meetStatusViewModel: MeetStatusViewModel
-    init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, assistantFeatureFlagStore: AssistantFeatureFlagStore, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
+    init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, assistantFeatureFlagStore: AssistantFeatureFlagStore, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil, initialAssistantName: String? = nil) {
         self.conversationManager = conversationManager
         self.listStore = conversationManager.listStore
         self.appListManager = appListManager
@@ -133,8 +133,8 @@ struct MainWindowView: View {
         self.updateManager = updateManager
         self.onSendWakeUp = onSendWakeUp
         let cached = IdentityInfo.loadFromDiskCache()
-        self._cachedAssistantName = State(initialValue: AssistantDisplayName.resolve(cached?.name, fallback: "Your Assistant"))
-        self._assistantNameResolved = State(initialValue: cached != nil)
+        self._cachedAssistantName = State(initialValue: AssistantDisplayName.resolve(cached?.name, initialAssistantName, fallback: "Your Assistant"))
+        self._assistantNameResolved = State(initialValue: cached != nil || initialAssistantName != nil)
         self._showComingAlive = State(initialValue: onSendWakeUp != nil)
         // Show skeleton loading only for normal launches (not post-onboarding where
         // ComingAliveOverlay handles the transition).

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -69,8 +69,18 @@ struct IntelligencePanel: View {
             }
         }
         .task {
-            let info = await IdentityInfo.loadAsync()
-            cachedAssistantName = AssistantDisplayName.resolve(info?.name, fallback: "Your Assistant")
+            let info = await IdentityInfo.refreshCache()
+            if let name = AssistantDisplayName.firstUserFacing(from: [info?.name]) {
+                cachedAssistantName = name
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .identityChanged)) { _ in
+            Task {
+                let info = await IdentityInfo.refreshCache()
+                if let name = AssistantDisplayName.firstUserFacing(from: [info?.name]) {
+                    cachedAssistantName = name
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix sidebar and intelligence panel showing "Your Assistant" instead of the name chosen during onboarding
- Fix `persistOnboardingArtifacts` skipping IDENTITY.md writes when the template file already exists
- Fix cache warm ordering to be explicit about IDENTITY.md→warm sequencing

## What changed

**Three root causes fixed:**

1. **Re-hatch flow missing `pendingPreChatContext`** — the re-hatch `onComplete` handler never stored the pre-chat context, so `ensureMainWindowExists` had no name to seed the identity cache. Also added `onboardingState.assistantName` as a fallback (always populated, unlike `preChatContext` which is gated behind a disabled feature flag).

2. **Gateway fetch clobbering seeded name** — `handleCoreLayoutAppear` and `IntelligencePanel.task` unconditionally overwrote `cachedAssistantName` with the gateway fetch result, even when it returned nil (IDENTITY.md not yet written). Now they only update the name when the fetch returns a valid one.

3. **`persistOnboardingArtifacts` skipping existing IDENTITY.md** — the hatch creates a template IDENTITY.md with `_(not yet chosen)_` placeholders, and persist checked `!existsSync()` before writing. Now it updates the `**Name:**` field in-place when the file already exists.

**Cache warm ordering** — deferred `persistOnboardingArtifacts` on the canned greeting path to run in the same `setTimeout` as `warmPromptCache`, making the IDENTITY.md→warm sequencing explicit.

## Test plan
- [ ] Retire assistant → re-hatch with a new name → sidebar shows the new name immediately
- [ ] Intelligence panel header shows "About {name}" (not "About Your Assistant")
- [ ] Identity tab shows "I'm {name}!" (not "Hi, I'm Claude")
- [ ] Cold launch with existing assistant still shows the correct name
- [ ] Sending first message after hatch writes the name into IDENTITY.md template

Closes JARVIS-580

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
