### PR TITLE
test(deepgram-realtime): extend KeepAlive wait window to reduce CI flake

### DIFF
--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -814,8 +814,9 @@ describe("DeepgramRealtimeTranscriber", () => {
       keepaliveIntervalMs: 30,
     });
 
-    // Wait long enough for at least two KeepAlives to fire.
-    await new Promise((resolve) => setTimeout(resolve, 95));
+    // Wait long enough that at least two KeepAlives fire even on a loaded
+    // CI runner with event-loop jitter.
+    await new Promise((resolve) => setTimeout(resolve, 250));
 
     const keepalives = mockWs.sentData.filter(
       (d) => typeof d === "string" && d === '{"type":"KeepAlive"}',


### PR DESCRIPTION
## Summary
- The `sends KeepAlive frames at the configured interval while open` test waited only 95ms for a 30ms-interval timer, leaving ~5ms of slack per expected fire. The [failing job](https://github.com/vellum-ai/vellum-assistant/actions/runs/24799548609/job/72578194842) saw only 1 KeepAlive when the test expected `>= 2`.
- Bump the wait to 250ms so roughly 8 fires are expected, making `>= 2` robust to event-loop jitter on loaded CI runners without meaningfully slowing the test.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24799548609/job/72578194842

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
