### PR TITLE
fix(image-gen): derive provider from explicit model override

### DIFF
--- a/assistant/src/__tests__/image-service-dispatcher.test.ts
+++ b/assistant/src/__tests__/image-service-dispatcher.test.ts
@@ -62,7 +62,11 @@ mock.module("../media/openai-image-service.js", () => ({
 }));
 
 // Import after mocking
-import { generateImage, mapImageGenError } from "../media/image-service.js";
+import {
+  generateImage,
+  mapImageGenError,
+  providerForModel,
+} from "../media/image-service.js";
 
 // ---------------------------------------------------------------------------
 // Shared fixtures
@@ -134,5 +138,38 @@ describe("image-service dispatcher", () => {
     expect(openaiErrorCalls).toEqual([err]);
     expect(geminiErrorCalls).toEqual([]);
     expect(mapped).toBe("openai-mapped");
+  });
+});
+
+describe("providerForModel", () => {
+  test("returns fallback when model is undefined", () => {
+    expect(providerForModel(undefined, "gemini")).toBe("gemini");
+    expect(providerForModel(undefined, "openai")).toBe("openai");
+  });
+
+  test("routes gpt-* models to openai regardless of fallback", () => {
+    expect(providerForModel("gpt-image-2", "gemini")).toBe("openai");
+    expect(providerForModel("gpt-image-2", "openai")).toBe("openai");
+    expect(providerForModel("gpt-4o-image", "gemini")).toBe("openai");
+  });
+
+  test("routes dall-e-* models to openai regardless of fallback", () => {
+    expect(providerForModel("dall-e-3", "gemini")).toBe("openai");
+    expect(providerForModel("dall-e-2", "gemini")).toBe("openai");
+  });
+
+  test("routes gemini-* models to gemini regardless of fallback", () => {
+    expect(providerForModel("gemini-3.1-flash-image-preview", "openai")).toBe(
+      "gemini",
+    );
+    expect(providerForModel("gemini-3-pro-image-preview", "openai")).toBe(
+      "gemini",
+    );
+  });
+
+  test("returns fallback for unrecognized model prefixes", () => {
+    expect(providerForModel("unknown-model", "gemini")).toBe("gemini");
+    expect(providerForModel("unknown-model", "openai")).toBe("openai");
+    expect(providerForModel("", "gemini")).toBe("gemini");
   });
 });

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -223,6 +223,62 @@ describe("image-studio skill script wrapper", () => {
     expect(result.content).not.toContain("No Gemini API key");
   });
 
