### PR TITLE
fix: restore deep_link_metadata and conversationId forwarding

### DIFF
--- a/assistant/src/cli/commands/notifications.ts
+++ b/assistant/src/cli/commands/notifications.ts
@@ -95,6 +95,10 @@ Examples:
       "--dedupe-key <key>",
       "Optional dedupe key to suppress duplicate notifications",
     )
+    .option(
+      "--deep-link-metadata <json>",
+      "Optional JSON metadata clients can use for deep linking",
+    )
     .addHelpText(
       "after",
       `
@@ -131,6 +135,7 @@ Examples:
           preferredChannels?: string;
           sessionId?: string;
           dedupeKey?: string;
+          deepLinkMetadata?: string;
         },
         cmd: Command,
       ) => {
@@ -181,6 +186,24 @@ Examples:
               .filter((ch) => ch.length > 0);
           }
 
+          // Parse --deep-link-metadata
+          let deepLinkMetadata: Record<string, unknown> | undefined;
+          if (opts.deepLinkMetadata != null) {
+            try {
+              deepLinkMetadata = JSON.parse(opts.deepLinkMetadata) as Record<
+                string,
+                unknown
+              >;
+            } catch {
+              writeOutput(cmd, {
+                ok: false,
+                error: `Invalid deep-link-metadata: must be a valid JSON string`,
+              });
+              process.exitCode = 1;
+              return;
+            }
+          }
+
           const sourceContextId = opts.sessionId ?? `cli-${Date.now()}`;
 
           const result = await cliIpcCall<{
@@ -204,6 +227,7 @@ Examples:
               requestedBySource: opts.sourceChannel,
               ...(opts.title ? { requestedTitle: opts.title } : {}),
               ...(preferredChannels?.length ? { preferredChannels } : {}),
+              ...(deepLinkMetadata ? { deepLinkMetadata } : {}),
             },
             ...(opts.dedupeKey ? { dedupeKey: opts.dedupeKey } : {}),
             throwOnError: true,

--- a/skills/notifications/tools/send-notification.ts
+++ b/skills/notifications/tools/send-notification.ts
@@ -8,7 +8,7 @@
 
 export async function run(
   input: Record<string, unknown>,
-  _context: { workingDir: string; conversationId: string },
+  context: { workingDir: string; conversationId: string },
 ): Promise<{ content: string; isError: boolean }> {
   const args: string[] = [
     "notifications",
@@ -37,11 +37,18 @@ export async function run(
   if (typeof input.dedupe_key === "string" && input.dedupe_key) {
     args.push("--dedupe-key", input.dedupe_key);
   }
-  if (typeof input.conversation_id === "string" && input.conversation_id) {
-    args.push("--session-id", input.conversation_id);
+  const sessionId =
+    typeof input.conversation_id === "string" && input.conversation_id
+      ? input.conversation_id
+      : context.conversationId || undefined;
+  if (sessionId) {
+    args.push("--session-id", sessionId);
   }
   if (Array.isArray(input.preferred_channels) && input.preferred_channels.length > 0) {
     args.push("--preferred-channels", input.preferred_channels.join(","));
+  }
+  if (input.deep_link_metadata != null && typeof input.deep_link_metadata === "object") {
+    args.push("--deep-link-metadata", JSON.stringify(input.deep_link_metadata));
   }
 
   // Boolean flags


### PR DESCRIPTION
## Summary
Fixes parameter forwarding gaps in the unbundled notifications skill.

**Gap 1:** deep_link_metadata declared in schema but dropped by CLI shim
**Gap 2:** context.conversationId fallback lost in CLI shim
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
