### PR TITLE
refactor(media): extract shared image-generation types

### DIFF
--- a/assistant/src/media/types.ts
+++ b/assistant/src/media/types.ts
@@ -1,0 +1,33 @@
+export type ImageGenProvider = "gemini" | "openai";
+
+export interface DirectCredentials {
+  type: "direct";
+  apiKey: string;
+}
+export interface ManagedProxyCredentials {
+  type: "managed-proxy";
+  assistantApiKey: string;
+  baseUrl: string;
+}
+export type ImageGenCredentials = DirectCredentials | ManagedProxyCredentials;
+
+export interface ImageGenerationRequest {
+  prompt: string;
+  mode: "generate" | "edit";
+  sourceImages?: Array<{ mimeType: string; dataBase64: string }>;
+  model?: string;
+  variants?: number;
+}
+
+export interface GeneratedImage {
+  mimeType: string;
+  dataBase64: string;
+  title?: string;
+}
+export interface ImageGenerationResult {
+  images: GeneratedImage[];
+  text?: string;
+  resolvedModel: string;
+}
+
+export const MAX_VARIANTS = 4;


### PR DESCRIPTION
## Summary
- Introduce assistant/src/media/types.ts with provider-agnostic types (ImageGenProvider, ImageGenCredentials, ImageGenerationRequest, ImageGenerationResult, GeneratedImage, MAX_VARIANTS).
- No existing file modified; types are structurally compatible with the inline types in gemini-image-service.ts.

Part of plan: gpt-image-2-support.md (PR 1 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
