### PR TITLE
feat(macOS): add VNotification variants to Feedback component gallery

### DIFF
--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -91,6 +91,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                 GalleryComponent("vTag", "VTag", keywords: ["tag", "category", "kind"], description: "Colored tag for categorizing items with pastel backgrounds."),
                 GalleryComponent("vLoadingIndicator", "VLoadingIndicator", keywords: ["loading", "spinner"], description: "Spinning indicator for inline loading states. Use VSkeletonBone for structured loading layouts."),
                 GalleryComponent("vToast", "VToast", keywords: ["toast", "notification"], description: "Temporary notification banner with auto-dismiss and action support."),
+                GalleryComponent("vNotification", "VNotification", keywords: ["notification", "banner", "notice", "alert bar", "inline status"], description: "Compact single-line notification bar with tone, optional action, and dismiss. Use when you need a slim inline or pinned status indicator — smaller than VToast, more actionable than VInlineMessage."),
                 GalleryComponent("vInlineMessage", "VInlineMessage", keywords: ["inline message", "alert"], description: "Persistent inline alert with icon and semantic color (info, warning, error, success)."),
                 GalleryComponent("vShortcutTag", "VShortcutTag", keywords: ["shortcut", "keyboard"], description: "Keyboard shortcut display tag showing key combinations."),
                 GalleryComponent("vCopyButton", "VCopyButton", keywords: ["copy", "clipboard"], description: "One-click copy button with animated checkmark success feedback."),

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -237,6 +237,152 @@ struct FeedbackGallerySection: View {
                 }
             }
 
+            if filter == nil || filter == "vNotification" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+                // MARK: - VNotification
+                GallerySectionHeader(
+                    title: "VNotification",
+                    description: "Compact single-line feedback bar. Supports 4 tones × 2 styles, with optional leading icon, action label, and dismiss button."
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        // 4 tones × 2 styles grid
+                        LazyVGrid(
+                            columns: [GridItem(.flexible()), GridItem(.flexible())],
+                            spacing: VSpacing.md
+                        ) {
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Positive · Weak").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .positive,
+                                    style: .weak,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Positive · Strong").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .positive,
+                                    style: .strong,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Negative · Weak").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .negative,
+                                    style: .weak,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Negative · Strong").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .negative,
+                                    style: .strong,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Warning · Weak").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .warning,
+                                    style: .weak,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Warning · Strong").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .warning,
+                                    style: .strong,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Neutral · Weak").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .neutral,
+                                    style: .weak,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Neutral · Strong").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .neutral,
+                                    style: .strong,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                        }
+
+                        Divider().background(VColor.borderBase)
+
+                        // Optional slots
+                        Text("Optional slots")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                        VStack(alignment: .leading, spacing: VSpacing.sm) {
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Message only").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .positive,
+                                    style: .weak
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Message + dismiss").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .positive,
+                                    style: .weak,
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Message + action").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .positive,
+                                    style: .weak,
+                                    actionLabel: "Action",
+                                    onAction: {}
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
             if filter == nil || filter == "vInlineMessage" {
                 if filter == nil {
                     Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
@@ -536,6 +682,7 @@ extension FeedbackGallerySection {
         case "vTag": FeedbackGallerySection(filter: "vTag")
         case "vLoadingIndicator": FeedbackGallerySection(filter: "vLoadingIndicator")
         case "vToast": FeedbackGallerySection(filter: "vToast")
+        case "vNotification": FeedbackGallerySection(filter: "vNotification")
         case "vInlineMessage": FeedbackGallerySection(filter: "vInlineMessage")
         case "vShortcutTag": FeedbackGallerySection(filter: "vShortcutTag")
         case "vCopyButton": FeedbackGallerySection(filter: "vCopyButton")


### PR DESCRIPTION
## Summary
- Register VNotification in ComponentGalleryView under the Feedback category
- Add 8 tone×style preview variants (positive/negative/warning/neutral × weak/strong) plus 3 optional-slot variants (message only, message+dismiss, message+action) in FeedbackGallerySection
- Add componentPage router case so 'VNotification' in the gallery sidebar opens its filtered page

Part of plan: v-notification.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
