### PR TITLE
refactor(media): extract image-gen credential resolution

### DIFF
--- a/assistant/src/__tests__/image-credentials.test.ts
+++ b/assistant/src/__tests__/image-credentials.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must appear before importing the module under test
+// ---------------------------------------------------------------------------
+
+let mockProviderKey: string | undefined;
+let mockManagedBaseUrl: string | undefined;
+let mockAssistantApiKey = "";
+
+mock.module("../security/secure-keys.js", () => ({
+  getProviderKeyAsync: async (_provider: string) => mockProviderKey,
+}));
+
+mock.module("../providers/managed-proxy/context.js", () => ({
+  buildManagedBaseUrl: async (_provider: string) => mockManagedBaseUrl,
+  resolveManagedProxyContext: async () => ({
+    enabled: !!mockManagedBaseUrl,
+    platformBaseUrl: mockManagedBaseUrl ? "https://platform.example.com" : "",
+    assistantApiKey: mockAssistantApiKey,
+  }),
+}));
+
+// Import after mocks
+import { resolveImageGenCredentials } from "../media/image-credentials.js";
+
+describe("resolveImageGenCredentials", () => {
+  beforeEach(() => {
+    mockProviderKey = undefined;
+    mockManagedBaseUrl = undefined;
+    mockAssistantApiKey = "";
+  });
+
+  describe("managed mode", () => {
+    test("returns managed-proxy credentials when buildManagedBaseUrl resolves", async () => {
+      mockManagedBaseUrl = "https://platform.example.com/proxy/gemini";
+      mockAssistantApiKey = "sk-assistant-key";
+
+      const result = await resolveImageGenCredentials({
+        provider: "gemini",
+        mode: "managed",
+      });
+
+      expect(result.errorHint).toBeUndefined();
+      expect(result.credentials).toEqual({
+        type: "managed-proxy",
+        assistantApiKey: "sk-assistant-key",
+        baseUrl: "https://platform.example.com/proxy/gemini",
+      });
+    });
+
+    test("returns errorHint mentioning 'log in to Vellum' when managed base URL is unavailable", async () => {
+      mockManagedBaseUrl = undefined;
+
+      const result = await resolveImageGenCredentials({
+        provider: "gemini",
+        mode: "managed",
+      });
+
+      expect(result.credentials).toBeUndefined();
+      expect(result.errorHint).toBeDefined();
+      expect(result.errorHint).toContain("log in to Vellum");
+    });
+  });
+
+  describe("your-own mode", () => {
+    test("returns direct credentials for gemini when key is present", async () => {
+      mockProviderKey = "gemini-api-key";
+
+      const result = await resolveImageGenCredentials({
+        provider: "gemini",
+        mode: "your-own",
+      });
+
+      expect(result.errorHint).toBeUndefined();
+      expect(result.credentials).toEqual({
+        type: "direct",
+        apiKey: "gemini-api-key",
+      });
+    });
+
+    test("returns errorHint mentioning 'Gemini API key' when no key is set", async () => {
+      mockProviderKey = undefined;
+
+      const result = await resolveImageGenCredentials({
+        provider: "gemini",
+        mode: "your-own",
+      });
+
+      expect(result.credentials).toBeUndefined();
+      expect(result.errorHint).toBeDefined();
+      expect(result.errorHint).toContain("Gemini API key");
+    });
+
+    test("returns direct credentials for openai when key is present", async () => {
+      mockProviderKey = "openai-api-key";
+
+      const result = await resolveImageGenCredentials({
+        provider: "openai",
+        mode: "your-own",
+      });
+
+      expect(result.errorHint).toBeUndefined();
+      expect(result.credentials).toEqual({
+        type: "direct",
+        apiKey: "openai-api-key",
+      });
+    });
+
+    test("returns errorHint mentioning 'OpenAI API key' when no key is set", async () => {
+      mockProviderKey = undefined;
+
+      const result = await resolveImageGenCredentials({
+        provider: "openai",
+        mode: "your-own",
+      });
+
+      expect(result.credentials).toBeUndefined();
+      expect(result.errorHint).toBeDefined();
+      expect(result.errorHint).toContain("OpenAI API key");
+    });
+  });
+});

--- a/assistant/src/media/image-credentials.ts
+++ b/assistant/src/media/image-credentials.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared credential resolver for image-generation call sites.
+ *
+ * Consolidates the logic that was previously duplicated across the
+ * image-studio tool, the CLI `image-generation` command, and the
+ * app-icon generator. Each site picks between the managed-proxy path
+ * (routes through the platform) and the "your own" path (direct
+ * provider API key), and both paths need consistent, provider-aware
+ * error hints when credentials are unavailable.
+ */
+
+import {
+  buildManagedBaseUrl,
+  resolveManagedProxyContext,
+} from "../providers/managed-proxy/context.js";
+import { getProviderKeyAsync } from "../security/secure-keys.js";
+import type { ImageGenCredentials, ImageGenProvider } from "./types.js";
+
+/**
+ * Resolve credentials for an image-generation request.
+ *
+ * - `mode === "managed"`: returns managed-proxy credentials when the
+ *   platform URL and assistant API key are both configured, otherwise
+ *   returns a hint telling the user to log in or switch modes.
+ * - `mode === "your-own"`: returns direct credentials when the provider
+ *   API key is present in secure storage (or the env-var fallback),
+ *   otherwise returns a provider-aware hint pointing at Settings.
+ */
+export async function resolveImageGenCredentials(opts: {
+  provider: ImageGenProvider;
+  mode: "managed" | "your-own";
+}): Promise<{ credentials?: ImageGenCredentials; errorHint?: string }> {
+  const { provider, mode } = opts;
+
+  if (mode === "managed") {
+    const baseUrl = await buildManagedBaseUrl(provider);
+    if (!baseUrl) {
+      return {
+        errorHint:
+          "Managed proxy is not available. Please log in to Vellum or switch to Your Own mode.",
+      };
+    }
+    const ctx = await resolveManagedProxyContext();
+    return {
+      credentials: {
+        type: "managed-proxy",
+        assistantApiKey: ctx.assistantApiKey,
+        baseUrl,
+      },
+    };
+  }
+
+  // mode === "your-own"
+  const apiKey = await getProviderKeyAsync(provider);
+  if (apiKey) {
+    return { credentials: { type: "direct", apiKey } };
+  }
+  return { errorHint: providerKeyHint(provider) };
+}
+
+function providerKeyHint(provider: ImageGenProvider): string {
+  switch (provider) {
+    case "gemini":
+      return "No Gemini API key configured. Please set your Gemini API key in Settings > Models & Services.";
+    case "openai":
+      return "No OpenAI API key configured. Please set your OpenAI API key in Settings > Models & Services.";
+  }
+}


### PR DESCRIPTION
## Summary
- New assistant/src/media/image-credentials.ts exporting resolveImageGenCredentials({ provider, mode }) that returns credentials or a provider-aware errorHint.
- Consolidates logic that is currently duplicated across the image-studio tool, CLI command, and app-icon-generator (collapsed by later PRs).
- Unit tests covering managed enabled/disabled, both providers, key present/absent.

Part of plan: gpt-image-2-support.md (PR 5 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
