### PR TITLE
fix(ci): multiline match + empty-allowlist tolerance in flexframe lint (addresses #27554 reviews)

### DIFF
--- a/clients/scripts/check-flexframe.sh
+++ b/clients/scripts/check-flexframe.sh
@@ -70,7 +70,16 @@ fi
 # (lines whose first non-whitespace is `//` or `///`). AGENTS.md-style
 # warnings like `// ⚠️ No .frame(maxWidth:) in LazyVStack cells` would
 # otherwise false-positive.
-RAW_HITS=$(rg -n --no-heading "$PATTERN" "${SCAN_DIRS[@]}" 2>/dev/null \
+#
+# `-U --multiline-dotall` enables multiline matching so `.frame(` wrapped
+# across lines (opening paren on one line, `maxWidth:` on the next) is
+# caught. Without this, code formatted as `.frame(\n    maxWidth: …\n)`
+# bypasses the lint silently — a real escape already present at
+# ChatLoadingSkeleton.swift before this PR. ripgrep reports only the
+# START line of a multiline match, so the comment filter (which only
+# inspects that line) stays correct: the outer `.frame(` never itself
+# starts with `//`.
+RAW_HITS=$(rg -U --multiline-dotall -n --no-heading "$PATTERN" "${SCAN_DIRS[@]}" 2>/dev/null \
   | grep -vE '^[^:]+:[0-9]+:[[:space:]]*//' \
   || true)
 
@@ -131,9 +140,17 @@ HEADER
 fi
 
 # Load the allowlist (strip comments + blank lines), preserving multiplicity.
+#
+# `grep -v` exits 1 when no lines match — under `set -euo pipefail` that
+# would abort the script if the allowlist is ever header-only (e.g. after
+# a full cleanup or `--update-baseline` with zero observed violations).
+# `|| true` tolerates that edge case so a clean state stays clean.
 ALLOWLIST_ENTRIES=""
 if [[ -f "$ALLOWLIST_FILE" ]]; then
-  ALLOWLIST_ENTRIES=$(grep -vE '^([[:space:]]*#|[[:space:]]*$)' "$ALLOWLIST_FILE" | sort)
+  ALLOWLIST_RAW=$(grep -vE '^([[:space:]]*#|[[:space:]]*$)' "$ALLOWLIST_FILE" || true)
+  if [[ -n "$ALLOWLIST_RAW" ]]; then
+    ALLOWLIST_ENTRIES=$(printf '%s\n' "$ALLOWLIST_RAW" | sort)
+  fi
 fi
 
 # New violations = observed - allowlist (multiset difference preserved by `comm -23`).

--- a/clients/scripts/flexframe-allowlist.txt
+++ b/clients/scripts/flexframe-allowlist.txt
@@ -40,11 +40,13 @@ clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift|.frame(max
 clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift|.frame(maxWidth: VSpacing.chatBubbleMaxWidth)
 clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift|.frame(maxWidth: .infinity)
 clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift|.frame(maxWidth: .infinity, alignment: .leading)
+clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift|.frame(
 clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift|.frame(maxWidth: .infinity, alignment: .trailing)
 clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift|.frame(maxWidth: VSpacing.chatBubbleMaxWidth * 0.45, alignment: .trailing)
 clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift|.frame(maxWidth: VSpacing.chatBubbleMaxWidth * 0.65)
 clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift|.frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
 clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift|.frame(maxWidth: VSpacing.chatColumnMaxWidth, alignment: .leading)
+clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift|maxWidth: VSpacing.chatBubbleMaxWidth * assistantLineWidths[idx],
 clients/macos/vellum-assistant/Features/Chat/ChatView.swift|.frame(maxWidth: .infinity, maxHeight: .infinity)
 clients/macos/vellum-assistant/Features/Chat/ChatView.swift|.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
 clients/macos/vellum-assistant/Features/Chat/ChatView.swift|.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)


### PR DESCRIPTION
## Summary

Addresses two Codex review findings on [#27554](https://github.com/vellum-ai/vellum-assistant/pull/27554) (LUM-1116 Phase 3):

- **P1** — Main scan now uses `rg -U --multiline-dotall` so `.frame(` wrapped across lines is caught. Before this, [`ChatLoadingSkeleton.swift:58-61`](clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift:58) was silently bypassing the lint despite living in the scanned directory. The pattern `\.frame\(\s*max(Width|Height)\s*:` matches cleanly in multiline mode since `\s` includes newlines. ripgrep reports the start line of the match, so the comment-line filter stays correct.
- **P2** — Allowlist load (`grep -v '^#|^$' allowlist.txt | sort`) now tolerates `grep`'s exit-1 on no-match via `|| true`. Before this, a header-only allowlist would abort the script under `set -euo pipefail` — so after an imagined full cleanup or fresh `--update-baseline` run with zero observed violations, CI would fail from a clean state.

The new `ChatLoadingSkeleton.swift:58-61` multi-line violation is allowlisted rather than rewritten: the FlexFrame wraps a `chatBone` (a `RoundedRectangle` leaf), so cascade cost is O(0) — same rationale as other allowlisted entries in that file. Rewriting to `HStack + Spacer` would change the shimmer's varied-width visual.

## Tests

- `bash clients/scripts/check-flexframe.sh` — passes (`172 allowlisted, 0 new`).
- Injected multi-line `.frame(\n    maxWidth: 100,\n    alignment: .leading\n)` — caught, exit 1.
- Injected single-line `.frame(maxWidth: 100)` — still caught (P1 regression check).
- Empty allowlist (header/blank only) + no violations → exit 0 (P2 new path; before the fix the script aborted on pipefail).

## Related

- LUM-1116 Phase 3 (the lint rule itself): #27554
- LUM-1116 Phase 1 (signpost instrumentation): #27552
- AGENTS.md:277-286 — FlexFrame rule
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
