### PR TITLE
fix(permissions): make v3 gateway threshold override ask rules, strict mode, and skill tool gates

### DIFF
--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -327,6 +327,44 @@ describe("no rule — third-party skill tool", () => {
     // Bundled skill + Low risk + no rule → handled by step 9 or 11
     expect(result.decision).toBe("allow");
   });
+
+  test("skill origin, not bundled, gateway threshold covers risk → allow", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "custom_tool",
+      toolOrigin: "skill",
+      isSkillBundled: false,
+      autoApproveUpTo: "medium",
+      isGatewayThreshold: true,
+    });
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("within auto-approve threshold");
+  });
+
+  test("skill origin, not bundled, gateway threshold does not cover risk → prompt", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.High,
+      toolName: "custom_tool",
+      toolOrigin: "skill",
+      isSkillBundled: false,
+      autoApproveUpTo: "medium",
+      isGatewayThreshold: true,
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("Skill tool");
+  });
+
+  test("hasManifestOverride, gateway threshold covers risk → allow", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "unknown_tool",
+      hasManifestOverride: true,
+      autoApproveUpTo: "low",
+      isGatewayThreshold: true,
+    });
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("within auto-approve threshold");
+  });
 });
 
 // ── No rule: strict mode ─────────────────────────────────────────────────────
