### PR TITLE
fix(title): block 'Missing Context' meta-outputs from auto-title flow

### DIFF
--- a/assistant/src/__tests__/conversation-title-service.test.ts
+++ b/assistant/src/__tests__/conversation-title-service.test.ts
@@ -214,6 +214,122 @@ describe("conversation-title-service", () => {
     );
   });
 
+  test("rejects meta-failure outputs like 'Missing Context' and uses fallback", async () => {
+    mockRunBtwSidechain.mockImplementationOnce(async () => ({
+      text: "Missing Context",
+      hadTextDeltas: true,
+      response: {
+        content: [{ type: "text", text: "Missing Context" }],
+        model: "test-model",
+        usage: { inputTokens: 10, outputTokens: 5 },
+        stopReason: "end_turn",
+      },
+    }));
+
+    const provider = {
+      name: "test-provider",
+      sendMessage: mock(async () => {
+        throw new Error("should not call directly");
+      }),
+    };
+
+    const result = await generateAndPersistConversationTitle({
+      conversationId: "conv-1",
+      provider,
+      userMessage: "so about that t-shirt...",
+    });
+
+    expect(result.title).toBe("Untitled Conversation");
+    expect(mockUpdateConversationTitle).toHaveBeenCalledWith(
+      "conv-1",
+      "Untitled Conversation",
+      1,
+    );
+  });
+
+  test.each([
+    "missing context",
+    "No Context",
+    "Insufficient Context",
+    "Unclear Request",
+    "No Topic",
+    "Empty Conversation",
+  ])("rejects meta-failure variant: %s", async (bad) => {
+    mockRunBtwSidechain.mockImplementationOnce(async () => ({
+      text: bad,
+      hadTextDeltas: true,
+      response: {
+        content: [{ type: "text", text: bad }],
+        model: "test-model",
+        usage: { inputTokens: 10, outputTokens: 5 },
+        stopReason: "end_turn",
+      },
+    }));
+
+    const provider = {
+      name: "test-provider",
+      sendMessage: mock(async () => {
+        throw new Error("should not call directly");
+      }),
+    };
+
+    const result = await generateAndPersistConversationTitle({
+      conversationId: "conv-1",
+      provider,
+      userMessage: "something",
+    });
+
+    expect(result.title).toBe("Untitled Conversation");
+  });
+
+  test("regeneration skips LLM call when recent messages have no extractable text", async () => {
+    mockGetMessages.mockReturnValueOnce([
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "tool_use", id: "toolu_1", name: "bash", input: {} },
+        ]),
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_1",
+            content: [{ type: "image", source: {} }],
+          },
+        ]),
+      },
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "tool_use", id: "toolu_2", name: "bash", input: {} },
+        ]),
+      },
+    ]);
+
+    mockGetConversation.mockReturnValueOnce({
+      title: "Existing Title",
+      isAutoTitle: 1,
+    });
+
+    const provider = {
+      name: "test-provider",
+      sendMessage: mock(async () => {
+        throw new Error("should not call directly");
+      }),
+    };
+
+    const result = await regenerateConversationTitle({
+      conversationId: "conv-1",
+      provider,
+    });
+
+    expect(mockRunBtwSidechain).not.toHaveBeenCalled();
+    expect(mockUpdateConversationTitle).not.toHaveBeenCalled();
+    expect(result).toEqual({ title: "Existing Title", updated: false });
+  });
+
   test("title prompt content does not contain generation instructions", async () => {
     const provider = {
       name: "test-provider",

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -234,6 +234,12 @@ export async function regenerateConversationTitle(
   }
 
   const prompt = buildRegenerationPrompt(recentMessages);
+  // Skip the LLM call if no messages yielded extractable text — the prompt
+  // would be just the "Recent messages:" header, and the model tends to
+  // fabricate a meta-title about the emptiness rather than decline.
+  if (!/\n(?:User|Assistant): /.test(prompt)) {
+    return { title: conversation.title ?? UNTITLED_FALLBACK, updated: false };
+  }
   const result = await runBtwSidechain({
     content: prompt,
     provider,
@@ -296,6 +302,7 @@ function buildTitleSystemPrompt(): string {
     "- Do NOT echo back what the user asked you to do",
     "- Do NOT respond to the conversation content",
     "- Do NOT assess feasibility or comment on capabilities",
+    "- If input is sparse or references external context, extract a topic from the words that ARE present (e.g. 'so about that t-shirt...' → 'T-Shirt Discussion'). Never describe the absence, emptiness, or insufficiency of context — titles like 'Missing Context', 'Unclear Request', 'No Topic' are forbidden",
   ].join("\n");
 }
 
@@ -329,9 +336,27 @@ function buildTitlePrompt(
   return parts.join("\n");
 }
 
+const META_FAILURE_TITLES = new Set([
+  "missing context",
+  "no context",
+  "insufficient context",
+  "unclear context",
+  "empty context",
+  "no topic",
+  "unclear topic",
+  "unclear request",
+  "unclear message",
+  "empty conversation",
+  "empty message",
+  "no content",
+]);
+
 function normalizeTitle(raw: string): string {
   let title = raw.trim().replace(/^["']|["']$/g, "");
   title = stripMarkdown(title);
+  if (META_FAILURE_TITLES.has(title.toLowerCase())) {
+    return "";
+  }
   return title;
 }
 


### PR DESCRIPTION
## Summary
- The auto-title LLM occasionally returns refusal-shaped outputs (e.g. \`Missing Context\`) when given sparse / self-referential first messages, and those outputs were persisted as-is. Adds a literal blocklist in \`normalizeTitle\` so those outputs fall through to the existing \`UNTITLED_FALLBACK\` branch.
- Strengthens the title system prompt with an explicit rule banning meta-commentary about the absence of context, plus a positive example.
- Short-circuits the second-pass regeneration when the last 3 messages yield no extractable text (tool-only windows), avoiding an LLM call on a \`Recent messages:\`-only prompt that also tends to produce meta-titles.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