+  test("explicit model override routes to owning provider (gemini config → openai call)", async () => {
+    // Config says the user's default provider is gemini, but the LLM
+    // explicitly requests a gpt-* model. The tool must dispatch to OpenAI
+    // and resolve OpenAI credentials, not fall back to Gemini's default.
+    mockImageGenProvider = "gemini";
+    mockOpenAIKey = "openai-direct-key";
+
+    const result = await run(
+      { prompt: "a robot", model: "gpt-image-2" },
+      fakeContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(lastGenerateProvider).toBe("openai");
+    expect(lastGenerateCredentials).toEqual({
+      type: "direct",
+      apiKey: "openai-direct-key",
+    });
+  });
+
+  test("explicit model override routes to owning provider (openai config → gemini call)", async () => {
+    // The inverse: config says openai but the LLM asks for a gemini-* model.
+    mockImageGenProvider = "openai";
+    mockGeminiKey = "gemini-direct-key";
+
+    const result = await run(
+      { prompt: "a cat", model: "gemini-3-pro-image-preview" },
+      fakeContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(lastGenerateProvider).toBe("gemini");
+    expect(lastGenerateCredentials).toEqual({
+      type: "direct",
+      apiKey: "gemini-direct-key",
+    });
+  });
+
+  test("cross-provider override surfaces owning provider's credential error", async () => {
+    // Config: gemini (with a gemini key). LLM asks for gpt-image-2 but the
+    // OpenAI key is missing. The error hint must reference OpenAI, not
+    // Gemini, because the dispatch target is OpenAI.
+    mockImageGenProvider = "gemini";
+    mockGeminiKey = "test-gemini-key";
+    mockOpenAIKey = undefined;
+
+    const result = await run(
+      { prompt: "a robot", model: "gpt-image-2" },
+      fakeContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("OpenAI");
+    expect(result.content).not.toContain("No Gemini API key");
+  });
+
   test("returns generated image with contentBlocks", async () => {
     const result = await run({ prompt: "a sunset" }, fakeContext);
 

--- a/assistant/src/cli/commands/__tests__/image-generation.test.ts
+++ b/assistant/src/cli/commands/__tests__/image-generation.test.ts
@@ -469,6 +469,91 @@ describe("provider dispatch", () => {
     expect(creds.type).toBe("direct");
     expect(creds.apiKey).toBe("test-openai-key");
   });
+
+  test("cross-provider override: config=gemini + --model gpt-image-2 dispatches to openai", async () => {
+    // Config still points at gemini (the user's Settings default), but the
+    // CLI caller explicitly picks gpt-image-2. The command must dispatch to
+    // OpenAI and resolve OpenAI credentials, not fall back to Gemini's
+    // default model.
+    mockConfig.services["image-generation"].mode = "your-own";
+    mockConfig.services["image-generation"].provider = "gemini";
+    mockConfig.services["image-generation"].model =
+      "gemini-3.1-flash-image-preview";
+    mockProviderKeys.openai = "test-openai-key";
+    mockGenerateResult = {
+      images: [
+        {
+          mimeType: "image/png",
+          dataBase64: Buffer.from("fake-png-data").toString("base64"),
+        },
+      ],
+      resolvedModel: "gpt-image-2",
+    };
+    const outDir = join(os.tmpdir(), `img-cross-openai-${Date.now()}`);
+
+    const { exitCode } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--model",
+      "gpt-image-2",
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastGenerateCall).toBeDefined();
+    expect(lastGenerateCall!.provider).toBe("openai");
+    const req = lastGenerateCall!.request as { model: string };
+    expect(req.model).toBe("gpt-image-2");
+    const creds = lastGenerateCall!.credentials as {
+      type: string;
+      apiKey: string;
+    };
+    expect(creds.type).toBe("direct");
+    expect(creds.apiKey).toBe("test-openai-key");
+  });
+
+  test("cross-provider override: config=openai + --model gemini-3-pro-image-preview dispatches to gemini", async () => {
+    mockConfig.services["image-generation"].mode = "your-own";
+    mockConfig.services["image-generation"].provider = "openai";
+    mockConfig.services["image-generation"].model = "gpt-image-2";
+    mockProviderKeys.gemini = "test-gemini-key";
+    mockGenerateResult = {
+      images: [
+        {
+          mimeType: "image/png",
+          dataBase64: Buffer.from("fake-png-data").toString("base64"),
+        },
+      ],
+      resolvedModel: "gemini-3-pro-image-preview",
+    };
+    const outDir = join(os.tmpdir(), `img-cross-gemini-${Date.now()}`);
+
+    const { exitCode } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--model",
+      "gemini-3-pro-image-preview",
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastGenerateCall).toBeDefined();
+    expect(lastGenerateCall!.provider).toBe("gemini");
+    const req = lastGenerateCall!.request as { model: string };
+    expect(req.model).toBe("gemini-3-pro-image-preview");
+    const creds = lastGenerateCall!.credentials as {
+      type: string;
+      apiKey: string;
+    };
+    expect(creds.type).toBe("direct");
+    expect(creds.apiKey).toBe("test-gemini-key");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/image-generation.ts
+++ b/assistant/src/cli/commands/image-generation.ts
@@ -10,6 +10,7 @@ import {
   generateImage,
   type ImageGenCredentials,
   mapImageGenError,
+  providerForModel,
 } from "../../media/image-service.js";
 import { log } from "../logger.js";
 
@@ -150,8 +151,14 @@ Examples:
     const config = getConfig();
     const svc = config.services["image-generation"];
 
+    // Derive provider from the explicit `--model` override when supplied so
+    // that `--model gpt-image-2` routes to OpenAI even when config.provider
+    // is `gemini` (and vice-versa). Without this, the Gemini service would
+    // silently downgrade unknown models to its default.
+    const provider = providerForModel(modelOverride, svc.provider);
+
     const { credentials, errorHint } = await resolveImageGenCredentials({
-      provider: svc.provider,
+      provider,
       mode: svc.mode,
     });
 
@@ -219,7 +226,7 @@ Examples:
 
     // --- Generate image ---
     try {
-      const result = await generateImage(svc.provider, resolvedCredentials, {
+      const result = await generateImage(provider, resolvedCredentials, {
         prompt,
         mode,
         sourceImages,
@@ -270,7 +277,7 @@ Examples:
         }
       }
     } catch (error) {
-      const errorMsg = mapImageGenError(svc.provider, error);
+      const errorMsg = mapImageGenError(provider, error);
       if (jsonOutput) {
         process.stdout.write(
           JSON.stringify({ ok: false, error: errorMsg }) + "\n",

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -3,6 +3,7 @@ import { resolveImageGenCredentials } from "../../../../media/image-credentials.
 import {
   generateImage,
   mapImageGenError,
+  providerForModel,
 } from "../../../../media/image-service.js";
 import { getFilePathBySourcePath } from "../../../../memory/attachments-store.js";
 import type { ImageContent } from "../../../../providers/types.js";
@@ -18,8 +19,13 @@ export async function run(
 ): Promise<ToolExecutionResult> {
   const config = getConfig();
   const svc = config.services["image-generation"];
+  const modelOverride = input.model as string | undefined;
+  // Derive provider from the explicit model when supplied so that requesting
+  // e.g. `gpt-image-2` while config.provider === "gemini" routes to OpenAI
+  // instead of silently falling back to the Gemini default model.
+  const provider = providerForModel(modelOverride, svc.provider);
   const { credentials, errorHint } = await resolveImageGenCredentials({
-    provider: svc.provider,
+    provider,
     mode: svc.mode,
   });
   if (!credentials) {
@@ -32,9 +38,7 @@ export async function run(
   const prompt = input.prompt as string;
   const mode = (input.mode as "generate" | "edit") ?? "generate";
   const sourcePaths = input.source_paths as string[] | undefined;
-  const model =
-    (input.model as string | undefined) ??
-    config.services["image-generation"].model;
+  const model = modelOverride ?? config.services["image-generation"].model;
   const variants = input.variants as number | undefined;
 
   // Resolve source images from file paths (sandboxed to workingDir, edit mode only)
@@ -88,7 +92,7 @@ export async function run(
   }
 
   try {
-    const result = await generateImage(svc.provider, credentials, {
+    const result = await generateImage(provider, credentials, {
       prompt,
       mode,
       sourceImages,
@@ -124,7 +128,7 @@ export async function run(
     };
   } catch (error) {
     return {
-      content: mapImageGenError(svc.provider, error),
+      content: mapImageGenError(provider, error),
       isError: true,
     };
   }

--- a/assistant/src/media/image-service.ts
+++ b/assistant/src/media/image-service.ts
@@ -33,6 +33,30 @@ export function mapImageGenError(
   return mapGeminiError(error);
 }
 
+/**
+ * Derive the owning provider from an explicit model ID.
+ *
+ * When a caller (LLM tool invocation, CLI `--model` flag) passes an explicit
+ * `model` argument, the request should dispatch to the provider that owns
+ * that model — not to the user's configured Settings provider. Without this,
+ * asking for `gpt-image-2` while `services["image-generation"].provider` is
+ * `gemini` silently falls back to the Gemini default model.
+ *
+ * Model prefix mapping:
+ *   - `gpt-*` or `dall-e-*` → `openai`
+ *   - `gemini-*`            → `gemini`
+ *   - anything else (or `undefined`) → the provided `fallback`
+ */
+export function providerForModel(
+  model: string | undefined,
+  fallback: ImageGenProvider,
+): ImageGenProvider {
+  if (!model) return fallback;
+  if (model.startsWith("gpt-") || model.startsWith("dall-e-")) return "openai";
+  if (model.startsWith("gemini-")) return "gemini";
+  return fallback;
+}
+
 export type {
   GeneratedImage,
   ImageGenCredentials,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for gpt-image-2-support.md.

**Gap:** media_generate_image and the CLI generate command dispatched with the configured services['image-generation'].provider even when the caller explicitly requested a model that belongs to a different provider, causing silent fallback to the Gemini default model when LLM/user asked for gpt-image-2 while config.provider was gemini.
**Fix:** Added providerForModel(model, fallback) helper in image-service.ts. Tool and CLI now derive the provider from the model argument when supplied (gpt-*/dall-e-* -> openai, gemini-* -> gemini), falling back to svc.provider only when no explicit model is passed. Tests cover the cross-provider override path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
