### PR TITLE
fix(playground): inject-failures circular import + circuit_closed transition guard

### DIFF
--- a/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
@@ -179,6 +179,32 @@ describe("POST /v1/conversations/:id/playground/inject-compaction-failures", () 
     });
   });
 
+  test("is a no-op on the event channel when circuitOpenForMs: 0 but the breaker is already closed", async () => {
+    const conversation = makeConversation("conv-already-closed");
+    // Breaker is already closed before the request.
+    expect(conversation.compactionCircuitOpenUntil).toBeNull();
+
+    const deps = makeDeps({ enabled: true, conversation });
+    const route = getInjectRoute(deps);
+
+    const res = await invoke(route, conversation.conversationId, {
+      circuitOpenForMs: 0,
+    });
+    expect(res.status).toBe(200);
+
+    // Still null after the request.
+    expect(conversation.compactionCircuitOpenUntil).toBeNull();
+    // Critically: no `compaction_circuit_closed` event is emitted, since
+    // there was no open→closed transition. Clients must not see a spurious
+    // close event.
+    expect(conversation.sentMessages).toHaveLength(0);
+
+    // Response body still reflects the expected shape.
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.compactionCircuitOpenUntil).toBeNull();
+    expect(body.isCircuitOpen).toBe(false);
+  });
+
   test("rejects out-of-range consecutiveFailures with 400", async () => {
     const conversation = makeConversation();
     const deps = makeDeps({ enabled: true, conversation });

--- a/assistant/src/runtime/routes/playground/inject-failures.ts
+++ b/assistant/src/runtime/routes/playground/inject-failures.ts
@@ -22,8 +22,8 @@ import { estimatePromptTokens } from "../../../context/token-estimator.js";
 import type { Conversation } from "../../../daemon/conversation.js";
 import { httpError } from "../../http-errors.js";
 import type { RouteDefinition } from "../../http-router.js";
+import type { PlaygroundRouteDeps } from "./deps.js";
 import { assertPlaygroundEnabled } from "./guard.js";
-import type { PlaygroundRouteDeps } from "./index.js";
 
 const InjectBodySchema = z.object({
   consecutiveFailures: z.number().int().min(0).max(10).optional(),
@@ -82,14 +82,17 @@ export function injectFailuresRouteDefinitions(
 
         if (circuitOpenForMs !== undefined) {
           if (circuitOpenForMs === 0) {
-            conversation.compactionCircuitOpenUntil = null;
-            // Mirror the `compaction_circuit_closed` transition event the
-            // daemon emits when the breaker auto-closes after a successful
-            // compaction, so the Swift banner dismisses immediately.
-            conversation.sendToClient({
-              type: "compaction_circuit_closed",
-              conversationId: conversation.conversationId,
-            });
+            // Mirror `trackCompactionOutcome()` (and `reset-circuit.ts`) —
+            // emit `compaction_circuit_closed` only on the open→closed
+            // transition so clients don't receive a redundant close event
+            // when the breaker was already closed.
+            if (conversation.compactionCircuitOpenUntil !== null) {
+              conversation.compactionCircuitOpenUntil = null;
+              conversation.sendToClient({
+                type: "compaction_circuit_closed",
+                conversationId: conversation.conversationId,
+              });
+            }
           } else {
             const openUntil = Date.now() + circuitOpenForMs;
             conversation.compactionCircuitOpenUntil = openUntil;
@@ -109,11 +112,9 @@ export function injectFailuresRouteDefinitions(
 }
 
 // ---------------------------------------------------------------------------
-// Local state-builder — shared shape across PR 7/8/9.
-//
-// PR 9 (the state endpoint) will extract a canonical shared implementation of
-// this helper. For now each parallel PR maintains an identical copy so the
-// three file-level diffs stay independent.
+// Local state-builder — identical in shape to `buildCompactionStateResponse`
+// in `state.ts` and the local copy in `reset-circuit.ts`. A follow-up cleanup
+// can consolidate these onto `state.ts`'s exported helper.
 // ---------------------------------------------------------------------------
 
 export interface CompactionStateResponse {


### PR DESCRIPTION
## Summary
Two fixes to `inject-failures.ts`:
- Import `PlaygroundRouteDeps` from `./deps.js` instead of `./index.js` to break the import cycle.
- Wrap the `circuitOpenForMs === 0` branch in a transition guard so `compaction_circuit_closed` only emits when the circuit was actually open; mirrors `reset-circuit.ts`.

Adds a regression test for the already-closed no-op path.

Addresses gaps identified during self-review of the compaction-playground plan (#27253).

Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
