### PR TITLE
chore(home-feed): remove legacy type+source dispatch heuristics [JARVIS-579]

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanelKind.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanelKind.swift
@@ -19,31 +19,19 @@ enum HomeDetailPanelKind: Equatable {
     case toolPermission(FeedItem)
     case updatesList(FeedItem)
 
-    /// Maps a `FeedItem` to its detail-panel kind, or returns `nil` when the
-    /// item should keep the existing conversation-open flow.
-    ///
-    /// Checks `item.detailPanel` first (server-driven dispatch). Falls back
-    /// to legacy heuristics when the field is absent:
-    ///   - `.thread` + `.calendar` source → `.scheduled`
-    ///   - `.nudge` (any source)          → `.nudge`
-    ///   - everything else                → `nil`
+    /// Resolves from the wire-contract `detailPanel` field. Returns `nil`
+    /// when absent.
     static func resolve(for item: FeedItem) -> HomeDetailPanelKind? {
-        if let panel = item.detailPanel {
-            switch panel.kind {
-            case .emailDraft: return .emailDraft(item)
-            case .documentPreview: return .documentPreview(item)
-            case .permissionChat: return .permissionChat(item)
-            case .paymentAuth: return .paymentAuth(item)
-            case .toolPermission: return .toolPermission(item)
-            case .updatesList: return .updatesList(item)
-            }
+        guard let panel = item.detailPanel else {
+            return nil
         }
-        if item.type == .thread && item.source == .calendar {
-            return .scheduled(item)
+        switch panel.kind {
+        case .emailDraft: return .emailDraft(item)
+        case .documentPreview: return .documentPreview(item)
+        case .permissionChat: return .permissionChat(item)
+        case .paymentAuth: return .paymentAuth(item)
+        case .toolPermission: return .toolPermission(item)
+        case .updatesList: return .updatesList(item)
         }
-        if item.type == .nudge {
-            return .nudge(item)
-        }
-        return nil
     }
 }


### PR DESCRIPTION
## Summary
- Removed legacy .thread+.calendar and .nudge heuristics from HomeDetailPanelKind.resolve(for:)
- All dispatch now flows through the wire-contract detailPanel field
- Retained placeholder fixtures where still referenced by PanelCoordinator

Part of plan: home-feed-detail-panel-dispatch.md (PR 5 of 5)

<!-- skip-ci -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
