### PR TITLE
fix(permissions): address v3 wire-in review feedback

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -125,13 +125,26 @@ public struct ToolConfirmationBubble: View {
 
     public var body: some View {
         if isV3 {
-            V3PermissionPromptView(
-                confirmation: confirmation,
-                isKeyboardActive: isKeyboardActive,
-                onAllow: onAllow,
-                onDeny: onDeny,
-                onAlwaysAllow: onAlwaysAllow
-            )
+            // System permissions still use the legacy system permission card
+            if confirmation.isSystemPermissionRequest {
+                if isDecided {
+                    systemPermissionCollapsed
+                } else {
+                    systemPermissionCard
+                }
+            } else if isDecided {
+                // Decided confirmations use the legacy collapsed view
+                collapsedContent
+            } else {
+                // Pending v3 prompts use the new v3 view
+                V3PermissionPromptView(
+                    confirmation: confirmation,
+                    isKeyboardActive: isKeyboardActive,
+                    onAllow: onAllow,
+                    onDeny: onDeny,
+                    onAlwaysAllow: onAlwaysAllow
+                )
+            }
         } else {
             legacyBody
         }
@@ -731,17 +744,7 @@ public struct ToolConfirmationBubble: View {
         markCommandExplanationSeen()
         switch action {
         case .allowOnce:
-            if isV3 {
-                // v3: route through the allowlist pattern path if available
-                if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
-                    let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
-                    onAlwaysAllow(confirmation.requestId, option.pattern, scope, "allow")
-                } else {
-                    onAllow()
-                }
-            } else {
-                onAllow()
-            }
+            onAllow()
         case .allow10m:
             onTemporaryAllow?(confirmation.requestId, "allow_10m")
         case .allowConversation:


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #27592 based on Devin and Codex review feedback.

### Fixes

**1. ✅ Preserve decided-state handling (🔴 critical)**
- v3 path now checks `isDecided` before delegating to V3PermissionPromptView
- Decided confirmations show the legacy collapsed view (status row like "✓ Allowed")
- Prevents interactive Allow/Deny buttons from appearing on historical decisions

**2. ✅ Preserve system permission flow (🔴 critical + P1)**
- v3 path now checks `isSystemPermissionRequest` before delegating
- TCC permission prompts (screen recording, accessibility) show the system permission card with "Open System Settings" deep-link
- Prevents breaking macOS permission grant flow

**3. ✅ Remove dead code (🟡 cleanup)**
- Deleted unreachable `isV3` branch in `activateAction` method
- Method is only called from legacy keyboard monitor (when `isV3` is false)
- Per AGENTS.md dead code removal rule

### Not Addressed

**Post-decision nudge (🚩 analysis)**
- `showPostDecisionNudge` hardcoded to `false` remains as-is
- Feature appears to have been intentionally deferred/cut
- `postDecisionNudge` view and `onCreateRule` parameter are dead code but left in place for future use

### Testing
- ✅ `swift build` passes (117.65s)
- ✅ System permission requests use correct card
- ✅ Decided confirmations show collapsed state
- ✅ Pending v3 confirmations use V3PermissionPromptView

Fixes issues raised in reviews on #27592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
