### PR TITLE
feat(oauth): expose managed_service_is_paid in provider summary

### DIFF
--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -289,6 +289,7 @@ describe("serializeProviderSummary", () => {
       requires_client_secret: true,
       logo_url: null,
       supports_managed_mode: true,
+      managed_service_is_paid: false,
       feature_flag: null,
     });
   });

--- a/assistant/src/__tests__/oauth-providers-routes.test.ts
+++ b/assistant/src/__tests__/oauth-providers-routes.test.ts
@@ -163,6 +163,7 @@ describe("GET /v1/oauth/providers", () => {
       "requires_client_secret",
       "logo_url",
       "supports_managed_mode",
+      "managed_service_is_paid",
       "feature_flag",
     ];
 

--- a/assistant/src/oauth/provider-serializer.ts
+++ b/assistant/src/oauth/provider-serializer.ts
@@ -32,6 +32,7 @@ export interface SerializedProviderSummary {
   requires_client_secret: boolean;
   logo_url: string | null;
   supports_managed_mode: boolean;
+  managed_service_is_paid: boolean;
   feature_flag: string | null;
 }
 
@@ -86,6 +87,7 @@ function _serializeProvider(
     clientIdPlaceholder: row.clientIdPlaceholder ?? null,
     requiresClientSecret: !!(row.requiresClientSecret ?? 1),
     supportsManagedMode: !!row.managedServiceConfigKey,
+    managedServiceIsPaid: !!row.managedServiceIsPaid,
     defaultScopes: row.defaultScopes ? JSON.parse(row.defaultScopes) : [],
     scopePolicy: row.scopePolicy ? JSON.parse(row.scopePolicy) : {},
     scopeSeparator: row.scopeSeparator,
@@ -140,6 +142,7 @@ export function serializeProviderSummary(
     requires_client_secret: !!(row.requiresClientSecret ?? 1),
     logo_url: row.logoUrl ?? null,
     supports_managed_mode: !!row.managedServiceConfigKey,
+    managed_service_is_paid: !!row.managedServiceIsPaid,
     feature_flag: row.featureFlag ?? null,
   };
 }


### PR DESCRIPTION
## Summary
- Extend `SerializedProviderSummary` + `serializeProviderSummary` + full `_serializeProvider` to expose `managed_service_is_paid` / `managedServiceIsPaid`.

Part of plan: twitter-paid-badge.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
