### PR TITLE
fix: restore legacy heuristic fallbacks in HomeDetailPanelKind.resolve [JARVIS-579]

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanelKind.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanelKind.swift
@@ -19,19 +19,31 @@ enum HomeDetailPanelKind: Equatable {
     case toolPermission(FeedItem)
     case updatesList(FeedItem)
 
-    /// Resolves from the wire-contract `detailPanel` field. Returns `nil`
-    /// when absent.
+    /// Resolves from the wire-contract `detailPanel` field when present,
+    /// otherwise falls back to legacy type+source heuristics so
+    /// scheduled/nudge panels remain reachable for items that don't yet
+    /// carry a `detailPanel`.
     static func resolve(for item: FeedItem) -> HomeDetailPanelKind? {
-        guard let panel = item.detailPanel else {
-            return nil
+        if let panel = item.detailPanel {
+            switch panel.kind {
+            case .emailDraft: return .emailDraft(item)
+            case .documentPreview: return .documentPreview(item)
+            case .permissionChat: return .permissionChat(item)
+            case .paymentAuth: return .paymentAuth(item)
+            case .toolPermission: return .toolPermission(item)
+            case .updatesList: return .updatesList(item)
+            }
         }
-        switch panel.kind {
-        case .emailDraft: return .emailDraft(item)
-        case .documentPreview: return .documentPreview(item)
-        case .permissionChat: return .permissionChat(item)
-        case .paymentAuth: return .paymentAuth(item)
-        case .toolPermission: return .toolPermission(item)
-        case .updatesList: return .updatesList(item)
+
+        // Legacy heuristic fallbacks — kept until the daemon populates
+        // `detailPanel` for every item type.
+        switch item.type {
+        case .thread where item.source == .calendar:
+            return .scheduled(item)
+        case .nudge:
+            return .nudge(item)
+        default:
+            return nil
         }
     }
 }


### PR DESCRIPTION
## Summary
Restores the legacy type+source dispatch heuristics as fallback in resolve(for:) so scheduled/nudge panels remain reachable for items that don't yet carry detailPanel.

**Gap:** Legacy dispatch removed prematurely
**What was expected:** Heuristics should remain until daemon populates detailPanel
**What was found:** resolve(for:) returned nil for all items without detailPanel
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
