### PR TITLE
docs(plugins): fix broken copy path + rewrite daemon→assistant in user docs

### DIFF
--- a/assistant/docs/plugins.md
+++ b/assistant/docs/plugins.md
@@ -41,7 +41,7 @@ off that one `Plugin` object.
 my-plugin/
 ├── package.json      # Node/Bun package metadata
 ├── README.md         # optional — human docs
-└── register.ts       # the entry point the daemon imports
+└── register.ts       # the entry point the assistant imports
 ```
 
 The `Plugin` shape is declared in
@@ -73,11 +73,11 @@ loader lives in
 has three key properties:
 
 - **Compiled wins.** If both `register.js` and `register.ts` are present,
-  the compiled `.js` file is loaded. This matches how the compiled daemon
-  binary resolves modules in production.
+  the compiled `.js` file is loaded. This matches how the compiled
+  assistant binary resolves modules in production.
 - **Per-plugin isolation.** If one plugin throws at import time, the error
   is logged with the plugin directory and the loader moves on. Other
-  plugins still load. One broken plugin cannot brick the daemon.
+  plugins still load. One broken plugin cannot brick the assistant.
 - **Per-instance.** The scan runs under `vellumRoot()`, which honors the
   multi-instance `BASE_DATA_DIR` override. Each assistant instance loads
   its own plugin set.
@@ -152,7 +152,7 @@ keys (the same keys declared in
 `meta/feature-flags/feature-flag-registry.json`). The bootstrap checks each
 key against `isAssistantFeatureFlagEnabled` before touching the plugin. If
 **any** listed flag is disabled, the plugin is skipped entirely for the
-duration of this daemon boot:
+duration of this assistant boot:
 
 - `init()` is **not** invoked.
 - `tools`, `routes`, and `skills` are **not** registered.
@@ -160,8 +160,8 @@ duration of this daemon boot:
   nothing to tear down on shutdown.
 
 Flag state is resolved once at bootstrap time. Flipping a `requiresFlag`
-key at runtime does not hot-reload the plugin — restart the daemon after
-changing the flag to pick up the new state. An empty `requiresFlag` (or
+key at runtime does not hot-reload the plugin — restart the assistant
+after changing the flag to pick up the new state. An empty `requiresFlag` (or
 the field being absent) means the plugin activates unconditionally.
 
 The skip path emits a single `info`-level log line naming both the plugin
@@ -494,8 +494,8 @@ export interface PluginInitContext {
 ```
 
 `pluginStorageDir` is a per-plugin writable directory. Use it for
-persistent state — cache files, counters, anything that must survive a
-daemon restart. The bootstrap creates it on demand.
+persistent state — cache files, counters, anything that must survive an
+assistant restart. The bootstrap creates it on demand.
 
 ## Tool, route, and skill contributions
 
@@ -623,12 +623,12 @@ import API — a plugin's export surface is intentionally limited to the
 For cross-cutting concerns (broadcasting events, reacting to
 system-level changes), use the `assistantEventHub` pub/sub in
 [`runtime/assistant-event-hub.ts`](../src/runtime/assistant-event-hub.ts).
-The hub is the canonical place to publish events from inside the daemon
-process and to subscribe from anywhere that has access to the daemon's
-module graph.
+The hub is the canonical place to publish events from inside the
+assistant process and to subscribe from anywhere that has access to the
+assistant's module graph.
 
 Do not add new HTTP endpoints to implement plugin-to-plugin messaging
-inside a single daemon process.
+inside a single assistant process.
 
 `manifest.provides` is reserved as the hook for a future cross-plugin
 capability-negotiation protocol but is **not currently consumed by any
@@ -640,7 +640,7 @@ that adding real consumers later does not require bumping
 
 ## Hot reload
 
-**Not supported in v1.** Registering a plugin takes effect at daemon
+**Not supported in v1.** Registering a plugin takes effect at assistant
 startup only. To pick up a new or modified plugin:
 
 ```bash
@@ -648,7 +648,7 @@ vellum restart
 ```
 
 The registry's internal state is not mutable at runtime. `init()` and
