### PR TITLE
test(image-generation): mock providerForModel in image-service stub

### DIFF
--- a/assistant/src/cli/commands/__tests__/image-generation.test.ts
+++ b/assistant/src/cli/commands/__tests__/image-generation.test.ts
@@ -107,6 +107,13 @@ mock.module("../../../media/image-service.js", () => ({
       return `Mapped error (${String(provider)}): ${error.message}`;
     return "An unexpected error occurred during image generation.";
   },
+  providerForModel: (model: string | undefined, fallback: string) => {
+    if (!model) return fallback;
+    if (model.startsWith("gpt-") || model.startsWith("dall-e-"))
+      return "openai";
+    if (model.startsWith("gemini-")) return "gemini";
+    return fallback;
+  },
 }));
 
 mock.module("../../../util/logger.js", () => ({


### PR DESCRIPTION
## Summary

- The CLI `image-generation` command now imports `providerForModel` from `media/image-service` (added in #27542), but `src/cli/commands/__tests__/image-generation.test.ts` mocks `image-service.js` without re-exporting it, so Bun throws `SyntaxError: Export named 'providerForModel' not found` at import time and the whole Test job fails on main.
- Add `providerForModel` to the mock with the same prefix semantics as the real function so provider-dispatch tests still hit the right branch.

## Original prompt

--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24800207397/job/72580493228
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
