### PR TITLE
fix(plugins): unshadow user historyRepair middleware + tolerate timeouts

### DIFF
--- a/assistant/src/__tests__/history-repair-pipeline.test.ts
+++ b/assistant/src/__tests__/history-repair-pipeline.test.ts
@@ -321,6 +321,49 @@ describe("historyRepair pipeline — end-to-end via runPipeline", () => {
     expect(result.stats).toEqual(customStats);
   });
 
+  test("user plugin registered AFTER the default still runs (no shadowing)", async () => {
+    // Production registration order: defaults load first via the side-effect
+    // imports in `defaults/index.ts`, then user plugins register on top via
+    // `bootstrapPlugins()`. The user's middleware ends up at a deeper onion
+    // layer than the default. If the default's middleware were to bypass
+    // `next` and call the terminal directly, the user middleware would never
+    // run — this test guards against that regression.
+    registerPlugin(defaultHistoryRepairPlugin);
+
+    let userMiddlewareRan = false;
+    const userMiddleware: Middleware<
+      HistoryRepairArgs,
+      HistoryRepairResult
+    > = async (args, next) => {
+      userMiddlewareRan = true;
+      return next(args);
+    };
+    registerPlugin({
+      manifest: {
+        name: "late-user-plugin",
+        version: "0.0.1",
+        requires: { pluginRuntime: "v1", historyRepairApi: "v1" },
+      },
+      middleware: { historyRepair: userMiddleware },
+    });
+
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "hello" }] },
+    ];
+
+    await runPipeline<HistoryRepairArgs, HistoryRepairResult>(
+      "historyRepair",
+      getMiddlewaresFor("historyRepair"),
+      async (args) => defaultHistoryRepairTerminal(args),
+      { history: messages, provider: "anthropic" },
+      makeCtx(),
+      DEFAULT_TIMEOUTS.historyRepair,
+    );
+
+    expect(userMiddlewareRan).toBe(true);
+  });
+
   test("runs well under the 1s DEFAULT_TIMEOUTS.historyRepair budget", async () => {
     registerPlugin(defaultHistoryRepairPlugin);
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1483,26 +1483,41 @@ export async function runAgentLoopImpl(
     }
 
     // Pre-run repair — routed through the `historyRepair` plugin pipeline so
-    // plugins can observe or override repair behavior. The default plugin
-    // (registered in `external-plugins-bootstrap.ts`) delegates to
-    // `repairHistory` unchanged, preserving existing behavior.
+    // plugins can observe or override repair behavior. The default plugin's
+    // middleware is a passthrough; the actual repair runs in the terminal
+    // (`defaultHistoryRepairTerminal`).
     let preRepairMessages = runMessages;
-    const preRunRepair = await runPipeline<
-      HistoryRepairArgs,
-      HistoryRepairResult
-    >(
-      "historyRepair",
-      getMiddlewaresFor("historyRepair"),
-      async (args) => defaultHistoryRepairTerminal(args),
-      { history: runMessages, provider: ctx.provider.name },
-      buildPluginTurnContext(ctx, reqId),
-      DEFAULT_TIMEOUTS.historyRepair,
-    );
+    let preRunRepair: HistoryRepairResult | null = null;
+    try {
+      preRunRepair = await runPipeline<HistoryRepairArgs, HistoryRepairResult>(
+        "historyRepair",
+        getMiddlewaresFor("historyRepair"),
+        async (args) => defaultHistoryRepairTerminal(args),
+        { history: runMessages, provider: ctx.provider.name },
+        buildPluginTurnContext(ctx, reqId),
+        DEFAULT_TIMEOUTS.historyRepair,
+      );
+    } catch (err) {
+      if (err instanceof PluginTimeoutError) {
+        // Pipeline exceeded its budget — likely a misbehaving third-party
+        // middleware. Degrade gracefully by proceeding with the un-repaired
+        // history rather than turn-fatal-erroring; un-repaired history is
+        // strictly better than no turn at all, and the provider call itself
+        // will still error visibly if the drift is unrecoverable.
+        rlog.warn(
+          { err, phase: "pre_run" },
+          "historyRepair pipeline timed out — proceeding with un-repaired history",
+        );
+      } else {
+        throw err;
+      }
+    }
     if (
-      preRunRepair.stats.assistantToolResultsMigrated > 0 ||
-      preRunRepair.stats.missingToolResultsInserted > 0 ||
-      preRunRepair.stats.orphanToolResultsDowngraded > 0 ||
-      preRunRepair.stats.consecutiveSameRoleMerged > 0
+      preRunRepair !== null &&
+      (preRunRepair.stats.assistantToolResultsMigrated > 0 ||
+        preRunRepair.stats.missingToolResultsInserted > 0 ||
+        preRunRepair.stats.orphanToolResultsDowngraded > 0 ||
+        preRunRepair.stats.consecutiveSameRoleMerged > 0)
     ) {
       rlog.warn(
         { phase: "pre_run", ...preRunRepair.stats },
@@ -1773,6 +1788,15 @@ export async function runAgentLoopImpl(
         { phase: "retry" },
         "Provider ordering error detected, attempting one-shot deep-repair retry",
       );
+      // Design note: deep-repair intentionally bypasses the `historyRepair`
+      // plugin pipeline. Deep-repair is a recovery-only path triggered by a
+      // provider ordering error — it must be deterministic and unaffected by
+      // user middleware that might have caused (or be unable to recover from)
+      // the original drift. Plugins can already observe / override the
+      // pre-run repair via the `historyRepair` pipeline above; widening that
+      // surface to deep-repair is intentionally deferred until there's a
+      // concrete plugin-level use case. Do not route this call through
+      // `runPipeline` without first revisiting that contract.
       const retryRepair = deepRepairHistory(runMessages);
       runMessages = retryRepair.messages;
       const retryStrip = stripHistoricalWebSearchResults(runMessages);

--- a/assistant/src/plugins/defaults/history-repair.ts
+++ b/assistant/src/plugins/defaults/history-repair.ts
@@ -1,18 +1,26 @@
 /**
- * Default `historyRepair` plugin — preserves pre-plugins behavior.
+ * Default `historyRepair` plugin.
  *
- * Wraps {@link repairHistory} from `daemon/history-repair.ts`. The orchestrator
- * invokes this pipeline once per turn, just before the provider call, to
- * collapse common history drift (orphan tool_result blocks, missing
- * tool_result blocks, same-role-consecutive messages). The deep-repair
- * fallback (`deepRepairHistory`) — invoked only after a provider ordering
- * error — remains a direct call in the orchestrator for now; future PRs can
- * widen the pipeline if deep-repair turns out to have swap points worth
- * exposing to plugin authors.
+ * The plugin's middleware is a passthrough — it calls `next(args)` and returns
+ * the result unchanged. The actual repair lives in
+ * {@link defaultHistoryRepairTerminal}, which is wired in as the pipeline's
+ * `terminal` argument by `runPipeline` call sites in
+ * `daemon/conversation-agent-loop.ts`. This separation matters: the default
+ * plugin is registered before any user plugin (defaults load first in
+ * `bootstrapPlugins()`), which puts it at the OUTERMOST position of the onion
+ * chain. If the default middleware were to invoke the terminal directly
+ * without calling `next`, it would shadow every later-registered plugin.
+ * Routing through `next(args)` lets user middleware participate normally.
  *
  * Plugins that override this middleware receive both `history` and `provider`
  * so they can route behavior per provider (e.g. strip blocks a specific
  * provider can't handle) without reaching into ambient state.
+ *
+ * Scope: this pipeline wraps only the standard pre-run repair (`repairHistory`).
+ * The orchestrator's one-shot deep-repair fallback (`deepRepairHistory`),
+ * invoked only after a provider ordering error, intentionally bypasses the
+ * pipeline today — see the design note at the `deepRepairHistory` call site
+ * in `daemon/conversation-agent-loop.ts`.
  */
 
 import { repairHistory } from "../../daemon/history-repair.js";
@@ -27,7 +35,9 @@ import {
 
 /**
  * Terminal handler for the `historyRepair` pipeline. Exported so tests can
- * verify default behavior directly without going through `runPipeline`.
+ * verify default behavior directly without going through `runPipeline`, and
+ * so `daemon/conversation-agent-loop.ts` can pass it as the `terminal`
+ * argument to `runPipeline`.
  */
 export function defaultHistoryRepairTerminal(
   args: HistoryRepairArgs,
@@ -35,9 +45,10 @@ export function defaultHistoryRepairTerminal(
   return repairHistory(args.history);
 }
 
-const terminal: Middleware<HistoryRepairArgs, HistoryRepairResult> = async (
+const passthrough: Middleware<HistoryRepairArgs, HistoryRepairResult> = async (
   args,
-) => defaultHistoryRepairTerminal(args);
+  next,
+) => next(args);
 
 export const defaultHistoryRepairPlugin: Plugin = {
   manifest: {
@@ -47,7 +58,7 @@ export const defaultHistoryRepairPlugin: Plugin = {
     requires: { pluginRuntime: "v1", historyRepairApi: "v1" },
   },
   middleware: {
-    historyRepair: terminal,
+    historyRepair: passthrough,
   },
 };
 


### PR DESCRIPTION
## Summary

Address review feedback on #27400 (history repair plugin pipeline):

- **Default-first shadowing.** `defaultHistoryRepairPlugin` middleware was a terminal that returned `defaultHistoryRepairTerminal(args)` without calling `next` — and because defaults register first, that put it at the OUTERMOST onion layer, shadowing any later-registered user middleware. Switch the middleware to a passthrough; the actual repair stays in `defaultHistoryRepairTerminal`, which the `runPipeline` call site already wires in as the `terminal` arg.
- **Timeout handling.** Wrap the `historyRepair` `runPipeline` call in `try/catch` for `PluginTimeoutError` and degrade to the un-repaired history rather than turn-fatal-erroring on a misbehaving third-party middleware. Mirrors the precedent in start-of-turn compaction.
- **Deep-repair asymmetry.** Add a visible design note at the `deepRepairHistory` call site in `conversation-agent-loop.ts` documenting the intentional pipeline bypass for the recovery-only retry path.
- **Stale AGENTS.md-style comments.** Rewrite "preserves pre-plugins behavior" / "preserving existing behavior" / "external-plugins-bootstrap.ts" references to reflect current state.
- **Skipped:** turnIndex inconsistency (already fixed — every pipeline call site now routes through the canonical `buildPluginTurnContext`, which uses `ctx.turnCount`).

Adds a regression test that registers a user plugin AFTER the default and asserts the user middleware actually runs.

## Test plan

- [x] `bun test src/__tests__/history-repair-pipeline.test.ts` — 9 pass
- [x] `bun test src/__tests__/plugin-types.test.ts src/__tests__/pipeline-runner.test.ts` — 23 pass
- [x] `bunx tsc --noEmit` clean for changed files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
