### PR TITLE
chore(cli): drop dead hooks entries from shell completions

### DIFF
--- a/assistant/src/cli/commands/completions.ts
+++ b/assistant/src/cli/commands/completions.ts
@@ -40,7 +40,6 @@ Examples:
         keys: ["list", "set", "delete"],
         trust: ["list", "remove", "clear"],
         memory: ["status", "backfill", "cleanup", "query", "rebuild-index"],
-        hooks: ["list", "enable", "disable", "install", "remove"],
         contacts: ["list", "invites", "get", "merge"],
         autonomy: ["get", "set"],
       };
@@ -50,7 +49,6 @@ Examples:
         "keys",
         "trust",
         "memory",
-        "hooks",
         "contacts",
         "autonomy",
         "audit",
@@ -63,7 +61,7 @@ Examples:
           process.stdout.write(generateBashCompletion(topLevel, subcommands));
           break;
         case "zsh":
-          process.stdout.write(generateZshCompletion(topLevel, subcommands));
+          process.stdout.write(generateZshCompletion(subcommands));
           break;
         case "fish":
           process.stdout.write(generateFishCompletion(topLevel, subcommands));
@@ -113,10 +111,7 @@ complete -F _assistant_completions assistant
 `;
 }
 
-function generateZshCompletion(
-  topLevel: string[],
-  subcommands: Record<string, string[]>,
-): string {
+function generateZshCompletion(subcommands: Record<string, string[]>): string {
   const subcmdCases = Object.entries(subcommands)
     .map(([cmd, subs]) => `        ${cmd}) compadd ${subs.join(" ")} ;;`)
     .join("\n");
@@ -132,7 +127,6 @@ _assistant() {
         'keys:Manage API keys in secure storage'
         'trust:Manage trust rules'
         'memory:Manage long-term memory'
-        'hooks:Manage hooks'
         'contacts:Manage the contact graph'
         'autonomy:View and configure autonomy tiers'
         'audit:Show recent tool invocations'
@@ -172,7 +166,6 @@ function generateFishCompletion(
     keys: "Manage API keys in secure storage",
     trust: "Manage trust rules",
     memory: "Manage long-term memory",
-    hooks: "Manage hooks",
     contacts: "Manage the contact graph",
     autonomy: "View and configure autonomy tiers",
     audit: "Show recent tool invocations",


### PR DESCRIPTION
Addresses Codex feedback on #27382 — the hooks subcommand was removed but completions.ts still advertised hooks, hooks subcommands, and help text. Since the entire hooks module has been removed (see #27392), these entries are now fully dead.

Also drops the now-unused `topLevel` parameter from `generateZshCompletion` (zsh hardcodes command descriptions inline and never used it).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
