### PR TITLE
fix(design-system): scope VBadge doc comment invariant to .accent + .solid

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Compact status indicator: count, dot, or text label with semantic tone.
 /// For categorization with colored backgrounds and icons, use `VTag` instead.
 /// Use `init(label:tone:)` for tone-aware label badges and `init(count:tone:)` for tone-aware count badges.
-/// Accent tone pairs adaptive `primaryBase` backgrounds with adaptive `contentInset` foregrounds so text stays legible in both light and dark mode.
+/// For the `.accent` tone with `.solid` emphasis, the adaptive `primaryBase` background is paired with adaptive `contentInset` foreground so text stays legible in both light and dark mode; other tone/emphasis pairs use their own fg/bg tokens (see `toneForegroundColor` / `toneBackgroundColor`).
 public struct VBadge: View {
     public enum Style {
         case count(Int)


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan self-review for `vbadge-accent-solid.md`.

**Gap:** The `VBadge` doc comment claimed "Accent tone pairs adaptive `primaryBase` with adaptive `contentInset`" as a blanket invariant. That's only true for `(.accent, .solid)`. The `(.accent, .subtle)` path uses `primaryBase.opacity(0.10)` bg with `primaryBase` fg.

**Fix:** Scope the sentence to `.solid` emphasis and point readers at `toneForegroundColor` / `toneBackgroundColor` for the full tone/emphasis matrix.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
