### PR TITLE
feat(runtime): add unified migration job status endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5762,6 +5762,111 @@ paths:
                   - conflicts
                   - manifest
                 additionalProperties: false
+  /v1/migrations/jobs/{job_id}:
+    get:
+      operationId: migrations_jobs_by_job_id_get
+      summary: Get migration job status
+      description:
+        "Return the current status of an async migration job (export or import). The response discriminates on
+        `status`: `processing` (pending or running), `complete` (with `result`), or `failed` (with `error`,
+        `error_code`, optional `upstream_status`). The `processing` value mirrors the platform's transport shape so CLI
+        clients can share a single parser across the platform and the daemon."
+      tags:
+        - migrations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    properties:
+                      job_id:
+                        type: string
+                      type:
+                        type: string
+                        enum:
+                          - export
+                          - import
+                      status:
+                        type: string
+                        const: processing
+                    required:
+                      - job_id
+                      - type
+                      - status
+                    additionalProperties: false
+                  - type: object
+                    properties:
+                      job_id:
+                        type: string
+                      type:
+                        type: string
+                        enum:
+                          - export
+                          - import
+                      status:
+                        type: string
+                        const: complete
+                      result: {}
+                    required:
+                      - job_id
+                      - type
+                      - status
+                      - result
+                    additionalProperties: false
+                  - type: object
+                    properties:
+                      job_id:
+                        type: string
+                      type:
+                        type: string
+                        enum:
+                          - export
+                          - import
+                      status:
+                        type: string
+                        const: failed
+                      error:
+                        type: string
+                      error_code:
+                        type: string
+                      upstream_status:
+                        type: integer
+                        minimum: -9007199254740991
+                        maximum: 9007199254740991
+                    required:
+                      - job_id
+                      - type
+                      - status
+                      - error
+                      - error_code
+                    additionalProperties: false
+        "404":
+          description: "No job matches the given id. Body shape: { error: { code: 'job_not_found' } }."
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - job_not_found
+                    required:
+                      - code
+                required:
+                  - error
+      parameters:
+        - name: job_id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/migrations/validate:
     post:
       operationId: migrations_validate_post

