### PR TITLE
fix(meet-chat): skip Tier 2 for backfilled chat messages to preserve debounce slot

### DIFF
--- a/skills/meet-join/contracts/events.ts
+++ b/skills/meet-join/contracts/events.ts
@@ -114,6 +114,16 @@ export const InboundChatEventSchema = z.object({
   fromName: z.string(),
   /** The chat message text. */
   text: z.string(),
+  /**
+   * True when the event is a replay of a chat message that was already in
+   * the DOM when the reader attached — i.e. part of the meeting's pre-
+   * existing chat history, not a message that arrived live. Consumers that
+   * treat every inbound chat as an opportunity to wake the agent
+   * (`chat-opportunity-detector`) must skip backfilled messages so an old
+   * history entry doesn't consume the Tier 2 debounce slot and silently
+   * drop a live message arriving right after attach.
+   */
+  isBackfill: z.boolean().optional(),
 });
 export type InboundChatEvent = z.infer<typeof InboundChatEventSchema>;
 

--- a/skills/meet-join/daemon/__tests__/chat-opportunity-detector.test.ts
+++ b/skills/meet-join/daemon/__tests__/chat-opportunity-detector.test.ts
@@ -107,6 +107,7 @@ function inboundChat(
   text: string,
   fromName = "Alice",
   fromId = "a",
+  options: { isBackfill?: boolean } = {},
 ): MeetBotEvent {
   return {
     type: "chat.inbound",
@@ -115,6 +116,7 @@ function inboundChat(
     fromId,
     fromName,
     text,
+    ...(options.isBackfill ? { isBackfill: true as const } : {}),
   };
 }
 
@@ -305,6 +307,71 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
     // operators grepping `tier1:*` in logs still see the trigger.
     const [prompt] = llm.mock.calls[0] as unknown as [string];
     expect(prompt).toContain("tier1:chat-always-on");
+
+    detector.dispose();
+  });
+
+  test("backfilled inbound chat does not invoke Tier 2 and preserves the debounce slot for a live message", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const clock = makeClock(1_000);
+    const llm = mock(
+      async (_prompt: string): Promise<ChatOpportunityDecision> => ({
+        shouldRespond: true,
+        reason: "live message should fire",
+      }),
+    );
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
+
+    const detector = new MeetChatOpportunityDetector({
+      meetingId: "m1",
+      assistantDisplayName: "Aria",
+      config: defaultConfig(),
+      voiceConfig: defaultVoiceConfig(),
+      callDetectorLLM: llm,
+      onOpportunity,
+      subscribe: dispatcher.subscribe,
+      now: clock.now,
+    });
+    detector.start();
+
+    // Reader attach: replay a pre-existing history message. With the
+    // isBackfill flag this must not enter Tier 2, so the debounce /
+    // in-flight slot stays free for the real live message next.
+    dispatcher.dispatch(
+      "m1",
+      inboundChat(
+        "m1",
+        "2024-01-01T00:00:00.000Z",
+        "old chat from before bot joined",
+        "Alice",
+        "a",
+        { isBackfill: true },
+      ),
+    );
+
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(0);
+    expect(detector.getStats().tier1Hits).toBe(0);
+    expect(detector.getStats().tier2Calls).toBe(0);
+
+    // A live message arriving well inside tier2DebounceMs (5s) must
+    // still fire Tier 2 because the backfill replay never consumed
+    // the debounce clock.
+    clock.advance(100);
+    dispatcher.dispatch(
+      "m1",
+      inboundChat("m1", "2024-01-01T00:00:00.100Z", "live question"),
+    );
+
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+    expect(onOpportunity).toHaveBeenCalledTimes(1);
+
+    const stats = detector.getStats();
+    expect(stats.tier1Hits).toBe(1);
+    expect(stats.tier2Calls).toBe(1);
+    expect(stats.tier2PositiveCount).toBe(1);
+    expect(stats.escalationsFired).toBe(1);
 
     detector.dispose();
   });

