### PR TITLE
fix(media): exhaustive switch in image-service dispatchers

### DIFF
--- a/assistant/src/media/image-service.ts
+++ b/assistant/src/media/image-service.ts
@@ -18,8 +18,16 @@ export function generateImage(
   credentials: ImageGenCredentials,
   request: ImageGenerationRequest,
 ): Promise<ImageGenerationResult> {
-  if (provider === "openai") return generateImageOpenAI(credentials, request);
-  return generateImageGemini(credentials, request);
+  switch (provider) {
+    case "openai":
+      return generateImageOpenAI(credentials, request);
+    case "gemini":
+      return generateImageGemini(credentials, request);
+    default: {
+      const _exhaustive: never = provider;
+      throw new Error(`Unknown image generation provider: ${_exhaustive}`);
+    }
+  }
 }
 
 /**
@@ -29,8 +37,16 @@ export function mapImageGenError(
   provider: ImageGenProvider,
   error: unknown,
 ): string {
-  if (provider === "openai") return mapOpenAIError(error);
-  return mapGeminiError(error);
+  switch (provider) {
+    case "openai":
+      return mapOpenAIError(error);
+    case "gemini":
+      return mapGeminiError(error);
+    default: {
+      const _exhaustive: never = provider;
+      throw new Error(`Unknown image generation provider: ${_exhaustive}`);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace if/else chains in `generateImage` and `mapImageGenError` with `switch` + `never` exhaustiveness check.
- Adding a new `ImageGenProvider` member now produces a compile-time error at each dispatcher call site instead of silently routing to Gemini.

Addresses Codex feedback on #27527 (already merged).

## Test plan
- [x] `bunx tsc --noEmit` (only pre-existing unrelated zod errors in skills/meet-join)
- [x] eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
