### PR TITLE
fix(playground): hydrate seeded conversations on demand for conv-scoped routes

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -2003,10 +2003,25 @@ export class RuntimeHttpServer {
         getHeartbeatService: this.getHeartbeatService,
       }),
       ...playgroundRouteDefinitions({
-        getConversationById: (id) => {
-          const s = this.findConversation?.(id);
-          if (!s || !("abort" in s)) return undefined;
-          return s as import("../daemon/conversation.js").Conversation;
+        getConversationById: async (id) => {
+          // Gate on DB existence first so genuinely-missing IDs return
+          // `undefined` (preserving the route handlers' 404 path) rather
+          // than triggering `getOrCreateConversation`'s create branch and
+          // masking the not-found case. For existing-but-not-loaded rows
+          // (e.g. freshly seeded by `POST /playground/seed-conversation`),
+          // hydrate the in-memory `Conversation` on demand so conv-scoped
+          // playground routes work without first opening the conversation
+          // in the main window.
+          if (!getConversation(id)) return undefined;
+          const sendDeps = this.sendMessageDeps;
+          if (!sendDeps) {
+            // Fall back to the in-memory active map when the daemon hasn't
+            // wired the hydration-capable accessor (e.g. unit tests).
+            const s = this.findConversation?.(id);
+            if (!s || !("abort" in s)) return undefined;
+            return s as import("../daemon/conversation.js").Conversation;
+          }
+          return sendDeps.getOrCreateConversation(id);
         },
         isPlaygroundEnabled: () =>
           isAssistantFeatureFlagEnabled("compaction-playground", getConfig()),

--- a/assistant/src/runtime/routes/playground/__tests__/force-compact.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/force-compact.test.ts
@@ -74,7 +74,7 @@ function makeDeps(
   overrides: Partial<PlaygroundRouteDeps> = {},
 ): PlaygroundRouteDeps {
   return {
-    getConversationById: () => undefined,
+    getConversationById: async () => undefined,
     isPlaygroundEnabled: () => true,
     listConversationsByTitlePrefix: () => [],
     deleteConversationById: () => false,
@@ -135,7 +135,7 @@ describe("forceCompactRouteDefinitions", () => {
   test("returns 404 with conversation_not_found code when the conversation is missing", async () => {
     const deps = makeDeps({
       isPlaygroundEnabled: () => true,
-      getConversationById: () => undefined,
+      getConversationById: async () => undefined,
     });
     const [route] = forceCompactRouteDefinitions(deps);
 
@@ -177,7 +177,7 @@ describe("forceCompactRouteDefinitions", () => {
 
     const deps = makeDeps({
       isPlaygroundEnabled: () => true,
-      getConversationById: () => fake.conversation,
+      getConversationById: async () => fake.conversation,
     });
     const [route] = forceCompactRouteDefinitions(deps);
 
@@ -222,7 +222,7 @@ describe("forceCompactRouteDefinitions", () => {
 
     const deps = makeDeps({
       isPlaygroundEnabled: () => true,
-      getConversationById: () => fake.conversation,
+      getConversationById: async () => fake.conversation,
     });
     const [route] = forceCompactRouteDefinitions(deps);
 
@@ -260,7 +260,7 @@ describe("forceCompactRouteDefinitions", () => {
 
     const deps = makeDeps({
       isPlaygroundEnabled: () => true,
-      getConversationById: () => fake.conversation,
+      getConversationById: async () => fake.conversation,
     });
     const [route] = forceCompactRouteDefinitions(deps);
 

--- a/assistant/src/runtime/routes/playground/__tests__/guard.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/guard.test.ts
@@ -7,7 +7,9 @@ import { playgroundRouteDefinitions } from "../index.js";
 
 function makeDeps(enabled: boolean): PlaygroundRouteDeps {
   return {
-    getConversationById: (_id: string): Conversation | undefined => undefined,
+    getConversationById: async (
+      _id: string,
+    ): Promise<Conversation | undefined> => undefined,
     isPlaygroundEnabled: () => enabled,
     listConversationsByTitlePrefix: () => [],
     deleteConversationById: () => false,

--- a/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
@@ -51,7 +51,7 @@ function makeDeps(
   const conversation = opts.conversation;
   return {
     isPlaygroundEnabled: () => enabled,
-    getConversationById: (id) => {
+    getConversationById: async (id) => {
       if (!conversation) return undefined;
       if (conversation.conversationId !== id) return undefined;
       return conversation as unknown as Conversation;

--- a/assistant/src/runtime/routes/playground/__tests__/reset-circuit.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/reset-circuit.test.ts
@@ -100,7 +100,7 @@ function makeDeps(
   overrides: Partial<PlaygroundRouteDeps> = {},
 ): PlaygroundRouteDeps {
   return {
-    getConversationById: () => undefined,
+    getConversationById: async () => undefined,
     isPlaygroundEnabled: () => true,
     listConversationsByTitlePrefix: () => [],
     deleteConversationById: () => false,
@@ -168,7 +168,7 @@ describe("reset-circuit route — gating", () => {
   test("returns 404 with playground_disabled code when the playground flag is disabled", async () => {
     const deps = makeDeps({
       isPlaygroundEnabled: () => false,
-      getConversationById: () => fake.conversation,
+      getConversationById: async () => fake.conversation,
     });
     const handler = getHandler(deps);
 
@@ -189,7 +189,7 @@ describe("reset-circuit route — gating", () => {
 
   test("returns 404 with conversation_not_found code when the conversation is missing", async () => {
     const deps = makeDeps({
-      getConversationById: () => undefined,
+      getConversationById: async () => undefined,
     });
     const handler = getHandler(deps);
 
@@ -214,7 +214,7 @@ describe("reset-circuit route — behavior", () => {
       compactionCircuitOpenUntil: future,
     });
     const deps = makeDeps({
-      getConversationById: () => fake.conversation,
+      getConversationById: async () => fake.conversation,
     });
     const handler = getHandler(deps);
 
@@ -249,7 +249,7 @@ describe("reset-circuit route — behavior", () => {
       compactionCircuitOpenUntil: null,
     });
     const deps = makeDeps({
-      getConversationById: () => fake.conversation,
+      getConversationById: async () => fake.conversation,
     });
     const handler = getHandler(deps);
 

--- a/assistant/src/runtime/routes/playground/__tests__/seed-conversation.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/seed-conversation.test.ts
@@ -28,7 +28,9 @@ function makeDeps(overrides?: { enabled?: boolean }): Spy {
   let nextMessageId = 0;
 
   const deps: PlaygroundRouteDeps = {
-    getConversationById: (_id: string): Conversation | undefined => undefined,
+    getConversationById: async (
+      _id: string,
+    ): Promise<Conversation | undefined> => undefined,
     isPlaygroundEnabled: () => overrides?.enabled ?? true,
     listConversationsByTitlePrefix: () => [],
     deleteConversationById: () => false,

--- a/assistant/src/runtime/routes/playground/__tests__/seeded-conversations.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/seeded-conversations.test.ts
@@ -14,7 +14,7 @@ interface StubOpts {
     messageCount: number;
     createdAt: number;
   }>;
-  getConversationById?: (id: string) => Conversation | undefined;
+  getConversationById?: (id: string) => Promise<Conversation | undefined>;
   deleteReturn?: boolean | ((id: string) => boolean);
 }
 
@@ -30,7 +30,7 @@ function makeStub(opts: StubOpts = {}): Stub {
   const deleteReturn = opts.deleteReturn ?? true;
   const deps: PlaygroundRouteDeps = {
     isPlaygroundEnabled: () => opts.enabled ?? true,
-    getConversationById: opts.getConversationById ?? (() => undefined),
+    getConversationById: opts.getConversationById ?? (async () => undefined),
     listConversationsByTitlePrefix: (prefix) => {
       listCalls.push(prefix);
       return opts.listRows ?? [];

--- a/assistant/src/runtime/routes/playground/__tests__/state.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/state.test.ts
@@ -30,7 +30,7 @@ function makeDeps(
   overrides: Partial<PlaygroundRouteDeps> = {},
 ): PlaygroundRouteDeps {
   return {
-    getConversationById: () => undefined,
+    getConversationById: async () => undefined,
     isPlaygroundEnabled: () => true,
     listConversationsByTitlePrefix: () => [],
     deleteConversationById: () => false,
@@ -110,7 +110,7 @@ describe("GET conversations/:id/playground/compaction-state", () => {
 
   test("returns 404 with conversation_not_found code when the conversation does not exist", async () => {
     const deps = makeDeps({
-      getConversationById: () => undefined,
+      getConversationById: async () => undefined,
     });
     const res = await invokeRoute(deps, "missing-id");
     expect(res.status).toBe(404);
@@ -124,7 +124,7 @@ describe("GET conversations/:id/playground/compaction-state", () => {
   test("fresh conversation with no messages returns a baseline payload", async () => {
     const conversation = makeFakeConversation();
     const deps = makeDeps({
-      getConversationById: () => conversation,
+      getConversationById: async () => conversation,
     });
     const res = await invokeRoute(deps);
     expect(res.status).toBe(200);
@@ -151,7 +151,7 @@ describe("GET conversations/:id/playground/compaction-state", () => {
       consecutiveCompactionFailures: 3,
     });
     const deps = makeDeps({
-      getConversationById: () => conversation,
+      getConversationById: async () => conversation,
     });
     const res = await invokeRoute(deps);
     expect(res.status).toBe(200);
@@ -169,7 +169,7 @@ describe("GET conversations/:id/playground/compaction-state", () => {
       compactionCircuitOpenUntil: past,
     });
     const deps = makeDeps({
-      getConversationById: () => conversation,
+      getConversationById: async () => conversation,
     });
     const res = await invokeRoute(deps);
     const body = (await res.json()) as ReturnType<
@@ -188,7 +188,7 @@ describe("GET conversations/:id/playground/compaction-state", () => {
       compactionCircuitOpenUntil: null,
     });
     const deps = makeDeps({
-      getConversationById: () => conversation,
+      getConversationById: async () => conversation,
     });
     const res = await invokeRoute(deps);
     const body = (await res.json()) as Record<string, unknown>;

--- a/assistant/src/runtime/routes/playground/deps.ts
+++ b/assistant/src/runtime/routes/playground/deps.ts
@@ -13,7 +13,17 @@
 import type { Conversation } from "../../../daemon/conversation.js";
 
 export interface PlaygroundRouteDeps {
-  readonly getConversationById: (id: string) => Conversation | undefined;
+  /**
+   * Resolve a conversation by ID for conv-scoped playground routes
+   * (`forceCompact`, `injectFailures`, `resetCircuit`, `getState`). Async
+   * because production wiring may need to hydrate a `Conversation` from the
+   * DB on demand — freshly-seeded rows live only in the DB until the daemon
+   * loads them. Implementations must return `undefined` for IDs that do not
+   * exist in the DB at all so route handlers can preserve their 404 path.
+   */
+  readonly getConversationById: (
+    id: string,
+  ) => Promise<Conversation | undefined>;
   readonly isPlaygroundEnabled: () => boolean;
   /**
    * List non-archived conversations whose title starts with `prefix`. Used by

--- a/assistant/src/runtime/routes/playground/force-compact.ts
+++ b/assistant/src/runtime/routes/playground/force-compact.ts
@@ -30,7 +30,7 @@ export function forceCompactRouteDefinitions(
         const gate = assertPlaygroundEnabled(deps);
         if (gate) return gate;
 
-        const conversation = deps.getConversationById(params.id);
+        const conversation = await deps.getConversationById(params.id);
         if (!conversation) {
           return conversationNotFoundResponse(params.id);
         }

--- a/assistant/src/runtime/routes/playground/inject-failures.ts
+++ b/assistant/src/runtime/routes/playground/inject-failures.ts
@@ -52,7 +52,7 @@ export function injectFailuresRouteDefinitions(
         const gate = assertPlaygroundEnabled(deps);
         if (gate) return gate;
 
-        const conversation = deps.getConversationById(params.id);
+        const conversation = await deps.getConversationById(params.id);
         if (!conversation) {
           return conversationNotFoundResponse(params.id);
         }

--- a/assistant/src/runtime/routes/playground/reset-circuit.ts
+++ b/assistant/src/runtime/routes/playground/reset-circuit.ts
@@ -42,11 +42,11 @@ export function resetCircuitRouteDefinitions(
       policyKey: "conversations/playground/reset-circuit",
       summary: "Clear compaction circuit-breaker state (dev-only playground)",
       tags: ["playground"],
-      handler: ({ params }) => {
+      handler: async ({ params }) => {
         const gate = assertPlaygroundEnabled(deps);
         if (gate) return gate;
 
-        const conversation = deps.getConversationById(params.id);
+        const conversation = await deps.getConversationById(params.id);
         if (!conversation) {
           return conversationNotFoundResponse(params.id);
         }

--- a/assistant/src/runtime/routes/playground/state.ts
+++ b/assistant/src/runtime/routes/playground/state.ts
@@ -62,11 +62,11 @@ export function stateRouteDefinitions(
       policyKey: "conversations/playground/state",
       summary: "Read current compaction state for a conversation",
       tags: ["playground"],
-      handler: ({ params }) => {
+      handler: async ({ params }) => {
         const gate = assertPlaygroundEnabled(deps);
         if (gate) return gate;
 
-        const conversation = deps.getConversationById(params.id);
+        const conversation = await deps.getConversationById(params.id);
         if (!conversation) {
           return conversationNotFoundResponse(params.id);
         }


### PR DESCRIPTION
## Summary
The playground `getConversationById` wiring previously only read from `server.conversations` (the in-memory active map), so freshly-seeded rows could not be exercised by conv-scoped playground routes (`forceCompact`, `injectFailures`, `resetCircuit`, `getState`) until the user opened the conversation in the main window. Switch to the hydration-capable accessor so playground calls hydrate the `Conversation` from the DB on demand.

Used `SendMessageDeps.getOrCreateConversation` (the same accessor the POST `/v1/messages` handler uses), gated behind a DB-existence check via `getConversation(id)` from `memory/conversation-crud.js`. The existence check is required because `getOrCreateConversation` always creates a brand-new `Conversation` when the row is missing — calling it unguarded would mask genuine 404s for IDs that don't exist in the DB at all. With the gate in place: missing rows return `undefined` (route handlers' 404 path fires correctly), existing-but-not-loaded rows hydrate via `Conversation.loadFromDb()`, and already-loaded rows are returned as-is from the in-memory map.

`PlaygroundRouteDeps.getConversationById` is now async (`Promise<Conversation | undefined>`) since hydration is async. All four conv-scoped route handlers (`force-compact`, `inject-failures`, `reset-circuit`, `state`) now `await` the lookup; `state` and `reset-circuit` handler functions were converted from sync to async. All seven existing playground test files updated to use `async () =>` mock returns.

Addresses a gap identified during self-review of the compaction-playground plan (#27253).

Part of #27253
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