-`onShutdown()` hooks are fired exactly once per daemon boot.
+`onShutdown()` hooks are fired exactly once per assistant boot.
 
 If you need hot reload for development, symlink your plugin directory
 into `~/.vellum/plugins/` so edits propagate, and automate the restart
@@ -678,7 +678,7 @@ match.
 
 Two plugins tried to register under the same `manifest.name`. Names must
 be globally unique. Rename one, or if this is a dev-reload issue,
-restart the daemon.
+restart the assistant.
 
 ### "plugin X requires credential Y but the credential store returned no value"
 
@@ -688,7 +688,7 @@ The credential named in `requiresCredential` is not set. Run:
 vellum credentials set Y
 ```
 
-…and restart the daemon.
+…and restart the assistant.
 
 ### "plugin X config validation failed: …"
 
@@ -709,18 +709,18 @@ background job that publishes results through `assistantEventHub`.
 Every pipeline invocation emits one structured line tagged
 `event=plugin.pipeline`. The fields:
 
-| Field                                      | Meaning                                                               |
-| ------------------------------------------ | --------------------------------------------------------------------- |
-| `pipeline`                                 | Pipeline name (`llmCall`, `toolExecute`, …).                          |
-| `chain`                                    | Ordered list of middleware function names, outermost first.           |
-| `durationMs`                               | Total time spent in the composed chain.                               |
-| `outcome`                                  | `"success"`, `"error"`, or `"timeout"`.                               |
-| `pluginName`                               | The specific plugin's name when the runner could attribute the frame. |
-| `timeoutMs`                                | The configured budget (only when one was set).                        |
-| `errorName`, `errorMessage`, `errorStack`  | Present on failure outcomes.                                          |
-| `requestId`, `conversationId`, `turnIndex` | Per-turn context for correlating with the rest of the daemon's logs.  |
+| Field                                      | Meaning                                                                 |
+| ------------------------------------------ | ----------------------------------------------------------------------- |
+| `pipeline`                                 | Pipeline name (`llmCall`, `toolExecute`, …).                            |
+| `chain`                                    | Ordered list of middleware function names, outermost first.             |
+| `durationMs`                               | Total time spent in the composed chain.                                 |
+| `outcome`                                  | `"success"`, `"error"`, or `"timeout"`.                                 |
+| `pluginName`                               | The specific plugin's name when the runner could attribute the frame.   |
+| `timeoutMs`                                | The configured budget (only when one was set).                          |
+| `errorName`, `errorMessage`, `errorStack`  | Present on failure outcomes.                                            |
+| `requestId`, `conversationId`, `turnIndex` | Per-turn context for correlating with the rest of the assistant's logs. |
 
-Pipe the daemon's stderr through `jq` to filter and inspect:
+Pipe the assistant's stderr through `jq` to filter and inspect:
 
 ```bash
 tail -f ~/.vellum/daemon.log | jq 'select(.event == "plugin.pipeline")'
@@ -745,10 +745,10 @@ tail -f ~/.vellum/daemon.log \
 - Confirm the directory is under `~/.vellum/plugins/` (or the per-instance
   equivalent under `$BASE_DATA_DIR/.vellum/plugins/`).
 - Confirm it has a `register.ts` or `register.js` at the top level.
-- Check the daemon's stderr for a line like
+- Check the assistant's stderr for a line like
   `loaded user plugin (side-effect import completed)` or
   `Failed to load user plugin <dir>: <err>`. Import-time throws are
-  logged but do not crash the daemon — the plugin is silently skipped
+  logged but do not crash the assistant — the plugin is silently skipped
   otherwise.
 - Verify `register.ts` calls `registerPlugin()` exactly once at module
   level. If the call is inside an unrelated conditional or wrapped in

--- a/assistant/examples/plugins/echo/README.md
+++ b/assistant/examples/plugins/echo/README.md
@@ -31,10 +31,11 @@ For the full plugin authoring guide, see
 ## Install locally
 
 The assistant scans `~/.vellum/plugins/*` for subdirectories containing a
