### PR TITLE
feat(runtime): add async import-from-gcs endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5724,6 +5724,73 @@ paths:
                     the importer.
               required:
                 - url
+  /v1/migrations/import-from-gcs:
+    post:
+      operationId: migrations_importfromgcs_post
+      summary: Start an async .vbundle import from a signed GCS URL
+      description:
+        Schedule a background import job that fetches the bundle at `bundle_url` and streams it through the
+        importer. Returns 202 with a `job_id`; poll `GET /v1/migrations/jobs/{job_id}` for status. 409 if another import
+        is already in flight.
+      tags:
+        - migrations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  job_id:
+                    type: string
+                  status:
+                    type: string
+                    const: pending
+                  type:
+                    type: string
+                    const: import
+                required:
+                  - job_id
+                  - status
+                  - type
+                additionalProperties: false
+        "409":
+          description:
+            "Another import job is already pending or running. Body shape: { error: { code: 'import_in_progress',
+            job_id: string } }."
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - import_in_progress
+                      job_id:
+                        type: string
+                    required:
+                      - code
+                      - job_id
+                required:
+                  - error
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                bundle_url:
+                  type: string
+                  format: uri
+              required:
+                - bundle_url
+              additionalProperties: false
   /v1/migrations/import-preflight:
     post:
       operationId: migrations_importpreflight_post

