### PR TITLE
fix(cli): include plugin-sourced skills in 'skills list' output

### DIFF
--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -78,7 +78,8 @@ Examples:
         const config = getConfig();
         const resolved = resolveSkillStates(localCatalog, config);
         const bundled = resolved.filter(
-          (r) => r.summary.source === "bundled",
+          (r) =>
+            r.summary.source === "bundled" || r.summary.source === "plugin",
         );
         const installed = resolved.filter(
           (r) =>
@@ -365,9 +366,7 @@ Examples:
 
         // ── Display bundled/installed results ─────────────────────────
         if (bundledMatches.length > 0) {
-          log.info(
-            `Bundled & installed skills (${bundledMatches.length}):\n`,
-          );
+          log.info(`Bundled & installed skills (${bundledMatches.length}):\n`);
           for (const s of bundledMatches) {
             const emoji = s.emoji ? `${s.emoji} ` : "";
             const tag = s.source === "bundled" ? " [bundled]" : " [installed]";


### PR DESCRIPTION
Addresses Devin feedback on #27409 — the CLI partition filter didn't include `source==='plugin'`, so plugin-contributed skills were silently dropped from both human and JSON output even though the daemon HTTP listing exposed them correctly. Bucket under `bundled` to match the daemon's `deriveKind` mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