-`register.{ts,js}` file and dynamic-imports each one during daemon startup.
-Dropping (or symlinking) this directory in place is enough to enable it.
+`register.{ts,js}` file and dynamic-imports each one during assistant
+startup. Dropping (or symlinking) this directory in place is enough to
+enable it.
 
-### Option 1 — symlink from the repo
+### Option 1 — symlink from the repo (recommended)
 
 From the repo root:
 
@@ -43,21 +44,39 @@ mkdir -p ~/.vellum/plugins
 ln -s "$(pwd)/assistant/examples/plugins/echo" ~/.vellum/plugins/echo
 ```
 
-Symlinks let you edit the plugin in-place and restart the daemon to pick
-up changes.
+Symlinks let you edit the plugin in-place and restart the assistant to
+pick up changes. **This is the only zero-edit install path** — the
+`register.ts` in this directory uses relative imports
+(`../../../src/plugins/registry.js`) that resolve into the in-repo
+assistant sources, so the file must stay reachable at that relative
+location.
 
-### Option 2 — copy
+### Option 2 — standalone copy (requires edits)
 
-If you prefer an isolated install that won't move with the repo:
+If you want a fully isolated install that does not depend on a local
+vellum-assistant checkout, a plain `cp -R` of this directory into
+`~/.vellum/plugins/echo/` will **not** work as-is: the relative imports
+in `register.ts` resolve to `~/.vellum/src/plugins/...`, which does not
+exist. The assistant does not currently publish the plugin API as an npm
+package, so to copy-and-adapt this template into a standalone plugin you
+must rewrite the imports in `register.ts` to point at an absolute path
+inside a vellum-assistant checkout, for example:
 
-```bash
-mkdir -p ~/.vellum/plugins
-cp -R assistant/examples/plugins/echo ~/.vellum/plugins/echo
+```ts
+// before (repo-local):
+import { registerPlugin } from "../../../src/plugins/registry.js";
+// after (standalone, edit to your checkout path):
+import { registerPlugin } from "/path/to/vellum-assistant/assistant/src/plugins/registry.js";
 ```
+
+Apply the same rewrite to the `import type` line that pulls from
+`../../../src/plugins/types.js`. Until a published package exists, the
+symlink recipe above is simpler and more portable for day-to-day
+development.
 
 ### Restart the assistant
 
-Plugins register at daemon startup. After installing, restart the
+Plugins register at assistant startup. After installing, restart the
 assistant:
 
 ```bash
@@ -66,9 +85,9 @@ vellum restart
 
 ## Verify it works
 
-With the plugin installed and the daemon restarted, send any message that
-exercises a pipeline — a conversation turn, a tool call, a title generation
-— and tail the daemon's stderr log:
+With the plugin installed and the assistant restarted, send any message
+that exercises a pipeline — a conversation turn, a tool call, a title
+generation — and tail the assistant's stderr log:
 
 ```bash
 tail -f ~/.vellum/daemon.log
@@ -91,7 +110,7 @@ original error still propagates.
 
 ## Uninstall
 
