### PR TITLE
fix(macOS): stop stamping dev-platform into bare-metal local hatches

### DIFF
--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -102,7 +102,12 @@ final class AppleContainersLauncher: AssistantManagementClient {
             builtLocally = true
         }
 
-        let platformURL = VellumEnvironment.current.containerPlatformURL
+        // TODO: Apple Containers can reach the host machine via the vmnet bridge gateway IP.
+        // This is available after the pod's VmnetNetwork is created,
+        // and will require some refactoring.
+        // For now, a true `local` build is not supported;
+        // target a remote platform environmentinstead.
+        let platformURL: String = VellumEnvironment.current.platformURL
 
         let config = AppleContainersPodRuntime.Configuration(
             instanceName: assistantName,

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -624,8 +624,8 @@ final class VellumCli: AssistantManagementClient {
 
         var env = Self.makeBaseEnvironment()
 
-        if env["VELLUM_PLATFORM_URL"] == nil {
-            env["VELLUM_PLATFORM_URL"] = VellumEnvironment.current.containerPlatformURL
+        if config.remote == "docker", env["VELLUM_PLATFORM_URL"] == nil {
+            env["VELLUM_PLATFORM_URL"] = VellumEnvironment.current.dockerHostPlatformURL
         }
 
         for (envVar, value) in config.providerApiKeys where !value.isEmpty {

--- a/clients/shared/App/VellumEnvironment.swift
+++ b/clients/shared/App/VellumEnvironment.swift
@@ -148,13 +148,19 @@ public enum VellumEnvironment: String {
         return current.webURL
     }
 
-    /// The platform URL to inject into containers (Docker, Apple Containers).
-    /// For `local`, containers can't reach `localhost` on the host, so we
-    /// fall back to the remote dev platform.
-    public var containerPlatformURL: String {
+    /// The platform URL to inject into containerized assistants.
+    ///
+    /// For local Docker containers setup, we can use `host.docker.internal`
+    /// to target platform services running locally on the host,
+    /// or else attach the assistants to the actual Docker network.
+    ///
+    /// This doesn't apply to Apple Containers: VMs can reach the host via the vmnet
+    /// bridge gateway IP. This is only known after the pod network is created,
+    /// and will require some refactoring to support.
+    public var dockerHostPlatformURL: String {
         switch self {
         case .local:
-            return "https://dev-platform.vellum.ai"
+            return "http://host.docker.internal:8000"
         default:
             return platformURL
         }


### PR DESCRIPTION
## Issue
1. Run
```bash
VELLUM_ENVIRONMENT=local ./build.sh run
```
without explicitly setting `VELLUM_PLATFORM_URL`.
2. Hatch a local bare metal assistant. This goes through `runRemoteHatch` for some reason 🤷 
3. `runRemoteHatch` also unconditionally calls `containerPlatformURL` and sets `VELLUM_PLATFORM_URL` for runtime daemon. This was intended for local containerized environments which we never GA'd (either docker or apple containers), and it fell back to `dev-platform.vellum.ai`.

Note that this bug didn't affect `vel up macos` which *did* set additional env vars

## Fix + Notes
Avoid calling `containerPlatformURL` (now `dockerHostPlatformURL`). We'll have to revisit this logic in the future -- this value is driven off both `VELLUM_ENVIRONMENT` and your assistant's hosting information.

Apple containers definitely won't work in `local` case -- need to refactor to expose vmnet host bridge IP

## Test plan

- [ ] Retire any existing local daemon (`vel retire …`).
- [ ] `VELLUM_ENVIRONMENT=local ./build.sh run` → Settings → Environment Variables: confirm `VELLUM_PLATFORM_URL` is **unset** on the daemon, and daemon resolves `http://localhost:8000` via its own `getPlatformBaseUrl`.
- [ ] `vel up macos` still works — daemon env shows `VELLUM_PLATFORM_URL=http://localhost:8000` (pre-set by `vel up`, forwarded through).
- [ ] Production/staging/dev release builds unaffected (`dockerHostPlatformURL == platformURL` for non-local envs).
- [ ] Docker hatch in `VELLUM_ENVIRONMENT=local` now gets `http://host.docker.internal:8000` instead of a silent redirect (not wired up end-to-end yet, per the TODO for local-docker support).
- [ ] Apple Container onboarding in non-local envs unchanged; `.local` path fails visibly until the vmnet gateway IP is threaded through (tracked in TODO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
