### PR TITLE
Harden cloud OAuth token minting with actor-token claim binding

### DIFF
--- a/gateway/src/__tests__/cloud-oauth-token.test.ts
+++ b/gateway/src/__tests__/cloud-oauth-token.test.ts
@@ -4,8 +4,10 @@ import "./test-preload.js";
 import {
   initSigningKey,
   loadOrCreateSigningKey,
+  mintToken,
   verifyToken,
 } from "../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
 import { createCloudOAuthTokenHandler } from "../http/routes/cloud-oauth-token.js";
 
 beforeAll(() => {
@@ -13,14 +15,22 @@ beforeAll(() => {
 });
 
 const handler = createCloudOAuthTokenHandler();
+const ASSISTANT_ID = "asst-123";
+const ACTOR_PRINCIPAL_ID = "user-456";
 
 /** Build a POST request to the cloud OAuth token endpoint. */
-function makeRequest(body: unknown): Request {
+function makeRequest(body: unknown, authorization?: string): Request {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (authorization) {
+    headers.authorization = authorization;
+  }
   return new Request(
     "http://gateway.test/v1/internal/oauth/chrome-extension/token",
     {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers,
       body: typeof body === "string" ? body : JSON.stringify(body),
     },
   );
@@ -28,8 +38,18 @@ function makeRequest(body: unknown): Request {
 
 describe("POST /v1/internal/oauth/chrome-extension/token", () => {
   test("happy path: valid body returns 200 with token, expiresIn, and guardianId", async () => {
+    const actorToken = mintToken({
+      aud: "vellum-gateway",
+      sub: `actor:${ASSISTANT_ID}:${ACTOR_PRINCIPAL_ID}`,
+      scope_profile: "actor_client_v1",
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 60,
+    });
     const res = await handler.handleMintToken(
-      makeRequest({ assistantId: "asst-123", actorPrincipalId: "user-456" }),
+      makeRequest(
+        { assistantId: ASSISTANT_ID, actorPrincipalId: ACTOR_PRINCIPAL_ID },
+        `Bearer ${actorToken}`,
+      ),
     );
 
     expect(res.status).toBe(200);
@@ -42,13 +62,15 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
     expect(typeof body.token).toBe("string");
     expect(body.token.split(".").length).toBe(3); // JWT format
     expect(body.expiresIn).toBe(3600);
-    expect(body.guardianId).toBe("user-456");
+    expect(body.guardianId).toBe(ACTOR_PRINCIPAL_ID);
 
     // Verify the minted token has the correct claims
     const result = verifyToken(body.token, "vellum-gateway");
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.claims.sub).toBe("actor:asst-123:user-456");
+      expect(result.claims.sub).toBe(
+        `actor:${ASSISTANT_ID}:${ACTOR_PRINCIPAL_ID}`,
+      );
       expect(result.claims.aud).toBe("vellum-gateway");
       expect(result.claims.scope_profile).toBe("actor_client_v1");
     }
@@ -65,7 +87,7 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
 
   test("missing actorPrincipalId returns 400", async () => {
     const res = await handler.handleMintToken(
-      makeRequest({ assistantId: "asst-123" }),
+      makeRequest({ assistantId: ASSISTANT_ID }),
     );
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
@@ -83,7 +105,7 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
 
   test("empty actorPrincipalId string returns 400", async () => {
     const res = await handler.handleMintToken(
-      makeRequest({ assistantId: "asst-123", actorPrincipalId: "" }),
+      makeRequest({ assistantId: ASSISTANT_ID, actorPrincipalId: "" }),
     );
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
@@ -92,7 +114,7 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
 
   test("whitespace-only strings return 400", async () => {
     const res = await handler.handleMintToken(
-      makeRequest({ assistantId: "   ", actorPrincipalId: "user-456" }),
+      makeRequest({ assistantId: "   ", actorPrincipalId: ACTOR_PRINCIPAL_ID }),
     );
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
@@ -117,7 +139,7 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
 
   test("non-string assistantId returns 400", async () => {
     const res = await handler.handleMintToken(
-      makeRequest({ assistantId: 123, actorPrincipalId: "user-456" }),
+      makeRequest({ assistantId: 123, actorPrincipalId: ACTOR_PRINCIPAL_ID }),
     );
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
@@ -126,7 +148,10 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
 
   test("colon in assistantId returns 400", async () => {
     const res = await handler.handleMintToken(
-      makeRequest({ assistantId: "asst:123", actorPrincipalId: "user-456" }),
+      makeRequest({
+        assistantId: "asst:123",
+        actorPrincipalId: ACTOR_PRINCIPAL_ID,
+      }),
     );
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
@@ -135,14 +160,75 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
 
   test("colon in actorPrincipalId returns 400", async () => {
     const res = await handler.handleMintToken(
-      makeRequest({ assistantId: "asst-123", actorPrincipalId: "user:456" }),
+      makeRequest({ assistantId: ASSISTANT_ID, actorPrincipalId: "user:456" }),
     );
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("colon");
   });
 
-  test("request without authorization header succeeds for valid payload", async () => {
+  test("request with invalid token returns 403", async () => {
+    const res = await handler.handleMintToken(
+      makeRequest(
+        { assistantId: ASSISTANT_ID, actorPrincipalId: ACTOR_PRINCIPAL_ID },
+        "Bearer not-a-jwt",
+      ),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("request with mismatched actor token assistant returns 403", async () => {
+    const actorToken = mintToken({
+      aud: "vellum-gateway",
+      sub: `actor:other-assistant:${ACTOR_PRINCIPAL_ID}`,
+      scope_profile: "actor_client_v1",
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 60,
+    });
+    const res = await handler.handleMintToken(
+      makeRequest(
+        { assistantId: ASSISTANT_ID, actorPrincipalId: ACTOR_PRINCIPAL_ID },
+        `Bearer ${actorToken}`,
+      ),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("request with mismatched actor token principal returns 403", async () => {
+    const actorToken = mintToken({
+      aud: "vellum-gateway",
+      sub: `actor:${ASSISTANT_ID}:other-user`,
+      scope_profile: "actor_client_v1",
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 60,
+    });
+    const res = await handler.handleMintToken(
+      makeRequest(
+        { assistantId: ASSISTANT_ID, actorPrincipalId: ACTOR_PRINCIPAL_ID },
+        `Bearer ${actorToken}`,
+      ),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("request with non-actor service token returns 403", async () => {
+    const serviceToken = mintToken({
+      aud: "vellum-gateway",
+      sub: "svc:gateway:self",
+      scope_profile: "gateway_service_v1",
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 60,
+    });
+    const res = await handler.handleMintToken(
+      makeRequest(
+        { assistantId: ASSISTANT_ID, actorPrincipalId: ACTOR_PRINCIPAL_ID },
+        `Bearer ${serviceToken}`,
+      ),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("request without authorization header succeeds for valid payload when auth is not enforced", async () => {
     const res = await handler.handleMintToken(
       new Request(
         "http://gateway.test/v1/internal/oauth/chrome-extension/token",
@@ -150,12 +236,27 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
-            assistantId: "asst-123",
-            actorPrincipalId: "user-456",
+            assistantId: ASSISTANT_ID,
+            actorPrincipalId: ACTOR_PRINCIPAL_ID,
           }),
         },
       ),
     );
     expect(res.status).toBe(200);
+  });
+
+  test("request without authorization header returns 403 when auth is enforced", async () => {
+    process.env.CHROME_OAUTH_TOKEN_REQUIRE_AUTH = "true";
+    try {
+      const res = await handler.handleMintToken(
+        makeRequest({
+          assistantId: ASSISTANT_ID,
+          actorPrincipalId: ACTOR_PRINCIPAL_ID,
+        }),
+      );
+      expect(res.status).toBe(403);
+    } finally {
+      delete process.env.CHROME_OAUTH_TOKEN_REQUIRE_AUTH;
+    }
   });
 });

--- a/gateway/src/http/routes/cloud-oauth-token.ts
+++ b/gateway/src/http/routes/cloud-oauth-token.ts
@@ -13,6 +13,8 @@
  */
 
 import { getLogger } from "../../logger.js";
+import { validateEdgeToken } from "../../auth/token-exchange.js";
+import { parseSub } from "../../auth/subject.js";
 import { mintToken } from "../../auth/token-service.js";
 import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
 
@@ -20,6 +22,10 @@ const log = getLogger("cloud-oauth-token");
 
 /** TTL for minted guardian tokens — 1 hour. */
 const GUARDIAN_TOKEN_TTL_SECONDS = 3600;
+
+function isAuthEnforced(): boolean {
+  return process.env.CHROME_OAUTH_TOKEN_REQUIRE_AUTH === "true";
+}
 
 export function createCloudOAuthTokenHandler() {
   return {
@@ -75,6 +81,46 @@ export function createCloudOAuthTokenHandler() {
           { error: "actorPrincipalId must not contain colon characters" },
           { status: 400 },
         );
+      }
+
+      const authHeader = req.headers.get("authorization");
+      const bearerToken = authHeader?.replace(/^Bearer\s+/i, "");
+      if (!bearerToken) {
+        if (isAuthEnforced()) {
+          return Response.json(
+            { error: "Authorization token is required" },
+            { status: 403 },
+          );
+        }
+        log.warn(
+          { assistantId, actorPrincipalId },
+          "Cloud OAuth token mint request missing bearer token; allowing legacy unauthenticated path",
+        );
+      } else {
+        const tokenResult = validateEdgeToken(bearerToken);
+        if (!tokenResult.ok) {
+          return Response.json({ error: "Forbidden" }, { status: 403 });
+        }
+
+        const callerSub = parseSub(tokenResult.claims.sub);
+        if (!callerSub.ok || callerSub.principalType !== "actor") {
+          return Response.json({ error: "Forbidden" }, { status: 403 });
+        }
+        if (
+          callerSub.assistantId !== assistantId ||
+          callerSub.actorPrincipalId !== actorPrincipalId
+        ) {
+          log.warn(
+            {
+              requestedAssistantId: assistantId,
+              requestedActorPrincipalId: actorPrincipalId,
+              callerAssistantId: callerSub.assistantId,
+              callerActorPrincipalId: callerSub.actorPrincipalId,
+            },
+            "Cloud OAuth token mint request token claims do not match requested principal",
+          );
+          return Response.json({ error: "Forbidden" }, { status: 403 });
+        }
       }
 
       const sub = `actor:${assistantId}:${actorPrincipalId}`;


### PR DESCRIPTION
## Summary
- Add progressive auth hardening to the chrome extension cloud OAuth token mint route so bearer tokens, when present, are validated and bound to the requested assistant and actor principal.
- Add CHROME_OAUTH_TOKEN_REQUIRE_AUTH=true enforcement mode so we can require authorization for this route after platform rollout without another code change.
- Expand unit tests to cover invalid and mismatched tokens, service-token rejection, default legacy behavior, and enforced-auth mode.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
