### PR TITLE
fix(plugins): unshadow tokenEstimate + keep calibration + freeze args

### DIFF
--- a/assistant/src/__tests__/token-estimate-pipeline.test.ts
+++ b/assistant/src/__tests__/token-estimate-pipeline.test.ts
@@ -23,7 +23,10 @@ import {
   estimateToolsTokens,
 } from "../context/token-estimator.js";
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
-import { defaultTokenEstimatePlugin } from "../plugins/defaults/token-estimate.js";
+import {
+  defaultTokenEstimatePlugin,
+  defaultTokenEstimateTerminal,
+} from "../plugins/defaults/token-estimate.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,
@@ -140,14 +143,11 @@ async function runViaPipeline(args: EstimateArgs): Promise<EstimateResult> {
   return runPipeline<EstimateArgs, EstimateResult>(
     "tokenEstimate",
     getMiddlewaresFor("tokenEstimate"),
-    // Terminal is a sentinel — the default plugin's middleware short-circuits
-    // so this should only run when no plugin contributes. We make it throw
-    // to catch any accidental fall-through.
-    async () => {
-      throw new Error(
-        "pipeline terminal reached — no middleware short-circuit",
-      );
-    },
+    // Mirror the production wiring in `daemon/conversation-agent-loop.ts`:
+    // the default plugin's middleware is a passthrough, so the terminal is
+    // wired in by the call site. Using the same terminal here means the
+    // tests exercise the exact composition shape that ships.
+    defaultTokenEstimateTerminal,
     args,
     makeCtx(),
     DEFAULT_TIMEOUTS.tokenEstimate,
@@ -339,6 +339,71 @@ describe("tokenEstimate pipeline — custom override", () => {
     };
     const pipelineResult = await runViaPipeline(args);
     expect(pipelineResult).toBe(rawEstimate(args) * 2);
+  });
+});
+
+describe("tokenEstimate pipeline — default does not shadow late plugins", () => {
+  test("user middleware registered AFTER the default still runs", async () => {
+    // Regression test for the default-first shadowing hazard: defaults are
+    // registered before user plugins in `bootstrapPlugins()`, putting the
+    // default at the OUTERMOST onion position. If the default middleware
+    // runs the estimate directly instead of calling `next(args)`, any user
+    // plugin loaded afterward is invisible. The default is a passthrough —
+    // this test fails loudly if that invariant ever regresses.
+    registerDefault();
+    const observed: EstimateArgs[] = [];
+    const observer: Middleware<EstimateArgs, EstimateResult> = async (
+      args,
+      next,
+      _ctx,
+    ) => {
+      observed.push(args);
+      // Return a sentinel so we can distinguish the observer's result from
+      // the default's output.
+      await next(args);
+      return 999_999;
+    };
+    const userPlugin: Plugin = {
+      manifest: {
+        name: "late-registered-observer",
+        version: "1.0.0",
+        requires: { pluginRuntime: "v1", tokenEstimateApi: "v1" },
+      },
+      middleware: { tokenEstimate: observer },
+    };
+    registerPlugin(userPlugin);
+
+    const args: EstimateArgs = {
+      history: TEXT_HISTORY,
+      systemPrompt: SYSTEM_PROMPT,
+      tools: [],
+      providerName: "anthropic",
+    };
+    const result = await runViaPipeline(args);
+    expect(observed.length).toBe(1);
+    expect(result).toBe(999_999);
+  });
+});
+
+describe("tokenEstimate pipeline — args are immutable to middleware", () => {
+  test("frozen history/tools reject in-place mutation attempts", () => {
+    // The call site freezes shallow clones of `history` and `tools` before
+    // handing them to the pipeline. This mirrors the runtime protection
+    // that stops a misbehaving middleware from trimming `args.history` in
+    // place — which would silently drop prompt context from the
+    // orchestrator's live `runMessages` array before the provider call.
+    const frozenHistory = Object.freeze([...TEXT_HISTORY]);
+    const frozenTools = Object.freeze([...SAMPLE_TOOLS]);
+    expect(() => {
+      (frozenHistory as Message[]).pop();
+    }).toThrow(TypeError);
+    expect(() => {
+      (frozenTools as ToolDefinition[]).push({
+        name: "extra",
+        description: "",
+        input_schema: { type: "object", properties: {} },
+      });
+    }).toThrow(TypeError);
   });
 });
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -96,7 +96,11 @@ import type {
   TurnContext as PluginTurnContext,
 } from "../plugins/types.js";
 import { PluginExecutionError, PluginTimeoutError } from "../plugins/types.js";
