### PR TITLE
feat(permissions): thread isContainerized through tool call data path

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -77,6 +77,7 @@ export type AgentEvent =
       contentBlocks?: ContentBlock[];
       riskLevel?: string;
       riskReason?: string;
+      isContainerized?: boolean;
       riskScopeOptions?: Array<{ pattern: string; label: string }>;
     }
   | { type: "tool_use_preview_start"; toolUseId: string; toolName: string }
@@ -200,6 +201,7 @@ export class AgentLoop {
         yieldToUser?: boolean;
         riskLevel?: string;
         riskReason?: string;
+        isContainerized?: boolean;
         riskScopeOptions?: Array<{ pattern: string; label: string }>;
       }>)
     | null;
@@ -229,6 +231,7 @@ export class AgentLoop {
       yieldToUser?: boolean;
       riskLevel?: string;
       riskReason?: string;
+      isContainerized?: boolean;
       riskScopeOptions?: Array<{ pattern: string; label: string }>;
     }>,
     resolveTools?: (history: Message[]) => ToolDefinition[],
@@ -769,6 +772,7 @@ export class AgentLoop {
             contentBlocks: result.contentBlocks,
             riskLevel: result.riskLevel,
             riskReason: result.riskReason,
+            isContainerized: result.isContainerized,
             riskScopeOptions: result.riskScopeOptions,
           });
         }

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -540,6 +540,7 @@ export function handleToolResult(
     toolUseId: event.toolUseId,
     riskLevel: event.riskLevel,
     riskReason: event.riskReason,
+    isContainerized: event.isContainerized,
     riskScopeOptions: event.riskScopeOptions,
   });
 }

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -149,6 +149,8 @@ export interface ToolResult {
   riskLevel?: string;
   /** Human-readable reason for the risk classification. */
   riskReason?: string;
+  /** Whether the daemon is running in a containerized (Docker) environment. */
+  isContainerized?: boolean;
   /** Scope options ladder for the rule editor modal (narrowest to broadest). */
   riskScopeOptions?: Array<{ pattern: string; label: string }>;
 }