--- a/assistant/src/__tests__/migration-import-from-gcs.test.ts
+++ b/assistant/src/__tests__/migration-import-from-gcs.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Integration tests for POST /v1/migrations/import-from-gcs.
+ *
+ * The endpoint kicks off an async import job that fetches a .vbundle from
+ * a signed GCS URL and streams it through the importer. The handler returns
+ * 202 with a `job_id`; the test then polls the in-process
+ * `migrationJobs` registry directly (no separate status endpoint yet — PR 4
+ * adds that) to assert the job progresses through `pending`/`running` to a
+ * terminal `complete` or `failed` state with the expected result / error
+ * mapping.
+ *
+ * Covered cases:
+ * - Happy path: 202 → poll → `complete` with `result.report.summary`.
+ * - Upstream fetch failure (HTTP 500): job ends `failed` with
+ *   `error.code === "fetch_failed"` and `error.upstreamStatus === 500`.
+ * - Validation failure (corrupt bundle): job ends `failed` with
+ *   `error.code === "validation_failed"`.
+ * - Concurrency: second import while the first is in flight → 409 with
+ *   `error.code === "import_in_progress"`.
+ */
+
+import {
+  createReadStream,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Test isolation: per-file workspace root.
+//
+// The streaming importer renames the workspace dir itself, so each test
+// needs a fresh tmp dir that the importer can swap into place.
+// ---------------------------------------------------------------------------
+
+const originalWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+
+function freshWorkspaceRoot(): string {
+  const parent = realpathSync(
+    mkdtempSync(join(tmpdir(), "migration-import-from-gcs-")),
+  );
+  const workspaceDir = join(parent, "workspace");
+  mkdirSync(workspaceDir, { recursive: true });
+  return workspaceDir;
+}
+
+function setWorkspaceDir(dir: string): void {
+  process.env.VELLUM_WORKSPACE_DIR = dir;
+}
+
+// ---------------------------------------------------------------------------
+// Mocks (mirrors migration-import-from-url.test.ts)
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  getAllRules: () => [],
+  isStarterBundleAccepted: () => false,
+  clearCache: () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  getGatewayPort: () => 7830,
+  getRuntimeHttpPort: () => 7821,
+  getRuntimeHttpHost: () => "127.0.0.1",
+  getRuntimeGatewayOriginSecret: () => undefined,
+  getIngressPublicBaseUrl: () => undefined,
+  setIngressPublicBaseUrl: () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks so module-level code picks up the stubs)
+// ---------------------------------------------------------------------------
+
+import { buildVBundle } from "../runtime/migrations/vbundle-builder.js";
+import {
+  migrationJobs,
+  type MigrationJob,
+} from "../runtime/migrations/job-registry.js";
+import {
+  _setUrlImportValidatorOptionsForTests,
+  handleMigrationImportFromGcs,
+} from "../runtime/routes/migration-routes.js";
+
+// ---------------------------------------------------------------------------
+// Local http fixture server
+// ---------------------------------------------------------------------------
+
+interface FixtureServer {
+  server: Server;
+  port: number;
+  close: () => Promise<void>;
+}
+
+async function startFixtureServer(
+  handler: (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
+  ) => void,
+): Promise<FixtureServer> {
+  const server = createServer(handler);
+  // Track every connection so `close()` can forcibly tear them down. Tests
+  // that intentionally hang the response body (to simulate an in-flight
+  // upstream fetch) would otherwise deadlock `server.close()`, which waits
+  // for clients to disconnect on their own.
+  const sockets = new Set<import("node:net").Socket>();
+  server.on("connection", (sock) => {
+    sockets.add(sock);
+    sock.on("close", () => sockets.delete(sock));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fixture server bound to unexpected address");
+  }
+  const port = address.port;
+  return {
+    server,
+    port,
+    close: async () => {
+      for (const sock of sockets) {
+        try {
+          sock.destroy();
+        } catch {
+          /* best effort */
+        }
+      }
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+function makeFakeSignedUrl(port: number): string {
+  // `validateGcsSignedUrl` requires a signature query param; pin a dummy.
+  return `http://127.0.0.1:${port}/bundle?X-Goog-Signature=fake`;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeSmallValidBundlePath(parent: string): string {
+  const { archive } = buildVBundle({
+    files: [
+      {
+        path: "workspace/data/db/assistant.db",
+        data: new TextEncoder().encode("SQLite format 3\0"),
+      },
+      {
+        path: "workspace/config.json",
+        data: new TextEncoder().encode(
+          JSON.stringify({ provider: "anthropic", model: "test-model" }),
+        ),
+      },
+    ],
+  });
+  const bundlePath = join(parent, "fixture-small.vbundle");
+  writeFileSync(bundlePath, archive);
+  return bundlePath;
+}
+
+function makeCorruptBundlePath(parent: string): string {
+  // Random bytes — not a gzip stream, not a tar, nothing the importer can
+  // parse. Drives `validation_failed` inside `streamCommitImport`.
+  const payload = new Uint8Array(4096);
+  for (let i = 0; i < payload.length; i += 1) {
+    payload[i] = Math.floor(Math.random() * 256);
+  }
+  const bundlePath = join(parent, "fixture-corrupt.vbundle");
+  writeFileSync(bundlePath, payload);
+  return bundlePath;
+}
+
+// ---------------------------------------------------------------------------
+// Poll helpers — the registry is in-process so we peek at `getJob` directly
+// until the job leaves the pending/running states.
+// ---------------------------------------------------------------------------
+
+async function pollJobUntilDone(
+  jobId: string,
+  timeoutMs = 30_000,
+): Promise<MigrationJob> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const job = migrationJobs.getJob(jobId);
+    if (!job) {
+      throw new Error(`Job ${jobId} disappeared from the registry`);
+    }
+    if (job.status === "complete" || job.status === "failed") {
+      return job;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Job ${jobId} did not finish within ${timeoutMs}ms`);
+}
+
+// ---------------------------------------------------------------------------
+// Global test-only allowlist: widen the URL validator to accept 127.0.0.1.
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  _setUrlImportValidatorOptionsForTests({
+    allowedHosts: ["127.0.0.1", "storage.googleapis.com"],
+  });
+});
+
+afterAll(() => {
+  _setUrlImportValidatorOptionsForTests(undefined);
+  if (originalWorkspaceDir !== undefined) {
+    process.env.VELLUM_WORKSPACE_DIR = originalWorkspaceDir;
+  }
+});
+
+// Each test gets its own workspace dir so the streaming importer's atomic
+// swap doesn't leak state across tests.
+let testWorkspaceRoot: string;
+let testParent: string;
+
+beforeEach(() => {
+  testWorkspaceRoot = freshWorkspaceRoot();
+  testParent = join(testWorkspaceRoot, "..");
+  setWorkspaceDir(testWorkspaceRoot);
+});
+
+afterEach(() => {
+  try {
+    rmSync(testParent, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Response shape types
+// ---------------------------------------------------------------------------
+
+interface AcceptedResponse {
+  job_id: string;
+  status: "pending";
+  type: "import";
+}
+
+interface ConflictResponse {
+  error: { code: "import_in_progress"; job_id: string };
+}
+
+interface BadRequestResponse {
+  error: { code: string; message: string };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/migrations/import-from-gcs", () => {
+  test("happy path: 202 → job completes with result.report.summary", async () => {
+    const bundlePath = makeSmallValidBundlePath(testParent);
+
+    const fixture = await startFixtureServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/octet-stream" });
+      createReadStream(bundlePath).pipe(res);
+    });
+
+    try {
+      const req = new Request(
+        "http://localhost/v1/migrations/import-from-gcs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
+        },
+      );
+
+      const res = await handleMigrationImportFromGcs(req);
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as AcceptedResponse;
+      expect(body.type).toBe("import");
+      expect(body.status).toBe("pending");
+      expect(typeof body.job_id).toBe("string");
+      expect(body.job_id.length).toBeGreaterThan(0);
+
+      const finalJob = await pollJobUntilDone(body.job_id);
+      expect(finalJob.status).toBe("complete");
+
+      const summary = finalJob.result as {
+        report: {
+          summary: {
+            total_files: number;
+            files_created: number;
+          };
+        };
+      };
+      expect(summary).toBeDefined();
+      expect(summary.report).toBeDefined();
+      expect(summary.report.summary.total_files).toBeGreaterThan(0);
+      expect(summary.report.summary.files_created).toBeGreaterThan(0);
+
+      // Workspace was swapped into place.
+      expect(
+        existsSync(join(testWorkspaceRoot, "data", "db", "assistant.db")),
+      ).toBe(true);
+      expect(existsSync(join(testWorkspaceRoot, "config.json"))).toBe(true);
+    } finally {
+      await fixture.close();
+    }
+  }, 30_000);
+
+  test("upstream 500: job ends failed with fetch_failed + upstreamStatus 500", async () => {
+    const fixture = await startFixtureServer((_req, res) => {
+      res.writeHead(500);
+      res.end("oh no");
+    });
+
+    try {
+      const req = new Request(
+        "http://localhost/v1/migrations/import-from-gcs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
+        },
+      );
+
+      const res = await handleMigrationImportFromGcs(req);
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as AcceptedResponse;
+
+      const finalJob = await pollJobUntilDone(body.job_id);
+      expect(finalJob.status).toBe("failed");
+      expect(finalJob.error?.code).toBe("fetch_failed");
+      expect(finalJob.error?.upstreamStatus).toBe(500);
+    } finally {
+      await fixture.close();
+    }
+  }, 30_000);
+
+  test("corrupt bundle: job ends failed with validation_failed", async () => {
+    const bundlePath = makeCorruptBundlePath(testParent);
+
+    const fixture = await startFixtureServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/octet-stream" });
+      createReadStream(bundlePath).pipe(res);
+    });
+
+    try {
+      const req = new Request(
+        "http://localhost/v1/migrations/import-from-gcs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
+        },
+      );
+
+      const res = await handleMigrationImportFromGcs(req);
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as AcceptedResponse;
+
+      const finalJob = await pollJobUntilDone(body.job_id);
+      expect(finalJob.status).toBe("failed");
+      // The streaming importer maps a mangled archive to
+      // `extraction_failed` (gunzip throws on the random payload before the
+      // tar layer even sees it). Parity with the URL-body path: that path
+      // returns 500 `{ reason: "extraction_failed" }` for the same input,
+      // and `runGcsImport` re-throws it as a `GcsImportError` carrying the
+      // same code.
+      expect(finalJob.error?.code).toBe("extraction_failed");
+    } finally {
+      await fixture.close();
+    }
+  }, 30_000);
+
+  test("second import while first is in flight returns 409", async () => {
+    // A fixture that never responds keeps the first job stuck in `pending`
+    // (the runner is scheduled on a microtask, but the handler's `fetch`
+    // hangs on the open socket). Even `pending` counts as in-flight for
+    // the concurrency check, so the 409 is deterministic regardless of
+    // event-loop timing.
+    const fixture = await startFixtureServer((_req, _res) => {
+      // Intentionally no response — hold the socket open.
+    });
+
+    let firstJobId: string | undefined;
+    try {
+      const firstReq = new Request(
+        "http://localhost/v1/migrations/import-from-gcs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
+        },
+      );
+      const firstRes = await handleMigrationImportFromGcs(firstReq);
+      expect(firstRes.status).toBe(202);
+      const firstBody = (await firstRes.json()) as AcceptedResponse;
+      firstJobId = firstBody.job_id;
+
+      const secondReq = new Request(
+        "http://localhost/v1/migrations/import-from-gcs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
+        },
+      );
+      const secondRes = await handleMigrationImportFromGcs(secondReq);
+      expect(secondRes.status).toBe(409);
+      const secondBody = (await secondRes.json()) as ConflictResponse;
+      expect(secondBody.error.code).toBe("import_in_progress");
+      expect(secondBody.error.job_id).toBe(firstBody.job_id);
+    } finally {
+      // Close the server — this destroys every tracked socket, which
+      // unblocks the first job's `fetch` and lets the runner settle into
+      // `failed`. Wait for that before returning so subsequent tests can
+      // start their own `"import"` job without tripping the registry's
+      // single-in-flight invariant.
+      await fixture.close();
+      if (firstJobId !== undefined) {
+        await pollJobUntilDone(firstJobId);
+      }
+    }
+  }, 30_000);
+
+  test("malformed body (missing bundle_url) returns 400", async () => {
+    const req = new Request(
+      "http://localhost/v1/migrations/import-from-gcs",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      },
+    );
+    const res = await handleMigrationImportFromGcs(req);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as BadRequestResponse;
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+});

--- a/assistant/src/__tests__/migration-import-from-gcs.test.ts
+++ b/assistant/src/__tests__/migration-import-from-gcs.test.ts
@@ -109,11 +109,11 @@ mock.module("../config/env.js", () => ({
 // Imports (after mocks so module-level code picks up the stubs)
 // ---------------------------------------------------------------------------
 
-import { buildVBundle } from "../runtime/migrations/vbundle-builder.js";
 import {
-  migrationJobs,
   type MigrationJob,
+  migrationJobs,
 } from "../runtime/migrations/job-registry.js";
+import { buildVBundle } from "../runtime/migrations/vbundle-builder.js";
 import {
   _setUrlImportValidatorOptionsForTests,
   handleMigrationImportFromGcs,
@@ -459,14 +459,11 @@ describe("POST /v1/migrations/import-from-gcs", () => {
   }, 30_000);
 
   test("malformed body (missing bundle_url) returns 400", async () => {
-    const req = new Request(
-      "http://localhost/v1/migrations/import-from-gcs",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      },
-    );
+    const req = new Request("http://localhost/v1/migrations/import-from-gcs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
     const res = await handleMigrationImportFromGcs(req);
     expect(res.status).toBe(400);
     const body = (await res.json()) as BadRequestResponse;

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -445,6 +445,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "migrations/export", scopes: ["settings.write"] },
   { endpoint: "migrations/import-preflight", scopes: ["settings.write"] },
   { endpoint: "migrations/import", scopes: ["settings.write"] },
+  { endpoint: "migrations/import-from-gcs", scopes: ["settings.write"] },
 
   // Backups
   { endpoint: "backups", scopes: ["settings.read"] },

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -44,6 +44,10 @@ import {
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import {
+  JobAlreadyInProgressError,
+  migrationJobs,
+} from "../migrations/job-registry.js";
+import {
   validateGcsSignedUrl,
   type ValidateGcsSignedUrlOptions,
 } from "../migrations/gcs-signed-url.js";
@@ -580,13 +584,16 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
 }
 
 // ---------------------------------------------------------------------------
-// URL-body variant of POST /v1/migrations/import
+// GCS URL import pipeline — shared by the URL-body branch of
+// POST /v1/migrations/import and POST /v1/migrations/import-from-gcs.
 // ---------------------------------------------------------------------------
 
 /** 60 minutes — matches the gateway's upstream fetch deadline. */
 const URL_FETCH_TIMEOUT_MS = 60 * 60 * 1000;
 
 const MigrationImportUrlBody = z.object({ url: z.string().min(1) });
+
+const MigrationImportFromGcsBody = z.object({ bundle_url: z.string().url() });
 
 /**
  * Marker attached to errors that originate from the upstream HTTP body
@@ -643,43 +650,96 @@ export function _setUrlImportValidatorOptionsForTests(
 }
 
 /**
- * Handle a JSON `{ "url": "..." }` body on POST /v1/migrations/import.
- *
- * Fetches the signed URL, pipes the response body through the streaming
- * importer, and returns the same response shapes as the raw-bytes path.
- * The signed URL is never logged or included in error responses — only the
- * extracted host and path make it into logs.
+ * Successful outcome of `runGcsImport`. Mirrors the inputs that
+ * `importCommitSuccessResponse` expects so callers can feed it straight
+ * into a Response builder OR return it as an async-job `result`.
  */
-async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
-  // ── 1. Parse JSON body ────────────────────────────────────────────────
-  let rawBody: unknown;
-  try {
-    rawBody = await req.json();
-  } catch (err) {
-    log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
-      "Failed to parse JSON body on migration import URL request",
-    );
-    return httpError("BAD_REQUEST", "Invalid JSON body", 400);
-  }
+export interface ImportSummary {
+  report: ImportCommitReport;
+  credentialsImported?: CredentialImportSummary;
+}
 
-  const parsed = MigrationImportUrlBody.safeParse(rawBody);
-  if (!parsed.success) {
-    return httpError(
-      "BAD_REQUEST",
-      "Request body must be { url: string } with a non-empty url",
-      400,
-    );
-  }
+/**
+ * Structured error thrown by `runGcsImport`. Carries the information needed
+ * to reconstruct the URL-body handler's legacy Response shapes and for the
+ * async-job registry to map to `error.code`/`upstreamStatus`.
+ */
+interface GcsImportErrorInit {
+  code:
+    | "invalid_url"
+    | "fetch_failed"
+    | "validation_failed"
+    | "extraction_failed"
+    | "write_failed";
+  message: string;
+  upstreamStatus?: number;
+  reason?: string;
+  errors?: Array<{ code: string; message: string; path?: string }>;
+  partial_report?: ImportCommitReport;
+}
 
-  // ── 2. Validate the URL (defense-in-depth; never log `parsed.data.url`).
-  const validated = validateGcsSignedUrl(parsed.data.url, urlValidatorOptions);
+class GcsImportError extends Error {
+  public readonly code: GcsImportErrorInit["code"];
+  public readonly upstreamStatus?: number;
+  public readonly reason?: string;
+  public readonly errors?: GcsImportErrorInit["errors"];
+  public readonly partial_report?: ImportCommitReport;
+
+  constructor(init: GcsImportErrorInit) {
+    super(init.message);
+    this.name = "GcsImportError";
+    this.code = init.code;
+    if (init.upstreamStatus !== undefined) {
+      this.upstreamStatus = init.upstreamStatus;
+    }
+    if (init.reason !== undefined) {
+      this.reason = init.reason;
+    }
+    if (init.errors !== undefined) {
+      this.errors = init.errors;
+    }
+    if (init.partial_report !== undefined) {
+      this.partial_report = init.partial_report;
+    }
+  }
+}
+
+/**
+ * Fetch a .vbundle from a signed GCS URL and commit it via the streaming
+ * importer. On success, returns an `ImportSummary` the caller can serialize
+ * into a Response or stash as an async-job `result`. On failure, throws a
+ * `GcsImportError`:
+ *
+ *   - `invalid_url`        → URL failed `validateGcsSignedUrl` (pre-fetch).
+ *   - `fetch_failed`       → upstream fetch error, non-2xx response, missing
+ *                            body, OR a mid-stream body teardown tagged via
+ *                            `kFetchBodyError`. `upstreamStatus` is populated
+ *                            for non-2xx responses.
+ *   - `validation_failed`  → the bundle failed schema/structural validation
+ *                            inside `streamCommitImport`; `errors` carries
+ *                            the per-issue list.
+ *   - `extraction_failed`  → bundle extraction threw (malformed archive, hash
+ *                            mismatch, etc.) that was NOT an upstream tear-
+ *                            down. `reason` carries the importer's string.
+ *   - `write_failed`       → post-extraction disk write error; `partial_report`
+ *                            is attached when the importer produced one.
+ *
+ * The signed URL is never echoed into errors or logs — only the extracted
+ * `host`/`path` are.
+ */
+export async function runGcsImport(
+  url: string,
+  _correlationId?: string,
+): Promise<ImportSummary> {
+  // ── 1. Validate the URL (defense-in-depth; never log the raw URL).
+  const validated = validateGcsSignedUrl(url, urlValidatorOptions);
   if (!validated.ok) {
-    // `reason` is a stable enum string and safe to include. The raw URL is
-    // not — it may contain a live signature. Callers get the reason so they
-    // can correct the URL without leaking anything into observability.
     log.warn({ reason: validated.reason }, "Rejected migration import URL");
-    return httpError("BAD_REQUEST", `Invalid URL: ${validated.reason}`, 400);
+    throw new GcsImportError({
+      code: "invalid_url",
+      message: `Invalid URL: ${validated.reason}`,
+      reason: validated.reason,
+    });
   }
 
   log.info(
@@ -689,10 +749,10 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
 
   const startedAt = Date.now();
 
-  // ── 3. Fetch the URL ──────────────────────────────────────────────────
+  // ── 2. Fetch the URL ──────────────────────────────────────────────────
   let upstream: Response;
   try {
-    upstream = await fetch(parsed.data.url, {
+    upstream = await fetch(url, {
       signal: AbortSignal.timeout(URL_FETCH_TIMEOUT_MS),
       // SSRF guard: `validateGcsSignedUrl` only vetted the initial URL.
       // Default fetch behavior follows 3xx responses, which would let a
@@ -710,10 +770,10 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
       },
       "Failed to fetch migration import URL",
     );
-    return Response.json(
-      { success: false, reason: "fetch_failed" },
-      { status: 502 },
-    );
+    throw new GcsImportError({
+      code: "fetch_failed",
+      message: err instanceof Error ? err.message : String(err),
+    });
   }
 
   if (!upstream.ok) {
@@ -731,14 +791,11 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
     } catch {
       /* best effort */
     }
-    return Response.json(
-      {
-        success: false,
-        reason: "fetch_failed",
-        upstream_status: upstream.status,
-      },
-      { status: 502 },
-    );
+    throw new GcsImportError({
+      code: "fetch_failed",
+      message: `Upstream fetch returned ${upstream.status}`,
+      upstreamStatus: upstream.status,
+    });
   }
 
   if (!upstream.body) {
@@ -746,13 +803,13 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
       { host: validated.host, path: validated.path },
       "Migration import URL fetch returned no body",
     );
-    return Response.json(
-      { success: false, reason: "fetch_failed" },
-      { status: 502 },
-    );
+    throw new GcsImportError({
+      code: "fetch_failed",
+      message: "Upstream fetch returned no body",
+    });
   }
 
-  // ── 4. Stream the response through the importer ──────────────────────
+  // ── 3. Stream the response through the importer ──────────────────────
   // Convert the WHATWG ReadableStream from fetch() into a Node Readable so
   // the tar-stream / gunzip / hash-verifier pipeline inside
   // streamCommitImport can consume it via `.pipe()`.
@@ -764,8 +821,8 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
   // from the upstream HTTP body (peer reset, abort mid-stream, etc.) with a
   // known symbol. When that tagged error surfaces out of
   // streamCommitImport's gunzip/tar pipeline, we can distinguish it from a
-  // legitimate bundle-format failure and map it to 502 fetch_failed instead
-  // of 500 extraction_failed — matching the OpenAPI contract for the URL
+  // legitimate bundle-format failure and map it to `fetch_failed` instead
+  // of `extraction_failed` — matching the OpenAPI contract for the URL
   // body shape. We also propagate errors from the wrapper back to the
   // upstream stream so its underlying connection is torn down cleanly.
   //
@@ -781,7 +838,7 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
   // `taggedSource`. The subsequent `close` on `upstreamNodeStream` is then a
   // cascaded effect of our own teardown, NOT a real upstream failure — so
   // we must NOT tag it as a fetch-body error, or local validation /
-  // extraction errors would be masked as 502 fetch_failed.
+  // extraction errors would be masked as fetch_failed.
   let localTeardownInitiated = false;
   upstreamNodeStream.on("end", () => {
     upstreamEnded = true;
@@ -817,8 +874,8 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
   // (malformed bundle, hash mismatch, size cap, etc.). We set
   // `localTeardownInitiated` BEFORE destroying upstream so the resulting
   // cascaded `close` on `upstreamNodeStream` isn't misclassified as a real
-  // upstream failure (which would return 502 fetch_failed and mask the
-  // actual validation error).
+  // upstream failure (which would return fetch_failed and mask the actual
+  // validation error).
   taggedSource.on("close", () => {
     if (!upstreamNodeStream.destroyed) {
       localTeardownInitiated = true;
@@ -867,10 +924,10 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
         },
         "Upstream body stream failed mid-import",
       );
-      return Response.json(
-        { success: false, reason: "fetch_failed" },
-        { status: 502 },
-      );
+      throw new GcsImportError({
+        code: "fetch_failed",
+        message: err instanceof Error ? err.message : String(err),
+      });
     }
     log.error(
       {
@@ -880,11 +937,10 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
       },
       "streamCommitImport threw during URL-body import",
     );
-    return httpError(
-      "INTERNAL_ERROR",
-      err instanceof Error ? err.message : "Unexpected import error",
-      500,
-    );
+    throw new GcsImportError({
+      code: "extraction_failed",
+      message: err instanceof Error ? err.message : "Unexpected import error",
+    });
   }
 
   if (!result.ok) {
@@ -902,10 +958,10 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
         },
         "Upstream body stream failed mid-import (detected via result)",
       );
-      return Response.json(
-        { success: false, reason: "fetch_failed" },
-        { status: 502 },
-      );
+      throw new GcsImportError({
+        code: "fetch_failed",
+        message: "Upstream body stream failed mid-import",
+      });
     }
     log.warn(
       {
@@ -915,7 +971,28 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
       },
       "streamCommitImport returned failure during URL-body import",
     );
-    return importCommitFailureResponse(result);
+    if (result.reason === "validation_failed") {
+      throw new GcsImportError({
+        code: "validation_failed",
+        message: "Bundle validation failed",
+        reason: result.reason,
+        errors: result.errors,
+      });
+    }
+    if (result.reason === "extraction_failed") {
+      throw new GcsImportError({
+        code: "extraction_failed",
+        message: result.message,
+        reason: result.reason,
+      });
+    }
+    // write_failed
+    throw new GcsImportError({
+      code: "write_failed",
+      message: result.message,
+      reason: result.reason,
+      partial_report: result.partial_report,
+    });
   }
 
   // Merge any warnings accumulated by the credential-import callback into
@@ -949,7 +1026,170 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
     "Migration import from URL complete",
   );
 
-  return importCommitSuccessResponse(result.report, credentialsImported);
+  return credentialsImported
+    ? { report: result.report, credentialsImported }
+    : { report: result.report };
+}
+
+/**
+ * Handle a JSON `{ "url": "..." }` body on POST /v1/migrations/import.
+ *
+ * Thin wrapper around `runGcsImport` that preserves the legacy synchronous
+ * Response shapes. `handleMigrationImportFromGcs` below uses the same helper
+ * asynchronously via the migration-job registry.
+ */
+async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
+  // ── 1. Parse JSON body ────────────────────────────────────────────────
+  let rawBody: unknown;
+  try {
+    rawBody = await req.json();
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to parse JSON body on migration import URL request",
+    );
+    return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+  }
+
+  const parsed = MigrationImportUrlBody.safeParse(rawBody);
+  if (!parsed.success) {
+    return httpError(
+      "BAD_REQUEST",
+      "Request body must be { url: string } with a non-empty url",
+      400,
+    );
+  }
+
+  try {
+    const summary = await runGcsImport(parsed.data.url);
+    return importCommitSuccessResponse(
+      summary.report,
+      summary.credentialsImported,
+    );
+  } catch (err) {
+    return gcsImportErrorToUrlBodyResponse(err);
+  }
+}
+
+/**
+ * Map a `runGcsImport` error (or any other thrown value) back to the
+ * legacy URL-body Response shapes. Kept here so both the URL-body handler
+ * and any future callers of `runGcsImport` that want the same wire shape
+ * can reuse the mapping.
+ */
+function gcsImportErrorToUrlBodyResponse(err: unknown): Response {
+  if (err instanceof GcsImportError) {
+    if (err.code === "invalid_url") {
+      return httpError("BAD_REQUEST", err.message, 400);
+    }
+    if (err.code === "fetch_failed") {
+      const body: { success: false; reason: "fetch_failed"; upstream_status?: number } = {
+        success: false,
+        reason: "fetch_failed",
+      };
+      if (err.upstreamStatus !== undefined) {
+        body.upstream_status = err.upstreamStatus;
+      }
+      return Response.json(body, { status: 502 });
+    }
+    if (err.code === "validation_failed") {
+      return Response.json({
+        success: false,
+        reason: "validation_failed",
+        errors: err.errors ?? [],
+      });
+    }
+    if (err.code === "extraction_failed") {
+      return Response.json(
+        {
+          success: false,
+          reason: "extraction_failed",
+          message: err.message,
+        },
+        { status: 500 },
+      );
+    }
+    // write_failed
+    return Response.json(
+      {
+        success: false,
+        reason: "write_failed",
+        message: err.message,
+        ...(err.partial_report ? { partial_report: err.partial_report } : {}),
+      },
+      { status: 500 },
+    );
+  }
+
+  log.error({ err }, "Unexpected error from runGcsImport");
+  return httpError(
+    "INTERNAL_ERROR",
+    err instanceof Error ? err.message : "Unexpected import error",
+    500,
+  );
+}
+
+/**
+ * POST /v1/migrations/import-from-gcs
+ *
+ * Kick off an async bundle import from a signed GCS URL. Returns 202 with a
+ * `job_id` the caller can poll via `GET /v1/migrations/jobs/:job_id`
+ * (PR 4). 409 if another import is already pending or running.
+ *
+ * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, svc_daemon, local.
+ */
+export async function handleMigrationImportFromGcs(
+  req: Request,
+): Promise<Response> {
+  let rawBody: unknown;
+  try {
+    rawBody = await req.json();
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to parse JSON body on migration import-from-gcs request",
+    );
+    return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+  }
+
+  const parsed = MigrationImportFromGcsBody.safeParse(rawBody);
+  if (!parsed.success) {
+    return httpError(
+      "BAD_REQUEST",
+      "Request body must be { bundle_url: string } with a valid URL",
+      400,
+    );
+  }
+
+  const { bundle_url } = parsed.data;
+
+  try {
+    const job = migrationJobs.startJob("import", async (jobRecord) =>
+      runGcsImport(bundle_url, jobRecord.id),
+    );
+    return Response.json(
+      { job_id: job.id, status: "pending", type: "import" },
+      { status: 202 },
+    );
+  } catch (err) {
+    if (err instanceof JobAlreadyInProgressError) {
+      return Response.json(
+        {
+          error: {
+            code: "import_in_progress",
+            job_id: err.existingJobId,
+          },
+        },
+        { status: 409 },
+      );
+    }
+    log.error({ err }, "Unexpected error scheduling import-from-gcs job");
+    return httpError(
+      "INTERNAL_ERROR",
+      err instanceof Error ? err.message : "Unexpected import error",
+      500,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1250,6 +1490,43 @@ export function migrationRouteDefinitions(): RouteDefinition[] {
         warnings: z.array(z.unknown()),
       }),
       handler: async ({ req }) => handleMigrationImport(req),
+    },
+    {
+      endpoint: "migrations/import-from-gcs",
+      method: "POST",
+      summary: "Start an async .vbundle import from a signed GCS URL",
+      description:
+        "Schedule a background import job that fetches the bundle at `bundle_url` and streams it through the importer. Returns 202 with a `job_id`; poll `GET /v1/migrations/jobs/{job_id}` for status. 409 if another import is already in flight.",
+      tags: ["migrations"],
+      requestBody: z.object({
+        bundle_url: z.string().url(),
+      }),
+      responseBody: z.object({
+        job_id: z.string(),
+        status: z.literal("pending"),
+        type: z.literal("import"),
+      }),
+      additionalResponses: {
+        "409": {
+          description:
+            "Another import job is already pending or running. Body shape: { error: { code: 'import_in_progress', job_id: string } }.",
+          schema: {
+            type: "object",
+            properties: {
+              error: {
+                type: "object",
+                properties: {
+                  code: { type: "string", enum: ["import_in_progress"] },
+                  job_id: { type: "string" },
+                },
+                required: ["code", "job_id"],
+              },
+            },
+            required: ["error"],
+          },
+        },
+      },
+      handler: async ({ req }) => handleMigrationImportFromGcs(req),
     },
   ];
 }

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -44,13 +44,13 @@ import {
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import {
-  JobAlreadyInProgressError,
-  migrationJobs,
-} from "../migrations/job-registry.js";
-import {
   validateGcsSignedUrl,
   type ValidateGcsSignedUrlOptions,
 } from "../migrations/gcs-signed-url.js";
+import {
+  JobAlreadyInProgressError,
+  migrationJobs,
+} from "../migrations/job-registry.js";
 import { streamExportVBundle } from "../migrations/vbundle-builder.js";
 import {
   analyzeImport,
@@ -1083,7 +1083,11 @@ function gcsImportErrorToUrlBodyResponse(err: unknown): Response {
       return httpError("BAD_REQUEST", err.message, 400);
     }
     if (err.code === "fetch_failed") {
-      const body: { success: false; reason: "fetch_failed"; upstream_status?: number } = {
+      const body: {
+        success: false;
+        reason: "fetch_failed";
+        upstream_status?: number;
+      } = {
         success: false,
         reason: "fetch_failed",
       };


### PR DESCRIPTION
## Summary
- Extracts the URL-body import pipeline into a shared `runGcsImport` helper.
- Adds `POST /v1/migrations/import-from-gcs` returning 202 + job_id, backed by the new `MigrationJobRegistry`.

Part of plan: teleport-gcs-unify.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
