### PR TITLE
fix(plugins): make defaultLlmCallPlugin a true passthrough

### DIFF
--- a/assistant/src/__tests__/llm-call-pipeline.test.ts
+++ b/assistant/src/__tests__/llm-call-pipeline.test.ts
@@ -197,6 +197,49 @@ describe("llmCall pipeline", () => {
     expect(provider.calls).toHaveLength(1);
   });
 
+  test("default registered first does not shadow later-registered user middleware", async () => {
+    // Regression for a shadowing bug where `defaultLlmCallPlugin` called
+    // `provider.sendMessage` directly instead of `next(args)`. Because the
+    // default registers at module load (before `bootstrapPlugins()` loads
+    // user plugins), it sat at the outermost layer in production — any
+    // user-registered `llmCall` middleware would have been silently skipped.
+    // This test locks in the fix by registering the default FIRST (matching
+    // production ordering) and asserting a user-registered spy still runs.
+    const observed: LLMCallArgs[] = [];
+    const spyPlugin: Plugin = {
+      manifest: {
+        name: "spy-llm-after-default",
+        version: "0.0.1",
+        requires: { pluginRuntime: "v1" },
+      },
+      middleware: {
+        llmCall: async (args, next, _ctx) => {
+          observed.push(args);
+          return next(args);
+        },
+      },
+    };
+
+    registerPlugin(defaultLlmCallPlugin);
+    registerPlugin(spyPlugin);
+
+    const provider = makeFakeProvider();
+    const args = makeArgs(provider);
+
+    await runPipeline<LLMCallArgs, LLMCallResult>(
+      "llmCall",
+      getMiddlewaresFor("llmCall"),
+      terminal,
+      args,
+      makeCtx(),
+      DEFAULT_TIMEOUTS.llmCall,
+    );
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0]!.provider).toBe(provider);
+    expect(provider.calls).toHaveLength(1);
+  });
+
   test("short-circuit middleware prevents the real provider call", async () => {
     const synthetic = makeResponse({
       model: "synthetic-model",

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -493,11 +493,15 @@ export class AgentLoop {
 
         // Wrap the provider call in the `llmCall` pipeline so middleware
         // contributed by plugins may observe, rewrite, short-circuit, or
-        // post-process every LLM request. The default plugin registered at
-        // bootstrap (`defaultLlmCallPlugin`) acts as the passthrough terminal
-        // and simply delegates back to `provider.sendMessage(...)`. Timeout
-        // is `null` (`DEFAULT_TIMEOUTS.llmCall`) — the provider layer already
-        // enforces its own HTTP-level budgets.
+        // post-process every LLM request. The terminal below is the real
+        // `provider.sendMessage(...)` call; middleware that call `next(args)`
+        // eventually reach it. The default `defaultLlmCallPlugin` contributes
+        // only a passthrough middleware that forwards to `next(args)` —
+        // registered at module load, it sits at the outermost layer in the
+        // onion, so short-circuiting there would silently disable every
+        // user-registered `llmCall` middleware. Timeout is `null`
+        // (`DEFAULT_TIMEOUTS.llmCall`) — the provider layer already enforces
+        // its own HTTP-level budgets.
         //
         // The `onEvent` wrapping is kept inside `args.options` so substitution
         // and streaming behavior exactly match the pre-pipeline call site.

--- a/assistant/src/plugins/defaults/llm-call.ts
+++ b/assistant/src/plugins/defaults/llm-call.ts
@@ -1,12 +1,20 @@
 /**
- * Default `llmCall` plugin — the passthrough terminal that delegates to
- * {@link Provider.sendMessage}.
+ * Default `llmCall` plugin — a true passthrough that declares the pipeline
+ * surface and always yields to downstream middleware.
  *
- * The plugin system wraps every LLM request in the `llmCall` pipeline. This
- * default ensures the pipeline always has a terminal to fall through to when
- * no other plugin short-circuits or overrides it: it reconstitutes the
- * provider call from {@link LLMCallArgs} and returns the raw
- * {@link ProviderResponse} unchanged.
+ * The plugin system wraps every LLM request in the `llmCall` pipeline. The
+ * actual call to {@link Provider.sendMessage} lives in the `runPipeline`
+ * terminal at the call site (`agent/loop.ts`); this default's only job is to
+ * contribute the manifest (`provides.llmCall: "v1"`) so other plugins can
+ * negotiate against the pipeline surface.
+ *
+ * Because this plugin is registered at module load — BEFORE user plugins are
+ * loaded by `bootstrapPlugins()` — it sits at the outermost layer in
+ * `composeMiddleware`'s onion ordering. If its middleware called
+ * `provider.sendMessage` directly (instead of `next(args)`) it would
+ * short-circuit the chain and silently disable every user-registered
+ * `llmCall` middleware in production. The middleware therefore just forwards
+ * to `next(args)`.
  *
  * Registered from `daemon/external-plugins-bootstrap.ts` via a side-effect
  * import so the plugin is present in the registry before
@@ -24,9 +32,10 @@ import {
 } from "../types.js";
 
 /**
- * The default LLM-call plugin. Its sole contribution is the `llmCall`
- * middleware, which calls `args.provider.sendMessage(...)` with the exact
- * fields `args` carries and returns the provider response as-is.
+ * The default LLM-call plugin. Its `llmCall` middleware is a passthrough that
+ * forwards to `next(args)` unchanged so any user-registered middleware
+ * (registered later, inner in the onion) still runs and the terminal at the
+ * call site performs the actual `provider.sendMessage(...)` call.
  *
  * Manifest declares `provides.llmCall: "v1"` so other plugins can negotiate
  * against the pipeline surface and `requires.pluginRuntime: "v1"` to satisfy
@@ -42,15 +51,10 @@ export const defaultLlmCallPlugin: Plugin = {
   middleware: {
     llmCall: async function defaultLlmCall(
       args: LLMCallArgs,
-      _next,
+      next,
       _ctx,
     ): Promise<LLMCallResult> {
-      return args.provider.sendMessage(
-        args.messages,
-        args.tools,
-        args.systemPrompt,
-        args.options,
-      );
+      return next(args);
     },
   },
 };


### PR DESCRIPTION
## Summary
- Addresses review feedback on #27397 flagged by both reviewers.
- `defaultLlmCallPlugin` middleware called `provider.sendMessage` directly instead of `next(args)`. Since it registers at module load (before `bootstrapPlugins()` loads user plugins), it sat at the outermost layer in `composeMiddleware`'s onion — short-circuiting there silently disabled every user-registered `llmCall` middleware in production.
- The terminal lambda in `agent/loop.ts` already performs the real `provider.sendMessage(...)` call, so the default's job reduces to contributing the `provides.llmCall: "v1"` manifest and forwarding via `next(args)`.
- Tests masked the bug because they registered user plugins BEFORE the default, giving user plugins outermost position — the opposite of production ordering. Added a regression test that registers the default FIRST and asserts a later-registered spy still runs.

## Test plan
- [x] `bun test src/__tests__/llm-call-pipeline.test.ts` — all 4 cases pass, including the new regression test
- [x] `bunx tsc --noEmit` in `assistant/` — clean
- [x] `bun run lint` — clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