@@ -161,6 +163,8 @@ export interface ConfirmationRequest {
   riskLevel: string;
   /** Human-readable reason for the risk classification (e.g. "Modifies remote repository state"). */
   riskReason?: string;
+  /** Whether the daemon is running in a containerized (Docker) environment. */
+  isContainerized?: boolean;
   executionTarget?: "sandbox" | "host";
   allowlistOptions: Array<{
     label: string;

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -67,6 +67,7 @@ export class PermissionPrompter {
     toolUseId?: string,
     hostAccessEnablePrompt?: boolean,
     riskReason?: string,
+    isContainerized?: boolean,
   ): Promise<{
     decision: UserDecision;
     selectedPattern?: string;
@@ -118,6 +119,7 @@ export class PermissionPrompter {
         input: redactSensitiveFields(input),
         riskLevel,
         riskReason,
+        isContainerized,
         allowlistOptions: allowlistOptions.map((o) => ({
           label: o.label,
           description: o.description,

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -117,6 +117,7 @@ export class ToolExecutor {
             riskLevel: string;
             riskReason: string;
             riskScopeOptions: Array<{ pattern: string; label: string }>;
+            isContainerized?: boolean;
           }
         | undefined;
       if (!gateResult.grantConsumed || context.requireFreshApproval) {
@@ -420,6 +421,7 @@ export class ToolExecutor {
           riskLevel: permRiskMeta.riskLevel,
           riskReason: permRiskMeta.riskReason,
           riskScopeOptions: permRiskMeta.riskScopeOptions,
+          isContainerized: permRiskMeta.isContainerized,
         };
       }
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -145,6 +145,7 @@ export class ToolExecutor {
             riskLevel: permRiskMeta?.riskLevel,
             riskReason: permRiskMeta?.riskReason,
             riskScopeOptions: permRiskMeta?.riskScopeOptions,
+            isContainerized: permRiskMeta?.isContainerized,
           };
         }
 

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -1,4 +1,5 @@
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { getHookManager } from "../hooks/manager.js";
 import { resolveThreshold } from "../permissions/approval-policy.js";
@@ -41,6 +42,7 @@ export type PermissionDecision =
         riskLevel: string;
         riskReason: string;
         riskScopeOptions: Array<{ pattern: string; label: string }>;
+        isContainerized?: boolean;
       };
     }
   | {
@@ -53,6 +55,7 @@ export type PermissionDecision =
         riskLevel: string;
         riskReason: string;
         riskScopeOptions: Array<{ pattern: string; label: string }>;
+        isContainerized?: boolean;
       };
     };
 
@@ -138,6 +141,7 @@ export class PermissionChecker {
           riskLevel: cachedAssessment.riskLevel,
           riskReason: cachedAssessment.reason,
           riskScopeOptions: cachedAssessment.scopeOptions,
+          isContainerized: getIsContainerized(),
         }
       : undefined;
 
@@ -419,6 +423,7 @@ export class PermissionChecker {
           context.toolUseId,
           v2ForcePrompt,
           riskReason,
+          getIsContainerized(),
         );
 
         const decision =

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -258,6 +258,8 @@ export interface ToolExecutionResult {
   riskLevel?: string;
   /** Human-readable reason for the risk classification. */
   riskReason?: string;
+  /** Whether the daemon is running in a containerized (Docker) environment. */
+  isContainerized?: boolean;
   /** Scope options ladder for the rule editor (narrowest to broadest). */
   riskScopeOptions?: Array<{ pattern: string; label: string }>;
   /**

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -905,6 +905,7 @@ private struct StepDetailRow: View {
                 riskReason: tc.riskReason ?? "",
                 scopeOptions: Self.scopeOptions(from: tc),
                 workingDir: Self.workingDir(from: tc),
+                isContainerized: tc.isContainerized,
                 onSave: { rule in
                     Task {
                         try? await Self.trustRuleClient.addTrustRule(

--- a/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
@@ -31,6 +31,7 @@ struct RuleEditorModal: View {
     let riskReason: String
     let scopeOptions: [ScopeOptionItem]
     let workingDir: String
+    let isContainerized: Bool
     let onSave: (SavedRule) -> Void
     let onDismiss: () -> Void
 
@@ -244,31 +245,10 @@ struct RuleEditorModal: View {
 
     // MARK: - Section 4: Scope
 
-    /// Whether the working directory looks like a real user project (not an
-    /// internal sandbox/container path). When false, the "In [project]" scope
-    /// option is hidden — only "Everywhere" is offered.
-    ///
-    // TODO: The daemon could provide an isContainerized flag on tool call data
-    // so the client doesn't need path heuristics to detect sandbox directories.
-    private var isUserProjectDir: Bool {
-        // Internal sandbox paths live under the XDG data directory structure:
-        // ~/.local/share/vellum/assistants/ (production)
-        // ~/.local/share/vellum-dev/assistants/ (development)
-        // ~/.local/share/vellum-staging/assistants/ (staging)
-        // ~/.local/share/vellum-test/assistants/ (test)
-        // ~/.local/share/vellum-local/assistants/ (local)
-        // Anchoring on "/.local/share/vellum" avoids false-matching legit user
-        // project paths like /Users/dev/code/vellum/assistants/my-bot/.
-        let lower = workingDir.lowercased()
-        if lower.contains("/.local/share/vellum/assistants/")
-            || lower.contains("/.local/share/vellum-dev/assistants/")
-            || lower.contains("/.local/share/vellum-staging/assistants/")
-            || lower.contains("/.local/share/vellum-test/assistants/")
-            || lower.contains("/.local/share/vellum-local/assistants/") {
-            return false
-        }
-        return true
-    }
+    /// Whether the working directory is a real user project (not an internal
+    /// sandbox/container path). When false, the "In [project]" scope option
+    /// is hidden — only "Everywhere" is offered.
+    private var isUserProjectDir: Bool { !isContainerized }
 
     @ViewBuilder
     private var scopeSection: some View {

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -1197,6 +1197,7 @@ final class ChatActionHandler {
                 vm.messages[msgIdx].toolCalls[tcIdx].workingDir = confirmation.scopeOptions
                     .first(where: { $0.scope != "everywhere" })?.scope
             }
+            vm.messages[msgIdx].toolCalls[tcIdx].isContainerized = msg.isContainerized ?? false
         }
         let confirmMsg = ChatMessage(
             role: .assistant,

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -887,6 +887,8 @@ public struct ToolCallData: Identifiable, Equatable {
     /// Working directory for this tool call (extracted from confirmation scope options).
     /// Persists after pendingConfirmation is cleared so the rule editor modal can use it.
     public var workingDir: String?
+    /// Whether the daemon is running in a containerized (Docker) environment.
+    public var isContainerized: Bool = false
     /// Accumulated streaming output from tool_output_chunk events (plain text only).
     /// Capped at 5000 characters (keeps the tail when exceeded).
     public var partialOutput: String = ""

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -441,7 +441,7 @@ extension ChatViewModel {
             messages[msgIndex].toolCalls[tcIndex].imageDataList = decoded.isEmpty ? msg.imageDataList : nil
             messages[msgIndex].toolCalls[tcIndex].riskLevel = msg.riskLevel
             messages[msgIndex].toolCalls[tcIndex].riskReason = msg.riskReason
-            messages[msgIndex].toolCalls[tcIndex].isContainerized = msg.isContainerized ?? false
+            if let containerized = msg.isContainerized { messages[msgIndex].toolCalls[tcIndex].isContainerized = containerized }
             messages[msgIndex].toolCalls[tcIndex].riskScopeOptions = msg.riskScopeOptions
             if let status = msg.status, !status.isEmpty {
                 messages[msgIndex].toolCalls[tcIndex].buildingStatus = status

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -441,6 +441,7 @@ extension ChatViewModel {
             messages[msgIndex].toolCalls[tcIndex].imageDataList = decoded.isEmpty ? msg.imageDataList : nil
             messages[msgIndex].toolCalls[tcIndex].riskLevel = msg.riskLevel
             messages[msgIndex].toolCalls[tcIndex].riskReason = msg.riskReason
+            messages[msgIndex].toolCalls[tcIndex].isContainerized = msg.isContainerized ?? false
             messages[msgIndex].toolCalls[tcIndex].riskScopeOptions = msg.riskScopeOptions
             if let status = msg.status, !status.isEmpty {
                 messages[msgIndex].toolCalls[tcIndex].buildingStatus = status

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -772,6 +772,8 @@ public struct ConfirmationRequest: Codable, Sendable {
     public let riskLevel: String
     /// Human-readable reason for the risk classification (e.g. "Modifies remote repository state").
     public let riskReason: String?
+    /// Whether the daemon is running in a containerized (Docker) environment.
+    public let isContainerized: Bool?
     public let executionTarget: String?
     public let allowlistOptions: [ConfirmationRequestAllowlistOption]
     public let scopeOptions: [ConfirmationRequestScopeOption]
@@ -785,13 +787,14 @@ public struct ConfirmationRequest: Codable, Sendable {
     /// The tool_use block ID for client-side correlation with specific tool calls.
     public let toolUseId: String?
 
-    public init(type: String, requestId: String, toolName: String, input: [String: AnyCodable], riskLevel: String, riskReason: String? = nil, executionTarget: String? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption], scopeOptions: [ConfirmationRequestScopeOption], diff: ConfirmationRequestDiff? = nil, sandboxed: Bool? = nil, conversationId: String? = nil, persistentDecisionsAllowed: Bool? = nil, temporaryOptionsAvailable: [String]? = nil, toolUseId: String? = nil) {
+    public init(type: String, requestId: String, toolName: String, input: [String: AnyCodable], riskLevel: String, riskReason: String? = nil, isContainerized: Bool? = nil, executionTarget: String? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption], scopeOptions: [ConfirmationRequestScopeOption], diff: ConfirmationRequestDiff? = nil, sandboxed: Bool? = nil, conversationId: String? = nil, persistentDecisionsAllowed: Bool? = nil, temporaryOptionsAvailable: [String]? = nil, toolUseId: String? = nil) {
         self.type = type
         self.requestId = requestId
         self.toolName = toolName
         self.input = input
         self.riskLevel = riskLevel
         self.riskReason = riskReason
+        self.isContainerized = isContainerized
         self.executionTarget = executionTarget
         self.allowlistOptions = allowlistOptions
         self.scopeOptions = scopeOptions
@@ -4832,10 +4835,12 @@ public struct ToolResult: Codable, Sendable {
     public let riskLevel: String?
     /// Human-readable reason for the risk classification.
     public let riskReason: String?
+    /// Whether the daemon is running in a containerized (Docker) environment.
+    public let isContainerized: Bool?
     /// Scope options ladder for the rule editor modal (narrowest to broadest).
     public let riskScopeOptions: [ToolResultRiskScopeOption]?
 
-    public init(type: String, toolName: String, result: String, isError: Bool? = nil, diff: ToolResultDiff? = nil, status: String? = nil, conversationId: String? = nil, imageDataList: [String]? = nil, toolUseId: String? = nil, riskLevel: String? = nil, riskReason: String? = nil, riskScopeOptions: [ToolResultRiskScopeOption]? = nil) {
+    public init(type: String, toolName: String, result: String, isError: Bool? = nil, diff: ToolResultDiff? = nil, status: String? = nil, conversationId: String? = nil, imageDataList: [String]? = nil, toolUseId: String? = nil, riskLevel: String? = nil, riskReason: String? = nil, isContainerized: Bool? = nil, riskScopeOptions: [ToolResultRiskScopeOption]? = nil) {
         self.type = type
         self.toolName = toolName
         self.result = result
@@ -4847,6 +4852,7 @@ public struct ToolResult: Codable, Sendable {
         self.toolUseId = toolUseId
         self.riskLevel = riskLevel
         self.riskReason = riskReason
+        self.isContainerized = isContainerized
         self.riskScopeOptions = riskScopeOptions
     }
 }


### PR DESCRIPTION
## Summary
- Thread `isContainerized` boolean from daemon's `getIsContainerized()` through the full tool call data path: ConfirmationRequest, ToolResult, AgentEvent, ToolExecutionResult, PermissionDecision → Swift ConfirmationRequest, ToolResult, ToolCallData
- Replace the fragile path-heuristic `isUserProjectDir` in RuleEditorModal (which matched `/.local/share/vellum*/assistants/`) with a simple `!isContainerized` check using the daemon-provided flag
- All new fields are optional with nil/false defaults for backwards compatibility — existing messages decode without error

## Original prompt
Thread an isContainerized boolean through the tool call data path so the SwiftUI client can use it instead of path heuristics. Follows the exact same pattern as riskLevel/riskReason/riskScopeOptions across 13 files (7 TypeScript, 6 Swift).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
