### PR TITLE
fix(cli/image-gen): prepend actionable `assistant keys set` command

### DIFF
--- a/assistant/src/cli/commands/__tests__/image-generation.test.ts
+++ b/assistant/src/cli/commands/__tests__/image-generation.test.ts
@@ -316,6 +316,10 @@ describe("credential errors", () => {
     const parsed = JSON.parse(stdout.trim());
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Gemini API key");
+    // CLI prepends the actionable `assistant keys set` command with the
+    // resolved provider — the shared hint is UI-neutral ("Settings") so
+    // without this prefix CLI users get no copy-pasteable next step.
+    expect(parsed.error).toContain("Run: assistant keys set gemini <key>");
   });
 
   test("--json outputs OpenAI-specific hint when provider=openai and no key set", async () => {
@@ -335,6 +339,7 @@ describe("credential errors", () => {
     const parsed = JSON.parse(stdout.trim());
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("OpenAI API key");
+    expect(parsed.error).toContain("Run: assistant keys set openai <key>");
   });
 
   test("--json outputs error when no credentials in managed mode", async () => {

--- a/assistant/src/cli/commands/image-generation.ts
+++ b/assistant/src/cli/commands/image-generation.ts
@@ -165,14 +165,14 @@ Examples:
     if (!credentials) {
       const baseHint =
         errorHint ?? "No credentials available for image generation.";
-      // The shared hint in image-credentials.ts is correct for tool surfaces
-      // but drops CLI-specific recovery guidance. When the managed proxy is
-      // unavailable (mode === "managed" with no platform base URL), the CLI
-      // user can authenticate or flip the mode — tell them how from the CLI.
+      // The shared hint in image-credentials.ts is UI-neutral (it points at
+      // "Settings > Models & Services"), which is correct for tool surfaces
+      // but drops the actionable CLI command. Prepend the exact command for
+      // each mode so CLI users see a next-step they can copy-paste.
       const hint =
         svc.mode === "managed"
           ? `${baseHint}\n  Run 'assistant auth login' to authenticate, or set services.image-generation.mode to 'your-own' in config.`
-          : baseHint;
+          : `Run: assistant keys set ${provider} <key>.\n${baseHint}`;
       if (jsonOutput) {
         process.stdout.write(JSON.stringify({ ok: false, error: hint }) + "\n");
       } else {


### PR DESCRIPTION
## Summary
- #27531 review from Devin: the shared `providerKeyHint()` helper generalized the old CLI-specific hint to "set your API key in Settings > Models & Services" — correct for macOS but wrong for CLI users, where CLI AGENTS.md requires actionable next-step commands.
- Mirror the existing managed-mode treatment in `image-generation generate`: leave the shared helper UI-neutral and prepend the actionable `Run: assistant keys set <provider> <key>` line from the CLI call-site when `svc.mode === "your-own"`. `provider` is the resolved dispatch provider (already computed by `providerForModel`), so this naturally picks `openai` for `gpt-image-2` and `gemini` otherwise.
- Help-text claim "depending on the configured model" is accurate against current behavior (#27542 made model drive provider) — no change.

## Test plan
- [x] `bun test src/cli/commands/__tests__/image-generation.test.ts` — my two new assertions (`Run: assistant keys set gemini <key>`, `Run: assistant keys set openai <key>`) pass; existing "your-own mode hint is NOT augmented with CLI auth guidance" still passes (we don't add `assistant auth login`). One unrelated managed-proxy-URL assertion was already failing on `main`.

Follow-up to #27531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
