### PR TITLE
feat(macos/settings): provider-aware API key field on image-gen card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -27,6 +27,12 @@ struct ImageGenerationServiceCard: View {
         authManager.isAuthenticated
     }
 
+    /// The API-key provider associated with the currently-selected draft model.
+    /// Flips between `"gemini"` and `"openai"` as the user switches models in the picker.
+    private var currentProvider: String {
+        SettingsStore.imageGenProvider(forModel: draftModel)
+    }
+
     /// True when the user has made changes worth saving.
     private var hasChanges: Bool {
         // In managed mode when not logged in, there is nothing actionable to save.
@@ -71,7 +77,7 @@ struct ImageGenerationServiceCard: View {
                         onSave: { save() },
                         savingLabel: "Validating...",
                         onReset: {
-                            store.clearImageGenKey()
+                            store.clearImageGenKey(for: currentProvider)
                             imageGenHasKey = false
                             apiKeyText = ""
                         },
@@ -86,7 +92,14 @@ struct ImageGenerationServiceCard: View {
             initialModel = store.selectedImageGenModel
         }
         .task {
-            imageGenHasKey = await APIKeyManager.hasKey(for: "gemini")
+            imageGenHasKey = await APIKeyManager.hasKey(for: currentProvider)
+        }
+        .onChange(of: draftModel) { _, _ in
+            // Re-fetch the "key configured" indicator when the user switches between
+            // Gemini and OpenAI models in the picker so the UI reflects the right provider.
+            Task {
+                imageGenHasKey = await APIKeyManager.hasKey(for: currentProvider)
+            }
         }
         .onChange(of: store.imageGenMode) { _, newValue in
             // Sync draft when external changes arrive (e.g. daemon reload)
@@ -129,7 +142,7 @@ struct ImageGenerationServiceCard: View {
             label: "API Key",
             hasKey: imageGenHasKey,
             text: $apiKeyText,
-            emptyPlaceholder: "Enter your Gemini API key",
+            emptyPlaceholder: currentProvider == "openai" ? "Enter your OpenAI API key" : "Enter your Gemini API key",
             errorMessage: store.imageGenKeySaveError
         )
         .disabled(store.imageGenKeySaving)
@@ -161,10 +174,11 @@ struct ImageGenerationServiceCard: View {
         let trimmedKey = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
         if draftMode == "your-own" && !trimmedKey.isEmpty {
             let keyTextBinding = $apiKeyText
-            store.saveImageGenKey(trimmedKey, onSuccess: { [self] in
+            let provider = currentProvider
+            store.saveImageGenKey(trimmedKey, for: provider, onSuccess: { [self] in
                 imageGenHasKey = true
                 keyTextBinding.wrappedValue = ""
-                showToast("Gemini API key saved", .success)
+                showToast("\(provider == "openai" ? "OpenAI" : "Gemini") API key saved", .success)
             })
         }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -918,15 +918,15 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    func saveImageGenKey(_ raw: String, onSuccess: (() -> Void)? = nil) {
+    func saveImageGenKey(_ raw: String, for provider: String = "gemini", onSuccess: (() -> Void)? = nil) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         imageGenKeySaveError = nil
         imageGenKeySaving = true
-        APIKeyManager.setKey(trimmed, for: "gemini")
-        removeDeletionTombstone(type: "api_key", name: "gemini")
+        APIKeyManager.setKey(trimmed, for: provider)
+        removeDeletionTombstone(type: "api_key", name: provider)
         Task {
-            let result = await APIKeyManager.setKey(trimmed, for: "gemini")
+            let result = await APIKeyManager.setKey(trimmed, for: provider)
             imageGenKeySaving = false
             if result.success {
                 scheduleRoutingSourceRefresh()
@@ -934,18 +934,18 @@ public final class SettingsStore: ObservableObject {
             } else if let error = result.error {
                 imageGenKeySaveError = error
                 if !result.isTransient {
-                    let _: Void = APIKeyManager.deleteKey(for: "gemini")
+                    let _: Void = APIKeyManager.deleteKey(for: provider)
                 }
             }
         }
     }
 
-    func clearImageGenKey() {
-        APIKeyManager.deleteKey(for: "gemini")
+    func clearImageGenKey(for provider: String = "gemini") {
+        APIKeyManager.deleteKey(for: provider)
         scheduleRoutingSourceRefresh()
         Task {
-            let deleted = await APIKeyManager.deleteKey(for: "gemini")
-            if !deleted { addDeletionTombstone(type: "api_key", name: "gemini") }
+            let deleted = await APIKeyManager.deleteKey(for: provider)
+            if !deleted { addDeletionTombstone(type: "api_key", name: provider) }
         }
     }
 


### PR DESCRIPTION
## Summary
- ImageGenerationServiceCard now derives the active provider from the selected model (Gemini vs OpenAI) and flips the API-key input, save/reset, and toast accordingly.
- Selecting GPT Image 2 shows 'Enter your OpenAI API key' and writes to the openai provider key; Nano Banana models show 'Enter your Gemini API key' and write to the gemini key.
- Re-queries hasKey when the model changes so the 'key configured' indicator reflects the right provider.

Part of plan: gpt-image-2-support.md (PR 10 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
