### PR TITLE
fix(injectors): correct after-memory-prefix ordering + split PKB into two blocks (#27425 review)

### DIFF
--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -4,10 +4,10 @@
  *
  * Covers:
  *
- * 1. The seven default injectors registered by `defaultInjectorsPlugin` come
+ * 1. The eight default injectors registered by `defaultInjectorsPlugin` come
  *    back from `getInjectors()` in the documented order (workspace-context →
- *    unified-turn-context → pkb → now-md → subagent-status → slack-messages
- *    → thread-focus).
+ *    unified-turn-context → pkb-context → pkb-reminder → now-md →
+ *    subagent-status → slack-messages → thread-focus).
  * 2. A third-party-registered injector at `order: 25` slots between
  *    `unified-turn-context` (order 20) and `pkb` (order 30), proving the
  *    extensibility contract.
@@ -76,14 +76,15 @@ describe("injector chain", () => {
     resetPluginRegistryForTests();
   });
 
-  test("defaultInjectorsPlugin registers the seven defaults in the documented order", () => {
+  test("defaultInjectorsPlugin registers the eight defaults in the documented order", () => {
     registerPlugin(defaultInjectorsPlugin);
 
     const names = getInjectors().map((i) => i.name);
     expect(names).toEqual([
       "workspace-context",
       "unified-turn-context",
-      "pkb",
+      "pkb-context",
+      "pkb-reminder",
       "now-md",
       "subagent-status",
       "slack-messages",
@@ -101,7 +102,8 @@ describe("injector chain", () => {
     expect(byName.get("unified-turn-context")).toBe(
       DEFAULT_INJECTOR_ORDER.unifiedTurnContext,
     );
-    expect(byName.get("pkb")).toBe(DEFAULT_INJECTOR_ORDER.pkb);
+    expect(byName.get("pkb-context")).toBe(DEFAULT_INJECTOR_ORDER.pkbContext);
+    expect(byName.get("pkb-reminder")).toBe(DEFAULT_INJECTOR_ORDER.pkbReminder);
     expect(byName.get("now-md")).toBe(DEFAULT_INJECTOR_ORDER.nowMd);
     expect(byName.get("subagent-status")).toBe(
       DEFAULT_INJECTOR_ORDER.subagentStatus,
@@ -112,7 +114,7 @@ describe("injector chain", () => {
     expect(byName.get("thread-focus")).toBe(DEFAULT_INJECTOR_ORDER.threadFocus);
   });
 
-  test("a third-party injector at order 25 slots between unified-turn-context (20) and pkb (30)", () => {
+  test("a third-party injector at order 25 slots between unified-turn-context (20) and pkb-context (30)", () => {
     registerPlugin(defaultInjectorsPlugin);
 
     const middleInjector: Injector = {
@@ -129,7 +131,8 @@ describe("injector chain", () => {
       "workspace-context", // 10
       "unified-turn-context", // 20
       "plugin-25", // 25 — slots in
-      "pkb", // 30
+      "pkb-context", // 30
+      "pkb-reminder", // 35
       "now-md", // 40
       "subagent-status", // 50
       "slack-messages", // 60
@@ -298,8 +301,9 @@ describe("injector chain", () => {
     //
     //   [workspace]            ← prepend order 10 (topmost)
     //   [unified-turn]         ← prepend order 20
-    //   [pkb (reminder+context)] ← after-memory-prefix order 30
-    //   [now-md]               ← after-memory-prefix order 40
+    //   [now-md]               ← after-memory-prefix order 40 (highest order, closest to memory)
+    //   [pkb-reminder]         ← after-memory-prefix order 35 (skipped when pkbActive=false)
+    //   [pkb-context]          ← after-memory-prefix order 30
     //   [user text]
     //   [subagent]             ← append order 50
     //
@@ -362,7 +366,7 @@ describe("injector chain", () => {
     );
   });
 
-  test("third-party injector at order 25 lands between unified-turn-context (20) and pkb (30) in the final message", async () => {
+  test("third-party injector at order 25 lands between unified-turn-context (20) and pkb-context (30) in the final message", async () => {
     // Proves the extensibility contract end-to-end: a plugin-registered
     // injector at `order: 25` with `placement: "prepend-user-tail"` slots
     // between the unified-turn prepend (order 20, executes just before

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -522,9 +522,9 @@ export function buildSubagentStatusBlock(
   return lines.join("\n");
 }
 
-// `injectSubagentStatus` was removed in G2.1 — the subagent-status default
-// injector (`plugins/defaults/injectors.ts`) now emits the block as an
-// `append-user-tail` placement. Use {@link applyRuntimeInjections} with
+// The `<active_subagents>` block is emitted by the `subagent-status` default
+// injector (`plugins/defaults/injectors.ts`) as an `append-user-tail`
+// placement. Use {@link applyRuntimeInjections} with
 // `options.subagentStatusBlock` set, or drive the injector chain directly
 // via `collectInjectorBlocks`.
 
@@ -570,10 +570,9 @@ export function readNowScratchpad(): string | null {
 }
 
 /**
- * `injectNowScratchpad` was removed in G2.1 — the now-md default injector
- * (`plugins/defaults/injectors.ts`) now emits the `<NOW.md>` block as an
- * `after-memory-prefix` placement. Use {@link applyRuntimeInjections} with
- * `options.nowScratchpad` set.
+ * The `<NOW.md>` block is emitted by the `now-md` default injector
+ * (`plugins/defaults/injectors.ts`) as an `after-memory-prefix` placement.
+ * Use {@link applyRuntimeInjections} with `options.nowScratchpad` set.
  */
 
 /** Strip `<NOW.md>` blocks injected by `injectNowScratchpad`. */
@@ -682,9 +681,9 @@ export function readPkbContext(): string | null {
   return parts.length > 0 ? parts.join("\n\n") : null;
 }
 
-// `injectPkbContext` was removed in G2.1 — the pkb default injector
-// (`plugins/defaults/injectors.ts`) now emits the `<knowledge_base>`
-// block as an `after-memory-prefix` placement on the same splice site.
+// The `<knowledge_base>` block is emitted by the `pkb-context` default
+// injector (`plugins/defaults/injectors.ts`) as an `after-memory-prefix`
+// placement, splicing immediately after any leading memory-prefix blocks.
 // Use {@link applyRuntimeInjections} with `options.pkbContext` set.
 
 /** Strip `<knowledge_base>` blocks injected by `injectPkbContext`. */
@@ -1061,11 +1060,10 @@ export function stripChannelCapabilityContext(messages: Message[]): Message[] {
   return stripUserTextBlocksByPrefix(messages, ["<channel_capabilities>"]);
 }
 
-// `injectWorkspaceTopLevelContext` was removed in G2.1 — the
-// workspace-context default injector (`plugins/defaults/injectors.ts`)
-// now emits the workspace block as a `prepend-user-tail` placement.
-// Use {@link applyRuntimeInjections} with
-// `options.workspaceTopLevelContext` set.
+// The workspace top-level context block is emitted by the
+// `workspace-context` default injector (`plugins/defaults/injectors.ts`)
+// as a `prepend-user-tail` placement. Use {@link applyRuntimeInjections}
+// with `options.workspaceTopLevelContext` set.
 
 /**
  * Strip `<active_workspace>` (and legacy `<active_dynamic_page>`) blocks
@@ -1979,18 +1977,27 @@ function synthesizeFallbackTurnContext(
  *  3. Drive the default + third-party {@link Injector} chain via
  *     {@link collectInjectorBlocks}.
  *  4. Apply the chain's `"replace-run-messages"` block (Slack chronological
- *     transcript) first so subsequent hardcoded branches operate on the
- *     replaced tail. When replacement fires, re-prepend any memory-prefix
- *     blocks that `graphMemory.prepareMemory` had attached to the original
- *     tail — the Slack transcript is rendered fresh from persisted rows and
+ *     transcript) first so subsequent branches operate on the replaced
+ *     tail. When replacement fires, re-prepend any memory-prefix blocks
+ *     that `graphMemory.prepareMemory` had attached to the original tail —
+ *     the Slack transcript is rendered fresh from persisted rows and
  *     carries no memory prefix of its own.
- *  5. Run the remaining hardcoded branches (`isNonInteractive`,
+ *  5. Apply the chain's `"after-memory-prefix"` blocks in ascending
+ *     `order`. This runs BEFORE step 6's hardcoded prepends so the
+ *     memory-prefix counter sees only the memory blocks on the tail —
+ *     any `<channel_capabilities>` / `<channel_command_context>` /
+ *     `<transport_hints>` prepended first would push the count to zero
+ *     and force PKB / NOW to splice at the top of the tail. Within the
+ *     after-memory block, each successive splice lands at the memory
+ *     boundary, pushing earlier splices further from memory — so
+ *     higher-`order` blocks end up closer to the memory prefix.
+ *  6. Run the remaining hardcoded branches (`isNonInteractive`,
  *     `voiceCallControlPrompt`, `activeSurface`, `channelCapabilities`,
  *     `channelCommandContext`, `transportHints`) in their historical order.
- *  6. Finally, apply the chain's remaining blocks by placement:
- *     `"after-memory-prefix"` in ascending `order`, `"append-user-tail"` in
- *     ascending `order`, `"prepend-user-tail"` in descending `order` so the
- *     lowest-`order` prepend lands topmost in the user tail content.
+ *  7. Finally, apply the chain's remaining blocks by placement:
+ *     `"append-user-tail"` in ascending `order`, then `"prepend-user-tail"`
+ *     in descending `order` so the lowest-`order` prepend lands topmost in
+ *     the user tail content.
  *
  * Returns the final message array plus a `blocks` object holding the exact
  * injected text for each captured block — callers persist those bytes to
@@ -2068,25 +2075,11 @@ export async function applyRuntimeInjections(
         case "now-md":
           nowScratchpadCaptured = block.text;
           break;
-        case "pkb":
-          // The pkb injector concatenates reminder + context into a single
-          // after-memory-prefix block. Recover each half from their known
-          // tag prefixes so the persisted metadata matches pre-migration
-          // bytes: `pkbSystemReminderBlock` is the raw reminder text (no
-          // `<system_reminder>` wrapper — `buildPkbReminder` supplies it)
-          // and `pkbContextBlock` is the `<knowledge_base>` block.
-          {
-            const text = block.text;
-            const kbStart = text.indexOf("<knowledge_base>");
-            if (kbStart >= 0) {
-              const reminder = text.slice(0, kbStart).replace(/\n+$/, "");
-              if (reminder.length > 0) pkbSystemReminderCaptured = reminder;
-              pkbContextCaptured = text.slice(kbStart);
-            } else if (text.length > 0) {
-              // Reminder-only (no PKB context).
-              pkbSystemReminderCaptured = text;
-            }
-          }
+        case "pkb-context":
+          pkbContextCaptured = block.text;
+          break;
+        case "pkb-reminder":
+          pkbSystemReminderCaptured = block.text;
           break;
       }
     }
@@ -2131,7 +2124,22 @@ export async function applyRuntimeInjections(
     }
   }
 
-  // ── Step 2: hardcoded branches that stayed outside the injector chain ──
+  // ── Step 2: after-memory-prefix chain blocks ──
+  // These splice relative to the memory-prefix count on the tail content,
+  // so they must run BEFORE the hardcoded prepends in step 3. Otherwise
+  // any prepended `<channel_capabilities>` / `<channel_command_context>` /
+  // `<transport_hints>` (none of which are memory-prefix blocks) would
+  // drop the count to 0 and PKB / NOW would splice at the very top of
+  // the tail instead of immediately after memory.
+  //
+  // Ascending `order`: each splice lands at the memory-prefix boundary,
+  // pushing any previously-spliced block one slot further from memory.
+  // So higher-`order` blocks end up closer to the memory prefix.
+  for (const block of afterMemory) {
+    result = applyInjectionBlock(result, block);
+  }
+
+  // ── Step 3: hardcoded branches that stayed outside the injector chain ──
   // These run in the same historical order as before G2.1 so their
   // interleaving with any prior tail content stays stable.
 
@@ -2217,13 +2225,7 @@ export async function applyRuntimeInjections(
     }
   }
 
-  // ── Step 3: apply remaining chain blocks by placement ──
-  // after-memory-prefix: ascending `order` so lower-order blocks end up
-  // closer to the memory prefix (later splices push earlier ones down).
-  for (const block of afterMemory) {
-    result = applyInjectionBlock(result, block);
-  }
-
+  // ── Step 4: apply remaining chain blocks by placement ──
   // append-user-tail: ascending `order` so lower-order blocks come first
   // in the append sequence.
   for (const block of appends) {

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -3,7 +3,7 @@
  * drives the per-turn injection sequence consumed by
  * `applyRuntimeInjections`.
  *
- * Each of the seven default injectors reads its per-turn inputs from
+ * Each of the eight default injectors reads its per-turn inputs from
  * `ctx.injectionInputs` (see {@link TurnInjectionInputs}), runs its gating
  * conditions (injection mode, feature flags, channel type, null-input
  * short-circuits), and returns an {@link InjectionBlock} with a
@@ -14,17 +14,20 @@
  * | ------------------------ | ----- | ----------------------- |
  * | `workspace-context`      | 10    | prepend-user-tail       |
  * | `unified-turn-context`   | 20    | prepend-user-tail       |
- * | `pkb`                    | 30    | after-memory-prefix     |
+ * | `pkb-context`            | 30    | after-memory-prefix     |
+ * | `pkb-reminder`           | 35    | after-memory-prefix     |
  * | `now-md`                 | 40    | after-memory-prefix     |
  * | `subagent-status`        | 50    | append-user-tail        |
  * | `slack-messages`         | 60    | replace-run-messages    |
  * | `thread-focus`           | 70    | append-user-tail        |
  *
  * `order` matches the intended final-content ordering: lower `order` ends
- * up closer to the top of the user message's content (for prepends), closer
- * to the memory prefix (for after-memory-prefix), or earlier in the tail
- * append sequence (for appends). The runtime-injection applier sorts and
- * applies blocks declaratively so this invariant holds even when
+ * up closer to the top of the user message's content (for prepends), and
+ * within `after-memory-prefix` each successive splice lands at the memory
+ * boundary — so higher-`order` blocks push earlier splices away and end up
+ * closer to the memory prefix themselves. For appends, ascending `order` is
+ * the natural left-to-right append sequence. The runtime-injection applier
+ * sorts and applies blocks declaratively so this invariant holds even when
  * third-party injectors slot additional blocks at fractional order values.
  *
  * Third-party plugins may register additional {@link Injector}s at any
@@ -79,7 +82,8 @@ const PKB_HINT_ARCHIVE_THRESHOLD = 0.7;
 export const DEFAULT_INJECTOR_ORDER = {
   workspaceContext: 10,
   unifiedTurnContext: 20,
-  pkb: 30,
+  pkbContext: 30,
+  pkbReminder: 35,
   nowMd: 40,
   subagentStatus: 50,
   slackMessages: 60,
@@ -145,60 +149,64 @@ export const unifiedTurnContextInjector: Injector = {
 };
 
 /**
- * `pkb` injector — order 30, after-memory-prefix.
+ * `pkb-context` injector — order 30, after-memory-prefix.
  *
- * Combines the `<system_reminder>` (PKB behavioural nudge + hybrid-search
- * hints) and the `<knowledge_base>` block (auto-injected PKB content) into
- * a single block spliced immediately after any leading memory-prefix blocks
- * so the final tail shape reads
- * `[...memory prefix, <system_reminder>, <knowledge_base>, ...user text]`.
+ * Emits the `<knowledge_base>` block (auto-injected PKB content) as its own
+ * after-memory-prefix splice. Lower `order` than `pkb-reminder` so when both
+ * fire, the reminder splices second and lands closer to the memory prefix,
+ * yielding `[...memory, <system_reminder>, <knowledge_base>, ...user text]`.
  *
- * Emitting both as one block preserves the ordering of the pre-migration
- * two-branch implementation (context splice first, reminder splice second)
- * without requiring two after-memory-prefix splice passes through the
- * message array. Third-party injectors that want to separate the two can
- * do so by omitting the `<system_reminder>` half when overriding.
+ * Emitting context and reminder as two separate blocks (rather than a single
+ * concatenated text) preserves the pre-migration two-ContentBlock shape that
+ * the rehydration path in `conversation-lifecycle.ts` recreates — keeping
+ * fresh-injection and rehydrated-history structurally identical so
+ * Anthropic's prefix cache matches across reloads.
  *
  * Gating:
- *  - `mode === "full"` for both halves.
- *  - `<knowledge_base>` — non-null `pkbContext`.
- *  - `<system_reminder>` — `pkbActive === true`.
- *  - Returns `null` when neither applies.
+ *  - `mode === "full"`.
+ *  - Non-null, non-empty `pkbContext`.
  */
-export const pkbInjector: Injector = {
-  name: "pkb",
-  order: DEFAULT_INJECTOR_ORDER.pkb,
+export const pkbContextInjector: Injector = {
+  name: "pkb-context",
+  order: DEFAULT_INJECTOR_ORDER.pkbContext,
   async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
     const inputs = readInjectionInputs(ctx);
     const mode = inputs.mode ?? "full";
     if (mode !== "full") return null;
-
-    const hasContext = !!inputs.pkbContext;
-    const hasReminder = !!inputs.pkbActive;
-    if (!hasContext && !hasReminder) return null;
-
-    const parts: string[] = [];
-
-    // Reminder appears first in the spliced block (matches pre-migration
-    // behaviour where the reminder was inserted second, pushing the
-    // previously-inserted context down).
-    if (hasReminder) {
-      const reminder = await buildPkbReminderWithHints(inputs);
-      parts.push(reminder);
-    }
-
-    if (hasContext) {
-      const contextBlock = buildPkbContextBlock(inputs.pkbContext!);
-      parts.push(contextBlock);
-    }
-
-    // Join reminder + context with a blank-line separator so the
-    // combined block renders as two logical sections — matches the
-    // pre-migration behaviour where they were two separate content
-    // blocks separated by the tokenizer's default inter-block newline.
+    if (!inputs.pkbContext) return null;
     return {
-      id: "pkb",
-      text: parts.join("\n\n"),
+      id: "pkb-context",
+      text: buildPkbContextBlock(inputs.pkbContext),
+      placement: "after-memory-prefix",
+    };
+  },
+};
+
+/**
+ * `pkb-reminder` injector — order 35, after-memory-prefix.
+ *
+ * Emits the PKB `<system_reminder>` (behavioural nudge + hybrid-search
+ * hints) as its own after-memory-prefix splice. Higher `order` than
+ * `pkb-context` so the reminder splices second and ends up immediately
+ * after the memory prefix, pushing `<knowledge_base>` one slot further
+ * down — matching the pre-migration [reminder, context] ordering.
+ *
+ * Gating:
+ *  - `mode === "full"`.
+ *  - `pkbActive === true`.
+ */
+export const pkbReminderInjector: Injector = {
+  name: "pkb-reminder",
+  order: DEFAULT_INJECTOR_ORDER.pkbReminder,
+  async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+    const inputs = readInjectionInputs(ctx);
+    const mode = inputs.mode ?? "full";
+    if (mode !== "full") return null;
+    if (!inputs.pkbActive) return null;
+    const reminder = await buildPkbReminderWithHints(inputs);
+    return {
+      id: "pkb-reminder",
+      text: reminder,
       placement: "after-memory-prefix",
     };
   },
@@ -451,7 +459,8 @@ export const defaultInjectorsPlugin: Plugin = {
   injectors: [
     workspaceContextInjector,
     unifiedTurnContextInjector,
-    pkbInjector,
+    pkbContextInjector,
+    pkbReminderInjector,
     nowMdInjector,
     subagentStatusInjector,
     slackMessagesInjector,


### PR DESCRIPTION
## Summary

Addresses reviewer feedback on #27425 (pluggable injector chain migration):

1. **Ordering bug** — `after-memory-prefix` blocks (PKB / NOW) were applied *after* the hardcoded `<channel_capabilities>` / `<channel_command_context>` / `<transport_hints>` prepends. Those prepends pushed the memory-prefix counter to 0, so PKB / NOW spliced at the top of the tail instead of after the memory prefix. Moved the after-memory-prefix loop ahead of the hardcoded branches so the counter still sees a clean memory prefix at the head of the tail.

2. **Inverted comment** — the `after-memory-prefix` ordering comment claimed lower-order blocks end up closer to memory. Each successive splice lands at the memory boundary and pushes earlier splices further away, so it's the higher-order block that ends up closer to memory (the existing NOW-above-PKB test confirms). Rewrote the comment and the `applyRuntimeInjections` docstring.

3. **Stale migration comments** — four `"was removed in G2.1"` comments in `conversation-runtime-assembly.ts` rewritten to describe current injector wiring instead of narrating the migration.

4. **PKB 2-block split** — `pkbInjector` joined `<system_reminder>` + `<knowledge_base>` into one text ContentBlock via `\n\n`. The rehydration path in `conversation-lifecycle.ts` recreates them as two separate blocks, so fresh-injection (1 block) diverged structurally from rehydrated-history (2 blocks) — bad for prefix-cache stability. Split into `pkb-context` (order 30) and `pkb-reminder` (order 35); the reminder's higher order puts it closer to memory, yielding `[...memory, <system_reminder>, <knowledge_base>, ...user text]`.

## Test plan

- [x] `bun test src/__tests__/injector-chain.test.ts` — 14/14 pass
- [x] `bun test src/__tests__/conversation-runtime-assembly.test.ts` — 162/162 pass
- [x] `bun test src/__tests__/conversation-agent-loop.test.ts` — 41/41 pass
- [x] `bun test src/__tests__/compaction-strip-metadata-clear.test.ts src/__tests__/conversation-lifecycle.test.ts src/__tests__/injection-block.test.ts src/__tests__/plugin-registry.test.ts src/__tests__/plugin-types.test.ts` — all pass
- [x] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
