### PR TITLE
fix(design-system): VPaidBadge collapse padding + use VRadius.sm

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VPaidBadge.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VPaidBadge.swift
@@ -13,10 +13,9 @@ public struct VPaidBadge: View {
                 .font(VFont.bodySmallEmphasised)
                 .foregroundStyle(VColor.contentDefault)
         }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
+        .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
         .background(VColor.systemPositiveWeak)
-        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Paid integration")
     }


### PR DESCRIPTION
## Summary
Addresses Codex P1 feedback on feature-branch PR #27512 (clients/AGENTS.md):
- Collapse stacked `.padding()` calls into a single `EdgeInsets` (avoids extra layout wrapper in list-heavy UI).
- Replace hardcoded `cornerRadius: 6` with `VRadius.sm` to use the shared radius scale (matches VBadge).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
