### PR TITLE
fix(plugins): handle-keyed skill-route unregistration

### DIFF
--- a/assistant/docs/plugins.md
+++ b/assistant/docs/plugins.md
@@ -540,7 +540,12 @@ Tools are unregistered automatically on shutdown. See
 
 An array of `SkillRoute` objects — the same shape the skill-route
 registry consumes. Registered via `registerSkillRoute` after `init()`
-succeeds, unregistered on shutdown.
+succeeds; the runtime retains the opaque handle returned by each call
+and uses those handles to unregister the plugin's routes on shutdown.
+Handle-keyed unregistration is deliberate: two owners (plugin vs.
+skill, or plugin vs. plugin) can legitimately declare the same regex,
+and identity matching ensures one owner's teardown cannot evict
+another owner's live routes.
 
 ```typescript
 const myPlugin: Plugin = {

--- a/assistant/src/__tests__/plugin-route-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-route-contribution.test.ts
@@ -3,9 +3,13 @@
  *
  * A plugin may declare a `routes` array on its {@link Plugin} shape; after
  * `init()` succeeds, bootstrap wires each entry into the skill-route registry
- * via {@link registerSkillRoute} so the runtime HTTP server can dispatch to
- * the plugin's handler. On shutdown, {@link unregisterSkillRoute} removes the
- * same entries so a teardown leaves no dangling surface behind.
+ * via {@link registerSkillRoute}, retains the opaque {@link SkillRouteHandle}
+ * it receives back, and on shutdown calls {@link unregisterSkillRoute} with
+ * that exact handle. Pattern-text matching was removed deliberately: two
+ * owners (e.g. a plugin and a skill) can legitimately register the same
+ * regex, and keying on `source + flags` would let one owner's teardown
+ * silently evict another owner's route, violating the "no traffic hits a
+ * plugin handler during onShutdown" invariant.
  *
  * The registry doesn't own HTTP itself — the tests here exercise:
  *
@@ -14,14 +18,14 @@
  *  2. Shutdown → `unregisterSkillRoute` drops the entry, and subsequent
  *     `matchSkillRoute` lookups return `null`.
  *  3. Plugins without `routes` (or with an empty array) bootstrap cleanly.
- *  4. `unregisterSkillRoute` accepts either the original pattern instance or
- *     an equivalent regex, so plugins that reconstruct the pattern at
- *     shutdown time still succeed.
+ *  4. When two plugins register regex patterns with identical `source+flags`,
+ *     each plugin's shutdown only removes its own route — the other plugin's
+ *     route stays live until its own teardown runs.
  *
  * Uses `mock.module` to stub credential resolution — bootstrap otherwise
  * tries to hit the real secure-key backend. `resetPluginRegistryForTests()`
- * isolates registry state between cases, and the skill-route registry is
- * swept via best-effort `unregisterSkillRoute` calls in `beforeEach`.
+ * isolates plugin-registry state and `resetSkillRoutesForTests()` isolates
+ * skill-route-registry state between cases.
  */
 
 import { rm } from "node:fs/promises";
@@ -52,8 +56,8 @@ import {
 import type { Plugin } from "../plugins/types.js";
 import {
   matchSkillRoute,
+  resetSkillRoutesForTests,
   type SkillRoute,
-  unregisterSkillRoute,
 } from "../runtime/skill-route-registry.js";
 
 // Redirect plugin storage creation into a per-process temp tree so the test
@@ -85,27 +89,14 @@ function buildPlugin(
   };
 }
 
-/**
- * Best-effort sweep — unregister every known test route so a prior failing
- * case cannot leak state into the next. `unregisterSkillRoute` is idempotent
- * (returns `false` for unknown patterns without throwing), so attempting to
- * drop a pattern that was never registered is safe.
- */
-function clearTestRoutes(patterns: RegExp[]): void {
-  for (const pattern of patterns) {
-    unregisterSkillRoute(pattern);
-  }
-}
-
 describe("plugin route contributions", () => {
   const echoPattern = /^\/_plugin\/echo$/;
-  const otherPattern = /^\/_plugin\/other$/;
 
   beforeEach(async () => {
     resetPluginRegistryForTests();
+    resetSkillRoutesForTests();
     getSecureKeyAsyncMock.mockReset();
     getSecureKeyAsyncMock.mockImplementation(async () => undefined);
-    clearTestRoutes([echoPattern, otherPattern]);
     await rm(TEST_INSTANCE_DIR, { recursive: true, force: true });
   });
 
@@ -186,10 +177,10 @@ describe("plugin route contributions", () => {
     expect(true).toBe(true);
   });
 
-  test("shutdown tolerates a route that was externally removed mid-flight", async () => {
-    // Guard against the case where a stale pattern no longer matches anything
-    // in the registry (e.g. the registry was cleared externally). The
-    // shutdown hook must not crash — unregisterSkillRoute returns false, and
+  test("shutdown tolerates a route whose registry entry was wiped externally", async () => {
+    // Guard against the case where a stale handle no longer points at a live
+    // registry entry (e.g. the registry was cleared externally). The shutdown
+    // hook must not crash — unregisterSkillRoute returns false, and
     // bootstrap's try/catch around the call swallows the signal. This
     // exercises the defensive path so a partial-crash recovery still runs
     // every plugin's onShutdown in reverse order.
@@ -211,42 +202,87 @@ describe("plugin route contributions", () => {
 
     await bootstrapPlugins(fakeCtx);
 
-    // External removal before the shutdown hook runs.
-    expect(unregisterSkillRoute(echoPattern)).toBe(true);
+    // Simulate an external wipe before the shutdown hook runs — e.g. a
+    // different subsystem calling `resetSkillRoutesForTests` or a hot-reload
+    // flow clearing the registry. The plugin's retained handle is now stale.
+    resetSkillRoutesForTests();
 
     await runShutdownHooks("test-shutdown");
 
-    // onShutdown still ran despite the stale route reference — proving the
+    // onShutdown still ran despite the stale handle — proving the
     // route-unregister step does not short-circuit plugin teardown.
     expect(shutdownFired).toBe(true);
   });
 
-  test("unregisterSkillRoute matches equivalent patterns (source + flags)", async () => {
-    // Plugins that reconstruct their regex at shutdown time (e.g. after
-    // reloading the manifest) must still land on the same registry slot.
-    // Identity-first matching with a source+flags fallback keeps the common
-    // case fast while tolerating the reconstruction pattern.
-    const pattern1 = /^\/_plugin\/echo$/;
-    const pattern2 = /^\/_plugin\/echo$/;
-    expect(pattern1).not.toBe(pattern2); // different instances
+  test("shutdown of one plugin does not evict a sibling's same-pattern route", async () => {
+    // Regression for the reviewer-flagged invariant: keying unregistration on
+    // `pattern.source + flags` would let plugin-A's teardown drop plugin-B's
+    // route when both declared regex with identical text. With handle-keyed
+    // identity, each plugin's teardown removes only its own registrations.
+    //
+    // We simulate this by wiring two plugins that both contribute a route
+    // matching `/^\/_plugin\/echo$/`. Teardown runs in reverse registration
+    // order, so plugin-B is torn down first; plugin-A's route must still
+    // match afterwards, and only disappear once plugin-A's own teardown
+    // runs.
+    let pluginAShutdown = false;
+    let pluginBShutdown = false;
 
-    const route: SkillRoute = {
-      pattern: pattern1,
-      methods: ["GET"],
-      handler: async () => new Response("ok", { status: 200 }),
-    };
+    registerPlugin(
+      buildPlugin("plugin-a", {
+        routes: [
+          {
+            pattern: /^\/_plugin\/echo$/,
+            methods: ["GET"],
+            handler: async () => new Response("a", { status: 200 }),
+          },
+        ],
+        async onShutdown() {
+          // When plugin-A's teardown runs, plugin-B has already been torn
+          // down — but plugin-A's route must still be live because
+          // `onShutdown` fires *after* the route-unregister step for this
+          // plugin but *before* it leaves teardownPlugin. We check liveness
+          // from plugin-B's teardown instead (see below).
+          pluginAShutdown = true;
+        },
+      }),
+    );
 
-    registerPlugin(buildPlugin("echo-plugin", { routes: [route] }));
+    registerPlugin(
+      buildPlugin("plugin-b", {
+        routes: [
+          {
+            pattern: /^\/_plugin\/echo$/,
+            methods: ["GET"],
+            handler: async () => new Response("b", { status: 200 }),
+          },
+        ],
+        async onShutdown() {
+          // Plugin-B's routes have already been unregistered by the time
+          // this fires, but plugin-A's route is still live — it only gets
+          // torn down after this hook returns and the loop moves on to
+          // plugin-A. Confirm the registry still has a matching route.
+          pluginBShutdown = true;
+          const matched = matchSkillRoute("/_plugin/echo", "GET");
+          expect(matched).not.toBeNull();
+          expect(matched!.kind).toBe("match");
+        },
+      }),
+    );
 
     await bootstrapPlugins(fakeCtx);
+
+    // Both plugins' routes landed in the registry; matching returns one of
+    // them (order defined by registration, but we only care that *some*
+    // route matches before shutdown starts).
     expect(matchSkillRoute("/_plugin/echo", "GET")).not.toBeNull();
 
-    // Unregister with a DIFFERENT RegExp instance having the same source.
-    expect(unregisterSkillRoute(pattern2)).toBe(true);
-    expect(matchSkillRoute("/_plugin/echo", "GET")).toBeNull();
+    await runShutdownHooks("test-shutdown");
 
-    // A second call with the equivalent pattern finds nothing — the single
-    // matching entry has already been removed.
-    expect(unregisterSkillRoute(pattern2)).toBe(false);
+    expect(pluginBShutdown).toBe(true);
+    expect(pluginAShutdown).toBe(true);
+
+    // After both plugins shut down, no routes remain.
+    expect(matchSkillRoute("/_plugin/echo", "GET")).toBeNull();
   });
 });

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -69,6 +69,7 @@ import {
 } from "../plugins/types.js";
 import {
   registerSkillRoute,
+  type SkillRouteHandle,
   unregisterSkillRoute,
 } from "../runtime/skill-route-registry.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
@@ -199,8 +200,13 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
   // Plugins that passed `requiresFlag` gating and therefore need the full
   // init → contribute → shutdown lifecycle. Plugins skipped by the flag gate
   // are omitted from this list so the shutdown hook below never tears down
-  // capabilities that were never wired up in the first place.
-  const activePlugins: Plugin[] = [];
+  // capabilities that were never wired up in the first place. Each entry
+  // carries the opaque route handles returned by `registerSkillRoute` so
+  // teardown can key on identity rather than regex-pattern text — two plugins
+  // registering the same pattern would otherwise step on each other's routes
+  // during shutdown, violating the "no traffic hits a plugin handler during
+  // onShutdown" invariant.
+  const activePlugins: ActivePlugin[] = [];
 
   // If one plugin's init or contribution phase throws, tear down any plugins
   // that already fully initialized (in reverse registration order) before
@@ -298,10 +304,14 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
       // Route contributions (PR 32) — registered after init() succeeds so a
       // plugin that fails to initialize never exposes a half-wired HTTP
       // surface. Mirrors the skill-route registry shape; see
-      // {@link PluginRouteRegistration}.
+      // {@link PluginRouteRegistration}. Retain every returned handle so the
+      // teardown path unregisters by identity rather than pattern text — two
+      // plugins (or a plugin and a skill) that happen to register the same
+      // regex must not evict each other's routes during shutdown.
+      const routeHandles: SkillRouteHandle[] = [];
       if (plugin.routes && plugin.routes.length > 0) {
         for (const route of plugin.routes) {
-          registerSkillRoute(route);
+          routeHandles.push(registerSkillRoute(route));
         }
         log.info(
           { plugin: name, count: plugin.routes.length },
@@ -333,7 +343,7 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
         }
       }
 
-      activePlugins.push(plugin);
+      activePlugins.push({ plugin, routeHandles });
 
       log.info({ plugin: name }, "plugin initialized");
     } catch (err) {
@@ -367,12 +377,23 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
   //      This mirrors the symmetry of registerPluginSkills() — every
   //      successful registration must get a matching unregister call,
   //      regardless of whether onShutdown throws.
-  const shutdownSnapshot: Plugin[] = [...activePlugins];
+  const shutdownSnapshot: ActivePlugin[] = [...activePlugins];
   registerShutdownHook("plugins", async (reason) => {
     for (let i = shutdownSnapshot.length - 1; i >= 0; i--) {
       await teardownPlugin(shutdownSnapshot[i]!, reason);
     }
   });
+}
+
+/**
+ * One plugin that made it through the full init + contribution phase. Holds
+ * every opaque {@link SkillRouteHandle} issued by `registerSkillRoute` so
+ * teardown can revoke exactly the routes this plugin contributed, even when
+ * the regex pattern text collides with another owner's registration.
+ */
+interface ActivePlugin {
+  readonly plugin: Plugin;
+  readonly routeHandles: readonly SkillRouteHandle[];
 }
 
 /**
@@ -384,24 +405,28 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
  * Shared between the normal shutdown hook and the bootstrap error path; both
  * consume plugins that already cleared every contribution step.
  */
-async function teardownPlugin(plugin: Plugin, reason: string): Promise<void> {
+async function teardownPlugin(
+  active: ActivePlugin,
+  reason: string,
+): Promise<void> {
+  const { plugin, routeHandles } = active;
   const name = plugin.manifest.name;
 
   // Unregister model-visible surfaces before invoking `onShutdown()` so the
   // plugin's onShutdown hook observes a registry state where its tools and
   // routes are already gone. `unregisterPluginTools` is a no-op when the
   // plugin never contributed tools, so we don't need to guard on
-  // `plugin.tools` here.
-  if (plugin.routes && plugin.routes.length > 0) {
-    for (const route of plugin.routes) {
-      try {
-        unregisterSkillRoute(route.pattern);
-      } catch (err) {
-        log.warn(
-          { err, plugin: name, pattern: route.pattern.source },
-          "plugin route unregister failed (continuing)",
-        );
-      }
+  // `plugin.tools` here. Route unregistration keys on the opaque handles
+  // retained at registration time — pattern text is not a stable key because
+  // two owners can legitimately register the same regex.
+  for (const handle of routeHandles) {
+    try {
+      unregisterSkillRoute(handle);
+    } catch (err) {
+      log.warn(
+        { err, plugin: name },
+        "plugin route unregister failed (continuing)",
+      );
     }
   }
 

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -1009,9 +1009,12 @@ export type PluginToolRegistration = Tool;
 /**
  * HTTP route registration contributed by a plugin. Plugins express routes as
  * {@link SkillRoute} values — the same shape the skill-route registry
- * consumes — so `registerSkillRoute`/`unregisterSkillRoute` can accept them
- * directly. Bootstrap wires the registrations after `init()` succeeds and
- * tears them down on shutdown.
+ * consumes — so `registerSkillRoute` can accept them directly. Bootstrap
+ * wires the registrations after `init()` succeeds, retains the opaque
+ * handle returned by each `registerSkillRoute` call, and uses those handles
+ * (not the regex patterns themselves) to unregister the plugin's routes on
+ * shutdown. Identity-keyed unregistration is what keeps sibling owners that
+ * happen to register the same regex from evicting each other's routes.
  */
 export type PluginRouteRegistration = SkillRoute;
 

--- a/assistant/src/runtime/skill-route-registry.ts
+++ b/assistant/src/runtime/skill-route-registry.ts
@@ -1,9 +1,16 @@
 /**
  * Registry for skill-provided HTTP route handlers.
  *
- * Skills register route matchers + handlers at initialization time. The
- * runtime HTTP server checks the registry for each inbound request before
- * falling through to its own route table.
+ * Skills and plugins register route matchers + handlers at initialization
+ * time. The runtime HTTP server checks the registry for each inbound request
+ * before falling through to its own route table.
+ *
+ * Registrations are identified by an opaque {@link SkillRouteHandle} returned
+ * from {@link registerSkillRoute}. Callers must pass that exact handle back
+ * to {@link unregisterSkillRoute} to remove the registration — pattern text
+ * is intentionally not a stable key, because two owners can legitimately
+ * register the same regex, and keying on `source + flags` would let one
+ * owner's teardown silently drop another owner's route.
  */
 
 import { getLogger } from "../util/logger.js";
@@ -23,50 +30,61 @@ export type SkillRouteMatch =
   | { kind: "match"; route: SkillRoute; match: RegExpMatchArray }
   | { kind: "methodMismatch"; allow: string[] };
 
-const routes: SkillRoute[] = [];
+/**
+ * Opaque token returned from {@link registerSkillRoute}. The token has no
+ * observable fields — callers must treat it as a black box whose only valid
+ * use is to pass it to {@link unregisterSkillRoute}. Identity comparison on
+ * the token is what the registry keys against, so every call to
+ * `registerSkillRoute` returns a fresh handle even when the route's
+ * `pattern`/`methods`/`handler` are deep-equal to an existing entry.
+ */
+declare const skillRouteHandleBrand: unique symbol;
+export interface SkillRouteHandle {
+  readonly [skillRouteHandleBrand]: true;
+}
+
+interface RegisteredRoute {
+  readonly handle: SkillRouteHandle;
+  readonly route: SkillRoute;
+}
+
+const routes: RegisteredRoute[] = [];
 
 /**
- * Register a skill-provided HTTP route. Called by skills at initialization time.
+ * Register a skill- or plugin-provided HTTP route. Called at initialization
+ * time. Returns an opaque handle the caller must retain and pass back to
+ * {@link unregisterSkillRoute} at teardown time. Do not attempt to derive
+ * the handle from the route's pattern — identity is the only stable key.
  */
-export function registerSkillRoute(route: SkillRoute): void {
-  routes.push(route);
+export function registerSkillRoute(route: SkillRoute): SkillRouteHandle {
+  const handle = Object.freeze({}) as SkillRouteHandle;
+  routes.push({ handle, route });
   log.info(
     { pattern: route.pattern.source, methods: route.methods },
     "Skill route registered",
   );
+  return handle;
 }
 
 /**
- * Unregister a previously-registered skill route.
- *
- * Matches by `RegExp` identity first (the common case — a caller passes back
- * the same `pattern` reference it handed to {@link registerSkillRoute}) and
- * falls back to `pattern.source + flags` equality so callers that rebuild an
- * equivalent regex still succeed. Removes at most one route per call — if two
- * routes were registered with identical patterns, the first match is dropped
- * and subsequent calls remove the rest.
+ * Unregister a previously-registered skill route by handle.
  *
  * Returns `true` if a route was removed, `false` otherwise. Not finding a
  * match is not an error: the plugin-shutdown path calls this best-effort for
- * every route a plugin contributed, and a stale reference (e.g. the registry
- * was cleared externally) should not crash shutdown.
+ * every handle a plugin retained, and a stale handle (e.g. the registry was
+ * cleared externally) should not crash shutdown.
  */
-export function unregisterSkillRoute(pattern: RegExp): boolean {
-  const index = routes.findIndex(
-    (route) =>
-      route.pattern === pattern ||
-      (route.pattern.source === pattern.source &&
-        route.pattern.flags === pattern.flags),
-  );
+export function unregisterSkillRoute(handle: SkillRouteHandle): boolean {
+  const index = routes.findIndex((entry) => entry.handle === handle);
   if (index === -1) {
-    log.warn(
-      { pattern: pattern.source },
-      "unregisterSkillRoute: no matching route found",
-    );
+    log.warn({}, "unregisterSkillRoute: no matching route found for handle");
     return false;
   }
-  routes.splice(index, 1);
-  log.info({ pattern: pattern.source }, "Skill route unregistered");
+  const [removed] = routes.splice(index, 1);
+  log.info(
+    { pattern: removed!.route.pattern.source },
+    "Skill route unregistered",
+  );
   return true;
 }
 
@@ -89,15 +107,25 @@ export function matchSkillRoute(
   method: string,
 ): SkillRouteMatch | null {
   const pathMatches: SkillRoute[] = [];
-  for (const route of routes) {
-    const match = path.match(route.pattern);
+  for (const entry of routes) {
+    const match = path.match(entry.route.pattern);
     if (!match) continue;
-    if (route.methods.includes(method)) {
-      return { kind: "match", route, match };
+    if (entry.route.methods.includes(method)) {
+      return { kind: "match", route: entry.route, match };
     }
-    pathMatches.push(route);
+    pathMatches.push(entry.route);
   }
   if (pathMatches.length === 0) return null;
   const allow = Array.from(new Set(pathMatches.flatMap((r) => r.methods)));
   return { kind: "methodMismatch", allow };
+}
+
+/**
+ * Test-only helper — drops every registered route. Production code has no
+ * legitimate need for this; a real shutdown walks the handles each owner
+ * retained. Exported so tests that bypass the normal shutdown path (e.g.
+ * those that crash mid-bootstrap) can reset registry state between cases.
+ */
+export function resetSkillRoutesForTests(): void {
+  routes.length = 0;
 }

--- a/skills/meet-join/__tests__/register.test.ts
+++ b/skills/meet-join/__tests__/register.test.ts
@@ -52,6 +52,10 @@ mock.module("../../../assistant/src/runtime/skill-route-registry.js", () => ({
     handler: (req: Request, match: RegExpMatchArray) => Promise<Response>;
   }) => {
     capturedRoutes.push(route);
+    // Real `registerSkillRoute` returns an opaque handle; mimic that shape
+    // so callers that retain the return value see something handle-like
+    // rather than `undefined`. Tests here don't invoke unregister.
+    return Object.freeze({});
   },
 }));
 


### PR DESCRIPTION
## Summary

Follow-up to #27407 addressing a Codex-flagged shutdown-invariant violation.

`unregisterSkillRoute` previously keyed on regex `source + flags` text, so if two owners (plugin vs plugin, or plugin vs skill) registered routes with identical patterns, one owner's teardown would silently evict another owner's route while the evicted owner's handler was still live — breaking PR #27407's own "no traffic hits a plugin handler during onShutdown" invariant.

- `registerSkillRoute` now returns an opaque `SkillRouteHandle`.
- `unregisterSkillRoute(handle)` keys on identity; pattern-text matching is gone.
- Plugin bootstrap retains handles per-plugin and uses them at teardown.
- Test-only `resetSkillRoutesForTests()` replaces the pattern-text sweep in test setup.
- New regression test: two plugins register the same regex; each plugin's teardown only drops its own route.

## Test plan

- [x] `bun test src/__tests__/plugin-route-contribution.test.ts` — 5 pass
- [x] `bun test skills/meet-join/__tests__/register.test.ts` — 4 pass
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
