### PR TITLE
test(plugins): drop stale per-pipeline DEFAULT_TIMEOUTS assertions

### DIFF
--- a/assistant/src/__tests__/memory-retrieval-pipeline.test.ts
+++ b/assistant/src/__tests__/memory-retrieval-pipeline.test.ts
@@ -329,10 +329,6 @@ describe("memoryRetrieval pipeline — default vs custom plugin", () => {
     expect(timeoutErr.message).toContain("memoryRetrieval");
   });
 
-  test("DEFAULT_TIMEOUTS.memoryRetrieval matches the 5s design-doc budget", () => {
-    expect(DEFAULT_TIMEOUTS.memoryRetrieval).toBe(5_000);
-  });
-
   test("onEvent is invoked by the default retriever's terminal path", async () => {
     const received: ServerMessage[] = [];
     const { memory } = makeFakeGraphMemory();

--- a/assistant/src/__tests__/tool-result-truncate-pipeline.test.ts
+++ b/assistant/src/__tests__/tool-result-truncate-pipeline.test.ts
@@ -6,7 +6,7 @@
  *   byte-for-byte identical output to calling the helper directly across
  *   short, long, and newline-bounded inputs (property-style).
  * - The pipeline routes through `runPipeline` with the
- *   `DEFAULT_TIMEOUTS.toolResultTruncate` budget (1s) and returns a
+ *   `DEFAULT_TIMEOUTS.toolResultTruncate` budget and returns a
  *   `{ content, truncated }` pair whose `truncated` flag matches whether
  *   the content actually changed.
  * - Plugins registered ahead of the default can short-circuit with their
@@ -348,13 +348,5 @@ describe("toolResultTruncate pipeline", () => {
       expect(result.content).toBe(`[wrapped] ${content}`);
       expect(result.truncated).toBe(false);
     });
-  });
-
-  // -------------------------------------------------------------------------
-  // Timeout budget is wired to DEFAULT_TIMEOUTS.toolResultTruncate
-  // -------------------------------------------------------------------------
-
-  test("DEFAULT_TIMEOUTS.toolResultTruncate is the 1s budget promised by the plan", () => {
-    expect(DEFAULT_TIMEOUTS.toolResultTruncate).toBe(1000);
   });
 });


### PR DESCRIPTION
## Summary
- Delete the `DEFAULT_TIMEOUTS.memoryRetrieval === 5_000` and `DEFAULT_TIMEOUTS.toolResultTruncate === 1_000` assertions that #27601 left stale when it raised the pipeline timeout floor to 30s.
- The canonical `DEFAULT_TIMEOUTS` table guard in `pipeline-runner.test.ts` already covers both entries with the current 30s values, so these were redundant duplicates — no coverage lost.
- Also refresh the header doc-comment in `tool-result-truncate-pipeline.test.ts` to stop claiming a 1s budget.

Unblocks the Test job that was failing on `main` after #27601.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24810334184/job/72613648287
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
