### PR TITLE
fix(extension): deduplicate error messages in popup sign-in failure state

### DIFF
--- a/clients/chrome-extension/popup/popup-state.test.ts
+++ b/clients/chrome-extension/popup/popup-state.test.ts
@@ -456,12 +456,22 @@ describe('deriveHealthStatusDisplay', () => {
     expect(status.text).toBe('Connection error');
   });
 
-  test('error with error message: includes message in text', () => {
+  test('error with error message: includes cleaned message in text', () => {
     const detail = makeDetail({ lastErrorMessage: 'Native host not installed' });
     const status = deriveHealthStatusDisplay('error', detail);
     expect(status.dotClass).toBe('disconnected');
-    expect(status.text).toContain('Error');
-    expect(status.text).toContain('Native host not installed');
+    expect(status.text).toBe('Native host not installed');
+  });
+
+  test('error with cloud sign-in message: strips prefixes and trace IDs', () => {
+    const detail = makeDetail({
+      lastErrorMessage: 'cloud sign-in failed: gateway_error (gateway_status_401) [trace=abc-123]',
+    });
+    const status = deriveHealthStatusDisplay('error', detail);
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toBe('Gateway_error (gateway_status_401)');
+    expect(status.text).not.toContain('cloud sign-in failed');
+    expect(status.text).not.toContain('[trace=');
   });
 
   test('reconnecting with disconnect code: still shows friendly message', () => {
@@ -619,8 +629,7 @@ describe('integrated health-to-display scenarios', () => {
 
     const status = deriveHealthStatusDisplay('error', detail);
     expect(status.dotClass).toBe('disconnected');
-    expect(status.text).toContain('Error');
-    expect(status.text).toContain('Native host not installed');
+    expect(status.text).toBe('Native host not installed');
 
     expect(shouldExpandTroubleshooting('error')).toBe(true);
   });

--- a/clients/chrome-extension/popup/popup-state.ts
+++ b/clients/chrome-extension/popup/popup-state.ts
@@ -374,7 +374,7 @@ export function deriveHealthStatusDisplay(
       return {
         dotClass: 'disconnected',
         text: detail?.lastErrorMessage
-          ? `Action required: ${detail.lastErrorMessage}`
+          ? `Action required: ${cleanErrorMessage(detail.lastErrorMessage, 'sign in or re-pair to continue')}`
           : 'Action required \u2014 sign in or re-pair to continue',
       };
     case 'error': {

--- a/clients/chrome-extension/popup/popup-state.ts
+++ b/clients/chrome-extension/popup/popup-state.ts
@@ -345,6 +345,18 @@ export function healthToPhase(health: ConnectionHealthState): ConnectionPhase {
  * | auth_required  | disconnected  | Action required (+ detail if available)  |
  * | error          | disconnected  | Error (+ detail if available)            |
  */
+
+/**
+ * Strip verbose prefixes and trace IDs from error messages to produce
+ * a concise, human-readable summary for display in the popup UI.
+ */
+export function cleanErrorMessage(raw: string, fallback: string): string {
+  return raw
+    .replace(/\[trace=[^\]]+\]/g, '')
+    .replace(/cloud sign-in failed:\s*/gi, '')
+    .trim() || fallback;
+}
+
 export function deriveHealthStatusDisplay(
   health: ConnectionHealthState,
   detail?: ConnectionHealthDetail,
@@ -365,13 +377,13 @@ export function deriveHealthStatusDisplay(
           ? `Action required: ${detail.lastErrorMessage}`
           : 'Action required \u2014 sign in or re-pair to continue',
       };
-    case 'error':
-      return {
-        dotClass: 'disconnected',
-        text: detail?.lastErrorMessage
-          ? `Error: ${detail.lastErrorMessage}`
-          : 'Connection error',
-      };
+    case 'error': {
+      let text = detail?.lastErrorMessage
+        ? cleanErrorMessage(detail.lastErrorMessage, 'Connection error')
+        : 'Connection error';
+      text = text.charAt(0).toUpperCase() + text.slice(1);
+      return { dotClass: 'disconnected', text };
+    }
   }
 }
 

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -733,7 +733,7 @@ btnCloudSignIn.addEventListener('click', async () => {
     setCloudStatus('Sign-in failed', false);
     showErrorTextWithDebug(
       `Sign-in failed: ${cleanErrorMessage(rawError, 'Unknown error')}`,
-      response.debugDetails,
+      response.debugDetails ?? rawError,
     );
   }
   btnCloudSignIn.disabled = false;

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -689,7 +689,10 @@ async function refreshCloudStatus(): Promise<void> {
       const debugDets = typeof (authErr as { debugDetails?: unknown }).debugDetails === 'string'
         ? (authErr as { debugDetails: string }).debugDetails
         : undefined;
-      showErrorTextWithDebug(cleanErrorMessage(rawMsg, 'Connection error'), debugDets ?? rawMsg);
+      // Fall back to rawMsg only when it contains a trace ID — otherwise
+      // passing it as debugText would duplicate the message in Debug Details.
+      const debugFallback = /\[trace=/.test(rawMsg) ? rawMsg : undefined;
+      showErrorTextWithDebug(cleanErrorMessage(rawMsg, 'Connection error'), debugDets ?? debugFallback);
     }
   } catch (err) {
     setCloudStatus(`Error: ${err instanceof Error ? err.message : String(err)}`, false);
@@ -731,9 +734,13 @@ btnCloudSignIn.addEventListener('click', async () => {
   } else {
     const rawError = response.error ?? 'Unknown error';
     setCloudStatus('Sign-in failed', false);
+    // Fall back to rawError only when it contains a trace ID — otherwise
+    // passing it as debugText would duplicate the error message in the
+    // Debug Details panel.
+    const debugFallback = /\[trace=/.test(rawError) ? rawError : undefined;
     showErrorTextWithDebug(
       `Sign-in failed: ${cleanErrorMessage(rawError, 'Unknown error')}`,
-      response.debugDetails ?? rawError,
+      response.debugDetails ?? debugFallback,
     );
   }
   btnCloudSignIn.disabled = false;

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -41,6 +41,7 @@ import {
   deriveSetupMessage,
   deriveHealthStatusDisplay,
   healthToPhase,
+  cleanErrorMessage,
   shouldExpandTroubleshooting,
   hasTroubleshootingControls,
   deriveEnvironmentHint,
@@ -240,17 +241,6 @@ function setPhase(phase: ConnectionPhase): void {
     paused: 'paused',
   };
   applyHealthState(healthMap[phase]);
-}
-
-/**
- * Render an inline error message without touching any other UI.
- *
- * Use this for generic popup errors -- e.g. cloud OAuth failures,
- * refresh exceptions, or generic service-worker messages.
- */
-function showErrorText(msg: string): void {
-  errorText.textContent = msg;
-  errorText.style.display = 'block';
 }
 
 function hideDebugDetails(): void {
@@ -688,9 +678,6 @@ async function refreshCloudStatus(): Promise<void> {
     // reconnect. The worker writes `vellum.relayAuthError` when the
     // cloud token refresh fails (see cloudReconnectHook in worker.ts)
     // and clears it on a successful connect.
-    //
-    // Use showErrorText directly: the message already instructs the
-    // user to sign in with Vellum (cloud) again, which is all they need.
     const authErrResult = await chrome.storage.local.get('vellum.relayAuthError');
     const authErr = authErrResult['vellum.relayAuthError'];
     if (
@@ -698,13 +685,11 @@ async function refreshCloudStatus(): Promise<void> {
       typeof authErr === 'object' &&
       typeof (authErr as { message?: unknown }).message === 'string'
     ) {
-      showErrorText((authErr as { message: string }).message);
-      if (typeof (authErr as { debugDetails?: unknown }).debugDetails === 'string') {
-        maybeShowDebugDetails(
-          (authErr as { message: string }).message,
-          (authErr as { debugDetails: string }).debugDetails,
-        );
-      }
+      const rawMsg = (authErr as { message: string }).message;
+      const debugDets = typeof (authErr as { debugDetails?: unknown }).debugDetails === 'string'
+        ? (authErr as { debugDetails: string }).debugDetails
+        : undefined;
+      showErrorTextWithDebug(cleanErrorMessage(rawMsg, 'Connection error'), debugDets ?? rawMsg);
     }
   } catch (err) {
     setCloudStatus(`Error: ${err instanceof Error ? err.message : String(err)}`, false);
@@ -744,9 +729,12 @@ btnCloudSignIn.addEventListener('click', async () => {
     setCloudStatus(`Signed in as guardian:${response.token.guardianId}`, true);
     hideDebugDetails();
   } else {
-    const message = `Sign-in failed: ${response.error ?? 'Unknown error'}`;
-    setCloudStatus(message, false);
-    showErrorTextWithDebug(message, response.debugDetails);
+    const rawError = response.error ?? 'Unknown error';
+    setCloudStatus('Sign-in failed', false);
+    showErrorTextWithDebug(
+      `Sign-in failed: ${cleanErrorMessage(rawError, 'Unknown error')}`,
+      response.debugDetails,
+    );
   }
   btnCloudSignIn.disabled = false;
 });


### PR DESCRIPTION
## Summary
- Extract `cleanErrorMessage()` helper that strips verbose `cloud sign-in failed:` prefixes and `[trace=...]` suffixes from error strings
- Status card now shows a concise error summary (e.g. "Gateway_error (gateway_status_401)") instead of the full nested message
- Error text box shows a clean "Sign-in failed: ..." message without trace IDs (trace stays in Debug Details only)
- Cloud status in Advanced section shows just "Sign-in failed" instead of repeating the full error

## Original prompt
Clean up the Chrome extension popup's error state to eliminate duplicative error messages on sign-in failure. When cloud sign-in fails, the popup was showing the same error information in 4 redundant places: status card, error text box, debug details, and cloud status text at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
