### PR TITLE
fix(macOS): OR-combine isPaid instead of short-circuit fallback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
@@ -65,7 +65,7 @@ struct IntegrationDetailModal: View {
     }
 
     private var isPaid: Bool {
-        providerMeta?.isPaid ?? yourOwnMeta?.isPaid ?? false
+        (providerMeta?.isPaid ?? false) || (yourOwnMeta?.isPaid ?? false)
     }
 
     // MARK: - Body


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for twitter-paid-badge.md.

**Gap:** `isPaid` in `IntegrationDetailModal` used `providerMeta?.isPaid ?? yourOwnMeta?.isPaid ?? false`, which short-circuits on `Optional(false)` and never consults the your-own metadata when the managed metadata is present. Switched to `(providerMeta?.isPaid ?? false) || (yourOwnMeta?.isPaid ?? false)` so the flag surfaces from either source.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
