### PR TITLE
fix(design-system): VBadge count badge adopts tone-aware adaptive foreground

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Compact status indicator: count, dot, or text label with semantic tone.
 /// For categorization with colored backgrounds and icons, use `VTag` instead.
+/// Use `init(label:tone:)` for tone-aware label badges and `init(count:tone:)` for tone-aware count badges.
 /// Accent tone pairs adaptive `primaryBase` backgrounds with adaptive `contentInset` foregrounds so text stays legible in both light and dark mode.
 public struct VBadge: View {
     public enum Style {
@@ -48,15 +49,28 @@ public struct VBadge: View {
         self.shape = shape
     }
 
+    public init(
+        count: Int,
+        tone: Tone = .accent,
+        emphasis: Emphasis = .solid,
+        shape: Shape = .pill
+    ) {
+        self.style = .count(count)
+        self.color = VColor.primaryBase  // overridden by tone resolution below; kept for API stability
+        self.tone = tone
+        self.emphasis = emphasis
+        self.shape = shape
+    }
+
     public var body: some View {
         switch style {
         case .count(let count):
             Text("\(count)")
                 .font(VFont.labelDefault)
-                .foregroundStyle(VColor.auxWhite)
+                .foregroundStyle(countForegroundColor)
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.vertical, VSpacing.xxs)
-                .background(color)
+                .background(countBackgroundColor)
                 .clipShape(Capsule())
                 .accessibilityLabel("\(count) \(count == 1 ? "item" : "items")")
 
@@ -68,13 +82,23 @@ public struct VBadge: View {
         case .label(let text):
             Text(text)
                 .font(VFont.labelDefault)
-                .foregroundStyle(labelForegroundColor)
+                .foregroundStyle(toneForegroundColor)
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.vertical, labelVerticalPadding)
-                .background(labelBackgroundColor)
+                .background(toneBackgroundColor)
                 .modifier(LabelShapeModifier(shape: shape, borderColor: labelBorderColor, borderWidth: labelBorderWidth))
                 .accessibilityLabel(text)
         }
+    }
+
+    // MARK: - Count Color Resolution
+
+    private var countForegroundColor: Color {
+        tone != nil ? toneForegroundColor : VColor.auxWhite
+    }
+
+    private var countBackgroundColor: Color {
+        tone != nil ? toneBackgroundColor : color
     }
 
     // MARK: - Shape Helpers
@@ -85,7 +109,7 @@ public struct VBadge: View {
 
     // MARK: - Color Resolution
 
-    private var labelForegroundColor: Color {
+    private var toneForegroundColor: Color {
         guard let tone else {
             return emphasis == .subtle ? VColor.contentEmphasized : VColor.auxWhite
         }
@@ -112,7 +136,7 @@ public struct VBadge: View {
         }
     }
 
-    private var labelBackgroundColor: Color {
+    private var toneBackgroundColor: Color {
         guard let tone else {
             return emphasis == .subtle ? color.opacity(0.2) : color
         }

--- a/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
@@ -275,7 +275,7 @@ struct DisplayGallerySection: View {
                                     .font(VFont.bodyMediumLighter)
                                     .foregroundStyle(VColor.contentDefault)
                                 Spacer()
-                                VBadge(style: .count(3))
+                                VBadge(count: 3, tone: .accent)
                             }
                         }
 

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -36,15 +36,15 @@ struct FeedbackGallerySection: View {
                             }
                             VStack(spacing: VSpacing.xs) {
                                 Text("Success").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                                VBadge(style: .count(Int(badgeCount)), color: VColor.systemPositiveStrong)
+                                VBadge(count: Int(badgeCount), tone: .positive)
                             }
                             VStack(spacing: VSpacing.xs) {
                                 Text("Error").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                                VBadge(style: .count(Int(badgeCount)), color: VColor.systemNegativeStrong)
+                                VBadge(count: Int(badgeCount), tone: .danger)
                             }
                             VStack(spacing: VSpacing.xs) {
                                 Text("Warning").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                                VBadge(style: .count(Int(badgeCount)), color: VColor.systemMidStrong)
+                                VBadge(count: Int(badgeCount), tone: .warning)
                             }
                         }
 

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -32,7 +32,7 @@ struct FeedbackGallerySection: View {
                         HStack(spacing: VSpacing.xl) {
                             VStack(spacing: VSpacing.xs) {
                                 Text("Accent").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                                VBadge(style: .count(Int(badgeCount)), color: VColor.primaryBase)
+                                VBadge(count: Int(badgeCount), tone: .accent)
                             }
                             VStack(spacing: VSpacing.xs) {
                                 Text("Success").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)


### PR DESCRIPTION
## Summary
- Add `VBadge(count:tone:emphasis:shape:)` that routes through the shared tone→fg/bg helpers so the Accent count pairs `primaryBase` ↔ `contentInset` (adaptive) instead of white-on-white in dark mode.
- Rename internal `labelForegroundColor`/`labelBackgroundColor` helpers to `toneForegroundColor`/`toneBackgroundColor` and share them with the `.count` branch.
- Migrate the Accent count badges in `FeedbackGallerySection` and `DisplayGallerySection` to the new tone-based init. Legacy `init(style:color:shape:)` remains source-compatible.

Part of plan: vbadge-accent-solid.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
