### PR TITLE
refactor(media): migrate gemini service to shared image-gen types

### DIFF
--- a/assistant/src/media/gemini-image-service.ts
+++ b/assistant/src/media/gemini-image-service.ts
@@ -1,45 +1,13 @@
 import { ApiError, GoogleGenAI } from "@google/genai";
 
-// --- Request / Response types ---
-
-interface ImageGenerationRequest {
-  prompt: string;
-  mode: "generate" | "edit";
-  /** Base64-encoded source images for edit mode */
-  sourceImages?: Array<{ mimeType: string; dataBase64: string }>;
-  /** Model override; defaults to 'gemini-3.1-flash-image-preview' */
-  model?: string;
-  /** Number of output variants (1-4, default 1) */
-  variants?: number;
-}
-
-/** Credentials for direct Gemini API access. */
-interface DirectCredentials {
-  type: "direct";
-  apiKey: string;
-}
-
-/** Credentials for managed proxy access (platform translates to Vertex AI). */
-interface ManagedProxyCredentials {
-  type: "managed-proxy";
-  assistantApiKey: string;
-  baseUrl: string;
-}
-
-export type ImageGenCredentials = DirectCredentials | ManagedProxyCredentials;
-
-interface GeneratedImage {
-  mimeType: string;
-  dataBase64: string;
-  /** Short title derived from the model's text response, if available. */
-  title?: string;
-}
-
-interface ImageGenerationResult {
-  images: GeneratedImage[];
-  text?: string;
-  resolvedModel: string;
-}
+import {
+  type GeneratedImage,
+  type ImageGenCredentials,
+  type ImageGenerationRequest,
+  type ImageGenerationResult,
+  type ManagedProxyCredentials,
+  MAX_VARIANTS,
+} from "./types.js";
 
 // --- Constants ---
 
@@ -48,7 +16,6 @@ const ALLOWED_MODELS = new Set([
   "gemini-3.1-flash-image-preview",
   "gemini-3-pro-image-preview",
 ]);
-const MAX_VARIANTS = 4;
 
 // --- Error mapping ---
 


### PR DESCRIPTION
## Summary

- Addresses Devin's feedback on #27521: at the time of that merge, `assistant/src/media/types.ts` was orphaned — no consumers imported from it.
- Subsequent PRs migrated `image-service.ts`, `openai-image-service.ts`, and `image-credentials.ts` to import from `types.ts`, but `gemini-image-service.ts` kept its locally duplicated definitions (ImageGenerationRequest, DirectCredentials, ManagedProxyCredentials, GeneratedImage, ImageGenerationResult, MAX_VARIANTS).
- This PR drops those local duplicates and imports the shared definitions, removing the soft-duplication risk Devin flagged.

Follow-up to #27521.

## Test plan

- [x] `bun test src/__tests__/gemini-image-service.test.ts src/__tests__/image-service-dispatcher.test.ts` — 26 pass
- [x] `bunx tsc --noEmit` — clean for media/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
