### PR TITLE
test(credential-invariants): allowlist media/image-credentials.ts importer

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -208,6 +208,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "providers/provider-availability.ts", // provider availability API key check
       "media/app-icon-generator.ts", // app icon generation API key lookup
       "media/avatar-router.ts", // avatar generation API key lookup
+      "media/image-credentials.ts", // shared image-gen credential resolver (provider API key lookup)
       "memory/embedding-backend.ts", // embedding backend API key lookup
       "daemon/providers-setup.ts", // provider initialization API key lookup
       "workspace/migrations/006-services-config.ts", // services config migration reads provider API keys


### PR DESCRIPTION
## Summary
- Add `media/image-credentials.ts` to the `ALLOWED_IMPORTERS` allowlist in `credential-security-invariants.test.ts`.
- The shared image-gen credential resolver (extracted in bff4ec8cce) calls `getProviderKeyAsync` from `secure-keys`, which the invariant test requires to be explicitly allowlisted.
- Fixes the failing `Invariant 2: secure-keys is only imported by authorized modules` test on main.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24798989439/job/72576246113
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
