### PR TITLE
docs(agent/loop): fix broken JSDoc @link reference

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -151,7 +151,7 @@ const MAX_EMPTY_RESPONSE_RETRIES = 1;
  * {@link AgentLoop.run}); this helper is the fallback used only by unit
  * tests that construct `AgentLoop` directly without an orchestrator.
  *
- * When the orchestrator-supplied context is present, {@link cloneWithTurnIndex}
+ * When the orchestrator-supplied context is present, {@link resolveLoopTurnContext}
  * is used instead of this helper so the pipeline sees the real
  * `conversationId`, trust, and `contextWindowManager`. In the fallback path
  * the returned context is still useful for pipeline logging: `requestId`


### PR DESCRIPTION
Addresses Devin feedback on #27422 — the JSDoc reference pointed at a function that does not exist in the codebase. Replaces with the real function name.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
