### PR TITLE
feat(permissions): wire v3 views into existing code

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -897,29 +897,50 @@ private struct StepDetailRow: View {
             }
         }
         .sheet(item: $ruleEditorToolCall) { tc in
-            RuleEditorModal(
-                toolName: tc.toolName,
-                displayName: tc.friendlyName,
-                command: tc.inputSummary,
-                currentRiskLevel: tc.riskLevel ?? "medium",
-                riskReason: tc.riskReason ?? "",
-                scopeOptions: Self.scopeOptions(from: tc),
-                workingDir: Self.workingDir(from: tc),
-                isContainerized: tc.isContainerized,
-                onSave: { rule in
-                    Task {
-                        try? await Self.trustRuleClient.addTrustRule(
-                            toolName: rule.toolName,
-                            pattern: rule.pattern,
-                            scope: rule.scope,
-                            decision: "allow",
-                            executionTarget: nil,
-                            riskLevel: rule.riskLevel
-                        )
-                    }
-                },
-                onDismiss: { ruleEditorToolCall = nil }
-            )
+            if assistantFeatureFlagStore.isEnabled("permission-controls-v3") {
+                V3RuleEditorModal(
+                    toolName: tc.toolName,
+                    riskLevel: tc.riskLevel ?? "medium",
+                    scopeOptions: Self.v3ScopeOptions(from: tc),
+                    onSave: { rule in
+                        Task {
+                            try? await Self.trustRuleClient.addTrustRule(
+                                toolName: rule.toolName,
+                                pattern: rule.pattern,
+                                scope: rule.scope,
+                                decision: "allow",
+                                executionTarget: nil,
+                                riskLevel: rule.riskLevel
+                            )
+                        }
+                    },
+                    onDismiss: { ruleEditorToolCall = nil }
+                )
+            } else {
+                RuleEditorModal(
+                    toolName: tc.toolName,
+                    displayName: tc.friendlyName,
+                    command: tc.inputSummary,
+                    currentRiskLevel: tc.riskLevel ?? "medium",
+                    riskReason: tc.riskReason ?? "",
+                    scopeOptions: Self.scopeOptions(from: tc),
+                    workingDir: Self.workingDir(from: tc),
+                    isContainerized: tc.isContainerized,
+                    onSave: { rule in
+                        Task {
+                            try? await Self.trustRuleClient.addTrustRule(
+                                toolName: rule.toolName,
+                                pattern: rule.pattern,
+                                scope: rule.scope,
+                                decision: "allow",
+                                executionTarget: nil,
+                                riskLevel: rule.riskLevel
+                            )
+                        }
+                    },
+                    onDismiss: { ruleEditorToolCall = nil }
+                )
+            }
         }
     }
 
