### PR TITLE
feat(macOS): add VNotification reusable feedback component

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -76,7 +76,7 @@ public struct VNotification: View {
                                 .foregroundStyle(foregroundColor)
                         }
                         .buttonStyle(.plain)
-                        .accessibilityLabel("Dismiss")
+                        .accessibilityLabel("Dismiss \(toneA11yLabel.lowercased()): \(message)")
                     }
                 }
             }

--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -55,6 +55,7 @@ public struct VNotification: View {
             Spacer()
 
             if hasTrailingCluster {
+                let actionRendered = actionLabel != nil && onAction != nil
                 HStack(spacing: VSpacing.sm) {
                     if let actionLabel, let onAction {
                         divider
@@ -67,7 +68,9 @@ public struct VNotification: View {
                         .accessibilityLabel(actionLabel)
                     }
                     if let onDismiss {
-                        divider
+                        if actionRendered {
+                            divider
+                        }
                         Button(action: onDismiss) {
                             VIconView(.x, size: 10)
                                 .foregroundStyle(foregroundColor)

--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -36,7 +36,7 @@ public struct VNotification: View {
             if showsLeadingIcon {
                 HStack(spacing: VSpacing.xs) {
                     VIconView(leadingIcon, size: 12)
-                        .foregroundStyle(foregroundColor)
+                        .foregroundStyle(iconColor)
                         .accessibilityHidden(true)
                     Text(message)
                         .font(textFont)
@@ -149,13 +149,19 @@ public struct VNotification: View {
 
     private var foregroundColor: Color {
         switch (tone, style) {
-        case (.warning, .strong): return VColor.auxBlack
         case (_, .strong): return VColor.contentInset
         case (.positive, .weak): return VColor.systemPositiveStrong
         case (.negative, .weak): return VColor.systemNegativeStrong
         case (.warning, .weak): return VColor.systemMidStrong
         case (.neutral, .weak): return VColor.contentTertiary
         }
+    }
+
+    private var iconColor: Color {
+        if case (.neutral, .weak) = (tone, style) {
+            return VColor.contentSecondary
+        }
+        return foregroundColor
     }
 
     private var dividerOpacity: Double {

--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -108,7 +108,7 @@ public struct VNotification: View {
 
     private var divider: some View {
         Rectangle()
-            .fill(foregroundColor.opacity(dividerOpacity))
+            .fill(VColor.contentInset.opacity(dividerOpacity))
             .frame(width: 1, height: 18)
             .accessibilityHidden(true)
     }
@@ -161,8 +161,8 @@ public struct VNotification: View {
     private var leadingIcon: VIcon {
         switch tone {
         case .positive: return .circleCheck
-        case .negative: return .circleX
-        case .warning: return .triangleAlert
+        case .negative: return .circleAlert
+        case .warning: return .info
         case .neutral: return .info
         }
     }

--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+
+/// Compact single-line notification bar with optional action and dismiss. Positioned inline or pinned above content. See FeedbackGallerySection for variants.
+public struct VNotification: View {
+    public enum Tone { case positive, negative, warning, neutral }
+    public enum Style { case weak, strong }
+
+    public let message: String
+    public var tone: Tone
+    public var style: Style
+    public var showsLeadingIcon: Bool
+    public var actionLabel: String?
+    public var onAction: (() -> Void)?
+    public var onDismiss: (() -> Void)?
+
+    public init(
+        _ message: String,
+        tone: Tone = .positive,
+        style: Style = .weak,
+        showsLeadingIcon: Bool = true,
+        actionLabel: String? = nil,
+        onAction: (() -> Void)? = nil,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.message = message
+        self.tone = tone
+        self.style = style
+        self.showsLeadingIcon = showsLeadingIcon
+        self.actionLabel = actionLabel
+        self.onAction = onAction
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        HStack(alignment: .center, spacing: 0) {
+            if showsLeadingIcon {
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(leadingIcon, size: 12)
+                        .foregroundStyle(foregroundColor)
+                        .accessibilityHidden(true)
+                    Text(message)
+                        .font(textFont)
+                        .foregroundStyle(textColor)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            } else {
+                Text(message)
+                    .font(textFont)
+                    .foregroundStyle(textColor)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            Spacer()
+
+            if hasTrailingCluster {
+                HStack(spacing: VSpacing.sm) {
+                    if let actionLabel, let onAction {
+                        divider
+                        Button(action: onAction) {
+                            Text(actionLabel)
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(foregroundColor)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(actionLabel)
+                    }
+                    if let onDismiss {
+                        divider
+                        Button(action: onDismiss) {
+                            VIconView(.x, size: 10)
+                                .foregroundStyle(foregroundColor)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Dismiss")
+                    }
+                }
+            }
+        }
+        .frame(height: 32)
+        .padding(.horizontal, VSpacing.sm)
+        .background(backgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .accessibilityElement(children: isInteractive ? .contain : .combine)
+    }
+
+    private var hasTrailingCluster: Bool {
+        (actionLabel != nil && onAction != nil) || onDismiss != nil
+    }
+
+    private var isInteractive: Bool {
+        (actionLabel != nil && onAction != nil) || onDismiss != nil
+    }
+
+    private var divider: some View {
+        Rectangle()
+            .fill(foregroundColor.opacity(dividerOpacity))
+            .frame(width: 1, height: 18)
+            .accessibilityHidden(true)
+    }
+
+    private var textFont: Font {
+        switch style {
+        case .weak: return VFont.bodyMediumDefault
+        case .strong: return VFont.bodyMediumLighter
+        }
+    }
+
+    private var textColor: Color {
+        if case .neutral = tone, case .weak = style {
+            return VColor.contentTertiary
+        }
+        return foregroundColor
+    }
+
+    private var backgroundColor: Color {
+        switch (tone, style) {
+        case (.positive, .weak): return VColor.systemPositiveWeak
+        case (.positive, .strong): return VColor.systemPositiveStrong
+        case (.negative, .weak): return VColor.systemNegativeWeak
+        case (.negative, .strong): return VColor.systemNegativeStrong
+        case (.warning, .weak): return VColor.systemMidWeak
+        case (.warning, .strong): return VColor.systemMidStrong
+        case (.neutral, .weak): return VColor.contentBackground
+        case (.neutral, .strong): return VColor.contentSecondary
+        }
+    }
+
+    private var foregroundColor: Color {
+        switch (tone, style) {
+        case (_, .strong): return VColor.contentInset
+        case (.positive, .weak): return VColor.systemPositiveStrong
+        case (.negative, .weak): return VColor.systemNegativeStrong
+        case (.warning, .weak): return VColor.systemMidStrong
+        case (.neutral, .weak): return VColor.contentTertiary
+        }
+    }
+
+    private var dividerOpacity: Double {
+        switch (tone, style) {
+        case (.neutral, .weak): return 0.20
+        default: return 0.30
+        }
+    }
+
+    private var leadingIcon: VIcon {
+        switch tone {
+        case .positive: return .circleCheck
+        case .negative: return .circleX
+        case .warning: return .triangleAlert
+        case .neutral: return .info
+        }
+    }
+}

--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -132,7 +132,7 @@ public struct VNotification: View {
 
     private var foregroundColor: Color {
         switch (tone, style) {
-        case (.warning, .strong): return VColor.primaryBase
+        case (.warning, .strong): return VColor.auxBlack
         case (_, .strong): return VColor.contentInset
         case (.positive, .weak): return VColor.systemPositiveStrong
         case (.negative, .weak): return VColor.systemNegativeStrong

--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -65,6 +65,7 @@ public struct VNotification: View {
                                 .foregroundStyle(foregroundColor)
                         }
                         .buttonStyle(.plain)
+                        .pointerCursor()
                         .accessibilityLabel(actionLabel)
                     }
                     if let onDismiss {
@@ -76,6 +77,7 @@ public struct VNotification: View {
                                 .foregroundStyle(foregroundColor)
                         }
                         .buttonStyle(.plain)
+                        .pointerCursor()
                         .accessibilityLabel("Dismiss \(toneA11yLabel.lowercased()): \(message)")
                     }
                 }

--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -108,9 +108,16 @@ public struct VNotification: View {
 
     private var divider: some View {
         Rectangle()
-            .fill(VColor.contentInset.opacity(dividerOpacity))
+            .fill(dividerColor.opacity(dividerOpacity))
             .frame(width: 1, height: 18)
             .accessibilityHidden(true)
+    }
+
+    private var dividerColor: Color {
+        switch style {
+        case .strong: return VColor.contentInset
+        case .weak: return foregroundColor
+        }
     }
 
     private var textFont: Font {

--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -86,6 +86,16 @@ public struct VNotification: View {
         .background(backgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .accessibilityElement(children: isInteractive ? .contain : .combine)
+        .accessibilityLabel("\(toneA11yLabel). \(message)")
+    }
+
+    private var toneA11yLabel: String {
+        switch tone {
+        case .positive: return "Success"
+        case .negative: return "Error"
+        case .warning: return "Warning"
+        case .neutral: return "Notice"
+        }
     }
 
     private var hasTrailingCluster: Bool {

--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -132,6 +132,7 @@ public struct VNotification: View {
 
     private var foregroundColor: Color {
         switch (tone, style) {
+        case (.warning, .strong): return VColor.primaryBase
         case (_, .strong): return VColor.contentInset
         case (.positive, .weak): return VColor.systemPositiveStrong
         case (.negative, .weak): return VColor.systemNegativeStrong

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -91,6 +91,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                 GalleryComponent("vTag", "VTag", keywords: ["tag", "category", "kind"], description: "Colored tag for categorizing items with pastel backgrounds."),
                 GalleryComponent("vLoadingIndicator", "VLoadingIndicator", keywords: ["loading", "spinner"], description: "Spinning indicator for inline loading states. Use VSkeletonBone for structured loading layouts."),
                 GalleryComponent("vToast", "VToast", keywords: ["toast", "notification"], description: "Temporary notification banner with auto-dismiss and action support."),
+                GalleryComponent("vNotification", "VNotification", keywords: ["notification", "banner", "notice", "alert bar", "inline status"], description: "Compact single-line notification bar with tone, optional action, and dismiss. Use when you need a slim inline or pinned status indicator — smaller than VToast, more actionable than VInlineMessage."),
                 GalleryComponent("vInlineMessage", "VInlineMessage", keywords: ["inline message", "alert"], description: "Persistent inline alert with icon and semantic color (info, warning, error, success)."),
                 GalleryComponent("vShortcutTag", "VShortcutTag", keywords: ["shortcut", "keyboard"], description: "Keyboard shortcut display tag showing key combinations."),
                 GalleryComponent("vCopyButton", "VCopyButton", keywords: ["copy", "clipboard"], description: "One-click copy button with animated checkmark success feedback."),

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -237,6 +237,152 @@ struct FeedbackGallerySection: View {
                 }
             }
 
+            if filter == nil || filter == "vNotification" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+                // MARK: - VNotification
+                GallerySectionHeader(
+                    title: "VNotification",
+                    description: "Compact single-line feedback bar. Supports 4 tones × 2 styles, with optional leading icon, action label, and dismiss button."
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        // 4 tones × 2 styles grid
+                        LazyVGrid(
+                            columns: [GridItem(.flexible()), GridItem(.flexible())],
+                            spacing: VSpacing.md
+                        ) {
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Positive · Weak").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .positive,
+                                    style: .weak,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Positive · Strong").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .positive,
+                                    style: .strong,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Negative · Weak").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .negative,
+                                    style: .weak,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Negative · Strong").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .negative,
+                                    style: .strong,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Warning · Weak").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .warning,
+                                    style: .weak,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Warning · Strong").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .warning,
+                                    style: .strong,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Neutral · Weak").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .neutral,
+                                    style: .weak,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Neutral · Strong").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .neutral,
+                                    style: .strong,
+                                    actionLabel: "Action",
+                                    onAction: {},
+                                    onDismiss: {}
+                                )
+                            }
+                        }
+
+                        Divider().background(VColor.borderBase)
+
+                        // Optional slots
+                        Text("Optional slots")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                        VStack(alignment: .leading, spacing: VSpacing.sm) {
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Message only").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .positive,
+                                    style: .weak
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Message + dismiss").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .positive,
+                                    style: .weak,
+                                    onDismiss: {}
+                                )
+                            }
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Message + action").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VNotification(
+                                    "This is a notification component",
+                                    tone: .positive,
+                                    style: .weak,
+                                    actionLabel: "Action",
+                                    onAction: {}
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
             if filter == nil || filter == "vInlineMessage" {
                 if filter == nil {
                     Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
@@ -536,6 +682,7 @@ extension FeedbackGallerySection {
         case "vTag": FeedbackGallerySection(filter: "vTag")
         case "vLoadingIndicator": FeedbackGallerySection(filter: "vLoadingIndicator")
         case "vToast": FeedbackGallerySection(filter: "vToast")
+        case "vNotification": FeedbackGallerySection(filter: "vNotification")
         case "vInlineMessage": FeedbackGallerySection(filter: "vInlineMessage")
         case "vShortcutTag": FeedbackGallerySection(filter: "vShortcutTag")
         case "vCopyButton": FeedbackGallerySection(filter: "vCopyButton")


### PR DESCRIPTION
## Summary
Add a reusable `VNotification` design system component (compact 32pt-tall inline notification bar) translated from the Figma "Notice" design. Supports 4 tones (positive/negative/warning/neutral) × 2 styles (weak/strong), with optional leading icon, action label, and dismiss button. All colors map to existing `VColor` semantic tokens — no new tokens introduced. Registered in the Component Gallery under Feedback.

## Self-review result
PASS — 1 gap fixed across 1 fix PR.

## PRs merged into feature branch
- #27496: feat(macOS): add VNotification feedback component to shared DesignSystem
- #27510: feat(macOS): add VNotification variants to Feedback component gallery

### Fix PRs
- #27514: fix(macOS): only render VNotification dismiss divider when action is also present

## Deliberate plan deviations
- Message text uses `.lineLimit(1) + .truncationMode(.tail)` instead of the plan's `.fixedSize(horizontal: false, vertical: true)`. Reason: the container is a fixed 32pt-tall bar; `.fixedSize(vertical: true)` would expand text vertically and clip. Fix applied during PR 1 external review (Codex P2).
- `.warning` tone uses `.triangleAlert` leading icon instead of the plan's `.info`. Reason: sibling `VInlineMessage` and `VToast` both use `.triangleAlert` for warnings; consistency matters more than the Figma's literal `info-circle` asset (which was likely a reused placeholder in the design file). Fix applied during PR 1 external review (Devin).

Part of plan: v-notification.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
