### PR TITLE
feat(image-studio): route media_generate_image through provider dispatcher

### DIFF
--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -10,14 +10,17 @@ import type { ToolContext } from "../tools/types.js";
 // Mock dependencies for the tool wrapper
 // ---------------------------------------------------------------------------
 
-let mockApiKey: string | undefined = "test-gemini-key";
+let mockGeminiKey: string | undefined = "test-gemini-key";
+let mockOpenAIKey: string | undefined = "test-openai-key";
 let mockImageGenMode: "your-own" | "managed" = "your-own";
+let mockImageGenProvider: "gemini" | "openai" = "gemini";
 let mockGenerateResult = {
   images: [{ mimeType: "image/png", dataBase64: "generated-data" }],
   text: "A beautiful image",
   resolvedModel: "gemini-3.1-flash-image-preview",
 };
 let mockGenerateError: Error | null = null;
+let lastGenerateProvider: unknown = null;
 let lastGenerateCredentials: unknown = null;
 
 mock.module("../config/loader.js", () => ({
@@ -31,7 +34,7 @@ mock.module("../config/loader.js", () => ({
       },
       "image-generation": {
         mode: mockImageGenMode,
-        provider: "gemini",
+        provider: mockImageGenProvider,
         model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "inference-provider-native" },
@@ -41,27 +44,33 @@ mock.module("../config/loader.js", () => ({
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (account: string) => {
-    if (account === "gemini") return mockApiKey;
+    if (account === "gemini") return mockGeminiKey;
+    if (account === "openai") return mockOpenAIKey;
     return undefined;
   },
   getProviderKeyAsync: async (provider: string) => {
-    if (provider === "gemini") return mockApiKey;
+    if (provider === "gemini") return mockGeminiKey;
+    if (provider === "openai") return mockOpenAIKey;
     return undefined;
   },
 }));
 
-mock.module("../media/gemini-image-service.js", () => ({
+mock.module("../media/image-service.js", () => ({
   generateImage: async (
+    provider: unknown,
     credentials: unknown,
     _request: Record<string, unknown>,
   ) => {
+    lastGenerateProvider = provider;
     lastGenerateCredentials = credentials;
     if (mockGenerateError) throw mockGenerateError;
     return mockGenerateResult;
   },
-  mapGeminiError: (error: unknown) => {
-    if (error instanceof Error) return `Mock error: ${error.message}`;
-    return "Mock unknown error";
+  mapImageGenError: (provider: unknown, error: unknown) => {
+    const providerLabel = provider === "openai" ? "OpenAI" : "Gemini";
+    if (error instanceof Error)
+      return `Mock ${providerLabel} error: ${error.message}`;
+    return `Mock ${providerLabel} unknown error`;
   },
 }));
 
@@ -97,14 +106,17 @@ const CONFIG_DIR = join(
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-  mockApiKey = "test-gemini-key";
+  mockGeminiKey = "test-gemini-key";
+  mockOpenAIKey = "test-openai-key";
   mockImageGenMode = "your-own";
+  mockImageGenProvider = "gemini";
   mockGenerateResult = {
     images: [{ mimeType: "image/png", dataBase64: "generated-data" }],
     text: "A beautiful image",
     resolvedModel: "gemini-3.1-flash-image-preview",
   };
   mockGenerateError = null;
+  lastGenerateProvider = null;
   lastGenerateCredentials = null;
   mockManagedBaseUrl = undefined;
   mockManagedProxyContext = {
@@ -127,7 +139,7 @@ describe("image-studio skill script wrapper", () => {
   });
 
   test("returns error when no API key and no managed proxy", async () => {
-    mockApiKey = undefined;
+    mockGeminiKey = undefined;
 
     const result = await run({ prompt: "a cat" }, fakeContext);
 
@@ -148,6 +160,7 @@ describe("image-studio skill script wrapper", () => {
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Generated 1 image");
+    expect(lastGenerateProvider).toBe("gemini");
     expect(lastGenerateCredentials).toEqual({
       type: "managed-proxy",
       assistantApiKey: "managed-key-123",
@@ -157,7 +170,7 @@ describe("image-studio skill script wrapper", () => {
 
   test("managed mode returns error when managed proxy is unavailable", async () => {
     mockImageGenMode = "managed";
-    mockApiKey = "direct-key"; // should be ignored in managed mode
+    mockGeminiKey = "direct-key"; // should be ignored in managed mode
     mockManagedBaseUrl = undefined;
 
     const result = await run({ prompt: "a cat" }, fakeContext);
@@ -168,7 +181,7 @@ describe("image-studio skill script wrapper", () => {
 
   test("your-own mode uses direct API key", async () => {
     mockImageGenMode = "your-own";
-    mockApiKey = "direct-key";
+    mockGeminiKey = "direct-key";
     mockManagedBaseUrl = "https://platform.example.com/v1/runtime-proxy/gemini";
     mockManagedProxyContext = {
       enabled: true,
@@ -178,10 +191,36 @@ describe("image-studio skill script wrapper", () => {
 
     await run({ prompt: "a cat" }, fakeContext);
 
+    expect(lastGenerateProvider).toBe("gemini");
     expect(lastGenerateCredentials).toEqual({
       type: "direct",
       apiKey: "direct-key",
     });
+  });
+
+  test("openai provider dispatches to OpenAI with its key", async () => {
+    mockImageGenProvider = "openai";
+    mockOpenAIKey = "openai-direct-key";
+
+    const result = await run({ prompt: "a robot" }, fakeContext);
+
+    expect(result.isError).toBe(false);
+    expect(lastGenerateProvider).toBe("openai");
+    expect(lastGenerateCredentials).toEqual({
+      type: "direct",
+      apiKey: "openai-direct-key",
+    });
+  });
+
+  test("openai provider returns OpenAI-specific error hint when no key", async () => {
+    mockImageGenProvider = "openai";
+    mockOpenAIKey = undefined;
+
+    const result = await run({ prompt: "a robot" }, fakeContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("OpenAI");
+    expect(result.content).not.toContain("No Gemini API key");
   });
 
   test("returns generated image with contentBlocks", async () => {
@@ -225,7 +264,17 @@ describe("image-studio skill script wrapper", () => {
     const result = await run({ prompt: "a cat" }, fakeContext);
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("Mock error: API failure");
+    expect(result.content).toContain("Mock Gemini error: API failure");
+  });
+
+  test("openai generation error uses OpenAI-specific mapping", async () => {
+    mockImageGenProvider = "openai";
+    mockGenerateError = new Error("openai failure");
+
+    const result = await run({ prompt: "a cat" }, fakeContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Mock OpenAI error: openai failure");
   });
 
   test("reads source images from file paths on disk", async () => {
@@ -330,6 +379,7 @@ describe("image-studio TOOLS.json manifest", () => {
     expect(props.model.enum).toEqual([
       "gemini-3.1-flash-image-preview",
       "gemini-3-pro-image-preview",
+      "gpt-image-2",
     ]);
     expect(props.variants.type).toBe("number");
   });

--- a/assistant/src/config/bundled-skills/image-studio/SKILL.md
+++ b/assistant/src/config/bundled-skills/image-studio/SKILL.md
@@ -25,10 +25,11 @@ You are an image generation assistant. When the user asks you to create or edit 
 
 - `gemini-3.1-flash-image-preview` (default) - Nano Banana 2, fast, good quality
 - `gemini-3-pro-image-preview` - Nano Banana Pro, higher quality, slower
+- `gpt-image-2` - OpenAI GPT Image 2, high fidelity, slower
 
 ## Tips
 
 - Be descriptive in your prompts for better results. Include details about style, composition, lighting, and mood.
 - When editing images, clearly describe what changes you want made to the source image.
 - Use the `variants` parameter (1-4) to generate multiple options and pick the best one.
-- If no Gemini API key is configured, the tool will return an error - ask the user to set one up.
+- If no API key is configured for the selected model's provider (Gemini or OpenAI), the tool will return an error - ask the user to set one up.

--- a/assistant/src/config/bundled-skills/image-studio/TOOLS.json
+++ b/assistant/src/config/bundled-skills/image-studio/TOOLS.json
@@ -29,7 +29,8 @@
             "type": "string",
             "enum": [
               "gemini-3.1-flash-image-preview",
-              "gemini-3-pro-image-preview"
+              "gemini-3-pro-image-preview",
+              "gpt-image-2"
             ],
             "description": "Which model to use for generation. If omitted, uses the user's configured preference."
           },

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -1,16 +1,11 @@
 import { getConfig } from "../../../../config/loader.js";
+import { resolveImageGenCredentials } from "../../../../media/image-credentials.js";
 import {
   generateImage,
-  type ImageGenCredentials,
-  mapGeminiError,
-} from "../../../../media/gemini-image-service.js";
+  mapImageGenError,
+} from "../../../../media/image-service.js";
 import { getFilePathBySourcePath } from "../../../../memory/attachments-store.js";
-import {
-  buildManagedBaseUrl,
-  resolveManagedProxyContext,
-} from "../../../../providers/managed-proxy/context.js";
 import type { ImageContent } from "../../../../providers/types.js";
-import { getProviderKeyAsync } from "../../../../security/secure-keys.js";
 import { sandboxPolicy } from "../../../../tools/shared/filesystem/path-policy.js";
 import type {
   ToolContext,
@@ -22,34 +17,16 @@ export async function run(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const config = getConfig();
-  const imageGenMode = config.services["image-generation"].mode;
-
-  // Resolve credentials strictly based on mode — no cross-mode fallbacks
-  let credentials: ImageGenCredentials | undefined;
-
-  if (imageGenMode === "managed") {
-    const managedBaseUrl = await buildManagedBaseUrl("gemini");
-    if (managedBaseUrl) {
-      const ctx = await resolveManagedProxyContext();
-      credentials = {
-        type: "managed-proxy",
-        assistantApiKey: ctx.assistantApiKey,
-        baseUrl: managedBaseUrl,
-      };
-    }
-  } else {
-    const apiKey = await getProviderKeyAsync("gemini");
-    if (apiKey) {
-      credentials = { type: "direct", apiKey };
-    }
-  }
-
+  const svc = config.services["image-generation"];
+  const { credentials, errorHint } = await resolveImageGenCredentials({
+    provider: svc.provider,
+    mode: svc.mode,
+  });
   if (!credentials) {
-    const hint =
-      imageGenMode === "managed"
-        ? "Managed proxy is not available. Please log in to Vellum or switch to Your Own mode."
-        : "No Gemini API key configured. Please set your Gemini API key in Settings > Models & Services.";
-    return { content: hint, isError: true };
+    return {
+      content: errorHint ?? "Image generation is not configured.",
+      isError: true,
+    };
   }
 
   const prompt = input.prompt as string;
@@ -111,7 +88,7 @@ export async function run(
   }
 
   try {
-    const result = await generateImage(credentials, {
+    const result = await generateImage(svc.provider, credentials, {
       prompt,
       mode,
       sourceImages,
@@ -147,7 +124,7 @@ export async function run(
     };
   } catch (error) {
     return {
-      content: mapGeminiError(error),
+      content: mapImageGenError(svc.provider, error),
       isError: true,
     };
   }


### PR DESCRIPTION
## Summary
- media_generate_image now resolves credentials via resolveImageGenCredentials and dispatches to generateImage(provider, ...) / mapImageGenError(provider, ...) — supports both Gemini and OpenAI.
- TOOLS.json model enum adds gpt-image-2; SKILL.md lists it with a provider-aware key tip.
- Tests extended to cover OpenAI dispatch and the OpenAI-no-key error hint.

Part of plan: gpt-image-2-support.md (PR 7 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
