### PR TITLE
fix(meet): independently gate voice mode from proactive chat (#27413 followup)

### DIFF
--- a/skills/meet-join/daemon/__tests__/chat-opportunity-detector.test.ts
+++ b/skills/meet-join/daemon/__tests__/chat-opportunity-detector.test.ts
@@ -1042,6 +1042,74 @@ describe("MeetChatOpportunityDetector — 1:1 voice mode", () => {
     detector.dispose();
   });
 
+  test("voice mode fires even when proactive chat is disabled", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const clock = makeClock(1_000);
+    const timers = makeManualTimers();
+    const llm = mock(
+      async (_prompt: string): Promise<ChatOpportunityDecision> => ({
+        shouldRespond: true,
+        reason: "LLM should never be consulted",
+      }),
+    );
+    const onOpportunity = mock((_event: ChatOpportunityEvent) => {});
+
+    const detector = new MeetChatOpportunityDetector({
+      meetingId: "m1",
+      assistantDisplayName: "Aria",
+      // Proactive chat disabled, voice mode enabled — voice mode is
+      // independently gated and must still wake on EOU.
+      config: defaultConfig({ enabled: false }),
+      voiceConfig: defaultVoiceConfig(),
+      callDetectorLLM: llm,
+      onOpportunity,
+      subscribe: dispatcher.subscribe,
+      now: clock.now,
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+    });
+    detector.start();
+
+    // Seed a 1:1 meeting: bot + one human.
+    dispatcher.dispatch(
+      "m1",
+      participantChange("m1", "2024-01-01T00:00:00.000Z", [
+        { id: "bot", name: "Aria", isSelf: true },
+        { id: "alice", name: "Alice" },
+      ]),
+    );
+
+    // A plain (non-keyword) utterance — Tier 1 would not match this,
+    // so a fired opportunity here can only be the voice-mode path.
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk(
+        "m1",
+        "2024-01-01T00:00:01.000Z",
+        "so what's on our agenda this week",
+      ),
+    );
+    await flushPromises();
+
+    // Voice EOU timer scheduled, no LLM call yet.
+    expect(timers.pendingCount()).toBe(1);
+    expect(llm).toHaveBeenCalledTimes(0);
+    expect(onOpportunity).toHaveBeenCalledTimes(0);
+
+    // Fire the EOU silence debounce.
+    timers.fireAll();
+    await flushPromises();
+
+    expect(llm).toHaveBeenCalledTimes(0);
+    expect(onOpportunity).toHaveBeenCalledTimes(1);
+    const [event] = onOpportunity.mock.calls[0] as unknown as [
+      ChatOpportunityEvent,
+    ];
+    expect(event.kind).toBe("voice");
+
+    detector.dispose();
+  });
+
   test("voice mode disabled falls back to Tier 1 + Tier 2 even in 1:1", async () => {
     const dispatcher = makeFakeDispatcher();
     const clock = makeClock(1_000);

--- a/skills/meet-join/daemon/__tests__/session-manager.test.ts
+++ b/skills/meet-join/daemon/__tests__/session-manager.test.ts
@@ -1631,22 +1631,18 @@ describe("MeetSessionManager proactive chat-opportunity detector wiring", () => 
   function overrideProactiveChatConfig(
     workspace: string,
     enabled: boolean,
+    voiceModeEnabled?: boolean,
   ): void {
     const configDir = join(workspace, "config");
     mkdirSync(configDir, { recursive: true });
     const meetConfigPath = join(configDir, "meet.json");
-    writeFileSync(
-      meetConfigPath,
-      JSON.stringify(
-        {
-          proactiveChat: {
-            enabled,
-          },
-        },
-        null,
-        2,
-      ),
-    );
+    const overrides: Record<string, unknown> = {
+      proactiveChat: { enabled },
+    };
+    if (voiceModeEnabled !== undefined) {
+      overrides.voiceMode = { enabled: voiceModeEnabled };
+    }
+    writeFileSync(meetConfigPath, JSON.stringify(overrides, null, 2));
   }
 
   afterEach(() => {
@@ -1776,8 +1772,11 @@ describe("MeetSessionManager proactive chat-opportunity detector wiring", () => 
     await manager.leave("m-voice-kind", "cleanup");
   });
 
-  test("proactiveChat.enabled=false skips detector construction entirely", async () => {
-    overrideProactiveChatConfig(preloadWorkspace, false);
+  test("proactiveChat and voiceMode both disabled skips detector construction entirely", async () => {
+    // The detector hosts both the proactive-chat (Tier 1+2) path and the
+    // 1:1 voice-mode EOU path. It is constructed whenever EITHER is on,
+    // so to verify "skipped construction" we must disable both.
+    overrideProactiveChatConfig(preloadWorkspace, false, false);
 
     const runner = makeMockRunner();
     const audioIngestFactory = makeFakeAudioIngestFactory();
@@ -1809,6 +1808,36 @@ describe("MeetSessionManager proactive chat-opportunity detector wiring", () => 
     await manager.leave("m-proactive-off", "cleanup");
   });
 
+  test("voiceMode-only enabled (proactiveChat off) still constructs the detector", async () => {
+    // Regression: voice mode must remain alive even if a user disables
+    // proactive chat — the two features are independently gated.
+    overrideProactiveChatConfig(preloadWorkspace, false, true);
+
+    const detectorFactory = makeFakeDetectorFactory();
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => makeMockRunner(),
+      getProviderKey: async () => "k",
+      getWorkspaceDir: () => workspaceDir,
+      botLeaveFetch: async () => {},
+      audioIngestFactory: makeFakeAudioIngestFactory().factory,
+      chatOpportunityDetectorFactory: detectorFactory.factory,
+      wakeAgent: async () => {},
+    });
+
+    await manager.join({
+      url: "u",
+      meetingId: "m-voice-only",
+      conversationId: "c",
+    });
+
+    const args = detectorFactory.lastArgs();
+    expect(args).not.toBeNull();
+    expect(args!.config.enabled).toBe(false);
+    expect(args!.voiceConfig.enabled).toBe(true);
+
+    await manager.leave("m-voice-only", "cleanup");
+  });
+
   test("leave disposes the detector and leave still works when detector is null", async () => {
     // First case — detector present, dispose on leave.
     overrideProactiveChatConfig(preloadWorkspace, true);
@@ -1830,9 +1859,10 @@ describe("MeetSessionManager proactive chat-opportunity detector wiring", () => 
     await managerOn.leave("m-dispose-on", "cleanup");
     expect(detectorFactoryOn.lastDetector()!.dispose).toHaveBeenCalledTimes(1);
 
-    // Second case — detector absent (enabled=false), leave must not throw
-    // on the `detector?.dispose()` / `detector?.getStats()` paths.
-    overrideProactiveChatConfig(preloadWorkspace, false);
+    // Second case — detector absent (both proactiveChat and voiceMode
+    // disabled), leave must not throw on the `detector?.dispose()` /
+    // `detector?.getStats()` paths.
+    overrideProactiveChatConfig(preloadWorkspace, false, false);
     const detectorFactoryOff = makeFakeDetectorFactory();
     const managerOff = _createMeetSessionManagerForTests({
       dockerRunnerFactory: () => makeMockRunner(),

--- a/skills/meet-join/daemon/chat-opportunity-detector.ts
+++ b/skills/meet-join/daemon/chat-opportunity-detector.ts
@@ -369,11 +369,16 @@ export class MeetChatOpportunityDetector {
         this.onParticipantChange(event);
         return;
       }
-      if (!this.config.enabled) return;
+      // Transcript chunks must reach `onTranscriptChunk` regardless of
+      // `config.enabled` so the 1:1 voice-mode EOU path can fire when
+      // proactive chat is off. The Tier 1 + Tier 2 branch inside is
+      // gated on `config.enabled` separately.
       if (event.type === "transcript.chunk") {
         this.onTranscriptChunk(event);
         return;
       }
+      // Inbound chat is purely a proactive-chat input; skip when off.
+      if (!this.config.enabled) return;
       if (event.type === "chat.inbound") {
         this.onInboundChat(event);
         return;
@@ -423,6 +428,10 @@ export class MeetChatOpportunityDetector {
       this.scheduleVoiceEouWake(raw);
       return;
     }
+
+    // Tier 1 + Tier 2 only run when proactive chat is enabled. Voice
+    // mode above is independently gated and reaches here on its own.
+    if (!this.config.enabled) return;
 
     const reason = this.tier1Match(raw);
     if (reason !== null) {

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -1328,14 +1328,17 @@ class MeetSessionManagerImpl {
 
     // Chat-opportunity detector — proactively watches transcript/chat for
     // moments where the assistant chiming in via meeting chat would help,
-    // and wakes the agent loop on positive Tier 2 verdicts. Constructed
-    // only when `services.meet.proactiveChat.enabled === true`; keeping
-    // the detector null when disabled means zero lifecycle overhead and
-    // no event-handler cost on the dispatcher path.
+    // and wakes the agent loop on positive Tier 2 verdicts. The detector
+    // also hosts the 1:1 voice-mode EOU path, which is independently
+    // gated from proactive chat. Construct it whenever EITHER feature is
+    // enabled so disabling proactive chat does not silently disable
+    // voice mode. When both are off, leaving the detector null means
+    // zero lifecycle overhead and no event-handler cost on the
+    // dispatcher path.
     const proactiveChatConfig = meet.proactiveChat;
     const voiceModeConfig = meet.voiceMode;
     const chatOpportunityDetector: MeetChatOpportunityDetectorLike | null =
-      proactiveChatConfig.enabled
+      proactiveChatConfig.enabled || voiceModeConfig.enabled
         ? this.deps.chatOpportunityDetectorFactory({
             meetingId,
             conversationId,


### PR DESCRIPTION
## Summary

Reviewer feedback on #27413 noted that the 1:1 voice-mode EOU path was double-gated by `proactiveChat.enabled` in two places, contradicting the PR claim that voice mode is independently gated:

- `skills/meet-join/daemon/session-manager.ts` only constructed the detector when `proactiveChat.enabled` was true.
- `skills/meet-join/daemon/chat-opportunity-detector.ts` short-circuited on `!this.config.enabled` in `onEvent` BEFORE the voice-mode branch in `onTranscriptChunk` could run.

The net effect was that disabling proactive chat silently disabled voice mode.

## Changes

- Construct the detector when `proactiveChat.enabled || voiceMode.enabled`.
- Restructure the event-dispatch guard so transcript chunks always reach `onTranscriptChunk`; the `config.enabled` check is moved to gate only the Tier 1 + Tier 2 path. Inbound chat (purely a proactive-chat input) remains gated.
- Update the existing "skips construction" / "leave with null detector" tests to disable both flags (since either alone now keeps the detector alive).
- Add two regression tests: voice-mode wakes when proactive chat is off (detector behavior), and detector is constructed when only voice mode is enabled (wiring behavior).

Part of #27413.

## Test plan

- [x] `bun test daemon/__tests__/chat-opportunity-detector.test.ts` (16 pass)
- [x] `bun test daemon/__tests__/session-manager.test.ts` (48 pass)
- [x] `bunx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
