### PR TITLE
fix(cli/docker): drop --privileged in favor of minimum caps for DinD

### DIFF
--- a/cli/src/lib/__tests__/docker.test.ts
+++ b/cli/src/lib/__tests__/docker.test.ts
@@ -29,9 +29,27 @@ function buildAssistantArgs(): string[] {
 }
 
 describe("serviceDockerRunArgs — assistant", () => {
-  test("runs privileged so the inner dockerd can manage cgroups/iptables/overlayfs", () => {
+  test("grants the minimum capability set needed for DinD (SYS_ADMIN + NET_ADMIN) rather than --privileged", () => {
     const args = buildAssistantArgs();
-    expect(args).toContain("--privileged");
+    expect(args).not.toContain("--privileged");
+    // --cap-add SYS_ADMIN and --cap-add NET_ADMIN are each passed as two
+    // adjacent args: "--cap-add" followed by the capability name.
+    const sysAdminIdx = args.indexOf("SYS_ADMIN");
+    expect(sysAdminIdx).toBeGreaterThan(0);
+    expect(args[sysAdminIdx - 1]).toBe("--cap-add");
+    const netAdminIdx = args.indexOf("NET_ADMIN");
+    expect(netAdminIdx).toBeGreaterThan(0);
+    expect(args[netAdminIdx - 1]).toBe("--cap-add");
+  });
+
+  test("disables the default seccomp and AppArmor profiles so the inner dockerd can mount overlayfs and run pivot_root", () => {
+    const args = buildAssistantArgs();
+    const seccompIdx = args.indexOf("seccomp=unconfined");
+    expect(seccompIdx).toBeGreaterThan(0);
+    expect(args[seccompIdx - 1]).toBe("--security-opt");
+    const apparmorIdx = args.indexOf("apparmor=unconfined");
+    expect(apparmorIdx).toBeGreaterThan(0);
+    expect(args[apparmorIdx - 1]).toBe("--security-opt");
   });
 
   test("mounts a dedicated named volume at /var/lib/docker for the inner dockerd data store", () => {
@@ -106,17 +124,17 @@ describe("Meet avatar device passthrough (VELLUM_MEET_AVATAR opt-in)", () => {
 
   test("resolveMeetAvatarDevicePath treats 0/false/no as disabled", () => {
     for (const value of ["", "0", "false", "FALSE", "no", " NO "]) {
-      expect(resolveMeetAvatarDevicePath({ [MEET_AVATAR_ENV_VAR]: value })).toBe(
-        null,
-      );
+      expect(
+        resolveMeetAvatarDevicePath({ [MEET_AVATAR_ENV_VAR]: value }),
+      ).toBe(null);
     }
   });
 
   test("resolveMeetAvatarDevicePath returns the default device path when enabled with a truthy value", () => {
     for (const value of ["1", "true", "YES"]) {
-      expect(resolveMeetAvatarDevicePath({ [MEET_AVATAR_ENV_VAR]: value })).toBe(
-        DEFAULT_MEET_AVATAR_DEVICE_PATH,
-      );
+      expect(
+        resolveMeetAvatarDevicePath({ [MEET_AVATAR_ENV_VAR]: value }),
+      ).toBe(DEFAULT_MEET_AVATAR_DEVICE_PATH);
     }
   });
 
@@ -132,9 +150,9 @@ describe("Meet avatar device passthrough (VELLUM_MEET_AVATAR opt-in)", () => {
   test("assistant args omit --device and the avatar env vars when VELLUM_MEET_AVATAR is unset", () => {
     const args = buildAssistantArgs();
     expect(args).not.toContain("--device");
-    expect(
-      args.some((a) => a.startsWith(`${MEET_AVATAR_ENV_VAR}=`)),
-    ).toBe(false);
+    expect(args.some((a) => a.startsWith(`${MEET_AVATAR_ENV_VAR}=`))).toBe(
+      false,
+    );
     expect(
       args.some((a) => a.startsWith(`${MEET_AVATAR_DEVICE_ENV_VAR}=`)),
     ).toBe(false);

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -635,8 +635,19 @@ export function serviceDockerRunArgs(opts: {
       // container runs its own `dockerd` so the Meet subsystem can spawn
       // sibling meet-bot containers without needing access to the host's
       // Docker engine. This requires:
-      //   - `--privileged` so the inner dockerd can manage cgroups, iptables,
-      //     overlayfs mounts, etc.
+      //   - `CAP_SYS_ADMIN` + `CAP_NET_ADMIN` so the inner dockerd can
+      //     configure cgroups, overlay mounts, network namespaces, and
+      //     iptables. We deliberately avoid `--privileged` (which grants the
+      //     full host capability set and access to every host device node)
+      //     to shrink the escape surface from any code running inside the
+      //     assistant container. See the "Security tradeoff for Docker mode"
+      //     note in AGENTS.md.
+      //   - `seccomp=unconfined` + `apparmor=unconfined` because Docker's
+      //     default seccomp profile blocks syscalls dockerd needs (e.g.
+      //     certain clone/unshare and pivot_root flags) and the default
+      //     AppArmor profile on Debian/Ubuntu hosts denies the mount
+      //     operations dockerd performs while launching bot containers. On
+      //     hosts where these LSMs are inactive, the options are no-ops.
       //   - A dedicated named volume mounted at `/var/lib/docker` so the
       //     inner Docker image cache and container state survive restarts of
       //     the assistant container.
@@ -646,7 +657,14 @@ export function serviceDockerRunArgs(opts: {
         "run",
         "--init",
         "-d",
-        "--privileged",
+        "--cap-add",
+        "SYS_ADMIN",
+        "--cap-add",
+        "NET_ADMIN",
+        "--security-opt",
+        "seccomp=unconfined",
+        "--security-opt",
+        "apparmor=unconfined",
         "--name",
         res.assistantContainer,
         `--network=${res.network}`,


### PR DESCRIPTION
## Summary
- Swap `--privileged` on the assistant container for the minimum capability set the inner dockerd actually needs: `CAP_SYS_ADMIN` + `CAP_NET_ADMIN`, plus `seccomp=unconfined` and `apparmor=unconfined` (required because default seccomp/AppArmor profiles block several dockerd syscalls and mount ops).
- Addresses Codex finding "Docker-mode assistant now runs as privileged container" (commit `a0e59e4`). `--privileged` + container-root collapsed the sandbox boundary; caps-only still exposes meaningful host-level capability but is strictly narrower (no full host cap set, no automatic host-device-node access).
- Update the matching unit tests in `cli/src/lib/__tests__/docker.test.ts`.

## Risk / what needs validation
This is a prototype that needs hands-on validation before we can be confident — flagging @m-abboud to drive that.
- Verify the inner \`dockerd\` still starts inside the assistant container under \`IS_CONTAINERIZED=true\`.
- End-to-end Meet bot: join a test meeting in Docker mode and confirm the recording lands in \`/workspace/meets/<id>/out\` as usual.
- Watch for EPERM / permission errors from dockerd startup, cgroup setup, overlay mounts, or iptables rules. If any appear, we may need to add \`SYS_RESOURCE\`, \`SETFCAP\`, or additional device allows — leave feedback and we can iterate.

If caps-only turns out to be insufficient in some configuration we don't have coverage for (e.g. a specific host distro/kernel combo), the easiest fallback is to revert to \`--privileged\` for that case while we narrow the surface.

AGENTS.md and ARCHITECTURE.md already documented this cap set as the minimum viable alternative to \`--privileged\`, so no doc changes ship with this PR; a follow-up can reword the docs to describe caps as the default rather than the alternative.

## Original prompt
the followup and tag m-abboud as a reviewer
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
