### PR TITLE
feat(macOS): paid badge on integrations list row

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationsPanelContent.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationsPanelContent.swift
@@ -291,11 +291,16 @@ private struct IntegrationItemRow: View {
                 IntegrationIcon.image(for: provider, size: 32)
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text(provider.display_name ?? provider.provider_key)
-                        .font(VFont.titleSmall)
-                        .foregroundStyle(VColor.contentEmphasized)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
+                    HStack(spacing: VSpacing.sm) {
+                        Text(provider.display_name ?? provider.provider_key)
+                            .font(VFont.titleSmall)
+                            .foregroundStyle(VColor.contentEmphasized)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        if provider.isPaid {
+                            VPaidBadge()
+                        }
+                    }
 
                     if let description = provider.description, !description.isEmpty {
                         Text(description)


### PR DESCRIPTION
## Summary
- Render `VPaidBadge()` next to the provider name in `IntegrationItemRow` when `provider.isPaid`.

Part of plan: twitter-paid-badge.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
