### PR TITLE
feat(onboarding): enable pre-chat onboarding flow by default [LUM-1131]

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -327,7 +327,7 @@
       "key": "onboarding-pre-chat",
       "label": "Pre-Chat Onboarding Flow",
       "description": "Gates the 3-screen pre-chat onboarding flow (tools, tasks/tone, name exchange) shown before the first conversation",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "home-tab",


### PR DESCRIPTION
## Summary
- Flips the `onboarding-pre-chat` feature flag `defaultEnabled` from `false` to `true`
- The 3-screen pre-chat onboarding flow (tools, tasks/tone, name exchange) will now be shown to all macOS users by default

## Test plan
- [x] Verified all 27 first-greeting tests pass (canned message content variations)
- [ ] QA: fresh install shows pre-chat onboarding screens before first conversation
- [ ] QA: existing users with prior conversations are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
