### PR TITLE
test(plugins): drop stale pipeline-runner timeoutMs assertions

### DIFF
--- a/assistant/src/__tests__/pipeline-runner.test.ts
+++ b/assistant/src/__tests__/pipeline-runner.test.ts
@@ -296,7 +296,6 @@ describe("runPipeline — structured log record", () => {
     expect(record.outcome).toBe("success");
     expect(typeof record.durationMs).toBe("number");
     expect(record.durationMs).toBeGreaterThanOrEqual(0);
-    expect(record.timeoutMs).toBe(DEFAULT_TIMEOUTS.compaction!);
     expect(record.requestId).toBe("req-test");
     expect(record.conversationId).toBe("conv-test");
     expect(record.turnIndex).toBe(3);
@@ -336,7 +335,6 @@ describe("runPipeline — structured log record", () => {
     expect(record.errorMessage).toBe("kaboom");
     expect(typeof record.errorStack).toBe("string");
     expect(record.pluginName).toBe("noisy-plugin");
-    expect(record.timeoutMs).toBe(DEFAULT_TIMEOUTS.toolError!);
   });
 
   test("timeout path records outcome=timeout + PluginTimeoutError fields", async () => {


### PR DESCRIPTION
## Summary

- After PR #27608 set every `DEFAULT_TIMEOUTS` entry to `null`, `record.timeoutMs` is only populated when a finite number is passed. Two assertions in `pipeline-runner.test.ts` (success path, error path) still compared against `DEFAULT_TIMEOUTS.compaction!` / `DEFAULT_TIMEOUTS.toolError!`, which now resolve to `null` while the record omits the field — turning main red.
- Drop the two stale assertions. `timeoutMs` field behavior (omitted when null, recorded when a real timeout is passed) is already canonically covered by the `null timeout omits timeoutMs field from the log record` test and the `timeout path records outcome=timeout...` test in the same file.

## Original prompt

--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24810566456/job/72614355895
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
