### PR TITLE
fix(design-system): VPaidBadge use VRadius.md

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VPaidBadge.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VPaidBadge.swift
@@ -15,7 +15,7 @@ public struct VPaidBadge: View {
         }
         .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
         .background(VColor.systemPositiveWeak)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Paid integration")
     }


### PR DESCRIPTION
Bump VPaidBadge corner radius from `VRadius.sm` (4pt) to `VRadius.md` (8pt) per design feedback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
