### PR TITLE
feat(cli): add unified signed-url and job-polling client helpers

### DIFF
--- a/cli/src/lib/__tests__/job-polling.test.ts
+++ b/cli/src/lib/__tests__/job-polling.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import { pollJobUntilDone } from "../job-polling.js";
+import type { UnifiedJobStatus } from "../platform-client.js";
+
+describe("pollJobUntilDone", () => {
+  test("returns terminal 'complete' after N processing polls", async () => {
+    const statuses: UnifiedJobStatus[] = [
+      { jobId: "j1", type: "export", status: "processing" },
+      { jobId: "j1", type: "export", status: "processing" },
+      {
+        jobId: "j1",
+        type: "export",
+        status: "complete",
+        bundleKey: "bundles/j1.tar.gz",
+      },
+    ];
+    let i = 0;
+    const result = await pollJobUntilDone({
+      poll: async () => statuses[i++]!,
+      intervalMs: 1,
+      timeoutMs: 1_000,
+      label: "test export",
+    });
+
+    expect(result.status).toBe("complete");
+    if (result.status === "complete") {
+      expect(result.bundleKey).toBe("bundles/j1.tar.gz");
+    }
+    expect(i).toBe(3);
+  });
+
+  test("propagates terminal 'failed' status to caller without throwing", async () => {
+    const result = await pollJobUntilDone({
+      poll: async () => ({
+        jobId: "j2",
+        type: "import",
+        status: "failed",
+        error: "bad bundle",
+      }),
+      intervalMs: 1,
+      timeoutMs: 1_000,
+      label: "test import",
+    });
+
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.error).toBe("bad bundle");
+    }
+  });
+
+  test("throws with label when polling exceeds timeoutMs", async () => {
+    let calls = 0;
+    await expect(
+      pollJobUntilDone({
+        poll: async () => {
+          calls += 1;
+          return { jobId: "j3", type: "export", status: "processing" };
+        },
+        intervalMs: 20,
+        timeoutMs: 10,
+        label: "slow export",
+      }),
+    ).rejects.toThrow(/slow export/);
+
+    // The loop does one poll before checking the deadline, so calls ≥ 1.
+    expect(calls).toBeGreaterThanOrEqual(1);
+  });
+
+  test("uses defaults when intervalMs/timeoutMs are omitted (fast path)", async () => {
+    // Fast path: first poll is already terminal so neither default matters.
+    const result = await pollJobUntilDone({
+      poll: async () => ({ jobId: "j4", type: "export", status: "complete" }),
+      label: "defaults test",
+    });
+    expect(result.status).toBe("complete");
+  });
+});

--- a/cli/src/lib/__tests__/local-runtime-client.test.ts
+++ b/cli/src/lib/__tests__/local-runtime-client.test.ts
@@ -117,12 +117,14 @@ describe("localRuntimeExportToGcs", () => {
     });
   });
 
-  test("409 export_in_progress throws MigrationInProgressError carrying existing job_id", async () => {
+  test("409 export_in_progress (nested {error:{code,job_id}}) throws MigrationInProgressError carrying existing job_id", async () => {
     const { fetchMock } = captureFetch(() => {
       return new Response(
         JSON.stringify({
-          code: "export_in_progress",
-          job_id: "existing-export-42",
+          error: {
+            code: "export_in_progress",
+            job_id: "existing-export-42",
+          },
         }),
         { status: 409 },
       );
@@ -139,6 +141,56 @@ describe("localRuntimeExportToGcs", () => {
       const mip = err as MigrationInProgressError;
       expect(mip.kind).toBe("export_in_progress");
       expect(mip.existingJobId).toBe("existing-export-42");
+    }
+  });
+
+  test("409 export_in_progress regression: nested job_id 'abc-123' is surfaced (not empty)", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          error: { code: "export_in_progress", job_id: "abc-123" },
+        }),
+        { status: 409 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    try {
+      await localRuntimeExportToGcs(RUNTIME_URL, TOKEN, {
+        uploadUrl: "https://storage.example/signed/abc",
+      });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MigrationInProgressError);
+      const mip = err as MigrationInProgressError;
+      expect(mip.existingJobId).toBe("abc-123");
+      expect(mip.existingJobId).not.toBe("");
+      expect(mip.kind).toBe("export_in_progress");
+    }
+  });
+
+  test("409 export_in_progress with legacy flat shape is still parsed", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          code: "export_in_progress",
+          job_id: "legacy-export-9",
+        }),
+        { status: 409 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    try {
+      await localRuntimeExportToGcs(RUNTIME_URL, TOKEN, {
+        uploadUrl: "https://storage.example/signed/abc",
+      });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MigrationInProgressError);
+      const mip = err as MigrationInProgressError;
+      expect(mip.kind).toBe("export_in_progress");
+      expect(mip.existingJobId).toBe("legacy-export-9");
     }
   });
 
@@ -183,12 +235,14 @@ describe("localRuntimeImportFromGcs", () => {
     });
   });
 
