### PR TITLE
revert(macOS): keep VInlineMessage for error banners + form info

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
@@ -233,7 +233,7 @@ struct IntegrationDetailModal: View {
             }
 
             if let error = store.managedError(for: providerKey) {
-                VNotification(error, tone: .negative)
+                VInlineMessage(error, tone: .error)
             }
         }
     }
@@ -351,7 +351,7 @@ struct IntegrationDetailModal: View {
             }
 
             if let error = store.yourOwnError(for: providerKey) {
-                VNotification(error, tone: .negative)
+                VInlineMessage(error, tone: .error)
             }
         }
         .onAppear {
@@ -376,7 +376,7 @@ struct IntegrationDetailModal: View {
                 )
             }
             if yourOwnMeta?.dashboard_url != nil {
-                VNotification("Find these in your \(displayName) Developer console.", tone: .neutral)
+                VInlineMessage("Find these in your \(displayName) Developer console.", tone: .info)
             }
 
             HStack(spacing: VSpacing.sm) {


### PR DESCRIPTION
Only the paid-cost notices (top of Managed + Your Own tabs) use VNotification. Error banners and the Developer-console hint stay on VInlineMessage because they may contain long strings that should wrap, not truncate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
