### PR TITLE
feat(runtime): add in-memory migration job registry

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/job-registry.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/job-registry.test.ts
@@ -200,6 +200,49 @@ describe("MigrationJobRegistry", () => {
     expect(registry.getJob(third.id)!.status).toBe("complete");
   });
 
+  test("returned job snapshots are decoupled from internal registry state", async () => {
+    const registry = new MigrationJobRegistry();
+
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const first = registry.startJob("export", async () => {
+      await gate;
+    });
+
+    // The synchronous return of startJob must be a snapshot, not the
+    // internal record. Mutating it (e.g. to simulate a caller stomping on
+    // `status`) must not unblock the single-in-flight invariant while the
+    // runner is still active.
+    first.status = "complete";
+    first.completedAt = Date.now();
+
+    await flushMicrotasks();
+    // Internal state is still running — the snapshot mutation did not leak.
+    expect(registry.getJob(first.id)!.status).toBe("running");
+
+    // Attempting a second same-type job must still reject.
+    expect(() => registry.startJob("export", async () => {})).toThrow(
+      JobAlreadyInProgressError,
+    );
+
+    // getJob snapshots are also decoupled: mutating the return value of
+    // getJob does not leak into listJobs or subsequent getJob calls.
+    const polled = registry.getJob(first.id)!;
+    polled.status = "failed";
+    expect(registry.getJob(first.id)!.status).toBe("running");
+    expect(registry.listJobs().find((j) => j.id === first.id)!.status).toBe(
+      "running",
+    );
+
+    // Settle.
+    release();
+    await flushMicrotasks();
+    expect(registry.getJob(first.id)!.status).toBe("complete");
+  });
+
   test("TTL sweep: completed jobs older than TTL are evicted", async () => {
     const registry = new MigrationJobRegistry();
     registry.completedJobTtlMs = 1_000; // 1s for test purposes

--- a/assistant/src/runtime/migrations/__tests__/job-registry.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/job-registry.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for the in-memory migration job registry.
+ *
+ * Covered:
+ * - Happy path: start -> poll pending -> poll running -> poll complete with result.
+ * - Failure path: runner throws -> job ends in `failed` with mapped error.
+ * - `kFetchBodyError` path: tagged thrown object maps to `fetch_failed` with
+ *   optional `upstreamStatus` preserved.
+ * - Concurrent limit: second export while one is pending/running rejects with
+ *   `JobAlreadyInProgressError`; a job of the other type is allowed alongside.
+ * - TTL sweep: completed job older than the TTL is evicted; job that is not
+ *   yet past TTL is retained.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  JobAlreadyInProgressError,
+  type MigrationJob,
+  MigrationJobRegistry,
+} from "../job-registry.js";
+
+const kFetchBodyError = Symbol.for("vellum.migrationImport.fetchBodyError");
+
+/** Spin the microtask queue N times so `queueMicrotask`-scheduled work runs. */
+async function flushMicrotasks(n = 4): Promise<void> {
+  for (let i = 0; i < n; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("MigrationJobRegistry", () => {
+  test("happy path: pending -> running -> complete with result", async () => {
+    const registry = new MigrationJobRegistry();
+
+    let release: (value: string) => void = () => {};
+    const gate = new Promise<string>((resolve) => {
+      release = resolve;
+    });
+
+    const job = registry.startJob("export", async (): Promise<string> => {
+      return await gate;
+    });
+
+    // Returned synchronously in pending state.
+    expect(job.status).toBe("pending");
+    expect(job.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(job.type).toBe("export");
+    expect(job.createdAt).toBeGreaterThan(0);
+    expect(job.startedAt).toBeUndefined();
+    expect(job.completedAt).toBeUndefined();
+
+    // Let the microtask run -> status flips to running with `startedAt` set.
+    await flushMicrotasks();
+    const running = registry.getJob(job.id);
+    expect(running).not.toBeNull();
+    expect(running!.status).toBe("running");
+    expect(running!.startedAt).toBeGreaterThanOrEqual(running!.createdAt);
+
+    // Resolve the runner and let it settle.
+    release("the-result");
+    await flushMicrotasks();
+
+    const done = registry.getJob(job.id);
+    expect(done).not.toBeNull();
+    expect(done!.status).toBe("complete");
+    expect(done!.result).toBe("the-result");
+    expect(done!.completedAt).toBeGreaterThanOrEqual(done!.startedAt ?? 0);
+    expect(done!.error).toBeUndefined();
+
+    // `listJobs` sees it too.
+    expect(registry.listJobs().map((j) => j.id)).toContain(job.id);
+  });
+
+  test("failure path: runner throws -> failed with mapped error", async () => {
+    const registry = new MigrationJobRegistry();
+    const job = registry.startJob("export", async () => {
+      throw new Error("boom");
+    });
+
+    await flushMicrotasks();
+
+    const done = registry.getJob(job.id);
+    expect(done).not.toBeNull();
+    expect(done!.status).toBe("failed");
+    expect(done!.error).toEqual({ code: "unknown", message: "boom" });
+    expect(done!.result).toBeUndefined();
+    expect(done!.completedAt).toBeGreaterThanOrEqual(done!.startedAt ?? 0);
+  });
+
+  test("runner-provided `code` overrides the default `unknown`", async () => {
+    const registry = new MigrationJobRegistry();
+    const job = registry.startJob("import", async () => {
+      const err = new Error("invalid manifest") as Error & { code: string };
+      err.code = "invalid_manifest";
+      throw err;
+    });
+
+    await flushMicrotasks();
+
+    const done = registry.getJob(job.id);
+    expect(done!.status).toBe("failed");
+    expect(done!.error).toEqual({
+      code: "invalid_manifest",
+      message: "invalid manifest",
+    });
+  });
+
+  test("kFetchBodyError path: tagged error maps to `fetch_failed`", async () => {
+    const registry = new MigrationJobRegistry();
+    const job = registry.startJob("import", async () => {
+      const err = new Error("upstream hung up") as Error & {
+        upstreamStatus?: number;
+      };
+      (err as unknown as Record<symbol, boolean>)[kFetchBodyError] = true;
+      err.upstreamStatus = 502;
+      throw err;
+    });
+
+    await flushMicrotasks();
+
+    const done = registry.getJob(job.id);
+    expect(done).not.toBeNull();
+    expect(done!.status).toBe("failed");
+    expect(done!.error).toEqual({
+      code: "fetch_failed",
+      message: "upstream hung up",
+      upstreamStatus: 502,
+    });
+  });
+
+  test("kFetchBodyError without upstreamStatus omits the field", async () => {
+    const registry = new MigrationJobRegistry();
+    const job = registry.startJob("import", async () => {
+      const err = new Error("aborted") as Error;
+      (err as unknown as Record<symbol, boolean>)[kFetchBodyError] = true;
+      throw err;
+    });
+
+    await flushMicrotasks();
+
+    const done = registry.getJob(job.id)!;
+    expect(done.status).toBe("failed");
+    expect(done.error).toEqual({
+      code: "fetch_failed",
+      message: "aborted",
+    });
+    expect(done.error?.upstreamStatus).toBeUndefined();
+  });
+
+  test("concurrent limit: second same-type job rejects; other type is allowed", async () => {
+    const registry = new MigrationJobRegistry();
+
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    // First export is pending (microtask hasn't run yet) — second export
+    // immediately rejects on the still-pending first job.
+    const first = registry.startJob("export", async () => {
+      await gate;
+    });
+    expect(first.status).toBe("pending");
+
+    expect(() => registry.startJob("export", async () => {})).toThrow(
+      JobAlreadyInProgressError,
+    );
+
+    // Advance to running — a same-type attempt still rejects.
+    await flushMicrotasks();
+    expect(registry.getJob(first.id)!.status).toBe("running");
+
+    let caught: unknown = null;
+    try {
+      registry.startJob("export", async () => {});
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(JobAlreadyInProgressError);
+    expect((caught as JobAlreadyInProgressError).existingJobId).toBe(first.id);
+
+    // A job of the *other* type is allowed in parallel.
+    const importJob = registry.startJob("import", async () => "ok");
+    expect(importJob.type).toBe("import");
+    expect(importJob.id).not.toBe(first.id);
+
+    // Settle both before leaving the test so no promises leak.
+    release();
+    await flushMicrotasks();
+    expect(registry.getJob(first.id)!.status).toBe("complete");
+    expect(registry.getJob(importJob.id)!.status).toBe("complete");
+
+    // And now a new export is allowed since nothing is in flight.
+    const third = registry.startJob("export", async () => "again");
+    expect(third.status).toBe("pending");
+    await flushMicrotasks();
+    expect(registry.getJob(third.id)!.status).toBe("complete");
+  });
+
+  test("TTL sweep: completed jobs older than TTL are evicted", async () => {
+    const registry = new MigrationJobRegistry();
+    registry.completedJobTtlMs = 1_000; // 1s for test purposes
+
+    const job = registry.startJob("export", async () => "done");
+    await flushMicrotasks();
+    const completed = registry.getJob(job.id)!;
+    expect(completed.status).toBe("complete");
+
+    // Before TTL: sweep is a no-op.
+    const originalNow = Date.now;
+    try {
+      Date.now = () => (completed.completedAt ?? 0) + 500;
+      registry.sweep();
+      expect(registry.getJob(job.id)).not.toBeNull();
+      expect(registry.listJobs().map((j) => j.id)).toContain(job.id);
+
+      // Past TTL: sweep evicts the completed job.
+      Date.now = () => (completed.completedAt ?? 0) + 2_000;
+      registry.sweep();
+      expect(registry.getJob(job.id)).toBeNull();
+      expect(registry.listJobs().map((j) => j.id)).not.toContain(job.id);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  test("TTL sweep: failed jobs are also evicted past TTL", async () => {
+    const registry = new MigrationJobRegistry();
+    registry.completedJobTtlMs = 500;
+
+    const job = registry.startJob("import", async () => {
+      throw new Error("nope");
+    });
+    await flushMicrotasks();
+    const failed = registry.getJob(job.id)!;
+    expect(failed.status).toBe("failed");
+
+    const originalNow = Date.now;
+    try {
+      Date.now = () => (failed.completedAt ?? 0) + 10_000;
+      registry.sweep();
+      expect(registry.getJob(job.id)).toBeNull();
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  test("TTL sweep: running jobs are never evicted", async () => {
+    const registry = new MigrationJobRegistry();
+    registry.completedJobTtlMs = 1;
+
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const job = registry.startJob("export", async () => {
+      await gate;
+    });
+    await flushMicrotasks();
+    expect(registry.getJob(job.id)!.status).toBe("running");
+
+    const originalNow = Date.now;
+    try {
+      Date.now = () => Number.MAX_SAFE_INTEGER;
+      registry.sweep();
+      expect(registry.getJob(job.id)).not.toBeNull();
+    } finally {
+      Date.now = originalNow;
+    }
+
+    // Cleanup: let the runner resolve.
+    release();
+    await flushMicrotasks();
+  });
+
+  test("getJob returns null for unknown ids", () => {
+    const registry = new MigrationJobRegistry();
+    expect(registry.getJob("nope")).toBeNull();
+  });
+
+  test("JobAlreadyInProgressError carries the existing job id", () => {
+    const err = new JobAlreadyInProgressError("export", "abc-123");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("JobAlreadyInProgressError");
+    expect(err.existingJobId).toBe("abc-123");
+    expect(err.message).toContain("export");
+    expect(err.message).toContain("abc-123");
+  });
+
+  test("MigrationJob interface shape is preserved on success", async () => {
+    const registry = new MigrationJobRegistry();
+    const job = registry.startJob("export", async () => ({ bytes: 42 }));
+    await flushMicrotasks();
+    const done: MigrationJob = registry.getJob(job.id)!;
+    expect(done.id).toBe(job.id);
+    expect(done.type).toBe("export");
+    expect(done.status).toBe("complete");
+    expect(done.result).toEqual({ bytes: 42 });
+  });
+});

--- a/assistant/src/runtime/migrations/job-registry.ts
+++ b/assistant/src/runtime/migrations/job-registry.ts
@@ -133,6 +133,27 @@ function mapError(err: unknown): MigrationJobError {
  */
 const DEFAULT_COMPLETED_JOB_TTL_MS = 10 * 60 * 1000;
 
+/**
+ * Return a shallow clone of a `MigrationJob` that is decoupled from the
+ * internal registry record. The optional `error` object is spread so
+ * callers cannot mutate the stored error either. `result` is `unknown` by
+ * design — callers that pass mutable values in and then mutate them
+ * externally are already outside the registry's invariants.
+ */
+function cloneJob(job: MigrationJob): MigrationJob {
+  const snapshot: MigrationJob = {
+    id: job.id,
+    type: job.type,
+    status: job.status,
+    createdAt: job.createdAt,
+  };
+  if (job.startedAt !== undefined) snapshot.startedAt = job.startedAt;
+  if (job.completedAt !== undefined) snapshot.completedAt = job.completedAt;
+  if (job.error !== undefined) snapshot.error = { ...job.error };
+  if (job.result !== undefined) snapshot.result = job.result;
+  return snapshot;
+}
+
 export class MigrationJobRegistry {
   private readonly jobs = new Map<string, MigrationJob>();
   /** Tracks the single in-flight (pending or running) job id per type. */
@@ -142,9 +163,14 @@ export class MigrationJobRegistry {
   public completedJobTtlMs: number = DEFAULT_COMPLETED_JOB_TTL_MS;
 
   /**
-   * Start a new migration job. Returns the `MigrationJob` record
-   * synchronously (status `"pending"`); the runner is scheduled via
-   * `queueMicrotask` so the caller can poll immediately.
+   * Start a new migration job. Returns a snapshot of the `MigrationJob`
+   * record synchronously (status `"pending"`); the runner is scheduled via
+   * `queueMicrotask` so the caller can poll via `getJob(id)` immediately.
+   *
+   * The returned object is a shallow clone decoupled from the internal
+   * record so that external mutation cannot violate the single-in-flight
+   * invariant (e.g. flipping a running job's status to `"complete"` must
+   * not unblock a same-type `startJob` while the runner is still active).
    *
    * Throws `JobAlreadyInProgressError` if another job of the same type is
    * already pending or running.
@@ -200,15 +226,16 @@ export class MigrationJobRegistry {
         );
     });
 
-    return job;
+    return cloneJob(job);
   }
 
   public getJob(id: string): MigrationJob | null {
-    return this.jobs.get(id) ?? null;
+    const job = this.jobs.get(id);
+    return job ? cloneJob(job) : null;
   }
 
   public listJobs(): MigrationJob[] {
-    return Array.from(this.jobs.values());
+    return Array.from(this.jobs.values(), cloneJob);
   }
 
   /**

--- a/assistant/src/runtime/migrations/job-registry.ts
+++ b/assistant/src/runtime/migrations/job-registry.ts
@@ -1,0 +1,254 @@
+/**
+ * In-memory registry for async migration jobs (export/import).
+ *
+ * Each job has a UUID, a type, a lifecycle (`pending` -> `running` ->
+ * `complete`/`failed`), and optional result/error payloads. Runners are
+ * scheduled with `queueMicrotask` so `startJob` returns synchronously and
+ * callers can immediately poll the job record.
+ *
+ * At most one job of each `MigrationJobType` may be in-flight at a time;
+ * attempting to start a second one while another is pending or running
+ * rejects with `JobAlreadyInProgressError`.
+ *
+ * Completed/failed jobs are kept for `completedJobTtlMs` (default 10
+ * minutes) so clients can still fetch the final status after the runner
+ * finishes, then evicted by `sweep()` which is wired to a periodic
+ * `setInterval` on the singleton. The interval is `unref()`'d so it does
+ * not block process shutdown.
+ */
+
+import { randomUUID } from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type MigrationJobType = "export" | "import";
+
+export type MigrationJobStatus = "pending" | "running" | "complete" | "failed";
+
+export interface MigrationJobError {
+  code: string;
+  message: string;
+  upstreamStatus?: number;
+}
+
+export interface MigrationJob {
+  id: string;
+  type: MigrationJobType;
+  status: MigrationJobStatus;
+  createdAt: number;
+  startedAt?: number;
+  completedAt?: number;
+  error?: MigrationJobError;
+  result?: unknown;
+}
+
+/**
+ * Thrown by `MigrationJobRegistry.startJob` when a job of the same type
+ * is already pending or running.
+ */
+export class JobAlreadyInProgressError extends Error {
+  public readonly existingJobId: string;
+
+  constructor(type: MigrationJobType, existingJobId: string) {
+    super(
+      `A ${type} migration job is already in progress (id=${existingJobId}).`,
+    );
+    this.name = "JobAlreadyInProgressError";
+    this.existingJobId = existingJobId;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// kFetchBodyError — preserve the tag convention used by the URL-body import
+// path in `routes/migration-routes.ts`. An error object carrying this symbol
+// was thrown from a failed upstream fetch body; we translate it into
+// `error.code = "fetch_failed"` for clients.
+// ---------------------------------------------------------------------------
+
+const kFetchBodyError = Symbol.for("vellum.migrationImport.fetchBodyError");
+
+function isFetchBodyError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  return (err as unknown as Record<symbol, boolean>)[kFetchBodyError] === true;
+}
+
+function extractUpstreamStatus(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  const status = (err as { upstreamStatus?: unknown }).upstreamStatus;
+  return typeof status === "number" ? status : undefined;
+}
+
+function mapError(err: unknown): MigrationJobError {
+  const message =
+    err instanceof Error
+      ? err.message
+      : typeof err === "object" &&
+          err !== null &&
+          "message" in err &&
+          typeof (err as { message?: unknown }).message === "string"
+        ? (err as { message: string }).message
+        : String(err);
+
+  if (isFetchBodyError(err)) {
+    const mapped: MigrationJobError = {
+      code: "fetch_failed",
+      message,
+    };
+    const upstreamStatus = extractUpstreamStatus(err);
+    if (upstreamStatus !== undefined) {
+      mapped.upstreamStatus = upstreamStatus;
+    }
+    return mapped;
+  }
+
+  // Runner-provided override: `err.code` wins over the `"unknown"` default
+  // so callers that throw typed errors get their codes preserved.
+  const overrideCode =
+    typeof err === "object" &&
+    err !== null &&
+    typeof (err as { code?: unknown }).code === "string"
+      ? (err as { code: string }).code
+      : undefined;
+
+  const mapped: MigrationJobError = {
+    code: overrideCode ?? "unknown",
+    message,
+  };
+  const upstreamStatus = extractUpstreamStatus(err);
+  if (upstreamStatus !== undefined) {
+    mapped.upstreamStatus = upstreamStatus;
+  }
+  return mapped;
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Default TTL for completed/failed jobs before `sweep()` evicts them.
+ * Exposed as a class field so tests can override the singleton's value.
+ */
+const DEFAULT_COMPLETED_JOB_TTL_MS = 10 * 60 * 1000;
+
+export class MigrationJobRegistry {
+  private readonly jobs = new Map<string, MigrationJob>();
+  /** Tracks the single in-flight (pending or running) job id per type. */
+  private readonly inFlight = new Map<MigrationJobType, string>();
+
+  /** TTL for completed/failed jobs; mutable so tests can tighten it. */
+  public completedJobTtlMs: number = DEFAULT_COMPLETED_JOB_TTL_MS;
+
+  /**
+   * Start a new migration job. Returns the `MigrationJob` record
+   * synchronously (status `"pending"`); the runner is scheduled via
+   * `queueMicrotask` so the caller can poll immediately.
+   *
+   * Throws `JobAlreadyInProgressError` if another job of the same type is
+   * already pending or running.
+   */
+  public startJob<T>(
+    type: MigrationJobType,
+    runner: (job: MigrationJob) => Promise<T>,
+  ): MigrationJob {
+    const existingId = this.inFlight.get(type);
+    if (existingId !== undefined) {
+      const existing = this.jobs.get(existingId);
+      if (
+        existing &&
+        (existing.status === "pending" || existing.status === "running")
+      ) {
+        throw new JobAlreadyInProgressError(type, existingId);
+      }
+      // Stale entry (e.g. sweep raced with a new start) — clear it.
+      this.inFlight.delete(type);
+    }
+
+    const job: MigrationJob = {
+      id: randomUUID(),
+      type,
+      status: "pending",
+      createdAt: Date.now(),
+    };
+    this.jobs.set(job.id, job);
+    this.inFlight.set(type, job.id);
+
+    queueMicrotask(() => {
+      job.status = "running";
+      job.startedAt = Date.now();
+      Promise.resolve()
+        .then(() => runner(job))
+        .then(
+          (result) => {
+            job.status = "complete";
+            job.completedAt = Date.now();
+            job.result = result;
+            if (this.inFlight.get(type) === job.id) {
+              this.inFlight.delete(type);
+            }
+          },
+          (err: unknown) => {
+            job.status = "failed";
+            job.completedAt = Date.now();
+            job.error = mapError(err);
+            if (this.inFlight.get(type) === job.id) {
+              this.inFlight.delete(type);
+            }
+          },
+        );
+    });
+
+    return job;
+  }
+
+  public getJob(id: string): MigrationJob | null {
+    return this.jobs.get(id) ?? null;
+  }
+
+  public listJobs(): MigrationJob[] {
+    return Array.from(this.jobs.values());
+  }
+
+  /**
+   * Drop completed/failed jobs whose `completedAt` is older than
+   * `completedJobTtlMs`. Pending/running jobs are always retained.
+   */
+  public sweep(): void {
+    const now = Date.now();
+    for (const [id, job] of this.jobs) {
+      if (job.status !== "complete" && job.status !== "failed") continue;
+      const completedAt = job.completedAt;
+      if (completedAt === undefined) continue;
+      if (now - completedAt >= this.completedJobTtlMs) {
+        this.jobs.delete(id);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton + sweep interval
+// ---------------------------------------------------------------------------
+
+/** Process-wide registry used by migration routes. */
+export const migrationJobs = new MigrationJobRegistry();
+
+/**
+ * How often the sweep runs. The singleton wires this via `setInterval`;
+ * the interval is `unref()`'d so it does not keep the event loop alive
+ * during shutdown. Tests that need to stop the interval can call
+ * `clearInterval(sweepIntervalId)`.
+ */
+const SWEEP_INTERVAL_MS = 60 * 1000;
+
+export const sweepIntervalId: NodeJS.Timeout = setInterval(() => {
+  migrationJobs.sweep();
+}, SWEEP_INTERVAL_MS);
+
+// `.unref()` exists on Node/Bun Timeout objects. Guard defensively in case
+// an alternative runtime returns a plain number.
+if (typeof (sweepIntervalId as { unref?: () => void }).unref === "function") {
+  (sweepIntervalId as { unref: () => void }).unref();
+}


### PR DESCRIPTION
## Summary
- Adds `MigrationJobRegistry` and singleton `migrationJobs` for tracking async export/import jobs in the local runtime.
- Preserves the `kFetchBodyError` error-code convention used by the existing URL-body import path.
- TTL sweep via unref'd setInterval keeps completed jobs discoverable for 10 minutes then evicts them.

Part of plan: teleport-gcs-unify.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
