### PR TITLE
fix(meet): synthesize lifecycle:left on container-exit teardown (#27434 review)

### DIFF
--- a/skills/meet-join/daemon/__tests__/session-manager.test.ts
+++ b/skills/meet-join/daemon/__tests__/session-manager.test.ts
@@ -790,6 +790,61 @@ describe("MeetSessionManager container-exit watcher", () => {
     }
   });
 
+  test("synthesizes lifecycle:left (detail=container-exit) so the storage writer flushes meta.json before teardown", async () => {
+    const runner = makeMockRunner();
+    const audioIngestFactory = makeFakeAudioIngestFactory();
+    const { dispose } = captureHub();
+    const dispatched: Array<{ type: string; detail?: string; state?: string }> =
+      [];
+
+    try {
+      const manager = _createMeetSessionManagerForTests({
+        dockerRunnerFactory: () => runner,
+        getProviderKey: async () => "k",
+        getWorkspaceDir: () => workspaceDir,
+        botLeaveFetch: async () => {},
+        audioIngestFactory: audioIngestFactory.factory,
+      });
+
+      await manager.join({
+        url: "u",
+        meetingId: "m-exit-lifecycle",
+        conversationId: "c",
+      });
+
+      // External subscriber, same channel the storage writer uses. We rely
+      // on this instead of the storageWriter mock because `MeetStorageWriter`
+      // only writes meta.json in response to `lifecycle:left` — missing that
+      // dispatch silently loses final meeting metadata on unexpected exits.
+      const unsub = meetEventDispatcher.subscribe(
+        "m-exit-lifecycle",
+        (event) => {
+          dispatched.push({
+            type: event.type,
+            detail: (event as { detail?: string }).detail,
+            state: (event as { state?: string }).state,
+          });
+        },
+      );
+
+      runner.fireContainerExit("container-123", 137);
+
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
+
+      unsub();
+
+      const leftEvent = dispatched.find(
+        (e) => e.type === "lifecycle" && e.state === "left",
+      );
+      expect(leftEvent).toBeDefined();
+      expect(leftEvent!.detail).toBe("container-exit");
+    } finally {
+      dispose();
+    }
+  });
+
   test("daemon-initiated leave() suppresses the watcher (no duplicate meet.error)", async () => {
     const runner = makeMockRunner();
     const audioIngestFactory = makeFakeAudioIngestFactory();

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -1958,6 +1958,27 @@ class MeetSessionManagerImpl {
     this.sessions.delete(meetingId);
     this.pendingBotTokens.delete(meetingId);
 
+    // Synthesize a `lifecycle:left` event BEFORE tearing the dispatcher
+    // down so the storage writer's `meta.json` flush runs while its
+    // subscription is still live. Without this, an unexpected container
+    // exit skips the only code path that writes final meeting metadata
+    // (MeetStorageWriter only flushes on `lifecycle:left`). Mirrors the
+    // dispatch in `leave()`.
+    try {
+      meetEventDispatcher.dispatch(meetingId, {
+        type: "lifecycle",
+        meetingId,
+        timestamp: new Date().toISOString(),
+        state: "left",
+        detail: "container-exit",
+      });
+    } catch (err) {
+      log.warn(
+        { err, meetingId },
+        "Meet synthesized lifecycle:left dispatch threw during container-exit teardown",
+      );
+    }
+
     try {
       session.conversationBridge.unsubscribe();
     } catch (err) {


### PR DESCRIPTION
## Summary

Addresses Codex + Devin review feedback on #27434: the per-session container-exit watcher's teardown was asymmetric with `leave()`. `MeetStorageWriter` only writes `meta.json` in response to a `lifecycle:left` event, and `leave()` explicitly synthesizes one before stopping the writer ([session-manager.ts:1717-1730](../blob/main/skills/meet-join/daemon/session-manager.ts#L1717-L1730)). `handleContainerExit` skipped that step, so unexpected-exit sessions silently lost final meeting metadata — contradicting the existing "symmetric teardown with leave()" comment.

- Synthesize a `lifecycle:left` event with `detail="container-exit"` between `sessions.delete()` and `conversationBridge.unsubscribe()`, mirroring `leave()`'s ordering.
- Add regression test that subscribes to `meetEventDispatcher` and asserts the dispatch lands on the container-exit path.

## Test plan

- [x] `bun test skills/meet-join/daemon/__tests__/session-manager.test.ts --grep "container"` — 11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
