### PR TITLE
fix(slack): strip tag-line wrapper from assistant rows

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -3666,6 +3666,125 @@ describe("assembleSlackActiveThreadFocusBlock", () => {
     expect(result!).toContain("@user");
   });
 
+  test("assistant reactions are not double-attributed (`@assistant: [... @assistant reacted ...]`)", () => {
+    // `renderReaction` bakes `@assistant` into the reaction tag line
+    // (`[11/14/23 14:28 @assistant reacted 👍 to Mxxxxxx]`). The
+    // post-render step that prepends `@assistant: ` to assistant content
+    // lines must skip reaction lines, otherwise the flattened block
+    // produces `@assistant: [... @assistant reacted ...]` — two
+    // attributions for one event.
+    const rows: SlackTranscriptInputRow[] = [
+      buildRow(
+        "user",
+        "Parent",
+        1_000,
+        buildMeta({ channelTs: PARENT_TS, displayName: "@alice" }),
+      ),
+      // Assistant reply in the thread — gets an `@assistant:` prefix.
+      buildRow(
+        "assistant",
+        "Assistant reply",
+        2_000,
+        buildMeta({
+          channelTs: "1700000005.000001",
+          threadTs: PARENT_TS,
+        }),
+      ),
+      // Assistant reaction on the parent — must NOT get a second prefix.
+      buildRow(
+        "assistant",
+        "[reaction]",
+        3_000,
+        buildMeta({
+          channelTs: "1700000008.000002",
+          eventKind: "reaction",
+          reaction: {
+            emoji: "👍",
+            targetChannelTs: PARENT_TS,
+            op: "added",
+          },
+        }),
+      ),
+      // Latest user row in the thread — required for `detectActiveThreadTs`
+      // to lock onto PARENT_TS (the latest user turn is the anchor).
+      buildRow(
+        "user",
+        "User follow-up",
+        4_000,
+        buildMeta({
+          channelTs: REPLY_TS,
+          threadTs: PARENT_TS,
+          displayName: "@alice",
+        }),
+      ),
+    ];
+    const result = assembleSlackActiveThreadFocusBlock(rows, SLACK_CAPS);
+    expect(result).not.toBeNull();
+    // Double-attribution anti-pattern must NOT appear anywhere.
+    expect(result!).not.toContain("@assistant: [");
+    // Both the reaction attribution and the reply prefix are still present.
+    expect(result!).toContain("@assistant reacted 👍");
+    expect(result!).toContain("@assistant: Assistant reply");
+  });
+
+  test("assistant reaction overflow trailer is not double-attributed", () => {
+    // When assistant reactions overflow the per-target cap, `renderSlackTranscript`
+    // emits a trailer line (`[…and N more reactions to Mxxxxxx]`) whose role
+    // is inherited from the first overflowing reaction — i.e. `assistant`. The
+    // trailer embeds no actor attribution but ends with the parent alias and
+    // shares the same `M<hex>]` signature as a real reaction line, so it must
+    // be detected by `isReactionTagLine` and skipped by the prefix step.
+    const PARENT_ALIAS_TS = PARENT_TS;
+    const buildAssistantReaction = (ts: string, emoji: string) =>
+      buildRow(
+        "assistant",
+        "[reaction]",
+        Number.parseFloat(ts) * 1000,
+        buildMeta({
+          channelTs: ts,
+          eventKind: "reaction",
+          reaction: {
+            emoji,
+            targetChannelTs: PARENT_ALIAS_TS,
+            op: "added",
+          },
+        }),
+      );
+    const rows: SlackTranscriptInputRow[] = [
+      buildRow(
+        "user",
+        "Parent",
+        1_000,
+        buildMeta({ channelTs: PARENT_TS, displayName: "@alice" }),
+      ),
+      // Overflow the default per-target cap (5) with 7 reactions so the
+      // trailer line is emitted with 2 excess.
+      buildAssistantReaction("1700000100.000001", "👍"),
+      buildAssistantReaction("1700000100.000002", "🎉"),
+      buildAssistantReaction("1700000100.000003", "🔥"),
+      buildAssistantReaction("1700000100.000004", "💯"),
+      buildAssistantReaction("1700000100.000005", "👏"),
+      buildAssistantReaction("1700000100.000006", "👀"),
+      buildAssistantReaction("1700000100.000007", "🚀"),
+      // Latest user row in the thread — required for `detectActiveThreadTs`.
+      buildRow(
+        "user",
+        "Follow-up",
+        2_000_000,
+        buildMeta({
+          channelTs: REPLY_TS,
+          threadTs: PARENT_TS,
+          displayName: "@alice",
+        }),
+      ),
+    ];
+    const result = assembleSlackActiveThreadFocusBlock(rows, SLACK_CAPS);
+    expect(result).not.toBeNull();
+    expect(result!).toContain("more reactions");
+    // The trailer line must not be double-attributed.
+    expect(result!).not.toMatch(/@assistant: \[…and \d+ more reaction/);
+  });
+
   test("emits a block even when the parent has not been backfilled yet", () => {
     // The inbound reply detects an `activeThreadTs` from its own
     // `threadTs`, but the parent (`channelTs === activeThreadTs`) has not

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2702,7 +2702,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
           },
           {
             role: "assistant",
-            content: [{ type: "text", text: "[11/14/23 14:26]: prior reply" }],
+            content: [{ type: "text", text: "prior reply" }],
           },
         ],
       },