@@ -938,6 +959,25 @@ private struct StepDetailRow: View {
         }
         return options.map { option in
             ScopeOptionItem(
+                label: option.label,
+                pattern: option.pattern
+            )
+        }
+    }
+
+    /// Constructs the V3 scope option items from the tool call's risk scope options.
+    /// Falls back to a single exact command option when none are provided.
+    private static func v3ScopeOptions(from toolCall: ToolCallData) -> [V3ScopeOptionItem] {
+        guard let options = toolCall.riskScopeOptions, !options.isEmpty else {
+            return [
+                V3ScopeOptionItem(
+                    label: toolCall.inputSummary,
+                    pattern: toolCall.inputSummary
+                )
+            ]
+        }
+        return options.map { option in
+            V3ScopeOptionItem(
                 label: option.label,
                 pattern: option.pattern
             )

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -100,9 +100,6 @@ public struct ToolConfirmationBubble: View {
 
         switch confirmation.state {
         case .approved:
-            if isV3 {
-                return "\(confirmation.toolCategory) allowed"
-            }
             switch confirmation.approvedDecision {
             case "allow_10m":
                 return "\(confirmation.toolCategory) allowed for 10 minutes"
@@ -120,12 +117,28 @@ public struct ToolConfirmationBubble: View {
         }
     }
 
-    /// Whether to show the post-decision "Create a rule" nudge (v3 only, unknown risk).
+    /// Whether to show the post-decision "Create a rule" nudge.
+    /// Note: This is not used in the legacy (v1/v2) flow.
     private var showPostDecisionNudge: Bool {
-        isV3 && isDecided && confirmation.riskLevel.lowercased() == "unknown" && onCreateRule != nil
+        false
     }
 
     public var body: some View {
+        if isV3 {
+            V3PermissionPromptView(
+                confirmation: confirmation,
+                isKeyboardActive: isKeyboardActive,
+                onAllow: onAllow,
+                onDeny: onDeny,
+                onAlwaysAllow: onAlwaysAllow
+            )
+        } else {
+            legacyBody
+        }
+    }
+
+    @ViewBuilder
+    private var legacyBody: some View {
         if confirmation.isSystemPermissionRequest {
             if isDecided {
                 systemPermissionCollapsed
@@ -235,41 +248,25 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private var pendingContent: some View {
-        let actions = isV3 ? v3TopLevelActions : topLevelActions
+        let actions = topLevelActions
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             // Adaptive layout: horizontal when wide, vertical when narrow
             if useCompactConfirmationLayout {
-                if isV3 {
-                    v3ConfirmationDescription
-                } else {
-                    confirmationDescription
-                }
+                confirmationDescription
                 HStack {
                     Spacer()
-                    if isV3 {
-                        v3ConfirmationActions
-                    } else {
-                        confirmationActions
-                    }
+                    confirmationActions
                 }
             } else {
                 HStack(alignment: .top, spacing: VSpacing.sm) {
-                    if isV3 {
-                        v3ConfirmationDescription
-                    } else {
-                        confirmationDescription
-                    }
+                    confirmationDescription
                     Spacer(minLength: VSpacing.md)
-                    if isV3 {
-                        v3ConfirmationActions
-                    } else {
-                        confirmationActions
-                    }
+                    confirmationActions
                 }
             }
 
-            // First-time educational banner for command confirmations (hidden in v3)
-            if !isV3 && isCommandTool && !hasSeenCommandExplanation {
+            // First-time educational banner for command confirmations
+            if isCommandTool && !hasSeenCommandExplanation {
                 commandExplanationBanner
             }
 
@@ -659,94 +656,6 @@ public struct ToolConfirmationBubble: View {
                     }
                 }
             }
-        }
-    }
-
-    // MARK: - v3 Simplified Prompt
-
-    private var v3TopLevelActions: [ToolConfirmationKeyboardModel.Action] {
-        [.allowOnce, .dontAllow]
-    }
-
-    /// v3 description: tool name with inline risk badge and optional risk reason.
-    @ViewBuilder
-    private var v3ConfirmationDescription: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
-            HStack(spacing: VSpacing.sm) {
-                Text(confirmation.humanDescription)
-                    .font(VFont.bodyMediumEmphasised)
-                    .foregroundStyle(VColor.contentDefault)
-                    .fixedSize(horizontal: false, vertical: true)
-                v3RiskBadge
-            }
-            if let reason = confirmation.riskReason, !reason.isEmpty {
-                Text(reason)
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-    }
-
-    /// Inline risk level badge for v3 prompts.
-    @ViewBuilder
-    private var v3RiskBadge: some View {
-        let level = confirmation.riskLevel
-        let label = level.isEmpty ? "Unknown" : level.prefix(1).uppercased() + level.dropFirst()
-        Text(label)
-            .font(VFont.labelDefault)
-            .foregroundStyle(v3RiskBadgeTextColor)
-            .padding(EdgeInsets(top: 2, leading: 6, bottom: 2, trailing: 6))
-            .background(v3RiskBadgeBackgroundColor)
-            .clipShape(Capsule())
-    }
-
-    private var v3RiskBadgeBackgroundColor: Color {
-        switch confirmation.riskLevel.lowercased() {
-        case "low": VColor.systemPositiveStrong
-        case "medium": VColor.systemMidStrong
-        case "high": VColor.systemNegativeStrong
-        default: VColor.contentSecondary
-        }
-    }
-
-    private var v3RiskBadgeTextColor: Color {
-        switch confirmation.riskLevel.lowercased() {
-        case "medium": VColor.auxBlack
-        default: VColor.auxWhite
-        }
-    }
-
-    /// v3 simplified actions: flat Allow + Deny buttons, no split button or duration.
-    private var v3ConfirmationActions: some View {
-        HStack(spacing: VSpacing.sm) {
-            VButton(label: "Allow", style: .primary, size: .compact) {
-                markCommandExplanationSeen()
-                // In v3, "Allow" sends the selected allowlist pattern + scope
-                // through the always-allow path when patterns are available,
-                // otherwise falls back to a simple allow.
-                if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
-                    let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
-                    onAlwaysAllow(confirmation.requestId, option.pattern, scope, "allow")
-                } else {
-                    onAllow()
-                }
-            }
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .strokeBorder(VColor.primaryBase, lineWidth: keyboardModel?.selectedAction == .allowOnce ? 2 : 0)
-                    .allowsHitTesting(false)
-            )
-
-            VButton(label: "Deny", style: .danger, size: .compact) {
-                markCommandExplanationSeen()
-                onDeny()
-            }
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .strokeBorder(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
-                    .allowsHitTesting(false)
-            )
         }
     }
 


### PR DESCRIPTION
## Summary

Refactors `ToolConfirmationBubble` and `AssistantProgressView` to delegate to the new standalone V3 views when the `permission-controls-v3` flag is enabled.

### Changes

**`clients/shared/Features/Chat/ToolConfirmationBubble.swift`**
- Replaced all interleaved `isV3` branching with a single top-level delegation
- When `isV3` is true, delegates to `V3PermissionPromptView`
- Moved all v1/v2 logic into `legacyBody` computed property (no behavior changes)
- Deleted all v3-specific code: `v3TopLevelActions`, `v3ConfirmationDescription`, `v3RiskBadge`, `v3RiskBadgeBackgroundColor`, `v3RiskBadgeTextColor`, `v3ConfirmationActions`
- Removed all `isV3` conditional checks from the legacy body

**`clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift`**
- Updated `.sheet(item: $ruleEditorToolCall)` presentation to use `V3RuleEditorModal` when the v3 flag is enabled
- Added `v3ScopeOptions(from:)` helper to map `ToolCallData` to `V3ScopeOptionItem` array
- Legacy `RuleEditorModal` remains unchanged and is used when flag is off

### Testing
- ✅ `swift build` passes (113.43s)
- ✅ No changes to v1/v2 behavior (flag-off path)
- ✅ V3 views now integrated behind feature flag

Part of the V3 permission controls rollout. Depends on PR #27578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
