### PR TITLE
fix(meet-chat): prefer data-message-id over content hash for remount dedup

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/chat.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/chat.test.ts
@@ -344,6 +344,39 @@ describe("startChatReader", () => {
     expect(ev.text).toBe("ping");
   });
 
+  test("emits both messages when content hash collides but data-message-ids differ", async () => {
+    // Regression: the content-hash fallback (sender+timestamp+text) collapses
+    // two genuinely distinct messages that happen to share a second-granular
+    // timestamp and identical text — common when a user double-sends the same
+    // quick reply. When Meet exposes `data-message-id` on listitems, the
+    // reader must key dedup off it instead of the content hash so both
+    // messages emit.
+    const events: ExtensionToBotMessage[] = [];
+    reader = startChatReader({
+      meetingId: "m1",
+      selfName: "Bot",
+      onEvent: (ev) => events.push(ev),
+    });
+    events.length = 0;
+
+    installed!.appendMessage({
+      id: "msg-a",
+      sender: "Bob",
+      text: "same",
+      datetime: "2026-04-15T12:36:00Z",
+    });
+    installed!.appendMessage({
+      id: "msg-b",
+      sender: "Bob",
+      text: "same",
+      datetime: "2026-04-15T12:36:00Z",
+    });
+    await flushMicrotasks();
+
+    const chatEvents = events.filter((e) => e.type === "chat.inbound");
+    expect(chatEvents.length).toBe(2);
+  });
+
   test("clicks the panel toggle when the chat panel is closed", async () => {
     installed!.closePanel();
     expect(installed!.panelToggleClicks()).toBe(0);

--- a/skills/meet-join/meet-controller-ext/src/features/chat.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/chat.ts
@@ -183,12 +183,15 @@ export function startChatReader(opts: ChatReaderOptions): ChatReader {
   // Dedup across extract() calls. DOM-node identity is the primary key —
   // a `role="listitem"` is not reinstantiated once the panel is open, so
   // a WeakSet on the node is sufficient for the common case. A secondary
-  // content-hash set covers re-mounts (panel close → reopen): the node
-  // identity is new, but the rendered sender+text+time triple is stable
-  // enough to suppress a duplicate fire. `data-message-id` is preferred
-  // when Meet exposes it, but it's not present on the live DOM today.
+  // per-message key covers re-mounts (panel close → reopen): the node
+  // identity is new, but the rendered message has a stable identifier.
+  // Prefer `data-message-id` when Meet exposes it (strongest signal, robust
+  // against timestamp-granularity collisions); fall back to a
+  // sender+timestamp+text content hash only when the attribute is absent
+  // (live Meet today, and the fixture path that carries data-message-id
+  // exercises the preferred branch).
   const seenNodes = new WeakSet<Element>();
-  const seenContentHashes = new Set<string>();
+  const seenMessageKeys = new Set<string>();
 
   let emittedCount = 0;
   let diagnosticEmitted = false;
@@ -344,11 +347,19 @@ export function startChatReader(opts: ChatReaderOptions): ChatReader {
         fromName === opts.selfName;
       if (isSelf) continue;
 
-      // Content hash covers panel close → reopen remounts where the DOM
-      // node identity changes but the rendered message is the same.
-      const contentHash = `${fromName}\u0001${timestamp}\u0001${text}`;
-      if (seenContentHashes.has(contentHash)) continue;
-      seenContentHashes.add(contentHash);
+      // Remount dedup (panel close → reopen): the DOM node identity
+      // changes but the rendered message is the same. Prefer Meet's own
+      // `data-message-id` when present — it's the strongest signal and
+      // distinguishes two messages that happen to share a timestamp
+      // second. Fall back to the sender+timestamp+text content hash only
+      // when the attribute is absent (live Meet today).
+      const messageId = msg.getAttribute("data-message-id");
+      const dedupKey =
+        messageId && messageId.length > 0
+          ? `id\u0001${messageId}`
+          : `hash\u0001${fromName}\u0001${timestamp}\u0001${text}`;
+      if (seenMessageKeys.has(dedupKey)) continue;
+      seenMessageKeys.add(dedupKey);
 
       // Sender-side id when Meet exposes one; otherwise fall back to the
       // display name (stable enough within a meeting).


### PR DESCRIPTION
## Summary

Follow-up to #27428 addressing Codex review feedback.

The remount-dedup path (panel close → reopen) previously keyed only off a
`sender+timestamp+text` content hash. That collapses two genuinely distinct
messages that share a second-granular timestamp and identical text — e.g. a
quick double-sent reply.

When Meet exposes `data-message-id` on listitems, prefer it as the strongest
signal. Fall back to the content hash only when the attribute is absent (live
Meet today).

The WeakSet-on-node primary dedup is unchanged — that's DOM-identity based
and a separate concern.

## Test plan
- [x] Existing 27 tests in `chat.test.ts` still pass.
- [x] New regression test: two messages with identical `(sender, text, timestamp)` but different `data-message-id`s emit both events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
