### PR TITLE
feat(macOS): decode managed_service_is_paid on OAuthProviderMetadata

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -4216,6 +4216,7 @@ struct OAuthProviderMetadata: Codable, Sendable {
     let client_id_placeholder: String?
     let requires_client_secret: Bool
     let logo_url: String?
+    let managed_service_is_paid: Bool?
 
     /// The platform OAuth slug is the provider_key itself (bare name, e.g. "google").
     var platformOAuthSlug: String {
@@ -4226,6 +4227,12 @@ struct OAuthProviderMetadata: Codable, Sendable {
     var logoURL: URL? {
         guard let raw = logo_url, !raw.isEmpty else { return nil }
         return URL(string: raw)
+    }
+
+    /// Whether this provider's managed service incurs additional costs.
+    /// Falls back to `false` when the daemon didn't supply the flag.
+    var isPaid: Bool {
+        managed_service_is_paid ?? false
     }
 }
 


### PR DESCRIPTION
## Summary
- Add optional `managed_service_is_paid: Bool?` field to `OAuthProviderMetadata` + `isPaid` computed helper.
- Optional so older daemons without the field still decode.

Part of plan: twitter-paid-badge.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
