### PR TITLE
fix(plugins/overflow-reduce): honor abort + separate step/accumulated compaction flags

### DIFF
--- a/assistant/src/__tests__/overflow-reduce-pipeline.test.ts
+++ b/assistant/src/__tests__/overflow-reduce-pipeline.test.ts
@@ -179,7 +179,8 @@ async function runInlineBaseline(args: {
   readonly reinjectForMode: (
     reducedMessages: Message[],
     mode: InjectionMode,
-    didCompact: boolean,
+    stepCompacted: boolean,
+    accumulatedCompacted: boolean,
   ) => Promise<Message[]>;
   readonly estimatePostInjection: (runMsgs: Message[]) => number;
 }): Promise<{
@@ -198,6 +199,7 @@ async function runInlineBaseline(args: {
   let attempts = 0;
 
   while (attempts < args.maxAttempts && !reducerState.exhausted) {
+    args.abortSignal?.throwIfAborted();
     attempts++;
     const step = await reduceContextOverflow(
       messages,
@@ -217,13 +219,17 @@ async function runInlineBaseline(args: {
     messages = step.messages;
     injectionMode = step.state.injectionMode;
 
-    if (step.compactionResult?.compacted) {
+    const stepCompacted = step.compactionResult?.compacted === true;
+    if (stepCompacted) {
       reducerCompacted = true;
     }
+
+    args.abortSignal?.throwIfAborted();
 
     runMessages = await args.reinjectForMode(
       messages,
       injectionMode,
+      stepCompacted,
       reducerCompacted,
     );
 
@@ -243,7 +249,11 @@ async function runInlineBaseline(args: {
 
 function buildArgs(messages: Message[]): {
   args: OverflowReduceArgs;
-  reinjectCalls: Array<{ mode: InjectionMode; didCompact: boolean }>;
+  reinjectCalls: Array<{
+    mode: InjectionMode;
+    stepCompacted: boolean;
+    accumulatedCompacted: boolean;
+  }>;
   compactionResults: ContextWindowResult[];
   rawCompactFn: (
     messages: Message[],
@@ -251,7 +261,11 @@ function buildArgs(messages: Message[]): {
     options: ContextWindowCompactOptions,
   ) => Promise<ContextWindowResult>;
 } {
-  const reinjectCalls: Array<{ mode: InjectionMode; didCompact: boolean }> = [];
+  const reinjectCalls: Array<{
+    mode: InjectionMode;
+    stepCompacted: boolean;
+    accumulatedCompacted: boolean;
+  }> = [];
   const compactionResults: ContextWindowResult[] = [];
   const compactFn = makeCompactFn();
 
@@ -263,9 +277,10 @@ function buildArgs(messages: Message[]): {
   const reinjectForMode = async (
     reducedMessages: Message[],
     mode: InjectionMode,
-    didCompact: boolean,
+    stepCompacted: boolean,
+    accumulatedCompacted: boolean,
   ): Promise<Message[]> => {
-    reinjectCalls.push({ mode, didCompact });
+    reinjectCalls.push({ mode, stepCompacted, accumulatedCompacted });
     return reducedMessages;
   };
 
@@ -544,6 +559,118 @@ describe("overflow-reduce pipeline", () => {
 
       expect(result.attempts).toBeGreaterThanOrEqual(1);
       expect(result.reducerState.appliedTiers.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("abort signal propagation", () => {
+    test("middleware bails between iterations when abortSignal fires", async () => {
+      // History that won't converge in one step — multiple iterations.
+      const longToolResult = "r".repeat(8000);
+      const history: Message[] = [
+        msg("user", "Start"),
+        toolUseMsg("tu_1", "read_file"),
+        toolResultMsg("tu_1", longToolResult),
+        msg("user", "Next"),
+      ];
+
+      const controller = new AbortController();
+      const build = buildArgs(history);
+      // Abort on the first `estimatePostInjection` — simulates the
+      // pipeline-level timeout firing mid-turn. The next loop iteration
+      // must see the signal and throw rather than starting another round.
+      let estimateCalls = 0;
+      const aborting: OverflowReduceArgs = {
+        ...build.args,
+        abortSignal: controller.signal,
+        estimatePostInjection: () => {
+          estimateCalls++;
+          if (estimateCalls === 1) controller.abort();
+          // Return a value that guarantees another iteration would fire
+          // without the abort gate.
+          return build.args.preflightBudget + 1_000_000;
+        },
+      };
+
+      expect(
+        defaultOverflowReduceMiddleware(
+          aborting,
+          async () => {
+            throw new Error("next should not be invoked");
+          },
+          makeTurnContext(),
+        ),
+      ).rejects.toThrow();
+      // Give the event loop a tick to resolve the rejected promise.
+      await Promise.resolve();
+      // Exactly one iteration ran; the abort gate stopped the next round.
+      expect(estimateCalls).toBe(1);
+    });
+
+    test("middleware refuses to start when abortSignal is already aborted", async () => {
+      const history: Message[] = [msg("user", "Hi")];
+      const controller = new AbortController();
+      controller.abort();
+      const build = buildArgs(history);
+      const args: OverflowReduceArgs = {
+        ...build.args,
+        abortSignal: controller.signal,
+      };
+
+      expect(
+        defaultOverflowReduceMiddleware(
+          args,
+          async () => {
+            throw new Error("next should not be invoked");
+          },
+          makeTurnContext(),
+        ),
+      ).rejects.toThrow();
+      await Promise.resolve();
+      // Reducer never ran — zero compaction and reinject callbacks observed.
+      expect(build.compactionResults).toHaveLength(0);
+      expect(build.reinjectCalls).toHaveLength(0);
+    });
+  });
+
+  describe("reinjectForMode two-flag semantics", () => {
+    test("stepCompacted reflects current iteration; accumulatedCompacted stays sticky", async () => {
+      // Force multiple iterations by returning over-budget until the loop
+      // exits on maxAttempts. First iteration compacts (stepCompacted=true);
+      // subsequent iterations run other tiers (stepCompacted=false), but
+      // accumulatedCompacted must remain true for slack suppression.
+      const longToolResult = "r".repeat(8000);
+      const history: Message[] = [
+        msg("user", "Start"),
+        toolUseMsg("tu_1", "read_file"),
+        toolResultMsg("tu_1", longToolResult),
+        msg("user", "Next"),
+      ];
+      const build = buildArgs(history);
+      const overBudget: OverflowReduceArgs = {
+        ...build.args,
+        estimatePostInjection: () => build.args.preflightBudget + 1_000_000,
+      };
+
+      await defaultOverflowReduceMiddleware(
+        overBudget,
+        async () => {
+          throw new Error("next should not be invoked");
+        },
+        makeTurnContext(),
+      );
+
+      // At least one compaction attempt happened.
+      expect(build.reinjectCalls.length).toBeGreaterThanOrEqual(1);
+      // The first iteration that compacted set accumulatedCompacted=true,
+      // and every subsequent call continues to see it true — even when
+      // that iteration's own step did NOT compact.
+      const firstCompactedAt = build.reinjectCalls.findIndex(
+        (c) => c.stepCompacted,
+      );
+      expect(firstCompactedAt).toBeGreaterThanOrEqual(0);
+      for (let i = firstCompactedAt; i < build.reinjectCalls.length; i++) {
+        expect(build.reinjectCalls[i]!.accumulatedCompacted).toBe(true);
+      }
     });
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1403,7 +1403,12 @@ export async function runAgentLoopImpl(
             shouldInjectWorkspace = true;
           }
         },
-        reinjectForMode: async (reducedMessages, mode, didCompact) => {
+        reinjectForMode: async (
+          reducedMessages,
+          mode,
+          stepCompacted,
+          accumulatedCompacted,
+        ) => {
           // Mirror the pre-PR-23 behavior: `ctx.messages` must track the
           // reducer's latest output before re-injection runs, because other
           // sites consulted through `injectionOpts` (`workspaceTopLevelContext`,
@@ -1414,22 +1419,24 @@ export async function runAgentLoopImpl(
           // injection assembly on the same turn.
           ctx.messages = reducedMessages;
 
-          // When compaction ran it strips existing NOW.md / PKB blocks,
-          // so we must re-inject the current content. Otherwise rely on
-          // the deduplicated value from injectionOpts to avoid duplicate
-          // injection.
+          // When THIS iteration compacted, it stripped existing NOW.md /
+          // PKB blocks — so we re-inject current content. A later iteration
+          // that only truncates or downgrades must NOT re-force PKB/NOW,
+          // or each round would grow the token count. Matches the
+          // pre-PR-23 per-iteration `step.compactionResult?.compacted` gate.
           const injection = await applyRuntimeInjections(reducedMessages, {
             ...injectionOpts,
-            ...(didCompact && { pkbContext: currentPkbContent }),
-            ...(didCompact && { nowScratchpad: currentNowContent }),
+            ...(stepCompacted && { pkbContext: currentPkbContent }),
+            ...(stepCompacted && { nowScratchpad: currentNowContent }),
             workspaceTopLevelContext: shouldInjectWorkspace
               ? ctx.workspaceTopLevelContext
               : null,
-            // Once the reducer has compacted `ctx.messages`, the captured
+            // Once ANY iteration has compacted `ctx.messages`, the captured
             // `slackChronologicalMessages` snapshot (built from the full
             // persisted transcript) would overwrite the compacted history
-            // and undo compaction. Suppress the override from here on.
-            slackChronologicalMessages: didCompact
+            // and undo compaction. Suppress the override from here on —
+            // sticky across subsequent non-compacting iterations.
+            slackChronologicalMessages: accumulatedCompacted
               ? null
               : injectionOpts.slackChronologicalMessages,
             mode,

--- a/assistant/src/plugins/defaults/overflow-reduce.ts
+++ b/assistant/src/plugins/defaults/overflow-reduce.ts
@@ -56,6 +56,17 @@ export const defaultOverflowReduceMiddleware: Middleware<
   let attempts = 0;
 
   while (attempts < args.maxAttempts && !reducerState.exhausted) {
+    // Abort check at the top of every iteration. When the pipeline runner
+    // arms a timeout (or the caller aborts externally), `args.abortSignal`
+    // is linked to that trigger via `linkAbortSignal`, so this check lets
+    // us bail out BETWEEN iterations rather than letting another round of
+    // compaction / re-injection mutate `ctx.messages` after the turn has
+    // already failed. Individual `reduceContextOverflow` calls also honor
+    // the signal, but without this gate a fresh iteration could still
+    // start after the signal fires, since the previous one returned
+    // normally before the abort propagated.
+    args.abortSignal?.throwIfAborted();
+
     attempts++;
     args.emitActivityState();
 
@@ -78,14 +89,23 @@ export const defaultOverflowReduceMiddleware: Middleware<
     messages = step.messages;
     injectionMode = step.state.injectionMode;
 
+    // Per-iteration compaction flag: whether THIS step just produced a
+    // fresh compaction. PKB / NOW re-injection is gated on this — see the
+    // reinjectForMode JSDoc for why the two signals differ.
+    const stepCompacted = step.compactionResult?.compacted === true;
+
     // Let the orchestrator apply compaction side effects (circuit-breaker
     // tracking, event emission, ctx mutation) before we re-inject.
     if (step.compactionResult) {
       await args.onCompactionResult(step.compactionResult);
-      if (step.compactionResult.compacted) {
+      if (stepCompacted) {
         reducerCompacted = true;
       }
     }
+
+    // Second abort gate — if the side effects or the step itself took us
+    // past the deadline, don't rebuild runMessages or iterate again.
+    args.abortSignal?.throwIfAborted();
 
     // Rebuild runMessages via the orchestrator-supplied helper (which
     // re-runs `applyRuntimeInjections` with potentially downgraded mode
@@ -94,9 +114,15 @@ export const defaultOverflowReduceMiddleware: Middleware<
     // has to read from mutable shared state to rebuild runMessages — a
     // tier that doesn't trigger compaction (tool-result truncation, media
     // stubbing) won't update `ctx.messages` on its own.
+    //
+    // `stepCompacted` and `reducerCompacted` are both passed so the
+    // orchestrator can gate PKB / NOW re-injection per-iteration while
+    // keeping `slackChronologicalMessages` suppressed once any iteration
+    // has compacted.
     runMessages = await args.reinjectForMode(
       messages,
       injectionMode,
+      stepCompacted,
       reducerCompacted,
     );
 

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -399,11 +399,27 @@ export interface OverflowReduceArgs {
    * leak into the pipeline surface. The plugin passes the current reduced
    * messages array explicitly so the orchestrator doesn't need to read
    * mutable shared state. Returns the new `runMessages`.
+   *
+   * Two distinct "did compact" signals are passed so the orchestrator can
+   * match the pre-PR-23 semantics:
+   * - `stepCompacted` — whether THIS iteration's reducer step produced a
+   *   fresh compaction. Gates PKB / NOW re-injection: compaction strips the
+   *   existing blocks, so only iterations that just compacted need the
+   *   content re-threaded. Iterations that only truncated tool results or
+   *   downgraded injections must NOT force a re-injection or the token
+   *   count grows each round.
+   * - `accumulatedCompacted` — whether ANY iteration in this pipeline
+   *   invocation has compacted. Gates `slackChronologicalMessages`
+   *   suppression: once compaction has run, the captured Slack transcript
+   *   snapshot would overwrite the compacted history, so it must stay
+   *   suppressed for every subsequent iteration even if that iteration
+   *   didn't re-compact.
    */
   readonly reinjectForMode: (
     messages: Message[],
     mode: InjectionMode,
-    didCompact: boolean,
+    stepCompacted: boolean,
+    accumulatedCompacted: boolean,
   ) => Promise<Message[]>;
   /**
    * Invoked after each step to post-estimate the rebuilt `runMessages`.


### PR DESCRIPTION
## Summary
Follow-up to #27408 addressing reviewer feedback on correctness of the overflow-reduce pipeline.

- **Abort cancellation gap.** The default middleware's tier loop threaded `abortSignal` into `reduceContextOverflow` but did not gate subsequent iterations on the signal. If the pipeline timeout (or the caller's controller) fired mid-iteration, the loop could start another round — mutating `ctx.messages`, emitting compaction events, and rebuilding injections after the turn had already failed with `PluginTimeoutError`. Now call `abortSignal.throwIfAborted()` at the top of each iteration and after the reducer step so aborts exit between rounds instead of leaking side effects.
- **reinjectForMode semantics drift.** The middleware passed the *accumulated* `reducerCompacted` flag to `reinjectForMode`, and the orchestrator used it for both PKB/NOW re-injection and `slackChronologicalMessages` suppression. Once any iteration compacted, every later iteration incorrectly forced PKB/NOW re-injection — altering token counts on tool-result-truncation and media-stubbing tiers. The pre-#27408 inline loop checked `step.compactionResult?.compacted` per-iteration for PKB/NOW while keeping the accumulated flag only for slack suppression. This PR splits the signal into `stepCompacted` (per-iteration) and `accumulatedCompacted` (sticky) and restores the original behavior.
- **No-middleware fallback (already fixed in-tree).** The reviewer flagged a terminal handler that returned `reducerState.exhausted = true` and short-circuited the convergence loop. The terminal has since been changed to throw `PluginExecutionError`, so this branch is no longer reachable. Documented in the commit for the audit trail.

Regression tests cover:
- Abort gate between iterations (signal fires mid-turn → next iteration throws, no extra side effects).
- Pre-aborted signal short-circuits before the first reducer step.
- Two-flag re-injection semantics (`accumulatedCompacted` stays sticky after the first compaction while `stepCompacted` reflects the current step).

## Test plan
- [x] `bun test src/__tests__/overflow-reduce-pipeline.test.ts`
- [x] `bun test src/__tests__/conversation-agent-loop-overflow.test.ts src/__tests__/plugin-types.test.ts src/__tests__/context-overflow-reducer.test.ts`
- [x] `bunx tsc --noEmit`
- [x] `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
