### PR TITLE
feat(home-feed): replace dual selectedItemId state vars with unified HomeDetailPanelKind dispatcher [JARVIS-579]

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanelKind.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanelKind.swift
@@ -1,0 +1,33 @@
+import VellumAssistantShared
+
+/// Discriminator that drives which detail panel the Home page renders in its
+/// trailing split pane. Each case carries the originating `FeedItem` so the
+/// panel can read item fields directly — no secondary lookup in `feedStore`
+/// required.
+///
+/// `resolve(for:)` centralizes the dispatch rules that were previously
+/// scattered across `HomePageView.openItem(_:)` and
+/// `PanelCoordinator.homePanelView(…)`, so every call site agrees on which
+/// items produce panels and which fall through to the conversation flow.
+enum HomeDetailPanelKind: Equatable {
+    case scheduled(FeedItem)
+    case nudge(FeedItem)
+
+    /// Maps a `FeedItem` to its detail-panel kind, or returns `nil` when the
+    /// item should keep the existing conversation-open flow.
+    ///
+    /// Legacy dispatch rules (will be replaced by `item.detailPanel` in PR 4):
+    ///   - `.thread` + `.calendar` source → `.scheduled`
+    ///   - `.nudge` (any source)          → `.nudge`
+    ///   - everything else                → `nil`
+    static func resolve(for item: FeedItem) -> HomeDetailPanelKind? {
+        // TODO(PR4): read item.detailPanel here
+        if item.type == .thread && item.source == .calendar {
+            return .scheduled(item)
+        }
+        if item.type == .nudge {
+            return .nudge(item)
+        }
+        return nil
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -42,20 +42,14 @@ struct HomePageView<DetailPanel: View>: View {
     /// Fired when the user taps one of the suggestion pills. The parent
     /// opens a fresh conversation seeded with the suggestion label.
     let onSuggestionSelected: (HomeSuggestion) -> Void
-    /// Fired when the user taps a `.thread` (scheduled) feed item — the
-    /// parent presents the scheduled detail panel instead of opening a
-    /// conversation. All other item types keep the conversation flow.
+    /// Fired when the user taps a feed item that resolves to a detail
+    /// panel via ``HomeDetailPanelKind.resolve(for:)``. The parent
+    /// presents the appropriate panel instead of opening a conversation.
     /// Declared as `var` with a no-op default so the synthesized memberwise
     /// initializer still accepts this argument (Swift bakes `let` defaults
     /// in and omits them from the memberwise init, which breaks the
     /// convenience-init forwarding path and any direct memberwise callers).
-    var onScheduledItemSelected: (FeedItem) -> Void = { _ in }
-    /// Fired when the user taps a `.nudge` feed item — the parent
-    /// presents the nudge detail panel (N cards with optional actions)
-    /// instead of opening a conversation via triggerAction. Same var-
-    /// with-default pattern as `onScheduledItemSelected` so the
-    /// memberwise init stays usable from tests and non-nudge callers.
-    var onNudgeSelected: (FeedItem) -> Void = { _ in }
+    var onDetailPanelSelected: (FeedItem) -> Void = { _ in }
     /// Drives the two-pane split. When false, the home content renders in
     /// its original single-column layout and the `detailPanel` slot is
     /// ignored.
@@ -348,9 +342,9 @@ struct HomePageView<DetailPanel: View>: View {
 
     // MARK: - Actions
 
-    /// Opens the feed item. Calendar-sourced `.thread` items are
-    /// scheduled jobs and route to the detail panel via
-    /// `onScheduledItemSelected`; every other item (including other
+    /// Opens the feed item. Items that resolve to a detail panel via
+    /// ``HomeDetailPanelKind.resolve(for:)`` route to
+    /// `onDetailPanelSelected`; every other item (including non-calendar
     /// `.thread` items such as rollup-producer general-purpose threads)
     /// keeps the existing "trigger the `open` action and navigate into
     /// the resulting conversation" flow. The daemon interprets any
@@ -358,19 +352,11 @@ struct HomePageView<DetailPanel: View>: View {
     /// conversation with the first available action's prompt (or the
     /// item summary if there are no actions).
     ///
-    /// Gating on `source == .calendar` (Codex P1 on PR #27475): `.thread`
-    /// is also used by non-scheduled rollups, so type alone isn't enough
-    /// to identify a scheduled job.
-    ///
     /// Exposed as `internal` (not `private`) so routing tests can drive it
     /// directly without needing to render the full view tree.
     func openItem(_ item: FeedItem) {
-        if item.type == .thread && item.source == .calendar {
-            onScheduledItemSelected(item)
-            return
-        }
-        if item.type == .nudge {
-            onNudgeSelected(item)
+        if HomeDetailPanelKind.resolve(for: item) != nil {
+            onDetailPanelSelected(item)
             return
         }
         if let conversationId = item.conversationId {
@@ -452,8 +438,7 @@ extension HomePageView where DetailPanel == EmptyView {
         onStartNewChat: @escaping () -> Void,
         onDismissSuggestions: @escaping () -> Void,
         onSuggestionSelected: @escaping (HomeSuggestion) -> Void,
-        onScheduledItemSelected: @escaping (FeedItem) -> Void = { _ in },
-        onNudgeSelected: @escaping (FeedItem) -> Void = { _ in }
+        onDetailPanelSelected: @escaping (FeedItem) -> Void = { _ in }
     ) {
         self.init(
             store: store,
@@ -463,8 +448,7 @@ extension HomePageView where DetailPanel == EmptyView {
             onStartNewChat: onStartNewChat,
             onDismissSuggestions: onDismissSuggestions,
             onSuggestionSelected: onSuggestionSelected,
-            onScheduledItemSelected: onScheduledItemSelected,
-            onNudgeSelected: onNudgeSelected,
+            onDetailPanelSelected: onDetailPanelSelected,
             isDetailPanelVisible: false,
             detailPanel: { EmptyView() }
         )

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -113,17 +113,12 @@ struct MainWindowView: View {
     /// lands on Home, without having to refresh.
     @State var meetStatusViewModel: MeetStatusViewModel
     /// When non-nil, the Home panel splits into a two-pane layout and
-    /// renders ``HomeScheduledDetailPanel`` on the trailing edge for the
-    /// tapped scheduled (`.thread`) feed item. Owned here (rather than
+    /// renders the appropriate detail panel on the trailing edge for the
+    /// tapped feed item. Driven by ``HomeDetailPanelKind.resolve(for:)``
+    /// so all dispatch rules live in one place. Owned here (rather than
     /// inside ``HomePageView``) so the selection survives any @ViewBuilder
     /// rebuild of the Home panel wrapper.
-    @State var selectedScheduledItemId: String? = nil
-    /// Parallel to ``selectedScheduledItemId``: when non-nil, the Home
-    /// panel renders ``HomeNudgeDetailPanel`` for the tapped `.nudge`
-    /// feed item, surfacing the nudge's associated action cards.
-    /// At most one of `selectedScheduledItemId` / `selectedNudgeItemId`
-    /// is non-nil at a time — opening one clears the other.
-    @State var selectedNudgeItemId: String? = nil
+    @State var activeHomeDetailPanel: HomeDetailPanelKind? = nil
     init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, assistantFeatureFlagStore: AssistantFeatureFlagStore, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil, initialAssistantName: String? = nil) {
         self.conversationManager = conversationManager
         self.listStore = conversationManager.listStore

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -161,11 +161,11 @@ extension MainWindowView {
         // first scroll viewport. ``HomePageView`` paints its own full
         // background internally, so no outer chrome is needed here.
         //
-        // Split layout: when a scheduled (`.thread`) feed item is tapped
-        // we stash its id in ``selectedScheduledItemId`` and flip the
-        // two-pane layout on. The trailing pane renders
-        // ``HomeScheduledDetailPanel`` with placeholder metadata — real
-        // schedule fields are a daemon follow-up.
+        // Split layout: when a feed item resolves to a detail panel via
+        // ``HomeDetailPanelKind.resolve(for:)``, we stash the resolved
+        // kind in ``activeHomeDetailPanel`` and flip the two-pane layout
+        // on. The trailing pane renders the appropriate detail panel —
+        // real schedule/nudge fields are a daemon follow-up.
         HomePageView(
             store: homeStore,
             feedStore: feedStore,
@@ -183,15 +183,12 @@ extension MainWindowView {
                     windowState.showToast(message: "Couldn't open the conversation.", style: .error)
                     return
                 }
-                // Codex P2 (#27467) + Devin (#27475): clear BOTH detail-
-                // panel selections before navigating away so re-entering
-                // Home doesn't show a stale split layout. Belt-and-
-                // suspenders with .onDisappear below in case the Home
-                // view stays mounted across this navigation path. Both
-                // ids are cleared (not just scheduled) for consistency
-                // with the other navigation exit paths.
-                selectedScheduledItemId = nil
-                selectedNudgeItemId = nil
+                // Codex P2 (#27467) + Devin (#27475): clear the detail
+                // panel before navigating away so re-entering Home
+                // doesn't show a stale split layout. Belt-and-suspenders
+                // with .onDisappear below in case the Home view stays
+                // mounted across this navigation path.
+                activeHomeDetailPanel = nil
                 onDismiss()
                 windowState.selection = .conversation(uuid)
             },
@@ -203,11 +200,9 @@ extension MainWindowView {
                 // ``windowState.selection`` internally, and ``onDismiss``
                 // clears it, so running them in this order keeps the
                 // freshly-created conversation as the final selection.
-                // Clear detail-panel selections inline for consistency
-                // with the other Home exit paths (Devin feedback on
-                // PR #27475).
-                selectedScheduledItemId = nil
-                selectedNudgeItemId = nil
+                // Clear detail panel inline for consistency with the
+                // other Home exit paths (Devin feedback on PR #27475).
+                activeHomeDetailPanel = nil
                 onDismiss()
                 startNewConversation()
             },
@@ -221,30 +216,23 @@ extension MainWindowView {
                 // the short pill label — the label is ~3 words, the
                 // prompt is the actual seed message the daemon authored).
                 // `forceNew: true` is critical — we always want the Home
-                // suggestion bar to create a fresh thread. Clear detail-
-                // panel selections inline for consistency with the other
-                // Home exit paths (Devin feedback on PR #27475).
-                selectedScheduledItemId = nil
-                selectedNudgeItemId = nil
+                // suggestion bar to create a fresh thread. Clear detail
+                // panel inline for consistency with the other Home exit
+                // paths (Devin feedback on PR #27475).
+                activeHomeDetailPanel = nil
                 conversationManager.openConversation(message: suggestion.prompt, forceNew: true)
                 onDismiss()
                 if let id = conversationManager.activeConversationId {
                     windowState.selection = .conversation(id)
                 }
             },
-            onScheduledItemSelected: { item in
-                // Opening one detail panel closes the other — at most
-                // one panel at a time.
-                selectedNudgeItemId = nil
-                selectedScheduledItemId = item.id
+            onDetailPanelSelected: { item in
+                activeHomeDetailPanel = HomeDetailPanelKind.resolve(for: item)
             },
-            onNudgeSelected: { item in
-                selectedScheduledItemId = nil
-                selectedNudgeItemId = item.id
-            },
-            isDetailPanelVisible: selectedScheduledItemId != nil || selectedNudgeItemId != nil,
+            isDetailPanelVisible: activeHomeDetailPanel != nil,
             detailPanel: {
-                if let selectedId = selectedScheduledItemId {
+                switch activeHomeDetailPanel {
+                case .scheduled(let item):
                     let details = HomeScheduledDetails.placeholder
                     // Surface the tapped item's title so distinct scheduled
                     // rows render distinct panel headers while the rest of
@@ -254,23 +242,21 @@ extension MainWindowView {
                     // metadata when the daemon surfaces scheduled-item
                     // fields on FeedItem (see .private/plans/home-feed-groups.md
                     // follow-up).
-                    let selectedItem = feedStore.items.first(where: { $0.id == selectedId })
                     HomeScheduledDetailPanel(
-                        title: selectedItem?.title ?? "Scheduled Thing",
+                        title: item.title,
                         description: details.description,
                         rows: details.displayRows().map { row in
                             HomeScheduledDetailPanel.DetailRow(key: row.key, value: row.value)
                         },
                         primaryActionLabel: "Action",
                         secondaryActionLabel: "Action",
-                        onClose: { selectedScheduledItemId = nil },
-                        onPrimaryAction: { selectedScheduledItemId = nil },
-                        onSecondaryAction: { selectedScheduledItemId = nil }
+                        onClose: { activeHomeDetailPanel = nil },
+                        onPrimaryAction: { activeHomeDetailPanel = nil },
+                        onSecondaryAction: { activeHomeDetailPanel = nil }
                     )
-                } else if let selectedId = selectedNudgeItemId {
-                    let selectedItem = feedStore.items.first(where: { $0.id == selectedId })
+                case .nudge(let item):
                     HomeNudgeDetailPanel(
-                        title: selectedItem?.title ?? "Heartbeat",
+                        title: item.title,
                         icon: .heart,
                         iconForeground: VColor.feedNudgeStrong,
                         iconBackground: VColor.feedNudgeWeak,
@@ -278,11 +264,13 @@ extension MainWindowView {
                         cards: HomeNudgeDetailPanelPlaceholders.sampleCards,
                         primaryActionLabel: "Resolve All",
                         secondaryActionLabel: "Clear All",
-                        onClose: { selectedNudgeItemId = nil },
-                        onPrimaryAction: { selectedNudgeItemId = nil },
-                        onSecondaryAction: { selectedNudgeItemId = nil },
+                        onClose: { activeHomeDetailPanel = nil },
+                        onPrimaryAction: { activeHomeDetailPanel = nil },
+                        onSecondaryAction: { activeHomeDetailPanel = nil },
                         onCardAction: { _, _ in }
                     )
+                case nil:
+                    EmptyView()
                 }
             }
         )
@@ -292,12 +280,11 @@ extension MainWindowView {
         }
         .onDisappear {
             homeStore.isHomeTabVisible = false
-            // Codex P2 feedback (#27467): clear detail-panel selections so
+            // Codex P2 feedback (#27467): clear the detail panel so
             // re-entering Home doesn't show a stale split layout when the
             // user leaves Home through routes other than the detail panel's
             // own close/action buttons (sidebar switch, conversation open, etc.).
-            selectedScheduledItemId = nil
-            selectedNudgeItemId = nil
+            activeHomeDetailPanel = nil
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))

--- a/clients/macos/vellum-assistantTests/Features/Home/HomeScheduledRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Home/HomeScheduledRoutingTests.swift
@@ -4,8 +4,8 @@ import XCTest
 @testable import VellumAssistantShared
 
 /// Routing tests for ``HomePageView.openItem(_:)`` — verify that tapping a
-/// `.thread` (scheduled) feed item fires `onScheduledItemSelected` and
-/// skips the triggerAction flow, while non-`.thread` types leave the
+/// feed item that resolves to a detail panel fires `onDetailPanelSelected`
+/// and skips the triggerAction flow, while non-panel types leave the
 /// callback silent and fall through to the existing conversation flow.
 ///
 /// ``openItem`` is exposed as `internal` (not `private`) specifically so
@@ -54,8 +54,7 @@ final class HomeScheduledRoutingTests: XCTestCase {
     private func makeView(
         homeStore: HomeStore,
         feedStore: HomeFeedStore,
-        onScheduledItemSelected: @escaping (FeedItem) -> Void = { _ in },
-        onNudgeSelected: @escaping (FeedItem) -> Void = { _ in },
+        onDetailPanelSelected: @escaping (FeedItem) -> Void = { _ in },
         onFeedConversationOpened: @escaping (String) -> Void = { _ in }
     ) -> HomePageView<EmptyView> {
         let (meetStream, _) = AsyncStream<ServerMessage>.makeStream()
@@ -71,21 +70,20 @@ final class HomeScheduledRoutingTests: XCTestCase {
             onStartNewChat: {},
             onDismissSuggestions: {},
             onSuggestionSelected: { _ in },
-            onScheduledItemSelected: onScheduledItemSelected,
-            onNudgeSelected: onNudgeSelected
+            onDetailPanelSelected: onDetailPanelSelected
         )
     }
 
     // MARK: - Tests
 
-    func test_openItem_calendarSourcedThread_firesScheduledCallback() async {
+    func test_openItem_calendarSourcedThread_firesDetailPanelCallback() async {
         let (homeStore, feedStore, feedClient) = makeStores()
         var captured: [FeedItem] = []
         var conversationOpens = 0
         let view = makeView(
             homeStore: homeStore,
             feedStore: feedStore,
-            onScheduledItemSelected: { item in captured.append(item) },
+            onDetailPanelSelected: { item in captured.append(item) },
             onFeedConversationOpened: { _ in conversationOpens += 1 }
         )
 
@@ -93,7 +91,7 @@ final class HomeScheduledRoutingTests: XCTestCase {
         view.openItem(item)
 
         XCTAssertEqual(captured.map { $0.id }, ["sched-1"],
-                       "calendar-sourced thread should fire the scheduled callback exactly once")
+                       "calendar-sourced thread should fire the detail panel callback exactly once")
         XCTAssertEqual(feedClient.triggerCallCount, 0,
                        "calendar-sourced thread must not round-trip through triggerAction")
         XCTAssertEqual(conversationOpens, 0,
@@ -103,7 +101,7 @@ final class HomeScheduledRoutingTests: XCTestCase {
     /// Gates the scheduled flow on `source == .calendar` (Codex P1 on
     /// PR #27475): `.thread` is also used by rollup-producer for general
     /// multi-action threads that must keep the conversation-open flow.
-    func test_openItem_nonCalendarThread_skipsScheduledCallback() async {
+    func test_openItem_nonCalendarThread_skipsDetailPanelCallback() async {
         // As with the non-thread test below we only assert the spy — we
         // don't wait on the detached triggerAction Task. HomeFeedStoreTests
         // covers that path.
@@ -114,84 +112,79 @@ final class HomeScheduledRoutingTests: XCTestCase {
             let view = makeView(
                 homeStore: homeStore,
                 feedStore: feedStore,
-                onScheduledItemSelected: { item in captured.append(item) }
+                onDetailPanelSelected: { item in captured.append(item) }
             )
 
             let label = source.map { "\($0)" } ?? "nil"
             view.openItem(makeItem(id: "rollup-\(label)", type: .thread, source: source))
 
             XCTAssertTrue(captured.isEmpty,
-                          "\(label)-sourced thread must not fire the scheduled callback")
+                          "\(label)-sourced thread must not fire the detail panel callback")
         }
     }
 
-    func test_openItem_nonThreadType_skipsScheduledCallback() async {
+    func test_openItem_nonPanelTypes_skipDetailPanelCallback() async {
         // We only assert the callback SPY — we deliberately avoid asserting
         // anything about the async `feedStore.triggerAction` path here:
         // wiring up deterministic waits for the detached Task would
         // duplicate HomeFeedStoreTests coverage without adding signal for
         // this routing check. See note on the test class for rationale.
         let (homeStore, feedStore, _) = makeStores()
-        for nonThreadType in [FeedItemType.nudge, .digest, .action] {
+        for nonPanelType in [FeedItemType.digest, .action] {
             var captured: [FeedItem] = []
             let view = makeView(
                 homeStore: homeStore,
                 feedStore: feedStore,
-                onScheduledItemSelected: { item in captured.append(item) }
+                onDetailPanelSelected: { item in captured.append(item) }
             )
 
-            // Use calendar source here to prove that type-gating runs
-            // independently of the source gate — even a calendar-sourced
-            // non-thread must not route through the scheduled callback.
-            view.openItem(makeItem(id: "n-\(nonThreadType)", type: nonThreadType, source: .calendar))
+            // Use nil source so HomeDetailPanelKind.resolve returns nil
+            // for these types (digest and action never resolve to a panel).
+            view.openItem(makeItem(id: "n-\(nonPanelType)", type: nonPanelType))
 
             XCTAssertTrue(captured.isEmpty,
-                          "\(nonThreadType) taps must not fire the scheduled callback")
+                          "\(nonPanelType) taps must not fire the detail panel callback")
         }
     }
 
     // MARK: - Nudge routing
 
-    func test_openItem_nudgeType_firesNudgeCallback() async {
+    func test_openItem_nudgeType_firesDetailPanelCallback() async {
         let (homeStore, feedStore, feedClient) = makeStores()
-        var capturedNudges: [FeedItem] = []
-        var capturedScheduled: [FeedItem] = []
+        var captured: [FeedItem] = []
         var conversationOpens = 0
         let view = makeView(
             homeStore: homeStore,
             feedStore: feedStore,
-            onScheduledItemSelected: { capturedScheduled.append($0) },
-            onNudgeSelected: { capturedNudges.append($0) },
+            onDetailPanelSelected: { captured.append($0) },
             onFeedConversationOpened: { _ in conversationOpens += 1 }
         )
 
         let item = makeItem(id: "nudge-1", type: .nudge)
         view.openItem(item)
 
-        XCTAssertEqual(capturedNudges.map { $0.id }, ["nudge-1"],
-                       "nudge callback should fire exactly once with the tapped item")
-        XCTAssertTrue(capturedScheduled.isEmpty,
-                      "nudge taps must not fire the scheduled callback")
+        XCTAssertEqual(captured.map { $0.id }, ["nudge-1"],
+                       "detail panel callback should fire exactly once with the tapped nudge item")
         XCTAssertEqual(feedClient.triggerCallCount, 0,
                        "nudge taps must not round-trip through triggerAction")
         XCTAssertEqual(conversationOpens, 0,
                        "nudge taps must not attempt to open a conversation")
     }
 
-    func test_openItem_nonNudgeType_skipsNudgeCallback() async {
+    func test_openItem_nonPanelThread_skipsDetailPanelCallback() async {
+        // Non-calendar threads should NOT fire the detail panel callback
+        // — they fall through to the conversation flow.
         let (homeStore, feedStore, _) = makeStores()
-        for nonNudgeType in [FeedItemType.digest, .action, .thread] {
-            var captured: [FeedItem] = []
-            let view = makeView(
-                homeStore: homeStore,
-                feedStore: feedStore,
-                onNudgeSelected: { captured.append($0) }
-            )
+        var captured: [FeedItem] = []
+        let view = makeView(
+            homeStore: homeStore,
+            feedStore: feedStore,
+            onDetailPanelSelected: { captured.append($0) }
+        )
 
-            view.openItem(makeItem(id: "x-\(nonNudgeType)", type: nonNudgeType))
+        view.openItem(makeItem(id: "x-thread", type: .thread))
 
-            XCTAssertTrue(captured.isEmpty,
-                          "\(nonNudgeType) taps must not fire the nudge callback")
-        }
+        XCTAssertTrue(captured.isEmpty,
+                      "non-calendar thread taps must not fire the detail panel callback")
     }
 }


### PR DESCRIPTION
## Summary
- Created HomeDetailPanelKind enum with .scheduled and .nudge cases + resolve(for:) static method
- Replaced two @State vars (selectedScheduledItemId, selectedNudgeItemId) with one activeHomeDetailPanel
- Replaced two callbacks (onScheduledItemSelected, onNudgeSelected) with one onDetailPanelSelected
- PanelCoordinator detailPanel closure uses switch instead of if-let chains

Part of plan: home-feed-detail-panel-dispatch.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
