### PR TITLE
fix(plugins): bound user-plugin dynamic imports with a timeout

### DIFF
--- a/assistant/src/__tests__/user-plugin-loader.test.ts
+++ b/assistant/src/__tests__/user-plugin-loader.test.ts
@@ -134,6 +134,50 @@ registerPlugin({
     expect(getRegisteredPlugins()).toHaveLength(0);
   });
 
+  test("plugin with hanging top-level await is timed out and skipped", async () => {
+    // A plugin whose module evaluation never resolves (hanging top-level
+    // await) would otherwise block daemon startup indefinitely. The loader
+    // must bound the import with a timeout so the hang is isolated the same
+    // way a thrown error would be. A neighboring well-behaved plugin must
+    // still load.
+    writePlugin(
+      "hanging-plugin",
+      `
+await new Promise(() => {
+  // Intentionally never resolves — simulates a plugin whose top-level
+  // await blocks forever.
+});
+registerPlugin({
+  manifest: {
+    name: "hanging-plugin",
+    version: "0.0.1",
+    requires: { pluginRuntime: "v1" },
+  },
+});
+`,
+    );
+    writePlugin(
+      "healthy-plugin",
+      `
+registerPlugin({
+  manifest: {
+    name: "healthy-plugin",
+    version: "0.0.1",
+    requires: { pluginRuntime: "v1" },
+  },
+});
+`,
+    );
+
+    // Use a short test-only timeout so the suite does not wait the full
+    // production 10s for the hung-plugin path.
+    await loadUserPlugins({ importTimeoutMs: 250 });
+
+    const names = getRegisteredPlugins().map((p) => p.manifest.name);
+    expect(names).toContain("healthy-plugin");
+    expect(names).not.toContain("hanging-plugin");
+  });
+
   test("subdirectory without register.{ts,js} is silently skipped", async () => {
     // Populate a directory that looks like a plugin but lacks a register
     // file. The loader must skip it without throwing.

--- a/assistant/src/plugins/user-loader.ts
+++ b/assistant/src/plugins/user-loader.ts
@@ -19,6 +19,11 @@
  *   boundary: the offending directory is logged with `"Failed to load user
  *   plugin <dir>: <err>"` and the loader moves on to the next candidate.
  *   One bad user plugin must not crash the daemon.
+ * - Bounds each dynamic import with a timeout
+ *   ({@link USER_PLUGIN_IMPORT_TIMEOUT_MS}) so a plugin whose top-level
+ *   `await` hangs or whose module evaluation never resolves cannot stall
+ *   daemon startup. Timed-out plugins are logged and skipped just like
+ *   thrown-error plugins.
  *
  * Call order relative to the rest of the plugin system:
  *
@@ -39,6 +44,17 @@ import { vellumRoot } from "../util/platform.js";
 const log = getLogger("user-plugin-loader");
 
 /**
+ * Upper bound on how long a single user plugin's dynamic `import()` may take.
+ * A plugin with a hanging top-level `await` (or a never-resolving module
+ * evaluation) would otherwise block daemon startup indefinitely, since a raw
+ * `try/catch` only isolates thrown errors — not hung promises. Ten seconds is
+ * generous relative to a typical side-effect registration (milliseconds) and
+ * matches the per-plugin isolation contract: slow plugins get skipped the
+ * same way thrown-error plugins do.
+ */
+const USER_PLUGIN_IMPORT_TIMEOUT_MS = 10_000;
+
+/**
  * Scan `vellumRoot()/plugins/` for subdirectories containing a
  * `register.{ts,js}` file, and dynamic-import each one so the module's
  * side-effecting {@link registerPlugin} calls populate the registry.
@@ -56,7 +72,11 @@ const log = getLogger("user-plugin-loader");
  * before {@link bootstrapPlugins} — see the module docstring for the ordering
  * contract.
  */
-export async function loadUserPlugins(): Promise<void> {
+export async function loadUserPlugins(
+  options: { importTimeoutMs?: number } = {},
+): Promise<void> {
+  const importTimeoutMs =
+    options.importTimeoutMs ?? USER_PLUGIN_IMPORT_TIMEOUT_MS;
   const pluginsDir = join(vellumRoot(), "plugins");
   if (!existsSync(pluginsDir)) {
     log.debug(
@@ -116,12 +136,31 @@ export async function loadUserPlugins(): Promise<void> {
     // `import()` with a `file://` URL works identically under Node and bun
     // and sidesteps platform-specific absolute-path quirks on Windows.
     const moduleUrl = pathToFileURL(registerPath).href;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     try {
-      await import(moduleUrl);
-      log.info(
-        { pluginDir, registerPath },
-        "loaded user plugin (side-effect import completed)",
-      );
+      // Race the import against a timeout so a plugin with a hanging top-level
+      // await or never-resolving module evaluation cannot stall daemon startup.
+      // The per-plugin try/catch already handles thrown errors; this extends
+      // the isolation boundary to cover hung promises as well.
+      const timeoutSentinel = Symbol("user-plugin-import-timeout");
+      const timeoutPromise = new Promise<typeof timeoutSentinel>((resolve) => {
+        timeoutHandle = setTimeout(
+          () => resolve(timeoutSentinel),
+          importTimeoutMs,
+        );
+      });
+      const result = await Promise.race([import(moduleUrl), timeoutPromise]);
+      if (result === timeoutSentinel) {
+        log.warn(
+          { pluginDir, registerPath, timeoutMs: importTimeoutMs },
+          `Timed out loading user plugin ${pluginDir} after ${importTimeoutMs}ms — skipping`,
+        );
+      } else {
+        log.info(
+          { pluginDir, registerPath },
+          "loaded user plugin (side-effect import completed)",
+        );
+      }
     } catch (err) {
       // One plugin's failure must never prevent other plugins from loading
       // or crash the daemon. Log with the directory name so operators can
@@ -131,6 +170,8 @@ export async function loadUserPlugins(): Promise<void> {
         { err, pluginDir },
         `Failed to load user plugin ${pluginDir}: ${message}`,
       );
+    } finally {
+      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
     }
   }
 }


### PR DESCRIPTION
Addresses Codex feedback on #27403 — a user plugin with a hanging top-level await could block daemon startup indefinitely. Races each dynamic import against a 10s timeout and skips plugins that exceed it, extending the existing per-plugin isolation contract from thrown errors to hung promises.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
