### PR TITLE
fix: update requestedScopes doc comment to reflect replacement semantics

### DIFF
--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -50,7 +50,7 @@ function safeJsonParse<T>(value: string | null | undefined, fallback: T): T {
 export interface OAuthConnectOptions {
   /** Canonical service name (e.g. "google", "slack"). */
   service: string;
-  /** Scopes to request beyond the provider's defaults. */
+  /** Scopes to request. When provided, used instead of the provider's default scopes. */
   requestedScopes?: string[];
   /** OAuth2 client ID (required). */
   clientId: string;


### PR DESCRIPTION
## Summary
Fixes stale doc comment on requestedScopes field that said "beyond the provider's defaults" (implying additive behavior). The new scope model uses requested scopes directly when provided, replacing defaults rather than augmenting them.

Part of plan: simplify-oauth-scope-model.md (fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
