### PR TITLE
fix(config): share image-gen provider-prefix helper across setter and migration

### DIFF
--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -8,6 +8,7 @@ import {
   setServiceField,
 } from "../../config/raw-config-utils.js";
 import { VALID_INFERENCE_PROVIDERS } from "../../config/schemas/services.js";
+import { providerForImageModelPrefix } from "../../media/types.js";
 import type { ProviderCatalogEntry } from "../../providers/model-catalog.js";
 import {
   isModelInCatalog,
@@ -219,16 +220,16 @@ export async function setModel(
 export function setImageGenModel(modelId: string, ctx: ModelSetContext): void {
   const raw = loadRawConfig();
   setServiceField(raw, "image-generation", "model", modelId);
-  // Mirror the prefix logic used by workspace migration
-  // 006-services-config.ts: OpenAI-prefixed models map to the "openai"
-  // provider, everything else defaults to "gemini". Keeping the derived
-  // provider in sync with the selected model prevents downstream routing
-  // from sending a Gemini request to an OpenAI model (or vice versa).
-  const derivedProvider =
-    modelId.startsWith("gpt-") || modelId.startsWith("dall-e-")
-      ? "openai"
-      : "gemini";
-  setServiceField(raw, "image-generation", "provider", derivedProvider);
+  // Keep the derived provider in sync with the selected model so downstream
+  // routing never sends a Gemini request to an OpenAI model (or vice versa).
+  // The prefix logic is shared with workspace migration 006-services-config
+  // via providerForImageModelPrefix().
+  setServiceField(
+    raw,
+    "image-generation",
+    "provider",
+    providerForImageModelPrefix(modelId),
+  );
 
   const wasSuppressed = ctx.suppressConfigReload;
   ctx.setSuppressConfigReload(true);

--- a/assistant/src/media/types.ts
+++ b/assistant/src/media/types.ts
@@ -31,3 +31,16 @@ export interface ImageGenerationResult {
 }
 
 export const MAX_VARIANTS = 4;
+
+/**
+ * Derive the image-generation provider from a model identifier by prefix.
+ * Canonical mapping shared between the runtime model setter
+ * (`setImageGenModel`) and workspace migration 006-services-config so the
+ * two cannot drift. Unknown models fall through to "gemini".
+ */
+export function providerForImageModelPrefix(model: string): ImageGenProvider {
+  if (model.startsWith("gpt") || model.startsWith("dall-e")) {
+    return "openai";
+  }
+  return "gemini";
+}

--- a/assistant/src/workspace/migrations/006-services-config.ts
+++ b/assistant/src/workspace/migrations/006-services-config.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { providerForImageModelPrefix } from "../../media/types.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
   getProviderKeyAsync,
@@ -110,10 +111,7 @@ export const servicesConfigMigration: WorkspaceMigration = {
     services["image-generation"] = {
       ...(existingServices["image-generation"] ?? {}),
       mode: "your-own",
-      provider:
-        imageGenModel.startsWith("dall-e") || imageGenModel.startsWith("gpt")
-          ? "openai"
-          : "gemini",
+      provider: providerForImageModelPrefix(imageGenModel),
       model: imageGenModel,
     };
 


### PR DESCRIPTION
## Summary
- `setImageGenModel` and workspace migration `006-services-config` both derive the image-gen provider from the model ID's prefix, but they used different prefix strings — `"gpt-"`/`"dall-e-"` (with trailing hyphens) in the setter vs. `"gpt"`/`"dall-e"` (no trailing hyphens) in the migration. A hyphenless future model ID (e.g. `gpt5image`) would route to `openai` via the migration but `gemini` via the setter, producing a config with provider/model from different providers.
- Extract a shared `providerForImageModelPrefix(model)` helper in `assistant/src/media/types.ts` and call it from both sites. The migration's semantics (no trailing hyphens) is the canonical behavior.

## Test plan
- [x] `bun test src/__tests__/config-model-image-provider.test.ts` — covers `gemini`, `gpt-image-2`, `dall-e-3`, and provider-flip scenarios through `setImageGenModel`.
- [x] `bun test src/__tests__/workspace-migration-006-services-config.test.ts` — existing migration suite still green.
- [x] `bun run lint`

Addresses review feedback on #27522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
