### PR TITLE
fix(playground): skip memory indexing for seeded conversations

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -2023,8 +2023,14 @@ export class RuntimeHttpServer {
           const row = createConversation({ title });
           return { id: row.id };
         },
-        addMessage: async (conversationId, role, contentJson) => {
-          const persisted = await addMessage(conversationId, role, contentJson);
+        addMessage: async (conversationId, role, contentJson, options) => {
+          const persisted = await addMessage(
+            conversationId,
+            role,
+            contentJson,
+            undefined,
+            options,
+          );
           return { id: persisted.id };
         },
       }),

--- a/assistant/src/runtime/routes/playground/__tests__/seed-conversation.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/seed-conversation.test.ts
@@ -8,7 +8,12 @@ import {
   seedConversationRouteDefinitions,
 } from "../seed-conversation.js";
 
-type AddMessageArgs = [string, "user" | "assistant", string];
+type AddMessageArgs = [
+  string,
+  "user" | "assistant",
+  string,
+  { skipIndexing?: boolean } | undefined,
+];
 
 interface Spy {
   deps: PlaygroundRouteDeps;
@@ -31,8 +36,8 @@ function makeDeps(overrides?: { enabled?: boolean }): Spy {
       createdTitles.push(title);
       return { id: `conv-${++nextConvId}` };
     },
-    addMessage: async (conversationId, role, contentJson) => {
-      addedMessages.push([conversationId, role, contentJson]);
+    addMessage: async (conversationId, role, contentJson, options) => {
+      addedMessages.push([conversationId, role, contentJson, options]);
       return { id: `msg-${++nextMessageId}` };
     },
   };
@@ -94,7 +99,7 @@ describe("POST /v1/playground/seed-conversation", () => {
 
     // Roles alternate user/assistant across the 10 inserted messages.
     for (let i = 0; i < spy.addedMessages.length; i++) {
-      const [convId, role, contentJson] = spy.addedMessages[i];
+      const [convId, role, contentJson, options] = spy.addedMessages[i];
       expect(convId).toBe("conv-1");
       expect(role).toBe(i % 2 === 0 ? "user" : "assistant");
       // Content is a JSON-encoded array of blocks matching the in-memory
@@ -105,6 +110,10 @@ describe("POST /v1/playground/seed-conversation", () => {
       }>;
       expect(parsed[0].type).toBe("text");
       expect(parsed[0].text.length).toBeGreaterThan(0);
+      // Every seeded message must skip memory/vector indexing — the
+      // lorem-ipsum payload has no semantic value and embedding it would
+      // pollute the vector store.
+      expect(options?.skipIndexing).toBe(true);
     }
   });
 

--- a/assistant/src/runtime/routes/playground/deps.ts
+++ b/assistant/src/runtime/routes/playground/deps.ts
@@ -39,6 +39,7 @@ export interface PlaygroundRouteDeps {
     conversationId: string,
     role: "user" | "assistant",
     contentJson: string,
+    options?: { skipIndexing?: boolean },
   ) => Promise<{ id: string }>;
   // Later PRs will extend this interface with additional capabilities.
   // Keep this list minimal.

--- a/assistant/src/runtime/routes/playground/seed-conversation.ts
+++ b/assistant/src/runtime/routes/playground/seed-conversation.ts
@@ -110,7 +110,13 @@ export function seedConversationRouteDefinitions(
           const contentJson = JSON.stringify([
             { type: "text", text: msg.text },
           ]);
-          await deps.addMessage(conversationId, msg.role, contentJson);
+          // Skip memory/vector indexing for seeded synthetic messages — the
+          // lorem-ipsum content has no semantic value and would otherwise
+          // spam the embedding pipeline (2 embeddings per turn × up to 500
+          // turns) and pollute the vector store.
+          await deps.addMessage(conversationId, msg.role, contentJson, {
+            skipIndexing: true,
+          });
         }
 
         // Reconstruct the in-memory Message[] shape estimatePromptTokens


### PR DESCRIPTION
## Summary
Pass `skipIndexing: true` when seeding synthetic user/assistant messages so lorem-ipsum content doesn't generate embeddings and pollute the memory store. For a 500-turn seed, this avoids 1000 wasted embedding calls and keeps the vector index clean.

If the underlying `addMessage` helper didn't already expose a skip-indexing option, it was extended backward-compatibly (default: index as before).

Addresses a gap identified during self-review of the compaction-playground plan (#27253).

Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
