### PR TITLE
fix(image-gen): clear API key on provider switch; restore CLI auth hint

### DIFF
--- a/assistant/src/cli/commands/__tests__/image-generation.test.ts
+++ b/assistant/src/cli/commands/__tests__/image-generation.test.ts
@@ -344,7 +344,39 @@ describe("credential errors", () => {
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout.trim());
     expect(parsed.ok).toBe(false);
+    // Base hint from image-credentials.ts is preserved.
     expect(parsed.error).toContain("Managed proxy");
+    // CLI augments the hint with CLI-specific recovery guidance so users
+    // know how to resolve the problem from the CLI (the shared hint is
+    // tool-flavored and only mentions the Vellum app).
+    expect(parsed.error).toContain("assistant auth login");
+    expect(parsed.error).toContain(
+      "services.image-generation.mode to 'your-own'",
+    );
+  });
+
+  test("your-own mode hint is NOT augmented with CLI auth guidance", async () => {
+    // The CLI-specific `assistant auth login` guidance only makes sense when
+    // the user is trying to use managed mode. In your-own mode, the shared
+    // hint (pointing at Settings > Models & Services for the API key) is
+    // already actionable from the CLI perspective (the key is in secure
+    // storage, the user just hasn't set it). Augmenting here would confuse
+    // the user into thinking they need to authenticate to Vellum.
+    mockConfig.services["image-generation"].mode = "your-own";
+    mockConfig.services["image-generation"].provider = "gemini";
+    mockProviderKeys.gemini = undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "A sunset",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).not.toContain("assistant auth login");
   });
 });
 

--- a/assistant/src/cli/commands/image-generation.ts
+++ b/assistant/src/cli/commands/image-generation.ts
@@ -156,8 +156,16 @@ Examples:
     });
 
     if (!credentials) {
-      const hint =
+      const baseHint =
         errorHint ?? "No credentials available for image generation.";
+      // The shared hint in image-credentials.ts is correct for tool surfaces
+      // but drops CLI-specific recovery guidance. When the managed proxy is
+      // unavailable (mode === "managed" with no platform base URL), the CLI
+      // user can authenticate or flip the mode — tell them how from the CLI.
+      const hint =
+        svc.mode === "managed"
+          ? `${baseHint}\n  Run 'assistant auth login' to authenticate, or set services.image-generation.mode to 'your-own' in config.`
+          : baseHint;
       if (jsonOutput) {
         process.stdout.write(JSON.stringify({ ok: false, error: hint }) + "\n");
       } else {

--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -94,7 +94,19 @@ struct ImageGenerationServiceCard: View {
         .task {
             imageGenHasKey = await APIKeyManager.hasKey(for: currentProvider)
         }
-        .onChange(of: draftModel) { _, _ in
+        .onChange(of: draftModel) { oldValue, newValue in
+            // When the user picks a model whose provider differs from the previous
+            // selection (e.g. a Gemini model → an OpenAI model), clear any typed
+            // API-key text. Without this, a partially-typed Gemini key could be
+            // submitted under the openai credential slot (or vice versa) if the
+            // user switches models before hitting Save. Clearing only on actual
+            // provider change avoids disrupting in-flight typing when the user
+            // just switches between two models of the same provider.
+            let oldProvider = SettingsStore.imageGenProvider(forModel: oldValue)
+            let newProvider = SettingsStore.imageGenProvider(forModel: newValue)
+            if oldProvider != newProvider {
+                apiKeyText = ""
+            }
             // Re-fetch the "key configured" indicator when the user switches between
             // Gemini and OpenAI models in the picker so the UI reflects the right provider.
             Task {


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for gpt-image-2-support.md.

1. **Swift key-mixup**: `ImageGenerationServiceCard` now clears `apiKeyText` when the selected model's provider changes (Gemini ↔ OpenAI), preventing a typed Gemini key from being saved to the OpenAI credential slot if the user switches provider pre-Save. Clearing only on actual provider change avoids disrupting in-flight typing when the user just switches between two models of the same provider.
2. **CLI hint regression**: The managed-mode "no credentials" hint in the CLI now includes `Run 'assistant auth login' to authenticate, or set services.image-generation.mode to 'your-own' in config.` guidance, which was dropped in PR 8's refactor to the shared hint. The shared tool-flavored hint in `image-credentials.ts` is unchanged — the CLI augments it only when `svc.mode === "managed"`.

## Test plan
- [x] `bun test src/cli/commands/__tests__/image-generation.test.ts` — 23 tests pass including the new `your-own mode hint is NOT augmented` negative assertion.
- [x] `bun run lint` clean.
- [ ] Swift build: pre-push hook failed on the unrelated SwiftMath cache issue (`no versions of 'swiftmath' match the requirement 1.7.3`) — pushed with `--no-verify` per repo-level guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
