### PR TITLE
fix(plugins): give plugin tools a disjoint origin namespace (#27406 review)

### DIFF
--- a/assistant/docs/plugins.md
+++ b/assistant/docs/plugins.md
@@ -505,9 +505,10 @@ middleware. Each is optional.
 ### Tools (`plugin.tools`)
 
 An array of `Tool` objects. The bootstrap registers them with the global
-tool registry after `init()` succeeds, stamping `origin: "skill"` and
-`ownerSkillId: <plugin.name>` so they participate in skill-scoped
-ref-counting.
+tool registry after `init()` succeeds, stamping `origin: "plugin"` and
+`ownerPluginId: <plugin.name>` so they live in a ref-count namespace
+disjoint from real skills (a plugin whose `manifest.name` happens to
+match a skill id cannot collide with that skill's registrations).
 
 ```typescript
 const myPlugin: Plugin = {

--- a/assistant/src/__tests__/plugin-tool-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-tool-contribution.test.ts
@@ -6,14 +6,13 @@
  *
  * - Registering a plugin with `tools: Tool[]`, running `bootstrapPlugins`,
  *   and observing the contributed tool via `getAllTools()` / `getTool()`.
- * - Tool ownership metadata (`origin: "skill"`, `ownerSkillId: <plugin>`)
+ * - Tool ownership metadata (`origin: "plugin"`, `ownerPluginId: <plugin>`)
  *   stamped authoritatively by `registerPluginTools` regardless of what the
  *   plugin author set on the incoming object.
  * - Shutdown hook unregistering the contributed tools so the registry is
  *   clean again after teardown.
- * - Thin-wrapper semantics of `registerPluginTools` /
- *   `unregisterPluginTools` over `registerSkillTools` /
- *   `unregisterSkillTools`, including ref-counting.
+ * - Direct `registerPluginTools` / `unregisterPluginTools` semantics,
+ *   including the plugin-scoped ref count.
  *
  * Uses `mock.module` to stub the credential store so bootstrap doesn't hit
  * the real backend. `resetPluginRegistryForTests()` and
@@ -55,7 +54,7 @@ import {
   __clearRegistryForTesting,
   __resetRegistryForTesting,
   getAllTools,
-  getSkillRefCount,
+  getPluginRefCount,
   getTool,
   registerPluginTools,
   unregisterPluginTools,
@@ -140,9 +139,11 @@ describe("plugin tool contributions", () => {
     expect(retrieved).toBeDefined();
     // Ownership metadata must be stamped authoritatively by the bootstrap —
     // the registry uses it to drive ref-counting and conflict detection when
-    // the plugin shuts down or is hot-reloaded.
-    expect(retrieved?.origin).toBe("skill");
-    expect(retrieved?.ownerSkillId).toBe("alpha-contributor");
+    // the plugin shuts down or is hot-reloaded. Plugin tools live in their
+    // own `origin: "plugin"` namespace, disjoint from real skills, so a
+    // plugin name that happens to match a skill id cannot collide.
+    expect(retrieved?.origin).toBe("plugin");
+    expect(retrieved?.ownerPluginId).toBe("alpha-contributor");
 
     // The tool surfaces in the global `getAllTools()` snapshot, which is
     // what downstream consumers (tool-manifest, session projection) read.
@@ -163,7 +164,7 @@ describe("plugin tool contributions", () => {
     await runShutdownHooks("test-shutdown");
 
     expect(getTool("bravo-tool")).toBeUndefined();
-    expect(getSkillRefCount("bravo-contributor")).toBe(0);
+    expect(getPluginRefCount("bravo-contributor")).toBe(0);
   });
 
   test("bootstrap is a no-op for plugins that declare no tools", async () => {
@@ -220,32 +221,36 @@ describe("registerPluginTools / unregisterPluginTools helpers", () => {
     __resetRegistryForTesting();
   });
 
-  test("registerPluginTools stamps origin and ownerSkillId from the plugin name", () => {
+  test("registerPluginTools stamps origin and ownerPluginId from the plugin name", () => {
     // Even if the plugin author hands in a tool with no ownership metadata,
     // the helper fills it in so the tool can be unregistered later.
     const accepted = registerPluginTools("my-plugin", [
       makeFakeTool("pt_stamped"),
     ]);
     expect(accepted).toHaveLength(1);
-    expect(accepted[0]?.origin).toBe("skill");
-    expect(accepted[0]?.ownerSkillId).toBe("my-plugin");
+    expect(accepted[0]?.origin).toBe("plugin");
+    expect(accepted[0]?.ownerPluginId).toBe("my-plugin");
 
     const retrieved = getTool("pt_stamped");
-    expect(retrieved?.origin).toBe("skill");
-    expect(retrieved?.ownerSkillId).toBe("my-plugin");
+    expect(retrieved?.origin).toBe("plugin");
+    expect(retrieved?.ownerPluginId).toBe("my-plugin");
   });
 
   test("registerPluginTools overwrites any pre-existing ownership metadata", () => {
     // A plugin author could (maliciously or mistakenly) hand in a tool
-    // pre-tagged with another skill's ID. The helper must overwrite it so
-    // the bootstrap is always the source of truth for ownership.
+    // pre-tagged with another skill's or plugin's ID. The helper must
+    // overwrite it so the bootstrap is always the source of truth for
+    // ownership — and it must clear cross-origin fields (ownerSkillId /
+    // ownerMcpServerId) so the stamped tool cannot leak across namespaces.
     const spoofed = makeFakeTool("pt_spoof", {
       origin: "skill",
       ownerSkillId: "some-other-skill",
     });
     registerPluginTools("my-plugin", [spoofed]);
     const retrieved = getTool("pt_spoof");
-    expect(retrieved?.ownerSkillId).toBe("my-plugin");
+    expect(retrieved?.origin).toBe("plugin");
+    expect(retrieved?.ownerPluginId).toBe("my-plugin");
+    expect(retrieved?.ownerSkillId).toBeUndefined();
   });
 
   test("unregisterPluginTools removes the plugin's tools", () => {
@@ -269,13 +274,13 @@ describe("registerPluginTools / unregisterPluginTools helpers", () => {
   test("ref-counting: repeated registrations require matching unregister calls", () => {
     registerPluginTools("rc-plugin", [makeFakeTool("pt_rc")]);
     registerPluginTools("rc-plugin", [makeFakeTool("pt_rc")]);
-    expect(getSkillRefCount("rc-plugin")).toBe(2);
+    expect(getPluginRefCount("rc-plugin")).toBe(2);
 
     unregisterPluginTools("rc-plugin");
     expect(getTool("pt_rc")).toBeDefined();
 
     unregisterPluginTools("rc-plugin");
     expect(getTool("pt_rc")).toBeUndefined();
-    expect(getSkillRefCount("rc-plugin")).toBe(0);
+    expect(getPluginRefCount("rc-plugin")).toBe(0);
   });
 });

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -285,14 +285,25 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
       // After init succeeds, wire in the plugin's model-visible capabilities.
       // Tool contributions (PR 31) register only after `init()` succeeds so a
       // plugin that fails mid-init never leaves partially-wired tools behind.
-      // Tool registration failures throw up the stack to abort bootstrap,
-      // matching the strict-fail semantics of `init()` errors.
+      // Tool registration failures are wrapped in a PluginExecutionError so
+      // the offending plugin name surfaces in the abort — matching the
+      // strict-fail semantics of `init()` errors.
       if (plugin.tools && plugin.tools.length > 0) {
-        const accepted = registerPluginTools(name, plugin.tools);
-        log.info(
-          { plugin: name, count: accepted.length },
-          "plugin tools registered",
-        );
+        try {
+          const accepted = registerPluginTools(name, plugin.tools);
+          log.info(
+            { plugin: name, count: accepted.length },
+            "plugin tools registered",
+          );
+        } catch (err) {
+          throw new PluginExecutionError(
+            `plugin ${name} tool registration failed: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            name,
+            { cause: err },
+          );
+        }
       }
 
       // Route contributions (PR 32) — registered after init() succeeds so a

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -717,7 +717,11 @@ export async function check(
         ? isWorkspaceScopedInvocation(toolName, input, workingDir)
         : false,
     toolOrigin:
-      tool?.origin === "skill" ? "skill" : tool ? "builtin" : undefined,
+      tool?.origin === "skill" || tool?.origin === "plugin"
+        ? "skill"
+        : tool
+          ? "builtin"
+          : undefined,
     isSkillBundled: tool?.ownerSkillBundled ?? false,
     hasManifestOverride: !!manifestOverride,
     autoApproveUpTo: resolvedThreshold,

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -988,12 +988,12 @@ export interface Injector {
 
 /**
  * Tool registration contributed by a plugin. Uses the canonical {@link Tool}
- * interface from the tool registry — the bootstrap stamps `origin: "skill"`
- * and `ownerSkillId: <plugin.name>` before handing the batch to
- * `registerSkillTools` so plugin-scoped ref-counting and conflict detection
- * reuse the skill-tool machinery. Plugin authors supply the functional fields
- * (`name`, `description`, `getDefinition`, `execute`, etc.) and leave the
- * ownership metadata to the bootstrap to set authoritatively.
+ * interface from the tool registry — the bootstrap stamps `origin: "plugin"`
+ * and `ownerPluginId: <plugin.name>` before handing the batch to
+ * `registerPluginTools`, which keeps plugin ref-counts and conflict detection
+ * in a namespace disjoint from real skills. Plugin authors supply the
+ * functional fields (`name`, `description`, `getDefinition`, `execute`, etc.)
+ * and leave the ownership metadata to the bootstrap to set authoritatively.
  */
 export type PluginToolRegistration = Tool;
 /**

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -68,6 +68,12 @@ let coreToolsSnapshot: Map<string, Tool> | null = null;
 // Tools are only removed from the global registry when this drops to 0.
 const skillRefCount = new Map<string, number>();
 
+// Plugin-tool refcount lives in its own namespace so plugin and skill IDs
+// cannot collide in the ref map even if a plugin's `manifest.name` happens to
+// match a skill id. Conflict detection on `tools` (keyed by tool name) is
+// separate and covers the case of two extensions choosing the same tool name.
+const pluginRefCount = new Map<string, number>();
+
 export function registerTool(tool: Tool): void {
   const existing = tools.get(tool.name);
   if (existing) {
@@ -108,10 +114,22 @@ export function registerSkillTools(newTools: Tool[]): Tool[] {
         );
         continue;
       }
-      // Existing is also a skill tool - only allow replacement from the same owner.
-      if (existing.ownerSkillId !== tool.ownerSkillId) {
+      // Existing is from a different origin (plugin/mcp) or a different
+      // skill — skill tools can only replace themselves (hot-reload).
+      if (
+        existing.origin !== "skill" ||
+        existing.ownerSkillId !== tool.ownerSkillId
+      ) {
+        const owner =
+          existing.origin === "skill"
+            ? `skill "${existing.ownerSkillId}"`
+            : existing.origin === "plugin"
+              ? `plugin "${existing.ownerPluginId}"`
+              : existing.origin === "mcp"
+                ? `MCP server "${existing.ownerMcpServerId}"`
+                : `${existing.origin ?? "unknown"}-origin tool`;
         throw new Error(
-          `Skill tool "${tool.name}" is already registered by skill "${existing.ownerSkillId}"`,
+          `Skill tool "${tool.name}" is already registered by ${owner}`,
         );
       }
     }
@@ -137,38 +155,108 @@ export function registerSkillTools(newTools: Tool[]): Tool[] {
 }
 
 /**
- * Register tools contributed by a plugin. Thin wrapper around
- * {@link registerSkillTools} that stamps `origin: "skill"` and
- * `ownerSkillId: pluginName` on every incoming tool so plugin-scoped
- * ref-counting, conflict detection, and hot-reload replacement reuse the
- * skill-tool machinery without plugin authors having to fill in ownership
- * metadata manually. Plugins and skills share the same tool-origin slot
- * because they play the same role in the registry — a batch of model-visible
- * tools owned by a named, dynamically-registered extension.
+ * Register tools contributed by a plugin. Stamps `origin: "plugin"` and
+ * `ownerPluginId: pluginName` on every incoming tool so plugin ownership is
+ * tracked in a namespace disjoint from skill tools — if a plugin's
+ * `manifest.name` happens to match a skill id, the two do not share refcount
+ * state or conflict-detection paths.
  *
- * The stamp is authoritative: any pre-existing `origin` or `ownerSkillId`
- * fields on the incoming tools are overwritten so the bootstrap cannot be
- * spoofed into claiming tools on behalf of an unrelated skill.
+ * Conflict handling mirrors {@link registerSkillTools}: collisions with core
+ * tools log a warning and skip; collisions with tools owned by a different
+ * plugin, skill, or MCP server throw; re-registering the same plugin's own
+ * tool (hot reload) is allowed.
+ *
+ * The stamp is authoritative: any pre-existing `origin` / `ownerPluginId` /
+ * `ownerSkillId` / `ownerMcpServerId` fields on the incoming tools are
+ * overwritten so the bootstrap cannot be spoofed into claiming tools on
+ * behalf of an unrelated extension.
  */
 export function registerPluginTools(
   pluginName: string,
   newTools: Tool[],
 ): Tool[] {
-  const stamped = newTools.map((tool) => ({
+  const stamped: Tool[] = newTools.map((tool) => ({
     ...tool,
-    origin: "skill" as const,
-    ownerSkillId: pluginName,
+    origin: "plugin" as const,
+    ownerPluginId: pluginName,
+    ownerSkillId: undefined,
+    ownerMcpServerId: undefined,
   }));
-  return registerSkillTools(stamped);
+
+  const accepted: Tool[] = [];
+  for (const tool of stamped) {
+    const existing = tools.get(tool.name);
+    if (existing) {
+      const existingIsCore = existing.origin === "core" || !existing.origin;
+      if (existingIsCore) {
+        log.warn(
+          { toolName: tool.name, pluginName },
+          `Plugin "${pluginName}" tried to register tool "${tool.name}" which conflicts with a core tool. Skipping.`,
+        );
+        continue;
+      }
+      if (existing.origin === "plugin") {
+        if (existing.ownerPluginId !== pluginName) {
+          throw new Error(
+            `Plugin tool "${tool.name}" is already registered by plugin "${existing.ownerPluginId}"`,
+          );
+        }
+        // Same plugin re-registering its own tool (hot reload) — allow.
+      } else {
+        // Conflict with a skill or MCP-owned tool.
+        throw new Error(
+          `Plugin "${pluginName}" tried to register tool "${tool.name}" which conflicts with a ${existing.origin}-origin tool`,
+        );
+      }
+    }
+    accepted.push(tool);
+  }
+
+  for (const tool of accepted) {
+    tools.set(tool.name, tool);
+    log.info(
+      { name: tool.name, ownerPluginId: tool.ownerPluginId },
+      "Plugin tool registered",
+    );
+  }
+
+  if (accepted.length > 0) {
+    pluginRefCount.set(pluginName, (pluginRefCount.get(pluginName) ?? 0) + 1);
+  }
+
+  return accepted;
 }
 
 /**
- * Unregister tools contributed by a plugin. Thin wrapper around
- * {@link unregisterSkillTools} — see that function for ref-counting
- * semantics. Safe to call when the plugin never contributed tools (no-op).
+ * Decrement the reference count for a plugin and remove its tools only when
+ * no more references remain. Safe to call when the plugin never contributed
+ * tools (no-op).
  */
 export function unregisterPluginTools(pluginName: string): void {
-  unregisterSkillTools(pluginName);
+  const current = pluginRefCount.get(pluginName) ?? 0;
+  if (current > 1) {
+    pluginRefCount.set(pluginName, current - 1);
+    log.info(
+      { pluginName, remaining: current - 1 },
+      "Decremented plugin ref count, tools kept",
+    );
+    return;
+  }
+
+  pluginRefCount.delete(pluginName);
+  for (const [name, tool] of tools) {
+    if (tool.origin === "plugin" && tool.ownerPluginId === pluginName) {
+      tools.delete(name);
+      log.info({ name, pluginName }, "Plugin tool unregistered");
+    }
+  }
+}
+
+/**
+ * Return the current reference count for a plugin's tools. Exposed for testing.
+ */
+export function getPluginRefCount(pluginName: string): number {
+  return pluginRefCount.get(pluginName) ?? 0;
 }
 
 /**
@@ -222,6 +310,17 @@ export function registerMcpTools(newTools: Tool[]): Tool[] {
             skillId: existing.ownerSkillId,
           },
           `MCP server "${tool.ownerMcpServerId}" tried to register tool "${tool.name}" which conflicts with skill tool from "${existing.ownerSkillId}". Skipping.`,
+        );
+        continue;
+      }
+      if (existing.origin === "plugin") {
+        log.warn(
+          {
+            toolName: tool.name,
+            serverId: tool.ownerMcpServerId,
+            pluginName: existing.ownerPluginId,
+          },
+          `MCP server "${tool.ownerMcpServerId}" tried to register tool "${tool.name}" which conflicts with plugin tool from "${existing.ownerPluginId}". Skipping.`,
         );
         continue;
       }
@@ -376,6 +475,7 @@ export async function initializeTools(): Promise<void> {
     coreToolsSnapshot = new Map<string, Tool>();
     for (const [name, tool] of tools) {
       if (tool.origin === "skill") continue;
+      if (tool.origin === "plugin") continue;
       // Exclude pre-existing tools not declared in the manifest
       if (preExisting.has(name) && !manifestToolNames.has(name)) continue;
       coreToolsSnapshot.set(name, tool);
@@ -398,6 +498,7 @@ export async function initializeTools(): Promise<void> {
 export function __resetRegistryForTesting(): void {
   tools.clear();
   skillRefCount.clear();
+  pluginRefCount.clear();
 
   if (coreToolsSnapshot) {
     for (const [name, tool] of coreToolsSnapshot) {
@@ -414,4 +515,5 @@ export function __resetRegistryForTesting(): void {
 export function __clearRegistryForTesting(): void {
   tools.clear();
   skillRefCount.clear();
+  pluginRefCount.clear();
 }

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -320,12 +320,14 @@ export interface Tool {
   defaultRiskLevel: RiskLevel;
   /** When set to 'proxy', the tool is forwarded to a connected client rather than executed locally. */
   executionMode?: "local" | "proxy";
-  /** Whether this tool is a core built-in, provided by a skill, or from an MCP server. */
-  origin?: "core" | "skill" | "mcp";
+  /** Whether this tool is a core built-in, provided by a skill, contributed by a plugin, or from an MCP server. */
+  origin?: "core" | "skill" | "mcp" | "plugin";
   /** If origin is 'skill', the ID of the owning skill. */
   ownerSkillId?: string;
   /** If origin is 'mcp', the ID of the owning MCP server. */
   ownerMcpServerId?: string;
+  /** If origin is 'plugin', the name of the owning plugin. */
+  ownerPluginId?: string;
   /** Content-hash of the owning skill's source at registration time. */
   ownerSkillVersionHash?: string;
   /** Whether the owning skill is bundled with the daemon (trusted first-party). */


### PR DESCRIPTION
## Summary
Addresses reviewer feedback on #27406:

- **Origin namespace collision.** `registerPluginTools` previously stamped plugin tools as `origin: "skill"` + `ownerSkillId`, merging plugin ownership into the same `skillRefCount` map and conflict-check path as real skills. A plugin whose `manifest.name` matched a skill id would collide. Plugin tools now carry `origin: "plugin"` + `ownerPluginId`, tracked in a separate `pluginRefCount` map with their own conflict-detection against core/skill/mcp tools.
- **Plugin tools filtered out of LLM manifest.** `getAllToolDefinitions` excludes `origin === "skill"` (session-projected), so the old stamp silently dropped plugin tools before the LLM saw them. Under the new origin, plugin tools flow through the manifest normally.
- **Missing try/catch around `registerPluginTools`.** The bootstrap now wraps the registration in `PluginExecutionError` so conflict throws are attributed to the offending plugin, matching adjacent `init()` / skill-registration error handling.
- Approval policy: plugin tools still escalate to `toolOrigin: "skill"` in `ApprovalContext` so third-party code keeps elevated scrutiny.

Follow-up to PR #27406.

## Test plan
- [x] `bun test src/__tests__/plugin-tool-contribution.test.ts` — registry-level + bootstrap tests updated and pass.
- [x] `bun test src/__tests__/registry.test.ts src/__tests__/tool-executor.test.ts src/__tests__/conversation-skill-tools.test.ts` — unaffected.
- [x] `bunx tsc --noEmit` — clean in `assistant/src` (preexisting meet-join zod type errors unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
