### PR TITLE
fix(macOS): only render VNotification dismiss divider when action is also present

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -55,6 +55,7 @@ public struct VNotification: View {
             Spacer()
 
             if hasTrailingCluster {
+                let actionRendered = actionLabel != nil && onAction != nil
                 HStack(spacing: VSpacing.sm) {
                     if let actionLabel, let onAction {
                         divider
@@ -67,7 +68,9 @@ public struct VNotification: View {
                         .accessibilityLabel(actionLabel)
                     }
                     if let onDismiss {
-                        divider
+                        if actionRendered {
+                            divider
+                        }
                         Button(action: onDismiss) {
                             VIconView(.x, size: 10)
                                 .foregroundStyle(foregroundColor)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan self-review for v-notification.md.

**Gap:** Dangling divider when only dismiss is present
**What was expected:** The divider should separate content from a text label. When `onDismiss` is provided without `actionLabel`, the leading divider looks like a stray hairline with only the × icon after it.
**What was found:** The trailing cluster unconditionally prefixed a divider before both the action and the dismiss button, producing `[Spacer] [divider] [×]` in the dismiss-only case.

Fix: only render the divider before the dismiss button when the action was also rendered. Preserves the `[divider ACTION divider ×]` pattern for the full case and `[divider ACTION]` for action-only, while dismiss-only now renders cleanly as `[×]`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
