### PR TITLE
feat(ipc): add emit_notification_signal and list_notification_events IPC routes

### DIFF
--- a/assistant/src/ipc/routes/index.ts
+++ b/assistant/src/ipc/routes/index.ts
@@ -5,6 +5,7 @@ import { cacheRoutes } from "./cache.js";
 import { getContactRoute } from "./get-contact.js";
 import { listClientsRoute } from "./list-clients.js";
 import { mergeContactsRoute } from "./merge-contacts.js";
+import { notificationRoutes } from "./notification.js";
 import { renameConversationRoute } from "./rename-conversation.js";
 import { searchContactsRoute } from "./search-contacts.js";
 import { taskTemplateRoutes } from "./task.js";
@@ -26,6 +27,7 @@ export const cliIpcRoutes: IpcRoute[] = [
   uiRequestRoute,
   upsertContactRoute,
   wakeConversationRoute,
+  ...notificationRoutes,
   ...cacheRoutes,
   ...taskTemplateRoutes,
   ...taskQueueRoutes,

--- a/assistant/src/ipc/routes/notification.ts
+++ b/assistant/src/ipc/routes/notification.ts
@@ -1,0 +1,133 @@
+/**
+ * IPC routes for the notification pipeline.
+ *
+ * Exposes emit_notification_signal and list_notification_events so CLI
+ * commands and external skill processes can drive the notification
+ * pipeline over the Unix domain socket IPC.
+ */
+
+import { z } from "zod";
+
+import { emitNotificationSignal } from "../../notifications/emit-signal.js";
+import { listEvents } from "../../notifications/events-store.js";
+import type { AttentionHints } from "../../notifications/signal.js";
+import type { IpcRoute } from "../cli-server.js";
+
+// ── Param schemas ─────────────────────────────────────────────────────
+
+const AttentionHintsSchema = z.object({
+  requiresAction: z.boolean(),
+  urgency: z.enum(["low", "medium", "high"]),
+  deadlineAt: z.number().optional(),
+  isAsyncBackground: z.boolean(),
+  visibleInSourceNow: z.boolean(),
+});
+
+const EmitSignalParams = z.object({
+  sourceEventName: z.string().min(1),
+  sourceChannel: z.enum([
+    "assistant_tool",
+    "vellum",
+    "phone",
+    "telegram",
+    "slack",
+    "scheduler",
+    "watcher",
+  ]),
+  sourceContextId: z.string().min(1),
+  attentionHints: AttentionHintsSchema,
+  contextPayload: z.record(z.string(), z.unknown()).optional(),
+  routingIntent: z
+    .enum(["single_channel", "multi_channel", "all_channels"])
+    .optional(),
+  dedupeKey: z.string().optional(),
+  throwOnError: z.boolean().optional(),
+});
+
+const ListNotificationEventsParams = z.object({
+  limit: z.number().int().positive().optional(),
+  sourceEventName: z.string().optional(),
+});
+
+// ── Handlers ──────────────────────────────────────────────────────────
+
+async function handleEmitSignal(params?: Record<string, unknown>): Promise<{
+  signalId: string;
+  dispatched: boolean;
+  deduplicated: boolean;
+  reason: string;
+}> {
+  const validated = EmitSignalParams.parse(params);
+  const result = await emitNotificationSignal({
+    sourceEventName: validated.sourceEventName,
+    sourceChannel: validated.sourceChannel,
+    sourceContextId: validated.sourceContextId,
+    attentionHints: validated.attentionHints as AttentionHints,
+    contextPayload: validated.contextPayload as Record<string, unknown>,
+    routingIntent: validated.routingIntent,
+    dedupeKey: validated.dedupeKey,
+    throwOnError: validated.throwOnError,
+  });
+  return {
+    signalId: result.signalId,
+    dispatched: result.dispatched,
+    deduplicated: result.deduplicated,
+    reason: result.reason,
+  };
+}
+
+function handleListEvents(params?: Record<string, unknown>): Array<{
+  id: string;
+  sourceEventName: string;
+  sourceChannel: string;
+  sourceContextId: string;
+  urgency: string;
+  dedupeKey: string | null;
+  createdAt: string;
+}> {
+  const validated = ListNotificationEventsParams.parse(params);
+  const rows = listEvents({
+    limit: validated.limit,
+    sourceEventName: validated.sourceEventName,
+  });
+  return rows.map((row) => {
+    let urgency = "unknown";
+    try {
+      const hints = JSON.parse(row.attentionHintsJson) as {
+        urgency?: string;
+      };
+      if (hints.urgency) {
+        urgency = hints.urgency;
+      }
+    } catch {
+      // Leave urgency as "unknown" if parsing fails.
+    }
+    return {
+      id: row.id,
+      sourceEventName: row.sourceEventName,
+      sourceChannel: row.sourceChannel,
+      sourceContextId: row.sourceContextId,
+      urgency,
+      dedupeKey: row.dedupeKey,
+      createdAt: new Date(row.createdAt).toISOString(),
+    };
+  });
+}
+
+// ── Route definitions ─────────────────────────────────────────────────
+
+export const emitNotificationSignalRoute: IpcRoute = {
+  method: "emit_notification_signal",
+  handler: handleEmitSignal,
+};
+
+export const listNotificationEventsRoute: IpcRoute = {
+  method: "list_notification_events",
+  handler: handleListEvents,
+};
+
+/** All notification IPC routes. */
+export const notificationRoutes: IpcRoute[] = [
+  emitNotificationSignalRoute,
+  listNotificationEventsRoute,
+];


### PR DESCRIPTION
## Summary
- Add two new IPC routes: emit_notification_signal and list_notification_events
- These routes expose the notification pipeline to CLI commands via the daemon's Unix socket IPC
- Follows established IPC route patterns (Zod validation, clean JSON responses)

Part of plan: unbundle-notif-skill.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