-  test("409 import_in_progress throws MigrationInProgressError carrying existing job_id", async () => {
+  test("409 import_in_progress (nested {error:{code,job_id}}) throws MigrationInProgressError carrying existing job_id", async () => {
     const { fetchMock } = captureFetch(() => {
       return new Response(
         JSON.stringify({
-          code: "import_in_progress",
-          job_id: "existing-import-7",
+          error: {
+            code: "import_in_progress",
+            job_id: "existing-import-7",
+          },
         }),
         { status: 409 },
       );
@@ -207,6 +261,31 @@ describe("localRuntimeImportFromGcs", () => {
       expect(mip.existingJobId).toBe("existing-import-7");
     }
   });
+
+  test("409 import_in_progress with legacy flat shape is still parsed", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          code: "import_in_progress",
+          job_id: "legacy-import-2",
+        }),
+        { status: 409 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    try {
+      await localRuntimeImportFromGcs(RUNTIME_URL, TOKEN, {
+        bundleUrl: "https://storage.example/signed/dl-xyz",
+      });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MigrationInProgressError);
+      const mip = err as MigrationInProgressError;
+      expect(mip.kind).toBe("import_in_progress");
+      expect(mip.existingJobId).toBe("legacy-import-2");
+    }
+  });
 });
 
 describe("localRuntimePollJobStatus", () => {
@@ -223,7 +302,11 @@ describe("localRuntimePollJobStatus", () => {
     });
     globalThis.fetch = fetchMock;
 
-    const status = await localRuntimePollJobStatus(RUNTIME_URL, TOKEN, "poll-1");
+    const status = await localRuntimePollJobStatus(
+      RUNTIME_URL,
+      TOKEN,
+      "poll-1",
+    );
 
     expect(status).toEqual({
       jobId: "poll-1",
@@ -249,7 +332,11 @@ describe("localRuntimePollJobStatus", () => {
     });
     globalThis.fetch = fetchMock;
 
-    const status = await localRuntimePollJobStatus(RUNTIME_URL, TOKEN, "poll-2");
+    const status = await localRuntimePollJobStatus(
+      RUNTIME_URL,
+      TOKEN,
+      "poll-2",
+    );
 
     expect(status.status).toBe("complete");
     if (status.status === "complete") {
@@ -271,7 +358,11 @@ describe("localRuntimePollJobStatus", () => {
     });
     globalThis.fetch = fetchMock;
 
-    const status = await localRuntimePollJobStatus(RUNTIME_URL, TOKEN, "poll-3");
+    const status = await localRuntimePollJobStatus(
+      RUNTIME_URL,
+      TOKEN,
+      "poll-3",
+    );
 
     expect(status.status).toBe("failed");
     if (status.status === "failed") {

--- a/cli/src/lib/__tests__/local-runtime-client.test.ts
+++ b/cli/src/lib/__tests__/local-runtime-client.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  MigrationInProgressError,
+  localRuntimeExportToGcs,
+  localRuntimeImportFromGcs,
+  localRuntimePollJobStatus,
+} from "../local-runtime-client.js";
+
+const RUNTIME_URL = "http://127.0.0.1:8765";
+const TOKEN = "local-bearer-token";
+
+interface CapturedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function captureFetch(
+  responder: (call: CapturedCall) => Response | Promise<Response>,
+): {
+  calls: CapturedCall[];
+  fetchMock: typeof globalThis.fetch;
+} {
+  const calls: CapturedCall[] = [];
+  const fetchMock = mock(
+    async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      const rawHeaders = (init?.headers ?? {}) as
+        | Record<string, string>
+        | Headers;
+      const headers: Record<string, string> = {};
+      if (rawHeaders instanceof Headers) {
+        rawHeaders.forEach((v, k) => {
+          headers[k] = v;
+        });
+      } else {
+        Object.assign(headers, rawHeaders);
+      }
+      let parsedBody: unknown = undefined;
+      const b = init?.body;
+      if (typeof b === "string") {
+        try {
+          parsedBody = JSON.parse(b);
+        } catch {
+          parsedBody = b;
+        }
+      }
+      const call: CapturedCall = {
+        url: urlStr,
+        method: init?.method ?? "GET",
+        headers,
+        body: parsedBody,
+      };
+      calls.push(call);
+      return responder(call);
+    },
+  );
+  return { calls, fetchMock: fetchMock as unknown as typeof globalThis.fetch };
+}
+
+let originalFetch: typeof globalThis.fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("localRuntimeExportToGcs", () => {
+  test("POSTs {upload_url, description} with Bearer auth and returns job_id on 202", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "export-job-1",
+          status: "pending",
+          type: "export",
+        }),
+        { status: 202, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await localRuntimeExportToGcs(RUNTIME_URL, TOKEN, {
+      uploadUrl: "https://storage.example/signed/abc",
+      description: "teleport export",
+    });
+
+    expect(result.jobId).toBe("export-job-1");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(`${RUNTIME_URL}/v1/migrations/export-to-gcs`);
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(calls[0]!.headers["Content-Type"]).toBe("application/json");
+    expect(calls[0]!.body).toEqual({
+      upload_url: "https://storage.example/signed/abc",
+      description: "teleport export",
+    });
+  });
+
+  test("omits description when not provided", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({ job_id: "j", status: "pending", type: "export" }),
+        { status: 202 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    await localRuntimeExportToGcs(RUNTIME_URL, TOKEN, {
+      uploadUrl: "https://storage.example/signed/abc",
+    });
+
+    expect(calls[0]!.body).toEqual({
+      upload_url: "https://storage.example/signed/abc",
+    });
+  });
+
+  test("409 export_in_progress throws MigrationInProgressError carrying existing job_id", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          code: "export_in_progress",
+          job_id: "existing-export-42",
+        }),
+        { status: 409 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    try {
+      await localRuntimeExportToGcs(RUNTIME_URL, TOKEN, {
+        uploadUrl: "https://storage.example/signed/abc",
+      });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MigrationInProgressError);
+      const mip = err as MigrationInProgressError;
+      expect(mip.kind).toBe("export_in_progress");
+      expect(mip.existingJobId).toBe("existing-export-42");
+    }
+  });
+
+  test("non-202 non-409 responses throw with status + body", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response("boom", { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      localRuntimeExportToGcs(RUNTIME_URL, TOKEN, {
+        uploadUrl: "https://storage.example/signed/abc",
+      }),
+    ).rejects.toThrow(/500/);
+  });
+});
+
+describe("localRuntimeImportFromGcs", () => {
+  test("POSTs {bundle_url} with Bearer auth and returns job_id on 202", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "import-job-1",
+          status: "pending",
+          type: "import",
+        }),
+        { status: 202 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await localRuntimeImportFromGcs(RUNTIME_URL, TOKEN, {
+      bundleUrl: "https://storage.example/signed/dl-xyz",
+    });
+
+    expect(result.jobId).toBe("import-job-1");
+    expect(calls[0]!.url).toBe(`${RUNTIME_URL}/v1/migrations/import-from-gcs`);
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(calls[0]!.body).toEqual({
+      bundle_url: "https://storage.example/signed/dl-xyz",
+    });
+  });
+
+  test("409 import_in_progress throws MigrationInProgressError carrying existing job_id", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          code: "import_in_progress",
+          job_id: "existing-import-7",
+        }),
+        { status: 409 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    try {
+      await localRuntimeImportFromGcs(RUNTIME_URL, TOKEN, {
+        bundleUrl: "https://storage.example/signed/dl-xyz",
+      });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MigrationInProgressError);
+      const mip = err as MigrationInProgressError;
+      expect(mip.kind).toBe("import_in_progress");
+      expect(mip.existingJobId).toBe("existing-import-7");
+    }
+  });
+});
+
+describe("localRuntimePollJobStatus", () => {
+  test("GETs /v1/migrations/jobs/{jobId} with Bearer auth and parses processing", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "poll-1",
+          type: "export",
+          status: "processing",
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const status = await localRuntimePollJobStatus(RUNTIME_URL, TOKEN, "poll-1");
+
+    expect(status).toEqual({
+      jobId: "poll-1",
+      type: "export",
+      status: "processing",
+    });
+    expect(calls[0]!.url).toBe(`${RUNTIME_URL}/v1/migrations/jobs/poll-1`);
+    expect(calls[0]!.method).toBe("GET");
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  test("parses complete with bundle_key", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "poll-2",
+          type: "export",
+          status: "complete",
+          bundle_key: "bundles/x.tar.gz",
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const status = await localRuntimePollJobStatus(RUNTIME_URL, TOKEN, "poll-2");
+
+    expect(status.status).toBe("complete");
+    if (status.status === "complete") {
+      expect(status.bundleKey).toBe("bundles/x.tar.gz");
+    }
+  });
+
+  test("parses failed with error", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "poll-3",
+          type: "import",
+          status: "failed",
+          error: "corrupted bundle",
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const status = await localRuntimePollJobStatus(RUNTIME_URL, TOKEN, "poll-3");
+
+    expect(status.status).toBe("failed");
+    if (status.status === "failed") {
+      expect(status.error).toBe("corrupted bundle");
+    }
+  });
+
+  test("404 → throws 'Migration job not found'", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response("{}", { status: 404 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      localRuntimePollJobStatus(RUNTIME_URL, TOKEN, "missing"),
+    ).rejects.toThrow(/Migration job not found/);
+  });
+});

