### PR TITLE
fix: update stale send_notification tool references to CLI command

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -145,10 +145,10 @@ Telegram is supported as a messaging provider with limited capabilities compared
 
 ## Notifications vs Messages
 
-- `send_notification` is provided by the **notifications** skill (always active) -- use it when the user asks for an alert/notification (for example "send this as a desktop notification").
+- Notifications are sent via the **notifications** skill (always active) using `assistant notifications send` in `bash` -- use it when the user asks for an alert/notification (for example "send this as a desktop notification").
 - Use `messaging_send` when the user asks to send a message into a specific chat/email destination.
-- `send_notification` channel routing is LLM-driven; `preferred_channels` are hints, not hard channel forcing.
-- Before using `messaging_send` or `send_notification`, look up the recipient's contact record with `contact_search` to inform tone and content (see **Recipient Context** below).
+- Notification channel routing is LLM-driven; `--preferred-channels` are hints, not hard channel forcing.
+- Before using `messaging_send` or sending a notification, look up the recipient's contact record with `contact_search` to inform tone and content (see **Recipient Context** below).
 
 ## Personalized Drafting
 

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -189,7 +189,7 @@ Scheduled messages run without user interaction. If the task produces output tha
 Choose the right delivery tool based on the content:
 
 - **Rich content** (digests, summaries, reports): For Gmail, use `messaging_send` with the target platform and conversation ID. For Slack, use the Slack Web API directly via CLI (`chat.postMessage`). This preserves the full content and posts directly.
-- **Short alerts** (status updates, completion notices): Use `send_notification` to let the notification router pick the best channel. Note: the router's decision engine rewrites content into short alerts, so it is not suitable for rich content.
+- **Short alerts** (status updates, completion notices): Use `assistant notifications send` via `bash` to let the notification router pick the best channel. Note: the router's decision engine rewrites content into short alerts, so it is not suitable for rich content.
 
 Example schedule message for a Slack digest:
 

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -86,7 +86,7 @@ When you need to send a DM or look up a Slack user by name, check contacts first
 ## Delivery Notes
 
 - For rich content (digests, reports, formatted summaries): use the Slack API directly via `chat.postMessage` with blocks
-- For short alerts: `send_notification` is fine — it lets the notification router pick the best channel
+- For short alerts: `assistant notifications send` via `bash` is fine — it lets the notification router pick the best channel
 - For scheduled tasks: always include an explicit Slack API call to deliver results, otherwise output only lives in the conversation log
 
 ## Threading

--- a/skills/time-based-actions/SKILL.md
+++ b/skills/time-based-actions/SKILL.md
@@ -22,22 +22,22 @@ Quick-reference decision guide for choosing the right tool when users ask about 
    - Examples: "every day at 9am", "weekly on Mondays", "every 2 hours"
 
 3. **Does the request need an alert RIGHT NOW (no delay)?**
-   - YES -> `send_notification`
+   - YES -> `assistant notifications send` via `bash`
    - Examples: "send me a notification", "alert me now", "ping me"
 
 4. **Is the request about tracking work with no time trigger?**
    - YES -> `task_list_add`
    - Examples: "add to my tasks", "remind me to do X" (no time), "put this on my list"
 
-## Critical Warning: `send_notification` is IMMEDIATE-ONLY
+## Critical Warning: `assistant notifications send` is IMMEDIATE-ONLY
 
-`send_notification` fires **instantly** when called. It has **NO delay, scheduling, or future-time capability**. NEVER use it for:
+`assistant notifications send` fires **instantly** when called. It has **NO delay, scheduling, or future-time capability**. NEVER use it for:
 
 - "Remind me in 5 minutes" -> use `reminder_create`
 - "Alert me at 3pm" -> use `reminder_create`
 - "Notify me tomorrow" -> use `reminder_create`
 
-If you use `send_notification` for any of these, the notification fires immediately and the user misses their intended reminder.
+If you use `assistant notifications send` for any of these, the notification fires immediately and the user misses their intended reminder.
 
 ## Critical Warning: `task_list_add` has NO time trigger
 
