### PR TITLE
fix: correct Gemini embedding test expectation for non-managed requests

### DIFF
--- a/assistant/src/memory/embedding-gemini.test.ts
+++ b/assistant/src/memory/embedding-gemini.test.ts
@@ -181,7 +181,7 @@ describe("GeminiEmbeddingBackend", () => {
       const body = JSON.parse(init.body as string);
       expect(body.taskType).toBeUndefined();
       expect(body.outputDimensionality).toBeUndefined();
-      expect(Object.keys(body)).toEqual(["model", "content"]);
+      expect(Object.keys(body)).toEqual(["content"]);
     });
   });
 


### PR DESCRIPTION
## Summary
- The `embedding-gemini.test.ts` test for "omits both when options is undefined" expected `["model", "content"]` in the request body, but the implementation only includes `model` when `managedBaseUrl` is set. Since the test creates the backend without `managedBaseUrl`, the body should only contain `["content"]`.
- Updated the assertion to match the actual implementation behavior.

## Original prompt
help me fix CI on https://github.com/vellum-ai/vellum-assistant/actions/runs/24807854356
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
