### PR TITLE
fix(design-system): register VPaidBadge in ComponentGalleryView

### DIFF
--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -97,6 +97,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                 GalleryComponent("vBusyIndicator", "VBusyIndicator", keywords: ["busy", "activity"], description: "Activity indicator for small, contained loading states."),
                 GalleryComponent("vSkeletonBone", "VSkeletonBone", keywords: ["skeleton", "placeholder"], description: "Placeholder bone with shimmer animation for loading skeletons. Compose multiple bones to match the target layout."),
                 GalleryComponent("vSkillTypePill", "VSkillTypePill", keywords: ["skill type", "pill"], description: "Colored pill showing a skill type category."),
+                GalleryComponent("vPaidBadge", "VPaidBadge", keywords: ["paid", "badge", "dollar"], description: "Pill badge marking an integration or feature as paid."),
                 GalleryComponent("vInfoTooltip", "VInfoTooltip", keywords: ["info", "tooltip"], description: "Info icon with hover tooltip for contextual help text."),
                 GalleryComponent("vContextWindowIndicator", "VContextWindowIndicator", keywords: ["context window", "progress", "ring"], description: "Circular ring showing context window fill level with hover popover."),
             ]


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for twitter-paid-badge.md.

**Gap:** `VPaidBadge` was added to `FeedbackGallerySection` but never registered in `ComponentGalleryView`'s feedback list, so the component was not discoverable via the gallery's main index/search.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
