### PR TITLE
fix(oauth): thread managedServiceIsPaid through updateProvider

### DIFF
--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -451,6 +451,7 @@ export function updateProvider(
     identityFormat: string;
     identityOkField: string;
     featureFlag: string;
+    managedServiceIsPaid: boolean;
   }>,
 ): OAuthProviderRow | undefined {
   const existing = getProvider(provider);
@@ -519,6 +520,8 @@ export function updateProvider(
   if (params.identityOkField !== undefined)
     set.identityOkField = params.identityOkField;
   if (params.featureFlag !== undefined) set.featureFlag = params.featureFlag;
+  if (params.managedServiceIsPaid !== undefined)
+    set.managedServiceIsPaid = params.managedServiceIsPaid ? 1 : 0;
 
   db.update(oauthProviders)
     .set(set)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for twitter-paid-badge.md.

**Gap:** `updateProvider` in `oauth-store.ts` was missing the `managedServiceIsPaid` field added in PR #27501, so `providers update` CLI silently dropped the flag. Mirrors the `requiresClientSecret` 0/1 coercion pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
