### PR TITLE
fix(plugins): unshadow user persistence middleware + correct syncToDisk nullish check

### DIFF
--- a/assistant/src/__tests__/persistence-pipeline.test.ts
+++ b/assistant/src/__tests__/persistence-pipeline.test.ts
@@ -28,7 +28,10 @@ import {
   updateMessageMetadata,
 } from "../memory/conversation-crud.js";
 import { getDb, initializeDb } from "../memory/db.js";
-import { defaultPersistencePlugin } from "../plugins/defaults/persistence.js";
+import {
+  defaultPersistencePlugin,
+  defaultPersistenceTerminal,
+} from "../plugins/defaults/persistence.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,
@@ -74,16 +77,6 @@ function makeCtx(overrides: Partial<TurnContext> = {}): TurnContext {
   };
 }
 
-// The terminal passed into `runPipeline` is a no-op that asserts the chain
-// resolved without reaching here — the default plugin always handles the
-// operation itself, and custom short-circuit plugins in these tests also
-// never call `next`.
-const noopTerminal = (_args: PersistArgs): Promise<PersistResult> => {
-  throw new Error(
-    "persistence terminal reached: the default plugin should handle every op",
-  );
-};
-
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe("persistence pipeline", () => {
@@ -118,7 +111,7 @@ describe("persistence pipeline", () => {
     const result = (await runPipeline<PersistArgs, PersistResult>(
       "persistence",
       getMiddlewaresFor("persistence"),
-      noopTerminal,
+      defaultPersistenceTerminal,
       {
         op: "add",
         conversationId: conv.id,
@@ -161,7 +154,7 @@ describe("persistence pipeline", () => {
     const result = await runPipeline<PersistArgs, PersistResult>(
       "persistence",
       getMiddlewaresFor("persistence"),
-      noopTerminal,
+      defaultPersistenceTerminal,
       {
         op: "update",
         messageId: msg.id,
@@ -206,7 +199,7 @@ describe("persistence pipeline", () => {
     const result = (await runPipeline<PersistArgs, PersistResult>(
       "persistence",
       getMiddlewaresFor("persistence"),
-      noopTerminal,
+      defaultPersistenceTerminal,
       { op: "delete", messageId: msg.id },
       makeCtx({ conversationId: conv.id }),
       DEFAULT_TIMEOUTS.persistence,
@@ -290,7 +283,7 @@ describe("persistence pipeline", () => {
     const addResult = (await runPipeline<PersistArgs, PersistResult>(
       "persistence",
       getMiddlewaresFor("persistence"),
-      noopTerminal,
+      defaultPersistenceTerminal,
       {
         op: "add",
         conversationId: conv.id,
@@ -308,7 +301,7 @@ describe("persistence pipeline", () => {
     await runPipeline<PersistArgs, PersistResult>(
       "persistence",
       getMiddlewaresFor("persistence"),
-      noopTerminal,
+      defaultPersistenceTerminal,
       {
         op: "update",
         messageId: "mock-1",
@@ -325,7 +318,7 @@ describe("persistence pipeline", () => {
     const delResult = (await runPipeline<PersistArgs, PersistResult>(
       "persistence",
       getMiddlewaresFor("persistence"),
-      noopTerminal,
+      defaultPersistenceTerminal,
       { op: "delete", messageId: "mock-1" },
       makeCtx({ conversationId: conv.id }),
       DEFAULT_TIMEOUTS.persistence,
@@ -335,5 +328,50 @@ describe("persistence pipeline", () => {
 
     // The real DB must not have been touched by any of the three ops.
     expect(getMessages(conv.id)).toHaveLength(dbRowsBefore);
+  });
+
+  test("user plugin registered AFTER the default still runs (no shadowing)", async () => {
+    // Production registration order: defaults load first via the side-effect
+    // imports in `defaults/index.ts`, then user plugins register on top via
+    // `bootstrapPlugins()`. The user's middleware ends up at a deeper onion
+    // layer than the default. If the default's middleware were to bypass
+    // `next` and call the terminal directly, the user middleware would never
+    // run — this test guards against that regression.
+    registerPlugin(defaultPersistencePlugin);
+
+    let userMiddlewareRan = false;
+    const userMiddleware: Middleware<PersistArgs, PersistResult> = async (
+      args,
+      next,
+    ) => {
+      userMiddlewareRan = true;
+      return next(args);
+    };
+    registerPlugin({
+      manifest: {
+        name: "late-user-plugin",
+        version: "0.0.1",
+        requires: { pluginRuntime: "v1" },
+      },
+      middleware: { persistence: userMiddleware },
+    });
+
+    const conv = createConversation();
+    await runPipeline<PersistArgs, PersistResult>(
+      "persistence",
+      getMiddlewaresFor("persistence"),
+      defaultPersistenceTerminal,
+      {
+        op: "add",
+        conversationId: conv.id,
+        role: "user",
+        content: "shadow-check",
+        addOptions: { skipIndexing: true },
+      },
+      makeCtx({ conversationId: conv.id }),
+      DEFAULT_TIMEOUTS.persistence,
+    );
+
+    expect(userMiddlewareRan).toBe(true);
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -31,6 +31,7 @@ import {
   type SlackMessageMetadata,
   writeSlackMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
+import { defaultPersistenceTerminal } from "../plugins/defaults/persistence.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import { getMiddlewaresFor } from "../plugins/registry.js";
 import type {
@@ -85,18 +86,6 @@ function buildHandlerTurnContext(deps: EventHandlerDeps): TurnContext {
         trustClass: "unknown",
       },
   };
-}
-
-/**
- * Terminal fed into the `persistence` pipeline. The default plugin
- * (registered at daemon bootstrap) always handles each op, so reaching the
- * terminal signals a configuration bug. Shared with `conversation-agent-loop.ts`
- * via the same message text for ops-grepability.
- */
-function persistenceTerminal(_args: PersistArgs): Promise<PersistResult> {
-  throw new Error(
-    "persistence terminal reached: the default plugin should handle every op",
-  );
 }
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -767,21 +756,23 @@ export async function handleMessageComplete(
     };
     // Route the add + disk-view sync through the `persistence` pipeline so
     // plugins can observe or override both operations together. The default
-    // plugin performs the add and, because `syncToDisk` is true, immediately
-    // calls `syncMessageToDisk` against the just-persisted row — preserving
-    // the pre-pipeline behavior.
+    // plugin's terminal performs the add and, when `syncToDisk` is true,
+    // immediately calls `syncMessageToDisk` against the just-persisted row.
+    // `getConversation` returns `ConversationRow | null`, so `!= null`
+    // gates on a real row (skipping the sync when the conversation was
+    // not found rather than asking the disk-view to resolve a missing id).
     const convForToolResult = getConversation(deps.ctx.conversationId);
     await runPipeline<PersistArgs, PersistResult>(
       "persistence",
       getMiddlewaresFor("persistence"),
-      persistenceTerminal,
+      defaultPersistenceTerminal,
       {
         op: "add",
         conversationId: deps.ctx.conversationId,
         role: "user",
         content: JSON.stringify(toolResultBlocks),
         metadata: toolResultMetadata,
-        syncToDisk: convForToolResult !== undefined,
+        syncToDisk: convForToolResult != null,
         createdAtMs: convForToolResult?.createdAt,
       },
       buildHandlerTurnContext(deps),
@@ -876,12 +867,11 @@ export async function handleMessageComplete(
   // Route the assistant-message persistence through the `persistence`
   // pipeline. No `syncToDisk` here — the orchestrator separately invokes
   // `syncMessageToDisk` on `state.lastAssistantMessageId` after the loop
-  // completes (see `conversation-agent-loop.ts::syncLastAssistantMessageToDisk`),
-  // matching the pre-pipeline behavior exactly.
+  // completes (see `conversation-agent-loop.ts::syncLastAssistantMessageToDisk`).
   const assistantPersistResult = (await runPipeline<PersistArgs, PersistResult>(
     "persistence",
     getMiddlewaresFor("persistence"),
-    persistenceTerminal,
+    defaultPersistenceTerminal,
     {
       op: "add",
       conversationId: deps.ctx.conversationId,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -74,6 +74,7 @@ import {
   type GraphMemoryPayload,
   runDefaultMemoryRetrieval,
 } from "../plugins/defaults/memory-retrieval.js";
+import { defaultPersistenceTerminal } from "../plugins/defaults/persistence.js";
 import { defaultTitleGenerateTerminal } from "../plugins/defaults/title-generate.js";
 import { defaultTokenEstimateTerminal } from "../plugins/defaults/token-estimate.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
@@ -173,17 +174,6 @@ import type { TraceEmitter } from "./trace-emitter.js";
 import { stripHistoricalWebSearchResults } from "./web-search-history.js";
 
 const log = getLogger("conversation-agent-loop");
-
-/**
- * Terminal fed into the `persistence` pipeline. The default plugin (registered
- * at daemon bootstrap) always handles each op, so reaching the terminal
- * signals a configuration bug.
- */
-function persistenceTerminal(_args: PersistArgs): Promise<PersistResult> {
-  throw new Error(
-    "persistence terminal reached: the default plugin should handle every op",
-  );
-}
 
 /** Title-cased friendly labels for tool names, used in confirmation chips. */
 const TOOL_FRIENDLY_LABEL: Record<string, string> = {
@@ -930,7 +920,7 @@ export async function runAgentLoopImpl(
           await runPipeline<PersistArgs, PersistResult>(
             "persistence",
             getMiddlewaresFor("persistence"),
-            persistenceTerminal,
+            defaultPersistenceTerminal,
             {
               op: "update",
               messageId: userMessageId,
@@ -1273,7 +1263,7 @@ export async function runAgentLoopImpl(
         await runPipeline<PersistArgs, PersistResult>(
           "persistence",
           getMiddlewaresFor("persistence"),
-          persistenceTerminal,
+          defaultPersistenceTerminal,
           {
             op: "update",
             messageId: userMessageId,
@@ -2224,7 +2214,7 @@ export async function runAgentLoopImpl(
       await runPipeline<PersistArgs, PersistResult>(
         "persistence",
         getMiddlewaresFor("persistence"),
-        persistenceTerminal,
+        defaultPersistenceTerminal,
         {
           op: "add",
           conversationId: ctx.conversationId,
@@ -2270,7 +2260,7 @@ export async function runAgentLoopImpl(
       await runPipeline<PersistArgs, PersistResult>(
         "persistence",
         getMiddlewaresFor("persistence"),
-        persistenceTerminal,
+        defaultPersistenceTerminal,
         {
           op: "add",
           conversationId: ctx.conversationId,

--- a/assistant/src/plugins/defaults/persistence.ts
+++ b/assistant/src/plugins/defaults/persistence.ts
@@ -1,14 +1,30 @@
 /**
- * Default `persistence` plugin — the passthrough terminal that delegates to
- * the message-CRUD functions in `memory/conversation-crud.ts` and (for `add`
- * ops with `syncToDisk: true`) the disk-view projector in
- * `memory/conversation-disk-view.ts`.
+ * Default `persistence` plugin.
  *
- * The plugin system wraps every message-persistence operation in the
- * `persistence` pipeline. This default ensures the pipeline always has a
- * terminal to fall through to when no other plugin short-circuits or
- * overrides it: it dispatches on the discriminated `op` field and calls the
- * matching underlying function with identical arguments.
+ * The plugin's middleware is a passthrough — it calls `next(args)` and returns
+ * the result unchanged. The actual dispatch lives in
+ * {@link defaultPersistenceTerminal}, which is wired in as the pipeline's
+ * `terminal` argument by `runPipeline` call sites in
+ * `daemon/conversation-agent-loop.ts` and
+ * `daemon/conversation-agent-loop-handlers.ts`. This separation matters: the
+ * default plugin is registered before any user plugin (defaults load first in
+ * `bootstrapPlugins()`), which puts it at the OUTERMOST position of the onion
+ * chain. If the default middleware were to invoke the terminal directly
+ * without calling `next`, it would shadow every later-registered plugin.
+ * Routing through `next(args)` lets user middleware participate normally.
+ *
+ * The terminal dispatches on the discriminated {@link PersistArgs.op} field:
+ *
+ * - `add`    → {@link addMessage}, optionally followed by
+ *              {@link syncMessageToDisk} when `args.syncToDisk` is true.
+ * - `update` → {@link updateMessageMetadata} (returns `void`, wrapped as
+ *              `{ op: "update" }`).
+ * - `delete` → {@link deleteMessageById} (returns the segment/summary IDs
+ *              the caller must clean up out-of-band).
+ *
+ * Manifest declares `provides.persistence: "v1"` so other plugins can
+ * negotiate against the pipeline surface and `requires.pluginRuntime: "v1"`
+ * to satisfy the registry's mandatory capability check.
  *
  * Registered from `daemon/external-plugins-bootstrap.ts` via a side-effect
  * import so the plugin is present in the registry before
@@ -25,6 +41,7 @@ import {
 import { syncMessageToDisk } from "../../memory/conversation-disk-view.js";
 import { registerPlugin } from "../registry.js";
 import {
+  type Middleware,
   type PersistArgs,
   type PersistResult,
   type Plugin,
@@ -32,20 +49,51 @@ import {
 } from "../types.js";
 
 /**
- * The default persistence plugin. Its sole contribution is the `persistence`
- * middleware, which narrows on {@link PersistArgs.op} and dispatches:
- *
- * - `add`    → {@link addMessage}, optionally followed by
- *              {@link syncMessageToDisk} when `args.syncToDisk` is true.
- * - `update` → {@link updateMessageMetadata} (returns `void`, wrapped as
- *              `{ op: "update" }`).
- * - `delete` → {@link deleteMessageById} (returns the segment/summary IDs
- *              the caller must clean up out-of-band).
- *
- * Manifest declares `provides.persistence: "v1"` so other plugins can
- * negotiate against the pipeline surface and `requires.pluginRuntime: "v1"`
- * to satisfy the registry's mandatory capability check.
+ * Terminal handler for the `persistence` pipeline. Exported so tests can
+ * verify default behavior directly without going through `runPipeline`, and
+ * so the `daemon/conversation-agent-loop*.ts` call sites can pass it as the
+ * `terminal` argument to `runPipeline`.
  */
+export async function defaultPersistenceTerminal(
+  args: PersistArgs,
+): Promise<PersistResult> {
+  switch (args.op) {
+    case "add": {
+      const message = await addMessage(
+        args.conversationId,
+        args.role,
+        args.content,
+        args.metadata,
+        args.addOptions,
+      );
+      // Sync the just-persisted row to the JSONL disk view when the caller
+      // opted in. The handler that emits tool-result rows sets
+      // `syncToDisk: true` so the disk view stays in lockstep with the DB.
+      if (args.syncToDisk && args.createdAtMs !== undefined) {
+        syncMessageToDisk(args.conversationId, message.id, args.createdAtMs);
+      }
+      return { op: "add", message };
+    }
+    case "update": {
+      updateMessageMetadata(args.messageId, args.updates);
+      return { op: "update" };
+    }
+    case "delete": {
+      const deleted = deleteMessageById(args.messageId);
+      return {
+        op: "delete",
+        segmentIds: deleted.segmentIds,
+        deletedSummaryIds: deleted.deletedSummaryIds,
+      };
+    }
+  }
+}
+
+const passthrough: Middleware<PersistArgs, PersistResult> = async (
+  args,
+  next,
+) => next(args);
+
 export const defaultPersistencePlugin: Plugin = {
   manifest: {
     name: "default-persistence",
@@ -54,47 +102,7 @@ export const defaultPersistencePlugin: Plugin = {
     requires: { pluginRuntime: "v1" },
   },
   middleware: {
-    persistence: async function defaultPersistence(
-      args: PersistArgs,
-      _next,
-      _ctx,
-    ): Promise<PersistResult> {
-      switch (args.op) {
-        case "add": {
-          const message = await addMessage(
-            args.conversationId,
-            args.role,
-            args.content,
-            args.metadata,
-            args.addOptions,
-          );
-          // Sync the just-persisted row to the JSONL disk view when the
-          // caller opted in. Mirrors the pattern in the pre-pipeline call
-          // sites (handler emits tool-result rows, then syncs them) so the
-          // default plugin preserves observable behavior.
-          if (args.syncToDisk && args.createdAtMs !== undefined) {
-            syncMessageToDisk(
-              args.conversationId,
-              message.id,
-              args.createdAtMs,
-            );
-          }
-          return { op: "add", message };
-        }
-        case "update": {
-          updateMessageMetadata(args.messageId, args.updates);
-          return { op: "update" };
-        }
-        case "delete": {
-          const deleted = deleteMessageById(args.messageId);
-          return {
-            op: "delete",
-            segmentIds: deleted.segmentIds,
-            deletedSummaryIds: deleted.deletedSummaryIds,
-          };
-        }
-      }
-    },
+    persistence: passthrough,
   },
 };
 


### PR DESCRIPTION
## Summary

Address review feedback on #27410.

- **Default-first shadowing** — `defaultPersistencePlugin` registered at module load is outermost in the onion chain; its middleware short-circuited without calling `next()`, so any later-registered user persistence plugin would never run. Switch the middleware to a passthrough and move the dispatch into an exported `defaultPersistenceTerminal` that the `runPipeline` call sites in `conversation-agent-loop.ts` / `conversation-agent-loop-handlers.ts` now pass as the `terminal` argument. Mirrors the precedent set by #27635 for `historyRepair`.

- **`syncToDisk` null-vs-undefined check** — `getConversation` returns `ConversationRow | null`, so `convForToolResult !== undefined` evaluated to `true` even when the row was missing. Currently masked by a downstream guard in the default plugin, but custom persistence plugins inspecting `syncToDisk` alone would have synced a non-existent conversation. Fixed to `!= null`.

- **AGENTS.md comment violations** — rewrite three "pre-pipeline" / "Mirrors the pattern in the pre-pipeline call sites" comments to describe current state.

- **Regression test** — new `persistence-pipeline.test.ts` case registers a user plugin AFTER the default and asserts the user middleware actually runs.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean
- [x] `bun test src/__tests__/persistence-pipeline.test.ts` — 5 pass including the new shadowing regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
