### PR TITLE
Add homepage_url to Chrome extension manifest

### DIFF
--- a/clients/chrome-extension/manifest.json
+++ b/clients/chrome-extension/manifest.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "minimum_chrome_version": "116",
   "description": "Bridges the Vellum assistant to your live browser session via Chrome DevTools Protocol (CDP) through chrome.debugger.",
+  "homepage_url": "https://www.vellum.ai",
 
   "permissions": [
     "debugger",


### PR DESCRIPTION
## Summary
- Add `homepage_url: https://www.vellum.ai` to the Chrome extension manifest so users can see a link back to Vellum from `chrome://extensions`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
