### PR TITLE
fix(oauth): assign boolean to managedServiceIsPaid in updateProvider

### DIFF
--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -521,7 +521,7 @@ export function updateProvider(
     set.identityOkField = params.identityOkField;
   if (params.featureFlag !== undefined) set.featureFlag = params.featureFlag;
   if (params.managedServiceIsPaid !== undefined)
-    set.managedServiceIsPaid = params.managedServiceIsPaid ? 1 : 0;
+    set.managedServiceIsPaid = params.managedServiceIsPaid;
 
   db.update(oauthProviders)
     .set(set)


### PR DESCRIPTION
## Summary
Addresses round-2 review: the column is declared with Drizzle `mode: "boolean"`, so `updateProvider` should assign a boolean (matching the insert/seed path) instead of `? 1 : 0`. Keeps the read/write round-trip consistent and satisfies Drizzle's inferred update type.

Part of plan: twitter-paid-badge.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
