### PR TITLE
fix(design-system): VBadge `.accent` solid label uses adaptive `contentInset` foreground

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Compact status indicator: count, dot, or text label with semantic tone.
 /// For categorization with colored backgrounds and icons, use `VTag` instead.
+/// Accent tone pairs adaptive `primaryBase` backgrounds with adaptive `contentInset` foregrounds so text stays legible in both light and dark mode.
 public struct VBadge: View {
     public enum Style {
         case count(Int)
@@ -90,7 +91,9 @@ public struct VBadge: View {
         }
 
         switch (tone, emphasis) {
-        case (.accent, .solid), (.positive, .solid), (.danger, .solid):
+        case (.accent, .solid):
+            return VColor.contentInset
+        case (.positive, .solid), (.danger, .solid):
             return VColor.auxWhite
         case (.warning, .solid):
             return VColor.contentEmphasized


### PR DESCRIPTION
## Summary
- Split the combined `(.accent/.positive/.danger, .solid)` case in `labelForegroundColor` so `.accent` returns the adaptive `VColor.contentInset` (inverse of `primaryBase`), while non-adaptive `.positive`/`.danger` backgrounds keep `.auxWhite`.
- Fixes white-on-white invisibility of the accent-solid label in dark mode.

Part of plan: vbadge-accent-solid.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
