### PR TITLE
fix: route avatar generation through provider dispatcher

### DIFF
--- a/assistant/src/__tests__/avatar-generator.test.ts
+++ b/assistant/src/__tests__/avatar-generator.test.ts
@@ -96,8 +96,10 @@ describe("generateAndSaveAvatar", () => {
     expect(result.content).toContain("No image data returned");
   });
 
-  test("generic error returns mapped message", async () => {
-    mockRouterError = new Error("Network timeout");
+  test("router-mapped error message is surfaced verbatim", async () => {
+    // avatar-router now maps provider errors before throwing, so the
+    // generator just surfaces error.message directly.
+    mockRouterError = new Error("Image generation failed: Network timeout");
 
     const result = await executeAvatar("a cat");
 

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -206,8 +206,6 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "config/bundled-skills/media-processing/tools/analyze-keyframes.ts", // keyframe analysis tool API key lookup
       "providers/registry.ts", // provider registry API key lookup for initialization
       "providers/provider-availability.ts", // provider availability API key check
-      "media/app-icon-generator.ts", // app icon generation API key lookup
-      "media/avatar-router.ts", // avatar generation API key lookup
       "media/image-credentials.ts", // shared image-gen credential resolver (provider API key lookup)
       "memory/embedding-backend.ts", // embedding backend API key lookup
       "daemon/providers-setup.ts", // provider initialization API key lookup

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -1,60 +1,45 @@
 import { getConfig } from "../config/loader.js";
-import {
-  buildManagedBaseUrl,
-  resolveManagedProxyContext,
-} from "../providers/managed-proxy/context.js";
-import { getProviderKeyAsync } from "../security/secure-keys.js";
 import { ConfigError, ProviderError } from "../util/errors.js";
-import {
-  generateImage,
-  type ImageGenCredentials,
-} from "./gemini-image-service.js";
+import { resolveImageGenCredentials } from "./image-credentials.js";
+import { generateImage, mapImageGenError } from "./image-service.js";
 
 export async function generateAvatar(
   prompt: string,
 ): Promise<{ imageBase64: string; mimeType: string }> {
   const config = getConfig();
-  const imageGenMode = config.services["image-generation"].mode;
+  const svc = config.services["image-generation"];
 
-  // Resolve credentials strictly based on mode — no cross-mode fallbacks
-  let credentials: ImageGenCredentials | undefined;
-
-  if (imageGenMode === "managed") {
-    const managedBaseUrl = await buildManagedBaseUrl("gemini");
-    if (managedBaseUrl) {
-      const ctx = await resolveManagedProxyContext();
-      credentials = {
-        type: "managed-proxy",
-        assistantApiKey: ctx.assistantApiKey,
-        baseUrl: managedBaseUrl,
-      };
-    }
-  } else {
-    const geminiKey = await getProviderKeyAsync("gemini");
-    if (geminiKey) {
-      credentials = { type: "direct", apiKey: geminiKey };
-    }
-  }
+  const { credentials, errorHint } = await resolveImageGenCredentials({
+    provider: svc.provider,
+    mode: svc.mode,
+  });
 
   if (!credentials) {
-    const hint =
-      imageGenMode === "managed"
-        ? "Managed proxy is not available. Please log in to Vellum or switch to Your Own mode."
-        : "Gemini API key is not configured. Please set your Gemini API key in Settings > Models & Services.";
-    throw new ConfigError(hint);
+    throw new ConfigError(errorHint ?? "Image generation is not configured.");
   }
 
-  const result = await generateImage(credentials, {
-    prompt,
-    mode: "generate",
-    model: config.services["image-generation"].model,
-  });
+  let result;
+  try {
+    result = await generateImage(svc.provider, credentials, {
+      prompt,
+      mode: "generate",
+      model: svc.model,
+    });
+  } catch (error) {
+    // Re-throw with a provider-aware, user-friendly message so callers
+    // (e.g. avatar-generator) don't need provider context to surface a
+    // useful error.
+    throw new ProviderError(
+      mapImageGenError(svc.provider, error),
+      svc.provider,
+    );
+  }
 
   const image = result.images[0];
   if (!image) {
     throw new ProviderError(
-      "Gemini image generation returned no images.",
-      "gemini",
+      "Image generation returned no images.",
+      svc.provider,
     );
   }
 

--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -3,7 +3,6 @@ import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 import { generateAvatar } from "../../media/avatar-router.js";
-import { mapGeminiError } from "../../media/gemini-image-service.js";
 import { getLogger } from "../../util/logger.js";
 import { getAvatarImagePath } from "../../util/platform.js";
 
@@ -69,7 +68,12 @@ export async function generateAndSaveAvatar(
       isError: false,
     };
   } catch (error) {
-    const message = mapGeminiError(error);
+    // avatar-router already throws with a provider-aware, user-friendly
+    // message — just surface error.message directly.
+    const message =
+      error instanceof Error
+        ? error.message
+        : "An unexpected error occurred during image generation.";
     log.error({ error: message }, "Avatar generation failed");
     return {
       content: `Avatar generation failed: ${message}`,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for gpt-image-2-support.md.

**Gap:** avatar-router.ts and avatar-generator.ts were not migrated to the provider dispatcher, so selecting gpt-image-2 in Settings with an OpenAI-only configuration caused avatar generation to fail with a 'Gemini API key is not configured' error.
**Fix:** avatar-router.ts now resolves credentials via resolveImageGenCredentials and dispatches to generateImage(provider, ...) from image-service.js. avatar-generator.ts surfaces the router's pre-mapped error message directly (no provider context needed).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
