### PR TITLE
fix: forward conversationId and detailPanel in HomeFeedStore.replacingStatus [JARVIS-579]

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
@@ -253,6 +253,8 @@ public final class HomeFeedStore {
             minTimeAway: item.minTimeAway,
             actions: item.actions,
             urgency: item.urgency,
+            conversationId: item.conversationId,
+            detailPanel: item.detailPanel,
             author: item.author,
             createdAt: item.createdAt
         )


### PR DESCRIPTION
## Summary
Forwards conversationId and detailPanel when rebuilding FeedItem in replacingStatus so status changes don't lose panel/conversation associations.

**Gap:** replacingStatus drops detailPanel and conversationId
**What was expected:** All fields forwarded
**What was found:** Both fields dropped during rebuild

> [skip ci]
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