-import type { ContentBlock, Message } from "../providers/types.js";
+import type {
+  ContentBlock,
+  Message,
+  ToolDefinition,
+} from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
 import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
@@ -1330,9 +1334,18 @@ export async function runAgentLoopImpl(
         getMiddlewaresFor("tokenEstimate"),
         defaultTokenEstimateTerminal,
         {
-          history,
+          // Shallow-frozen copies so a misbehaving middleware that mutates
+          // `args.history` or `args.tools` in place (e.g. trims the array
+          // before calling next) can't silently strip prompt context from
+          // the orchestrator's live `runMessages` / resolved-tools arrays.
+          // TypeScript `readonly` on `EstimateArgs` does not prevent
+          // `push`/`splice` at runtime; the frozen wrapper throws in strict
+          // mode and isolates any mutation attempts from the call-site state.
+          history: Object.freeze([...history]) as Message[],
           systemPrompt: ctx.systemPrompt,
-          tools: ctx.agentLoop.getResolvedTools(history),
+          tools: Object.freeze([
+            ...ctx.agentLoop.getResolvedTools(history),
+          ]) as ToolDefinition[],
           providerName: estimationProviderName,
         },
         pipelineTurnCtx,

--- a/assistant/src/plugins/defaults/token-estimate.ts
+++ b/assistant/src/plugins/defaults/token-estimate.ts
@@ -1,53 +1,68 @@
 /**
- * Default `tokenEstimate` pipeline plugin.
+ * Default `tokenEstimate` plugin.
  *
- * The `tokenEstimate` pipeline produces the user-facing prompt-token estimate
- * the orchestrator consults before calling a provider — the value that drives
- * preflight overflow gating and the mid-loop checkpoint yield decision. This
- * plugin's terminal middleware delegates to
- * {@link import("../../context/token-estimator.js").estimatePromptTokensRaw estimatePromptTokensRaw},
- * so the default output matches the uncalibrated raw estimator.
+ * The plugin's middleware is a passthrough — it calls `next(args)` and returns
+ * the result unchanged. The actual estimate lives in
+ * {@link defaultTokenEstimateTerminal}, which is wired in as the pipeline's
+ * `terminal` argument by `runPipeline` call sites in
+ * `daemon/conversation-agent-loop.ts`. This separation matters: the default
+ * plugin is registered before any user plugin (defaults load first in
+ * `bootstrapPlugins()`), which puts it at the OUTERMOST position of the onion
+ * chain. If the default middleware were to invoke the terminal directly
+ * without calling `next`, it would shadow every later-registered plugin. The
+ * passthrough lets user middleware that wraps the default (e.g. a doubler, a
+ * provider-native `countTokens` override) participate normally.
  *
- * The calibration path in `agent/loop.ts` (pre-send raw estimate recorded
- * alongside provider-reported ground truth) stays outside the pipeline on
- * purpose: calibration must see the raw estimate so the EWMA learns against
- * provider truth instead of chasing its own corrected output. Pipelines are
- * for user-facing estimates only.
- *
- * Custom plugins can override by contributing their own `tokenEstimate`
- * middleware via the registry — e.g. a plugin that calls a provider-native
- * `countTokens` endpoint and short-circuits the chain by skipping `next`.
+ * The terminal delegates to
+ * {@link import("../../context/token-estimator.js").estimatePromptTokens estimatePromptTokens},
+ * which applies the EWMA calibration correction recorded from past provider
+ * responses. Preflight + mid-loop checks must use the calibrated estimate —
+ * before this pipeline existed, both call sites invoked `estimatePromptTokens`
+ * directly, and the calibrated estimate is what keeps the overflow gate
+ * consistent with the convergence path in the reducer. The pre-send
+ * calibration capture in `agent/loop.ts` still uses `estimatePromptTokensRaw`
+ * on purpose — the calibrator must learn against the raw estimate so the EWMA
+ * converges against provider ground truth rather than chasing its own
+ * corrected output. Pipelines produce user-facing estimates; calibration
+ * capture stays outside the pipeline.
  */
 
 import {
-  estimatePromptTokensRaw,
+  estimatePromptTokens,
   estimateToolsTokens,
 } from "../../context/token-estimator.js";
 import { registerPlugin } from "../registry.js";
 import {
   type EstimateArgs,
   type EstimateResult,
+  type Middleware,
   type Plugin,
   PluginExecutionError,
 } from "../types.js";
 
 /**
- * Terminal middleware for the `tokenEstimate` pipeline. Computes the tool
- * token budget from `args.tools` and delegates to {@link estimatePromptTokensRaw}
- * with the canonical provider key. Short-circuits the chain by ignoring
- * `next` — this plugin is the last stop when no other plugin supplies its
- * own `tokenEstimate` middleware.
+ * Terminal handler for the `tokenEstimate` pipeline. Computes the tool token
+ * budget from `args.tools` and delegates to {@link estimatePromptTokens} with
+ * the canonical provider key, applying the EWMA calibration correction.
+ * Exported so tests can verify default behavior directly without going through
+ * `runPipeline`, and so `daemon/conversation-agent-loop.ts` can pass it as the
+ * `terminal` argument to `runPipeline`.
  */
 export const defaultTokenEstimateTerminal = async (
   args: EstimateArgs,
 ): Promise<EstimateResult> => {
   const toolTokenBudget =
     args.tools.length > 0 ? estimateToolsTokens(args.tools) : 0;
-  return estimatePromptTokensRaw(args.history, args.systemPrompt, {
+  return estimatePromptTokens(args.history, args.systemPrompt, {
     providerName: args.providerName,
     toolTokenBudget,
   });
 };
+
+const passthrough: Middleware<EstimateArgs, EstimateResult> = async (
+  args,
+  next,
+) => next(args);
 
 /**
  * Default `tokenEstimate` plugin. Registered by
@@ -62,8 +77,7 @@ export const defaultTokenEstimatePlugin: Plugin = {
     requires: { pluginRuntime: "v1", tokenEstimateApi: "v1" },
   },
   middleware: {
-    tokenEstimate: async (args, _next, _ctx) =>
-      defaultTokenEstimateTerminal(args),
+    tokenEstimate: passthrough,
   },
 };
 


### PR DESCRIPTION
Follow-up on #27411 addressing three reviewer findings.

## Summary

- **Default-first shadowing**: default middleware was a terminal ignoring `next`, hiding any late-registered user plugin. Switched to a passthrough; the terminal stays wired at the call site. Mirrors #27635.
- **Calibration regression**: default terminal delegated to `estimatePromptTokensRaw`, dropping the EWMA correction preflight relied on before this pipeline existed — making preflight less conservative than the reducer convergence path. Swapped to `estimatePromptTokens`. Calibration capture in `agent/loop.ts` still uses raw on purpose.
- **Live-ref mutation hazard**: pipeline passed live `runMessages`/resolved-tools references. A misbehaving middleware that trims `args.history` or `args.tools` in place would silently drop prompt context. Shallow-clone + `Object.freeze` at the call site.

## Test plan
- [x] `bun test src/__tests__/token-estimate-pipeline.test.ts` — 10 pass, includes new regression tests for default-first shadowing + frozen-args mutation.
- [x] `bunx tsc --noEmit` on `assistant/src` — clean.
- [ ] CI to verify the broader suite.

Closes the three follow-ups from PR #27411 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
