### PR TITLE
fix(network-prompt): correct misleading auth-warning wording

### DIFF
--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -133,13 +133,6 @@ describe("createProxyApprovalCallback", () => {
   test("returns true when user allows an ask_missing_credential request", async () => {
     const ctx = makeContext();
 
-    const _resolvePrompt:
-      | ((v: {
-          decision: string;
-          selectedPattern?: string;
-          selectedScope?: string;
-        }) => void)
-      | null = null;
     const prompterSendToClient = mock(() => {});
     const prompter = new PermissionPrompter(prompterSendToClient);
 
@@ -385,7 +378,9 @@ describe("createProxyApprovalCallback", () => {
       expect(msg.input).toHaveProperty("known_credential_patterns", [
         "*.fal.ai",
       ]);
-      expect(msg.input.reason).toMatch(/No credential in this session/);
+      expect(msg.input.reason).toMatch(
+        /A known credential template matches this host.*caller-supplied auth headers will still be sent/,
+      );
       expect(msg.input).not.toHaveProperty("proxy_session_id");
       prompter.resolveConfirmation(msg.requestId, "allow");
       return p;

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -398,8 +398,8 @@ export function createProxyApprovalCallback(
     }
     input.reason =
       decision.kind === "ask_missing_credential"
-        ? "No credential in this session matches this host. Approving will send the request without authentication."
-        : "This host isn't covered by any known credential template. Approving will send the request as-is.";
+        ? "A known credential template matches this host, but no credential is bound to this session. Approving will forward the request as-is — the assistant won't inject a credential, but any caller-supplied auth headers will still be sent."
+        : "This host isn't covered by any known credential template. Approving will forward the request as-is, including any caller-supplied auth headers.";
     if (decision.kind === "ask_missing_credential") {
       input.known_credential_patterns = decision.matchingPatterns;
     }


### PR DESCRIPTION
## Summary

Follow-up to #27536. Codex flagged that the `ask_missing_credential`
approval-prompt reason text claimed the request would be sent
"without authentication" — but the forwarder still passes through
non-hop-by-hop headers, including any caller-supplied `Authorization`
header. The old wording was a false assertion that could mislead a
user into approving on safer-than-actual assumptions.

- Rewrite the `ask_missing_credential` reason: "A known credential
  template matches this host, but no credential is bound to this
  session. Approving will forward the request as-is — the assistant
  won't inject a credential, but any caller-supplied auth headers will
  still be sent."
- Tighten `ask_unauthenticated` wording for symmetry — explicitly note
  caller-supplied auth headers are still forwarded.
- Update the test snapshot to match.
- Drop a pre-existing unused `_resolvePrompt` declaration that the
  type-checker started flagging.

## Test plan

- [x] `bun test src/__tests__/proxy-approval-callback.test.ts` (21 pass)
- [x] `bunx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
