### PR TITLE
security(gateway): require internal auth on chrome OAuth token mint endpoint

### DIFF
--- a/gateway/src/__tests__/cloud-oauth-token.test.ts
+++ b/gateway/src/__tests__/cloud-oauth-token.test.ts
@@ -1,13 +1,18 @@
-import { describe, test, expect, beforeAll } from "bun:test";
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from "bun:test";
 import "./test-preload.js";
 
 import {
   initSigningKey,
   loadOrCreateSigningKey,
-  mintToken,
   verifyToken,
 } from "../auth/token-service.js";
-import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
 import { createCloudOAuthTokenHandler } from "../http/routes/cloud-oauth-token.js";
 
 beforeAll(() => {
@@ -17,6 +22,21 @@ beforeAll(() => {
 const handler = createCloudOAuthTokenHandler();
 const ASSISTANT_ID = "asst-123";
 const ACTOR_PRINCIPAL_ID = "user-456";
+const PLATFORM_INTERNAL_API_KEY = "platform-internal-key";
+const ORIGINAL_PLATFORM_INTERNAL_API_KEY =
+  process.env.PLATFORM_INTERNAL_API_KEY;
+
+beforeEach(() => {
+  process.env.PLATFORM_INTERNAL_API_KEY = PLATFORM_INTERNAL_API_KEY;
+});
+
+afterEach(() => {
+  if (ORIGINAL_PLATFORM_INTERNAL_API_KEY === undefined) {
+    delete process.env.PLATFORM_INTERNAL_API_KEY;
+    return;
+  }
+  process.env.PLATFORM_INTERNAL_API_KEY = ORIGINAL_PLATFORM_INTERNAL_API_KEY;
+});
 
 /** Build a POST request to the cloud OAuth token endpoint. */
 function makeRequest(body: unknown, authorization?: string): Request {
@@ -38,17 +58,10 @@ function makeRequest(body: unknown, authorization?: string): Request {
 
 describe("POST /v1/internal/oauth/chrome-extension/token", () => {
   test("happy path: valid body returns 200 with token, expiresIn, and guardianId", async () => {
-    const actorToken = mintToken({
-      aud: "vellum-gateway",
-      sub: `actor:${ASSISTANT_ID}:${ACTOR_PRINCIPAL_ID}`,
-      scope_profile: "actor_client_v1",
-      policy_epoch: CURRENT_POLICY_EPOCH,
-      ttlSeconds: 60,
-    });
     const res = await handler.handleMintToken(
       makeRequest(
         { assistantId: ASSISTANT_ID, actorPrincipalId: ACTOR_PRINCIPAL_ID },
-        `Bearer ${actorToken}`,
+        `Bearer ${PLATFORM_INTERNAL_API_KEY}`,
       ),
     );
 
@@ -167,96 +180,45 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
     expect(body.error).toContain("colon");
   });
 
-  test("request with invalid token returns 403", async () => {
+  test("request without authorization header returns 403", async () => {
+    const res = await handler.handleMintToken(
+      makeRequest({
+        assistantId: ASSISTANT_ID,
+        actorPrincipalId: ACTOR_PRINCIPAL_ID,
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("request with invalid bearer token returns 403", async () => {
     const res = await handler.handleMintToken(
       makeRequest(
         { assistantId: ASSISTANT_ID, actorPrincipalId: ACTOR_PRINCIPAL_ID },
-        "Bearer not-a-jwt",
+        "Bearer wrong-internal-key",
       ),
     );
     expect(res.status).toBe(403);
   });
 
-  test("request with mismatched actor token assistant returns 403", async () => {
-    const actorToken = mintToken({
-      aud: "vellum-gateway",
-      sub: `actor:other-assistant:${ACTOR_PRINCIPAL_ID}`,
-      scope_profile: "actor_client_v1",
-      policy_epoch: CURRENT_POLICY_EPOCH,
-      ttlSeconds: 60,
-    });
+  test("request with non-bearer authorization header returns 403", async () => {
     const res = await handler.handleMintToken(
       makeRequest(
         { assistantId: ASSISTANT_ID, actorPrincipalId: ACTOR_PRINCIPAL_ID },
-        `Bearer ${actorToken}`,
+        "Api-Key some-key",
       ),
     );
     expect(res.status).toBe(403);
   });
 
-  test("request with mismatched actor token principal returns 403", async () => {
-    const actorToken = mintToken({
-      aud: "vellum-gateway",
-      sub: `actor:${ASSISTANT_ID}:other-user`,
-      scope_profile: "actor_client_v1",
-      policy_epoch: CURRENT_POLICY_EPOCH,
-      ttlSeconds: 60,
-    });
+  test("request returns 503 when PLATFORM_INTERNAL_API_KEY is not configured", async () => {
+    delete process.env.PLATFORM_INTERNAL_API_KEY;
+
     const res = await handler.handleMintToken(
       makeRequest(
         { assistantId: ASSISTANT_ID, actorPrincipalId: ACTOR_PRINCIPAL_ID },
-        `Bearer ${actorToken}`,
+        `Bearer ${PLATFORM_INTERNAL_API_KEY}`,
       ),
     );
-    expect(res.status).toBe(403);
-  });
-
-  test("request with non-actor service token returns 403", async () => {
-    const serviceToken = mintToken({
-      aud: "vellum-gateway",
-      sub: "svc:gateway:self",
-      scope_profile: "gateway_service_v1",
-      policy_epoch: CURRENT_POLICY_EPOCH,
-      ttlSeconds: 60,
-    });
-    const res = await handler.handleMintToken(
-      makeRequest(
-        { assistantId: ASSISTANT_ID, actorPrincipalId: ACTOR_PRINCIPAL_ID },
-        `Bearer ${serviceToken}`,
-      ),
-    );
-    expect(res.status).toBe(403);
-  });
-
-  test("request without authorization header succeeds for valid payload when auth is not enforced", async () => {
-    const res = await handler.handleMintToken(
-      new Request(
-        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            assistantId: ASSISTANT_ID,
-            actorPrincipalId: ACTOR_PRINCIPAL_ID,
-          }),
-        },
-      ),
-    );
-    expect(res.status).toBe(200);
-  });
-
-  test("request without authorization header returns 403 when auth is enforced", async () => {
-    process.env.CHROME_OAUTH_TOKEN_REQUIRE_AUTH = "true";
-    try {
-      const res = await handler.handleMintToken(
-        makeRequest({
-          assistantId: ASSISTANT_ID,
-          actorPrincipalId: ACTOR_PRINCIPAL_ID,
-        }),
-      );
-      expect(res.status).toBe(403);
-    } finally {
-      delete process.env.CHROME_OAUTH_TOKEN_REQUIRE_AUTH;
-    }
+    expect(res.status).toBe(503);
   });
 });

--- a/gateway/src/http/routes/cloud-oauth-token.ts
+++ b/gateway/src/http/routes/cloud-oauth-token.ts
@@ -7,14 +7,11 @@
  *
  * POST /v1/internal/oauth/chrome-extension/token
  *   Body: { assistantId: string, actorPrincipalId: string }
- *   Auth: none at gateway router layer (request reaches here only via
- *         platform-owned vembda gateway-query plumbing)
+ *   Auth: Authorization: Bearer <PLATFORM_INTERNAL_API_KEY>
  *   Returns: { token: string, expiresIn: number, guardianId: string }
  */
 
 import { getLogger } from "../../logger.js";
-import { validateEdgeToken } from "../../auth/token-exchange.js";
-import { parseSub } from "../../auth/subject.js";
 import { mintToken } from "../../auth/token-service.js";
 import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
 
@@ -22,10 +19,6 @@ const log = getLogger("cloud-oauth-token");
 
 /** TTL for minted guardian tokens — 1 hour. */
 const GUARDIAN_TOKEN_TTL_SECONDS = 3600;
-
-function isAuthEnforced(): boolean {
-  return process.env.CHROME_OAUTH_TOKEN_REQUIRE_AUTH === "true";
-}
 
 export function createCloudOAuthTokenHandler() {
   return {
@@ -83,44 +76,20 @@ export function createCloudOAuthTokenHandler() {
         );
       }
 
-      const authHeader = req.headers.get("authorization");
-      const bearerToken = authHeader?.replace(/^Bearer\s+/i, "");
-      if (!bearerToken) {
-        if (isAuthEnforced()) {
-          return Response.json(
-            { error: "Authorization token is required" },
-            { status: 403 },
-          );
-        }
-        log.warn(
-          { assistantId, actorPrincipalId },
-          "Cloud OAuth token mint request missing bearer token; allowing legacy unauthenticated path",
+      const expectedInternalKey = process.env.PLATFORM_INTERNAL_API_KEY?.trim();
+      if (!expectedInternalKey) {
+        log.error(
+          "PLATFORM_INTERNAL_API_KEY is not configured; refusing cloud OAuth token mint request",
         );
-      } else {
-        const tokenResult = validateEdgeToken(bearerToken);
-        if (!tokenResult.ok) {
-          return Response.json({ error: "Forbidden" }, { status: 403 });
-        }
+        return Response.json(
+          { error: "Internal auth is not configured" },
+          { status: 503 },
+        );
+      }
 
-        const callerSub = parseSub(tokenResult.claims.sub);
-        if (!callerSub.ok || callerSub.principalType !== "actor") {
-          return Response.json({ error: "Forbidden" }, { status: 403 });
-        }
-        if (
-          callerSub.assistantId !== assistantId ||
-          callerSub.actorPrincipalId !== actorPrincipalId
-        ) {
-          log.warn(
-            {
-              requestedAssistantId: assistantId,
-              requestedActorPrincipalId: actorPrincipalId,
-              callerAssistantId: callerSub.assistantId,
-              callerActorPrincipalId: callerSub.actorPrincipalId,
-            },
-            "Cloud OAuth token mint request token claims do not match requested principal",
-          );
-          return Response.json({ error: "Forbidden" }, { status: 403 });
-        }
+      const bearerToken = extractBearerToken(req);
+      if (!bearerToken || bearerToken !== expectedInternalKey) {
+        return Response.json({ error: "Forbidden" }, { status: 403 });
       }
 
       const sub = `actor:${assistantId}:${actorPrincipalId}`;
@@ -153,4 +122,12 @@ export function createCloudOAuthTokenHandler() {
       }
     },
   };
+}
+
+function extractBearerToken(req: Request): string | null {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
+    return null;
+  }
+  return authHeader.slice(7).trim();
 }

--- a/gateway/src/http/routes/cloud-oauth-token.ts
+++ b/gateway/src/http/routes/cloud-oauth-token.ts
@@ -11,6 +11,7 @@
  *   Returns: { token: string, expiresIn: number, guardianId: string }
  */
 
+import { timingSafeEqual } from "node:crypto";
 import { getLogger } from "../../logger.js";
 import { mintToken } from "../../auth/token-service.js";
 import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
@@ -88,7 +89,7 @@ export function createCloudOAuthTokenHandler() {
       }
 
       const bearerToken = extractBearerToken(req);
-      if (!bearerToken || bearerToken !== expectedInternalKey) {
+      if (!matchesInternalKey(bearerToken, expectedInternalKey)) {
         return Response.json({ error: "Forbidden" }, { status: 403 });
       }
 
@@ -130,4 +131,15 @@ function extractBearerToken(req: Request): string | null {
     return null;
   }
   return authHeader.slice(7).trim();
+}
+
+function matchesInternalKey(
+  providedKey: string | null,
+  expectedKey: string,
+): boolean {
+  if (!providedKey) return false;
+  const provided = Buffer.from(providedKey);
+  const expected = Buffer.from(expectedKey);
+  if (provided.length !== expected.length) return false;
+  return timingSafeEqual(provided, expected);
 }


### PR DESCRIPTION
## Summary
- require `Authorization: Bearer <PLATFORM_INTERNAL_API_KEY>` for `POST /v1/internal/oauth/chrome-extension/token`
- remove legacy unauthenticated/actor-JWT path for this endpoint
- add focused tests for missing/invalid auth and missing internal-key configuration

## Why
`/v1/internal/oauth/chrome-extension/token` should only be callable by trusted platform-to-gateway plumbing. This hardens the route to fail closed.

## Validation
- `cd gateway && bun test src/__tests__/cloud-oauth-token.test.ts`
- `cd gateway && bun test src/__tests__/route-schema-guard.test.ts`
- `cd gateway && bunx tsc --noEmit`

## Paired PR
- platform sender update: https://github.com/vellum-ai/vellum-assistant-platform/pull/4771

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

