### PR TITLE
fix(plugins): add missing turnApi/memoryRetrievalApi to capability table

### DIFF
--- a/assistant/src/plugins/registry.ts
+++ b/assistant/src/plugins/registry.ts
@@ -43,15 +43,22 @@ import {
  * top-level context APIs plugins most commonly consume.
  */
 export const ASSISTANT_API_VERSIONS: Record<string, string[]> = {
-  // Runtime APIs every plugin interacts with at some level.
+  // Runtime APIs every plugin interacts with at some level. `memoryApi` is the
+  // broader memory-subsystem capability (distinct from the `memoryRetrieval`
+  // pipeline, which gets its own `memoryRetrievalApi` entry below).
   pluginRuntime: ["v1"],
   memoryApi: ["v1"],
   compactionApi: ["v1"],
   persistenceApi: ["v1"],
 
-  // Per-pipeline APIs. One entry per pipeline slot in {@link PipelineName}.
+  // Per-pipeline APIs. One entry for every slot in {@link PipelineName} that
+  // isn't already covered by the runtime-APIs block above (`compaction` and
+  // `persistence` live there because plugins commonly interact with them
+  // outside a pipeline middleware context).
+  turnApi: ["v1"],
   llmCallApi: ["v1"],
   toolExecuteApi: ["v1"],
+  memoryRetrievalApi: ["v1"],
   historyRepairApi: ["v1"],
   tokenEstimateApi: ["v1"],
   overflowReduceApi: ["v1"],


### PR DESCRIPTION
## Summary

Addresses Codex and Devin feedback on #27391 — the capability-version table in `assistant/src/plugins/registry.ts` omitted two entries that `PipelineName` enumerates, so plugins that required `turnApi` or `memoryRetrievalApi` would be rejected as "unknown capability".

- Added `turnApi: ["v1"]` and `memoryRetrievalApi: ["v1"]` entries.
- Clarified the docstring around why `compactionApi` and `persistenceApi` live in the runtime-APIs block rather than the per-pipeline block, and why `memoryApi` (broader memory subsystem) is distinct from `memoryRetrievalApi` (the pipeline).

## Test plan

- [x] `bun test src/__tests__/plugin-registry.test.ts` passes (13/13)
- [x] `bunx tsc --noEmit` clean for `assistant/`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
