### PR TITLE
fix(macos/settings): guard image-gen provider state against async races (#27535 review)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -22,6 +22,9 @@ struct ImageGenerationServiceCard: View {
     @State private var initialModel: String = ""
     /// Whether the image generation provider has a stored API key (fetched per-component).
     @State private var imageGenHasKey = false
+    /// In-flight `APIKeyManager.hasKey` lookup — tracked so rapid provider switches
+    /// can cancel stale responses before they overwrite the current provider's state.
+    @State private var hasKeyTask: Task<Void, Never>?
 
     private var isLoggedIn: Bool {
         authManager.isAuthenticated
@@ -92,7 +95,7 @@ struct ImageGenerationServiceCard: View {
             initialModel = store.selectedImageGenModel
         }
         .task {
-            imageGenHasKey = await APIKeyManager.hasKey(for: currentProvider)
+            await refreshHasKey(for: currentProvider)
         }
         .onChange(of: draftModel) { oldValue, newValue in
             // When the user picks a model whose provider differs from the previous
@@ -109,8 +112,12 @@ struct ImageGenerationServiceCard: View {
             }
             // Re-fetch the "key configured" indicator when the user switches between
             // Gemini and OpenAI models in the picker so the UI reflects the right provider.
-            Task {
-                imageGenHasKey = await APIKeyManager.hasKey(for: currentProvider)
+            // Cancel any in-flight lookup so a slow prior-provider response can't
+            // overwrite state for the current provider (hasKey has a 5s network timeout).
+            hasKeyTask?.cancel()
+            let targetProvider = newProvider
+            hasKeyTask = Task {
+                await refreshHasKey(for: targetProvider)
             }
         }
         .onChange(of: store.imageGenMode) { _, newValue in
@@ -188,7 +195,19 @@ struct ImageGenerationServiceCard: View {
             let keyTextBinding = $apiKeyText
             let provider = currentProvider
             store.saveImageGenKey(trimmedKey, for: provider, onSuccess: { [self] in
-                imageGenHasKey = true
+                // Validation can take seconds; the user may have switched providers
+                // while it ran. Only flip the indicator directly when the save-time
+                // provider still matches the card's current provider — otherwise
+                // re-query so the displayed state reflects the now-visible provider.
+                if provider == currentProvider {
+                    imageGenHasKey = true
+                } else {
+                    hasKeyTask?.cancel()
+                    let targetProvider = currentProvider
+                    hasKeyTask = Task {
+                        await refreshHasKey(for: targetProvider)
+                    }
+                }
                 keyTextBinding.wrappedValue = ""
                 showToast("\(provider == "openai" ? "OpenAI" : "Gemini") API key saved", .success)
             })
@@ -205,5 +224,16 @@ struct ImageGenerationServiceCard: View {
             store.setImageGenModel(capturedModel)
         }
         initialModel = draftModel
+    }
+
+    /// Fetch `hasKey` for `provider` and write the result only if the card's
+    /// current provider still matches. Guards against stale responses from a
+    /// prior provider arriving after the user has already switched.
+    private func refreshHasKey(for provider: String) async {
+        let result = await APIKeyManager.hasKey(for: provider)
+        if Task.isCancelled { return }
+        if provider == currentProvider {
+            imageGenHasKey = result
+        }
     }
 }


### PR DESCRIPTION
## Summary

Addresses reviewer feedback on #27535 (merged). Both Codex and Devin flagged the same two async race bugs in the provider-aware image-generation settings card:

1. **Picker onChange race** — `onChange(of: draftModel)` launched an unscoped `Task` on every switch. `APIKeyManager.hasKey` has a 5s network timeout, so rapid Gemini↔OpenAI switching could leave a stale response arriving last and overwriting the current provider's \`imageGenHasKey\`.
2. **Post-save callback race** — after \`saveImageGenKey\` success, the callback set \`imageGenHasKey = true\` for whichever provider the card was currently showing. If the user switched providers during validation, the card would flip "key configured" for the wrong one.

## Changes

- Track the in-flight \`hasKey\` lookup in \`@State hasKeyTask\` and cancel it at the top of \`onChange(of: draftModel)\`.
- Extract a \`refreshHasKey(for:)\` helper that writes the result only when the fetched provider still equals \`currentProvider\` — cancellation + identity check together.
- In the save-success closure, capture \`provider\` at save time. If it still matches \`currentProvider\`, flip \`imageGenHasKey\` directly; otherwise re-query via the same cancellation-aware helper.

## Test plan
- [ ] Open Settings → Image Generation in Your Own mode
- [ ] Rapidly switch between a Gemini model and an OpenAI model; confirm the "key configured" indicator reflects the currently-selected provider and does not flicker from a late response
- [ ] Enter an API key, hit Save, switch providers before validation returns; confirm the saved-provider toast still fires and the indicator reflects the *currently-visible* provider (re-queried), not the save-time one
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