@@ -162,5 +162,5 @@ Use the following heuristics to pick `routing_intent`:
 | ------------------- | ---------------------- | ---------------- | --------------------------------------------- |
 | `reminder_create`   | Future time (one-shot) | No               | Timed notification or timed autonomous action |
 | `schedule_create`   | Recurring pattern      | Yes (cron/RRULE) | Recurring automated jobs                      |
-| `send_notification` | **Immediate only**     | No               | Alert the user right now                      |
+| `assistant notifications send` | **Immediate only** | No           | Alert the user right now                      |
 | `task_list_add`     | **No time trigger**    | No               | Track work in the task queue                  |

--- a/skills/time-based-actions/SKILL.md
+++ b/skills/time-based-actions/SKILL.md
@@ -139,28 +139,30 @@ Use the following heuristics to pick `routing_intent`:
   3. If neither field is present or the interface is `cli`, omit `preferred_channels`.
 
   When a channel is determined, include it as a routing hint:
+
   ```
   routing_hints: { preferred_channels: ["<resolved channel>"] }
   routing_intent: "all_channels"
   ```
+
 - **Never use `single_channel` as a passive default.** If you haven't thought about which channel to use, use `all_channels`.
 
 ### Examples
 
-| Scenario                                                    | routing_intent   | routing_hints                          |
-| ----------------------------------------------------------- | ---------------- | -------------------------------------- |
-| `source_channel: telegram` in turn_context                  | `all_channels`   | `{ preferred_channels: ["telegram"] }` |
-| No `source_channel`, `interface: macos`                     | `all_channels`   | `{ preferred_channels: ["vellum"] }`   |
-| No `source_channel`, `interface: ios`                       | `all_channels`   | `{ preferred_channels: ["vellum"] }`   |
-| User says "remind me on Telegram"                           | `single_channel` | `{ preferred_channels: ["telegram"] }` |
-| No `source_channel`, `interface: cli`                       | `all_channels`   | `{}`                                   |
-| No channel info available                                   | `all_channels`   | `{}`                                   |
+| Scenario                                   | routing_intent   | routing_hints                          |
+| ------------------------------------------ | ---------------- | -------------------------------------- |
+| `source_channel: telegram` in turn_context | `all_channels`   | `{ preferred_channels: ["telegram"] }` |
+| No `source_channel`, `interface: macos`    | `all_channels`   | `{ preferred_channels: ["vellum"] }`   |
+| No `source_channel`, `interface: ios`      | `all_channels`   | `{ preferred_channels: ["vellum"] }`   |
+| User says "remind me on Telegram"          | `single_channel` | `{ preferred_channels: ["telegram"] }` |
+| No `source_channel`, `interface: cli`      | `all_channels`   | `{}`                                   |
+| No channel info available                  | `all_channels`   | `{}`                                   |
 
 ## Tool Summary
 
-| Tool                | Timing                 | Recurrence       | Purpose                                       |
-| ------------------- | ---------------------- | ---------------- | --------------------------------------------- |
-| `reminder_create`   | Future time (one-shot) | No               | Timed notification or timed autonomous action |
-| `schedule_create`   | Recurring pattern      | Yes (cron/RRULE) | Recurring automated jobs                      |
-| `assistant notifications send` | **Immediate only** | No           | Alert the user right now                      |
-| `task_list_add`     | **No time trigger**    | No               | Track work in the task queue                  |
+| Tool                           | Timing                 | Recurrence       | Purpose                                       |
+| ------------------------------ | ---------------------- | ---------------- | --------------------------------------------- |
+| `reminder_create`              | Future time (one-shot) | No               | Timed notification or timed autonomous action |
+| `schedule_create`              | Recurring pattern      | Yes (cron/RRULE) | Recurring automated jobs                      |
+| `assistant notifications send` | **Immediate only**     | No               | Alert the user right now                      |
+| `task_list_add`                | **No time trigger**    | No               | Track work in the task queue                  |


### PR DESCRIPTION
## Summary
- Update all skill docs that referenced `send_notification` as a callable tool to reference `assistant notifications send` via bash instead
- Fixes stale references in messaging, schedule, time-based-actions, and slack skill docs after the notifications skill was unbundled in #27692

## Original prompt
Update stale send_notification tool references in bundled skill docs after the notifications skill was unbundled (PR #27692).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
