### PR TITLE
fix(ci): include flexframe-lint in macos Slack notify status (addresses #27554 review)

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -324,7 +324,7 @@ jobs:
 
   notify-macos:
     name: Slack Notification (macOS)
-    needs: [changes, test, build]
+    needs: [changes, test, build, flexframe-lint]
     if: always()
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -337,11 +337,11 @@ jobs:
         run: |
           GITHUB_USER="${{ github.actor }}"
 
-          if [[ "${{ needs.test.result }}" == "failure" ]] || [[ "${{ needs.build.result }}" == "failure" ]]; then
+          if [[ "${{ needs.test.result }}" == "failure" ]] || [[ "${{ needs.build.result }}" == "failure" ]] || [[ "${{ needs.flexframe-lint.result }}" == "failure" ]]; then
             STATUS="failure"
-          elif [[ "${{ needs.test.result }}" == "cancelled" ]] || [[ "${{ needs.build.result }}" == "cancelled" ]]; then
+          elif [[ "${{ needs.test.result }}" == "cancelled" ]] || [[ "${{ needs.build.result }}" == "cancelled" ]] || [[ "${{ needs.flexframe-lint.result }}" == "cancelled" ]]; then
             STATUS="cancelled"
-          elif [[ "${{ needs.test.result }}" == "skipped" ]] && [[ "${{ needs.build.result }}" == "skipped" ]]; then
+          elif [[ "${{ needs.test.result }}" == "skipped" ]] && [[ "${{ needs.build.result }}" == "skipped" ]] && [[ "${{ needs.flexframe-lint.result }}" == "skipped" ]]; then
             STATUS="skipped"
           else
             STATUS="success"


### PR DESCRIPTION
## Summary

Addresses Devin review finding on [#27554](https://github.com/vellum-ai/vellum-assistant/pull/27554):

The `notify-macos` job in [`.github/workflows/ci-main-macos.yaml`](.github/workflows/ci-main-macos.yaml) has `needs: [changes, test, build]` and computes status solely from `needs.test.result` / `needs.build.result`. When `flexframe-lint` was added in #27554, it wasn't wired into this status logic — so a main-branch `flexframe-lint` failure would silently report success to Slack while GitHub's workflow-level status would still show red.

Fix: add `flexframe-lint` to `needs[]` and to the three status branches (failure / cancelled / skipped). The skipped branch uses `&&` across all three so partial-skip runs still drive status from whichever job actually ran.

## Verification

- `.github/workflows/pr-macos.yaml` has no `notify` job — only `ci-main-macos.yaml` needs this fix.
- No other `ci-main-*.yaml` workflows reference `flexframe-lint`.
- `continue-on-error: true` on `notify-macos` is preserved — the Slack send itself can still fail without taking the run down.

## Related

- LUM-1116 Phase 3 (the lint rule itself): #27554
- Follow-up that fixed earlier Codex findings: #27556
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