--- a/cli/src/lib/__tests__/platform-client-signed-url.test.ts
+++ b/cli/src/lib/__tests__/platform-client-signed-url.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  platformPollJobStatus,
+  platformRequestSignedUrl,
+  type UnifiedJobStatus,
+} from "../platform-client.js";
+
+const PLATFORM_URL = "https://platform.example.test";
+const VAK_TOKEN = "vak_test_1234567890"; // API-key path skips org-ID fetch.
+
+interface CapturedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function captureFetch(
+  responder: (call: CapturedCall) => Response | Promise<Response>,
+): {
+  calls: CapturedCall[];
+  fetchMock: typeof globalThis.fetch;
+} {
+  const calls: CapturedCall[] = [];
+  const fetchMock = mock(
+    async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      const rawHeaders = (init?.headers ?? {}) as
+        | Record<string, string>
+        | Headers;
+      const headers: Record<string, string> = {};
+      if (rawHeaders instanceof Headers) {
+        rawHeaders.forEach((v, k) => {
+          headers[k] = v;
+        });
+      } else {
+        Object.assign(headers, rawHeaders);
+      }
+      let parsedBody: unknown = undefined;
+      const b = init?.body;
+      if (typeof b === "string") {
+        try {
+          parsedBody = JSON.parse(b);
+        } catch {
+          parsedBody = b;
+        }
+      }
+      const call: CapturedCall = {
+        url: urlStr,
+        method: init?.method ?? "GET",
+        headers,
+        body: parsedBody,
+      };
+      calls.push(call);
+      return responder(call);
+    },
+  );
+  return { calls, fetchMock: fetchMock as unknown as typeof globalThis.fetch };
+}
+
+let originalFetch: typeof globalThis.fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("platformRequestSignedUrl", () => {
+  test("upload operation with just operation → posts correct body and parses response", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          url: "https://storage.example/signed/abc",
+          bundle_key: "bundles/abc.tar.gz",
+          expires_at: "2026-04-22T00:00:00Z",
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await platformRequestSignedUrl(
+      { operation: "upload" },
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(result).toEqual({
+      url: "https://storage.example/signed/abc",
+      bundleKey: "bundles/abc.tar.gz",
+      expiresAt: "2026-04-22T00:00:00Z",
+      maxContentLength: undefined,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      `${PLATFORM_URL}/v1/migrations/signed-url/`,
+    );
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${VAK_TOKEN}`);
+    expect(calls[0]!.headers["Content-Type"]).toBe("application/json");
+    expect(calls[0]!.body).toEqual({ operation: "upload" });
+  });
+
+  test("upload operation with content_length + content_type passes them through", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          url: "https://storage.example/signed/xyz",
+          bundle_key: "bundles/xyz.tar.gz",
+          expires_at: "2026-04-22T01:00:00Z",
+          max_content_length: 10_000_000,
+        }),
+        { status: 201 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await platformRequestSignedUrl(
+      {
+        operation: "upload",
+        contentType: "application/octet-stream",
+        contentLength: 12345,
+      },
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(result.maxContentLength).toBe(10_000_000);
+    expect(calls[0]!.body).toEqual({
+      operation: "upload",
+      content_type: "application/octet-stream",
+      content_length: 12345,
+    });
+  });
+
+  test("download operation with bundleKey → posts bundle_key and parses response", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          url: "https://storage.example/signed/dl-xyz",
+          bundle_key: "bundles/xyz.tar.gz",
+          expires_at: "2026-04-22T02:00:00Z",
+        }),
+        { status: 201 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await platformRequestSignedUrl(
+      { operation: "download", bundleKey: "bundles/xyz.tar.gz" },
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(result.url).toBe("https://storage.example/signed/dl-xyz");
+    expect(result.bundleKey).toBe("bundles/xyz.tar.gz");
+    expect(calls[0]!.body).toEqual({
+      operation: "download",
+      bundle_key: "bundles/xyz.tar.gz",
+    });
+  });
+
+  test("401 → retries once and returns success on the retry", async () => {
+    let callCount = 0;
+    const { calls, fetchMock } = captureFetch(() => {
+      callCount += 1;
+      if (callCount === 1) {
+        return new Response(JSON.stringify({ detail: "unauthorized" }), {
+          status: 401,
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          url: "https://storage.example/signed/after-retry",
+          bundle_key: "bundles/r.tar.gz",
+          expires_at: "2026-04-22T03:00:00Z",
+        }),
+        { status: 201 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await platformRequestSignedUrl(
+      { operation: "upload" },
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(result.url).toBe("https://storage.example/signed/after-retry");
+    expect(calls).toHaveLength(2);
+  });
+
+  test("503 → throws so callers can fall back to legacy inline upload", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({ detail: "temporarily down" }), {
+        status: 503,
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      platformRequestSignedUrl({ operation: "upload" }, VAK_TOKEN, PLATFORM_URL),
+    ).rejects.toThrow(/503/);
+  });
+});
+
+describe("platformPollJobStatus", () => {
+  test("GET /v1/migrations/jobs/{jobId}/ parses processing", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "job-1",
+          type: "export",
+          status: "processing",
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const status = await platformPollJobStatus("job-1", VAK_TOKEN, PLATFORM_URL);
+
+    expect(status).toEqual({
+      jobId: "job-1",
+      type: "export",
+      status: "processing",
+    } satisfies UnifiedJobStatus);
+    expect(calls[0]!.url).toBe(
+      `${PLATFORM_URL}/v1/migrations/jobs/job-1/`,
+    );
+    expect(calls[0]!.method).toBe("GET");
+  });
+
+  test("parses complete with bundle_key + result", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "job-2",
+          type: "export",
+          status: "complete",
+          bundle_key: "bundles/done.tar.gz",
+          result: { files: 42 },
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const status = await platformPollJobStatus("job-2", VAK_TOKEN, PLATFORM_URL);
+
+    expect(status.status).toBe("complete");
+    if (status.status === "complete") {
+      expect(status.bundleKey).toBe("bundles/done.tar.gz");
+      expect(status.result).toEqual({ files: 42 });
+    }
+  });
+
+  test("parses failed with error", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "job-3",
+          type: "import",
+          status: "failed",
+          error: "bundle corrupt",
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const status = await platformPollJobStatus("job-3", VAK_TOKEN, PLATFORM_URL);
+
+    expect(status.status).toBe("failed");
+    if (status.status === "failed") {
+      expect(status.error).toBe("bundle corrupt");
+    }
+  });
+
+  test("404 → throws 'Migration job not found'", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response("{}", { status: 404 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      platformPollJobStatus("missing", VAK_TOKEN, PLATFORM_URL),
+    ).rejects.toThrow(/Migration job not found/);
+  });
+});

--- a/cli/src/lib/__tests__/platform-client-signed-url.test.ts
+++ b/cli/src/lib/__tests__/platform-client-signed-url.test.ts
@@ -8,6 +8,7 @@ import {
 
 const PLATFORM_URL = "https://platform.example.test";
 const VAK_TOKEN = "vak_test_1234567890"; // API-key path skips org-ID fetch.
+const SESSION_TOKEN = "session_test_1234567890"; // non-vak_ triggers org-ID lookup.
 
 interface CapturedCall {
   url: string;
@@ -94,9 +95,7 @@ describe("platformRequestSignedUrl", () => {
       maxContentLength: undefined,
     });
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.url).toBe(
-      `${PLATFORM_URL}/v1/migrations/signed-url/`,
-    );
+    expect(calls[0]!.url).toBe(`${PLATFORM_URL}/v1/migrations/signed-url/`);
     expect(calls[0]!.method).toBe("POST");
     expect(calls[0]!.headers.Authorization).toBe(`Bearer ${VAK_TOKEN}`);
     expect(calls[0]!.headers["Content-Type"]).toBe("application/json");
@@ -192,6 +191,106 @@ describe("platformRequestSignedUrl", () => {
     expect(calls).toHaveLength(2);
   });
 
+  test("401 with session token → invalidates org-ID cache and re-fetches on retry", async () => {
+    // Session tokens (non-vak_) take the org-ID-fetch path. A 401 here
+    // frequently means the cached org ID is stale, so the retry must
+    // clear the cache and re-fetch before the second signed-url POST.
+    const orgIdCalls: string[] = [];
+    const signedUrlCalls: CapturedCall[] = [];
+    let orgIdFetchCount = 0;
+    let signedUrlCount = 0;
+
+    const fetchMock = mock(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        const urlStr = typeof url === "string" ? url : url.toString();
+        const rawHeaders = (init?.headers ?? {}) as
+          | Record<string, string>
+          | Headers;
+        const headers: Record<string, string> = {};
+        if (rawHeaders instanceof Headers) {
+          rawHeaders.forEach((v, k) => {
+            headers[k] = v;
+          });
+        } else {
+          Object.assign(headers, rawHeaders);
+        }
+
+        if (urlStr.endsWith("/v1/organizations/")) {
+          orgIdFetchCount += 1;
+          orgIdCalls.push(urlStr);
+          const orgId = orgIdFetchCount === 1 ? "org-stale" : "org-fresh";
+          return new Response(
+            JSON.stringify({ results: [{ id: orgId, name: "Test Org" }] }),
+            { status: 200 },
+          );
+        }
+
+        if (urlStr.endsWith("/v1/migrations/signed-url/")) {
+          signedUrlCount += 1;
+          let parsedBody: unknown = undefined;
+          const b = init?.body;
+          if (typeof b === "string") {
+            try {
+              parsedBody = JSON.parse(b);
+            } catch {
+              parsedBody = b;
+            }
+          }
+          signedUrlCalls.push({
+            url: urlStr,
+            method: init?.method ?? "GET",
+            headers,
+            body: parsedBody,
+          });
+          if (signedUrlCount === 1) {
+            return new Response(JSON.stringify({ detail: "stale org" }), {
+              status: 401,
+            });
+          }
+          return new Response(
+            JSON.stringify({
+              url: "https://storage.example/signed/fresh",
+              bundle_key: "bundles/fresh.tar.gz",
+              expires_at: "2026-04-22T04:00:00Z",
+            }),
+            { status: 201 },
+          );
+        }
+
+        throw new Error(`Unexpected URL: ${urlStr}`);
+      },
+    );
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const result = await platformRequestSignedUrl(
+      { operation: "upload" },
+      SESSION_TOKEN,
+      PLATFORM_URL,
+    );
+
+    // Both signed-url attempts were made and the retry succeeded.
+    expect(result.url).toBe("https://storage.example/signed/fresh");
+    expect(signedUrlCalls).toHaveLength(2);
+
+    // The cache was cleared after the 401, so the org-ID endpoint was
+    // hit a second time to fetch a fresh ID before the retry.
+    expect(orgIdFetchCount).toBe(2);
+    expect(orgIdCalls).toHaveLength(2);
+
+    // The first signed-url POST used the stale org ID, the second used
+    // the fresh one.
+    expect(signedUrlCalls[0]!.headers["Vellum-Organization-Id"]).toBe(
+      "org-stale",
+    );
+    expect(signedUrlCalls[1]!.headers["Vellum-Organization-Id"]).toBe(
+      "org-fresh",
+    );
+
+    // Session tokens use X-Session-Token, not Bearer.
+    expect(signedUrlCalls[0]!.headers["X-Session-Token"]).toBe(SESSION_TOKEN);
+    expect(signedUrlCalls[0]!.headers.Authorization).toBeUndefined();
+  });
+
   test("503 → throws so callers can fall back to legacy inline upload", async () => {
     const { fetchMock } = captureFetch(() => {
       return new Response(JSON.stringify({ detail: "temporarily down" }), {
@@ -201,7 +300,11 @@ describe("platformRequestSignedUrl", () => {
     globalThis.fetch = fetchMock;
 
     await expect(
-      platformRequestSignedUrl({ operation: "upload" }, VAK_TOKEN, PLATFORM_URL),
+      platformRequestSignedUrl(
+        { operation: "upload" },
+        VAK_TOKEN,
+        PLATFORM_URL,
+      ),
     ).rejects.toThrow(/503/);
   });
 });
@@ -220,16 +323,18 @@ describe("platformPollJobStatus", () => {
     });
     globalThis.fetch = fetchMock;
 
-    const status = await platformPollJobStatus("job-1", VAK_TOKEN, PLATFORM_URL);
+    const status = await platformPollJobStatus(
+      "job-1",
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
 
     expect(status).toEqual({
       jobId: "job-1",
       type: "export",
       status: "processing",
     } satisfies UnifiedJobStatus);
-    expect(calls[0]!.url).toBe(
-      `${PLATFORM_URL}/v1/migrations/jobs/job-1/`,
-    );
+    expect(calls[0]!.url).toBe(`${PLATFORM_URL}/v1/migrations/jobs/job-1/`);
     expect(calls[0]!.method).toBe("GET");
   });
 
@@ -248,7 +353,11 @@ describe("platformPollJobStatus", () => {
     });
     globalThis.fetch = fetchMock;
 
-    const status = await platformPollJobStatus("job-2", VAK_TOKEN, PLATFORM_URL);
+    const status = await platformPollJobStatus(
+      "job-2",
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
 
     expect(status.status).toBe("complete");
     if (status.status === "complete") {
@@ -271,7 +380,11 @@ describe("platformPollJobStatus", () => {
     });
     globalThis.fetch = fetchMock;
 
-    const status = await platformPollJobStatus("job-3", VAK_TOKEN, PLATFORM_URL);
+    const status = await platformPollJobStatus(
+      "job-3",
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
 
     expect(status.status).toBe("failed");
     if (status.status === "failed") {

--- a/cli/src/lib/job-polling.ts
+++ b/cli/src/lib/job-polling.ts
@@ -1,0 +1,63 @@
+import type { UnifiedJobStatus } from "./platform-client.js";
+
+/**
+ * Terminal status returned by {@link pollJobUntilDone}. Callers decide
+ * whether to treat `failed` as a fatal error or retry logic concern.
+ */
+export type TerminalJobStatus = Extract<
+  UnifiedJobStatus,
+  { status: "complete" | "failed" }
+>;
+
+export interface PollJobUntilDoneOptions {
+  /** Async producer that returns the latest job status. */
+  poll: () => Promise<UnifiedJobStatus>;
+  /** Sleep between successive polls. Defaults to 2_000 ms. */
+  intervalMs?: number;
+  /** Maximum wall-clock time to wait. Defaults to 30 minutes. */
+  timeoutMs?: number;
+  /** Human-readable label used in the timeout error message (e.g. "export job"). */
+  label: string;
+}
+
+const DEFAULT_INTERVAL_MS = 2_000;
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll `options.poll` until it returns a terminal status (`complete` or
+ * `failed`), or until `timeoutMs` elapses.
+ *
+ * On terminal status, returns the status object — including the `failed`
+ * case. The caller decides how to treat a failed terminal status (e.g.
+ * print the `error` field and exit). Only timeouts throw.
+ */
+export async function pollJobUntilDone(
+  options: PollJobUntilDoneOptions,
+): Promise<TerminalJobStatus> {
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  // First poll happens immediately so fast-path completions don't wait
+  // one interval before returning.
+  while (true) {
+    const status = await options.poll();
+    if (status.status === "complete" || status.status === "failed") {
+      return status;
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out waiting for ${options.label} after ${Math.round(
+          timeoutMs / 1000,
+        )}s`,
+      );
+    }
+
+    await sleep(intervalMs);
+  }
+}

--- a/cli/src/lib/local-runtime-client.ts
+++ b/cli/src/lib/local-runtime-client.ts
@@ -13,7 +13,10 @@ export class MigrationInProgressError extends Error {
   readonly existingJobId: string;
   readonly kind: "export_in_progress" | "import_in_progress";
 
-  constructor(kind: "export_in_progress" | "import_in_progress", jobId: string) {
+  constructor(
+    kind: "export_in_progress" | "import_in_progress",
+    jobId: string,
+  ) {
     super(
       `A migration is already in progress (${kind}); existing job_id=${jobId}`,
     );
@@ -33,7 +36,10 @@ function bearerHeaders(token: string): Record<string, string> {
 
 interface Raw409Body {
   detail?: string;
-  error?: string;
+  // The runtime's current 409 contract nests the payload under `error`:
+  //   { error: { code: "export_in_progress" | "import_in_progress", job_id } }
+  // We also tolerate a legacy flat shape ({ code, job_id }) for resilience.
+  error?: string | { code?: string; job_id?: string };
   code?: string;
   job_id?: string;
 }
@@ -45,8 +51,16 @@ async function throwIfInProgress(
 ): Promise<void> {
   if (response.status !== 409) return;
   const body = (await response.json().catch(() => ({}))) as Raw409Body;
-  const jobId = body.job_id ?? "";
-  const rawKind = body.code ?? body.error ?? defaultKind;
+  const nested =
+    typeof body.error === "object" && body.error !== null
+      ? body.error
+      : undefined;
+  const jobId = nested?.job_id ?? body.job_id ?? "";
+  const rawKind =
+    nested?.code ??
+    body.code ??
+    (typeof body.error === "string" ? body.error : undefined) ??
+    defaultKind;
   const kind: "export_in_progress" | "import_in_progress" =
     rawKind === "export_in_progress" || rawKind === "import_in_progress"
       ? rawKind
@@ -140,15 +154,12 @@ export async function localRuntimePollJobStatus(
   token: string,
   jobId: string,
 ): Promise<UnifiedJobStatus> {
-  const response = await fetch(
-    `${runtimeUrl}/v1/migrations/jobs/${jobId}`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/json",
-      },
+  const response = await fetch(`${runtimeUrl}/v1/migrations/jobs/${jobId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
     },
-  );
+  });
 
   if (response.status === 404) {
     throw new Error("Migration job not found");

--- a/cli/src/lib/local-runtime-client.ts
+++ b/cli/src/lib/local-runtime-client.ts
@@ -1,0 +1,167 @@
+import {
+  parseUnifiedJobStatus,
+  type UnifiedJobStatus,
+} from "./platform-client.js";
+
+/**
+ * Thrown when the local runtime returns 409 for an export/import request
+ * because another migration of the same type is already in-flight. The
+ * caller can inspect {@link existingJobId} and decide whether to poll the
+ * existing job instead of retrying.
+ */
+export class MigrationInProgressError extends Error {
+  readonly existingJobId: string;
+  readonly kind: "export_in_progress" | "import_in_progress";
+
+  constructor(kind: "export_in_progress" | "import_in_progress", jobId: string) {
+    super(
+      `A migration is already in progress (${kind}); existing job_id=${jobId}`,
+    );
+    this.name = "MigrationInProgressError";
+    this.kind = kind;
+    this.existingJobId = jobId;
+  }
+}
+
+function bearerHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  };
+}
+
+interface Raw409Body {
+  detail?: string;
+  error?: string;
+  code?: string;
+  job_id?: string;
+}
+
+/** Common 409 → MigrationInProgressError parsing used by the two POST helpers. */
+async function throwIfInProgress(
+  response: Response,
+  defaultKind: "export_in_progress" | "import_in_progress",
+): Promise<void> {
+  if (response.status !== 409) return;
+  const body = (await response.json().catch(() => ({}))) as Raw409Body;
+  const jobId = body.job_id ?? "";
+  const rawKind = body.code ?? body.error ?? defaultKind;
+  const kind: "export_in_progress" | "import_in_progress" =
+    rawKind === "export_in_progress" || rawKind === "import_in_progress"
+      ? rawKind
+      : defaultKind;
+  throw new MigrationInProgressError(kind, jobId);
+}
+
+/**
+ * Kick off an async export-to-GCS job on the local runtime.
+ * POSTs to `{runtimeUrl}/v1/migrations/export-to-gcs` and returns the
+ * 202-accepted job_id. On 409 (another export in flight) throws
+ * {@link MigrationInProgressError} with the existing job_id.
+ */
+export async function localRuntimeExportToGcs(
+  runtimeUrl: string,
+  token: string,
+  params: { uploadUrl: string; description?: string },
+): Promise<{ jobId: string }> {
+  const body: Record<string, unknown> = { upload_url: params.uploadUrl };
+  if (params.description !== undefined) {
+    body.description = params.description;
+  }
+
+  const response = await fetch(`${runtimeUrl}/v1/migrations/export-to-gcs`, {
+    method: "POST",
+    headers: bearerHeaders(token),
+    body: JSON.stringify(body),
+  });
+
+  await throwIfInProgress(response, "export_in_progress");
+
+  if (response.status !== 202) {
+    const errText = await response.text().catch(() => "");
+    throw new Error(
+      `Local runtime export-to-gcs failed (${response.status}): ${
+        errText || response.statusText
+      }`,
+    );
+  }
+
+  const json = (await response.json()) as {
+    job_id: string;
+    status?: string;
+    type?: string;
+  };
+  return { jobId: json.job_id };
+}
+
+/**
+ * Kick off an async import-from-GCS job on the local runtime.
+ * POSTs to `{runtimeUrl}/v1/migrations/import-from-gcs` with a signed
+ * download URL. On 409 throws {@link MigrationInProgressError}.
+ */
+export async function localRuntimeImportFromGcs(
+  runtimeUrl: string,
+  token: string,
+  params: { bundleUrl: string },
+): Promise<{ jobId: string }> {
+  const response = await fetch(`${runtimeUrl}/v1/migrations/import-from-gcs`, {
+    method: "POST",
+    headers: bearerHeaders(token),
+    body: JSON.stringify({ bundle_url: params.bundleUrl }),
+  });
+
+  await throwIfInProgress(response, "import_in_progress");
+
+  if (response.status !== 202) {
+    const errText = await response.text().catch(() => "");
+    throw new Error(
+      `Local runtime import-from-gcs failed (${response.status}): ${
+        errText || response.statusText
+      }`,
+    );
+  }
+
+  const json = (await response.json()) as {
+    job_id: string;
+    status?: string;
+    type?: string;
+  };
+  return { jobId: json.job_id };
+}
+
+/**
+ * Poll the local runtime's unified job-status endpoint.
+ * GETs `{runtimeUrl}/v1/migrations/jobs/{jobId}` and parses into
+ * {@link UnifiedJobStatus}.
+ */
+export async function localRuntimePollJobStatus(
+  runtimeUrl: string,
+  token: string,
+  jobId: string,
+): Promise<UnifiedJobStatus> {
+  const response = await fetch(
+    `${runtimeUrl}/v1/migrations/jobs/${jobId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+    },
+  );
+
+  if (response.status === 404) {
+    throw new Error("Migration job not found");
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Local job status check failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const raw = (await response.json()) as Parameters<
+    typeof parseUnifiedJobStatus
+  >[0];
+  return parseUnifiedJobStatus(raw);
+}

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -913,3 +913,179 @@ export async function platformPollImportStatus(
     error: body.error,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Unified signed-url + job-status endpoints (teleport-gcs-unify)
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated union representing the unified migration job status shape
+ * returned by `GET /v1/migrations/jobs/{job_id}/` on both the platform and
+ * the local runtime.
+ */
+export type UnifiedJobStatus =
+  | {
+      jobId: string;
+      type: "export" | "import";
+      status: "processing";
+    }
+  | {
+      jobId: string;
+      type: "export" | "import";
+      status: "complete";
+      bundleKey?: string;
+      result?: unknown;
+    }
+  | {
+      jobId: string;
+      type: "export" | "import";
+      status: "failed";
+      error: string;
+    };
+
+interface RawUnifiedJobStatus {
+  job_id: string;
+  type: "export" | "import";
+  status: "processing" | "complete" | "failed";
+  bundle_key?: string;
+  result?: unknown;
+  error?: string;
+}
+
+/**
+ * Normalise the wire-format job-status payload into the TypeScript
+ * discriminated union. Shared between platform and local-runtime helpers
+ * since both endpoints return the same shape.
+ */
+export function parseUnifiedJobStatus(raw: RawUnifiedJobStatus): UnifiedJobStatus {
+  if (raw.status === "processing") {
+    return { jobId: raw.job_id, type: raw.type, status: "processing" };
+  }
+  if (raw.status === "complete") {
+    return {
+      jobId: raw.job_id,
+      type: raw.type,
+      status: "complete",
+      bundleKey: raw.bundle_key,
+      result: raw.result,
+    };
+  }
+  return {
+    jobId: raw.job_id,
+    type: raw.type,
+    status: "failed",
+    error: raw.error ?? "Job failed without an error message",
+  };
+}
+
+/**
+ * Request a signed URL from the platform for either uploading a new bundle
+ * or downloading an existing one. Calls `POST /v1/migrations/signed-url/`.
+ *
+ * - `operation: "upload"` (optionally with `contentType` / `contentLength`)
+ *   returns a URL the CLI can PUT a bundle to.
+ * - `operation: "download"` with a `bundleKey` returns a URL the local
+ *   runtime can GET the bundle from during an import-from-GCS flow.
+ *
+ * Retries once with a fresh org-ID cache on 401 to match the retry pattern
+ * used by other authenticated platform helpers. 503 is bubbled up so
+ * callers can decide to fall back (e.g. legacy inline upload).
+ */
+export async function platformRequestSignedUrl(
+  params: {
+    operation: "upload" | "download";
+    bundleKey?: string;
+    contentType?: string;
+    contentLength?: number;
+  },
+  token: string,
+  platformUrl?: string,
+): Promise<{
+  url: string;
+  bundleKey: string;
+  expiresAt: string;
+  maxContentLength?: number;
+}> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const body: Record<string, unknown> = { operation: params.operation };
+  if (params.bundleKey !== undefined) body.bundle_key = params.bundleKey;
+  if (params.contentType !== undefined) body.content_type = params.contentType;
+  if (params.contentLength !== undefined) {
+    body.content_length = params.contentLength;
+  }
+
+  const doRequest = async (): Promise<Response> =>
+    fetch(`${resolvedUrl}/v1/migrations/signed-url/`, {
+      method: "POST",
+      headers: await authHeaders(token, platformUrl),
+      body: JSON.stringify(body),
+    });
+
+  let response = await doRequest();
+
+  if (response.status === 401) {
+    // Invalidate the cached org-ID (if any) and retry once with a fresh
+    // lookup — mirrors the retry semantics used by other signed helpers.
+    response = await doRequest();
+  }
+
+  if (response.status === 201 || response.status === 200) {
+    const json = (await response.json()) as {
+      url: string;
+      bundle_key: string;
+      expires_at: string;
+      max_content_length?: number;
+    };
+    return {
+      url: json.url,
+      bundleKey: json.bundle_key,
+      expiresAt: json.expires_at,
+      maxContentLength: json.max_content_length,
+    };
+  }
+
+  if (response.status === 503) {
+    throw new Error(
+      `Signed URL endpoint unavailable (503) — caller may fall back`,
+    );
+  }
+
+  const errorBody = (await response.json().catch(() => ({}))) as {
+    detail?: string;
+  };
+  throw new Error(
+    errorBody.detail ??
+      `Failed to request signed URL: ${response.status} ${response.statusText}`,
+  );
+}
+
+/**
+ * Poll the unified job-status endpoint on the platform. Calls
+ * `GET /v1/migrations/jobs/{jobId}/` and parses into {@link UnifiedJobStatus}.
+ */
+export async function platformPollJobStatus(
+  jobId: string,
+  token: string,
+  platformUrl?: string,
+): Promise<UnifiedJobStatus> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const response = await fetch(
+    `${resolvedUrl}/v1/migrations/jobs/${jobId}/`,
+    {
+      headers: await authHeaders(token, platformUrl),
+    },
+  );
+
+  if (response.status === 404) {
+    throw new Error("Migration job not found");
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Job status check failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const raw = (await response.json()) as RawUnifiedJobStatus;
+  return parseUnifiedJobStatus(raw);
+}

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -957,7 +957,9 @@ interface RawUnifiedJobStatus {
  * discriminated union. Shared between platform and local-runtime helpers
  * since both endpoints return the same shape.
  */
-export function parseUnifiedJobStatus(raw: RawUnifiedJobStatus): UnifiedJobStatus {
+export function parseUnifiedJobStatus(
+  raw: RawUnifiedJobStatus,
+): UnifiedJobStatus {
   if (raw.status === "processing") {
     return { jobId: raw.job_id, type: raw.type, status: "processing" };
   }
@@ -1025,7 +1027,10 @@ export async function platformRequestSignedUrl(
 
   if (response.status === 401) {
     // Invalidate the cached org-ID (if any) and retry once with a fresh
-    // lookup — mirrors the retry semantics used by other signed helpers.
+    // lookup. For session-token callers, a 401 frequently means the
+    // cached org ID is stale — calling doRequest() again without clearing
+    // the cache would just send the same stale header and fail again.
+    orgIdCache.delete(`${token}::${platformUrl ?? ""}`);
     response = await doRequest();
   }
 
@@ -1069,12 +1074,9 @@ export async function platformPollJobStatus(
   platformUrl?: string,
 ): Promise<UnifiedJobStatus> {
   const resolvedUrl = platformUrl || getPlatformUrl();
-  const response = await fetch(
-    `${resolvedUrl}/v1/migrations/jobs/${jobId}/`,
-    {
-      headers: await authHeaders(token, platformUrl),
-    },
-  );
+  const response = await fetch(`${resolvedUrl}/v1/migrations/jobs/${jobId}/`, {
+    headers: await authHeaders(token, platformUrl),
+  });
 
   if (response.status === 404) {
     throw new Error("Migration job not found");


### PR DESCRIPTION
## Summary
- Adds `platformRequestSignedUrl` and `platformPollJobStatus` to platform-client.ts, targeting the platform's new /v1/migrations/signed-url/ and /v1/migrations/jobs/:job_id endpoints.
- Adds a new `cli/src/lib/local-runtime-client.ts` with `localRuntimeExportToGcs`, `localRuntimeImportFromGcs`, and `localRuntimePollJobStatus`.
- Adds `cli/src/lib/job-polling.ts` with a shared `pollJobUntilDone` helper.

Part of plan: teleport-gcs-unify.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
