### PR TITLE
fix(macos/host-browser): clamp + validate timeout before UInt64 conversion

### DIFF
--- a/clients/shared/Network/HostBrowserExecutor.swift
+++ b/clients/shared/Network/HostBrowserExecutor.swift
@@ -121,7 +121,13 @@ public final class HostBrowserExecutor {
             )
         }
 
-        let timeout = request.timeoutSeconds ?? Self.defaultTimeoutSeconds
+        // Guard against values that would trap `UInt64(timeout * 1e9)` in
+        // `sendCDPCommand` — `timeoutSeconds` is decoded from JSON without range
+        // validation, so negatives, NaN, or ±infinity can reach this path.
+        let rawTimeout = request.timeoutSeconds ?? Self.defaultTimeoutSeconds
+        let timeout: TimeInterval = (rawTimeout.isFinite && rawTimeout >= 0)
+            ? rawTimeout
+            : Self.defaultTimeoutSeconds
 
         // Step 1: Discover available targets via /json/list
         let targetsURL = URL(string: "http://\(host):\(port)/json/list")!


### PR DESCRIPTION
## Summary

Addresses Codex feedback on #27618 — the Task.sleep migration introduced a crash-on-bad-input regression: `UInt64(timeout * 1_000_000_000)` traps on negative or non-finite Doubles, and `HostBrowserRequest.timeoutSeconds` is decoded from JSON without range validation. The prior `DispatchQueue.asyncAfter` path clamped negative deadlines to fire-immediately; the new `Task.sleep` path crashes.

- Adds an `isFinite` + `>= 0` guard in `HostBrowserExecutor.sendCDPCommand` before the `UInt64` conversion
- Falls back to `defaultTimeoutSeconds` (30s) on malformed input instead of trapping, preserving caller intent with a reasonable budget

## Test plan

- [x] Manual reasoning: negative / NaN / ±infinity values now flow through the default branch; positive finite values unchanged
- [ ] CI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
