### PR TITLE
fix(media): resolve managed-proxy context atomically in image-credentials

### DIFF
--- a/assistant/src/__tests__/image-credentials.test.ts
+++ b/assistant/src/__tests__/image-credentials.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // ---------------------------------------------------------------------------
 
 let mockProviderKey: string | undefined;
-let mockManagedBaseUrl: string | undefined;
+let mockPlatformBaseUrl = "";
 let mockAssistantApiKey = "";
 
 mock.module("../security/secure-keys.js", () => ({
@@ -13,10 +13,9 @@ mock.module("../security/secure-keys.js", () => ({
 }));
 
 mock.module("../providers/managed-proxy/context.js", () => ({
-  buildManagedBaseUrl: async (_provider: string) => mockManagedBaseUrl,
   resolveManagedProxyContext: async () => ({
-    enabled: !!mockManagedBaseUrl,
-    platformBaseUrl: mockManagedBaseUrl ? "https://platform.example.com" : "",
+    enabled: !!mockPlatformBaseUrl && !!mockAssistantApiKey,
+    platformBaseUrl: mockPlatformBaseUrl,
     assistantApiKey: mockAssistantApiKey,
   }),
 }));
@@ -27,13 +26,13 @@ import { resolveImageGenCredentials } from "../media/image-credentials.js";
 describe("resolveImageGenCredentials", () => {
   beforeEach(() => {
     mockProviderKey = undefined;
-    mockManagedBaseUrl = undefined;
+    mockPlatformBaseUrl = "";
     mockAssistantApiKey = "";
   });
 
   describe("managed mode", () => {
-    test("returns managed-proxy credentials when buildManagedBaseUrl resolves", async () => {
-      mockManagedBaseUrl = "https://platform.example.com/proxy/gemini";
+    test("returns managed-proxy credentials when context is enabled", async () => {
+      mockPlatformBaseUrl = "https://platform.example.com";
       mockAssistantApiKey = "sk-assistant-key";
 
       const result = await resolveImageGenCredentials({
@@ -45,12 +44,27 @@ describe("resolveImageGenCredentials", () => {
       expect(result.credentials).toEqual({
         type: "managed-proxy",
         assistantApiKey: "sk-assistant-key",
-        baseUrl: "https://platform.example.com/proxy/gemini",
+        baseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
       });
     });
 
-    test("returns errorHint mentioning 'log in to Vellum' when managed base URL is unavailable", async () => {
-      mockManagedBaseUrl = undefined;
+    test("returns errorHint mentioning 'log in to Vellum' when platform URL is missing", async () => {
+      mockPlatformBaseUrl = "";
+      mockAssistantApiKey = "sk-assistant-key";
+
+      const result = await resolveImageGenCredentials({
+        provider: "gemini",
+        mode: "managed",
+      });
+
+      expect(result.credentials).toBeUndefined();
+      expect(result.errorHint).toBeDefined();
+      expect(result.errorHint).toContain("log in to Vellum");
+    });
+
+    test("returns errorHint when assistant API key is empty (TOCTOU-safe)", async () => {
+      mockPlatformBaseUrl = "https://platform.example.com";
+      mockAssistantApiKey = "";
 
       const result = await resolveImageGenCredentials({
         provider: "gemini",

--- a/assistant/src/media/image-credentials.ts
+++ b/assistant/src/media/image-credentials.ts
@@ -1,18 +1,15 @@
 /**
- * Shared credential resolver for image-generation call sites.
+ * Shared credential resolver for image-generation call sites (image-studio
+ * tool, CLI `image-generation` command, app-icon generator).
  *
- * Consolidates the logic that was previously duplicated across the
- * image-studio tool, the CLI `image-generation` command, and the
- * app-icon generator. Each site picks between the managed-proxy path
- * (routes through the platform) and the "your own" path (direct
- * provider API key), and both paths need consistent, provider-aware
- * error hints when credentials are unavailable.
+ * Each call site picks between the managed-proxy path (routes through the
+ * platform) and the "your own" path (direct provider API key). This module
+ * resolves either path and returns a provider-aware error hint when
+ * credentials are unavailable.
  */
 
-import {
-  buildManagedBaseUrl,
-  resolveManagedProxyContext,
-} from "../providers/managed-proxy/context.js";
+import { MANAGED_PROVIDER_META } from "../providers/managed-proxy/constants.js";
+import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
 import { getProviderKeyAsync } from "../security/secure-keys.js";
 import type { ImageGenCredentials, ImageGenProvider } from "./types.js";
 
@@ -33,19 +30,27 @@ export async function resolveImageGenCredentials(opts: {
   const { provider, mode } = opts;
 
   if (mode === "managed") {
-    const baseUrl = await buildManagedBaseUrl(provider);
-    if (!baseUrl) {
+    // Resolve platform URL + assistant API key from a single snapshot so
+    // baseUrl and assistantApiKey can't diverge if the credential is cleared
+    // between lookups.
+    const meta = MANAGED_PROVIDER_META[provider];
+    const ctx = await resolveManagedProxyContext();
+    if (
+      !meta?.managed ||
+      !meta.proxyPath ||
+      !ctx.enabled ||
+      !ctx.assistantApiKey
+    ) {
       return {
         errorHint:
           "Managed proxy is not available. Please log in to Vellum or switch to Your Own mode.",
       };
     }
-    const ctx = await resolveManagedProxyContext();
     return {
       credentials: {
         type: "managed-proxy",
         assistantApiKey: ctx.assistantApiKey,
-        baseUrl,
+        baseUrl: `${ctx.platformBaseUrl}${meta.proxyPath}`,
       },
     };
   }


### PR DESCRIPTION
## Summary

Follow-up to #27525 addressing reviewer feedback.

- **TOCTOU fix**: `resolveImageGenCredentials` previously called `buildManagedBaseUrl()` and `resolveManagedProxyContext()` as two separate async lookups. Between the two awaits the assistant API key could be revoked/cleared, so the function could return managed-proxy credentials with an empty `assistantApiKey` — downstream 401s instead of the polished "log in to Vellum" hint. Resolve the context once and derive `baseUrl` from the same snapshot using `MANAGED_PROVIDER_META` directly, and require `assistantApiKey` to be non-empty before returning managed credentials.
- **JSDoc cleanup**: Rewrite the module header to describe current behavior instead of narrating history ("previously duplicated across..."), per AGENTS.md comments-describe-current-state rule.
- Add a regression test covering the case where the platform URL is present but the assistant API key is empty (previously the 'success path with empty key' outcome).

## Test plan

- [x] `bun test src/__tests__/image-credentials.test.ts` passes (7 tests, including new TOCTOU-safe case)
- [x] `bunx tsc --noEmit` clean for `assistant/src/media/image-credentials.ts` and its test
- [x] Lint + formatting clean via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
