### PR TITLE
feat(design-system): add VRadius.chip (6pt) and use it in VPaidBadge

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VPaidBadge.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VPaidBadge.swift
@@ -15,7 +15,7 @@ public struct VPaidBadge: View {
         }
         .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
         .background(VColor.systemPositiveWeak)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.chip))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Paid integration")
     }

--- a/clients/shared/DesignSystem/Tokens/RadiusTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/RadiusTokens.swift
@@ -9,6 +9,10 @@ public enum VRadius {
     public static let xl: CGFloat  = 16
     public static let xxl: CGFloat = 20
 
+    /// 6pt radius for chip/tag/badge-style components. Sits between `sm`
+    /// (4pt) and `md` (8pt); use when neither t-shirt step matches.
+    public static let chip: CGFloat = 6
+
     /// Matches the macOS NSWindow corner radius (~10pt on Ventura+).
     /// Use when clipping content to align with the system window chrome.
     public static let window: CGFloat = 10


### PR DESCRIPTION
Adds a new `VRadius.chip` = 6pt token to fill the gap between `sm` (4) and `md` (8) for chip/tag/badge-style components. Switches VPaidBadge from `VRadius.md` to `VRadius.chip` to match the Figma spec exactly.

Existing hardcoded-6 sites (`VTag`, `VSegmentControl`, a couple of feature files) are left alone in this PR — they can migrate to `VRadius.chip` in a separate cleanup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
