### PR TITLE
fix(compaction): route overflow reducer's forced tier through compaction pipeline

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1371,12 +1371,30 @@ export async function runAgentLoopImpl(
         toolTokenBudget,
         maxAttempts: overflowRecovery.maxAttempts,
         abortSignal: abortController.signal,
-        compactFn: (msgs, signal, opts) =>
-          ctx.contextWindowManager.maybeCompact(
-            msgs,
-            signal!,
-            opts as Parameters<ContextWindowManager["maybeCompact"]>[2],
-          ),
+        compactFn: async (msgs, signal, opts) =>
+          // Route the reducer's forced-compaction tier through the
+          // `compaction` pipeline so registered plugins observe these
+          // invocations. Without this, custom compaction middleware only
+          // sees the three orchestrator-owned call sites and misses the
+          // reducer-initiated forced compactions entirely.
+          (await runPipeline<CompactionArgs, CompactionResult>(
+            "compaction",
+            getMiddlewaresFor("compaction"),
+            (args) =>
+              defaultCompactionTerminal(
+                args,
+                buildPluginTurnContext(ctx, reqId),
+              ),
+            {
+              messages: msgs,
+              signal,
+              options: opts,
+            },
+            buildPluginTurnContext(ctx, reqId),
+            DEFAULT_TIMEOUTS.compaction,
+          )) as Awaited<
+            ReturnType<typeof ctx.contextWindowManager.maybeCompact>
+          >,
         emitActivityState: () => {
           ctx.emitActivityState(
             "thinking",


### PR DESCRIPTION
## Summary

Follow-up to #27404. The overflow reducer's `compactFn` callback wired in from `conversation-agent-loop.ts` was calling `ContextWindowManager.maybeCompact` directly, bypassing the new `compaction` plugin pipeline. Custom plugins registered against the `compaction` slot only saw the three orchestrator-owned call sites (start-of-turn, mid-loop, emergency) and missed every reducer-initiated forced compaction triggered by the preflight overflow path.

Route `compactFn` through `runPipeline('compaction', ...)` with the same terminal + turn-context construction used by the peer call sites so plugin observers fire for all four compaction origins.

**Timeout cancellation gap (other half of the reviewer feedback)** was already addressed in #27615 — the pipeline runner now wires its timeout to abort a linked inner signal, and the three orchestrator call sites catch `PluginTimeoutError` and degrade gracefully.

## Test plan

- [x] Existing tests pass: `bun test src/__tests__/overflow-reduce-pipeline.test.ts src/__tests__/compaction-pipeline.test.ts src/__tests__/compaction-timeout-recovery.test.ts src/__tests__/conversation-agent-loop-overflow.test.ts` (16 pass, 7 todo, 0 fail)
- [x] Type-check clean in `assistant/`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
