### PR TITLE
fix(macos): log circuit_closed events even when state is unchanged

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -366,17 +366,17 @@ final class ChatActionHandler {
 
         case .compactionCircuitClosed(let event):
             guard belongsToConversation(event.conversationId) else { return }
+            vm.appendCompactionEvent(CompactionEventLogEntry(
+                timestamp: Date(),
+                kind: "circuit_closed",
+                summary: "Circuit closed"
+            ))
             // Skip the no-op write when the banner already self-dismissed via
             // the 60s timer; writing nil→nil would still trigger an
             // `@Observable` invalidation.
             guard vm.compactionCircuitOpenUntil != nil else { return }
             vm.compactionCircuitOpenUntil = nil
             log.info("Auto-compaction resumed (circuit breaker closed)")
-            vm.appendCompactionEvent(CompactionEventLogEntry(
-                timestamp: Date(),
-                kind: "circuit_closed",
-                summary: "Circuit closed"
-            ))
 
         default:
             break


### PR DESCRIPTION
## Summary
Move the `appendCompactionEvent(.init(kind: "circuit_closed", ...))` append above the `guard vm.compactionCircuitOpenUntil != nil else { return }` short-circuit in the `compaction_circuit_closed` handler so timer-driven auto-dismiss closures are recorded in the event log.

Addresses a gap identified during self-review of the compaction-playground plan (#27253).

Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
