### PR TITLE
fix(macos): require platform auth for managed assistants on startup

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -67,14 +67,6 @@ enum APIKeyManager {
         return ids
     }()
 
-    /// Returns true if any known provider has a key configured.
-    static func hasAnyKey() -> Bool {
-        for provider in allSyncableProviders {
-            if getKey(for: provider) != nil { return true }
-        }
-        return false
-    }
-
     // MARK: - Migration from UserDefaults
 
     /// One-time migration: copies API keys from UserDefaults to credential

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -15,9 +15,8 @@ extension AppDelegate {
             await authManager.checkSession()
             SentryDeviceInfo.updateUserTag(authManager.currentUser?.id)
             let isAuthed = authManager.isAuthenticated
-            let hasKey = APIKeyManager.hasAnyKey()
-            log.info("[authFlow] isAuthenticated=\(isAuthed) hasAnyKey=\(hasKey)")
-            if isAuthed || hasKey {
+            log.info("[authFlow] isAuthenticated=\(isAuthed)")
+            if isAuthed {
                 // Delegate the post-auth routing decision to
                 // ReturningUserRouter so this call site and ReauthView
                 // share one source of truth.
@@ -49,13 +48,17 @@ extension AppDelegate {
                     showAuthWindow()
                 }
             } else {
-                // Check if the lockfile has a non-managed assistant we can connect to
-                // without authentication. Local/remote assistants run independently
-                // of the platform auth session, so the app can open in a logged-out
-                // state and the user can sign in from Settings > General.
-                // Skip managed assistants from a different platform environment.
-                // Migration: fall back to UserDefaults for users upgrading from
-                // the old version whose lockfile doesn't yet have activeAssistant.
+                // Not authenticated: only non-managed assistants may bypass
+                // the auth window. Local/remote assistants run independently
+                // of the platform auth session, so the app can open in a
+                // logged-out state and the user can sign in from Settings >
+                // General. Managed (platform-hosted) assistants always
+                // require platform authentication — presence of locally
+                // stored provider API keys does NOT substitute for a
+                // platform session.
+                // Migration: fall back to UserDefaults for users upgrading
+                // from the old version whose lockfile doesn't yet have
+                // activeAssistant.
                 let storedId = LockfileAssistant.loadActiveAssistantId()
                     ?? UserDefaults.standard.string(forKey: "connectedAssistantId")
                 let assistant = storedId.flatMap { LockfileAssistant.loadByName($0) }


### PR DESCRIPTION
## Summary

- Remove the `hasAnyKey` shortcut from the startup auth gate in `startAuthenticatedFlow()`. Locally-stored LLM provider API keys no longer substitute for a platform auth session when deciding whether to show the login window.
- Unauthenticated users with a managed (platform-hosted) assistant in the lockfile now hit the existing `!assistant.isManaged` check and are correctly routed to `showAuthWindow()` instead of `proceedToApp()`.
- Local/remote (non-managed) assistants still open the app in a logged-out state — users can sign in from Settings > General as before.

### Repro (before this change)

1. Have a platform-hosted (managed) assistant in the lockfile.
2. Be logged out (`authManager.isAuthenticated == false`).
3. Have any LLM provider API key stored locally (Anthropic, OpenAI, etc.) so `APIKeyManager.hasAnyKey() == true`.

Result before: `startAuthenticatedFlow()` entered the router fast path because of `isAuthed || hasKey`, `ReturningUserRouter.decideFast()` returned `.autoConnect` for the managed lockfile entry, and `proceedToApp()` was called without any login prompt.

Result after: the `isAuthed` gate fails, the else branch runs, and `!assistant.isManaged` blocks auto-connect → `showAuthWindow()`.

## Original prompt

go with the clean option
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
