### PR TITLE
fix: update onboarding name exchange labels to question format

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -78,7 +78,7 @@ struct NameExchangeView: View {
             VStack(spacing: VSpacing.lg) {
                 // "I'll call you..." field
                 VTextField(
-                    "I'll call you...",
+                    "What's your name?",
                     placeholder: "Your name",
                     text: $userName
                 )
@@ -86,7 +86,7 @@ struct NameExchangeView: View {
                 // "Call me..." field + suggestion pills
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     VTextField(
-                        "Call me...",
+                        "What should I go by?",
                         placeholder: "Assistant name",
                         text: $assistantName
                     )


### PR DESCRIPTION
## Summary
- Updates the NameExchangeView field labels from imperative style ("I'll call you...", "Call me...") to question format ("What's your name?", "What should I go by?") to match the design mock.

## Test plan
- [ ] Launch the app and go through the prechat onboarding flow
- [ ] Verify the last step shows "What's your name?" and "What should I go by?" as field labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
