### PR TITLE
fix(meet-bot): set LC_ALL and LC_CTYPE for xdotool spawns

### DIFF
--- a/skills/meet-join/bot/__tests__/xdotool-type.test.ts
+++ b/skills/meet-join/bot/__tests__/xdotool-type.test.ts
@@ -89,13 +89,14 @@ describe("xdotoolType", () => {
     expect(fake.calls[0]!.options.env?.DISPLAY).toBe(":99");
   });
 
-  test("forces LANG=C.UTF-8 so xdotool can type non-ASCII characters", async () => {
+  test("forces a UTF-8 locale so xdotool can type non-ASCII characters", async () => {
     // Without an explicit UTF-8 locale, xdotool runs in POSIX/C and aborts
     // a chat message on the first multi-byte byte (em-dash, curly
     // apostrophe, emoji) with "Invalid multi-byte sequence encountered",
-    // leaving a partial string in the composer. Pin the env so that
-    // failure mode can't return if the bot is invoked outside the
-    // container (e.g. local dev) where the host locale may not be UTF-8.
+    // leaving a partial string in the composer. glibc's locale precedence
+    // is LC_ALL > LC_CTYPE > LANG, so all three must be pinned — hosts
+    // that export LC_ALL=C (common in CI and some dev shells) would
+    // otherwise defeat a LANG-only override.
     const child = makeFakeChild();
     const fake = makeFakeSpawn(child);
 
@@ -108,6 +109,8 @@ describe("xdotoolType", () => {
     await pending;
 
     expect(fake.calls[0]!.options.env?.LANG).toBe("C.UTF-8");
+    expect(fake.calls[0]!.options.env?.LC_CTYPE).toBe("C.UTF-8");
+    expect(fake.calls[0]!.options.env?.LC_ALL).toBe("C.UTF-8");
   });
 
   test("passes text starting with '-' safely via the '--' end-of-options marker", async () => {

--- a/skills/meet-join/bot/src/browser/xdotool-type.ts
+++ b/skills/meet-join/bot/src/browser/xdotool-type.ts
@@ -116,18 +116,21 @@ export async function xdotoolType(opts: XdotoolTypeOptions): Promise<void> {
       else resolve();
     };
 
-    // Force `LANG=C.UTF-8` for the xdotool process. xdotool's text-typing
+    // Force a UTF-8 locale for the xdotool process. xdotool's text-typing
     // path uses the inherited locale to decode the argv string, and in the
     // POSIX/C locale it rejects any non-ASCII byte with `Invalid multi-byte
-    // sequence encountered`, aborting partway through the message. The bot
-    // container's Dockerfile already sets `LANG=C.UTF-8`, but pinning it
-    // here keeps non-container callers (tests, local dev) from re-breaking
-    // the typing path if their host locale drifts.
+    // sequence encountered`, aborting partway through the message. glibc's
+    // locale precedence is `LC_ALL > LC_CTYPE > LANG`, so overriding only
+    // `LANG` still loses on hosts that export `LC_ALL=C` (common in CI and
+    // some dev shells). Set all three so the override is authoritative
+    // regardless of the inherited environment.
     const child = spawnFn(binary, args, {
       env: {
         ...process.env,
         DISPLAY: opts.display,
         LANG: "C.UTF-8",
+        LC_CTYPE: "C.UTF-8",
+        LC_ALL: "C.UTF-8",
       },
     });
 


### PR DESCRIPTION
Addresses Codex feedback on #27430 — glibc locale precedence is LC_ALL > LC_CTYPE > LANG, so overriding only LANG still fails on hosts that export LC_ALL=C (common in CI and some dev shells). Sets LC_ALL and LC_CTYPE alongside LANG so the C.UTF-8 override is authoritative regardless of the inherited environment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
