### PR TITLE
fix(home): polish feed icons, labels, and detail panel routing (JARVIS-579)

### DIFF
--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -196,12 +196,12 @@ export class FilingService {
         source: "filing",
         groupId: "system:background",
         origin: "filing",
-        systemHint: "Filing",
+        systemHint: "Knowledge base filing",
       });
 
       this.deps.onConversationCreated?.({
         conversationId: conversation.id,
-        title: "Filing",
+        title: "Knowledge base filing",
       });
 
       await this.deps.processMessage(conversation.id, FILING_PROMPT_TEMPLATE, {

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { HeartbeatAlert } from "../daemon/message-protocol.js";
-import { writeAssistantFeedItem } from "../home/assistant-feed-authoring.js";
+import { emitFeedEvent } from "../home/emit-feed-event.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import {
   GUARDIAN_PERSONA_TEMPLATE,
@@ -398,11 +398,12 @@ export class HeartbeatService {
 
       log.info({ conversationId: conversation.id }, "Heartbeat completed");
 
-      void writeAssistantFeedItem({
-        type: "nudge",
+      const today = new Date().toISOString().split("T")[0];
+      void emitFeedEvent({
         source: "assistant",
         title: "Heartbeat",
         summary: "Heartbeat check completed.",
+        dedupKey: `heartbeat:ok:${today}`,
         priority: 30,
       }).catch((err) => {
         log.warn(
@@ -422,11 +423,12 @@ export class HeartbeatService {
         log.error({ alertErr }, "Failed to broadcast heartbeat alert");
       }
 
-      void writeAssistantFeedItem({
-        type: "nudge",
+      const today = new Date().toISOString().split("T")[0];
+      void emitFeedEvent({
         source: "assistant",
         title: "Heartbeat",
         summary: "Heartbeat check failed. Check logs for details.",
+        dedupKey: `heartbeat:fail:${today}`,
         priority: 55,
         urgency: "medium",
       }).catch(() => {});

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { HeartbeatAlert } from "../daemon/message-protocol.js";
-import { emitFeedEvent } from "../home/emit-feed-event.js";
+import { writeAssistantFeedItem } from "../home/assistant-feed-authoring.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import {
   GUARDIAN_PERSONA_TEMPLATE,
@@ -398,11 +398,11 @@ export class HeartbeatService {
 
       log.info({ conversationId: conversation.id }, "Heartbeat completed");
 
-      void emitFeedEvent({
+      void writeAssistantFeedItem({
+        type: "nudge",
         source: "assistant",
         title: "Heartbeat",
         summary: "Heartbeat check completed.",
-        dedupKey: `heartbeat:ok:${new Date().toISOString().split("T")[0]}`,
         priority: 30,
       }).catch((err) => {
         log.warn(
@@ -422,11 +422,11 @@ export class HeartbeatService {
         log.error({ alertErr }, "Failed to broadcast heartbeat alert");
       }
 
-      void emitFeedEvent({
+      void writeAssistantFeedItem({
+        type: "nudge",
         source: "assistant",
         title: "Heartbeat",
         summary: "Heartbeat check failed. Check logs for details.",
-        dedupKey: `heartbeat:fail:${new Date().toISOString().split("T")[0]}`,
         priority: 55,
         urgency: "medium",
       }).catch(() => {});

--- a/assistant/src/home/__tests__/rollup-producer.test.ts
+++ b/assistant/src/home/__tests__/rollup-producer.test.ts
@@ -104,7 +104,7 @@ function toolUseContent(input: unknown): ContentBlock {
 const oneAction: FeedItem[] = [
   makeAction({
     id: "a1",
-    source: "gmail",
+    source: "assistant",
     title: "Replied to Alice",
     summary: "Sent a reply to alice@example.com.",
     createdAt: "2026-04-14T11:30:00.000Z",
@@ -117,6 +117,22 @@ beforeEach(() => {
 
 describe("runRollupProducer", () => {
   test("writes each digest/thread returned in the tool call", async () => {
+    const actions: FeedItem[] = [
+      makeAction({
+        id: "a1",
+        source: "gmail",
+        title: "Replied to Alice",
+        summary: "Sent a reply.",
+        createdAt: "2026-04-14T11:30:00.000Z",
+      }),
+      makeAction({
+        id: "a2",
+        source: "assistant",
+        title: "Outreach step 1",
+        summary: "Sent emails.",
+        createdAt: "2026-04-14T11:45:00.000Z",
+      }),
+    ];
     const provider = scriptedProvider([
       toolUseContent({
         items: [
@@ -141,7 +157,7 @@ describe("runRollupProducer", () => {
     const result = await runRollupProducer(new Date(), {
       writeItem,
       loadRelationshipState: stubRelationshipState,
-      loadRecentActions: stubLoadRecentActions(oneAction),
+      loadRecentActions: stubLoadRecentActions(actions),
       resolveProvider: () => provider,
     });
 
@@ -219,6 +235,7 @@ describe("runRollupProducer", () => {
     expect(capturedPrompt).toContain("Posted in #general");
     expect(capturedPrompt).toContain("[gmail]");
     expect(capturedPrompt).toContain("[slack]");
+    expect(capturedPrompt).toContain("Sources present in the activity log:");
   });
 
   test("returns empty_items when the model emits an empty items array", async () => {
@@ -406,6 +423,54 @@ describe("runRollupProducer", () => {
     release!([toolUseContent({ items: [] })]);
     const firstResult = await first;
     expect(firstResult.skippedReason).toBe("empty_items");
+  });
+
+  test("rejects rollup items whose source is not present in the input actions", async () => {
+    const actions: FeedItem[] = [
+      makeAction({
+        id: "a1",
+        source: "assistant",
+        title: "Did a thing",
+        summary: "Background task completed.",
+      }),
+    ];
+    const provider = scriptedProvider([
+      toolUseContent({
+        items: [
+          {
+            type: "digest",
+            source: "slack",
+            title: "Inbox and slack activity",
+            summary: "Hallucinated slack summary.",
+          },
+          {
+            type: "digest",
+            source: "gmail",
+            title: "Inbox activity overnight",
+            summary: "Hallucinated gmail summary.",
+          },
+          {
+            type: "digest",
+            source: "assistant",
+            title: "Background tasks completed",
+            summary: "Valid assistant digest.",
+          },
+        ],
+      }),
+    ]);
+
+    const result = await runRollupProducer(new Date(), {
+      writeItem,
+      loadRelationshipState: stubRelationshipState,
+      loadRecentActions: stubLoadRecentActions(actions),
+      resolveProvider: () => provider,
+    });
+
+    expect(result.wroteCount).toBe(1);
+    expect(writeItem).toHaveBeenCalledTimes(1);
+    expect(writeItem.mock.calls[0]![0].title).toBe(
+      "Background tasks completed",
+    );
   });
 
   test("clamps priority to the valid [0, 100] window", async () => {

--- a/assistant/src/home/rollup-producer.ts
+++ b/assistant/src/home/rollup-producer.ts
@@ -259,10 +259,12 @@ async function runRollupProducerInner(
     return { wroteCount: 0, skippedReason: "empty_items" };
   }
 
+  const validSources = new Set(actions.map((a) => a.source).filter(Boolean));
+
   const capped = rawItems.slice(0, MAX_ITEMS_PER_ROLLUP);
   const accepted: WriteAssistantFeedItemParams[] = [];
   for (const raw of capped) {
-    const params = coerceRollupItem(raw);
+    const params = coerceRollupItem(raw, validSources);
     if (params) accepted.push(params);
   }
 
@@ -356,6 +358,9 @@ function buildUserPrompt(
     "Known facts about the user (for context only — do NOT invent roll-ups from these):",
     factLines.length > 0 ? factLines : "  (none yet)",
     "",
+    `Sources present in the activity log: ${[...new Set(actions.map((a) => a.source).filter(Boolean))].join(", ") || "(none)"}`,
+    "IMPORTANT: Only use sources that appear in the list above. Do NOT reference services (Gmail, Slack, etc.) that have no activity log entries.",
+    "",
     "Consolidate the activity log above into a small set of `digest` or `thread` roll-up items. Remember: prefer 0 items over filler, and only roll up when several related actions cluster into a coherent story. Use the `write_feed_items` tool.",
   ].join("\n");
 }
@@ -368,7 +373,10 @@ function buildUserPrompt(
  * the `type` narrowing to digest/thread (actions and nudges are
  * rejected here even if the model ignores the tool schema).
  */
-function coerceRollupItem(raw: unknown): WriteAssistantFeedItemParams | null {
+function coerceRollupItem(
+  raw: unknown,
+  validSources: Set<string | undefined>,
+): WriteAssistantFeedItemParams | null {
   if (!raw || typeof raw !== "object") return null;
   const obj = raw as Record<string, unknown>;
 
@@ -389,6 +397,7 @@ function coerceRollupItem(raw: unknown): WriteAssistantFeedItemParams | null {
     source === "calendar" ||
     source === "assistant"
   ) {
+    if (!validSources.has(source)) return null;
     coercedSource = source;
   }
 

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanelKind.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanelKind.swift
@@ -18,12 +18,12 @@ enum HomeDetailPanelKind: Equatable {
     case paymentAuth(FeedItem)
     case toolPermission(FeedItem)
     case updatesList(FeedItem)
+    case generic(FeedItem)
 
     /// Resolves from the wire-contract `detailPanel` field when present,
-    /// otherwise falls back to legacy type+source heuristics so
-    /// scheduled/nudge panels remain reachable for items that don't yet
-    /// carry a `detailPanel`.
-    static func resolve(for item: FeedItem) -> HomeDetailPanelKind? {
+    /// otherwise falls back to type+source heuristics, and finally to a
+    /// generic panel so every feed item opens a detail view on tap.
+    static func resolve(for item: FeedItem) -> HomeDetailPanelKind {
         if let panel = item.detailPanel {
             switch panel.kind {
             case .emailDraft: return .emailDraft(item)
@@ -35,15 +35,13 @@ enum HomeDetailPanelKind: Equatable {
             }
         }
 
-        // Legacy heuristic fallbacks — kept until the daemon populates
-        // `detailPanel` for every item type.
         switch item.type {
         case .thread where item.source == .calendar:
             return .scheduled(item)
         case .nudge:
             return .nudge(item)
         default:
-            return nil
+            return .generic(item)
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedFilterBar.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedFilterBar.swift
@@ -2,33 +2,22 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Horizontal filter bar rendered between the suggestion pills and the
-/// time-grouped Home feed. Figma: `3596:79557` (New App).
+/// time-grouped Home feed.
 ///
-/// Layout: a 12pt "Filter:" caption + a row of four 26pt icon-circle
-/// chips — Heartbeat (`.nudge`), Input (`.action`), Notification
-/// (`.digest`), and Schedule (`.thread`). Chips are single-select:
+/// Layout: "Filter:" caption + four icon-circle chips + an animated
+/// label that appears when a chip is selected. Chips are single-select:
 /// tapping a chip makes it the active filter; tapping the active chip
-/// again clears the filter. A nil ``selected`` means "show everything" —
-/// the parent view is responsible for applying the filter to its feed.
-///
-/// The chip shape + tint mapping is intentionally aligned with
-/// ``HomeRecapRow``'s leading icon, so the filter chips and the row
-/// icons read as a single visual language.
+/// again clears the filter. A nil ``selected`` means "show everything".
 struct HomeFeedFilterBar: View {
     let selected: FeedItemType?
     let onToggle: (FeedItemType) -> Void
 
-    /// Order matches the Figma mock (Heartbeat, Input, Notification,
-    /// Schedule). Kept as a static list so the iteration order is
-    /// deterministic across renders.
+    /// Kept as a static list so the iteration order is deterministic.
     private static let chipOrder: [FeedItemType] = [.nudge, .action, .digest, .thread]
 
     var body: some View {
         HStack(alignment: .center, spacing: VSpacing.sm) {
             Text("Filter:")
-                // Figma label: 12pt Inter Semibold, #5A6672 →
-                // `bodySmallEmphasised` (DM Sans 500-weight 12pt, our
-                // closest equivalent) + `contentSecondary` token.
                 .font(VFont.bodySmallEmphasised)
                 .foregroundStyle(VColor.contentSecondary)
 
@@ -39,7 +28,15 @@ struct HomeFeedFilterBar: View {
                     onToggle: { onToggle(type) }
                 )
             }
+
+            if let selected {
+                Text(HomeFeedFilterChip.label(for: selected))
+                    .font(VFont.bodySmallEmphasised)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .transition(.opacity)
+            }
         }
+        .animation(VAnimation.standard, value: selected)
     }
 }
 
@@ -116,13 +113,18 @@ private struct HomeFeedFilterChip: View {
         }
     }
 
-    /// Human-readable name used in the VoiceOver label.
-    private var accessibilityName: String {
+    /// Human-readable label for VoiceOver and the visible selected-state
+    /// caption in the filter bar.
+    static func label(for type: FeedItemType) -> String {
         switch type {
         case .nudge:   return "Heartbeat"
-        case .action:  return "Input"
-        case .digest:  return "Notification"
-        case .thread:  return "Schedule"
+        case .action:  return "Needs attention"
+        case .digest:  return "Just so you know"
+        case .thread:  return "Scheduled"
         }
+    }
+
+    private var accessibilityName: String {
+        Self.label(for: type)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -291,15 +291,11 @@ struct HomePageView<DetailPanel: View>: View {
 
     // MARK: - Recap row styling
 
-    /// Icon glyph for a feed item, driven by type + source. Mapping
-    /// follows the Figma spec:
-    ///   nudge + assistant   → heart
-    ///   action              → arrow-left (inbound intent)
-    ///   digest              → bell
-    ///   thread              → calendar (aligned with the Schedule
-    ///                                    filter chip so row icons
-    ///                                    and chips share one visual
-    ///                                    language)
+    /// Icon glyph for a feed item, driven by type:
+    ///   nudge  → heart     (Heartbeat)
+    ///   action → arrowLeft (Needs attention)
+    ///   digest → bell      (Just so you know)
+    ///   thread → calendar  (Scheduled)
     private func icon(for item: FeedItem) -> VIcon {
         switch item.type {
         case .nudge:
@@ -342,35 +338,10 @@ struct HomePageView<DetailPanel: View>: View {
 
     // MARK: - Actions
 
-    /// Opens the feed item. Items that resolve to a detail panel via
-    /// ``HomeDetailPanelKind.resolve(for:)`` route to
-    /// `onDetailPanelSelected`; every other item (including non-calendar
-    /// `.thread` items such as rollup-producer general-purpose threads)
-    /// keeps the existing "trigger the `open` action and navigate into
-    /// the resulting conversation" flow. The daemon interprets any
-    /// unknown action id as an "open" intent and seeds the new
-    /// conversation with the first available action's prompt (or the
-    /// item summary if there are no actions).
-    ///
-    /// Exposed as `internal` (not `private`) so routing tests can drive it
-    /// directly without needing to render the full view tree.
+    /// Opens the detail panel for the tapped feed item. Every item
+    /// resolves to a panel kind via ``HomeDetailPanelKind.resolve(for:)``.
     func openItem(_ item: FeedItem) {
-        if HomeDetailPanelKind.resolve(for: item) != nil {
-            onDetailPanelSelected(item)
-            return
-        }
-        if let conversationId = item.conversationId {
-            onFeedConversationOpened(conversationId)
-            return
-        }
-        Task {
-            if let conversationId = await feedStore.triggerAction(
-                itemId: item.id,
-                actionId: "open"
-            ) {
-                onFeedConversationOpened(conversationId)
-            }
-        }
+        onDetailPanelSelected(item)
     }
 
     /// Dismisses the feed item — store optimistically removes it from

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -227,7 +227,8 @@ extension MainWindowView {
                 }
             },
             onDetailPanelSelected: { item in
-                activeHomeDetailPanel = HomeDetailPanelKind.resolve(for: item)
+                let resolved = HomeDetailPanelKind.resolve(for: item)
+                activeHomeDetailPanel = resolved
             },
             isDetailPanelVisible: activeHomeDetailPanel != nil,
             detailPanel: {
@@ -325,6 +326,27 @@ extension MainWindowView {
                         onDismiss: { activeHomeDetailPanel = nil }
                     ) {
                         HomeUpdatesListDetailCard(item: item)
+                    }
+                case .generic(let item):
+                    HomeDetailPanel(
+                        icon: iconForFeedItem(item),
+                        title: item.title,
+                        iconForeground: iconForegroundForFeedItem(item),
+                        iconBackground: iconBackgroundForFeedItem(item),
+                        onGoToThread: item.conversationId.flatMap { id in
+                            UUID(uuidString: id).map { uuid in
+                                {
+                                    activeHomeDetailPanel = nil
+                                    windowState.selection = .conversation(uuid)
+                                }
+                            }
+                        },
+                        onDismiss: { activeHomeDetailPanel = nil }
+                    ) {
+                        Text(item.summary)
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                            .padding(VSpacing.lg)
                     }
                 case nil:
                     EmptyView()
@@ -844,6 +866,35 @@ extension MainWindowView {
                 onMicrophoneToggle: onMicrophoneToggle
             )
         }
+    }
+}
+
+// MARK: - Feed Item Icon Helpers
+
+private func iconForFeedItem(_ item: FeedItem) -> VIcon {
+    switch item.type {
+    case .nudge:   return .heart
+    case .action:  return .arrowLeft
+    case .digest:  return .bell
+    case .thread:  return .calendar
+    }
+}
+
+private func iconForegroundForFeedItem(_ item: FeedItem) -> Color {
+    switch item.type {
+    case .nudge:   return VColor.feedNudgeStrong
+    case .action:  return VColor.systemInfoStrong
+    case .digest:  return VColor.feedDigestStrong
+    case .thread:  return VColor.feedThreadStrong
+    }
+}
+
+private func iconBackgroundForFeedItem(_ item: FeedItem) -> Color {
+    switch item.type {
+    case .nudge:   return VColor.feedNudgeWeak
+    case .action:  return VColor.systemInfoWeak
+    case .digest:  return VColor.feedDigestWeak
+    case .thread:  return VColor.feedThreadWeak
     }
 }
 


### PR DESCRIPTION
## Summary
- **Filter labels**: Renamed "Input" → "Needs attention", "Notification" → "Just so you know", "Schedule" → "Scheduled". Active filter now shows its label text next to the chip.
- **Heartbeat icon**: Heartbeat feed events now emit as `nudge` type (heart icon) instead of `action` (arrow icon).
- **Filing title**: Filing conversations use "Knowledge base filing" instead of bare "Filing".
- **Rollup source validation**: Rollup producer now validates sources against input actions and rejects hallucinated gmail/slack digests when those services aren't connected.
- **Detail panel routing**: All feed items now open a detail panel on click — items without a specific panel kind get a generic panel showing title, summary, and a "Go to Thread" button when a conversation is linked.

## Test plan
- [x] `bun test rollup-producer.test.ts` — 13/13 pass (includes new hallucinated-source rejection test)
- [x] `./build.sh` — macOS client compiles cleanly
- [x] Verified in-app: all list items open a detail panel, filter labels display correctly

Closes JARVIS-579

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
