### PR TITLE
feat(cli/image-generation): route generate command through provider dispatcher

### DIFF
--- a/assistant/src/cli/commands/__tests__/image-generation.test.ts
+++ b/assistant/src/cli/commands/__tests__/image-generation.test.ts
@@ -11,6 +11,7 @@
  *   - Edit mode with --source (source images passed through)
  *   - --variants passed through
  *   - --model override
+ *   - Provider dispatch (gemini vs openai)
  */
 
 import { existsSync, readFileSync } from "node:fs";
@@ -29,7 +30,7 @@ let mockConfig = {
   services: {
     "image-generation": {
       mode: "your-own" as "managed" | "your-own",
-      provider: "gemini" as const,
+      provider: "gemini" as "gemini" | "openai",
       model: "gemini-3.1-flash-image-preview",
     },
   },
@@ -45,8 +46,8 @@ let mockManagedProxyContext = {
   assistantApiKey: "",
 };
 
-/** Key returned by getProviderKeyAsync() */
-let mockProviderKey: string | undefined = undefined;
+/** Key returned by getProviderKeyAsync(). Keyed by provider. */
+let mockProviderKeys: Record<string, string | undefined> = {};
 
 /** Result returned by generateImage() */
 let mockGenerateResult: {
@@ -68,6 +69,7 @@ let mockGenerateError: Error | undefined = undefined;
 
 /** Captured generateImage call args */
 let lastGenerateCall: {
+  provider: unknown;
   credentials: unknown;
   request: unknown;
 } | null = null;
@@ -87,17 +89,22 @@ mock.module("../../../providers/managed-proxy/context.js", () => ({
 }));
 
 mock.module("../../../security/secure-keys.js", () => ({
-  getProviderKeyAsync: async () => mockProviderKey,
+  getProviderKeyAsync: async (provider: string) => mockProviderKeys[provider],
 }));
 
-mock.module("../../../media/gemini-image-service.js", () => ({
-  generateImage: async (credentials: unknown, request: unknown) => {
-    lastGenerateCall = { credentials, request };
+mock.module("../../../media/image-service.js", () => ({
+  generateImage: async (
+    provider: unknown,
+    credentials: unknown,
+    request: unknown,
+  ) => {
+    lastGenerateCall = { provider, credentials, request };
     if (mockGenerateError) throw mockGenerateError;
     return mockGenerateResult;
   },
-  mapGeminiError: (error: unknown) => {
-    if (error instanceof Error) return `Mapped error: ${error.message}`;
+  mapImageGenError: (provider: unknown, error: unknown) => {
+    if (error instanceof Error)
+      return `Mapped error (${String(provider)}): ${error.message}`;
     return "An unexpected error occurred during image generation.";
   },
 }));
@@ -194,7 +201,7 @@ beforeEach(() => {
     platformBaseUrl: "",
     assistantApiKey: "",
   };
-  mockProviderKey = undefined;
+  mockProviderKeys = {};
   mockGenerateResult = {
     images: [
       {
@@ -221,6 +228,10 @@ describe("help text", () => {
     expect(stdout).toContain("your-own");
     expect(stdout).toContain("Examples:");
     expect(stdout).toContain("generate");
+    // Both providers mentioned and gpt-image-2 listed as a supported model.
+    expect(stdout).toContain("Gemini");
+    expect(stdout).toContain("OpenAI");
+    expect(stdout).toContain("gpt-image-2");
   });
 
   test("image-generation generate --help renders argument docs and examples", async () => {
@@ -245,7 +256,7 @@ describe("help text", () => {
 
 describe("required arguments", () => {
   test("generate requires --prompt", async () => {
-    mockProviderKey = "test-key";
+    mockProviderKeys.gemini = "test-key";
     const { exitCode } = await runCommand(["image-generation", "generate"]);
     expect(exitCode).not.toBe(0);
   });
@@ -258,7 +269,7 @@ describe("required arguments", () => {
 describe("credential errors", () => {
   test("exits with code 1 when no credentials in your-own mode", async () => {
     mockConfig.services["image-generation"].mode = "your-own";
-    mockProviderKey = undefined;
+    mockProviderKeys.gemini = undefined;
 
     const { exitCode } = await runCommand([
       "image-generation",
@@ -282,9 +293,10 @@ describe("credential errors", () => {
     expect(exitCode).toBe(1);
   });
 
-  test("--json outputs error when no credentials in your-own mode", async () => {
+  test("--json outputs error when no credentials in your-own mode (gemini)", async () => {
     mockConfig.services["image-generation"].mode = "your-own";
-    mockProviderKey = undefined;
+    mockConfig.services["image-generation"].provider = "gemini";
+    mockProviderKeys.gemini = undefined;
 
     const { exitCode, stdout } = await runCommand([
       "image-generation",
@@ -297,6 +309,25 @@ describe("credential errors", () => {
     const parsed = JSON.parse(stdout.trim());
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Gemini API key");
+  });
+
+  test("--json outputs OpenAI-specific hint when provider=openai and no key set", async () => {
+    mockConfig.services["image-generation"].mode = "your-own";
+    mockConfig.services["image-generation"].provider = "openai";
+    mockConfig.services["image-generation"].model = "gpt-image-2";
+    mockProviderKeys.openai = undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "A sunset",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("OpenAI API key");
   });
 
   test("--json outputs error when no credentials in managed mode", async () => {
@@ -324,7 +355,7 @@ describe("credential errors", () => {
 describe("credential resolution", () => {
   test("your-own mode uses getProviderKeyAsync for direct credentials", async () => {
     mockConfig.services["image-generation"].mode = "your-own";
-    mockProviderKey = "test-gemini-key";
+    mockProviderKeys.gemini = "test-gemini-key";
 
     await runCommand([
       "image-generation",
@@ -375,12 +406,78 @@ describe("credential resolution", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Provider dispatch
+// ---------------------------------------------------------------------------
+
+describe("provider dispatch", () => {
+  test("provider=gemini is forwarded to the dispatcher", async () => {
+    mockConfig.services["image-generation"].mode = "your-own";
+    mockConfig.services["image-generation"].provider = "gemini";
+    mockProviderKeys.gemini = "test-gemini-key";
+    const outDir = join(os.tmpdir(), `img-dispatch-gemini-${Date.now()}`);
+
+    const { exitCode } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastGenerateCall).toBeDefined();
+    expect(lastGenerateCall!.provider).toBe("gemini");
+  });
+
+  test("provider=openai with --model gpt-image-2 is forwarded to the dispatcher", async () => {
+    mockConfig.services["image-generation"].mode = "your-own";
+    mockConfig.services["image-generation"].provider = "openai";
+    mockConfig.services["image-generation"].model = "gpt-image-2";
+    mockProviderKeys.openai = "test-openai-key";
+    mockGenerateResult = {
+      images: [
+        {
+          mimeType: "image/png",
+          dataBase64: Buffer.from("fake-png-data").toString("base64"),
+        },
+      ],
+      resolvedModel: "gpt-image-2",
+    };
+    const outDir = join(os.tmpdir(), `img-dispatch-openai-${Date.now()}`);
+
+    const { exitCode } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--model",
+      "gpt-image-2",
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastGenerateCall).toBeDefined();
+    expect(lastGenerateCall!.provider).toBe("openai");
+    const req = lastGenerateCall!.request as { model: string };
+    expect(req.model).toBe("gpt-image-2");
+    const creds = lastGenerateCall!.credentials as {
+      type: string;
+      apiKey: string;
+    };
+    expect(creds.type).toBe("direct");
+    expect(creds.apiKey).toBe("test-openai-key");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Generate mode success
 // ---------------------------------------------------------------------------
 
 describe("generate mode", () => {
   test("generates image and prints file path to stdout", async () => {
-    mockProviderKey = "test-key";
+    mockProviderKeys.gemini = "test-key";
     const outDir = join(os.tmpdir(), `img-gen-test-${Date.now()}`);
 
     const { exitCode, stdout } = await runCommand([
@@ -407,7 +504,7 @@ describe("generate mode", () => {
   });
 
   test("--json produces structured output with paths, MIME types, and sizes", async () => {
-    mockProviderKey = "test-key";
+    mockProviderKeys.gemini = "test-key";
     mockGenerateResult = {
       images: [
         {
@@ -449,7 +546,7 @@ describe("generate mode", () => {
 
 describe("edit mode", () => {
   test("exits with code 1 when --mode edit is used without --source", async () => {
-    mockProviderKey = "test-key";
+    mockProviderKeys.gemini = "test-key";
 
     const { exitCode, stdout } = await runCommand([
       "image-generation",
@@ -470,7 +567,7 @@ describe("edit mode", () => {
   });
 
   test("passes source images to generateImage in edit mode", async () => {
-    mockProviderKey = "test-key";
+    mockProviderKeys.gemini = "test-key";
 
     // Use a real temp file for the source image
     const sourceDir = join(os.tmpdir(), `img-src-test-${Date.now()}`);
@@ -515,7 +612,7 @@ describe("edit mode", () => {
 
 describe("variants", () => {
   test("non-numeric --variants defaults to 1", async () => {
-    mockProviderKey = "test-key";
+    mockProviderKeys.gemini = "test-key";
     const outDir = join(os.tmpdir(), `img-nan-variants-${Date.now()}`);
 
     const { exitCode } = await runCommand([
@@ -536,7 +633,7 @@ describe("variants", () => {
   });
 
   test("--variants is passed through to generateImage", async () => {
-    mockProviderKey = "test-key";
+    mockProviderKeys.gemini = "test-key";
     mockGenerateResult = {
       images: [
         {
@@ -587,7 +684,7 @@ describe("variants", () => {
 
 describe("model override", () => {
   test("--model overrides config model", async () => {
-    mockProviderKey = "test-key";
+    mockProviderKeys.gemini = "test-key";
     const outDir = join(os.tmpdir(), `img-model-test-${Date.now()}`);
 
     await runCommand([
@@ -607,7 +704,7 @@ describe("model override", () => {
   });
 
   test("falls back to config model when --model is not provided", async () => {
-    mockProviderKey = "test-key";
+    mockProviderKeys.gemini = "test-key";
     mockConfig.services["image-generation"].model =
       "gemini-3.1-flash-image-preview";
     const outDir = join(os.tmpdir(), `img-model-fallback-${Date.now()}`);
@@ -633,7 +730,7 @@ describe("model override", () => {
 
 describe("error handling", () => {
   test("maps generateImage error and exits with code 1", async () => {
-    mockProviderKey = "test-key";
+    mockProviderKeys.gemini = "test-key";
     mockGenerateError = new Error("API rate limit exceeded");
 
     const { exitCode } = await runCommand([
@@ -647,7 +744,7 @@ describe("error handling", () => {
   });
 
   test("--json outputs mapped error on generateImage failure", async () => {
-    mockProviderKey = "test-key";
+    mockProviderKeys.gemini = "test-key";
     mockGenerateError = new Error("Connection timeout");
 
     const { exitCode, stdout } = await runCommand([

--- a/assistant/src/cli/commands/image-generation.ts
+++ b/assistant/src/cli/commands/image-generation.ts
@@ -5,16 +5,12 @@ import { join } from "node:path";
 import { Command } from "commander";
 
 import { getConfig } from "../../config/loader.js";
+import { resolveImageGenCredentials } from "../../media/image-credentials.js";
 import {
   generateImage,
   type ImageGenCredentials,
-  mapGeminiError,
-} from "../../media/gemini-image-service.js";
-import {
-  buildManagedBaseUrl,
-  resolveManagedProxyContext,
-} from "../../providers/managed-proxy/context.js";
-import { getProviderKeyAsync } from "../../security/secure-keys.js";
+  mapImageGenError,
+} from "../../media/image-service.js";
 import { log } from "../logger.js";
 
 // ---------------------------------------------------------------------------
@@ -72,11 +68,12 @@ export function registerImageGenerationCommand(program: Command): void {
     `
 Modes:
   managed    — Uses platform-managed credentials (requires login to Vellum).
-  your-own   — Uses your own Gemini API key configured in settings.
+  your-own   — Uses your own Gemini or OpenAI API key depending on the configured model.
 
 Supported models:
   gemini-3.1-flash-image-preview (default)
   gemini-3-pro-image-preview
+  gpt-image-2
 
 Examples:
   $ assistant image-generation generate --prompt "A sunset over the ocean"
@@ -114,12 +111,14 @@ Notes:
   Edit mode (--mode edit) requires at least one --source image file.
   Output files are named image-1.png, image-2.png, etc. (extension matches MIME type).
   Default output directory is the system temp directory.
+  Uses your own Gemini or OpenAI API key depending on the configured model.
 
 Examples:
   $ assistant image-generation generate --prompt "A mountain landscape at dawn"
   $ assistant image-generation generate --prompt "Make it darker" --mode edit --source input.png
   $ assistant image-generation generate --prompt "Logo variations" --variants 4 --output-dir ./logos
-  $ assistant image-generation generate --prompt "A robot" --model gemini-3-pro-image-preview --json`,
+  $ assistant image-generation generate --prompt "A robot" --model gemini-3-pro-image-preview --json
+  $ assistant image-generation generate --prompt "A robot" --model gpt-image-2 --json`,
   );
 
   generate.action(async (opts) => {
@@ -149,33 +148,16 @@ Examples:
 
     // --- Resolve credentials ---
     const config = getConfig();
-    const imageGenMode = config.services["image-generation"].mode;
+    const svc = config.services["image-generation"];
 
-    let credentials: ImageGenCredentials | undefined;
-
-    if (imageGenMode === "managed") {
-      const managedBaseUrl = await buildManagedBaseUrl("gemini");
-      if (managedBaseUrl) {
-        const ctx = await resolveManagedProxyContext();
-        credentials = {
-          type: "managed-proxy",
-          assistantApiKey: ctx.assistantApiKey,
-          baseUrl: managedBaseUrl,
-        };
-      }
-    } else {
-      const apiKey = await getProviderKeyAsync("gemini");
-      if (apiKey) {
-        credentials = { type: "direct", apiKey };
-      }
-    }
+    const { credentials, errorHint } = await resolveImageGenCredentials({
+      provider: svc.provider,
+      mode: svc.mode,
+    });
 
     if (!credentials) {
       const hint =
-        imageGenMode === "managed"
-          ? "Managed proxy is not available. Please log in to Vellum or switch to your-own mode:\n  Run 'assistant auth login' to authenticate, or set services.image-generation.mode to 'your-own' in config."
-          : "No Gemini API key configured. Add your Gemini API key:\n  Run 'assistant keys set gemini <key>' or configure it in Settings > Models & Services.";
-
+        errorHint ?? "No credentials available for image generation.";
       if (jsonOutput) {
         process.stdout.write(JSON.stringify({ ok: false, error: hint }) + "\n");
       } else {
@@ -184,6 +166,8 @@ Examples:
       process.exitCode = 1;
       return;
     }
+
+    const resolvedCredentials: ImageGenCredentials = credentials;
 
     // --- Read source images for edit mode ---
     let sourceImages:
@@ -231,11 +215,11 @@ Examples:
     }
 
     // --- Resolve model ---
-    const model = modelOverride ?? config.services["image-generation"].model;
+    const model = modelOverride ?? svc.model;
 
     // --- Generate image ---
     try {
-      const result = await generateImage(credentials, {
+      const result = await generateImage(svc.provider, resolvedCredentials, {
         prompt,
         mode,
         sourceImages,
@@ -286,7 +270,7 @@ Examples:
         }
       }
     } catch (error) {
-      const errorMsg = mapGeminiError(error);
+      const errorMsg = mapImageGenError(svc.provider, error);
       if (jsonOutput) {
         process.stdout.write(
           JSON.stringify({ ok: false, error: errorMsg }) + "\n",


### PR DESCRIPTION
## Summary
- CLI 'assistant image-generation generate' now uses resolveImageGenCredentials and generateImage(provider, ...) / mapImageGenError(provider, ...).
- Help text lists gpt-image-2 and describes both Gemini and OpenAI key modes.
- Tests extended for gpt-image-2 dispatch and OpenAI-no-key error hint.

Part of plan: gpt-image-2-support.md (PR 8 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