--- a/skills/meet-join/daemon/chat-opportunity-detector.ts
+++ b/skills/meet-join/daemon/chat-opportunity-detector.ts
@@ -442,7 +442,15 @@ export class MeetChatOpportunityDetector {
     });
     while (this.chatBuffer.length > CHAT_BUFFER_SIZE) this.chatBuffer.shift();
 
-    // Every non-empty inbound chat proceeds to Tier 2 unconditionally.
+    // Backfilled replays of pre-existing DOM chat history populate the
+    // Tier 2 prompt context buffer but must NOT drive Tier 2 themselves.
+    // The reader emits one backfill event per already-mounted message on
+    // attach; treating those as live triggers would burn the debounce /
+    // in-flight slot and silently drop the first real live message that
+    // arrives inside the `tier2DebounceMs` window.
+    if (event.isBackfill === true) return;
+
+    // Every non-backfill inbound chat proceeds to Tier 2 unconditionally.
     // Chat volume is low enough (<1/5s typical) that the debounce +
     // escalation cooldown are sufficient throttles on their own, and a
     // keyword gate silently drops natural-but-unkeyworded invitations

--- a/skills/meet-join/meet-controller-ext/src/features/chat.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/chat.ts
@@ -311,7 +311,7 @@ export function startChatReader(opts: ChatReaderOptions): ChatReader {
     return { fromName, text, timestamp };
   };
 
-  const extract = (node: Element): void => {
+  const extract = (node: Element, isBackfill = false): void => {
     // Probe — don't require membership in the current MESSAGE_NODE set; the
     // structural fallback inside `chatSelectors.MESSAGE_NODE` is a descendant
     // selector, so `matches()` won't return `true` even when a passed-in
@@ -363,6 +363,12 @@ export function startChatReader(opts: ChatReaderOptions): ChatReader {
         fromId,
         fromName,
         text,
+        // True only for the initial replay of pre-existing DOM messages
+        // during reader attach. Downstream consumers use this to skip
+        // wake-the-agent paths (Tier 2 LLM check) for history entries
+        // that would otherwise burn the debounce slot a real live
+        // message is about to need.
+        ...(isBackfill ? { isBackfill: true as const } : {}),
       };
       emittedCount += 1;
       try {
@@ -374,12 +380,16 @@ export function startChatReader(opts: ChatReaderOptions): ChatReader {
   };
 
   // Backfill any messages already in the DOM when the reader attaches —
-  // otherwise we'd miss the pre-existing chat history.
+  // otherwise we'd miss the pre-existing chat history. Mark these events
+  // with `isBackfill: true` so the chat-opportunity detector skips Tier 2
+  // on them; a pre-existing history entry consuming the debounce slot
+  // would silently drop the first real live message that lands inside
+  // the debounce window.
   maybeEmitReaderDiagnostic();
   for (const existing of document.querySelectorAll(
     chatSelectors.MESSAGE_NODE,
   )) {
-    extract(existing);
+    extract(existing, true);
   }
 
   const observer = new MutationObserver((mutations) => {


### PR DESCRIPTION
Addresses Codex feedback on #27390 — the chat reader's replay-on-attach (skills/meet-join/meet-controller-ext/src/features/chat.ts) emits one chat.inbound event per pre-existing DOM message when the reader attaches. After #27390 removed the Tier 1 regex gate for inbound chat, every backfilled history entry would flow into Tier 2, burning the tier2DebounceMs / in-flight slot — so the first real live message arriving inside that window was silently dropped.

This PR:
- Adds an optional isBackfill: true flag to InboundChatEventSchema (contracts/events.ts).
- Tags events emitted during the reader's initial backfill loop (skills/meet-join/meet-controller-ext/src/features/chat.ts). Observer-driven events for live messages stay unflagged.
- In MeetChatOpportunityDetector.onInboundChat, short-circuits before the Tier 2 debounce check when isBackfill is true. The chat buffer is still populated so backfilled history remains in the Tier 2 prompt context for subsequent real triggers.
- Adds a regression test asserting a backfilled chat does not invoke Tier 2 and that a live message arriving 100ms later still fires.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
