### PR TITLE
fix: add notifications skill to catalog.json for auto-install

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -350,6 +350,18 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
+      "id": "notifications",
+      "name": "notifications",
+      "description": "Send notifications through the unified notification router",
+      "metadata": {
+        "emoji": "🔔",
+        "vellum": {
+          "display-name": "Notifications"
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "oura",
       "name": "oura",
       "description": "Pull sleep, activity, readiness, heart rate, and other health data from a connected Oura Ring via the Oura Cloud API V2",


### PR DESCRIPTION
## Summary
Adds the unbundled notifications skill to catalog.json so it can be auto-installed to user workspaces.

**Gap:** Notifications skill removed from bundled but not added to catalog.json
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
