### PR TITLE
fix(plugins): unshadow user emptyResponse middleware + drop "historic" comments

### DIFF
--- a/assistant/src/__tests__/empty-response-pipeline.test.ts
+++ b/assistant/src/__tests__/empty-response-pipeline.test.ts
@@ -19,7 +19,10 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
-import { defaultEmptyResponsePlugin } from "../plugins/defaults/empty-response.js";
+import {
+  defaultEmptyResponsePlugin,
+  defaultEmptyResponseTerminal,
+} from "../plugins/defaults/empty-response.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import {
   getMiddlewaresFor,
@@ -29,6 +32,7 @@ import {
 import type {
   EmptyResponseArgs,
   EmptyResponseDecision,
+  Middleware,
   Plugin,
   TurnContext,
 } from "../plugins/types.js";
@@ -79,7 +83,7 @@ async function runEmpty(
   return runPipeline(
     "emptyResponse",
     getMiddlewaresFor("emptyResponse"),
-    async () => ({ action: "accept" }),
+    async (a) => defaultEmptyResponseTerminal(a),
     args,
     makeCtx(),
     DEFAULT_TIMEOUTS.emptyResponse,
@@ -260,5 +264,42 @@ describe("emptyResponse pipeline — custom middleware overrides", () => {
     );
     expect(decision.action).toBe("nudge");
     expect(decision.nudgeText).toBe("ALTERED_NUDGE");
+  });
+
+  test("user plugin registered AFTER the default still runs (no shadowing)", async () => {
+    // Production registration order: defaults load first via the side-effect
+    // imports in `defaults/index.ts`, then user plugins register on top via
+    // `bootstrapPlugins()`. The user's middleware ends up at a deeper onion
+    // layer than the default. If the default's middleware were to bypass
+    // `next` and decide directly, the user middleware would never run — this
+    // test guards against that regression.
+    registerPlugin(defaultEmptyResponsePlugin);
+
+    let userMiddlewareRan = false;
+    const userMiddleware: Middleware<
+      EmptyResponseArgs,
+      EmptyResponseDecision
+    > = async (args, next) => {
+      userMiddlewareRan = true;
+      return next(args);
+    };
+    registerPlugin({
+      manifest: {
+        name: "late-user-empty-response",
+        version: "0.0.1",
+        requires: { pluginRuntime: "v1", emptyResponseApi: "v1" },
+      },
+      middleware: { emptyResponse: userMiddleware },
+    });
+
+    await runEmpty(
+      makeArgs({
+        responseContent: [],
+        toolUseTurns: 2,
+        priorAssistantHadVisibleText: false,
+      }),
+    );
+
+    expect(userMiddlewareRan).toBe(true);
   });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -10,6 +10,7 @@ import {
   calculateMaxToolResultChars,
   truncateToolResultText,
 } from "../context/tool-result-truncation.js";
+import { defaultEmptyResponseTerminal } from "../plugins/defaults/empty-response.js";
 import { defaultToolErrorTerminal } from "../plugins/defaults/tool-error.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import { getMiddlewaresFor } from "../plugins/registry.js";
@@ -712,7 +713,7 @@ export class AgentLoop {
         const emptyResponseDecision: EmptyResponseDecision = await runPipeline(
           "emptyResponse",
           getMiddlewaresFor("emptyResponse"),
-          async () => ({ action: "accept" }),
+          async (args) => defaultEmptyResponseTerminal(args),
           emptyResponseArgs,
           emptyResponseCtx,
           DEFAULT_TIMEOUTS.emptyResponse,
@@ -749,7 +750,7 @@ export class AgentLoop {
           );
         }
 
-        // action === "accept" — fall through. Preserve the historic log for
+        // action === "accept" — fall through. Emit a dedicated log line for
         // the specific "empty turn after tool results, retries exhausted"
         // case so ops dashboards that grep on this line keep working.
         if (

--- a/assistant/src/plugins/defaults/empty-response.ts
+++ b/assistant/src/plugins/defaults/empty-response.ts
@@ -1,18 +1,30 @@
 /**
- * Default plugin for the `emptyResponse` pipeline.
+ * Default `emptyResponse` plugin.
  *
- * Wraps the historic inline empty-response handling from
- * `agent/loop.ts` (see the comment block around `MAX_EMPTY_RESPONSE_RETRIES`).
+ * The plugin's middleware is a passthrough — it calls `next(args)` and returns
+ * the result unchanged. The actual decision lives in
+ * {@link defaultEmptyResponseTerminal}, which is wired in as the pipeline's
+ * `terminal` argument by the `runPipeline` call site in `agent/loop.ts`. This
+ * separation matters: the default plugin is registered before any user plugin
+ * (defaults load first in `bootstrapPlugins()`), which puts it at the
+ * OUTERMOST position of the onion chain. If the default middleware were to
+ * decide directly without calling `next`, it would shadow every
+ * later-registered plugin. Routing through `next(args)` lets user middleware
+ * participate normally.
  *
- * The pipeline is invoked once per assistant turn after an LLM response
- * lands. The default middleware inspects the turn snapshot and decides:
+ * Wiring the terminal at the call site (rather than relying on the plugin to
+ * be registered) also means the loop's nudge/accept/error behavior survives
+ * configurations that boot without the default plugin — e.g. unit tests that
+ * skip `bootstrapPlugins()`.
+ *
+ * The terminal inspects the turn snapshot and returns one of:
  *
  * 1. `"nudge"`  — the turn produced no visible text, no tool calls, follows
  *                 at least one prior tool-use turn, no earlier turn in this
  *                 run() has already delivered visible text, AND the retry
  *                 counter is below `maxEmptyResponseRetries`. The loop
- *                 appends `nudgeText` (the historic `<system_notice>…`
- *                 message) as a `user` turn and re-queries the model.
+ *                 appends `nudgeText` (the `<system_notice>…` message below)
+ *                 as a `user` turn and re-queries the model.
  * 2. `"accept"` — every other case. The turn either legitimately ended
  *                 (model said its piece earlier), is still in progress
  *                 (tool calls pending), or exhausted its retry budget. The
@@ -28,17 +40,55 @@
  */
 
 import { registerPlugin } from "../registry.js";
-import { type Plugin, PluginExecutionError } from "../types.js";
+import {
+  type EmptyResponseArgs,
+  type EmptyResponseResult,
+  type Middleware,
+  type Plugin,
+  PluginExecutionError,
+} from "../types.js";
 
 /**
- * Historic nudge text. Must stay verbatim so an existing plugin that wraps
- * the default cannot accidentally see a different string.
+ * Canonical nudge text. Must stay verbatim so a plugin that wraps the
+ * default cannot accidentally see a different string.
  *
  * Wire-compat note: this is shown to the LLM, not the user. Edits here
  * affect model behavior but not end-user UX directly.
  */
 const NUDGE_TEXT =
   "<system_notice>Your previous response was empty. You must respond to the user with a summary of what you found or did. Do not use any tools — just respond with text.</system_notice>";
+
+/**
+ * Terminal handler for the `emptyResponse` pipeline. Exported so tests can
+ * verify default behavior directly without going through `runPipeline`, and
+ * so `agent/loop.ts` can pass it as the `terminal` argument to `runPipeline`.
+ */
+export function defaultEmptyResponseTerminal(
+  args: EmptyResponseArgs,
+): EmptyResponseResult {
+  const hasVisibleText = args.responseContent.some(
+    (block) =>
+      block.type === "text" &&
+      typeof (block as { text?: unknown }).text === "string" &&
+      (block as { text: string }).text.trim().length > 0,
+  );
+
+  const isEmptyTurn =
+    !hasVisibleText &&
+    args.toolUseBlocksLength === 0 &&
+    args.toolUseTurns > 0 &&
+    !args.priorAssistantHadVisibleText;
+
+  if (isEmptyTurn && args.emptyResponseRetries < args.maxEmptyResponseRetries) {
+    return { action: "nudge", nudgeText: NUDGE_TEXT };
+  }
+  return { action: "accept" };
+}
+
+const passthrough: Middleware<EmptyResponseArgs, EmptyResponseResult> = async (
+  args,
+  next,
+) => next(args);
 
 /** Singleton plugin — the registry rejects duplicate registrations by name. */
 export const defaultEmptyResponsePlugin: Plugin = {
@@ -49,34 +99,7 @@ export const defaultEmptyResponsePlugin: Plugin = {
     requires: { pluginRuntime: "v1", emptyResponseApi: "v1" },
   },
   middleware: {
-    /**
-     * Terminal decision maker. Middleware wrapping this one may observe the
-     * decision via `next(args)` and override it — e.g. a plugin could force
-     * `"accept"` under a feature-flag, or turn an exhausted-retries case
-     * into `"error"` for louder telemetry.
-     */
-    emptyResponse: async (args, _next, _ctx) => {
-      const hasVisibleText = args.responseContent.some(
-        (block) =>
-          block.type === "text" &&
-          typeof (block as { text?: unknown }).text === "string" &&
-          (block as { text: string }).text.trim().length > 0,
-      );
-
-      const isEmptyTurn =
-        !hasVisibleText &&
-        args.toolUseBlocksLength === 0 &&
-        args.toolUseTurns > 0 &&
-        !args.priorAssistantHadVisibleText;
-
-      if (
-        isEmptyTurn &&
-        args.emptyResponseRetries < args.maxEmptyResponseRetries
-      ) {
-        return { action: "nudge", nudgeText: NUDGE_TEXT };
-      }
-      return { action: "accept" };
-    },
+    emptyResponse: passthrough,
   },
 };
 


### PR DESCRIPTION
## Summary

Address review feedback on #27399 (empty-response plugin pipeline):

- **Default-first shadowing.** `defaultEmptyResponsePlugin` middleware was a terminal that decided `nudge`/`accept` directly without calling `next` — and because defaults register first, that put it at the OUTERMOST onion layer, shadowing any later-registered user middleware. Switch the middleware to a passthrough; the actual decision moves into `defaultEmptyResponseTerminal`, which the `runPipeline` call site in `agent/loop.ts` now wires in as the `terminal` arg.
- **AgentLoop regression.** With the decision in the terminal at the call site, the loop's nudge/accept/error behavior survives configurations that skip default plugin registration (e.g. unit tests that bypass `bootstrapPlugins()`). The pre-PR call site terminal was a bare `{action: "accept"}`, so any caller that didn't register the default got no nudge.
- **AGENTS.md-violating comments.** Rewrite the module docstring (\"Wraps the historic inline empty-response handling from agent/loop.ts\") and three inline \"Historic\" / \"preserve the historic\" comments to describe current behavior without referencing the migration that produced it.

Mirrors the pattern from #27635 (historyRepair).

Adds a regression test that registers a user plugin AFTER the default and asserts the user middleware actually runs.

## Test plan

- [x] \`bun test src/__tests__/empty-response-pipeline.test.ts\` — 10 pass
- [x] \`bun test src/__tests__/agent-loop.test.ts\` — 46 pass (the 2 toolError-pipeline failures observed when the suites are batched in a single \`bun test\` invocation are pre-existing on \`main\` and tracked as a separate task — same shadowing pattern in the toolError default plugin)
- [x] \`bunx tsc --noEmit\` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
