### PR TITLE
Update BOOTSTRAP.md and first greeting phrasing

### DIFF
--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -85,7 +85,7 @@ describe("first-greeting", () => {
         assistantName: "Pip",
       });
       expect(greeting).toContain("Hey Alex, I'm Pip.");
-      expect(greeting).toContain("GitHub and Linear say");
+      expect(greeting).toContain("You mentioned using GitHub and Linear");
       expect(greeting).toContain(
         "shipping code or figuring out what to ship next",
       );
@@ -100,7 +100,7 @@ describe("first-greeting", () => {
         userName: "Alex",
         assistantName: "Pip",
       });
-      expect(greeting).toContain("Notion and Linear say");
+      expect(greeting).toContain("You mentioned using Notion and Linear");
       expect(greeting).toContain("writing a spec or pushing something forward");
     });
 
@@ -112,7 +112,7 @@ describe("first-greeting", () => {
         userName: "Alex",
         assistantName: "Luna",
       });
-      expect(greeting).toContain("Notion and Google Drive say");
+      expect(greeting).toContain("You mentioned using Notion and Google Drive");
       expect(greeting).toContain("drafting something or cleaning up docs");
     });
 
@@ -124,7 +124,7 @@ describe("first-greeting", () => {
         assistantName: "Pip",
       });
       expect(greeting).toContain("Probably shipping something or debugging");
-      expect(greeting).not.toContain("Your");
+      expect(greeting).not.toContain("You mentioned using");
     });
 
     it("single tool single task: GitHub + Building", () => {
@@ -135,7 +135,7 @@ describe("first-greeting", () => {
         userName: "Alex",
         assistantName: "Pip",
       });
-      expect(greeting).toContain("Your GitHub says");
+      expect(greeting).toContain("You mentioned using GitHub");
     });
 
     it("many hats: 4 selections", () => {
@@ -218,7 +218,7 @@ describe("first-greeting", () => {
       });
       expect(greeting).toContain("I'm Pip");
       expect(greeting).toContain("I'll get sharper");
-      expect(greeting).toContain("am I on the right track");
+      expect(greeting).toContain("Am I on the right track");
     });
 
     it("two-paragraph structure with blank line", () => {
@@ -247,7 +247,7 @@ describe("first-greeting", () => {
         userName: "Alex",
         assistantName: "Pip",
       });
-      expect(greeting).toContain("GitHub and Linear say");
+      expect(greeting).toContain("You mentioned using GitHub and Linear");
       expect(greeting).not.toContain("Apple Notes");
       expect(greeting).not.toContain("Notion");
     });
@@ -261,7 +261,7 @@ describe("first-greeting", () => {
         assistantName: "Pip",
       });
       expect(greeting).toContain("Probably shipping something or debugging");
-      expect(greeting).not.toContain("Your");
+      expect(greeting).not.toContain("You mentioned using");
     });
 
     it("life admin guess uses verb phrase", () => {
@@ -272,7 +272,9 @@ describe("first-greeting", () => {
         userName: "Alex",
         assistantName: "Pip",
       });
-      expect(greeting).toContain("Gmail and Google Calendar say");
+      expect(greeting).toContain(
+        "You mentioned using Gmail and Google Calendar",
+      );
       expect(greeting).toContain("juggling travel, bills, or household stuff");
     });
 

--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -48,11 +48,6 @@ describe("onboarding template contracts", () => {
       expect(bootstrap).toContain("file_edit");
     });
 
-    test("includes budget constraint", () => {
-      expect(bootstrap).toContain("$2");
-      expect(bootstrap).toContain("$5");
-    });
-
     test("contains core principle", () => {
       expect(bootstrap).toContain("earns its keep");
     });

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -175,13 +175,13 @@ function buildSpecificGuess(tasks: string[], tools: string[]): string {
   const relevant = pickRelevantTools(guess.preferredTools, tools);
 
   if (relevant.length === 2) {
-    return `Your ${relevant[0]} and ${relevant[1]} say you're probably ${guess.text} — am I on the right track, or something else on your mind?`;
+    return `You mentioned using ${relevant[0]} and ${relevant[1]} — probably ${guess.text}? Am I on the right track, or something else on your mind?`;
   }
   if (relevant.length === 1) {
-    return `Your ${relevant[0]} says you're probably ${guess.text} — am I on the right track, or something else on your mind?`;
+    return `You mentioned using ${relevant[0]} — probably ${guess.text}? Am I on the right track, or something else on your mind?`;
   }
 
-  return `Probably ${guess.text} — am I on the right track, or something else on your mind?`;
+  return `Probably ${guess.text}? Am I on the right track, or something else on your mind?`;
 }
 
 function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -2,7 +2,7 @@ _ Lines starting with _ are comments. They won't appear in the system prompt
 
 # BOOTSTRAP.md — First Conversation
 
-One conversation. You have a voice and a budget. Delete this file when you're done.
+One conversation, one shot. You have a voice and a first impression to make. Delete this file when you're done.
 
 ## The principle
 
@@ -21,6 +21,10 @@ If an `onboarding` JSON context is present, you already have their name and a se
 If there's no onboarding context, pick a working name for yourself ("I'll go by Pax") and get to work. Their name can come up later, or never.
 
 Match their energy, not just their format. Lowercase and terse gets lowercase and terse back. Warm gets warm, dry gets dry. Fake enthusiasm reads worse than silence.
+
+If it's unclear what to do — the user is vague, non-committal, or says something like "idk what to do with you" — proposing to ask them a few questions is a legitimate move. A new assistant asking "what should I know about how you work?" or "what have you been wanting from an assistant like me?" is what a real colleague would do on day one. Not a questionnaire, not intake — actual open questions you're curious about the answers to.
+
+If they take that offer, run it as a conversation. Three or four questions that build on each other, adapting based on what they say. Not a checklist. Stop when you have enough to do something useful, or when the conversation wants to go somewhere else.
 
 ## Identity
 
@@ -45,10 +49,6 @@ The current contents of all three files are in your system prompt — use that e
 If finishing the current task naturally points to something bigger — connecting an inbox, working inside Slack, drafting in their voice — mention it then. As the obvious next move, not an upsell. They take it or leave it.
 
 If nothing comes up, don't force it.
-
-## Budget
-
-$2 soft, $5 hard.
 
 ## Wrap up
 


### PR DESCRIPTION
## Summary
- **BOOTSTRAP.md**: Reframes intro from "voice and a budget" to "voice and a first impression to make", adds guidance for handling vague/non-committal users (open questions → conversational flow), removes fixed dollar Budget section
- **First greeting**: Changes tool-based prefixes from "Your {tool} say(s) you're probably" to "You mentioned using {tool} — probably {guess}?" and closes all three variants (two-tool, one-tool, zero-tool) with "Am I on the right track, or something else on your mind?"

## Test plan
- [x] `bun test first-greeting.test.ts` — 27/27 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
