### PR TITLE
feat(media/app-icon): route app-icon generation through provider dispatcher

### DIFF
--- a/assistant/src/media/app-icon-generator.ts
+++ b/assistant/src/media/app-icon-generator.ts
@@ -1,5 +1,5 @@
 /**
- * Generates app icons using the Gemini image generation service.
+ * Generates app icons using the configured image-generation provider.
  *
  * Called as an async side-effect after app creation — never blocks
  * the main app_create flow. Icons are saved to the app's directory
@@ -11,25 +11,18 @@ import { join } from "node:path";
 
 import { getConfig } from "../config/loader.js";
 import { getAppDirPath } from "../memory/app-store.js";
-import {
-  buildManagedBaseUrl,
-  resolveManagedProxyContext,
-} from "../providers/managed-proxy/context.js";
-import { getProviderKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
-import {
-  generateImage,
-  type ImageGenCredentials,
-  mapGeminiError,
-} from "./gemini-image-service.js";
+import { resolveImageGenCredentials } from "./image-credentials.js";
+import { generateImage, mapImageGenError } from "./image-service.js";
 
 const log = getLogger("app-icon-generator");
 
 /**
  * Generate an app icon and save it to `~/.vellum/apps/{appId}/icon.png`.
  *
- * Uses Gemini image generation when an API key is available.
- * Silently no-ops if no key is configured or generation fails.
+ * Uses the configured image-generation provider when credentials are
+ * available. Silently no-ops if no credentials are configured or
+ * generation fails.
  */
 export async function generateAppIcon(
   appId: string,
@@ -37,34 +30,15 @@ export async function generateAppIcon(
   appDescription?: string,
 ): Promise<void> {
   const config = getConfig();
-  const imageGenMode = config.services["image-generation"].mode;
-
-  // Resolve credentials strictly based on mode — no cross-mode fallbacks
-  let credentials: ImageGenCredentials | undefined;
-
-  if (imageGenMode === "managed") {
-    const managedBaseUrl = await buildManagedBaseUrl("gemini");
-    if (managedBaseUrl) {
-      const ctx = await resolveManagedProxyContext();
-      credentials = {
-        type: "managed-proxy",
-        assistantApiKey: ctx.assistantApiKey,
-        baseUrl: managedBaseUrl,
-      };
-    }
-  } else {
-    const apiKey = await getProviderKeyAsync("gemini");
-    if (apiKey) {
-      credentials = { type: "direct", apiKey };
-    }
-  }
-
+  const svc = config.services["image-generation"];
+  const { credentials, errorHint } = await resolveImageGenCredentials({
+    provider: svc.provider,
+    mode: svc.mode,
+  });
   if (!credentials) {
-    const reason =
-      imageGenMode === "managed"
-        ? "Managed proxy is not available"
-        : "No Gemini API key configured";
-    log.debug(`${reason} — skipping app icon generation`);
+    log.debug(
+      `${errorHint ?? "Image generation is not configured"} — skipping app icon generation`,
+    );
     return;
   }
 
@@ -90,16 +64,19 @@ export async function generateAppIcon(
     "- Modern aesthetic similar to Apple's design language";
 
   try {
-    log.info({ appId, appName }, "Generating app icon via Gemini");
+    log.info({ appId, appName, provider: svc.provider }, "Generating app icon");
 
-    const result = await generateImage(credentials, {
+    const result = await generateImage(svc.provider, credentials, {
       prompt,
       mode: "generate",
-      model: config.services["image-generation"].model,
+      model: svc.model,
     });
 
     if (result.images.length === 0) {
-      log.warn({ appId }, "Gemini returned no image for app icon");
+      log.warn(
+        { appId, provider: svc.provider },
+        "Provider returned no image for app icon",
+      );
       return;
     }
 
@@ -111,9 +88,9 @@ export async function generateAppIcon(
 
     log.info({ appId, iconPath }, "App icon saved");
   } catch (error) {
-    const message = mapGeminiError(error);
+    const message = mapImageGenError(svc.provider, error);
     log.warn(
-      { appId, error: message },
+      { appId, provider: svc.provider, error: message },
       "App icon generation failed — skipping",
     );
   }


### PR DESCRIPTION
## Summary
- app-icon-generator now uses resolveImageGenCredentials and generateImage(provider, ...) so it honors the configured provider.
- Previously skipped silently for OpenAI-only users; now generates app icons via OpenAI when configured.

Part of plan: gpt-image-2-support.md (PR 9 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
