### PR TITLE
fix(memory): stop setting both model and _model on Gemini embedding requests

### DIFF
--- a/assistant/src/memory/embedding-gemini.test.ts
+++ b/assistant/src/memory/embedding-gemini.test.ts
@@ -276,9 +276,45 @@ describe("GeminiEmbeddingBackend", () => {
       // Should have Bearer auth header
       const headers = init.headers as Record<string, string>;
       expect(headers["Authorization"]).toBe("Bearer ast-managed-key");
-      // Managed path includes model in body for platform billing validation
+      // Managed path must NOT include `model` in the body — Gemini models it
+      // as a protobuf oneof populated from the URL path (internally `_model`)
+      // and rejects the duplicate with "oneof field '_model' is already set".
+      // See the comment in embedSingle() for the full invariant.
       const body = JSON.parse(init.body as string);
-      expect(body.model).toBe("models/gemini-embedding-2-preview");
+      expect(body.model).toBeUndefined();
+      expect(body._model).toBeUndefined();
+    });
+
+    test("never sets `model` or `_model` in the request body (oneof invariant)", async () => {
+      // Regression for JARVIS-587: every embed_segment job was failing with
+      // `Invalid value (oneof), oneof field '_model' is already set. Cannot
+      // set 'model'`. Ensure neither field is ever present on the wire,
+      // regardless of transport.
+      const managedBackend = new GeminiEmbeddingBackend(
+        "ast-managed-key",
+        "gemini-embedding-2-preview",
+        {
+          managedBaseUrl:
+            "https://platform.example.com/v1/runtime-proxy/gemini",
+          taskType: "RETRIEVAL_DOCUMENT",
+          dimensions: 3072,
+        },
+      );
+      await managedBackend.embed(["hello"]);
+
+      const directBackend = new GeminiEmbeddingBackend(
+        "direct-key",
+        "test-model",
+      );
+      await directBackend.embed(["hello"]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      for (const call of mockFetch.mock.calls) {
+        const [, init] = call as [string, RequestInit];
+        const body = JSON.parse(init.body as string);
+        expect(body.model).toBeUndefined();
+        expect(body._model).toBeUndefined();
+      }
     });
 
     test("uses direct Google API URL when managedBaseUrl is not set", async () => {

--- a/assistant/src/memory/embedding-gemini.ts
+++ b/assistant/src/memory/embedding-gemini.ts
@@ -60,14 +60,12 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
     const body: Record<string, unknown> = {
       content: { parts },
     };
-    // Include `model` in the body only for managed-proxy requests — the
-    // platform billing layer reads it from the body to validate rate cards.
-    // Direct Gemini API requests must NOT include it because the model is
-    // already in the URL path and the API rejects the duplicate (`oneof
-    // field '_model' is already set`).
-    if (this.managedBaseUrl) {
-      body.model = `models/${this.model}`;
-    }
+    // Do NOT set `model` in the body. Gemini's embedContent API models `model`
+    // as a protobuf oneof populated from the URL path (internally `_model`),
+    // so adding it to the body triggers a 400: "oneof field '_model' is
+    // already set. Cannot set 'model'". This holds for both the direct API
+    // and the managed proxy, which forwards the body unchanged; the platform
+    // billing layer parses the model from the URL path instead.
     if (this.taskType) body.taskType = this.taskType;
     if (this.dimensions) body.outputDimensionality = this.dimensions;
 


### PR DESCRIPTION
## Summary
- Remove the duplicate `model` field from the Gemini embeddings request body on the managed-proxy path. The API treats `model` (URL-path) and `model` (body) as a oneof (internally `_model`) and rejects any request that sets both.
- A previous fix (#27567) already stripped `model` from direct-API requests; this extends the same treatment to the managed-proxy transport, which forwards the body unchanged to Gemini and was still 400'ing.
- Update the existing managed-proxy test (was asserting `body.model === "models/<id>"`) and add a regression test that asserts neither `model` nor `_model` is ever on the wire.

## Context
Side-finding from the JARVIS-587 investigation. Every `embed_segment` memory job was 400'ing with `"Invalid value (oneof), oneof field '_model' is already set. Cannot set 'model'"`. Unrelated to the compaction timeout but extremely spammy in logs. See epic #27604.

The managed proxy can parse the model from the URL path (`/v1beta/models/<id>:embedContent`) for billing validation, so dropping it from the body does not regress platform accounting.

## Test plan
- [x] `bunx tsc --noEmit` passes (no new errors in memory/)
- [x] New regression test asserts the request body contains neither `model` nor `_model` for both transports
- [x] Existing tests pass (`bun test src/memory/embedding-gemini.test.ts` — 19/19; `bun test src/__tests__/embedding-managed-proxy-selection.test.ts` — 10/10)
- [x] `bun run lint` clean

Part of JARVIS-587
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
