### PR TITLE
fix(plugins): unshadow user toolError middleware + restore legacy nudge

### DIFF
--- a/assistant/src/__tests__/tool-error-pipeline.test.ts
+++ b/assistant/src/__tests__/tool-error-pipeline.test.ts
@@ -19,6 +19,7 @@ import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
 import {
   DEFAULT_TOOL_ERROR_NUDGE_TEXT,
   defaultToolErrorPlugin,
+  defaultToolErrorTerminal,
 } from "../plugins/defaults/tool-error.js";
 import { runPipeline } from "../plugins/pipeline.js";
 import {
@@ -51,10 +52,14 @@ function makeCtx(): TurnContext {
 async function runToolErrorPipeline(
   args: ToolErrorArgs,
 ): Promise<ToolErrorDecision> {
+  // Mirror the production call site in `agent/loop.ts`: the pipeline terminal
+  // is `defaultToolErrorTerminal`, not a no-op. The default plugin's
+  // middleware is a passthrough that calls `next(args)`, so the decision
+  // logic lives in the terminal.
   return runPipeline<ToolErrorArgs, ToolErrorDecision>(
     "toolError",
     getMiddlewaresFor("toolError"),
-    async () => ({ action: "skip" }),
+    async (pipelineArgs) => defaultToolErrorTerminal(pipelineArgs),
     args,
     makeCtx(),
     500,
@@ -185,16 +190,55 @@ describe("toolError pipeline", () => {
       expect(decision.action).toBe("skip");
     });
 
-    test("terminal fallback runs when no plugin is registered", async () => {
-      // No registerPlugin call — the registry is empty for this slot. The
-      // terminal we pass to runPipeline returns `skip`, which is what the
-      // caller receives.
+    test("terminal still produces the legacy nudge when no plugin is registered", async () => {
+      // No registerPlugin call — the registry is empty for this slot. Since
+      // `agent/loop.ts` now passes `defaultToolErrorTerminal` as the pipeline
+      // terminal (rather than an inline `() => skip`), direct AgentLoop
+      // callers that skip `bootstrapPlugins()` still get the legacy nudge.
       const decision = await runToolErrorPipeline({
         hasToolError: true,
         consecutiveErrorTurns: 1,
         maxConsecutiveErrorNudges: 3,
       });
-      expect(decision.action).toBe("skip");
+      expect(decision.action).toBe("nudge");
+      if (decision.action === "nudge") {
+        expect(decision.nudgeText).toBe(DEFAULT_TOOL_ERROR_NUDGE_TEXT);
+      }
+    });
+
+    test("user plugin registered AFTER the default still runs (no shadowing)", async () => {
+      // Production registration order: defaults load first via the side-effect
+      // imports in `defaults/index.ts`, then user plugins register on top via
+      // `bootstrapPlugins()`. The user's middleware ends up at a deeper onion
+      // layer than the default. If the default's middleware were to bypass
+      // `next` and call the decision logic directly, the user middleware
+      // would never run — this test guards against that regression.
+      registerPlugin(defaultToolErrorPlugin);
+
+      let userMiddlewareRan = false;
+      const userMiddleware: Middleware<
+        ToolErrorArgs,
+        ToolErrorDecision
+      > = async (args, next) => {
+        userMiddlewareRan = true;
+        return next(args);
+      };
+      registerPlugin({
+        manifest: {
+          name: "late-user-plugin",
+          version: "0.0.1",
+          requires: { pluginRuntime: "v1", toolErrorApi: "v1" },
+        },
+        middleware: { toolError: userMiddleware },
+      });
+
+      await runToolErrorPipeline({
+        hasToolError: true,
+        consecutiveErrorTurns: 1,
+        maxConsecutiveErrorNudges: 3,
+      });
+
+      expect(userMiddlewareRan).toBe(true);
     });
   });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -10,6 +10,7 @@ import {
   calculateMaxToolResultChars,
   truncateToolResultText,
 } from "../context/tool-result-truncation.js";
+import { defaultToolErrorTerminal } from "../plugins/defaults/tool-error.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import { getMiddlewaresFor } from "../plugins/registry.js";
 import type {
@@ -1027,11 +1028,15 @@ export class AgentLoop {
         >(
           "toolError",
           getMiddlewaresFor("toolError"),
-          // Terminal fallback: fires only when no plugin contributes a
-          // `toolError` middleware. The default plugin's middleware shadows
-          // this with the full decision logic, so production runs never hit
-          // the fallback.
-          async () => ({ action: "skip" }),
+          // Terminal: the canonical nudge decision. The default plugin's
+          // middleware is a passthrough (so later-registered user plugins
+          // aren't shadowed), so this terminal is what actually produces
+          // the decision when no user plugin overrides it. Wiring the
+          // decision here — rather than inside the default plugin's
+          // middleware — also preserves the legacy nudge for direct
+          // AgentLoop callers (tests, benchmarks) that skip
+          // `bootstrapPlugins()` and therefore never register the default.
+          async (args) => defaultToolErrorTerminal(args),
           toolErrorArgs,
           toolErrorCtx,
           DEFAULT_TIMEOUTS.toolError,

--- a/assistant/src/plugins/defaults/tool-error.ts
+++ b/assistant/src/plugins/defaults/tool-error.ts
@@ -1,14 +1,24 @@
 /**
- * Default `toolError` pipeline plugin.
+ * Default `toolError` plugin.
  *
- * Replicates the inline tool-error-nudge logic that previously lived in
- * `agent/loop.ts`: when the current turn produced at least one failed tool
- * result, append a system-notice block to the tool results that coaches the
- * LLM to either retry with corrected parameters (for recoverable errors) or
- * report the failure to the user (for unrecoverable ones). After the
- * consecutive-error-turn counter exceeds the cap the caller supplies, this
- * default stops nudging — the error is likely not something the LLM can fix
- * on its own and continuing to nudge only burns tokens.
+ * The plugin's middleware is a passthrough — it calls `next(args)` and returns
+ * the result unchanged. The actual nudge-decision logic lives in
+ * {@link defaultToolErrorTerminal}, which is wired in as the pipeline's
+ * `terminal` argument by the `runPipeline` call site in `agent/loop.ts`. This
+ * separation matters: the default plugin is registered before any user plugin
+ * (defaults load first via module-side-effect imports / `registerDefaultPlugins`),
+ * which puts it at the OUTERMOST position of the onion chain. If the default
+ * middleware invoked the decision logic directly without calling `next`, it
+ * would shadow every later-registered plugin. Routing through `next(args)`
+ * lets user middleware participate normally.
+ *
+ * The canonical nudge decision: when the current turn produced at least one
+ * failed tool result, append a system-notice block to the tool results that
+ * coaches the LLM to either retry with corrected parameters (for recoverable
+ * errors) or report the failure to the user (for unrecoverable ones). Once
+ * the consecutive-error-turn counter exceeds the caller-supplied cap, the
+ * nudge is skipped — the error is likely not something the LLM can fix on
+ * its own and continuing to nudge only burns tokens.
  *
  * Design doc: `.private/plans/agent-plugin-system.md` (PR 19).
  */
@@ -30,14 +40,17 @@ export const DEFAULT_TOOL_ERROR_NUDGE_TEXT =
   "<system_notice>One or more tool calls returned an error. If the error looks recoverable (e.g. missing or invalid parameters), fix the parameters and retry. If the error is clearly unrecoverable (e.g. a service is down, a resource does not exist, or a permission is permanently denied), report it to the user.</system_notice>";
 
 /**
- * Terminal handler for the `toolError` pipeline. Mirrors the pre-plugin
- * behavior: nudge iff the current turn had an error AND the consecutive-error
- * counter is within the cap. Once the cap is breached the caller should stop
- * appending the nudge (the error is likely unrecoverable and the LLM already
- * had multiple attempts to correct it).
+ * Terminal handler for the `toolError` pipeline. Nudge iff the current turn
+ * had an error AND the consecutive-error counter is within the cap. Once the
+ * cap is breached the caller should stop appending the nudge (the error is
+ * likely unrecoverable and the LLM already had multiple attempts to correct
+ * it).
  *
- * Exported so callers (and tests) can reuse the decision logic directly
- * without going through the pipeline runner.
+ * Exported so `agent/loop.ts` can pass it as the `terminal` argument to
+ * `runPipeline` (ensuring the nudge decision fires even when no plugin is
+ * registered — e.g. direct AgentLoop callers that skip `bootstrapPlugins()`)
+ * and so tests can verify the decision logic directly without going through
+ * the pipeline runner.
  */
 export const defaultToolErrorTerminal = async (
   args: ToolErrorArgs,
@@ -55,16 +68,17 @@ export const defaultToolErrorTerminal = async (
 };
 
 /**
- * Default middleware for the `toolError` slot. Acts as the terminal — it
- * returns a decision directly instead of calling `next`, so the pre-plugin
- * behavior fires even when no user plugin contributes its own middleware.
+ * Default middleware for the `toolError` slot. Passthrough — calls `next(args)`
+ * so later-registered user plugins still participate in the onion chain. The
+ * actual decision logic lives in {@link defaultToolErrorTerminal}, wired in
+ * at the `runPipeline` call site in `agent/loop.ts`.
  *
  * Named explicitly so the pipeline's structured log record carries
  * `"defaultToolErrorMiddleware"` in `chain` instead of an anonymous entry.
  */
 const defaultToolErrorMiddleware: Middleware<ToolErrorArgs, ToolErrorDecision> =
-  async function defaultToolErrorMiddleware(args, _next) {
-    return defaultToolErrorTerminal(args);
+  async function defaultToolErrorMiddleware(args, next) {
+    return next(args);
   };
 
 /**


### PR DESCRIPTION
## Summary

Address review feedback on #27395 (tool-error nudge plugin pipeline):

- **Default-first shadowing.** `defaultToolErrorPlugin` middleware was a terminal that bypassed `next` and returned the nudge decision directly — and because defaults register first, that put it at the OUTERMOST onion layer, shadowing any later-registered user middleware. Switch the middleware to a passthrough; the decision logic stays in `defaultToolErrorTerminal`, which the `runPipeline` call site in `agent/loop.ts` now wires in as the `terminal` arg (previously an inline `() => skip`).
- **Restore legacy nudge for pluginless callers.** The previous terminal fallback returned `skip`, so any AgentLoop caller that didn't run `bootstrapPlugins()` first silently lost the retry nudge. Terminal now runs `defaultToolErrorTerminal`, so direct AgentLoop usage (tests, benchmarks) still nudges on tool errors.
- **Rewrite AGENTS.md-violating comments.** Drop "previously lived in `agent/loop.ts`" and "Mirrors the pre-plugin behavior" from `tool-error.ts`. Drop "After this PR" wording in `external-plugins-bootstrap.ts` and rewrite the dead-branch comment to describe its current defensive purpose (tests that reset + stub the default registration).
- **Regression test.** Register the default, then register a user plugin on top, and assert the user middleware runs — guards against the shadowing regression recurring.

Mirrors the fix pattern from #27635 (same issue in `historyRepair`).

## Test plan

- [x] `bun test src/__tests__/tool-error-pipeline.test.ts` — 9 pass
- [x] `bun test src/__tests__/plugin-types.test.ts src/__tests__/pipeline-runner.test.ts src/__tests__/history-repair-pipeline.test.ts` — 32 pass
- [x] `bun test src/__tests__/agent-loop.test.ts` — 46 pass
- [x] `bunx tsc --noEmit` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
