### PR TITLE
fix(meet-join): require AUTH handshake on audio-ingest TCP connection

### DIFF
--- a/skills/meet-join/bot/__tests__/audio-capture.test.ts
+++ b/skills/meet-join/bot/__tests__/audio-capture.test.ts
@@ -90,6 +90,14 @@ function fakeFailedParec(exitCode: number): SpawnedParec {
 interface RecordingSocket extends CapturedSocket {
   /** All bytes written via `write()`, concatenated in order. */
   writes: Uint8Array[];
+  /**
+   * Writes excluding `AUTH <token>\n` handshake frames. Framing and
+   * chunking assertions should use this so they don't trip on the
+   * handshake the capture pipeline prepends to every attempt.
+   */
+  pcmWrites: Uint8Array[];
+  /** Handshake frames — one per successful reconnect attempt. */
+  authWrites: Uint8Array[];
   /** Count of `end()` invocations. */
   endCalls: number;
   /** Count of `destroy()` invocations. */
@@ -98,6 +106,26 @@ interface RecordingSocket extends CapturedSocket {
   triggerError(err: NodeJS.ErrnoException): void;
   /** Trigger a synthetic `close` event on this socket. */
   triggerClose(): void;
+}
+
+/**
+ * Detect an `AUTH <token>\n` handshake frame by its ASCII prefix and
+ * trailing newline. Intentionally loose on token content so rotating
+ * the fixture token doesn't require matching the exact value here.
+ */
+function isAuthFrame(w: Uint8Array): boolean {
+  if (w.length < 6) return false;
+  // "AUTH "
+  if (
+    w[0] !== 0x41 ||
+    w[1] !== 0x55 ||
+    w[2] !== 0x54 ||
+    w[3] !== 0x48 ||
+    w[4] !== 0x20
+  ) {
+    return false;
+  }
+  return w[w.length - 1] === 0x0a;
 }
 
 /**
@@ -114,6 +142,18 @@ function recordingSocket(): RecordingSocket {
 
   return {
     writes,
+    // The capture pipeline precedes every PCM stream with an
+    // `AUTH <token>\n` handshake, and it re-sends the handshake on
+    // every reconnect. Identify handshake writes by their `AUTH ` ASCII
+    // prefix + trailing newline so tests that share a single
+    // RecordingSocket across reconnect attempts still isolate PCM
+    // frames cleanly.
+    get pcmWrites() {
+      return writes.filter((w) => !isAuthFrame(w));
+    },
+    get authWrites() {
+      return writes.filter((w) => isAuthFrame(w));
+    },
     get endCalls() {
       return endCalls;
     },
@@ -206,6 +246,7 @@ describe("startAudioCapture — argv + defaults", () => {
     const capture = await startAudioCapture({
       daemonHost: "127.0.0.1",
       daemonPort: 9000,
+      authToken: "test-token",
       spawn: (argv) => {
         spawnedArgv.push([...argv]);
         return proc;
@@ -234,6 +275,7 @@ describe("startAudioCapture — argv + defaults", () => {
     const capture = await startAudioCapture({
       daemonHost: "127.0.0.1",
       daemonPort: 9000,
+      authToken: "test-token",
       sourceDevice: "custom_source.monitor",
       rateHz: 48_000,
       spawn: (argv) => {
@@ -263,6 +305,7 @@ describe("startAudioCapture — argv + defaults", () => {
     const capture = await startAudioCapture({
       daemonHost: "host.docker.internal",
       daemonPort: 42173,
+      authToken: "test-token",
       spawn: () => proc,
       connect: (host, port) => {
         seenTargets.push({ host, port });
@@ -285,6 +328,7 @@ describe("startAudioCapture — argv + defaults", () => {
       await startAudioCapture({
         daemonHost: "127.0.0.1",
         daemonPort: 9000,
+      authToken: "test-token",
         frameBytes: 0,
         spawn: () => proc,
         connect: () => sock,
@@ -294,6 +338,76 @@ describe("startAudioCapture — argv + defaults", () => {
     }
     expect(thrown).toBeInstanceOf(Error);
     expect((thrown as Error).message).toContain("frameBytes must be > 0");
+  });
+});
+
+describe("startAudioCapture — auth handshake", () => {
+  test("writes `AUTH <authToken>\\n` as the first bytes on every connection", async () => {
+    const { proc } = fakeParec([]);
+    const sock = recordingSocket();
+
+    const capture = await startAudioCapture({
+      daemonHost: "127.0.0.1",
+      daemonPort: 9000,
+      authToken: "tok-abc123",
+      spawn: () => proc,
+      connect: () => sock,
+    });
+
+    // The handshake is written synchronously at connect time — no wait
+    // needed. It must be the very first write, ahead of any PCM frame.
+    expect(sock.writes.length).toBeGreaterThanOrEqual(1);
+    const first = sock.writes[0]!;
+    const decoded = new TextDecoder().decode(first);
+    expect(decoded).toBe("AUTH tok-abc123\n");
+
+    await capture.stop();
+  });
+
+  test("resends the handshake after a reconnect", async () => {
+    // First attempt: parec fails and we reconnect.
+    const first = fakeFailedParec(1);
+    const { proc: second } = fakeParec([fakePcm(DEFAULT_FRAME_BYTES)]);
+    const procs = [first, second];
+    let spawnIdx = 0;
+    const sock = recordingSocket();
+
+    const capture = await startAudioCapture({
+      daemonHost: "127.0.0.1",
+      daemonPort: 9000,
+      authToken: "tok-reconnect",
+      spawn: () => procs[spawnIdx++]!,
+      connect: () => sock,
+    });
+
+    await waitFor(() => sock.pcmWrites.length === 1);
+    // Two auth writes (one per attempt): initial attempt + reconnect.
+    expect(sock.authWrites.length).toBe(2);
+    for (const frame of sock.authWrites) {
+      expect(new TextDecoder().decode(frame)).toBe("AUTH tok-reconnect\n");
+    }
+
+    await capture.stop();
+  });
+
+  test("rejects an empty authToken up front", async () => {
+    const { proc } = fakeParec([]);
+    const sock = recordingSocket();
+
+    let thrown: unknown;
+    try {
+      await startAudioCapture({
+        daemonHost: "127.0.0.1",
+        daemonPort: 9000,
+        authToken: "",
+        spawn: () => proc,
+        connect: () => sock,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain("authToken is required");
   });
 });
 
@@ -314,20 +428,22 @@ describe("startAudioCapture — framing", () => {
     const capture = await startAudioCapture({
       daemonHost: "127.0.0.1",
       daemonPort: 9000,
+      authToken: "test-token",
       spawn: () => proc,
       connect: () => sock,
     });
 
-    // Wait until all 5 frames have arrived at the socket.
-    await waitFor(() => sock.writes.length === 5);
+    // Wait until all 5 PCM frames have arrived at the socket (excluding
+    // the auth handshake that precedes them).
+    await waitFor(() => sock.pcmWrites.length === 5);
 
-    // Every write must be exactly `frameBytes` bytes.
-    for (const w of sock.writes) {
+    // Every PCM write must be exactly `frameBytes` bytes.
+    for (const w of sock.pcmWrites) {
       expect(w.length).toBe(frameBytes);
     }
 
-    // Concatenated writes must equal the original payload verbatim.
-    expect(concat(sock.writes)).toEqual(payload);
+    // Concatenated PCM writes must equal the original payload verbatim.
+    expect(concat(sock.pcmWrites)).toEqual(payload);
 
     await capture.stop();
   });
@@ -344,17 +460,18 @@ describe("startAudioCapture — framing", () => {
     const capture = await startAudioCapture({
       daemonHost: "127.0.0.1",
       daemonPort: 9000,
+      authToken: "test-token",
       frameBytes,
       spawn: () => proc,
       connect: () => sock,
     });
 
-    await waitFor(() => sock.writes.length === 1);
+    await waitFor(() => sock.pcmWrites.length === 1);
     // Give the pump a tick to confirm it doesn't emit another (short) frame
     // after the stream ends.
     await tick(20);
-    expect(sock.writes.length).toBe(1);
-    expect(sock.writes[0]!.length).toBe(frameBytes);
+    expect(sock.pcmWrites.length).toBe(1);
+    expect(sock.pcmWrites[0]!.length).toBe(frameBytes);
 
     await capture.stop();
   });
@@ -368,16 +485,17 @@ describe("startAudioCapture — framing", () => {
     const capture = await startAudioCapture({
       daemonHost: "127.0.0.1",
       daemonPort: 9000,
+      authToken: "test-token",
       frameBytes,
       spawn: () => proc,
       connect: () => sock,
     });
 
-    await waitFor(() => sock.writes.length === 3);
-    for (const w of sock.writes) {
+    await waitFor(() => sock.pcmWrites.length === 3);
+    for (const w of sock.pcmWrites) {
       expect(w.length).toBe(frameBytes);
     }
-    expect(concat(sock.writes)).toEqual(payload);
+    expect(concat(sock.pcmWrites)).toEqual(payload);
 
     await capture.stop();
   });
@@ -400,6 +518,7 @@ describe("startAudioCapture — reconnect", () => {
     const capture = await startAudioCapture({
       daemonHost: "127.0.0.1",
       daemonPort: 9000,
+      authToken: "test-token",
       spawn: (argv) => {
         spawnCalls.push([...argv]);
         const p = procs[spawnIdx++];
@@ -409,10 +528,12 @@ describe("startAudioCapture — reconnect", () => {
       connect: () => sock,
     });
 
-    // Two frames should arrive after the reconnect.
-    await waitFor(() => sock.writes.length === 2);
+    // Two frames should arrive after the reconnect. Each reconnect
+    // resends the handshake, so `writes` starts with the second
+    // attempt's auth frame; filter it out via `pcmWrites`.
+    await waitFor(() => sock.pcmWrites.length === 2);
     expect(spawnCalls.length).toBe(2);
-    expect(concat(sock.writes)).toEqual(payload);
+    expect(concat(sock.pcmWrites)).toEqual(payload);
 
     await capture.stop();
   });
@@ -425,6 +546,7 @@ describe("startAudioCapture — reconnect", () => {
     const capture = await startAudioCapture({
       daemonHost: "127.0.0.1",
       daemonPort: 9000,
+      authToken: "test-token",
       spawn: () => {
         spawnCount += 1;
         return fakeFailedParec(1);
@@ -458,6 +580,7 @@ describe("startAudioCapture — reconnect", () => {
     const capture = await startAudioCapture({
       daemonHost: "127.0.0.1",
       daemonPort: 9000,
+      authToken: "test-token",
       onError: (err) => errors.push(err),
       spawn: () => {
         spawnCount += 1;
@@ -492,11 +615,12 @@ describe("startAudioCapture — stop semantics", () => {
     const capture = await startAudioCapture({
       daemonHost: "127.0.0.1",
       daemonPort: 9000,
+      authToken: "test-token",
       spawn: () => proc,
       connect: () => sock,
     });
 
-    await waitFor(() => sock.writes.length === 1);
+    await waitFor(() => sock.pcmWrites.length === 1);
     await capture.stop();
 
     // `stop()` must have killed the fake parec (it resolves `killed`).
@@ -513,6 +637,7 @@ describe("startAudioCapture — stop semantics", () => {
     const capture = await startAudioCapture({
       daemonHost: "127.0.0.1",
       daemonPort: 9000,
+      authToken: "test-token",
       spawn: () => proc,
       connect: () => sock,
     });
@@ -537,6 +662,7 @@ describe("startAudioCapture — stop semantics", () => {
     const capture = await startAudioCapture({
       daemonHost: "127.0.0.1",
       daemonPort: 9000,
+      authToken: "test-token",
       spawn: () => procs[spawnIdx++]!,
       connect: () => (connectIdx++ === 0 ? sock1 : sock2),
     });
@@ -548,8 +674,8 @@ describe("startAudioCapture — stop semantics", () => {
     sock1.triggerError(connErr);
 
     // Expect the second socket to eventually receive the replayed payload.
-    await waitFor(() => sock2.writes.length === 1);
-    expect(concat(sock2.writes)).toEqual(payload);
+    await waitFor(() => sock2.pcmWrites.length === 1);
+    expect(concat(sock2.pcmWrites)).toEqual(payload);
 
     await capture.stop();
   });

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -921,9 +921,25 @@ export async function runBot(deps: BotDeps): Promise<void> {
       deps.exit(1);
       return;
     }
+    // The daemon refuses any audio-ingest connection that doesn't open
+    // with `AUTH <botApiToken>\n`, so we thread the same token the bot
+    // already uses for the HTTP API into the capture pipeline. Missing
+    // here means the daemon never set BOT_API_TOKEN — fail the boot
+    // explicitly rather than let the daemon silently drop our audio.
+    if (!env.botApiToken) {
+      await shutdown(
+        "error",
+        "BOT_API_TOKEN env var is missing — cannot authenticate audio-ingest to the daemon",
+      );
+      detachSigterm();
+      detachSigint();
+      deps.exit(1);
+      return;
+    }
     subsystems.audioCapture = await deps.startAudioCapture({
       daemonHost: env.daemonAudioHost,
       daemonPort: env.daemonAudioPort,
+      authToken: env.botApiToken,
       onError: (err) => {
         // Exhausted reconnect budget — the daemon is unreachable or the
         // pipeline is flapping. Shut the bot down so the daemon rolls the

--- a/skills/meet-join/bot/src/media/audio-capture.ts
+++ b/skills/meet-join/bot/src/media/audio-capture.ts
@@ -55,6 +55,12 @@ export const DEFAULT_FRAME_BYTES = 320;
 const MAX_RECONNECT_ATTEMPTS = 3;
 const RECONNECT_BACKOFF_MS = 500;
 
+/**
+ * Wire-format prefix for the auth handshake line. Must stay in lockstep
+ * with {@link AUDIO_INGEST_AUTH_PREFIX} on the daemon side.
+ */
+const AUDIO_INGEST_AUTH_PREFIX = "AUTH ";
+
 /** s16le is 2 bytes per sample. */
 const BYTES_PER_SAMPLE = 2;
 
@@ -78,6 +84,15 @@ export interface AudioCaptureOptions {
   daemonHost: string;
   /** TCP port the daemon's audio server is listening on. */
   daemonPort: number;
+  /**
+   * Per-session auth token the daemon issued to this bot (same value as
+   * `BOT_API_TOKEN` used for the HTTP API). Sent as the first bytes on
+   * every audio-ingest TCP connection — `AUTH <token>\n` — so the
+   * daemon, which binds its audio port on `0.0.0.0` to reach Linux
+   * Docker, can reject any other LAN peer that race-connects to the
+   * port. Must match the token in the daemon's in-memory session.
+   */
+  authToken: string;
   /**
    * Pulse source to capture from. Defaults to the monitor of the
    * `meet_capture` null-sink created by `pulse-setup.sh`.
@@ -232,6 +247,18 @@ export async function startAudioCapture(
       `startAudioCapture: frameBytes must be > 0, got ${frameBytes}`,
     );
   }
+  if (!opts.authToken) {
+    throw new Error(
+      "startAudioCapture: authToken is required — the daemon rejects unauthenticated audio-ingest connections",
+    );
+  }
+
+  // Prebuild the handshake frame once. `\n` terminates the line on the
+  // daemon side. Both lengths (prefix + 64-hex token + newline = 70 bytes)
+  // fit comfortably inside one TCP segment.
+  const authFrame = new TextEncoder().encode(
+    `${AUDIO_INGEST_AUTH_PREFIX}${opts.authToken}\n`,
+  );
 
   // Derive the stability threshold from the configured rate/frame size so the
   // reconnect-reset gate maps to a constant audio duration regardless of the
@@ -316,6 +343,34 @@ export async function startAudioCapture(
       };
     }
     currentSocket = sock;
+
+    // 2a. Send the auth handshake as the very first bytes on the
+    //     connection. The daemon's audio-ingest server waits for
+    //     `AUTH <token>\n` before it treats any traffic as PCM — without
+    //     this, it destroys the connection as an unauthenticated peer.
+    //     `write` queues the bytes; Node will flush them once the TCP
+    //     connection actually opens (synchronous return ≠ connected).
+    //     Treat handshake write errors the same as any other socket
+    //     failure so the retry loop reconnects.
+    try {
+      sock.write(authFrame);
+    } catch (err) {
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        // Best effort.
+      }
+      try {
+        sock.destroy();
+      } catch {
+        // Best effort.
+      }
+      return {
+        outcome: "socket",
+        error: err instanceof Error ? err : new Error(String(err)),
+        framesWritten: 0,
+      };
+    }
 
     // 3. Wait for either parec to exit, the socket to die, or `stop()`.
     const stoppedP = stopSignal.then(() => "stopped" as const);

--- a/skills/meet-join/daemon/__tests__/audio-ingest.test.ts
+++ b/skills/meet-join/daemon/__tests__/audio-ingest.test.ts
@@ -29,12 +29,22 @@ import type {
   SttStreamServerEvent,
 } from "../../../../assistant/src/stt/types.js";
 import {
+  AUDIO_INGEST_AUTH_PREFIX,
   BOT_CONNECT_TIMEOUT_MS,
+  HANDSHAKE_TIMEOUT_MS,
+  MAX_HANDSHAKE_BYTES,
   MeetAudioIngest,
   MeetAudioIngestError,
   type AudioIngestConnection,
   type AudioIngestServer,
 } from "../audio-ingest.js";
+
+/**
+ * Deterministic token used in every test that doesn't care about the token
+ * value. Keep it out of the 64-char hex shape the real bot generates so it
+ * is obvious at a glance that this is a test literal.
+ */
+const TEST_BOT_TOKEN = "test-bot-token-0123456789abcdef";
 import {
   __resetMeetSessionEventRouterForTests,
   getMeetSessionEventRouter,
@@ -121,19 +131,29 @@ class FakeSocketConnection implements AudioIngestConnection {
     this.destroyed = true;
   }
 
-  /** Test helper: feed inbound data. */
+  /**
+   * Test helper: feed inbound data.
+   *
+   * Snapshots `dataListeners` before iteration to mirror how Node's
+   * `EventEmitter.emit` freezes the listener array at emit time — a
+   * listener that adds another listener mid-emit must not have the new
+   * listener fire for the current chunk. The audio-ingest handshake
+   * relies on this: on successful auth it registers the PCM forwarder
+   * via `wireConnection(conn, meetingId)`, and without a snapshot the
+   * freshly-registered forwarder would see the auth-line bytes as PCM.
+   */
   emitData(chunk: Buffer): void {
-    for (const l of this.dataListeners) l(chunk);
+    for (const l of [...this.dataListeners]) l(chunk);
   }
 
   /** Test helper: simulate the bot disconnecting. */
   emitClose(): void {
-    for (const l of this.closeListeners) l();
+    for (const l of [...this.closeListeners]) l();
   }
 
   /** Test helper: simulate a socket-level error. */
   emitError(err: Error): void {
-    for (const l of this.errorListeners) l(err);
+    for (const l of [...this.errorListeners]) l(err);
   }
 }
 
@@ -165,10 +185,24 @@ class FakeAudioIngestServer implements AudioIngestServer {
     this.closedPromiseResolved = true;
   }
 
-  /** Test helper: deliver a new connection to all registered listeners. */
-  connectBot(): FakeSocketConnection {
+  /**
+   * Test helper: deliver a new connection to all registered listeners and,
+   * by default, emit the `AUTH <token>\n` handshake line so the ingest's
+   * handshake guard accepts the connection. Tests that exercise the
+   * handshake itself pass `authLine` to send a custom line (or `null` to
+   * send nothing).
+   */
+  connectBot(
+    options: { authLine?: string | null; authToken?: string } = {},
+  ): FakeSocketConnection {
     const conn = new FakeSocketConnection();
     for (const l of this.connectionListeners) l(conn);
+    if (options.authLine !== null) {
+      const line =
+        options.authLine ??
+        `${AUDIO_INGEST_AUTH_PREFIX}${options.authToken ?? TEST_BOT_TOKEN}\n`;
+      conn.emitData(Buffer.from(line, "utf8"));
+    }
     return conn;
   }
 }
@@ -257,7 +291,7 @@ describe("MeetAudioIngest.start", () => {
 
     // start() now resolves with { port, ready } as soon as the listener
     // is bound — `ready` is the promise that waits for the bot to dial in.
-    const { port, ready } = await setup.ingest.start("m1");
+    const { port, ready } = await setup.ingest.start("m1", TEST_BOT_TOKEN);
 
     expect(port).toBe(42000);
     expect(setup.listenCalls).toBe(1);
@@ -287,7 +321,7 @@ describe("MeetAudioIngest.start", () => {
       listen,
     });
 
-    await expect(ingest.start("m1")).rejects.toThrow(
+    await expect(ingest.start("m1", TEST_BOT_TOKEN)).rejects.toThrow(
       /stt auth failed/,
     );
     expect(listen).toHaveBeenCalledTimes(0);
@@ -311,7 +345,7 @@ describe("MeetAudioIngest.start", () => {
       },
     });
 
-    await expect(ingest.start("m1")).rejects.toThrow(
+    await expect(ingest.start("m1", TEST_BOT_TOKEN)).rejects.toThrow(
       /EADDRINUSE/,
     );
     expect(session).not.toBeNull();
@@ -344,7 +378,7 @@ describe("MeetAudioIngest.start", () => {
       },
     });
 
-    const rejection = ingest.start("m-missing");
+    const rejection = ingest.start("m-missing", TEST_BOT_TOKEN);
     await expect(rejection).rejects.toThrow(
       /No streaming-capable STT provider is configured/,
     );
@@ -391,7 +425,7 @@ describe("MeetAudioIngest.start", () => {
 
     try {
       const setup = newIngestSetup();
-      const { ready } = await setup.ingest.start("m1");
+      const { ready } = await setup.ingest.start("m1", TEST_BOT_TOKEN);
 
       // Let microtasks settle so the ingest has called `listen()` and
       // registered its watchdog.
@@ -405,7 +439,7 @@ describe("MeetAudioIngest.start", () => {
       pending[0].fired = true;
 
       await expect(ready).rejects.toThrow(
-        /bot did not connect to 127\.0\.0\.1:\d+ within/,
+        /bot did not connect to \*:\d+ within/,
       );
     } finally {
       globalThis.setTimeout = realSetTimeout;
@@ -421,7 +455,7 @@ describe("MeetAudioIngest.start", () => {
 describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
   test("forwards PCM bytes from the bot to the transcriber", async () => {
     const setup = newIngestSetup();
-    const { ready } = await setup.ingest.start("m-forward");
+    const { ready } = await setup.ingest.start("m-forward", TEST_BOT_TOKEN);
     await flushMicrotasks();
 
     const conn = setup.server.connectBot();
@@ -450,7 +484,7 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
       dispatchMock("m-partial", e),
     );
 
-    const { ready } = await setup.ingest.start("m-partial");
+    const { ready } = await setup.ingest.start("m-partial", TEST_BOT_TOKEN);
     await flushMicrotasks();
     setup.server.connectBot();
     await ready;
@@ -481,7 +515,7 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
     const captured: Array<unknown> = [];
     getMeetSessionEventRouter().register("m-final", (e) => captured.push(e));
 
-    const { ready } = await setup.ingest.start("m-final");
+    const { ready } = await setup.ingest.start("m-final", TEST_BOT_TOKEN);
     await flushMicrotasks();
     setup.server.connectBot();
     await ready;
@@ -506,7 +540,7 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
     const captured: Array<unknown> = [];
     getMeetSessionEventRouter().register("m-speaker", (e) => captured.push(e));
 
-    const { ready } = await setup.ingest.start("m-speaker");
+    const { ready } = await setup.ingest.start("m-speaker", TEST_BOT_TOKEN);
     await flushMicrotasks();
     setup.server.connectBot();
     await ready;
@@ -573,7 +607,7 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
     const captured: Array<unknown> = [];
     getMeetSessionEventRouter().register("m-ignore", (e) => captured.push(e));
 
-    const { ready } = await setup.ingest.start("m-ignore");
+    const { ready } = await setup.ingest.start("m-ignore", TEST_BOT_TOKEN);
     await flushMicrotasks();
     setup.server.connectBot();
     await ready;
@@ -602,7 +636,7 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
 describe("MeetAudioIngest PCM tee", () => {
   test("fans each PCM chunk to every subscriber in addition to the transcriber", async () => {
     const setup = newIngestSetup();
-    const { ready } = await setup.ingest.start("m-tee");
+    const { ready } = await setup.ingest.start("m-tee", TEST_BOT_TOKEN);
     await flushMicrotasks();
     const conn = setup.server.connectBot();
     await ready;
@@ -634,7 +668,7 @@ describe("MeetAudioIngest PCM tee", () => {
 
   test("a throwing subscriber is logged + removed and does not break peers", async () => {
     const setup = newIngestSetup();
-    const { ready } = await setup.ingest.start("m-throw");
+    const { ready } = await setup.ingest.start("m-throw", TEST_BOT_TOKEN);
     await flushMicrotasks();
     const conn = setup.server.connectBot();
     await ready;
@@ -664,7 +698,7 @@ describe("MeetAudioIngest PCM tee", () => {
     const received: Uint8Array[] = [];
     const unsub = setup.ingest.subscribePcm((c) => received.push(c));
 
-    const { ready } = await setup.ingest.start("m-early");
+    const { ready } = await setup.ingest.start("m-early", TEST_BOT_TOKEN);
     await flushMicrotasks();
     const conn = setup.server.connectBot();
     await ready;
@@ -678,7 +712,7 @@ describe("MeetAudioIngest PCM tee", () => {
 
   test("stop() drops all subscribers", async () => {
     const setup = newIngestSetup();
-    const { ready } = await setup.ingest.start("m-stop-subs");
+    const { ready } = await setup.ingest.start("m-stop-subs", TEST_BOT_TOKEN);
     await flushMicrotasks();
     const conn = setup.server.connectBot();
     await ready;
@@ -698,7 +732,7 @@ describe("MeetAudioIngest PCM tee", () => {
 describe("MeetAudioIngest.stop", () => {
   test("destroys connection, stops transcriber, closes server", async () => {
     const setup = newIngestSetup();
-    const { ready } = await setup.ingest.start("m-stop");
+    const { ready } = await setup.ingest.start("m-stop", TEST_BOT_TOKEN);
     await flushMicrotasks();
     const conn = setup.server.connectBot();
     await ready;
@@ -712,7 +746,7 @@ describe("MeetAudioIngest.stop", () => {
 
   test("is idempotent", async () => {
     const setup = newIngestSetup();
-    const { ready } = await setup.ingest.start("m-idem");
+    const { ready } = await setup.ingest.start("m-idem", TEST_BOT_TOKEN);
     await flushMicrotasks();
     setup.server.connectBot();
     await ready;
@@ -726,7 +760,7 @@ describe("MeetAudioIngest.stop", () => {
 
   test("drops audio sent after stop", async () => {
     const setup = newIngestSetup();
-    const { ready } = await setup.ingest.start("m-afterstop");
+    const { ready } = await setup.ingest.start("m-afterstop", TEST_BOT_TOKEN);
     const conn = setup.server.connectBot();
     await ready;
 
@@ -735,6 +769,182 @@ describe("MeetAudioIngest.stop", () => {
 
     // Stop was synchronous wrt. the connection — any late data is dropped.
     expect(setup.session.audioChunks).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth handshake
+// ---------------------------------------------------------------------------
+
+describe("MeetAudioIngest — auth handshake", () => {
+  test("throws synchronously if start() is called without a token", async () => {
+    const setup = newIngestSetup();
+    await expect(setup.ingest.start("m-no-token", "")).rejects.toThrow(
+      /botApiToken is required/,
+    );
+  });
+
+  test("rejects a connection whose handshake prefix is malformed and keeps the listener open for a later good connection", async () => {
+    const setup = newIngestSetup();
+    const { ready } = await setup.ingest.start("m-bad-prefix", TEST_BOT_TOKEN);
+    await flushMicrotasks();
+
+    // Bogus prefix — no "AUTH " — must be rejected.
+    const bad = setup.server.connectBot({ authLine: "HELLO world\n" });
+
+    // Give the handshake logic a tick to run.
+    await flushMicrotasks();
+    expect(bad.destroyed).toBe(true);
+
+    // A legitimate bot shows up afterwards — must still be accepted.
+    const good = setup.server.connectBot();
+    await ready;
+
+    good.emitData(Buffer.from([0xaa, 0xbb]));
+    expect(setup.session.audioChunks).toHaveLength(1);
+    expect(setup.session.audioChunks[0]).toEqual(Buffer.from([0xaa, 0xbb]));
+
+    await setup.ingest.stop();
+  });
+
+  test("rejects a connection that presents the wrong token", async () => {
+    const setup = newIngestSetup();
+    const { ready } = await setup.ingest.start("m-bad-token", TEST_BOT_TOKEN);
+    await flushMicrotasks();
+
+    const bad = setup.server.connectBot({
+      authLine: `${AUDIO_INGEST_AUTH_PREFIX}not-the-token\n`,
+    });
+    await flushMicrotasks();
+    expect(bad.destroyed).toBe(true);
+
+    // Real bot follows — succeeds.
+    setup.server.connectBot();
+    await ready;
+
+    await setup.ingest.stop();
+  });
+
+  test("rejects a connection that flood-writes without ever sending a newline", async () => {
+    const setup = newIngestSetup();
+    const { ready } = await setup.ingest.start(
+      "m-oversize",
+      TEST_BOT_TOKEN,
+    );
+    await flushMicrotasks();
+
+    const bad = setup.server.connectBot({ authLine: null });
+    // Send MAX_HANDSHAKE_BYTES + 1 bytes with no newline — handshake must
+    // give up and destroy the socket without pinning arbitrary memory.
+    bad.emitData(Buffer.alloc(MAX_HANDSHAKE_BYTES + 1, 0x41));
+    await flushMicrotasks();
+    expect(bad.destroyed).toBe(true);
+
+    setup.server.connectBot();
+    await ready;
+
+    await setup.ingest.stop();
+  });
+
+  test("rejects a connection that opens but never sends any data (handshake timeout)", async () => {
+    // Monkey-patch setTimeout so we can fire the handshake watchdog
+    // without waiting HANDSHAKE_TIMEOUT_MS of wall-clock time.
+    const realSetTimeout = globalThis.setTimeout;
+    const realClearTimeout = globalThis.clearTimeout;
+    type Timer = {
+      handle: symbol;
+      cb: () => void;
+      ms: number;
+      fired: boolean;
+    };
+    const timers: Timer[] = [];
+    let nextId = 0;
+    (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout = ((
+      cb: () => void,
+      ms: number,
+    ) => {
+      const handle = Symbol(`timer-${nextId++}`);
+      timers.push({ handle, cb, ms, fired: false });
+      return handle as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    (
+      globalThis as unknown as { clearTimeout: typeof clearTimeout }
+    ).clearTimeout = ((handle: unknown) => {
+      const t = timers.find((x) => x.handle === handle);
+      if (t) t.fired = true;
+    }) as typeof clearTimeout;
+
+    try {
+      const setup = newIngestSetup();
+      const { ready } = await setup.ingest.start(
+        "m-hshake-timeout",
+        TEST_BOT_TOKEN,
+      );
+      await flushMicrotasks();
+
+      const bad = setup.server.connectBot({ authLine: null });
+      await flushMicrotasks();
+
+      const handshakeTimer = timers.find(
+        (t) => !t.fired && t.ms === HANDSHAKE_TIMEOUT_MS,
+      );
+      expect(handshakeTimer).toBeDefined();
+      handshakeTimer!.cb();
+      handshakeTimer!.fired = true;
+
+      await flushMicrotasks();
+      expect(bad.destroyed).toBe(true);
+
+      // Listener still open — the real bot can still show up after the
+      // bogus peer timed out.
+      setup.server.connectBot();
+      await ready;
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+      globalThis.clearTimeout = realClearTimeout;
+    }
+  });
+
+  test("forwards PCM bytes that arrived in the same TCP segment as the handshake newline", async () => {
+    const setup = newIngestSetup();
+    const { ready } = await setup.ingest.start(
+      "m-residual",
+      TEST_BOT_TOKEN,
+    );
+    await flushMicrotasks();
+
+    // Single segment: AUTH line + newline + 3 PCM bytes. The ingest must
+    // replay the residual PCM into the transcriber so we don't silently
+    // drop the first frame when the bot pipes audio immediately after the
+    // handshake.
+    const combined = Buffer.concat([
+      Buffer.from(`${AUDIO_INGEST_AUTH_PREFIX}${TEST_BOT_TOKEN}\n`, "utf8"),
+      Buffer.from([0xde, 0xad, 0xbe]),
+    ]);
+    setup.server.connectBot({ authLine: null }).emitData(combined);
+    await ready;
+
+    expect(setup.session.audioChunks).toHaveLength(1);
+    expect(setup.session.audioChunks[0]).toEqual(Buffer.from([0xde, 0xad, 0xbe]));
+
+    await setup.ingest.stop();
+  });
+
+  test("drops any connection that opens after a successful auth", async () => {
+    const setup = newIngestSetup();
+    const { ready } = await setup.ingest.start("m-second", TEST_BOT_TOKEN);
+    await flushMicrotasks();
+
+    setup.server.connectBot();
+    await ready;
+
+    // A second, fully valid handshake must still be dropped — the ingest
+    // only wires the first accepted peer.
+    const second = setup.server.connectBot();
+    await flushMicrotasks();
+    expect(second.destroyed).toBe(true);
+
+    await setup.ingest.stop();
   });
 });
 
@@ -788,7 +998,7 @@ describe("MeetAudioIngest — default transcriber factory", () => {
     // Kick off start(); we don't need it to resolve, just to call the
     // resolver. Attach a noop rejection handler so the bot-connect timeout
     // doesn't surface as an unhandled rejection when the test finishes.
-    const { ready } = await ingest.start("m-diarize");
+    const { ready } = await ingest.start("m-diarize", TEST_BOT_TOKEN);
     // Attach a noop rejection handler so the bot-connect timeout (which we
     // never satisfy in this test) doesn't surface as an unhandled rejection.
     ready.catch(() => {});
@@ -812,10 +1022,10 @@ describe("MeetAudioIngest — default transcriber factory", () => {
       listen: async () => new FakeAudioIngestServer(),
     });
 
-    await expect(ingest.start("m-null")).rejects.toThrow(
+    await expect(ingest.start("m-null", TEST_BOT_TOKEN)).rejects.toThrow(
       MeetAudioIngestError,
     );
-    await expect(ingest.start("m-null2")).rejects.toThrow(
+    await expect(ingest.start("m-null2", TEST_BOT_TOKEN)).rejects.toThrow(
       /configured STT provider is unusable/i,
     );
   });

--- a/skills/meet-join/daemon/__tests__/avatar-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/avatar-e2e.test.ts
@@ -261,7 +261,7 @@ async function startRealBotServer(
  */
 function makeFakeAudioIngest(): MeetAudioIngestLike {
   return {
-    start: async () => {},
+    start: async () => ({ port: 42173, ready: Promise.resolve() }),
     stop: async () => {},
     subscribePcm: () => () => {},
   };

--- a/skills/meet-join/daemon/__tests__/chat-send-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/chat-send-e2e.test.ts
@@ -160,7 +160,7 @@ function captureHub(): {
  */
 function makeFakeAudioIngest(): MeetAudioIngestLike {
   return {
-    start: async () => {},
+    start: async () => ({ port: 42173, ready: Promise.resolve() }),
     stop: async () => {},
     subscribePcm: () => () => {},
   };

--- a/skills/meet-join/daemon/__tests__/proactive-chat-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/proactive-chat-e2e.test.ts
@@ -151,7 +151,7 @@ function startFakeBot(): FakeBotServer {
 /** Fake audio ingest — the session manager never touches it after start. */
 function makeFakeAudioIngest(): MeetAudioIngestLike {
   return {
-    start: async () => {},
+    start: async () => ({ port: 42173, ready: Promise.resolve() }),
     stop: async () => {},
     subscribePcm: () => () => {},
   };

--- a/skills/meet-join/daemon/__tests__/session-manager.test.ts
+++ b/skills/meet-join/daemon/__tests__/session-manager.test.ts
@@ -870,10 +870,15 @@ describe("MeetSessionManager audio ingest wiring", () => {
     const ingest = audioIngestFactory.getLastIngest();
     expect(ingest).not.toBeNull();
     expect(ingest!.start).toHaveBeenCalledTimes(1);
-    const call = ingest!.start.mock.calls[0] as unknown as [string];
-    expect(call).toHaveLength(1);
-    const [meetingId] = call;
+    const call = ingest!.start.mock.calls[0] as unknown as [string, string];
+    expect(call).toHaveLength(2);
+    const [meetingId, botApiToken] = call;
     expect(meetingId).toBe("m-audio");
+    // The session manager must hand the ingest the same per-session
+    // bot API token it threads into the container env so the bot's audio
+    // handshake lines up with the ingest's expected token.
+    expect(typeof botApiToken).toBe("string");
+    expect(botApiToken.length).toBeGreaterThan(0);
     // Session manager no longer fetches a Deepgram key — STT resolution
     // lives inside the audio ingest.
     expect(getProviderKey).not.toHaveBeenCalledWith("deepgram");
@@ -1276,7 +1281,7 @@ describe("MeetSessionManager dispatcher sequencing", () => {
       factory: () => {
         const subscribers = new Set<(bytes: Uint8Array) => void>();
         const ingest: MeetAudioIngestLike = {
-          start: async (meetingId: string) => {
+          start: async (meetingId: string, _botApiToken: string) => {
             // By the time audio ingest starts, the router handler must be
             // installed so transcripts fired during STT startup can reach
             // the dispatcher rather than falling through the unregistered

--- a/skills/meet-join/daemon/audio-ingest.ts
+++ b/skills/meet-join/daemon/audio-ingest.ts
@@ -34,6 +34,7 @@
  *     without touching real sockets or a real STT provider account.
  */
 
+import { timingSafeEqual } from "node:crypto";
 import {
   createServer as netCreateServer,
   type AddressInfo,
@@ -86,6 +87,44 @@ export const AUDIO_INGEST_BIND_HOST = "0.0.0.0";
  * rollback a bot that was still legitimately mid-join.
  */
 export const BOT_CONNECT_TIMEOUT_MS = 120_000;
+
+/**
+ * Wire-format prefix for the handshake line the bot sends as the first
+ * bytes of every audio-ingest TCP connection. The full line is
+ * `AUTH <botApiToken>\n`. Anything else — or a connection that opens
+ * more than {@link MAX_HANDSHAKE_BYTES} without a newline, or that does
+ * not finish its handshake within {@link HANDSHAKE_TIMEOUT_MS} — is
+ * dropped.
+ *
+ * The handshake exists because `AUDIO_INGEST_BIND_HOST` binds the TCP
+ * server to all interfaces (required so Linux Docker bots reach the
+ * daemon via `host.docker.internal:host-gateway`), which also means any
+ * other process on the host's LAN could race-connect and either inject
+ * raw PCM or hold the port open until the bot's connect watchdog trips.
+ * Reusing `BOT_API_TOKEN` (already generated per-meeting and shared with
+ * the bot through its env) keeps the secret surface area the same as
+ * the bot's HTTP API.
+ */
+export const AUDIO_INGEST_AUTH_PREFIX = "AUTH ";
+
+/**
+ * Wall-clock budget the bot has after TCP connect to deliver the
+ * handshake line. Intentionally short — a legitimate bot writes the
+ * line synchronously as the first bytes after `connect()` returns, so
+ * any delay past a few seconds is either a stuck attacker or a failed
+ * bot. We still keep the overall bot-connect budget at
+ * {@link BOT_CONNECT_TIMEOUT_MS} because the handshake fires against
+ * each individual connection, not against the listener as a whole.
+ */
+export const HANDSHAKE_TIMEOUT_MS = 10_000;
+
+/**
+ * Maximum bytes we buffer while waiting for the handshake's newline.
+ * Well above the handshake's true length (`"AUTH " + 64-char hex + "\n"`
+ * = 70 bytes) so benign TCP re-segmentation doesn't trip it, but small
+ * enough that a peer who never sends `\n` cannot pin arbitrary memory.
+ */
+export const MAX_HANDSHAKE_BYTES = 256;
 
 /**
  * Sample rate (Hz) of the PCM frames the meet-bot captures and forwards over
@@ -275,10 +314,16 @@ export class MeetAudioIngest {
    */
   async start(
     meetingId: string,
+    botApiToken: string,
   ): Promise<{ port: number; ready: Promise<void> }> {
     if (this.meetingId) {
       throw new Error(
         `MeetAudioIngest: start() called twice (meetingId=${this.meetingId})`,
+      );
+    }
+    if (!botApiToken) {
+      throw new Error(
+        "MeetAudioIngest: botApiToken is required — refusing to start without an auth token",
       );
     }
     this.meetingId = meetingId;
@@ -343,9 +388,12 @@ export class MeetAudioIngest {
       log.error({ err, meetingId }, "MeetAudioIngest: socket server error");
     });
 
-    // Wait for the bot to connect, bounded by BOT_CONNECT_TIMEOUT_MS.
-    // Returned to the caller as `ready` so container spawn can run
-    // concurrently with the connect wait.
+    // Wait for the bot to connect AND successfully complete the
+    // auth-token handshake, bounded by BOT_CONNECT_TIMEOUT_MS. Connections
+    // that fail the handshake are destroyed but do NOT reject `ready` —
+    // we keep the listener open so the real bot can still connect. The
+    // overall timeout is the backstop for the case where no legitimate
+    // bot ever shows up.
     const ready = new Promise<void>((resolve, reject) => {
       let settled = false;
 
@@ -365,8 +413,9 @@ export class MeetAudioIngest {
 
       server.onConnection((conn) => {
         if (settled) {
-          // Late connection after we already rejected — drop it so the
-          // caller's teardown path can proceed cleanly.
+          // Late connection after we already accepted a bot (or rejected
+          // on timeout) — drop it so the caller's teardown path can
+          // proceed cleanly.
           try {
             conn.destroy();
           } catch {
@@ -374,20 +423,128 @@ export class MeetAudioIngest {
           }
           return;
         }
-        settled = true;
-        clearTimeout(timer);
+        this.authenticateConnection(conn, botApiToken, {
+          onAccept: (residual) => {
+            if (settled) {
+              // Raced another connection; drop this one.
+              try {
+                conn.destroy();
+              } catch {
+                // Best effort.
+              }
+              return;
+            }
+            settled = true;
+            clearTimeout(timer);
 
-        this.connection = conn;
-        this.wireConnection(conn, meetingId);
-        log.info(
-          { meetingId, port: boundPort },
-          "MeetAudioIngest: bot connected",
-        );
-        resolve();
+            this.connection = conn;
+            this.wireConnection(conn, meetingId);
+            if (residual && residual.length > 0) {
+              // Any bytes the bot sent after the handshake newline in the
+              // same TCP segment are real PCM — forward them before
+              // handing the socket to the data listener so we don't
+              // silently drop them.
+              this.handlePcmChunk(residual, meetingId);
+            }
+            log.info(
+              { meetingId, port: boundPort },
+              "MeetAudioIngest: bot connected and authenticated",
+            );
+            resolve();
+          },
+          onReject: (reason) => {
+            // Drop the peer, keep listening for the real bot. We only
+            // log a counter-style field so repeated bad handshakes
+            // don't flood logs with duplicate messages.
+            log.warn(
+              { meetingId, port: boundPort, reason },
+              "MeetAudioIngest: rejected unauthenticated audio-ingest peer",
+            );
+            try {
+              conn.destroy();
+            } catch {
+              // Best effort.
+            }
+          },
+        });
       });
     });
 
     return { port: boundPort, ready };
+  }
+
+  /**
+   * Validate the handshake line the bot sends as the first bytes after
+   * TCP connect. Calls `onAccept` with any trailing PCM bytes that
+   * arrived in the same segment as the handshake (the bot pipes audio
+   * immediately after writing the auth line, so the first chunk will
+   * usually contain both). Calls `onReject` with a human-readable reason
+   * if the handshake is malformed, mismatched, oversized, or times out.
+   *
+   * The caller owns the connection lifetime — `onReject` does NOT
+   * destroy the socket so the caller can log/track the rejection before
+   * tearing it down.
+   */
+  private authenticateConnection(
+    conn: AudioIngestConnection,
+    expectedToken: string,
+    callbacks: {
+      onAccept: (residual: Buffer | null) => void;
+      onReject: (reason: string) => void;
+    },
+  ): void {
+    let settled = false;
+    let buffer = Buffer.alloc(0);
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      callbacks.onReject("handshake-timeout");
+    }, HANDSHAKE_TIMEOUT_MS);
+
+    const finish = (outcome: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      outcome();
+    };
+
+    conn.onData((chunk) => {
+      if (settled) return;
+      buffer = Buffer.concat([buffer, chunk]);
+      const newline = buffer.indexOf(0x0a);
+      if (newline === -1) {
+        if (buffer.length > MAX_HANDSHAKE_BYTES) {
+          finish(() => callbacks.onReject("handshake-too-long"));
+        }
+        return;
+      }
+      const line = buffer.subarray(0, newline).toString("utf8");
+      const residual =
+        newline + 1 < buffer.length ? buffer.subarray(newline + 1) : null;
+
+      if (!line.startsWith(AUDIO_INGEST_AUTH_PREFIX)) {
+        finish(() => callbacks.onReject("handshake-bad-prefix"));
+        return;
+      }
+      const presentedToken = line.slice(AUDIO_INGEST_AUTH_PREFIX.length);
+      if (!constantTimeTokenEqual(presentedToken, expectedToken)) {
+        finish(() => callbacks.onReject("handshake-bad-token"));
+        return;
+      }
+
+      finish(() => callbacks.onAccept(residual));
+    });
+
+    conn.onClose(() => {
+      if (settled) return;
+      finish(() => callbacks.onReject("handshake-closed"));
+    });
+
+    conn.onError((err) => {
+      if (settled) return;
+      finish(() => callbacks.onReject(`handshake-error:${err.message}`));
+    });
   }
 
   /**
@@ -453,38 +610,7 @@ export class MeetAudioIngest {
    * misbehaving consumer cannot break peers.
    */
   private wireConnection(conn: AudioIngestConnection, meetingId: string): void {
-    conn.onData((chunk) => {
-      if (this.stopped) return;
-      const transcriber = this.transcriber;
-      if (transcriber) {
-        try {
-          // The streaming endpoint accepts raw PCM bytes. The mimeType is
-          // informational for provider adapters; pass a sensible default.
-          transcriber.sendAudio(chunk, "audio/pcm");
-        } catch (err) {
-          log.warn(
-            { err, meetingId },
-            "MeetAudioIngest: transcriber.sendAudio threw",
-          );
-        }
-      }
-      // Fan the raw bytes out to every PCM subscriber. Snapshot the set so
-      // a callback removing itself mid-iteration doesn't skip a neighbor.
-      // Subscribers that throw are logged and removed on the spot.
-      if (this.pcmSubscribers.size > 0) {
-        for (const subscriber of Array.from(this.pcmSubscribers)) {
-          try {
-            subscriber(chunk);
-          } catch (err) {
-            log.warn(
-              { err, meetingId },
-              "MeetAudioIngest: PCM subscriber threw — removing",
-            );
-            this.pcmSubscribers.delete(subscriber);
-          }
-        }
-      }
-    });
+    conn.onData((chunk) => this.handlePcmChunk(chunk, meetingId));
 
     conn.onClose(() => {
       log.info({ meetingId }, "MeetAudioIngest: bot connection closed");
@@ -493,6 +619,45 @@ export class MeetAudioIngest {
     conn.onError((err) => {
       log.warn({ err, meetingId }, "MeetAudioIngest: bot connection error");
     });
+  }
+
+  /**
+   * Forward a single PCM chunk to the streaming transcriber and fan it
+   * out to every subscriber. Extracted from the `onData` handler so the
+   * handshake path can replay trailing bytes that arrived in the same
+   * segment as the auth line without duplicating the forwarding logic.
+   */
+  private handlePcmChunk(chunk: Buffer, meetingId: string): void {
+    if (this.stopped) return;
+    const transcriber = this.transcriber;
+    if (transcriber) {
+      try {
+        // The streaming endpoint accepts raw PCM bytes. The mimeType is
+        // informational for provider adapters; pass a sensible default.
+        transcriber.sendAudio(chunk, "audio/pcm");
+      } catch (err) {
+        log.warn(
+          { err, meetingId },
+          "MeetAudioIngest: transcriber.sendAudio threw",
+        );
+      }
+    }
+    // Fan the raw bytes out to every PCM subscriber. Snapshot the set so
+    // a callback removing itself mid-iteration doesn't skip a neighbor.
+    // Subscribers that throw are logged and removed on the spot.
+    if (this.pcmSubscribers.size > 0) {
+      for (const subscriber of Array.from(this.pcmSubscribers)) {
+        try {
+          subscriber(chunk);
+        } catch (err) {
+          log.warn(
+            { err, meetingId },
+            "MeetAudioIngest: PCM subscriber threw — removing",
+          );
+          this.pcmSubscribers.delete(subscriber);
+        }
+      }
+    }
   }
 
   /**
@@ -534,6 +699,30 @@ export class MeetAudioIngest {
 
     getMeetSessionEventRouter().dispatch(meetingId, transcript);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Handshake helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Constant-time comparison of the presented token against the expected
+ * token. Returns `false` whenever the lengths differ so a mismatched
+ * length does not fall through to `timingSafeEqual` (which throws on
+ * unequal buffer sizes).
+ *
+ * Both inputs are treated as UTF-8 — the token is hex-encoded in
+ * practice, so UTF-8 and ASCII are identical.
+ */
+function constantTimeTokenEqual(
+  presented: string,
+  expected: string,
+): boolean {
+  if (presented.length !== expected.length) return false;
+  const a = Buffer.from(presented, "utf8");
+  const b = Buffer.from(expected, "utf8");
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -443,8 +443,20 @@ export interface MeetAudioIngestLike {
    * bot container as `DAEMON_AUDIO_PORT`, and `ready` resolves once the
    * bot has actually connected (or rejects on timeout). Splitting the two
    * lets the container spawn run concurrently with the bot-connect wait.
+   *
+   * `botApiToken` is the same per-session token the session manager
+   * threads into `BOT_API_TOKEN` for the bot container. The ingest
+   * requires the bot to send `AUTH <token>\n` as the first bytes over
+   * the TCP connection and destroys any peer that doesn't match — this
+   * closes the hole opened by binding the audio server on
+   * `0.0.0.0` (so Linux Docker bots can reach it via
+   * `host.docker.internal:host-gateway`), which would otherwise let any
+   * LAN-adjacent process inject PCM or stall the listener.
    */
-  start(meetingId: string): Promise<{ port: number; ready: Promise<void> }>;
+  start(
+    meetingId: string,
+    botApiToken: string,
+  ): Promise<{ port: number; ready: Promise<void> }>;
   stop(): Promise<void>;
   subscribePcm(cb: (bytes: Uint8Array) => void): () => void;
 }
@@ -1106,7 +1118,7 @@ class MeetSessionManagerImpl {
     let audioIngestReady: Promise<void>;
     let audioPort: number;
     try {
-      const handle = await audioIngest.start(meetingId);
+      const handle = await audioIngest.start(meetingId, botApiToken);
       audioPort = handle.port;
       audioIngestReady = handle.ready;
     } catch (err) {


### PR DESCRIPTION
## Summary

- Daemon's audio-ingest TCP server now requires \`AUTH <botApiToken>\n\` as the first bytes of every connection. The bot sends this before piping PCM; the daemon rejects anything else with the connection destroyed.
- Reuses the per-meeting \`botApiToken\` the session manager already threads into the bot container as \`BOT_API_TOKEN\`, so no new secret surface. Constant-time token compare via \`node:crypto\`'s \`timingSafeEqual\`.
- Handshake has its own short budget (\`HANDSHAKE_TIMEOUT_MS\` = 10s) and max-bytes cap (\`MAX_HANDSHAKE_BYTES\` = 256) to prevent a peer from pinning memory by never sending \`\n\`. Residual PCM bytes that arrive in the same TCP segment as the handshake newline are forwarded instead of dropped.
- Rejected peers are destroyed but the listener stays open for the real bot — only \`BOT_CONNECT_TIMEOUT_MS\` rejects \`ready\`.

## Background

Addresses codex review feedback on #27374. That PR switched \`AUDIO_INGEST_BIND_HOST\` from \`127.0.0.1\` to \`0.0.0.0\` so Linux Docker bots can reach the daemon via \`host.docker.internal:host-gateway\`. Codex flagged that the listener now accepts the first inbound connection without any peer check — any LAN-adjacent process could race-connect and either inject raw PCM or stall the listener until the watchdog trips.

## Test plan

- [x] \`bun test skills/meet-join/daemon/__tests__/audio-ingest.test.ts\` — 26 pass (adds 7 handshake-specific tests: bad prefix, bad token, oversize buffer, handshake timeout, residual PCM in same segment, second-connection drop, missing-token guard)
- [x] \`bun test skills/meet-join/daemon/__tests__/session-manager.test.ts\` — 47 pass
- [x] \`bun test skills/meet-join/bot/__tests__/audio-capture.test.ts\` — 16 pass (3 new handshake tests)
- [x] \`bun test skills/meet-join/bot/__tests__/main.test.ts\` — 39 pass
- [x] Pre-existing e2e failure count on main matches post-change count (19 fail → 19 fail, all unrelated MockRunner / inner-dockerd harness issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
