### PR TITLE
refactor(playground): consolidate PLAYGROUND_TITLE_PREFIX to single source of truth

### DIFF
--- a/assistant/src/runtime/routes/playground/__tests__/seeded-conversations.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/seeded-conversations.test.ts
@@ -3,10 +3,8 @@ import { describe, expect, test } from "bun:test";
 import type { Conversation } from "../../../../daemon/conversation.js";
 import type { RouteDefinition } from "../../../http-router.js";
 import type { PlaygroundRouteDeps } from "../deps.js";
-import {
-  PLAYGROUND_TITLE_PREFIX,
-  seededConversationsRouteDefinitions,
-} from "../seeded-conversations.js";
+import { PLAYGROUND_TITLE_PREFIX } from "../seed-conversation.js";
+import { seededConversationsRouteDefinitions } from "../seeded-conversations.js";
 
 interface StubOpts {
   enabled?: boolean;

--- a/assistant/src/runtime/routes/playground/seeded-conversations.ts
+++ b/assistant/src/runtime/routes/playground/seeded-conversations.ts
@@ -8,15 +8,7 @@
 import { httpError } from "../../http-errors.js";
 import type { RouteDefinition } from "../../http-router.js";
 import { assertPlaygroundEnabled, type PlaygroundRouteDeps } from "./index.js";
-
-/**
- * Title prefix every playground-seeded conversation starts with. PR 6
- * (seed-conversation) is expected to export this constant from
- * `./seed-conversation.ts`. Until PR 6 lands, declare it locally so this
- * file can be merged independently. On rebase, switch to the imported value
- * from `./seed-conversation.js` to avoid two sources of truth.
- */
-export const PLAYGROUND_TITLE_PREFIX = "[Playground] ";
+import { PLAYGROUND_TITLE_PREFIX } from "./seed-conversation.js";
 
 export function seededConversationsRouteDefinitions(
   deps: PlaygroundRouteDeps,


### PR DESCRIPTION
## Summary
Delete the duplicate `PLAYGROUND_TITLE_PREFIX` export in `seeded-conversations.ts` and import it from `./seed-conversation.js` instead. A future change to the prefix would otherwise silently drift between the seed path and the list/delete path. Also removes the stale 'On rebase, switch to importing from seed-conversation.js' comment that now lies about the state.

Addresses the explicit 'single source of truth' invariant from the compaction-playground plan (#27253).

Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