-Remove the symlink (or the copied directory) and restart the daemon:
+Remove the symlink (or the copied directory) and restart the assistant:
 
 ```bash
 rm ~/.vellum/plugins/echo

--- a/assistant/examples/plugins/echo/register.ts
+++ b/assistant/examples/plugins/echo/register.ts
@@ -3,12 +3,36 @@
  * line per invocation to stderr.
  *
  * This plugin is bundled in the repository as an authoring reference. It is
- * not shipped with the assistant runtime; to try it locally, symlink (or
- * copy) this directory into `~/.vellum/plugins/echo/` and restart the daemon.
- * See `README.md` in this directory for the full install recipe and
+ * not shipped with the assistant runtime; to try it locally, symlink this
+ * directory into `~/.vellum/plugins/echo/` and restart the assistant. See
+ * `README.md` in this directory for the full install recipe and
  * `assistant/docs/plugins.md` for general plugin authoring docs.
  *
- * Design:
+ * ## IMPORTANT — imports below are REPO-LOCAL
+ *
+ * The relative imports from `../../../src/plugins/...` resolve correctly
+ * only while this file lives inside the vellum-assistant repo at
+ * `assistant/examples/plugins/echo/`. The path walks back to
+ * `assistant/src/plugins/` so the example compiles against the assistant's
+ * in-repo types.
+ *
+ * If you copy (rather than symlink) this directory to
+ * `~/.vellum/plugins/echo/`, these imports will fail because
+ * `~/.vellum/src/plugins/...` does not exist. The assistant does not
+ * currently publish the plugin API as an npm package, so the only
+ * zero-edit install path is the symlink recipe (Option 1 in README.md).
+ *
+ * For a standalone copy that lives outside the repo, you must either:
+ * - Point the imports at an absolute path into a vellum-assistant checkout
+ *   (`/path/to/vellum-assistant/assistant/src/plugins/registry.js`), or
+ * - Rewrite the plugin to consume only the public types you need and drop
+ *   the direct registry import in favor of your own entry-point wiring.
+ *
+ * See README.md "Option 2 — standalone copy" for the recommended
+ * standalone-template adaptation steps.
+ *
+ * ## Design
+ *
  * - Registers an observer middleware on every slot of `PipelineMiddlewareMap`.
  * - Each middleware records a start timestamp, calls `next(args)`, and on
  *   return — whether successful or not — emits one JSON line on `stderr` with
@@ -22,17 +46,6 @@
  * The file exports no named symbols at module level — it only runs
  * `registerPlugin(echoPlugin)` as an import-time side effect, matching the
  * user-plugin-loader contract (see `assistant/src/plugins/user-loader.ts`).
- *
- * Implementation note on the relative import path below: user plugins live
- * under `~/.vellum/plugins/<name>/` at runtime and import the assistant's
- * `registerPlugin` / type surface via whatever resolution path the daemon
- * exposes. When running the compiled daemon binary, the registry module is
- * already inside the bundle — the `import()` call from `user-loader.ts`
- * loads this `register.ts` file, and Node/bun resolves the relative import
- * against the real on-disk layout. For the in-repo example, the relative
- * path walks back from `assistant/examples/plugins/echo/` to
- * `assistant/src/plugins/` so the example compiles cleanly against the
- * assistant's types.
  */
 
 import { registerPlugin } from "../../../src/plugins/registry.js";
@@ -72,7 +85,7 @@ const PLUGIN_NAME = "echo";
 
 /**
  * One line written to stderr per pipeline invocation. Kept intentionally
- * compact — pino-style JSON so operators can pipe the daemon's stderr
+ * compact — pino-style JSON so operators can pipe the assistant's stderr
  * through `jq` without reshaping.
  */
 function emit(


### PR DESCRIPTION
## Summary

Follow-up to #27414 addressing reviewer feedback:

1. **Echo plugin template was broken on the Option-2 copy path.** `assistant/examples/plugins/echo/register.ts` imports from `../../../src/plugins/registry.js`, which resolves into the in-repo assistant sources. When a user follows README Option 2 (`cp -R … ~/.vellum/plugins/echo/`), those imports resolve to `~/.vellum/src/plugins/...` and `loadUserPlugins` throws on import.

   - No published npm package for the plugin API exists yet, so option (a) isn't available.
   - Opted for option (b): mark the relative imports clearly as repo-local-only in `register.ts` with a standalone-template adaptation note, and rewrite README Option 2 as a "standalone copy (requires edits)" section that shows users exactly how to rewrite the imports.
   - Option 1 (symlink) stays the recommended zero-edit path.

2. **Per AGENTS.md, user-facing docs should say "assistant" rather than "daemon".** Rewrote conceptual "daemon" → "assistant" in:
   - `assistant/docs/plugins.md` (~15 occurrences)
   - `assistant/examples/plugins/echo/README.md`
   - `assistant/examples/plugins/echo/register.ts` doc comments

   Literal filenames (`daemon.log`) were left alone.

## Test plan

- [x] `bunx tsc --noEmit` in `assistant/` — passes
- [x] `bun run lint` on `examples/plugins/echo/register.ts` — passes
- [x] Prettier clean
- [x] Docs-only and comment-only changes; no runtime code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
