### PR TITLE
diag(macos): os_signpost markers around transition + fixedSize boundaries (LUM-1116 Phase 1)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -132,6 +132,7 @@ struct ChatConversationErrorToast: View {
         .background(accent)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .transition(.move(edge: .top).combined(with: .opacity))
+        .layoutHangSignpost("chat.errorToast")
     }
 
     // MARK: - Category Helpers
@@ -236,6 +237,7 @@ struct CreditsExhaustedBanner: View {
             )
         )
         .transition(.move(edge: .bottom).combined(with: .opacity))
+        .layoutHangSignpost("chat.creditsExhaustedBanner")
     }
 }
 
@@ -271,6 +273,7 @@ struct CompactionCircuitOpenBanner: View {
         .background(VColor.systemMidStrong)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .transition(.move(edge: .top).combined(with: .opacity))
+        .layoutHangSignpost("chat.compactionCircuitOpenBanner")
         .onReceive(timer) { tick in
             if tick >= openUntil {
                 onExpired()
@@ -324,5 +327,6 @@ struct MissingApiKeyBanner: View {
             )
         )
         .transition(.move(edge: .bottom).combined(with: .opacity))
+        .layoutHangSignpost("chat.missingApiKeyBanner")
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -211,6 +211,7 @@ struct ChatView: View {
                 .padding(.trailing, VSpacing.xl)
                 .padding(.top, VSpacing.sm)
                 .transition(.opacity.combined(with: .move(edge: .top)))
+                .layoutHangSignpost("chat.searchBar")
             }
         }
         .animation(VAnimation.fast, value: isSearchActive)
@@ -468,6 +469,7 @@ struct ChatView: View {
                     composerAttachments: $viewModel.pendingAttachments
                 )
                 .transition(.move(edge: .bottom).combined(with: .opacity))
+                .layoutHangSignpost("chat.queuedMessagesDrawer")
             }
 
             if isReadonly {
@@ -654,6 +656,7 @@ struct ChatView: View {
             .padding(.horizontal, VSpacing.lg)
             .padding(.bottom, VSpacing.xxxl + VSpacing.xxl)
             .transition(.opacity.combined(with: .move(edge: .bottom)))
+            .layoutHangSignpost("chat.btwOverlay")
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -91,6 +91,7 @@ struct ComposerSection: View, Equatable {
                     .padding(.horizontal, VSpacing.lg)
                     .padding(.bottom, VSpacing.sm)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .layoutHangSignpost("composer.watchProgress")
             }
 
             ComposerView(

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -141,6 +141,7 @@ struct ComposerView: View, Equatable {
                     onSelect: { command in selectSlashCommand(command) }
                 )
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
+                .layoutHangSignpost("composer.slashCommandPopup")
             }
 
             if composerController.showEmojiMenu {
@@ -150,6 +151,7 @@ struct ComposerView: View, Equatable {
                     onSelect: { entry in selectEmoji(entry) }
                 )
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
+                .layoutHangSignpost("composer.emojiPickerPopup")
             }
 
             // Composer box — switches on the two-mode state machine
@@ -167,6 +169,7 @@ struct ComposerView: View, Equatable {
         }
         #endif
         .fixedSize(horizontal: false, vertical: true)
+        .layoutHangSignpost("composer.outerVStack.fixedSize")
         .padding(.horizontal, VSpacing.lg)
         .padding(.top, VSpacing.sm)
         .disabled(!isInteractionEnabled)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListHelperViews.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListHelperViews.swift
@@ -40,6 +40,7 @@ struct ScrollToLatestOverlayView: View {
             .background { ScrollWheelPassthrough() }
             .padding(.bottom, VSpacing.lg)
             .transition(.move(edge: .bottom).combined(with: .opacity))
+            .layoutHangSignpost("chat.scrollToLatestOverlay")
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/QueuedMessagesDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/QueuedMessagesDrawer.swift
@@ -43,6 +43,7 @@ struct QueuedMessagesDrawer: View {
                 .strokeBorder(VColor.borderBase, lineWidth: 1)
         )
         .fixedSize(horizontal: false, vertical: true)
+        .layoutHangSignpost("chat.queuedMessagesDrawer.fixedSize")
         .widthCap(VSpacing.chatColumnMaxWidth)
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/RecoveryModeBanner.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RecoveryModeBanner.swift
@@ -82,6 +82,7 @@ struct RecoveryModeBanner: View {
             )
         )
         .transition(.move(edge: .bottom).combined(with: .opacity))
+        .layoutHangSignpost("chat.recoveryModeBanner")
         .accessibilityElement(children: .contain)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowToastOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowToastOverlay.swift
@@ -19,6 +19,7 @@ struct MainWindowToastOverlay: View {
             .padding(.horizontal, VSpacing.xl)
             .padding(.bottom, VSpacing.xl)
             .transition(.move(edge: .bottom).combined(with: .opacity))
+            .layoutHangSignpost("mainWindow.toastOverlay")
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowZoomIndicator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowZoomIndicator.swift
@@ -14,6 +14,7 @@ struct MainWindowZoomIndicator: View {
                 .transition(.move(edge: .top).combined(with: .opacity))
                 .padding(.top, 40)
                 .shadow(color: VColor.auxBlack.opacity(0.15), radius: 8, y: 2)
+                .layoutHangSignpost("mainWindow.zoomIndicator")
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -914,6 +914,7 @@ struct ActiveChatViewWrapper: View {
                     onBack: dismissInspector
                 )
                 .transition(.move(edge: .trailing).combined(with: .opacity))
+                .layoutHangSignpost("panel.messageInspector")
             }
         }
         .animation(VAnimation.standard, value: windowState.inspectorMessageId)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -127,6 +127,7 @@ struct IdentityPanel: View {
                     .frame(width: computedSidebarWidth)
                     .padding(.trailing, VSpacing.lg)
                     .transition(.move(edge: .leading).combined(with: .opacity))
+                    .layoutHangSignpost("panel.identity.sidebar")
                 }
 
             // Hex grid fills the rest of the space — card when not fullscreen

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -118,6 +118,7 @@ struct MemoriesPanel: View {
                         .frame(width: 400)
                         .frame(maxHeight: .infinity)
                         .transition(.move(edge: .trailing).combined(with: .opacity))
+                        .layoutHangSignpost("panel.memories.detailSheet")
                         .onKeyPress(.escape) {
                             withAnimation(VAnimation.panel) { selectedItem = nil }
                             return .handled

--- a/clients/macos/vellum-assistant/Telemetry/PerfSignposts.swift
+++ b/clients/macos/vellum-assistant/Telemetry/PerfSignposts.swift
@@ -1,5 +1,6 @@
 import Foundation
 import os
+import SwiftUI
 
 // MARK: - Performance Signposts
 
@@ -11,6 +12,23 @@ enum PerfSignposts {
     static let log = OSLog(
         subsystem: Bundle.appBundleIdentifier,
         category: .pointsOfInterest
+    )
+
+    /// Dedicated log category for `.transition(.move…)` and `.fixedSize()`
+    /// boundary breadcrumbs used to triage Sentry main-thread hangs whose
+    /// stack trace fingerprints an `_HStackLayout`/`_VStackLayout` sort
+    /// inside `SizeFittingLayoutComputer.Engine.explicitAlignment` (see
+    /// LUM-1116 / MACOS-66). The view name is emitted as a `.event`
+    /// signpost on appear and disappear so the next hang event ships
+    /// with a short breadcrumb trail identifying the exact transition
+    /// or sizing boundary that was on-screen when the hang fired.
+    ///
+    /// Filter in Instruments' Points of Interest track (or spindump
+    /// `os_log` section) by category `layout-hangs` to see only these
+    /// breadcrumbs without the noise from other signposts.
+    static let layoutHangs = OSLog(
+        subsystem: Bundle.appBundleIdentifier,
+        category: "layout-hangs"
     )
 
     // MARK: - Chat Surface Signpost Helpers
@@ -74,5 +92,37 @@ enum PerfSignposts {
     /// Marks the end of a first-responder sync cycle.
     static func endFirstResponderSync(_ signpostID: OSSignpostID) {
         os_signpost(.end, log: log, name: "firstResponderSync", signpostID: signpostID)
+    }
+}
+
+// MARK: - Layout Hang Breadcrumb Modifier
+
+extension View {
+    /// Emit `os_signpost(.event …)` markers when this view appears and
+    /// disappears, tagged with `name` on the `layout-hangs` log category.
+    ///
+    /// This is intentionally a zero-cost diagnostic — `.event` signposts are
+    /// safe on the main thread, allocate nothing (because `name` must be a
+    /// `StaticString`), and are elided from Sentry binary hang traces but
+    /// survive in spindumps / Instruments / unified logging.
+    ///
+    /// Apply to `.transition(.move…)` call sites and `.fixedSize()` component
+    /// boundaries so that when a Sentry hang trace lands with a stack like
+    /// `SizeFittingLayoutComputer.Engine.explicitAlignment → _HStackLayout →
+    /// _VStackLayout → …` (MACOS-66 / LUM-1116) we can read the recent
+    /// signpost breadcrumb and identify which concrete view was on-screen —
+    /// the stack alone doesn't name user-defined views.
+    ///
+    /// `name` is `StaticString` to guarantee no per-call allocation and no
+    /// risk of touching non-trivial Swift runtime machinery on the main
+    /// thread while the layout engine is already in a hot loop.
+    func layoutHangSignpost(_ name: StaticString) -> some View {
+        self
+            .onAppear {
+                os_signpost(.event, log: PerfSignposts.layoutHangs, name: name, "appear")
+            }
+            .onDisappear {
+                os_signpost(.event, log: PerfSignposts.layoutHangs, name: name, "disappear")
+            }
     }
 }


### PR DESCRIPTION
## Summary

- Add `layoutHangSignpost(_:)` SwiftUI view modifier in `Telemetry/PerfSignposts.swift` that emits `os_signpost(.event …)` markers on `onAppear` / `onDisappear` against a new `layout-hangs` log category.
- Apply it at every `.transition(.move…)` site in the macOS app (13 sites) and at two `.fixedSize()` component boundaries (composer outer VStack, queued-messages drawer).
- Pure diagnostics — no behavior change, no new runtime cost beyond the `os_signpost` syscall. `StaticString` names guarantee zero allocation on the main thread.

## Why

Sentry main-thread hangs in `MACOS-66` and related (LUM-1116) fingerprint `SizeFittingLayoutComputer.Engine.explicitAlignment → _HStackLayout × 2 → Color → MoveTransition.MoveLayout → _VStackLayout × 5 → StackLayout.prioritize → MutableCollection.sort`. The stack contains zero user-defined view names, so we can't tell which `.transition(.move…)` call site is driving it. `LUM-1111` (MACOS-KE) separately confirms a sidebar transition *can* hang — direct evidence that this code path is implicated.

With `.event` signposts emitting a view name on appear/disappear, the next hang event will ship with a recent signpost breadcrumb naming the active view — the missing piece needed to cut a Phase 2 targeted fix.

This PR does **not** fix any hang by itself.

## Instrumented sites

### `.transition(.move…)` sites

| File | Line | Signpost name |
|---|---|---|
| `Features/Chat/ComposerSection.swift` | 94 | `composer.watchProgress` |
| `Features/Chat/ChatView.swift` | 214 | `chat.searchBar` |
| `Features/Chat/ChatView.swift` | 471 | `chat.queuedMessagesDrawer` |
| `Features/Chat/ChatView.swift` | 659 | `chat.btwOverlay` |
| `Features/Chat/ChatErrorToastView.swift` | 135 | `chat.errorToast` |
| `Features/Chat/ChatErrorToastView.swift` | 239 | `chat.creditsExhaustedBanner` |
| `Features/Chat/ChatErrorToastView.swift` | 274 | `chat.compactionCircuitOpenBanner` |
| `Features/Chat/ChatErrorToastView.swift` | 327 | `chat.missingApiKeyBanner` |
| `Features/Chat/RecoveryModeBanner.swift` | 85 | `chat.recoveryModeBanner` |
| `Features/Chat/ComposerView.swift` | 144 | `composer.slashCommandPopup` |
| `Features/Chat/ComposerView.swift` | 153 | `composer.emojiPickerPopup` |
| `Features/Chat/MessageListHelperViews.swift` | 43 | `chat.scrollToLatestOverlay` |
| `Features/MainWindow/PanelCoordinator.swift` | 917 | `panel.messageInspector` |
| `Features/MainWindow/MainWindowZoomIndicator.swift` | 17 | `mainWindow.zoomIndicator` |
| `Features/MainWindow/MainWindowToastOverlay.swift` | 22 | `mainWindow.toastOverlay` |
| `Features/MainWindow/Panels/MemoriesPanel.swift` | 121 | `panel.memories.detailSheet` |
| `Features/MainWindow/Panels/IdentityPanel.swift` | 130 | `panel.identity.sidebar` |

### `.fixedSize()` component boundaries

| File | Line | Signpost name |
|---|---|---|
| `Features/Chat/ComposerView.swift` | 172 | `composer.outerVStack.fixedSize` |
| `Features/Chat/QueuedMessagesDrawer.swift` | 46 | `chat.queuedMessagesDrawer.fixedSize` |

Note: leaf `Text.fixedSize()` calls are intentionally NOT instrumented — they're cheap, frequent, and not the layout-engine boundary that matters for the `SizeFittingLayoutComputer` stack. LazyVStack cells are also intentionally skipped to avoid O(visible) × frames noise.

## Implementation

Extended the existing `PerfSignposts` namespace (`Telemetry/PerfSignposts.swift`) instead of adding a new helper — there was already an `os_signpost` wrapper used for profiling, so we reuse the same module:

```swift
static let layoutHangs = OSLog(
    subsystem: Bundle.appBundleIdentifier,
    category: "layout-hangs"
)

extension View {
    func layoutHangSignpost(_ name: StaticString) -> some View {
        self
            .onAppear  { os_signpost(.event, log: PerfSignposts.layoutHangs, name: name, "appear") }
            .onDisappear { os_signpost(.event, log: PerfSignposts.layoutHangs, name: name, "disappear") }
    }
}
```

`StaticString` is required (not `String`) so the call site can't allocate. The log is a dedicated category (`layout-hangs`) distinct from the Points-of-Interest log that `PerfSignposts` already uses, so these can be filtered cleanly without drowning in Markdown-parse / scroll-intent / body-evaluation signposts.

## Test plan

- [x] `swift build --target VellumAssistantLib` compiles cleanly in the worktree.
- [ ] After merge, cut a build and open Instruments → Points of Interest. In the filter bar, scope to category `layout-hangs`. Trigger any instrumented view (send a message to queue it, open a panel, show a banner) and confirm `appear` / `disappear` events land in the track with the expected name.
- [ ] Ship on next release. Wait for `MACOS-66` (or a related `SizeFittingLayoutComputer.Engine.explicitAlignment` hang) to fire. Pull the spindump from the attached event, find the last few `os_signpost` entries on the `layout-hangs` category, and identify the view name that was appearing/disappearing when the hang started. Use that to cut a targeted Phase 2 fix.

### Reading the signposts in Instruments

```
1. Product → Profile (or `instruments -t "Points of Interest" <app>`)
2. Switch to the "Points of Interest" instrument.
3. In the detail panel, expand "Subsystems" and scope to
   `com.vellum.vellum-assistant` / category `layout-hangs`.
4. Each event shows the view name as its message string ("appear" or
   "disappear"). The track visualizes which view is on-screen when.
```

In a Sentry hang spindump, search for `layout-hangs` in the unified-log section for the equivalent breadcrumb.

## Constraints respected

- No behavior change — only `.onAppear` / `.onDisappear` callbacks added via a non-intrusive `some View` modifier.
- `.event` markers only (no begin/end intervals, no `OSSignpostID` tracking).
- No instrumentation inside `LazyVStack` cells (O(visible × frames) blast radius).
- `StaticString` names — no main-thread allocation risk.
- Zero-cost in release builds (signposts elide to a syscall when the log is not being streamed).

## Linear / Sentry

- Linear: [LUM-1116](https://linear.app/illuminati/issue/LUM-1116) — Phase 1 (instrumentation).
- Sentry: MACOS-66 and related `SizeFittingLayoutComputer.Engine.explicitAlignment` main-thread hangs.
- Related: LUM-1111 (MACOS-KE, `SidebarSectionView.body.getter:147`).

## Deferred

Phase 2 will use the signpost breadcrumb from the next production hang to cut a targeted fix (reshape the transition/fixedSize combination on the culprit view). No Phase 2 work in this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
