### PR TITLE
fix(plugins/memory): thread AbortSignal via MemoryArgs so timeouts cancel retrieval

### DIFF
--- a/assistant/src/__tests__/memory-retrieval-pipeline.test.ts
+++ b/assistant/src/__tests__/memory-retrieval-pipeline.test.ts
@@ -110,7 +110,6 @@ function makeDeps(
     messages: [],
     graphMemory: memory,
     config: {} as AssistantConfig,
-    abortSignal: new AbortController().signal,
     onEvent: () => {},
     isTrustedActor: true,
     ...overrides,
@@ -327,6 +326,59 @@ describe("memoryRetrieval pipeline — default vs custom plugin", () => {
     // timer fires. The default pipeline doesn't bind a plugin name, so
     // the attribution is undefined — still fail the turn cleanly.
     expect(timeoutErr.message).toContain("memoryRetrieval");
+  });
+
+  test("pipeline timeout aborts the signal threaded into prepareMemory", async () => {
+    // Regression for the cancellation gap: before `MemoryArgs.signal` was
+    // swapped by the pipeline's abort-linker, a pipeline timeout rejected
+    // the race but left `prepareMemory` running — mutating graph state
+    // after the turn had already errored. This test wires a long-running
+    // `prepareMemory` fake, arms a tight budget, and asserts the signal
+    // the terminal actually received reports `aborted === true` once the
+    // timer fires.
+    let capturedSignal: AbortSignal | undefined;
+    const hangingPrepare = mock(
+      (
+        _msgs: Message[],
+        _cfg: AssistantConfig,
+        signal: AbortSignal,
+        _onEvent: (msg: ServerMessage) => void,
+      ) => {
+        capturedSignal = signal;
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new Error("aborted")));
+        });
+      },
+    );
+    const graphMemory = {
+      prepareMemory: hangingPrepare,
+    } as unknown as ConversationGraphMemory;
+    const deps = makeDeps({ graphMemory });
+    const outerController = new AbortController();
+    const args = makeMemoryArgs({ signal: outerController.signal });
+
+    let caught: unknown;
+    try {
+      await runPipeline(
+        "memoryRetrieval",
+        getMiddlewaresFor("memoryRetrieval"),
+        (innerArgs: MemoryArgs) => runDefaultMemoryRetrieval(innerArgs, deps),
+        args,
+        makeTurnCtx(),
+        30,
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(PluginTimeoutError);
+    expect(capturedSignal).toBeDefined();
+    // The signal the terminal observed must be the pipeline's linked
+    // signal (not the caller's bare signal), and it must be aborted so
+    // `prepareMemory` stops work instead of running to completion after
+    // the race has already rejected.
+    expect(capturedSignal).not.toBe(outerController.signal);
+    expect(capturedSignal!.aborted).toBe(true);
   });
 
   test("onEvent is invoked by the default retriever's terminal path", async () => {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -872,12 +872,18 @@ export async function runAgentLoopImpl(
       conversationId: ctx.conversationId,
       trustContext: ctx.trustContext,
       turnIndex: ctx.turnCount,
+      // Pass the abort signal via `args` (not `deps`) so the pipeline
+      // runner's `linkAbortSignal` can swap it for a signal linked to the
+      // pipeline's internal controller — on a plugin-set timeout or
+      // external cancel, the linked signal aborts and `prepareMemory`
+      // stops mutating graph state / emitting events after the pipeline
+      // has already errored.
+      signal: abortController.signal,
     };
     const memoryDeps: DefaultMemoryRetrievalDeps = {
       messages: ctx.messages,
       graphMemory: ctx.graphMemory,
       config: getConfig(),
-      abortSignal: abortController.signal,
       onEvent,
       isTrustedActor,
     };

--- a/assistant/src/plugins/defaults/memory-retrieval.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval.ts
@@ -68,10 +68,16 @@ export interface GraphMemoryPayload {
 
 /**
  * External state the default retriever needs but the pipeline args cannot
- * carry (conversation-scoped graph handle, per-turn abort signal, event
- * sink, live message list). Passed as a second argument to
- * {@link runDefaultMemoryRetrieval} rather than threaded through
- * {@link MemoryArgs} to keep the plugin-facing pipeline surface minimal.
+ * carry (conversation-scoped graph handle, event sink, live message list).
+ * Passed as a second argument to {@link runDefaultMemoryRetrieval} rather
+ * than threaded through {@link MemoryArgs} to keep the plugin-facing
+ * pipeline surface minimal.
+ *
+ * The per-turn abort signal lives on {@link MemoryArgs.signal} instead of
+ * here so the pipeline runner's `linkAbortSignal` can swap it for an
+ * internally-linked signal — that way a plugin timeout actually cancels
+ * the underlying `prepareMemory` work instead of letting it run after
+ * `Promise.race` has already rejected.
  */
 export interface DefaultMemoryRetrievalDeps {
   /** Live message list for this turn (pre-injection). */
@@ -80,8 +86,6 @@ export interface DefaultMemoryRetrievalDeps {
   readonly graphMemory: ConversationGraphMemory;
   /** Assistant config snapshot. */
   readonly config: AssistantConfig;
-  /** Abort signal wired to the turn's cancellation budget. */
-  readonly abortSignal: AbortSignal;
   /** Event sink used by the graph retriever (memory_status events). */
   readonly onEvent: (msg: ServerMessage) => void;
   /** True when the actor for this turn is trusted (guardian-class). */
@@ -99,7 +103,7 @@ export interface DefaultMemoryRetrievalDeps {
  * {@link DEFAULT_MEMORY_GRAPH_KIND} to consume it.
  */
 export async function runDefaultMemoryRetrieval(
-  _args: MemoryArgs,
+  args: MemoryArgs,
   deps: DefaultMemoryRetrievalDeps,
 ): Promise<MemoryResult> {
   // NOW.md and PKB are read unconditionally — the agent loop decides
@@ -117,10 +121,15 @@ export async function runDefaultMemoryRetrieval(
     };
   }
 
+  // `prepareMemory` requires a non-optional signal. In production the agent
+  // loop always threads one via `args.signal`; the fallback `AbortController`
+  // keeps direct callers (e.g. tests that skip the pipeline) working without
+  // forcing every call site to synthesize a dummy signal.
+  const abortSignal = args.signal ?? new AbortController().signal;
   const graphResult = await deps.graphMemory.prepareMemory(
     deps.messages,
     deps.config,
-    deps.abortSignal,
+    abortSignal,
     deps.onEvent,
   );
 

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -222,11 +222,21 @@ export type MemoryBlock = unknown;
  * Inputs to the memory-retrieval pipeline. The pipeline takes only
  * identifiers and the trust context — the actual data sources (PKB files,
  * NOW.md, memory graph) are side-effectful and read by the terminal.
+ *
+ * `signal` is the per-turn abort signal forwarded to the memory graph's
+ * `prepareMemory` call. Carrying it on `args` (rather than on the
+ * `DefaultMemoryRetrievalDeps` extra-state bundle) is load-bearing: the
+ * pipeline runner's `linkAbortSignal` swaps any `AbortSignal`-typed
+ * property on top-level args for an internal linked signal, so a plugin
+ * timeout (or external cancel) actually reaches `prepareMemory` and cancels
+ * the underlying retrieval instead of letting it run to completion after
+ * the pipeline has already errored.
  */
 export interface MemoryArgs {
   readonly conversationId: string;
   readonly trustContext: TrustContext | undefined;
   readonly turnIndex: number;
+  readonly signal?: AbortSignal;
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #27402. Addresses reviewer feedback on the memory-retrieval pipeline's abort-signal threading.

**The gap:** The per-turn abort signal lived on `DefaultMemoryRetrievalDeps`, so the pipeline runner's `linkAbortSignal` (which swaps `AbortSignal`-typed properties on top-level `args`) had nothing to intercept. On a pipeline timeout, `Promise.race` rejected but `runDefaultMemoryRetrieval` / `graphMemory.prepareMemory` kept running — mutating graph state and emitting events after the turn had already errored.

**The fix:** Move the signal to `MemoryArgs.signal` (matching the `CompactionArgs.signal` pattern) and drop it from `DefaultMemoryRetrievalDeps`. The runner now swaps it for an internally-linked signal on each pipeline invocation, so a plugin-set timeout (or external cancel) actually reaches `prepareMemory`.

Regression test: arms a tight pipeline budget with a hanging `prepareMemory`, asserts the terminal observed the linked signal (not the caller's bare one), and that it reports `aborted === true` after the timer fires.

## Note on the 5s budget concern

The second reviewer finding (5s retrieval budget may cause `PluginTimeoutError` on slow networks or large graphs) is moot as of #27601/#27603/#27608, which set `DEFAULT_TIMEOUTS.memoryRetrieval = null` — the default path no longer arms a timer at all. The AbortSignal threading in this PR is still load-bearing for:

- User plugins that set their own per-call timeout via `runPipeline`'s `timeoutMs`.
- External cancellation (actor abort, daemon shutdown) propagating into the graph retriever.

## Test plan

- [x] `bun test src/__tests__/memory-retrieval-pipeline.test.ts` — 12 pass (including new abort-propagation regression)
- [x] `bun test src/__tests__/plugin-types.test.ts` — 5 pass
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
