### PR TITLE
refactor(skills): unbundle skills-catalog → vellum-skills-catalog

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -195,7 +195,7 @@ private let subCategoryMap: [SkillCategory: [SubCategoryDef]] = [
         SubCategoryDef(label: "Services", emoji: "\u{1F6D2}", skillIds: ["amazon", "doordash", "restaurant-reservation"]),
     ],
     .knowledge: [
-        SubCategoryDef(label: "Learning", emoji: "\u{1F9E0}", skillIds: ["knowledge-graph", "skills-catalog", "self-upgrade"]),
+        SubCategoryDef(label: "Learning", emoji: "\u{1F9E0}", skillIds: ["knowledge-graph", "vellum-skills-catalog", "self-upgrade"]),
         SubCategoryDef(label: "Daily", emoji: "\u{2600}\u{FE0F}", skillIds: ["start-the-day", "weather"]),
     ],
 ]

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -702,7 +702,7 @@
       "name": "vellum-skills-catalog",
       "description": "Discover bundled skills and search/install community skills from the skills.sh registry",
       "metadata": {
-        "emoji": "\\U0001F9E9",
+        "emoji": "🧩",
         "vellum": {
           "display-name": "Skills Catalog",
           "activation-hints": [

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -698,6 +698,29 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
+      "id": "vellum-skills-catalog",
+      "name": "vellum-skills-catalog",
+      "description": "Discover bundled skills and search/install community skills from the skills.sh registry",
+      "metadata": {
+        "emoji": "\\U0001F9E9",
+        "vellum": {
+          "display-name": "Skills Catalog",
+          "activation-hints": [
+            "what can you do",
+            "find a skill",
+            "install a skill",
+            "community skills",
+            "skills.sh",
+            "search for skills"
+          ],
+          "avoid-when": [
+            "User is asking about a specific bundled skill already visible in the catalog"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "vellum-sounds",
       "name": "vellum-sounds",
       "description": "Customize the macOS app's sound effects — add sound files to the workspace, enable sounds globally, set volume, and assign sounds to 9 app events (message sent, task complete, notifications, etc.)",

--- a/skills/vellum-skills-catalog/SKILL.md
+++ b/skills/vellum-skills-catalog/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: skills-catalog
+name: vellum-skills-catalog
 description: Discover bundled skills and search/install community skills from the skills.sh registry
 compatibility: "Designed for Vellum personal assistants"
 metadata:

--- a/skills/vellum-skills-catalog/SKILL.md
+++ b/skills/vellum-skills-catalog/SKILL.md
@@ -3,7 +3,7 @@ name: vellum-skills-catalog
 description: Discover bundled skills and search/install community skills from the skills.sh registry
 compatibility: "Designed for Vellum personal assistants"
 metadata:
-  emoji: "\U0001F9E9"
+  emoji: "🧩"
   vellum:
     display-name: "Skills Catalog"
     activation-hints:

--- a/skills/vellum-skills-catalog/SKILL.md
+++ b/skills/vellum-skills-catalog/SKILL.md
@@ -53,6 +53,7 @@ assistant skills add <owner>/<repo>@<skill-name>
 ```
 
 For example:
+
 ```bash
 assistant skills add vercel-labs/skills@find-skills
 ```


### PR DESCRIPTION
## Summary
- Moved `assistant/src/config/bundled-skills/skills-catalog/SKILL.md` to `skills/vellum-skills-catalog/SKILL.md`
- Renamed the skill from `skills-catalog` to `vellum-skills-catalog` in the frontmatter
- Deleted the old bundled skill directory

## Original prompt
Help me migrate assistant/src/config/bundled-skills/skills-catalog/SKILL.md to skills/ and unbundle it. Rename it `vellum-skills-catalog` while we're at it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
