### PR TITLE
fix(config): derive image-gen provider from model prefix in setImageGenModel

### DIFF
--- a/assistant/src/__tests__/config-model-image-provider.test.ts
+++ b/assistant/src/__tests__/config-model-image-provider.test.ts
@@ -1,0 +1,110 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { invalidateConfigCache } from "../config/loader.js";
+import {
+  type ModelSetContext,
+  setImageGenModel,
+} from "../daemon/handlers/config-model.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  const dirs = [WORKSPACE_DIR, join(WORKSPACE_DIR, "data")];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+function writeConfig(obj: unknown): void {
+  writeFileSync(CONFIG_PATH, JSON.stringify(obj));
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+}
+
+function makeCtx(): ModelSetContext {
+  return {
+    conversations: new Map(),
+    suppressConfigReload: false,
+    setSuppressConfigReload: () => {},
+    updateConfigFingerprint: () => {},
+    debounceTimers: {
+      // No-op scheduler: the test asserts the persisted config shape, not
+      // the debounce behaviour. Firing the callback synchronously would
+      // mutate state after the assertion; dropping it keeps the test
+      // deterministic.
+      schedule: (_key: string, _fn: () => void, _ms: number) => {},
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  ensureTestDir();
+  writeConfig({});
+  invalidateConfigCache();
+});
+
+afterEach(() => {
+  try {
+    writeConfig({});
+    invalidateConfigCache();
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("setImageGenModel — provider derived from model prefix", () => {
+  test("gemini model writes provider=gemini", () => {
+    setImageGenModel("gemini-3.1-flash-image-preview", makeCtx());
+
+    const config = readConfig();
+    const imageGen = (config.services as any)?.["image-generation"];
+    expect(imageGen?.model).toBe("gemini-3.1-flash-image-preview");
+    expect(imageGen?.provider).toBe("gemini");
+  });
+
+  test("gpt-image-2 writes provider=openai", () => {
+    setImageGenModel("gpt-image-2", makeCtx());
+
+    const config = readConfig();
+    const imageGen = (config.services as any)?.["image-generation"];
+    expect(imageGen?.model).toBe("gpt-image-2");
+    expect(imageGen?.provider).toBe("openai");
+  });
+
+  test("dall-e-3 writes provider=openai", () => {
+    setImageGenModel("dall-e-3", makeCtx());
+
+    const config = readConfig();
+    const imageGen = (config.services as any)?.["image-generation"];
+    expect(imageGen?.model).toBe("dall-e-3");
+    expect(imageGen?.provider).toBe("openai");
+  });
+
+  test("switching from gemini to openai flips provider in place", () => {
+    setImageGenModel("gemini-3.1-flash-image-preview", makeCtx());
+    let imageGen = (readConfig().services as any)?.["image-generation"];
+    expect(imageGen?.provider).toBe("gemini");
+
+    setImageGenModel("gpt-image-2", makeCtx());
+    imageGen = (readConfig().services as any)?.["image-generation"];
+    expect(imageGen?.model).toBe("gpt-image-2");
+    expect(imageGen?.provider).toBe("openai");
+  });
+});

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -219,6 +219,16 @@ export async function setModel(
 export function setImageGenModel(modelId: string, ctx: ModelSetContext): void {
   const raw = loadRawConfig();
   setServiceField(raw, "image-generation", "model", modelId);
+  // Mirror the prefix logic used by workspace migration
+  // 006-services-config.ts: OpenAI-prefixed models map to the "openai"
+  // provider, everything else defaults to "gemini". Keeping the derived
+  // provider in sync with the selected model prevents downstream routing
+  // from sending a Gemini request to an OpenAI model (or vice versa).
+  const derivedProvider =
+    modelId.startsWith("gpt-") || modelId.startsWith("dall-e-")
+      ? "openai"
+      : "gemini";
+  setServiceField(raw, "image-generation", "provider", derivedProvider);
 
   const wasSuppressed = ctx.suppressConfigReload;
   ctx.setSuppressConfigReload(true);


### PR DESCRIPTION
## Summary
- setImageGenModel now writes both model and derived provider (gpt-*/dall-e-* → openai, else gemini), matching the prefix logic in workspace migration 006.
- Adds config-model-image-provider.test.ts covering Gemini, gpt-image-2, and dall-e-3 selections.

Part of plan: gpt-image-2-support.md (PR 2 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