@@ -3826,7 +3826,7 @@ describe("assembleSlackChronologicalMessages", () => {
       },
       {
         role: "assistant",
-        content: [{ type: "text", text: "[11/14/23 14:26]: hi back!" }],
+        content: [{ type: "text", text: "hi back!" }],
       },
       {
         role: "user",
@@ -3877,9 +3877,9 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(result!.map((m) => (m.content[0] as { text: string }).text)).toEqual(
       [
         "[11/14/23 14:25]: old hi",
-        "[11/14/23 14:26]: old reply",
+        "old reply",
         "[11/14/23 14:28 @alice]: fresh hi",
-        "[11/14/23 14:30]: fresh reply",
+        "fresh reply",
       ],
     );
     expect(result!.map((m) => m.role)).toEqual([
@@ -4035,7 +4035,7 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(rendered[1]!).toEqual({
       role: "assistant",
       content: [
-        { type: "text", text: "[11/14/23 14:26]: looking it up" },
+        { type: "text", text: "looking it up" },
         {
           type: "tool_use",
           id: "tu_1",
@@ -4357,11 +4357,11 @@ describe("assembleSlackChronologicalMessages", () => {
       role: "user",
       content: [{ type: "text", text: "[11/14/23 23:03 @alice]: hi" }],
     });
-    // Row 2: assistant tag line + tool_use(abc).
+    // Row 2: assistant content + tool_use(abc) — no tag line.
     expect(result![1]).toEqual({
       role: "assistant",
       content: [
-        { type: "text", text: "[11/14/23 23:03]: checking..." },
+        { type: "text", text: "checking..." },
         {
           type: "tool_use",
           id: "tu_abc",
@@ -4377,11 +4377,11 @@ describe("assembleSlackChronologicalMessages", () => {
         { type: "tool_result", tool_use_id: "tu_abc", content: "result 1" },
       ],
     });
-    // Row 4: assistant tag line + tool_use(def).
+    // Row 4: assistant content + tool_use(def) — no tag line.
     expect(result![3]).toEqual({
       role: "assistant",
       content: [
-        { type: "text", text: "[11/14/23 23:03]: one more lookup..." },
+        { type: "text", text: "one more lookup..." },
         {
           type: "tool_use",
           id: "tu_def",
@@ -4397,10 +4397,10 @@ describe("assembleSlackChronologicalMessages", () => {
         { type: "tool_result", tool_use_id: "tu_def", content: "result 2" },
       ],
     });
-    // Row 6: assistant final text-only answer, rendered as tag line only.
+    // Row 6: assistant final text-only answer, content-only (no tag line).
     expect(result![5]).toEqual({
       role: "assistant",
-      content: [{ type: "text", text: "[11/14/23 23:03]: all done" }],
+      content: [{ type: "text", text: "all done" }],
     });
     // Row 7: user follow-up tag line.
     expect(result![6]).toEqual({

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -23,6 +23,7 @@ import type { QdrantSparseVector } from "../memory/qdrant-client.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import {
   extractTagLineTexts,
+  isReactionTagLine,
   type RenderableSlackMessage,
   renderSlackTranscript,
 } from "../messaging/providers/slack/render-transcript.js";
@@ -1549,25 +1550,31 @@ function buildActiveThreadBlockFromRenderable(
   if (members.length === 0) return null;
 
   // The active-thread block is flattened to plain text below, which discards
-  // `Message.role`. Force a role-derived sender label on any user row whose
-  // `rowToRenderable` emitted `null` (no real Slack displayName) so speaker
-  // attribution survives the flattening. Assistant rows are handled in the
-  // post-render step — `renderSlackTranscript` emits assistant content with
-  // no tag-line wrapper (to prevent the model mimicking `[MM/DD/YY HH:MM]:`
-  // prefixes in outbound replies), so we prepend an explicit `@assistant:`
-  // label to the flattened line here.
-  const labeledMembers = members.map((m) =>
-    m.senderLabel || m.role === "assistant"
-      ? m
-      : { ...m, senderLabel: "@user" },
-  );
+  // `Message.role`. Assistant rows are relabeled in the post-render step:
+  // `renderSlackTranscript` emits assistant content with no tag-line wrapper
+  // (to prevent the model mimicking `[MM/DD/YY HH:MM]:` prefixes in outbound
+  // replies), so we prepend an explicit `@assistant:` label to the flattened
+  // line. Unnamed user rows (no real Slack displayName) get a `@user`
+  // senderLabel here so their tag line carries attribution through the
+  // renderer. Labeled user rows and assistant rows pass through unchanged.
+  const labeledMembers = members.map((m) => {
+    if (m.role === "assistant") return m;
+    if (m.senderLabel !== null) return m;
+    return { ...m, senderLabel: "@user" };
+  });
 
   const rendered = renderSlackTranscript(labeledMembers);
   if (rendered.length === 0) return null;
+  // Reaction / overflow-trailer lines already embed `@assistant` inline, so
+  // `isReactionTagLine` is used to skip those and avoid double-attribution
+  // (`@assistant: [... @assistant reacted ...]`). Regular content and the
+  // `[deleted]` sentinel get the prefix so attribution survives flattening.
   const lines = rendered
     .map((msg) => {
       const text = extractTagLineTexts([msg])[0] ?? "";
-      return msg.role === "assistant" ? `@assistant: ${text}` : text;
+      return msg.role === "assistant" && !isReactionTagLine(text)
+        ? `@assistant: ${text}`
+        : text;
     })
     .join("\n");
   return `<active_thread>\n${lines}\n</active_thread>`;

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1549,21 +1549,27 @@ function buildActiveThreadBlockFromRenderable(
   if (members.length === 0) return null;
 
   // The active-thread block is flattened to plain text below, which discards
-  // `Message.role`. Force a role-derived sender label on any member whose
-  // `rowToRenderable` emitted `null` (assistant rows, user rows without a
-  // real Slack displayName) so speaker attribution survives the flattening.
+  // `Message.role`. Force a role-derived sender label on any user row whose
+  // `rowToRenderable` emitted `null` (no real Slack displayName) so speaker
+  // attribution survives the flattening. Assistant rows are handled in the
+  // post-render step — `renderSlackTranscript` emits assistant content with
+  // no tag-line wrapper (to prevent the model mimicking `[MM/DD/YY HH:MM]:`
+  // prefixes in outbound replies), so we prepend an explicit `@assistant:`
+  // label to the flattened line here.
   const labeledMembers = members.map((m) =>
-    m.senderLabel
+    m.senderLabel || m.role === "assistant"
       ? m
-      : {
-          ...m,
-          senderLabel: m.role === "assistant" ? "@assistant" : "@user",
-        },
+      : { ...m, senderLabel: "@user" },
   );
 
   const rendered = renderSlackTranscript(labeledMembers);
   if (rendered.length === 0) return null;
-  const lines = extractTagLineTexts(rendered).join("\n");
+  const lines = rendered
+    .map((msg) => {
+      const text = extractTagLineTexts([msg])[0] ?? "";
+      return msg.role === "assistant" ? `@assistant: ${text}` : text;
+    })
+    .join("\n");
   return `<active_thread>\n${lines}\n</active_thread>`;
 }
 

--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -228,11 +228,17 @@ describe("renderSlackTranscript — basics", () => {
     ]);
   });
 
-  test("omits sender label for assistant-role message (role slot conveys identity)", () => {
+  test("assistant-role message emits content with no tag-line wrapper", () => {
+    // Rationale: the `role` slot already conveys identity, and the
+    // assistant responds ~immediately after the triggering user message
+    // so the timestamp would add little beyond chronological adjacency.
+    // Keeping a bracketed tag on assistant rows caused the model to
+    // mimic the `[MM/DD/YY HH:MM]:` format as a literal prefix in new
+    // outbound Slack replies.
     const out = renderSlackTranscript([
       userMsg(TS_14_25, null, "yo 👋", { role: "assistant" }),
     ]);
-    expect(out).toEqual([textMsg("assistant", "[11/14/23 14:25]: yo 👋")]);
+    expect(out).toEqual([textMsg("assistant", "yo 👋")]);
   });
 
   test("omits sender label for user-role message with null senderLabel (no displayName)", () => {
@@ -245,41 +251,38 @@ describe("renderSlackTranscript — basics", () => {
     expect(out).toEqual([textMsg("user", "[11/14/23 14:25]: hi")]);
   });
 
-  test("omits sender label in thread-reply tag for assistant row", () => {
-    const alias = parentAlias(TS_14_25);
+  test("thread-reply assistant row emits content-only — no tag wrapper, no thread arrow", () => {
     const out = renderSlackTranscript([
       userMsg(TS_14_28, null, "got it", {
         threadTs: TS_14_25,
         role: "assistant",
       }),
     ]);
-    expect(out).toEqual([
-      textMsg("assistant", `[11/14/23 14:28 → ${alias}]: got it`),
-    ]);
+    expect(out).toEqual([textMsg("assistant", "got it")]);
   });
 
-  test("omits sender label in deleted tag for assistant row", () => {
+  test("deleted assistant row collapses to the `[deleted]` sentinel", () => {
+    // Chronology must still be preserved — we emit a stable short sentinel
+    // rather than eliding the row entirely. The sentinel is intentionally
+    // different from the user-row `[MM/DD/YY — deleted MM/DD/YY]` form so
+    // the model has no timestamp pattern to mimic in new outbound replies.
     const out = renderSlackTranscript([
       userMsg(TS_14_25, null, "(removed)", {
         deletedAt: MS_14_32,
         role: "assistant",
       }),
     ]);
-    expect(out).toEqual([
-      textMsg("assistant", "[11/14/23 14:25 — deleted 11/14/23 14:32]"),
-    ]);
+    expect(out).toEqual([textMsg("assistant", "[deleted]")]);
   });
 
-  test("omits sender label in edited tag for assistant row", () => {
+  test("edited assistant row emits the latest content verbatim — no edit suffix", () => {
     const out = renderSlackTranscript([
       userMsg(TS_14_25, null, "v2", {
         editedAt: MS_14_30,
         role: "assistant",
       }),
     ]);
-    expect(out).toEqual([
-      textMsg("assistant", "[11/14/23 14:25, edited 11/14/23 14:30]: v2"),
-    ]);
+    expect(out).toEqual([textMsg("assistant", "v2")]);
   });
 
   test("reaction with null senderLabel falls back on role-derived subject", () => {
@@ -709,11 +712,11 @@ describe("renderSlackTranscript — mixed legacy + post-upgrade", () => {
     expect(texts[1].includes("→")).toBe(false);
   });
 
-  test("legacy assistant row carries assistant role", () => {
+  test("legacy assistant row carries assistant role and emits content verbatim", () => {
     const out = renderSlackTranscript([
       legacyMsg(MS_14_25, "@bot", "ack", "assistant"),
     ]);
-    expect(out).toEqual([textMsg("assistant", "[11/14/23 14:25 @bot]: ack")]);
+    expect(out).toEqual([textMsg("assistant", "ack")]);
   });
 
   test("preserves message role faithfully across mixed inputs", () => {
@@ -873,7 +876,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     expect(out[0]).toEqual({
       role: "assistant",
       content: [
-        { type: "text", text: "[11/14/23 14:25]: looking it up" },
+        { type: "text", text: "looking it up" },
         { type: "tool_use", id: "tu_1", name: "search", input: { q: "x" } },
       ],
     });
@@ -921,7 +924,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
         role: "assistant",
         content: [
           { type: "thinking", thinking: "let me think", signature: "sig-abc" },
-          { type: "text", text: "[11/14/23 14:25]: here's the answer" },
+          { type: "text", text: "here's the answer" },
         ],
       },
     ]);
@@ -946,7 +949,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
       {
         role: "assistant",
         content: [
-          { type: "text", text: "[11/14/23 14:25]: doing a thing" },
+          { type: "text", text: "doing a thing" },
           { type: "tool_use", id: "tu_A", name: "op", input: {} },
           { type: "tool_result", tool_use_id: "tu_A", content: "ok" },
         ],
@@ -954,7 +957,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     ]);
   });
 
-  test("[text, ui_surface] assistant row strips ui_surface — only tag line remains", () => {
+  test("[text, ui_surface] assistant row strips ui_surface — only content remains", () => {
     const base: RenderableSlackMessage = {
       ...userMsg(TS_14_25, null, "reply body", { role: "assistant" }),
       contentBlocks: [
@@ -969,7 +972,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     expect(out).toEqual([
       {
         role: "assistant",
-        content: [{ type: "text", text: "[11/14/23 14:25]: reply body" }],
+        content: [{ type: "text", text: "reply body" }],
       },
     ]);
   });
@@ -991,7 +994,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     expect(out).toEqual([
       {
         role: "assistant",
-        content: [{ type: "text", text: "[11/14/23 14:25]: web search" }],
+        content: [{ type: "text", text: "web search" }],
       },
     ]);
   });
@@ -1077,7 +1080,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
         content: [
           {
             type: "text",
-            text: "[11/14/23 14:25]: ran a web search [stripped non-replayable: server_tool_use(web_search), ui_surface]",
+            text: "ran a web search [stripped non-replayable: server_tool_use(web_search), ui_surface]",
           },
         ],
       },
@@ -1155,7 +1158,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
     expect(out).toEqual([
       {
         role: "assistant",
-        content: [{ type: "text", text: "[11/14/23 14:25]: looking it up" }],
+        content: [{ type: "text", text: "looking it up" }],
       },
     ]);
   });
@@ -1206,7 +1209,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
       {
         role: "assistant",
         content: [
-          { type: "text", text: "[11/14/23 14:25]: running op" },
+          { type: "text", text: "running op" },
           { type: "tool_use", id: "tu_paired", name: "op", input: { a: 1 } },
         ],
       },
@@ -1296,7 +1299,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
       {
         role: "assistant",
         content: [
-          { type: "text", text: "[11/14/23 14:25]: running op" },
+          { type: "text", text: "running op" },
           { type: "tool_use", id: "tu_paired", name: "op", input: {} },
         ],
       },
@@ -1308,7 +1311,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
       },
       {
         role: "assistant",
-        content: [{ type: "text", text: "[11/14/23 14:28]: looking" }],
+        content: [{ type: "text", text: "looking" }],
       },
       {
         role: "user",
@@ -1365,7 +1368,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
               filename: "doc.pdf",
             },
           },
-          { type: "text", text: "[11/14/23 14:25]: here you go" },
+          { type: "text", text: "here you go" },
         ],
       },
     ]);

--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, test } from "bun:test";
 import type { Message } from "../../../providers/types.js";
 import {
   extractTagLineTexts,
+  isReactionTagLine,
   parentAlias,
   type RenderableSlackMessage,
   renderSlackTranscript,
@@ -381,6 +382,50 @@ describe("parentAlias", () => {
   test("starts with M and is 7 chars long (M + 6 hex)", () => {
     const a = parentAlias("1700000000.000100");
     expect(a).toMatch(/^M[0-9a-f]{6}$/);
+  });
+});
+
+// ── isReactionTagLine ────────────────────────────────────────────────────────
+
+describe("isReactionTagLine", () => {
+  // Pinned to the exact shapes `renderReaction` and the overflow trailer
+  // produce. The helper is the public contract that lets consumers
+  // re-label the transcript without double-attributing reaction lines,
+  // so drift here silently breaks `buildActiveThreadBlockFromRenderable`.
+  const alias = parentAlias("1700000000.000100");
+
+  test("matches reaction-add line", () => {
+    expect(
+      isReactionTagLine(`[11/14/23 14:28 @bob reacted 👍 to ${alias}]`),
+    ).toBe(true);
+  });
+
+  test("matches reaction-remove line", () => {
+    expect(
+      isReactionTagLine(`[11/14/23 14:28 @bob removed 👍 from ${alias}]`),
+    ).toBe(true);
+  });
+
+  test("matches overflow trailer line", () => {
+    expect(isReactionTagLine(`[…and 2 more reactions to ${alias}]`)).toBe(true);
+  });
+
+  test("does not match a regular message tag line", () => {
+    expect(isReactionTagLine("[11/14/23 14:25 @alice]: hi")).toBe(false);
+  });
+
+  test("does not match content-only assistant output", () => {
+    expect(isReactionTagLine("on it. here's the answer")).toBe(false);
+  });
+
+  test("does not match the `[deleted]` sentinel", () => {
+    expect(isReactionTagLine("[deleted]")).toBe(false);
+  });
+
+  test("does not match a user-deleted marker", () => {
+    expect(
+      isReactionTagLine("[11/14/23 14:25 @alice — deleted 11/14/23 14:32]"),
+    ).toBe(false);
   });
 });
 

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -140,8 +140,23 @@ function sortKey(msg: RenderableSlackMessage): number {
 /**
  * Render a single non-reaction message (post-upgrade or legacy) as one
  * tagged line.
+ *
+ * Assistant rows emit their content verbatim with no bracketed wrapper.
+ * The `role` slot already conveys identity, and the assistant replies
+ * ~immediately after the triggering user message so the chronological
+ * adjacency carries the same information as a timestamp. Keeping a
+ * `[MM/DD/YY HH:MM]:` prefix on the assistant's own past turns caused
+ * the model to mimic the exact format as a literal prefix in new
+ * outbound Slack replies (`[04/22/26 21:25]: on it. ...`). Deleted
+ * assistant rows collapse to the short `[deleted]` sentinel so chronology
+ * is preserved without carrying a mimickable timestamp.
  */
 function renderMessage(msg: RenderableSlackMessage): string {
+  if (msg.role === "assistant") {
+    if (msg.metadata?.deletedAt !== undefined) return "[deleted]";
+    return msg.content;
+  }
+
   const meta = msg.metadata;
   const senderPart = msg.senderLabel ? ` ${msg.senderLabel}` : "";
   if (!meta) {

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -150,6 +150,24 @@ function sortKey(msg: RenderableSlackMessage): number {
  * outbound Slack replies (`[04/22/26 21:25]: on it. ...`). Deleted
  * assistant rows collapse to the short `[deleted]` sentinel so chronology
  * is preserved without carrying a mimickable timestamp.
+ *
+ * Tradeoffs deliberately accepted by this simplification:
+ * - Thread arrows (`→ Mxxxxxx`) are dropped from assistant rows. In the
+ *   common single-thread-at-a-time case, role alternation + chronological
+ *   adjacency tells the model which user turn each assistant reply answers,
+ *   so no attribution is lost. The degenerate case is a channel where the
+ *   assistant is fielding two thread conversations in parallel and the
+ *   model has to disambiguate which reply lands in which thread from the
+ *   full chronological transcript — the bracketed arrow previously carried
+ *   that signal and is now absent. The `<active_thread>` focus block
+ *   (single thread by construction) is unaffected.
+ * - Edited assistant rows render only the latest content, not an edit
+ *   marker. Edits are rare for the assistant and the latest content is the
+ *   only replayable signal anyway.
+ *
+ * Any alternative "subtle" marker (e.g. an unbracketed `→ Mxxxxxx`) would
+ * reintroduce a consistent, mimickable prefix pattern — the very problem
+ * this function is designed to avoid — so we keep the content-only form.
  */
 function renderMessage(msg: RenderableSlackMessage): string {
   if (msg.role === "assistant") {

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -96,6 +96,31 @@ export function parentAlias(channelTs: string): string {
 }
 
 /**
+ * Trailing signature of a reaction or reaction-overflow line, both of
+ * which end with a `parentAlias` target and a closing bracket:
+ * `[... reacted 👍 to M1a2b3c]`, `[... removed 👍 from M1a2b3c]`,
+ * `[…and N more reactions to M1a2b3c]`. Regular message tag lines end
+ * with the message body, not with `]`, so they never match.
+ */
+const REACTION_TAG_LINE_SUFFIX = /M[0-9a-f]{6}\]$/;
+
+/**
+ * Whether a rendered tag-line string was produced by the reaction or
+ * reaction-overflow code paths (`renderReaction` / the overflow trailer).
+ *
+ * Reaction lines already embed the actor attribution inline
+ * (`[11/14/23 14:28 @assistant reacted 👍 to M1a2b3c]`), so consumers
+ * that flatten the rendered transcript and re-apply role labels should
+ * skip these lines to avoid double-attribution.
+ *
+ * Co-located with `renderReaction` and `parentAlias` so the format
+ * knowledge lives with the functions that own the line shape.
+ */
+export function isReactionTagLine(text: string): boolean {
+  return REACTION_TAG_LINE_SUFFIX.test(text);
+}
+
+/**
  * Format a Slack ts (`"1700000000.000100"`) as `MM/DD/YY HH:MM` (UTC).
  *
  * Slack ts is `<unix-seconds>.<microseconds>`; we treat it as a unix epoch


### PR DESCRIPTION
## Summary
- The Slack transcript renderer wrapped assistant rows with a `[MM/DD/YY HH:MM]:` tag line. The model then mimicked the format as a literal prefix in new outbound replies (`[04/22/26 21:25]: on it. ...`).
- Render assistant-row content verbatim with no bracket wrapper. Role identifies the sender, and assistants respond ~immediately, so the chronological adjacency carries the same info as a timestamp. Deleted assistant rows collapse to `[deleted]`. User rows unchanged.
- Preserve `@assistant:` attribution inside the flattened `<active_thread>` focus block via a post-render prepend, since the renderer no longer embeds it in the tag line.

## Original prompt
go with just #2 - it's fair to assume that the assistant always responds roughly right away
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
