### PR TITLE
docs(injectors): clean up stale migration comments + fix registration docstring (PR #27396 review)

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1699,10 +1699,10 @@ export async function collectInjectorBlocks(
  * skipped entirely (no leading/trailing blank lines). When no injector
  * contributes, the function returns an empty string.
  *
- * Kept for the PR 21 test suite (which asserts the concatenation contract)
- * and for callers that want a single informational string view of the chain.
- * The canonical integration point is {@link applyRuntimeInjections}, which
- * uses {@link collectInjectorBlocks} + placement-aware application to splice
+ * Used by tests that assert the concatenation contract and by callers that
+ * want a single informational string view of the chain. The canonical
+ * integration point is {@link applyRuntimeInjections}, which uses
+ * {@link collectInjectorBlocks} + placement-aware application to splice
  * each block into the per-turn message array.
  */
 export async function composeInjectorChain(ctx: TurnContext): Promise<string> {
@@ -1831,7 +1831,7 @@ export interface RuntimeInjectionOptions {
   pkbContext?: string | null;
   pkbActive?: boolean;
   /**
-   * Dense query vector surfaced from the graph memory retriever (PR 3).
+   * Dense query vector surfaced from the graph memory retriever.
    * When present together with `pkbActive`, used to run `searchPkbFiles`
    * to surface relevance hints in the PKB system reminder. When missing,
    * the reminder falls back to the flat static text.
@@ -1901,8 +1901,8 @@ export interface RuntimeInjectionOptions {
    * {@link Injector}s via {@link collectInjectorBlocks}. When omitted,
    * `applyRuntimeInjections` synthesizes an ephemeral context (with a
    * fallback `trust` classification) so the default-injector chain still
-   * runs — test call sites that pass option fields without a matching
-   * `turnContext` continue to exercise the same code path.
+   * runs — call sites that build the options bag without holding a full
+   * `TurnContext` get the same chain output.
    *
    * When provided, the caller's `trust`, `conversationId`, `turnIndex`,
    * etc. are preserved; the function layers its per-turn

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -1,14 +1,14 @@
 /**
  * Default runtime injector plugin — the canonical chain of injectors that
- * replaces the hardcoded injection sequence previously baked into
- * `applyRuntimeInjections` (pre-migration).
+ * drives the per-turn injection sequence consumed by
+ * `applyRuntimeInjections`.
  *
  * Each of the seven default injectors reads its per-turn inputs from
  * `ctx.injectionInputs` (see {@link TurnInjectionInputs}), runs its gating
  * conditions (injection mode, feature flags, channel type, null-input
  * short-circuits), and returns an {@link InjectionBlock} with a
- * {@link InjectionPlacement} that preserves the byte-for-byte positional
- * semantics of the pre-migration `inject*` helpers:
+ * {@link InjectionPlacement} that yields the canonical positional
+ * semantics expected by the assembly pipeline:
  *
  * | name                     | order | placement               |
  * | ------------------------ | ----- | ----------------------- |
@@ -32,12 +32,11 @@
  * sorted ascending, so a plugin-registered injector at `order: 25`
  * reliably slots between `unified-turn-context` (20) and `pkb` (30).
  *
- * Registration happens via a side-effect import in
- * `daemon/external-plugins-bootstrap.ts` so the default chain is present for
- * every assistant boot.
- *
- * Design doc: `.private/plans/agent-plugin-system.md` (PR 21 — scaffolding,
- * G2.1 — full migration).
+ * Registration happens via a module-load side effect at the bottom of this
+ * file — importing the module is enough to populate the registry. The
+ * explicit `registerDefaultPlugins()` call in `plugins/defaults/index.ts`
+ * (invoked from `daemon/external-plugins-bootstrap.ts`) re-registers the
+ * same plugin idempotently, so either entry point alone is sufficient.
  */
 
 import { resolve } from "node:path";
@@ -225,9 +224,6 @@ function buildPkbContextBlock(content: string): string {
  * enough scope metadata is available, run the hybrid PKB search to
  * surface up to three relevance hints; fall back to the flat static
  * reminder on empty results or any error.
- *
- * Lifted verbatim from the pre-migration `applyRuntimeInjections` branch
- * so the emitted bytes match.
  */
 async function buildPkbReminderWithHints(
   inputs: TurnInjectionInputs,


### PR DESCRIPTION
## Summary

Follow-up to review feedback on #27396.

- **AGENTS.md violations**: rewrote comments referencing \"PR 21\", \"PR 3\", \"pre-migration\", \"G2.1\" in `injectors.ts` (module docstring + PKB reminder docstring) and `conversation-runtime-assembly.ts` (composeInjectorChain docstring, pkbQueryVector docstring, turnContext option docstring) so they describe current state.
- **Factually-wrong docstring**: corrected the registration claim on `defaultInjectorsPlugin`. Registration happens via a module-load side effect at the bottom of `injectors.ts`; `external-plugins-bootstrap.ts` uses a *named* import + explicit `registerDefaultPlugins()` call (idempotent re-register), not a side-effect import.
- **Finding 1 (gate)**: already fixed in #27425 — `applyRuntimeInjections` now synthesizes a fallback `TurnContext` when `options.turnContext` is unset, so the chain runs unconditionally for every production caller. No code change needed here.

## Test plan

- [x] `bunx tsc --noEmit` (assistant)
- [x] `bun test src/__tests__/injector-chain.test.ts` (14 pass)
- [x] `bun test src/__tests__/conversation-runtime-workspace.test.ts src/__tests__/conversation-runtime-assembly.test.ts` (168 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
