### PR TITLE
refactor(skills): unbundle heartbeat skill → vellum-heartbeat

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -640,7 +640,7 @@
       "name": "vellum-heartbeat",
       "description": "Configure periodic background checklist runs",
       "metadata": {
-        "emoji": "\\U0001F493",
+        "emoji": "💓",
         "vellum": {
           "display-name": "Heartbeat",
           "activation-hints": [

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -636,6 +636,24 @@
       "compatibility": "Designed for Vellum personal assistants. Requires Python 3, bun, and the assistant credentials CLI."
     },
     {
+      "id": "vellum-heartbeat",
+      "name": "vellum-heartbeat",
+      "description": "Configure periodic background checklist runs",
+      "metadata": {
+        "emoji": "\\U0001F493",
+        "vellum": {
+          "display-name": "Heartbeat",
+          "activation-hints": [
+            "Set up a heartbeat, periodic checklist, background health check, or recurring background task"
+          ],
+          "avoid-when": [
+            "One-off or recurring schedules with specific payloads - use the schedule skill instead"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "vellum-oauth-integrations",
       "name": "vellum-oauth-integrations",
       "description": "Act on behalf of your user in any third-party software that supports OAuth 2.0",

--- a/skills/vellum-heartbeat/SKILL.md
+++ b/skills/vellum-heartbeat/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: heartbeat
+name: vellum-heartbeat
 description: Configure periodic background checklist runs
 compatibility: "Designed for Vellum personal assistants"
 metadata:

--- a/skills/vellum-heartbeat/SKILL.md
+++ b/skills/vellum-heartbeat/SKILL.md
@@ -23,6 +23,7 @@ Edit `config.json` using `file_edit`:
 3. **Optional active hours**: Set `heartbeat.activeHoursStart` and `heartbeat.activeHoursEnd` (0-23) to restrict runs to certain hours. Both must be set together.
 
 Example config.json heartbeat section:
+
 ```json
 {
   "heartbeat": {

--- a/skills/vellum-heartbeat/SKILL.md
+++ b/skills/vellum-heartbeat/SKILL.md
@@ -3,7 +3,7 @@ name: vellum-heartbeat
 description: Configure periodic background checklist runs
 compatibility: "Designed for Vellum personal assistants"
 metadata:
-  emoji: "\U0001F493"
+  emoji: "💓"
   vellum:
     display-name: "Heartbeat"
     activation-hints:


### PR DESCRIPTION
## Summary
- Moved `assistant/src/config/bundled-skills/heartbeat/SKILL.md` to `skills/vellum-heartbeat/SKILL.md`
- Renamed skill from `heartbeat` to `vellum-heartbeat` in frontmatter
- Deleted the old bundled skill directory

## Original prompt
Help me migrate assistant/src/config/bundled-skills/heartbeat/SKILL.md to skills/ and unbundle it. Rename it `vellum-heartbeat` while we're at it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
