### PR TITLE
fix(playground): distinguish flag-off vs missing-conversation 404 in client

### DIFF
--- a/assistant/src/runtime/routes/playground/__tests__/force-compact.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/force-compact.test.ts
@@ -117,7 +117,7 @@ describe("forceCompactRouteDefinitions", () => {
     expect(routes[0].policyKey).toBe("conversations/playground/compact");
   });
 
-  test("returns 404 when the playground flag is disabled", async () => {
+  test("returns 404 with playground_disabled code when the playground flag is disabled", async () => {
     const deps = makeDeps({ isPlaygroundEnabled: () => false });
     const [route] = forceCompactRouteDefinitions(deps);
 
@@ -127,10 +127,12 @@ describe("forceCompactRouteDefinitions", () => {
     const body = (await res.json()) as {
       error: { code: string; message: string };
     };
-    expect(body.error.code).toBe("NOT_FOUND");
+    // Distinct from `conversation_not_found` so the Swift client can
+    // surface the right toast text without sniffing the URL path.
+    expect(body.error.code).toBe("playground_disabled");
   });
 
-  test("returns 404 when the conversation is missing", async () => {
+  test("returns 404 with conversation_not_found code when the conversation is missing", async () => {
     const deps = makeDeps({
       isPlaygroundEnabled: () => true,
       getConversationById: () => undefined,
@@ -143,7 +145,7 @@ describe("forceCompactRouteDefinitions", () => {
     const body = (await res.json()) as {
       error: { code: string; message: string };
     };
-    expect(body.error.code).toBe("NOT_FOUND");
+    expect(body.error.code).toBe("conversation_not_found");
     expect(body.error.message).toContain("conv-missing");
   });
 

--- a/assistant/src/runtime/routes/playground/__tests__/guard.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/guard.test.ts
@@ -30,8 +30,13 @@ describe("assertPlaygroundEnabled", () => {
     const body = (await result?.json()) as {
       error: { code: string; message: string };
     };
-    expect(body.error.code).toBe("NOT_FOUND");
-    expect(body.error.message).toBe("Not found");
+    // The body code must be `playground_disabled` (not the generic
+    // `NOT_FOUND`) so the Swift `CompactionPlaygroundClient` can route
+    // this to `.notAvailable` rather than `.notFound`. The two cases
+    // collide on conv-scoped routes because this guard runs *before*
+    // the conversation lookup — the URL alone cannot tell them apart.
+    expect(body.error.code).toBe("playground_disabled");
+    expect(body.error.message).toBe("Compaction playground is not enabled");
   });
 
   test("returns null when the flag is enabled", () => {

--- a/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
@@ -98,7 +98,7 @@ async function invoke(
 }
 
 describe("POST /v1/conversations/:id/playground/inject-compaction-failures", () => {
-  test("returns 404 when the compaction-playground flag is disabled", async () => {
+  test("returns 404 with playground_disabled code when the compaction-playground flag is disabled", async () => {
     const conversation = makeConversation();
     const deps = makeDeps({ enabled: false, conversation });
     const route = getInjectRoute(deps);
@@ -106,12 +106,19 @@ describe("POST /v1/conversations/:id/playground/inject-compaction-failures", () 
     const res = await invoke(route, conversation.conversationId, {});
     expect(res.status).toBe(404);
 
+    const body = (await res.json()) as {
+      error: { code: string; message: string };
+    };
+    // Distinct from `conversation_not_found` so the Swift client can
+    // surface the right toast text without sniffing the URL path.
+    expect(body.error.code).toBe("playground_disabled");
+
     // Flag-gated — the handler must not mutate conversation state or emit
     // events when the playground is disabled.
     expect(conversation.sentMessages).toHaveLength(0);
   });
 
-  test("returns 404 when the conversation is missing", async () => {
+  test("returns 404 with conversation_not_found code when the conversation is missing", async () => {
     const deps = makeDeps({ enabled: true, conversation: undefined });
     const route = getInjectRoute(deps);
 
@@ -121,7 +128,8 @@ describe("POST /v1/conversations/:id/playground/inject-compaction-failures", () 
     const body = (await res.json()) as {
       error: { code: string; message: string };
     };
-    expect(body.error.code).toBe("NOT_FOUND");
+    expect(body.error.code).toBe("conversation_not_found");
+    expect(body.error.message).toContain("missing-conv-id");
   });
 
   test("mutates both fields and emits compaction_circuit_open when both provided", async () => {

--- a/assistant/src/runtime/routes/playground/__tests__/reset-circuit.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/reset-circuit.test.ts
@@ -165,7 +165,7 @@ describe("reset-circuit route — gating", () => {
     fake = makeFakeConversation();
   });
 
-  test("returns 404 when the playground flag is disabled", async () => {
+  test("returns 404 with playground_disabled code when the playground flag is disabled", async () => {
     const deps = makeDeps({
       isPlaygroundEnabled: () => false,
       getConversationById: () => fake.conversation,
@@ -178,14 +178,16 @@ describe("reset-circuit route — gating", () => {
     const body = (await readJsonBody(response)) as {
       error: { code: string; message: string };
     };
-    expect(body.error.code).toBe("NOT_FOUND");
+    // Distinct from `conversation_not_found` so the Swift client can
+    // surface the right toast text without sniffing the URL path.
+    expect(body.error.code).toBe("playground_disabled");
     // State must not be mutated and no event emitted on the disabled path.
     expect(fake.state.consecutiveCompactionFailures).toBe(0);
     expect(fake.state.compactionCircuitOpenUntil).toBeNull();
     expect(fake.sent).toHaveLength(0);
   });
 
-  test("returns 404 when the conversation is missing", async () => {
+  test("returns 404 with conversation_not_found code when the conversation is missing", async () => {
     const deps = makeDeps({
       getConversationById: () => undefined,
     });
@@ -199,7 +201,7 @@ describe("reset-circuit route — gating", () => {
     const body = (await readJsonBody(response)) as {
       error: { code: string; message: string };
     };
-    expect(body.error.code).toBe("NOT_FOUND");
+    expect(body.error.code).toBe("conversation_not_found");
     expect(body.error.message).toContain("missing-id");
   });
 });

--- a/assistant/src/runtime/routes/playground/__tests__/seed-conversation.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/seed-conversation.test.ts
@@ -69,7 +69,7 @@ function makeCtx(body: unknown) {
 }
 
 describe("POST /v1/playground/seed-conversation", () => {
-  test("returns 404 when the playground flag is disabled", async () => {
+  test("returns 404 with playground_disabled code when the playground flag is disabled", async () => {
     const { deps } = makeDeps({ enabled: false });
     const handler = getSeedHandler(deps);
 
@@ -77,7 +77,9 @@ describe("POST /v1/playground/seed-conversation", () => {
     expect(res.status).toBe(404);
 
     const body = (await res.json()) as { error: { code: string } };
-    expect(body.error.code).toBe("NOT_FOUND");
+    // Distinct from `conversation_not_found` so the Swift client can
+    // surface the right toast text without sniffing the URL path.
+    expect(body.error.code).toBe("playground_disabled");
   });
 
   test("seeds N turns as 2N messages and returns conversation id", async () => {

--- a/assistant/src/runtime/routes/playground/__tests__/seeded-conversations.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/seeded-conversations.test.ts
@@ -68,7 +68,7 @@ function ctx(params: Record<string, string> = {}) {
 }
 
 describe("seededConversationsRouteDefinitions — flag disabled", () => {
-  test("GET list returns 404 when the playground flag is off", async () => {
+  test("GET list returns 404 with playground_disabled code when the playground flag is off", async () => {
     const { deps, listCalls } = makeStub({ enabled: false });
     const routes = seededConversationsRouteDefinitions(deps);
     const route = findRoute(routes, "GET", "playground/seeded-conversations");
@@ -76,10 +76,14 @@ describe("seededConversationsRouteDefinitions — flag disabled", () => {
     const res = await route.handler(ctx());
 
     expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string } };
+    // Distinct from `conversation_not_found` so the Swift client can
+    // surface the right toast text without sniffing the URL path.
+    expect(body.error.code).toBe("playground_disabled");
     expect(listCalls).toEqual([]);
   });
 
-  test("DELETE single returns 404 when the playground flag is off", async () => {
+  test("DELETE single returns 404 with playground_disabled code when the playground flag is off", async () => {
     const { deps, deleteCalls } = makeStub({ enabled: false });
     const routes = seededConversationsRouteDefinitions(deps);
     const route = findRoute(
@@ -91,10 +95,12 @@ describe("seededConversationsRouteDefinitions — flag disabled", () => {
     const res = await route.handler(ctx({ id: "conv-1" }));
 
     expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("playground_disabled");
     expect(deleteCalls).toEqual([]);
   });
 
-  test("DELETE bulk returns 404 when the playground flag is off", async () => {
+  test("DELETE bulk returns 404 with playground_disabled code when the playground flag is off", async () => {
     const { deps, listCalls, deleteCalls } = makeStub({ enabled: false });
     const routes = seededConversationsRouteDefinitions(deps);
     const route = findRoute(
@@ -106,6 +112,8 @@ describe("seededConversationsRouteDefinitions — flag disabled", () => {
     const res = await route.handler(ctx());
 
     expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("playground_disabled");
     expect(listCalls).toEqual([]);
     expect(deleteCalls).toEqual([]);
   });

--- a/assistant/src/runtime/routes/playground/__tests__/state.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/state.test.ts
@@ -98,15 +98,17 @@ describe("GET conversations/:id/playground/compaction-state", () => {
     expect(route.tags).toEqual(["playground"]);
   });
 
-  test("returns 404 when the playground flag is disabled", async () => {
+  test("returns 404 with playground_disabled code when the playground flag is disabled", async () => {
     const deps = makeDeps({ isPlaygroundEnabled: () => false });
     const res = await invokeRoute(deps);
     expect(res.status).toBe(404);
     const body = (await res.json()) as { error: { code: string } };
-    expect(body.error.code).toBe("NOT_FOUND");
+    // Distinct from `conversation_not_found` so the Swift client can
+    // surface the right toast text without sniffing the URL path.
+    expect(body.error.code).toBe("playground_disabled");
   });
 
-  test("returns 404 when the conversation does not exist", async () => {
+  test("returns 404 with conversation_not_found code when the conversation does not exist", async () => {
     const deps = makeDeps({
       getConversationById: () => undefined,
     });
@@ -115,7 +117,7 @@ describe("GET conversations/:id/playground/compaction-state", () => {
     const body = (await res.json()) as {
       error: { code: string; message: string };
     };
-    expect(body.error.code).toBe("NOT_FOUND");
+    expect(body.error.code).toBe("conversation_not_found");
     expect(body.error.message).toContain("missing-id");
   });
 

--- a/assistant/src/runtime/routes/playground/conversation-not-found.ts
+++ b/assistant/src/runtime/routes/playground/conversation-not-found.ts
@@ -1,0 +1,29 @@
+/**
+ * Body code for "conversation lookup returned no row" 404s on
+ * conversation-scoped playground routes. Distinct from the generic
+ * `NOT_FOUND` code (and from `playground_disabled`, see `guard.ts`) so
+ * the Swift `CompactionPlaygroundClient` can pick `.notFound` over
+ * `.notAvailable` from the response body rather than from a URL-path
+ * heuristic. Without this distinction the `assertPlaygroundEnabled`
+ * guard's flag-off 404 (which fires *before* the conversation lookup on
+ * every conv-scoped route) would be indistinguishable from a real
+ * missing-conversation 404.
+ */
+export const CONVERSATION_NOT_FOUND_CODE = "conversation_not_found";
+
+/**
+ * Build a 404 response for a missing conversation on a playground route.
+ * Uses a distinguishing body `code` so the Swift client can route this
+ * to `.notFound` (rather than `.notAvailable`).
+ */
+export function conversationNotFoundResponse(conversationId: string): Response {
+  return Response.json(
+    {
+      error: {
+        code: CONVERSATION_NOT_FOUND_CODE,
+        message: `Conversation ${conversationId} not found`,
+      },
+    },
+    { status: 404 },
+  );
+}

--- a/assistant/src/runtime/routes/playground/force-compact.ts
+++ b/assistant/src/runtime/routes/playground/force-compact.ts
@@ -13,6 +13,7 @@
 import { estimatePromptTokens } from "../../../context/token-estimator.js";
 import { httpError } from "../../http-errors.js";
 import type { RouteDefinition } from "../../http-router.js";
+import { conversationNotFoundResponse } from "./conversation-not-found.js";
 import { assertPlaygroundEnabled, type PlaygroundRouteDeps } from "./index.js";
 
 export function forceCompactRouteDefinitions(
@@ -31,11 +32,7 @@ export function forceCompactRouteDefinitions(
 
         const conversation = deps.getConversationById(params.id);
         if (!conversation) {
-          return httpError(
-            "NOT_FOUND",
-            `Conversation ${params.id} not found`,
-            404,
-          );
+          return conversationNotFoundResponse(params.id);
         }
 
         // Per-conversation in-flight guard. `Conversation.processing` is set

--- a/assistant/src/runtime/routes/playground/guard.ts
+++ b/assistant/src/runtime/routes/playground/guard.ts
@@ -1,5 +1,17 @@
-import { httpError } from "../../http-errors.js";
 import type { PlaygroundRouteDeps } from "./deps.js";
+
+/**
+ * Body code for flag-off playground 404s. Distinct from the generic
+ * `NOT_FOUND` code so the Swift `CompactionPlaygroundClient` can route
+ * these to `.notAvailable` (toast: "Playground endpoints disabled")
+ * rather than `.notFound` (toast: "Conversation not found"). The two
+ * cases are otherwise indistinguishable on conv-scoped routes because
+ * `assertPlaygroundEnabled` runs *before* the conversation lookup, so a
+ * URL-path heuristic on the client misclassifies flag-off as missing-
+ * conversation. See `conversation-not-found.ts` for the matching code on
+ * the other branch.
+ */
+export const PLAYGROUND_DISABLED_CODE = "playground_disabled";
 
 /**
  * Defense-in-depth guard every playground route calls first. Returns a 404
@@ -11,7 +23,15 @@ export function assertPlaygroundEnabled(
   deps: PlaygroundRouteDeps,
 ): Response | null {
   if (!deps.isPlaygroundEnabled()) {
-    return httpError("NOT_FOUND", "Not found", 404);
+    return Response.json(
+      {
+        error: {
+          code: PLAYGROUND_DISABLED_CODE,
+          message: "Compaction playground is not enabled",
+        },
+      },
+      { status: 404 },
+    );
   }
   return null;
 }

--- a/assistant/src/runtime/routes/playground/inject-failures.ts
+++ b/assistant/src/runtime/routes/playground/inject-failures.ts
@@ -22,6 +22,7 @@ import { estimatePromptTokens } from "../../../context/token-estimator.js";
 import type { Conversation } from "../../../daemon/conversation.js";
 import { httpError } from "../../http-errors.js";
 import type { RouteDefinition } from "../../http-router.js";
+import { conversationNotFoundResponse } from "./conversation-not-found.js";
 import type { PlaygroundRouteDeps } from "./deps.js";
 import { assertPlaygroundEnabled } from "./guard.js";
 
@@ -53,11 +54,7 @@ export function injectFailuresRouteDefinitions(
 
         const conversation = deps.getConversationById(params.id);
         if (!conversation) {
-          return httpError(
-            "NOT_FOUND",
-            `Conversation ${params.id} not found`,
-            404,
-          );
+          return conversationNotFoundResponse(params.id);
         }
 
         let rawBody: unknown = {};

--- a/assistant/src/runtime/routes/playground/reset-circuit.ts
+++ b/assistant/src/runtime/routes/playground/reset-circuit.ts
@@ -24,11 +24,11 @@
 import { getConfig } from "../../../config/loader.js";
 import { estimatePromptTokens } from "../../../context/token-estimator.js";
 import type { Conversation } from "../../../daemon/conversation.js";
-import { httpError } from "../../http-errors.js";
 import type { RouteDefinition } from "../../http-router.js";
 // Import directly from the source modules (not ./index.js) — index.ts imports
 // this file's `resetCircuitRouteDefinitions`, so pulling its re-exports back
 // through the barrel would create a cycle.
+import { conversationNotFoundResponse } from "./conversation-not-found.js";
 import type { PlaygroundRouteDeps } from "./deps.js";
 import { assertPlaygroundEnabled } from "./guard.js";
 
@@ -48,11 +48,7 @@ export function resetCircuitRouteDefinitions(
 
         const conversation = deps.getConversationById(params.id);
         if (!conversation) {
-          return httpError(
-            "NOT_FOUND",
-            `Conversation ${params.id} not found`,
-            404,
-          );
+          return conversationNotFoundResponse(params.id);
         }
 
         conversation.consecutiveCompactionFailures = 0;

--- a/assistant/src/runtime/routes/playground/state.ts
+++ b/assistant/src/runtime/routes/playground/state.ts
@@ -14,8 +14,8 @@
 import { getConfig } from "../../../config/loader.js";
 import { estimatePromptTokens } from "../../../context/token-estimator.js";
 import type { Conversation } from "../../../daemon/conversation.js";
-import { httpError } from "../../http-errors.js";
 import type { RouteDefinition } from "../../http-router.js";
+import { conversationNotFoundResponse } from "./conversation-not-found.js";
 import { assertPlaygroundEnabled, type PlaygroundRouteDeps } from "./index.js";
 
 /**
@@ -68,11 +68,7 @@ export function stateRouteDefinitions(
 
         const conversation = deps.getConversationById(params.id);
         if (!conversation) {
-          return httpError(
-            "NOT_FOUND",
-            `Conversation ${params.id} not found`,
-            404,
-          );
+          return conversationNotFoundResponse(params.id);
         }
 
         return Response.json(buildCompactionStateResponse(conversation));

--- a/clients/shared/Network/CompactionPlaygroundClient.swift
+++ b/clients/shared/Network/CompactionPlaygroundClient.swift
@@ -142,25 +142,70 @@ public struct CompactionPlaygroundClient: CompactionPlaygroundClientProtocol {
 
     /// Maps non-success responses to ``CompactionPlaygroundError``.
     ///
-    /// 404 on a path without a `/conversations/` segment indicates the
-    /// playground feature flag is disabled on the daemon — the daemon's
-    /// `/v1/assistants/{id}/playground/*` routes aren't mounted when the flag
-    /// is off. 404 on a conversation-scoped path indicates the conversation
-    /// doesn't exist.
+    /// On a 404, the daemon now distinguishes the two cases via a
+    /// machine-readable `code` field in the JSON body: `playground_disabled`
+    /// (the `compaction-playground` feature flag is off, surfaced as
+    /// ``CompactionPlaygroundError/notAvailable``) and
+    /// `conversation_not_found` (the requested conversation doesn't exist,
+    /// surfaced as ``CompactionPlaygroundError/notFound``). The body-based
+    /// classifier is required for conversation-scoped routes
+    /// (`forceCompact`, `injectFailures`, `resetCircuit`, `getState`)
+    /// because the daemon's `assertPlaygroundEnabled` guard runs *before*
+    /// the conversation lookup — a flag-off 404 and a missing-conversation
+    /// 404 hit the same URL, so a URL-path heuristic alone misclassifies
+    /// flag-off as `.notFound`.
+    ///
+    /// A URL-path fallback remains for deploy-time version skew: an updated
+    /// client may briefly talk to an old daemon that returns the legacy
+    /// generic `NOT_FOUND` body (or no parseable body at all). The fallback
+    /// preserves the previous classification heuristic so the UX doesn't
+    /// regress during the rollout window.
     private func throwIfUnsuccessful(_ response: GatewayHTTPClient.Response, path: String) throws {
         guard !response.isSuccess else { return }
 
         if response.statusCode == 404 {
+            if let code = parseErrorCode(from: response.data) {
+                switch code {
+                case "playground_disabled":
+                    log.error("compaction playground 404 (flag off) for path \(path, privacy: .public)")
+                    throw CompactionPlaygroundError.notAvailable
+                case "conversation_not_found":
+                    log.error("compaction playground 404 (conversation not found) for path \(path, privacy: .public)")
+                    throw CompactionPlaygroundError.notFound
+                default:
+                    // Unknown body code — fall through to the path heuristic
+                    // rather than swallowing as a generic HTTP 404.
+                    break
+                }
+            }
+
+            // Path-based fallback for old daemons that don't include the
+            // distinguishing `code` field. Conversation-scoped routes 404 if
+            // the conversation is missing; flat `/playground/*` routes 404
+            // if the flag is off. This matches the pre-fix behavior.
             if path.contains("/conversations/") {
-                log.error("compaction playground 404 (not found) for path \(path, privacy: .public)")
+                log.error("compaction playground 404 (not found, fallback) for path \(path, privacy: .public)")
                 throw CompactionPlaygroundError.notFound
             } else {
-                log.error("compaction playground 404 (flag off) for path \(path, privacy: .public)")
+                log.error("compaction playground 404 (flag off, fallback) for path \(path, privacy: .public)")
                 throw CompactionPlaygroundError.notAvailable
             }
         }
 
         log.error("compaction playground HTTP \(response.statusCode, privacy: .public) for path \(path, privacy: .public)")
         throw CompactionPlaygroundError.http(statusCode: response.statusCode)
+    }
+
+    /// Best-effort parse of `{ "error": { "code": "<string>" } }` from the
+    /// response body. Returns `nil` on any structural mismatch so the caller
+    /// can fall back to a URL-path heuristic rather than throwing on
+    /// malformed bodies.
+    private func parseErrorCode(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let errorObj = json["error"] as? [String: Any],
+              let code = errorObj["code"] as? String else {
+            return nil
+        }
+        return code
     }
 }


### PR DESCRIPTION
## Summary
The Swift client previously mapped any 404 to `.notFound` for conv-scoped routes, making the `.notAvailable` catches in the macOS UI sections dead code (flag-off looked like "conversation not found"). Add a distinguishing `code` field to playground 404 bodies (`playground_disabled` vs `conversation_not_found`) and parse the body in `CompactionPlaygroundClient.throwIfUnsuccessful` to pick the right error variant. Keeps a path-based fallback for deploy-time client/daemon version skew.

Addresses a gap identified during self-review of the compaction-playground plan (#27253).

Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
