### PR TITLE
fix(host-browser): close CancelState race between continuation and resource creation

### DIFF
--- a/clients/shared/Network/HostBrowserExecutor.swift
+++ b/clients/shared/Network/HostBrowserExecutor.swift
@@ -403,7 +403,20 @@ public final class HostBrowserExecutor {
                 state.session = session
                 state.wsTask = wsTask
                 state.timeoutWork = timeoutTask
+                let tornDownDuringGap = state.resumed
                 state.lock.unlock()
+
+                // If teardown() fired between the first `alreadyResumed`
+                // check and storing the resources above, it called cancel/
+                // invalidate on nil values and left these just-created
+                // resources dangling. Clean them up now and bail out —
+                // teardown() already resumed the continuation.
+                if tornDownDuringGap {
+                    wsTask.cancel(with: .goingAway, reason: nil)
+                    session.invalidateAndCancel()
+                    timeoutTask.cancel()
+                    return
+                }
 
                 wsTask.resume()
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for host-browser-robustness.md.

**Gap:** Race condition in CancelState between continuation storage and session creation
**What was expected:** All resources cleaned up regardless of cancellation timing
**What was found:** Narrow window where teardown fires on nil resources, leaving subsequently-created ones dangling
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
