### PR TITLE
feat(network-prompt): enrich network_request approval with HTTP context

### DIFF
--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -381,13 +381,79 @@ describe("createProxyApprovalCallback", () => {
       // Verify the confirmation request uses the network_request tool name
       expect(msg.toolName).toBe("network_request");
       expect(msg.input).toHaveProperty("url", "https://api.fal.ai:443/v1/run");
-      expect(msg.input).toHaveProperty("matching_patterns", ["*.fal.ai"]);
+      expect(msg.input).toHaveProperty("scheme", "https");
+      expect(msg.input).toHaveProperty("known_credential_patterns", [
+        "*.fal.ai",
+      ]);
+      expect(msg.input.reason).toMatch(/No credential in this session/);
+      expect(msg.input).not.toHaveProperty("proxy_session_id");
       prompter.resolveConfirmation(msg.requestId, "allow");
       return p;
     };
 
     const callback = createProxyApprovalCallback(prompter, ctx);
     await callback(makeAskMissingCredentialRequest());
+  });
+
+  test("surfaces method and curated headers when the proxy has HTTP-level context", async () => {
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = (prompterSendToClient.mock.calls as unknown[][])[0];
+      const msg = call[0] as {
+        requestId: string;
+        input: Record<string, unknown>;
+      };
+      expect(msg.input).toHaveProperty("method", "POST");
+      expect(msg.input).toHaveProperty("request_headers", {
+        "content-type": "application/json",
+        "user-agent": "curl/8.5.0",
+      });
+      expect(msg.input).not.toHaveProperty("connection_detail_available");
+      prompter.resolveConfirmation(msg.requestId, "allow");
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    await callback(
+      makeAskUnauthenticatedRequest({
+        method: "POST",
+        requestHeaders: {
+          "content-type": "application/json",
+          "user-agent": "curl/8.5.0",
+        },
+      }),
+    );
+  });
+
+  test("marks connection_detail_available=no for HTTPS CONNECT approvals", async () => {
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = (prompterSendToClient.mock.calls as unknown[][])[0];
+      const msg = call[0] as {
+        requestId: string;
+        input: Record<string, unknown>;
+      };
+      expect(msg.input).toHaveProperty("connection_detail_available", "no");
+      expect(msg.input).not.toHaveProperty("method");
+      expect(msg.input).not.toHaveProperty("request_headers");
+      prompter.resolveConfirmation(msg.requestId, "allow");
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    await callback(makeAskUnauthenticatedRequest());
   });
 
   test("sends correct tool name for ask_unauthenticated decisions", async () => {

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -376,10 +376,23 @@ export function createProxyApprovalCallback(
 
     const input: Record<string, unknown> = {
       url,
-      proxy_session_id: request.sessionId,
+      scheme,
     };
+    if (request.method) {
+      input.method = request.method;
+    }
+    if (request.requestHeaders && Object.keys(request.requestHeaders).length) {
+      input.request_headers = request.requestHeaders;
+    }
+    input.reason =
+      decision.kind === "ask_missing_credential"
+        ? "No credential in this session matches this host. Approving will send the request without authentication."
+        : "This host isn't covered by any known credential template. Approving will send the request as-is.";
     if (decision.kind === "ask_missing_credential") {
-      input.matching_patterns = decision.matchingPatterns;
+      input.known_credential_patterns = decision.matchingPatterns;
+    }
+    if (!request.method) {
+      input.connection_detail_available = "no";
     }
 
     const riskLevel: string = "medium";

--- a/assistant/src/outbound-proxy/http-forwarder.ts
+++ b/assistant/src/outbound-proxy/http-forwarder.ts
@@ -27,12 +27,19 @@ const HOP_BY_HOP = new Set([
  * Optional callback for credential injection or policy gating.
  * Called before the upstream request is sent. Returns extra headers
  * to merge, or null to reject the request.
+ *
+ * `method` and `requestHeaders` are populated for plain-HTTP proxied
+ * requests (absolute-URL form). For HTTPS CONNECT tunnels the proxy has
+ * not yet terminated TLS and cannot see HTTP-level details, so these are
+ * left undefined.
  */
 export type PolicyCallback = (
   hostname: string,
   port: number | null,
   path: string,
   scheme: "http" | "https",
+  method?: string,
+  requestHeaders?: IncomingMessage["headers"],
 ) => Promise<Record<string, string> | null>;
 
 /**
@@ -141,6 +148,8 @@ export function forwardHttpRequest(
       parsed.port ? Number(parsed.port) : null,
       path,
       "http",
+      clientReq.method,
+      clientReq.headers,
     )
       .then((extraHeaders) => {
         if (extraHeaders == null) {

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -82,6 +82,36 @@ const ALLOWED_HOST_PATTERNS: readonly string[] = (() => {
 })();
 
 /**
+ * Non-sensitive HTTP request headers that are safe to surface in the
+ * `network_request` approval prompt. Strict allowlist to keep Authorization,
+ * Cookie, X-Api-Key, and other custom credential-bearing headers off-screen.
+ */
+const APPROVAL_HEADER_ALLOWLIST: readonly string[] = [
+  "content-type",
+  "content-length",
+  "user-agent",
+  "accept",
+];
+
+/**
+ * Project an incoming header map onto {@link APPROVAL_HEADER_ALLOWLIST},
+ * collapsing multi-value arrays to a comma-joined string. Returns undefined
+ * when no headers are available (e.g. HTTPS CONNECT path).
+ */
+function filterApprovalHeaders(
+  raw: Record<string, string | string[] | undefined> | undefined,
+): Record<string, string> | undefined {
+  if (!raw) return undefined;
+  const out: Record<string, string> = {};
+  for (const key of APPROVAL_HEADER_ALLOWLIST) {
+    const value = raw[key];
+    if (value === undefined) continue;
+    out[key] = Array.isArray(value) ? value.join(", ") : value;
+  }
+  return out;
+}
+
+/**
  * Returns `true` when `hostname` matches any entry in
  * {@link ALLOWED_HOST_PATTERNS}.
  */
@@ -292,12 +322,16 @@ function buildSessionStartHooks(): SessionStartHooks {
         return allKnownCache;
       }
 
-      // Build the policy callback for HTTP/CONNECT request gating
+      // Build the policy callback for HTTP/CONNECT request gating.
+      // `method` / `reqHeaders` are populated for plain-HTTP proxied requests
+      // and undefined for HTTPS CONNECT tunnels (TLS not yet terminated).
       const policyCallback: PolicyCallback = async (
         hostname: string,
         port: number | null,
         reqPath: string,
         scheme: "http" | "https",
+        method?: string,
+        reqHeaders?: Record<string, string | string[] | undefined>,
       ) => {
         if (isAllowedHost(hostname)) {
           log.debug({ hostname }, "Allowing always-permitted host");
@@ -356,6 +390,8 @@ function buildSessionStartHooks(): SessionStartHooks {
               const approved = await managed.approvalCallback({
                 decision,
                 sessionId: managed.session.id,
+                method,
+                requestHeaders: filterApprovalHeaders(reqHeaders),
               });
               return approved ? {} : null;
             }

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -291,6 +291,10 @@ export interface ProxyApprovalRequest {
     matchingPatterns?: string[];
   };
   sessionId: string;
+  /** HTTP method (plain HTTP only; undefined for HTTPS CONNECT tunnels). */
+  method?: string;
+  /** Curated non-sensitive headers (plain HTTP only). */
+  requestHeaders?: Record<string, string>;
 }
 
 /** Callback for proxy policy decisions requiring user confirmation. Returns true if approved. */

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -113,6 +113,13 @@ public struct ToolConfirmationData: Equatable {
                 return "The assistant wants to open \(host)"
             }
             return "The assistant wants to open a page"
+        case "network_request":
+            let url = (input["url"]?.value as? String) ?? ""
+            let host = URL(string: url)?.host ?? "an external host"
+            if let method = input["method"]?.value as? String {
+                return "The assistant wants to send a \(method) request to \(host)"
+            }
+            return "The assistant wants to open a connection to \(host)"
         case "schedule_create":
             let name = (input["name"]?.value as? String) ?? ""
             return name.isEmpty
@@ -152,6 +159,27 @@ public struct ToolConfirmationData: Equatable {
                 return command + "\n\ntimeout_seconds: \(timeout)"
             }
             return command
+        case "network_request":
+            var parts: [String] = []
+            if let url = input["url"]?.value as? String { parts.append("URL: \(url)") }
+            if let method = input["method"]?.value as? String { parts.append("Method: \(method)") }
+            if let reason = input["reason"]?.value as? String { parts.append("\nReason: \(reason)") }
+            if let headers = input["request_headers"]?.value as? [String: Any], !headers.isEmpty {
+                parts.append("\nHeaders:")
+                for (k, v) in headers.sorted(by: { $0.key < $1.key }) {
+                    parts.append("  \(k): \(v)")
+                }
+            }
+            if let patterns = input["known_credential_patterns"]?.value as? [Any] {
+                let strs = patterns.compactMap { $0 as? String }
+                if !strs.isEmpty {
+                    parts.append("\nKnown credential patterns: \(strs.joined(separator: ", "))")
+                }
+            }
+            if (input["method"]?.value as? String) == nil {
+                parts.append("\n(HTTPS connection \u{2014} method, headers, and body are encrypted and not visible to the proxy.)")
+            }
+            return parts.joined(separator: "\n")
         default:
             break
         }
@@ -167,6 +195,9 @@ public struct ToolConfirmationData: Equatable {
                 formatted = "\(num)"
             } else if let num = value as? Double {
                 formatted = "\(num)"
+            } else if let arr = value as? [Any] {
+                let strs = arr.compactMap { $0 as? String }
+                formatted = strs.isEmpty ? "\(value)" : strs.joined(separator: ", ")
             } else {
                 formatted = "\(value)"
             }
@@ -739,6 +770,16 @@ public func confirmationHumanDescription(
             return "Allow opening \(host)?"
         }
         return "Allow opening a page?"
+    case "network_request":
+        let url = (input["url"]?.value as? String) ?? ""
+        let host = URL(string: url)?.host
+        let scheme = (input["scheme"]?.value as? String) ?? "https"
+        let method = input["method"]?.value as? String
+        if let host {
+            if let method { return "Allow \(method) \(scheme)://\(host)?" }
+            return "Allow \(scheme.uppercased()) connection to \(host)?"
+        }
+        return "Allow a network request?"
     case "credential_store":
         let action = (input["action"]?.value as? String) ?? ""
         let service = (input["service"]?.value as? String) ?? ""

--- a/packages/egress-proxy/src/types.ts
+++ b/packages/egress-proxy/src/types.ts
@@ -197,12 +197,19 @@ export type PolicyDecision =
 /**
  * Callback invoked by the proxy HTTP forwarder for each outbound request.
  * Returns injected headers on allow, or `null` to block the request.
+ *
+ * `method` and `requestHeaders` are populated for plain-HTTP proxied
+ * requests (absolute-URL form). For HTTPS CONNECT tunnels the proxy has
+ * not yet terminated TLS and cannot see HTTP-level details, so these are
+ * left undefined.
  */
 export type PolicyCallback = (
   hostname: string,
   port: number | null,
   path: string,
   scheme: "http" | "https",
+  method?: string,
+  requestHeaders?: Record<string, string | string[] | undefined>,
 ) => Promise<Record<string, string> | null>;
 
 /**
@@ -216,6 +223,18 @@ export interface ProxyApprovalRequest {
     | PolicyDecisionAskUnauthenticated;
   /** The proxy session ID that originated the request. */
   sessionId: ProxySessionId;
+  /**
+   * HTTP method of the incoming request, when available. Undefined for HTTPS
+   * CONNECT tunnels — at CONNECT time the proxy has not terminated TLS so
+   * no HTTP-level information is visible.
+   */
+  method?: string;
+  /**
+   * Curated subset of request headers, when available. Only non-sensitive
+   * headers are surfaced (content-type, content-length, user-agent, accept).
+   * Undefined for HTTPS CONNECT tunnels.
+   */
+  requestHeaders?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Plain-HTTP proxied requests now carry HTTP method and a curated non-sensitive header subset (`content-type`, `content-length`, `user-agent`, `accept`) through the policy callback into the approval prompt. HTTPS CONNECT remains host/port-only because TLS has not yet terminated.
- The prompt's input dict is rebuilt: drop the internal `proxy_session_id` handle, rename `matching_patterns` to `known_credential_patterns`, add a human-readable `reason`, and mark CONNECT-only prompts with `connection_detail_available=no`.
- macOS/iOS prompt rendering gets dedicated `network_request` cases for the title, details summary, and full input preview. The new preview shows URL, method, reason, headers, and known credential patterns — plus an explicit note when HTTPS hides request details. Also fixes the `[Optional("...")]` fallback rendering for string-array inputs.

## Original prompt
it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
