### PR TITLE
feat(permissions): standalone V3 permission prompt and rule editor modal

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/V3RuleEditorModal.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/V3RuleEditorModal.swift
@@ -32,9 +32,16 @@ struct V3RuleEditorModal: View {
     @State private var selectedRiskLevel: String = "medium"
     @State private var isSaving: Bool = false
 
-    /// Generalized pattern options (skips the exact match at index 0)
+    /// Generalized pattern options.
+    /// If scopeOptions has multiple elements, skip the exact match at index 0.
+    /// If scopeOptions has only 1 element (single wildcard), show it directly.
     private var generalizedOptions: [V3ScopeOptionItem] {
-        Array(scopeOptions.dropFirst())
+        scopeOptions.count > 1 ? Array(scopeOptions.dropFirst()) : scopeOptions
+    }
+
+    /// Whether we're showing a single wildcard option (not skipping index 0)
+    private var isSingleOption: Bool {
+        scopeOptions.count == 1
     }
 
     /// Contextual hint for the selected risk level
@@ -81,8 +88,8 @@ struct V3RuleEditorModal: View {
         .background(VColor.surfaceLift)
         .onAppear {
             selectedRiskLevel = riskLevel.isEmpty ? "medium" : riskLevel
-            // If generalizedOptions is empty, default to index 0 (exact match)
-            if generalizedOptions.isEmpty {
+            // If single option, use index 0. Otherwise, start at index 1 (skip exact match)
+            if isSingleOption {
                 selectedPatternIndex = 0
             }
         }
@@ -122,12 +129,14 @@ struct V3RuleEditorModal: View {
 
     @ViewBuilder
     private func patternRow(option: V3ScopeOptionItem, index: Int) -> some View {
+        // If single option, map directly to index 0. Otherwise, offset by 1 since we skip index 0.
+        let targetIndex = isSingleOption ? index : index + 1
         Button {
-            selectedPatternIndex = index + 1 // Offset by 1 since we skip index 0
+            selectedPatternIndex = targetIndex
         } label: {
             HStack(spacing: VSpacing.sm) {
-                VIconView(selectedPatternIndex == index + 1 ? .circleDot : .circle, size: 14)
-                    .foregroundStyle(selectedPatternIndex == index + 1 ? VColor.primaryBase : VColor.contentTertiary)
+                VIconView(selectedPatternIndex == targetIndex ? .circleDot : .circle, size: 14)
+                    .foregroundStyle(selectedPatternIndex == targetIndex ? VColor.primaryBase : VColor.contentTertiary)
                     .accessibilityHidden(true)
 
                 Text(option.label)
@@ -141,8 +150,8 @@ struct V3RuleEditorModal: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(option.label)
-        .accessibilityAddTraits(selectedPatternIndex == index + 1 ? [.isSelected] : [])
-        .accessibilityValue(selectedPatternIndex == index + 1 ? "Selected" : "Not selected")
+        .accessibilityAddTraits(selectedPatternIndex == targetIndex ? [.isSelected] : [])
+        .accessibilityValue(selectedPatternIndex == targetIndex ? "Selected" : "Not selected")
     }
 
     // MARK: - Section 2: Treat as

--- a/clients/macos/vellum-assistant/Features/Chat/V3RuleEditorModal.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/V3RuleEditorModal.swift
@@ -1,0 +1,243 @@
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - Helper Types
+
+struct V3ScopeOptionItem: Identifiable, Equatable {
+    let id = UUID()
+    let label: String
+    let pattern: String
+}
+
+struct V3SavedRule {
+    let toolName: String
+    let pattern: String
+    let riskLevel: String
+    let scope: String
+}
+
+// MARK: - V3RuleEditorModal
+
+/// V3 Rule Editor Modal — minimal, focused on generalization and risk assessment.
+/// Shows only the generalized pattern options (skips exact match) and risk level picker.
+struct V3RuleEditorModal: View {
+    /// Raw tool identifier (e.g. "bash", "host_bash") used for trust rule persistence.
+    let toolName: String
+    let inputSummary: String
+    let riskLevel: String
+    let riskReason: String
+    let scopeOptions: [V3ScopeOptionItem]
+    let workingDir: String
+    let onSave: (V3SavedRule) -> Void
+    let onDismiss: () -> Void
+
+    @State private var selectedPatternIndex: Int = 1 // Start from first generalization (skip exact match at index 0)
+    @State private var selectedRiskLevel: String = "medium"
+    @State private var isSaving: Bool = false
+
+    /// Generalized pattern options (skips the exact match at index 0)
+    private var generalizedOptions: [V3ScopeOptionItem] {
+        Array(scopeOptions.dropFirst())
+    }
+
+    /// Maps a risk level string to a semantic color.
+    private func riskColor(for level: String) -> Color {
+        switch level.lowercased() {
+        case "high":
+            return VColor.systemNegativeStrong
+        case "medium":
+            return VColor.systemMidStrong
+        case "low":
+            return VColor.systemPositiveStrong
+        default:
+            return VColor.contentSecondary
+        }
+    }
+
+    /// Contextual hint for the selected risk level
+    private var riskLevelHint: String {
+        switch selectedRiskLevel.lowercased() {
+        case "low":
+            return "Will auto-approve in most configurations"
+        case "medium":
+            return "May require approval depending on your settings"
+        case "high":
+            return "Will always require approval"
+        default:
+            return ""
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack {
+                Text("Create Trust Rule")
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+                Spacer(minLength: 0)
+                VButton(
+                    label: "Close",
+                    iconOnly: VIcon.x.rawValue,
+                    style: .ghost,
+                    tintColor: VColor.contentTertiary
+                ) {
+                    onDismiss()
+                }
+            }
+            .padding(EdgeInsets(top: VSpacing.lg, leading: VSpacing.lg, bottom: VSpacing.md, trailing: VSpacing.lg))
+
+            VStack(alignment: .leading, spacing: VSpacing.xl) {
+                applyToSection
+                treatAsSection
+                saveSection
+            }
+            .padding(EdgeInsets(top: 0, leading: VSpacing.lg, bottom: VSpacing.lg, trailing: VSpacing.lg))
+        }
+        .frame(width: 480)
+        .background(VColor.surfaceLift)
+        .onAppear {
+            selectedRiskLevel = riskLevel.isEmpty ? "medium" : riskLevel
+        }
+    }
+
+    // MARK: - Section 1: Apply to
+
+    @ViewBuilder
+    private var applyToSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Apply to")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .accessibilityAddTraits(.isHeader)
+
+            if generalizedOptions.count == 1 {
+                // Single option: show as simple label, no radio buttons
+                Text(generalizedOptions[0].label)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                    .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.sm, bottom: VSpacing.sm, trailing: VSpacing.sm))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(VColor.surfaceBase)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            } else {
+                // Multiple options: show radio list
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    ForEach(Array(generalizedOptions.enumerated()), id: \.element.id) { index, option in
+                        patternRow(option: option, index: index)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func patternRow(option: V3ScopeOptionItem, index: Int) -> some View {
+        Button {
+            selectedPatternIndex = index + 1 // Offset by 1 since we skip index 0
+        } label: {
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: selectedPatternIndex == index + 1 ? "circle.inset.filled" : "circle")
+                    .foregroundStyle(selectedPatternIndex == index + 1 ? VColor.primaryBase : VColor.contentTertiary)
+                    .font(.system(size: 14))
+                    .accessibilityHidden(true)
+
+                Text(option.label)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+            }
+            .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.sm, bottom: VSpacing.sm, trailing: VSpacing.sm))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(option.label)
+        .accessibilityAddTraits(selectedPatternIndex == index + 1 ? [.isSelected] : [])
+        .accessibilityValue(selectedPatternIndex == index + 1 ? "Selected" : "Not selected")
+    }
+
+    // MARK: - Section 2: Treat as
+
+    @ViewBuilder
+    private var treatAsSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Treat as")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .accessibilityAddTraits(.isHeader)
+
+            HStack(spacing: VSpacing.sm) {
+                riskLevelButton(label: "Low", value: "low", color: VColor.systemPositiveStrong)
+                riskLevelButton(label: "Medium", value: "medium", color: VColor.systemMidStrong)
+                riskLevelButton(label: "High", value: "high", color: VColor.systemNegativeStrong)
+            }
+
+            if !riskLevelHint.isEmpty {
+                Text(riskLevelHint)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func riskLevelButton(label: String, value: String, color: Color) -> some View {
+        Button {
+            selectedRiskLevel = value
+        } label: {
+            HStack(spacing: VSpacing.xs) {
+                Circle()
+                    .fill(color)
+                    .frame(width: 8, height: 8)
+                Text(label)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+            }
+            .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
+            .background(
+                selectedRiskLevel == value
+                    ? VColor.surfaceActive
+                    : Color.clear
+            )
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.sm)
+                    .strokeBorder(
+                        selectedRiskLevel == value ? color : VColor.borderBase,
+                        lineWidth: selectedRiskLevel == value ? 1.5 : 0.5
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(selectedRiskLevel == value ? [.isSelected] : [])
+        .accessibilityValue(selectedRiskLevel == value ? "Selected" : "Not selected")
+    }
+
+    // MARK: - Save Button
+
+    @ViewBuilder
+    private var saveSection: some View {
+        HStack {
+            Spacer(minLength: 0)
+            VButton(
+                label: "Save Rule",
+                style: .primary,
+                isDisabled: isSaving || scopeOptions.isEmpty
+            ) {
+                guard !isSaving, !scopeOptions.isEmpty else { return }
+                isSaving = true
+                let selectedOption = scopeOptions[selectedPatternIndex]
+                // Always use "everywhere" scope (directory scoping removed in v1)
+                let rule = V3SavedRule(
+                    toolName: toolName,
+                    pattern: selectedOption.pattern,
+                    riskLevel: selectedRiskLevel,
+                    scope: "everywhere"
+                )
+                onSave(rule)
+                onDismiss()
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/V3RuleEditorModal.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/V3RuleEditorModal.swift
@@ -23,11 +23,8 @@ struct V3SavedRule {
 struct V3RuleEditorModal: View {
     /// Raw tool identifier (e.g. "bash", "host_bash") used for trust rule persistence.
     let toolName: String
-    let inputSummary: String
     let riskLevel: String
-    let riskReason: String
     let scopeOptions: [V3ScopeOptionItem]
-    let workingDir: String
     let onSave: (V3SavedRule) -> Void
     let onDismiss: () -> Void
 
@@ -38,20 +35,6 @@ struct V3RuleEditorModal: View {
     /// Generalized pattern options (skips the exact match at index 0)
     private var generalizedOptions: [V3ScopeOptionItem] {
         Array(scopeOptions.dropFirst())
-    }
-
-    /// Maps a risk level string to a semantic color.
-    private func riskColor(for level: String) -> Color {
-        switch level.lowercased() {
-        case "high":
-            return VColor.systemNegativeStrong
-        case "medium":
-            return VColor.systemMidStrong
-        case "low":
-            return VColor.systemPositiveStrong
-        default:
-            return VColor.contentSecondary
-        }
     }
 
     /// Contextual hint for the selected risk level
@@ -98,6 +81,10 @@ struct V3RuleEditorModal: View {
         .background(VColor.surfaceLift)
         .onAppear {
             selectedRiskLevel = riskLevel.isEmpty ? "medium" : riskLevel
+            // If generalizedOptions is empty, default to index 0 (exact match)
+            if generalizedOptions.isEmpty {
+                selectedPatternIndex = 0
+            }
         }
     }
 
@@ -113,14 +100,16 @@ struct V3RuleEditorModal: View {
 
             if generalizedOptions.count == 1 {
                 // Single option: show as simple label, no radio buttons
-                Text(generalizedOptions[0].label)
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentDefault)
-                    .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.sm, bottom: VSpacing.sm, trailing: VSpacing.sm))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(VColor.surfaceBase)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-            } else {
+                HStack {
+                    Text(generalizedOptions[0].label)
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentDefault)
+                        .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.sm, bottom: VSpacing.sm, trailing: VSpacing.sm))
+                        .background(VColor.surfaceBase)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    Spacer(minLength: 0)
+                }
+            } else if !generalizedOptions.isEmpty {
                 // Multiple options: show radio list
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     ForEach(Array(generalizedOptions.enumerated()), id: \.element.id) { index, option in
@@ -137,17 +126,17 @@ struct V3RuleEditorModal: View {
             selectedPatternIndex = index + 1 // Offset by 1 since we skip index 0
         } label: {
             HStack(spacing: VSpacing.sm) {
-                Image(systemName: selectedPatternIndex == index + 1 ? "circle.inset.filled" : "circle")
+                VIconView(selectedPatternIndex == index + 1 ? .circleDot : .circle, size: 14)
                     .foregroundStyle(selectedPatternIndex == index + 1 ? VColor.primaryBase : VColor.contentTertiary)
-                    .font(.system(size: 14))
                     .accessibilityHidden(true)
 
                 Text(option.label)
                     .font(VFont.bodyMediumDefault)
                     .foregroundStyle(VColor.contentDefault)
+
+                Spacer(minLength: 0)
             }
             .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.sm, bottom: VSpacing.sm, trailing: VSpacing.sm))
-            .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(RoundedRectangle(cornerRadius: VRadius.sm))
         }
         .buttonStyle(.plain)
@@ -223,9 +212,9 @@ struct V3RuleEditorModal: View {
             VButton(
                 label: "Save Rule",
                 style: .primary,
-                isDisabled: isSaving || scopeOptions.isEmpty
+                isDisabled: isSaving || scopeOptions.isEmpty || selectedPatternIndex >= scopeOptions.count
             ) {
-                guard !isSaving, !scopeOptions.isEmpty else { return }
+                guard !isSaving, !scopeOptions.isEmpty, selectedPatternIndex < scopeOptions.count else { return }
                 isSaving = true
                 let selectedOption = scopeOptions[selectedPatternIndex]
                 // Always use "everywhere" scope (directory scoping removed in v1)

--- a/clients/shared/Features/Chat/V3PermissionPromptView.swift
+++ b/clients/shared/Features/Chat/V3PermissionPromptView.swift
@@ -12,7 +12,6 @@ public struct V3PermissionPromptView: View {
     public let onAllow: () -> Void
     public let onDeny: () -> Void
     public let onAlwaysAllow: (String, String, String, String) -> Void
-    public let onTemporaryAllow: ((String, String) -> Void)?
 
     @State private var showTechnicalDetails = false
     @State private var keyboardModel: ToolConfirmationKeyboardModel?
@@ -25,15 +24,13 @@ public struct V3PermissionPromptView: View {
         isKeyboardActive: Bool,
         onAllow: @escaping () -> Void,
         onDeny: @escaping () -> Void,
-        onAlwaysAllow: @escaping (String, String, String, String) -> Void,
-        onTemporaryAllow: ((String, String) -> Void)? = nil
+        onAlwaysAllow: @escaping (String, String, String, String) -> Void
     ) {
         self.confirmation = confirmation
         self.isKeyboardActive = isKeyboardActive
         self.onAllow = onAllow
         self.onDeny = onDeny
         self.onAlwaysAllow = onAlwaysAllow
-        self.onTemporaryAllow = onTemporaryAllow
     }
 
     private var v3TopLevelActions: [ToolConfirmationKeyboardModel.Action] {

--- a/clients/shared/Features/Chat/V3PermissionPromptView.swift
+++ b/clients/shared/Features/Chat/V3PermissionPromptView.swift
@@ -1,0 +1,310 @@
+import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
+
+/// Standalone v3 permission prompt view.
+/// Provides a simplified Allow/Deny interface with inline risk badge,
+/// risk reason text, and keyboard support.
+public struct V3PermissionPromptView: View {
+    public let confirmation: ToolConfirmationData
+    public let isKeyboardActive: Bool
+    public let onAllow: () -> Void
+    public let onDeny: () -> Void
+    public let onAlwaysAllow: (String, String, String, String) -> Void
+    public let onTemporaryAllow: ((String, String) -> Void)?
+
+    @State private var showTechnicalDetails = false
+    @State private var keyboardModel: ToolConfirmationKeyboardModel?
+    #if os(macOS)
+    @State private var keyMonitor: Any?
+    #endif
+
+    public init(
+        confirmation: ToolConfirmationData,
+        isKeyboardActive: Bool,
+        onAllow: @escaping () -> Void,
+        onDeny: @escaping () -> Void,
+        onAlwaysAllow: @escaping (String, String, String, String) -> Void,
+        onTemporaryAllow: ((String, String) -> Void)? = nil
+    ) {
+        self.confirmation = confirmation
+        self.isKeyboardActive = isKeyboardActive
+        self.onAllow = onAllow
+        self.onDeny = onDeny
+        self.onAlwaysAllow = onAlwaysAllow
+        self.onTemporaryAllow = onTemporaryAllow
+    }
+
+    private var v3TopLevelActions: [ToolConfirmationKeyboardModel.Action] {
+        [.allowOnce, .dontAllow]
+    }
+
+    /// The full input preview for the inline display (all key-value pairs).
+    private var inlinePreviewText: String? {
+        let preview = confirmation.fullInputPreview
+        return preview.isEmpty ? nil : preview
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            // 1. Prompt line with risk badge
+            v3ConfirmationDescription
+
+            // 2. Actions: Allow + Deny
+            HStack {
+                Spacer()
+                v3ConfirmationActions
+            }
+
+            // 3. Show details disclosure
+            VStack(alignment: .leading, spacing: 0) {
+                Button {
+                    withAnimation(VAnimation.fast) {
+                        showTechnicalDetails.toggle()
+                    }
+                } label: {
+                    HStack(alignment: .firstTextBaseline, spacing: VSpacing.xxs) {
+                        VIconView(.chevronRight, size: 9)
+                            .foregroundStyle(VColor.contentDefault)
+                            .rotationEffect(.degrees(showTechnicalDetails ? 90 : 0))
+                            .frame(width: 9, height: 9)
+                        Text(showTechnicalDetails ? "Hide details" : "Show details")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                    }
+                    .padding(.leading, -1)
+                }
+                .buttonStyle(.plain)
+
+                if showTechnicalDetails {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        if let preview = inlinePreviewText {
+                            inlinePreview(preview)
+                        }
+                    }
+                    .padding(.top, VSpacing.xs)
+                    .transition(.opacity)
+                }
+            }
+            .clipped()
+        }
+        .padding(VSpacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surfaceOverlay)
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.borderBase, lineWidth: 0.5)
+                )
+        )
+        .textSelection(.disabled)
+        .onAppear {
+            if isKeyboardActive {
+                #if os(macOS)
+                installKeyMonitor(actions: v3TopLevelActions)
+                #else
+                keyboardModel = ToolConfirmationKeyboardModel(actions: v3TopLevelActions)
+                #endif
+            }
+        }
+        .onDisappear {
+            #if os(macOS)
+            removeKeyMonitor()
+            #endif
+        }
+        .onChange(of: isKeyboardActive) {
+            if isKeyboardActive {
+                #if os(macOS)
+                installKeyMonitor(actions: v3TopLevelActions)
+                #else
+                keyboardModel = ToolConfirmationKeyboardModel(actions: v3TopLevelActions)
+                #endif
+            } else {
+                #if os(macOS)
+                removeKeyMonitor()
+                #endif
+                keyboardModel = nil
+            }
+        }
+    }
+
+    // MARK: - Inline Preview
+
+    @ViewBuilder
+    private func inlinePreview(_ preview: String) -> some View {
+        codePreviewBlock(preview, maxHeight: 220)
+    }
+
+    @ViewBuilder
+    private func codePreviewBlock(_ content: String, maxHeight: CGFloat) -> some View {
+        ScrollView {
+            Text(content)
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .textSelection(.enabled)
+        }
+        .adaptiveScrollFrame(for: content, maxHeight: maxHeight, lineThreshold: Int(maxHeight / 16))
+        .padding(VSpacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(VColor.surfaceOverlay)
+        )
+    }
+
+    // MARK: - v3 Prompt Components
+
+    /// v3 description: tool name with inline risk badge and optional risk reason.
+    @ViewBuilder
+    private var v3ConfirmationDescription: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            HStack(spacing: VSpacing.sm) {
+                Text(confirmation.humanDescription)
+                    .font(VFont.bodyMediumEmphasised)
+                    .foregroundStyle(VColor.contentDefault)
+                    .fixedSize(horizontal: false, vertical: true)
+                v3RiskBadge
+            }
+            if let reason = confirmation.riskReason, !reason.isEmpty {
+                Text(reason)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    /// Inline risk level badge for v3 prompts.
+    @ViewBuilder
+    private var v3RiskBadge: some View {
+        let level = confirmation.riskLevel
+        let label = level.isEmpty ? "Unknown" : level.prefix(1).uppercased() + level.dropFirst()
+        Text(label)
+            .font(VFont.labelDefault)
+            .foregroundStyle(v3RiskBadgeTextColor)
+            .padding(EdgeInsets(top: 2, leading: 6, bottom: 2, trailing: 6))
+            .background(v3RiskBadgeBackgroundColor)
+            .clipShape(Capsule())
+    }
+
+    private var v3RiskBadgeBackgroundColor: Color {
+        switch confirmation.riskLevel.lowercased() {
+        case "low": VColor.systemPositiveStrong
+        case "medium": VColor.systemMidStrong
+        case "high": VColor.systemNegativeStrong
+        default: VColor.contentSecondary
+        }
+    }
+
+    private var v3RiskBadgeTextColor: Color {
+        switch confirmation.riskLevel.lowercased() {
+        case "medium": VColor.auxBlack
+        default: VColor.auxWhite
+        }
+    }
+
+    /// v3 simplified actions: flat Allow + Deny buttons, no split button or duration.
+    private var v3ConfirmationActions: some View {
+        HStack(spacing: VSpacing.sm) {
+            VButton(label: "Allow", style: .primary, size: .compact) {
+                // In v3, "Allow" sends the selected allowlist pattern + scope
+                // through the always-allow path when patterns are available,
+                // otherwise falls back to a simple allow.
+                if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
+                    let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
+                    onAlwaysAllow(confirmation.requestId, option.pattern, scope, "allow")
+                } else {
+                    onAllow()
+                }
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .strokeBorder(VColor.primaryBase, lineWidth: keyboardModel?.selectedAction == .allowOnce ? 2 : 0)
+                    .allowsHitTesting(false)
+            )
+
+            VButton(label: "Deny", style: .danger, size: .compact) {
+                onDeny()
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .strokeBorder(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
+                    .allowsHitTesting(false)
+            )
+        }
+    }
+
+    // MARK: - Key Monitor (macOS)
+
+    #if os(macOS)
+    /// The modifier flags we consider "intentional". Caps Lock, NumericPad, and
+    /// Function are excluded because they can be set passively (e.g. Caps Lock
+    /// is on, or the key physically sits on the numpad / function row) and
+    /// should not prevent keyboard shortcuts from working.
+    private static let intentionalModifiers: NSEvent.ModifierFlags = [.shift, .control, .option, .command]
+
+    private func installKeyMonitor(actions: [ToolConfirmationKeyboardModel.Action]) {
+        removeKeyMonitor()
+        keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            // If an editable text view (e.g. the composer) is the first responder,
+            // let the event pass through so it can handle Enter/Tab/Escape normally.
+            // Non-editable text views (e.g. selectable command previews inside the
+            // confirmation bubble) don't need these keys, so we still intercept them.
+            if let firstResponder = NSApp.keyWindow?.firstResponder as? NSTextView,
+               firstResponder.isEditable {
+                return event
+            }
+            let mods = event.modifierFlags.intersection(Self.intentionalModifiers)
+            // Top-level button row navigation
+            switch event.keyCode {
+            case 48 where mods == .shift:
+                // Shift+Tab — move left
+                keyboardModel?.moveLeft()
+                return nil
+            case 48 where mods.isEmpty:
+                // Plain Tab — move right (modified Tab passes through)
+                keyboardModel?.moveRight()
+                return nil
+            case 36 where mods.isEmpty, 76 where mods.isEmpty:
+                // Plain Return / numpad Enter — activate (modified Enter passes through, e.g. Shift+Enter for newline)
+                if let action = keyboardModel?.selectedAction {
+                    activateAction(action)
+                }
+                return nil
+            case 53 where mods.isEmpty:
+                // Plain Escape — deny (modified Escape passes through)
+                activateAction(.dontAllow)
+                return nil
+            default:
+                return event
+            }
+        }
+    }
+
+    private func removeKeyMonitor() {
+        if let monitor = keyMonitor {
+            NSEvent.removeMonitor(monitor)
+            keyMonitor = nil
+        }
+    }
+    #endif
+
+    /// Trigger the callback for a given top-level action.
+    private func activateAction(_ action: ToolConfirmationKeyboardModel.Action) {
+        switch action {
+        case .allowOnce:
+            // v3: route through the allowlist pattern path if available
+            if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
+                let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
+                onAlwaysAllow(confirmation.requestId, option.pattern, scope, "allow")
+            } else {
+                onAllow()
+            }
+        case .dontAllow:
+            onDeny()
+        default:
+            break
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the v3 permission UI into standalone views, completely separate from the v1/v2 code paths.

## Changes

### New Files

**`clients/shared/Features/Chat/V3PermissionPromptView.swift`**
- Standalone v3 permission prompt view
- Simplified Allow/Deny interface (no split button, no duration options)
- Inline risk badge (colored capsule: Low/Medium/High/Unknown)
- Risk reason text below the prompt
- Collapsible "Show details" disclosure for raw command preview
- Keyboard support (Tab/Return/Escape navigation)

**`clients/macos/vellum-assistant/Features/Chat/V3RuleEditorModal.swift`**
- Redesigned rule editor modal with minimal, focused layout
- Two-section design:
  - **"Apply to"**: Radio list of generalized pattern options (skips exact match, shows only human-friendly labels)
  - **"Treat as"**: Risk level picker (Low/Medium/High) with contextual hints
- Removed: Context section (tool name, command, risk display already visible in prompt)
- Removed: Scope/directory section (simplified for v1)

## Not Yet Wired

These views are **not yet integrated** into the existing code paths. PR 2 will update `ToolConfirmationBubble` and `AssistantProgressView` to delegate to these new views when the `permission-controls-v3` flag is enabled.

## Verification

- ✅ Compiles successfully with `swift build`
- ✅ No errors or warnings related to new files
- ✅ Design tokens (VFont, VColor, VSpacing, VRadius) used correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