@@ -369,6 +407,30 @@ describe("no rule — strict mode", () => {
       permissionsMode: "strict",
       toolOrigin: "skill",
       isSkillBundled: true,
+    });
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("Strict mode");
+  });
+
+  test("strict mode, gateway threshold covers risk → allow", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      toolName: "file_read",
+      permissionsMode: "strict",
+      autoApproveUpTo: "low",
+      isGatewayThreshold: true,
+    });
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toContain("within auto-approve threshold");
+  });
+
+  test("strict mode, gateway threshold does not cover risk → prompt", () => {
+    const result = evaluate({
+      riskLevel: RiskLevel.Medium,
+      toolName: "file_read",
+      permissionsMode: "strict",
+      autoApproveUpTo: "low",
+      isGatewayThreshold: true,
     });
     expect(result.decision).toBe("prompt");
     expect(result.reason).toContain("Strict mode");
@@ -764,13 +826,39 @@ describe("autoApproveUpTo threshold", () => {
       expect(result.matchedRule).toBe(denyRule);
     });
 
-    test("ask rule still prompts regardless of threshold", () => {
+    test("ask rule still prompts without gateway threshold flag", () => {
       const askRule = makeRule({ decision: "ask" });
       const result = evaluate({
         riskLevel: RiskLevel.Low,
         toolName: "bash",
         matchedRule: askRule,
         autoApproveUpTo: "medium",
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.matchedRule).toBe(askRule);
+    });
+
+    test("ask rule auto-approves when gateway threshold covers the risk", () => {
+      const askRule = makeRule({ decision: "ask" });
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "bash",
+        matchedRule: askRule,
+        autoApproveUpTo: "medium",
+        isGatewayThreshold: true,
+      });
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("within auto-approve threshold");
+    });
+
+    test("ask rule still prompts when gateway threshold does not cover the risk", () => {
+      const askRule = makeRule({ decision: "ask" });
+      const result = evaluate({
+        riskLevel: RiskLevel.High,
+        toolName: "bash",
+        matchedRule: askRule,
+        autoApproveUpTo: "medium",
+        isGatewayThreshold: true,
       });
       expect(result.decision).toBe("prompt");
       expect(result.matchedRule).toBe(askRule);

--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -864,6 +864,22 @@ describe("autoApproveUpTo threshold", () => {
       expect(result.matchedRule).toBe(askRule);
     });
 
+    test("skill_load_dynamic ask rule always prompts even with gateway threshold", () => {
+      const dynamicSkillAskRule = makeRule({
+        decision: "ask",
+        pattern: "skill_load_dynamic:my-skill",
+      });
+      const result = evaluate({
+        riskLevel: RiskLevel.Low,
+        toolName: "skill_load",
+        matchedRule: dynamicSkillAskRule,
+        autoApproveUpTo: "high",
+        isGatewayThreshold: true,
+      });
+      expect(result.decision).toBe("prompt");
+      expect(result.matchedRule).toBe(dynamicSkillAskRule);
+    });
+
     test("allow rule still allows non-High regardless of threshold", () => {
       const allowRule = makeRule({ decision: "allow" });
       const result = evaluate({

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -31,6 +31,13 @@ export interface ApprovalContext {
    * - "high": auto-approve everything unconditionally
    */
   autoApproveUpTo?: "none" | "low" | "medium" | "high";
+  /**
+   * When true, the auto-approve threshold was resolved from the gateway
+   * (permission-controls-v3). This enables threshold-based override of
+   * ask rules — the user's threshold setting takes precedence over
+   * default ask rules when the risk falls within the threshold.
+   */
+  isGatewayThreshold?: boolean;
 }
 
 // ── Threshold resolution ─────────────────────────────────────────────────────
@@ -91,6 +98,19 @@ const THRESHOLD_ORDINAL: Record<string, number> = {
   high: 2,
 };
 
+/**
+ * Check whether a risk level falls within the configured auto-approve threshold.
+ * Returns `true` when the risk is at or below the threshold (i.e. auto-approve).
+ */
+function isRiskWithinThreshold(
+  riskLevel: string,
+  autoApproveUpTo: string | undefined,
+): boolean {
+  const risk = RISK_ORDINAL[riskLevel] ?? 2;
+  const threshold = THRESHOLD_ORDINAL[autoApproveUpTo ?? "low"] ?? 0;
+  return risk <= threshold;
+}
+
 /** The outcome of an approval policy evaluation. */
 export interface ApprovalDecision {
   decision: "allow" | "prompt" | "deny";
@@ -112,15 +132,18 @@ export interface ApprovalPolicy {
  * The decision flow:
  *
  * 1. Deny rule → deny
- * 2. Ask rule → prompt
+ * 2. Ask rule + risk > autoApproveUpTo → prompt
+ *    Ask rule + risk ≤ autoApproveUpTo → allow (threshold overrides ask)
  * 3. Sandbox auto-approve: workspace mode + bash + sandboxAutoApprove → allow
  *    (Path resolution is baked into `hasSandboxAutoApprove` upstream: containerized
  *    environments skip path checks; non-containerized environments validate all
  *    path arguments against the workspace root.)
  * 4. Allow rule + non-High → allow
  * 5. Allow rule + High → fall through to risk-based
- * 6. No rule + third-party skill tool → prompt
- * 7. No rule + strict mode → prompt
+ * 6. No rule + third-party skill tool + risk > autoApproveUpTo → prompt
+ *    No rule + third-party skill tool + risk ≤ autoApproveUpTo → allow (v3 only)
+ * 7. No rule + strict mode + risk > autoApproveUpTo → prompt
+ *    No rule + strict mode + risk ≤ autoApproveUpTo → allow (v3 only)
  * 8. No rule + workspace mode + Low + workspace-scoped → allow
  * 9. No rule + Low + bundled skill → allow
  * 10. Risk ≤ autoApproveUpTo threshold → allow
@@ -149,8 +172,22 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       };
     }
 
-    // ── 2. Ask rules always prompt ────────────────────────────────────
+    // ── 2. Ask rules prompt — unless the gateway threshold covers the risk.
+    // When permission-controls-v3 is active (isGatewayThreshold), the user's
+    // threshold setting takes precedence over ask rules: if the risk falls
+    // within autoApproveUpTo, the ask rule is overridden and the tool
+    // auto-approves. Without v3, ask rules always prompt (preserving
+    // backward-compatible behavior for default ask rules on host tools, etc.).
     if (matchedRule && matchedRule.decision === "ask") {
+      if (
+        context.isGatewayThreshold &&
+        isRiskWithinThreshold(riskLevel, context.autoApproveUpTo)
+      ) {
+        return {
+          decision: "allow",
+          reason: `${riskLevel} risk: within auto-approve threshold (ask rule overridden)`,
+        };
+      }
       return {
         decision: "prompt",
         reason: `Matched ask rule: ${matchedRule.pattern}`,
@@ -186,15 +223,21 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       // High risk: fall through to risk-based regardless of rule
     }
 
-    // ── 6. No rule + third-party skill tool → prompt ──────────────────
+    // ── 6. No rule + third-party skill tool → prompt (unless v3 threshold covers it)
     if (!matchedRule) {
-      if (toolOrigin === "skill" && !isSkillBundled) {
-        return {
-          decision: "prompt",
-          reason: "Skill tool: requires approval by default",
-        };
-      }
-      if (hasManifestOverride && !toolOrigin) {
+      const isThirdPartySkill =
+        (toolOrigin === "skill" && !isSkillBundled) ||
+        (hasManifestOverride && !toolOrigin);
+      if (isThirdPartySkill) {
+        if (
+          context.isGatewayThreshold &&
+          isRiskWithinThreshold(riskLevel, context.autoApproveUpTo)
+        ) {
+          return {
+            decision: "allow",
+            reason: `${riskLevel} risk: within auto-approve threshold (skill tool)`,
+          };
+        }
         return {
           decision: "prompt",
           reason: "Skill tool: requires approval by default",
@@ -202,8 +245,17 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
       }
     }
 
-    // ── 7. No rule + strict mode → prompt ─────────────────────────────
+    // ── 7. No rule + strict mode → prompt (unless v3 threshold covers it)
     if (permissionsMode === "strict" && !matchedRule) {
+      if (
+        context.isGatewayThreshold &&
+        isRiskWithinThreshold(riskLevel, context.autoApproveUpTo)
+      ) {
+        return {
+          decision: "allow",
+          reason: `${riskLevel} risk: within auto-approve threshold (strict mode overridden)`,
+        };
+      }
       return {
         decision: "prompt",
         reason: "Strict mode: no matching rule, requires approval",
@@ -235,10 +287,7 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
     }
 
     // ── 10–11. Risk-based fallback: compare risk against configured threshold ─
-    const autoApproveUpTo = context.autoApproveUpTo ?? "low";
-    const risk = RISK_ORDINAL[riskLevel] ?? 2;
-    const threshold = THRESHOLD_ORDINAL[autoApproveUpTo] ?? 0;
-    if (risk <= threshold) {
+    if (isRiskWithinThreshold(riskLevel, context.autoApproveUpTo)) {
       return {
         decision: "allow",
         reason: `${riskLevel} risk: within auto-approve threshold`,

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -133,7 +133,8 @@ export interface ApprovalPolicy {
  *
  * 1. Deny rule → deny
  * 2. Ask rule + risk > autoApproveUpTo → prompt
- *    Ask rule + risk ≤ autoApproveUpTo → allow (threshold overrides ask)
+ *    Ask rule + risk ≤ autoApproveUpTo → allow (v3 only: threshold overrides ask)
+ *    Exception: skill_load_dynamic ask rules always prompt (inline-command safety gate)
  * 3. Sandbox auto-approve: workspace mode + bash + sandboxAutoApprove → allow
  *    (Path resolution is baked into `hasSandboxAutoApprove` upstream: containerized
  *    environments skip path checks; non-containerized environments validate all
@@ -178,8 +179,15 @@ export class DefaultApprovalPolicy implements ApprovalPolicy {
     // within autoApproveUpTo, the ask rule is overridden and the tool
     // auto-approves. Without v3, ask rules always prompt (preserving
     // backward-compatible behavior for default ask rules on host tools, etc.).
+    // Exception: skill_load_dynamic ask rules always prompt — they gate
+    // inline-command skill loads that execute embedded commands and must
+    // never be silently auto-approved.
     if (matchedRule && matchedRule.decision === "ask") {
+      const isDynamicSkillAsk = matchedRule.pattern.startsWith(
+        "skill_load_dynamic:",
+      );
       if (
+        !isDynamicSkillAsk &&
         context.isGatewayThreshold &&
         isRiskWithinThreshold(riskLevel, context.autoApproveUpTo)
       ) {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -721,6 +721,7 @@ export async function check(
     isSkillBundled: tool?.ownerSkillBundled ?? false,
     hasManifestOverride: !!manifestOverride,
     autoApproveUpTo: resolvedThreshold,
+    isGatewayThreshold: gatewayThreshold != null,
     hasSandboxAutoApprove,
   };
 

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -9,6 +9,7 @@ import {
   generateScopeOptions,
   getCachedAssessment,
 } from "../permissions/checker.js";
+import { getAutoApproveThreshold } from "../permissions/gateway-threshold-reader.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import { addRule } from "../permissions/trust-store.js";
 import { RiskLevel } from "../permissions/types.js";
@@ -254,10 +255,15 @@ export class PermissionChecker {
         const isDynamicSkillLoad =
           result.matchedRule?.pattern.startsWith("skill_load_dynamic:") ===
           true;
-        const bgThreshold = resolveThreshold(
-          cfg.permissions.autoApproveUpTo,
+        // Use gateway threshold when v3 is enabled, falling back to config.
+        // getAutoApproveThreshold returns from cache (populated by check() above).
+        const gatewayBgThreshold = await getAutoApproveThreshold(
+          context.conversationId,
           "background",
         );
+        const bgThreshold =
+          gatewayBgThreshold ??
+          resolveThreshold(cfg.permissions.autoApproveUpTo, "background");
         const thresholdOrdinal: Record<string, number> = {
           none: -1,
           low: 0,

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -255,46 +255,50 @@ export class PermissionChecker {
         const isDynamicSkillLoad =
           result.matchedRule?.pattern.startsWith("skill_load_dynamic:") ===
           true;
-        // Use gateway threshold when v3 is enabled, falling back to config.
-        // getAutoApproveThreshold returns from cache (populated by check() above).
-        const gatewayBgThreshold = await getAutoApproveThreshold(
-          context.conversationId,
-          "background",
-        );
-        const bgThreshold =
-          gatewayBgThreshold ??
-          resolveThreshold(cfg.permissions.autoApproveUpTo, "background");
-        const thresholdOrdinal: Record<string, number> = {
-          none: -1,
-          low: 0,
-          medium: 1,
-          high: 2,
-        };
-        const riskOrdinal: Record<string, number> = {
-          [RiskLevel.Low]: 0,
-          [RiskLevel.Medium]: 1,
-          [RiskLevel.High]: 2,
-        };
-        const withinThreshold =
-          (riskOrdinal[riskLevel] ?? 2) <= (thresholdOrdinal[bgThreshold] ?? 0);
         if (
           context.isInteractive === false &&
           context.trustClass === "guardian" &&
           !context.requireFreshApproval &&
           !isDynamicSkillLoad &&
-          !v2ForcePrompt &&
-          withinThreshold
+          !v2ForcePrompt
         ) {
-          log.info(
-            { toolName: name, riskLevel },
-            "Auto-approving for non-interactive guardian session",
+          // Use gateway threshold when v3 is enabled, falling back to config.
+          // getAutoApproveThreshold returns from cache (populated by check() above).
+          // Deferred inside the non-interactive branch so interactive prompts
+          // don't pay the gateway I/O cost.
+          const gatewayBgThreshold = await getAutoApproveThreshold(
+            context.conversationId,
+            "background",
           );
-          return {
-            allowed: true,
-            decision: "guardian_auto_approve",
-            riskLevel,
-            riskMeta,
+          const bgThreshold =
+            gatewayBgThreshold ??
+            resolveThreshold(cfg.permissions.autoApproveUpTo, "background");
+          const thresholdOrdinal: Record<string, number> = {
+            none: -1,
+            low: 0,
+            medium: 1,
+            high: 2,
           };
+          const riskOrdinal: Record<string, number> = {
+            [RiskLevel.Low]: 0,
+            [RiskLevel.Medium]: 1,
+            [RiskLevel.High]: 2,
+          };
+          const withinThreshold =
+            (riskOrdinal[riskLevel] ?? 2) <=
+            (thresholdOrdinal[bgThreshold] ?? 0);
+          if (withinThreshold) {
+            log.info(
+              { toolName: name, riskLevel },
+              "Auto-approving for non-interactive guardian session",
+            );
+            return {
+              allowed: true,
+              decision: "guardian_auto_approve",
+              riskLevel,
+              riskMeta,
+            };
+          }
         }
 
         // Non-interactive sessions have no client to respond to prompts -


### PR DESCRIPTION
## Summary

- When permission-controls-v3 is enabled, the gateway-backed auto-approve threshold now correctly overrides default ask rules (e.g. `host_bash **`), strict mode, and the third-party skill tool gate — previously these all short-circuited before the threshold check, making the v3 threshold picker ineffective
- Added `isGatewayThreshold` flag to `ApprovalContext` so the override only fires when the threshold comes from the v3 gateway (zero behavior change for non-v3 users)
- Extracted `isRiskWithinThreshold()` helper to deduplicate the ordinal comparison across steps 2, 6, 7, and 10, and updated the guardian non-interactive auto-approve path to also use the gateway threshold

## Original prompt
(but wait to merge until CI and reviews come back clean)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
