### PR TITLE
fix: manual-token providers falsely flagged in credential health

### DIFF
--- a/assistant/src/__tests__/credential-health-service.test.ts
+++ b/assistant/src/__tests__/credential-health-service.test.ts
@@ -50,6 +50,21 @@ mock.module("../oauth/oauth-store.js", () => ({
   getProvider: (provider: string) =>
     mockProviders.find((p) => p.provider === provider),
   isProviderConnected: () => false,
+  // Needed by manual-token-connection.ts at import time — these aren't
+  // invoked in this test suite but must resolve so the module loads.
+  createConnection: () => {
+    throw new Error("createConnection not mocked");
+  },
+  deleteConnection: () => {
+    throw new Error("deleteConnection not mocked");
+  },
+  getConnectionByProvider: () => undefined,
+  updateConnection: () => {
+    throw new Error("updateConnection not mocked");
+  },
+  upsertApp: async () => {
+    throw new Error("upsertApp not mocked");
+  },
 }));
 
 mock.module("../util/logger.js", () => ({
@@ -63,11 +78,8 @@ mock.module("../util/logger.js", () => ({
 
 // ── Import under test ────────────────────────────────────────────────
 
-const {
-  checkAllCredentials,
-  checkCredentialForProvider,
-  _setFetchFn,
-} = await import("../credential-health/credential-health-service.js");
+const { checkAllCredentials, checkCredentialForProvider, _setFetchFn } =
+  await import("../credential-health/credential-health-service.js");
 
 // Inject mock fetch via the test helper (Bun's global fetch can't be
 // overridden via globalThis assignment).
@@ -125,10 +137,7 @@ function addConnection(
 }
 
 function setToken(connectionId: string, token = "mock-token") {
-  secureKeyValues.set(
-    `oauth_connection/${connectionId}/access_token`,
-    token,
-  );
+  secureKeyValues.set(`oauth_connection/${connectionId}/access_token`, token);
 }
 
 // ── Tests ────────────────────────────────────────────────────────────
@@ -320,6 +329,66 @@ describe("credential-health-service", () => {
     expect(google!.status).toBe("healthy");
     // Slack: all scopes present, valid token -> healthy
     expect(slack!.status).toBe("healthy");
+  });
+
+  describe("manual-token providers", () => {
+    // slack_channel and telegram store their primary access token at
+    // credential/<provider>/bot_token rather than at
+    // oauth_connection/<id>/access_token. The health check must resolve the
+    // provider-specific path via manualTokenAccessCredentialKey — otherwise
+    // every manual-token connection gets flagged as missing_token and ends
+    // up in the heartbeat <credential-status> block even when credentials
+    // are valid.
+
+    test("slack_channel is healthy when bot_token is present and ping succeeds", async () => {
+      addProvider("slack_channel", {
+        pingUrl: "https://slack.com/api/auth.test",
+      });
+      addConnection("slack_channel", "conn-slack", {
+        expiresAt: null,
+        hasRefreshToken: false,
+        grantedScopes: [],
+      });
+      secureKeyValues.set("credential/slack_channel/bot_token", "xoxb-valid");
+
+      const report = await checkAllCredentials();
+      expect(report.results).toHaveLength(1);
+      expect(report.results[0]!.status).toBe("healthy");
+      expect(report.unhealthy).toHaveLength(0);
+    });
+
+    test("slack_channel is missing_token when bot_token is absent, even if OAuth access-token path is populated", async () => {
+      addProvider("slack_channel", {
+        pingUrl: "https://slack.com/api/auth.test",
+      });
+      addConnection("slack_channel", "conn-slack", {
+        expiresAt: null,
+        hasRefreshToken: false,
+        grantedScopes: [],
+      });
+      // Write to the OAuth access-token path — this must be IGNORED for
+      // manual-token providers, otherwise the fix isn't routing correctly.
+      secureKeyValues.set(
+        "oauth_connection/conn-slack/access_token",
+        "should-be-ignored",
+      );
+
+      const report = await checkAllCredentials();
+      expect(report.results[0]!.status).toBe("missing_token");
+    });
+
+    test("telegram resolves to credential/telegram/bot_token", async () => {
+      addProvider("telegram");
+      addConnection("telegram", "conn-tg", {
+        expiresAt: null,
+        hasRefreshToken: false,
+        grantedScopes: [],
+      });
+      secureKeyValues.set("credential/telegram/bot_token", "telegram-token");
+
+      const report = await checkAllCredentials();
+      expect(report.results[0]!.status).toBe("healthy");
+    });
   });
 
   describe("checkCredentialForProvider", () => {

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -16,6 +16,7 @@ import {
   oauthConnectionAccessTokenPath,
 } from "@vellumai/credential-storage";
 
+import { manualTokenAccessCredentialKey } from "../oauth/manual-token-connection.js";
 import {
   getProvider,
   listActiveConnectionsByProvider,
@@ -100,7 +101,9 @@ async function pingProvider(
 
   const body =
     method !== "GET" && pingBody
-      ? (typeof pingBody === "string" ? pingBody : JSON.stringify(pingBody))
+      ? typeof pingBody === "string"
+        ? pingBody
+        : JSON.stringify(pingBody)
       : undefined;
 
   try {
@@ -155,12 +158,22 @@ async function checkConnection(
     pingBody,
   } = opts;
 
-  const base = { connectionId, provider, accountInfo, missingScopes: [] as string[] };
+  const base = {
+    connectionId,
+    provider,
+    accountInfo,
+    missingScopes: [] as string[],
+  };
 
-  // 1. Check token presence
-  const token = await getSecureKeyAsync(
-    oauthConnectionAccessTokenPath(connectionId),
-  );
+  // 1. Check token presence. Manual-token providers (e.g. slack_channel,
+  // telegram) store their primary token under credential/<provider>/<field>
+  // rather than oauth_connection/<id>/access_token, so resolve the correct
+  // path before looking up the token — otherwise the lookup always returns
+  // null and marks these providers as "missing_token".
+  const tokenPath =
+    manualTokenAccessCredentialKey(provider) ??
+    oauthConnectionAccessTokenPath(connectionId);
+  const token = await getSecureKeyAsync(tokenPath);
   if (!token) {
     return {
       ...base,

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -431,7 +431,7 @@ ${checklist}
     if (unhealthyProviders.length > 0) {
       const providers = unhealthyProviders.join(", ");
       prompt += `\n\n<credential-status>
-The following providers have broken or expired OAuth credentials: ${providers}.
+The following providers have broken or expired credentials: ${providers}.
 Do NOT attempt to use tools for these providers — they will fail. Skip any checklist items that depend on them and note the outage in your summary.
 </credential-status>`;
     }

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -22,6 +22,29 @@ import {
 const MANUAL_TOKEN_CLIENT_ID = "manual-config";
 
 /**
+ * Return the secure-store key holding the primary access token for a
+ * manual-token provider, or null for OAuth providers whose tokens live at
+ * `oauth_connection/<id>/access_token`.
+ *
+ * Manual-token providers store their tokens under `credential/<provider>/<field>`
+ * via the generic credential store, so any code that validates tokens for these
+ * providers (e.g. credential-health checks) must resolve the path through here
+ * rather than assuming the OAuth access-token path.
+ */
+export function manualTokenAccessCredentialKey(
+  provider: string,
+): string | null {
+  switch (provider) {
+    case "slack_channel":
+      return credentialKey("slack_channel", "bot_token");
+    case "telegram":
+      return credentialKey("telegram", "bot_token");
+    default:
+      return null;
+  }
+}
+
+/**
  * Ensure an active oauth_connection row exists for the given manual-token
  * provider. Creates the synthetic oauth_app row on first use.
  *


### PR DESCRIPTION
## Summary
- `slack_channel` and `telegram` store their primary token at `credential/<provider>/bot_token`, but `credential-health-service.checkConnection` only looked at `oauth_connection/<id>/access_token`. Every healthy manual-token connection was flagged as `missing_token`, which fed the heartbeat `<credential-status>` block and caused the assistant to refuse Slack sends during heartbeats.
- Adds `manualTokenAccessCredentialKey()` in `manual-token-connection.ts` to map manual-token providers to their real credential key, and routes the health-check token lookup through it.
- Updates the heartbeat `<credential-status>` wording from "broken or expired OAuth credentials" to "broken or expired credentials" since manual-token providers aren't OAuth.
- New tests cover `slack_channel` healthy path, `slack_channel` `missing_token` even when the OAuth access-token path is populated (regression guard), and `telegram` resolving to the right path.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
