### PR TITLE
fix(playground): tear down in-memory Conversation + Qdrant vectors on seeded-conversation delete

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -72,6 +72,7 @@ import {
 import type { ExternalConversationBinding } from "../memory/external-conversation-store.js";
 import * as externalConversationStore from "../memory/external-conversation-store.js";
 import { listGroups } from "../memory/group-crud.js";
+import { enqueueMemoryJob } from "../memory/jobs-store.js";
 import { resolveStreamingTranscriber } from "../providers/speech-to-text/resolve.js";
 import {
   consumeCallback,
@@ -2016,7 +2017,29 @@ export class RuntimeHttpServer {
           // — `deleteConversation` always returns a result object even when
           // no row matched.
           if (!getConversation(id)) return false;
-          deleteConversation(id);
+          // Mirror the canonical DELETE /v1/conversations/:id handler in
+          // conversation-management-routes.ts: tear down the in-memory
+          // Conversation first (so a running agent loop can't write to a
+          // deleted row and trip FK constraints), then drop the DB row,
+          // then enqueue Qdrant vector cleanup for the returned segment
+          // and summary IDs. Without this, seeded-then-deleted playground
+          // conversations leak vectors and zombie Conversation objects.
+          if (this.findConversation?.(id)) {
+            this.conversationManagementDeps?.destroyConversation(id);
+          }
+          const deleted = deleteConversation(id);
+          for (const segId of deleted.segmentIds) {
+            enqueueMemoryJob("delete_qdrant_vectors", {
+              targetType: "segment",
+              targetId: segId,
+            });
+          }
+          for (const summaryId of deleted.deletedSummaryIds) {
+            enqueueMemoryJob("delete_qdrant_vectors", {
+              targetType: "summary",
+              targetId: summaryId,
+            });
+          }
           return true;
         },
         createConversation: async (title) => {


### PR DESCRIPTION
## Summary
The playground `deleteConversationById` wiring previously only removed the DB row, leaking Qdrant vector entries and (when the seeded conversation had been opened) leaving a zombie `Conversation` in `server.conversations`. Rewire to call `server.destroyConversation` first when the conversation is loaded, then `deleteConversation`, then enqueue Qdrant cleanup with the returned `DeletedMemoryIds` — matching the canonical `DELETE /v1/conversations/:id` handler in `conversation-management-routes.ts`.

Addresses a gap identified during self-review of the compaction-playground plan (#27253).

Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
