### PR TITLE
fix(runtime): enforce guardian bootstrap secret to close docker port-publish bypass

### DIFF
--- a/assistant/src/runtime/routes/__tests__/guardian-bootstrap-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/guardian-bootstrap-routes.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for the guardian bootstrap access gate.
+ *
+ * Exercises the peer-IP and bootstrap-secret checks that run before
+ * token minting. Downstream dependencies (contact store, credential
+ * service) are mocked so the tests focus on the gate logic.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  findGuardianForChannel: () => null,
+}));
+
+mock.module("../../../contacts/contacts-write.js", () => ({
+  createGuardianBinding: () => {},
+}));
+
+mock.module("../../auth/credential-service.js", () => ({
+  mintCredentialPair: () => ({
+    accessToken: "access-token",
+    accessTokenExpiresAt: Date.now() + 60_000,
+    refreshToken: "refresh-token",
+    refreshTokenExpiresAt: Date.now() + 60_000,
+    refreshAfter: Date.now() + 30_000,
+    guardianPrincipalId: "principal-test",
+  }),
+}));
+
+import { handleGuardianBootstrap } from "../guardian-bootstrap-routes.js";
+
+// Fake Bun server that returns a fixed peer IP for requestIP().
+function makeServer(peerIp: string) {
+  return {
+    requestIP: () => ({ address: peerIp, family: "IPv4", port: 12345 }),
+  };
+}
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost:7821/v1/guardian/init", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify({ platform: "cli", deviceId: "device-test" }),
+  });
+}
+
+const ENV_KEYS = [
+  "IS_CONTAINERIZED",
+  "GUARDIAN_BOOTSTRAP_SECRET",
+  "DISABLE_HTTP_AUTH",
+  "VELLUM_UNSAFE_AUTH_BYPASS",
+];
+const originalEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    originalEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (originalEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = originalEnv[key];
+  }
+});
+
+describe("handleGuardianBootstrap — containerized mode secret enforcement", () => {
+  beforeEach(() => {
+    process.env.IS_CONTAINERIZED = "true";
+  });
+
+  test("rejects with 403 when GUARDIAN_BOOTSTRAP_SECRET env is unset (fail-closed)", async () => {
+    // No GUARDIAN_BOOTSTRAP_SECRET in env — even a loopback peer must be
+    // rejected so misconfigured Docker deployments don't silently expose
+    // the token-minting endpoint.
+    const res = await handleGuardianBootstrap(
+      makeRequest({ "x-bootstrap-secret": "anything" }),
+      makeServer("127.0.0.1"),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("rejects with 403 when x-bootstrap-secret header is missing", async () => {
+    process.env.GUARDIAN_BOOTSTRAP_SECRET = "expected-secret";
+    const res = await handleGuardianBootstrap(
+      makeRequest(),
+      makeServer("172.17.0.1"),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("rejects with 403 when x-bootstrap-secret header does not match", async () => {
+    process.env.GUARDIAN_BOOTSTRAP_SECRET = "expected-secret";
+    const res = await handleGuardianBootstrap(
+      makeRequest({ "x-bootstrap-secret": "wrong-secret" }),
+      makeServer("172.17.0.1"),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("accepts a correct x-bootstrap-secret from a private-network peer", async () => {
+    process.env.GUARDIAN_BOOTSTRAP_SECRET = "expected-secret";
+    const res = await handleGuardianBootstrap(
+      makeRequest({ "x-bootstrap-secret": "expected-secret" }),
+      makeServer("172.17.0.1"),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("accepts any secret in a comma-separated GUARDIAN_BOOTSTRAP_SECRET list", async () => {
+    process.env.GUARDIAN_BOOTSTRAP_SECRET = "secret-a, secret-b ,secret-c";
+    const res = await handleGuardianBootstrap(
+      makeRequest({ "x-bootstrap-secret": "secret-b" }),
+      makeServer("10.0.0.5"),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("rejects a non-private peer even with a valid secret", async () => {
+    // The peer-IP gate still fires first, preventing LAN-scan exploits
+    // from requests that don't route through the Docker bridge.
+    process.env.GUARDIAN_BOOTSTRAP_SECRET = "expected-secret";
+    const res = await handleGuardianBootstrap(
+      makeRequest({ "x-bootstrap-secret": "expected-secret" }),
+      makeServer("8.8.8.8"),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("bypasses the secret check when HTTP auth is disabled (dev-only escape)", async () => {
+    process.env.DISABLE_HTTP_AUTH = "true";
+    process.env.VELLUM_UNSAFE_AUTH_BYPASS = "1";
+    const res = await handleGuardianBootstrap(
+      makeRequest(),
+      makeServer("192.168.1.10"),
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("handleGuardianBootstrap — bare-metal mode (unchanged)", () => {
+  // IS_CONTAINERIZED intentionally not set.
+
+  test("accepts a loopback peer without a bootstrap secret", async () => {
+    const res = await handleGuardianBootstrap(
+      makeRequest(),
+      makeServer("127.0.0.1"),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("rejects a non-loopback peer even on the private network", async () => {
+    const res = await handleGuardianBootstrap(
+      makeRequest(),
+      makeServer("192.168.1.50"),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("rejects when x-forwarded-for is present (gateway-proxied from non-loopback client)", async () => {
+    const res = await handleGuardianBootstrap(
+      makeRequest({ "x-forwarded-for": "203.0.113.5" }),
+      makeServer("127.0.0.1"),
+    );
+    expect(res.status).toBe(403);
+  });
+});

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -9,7 +9,7 @@
  * Only the hashed tokens are persisted.
  */
 
-import { createHash } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 
 import { v4 as uuid } from "uuid";
 
@@ -35,6 +35,32 @@ const log = getLogger("guardian-bootstrap");
 /** Hash a device ID for storage (same pattern as approved-devices-store). */
 function hashDeviceId(deviceId: string): string {
   return createHash("sha256").update(deviceId).digest("hex");
+}
+
+/**
+ * Validate the x-bootstrap-secret header against GUARDIAN_BOOTSTRAP_SECRET.
+ *
+ * The env var may be a single secret or a comma-separated list (matching the
+ * gateway's `parseBootstrapSecrets` contract). Returns true iff the header
+ * exactly matches any configured secret under constant-time comparison. An
+ * unset or empty env var returns false so callers can fail closed.
+ */
+function isBootstrapSecretValid(req: Request): boolean {
+  const raw = process.env.GUARDIAN_BOOTSTRAP_SECRET?.trim();
+  if (!raw) return false;
+  const expected = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const provided = req.headers.get("x-bootstrap-secret") ?? "";
+  if (provided.length === 0) return false;
+  const providedBuf = Buffer.from(provided);
+  for (const candidate of expected) {
+    const candBuf = Buffer.from(candidate);
+    if (candBuf.length !== providedBuf.length) continue;
+    if (timingSafeEqual(candBuf, providedBuf)) return true;
+  }
+  return false;
 }
 
 /**
@@ -90,10 +116,13 @@ export async function handleGuardianBootstrap(
   // In non-containerized (bare-metal) mode, restrict to loopback only —
   // the runtime binds to localhost and LAN peers should not be able to
   // bootstrap even if they somehow reach the endpoint.
-  // In containerized (Docker) mode, accept any private-network peer because
-  // the gateway connects over the Docker bridge (e.g. 172.17.0.1) and the
-  // GUARDIAN_BOOTSTRAP_SECRET enforced at the gateway layer provides the
-  // real authentication.
+  // In containerized (Docker) mode, the runtime HTTP port is published on
+  // the host so sibling Meet-bot containers can reach it via
+  // host.docker.internal. That exposure means the private-peer IP check
+  // alone is insufficient: any host-local process (or a DNS-rebinding web
+  // attack) can reach the endpoint. Defense-in-depth is handled below by
+  // requiring the x-bootstrap-secret header that the gateway injects from
+  // GUARDIAN_BOOTSTRAP_SECRET.
   const peerIp = server.requestIP(req)?.address;
   const containerized = getIsContainerized();
   const peerAllowed = containerized
@@ -101,6 +130,20 @@ export async function handleGuardianBootstrap(
     : isLoopbackAddress(peerIp ?? "");
   if (!peerAllowed && !isHttpAuthDisabled()) {
     return httpError("FORBIDDEN", "Bootstrap endpoint is local-only", 403);
+  }
+
+  // In containerized mode, require a valid bootstrap secret — this closes
+  // the bypass where a host-local client could hit the published runtime
+  // port directly and skip the gateway's gate. Fails closed if the env var
+  // is unset in containerized deployments.
+  if (containerized && !isHttpAuthDisabled()) {
+    if (!isBootstrapSecretValid(req)) {
+      log.warn(
+        { peerIp },
+        "Bootstrap rejected — invalid or missing bootstrap secret",
+      );
+      return httpError("FORBIDDEN", "Invalid bootstrap secret", 403);
+    }
   }
 
   // In non-containerized mode, any x-forwarded-for header means the request

--- a/cli/src/lib/__tests__/docker.test.ts
+++ b/cli/src/lib/__tests__/docker.test.ts
@@ -17,13 +17,16 @@ const imageTags: Record<ServiceName, string> = {
   gateway: "vellumai/vellum-gateway:test",
 };
 
-function buildAssistantArgs(): string[] {
+function buildAssistantArgs(
+  overrides: Partial<Parameters<typeof serviceDockerRunArgs>[0]> = {},
+): string[] {
   const res = dockerResourceNames(instanceName);
   const builders = serviceDockerRunArgs({
     gatewayPort: 7830,
     imageTags,
     instanceName,
     res,
+    ...overrides,
   });
   return builders.assistant();
 }
@@ -79,6 +82,18 @@ describe("serviceDockerRunArgs — assistant", () => {
     expect(portIndex).toBeGreaterThan(0);
     expect(args[portIndex - 1]).toBe("-p");
   });
+
+  test("forwards GUARDIAN_BOOTSTRAP_SECRET into the assistant container when provided, so the runtime can validate the gateway's x-bootstrap-secret header and close the published-port bypass", () => {
+    const args = buildAssistantArgs({ bootstrapSecret: "super-secret-abc" });
+    expect(args).toContain("GUARDIAN_BOOTSTRAP_SECRET=super-secret-abc");
+  });
+
+  test("omits GUARDIAN_BOOTSTRAP_SECRET when no bootstrapSecret is provided (bare-metal-style caller should not inherit a stale secret)", () => {
+    const args = buildAssistantArgs();
+    expect(args.some((a) => a.startsWith("GUARDIAN_BOOTSTRAP_SECRET="))).toBe(
+      false,
+    );
+  });
 });
 
 describe("Meet avatar device passthrough (VELLUM_MEET_AVATAR opt-in)", () => {
@@ -106,17 +121,17 @@ describe("Meet avatar device passthrough (VELLUM_MEET_AVATAR opt-in)", () => {
 
   test("resolveMeetAvatarDevicePath treats 0/false/no as disabled", () => {
     for (const value of ["", "0", "false", "FALSE", "no", " NO "]) {
-      expect(resolveMeetAvatarDevicePath({ [MEET_AVATAR_ENV_VAR]: value })).toBe(
-        null,
-      );
+      expect(
+        resolveMeetAvatarDevicePath({ [MEET_AVATAR_ENV_VAR]: value }),
+      ).toBe(null);
     }
   });
 
   test("resolveMeetAvatarDevicePath returns the default device path when enabled with a truthy value", () => {
     for (const value of ["1", "true", "YES"]) {
-      expect(resolveMeetAvatarDevicePath({ [MEET_AVATAR_ENV_VAR]: value })).toBe(
-        DEFAULT_MEET_AVATAR_DEVICE_PATH,
-      );
+      expect(
+        resolveMeetAvatarDevicePath({ [MEET_AVATAR_ENV_VAR]: value }),
+      ).toBe(DEFAULT_MEET_AVATAR_DEVICE_PATH);
     }
   });
 
@@ -132,9 +147,9 @@ describe("Meet avatar device passthrough (VELLUM_MEET_AVATAR opt-in)", () => {
   test("assistant args omit --device and the avatar env vars when VELLUM_MEET_AVATAR is unset", () => {
     const args = buildAssistantArgs();
     expect(args).not.toContain("--device");
-    expect(
-      args.some((a) => a.startsWith(`${MEET_AVATAR_ENV_VAR}=`)),
-    ).toBe(false);
+    expect(args.some((a) => a.startsWith(`${MEET_AVATAR_ENV_VAR}=`))).toBe(
+      false,
+    );
     expect(
       args.some((a) => a.startsWith(`${MEET_AVATAR_DEVICE_ENV_VAR}=`)),
     ).toBe(false);

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -712,6 +712,14 @@ export function serviceDockerRunArgs(opts: {
       if (opts.signingKey) {
         args.push("-e", `ACTOR_TOKEN_SIGNING_KEY=${opts.signingKey}`);
       }
+      if (opts.bootstrapSecret) {
+        // Mirror the secret into the assistant container so the runtime's
+        // guardian-bootstrap handler can validate the x-bootstrap-secret
+        // header forwarded by the gateway. Without this, the published
+        // runtime port would expose an unauthenticated token-minting
+        // endpoint reachable from the host bypassing the gateway's gate.
+        args.push("-e", `GUARDIAN_BOOTSTRAP_SECRET=${opts.bootstrapSecret}`);
+      }
       for (const envVar of [
         ...Object.values(PROVIDER_ENV_VAR_NAMES),
         "VELLUM_ENVIRONMENT",


### PR DESCRIPTION
## Summary

- **Vulnerability**: In Docker mode, `cli/src/lib/docker.ts` publishes the assistant's HTTP port on `0.0.0.0` so sibling Meet-bot containers can reach the daemon via `host.docker.internal`. The runtime's `/v1/guardian/init` runs **before** JWT auth (`http-server.ts:1056-1063`) and, in containerized mode, accepts any private-network peer (`guardian-bootstrap-routes.ts:97-104`). The gateway's `GUARDIAN_BOOTSTRAP_SECRET` gate was the only secret check — but the published port let host-local processes (and DNS-rebinding browsers) skip the gateway entirely and mint guardian access/refresh tokens with no credentials.
- **Fix**: Validate `x-bootstrap-secret` at the runtime layer too, using the same env var the gateway already reads. The CLI forwards `GUARDIAN_BOOTSTRAP_SECRET` into the assistant container (next to the existing `ACTOR_TOKEN_SIGNING_KEY` plumbing). The runtime fails closed when the env var is missing in containerized mode. Bare-metal mode is untouched — the loopback-only IP gate remains the sole authority.
- **Tests**: New `guardian-bootstrap-routes.test.ts` covers containerized (missing/wrong/valid secret, comma-separated list, non-private peer, `DISABLE_HTTP_AUTH` dev bypass) and bare-metal (loopback OK, LAN rejected, `x-forwarded-for` rejected). `docker.test.ts` gains assertions that the secret is forwarded when provided and omitted when absent.

## Original prompt

`[Image #1] Is this reported security vulnerability legit, still active, and worth addressing?`

Yes — confirmed active on `main`, addressed by this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
