### PR TITLE
fix(image-gen): guard providerForModel against non-string input (#27542 review)

### DIFF
--- a/assistant/src/__tests__/image-service-dispatcher.test.ts
+++ b/assistant/src/__tests__/image-service-dispatcher.test.ts
@@ -172,4 +172,15 @@ describe("providerForModel", () => {
     expect(providerForModel("unknown-model", "openai")).toBe("openai");
     expect(providerForModel("", "gemini")).toBe("gemini");
   });
+
+  test("returns fallback for non-string inputs without throwing", () => {
+    // The tool's `input.model` is `unknown` — guard against LLM emitting
+    // `{"model": 123}` or other non-string values rather than crashing on
+    // `.startsWith`.
+    expect(providerForModel(123, "gemini")).toBe("gemini");
+    expect(providerForModel(null, "openai")).toBe("openai");
+    expect(providerForModel({}, "gemini")).toBe("gemini");
+    expect(providerForModel([], "openai")).toBe("openai");
+    expect(providerForModel(true, "gemini")).toBe("gemini");
+  });
 });

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -19,7 +19,7 @@ export async function run(
 ): Promise<ToolExecutionResult> {
   const config = getConfig();
   const svc = config.services["image-generation"];
-  const modelOverride = input.model as string | undefined;
+  const modelOverride = input.model;
   // Derive provider from the explicit model when supplied so that requesting
   // e.g. `gpt-image-2` while config.provider === "gemini" routes to OpenAI
   // instead of silently falling back to the Gemini default model.
@@ -38,7 +38,10 @@ export async function run(
   const prompt = input.prompt as string;
   const mode = (input.mode as "generate" | "edit") ?? "generate";
   const sourcePaths = input.source_paths as string[] | undefined;
-  const model = modelOverride ?? config.services["image-generation"].model;
+  const model =
+    typeof modelOverride === "string" && modelOverride
+      ? modelOverride
+      : config.services["image-generation"].model;
   const variants = input.variants as number | undefined;
 
   // Resolve source images from file paths (sandboxed to workingDir, edit mode only)

--- a/assistant/src/media/image-service.ts
+++ b/assistant/src/media/image-service.ts
@@ -64,10 +64,13 @@ export function mapImageGenError(
  *   - anything else (or `undefined`) → the provided `fallback`
  */
 export function providerForModel(
-  model: string | undefined,
+  model: unknown,
   fallback: ImageGenProvider,
 ): ImageGenProvider {
-  if (!model) return fallback;
+  // `model` originates from an LLM tool call's `input.model`, which is a
+  // `Record<string, unknown>` without runtime validation — so a non-string
+  // value (e.g. `{"model": 123}`) must not crash `.startsWith`.
+  if (typeof model !== "string" || !model) return fallback;
   if (model.startsWith("gpt-") || model.startsWith("dall-e-")) return "openai";
   if (model.startsWith("gemini-")) return "gemini";
   return fallback;


### PR DESCRIPTION
## Summary

Codex flagged on #27542: `providerForModel(modelOverride, svc.provider)` calls `model.startsWith` directly on `input.model`, which is typed `unknown` in the tool's `Record<string, unknown>` input. If an LLM emits `{"model": 123}`, the image-generate tool now throws `model.startsWith is not a function`. Pre-#27542, the code tolerated non-string `model` by falling back to `svc.model`.

- Widen `providerForModel`'s `model` parameter from `string | undefined` to `unknown` and short-circuit with `typeof model !== "string" || !model` before calling `startsWith`.
- Drop the unsafe `as string | undefined` cast at the `media_generate_image` call site; only use `modelOverride` as the dispatch model when it's actually a non-empty string.
- Add regression tests for `123`, `null`, `{}`, `[]`, and `true` inputs.

## Test plan

- [x] `bun test src/__tests__/image-service-dispatcher.test.ts` — 10 pass (5 new)
- [x] Typecheck on changed files clean (pre-existing meet-join/zod errors are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
