### PR TITLE
Revert: move CLI IPC socket from workspace to protected directory

### DIFF
--- a/assistant/src/__tests__/platform.test.ts
+++ b/assistant/src/__tests__/platform.test.ts
@@ -59,9 +59,8 @@ afterEach(() => {
 // otherwise under ~/.vellum/workspace.
 describe("path characterization", () => {
   test("all path helpers resolve to expected locations", () => {
-    // Without VELLUM_WORKSPACE_DIR or BASE_DATA_DIR override, everything is under ~/.vellum
+    // Without VELLUM_WORKSPACE_DIR override, workspace is under ~/.vellum
     delete process.env.VELLUM_WORKSPACE_DIR;
-    delete process.env.BASE_DATA_DIR;
     const root = join(homedir(), ".vellum");
     const ws = getWorkspaceDir();
     const data = getDataDir();
@@ -88,7 +87,6 @@ describe("path characterization", () => {
   });
 
   test("VELLUM_WORKSPACE_DIR overrides workspace location", () => {
-    delete process.env.BASE_DATA_DIR;
     process.env.VELLUM_WORKSPACE_DIR = "/tmp/custom-workspace";
     expect(getWorkspaceDir()).toBe("/tmp/custom-workspace");
     expect(getDataDir()).toBe("/tmp/custom-workspace/data");
@@ -117,7 +115,6 @@ describe("path characterization", () => {
 
   test("hooks directory is inside the workspace boundary", () => {
     delete process.env.VELLUM_WORKSPACE_DIR;
-    delete process.env.BASE_DATA_DIR;
     expect(getWorkspaceHooksDir().startsWith(getWorkspaceDir())).toBe(true);
   });
 
@@ -125,7 +122,6 @@ describe("path characterization", () => {
     // Use a temp VELLUM_WORKSPACE_DIR so ensureDataDir writes to a temp dir
     // rather than the real ~/.vellum. Root-level dirs still go to ~/.vellum
     // but we only verify workspace dirs here to avoid side effects.
-    delete process.env.BASE_DATA_DIR;
     const wsDir = join(tmpdir(), `platform-test-ws-${Date.now()}`);
     process.env.VELLUM_WORKSPACE_DIR = wsDir;
 

--- a/assistant/src/__tests__/test-preload.ts
+++ b/assistant/src/__tests__/test-preload.ts
@@ -20,16 +20,10 @@ import { installGatewayIpcMock } from "../__tests__/mock-gateway-ipc.js";
 import { resetDb } from "../memory/db-connection.js";
 import { _setStorePath } from "../security/encrypted-store.js";
 
-const savedBaseDataDir = process.env.BASE_DATA_DIR;
-
 const testDir = realpathSync(
   mkdtempSync(join(tmpdir(), "vellum-test-workspace-")),
 );
 process.env.VELLUM_WORKSPACE_DIR = testDir;
-// Also set BASE_DATA_DIR so that vellumRoot() (and all derived paths like
-// getProtectedDir()) resolve under the temp dir. This gives each test file
-// its own IPC socket path, preventing socket races between parallel files.
-process.env.BASE_DATA_DIR = testDir;
 process.env.VELLUM_PLATFORM_URL = "https://test-platform.vellum.ai";
 process.exitCode = 0;
 
@@ -62,11 +56,6 @@ afterAll(() => {
   process.exitCode = 0;
   delete process.env.VELLUM_WORKSPACE_DIR;
   delete process.env.VELLUM_PLATFORM_URL;
-  if (savedBaseDataDir !== undefined) {
-    process.env.BASE_DATA_DIR = savedBaseDataDir;
-  } else {
-    delete process.env.BASE_DATA_DIR;
-  }
   if (savedIsContainerized !== undefined) {
     process.env.IS_CONTAINERIZED = savedIsContainerized;
   }

--- a/assistant/src/ipc/__tests__/socket-path.test.ts
+++ b/assistant/src/ipc/__tests__/socket-path.test.ts
@@ -1,28 +1,67 @@
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { resolveIpcSocketPath } from "../socket-path.js";
 
-const LONG_BASE_DIR =
-  "/Users/alice-johnson/.local/share/vellum-dev/assistants/vellum-safe-dace-8hrt6e/.vellum/workspace";
+const LONG_WORKSPACE_DIR =
+  "/Users/noaflaherty/.local/share/vellum-dev/assistants/vellum-safe-dace-8hrt6e/.vellum/workspace";
+
+let savedWorkspaceDir: string | undefined;
+let savedBaseDataDir: string | undefined;
+
+beforeEach(() => {
+  savedWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  savedBaseDataDir = process.env.BASE_DATA_DIR;
+});
+
+afterEach(() => {
+  if (savedWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = savedWorkspaceDir;
+  }
+  if (savedBaseDataDir === undefined) {
+    delete process.env.BASE_DATA_DIR;
+  } else {
+    process.env.BASE_DATA_DIR = savedBaseDataDir;
+  }
+});
 
 describe("resolveIpcSocketPath", () => {
-  test("uses protected dir path when it is within the platform limit", () => {
-    const resolved = resolveIpcSocketPath(
-      "assistant-cli.sock",
-      "/tmp/vellum-test",
-    );
+  test("uses workspace path when it is within the platform limit", () => {
+    process.env.VELLUM_WORKSPACE_DIR = "/tmp/vellum-workspace-test";
+    delete process.env.BASE_DATA_DIR;
 
-    expect(resolved.source).toBe("protected");
-    expect(resolved.path).toBe("/tmp/vellum-test/assistant-cli.sock");
+    const resolved = resolveIpcSocketPath("assistant-cli.sock");
+
+    expect(resolved.source).toBe("workspace");
+    expect(resolved.path).toBe("/tmp/vellum-workspace-test/assistant-cli.sock");
     expect(Buffer.byteLength(resolved.path, "utf8")).toBeLessThanOrEqual(
       resolved.maxPathBytes,
     );
   });
 
-  test("falls back to tmpdir hash path when preferred path is too long", () => {
-    const resolved = resolveIpcSocketPath("assistant-cli.sock", LONG_BASE_DIR);
+  test("falls back to BASE_DATA_DIR/ipc when workspace path is too long", () => {
+    process.env.VELLUM_WORKSPACE_DIR = LONG_WORKSPACE_DIR;
+    process.env.BASE_DATA_DIR = "/tmp/vellum-instance-test";
+
+    const resolved = resolveIpcSocketPath("assistant-cli.sock");
+
+    expect(resolved.source).toBe("base-data-dir");
+    expect(resolved.path).toBe(
+      "/tmp/vellum-instance-test/ipc/assistant-cli.sock",
+    );
+    expect(Buffer.byteLength(resolved.path, "utf8")).toBeLessThanOrEqual(
+      resolved.maxPathBytes,
+    );
+  });
+
+  test("falls back to tmpdir hash path when workspace path is too long and BASE_DATA_DIR is absent", () => {
+    process.env.VELLUM_WORKSPACE_DIR = LONG_WORKSPACE_DIR;
+    delete process.env.BASE_DATA_DIR;
+
+    const resolved = resolveIpcSocketPath("assistant-cli.sock");
 
     expect(resolved.source).toBe("tmp-hash");
     expect(resolved.path.startsWith(join(tmpdir(), "vellum-ipc"))).toBe(true);

--- a/assistant/src/ipc/cli-client.ts
+++ b/assistant/src/ipc/cli-client.ts
@@ -5,7 +5,7 @@
  * Returns a typed result object so callers can distinguish success
  * from connection failures and method errors.
  *
- * The preferred socket path is `{protectedDir}/assistant-cli.sock`, with a
+ * The preferred socket path is `{workspaceDir}/assistant-cli.sock`, with a
  * deterministic fallback for long AF_UNIX paths.
  */
 

--- a/assistant/src/ipc/cli-server.ts
+++ b/assistant/src/ipc/cli-server.ts
@@ -10,7 +10,7 @@
  * - Request:  { "id": string, "method": string, "params"?: Record<string, unknown> }
  * - Response: { "id": string, "result"?: unknown, "error"?: string }
  *
- * The preferred socket path is `{protectedDir}/assistant-cli.sock`. On
+ * The preferred socket path is `{workspaceDir}/assistant-cli.sock`. On
  * platforms with strict AF_UNIX path limits (notably macOS), the server falls
  * back to a shorter deterministic path so CLI commands can still connect.
  */
@@ -64,11 +64,11 @@ export class CliIpcServer {
   constructor() {
     const socketResolution = resolveIpcSocketPath("assistant-cli.sock");
     this.socketPath = socketResolution.path;
-    if (socketResolution.source !== "protected") {
+    if (socketResolution.source !== "workspace") {
       log.warn(
         {
           source: socketResolution.source,
-          preferredPath: socketResolution.preferredPath,
+          workspacePath: socketResolution.workspacePath,
           resolvedPath: socketResolution.path,
           maxPathBytes: socketResolution.maxPathBytes,
         },

--- a/assistant/src/ipc/gateway-client.ts
+++ b/assistant/src/ipc/gateway-client.ts
@@ -12,7 +12,6 @@
 import { connect, type Socket } from "node:net";
 
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
 import { resolveIpcSocketPath } from "./socket-path.js";
 
 const log = getLogger("gateway-ipc-client");
@@ -177,7 +176,5 @@ export async function ipcGetFeatureFlags(): Promise<Record<string, boolean>> {
 // ---------------------------------------------------------------------------
 
 function getGatewaySocketPath(): string {
-  // The gateway server binds its socket under the workspace directory,
-  // so the client must resolve with getWorkspaceDir() to match.
-  return resolveIpcSocketPath("gateway.sock", getWorkspaceDir()).path;
+  return resolveIpcSocketPath("gateway.sock").path;
 }

--- a/assistant/src/ipc/socket-path.ts
+++ b/assistant/src/ipc/socket-path.ts
@@ -2,18 +2,23 @@ import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { getProtectedDir } from "../util/platform.js";
+import { getWorkspaceDir } from "../util/platform.js";
 
 const DARWIN_UNIX_SOCKET_MAX_PATH_BYTES = 103;
 const DEFAULT_UNIX_SOCKET_MAX_PATH_BYTES = 107;
 const IPC_TMP_DIR_NAME = "vellum-ipc";
+const IPC_BASE_DATA_DIR_NAME = "ipc";
 
-export type IpcSocketPathSource = "protected" | "tmp-hash" | "tmp-short-hash";
+export type IpcSocketPathSource =
+  | "workspace"
+  | "base-data-dir"
+  | "tmp-hash"
+  | "tmp-short-hash";
 
 export interface IpcSocketPathResolution {
   path: string;
   source: IpcSocketPathSource;
-  preferredPath: string;
+  workspacePath: string;
   maxPathBytes: number;
 }
 
@@ -27,12 +32,18 @@ function isPathWithinSocketLimit(path: string, maxPathBytes: number): boolean {
   return Buffer.byteLength(path, "utf8") <= maxPathBytes;
 }
 
+function buildBaseDataDirCandidate(socketFileName: string): string | null {
+  const baseDataDir = process.env.BASE_DATA_DIR?.trim();
+  if (!baseDataDir) return null;
+  return join(baseDataDir, IPC_BASE_DATA_DIR_NAME, socketFileName);
+}
+
 function buildTmpCandidate(
-  preferredPath: string,
+  workspacePath: string,
   socketFileName: string,
 ): { hashedPath: string; shortPath: string } {
   const hash = createHash("sha256")
-    .update(preferredPath)
+    .update(workspacePath)
     .digest("hex")
     .slice(0, 12);
   return {
@@ -43,26 +54,39 @@ function buildTmpCandidate(
 
 export function resolveIpcSocketPath(
   socketFileName: string,
-  baseDir: string = getProtectedDir(),
+  workspaceDir: string = getWorkspaceDir(),
 ): IpcSocketPathResolution {
   const maxPathBytes = getUnixSocketMaxPathBytes();
-  const preferredPath = join(baseDir, socketFileName);
+  const workspacePath = join(workspaceDir, socketFileName);
 
-  if (isPathWithinSocketLimit(preferredPath, maxPathBytes)) {
+  if (isPathWithinSocketLimit(workspacePath, maxPathBytes)) {
     return {
-      path: preferredPath,
-      source: "protected",
-      preferredPath,
+      path: workspacePath,
+      source: "workspace",
+      workspacePath,
       maxPathBytes,
     };
   }
 
-  const tmpCandidate = buildTmpCandidate(preferredPath, socketFileName);
+  const baseDataDirCandidate = buildBaseDataDirCandidate(socketFileName);
+  if (
+    baseDataDirCandidate &&
+    isPathWithinSocketLimit(baseDataDirCandidate, maxPathBytes)
+  ) {
+    return {
+      path: baseDataDirCandidate,
+      source: "base-data-dir",
+      workspacePath,
+      maxPathBytes,
+    };
+  }
+
+  const tmpCandidate = buildTmpCandidate(workspacePath, socketFileName);
   if (isPathWithinSocketLimit(tmpCandidate.hashedPath, maxPathBytes)) {
     return {
       path: tmpCandidate.hashedPath,
       source: "tmp-hash",
-      preferredPath,
+      workspacePath,
       maxPathBytes,
     };
   }
@@ -70,7 +94,7 @@ export function resolveIpcSocketPath(
   return {
     path: tmpCandidate.shortPath,
     source: "tmp-short-hash",
-    preferredPath,
+    workspacePath,
     maxPathBytes,
   };
 }

--- a/gateway/src/__tests__/ipc-socket-path.test.ts
+++ b/gateway/src/__tests__/ipc-socket-path.test.ts
@@ -1,18 +1,39 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { resolveIpcSocketPath } from "../ipc/socket-path.js";
 
 const LONG_WORKSPACE_DIR =
-  "/Users/alice-johnson/.local/share/vellum-dev/assistants/vellum-safe-dace-8hrt6e/.vellum/workspace";
+  "/Users/noaflaherty/.local/share/vellum-dev/assistants/vellum-safe-dace-8hrt6e/.vellum/workspace";
+
+let savedWorkspaceDir: string | undefined;
+let savedBaseDataDir: string | undefined;
+
+beforeEach(() => {
+  savedWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  savedBaseDataDir = process.env.BASE_DATA_DIR;
+});
+
+afterEach(() => {
+  if (savedWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = savedWorkspaceDir;
+  }
+  if (savedBaseDataDir === undefined) {
+    delete process.env.BASE_DATA_DIR;
+  } else {
+    process.env.BASE_DATA_DIR = savedBaseDataDir;
+  }
+});
 
 describe("resolveIpcSocketPath", () => {
   test("uses workspace path when it is within the platform limit", () => {
-    const resolved = resolveIpcSocketPath(
-      "gateway.sock",
-      "/tmp/vellum-workspace-test",
-    );
+    process.env.VELLUM_WORKSPACE_DIR = "/tmp/vellum-workspace-test";
+    delete process.env.BASE_DATA_DIR;
+
+    const resolved = resolveIpcSocketPath("gateway.sock");
 
     expect(resolved.source).toBe("workspace");
     expect(resolved.path).toBe("/tmp/vellum-workspace-test/gateway.sock");
@@ -21,8 +42,24 @@ describe("resolveIpcSocketPath", () => {
     );
   });
 
-  test("falls back to tmpdir hash path when workspace path is too long", () => {
-    const resolved = resolveIpcSocketPath("gateway.sock", LONG_WORKSPACE_DIR);
+  test("falls back to BASE_DATA_DIR/ipc when workspace path is too long", () => {
+    process.env.VELLUM_WORKSPACE_DIR = LONG_WORKSPACE_DIR;
+    process.env.BASE_DATA_DIR = "/tmp/vellum-instance-test";
+
+    const resolved = resolveIpcSocketPath("gateway.sock");
+
+    expect(resolved.source).toBe("base-data-dir");
+    expect(resolved.path).toBe("/tmp/vellum-instance-test/ipc/gateway.sock");
+    expect(Buffer.byteLength(resolved.path, "utf8")).toBeLessThanOrEqual(
+      resolved.maxPathBytes,
+    );
+  });
+
+  test("falls back to tmpdir hash path when workspace path is too long and BASE_DATA_DIR is absent", () => {
+    process.env.VELLUM_WORKSPACE_DIR = LONG_WORKSPACE_DIR;
+    delete process.env.BASE_DATA_DIR;
+
+    const resolved = resolveIpcSocketPath("gateway.sock");
 
     expect(resolved.source).toBe("tmp-hash");
     expect(resolved.path.startsWith(join(tmpdir(), "vellum-ipc"))).toBe(true);

--- a/gateway/src/ipc/socket-path.ts
+++ b/gateway/src/ipc/socket-path.ts
@@ -7,8 +7,13 @@ import { getWorkspaceDir } from "../paths.js";
 const DARWIN_UNIX_SOCKET_MAX_PATH_BYTES = 103;
 const DEFAULT_UNIX_SOCKET_MAX_PATH_BYTES = 107;
 const IPC_TMP_DIR_NAME = "vellum-ipc";
+const IPC_BASE_DATA_DIR_NAME = "ipc";
 
-export type IpcSocketPathSource = "workspace" | "tmp-hash" | "tmp-short-hash";
+export type IpcSocketPathSource =
+  | "workspace"
+  | "base-data-dir"
+  | "tmp-hash"
+  | "tmp-short-hash";
 
 export interface IpcSocketPathResolution {
   path: string;
@@ -25,6 +30,12 @@ function getUnixSocketMaxPathBytes(): number {
 
 function isPathWithinSocketLimit(path: string, maxPathBytes: number): boolean {
   return Buffer.byteLength(path, "utf8") <= maxPathBytes;
+}
+
+function buildBaseDataDirCandidate(socketFileName: string): string | null {
+  const baseDataDir = process.env.BASE_DATA_DIR?.trim();
+  if (!baseDataDir) return null;
+  return join(baseDataDir, IPC_BASE_DATA_DIR_NAME, socketFileName);
 }
 
 function buildTmpCandidate(
@@ -52,6 +63,19 @@ export function resolveIpcSocketPath(
     return {
       path: workspacePath,
       source: "workspace",
+      workspacePath,
+      maxPathBytes,
+    };
+  }
+
+  const baseDataDirCandidate = buildBaseDataDirCandidate(socketFileName);
+  if (
+    baseDataDirCandidate &&
+    isPathWithinSocketLimit(baseDataDirCandidate, maxPathBytes)
+  ) {
+    return {
+      path: baseDataDirCandidate,
+      source: "base-data-dir",
       workspacePath,
       maxPathBytes,
     };


### PR DESCRIPTION
## Summary
- Reverts d293d831b1 ("fix(ipc): move CLI IPC socket from workspace to protected directory (#27582)")
- Restores the IPC socket to the workspace directory with the original fallback chain

## Original prompt
help me revert d293d83
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
