### PR TITLE
refactor(home-feed): consolidate HomeScheduledDetailPanel and HomeNudgeDetailPanel onto HomeDetailPanel chrome [JARVIS-579]

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift
@@ -23,6 +23,12 @@ struct HomeDetailPanel<Content: View>: View {
 
     let icon: VIcon?
     let title: String
+    /// Optional foreground tint for the icon chip. Falls back to
+    /// `VColor.primaryBase` when `nil`.
+    var iconForeground: Color? = nil
+    /// Optional background fill for the icon chip. Falls back to
+    /// `VColor.surfaceBase` when `nil`.
+    var iconBackground: Color? = nil
     /// Tap handler for the trailing "Go to Thread" button in the header.
     /// Pass `nil` to hide the button (e.g. previews that don't surface a
     /// thread affordance).
@@ -76,11 +82,11 @@ struct HomeDetailPanel<Content: View>: View {
             HStack(spacing: VSpacing.sm) {
                 if let icon {
                     RoundedRectangle(cornerRadius: VRadius.md)
-                        .fill(VColor.surfaceBase)
+                        .fill(iconBackground ?? VColor.surfaceBase)
                         .frame(width: 32, height: 32)
                         .overlay {
                             VIconView(icon, size: 20)
-                                .foregroundStyle(VColor.primaryBase)
+                                .foregroundStyle(iconForeground ?? VColor.primaryBase)
                         }
                         .accessibilityHidden(true)
                 }

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeNudgeDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeNudgeDetailPanel.swift
@@ -69,11 +69,17 @@ struct HomeNudgeDetailPanel: View {
         HomeDetailPanel(
             icon: icon,
             title: title,
+            iconForeground: iconForeground,
+            iconBackground: iconBackground,
             onDismiss: onClose,
-            scrollable: true
+            scrollable: false
         ) {
             VStack(alignment: .leading, spacing: 0) {
-                bodySection
+                ScrollView {
+                    bodySection
+                }
+                .layoutPriority(1)
+
                 footer
             }
         }

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeNudgeDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeNudgeDetailPanel.swift
@@ -66,69 +66,17 @@ struct HomeNudgeDetailPanel: View {
     let onCardAction: (Card, CardAction) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            header
-
-            Rectangle()
-                .fill(VColor.borderHover)
-                .frame(height: 1)
-                .accessibilityHidden(true)
-
-            ScrollView {
+        HomeDetailPanel(
+            icon: icon,
+            title: title,
+            onDismiss: onClose,
+            scrollable: true
+        ) {
+            VStack(alignment: .leading, spacing: 0) {
                 bodySection
+                footer
             }
-
-            footer
         }
-        .frame(minWidth: 480, idealWidth: 600, maxWidth: .infinity)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.xl, style: .continuous)
-                .fill(VColor.surfaceLift)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.xl, style: .continuous)
-                .strokeBorder(VColor.borderHover, lineWidth: 1)
-        )
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(Text(title))
-    }
-
-    // MARK: - Header
-
-    private var header: some View {
-        HStack(alignment: .center) {
-            HStack(spacing: VSpacing.sm) {
-                ZStack {
-                    Circle().fill(iconBackground)
-                    VIconView(icon, size: 12)
-                        .foregroundStyle(iconForeground)
-                }
-                .frame(width: 26, height: 26)
-                .accessibilityHidden(true)
-
-                Text(title)
-                    .font(VFont.titleSmall)
-                    .foregroundStyle(VColor.contentEmphasized)
-                    .accessibilityAddTraits(.isHeader)
-            }
-
-            Spacer(minLength: 0)
-
-            Button(action: onClose) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: VRadius.md, style: .continuous)
-                        .strokeBorder(VColor.borderElement, lineWidth: 1)
-                    VIconView(.x, size: 9)
-                        .foregroundStyle(VColor.contentEmphasized)
-                }
-                .frame(width: 32, height: 32)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .pointerCursor()
-            .accessibilityLabel(Text("Close"))
-        }
-        .padding(VSpacing.lg)
     }
 
     // MARK: - Body

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeScheduledDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeScheduledDetailPanel.swift
@@ -37,6 +37,8 @@ struct HomeScheduledDetailPanel: View {
         HomeDetailPanel(
             icon: .calendar,
             title: title,
+            iconForeground: VColor.feedThreadStrong,
+            iconBackground: VColor.feedThreadWeak,
             onDismiss: onClose,
             scrollable: false
         ) {

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeScheduledDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeScheduledDetailPanel.swift
@@ -34,69 +34,18 @@ struct HomeScheduledDetailPanel: View {
     let onSecondaryAction: (() -> Void)?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            header
-
-            Rectangle()
-                .fill(VColor.borderHover)
-                .frame(height: 1)
-                .accessibilityHidden(true)
-
-            bodySection
-
-            Spacer(minLength: VSpacing.lg)
-
-            footer
-        }
-        .frame(minWidth: 480, idealWidth: 600, maxWidth: .infinity)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.xl, style: .continuous)
-                .fill(VColor.surfaceLift)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.xl, style: .continuous)
-                .strokeBorder(VColor.borderHover, lineWidth: 1)
-        )
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(Text(title))
-    }
-
-    // MARK: - Header
-
-    private var header: some View {
-        HStack(alignment: .center) {
-            HStack(spacing: VSpacing.sm) {
-                ZStack {
-                    Circle().fill(VColor.feedThreadWeak)
-                    VIconView(.calendar, size: 12)
-                        .foregroundStyle(VColor.feedThreadStrong)
-                }
-                .frame(width: 26, height: 26)
-                .accessibilityHidden(true)
-
-                Text(title)
-                    .font(VFont.titleSmall)
-                    .foregroundStyle(VColor.contentEmphasized)
-                    .accessibilityAddTraits(.isHeader)
+        HomeDetailPanel(
+            icon: .calendar,
+            title: title,
+            onDismiss: onClose,
+            scrollable: false
+        ) {
+            VStack(alignment: .leading, spacing: 0) {
+                bodySection
+                Spacer(minLength: VSpacing.lg)
+                footer
             }
-
-            Spacer(minLength: 0)
-
-            Button(action: onClose) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: VRadius.md, style: .continuous)
-                        .strokeBorder(VColor.borderElement, lineWidth: 1)
-                    VIconView(.x, size: 9)
-                        .foregroundStyle(VColor.contentEmphasized)
-                }
-                .frame(width: 32, height: 32)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .pointerCursor()
-            .accessibilityLabel(Text("Close"))
         }
-        .padding(VSpacing.lg)
     }
 
     // MARK: - Body


### PR DESCRIPTION
## Summary
- Refactored HomeScheduledDetailPanel to delegate its header/chrome to HomeDetailPanel instead of hand-rolling its own
- Refactored HomeNudgeDetailPanel to delegate its header/chrome to HomeDetailPanel instead of hand-rolling its own
- Icon chip shape unifies from 26pt Circle to 32pt RoundedRectangle (matches HomeDetailPanel)

Part of plan: home-feed-detail-panel-dispatch.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
