### PR TITLE
feat(home-feed): add HomeDetailPanelKind cases for all panel variants and wire render arms [JARVIS-579]

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeAuthDetailCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeAuthDetailCard.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Stub body component for payment-authorization detail panels.
+/// Will be replaced with a rich approval UI when the daemon surfaces
+/// structured payment-auth fields on `FeedItem`.
+struct HomeAuthDetailCard: View {
+    let item: FeedItem
+
+    var body: some View {
+        Text(item.title)
+            .font(VFont.bodyMediumDefault)
+            .foregroundStyle(VColor.contentSecondary)
+            .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanelKind.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanelKind.swift
@@ -12,6 +12,12 @@ import VellumAssistantShared
 enum HomeDetailPanelKind: Equatable {
     case scheduled(FeedItem)
     case nudge(FeedItem)
+    case emailDraft(FeedItem)
+    case documentPreview(FeedItem)
+    case permissionChat(FeedItem)
+    case paymentAuth(FeedItem)
+    case toolPermission(FeedItem)
+    case updatesList(FeedItem)
 
     /// Maps a `FeedItem` to its detail-panel kind, or returns `nil` when the
     /// item should keep the existing conversation-open flow.

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionDetailCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionDetailCard.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Stub body component for tool-permission detail panels.
+/// Will be replaced with a rich permission approval UI when the daemon
+/// surfaces structured permission fields on `FeedItem`.
+struct HomePermissionDetailCard: View {
+    let item: FeedItem
+
+    var body: some View {
+        Text(item.title)
+            .font(VFont.bodyMediumDefault)
+            .foregroundStyle(VColor.contentSecondary)
+            .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeUpdatesListDetailCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeUpdatesListDetailCard.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Stub body component for updates-list detail panels.
+/// Will be replaced with a rich list UI when the daemon surfaces
+/// structured update items on `FeedItem`.
+struct HomeUpdatesListDetailCard: View {
+    let item: FeedItem
+
+    var body: some View {
+        Text(item.title)
+            .font(VFont.bodyMediumDefault)
+            .foregroundStyle(VColor.contentSecondary)
+            .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -269,6 +269,63 @@ extension MainWindowView {
                         onSecondaryAction: { activeHomeDetailPanel = nil },
                         onCardAction: { _, _ in }
                     )
+                case .emailDraft(let item):
+                    HomeDetailPanel(
+                        icon: nil,
+                        title: item.title,
+                        onDismiss: { activeHomeDetailPanel = nil }
+                    ) {
+                        Text(item.summary)
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                            .padding(VSpacing.lg)
+                    }
+                case .documentPreview(let item):
+                    HomeDetailPanel(
+                        icon: nil,
+                        title: item.title,
+                        onDismiss: { activeHomeDetailPanel = nil }
+                    ) {
+                        Text(item.summary)
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                            .padding(VSpacing.lg)
+                    }
+                case .permissionChat(let item):
+                    HomeDetailPanel(
+                        icon: nil,
+                        title: item.title,
+                        onDismiss: { activeHomeDetailPanel = nil }
+                    ) {
+                        Text(item.summary)
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                            .padding(VSpacing.lg)
+                    }
+                case .paymentAuth(let item):
+                    HomeDetailPanel(
+                        icon: nil,
+                        title: item.title,
+                        onDismiss: { activeHomeDetailPanel = nil }
+                    ) {
+                        HomeAuthDetailCard(item: item)
+                    }
+                case .toolPermission(let item):
+                    HomeDetailPanel(
+                        icon: nil,
+                        title: item.title,
+                        onDismiss: { activeHomeDetailPanel = nil }
+                    ) {
+                        HomePermissionDetailCard(item: item)
+                    }
+                case .updatesList(let item):
+                    HomeDetailPanel(
+                        icon: nil,
+                        title: item.title,
+                        onDismiss: { activeHomeDetailPanel = nil }
+                    ) {
+                        HomeUpdatesListDetailCard(item: item)
+                    }
                 case nil:
                     EmptyView()
                 }


### PR DESCRIPTION
## Summary
- Added 6 new HomeDetailPanelKind cases: emailDraft, documentPreview, permissionChat, paymentAuth, toolPermission, updatesList
- Created 3 stub body components: HomeAuthDetailCard, HomePermissionDetailCard, HomeUpdatesListDetailCard (renamed with `Detail` suffix to avoid name collision with existing RecapCards components)
- Wired all 8 cases in PanelCoordinator's switch with placeholder content for new cases

Part of plan: home-feed-detail-panel-dispatch.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
