### PR TITLE
fix(host-browser): add cdp_session_not_found and cancelled to transport error codes

### DIFF
--- a/assistant/src/tools/browser/cdp-client/extension-cdp-client.ts
+++ b/assistant/src/tools/browser/cdp-client/extension-cdp-client.ts
@@ -21,6 +21,8 @@ const TRANSPORT_ERROR_CODES = new Set([
   "unreachable",
   "timeout",
   "non_loopback",
+  "cdp_session_not_found",
+  "cancelled",
 ]);
 
 /**
@@ -174,7 +176,8 @@ export class ExtensionCdpClient implements ScopedCdpClient {
  *
  * Structured envelopes from the host_browser dispatcher carry a
  * `code` string field (e.g. `"transport_error"`, `"unreachable"`,
- * `"timeout"`, `"non_loopback"`). When the code matches a known
+ * `"timeout"`, `"non_loopback"`, `"cdp_session_not_found"`,
+ * `"cancelled"`). When the code matches a known
  * transport-level value, the error is eligible for factory failover.
  * All other codes (or missing codes) are treated as CDP command
  * errors that should propagate without failover.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for host-browser-robustness.md.

**Gap:** cdp_session_not_found not in TRANSPORT_ERROR_CODES
**What was expected:** New error codes should trigger transport-level failover
**What was found:** They were being misclassified as cdp_error
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
