### PR TITLE
fix(tools/executor): drop pipeline timeout + honor executionChannel (PR #27401 review)

### DIFF
--- a/assistant/src/__tests__/tool-execute-pipeline.test.ts
+++ b/assistant/src/__tests__/tool-execute-pipeline.test.ts
@@ -333,6 +333,48 @@ describe("ToolExecutor.execute → toolExecute pipeline", () => {
     expect(lastToolCall).toBeUndefined();
   });
 
+  test("slow middleware does not trip a pipeline-level timeout", async () => {
+    // Regression: `ToolExecutor.execute` used to pass the per-tool timeout
+    // to `runPipeline`, which made the pipeline race everything upstream of
+    // the tool call (permission checks, approval waits, middleware) against
+    // the same budget. A slow human clicking "allow" produced a
+    // `PluginTimeoutError` thrown past `executeInternal`'s catch block,
+    // breaking the `execute()` never-throws contract. The pipeline is now
+    // untimed; `executeWithTimeout` inside `executeInternal` is the sole
+    // enforcer of the per-tool budget and only wraps the actual tool call.
+    const slow: Middleware<ToolExecuteArgs, ToolExecuteResult> =
+      async function slowMw(args, next) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return next(args);
+      };
+    registerPlugin({
+      manifest: {
+        name: "slow-tool-execute",
+        version: "0.0.1",
+        requires: { pluginRuntime: "v1" },
+      },
+      middleware: { toolExecute: slow },
+    });
+
+    const prev = mockConfig.timeouts.toolExecutionTimeoutSec;
+    mockConfig.timeouts.toolExecutionTimeoutSec = 0.01;
+    try {
+      const executor = new ToolExecutor(makePrompter());
+      const result = await executor.execute(
+        "file_read",
+        { path: "README.md" },
+        makeContext(),
+      );
+      // Middleware phase (50ms) exceeds the per-tool budget (10ms), but
+      // that budget is only enforced inside `executeWithTimeout` around
+      // the tool invocation itself. The terminal runs and succeeds.
+      expect(result.isError).toBe(false);
+      expect(result.content).toBe("real tool output");
+    } finally {
+      mockConfig.timeouts.toolExecutionTimeoutSec = prev;
+    }
+  });
+
   test("multiple middlewares compose in registration order (outer-first)", async () => {
     const trace: string[] = [];
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 
+import { parseChannelId } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import { bridgeCesApproval } from "../credential-execution/approval-bridge.js";
 import { isCesShellLockdownEnabled } from "../credential-execution/feature-gates.js";
@@ -64,15 +65,6 @@ export class ToolExecutor {
      */
     turnContext?: TurnContext,
   ): Promise<ToolExecutionResult> {
-    // Compute the per-tool timeout budget upfront so the pipeline timeout
-    // matches the existing per-tool timeout. `toolExecute` is intentionally
-    // `null` in `DEFAULT_TIMEOUTS` because `ToolExecutor` already enforces
-    // per-tool timeouts inside `executeWithTimeout`; we pass the same
-    // budget to `runPipeline` so a runaway middleware doesn't silently
-    // exceed the tool's configured limit, without double-enforcing on the
-    // happy path (the pipeline race is a cheap backstop).
-    const perToolTimeoutMs = computePerToolTimeoutMs(name, input);
-
     // Prefer the orchestrator-supplied `turnContext` so the pipeline sees
     // the real conversation identity, per-turn trust, and context-window
     // manager. When absent (CLI / test invocations that bypass the agent
@@ -83,7 +75,7 @@ export class ToolExecutor {
       conversationId: context.conversationId,
       turnIndex: 0,
       trust: {
-        sourceChannel: "vellum",
+        sourceChannel: parseChannelId(context.executionChannel) ?? "vellum",
         trustClass: context.trustClass,
       },
     };
@@ -91,13 +83,22 @@ export class ToolExecutor {
     const middlewares = getMiddlewaresFor("toolExecute");
     const pipelineArgs: ToolExecuteArgs = { name, input, context };
 
+    // No pipeline-level timeout: `executeInternal` already wraps the real
+    // tool invocation in `executeWithTimeout`, which is the sole enforcer
+    // of the per-tool budget. Propagating `perToolTimeoutMs` to
+    // `runPipeline` made the pipeline race everything upstream of the
+    // tool call — permission checks, approval waits, middleware — against
+    // the same budget, so a slow human clicking "allow" produced a
+    // `PluginTimeoutError` thrown past `executeInternal`'s catch block,
+    // breaking the `execute()` never-throws contract. Letting the pipeline
+    // run untimed keeps the contract intact; runaway middleware is a
+    // plugin-health concern handled by per-plugin timeouts, not here.
     return runPipeline<ToolExecuteArgs, ToolExecuteResult>(
       "toolExecute",
       middlewares,
       (args) => this.executeInternal(args.name, args.input, args.context),
       pipelineArgs,
       turnCtx,
-      perToolTimeoutMs,
     );
   }
 
@@ -501,15 +502,8 @@ export { PermissionChecker } from "./permission-checker.js";
  * handles cleanup before the executor wrapper trips. Non-shell tools use
  * the generic `toolExecutionTimeoutSec` configuration value.
  *
- * Called from two sites:
- * 1. The public `ToolExecutor.execute` wrapper — passes the result to
- *    `runPipeline` as the pipeline-level timeout so middleware inherits
- *    the same budget the tool enforces internally.
- * 2. `executeInternal` — passes the result to `executeWithTimeout` around
- *    the actual tool invocation.
- *
- * Both sites see the same value because `getConfig()` returns a cached
- * object; there is no observable divergence.
+ * Consumed by `executeInternal` via `executeWithTimeout`, which is the
+ * sole enforcer of the per-tool budget.
  */
 function computePerToolTimeoutMs(
   name: string,


### PR DESCRIPTION
## Summary

Addresses reviewer feedback on #27401.

- **Pipeline timeout removed.** `ToolExecutor.execute` was passing the per-tool timeout to `runPipeline`, which made the pipeline race permission checks, approval waits, and middleware against the same budget meant for the tool call itself. When exceeded, `runPipeline` threw `PluginTimeoutError` past `executeInternal`'s catch block, breaking `execute()`'s never-throws contract. `executeWithTimeout` inside `executeInternal` is now the sole enforcer; the pipeline runs untimed.
- **`sourceChannel` no longer hardcoded.** The synthesized fallback `TurnContext` now uses `parseChannelId(context.executionChannel) ?? "vellum"` instead of always `"vellum"`, so middleware that discriminates on channel sees the real channel on CLI/test paths where the orchestrator-supplied `TurnContext` is absent.
- Third review item (`defaultLlmCallPlugin` missing from `registerDefaultPlugins`) was already fixed on `main` in #27633 — no action needed here.

## Test plan

- [x] `bun test src/__tests__/tool-execute-pipeline.test.ts` — added regression covering slow middleware against a tight per-tool budget
- [x] `bun test src/__tests__/tool-executor.test.ts` (105 tests) — unchanged
- [x] `bun test src/__tests__/pipeline-runner.test.ts` (18 tests) — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
