### PR TITLE
feat(media): add provider dispatcher for image generation

### DIFF
--- a/assistant/src/__tests__/image-service-dispatcher.test.ts
+++ b/assistant/src/__tests__/image-service-dispatcher.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  ImageGenCredentials,
+  ImageGenerationRequest,
+  ImageGenerationResult,
+} from "../media/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock recording state
+// ---------------------------------------------------------------------------
+
+interface GenerateCall {
+  credentials: ImageGenCredentials;
+  request: ImageGenerationRequest;
+}
+
+let geminiCalls: GenerateCall[] = [];
+let openaiCalls: GenerateCall[] = [];
+let geminiErrorCalls: unknown[] = [];
+let openaiErrorCalls: unknown[] = [];
+
+let geminiResult: ImageGenerationResult = {
+  images: [],
+  resolvedModel: "gemini-mock",
+};
+let openaiResult: ImageGenerationResult = {
+  images: [],
+  resolvedModel: "openai-mock",
+};
+
+// ---------------------------------------------------------------------------
+// Mock underlying services — must run before the module under test is imported
+// ---------------------------------------------------------------------------
+
+mock.module("../media/gemini-image-service.js", () => ({
+  generateImage: async (
+    credentials: ImageGenCredentials,
+    request: ImageGenerationRequest,
+  ): Promise<ImageGenerationResult> => {
+    geminiCalls.push({ credentials, request });
+    return geminiResult;
+  },
+  mapGeminiError: (error: unknown): string => {
+    geminiErrorCalls.push(error);
+    return "gemini-mapped";
+  },
+}));
+
+mock.module("../media/openai-image-service.js", () => ({
+  generateImageOpenAI: async (
+    credentials: ImageGenCredentials,
+    request: ImageGenerationRequest,
+  ): Promise<ImageGenerationResult> => {
+    openaiCalls.push({ credentials, request });
+    return openaiResult;
+  },
+  mapOpenAIError: (error: unknown): string => {
+    openaiErrorCalls.push(error);
+    return "openai-mapped";
+  },
+}));
+
+// Import after mocking
+import { generateImage, mapImageGenError } from "../media/image-service.js";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const directCreds: ImageGenCredentials = {
+  type: "direct",
+  apiKey: "test-key",
+};
+
+const request: ImageGenerationRequest = {
+  prompt: "a friendly test image",
+  mode: "generate",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("image-service dispatcher", () => {
+  beforeEach(() => {
+    geminiCalls = [];
+    openaiCalls = [];
+    geminiErrorCalls = [];
+    openaiErrorCalls = [];
+    geminiResult = {
+      images: [{ mimeType: "image/png", dataBase64: "gemini-bytes" }],
+      resolvedModel: "gemini-3.1-flash-image-preview",
+    };
+    openaiResult = {
+      images: [{ mimeType: "image/png", dataBase64: "openai-bytes" }],
+      resolvedModel: "gpt-image-2",
+    };
+  });
+
+  test("generateImage('gemini', ...) delegates to the Gemini implementation", async () => {
+    const result = await generateImage("gemini", directCreds, request);
+
+    expect(geminiCalls).toHaveLength(1);
+    expect(geminiCalls[0]?.credentials).toBe(directCreds);
+    expect(geminiCalls[0]?.request).toBe(request);
+    expect(openaiCalls).toHaveLength(0);
+    expect(result).toEqual(geminiResult);
+  });
+
+  test("generateImage('openai', ...) delegates to the OpenAI implementation", async () => {
+    const result = await generateImage("openai", directCreds, request);
+
+    expect(openaiCalls).toHaveLength(1);
+    expect(openaiCalls[0]?.credentials).toBe(directCreds);
+    expect(openaiCalls[0]?.request).toBe(request);
+    expect(geminiCalls).toHaveLength(0);
+    expect(result).toEqual(openaiResult);
+  });
+
+  test("mapImageGenError('gemini', err) delegates to mapGeminiError", () => {
+    const err = new Error("boom");
+    const mapped = mapImageGenError("gemini", err);
+
+    expect(geminiErrorCalls).toEqual([err]);
+    expect(openaiErrorCalls).toEqual([]);
+    expect(mapped).toBe("gemini-mapped");
+  });
+
+  test("mapImageGenError('openai', err) delegates to mapOpenAIError", () => {
+    const err = new Error("kapow");
+    const mapped = mapImageGenError("openai", err);
+
+    expect(openaiErrorCalls).toEqual([err]);
+    expect(geminiErrorCalls).toEqual([]);
+    expect(mapped).toBe("openai-mapped");
+  });
+});

--- a/assistant/src/media/image-service.ts
+++ b/assistant/src/media/image-service.ts
@@ -1,0 +1,42 @@
+import {
+  generateImage as generateImageGemini,
+  mapGeminiError,
+} from "./gemini-image-service.js";
+import { generateImageOpenAI, mapOpenAIError } from "./openai-image-service.js";
+import type {
+  ImageGenCredentials,
+  ImageGenerationRequest,
+  ImageGenerationResult,
+  ImageGenProvider,
+} from "./types.js";
+
+/**
+ * Dispatch image generation to the provider-specific implementation.
+ */
+export function generateImage(
+  provider: ImageGenProvider,
+  credentials: ImageGenCredentials,
+  request: ImageGenerationRequest,
+): Promise<ImageGenerationResult> {
+  if (provider === "openai") return generateImageOpenAI(credentials, request);
+  return generateImageGemini(credentials, request);
+}
+
+/**
+ * Dispatch error mapping to the provider-specific implementation.
+ */
+export function mapImageGenError(
+  provider: ImageGenProvider,
+  error: unknown,
+): string {
+  if (provider === "openai") return mapOpenAIError(error);
+  return mapGeminiError(error);
+}
+
+export type {
+  GeneratedImage,
+  ImageGenCredentials,
+  ImageGenerationRequest,
+  ImageGenerationResult,
+  ImageGenProvider,
+} from "./types.js";


### PR DESCRIPTION
## Summary
- New assistant/src/media/image-service.ts exporting generateImage(provider, ...) and mapImageGenError(provider, ...) that dispatch to gemini-image-service or openai-image-service based on the provider argument.
- Re-exports shared types so callers can import from one module.
- Unit tests verifying the dispatcher routes to the right underlying service for both providers and both functions.

Part of plan: gpt-image-2-support.md (PR 6 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
