### PR TITLE
fix(plugins): harden bootstrap failure modes (PR #27394 review)

### DIFF
--- a/assistant/src/__tests__/plugin-bootstrap.test.ts
+++ b/assistant/src/__tests__/plugin-bootstrap.test.ts
@@ -229,6 +229,55 @@ describe("plugin bootstrap", () => {
     expect(msg).toContain("kaboom");
   });
 
+  test("partial-init failure: earlier plugins' onShutdown runs in reverse before the error propagates", async () => {
+    // If plugin N throws during init, every plugin 1..N-1 that already made
+    // it through its full init+contribution phase must have onShutdown()
+    // invoked in reverse registration order before bootstrap re-throws.
+    // Without this, earlier plugins leak live tools/routes/skills because
+    // the shutdown hook is only registered once the entire loop completes.
+    const callOrder: string[] = [];
+    registerPlugin(
+      buildPlugin("survivor-a", {
+        async init() {},
+        async onShutdown() {
+          callOrder.push("survivor-a");
+        },
+      }),
+    );
+    registerPlugin(
+      buildPlugin("survivor-b", {
+        async init() {},
+        async onShutdown() {
+          callOrder.push("survivor-b");
+        },
+      }),
+    );
+    registerPlugin(
+      buildPlugin("failing", {
+        async init() {
+          throw new Error("mid-bootstrap failure");
+        },
+        async onShutdown() {
+          // Never called — this plugin never completes init, so it was never
+          // added to the active list that teardown walks.
+          callOrder.push("failing");
+        },
+      }),
+    );
+
+    let caught: unknown;
+    try {
+      await bootstrapPlugins(fakeCtx);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(PluginExecutionError);
+
+    // Reverse order: survivor-b registered after survivor-a, so it tears
+    // down first; "failing" never entered the active list.
+    expect(callOrder).toEqual(["survivor-b", "survivor-a"]);
+  });
+
   test("shutdown order: onShutdown fires in reverse registration order", async () => {
     const callOrder: string[] = [];
     registerPlugin(

--- a/assistant/src/__tests__/plugin-registry.test.ts
+++ b/assistant/src/__tests__/plugin-registry.test.ts
@@ -82,6 +82,38 @@ describe("plugin registry", () => {
     expect(() => registerPlugin(bad)).toThrow(/manifest\.name is required/);
   });
 
+  test("throws on non-kebab-case plugin names (path-traversal guard)", () => {
+    // Plugin names flow into filesystem paths (`plugins-data/<name>/`), so the
+    // registry must reject anything that could escape the storage directory
+    // or otherwise deviate from the kebab-case contract.
+    const cases = [
+      "../evil",
+      "../../etc",
+      "evil/with/slashes",
+      "has space",
+      "Has-Uppercase",
+      "-leading-hyphen",
+      "trailing-hyphen-",
+      "double--hyphen",
+      ".",
+      "",
+    ];
+    for (const name of cases) {
+      const plugin = buildPlugin(name || "x");
+      // Override the name post-build so the empty-string case exercises the
+      // same code path as the others (buildPlugin uses the literal value).
+      (plugin.manifest as { name: string }).name = name;
+      expect(() => registerPlugin(plugin)).toThrow(PluginExecutionError);
+    }
+  });
+
+  test("accepts valid kebab-case plugin names", () => {
+    for (const name of ["a", "abc", "a-b", "a1-b2", "foo-bar-baz"]) {
+      resetPluginRegistryForTests();
+      expect(() => registerPlugin(buildPlugin(name))).not.toThrow();
+    }
+  });
+
   test("throws when manifest.version is missing", () => {
     const bad = {
       manifest: {

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -187,10 +187,9 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
 
   const plugins = getRegisteredPlugins();
   if (plugins.length === 0) {
-    // No-op fast path — the registry is empty. After this PR the default
-    // injectors are always present, but this branch stays defensive for
-    // tests that call `resetPluginRegistryForTests()` and stub the
-    // default registration.
+    // No-op fast path. The default injectors normally populate the registry,
+    // so this branch is primarily for tests that call
+    // `resetPluginRegistryForTests()` and stub the default registration.
     log.debug("bootstrapPlugins: registry empty — skipping");
     return;
   }
@@ -202,6 +201,17 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
   // are omitted from this list so the shutdown hook below never tears down
   // capabilities that were never wired up in the first place.
   const activePlugins: Plugin[] = [];
+
+  // If one plugin's init or contribution phase throws, tear down any plugins
+  // that already fully initialized (in reverse registration order) before
+  // re-throwing. Without this, a mid-loop failure would leave earlier plugins
+  // with live tools/routes/skills and no `onShutdown()` call — the shutdown
+  // hook is only registered once the loop completes successfully.
+  async function teardownPartialInit(): Promise<void> {
+    for (let i = activePlugins.length - 1; i >= 0; i--) {
+      await teardownPlugin(activePlugins[i]!, "bootstrap-failed");
+    }
+  }
 
   for (const plugin of plugins) {
     const name = plugin.manifest.name;
@@ -226,105 +236,115 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
       continue;
     }
 
-    // Credential resolution — gather every entry in `requiresCredential`
-    // before calling `init()` so the plugin receives a fully-populated map.
-    const credentials: Record<string, string> = {};
-    const required = plugin.manifest.requiresCredential ?? [];
-    for (const key of required) {
-      credentials[key] = await resolveCredentialOrThrow(name, key);
-    }
-
-    // Per-plugin config block, validated against the manifest's parser-like
-    // validator when one is declared.
-    const rawConfig = getPluginConfigRaw(ctx.config, name);
-    const config = validatePluginConfig(
-      name,
-      plugin.manifest.config,
-      rawConfig,
-    );
-
-    // Per-plugin writable data directory. Created lazily during bootstrap
-    // rather than at registration time so the side effect is isolated to
-    // the boot path.
-    const pluginStorageDir = ensurePluginStorageDir(name);
-
-    const initContext: PluginInitContext = {
-      config,
-      credentials,
-      logger: log.child({ plugin: name }),
-      pluginStorageDir,
-      assistantVersion: ctx.assistantVersion,
-      apiVersions: ASSISTANT_API_VERSIONS,
-    };
-
-    if (plugin.init) {
-      try {
-        await plugin.init(initContext);
-      } catch (err) {
-        throw new PluginExecutionError(
-          `plugin ${name} init() failed: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-          name,
-          { cause: err },
-        );
+    try {
+      // Credential resolution — gather every entry in `requiresCredential`
+      // before calling `init()` so the plugin receives a fully-populated map.
+      const credentials: Record<string, string> = {};
+      const required = plugin.manifest.requiresCredential ?? [];
+      for (const key of required) {
+        credentials[key] = await resolveCredentialOrThrow(name, key);
       }
-    }
 
-    // After init succeeds, wire in the plugin's model-visible capabilities.
-    // Tool contributions (PR 31) register only after `init()` succeeds so a
-    // plugin that fails mid-init never leaves partially-wired tools behind.
-    // Tool registration failures throw up the stack to abort bootstrap,
-    // matching the strict-fail semantics of `init()` errors.
-    if (plugin.tools && plugin.tools.length > 0) {
-      const accepted = registerPluginTools(name, plugin.tools);
-      log.info(
-        { plugin: name, count: accepted.length },
-        "plugin tools registered",
+      // Per-plugin config block, validated against the manifest's parser-like
+      // validator when one is declared.
+      const rawConfig = getPluginConfigRaw(ctx.config, name);
+      const config = validatePluginConfig(
+        name,
+        plugin.manifest.config,
+        rawConfig,
       );
-    }
 
-    // Route contributions (PR 32) — registered after init() succeeds so a
-    // plugin that fails to initialize never exposes a half-wired HTTP
-    // surface. Mirrors the skill-route registry shape; see
-    // {@link PluginRouteRegistration}.
-    if (plugin.routes && plugin.routes.length > 0) {
-      for (const route of plugin.routes) {
-        registerSkillRoute(route);
+      // Per-plugin writable data directory. Created lazily during bootstrap
+      // rather than at registration time so the side effect is isolated to
+      // the boot path.
+      const pluginStorageDir = ensurePluginStorageDir(name);
+
+      const initContext: PluginInitContext = {
+        config,
+        credentials,
+        logger: log.child({ plugin: name }),
+        pluginStorageDir,
+        assistantVersion: ctx.assistantVersion,
+        apiVersions: ASSISTANT_API_VERSIONS,
+      };
+
+      if (plugin.init) {
+        try {
+          await plugin.init(initContext);
+        } catch (err) {
+          throw new PluginExecutionError(
+            `plugin ${name} init() failed: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            name,
+            { cause: err },
+          );
+        }
       }
-      log.info(
-        { plugin: name, count: plugin.routes.length },
-        "plugin routes registered",
-      );
-    }
 
-    // Skills (PR 33) register into the in-memory plugin-skill catalog so
-    // `skill_load` / `skill_execute` can resolve them alongside filesystem
-    // skills. A registration failure aborts bootstrap with the plugin named
-    // — same strict-fail posture as init() throws.
-    if (plugin.skills && plugin.skills.length > 0) {
-      try {
-        // `plugin.skills` is typed as `PluginSkillRegistration[]` at the
-        // Plugin interface — the type assertion here is a narrowing from
-        // that generic slot into the concrete shape the registry expects.
-        registerPluginSkills(
-          name,
-          plugin.skills as readonly PluginSkillRegistration[],
-        );
-      } catch (err) {
-        throw new PluginExecutionError(
-          `plugin ${name} skill registration failed: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-          name,
-          { cause: err },
+      // After init succeeds, wire in the plugin's model-visible capabilities.
+      // Tool contributions (PR 31) register only after `init()` succeeds so a
+      // plugin that fails mid-init never leaves partially-wired tools behind.
+      // Tool registration failures throw up the stack to abort bootstrap,
+      // matching the strict-fail semantics of `init()` errors.
+      if (plugin.tools && plugin.tools.length > 0) {
+        const accepted = registerPluginTools(name, plugin.tools);
+        log.info(
+          { plugin: name, count: accepted.length },
+          "plugin tools registered",
         );
       }
+
+      // Route contributions (PR 32) — registered after init() succeeds so a
+      // plugin that fails to initialize never exposes a half-wired HTTP
+      // surface. Mirrors the skill-route registry shape; see
+      // {@link PluginRouteRegistration}.
+      if (plugin.routes && plugin.routes.length > 0) {
+        for (const route of plugin.routes) {
+          registerSkillRoute(route);
+        }
+        log.info(
+          { plugin: name, count: plugin.routes.length },
+          "plugin routes registered",
+        );
+      }
+
+      // Skills register into the in-memory plugin-skill catalog so
+      // `skill_load` / `skill_execute` can resolve them alongside filesystem
+      // skills. A registration failure aborts bootstrap with the plugin named
+      // — same strict-fail posture as init() throws.
+      if (plugin.skills && plugin.skills.length > 0) {
+        try {
+          // `plugin.skills` is typed as `PluginSkillRegistration[]` at the
+          // Plugin interface — the type assertion here is a narrowing from
+          // that generic slot into the concrete shape the registry expects.
+          registerPluginSkills(
+            name,
+            plugin.skills as readonly PluginSkillRegistration[],
+          );
+        } catch (err) {
+          throw new PluginExecutionError(
+            `plugin ${name} skill registration failed: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            name,
+            { cause: err },
+          );
+        }
+      }
+
+      activePlugins.push(plugin);
+
+      log.info({ plugin: name }, "plugin initialized");
+    } catch (err) {
+      // Tear down every plugin that already made it through its full init +
+      // contribution phase, in reverse order, before propagating the error.
+      // Without this, the caller would see a partially-wired registry (tools,
+      // routes, skills all live) with no shutdown hook to clean them up, since
+      // `registerShutdownHook` is only called after the loop completes.
+      await teardownPartialInit();
+      throw err;
     }
-
-    activePlugins.push(plugin);
-
-    log.info({ plugin: name }, "plugin initialized");
   }
 
   // Shutdown hook — walks plugins in REVERSE registration order. We snapshot
@@ -350,61 +370,73 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
   const shutdownSnapshot: Plugin[] = [...activePlugins];
   registerShutdownHook("plugins", async (reason) => {
     for (let i = shutdownSnapshot.length - 1; i >= 0; i--) {
-      const plugin = shutdownSnapshot[i]!;
-      const name = plugin.manifest.name;
-
-      // Unregister model-visible surfaces before invoking `onShutdown()` so
-      // the plugin's onShutdown hook observes a registry state where its
-      // tools and routes are already gone. Plugin authors can safely tear
-      // down whatever those surfaces depended on inside onShutdown.
-      // `unregisterPluginTools` is a no-op when the plugin never
-      // contributed tools, so we don't need to guard on `plugin.tools` here.
-      if (plugin.routes && plugin.routes.length > 0) {
-        for (const route of plugin.routes) {
-          try {
-            unregisterSkillRoute(route.pattern);
-          } catch (err) {
-            log.warn(
-              { err, plugin: name, pattern: route.pattern.source },
-              "plugin route unregister failed (continuing)",
-            );
-          }
-        }
-      }
-
-      try {
-        unregisterPluginTools(name);
-      } catch (err) {
-        log.warn(
-          { err, plugin: name, reason },
-          "plugin tool unregister failed (continuing with remaining plugins)",
-        );
-      }
-
-      if (plugin.onShutdown) {
-        try {
-          await plugin.onShutdown();
-        } catch (err) {
-          // Swallow — we want every plugin's onShutdown to get a chance to
-          // run even when an earlier one throws. The outer runShutdownHooks
-          // already logs at hook level, but the plugin-name attribution here
-          // is what operators read first.
-          log.warn(
-            { err, plugin: name, reason },
-            "plugin onShutdown failed (continuing with remaining plugins)",
-          );
-        }
-      }
-      if (plugin.skills && plugin.skills.length > 0) {
-        try {
-          unregisterPluginSkills(name);
-        } catch (err) {
-          log.warn(
-            { err, plugin: name, reason },
-            "plugin skill unregistration failed (continuing with remaining plugins)",
-          );
-        }
-      }
+      await teardownPlugin(shutdownSnapshot[i]!, reason);
     }
   });
+}
+
+/**
+ * Tear down a single fully-initialized plugin: unregister routes, unregister
+ * tools, invoke `onShutdown()` if present, then unregister skills. Every step
+ * swallows errors and logs with plugin attribution so one bad plugin can't
+ * block teardown of the rest.
+ *
+ * Shared between the normal shutdown hook and the bootstrap error path; both
+ * consume plugins that already cleared every contribution step.
+ */
+async function teardownPlugin(plugin: Plugin, reason: string): Promise<void> {
+  const name = plugin.manifest.name;
+
+  // Unregister model-visible surfaces before invoking `onShutdown()` so the
+  // plugin's onShutdown hook observes a registry state where its tools and
+  // routes are already gone. `unregisterPluginTools` is a no-op when the
+  // plugin never contributed tools, so we don't need to guard on
+  // `plugin.tools` here.
+  if (plugin.routes && plugin.routes.length > 0) {
+    for (const route of plugin.routes) {
+      try {
+        unregisterSkillRoute(route.pattern);
+      } catch (err) {
+        log.warn(
+          { err, plugin: name, pattern: route.pattern.source },
+          "plugin route unregister failed (continuing)",
+        );
+      }
+    }
+  }
+
+  try {
+    unregisterPluginTools(name);
+  } catch (err) {
+    log.warn(
+      { err, plugin: name, reason },
+      "plugin tool unregister failed (continuing with remaining plugins)",
+    );
+  }
+
+  if (plugin.onShutdown) {
+    try {
+      await plugin.onShutdown();
+    } catch (err) {
+      // Swallow — we want every plugin's onShutdown to get a chance to run
+      // even when an earlier one throws. The outer runShutdownHooks already
+      // logs at hook level, but the plugin-name attribution here is what
+      // operators read first.
+      log.warn(
+        { err, plugin: name, reason },
+        "plugin onShutdown failed (continuing with remaining plugins)",
+      );
+    }
+  }
+
+  if (plugin.skills && plugin.skills.length > 0) {
+    try {
+      unregisterPluginSkills(name);
+    } catch (err) {
+      log.warn(
+        { err, plugin: name, reason },
+        "plugin skill unregistration failed (continuing with remaining plugins)",
+      );
+    }
+  }
 }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -711,8 +711,17 @@ export async function runDaemon(): Promise<void> {
     // populated (first-party static side-effect imports + user plugins
     // loaded above) and before the DaemonServer starts handling
     // conversations. Credential resolution + per-plugin storage directory
-    // creation happen here.
-    await bootstrapPlugins({ config, assistantVersion: APP_VERSION });
+    // creation happen here. Wrapped in try/catch so a failing plugin can't
+    // block daemon startup — bootstrapPlugins internally tears down any
+    // partially-initialized plugins before throwing.
+    try {
+      await bootstrapPlugins({ config, assistantVersion: APP_VERSION });
+    } catch (err) {
+      log.warn(
+        { err },
+        "Plugin bootstrap failed — continuing startup with degraded plugin functionality",
+      );
+    }
 
     // Start the DaemonServer (conversation manager) before Qdrant so HTTP
     // routes can begin accepting requests while Qdrant initializes.

--- a/assistant/src/plugins/registry.ts
+++ b/assistant/src/plugins/registry.ts
@@ -107,6 +107,17 @@ export function registerPlugin(plugin: Plugin): void {
       undefined,
     );
   }
+  // Plugin names flow into filesystem paths (e.g. `plugins-data/<name>/` in
+  // the bootstrap's `ensurePluginStorageDir`), so they must not contain path
+  // separators, `..`, or other characters that could escape the parent
+  // directory. Restrict to lowercase-kebab-case, which is the convention used
+  // by every first-party plugin and prevents path-traversal by construction.
+  if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(name)) {
+    throw new PluginExecutionError(
+      `plugin manifest.name "${name}" must be kebab-case (lowercase letters, digits, and single hyphens)`,
+      name,
+    );
+  }
   if (typeof manifest.version !== "string" || manifest.version.length === 0) {
     throw new PluginExecutionError(
       `plugin ${name} manifest.version is required`,


### PR DESCRIPTION
## Summary

Addresses four review findings on #27394:

1. **Daemon-never-blocks-startup.** Wrapped `bootstrapPlugins(...)` in `lifecycle.ts` with a `try/catch` that logs and continues. This matches the surrounding fallible startup steps (CES, Qdrant, backup worker, etc.) and brings the call in line with the AGENTS.md rule that the daemon must never block startup on a failing subsystem.

2. **Plugin-name path-traversal guard.** `registerPlugin` now rejects any name that does not match `/^[a-z0-9]+(-[a-z0-9]+)*$/`. Names previously only had to be non-empty strings, but they flow into `mkdirSync` paths via `ensurePluginStorageDir`, so a name like `"../etc"` could escape `~/.vellum/plugins-data/`. Every first-party plugin is already kebab-case, so no on-disk migration needed.

3. **Partial-init shutdown leak.** Extracted `teardownPlugin()` from the shutdown hook so it can run from two places: the normal shutdown flow, and a new `try/catch` around the per-plugin body. On mid-loop failure we now tear down every plugin that already completed its full init+contribution phase, in reverse registration order, before re-throwing. Previously, earlier plugins kept live tools/routes/skills with no `onShutdown()` because the shutdown hook was only registered at the end of the loop.

4. **Comment rot.** Rewrote the `"After this PR the default injectors are always present…"` comment in `external-plugins-bootstrap.ts` into a current-state description.

Regression tests added:
- Kebab-case rejection (including `"../evil"`, `"has space"`, uppercase, leading/trailing hyphen, double hyphen, empty).
- Reverse-order teardown when plugin N throws during init — survivor plugins 1..N-1 must have `onShutdown()` called in reverse before bootstrap re-throws.

## Test plan
- [x] `bun test src/__tests__/plugin-bootstrap.test.ts src/__tests__/plugin-registry.test.ts` — 28 pass, 0 fail.
- [x] `bunx tsc --noEmit` clean for touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
