### PR TITLE
feat(macos/settings): add gpt-image-2 to image-gen model list

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -74,12 +74,21 @@ public final class SettingsStore: ObservableObject {
     static let availableImageGenModels: [String] = [
         "gemini-3.1-flash-image-preview",
         "gemini-3-pro-image-preview",
+        "gpt-image-2",
     ]
 
     static let imageGenModelDisplayNames: [String: String] = [
         "gemini-3.1-flash-image-preview": "Nano Banana 2",
         "gemini-3-pro-image-preview": "Nano Banana Pro",
+        "gpt-image-2": "GPT Image 2",
     ]
+
+    static func imageGenProvider(forModel model: String) -> String {
+        if model.hasPrefix("gpt-") || model.hasPrefix("dall-e-") {
+            return "openai"
+        }
+        return "gemini"
+    }
 
     // MARK: - Settings Values
 


### PR DESCRIPTION
## Summary
- Add gpt-image-2 to availableImageGenModels and a GPT Image 2 display name.
- Add SettingsStore.imageGenProvider(forModel:) helper used by PR 10's settings card to show provider-aware API key fields.

Part of plan: gpt-image-2-support.md (PR 3 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