--- a/assistant/src/__tests__/migration-jobs-status.test.ts
+++ b/assistant/src/__tests__/migration-jobs-status.test.ts
@@ -1,0 +1,179 @@
+/**
+ * HTTP-layer tests for GET /v1/migrations/jobs/:job_id.
+ *
+ * Covered:
+ * - 404 `{ error: { code: "job_not_found" } }` for an unknown id.
+ * - `processing` response shape for a job that is still running (runner
+ *   blocked on a deferred gate).
+ * - `complete` response shape including the runner's `result`.
+ * - `failed` response shape — confirms `error_code`, `error` message, and
+ *   the optional `upstream_status` field are all populated when the runner
+ *   throws a `kFetchBodyError`-tagged error with `upstreamStatus`.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  getGatewayPort: () => 7830,
+  getRuntimeHttpPort: () => 7821,
+  getRuntimeHttpHost: () => "127.0.0.1",
+  getRuntimeGatewayOriginSecret: () => undefined,
+  getIngressPublicBaseUrl: () => undefined,
+  setIngressPublicBaseUrl: () => {},
+}));
+
+import { migrationJobs } from "../runtime/migrations/job-registry.js";
+import { handleMigrationJobStatus } from "../runtime/routes/migration-routes.js";
+
+const kFetchBodyError = Symbol.for("vellum.migrationImport.fetchBodyError");
+
+/** Spin the microtask queue so `queueMicrotask`-scheduled work runs. */
+async function flushMicrotasks(n = 4): Promise<void> {
+  for (let i = 0; i < n; i++) {
+    await Promise.resolve();
+  }
+}
+
+function makeRequest(): Request {
+  return new Request("http://127.0.0.1/v1/migrations/jobs/any");
+}
+
+describe("GET /v1/migrations/jobs/:job_id", () => {
+  test("404 job_not_found for unknown id", async () => {
+    const response = await handleMigrationJobStatus(makeRequest(), {
+      job_id: "00000000-0000-0000-0000-000000000000",
+    });
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("job_not_found");
+  });
+
+  test("processing status while the runner is still running", async () => {
+    // Keep the runner blocked so the job stays in `running` state.
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const job = migrationJobs.startJob("export", async () => {
+      await gate;
+      return { ok: true };
+    });
+    // Let `queueMicrotask` flip status from `pending` to `running`.
+    await flushMicrotasks();
+
+    try {
+      const response = await handleMigrationJobStatus(makeRequest(), {
+        job_id: job.id,
+      });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        job_id: string;
+        type: string;
+        status: string;
+      };
+      expect(body.job_id).toBe(job.id);
+      expect(body.type).toBe("export");
+      expect(body.status).toBe("processing");
+    } finally {
+      // Release the runner so the registry's in-flight slot frees up for
+      // other tests (and the job transitions to complete cleanly).
+      release();
+      await flushMicrotasks();
+    }
+  });
+
+  test("complete status includes the runner's result", async () => {
+    const resultPayload = { files_written: 3, manifest: { schema: "vbundle/1" } };
+
+    const job = migrationJobs.startJob("export", async () => resultPayload);
+    await flushMicrotasks();
+
+    const response = await handleMigrationJobStatus(makeRequest(), {
+      job_id: job.id,
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      job_id: string;
+      type: string;
+      status: string;
+      result: unknown;
+    };
+    expect(body.job_id).toBe(job.id);
+    expect(body.type).toBe("export");
+    expect(body.status).toBe("complete");
+    expect(body.result).toEqual(resultPayload);
+  });
+
+  test("failed status exposes error, error_code, and upstream_status", async () => {
+    const job = migrationJobs.startJob("import", async () => {
+      const err = new Error("upstream hung up") as Error & {
+        upstreamStatus?: number;
+      };
+      (err as unknown as Record<symbol, boolean>)[kFetchBodyError] = true;
+      err.upstreamStatus = 502;
+      throw err;
+    });
+    await flushMicrotasks();
+
+    const response = await handleMigrationJobStatus(makeRequest(), {
+      job_id: job.id,
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      job_id: string;
+      type: string;
+      status: string;
+      error: string;
+      error_code: string;
+      upstream_status?: number;
+    };
+    expect(body.job_id).toBe(job.id);
+    expect(body.type).toBe("import");
+    expect(body.status).toBe("failed");
+    expect(body.error).toBe("upstream hung up");
+    expect(body.error_code).toBe("fetch_failed");
+    expect(body.upstream_status).toBe(502);
+  });
+
+  test("failed status omits upstream_status when the runner error has none", async () => {
+    const job = migrationJobs.startJob("export", async () => {
+      const err = new Error("invalid manifest") as Error & { code: string };
+      err.code = "invalid_manifest";
+      throw err;
+    });
+    await flushMicrotasks();
+
+    const response = await handleMigrationJobStatus(makeRequest(), {
+      job_id: job.id,
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("failed");
+    expect(body.error).toBe("invalid manifest");
+    expect(body.error_code).toBe("invalid_manifest");
+    expect(body.upstream_status).toBeUndefined();
+  });
+});

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -445,6 +445,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "migrations/export", scopes: ["settings.write"] },
   { endpoint: "migrations/import-preflight", scopes: ["settings.write"] },
   { endpoint: "migrations/import", scopes: ["settings.write"] },
+  { endpoint: "migrations/jobs", scopes: ["settings.read"] },
 
   // Backups
   { endpoint: "backups", scopes: ["settings.read"] },

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -47,6 +47,7 @@ import {
   validateGcsSignedUrl,
   type ValidateGcsSignedUrlOptions,
 } from "../migrations/gcs-signed-url.js";
+import { migrationJobs } from "../migrations/job-registry.js";
 import { streamExportVBundle } from "../migrations/vbundle-builder.js";
 import {
   analyzeImport,
@@ -1134,6 +1135,70 @@ function importCommitFailureResponse(
 }
 
 // ---------------------------------------------------------------------------
+// GET /v1/migrations/jobs/:job_id
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /v1/migrations/jobs/:job_id
+ *
+ * Returns the current status of a migration job tracked by
+ * `MigrationJobRegistry`. The response shape is a discriminated union on
+ * `status`:
+ *
+ *   - `{ job_id, type, status: "processing" }`
+ *     Covers both the internal `pending` and `running` states — collapsed
+ *     into a single wire value to match the platform's transport shape used
+ *     by `ExportStatusProcessingSerializer` / `ImportStatusProcessingSerializer`.
+ *   - `{ job_id, type, status: "complete", result }`
+ *   - `{ job_id, type, status: "failed", error, error_code, upstream_status? }`
+ *
+ * 404 `{ error: { code: "job_not_found" } }` when no job matches the id.
+ */
+export async function handleMigrationJobStatus(
+  _req: Request,
+  params: { job_id: string },
+): Promise<Response> {
+  const job = migrationJobs.getJob(params.job_id);
+  if (job === null) {
+    return Response.json(
+      { error: { code: "job_not_found" } },
+      { status: 404 },
+    );
+  }
+
+  if (job.status === "complete") {
+    return Response.json({
+      job_id: job.id,
+      type: job.type,
+      status: "complete",
+      result: job.result,
+    });
+  }
+
+  if (job.status === "failed") {
+    const error = job.error;
+    const body: Record<string, unknown> = {
+      job_id: job.id,
+      type: job.type,
+      status: "failed",
+      error: error?.message ?? "unknown",
+      error_code: error?.code ?? "unknown",
+    };
+    if (error?.upstreamStatus !== undefined) {
+      body.upstream_status = error.upstreamStatus;
+    }
+    return Response.json(body);
+  }
+
+  // pending or running — collapse to the platform's "processing" wire value.
+  return Response.json({
+    job_id: job.id,
+    type: job.type,
+    status: "processing",
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
 
@@ -1250,6 +1315,56 @@ export function migrationRouteDefinitions(): RouteDefinition[] {
         warnings: z.array(z.unknown()),
       }),
       handler: async ({ req }) => handleMigrationImport(req),
+    },
+    {
+      endpoint: "migrations/jobs/:job_id",
+      method: "GET",
+      summary: "Get migration job status",
+      description:
+        "Return the current status of an async migration job (export or import). The response discriminates on `status`: `processing` (pending or running), `complete` (with `result`), or `failed` (with `error`, `error_code`, optional `upstream_status`). The `processing` value mirrors the platform's transport shape so CLI clients can share a single parser across the platform and the daemon.",
+      tags: ["migrations"],
+      responseBody: z.discriminatedUnion("status", [
+        z.object({
+          job_id: z.string(),
+          type: z.enum(["export", "import"]),
+          status: z.literal("processing"),
+        }),
+        z.object({
+          job_id: z.string(),
+          type: z.enum(["export", "import"]),
+          status: z.literal("complete"),
+          result: z.unknown(),
+        }),
+        z.object({
+          job_id: z.string(),
+          type: z.enum(["export", "import"]),
+          status: z.literal("failed"),
+          error: z.string(),
+          error_code: z.string(),
+          upstream_status: z.number().int().optional(),
+        }),
+      ]),
+      additionalResponses: {
+        "404": {
+          description:
+            "No job matches the given id. Body shape: { error: { code: 'job_not_found' } }.",
+          schema: {
+            type: "object",
+            properties: {
+              error: {
+                type: "object",
+                properties: {
+                  code: { type: "string", enum: ["job_not_found"] },
+                },
+                required: ["code"],
+              },
+            },
+            required: ["error"],
+          },
+        },
+      },
+      handler: ({ req, params }) =>
+        handleMigrationJobStatus(req, { job_id: params.job_id }),
     },
   ];
 }


### PR DESCRIPTION
## Summary
- Adds `GET /v1/migrations/jobs/:job_id` returning a discriminated-union status response (processing | complete | failed) for both export and import jobs.
- Mirrors the platform's transport shape so CLI clients can poll either side with the same parser.

Part of plan: teleport-gcs-unify.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
