### PR TITLE
docs(meet-join): update INGAME_READY_INDICATOR comments to chat/participants panel semantics

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/features/join.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/join.ts
@@ -19,10 +19,13 @@
  *   3. Populate the display name if the input is present.
  *   4. Click Join now (preferred — signed-in / same-domain flow) or fall back
  *      to Ask to join (locked meeting, host admits).
- *   5. Wait for the in-meeting UI. `INGAME_READY_INDICATOR` (the bottom-bar
- *      microphone toggle) is the canonical marker — it only mounts once the
- *      bot is in the meeting. The red "Leave call" button is NOT suitable
- *      because Meet renders it in both the waiting-room and in-meeting UIs.
+ *   5. Wait for the in-meeting UI. `INGAME_READY_INDICATOR` (the chat /
+ *      participants panel toggles in the bottom toolbar) is the canonical
+ *      marker — those buttons only mount once the bot is actually in the
+ *      meeting. The red "Leave call" button is NOT suitable because Meet
+ *      renders it in both the waiting-room and in-meeting UIs, and the mic
+ *      toggle is not suitable because Meet also renders it on the prejoin
+ *      lobby as part of the device-preview toolbar.
  *   6. Post `consentMessage` in chat via {@link postConsentMessage}. Best
  *      effort — if the chat composer can't be located we surface a
  *      diagnostic error but do NOT fail the join, since the bot is already
@@ -348,15 +351,17 @@ export async function runJoinFlow(opts: RunJoinFlowOptions): Promise<void> {
     message: `meet-ext: clicked admission button aria-label="${btnLabel}" screen=(${screenX},${screenY})`,
   });
 
-  // Step 5 — wait for the in-meeting UI. We use `INGAME_READY_INDICATOR`
-  // (aliased to the mic toggle) rather than `INGAME_LEAVE_BUTTON` because
-  // Meet renders the red "Leave call" button in BOTH the waiting-room and
-  // the in-meeting UIs — so `waitForSelector(INGAME_LEAVE_BUTTON)` resolves
-  // immediately after the "Ask to join" click, before the host has actually
-  // admitted the bot. That caused step 6 (post-consent-in-chat) to fire in
-  // the waiting room, where the chat panel does not exist. The mic toggle
-  // is only mounted by the in-meeting bottom toolbar, so it is a reliable
-  // post-admission signal. See `INGAME_READY_INDICATOR` in `dom/selectors.ts`.
+  // Step 5 — wait for the in-meeting UI. `INGAME_READY_INDICATOR` matches
+  // the chat / participants panel toggles (`"Chat with everyone"` /
+  // `"Show everyone"`), which Meet only mounts on the in-meeting bottom
+  // toolbar. It is reliable where `INGAME_LEAVE_BUTTON` is not — Meet
+  // renders the red "Leave call" button in both the waiting-room and the
+  // in-meeting UIs, so waiting on it resolves immediately after the "Ask
+  // to join" click and step 6 (post-consent-in-chat) fires in the waiting
+  // room where the chat panel does not exist. The mic toggle is also
+  // unsuitable because Meet renders it on the prejoin lobby as part of
+  // the device-preview toolbar. See `INGAME_READY_INDICATOR` in
+  // `dom/selectors.ts` for the full rationale.
   try {
     await waitForSelector(
       selectors.INGAME_READY_INDICATOR,


### PR DESCRIPTION
Addresses Devin feedback on #27384 — the file-level docstring and inline Step 5 comment in `skills/meet-join/meet-controller-ext/src/features/join.ts` still described `INGAME_READY_INDICATOR` as the bottom-bar microphone toggle. The selector now resolves to the chat / participants panel toggles (`"Chat with everyone"` / `"Show everyone"`) which only mount post-admission. Both comment blocks now match the current selector semantics.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
