### PR TITLE
refactor(cli): route teleport through GCS + async jobs for all sources and targets

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -861,10 +861,12 @@ describe("unified GCS flow — four directions", () => {
     try {
       await teleport();
 
-      // Signed-URL request for upload
+      // Signed-URL request for upload — pinned to the platform target's URL
+      // so upload and download land on the same platform.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
         expect.objectContaining({ operation: "upload" }),
         "platform-token",
+        "https://platform.vellum.ai",
       );
 
       // Runtime export-to-gcs kicked off with the signed upload URL
@@ -933,13 +935,16 @@ describe("unified GCS flow — four directions", () => {
       expect(platformPollJobStatusMock).toHaveBeenCalled();
 
       // For the local target we request a download URL keyed by the
-      // platform's bundle_key.
+      // platform's bundle_key. The URL must target the SOURCE platform
+      // (where the bundle was written) — pinned so a lockfile change
+      // can't split upload and download across instances.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
         {
           operation: "download",
           bundleKey: "platform-exports/org-1/bundle-abc.vbundle",
         },
         "platform-token",
+        "https://platform.vellum.ai",
       );
 
       // Runtime import-from-gcs was kicked off with that URL.
@@ -984,10 +989,13 @@ describe("unified GCS flow — four directions", () => {
     try {
       await teleport();
 
-      // Export: upload-URL, then local runtime drives the upload.
+      // Export and import must pin the same platform URL so the bundle
+      // lives in one place end-to-end. For local→docker neither side is
+      // platform, so we default to getPlatformUrl() (resolved once).
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
         expect.objectContaining({ operation: "upload" }),
         "platform-token",
+        "https://platform.vellum.ai",
       );
       expect(localRuntimeExportToGcsMock).toHaveBeenCalled();
 
@@ -998,6 +1006,7 @@ describe("unified GCS flow — four directions", () => {
           bundleKey: "bundle-key-123",
         },
         "platform-token",
+        "https://platform.vellum.ai",
       );
       expect(localRuntimeImportFromGcsMock).toHaveBeenCalledWith(
         "http://localhost:7822",
@@ -1045,10 +1054,12 @@ describe("unified GCS flow — four directions", () => {
       // Docker source should be put to sleep first.
       expect(sleepContainersMock).toHaveBeenCalled();
 
-      // Export leg: upload-URL, then runtime export
+      // Export leg: upload-URL (pinned to the same platform as import),
+      // then runtime export.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
         expect.objectContaining({ operation: "upload" }),
         "platform-token",
+        "https://platform.vellum.ai",
       );
       expect(localRuntimeExportToGcsMock).toHaveBeenCalledWith(
         "http://localhost:7822",
@@ -1068,6 +1079,97 @@ describe("unified GCS flow — four directions", () => {
       // Source retirement
       expect(retireDockerMock).toHaveBeenCalledWith("my-docker");
       expect(removeAssistantEntryMock).toHaveBeenCalledWith("my-docker");
+    } finally {
+      restoreFetch();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Target-platform URL threading: signed URL must be requested from the same
+// platform instance the import will run against. Codex P2 regression guard.
+// ---------------------------------------------------------------------------
+
+describe("signed-URL request targets the bundle-owning platform", () => {
+  test("local → existing platform target with non-default runtimeUrl: upload URL pinned to target's runtimeUrl", async () => {
+    setArgv("--from", "my-local", "--platform", "existing-platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    // Crucially, the target's runtimeUrl is NOT the default getPlatformUrl()
+    // return value — this is the regression case Codex flagged.
+    const platformEntry = makeEntry("existing-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://staging-platform.vellum.ai",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      if (name === "existing-platform") return platformEntry;
+      return null;
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      // The signed-URL request for upload MUST target the existing
+      // platform assistant's runtimeUrl, not the default platform URL.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        expect.objectContaining({ operation: "upload" }),
+        "platform-token",
+        "https://staging-platform.vellum.ai",
+      );
+
+      // And the import must run against the same platform.
+      expect(platformImportBundleFromGcsMock).toHaveBeenCalledWith(
+        "bundle-key-123",
+        "platform-token",
+        "https://staging-platform.vellum.ai",
+      );
+
+      // Assert none of the signed-URL calls used the default URL — if any
+      // did, upload and download would hit different platforms.
+      for (const call of platformRequestSignedUrlMock.mock.calls) {
+        expect(call[2]).toBe("https://staging-platform.vellum.ai");
+      }
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("platform → local with non-default source runtimeUrl: download URL pinned to source's runtimeUrl", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://dev-platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "dev-bundle-key",
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      // The download URL must be requested from the SOURCE platform (where
+      // the bundle was written by the server-side export), not the default.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        { operation: "download", bundleKey: "dev-bundle-key" },
+        "platform-token",
+        "https://dev-platform.vellum.ai",
+      );
     } finally {
       restoreFetch();
     }

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 // ---------------------------------------------------------------------------
-// Temp directory for lockfile isolation (same pattern as assistant-config.test.ts)
+// Temp directory for lockfile isolation
 // ---------------------------------------------------------------------------
 
 const testDir = mkdtempSync(join(tmpdir(), "cli-teleport-test-"));
@@ -23,16 +23,10 @@ process.env.VELLUM_LOCKFILE_DIR = testDir;
 // Mocks — must be set up before importing the module under test
 // ---------------------------------------------------------------------------
 
-// Import the real modules — do NOT mock them with mock.module() because
-// Bun's mock.module() replaces modules globally and the replacement leaks
-// into other test files (e.g. platform-client.test.ts, guardian-token.test.ts,
-// multi-local.test.ts) running in the same process with no way to unmock.
-// Instead, we use spyOn() on the imported module namespace objects — these
-// mutate only the current process's live binding and are restored via
-// mockRestore() in afterAll.
 import * as assistantConfig from "../lib/assistant-config.js";
 import * as guardianToken from "../lib/guardian-token.js";
 import * as platformClient from "../lib/platform-client.js";
+import * as localRuntimeClient from "../lib/local-runtime-client.js";
 
 const findAssistantByNameMock = spyOn(
   assistantConfig,
@@ -101,88 +95,31 @@ const platformInitiateExportMock = spyOn(
   platformClient,
   "platformInitiateExport",
 ).mockResolvedValue({
-  jobId: "job-1",
+  jobId: "platform-export-job-1",
   status: "pending",
 });
 
-const platformPollExportStatusMock = spyOn(
+const platformPollJobStatusMock = spyOn(
   platformClient,
-  "platformPollExportStatus",
+  "platformPollJobStatus",
 ).mockResolvedValue({
-  status: "complete" as string,
-  downloadUrl: "https://cdn.example.com/bundle.tar.gz",
+  jobId: "platform-job-1",
+  type: "export",
+  status: "complete",
+  bundleKey: "platform-bundle-key-abc",
 });
 
-const platformDownloadExportMock = spyOn(
+const platformRequestSignedUrlMock = spyOn(
   platformClient,
-  "platformDownloadExport",
-).mockImplementation(async () => {
-  const data = new Uint8Array([10, 20, 30]);
-  return new Response(data, { status: 200 });
-});
-
-const platformImportPreflightMock = spyOn(
-  platformClient,
-  "platformImportPreflight",
-).mockResolvedValue({
-  statusCode: 200,
-  body: {
-    can_import: true,
-    summary: {
-      files_to_create: 2,
-      files_to_overwrite: 1,
-      files_unchanged: 0,
-      total_files: 3,
-    },
-  } as Record<string, unknown>,
-});
-
-const platformImportBundleMock = spyOn(
-  platformClient,
-  "platformImportBundle",
-).mockResolvedValue({
-  statusCode: 200,
-  body: {
-    success: true,
-    summary: {
-      total_files: 3,
-      files_created: 2,
-      files_overwritten: 1,
-      files_skipped: 0,
-      backups_created: 1,
-    },
-  } as Record<string, unknown>,
-});
-
-const platformRequestUploadUrlMock = spyOn(
-  platformClient,
-  "platformRequestUploadUrl",
-).mockResolvedValue({
-  uploadUrl: "https://storage.googleapis.com/bucket/signed-upload-url",
-  bundleKey: "bundle-key-123",
+  "platformRequestSignedUrl",
+).mockImplementation(async (params) => ({
+  url:
+    params.operation === "upload"
+      ? "https://storage.googleapis.com/bucket/signed-upload"
+      : "https://storage.googleapis.com/bucket/signed-download",
+  bundleKey: params.bundleKey ?? "bundle-key-123",
   expiresAt: new Date(Date.now() + 3600_000).toISOString(),
-});
-
-const platformUploadToSignedUrlMock = spyOn(
-  platformClient,
-  "platformUploadToSignedUrl",
-).mockResolvedValue(undefined);
-
-const platformImportPreflightFromGcsMock = spyOn(
-  platformClient,
-  "platformImportPreflightFromGcs",
-).mockResolvedValue({
-  statusCode: 200,
-  body: {
-    can_import: true,
-    summary: {
-      files_to_create: 2,
-      files_to_overwrite: 1,
-      files_unchanged: 0,
-      total_files: 3,
-    },
-  } as Record<string, unknown>,
-});
+}));
 
 const platformImportBundleFromGcsMock = spyOn(
   platformClient,
@@ -197,6 +134,22 @@ const platformImportBundleFromGcsMock = spyOn(
       files_overwritten: 1,
       files_skipped: 0,
       backups_created: 1,
+    },
+  } as Record<string, unknown>,
+});
+
+const platformImportPreflightFromGcsMock = spyOn(
+  platformClient,
+  "platformImportPreflightFromGcs",
+).mockResolvedValue({
+  statusCode: 200,
+  body: {
+    can_import: true,
+    summary: {
+      files_to_create: 2,
+      files_to_overwrite: 1,
+      files_unchanged: 0,
+      total_files: 3,
     },
   } as Record<string, unknown>,
 });
@@ -240,6 +193,35 @@ const fetchOrganizationIdMock = spyOn(
   platformClient,
   "fetchOrganizationId",
 ).mockResolvedValue("org-1");
+
+const localRuntimeExportToGcsMock = spyOn(
+  localRuntimeClient,
+  "localRuntimeExportToGcs",
+).mockResolvedValue({ jobId: "local-export-job-1" });
+
+const localRuntimeImportFromGcsMock = spyOn(
+  localRuntimeClient,
+  "localRuntimeImportFromGcs",
+).mockResolvedValue({ jobId: "local-import-job-1" });
+
+const localRuntimePollJobStatusMock = spyOn(
+  localRuntimeClient,
+  "localRuntimePollJobStatus",
+).mockImplementation(async (_runtimeUrl, _token, jobId) => ({
+  jobId,
+  type: jobId.includes("import") ? "import" : "export",
+  status: "complete",
+  result: {
+    success: true,
+    summary: {
+      total_files: 3,
+      files_created: 2,
+      files_overwritten: 1,
+      files_skipped: 0,
+      backups_created: 1,
+    },
+  },
+}));
 
 const hatchLocalMock = mock(async () => {});
 
@@ -313,19 +295,18 @@ afterAll(() => {
   hatchAssistantMock.mockRestore();
   checkExistingPlatformAssistantMock.mockRestore();
   platformInitiateExportMock.mockRestore();
-  platformPollExportStatusMock.mockRestore();
-  platformDownloadExportMock.mockRestore();
-  platformImportPreflightMock.mockRestore();
-  platformImportBundleMock.mockRestore();
-  platformRequestUploadUrlMock.mockRestore();
-  platformUploadToSignedUrlMock.mockRestore();
-  platformImportPreflightFromGcsMock.mockRestore();
+  platformPollJobStatusMock.mockRestore();
+  platformRequestSignedUrlMock.mockRestore();
   platformImportBundleFromGcsMock.mockRestore();
+  platformImportPreflightFromGcsMock.mockRestore();
   ensureSelfHostedLocalRegistrationMock.mockRestore();
   injectCredentialsIntoAssistantMock.mockRestore();
   fetchCurrentUserMock.mockRestore();
   fetchOrganizationIdMock.mockRestore();
   computeDeviceIdMock.mockRestore();
+  localRuntimeExportToGcsMock.mockRestore();
+  localRuntimeImportFromGcsMock.mockRestore();
+  localRuntimePollJobStatusMock.mockRestore();
   rmSync(testDir, { recursive: true, force: true });
   delete process.env.VELLUM_LOCKFILE_DIR;
 });
@@ -335,11 +316,39 @@ let exitMock: ReturnType<typeof mock>;
 let originalExit: typeof process.exit;
 let consoleLogSpy: ReturnType<typeof spyOn>;
 let consoleErrorSpy: ReturnType<typeof spyOn>;
+let fetchCalls: Array<{ url: string; body: unknown }>;
+
+function defaultLocalRuntimePollImpl(
+  _runtimeUrl: string,
+  _token: string,
+  jobId: string,
+): Promise<{
+  jobId: string;
+  type: "export" | "import";
+  status: "complete";
+  result: Record<string, unknown>;
+}> {
+  return Promise.resolve({
+    jobId,
+    type: jobId.includes("import") ? "import" : "export",
+    status: "complete",
+    result: {
+      success: true,
+      summary: {
+        total_files: 3,
+        files_created: 2,
+        files_overwritten: 1,
+        files_skipped: 0,
+        backups_created: 1,
+      },
+    },
+  });
+}
 
 beforeEach(() => {
   originalArgv = [...process.argv];
+  fetchCalls = [];
 
-  // Reset all mocks
   findAssistantByNameMock.mockReset();
   findAssistantByNameMock.mockReturnValue(null);
   saveAssistantEntryMock.mockReset();
@@ -371,66 +380,25 @@ beforeEach(() => {
   });
   platformInitiateExportMock.mockReset();
   platformInitiateExportMock.mockResolvedValue({
-    jobId: "job-1",
+    jobId: "platform-export-job-1",
     status: "pending",
   });
-  platformPollExportStatusMock.mockReset();
-  platformPollExportStatusMock.mockResolvedValue({
+  platformPollJobStatusMock.mockReset();
+  platformPollJobStatusMock.mockResolvedValue({
+    jobId: "platform-job-1",
+    type: "export",
     status: "complete",
-    downloadUrl: "https://cdn.example.com/bundle.tar.gz",
+    bundleKey: "platform-bundle-key-abc",
   });
-  platformDownloadExportMock.mockReset();
-  platformDownloadExportMock.mockResolvedValue(
-    new Response(new Uint8Array([10, 20, 30]), { status: 200 }),
-  );
-  platformImportPreflightMock.mockReset();
-  platformImportPreflightMock.mockResolvedValue({
-    statusCode: 200,
-    body: {
-      can_import: true,
-      summary: {
-        files_to_create: 2,
-        files_to_overwrite: 1,
-        files_unchanged: 0,
-        total_files: 3,
-      },
-    },
-  });
-  platformImportBundleMock.mockReset();
-  platformImportBundleMock.mockResolvedValue({
-    statusCode: 200,
-    body: {
-      success: true,
-      summary: {
-        total_files: 3,
-        files_created: 2,
-        files_overwritten: 1,
-        files_skipped: 0,
-        backups_created: 1,
-      },
-    },
-  });
-  platformRequestUploadUrlMock.mockReset();
-  platformRequestUploadUrlMock.mockResolvedValue({
-    uploadUrl: "https://storage.googleapis.com/bucket/signed-upload-url",
-    bundleKey: "bundle-key-123",
+  platformRequestSignedUrlMock.mockReset();
+  platformRequestSignedUrlMock.mockImplementation(async (params) => ({
+    url:
+      params.operation === "upload"
+        ? "https://storage.googleapis.com/bucket/signed-upload"
+        : "https://storage.googleapis.com/bucket/signed-download",
+    bundleKey: params.bundleKey ?? "bundle-key-123",
     expiresAt: new Date(Date.now() + 3600_000).toISOString(),
-  });
-  platformUploadToSignedUrlMock.mockReset();
-  platformUploadToSignedUrlMock.mockResolvedValue(undefined);
-  platformImportPreflightFromGcsMock.mockReset();
-  platformImportPreflightFromGcsMock.mockResolvedValue({
-    statusCode: 200,
-    body: {
-      can_import: true,
-      summary: {
-        files_to_create: 2,
-        files_to_overwrite: 1,
-        files_unchanged: 0,
-        total_files: 3,
-      },
-    },
-  });
+  }));
   platformImportBundleFromGcsMock.mockReset();
   platformImportBundleFromGcsMock.mockResolvedValue({
     statusCode: 200,
@@ -442,6 +410,19 @@ beforeEach(() => {
         files_overwritten: 1,
         files_skipped: 0,
         backups_created: 1,
+      },
+    },
+  });
+  platformImportPreflightFromGcsMock.mockReset();
+  platformImportPreflightFromGcsMock.mockResolvedValue({
+    statusCode: 200,
+    body: {
+      can_import: true,
+      summary: {
+        files_to_create: 2,
+        files_to_overwrite: 1,
+        files_unchanged: 0,
+        total_files: 3,
       },
     },
   });
@@ -470,6 +451,13 @@ beforeEach(() => {
   fetchOrganizationIdMock.mockResolvedValue("org-1");
   computeDeviceIdMock.mockReset();
   computeDeviceIdMock.mockReturnValue("device-id-123");
+
+  localRuntimeExportToGcsMock.mockReset();
+  localRuntimeExportToGcsMock.mockResolvedValue({ jobId: "local-export-job-1" });
+  localRuntimeImportFromGcsMock.mockReset();
+  localRuntimeImportFromGcsMock.mockResolvedValue({ jobId: "local-import-job-1" });
+  localRuntimePollJobStatusMock.mockReset();
+  localRuntimePollJobStatusMock.mockImplementation(defaultLocalRuntimePollImpl);
 
   hatchLocalMock.mockReset();
   hatchLocalMock.mockResolvedValue(undefined);
@@ -505,7 +493,6 @@ afterEach(() => {
 });
 
 function setArgv(...args: string[]): void {
-  // teleport reads process.argv.slice(3)
   process.argv = ["bun", "vellum", "teleport", ...args];
 }
 
@@ -521,44 +508,22 @@ function makeEntry(
   };
 }
 
-/** Create a mock fetch that handles export and import endpoints. */
-function createFetchMock() {
-  return mock(async (url: string | URL | Request) => {
+/**
+ * Tracking fetch mock — records every call so tests can verify that the CLI
+ * never sends a bundle-sized request body. With the new GCS-unified flow
+ * all bundle bytes travel between the runtime and GCS directly, so the CLI
+ * should make zero fetch calls carrying binary payloads.
+ */
+function installTrackingFetch(): () => void {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
     const urlStr = typeof url === "string" ? url : url.toString();
-    if (urlStr.includes("/export")) {
-      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
-    }
-    if (urlStr.includes("/import-preflight")) {
-      return new Response(
-        JSON.stringify({
-          can_import: true,
-          summary: {
-            files_to_create: 1,
-            files_to_overwrite: 0,
-            files_unchanged: 0,
-            total_files: 1,
-          },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
-    }
-    if (urlStr.includes("/import")) {
-      return new Response(
-        JSON.stringify({
-          success: true,
-          summary: {
-            total_files: 1,
-            files_created: 1,
-            files_overwritten: 0,
-            files_skipped: 0,
-            backups_created: 0,
-          },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
-    }
+    fetchCalls.push({ url: urlStr, body: init?.body });
     return new Response("not found", { status: 404 });
-  });
+  }) as unknown as typeof globalThis.fetch;
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -663,20 +628,13 @@ describe("same-environment rejection", () => {
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Cannot teleport between two local assistants"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await expect(teleport()).rejects.toThrow("process.exit:1");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Cannot teleport between two local assistants"),
+    );
   });
 
-  test("source docker, target docker -> error (after resolving target)", async () => {
+  test("source docker, target docker -> error", async () => {
     setArgv("--from", "src", "--docker", "dst");
 
     const srcEntry = makeEntry("src", { cloud: "docker" });
@@ -688,22 +646,13 @@ describe("same-environment rejection", () => {
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Cannot teleport between two docker assistants",
-        ),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await expect(teleport()).rejects.toThrow("process.exit:1");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Cannot teleport between two docker assistants"),
+    );
   });
 
-  test("source vellum, target platform -> error (after resolving target)", async () => {
+  test("source vellum, target platform -> error", async () => {
     setArgv("--from", "src", "--platform", "dst");
 
     const srcEntry = makeEntry("src", {
@@ -721,19 +670,12 @@ describe("same-environment rejection", () => {
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Cannot teleport between two platform assistants",
-        ),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await expect(teleport()).rejects.toThrow("process.exit:1");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Cannot teleport between two platform assistants",
+      ),
+    );
   });
 
   test("same-env rejection happens before hatching (no orphaned assistants)", async () => {
@@ -749,59 +691,15 @@ describe("same-environment rejection", () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Cannot teleport between two local assistants"),
     );
-    // Crucially: no hatch should have been called — the early guard fires first
-    expect(hatchLocalMock).not.toHaveBeenCalled();
-    expect(hatchDockerMock).not.toHaveBeenCalled();
-    expect(hatchAssistantMock).not.toHaveBeenCalled();
-  });
-
-  test("same-env rejection before hatching for docker", async () => {
-    setArgv("--from", "my-docker", "--docker");
-
-    const dockerEntry = makeEntry("my-docker", { cloud: "docker" });
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-docker") return dockerEntry;
-      return null;
-    });
-
-    await expect(teleport()).rejects.toThrow("process.exit:1");
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Cannot teleport between two docker assistants"),
-    );
-    expect(hatchLocalMock).not.toHaveBeenCalled();
-    expect(hatchDockerMock).not.toHaveBeenCalled();
-    expect(hatchAssistantMock).not.toHaveBeenCalled();
-  });
-
-  test("same-env rejection before hatching for platform (vellum cloud)", async () => {
-    setArgv("--from", "my-cloud", "--platform");
-
-    const platformEntry = makeEntry("my-cloud", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-cloud") return platformEntry;
-      return null;
-    });
-
-    await expect(teleport()).rejects.toThrow("process.exit:1");
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "Cannot teleport between two platform assistants",
-      ),
-    );
     expect(hatchLocalMock).not.toHaveBeenCalled();
     expect(hatchDockerMock).not.toHaveBeenCalled();
     expect(hatchAssistantMock).not.toHaveBeenCalled();
   });
 
   test("flag says docker but resolved target is local -> rejects cloud mismatch", async () => {
-    // User passes --docker but the named target is actually a local assistant
     setArgv("--from", "src", "--docker", "misidentified");
 
     const srcEntry = makeEntry("src", { cloud: "vellum" });
-    // Target is actually local despite the --docker flag
     const dstEntry = makeEntry("misidentified", { cloud: "local" });
 
     findAssistantByNameMock.mockImplementation((name: string) => {
@@ -832,16 +730,11 @@ describe("resolveOrHatchTarget", () => {
     const result = await resolveOrHatchTarget("docker", "my-docker");
     expect(result).toBe(dockerEntry);
     expect(hatchDockerMock).not.toHaveBeenCalled();
-    expect(consoleLogSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Target: my-docker (docker)"),
-    );
   });
 
   test("name not found -> hatch docker", async () => {
     const newEntry = makeEntry("new-one", { cloud: "docker" });
     findAssistantByNameMock.mockImplementation((name: string) => {
-      // First call: lookup by name -> not found
-      // Second call: after hatch -> found
       if (name === "new-one" && hatchDockerMock.mock.calls.length > 0) {
         return newEntry;
       }
@@ -859,12 +752,10 @@ describe("resolveOrHatchTarget", () => {
     expect(result).toBe(newEntry);
   });
 
-  test("no name -> hatch local with null name, discovers via diff", async () => {
+  test("no name -> hatch local, discovers via diff", async () => {
     const existingEntry = makeEntry("existing-local", { cloud: "local" });
     const newEntry = makeEntry("auto-generated", { cloud: "local" });
 
-    // Before hatch: only the existing entry
-    // After hatch: existing + new entry
     loadAllAssistantsMock.mockImplementation(() => {
       if (hatchLocalMock.mock.calls.length > 0) {
         return [existingEntry, newEntry];
@@ -873,13 +764,7 @@ describe("resolveOrHatchTarget", () => {
     });
 
     const result = await resolveOrHatchTarget("local");
-    expect(hatchLocalMock).toHaveBeenCalledWith(
-      "vellum",
-      null,
-      false,
-      false,
-      {},
-    );
+    expect(hatchLocalMock).toHaveBeenCalled();
     expect(result).toBe(newEntry);
   });
 
@@ -903,16 +788,10 @@ describe("resolveOrHatchTarget", () => {
 
     const result = await resolveOrHatchTarget("platform", "nonexistent");
     expect(hatchAssistantMock).toHaveBeenCalledWith("platform-token");
-    expect(saveAssistantEntryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        assistantId: "platform-new-id",
-        cloud: "vellum",
-      }),
-    );
     expect(result.assistantId).toBe("platform-new-id");
   });
 
-  test("platform with no name -> blocks when hatch returns reusedExisting (defensive safety net)", async () => {
+  test("platform with no name -> blocks when hatch returns reusedExisting", async () => {
     findAssistantByNameMock.mockReturnValue(null);
     hatchAssistantMock.mockResolvedValue({
       assistant: {
@@ -923,24 +802,11 @@ describe("resolveOrHatchTarget", () => {
       reusedExisting: true,
     });
 
-    // Defensive safety net: even though the pre-check in teleport() should
-    // catch this first, resolveOrHatchTarget still blocks on reusedExisting
-    // to guard against a TOCTOU race (matching the Swift client behavior).
     await expect(resolveOrHatchTarget("platform", undefined)).rejects.toThrow(
       "process.exit:1",
     );
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("already have a platform assistant"),
-    );
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Retire it first"),
-    );
-    // The existing assistant is saved to the lockfile so `vellum retire` can find it
-    expect(saveAssistantEntryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        assistantId: "existing-platform-id",
-        cloud: "vellum",
-      }),
     );
   });
 
@@ -973,33 +839,134 @@ describe("resolveOrHatchTarget", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Auto-retire tests
+// Unified GCS teleport flow — the four directions
 // ---------------------------------------------------------------------------
 
-describe("auto-retire", () => {
-  test("local -> docker: stops source before hatch, retires after import", async () => {
-    setArgv("--from", "my-local", "--docker");
+describe("unified GCS flow — four directions", () => {
+  test("local → platform: requests upload URL, drives local runtime export, imports from GCS", async () => {
+    setArgv("--from", "my-local", "--platform");
 
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      // Signed-URL request for upload
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        expect.objectContaining({ operation: "upload" }),
+        "platform-token",
+      );
+
+      // Runtime export-to-gcs kicked off with the signed upload URL
+      expect(localRuntimeExportToGcsMock).toHaveBeenCalledWith(
+        "http://localhost:7821",
+        "local-token",
+        expect.objectContaining({
+          uploadUrl: "https://storage.googleapis.com/bucket/signed-upload",
+        }),
+      );
+
+      // Poll continued until complete
+      expect(localRuntimePollJobStatusMock).toHaveBeenCalled();
+
+      // Import via GCS with the bundleKey returned from signed-URL request
+      expect(platformImportBundleFromGcsMock).toHaveBeenCalledWith(
+        "bundle-key-123",
+        "platform-token",
+        expect.any(String),
+      );
+
+      // No download-URL request on the import side (platform target pulls
+      // directly from GCS).
+      const downloadOps = platformRequestSignedUrlMock.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as { operation: string }).operation === "download",
+      );
+      expect(downloadOps.length).toBe(0);
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("platform → local: drives platform export, reads bundle_key, requests download URL for runtime import", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
     const localEntry = makeEntry("my-local", {
       cloud: "local",
-      resources: {
-        instanceDir: "/home/test",
-        pidFile: "/home/test/.vellum/assistant.pid",
-        signingKey: "key",
-        daemonPort: 7821,
-        gatewayPort: 7830,
-        qdrantPort: 6333,
-        cesPort: 8090,
-      },
+      bearerToken: "local-bearer",
     });
-    const dockerEntry = makeEntry("new-docker", { cloud: "docker" });
 
     findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
       if (name === "my-local") return localEntry;
       return null;
     });
 
-    // Simulate hatch creating a new docker entry
+    // Platform poll returns export-complete with a bundle_key.
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "platform-exports/org-1/bundle-abc.vbundle",
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      // Platform side: initiated server export and polled the unified status.
+      expect(platformInitiateExportMock).toHaveBeenCalled();
+      expect(platformPollJobStatusMock).toHaveBeenCalled();
+
+      // For the local target we request a download URL keyed by the
+      // platform's bundle_key.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        {
+          operation: "download",
+          bundleKey: "platform-exports/org-1/bundle-abc.vbundle",
+        },
+        "platform-token",
+      );
+
+      // Runtime import-from-gcs was kicked off with that URL.
+      expect(localRuntimeImportFromGcsMock).toHaveBeenCalledWith(
+        "http://localhost:7821",
+        "local-token",
+        expect.objectContaining({
+          bundleUrl: "https://storage.googleapis.com/bucket/signed-download",
+        }),
+      );
+      expect(localRuntimePollJobStatusMock).toHaveBeenCalled();
+
+      // No legacy inline-import helpers were touched.
+      // (Verified by the absence of fetch calls carrying bundle bodies —
+      // see "never buffers bundle bytes" assertion below.)
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("local → docker: export via upload URL, import via download URL", async () => {
+    setArgv("--from", "my-local", "--docker");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    const dockerEntry = makeEntry("new-docker", {
+      cloud: "docker",
+      runtimeUrl: "http://localhost:7822",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
     loadAllAssistantsMock.mockImplementation(() => {
       if (hatchDockerMock.mock.calls.length > 0) {
         return [localEntry, dockerEntry];
@@ -1007,31 +974,56 @@ describe("auto-retire", () => {
       return [localEntry];
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
-      // Source should be stopped (slept) before hatch
-      expect(stopProcessByPidFileMock).toHaveBeenCalled();
-      // Retire happens after successful import
+
+      // Export: upload-URL, then local runtime drives the upload.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        expect.objectContaining({ operation: "upload" }),
+        "platform-token",
+      );
+      expect(localRuntimeExportToGcsMock).toHaveBeenCalled();
+
+      // Import: download-URL for the docker target, then runtime import.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        {
+          operation: "download",
+          bundleKey: "bundle-key-123",
+        },
+        "platform-token",
+      );
+      expect(localRuntimeImportFromGcsMock).toHaveBeenCalledWith(
+        "http://localhost:7822",
+        "local-token",
+        expect.objectContaining({
+          bundleUrl: "https://storage.googleapis.com/bucket/signed-download",
+        }),
+      );
+
+      // Source retirement still happens on success for local↔docker.
       expect(retireLocalMock).toHaveBeenCalledWith("my-local", localEntry);
       expect(removeAssistantEntryMock).toHaveBeenCalledWith("my-local");
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
 
-  test("docker -> local: sleeps containers before hatch, retires after import", async () => {
+  test("docker → local: export via upload URL, import via download URL", async () => {
     setArgv("--from", "my-docker", "--local");
 
-    const dockerEntry = makeEntry("my-docker", { cloud: "docker" });
-    const localEntry = makeEntry("new-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-docker") return dockerEntry;
-      return null;
+    const dockerEntry = makeEntry("my-docker", {
+      cloud: "docker",
+      runtimeUrl: "http://localhost:7822",
     });
+    const localEntry = makeEntry("new-local", {
+      cloud: "local",
+      runtimeUrl: "http://localhost:7823",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-docker" ? dockerEntry : null,
+    );
 
     loadAllAssistantsMock.mockImplementation(() => {
       if (hatchLocalMock.mock.calls.length > 0) {
@@ -1040,259 +1032,295 @@ describe("auto-retire", () => {
       return [dockerEntry];
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
-      // Docker source should be slept (containers stopped) before hatch
+
+      // Docker source should be put to sleep first.
       expect(sleepContainersMock).toHaveBeenCalled();
-      // Retire happens after successful import
+
+      // Export leg: upload-URL, then runtime export
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        expect.objectContaining({ operation: "upload" }),
+        "platform-token",
+      );
+      expect(localRuntimeExportToGcsMock).toHaveBeenCalledWith(
+        "http://localhost:7822",
+        "local-token",
+        expect.objectContaining({
+          uploadUrl: "https://storage.googleapis.com/bucket/signed-upload",
+        }),
+      );
+
+      // Import leg: download-URL targets the new local runtime
+      expect(localRuntimeImportFromGcsMock).toHaveBeenCalledWith(
+        "http://localhost:7823",
+        "local-token",
+        expect.anything(),
+      );
+
+      // Source retirement
       expect(retireDockerMock).toHaveBeenCalledWith("my-docker");
       expect(removeAssistantEntryMock).toHaveBeenCalledWith("my-docker");
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
+});
 
-  test("--keep-source skips retire and removeAssistantEntry", async () => {
-    setArgv("--from", "my-local", "--docker", "--keep-source");
+// ---------------------------------------------------------------------------
+// Invariants: CLI never buffers bundle bytes
+// ---------------------------------------------------------------------------
 
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-    const dockerEntry = makeEntry("new-docker", { cloud: "docker" });
+describe("CLI never buffers bundle bytes", () => {
+  // A teleport bundle is always > 1 KiB in practice; anything near that size
+  // would mean the CLI is shuttling bytes when it shouldn't.
+  const BUNDLE_BODY_THRESHOLD_BYTES = 1024;
 
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
+  function bodySize(body: unknown): number {
+    if (typeof body === "string") return body.length;
+    if (body instanceof Uint8Array) return body.byteLength;
+    if (body instanceof ArrayBuffer) return body.byteLength;
+    if (body instanceof Blob) return body.size;
+    return 0;
+  }
 
-    loadAllAssistantsMock.mockImplementation(() => {
-      if (hatchDockerMock.mock.calls.length > 0) {
-        return [localEntry, dockerEntry];
-      }
-      return [localEntry];
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(retireLocalMock).not.toHaveBeenCalled();
-      expect(retireDockerMock).not.toHaveBeenCalled();
-      expect(removeAssistantEntryMock).not.toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("kept (--keep-source)"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("platform transfers skip retire", async () => {
+  test("local → platform: no fetch call carries a bundle-sized body", async () => {
     setArgv("--from", "my-local", "--platform");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      for (const call of fetchCalls) {
+        expect(bodySize(call.body)).toBeLessThan(BUNDLE_BODY_THRESHOLD_BYTES);
+      }
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("platform → local: no fetch call carries a bundle-sized body", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
 
     findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
       if (name === "my-local") return localEntry;
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "platform-exports/org-1/bundle.vbundle",
+    });
 
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
-      expect(retireLocalMock).not.toHaveBeenCalled();
-      expect(retireDockerMock).not.toHaveBeenCalled();
-      expect(removeAssistantEntryMock).not.toHaveBeenCalled();
+
+      for (const call of fetchCalls) {
+        expect(bodySize(call.body)).toBeLessThan(BUNDLE_BODY_THRESHOLD_BYTES);
+      }
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Polling behavior
+// ---------------------------------------------------------------------------
+
+describe("polling", () => {
+  test("local-runtime export poll continues until complete", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    let callIdx = 0;
+    localRuntimePollJobStatusMock.mockImplementation(
+      async (_runtimeUrl, _token, jobId) => {
+        callIdx++;
+        if (callIdx < 3) {
+          return {
+            jobId,
+            type: "export" as const,
+            status: "processing" as const,
+          };
+        }
+        return {
+          jobId,
+          type: "export" as const,
+          status: "complete" as const,
+          result: undefined,
+        };
+      },
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+      expect(callIdx).toBeGreaterThanOrEqual(3);
+    } finally {
+      restoreFetch();
     }
   });
 
+  test("local-runtime export failure → teleport exits 1", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    localRuntimePollJobStatusMock.mockResolvedValue({
+      jobId: "local-export-job-1",
+      type: "export",
+      status: "failed",
+      error: "simulated failure",
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("simulated failure"),
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("local-runtime import failure → teleport exits 1", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "key-1",
+    });
+
+    localRuntimePollJobStatusMock.mockImplementation(
+      async (_runtimeUrl, _token, jobId) => {
+        if (jobId.includes("import")) {
+          return {
+            jobId,
+            type: "import" as const,
+            status: "failed" as const,
+            error: "import blew up",
+          };
+        }
+        return {
+          jobId,
+          type: "export" as const,
+          status: "complete" as const,
+          result: undefined,
+        };
+      },
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("import blew up"),
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MigrationInProgressError handling
+// ---------------------------------------------------------------------------
+
+describe("MigrationInProgressError handling", () => {
+  test("local-runtime export already in flight → poll the existing job", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    localRuntimeExportToGcsMock.mockRejectedValue(
+      new localRuntimeClient.MigrationInProgressError(
+        "export_in_progress",
+        "existing-job-42",
+      ),
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+      // Should have polled the existing job id.
+      const polledIds = localRuntimePollJobStatusMock.mock.calls.map(
+        (call: unknown[]) => call[2],
+      );
+      expect(polledIds).toContain("existing-job-42");
+    } finally {
+      restoreFetch();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dry-run behavior
+// ---------------------------------------------------------------------------
+
+describe("dry-run", () => {
   test("dry-run without existing target does not hatch or export", async () => {
     setArgv("--from", "my-local", "--docker", "--dry-run");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
 
     await teleport();
 
-    // Should NOT hatch, export, import, or retire
     expect(hatchDockerMock).not.toHaveBeenCalled();
     expect(hatchLocalMock).not.toHaveBeenCalled();
     expect(hatchAssistantMock).not.toHaveBeenCalled();
     expect(retireLocalMock).not.toHaveBeenCalled();
     expect(retireDockerMock).not.toHaveBeenCalled();
-    expect(removeAssistantEntryMock).not.toHaveBeenCalled();
+    expect(localRuntimeExportToGcsMock).not.toHaveBeenCalled();
+    expect(localRuntimeImportFromGcsMock).not.toHaveBeenCalled();
   });
 
-  test("dry-run with existing target runs preflight without hatching", async () => {
-    setArgv("--from", "my-local", "--docker", "my-docker", "--dry-run");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-    const dockerEntry = makeEntry("my-docker", { cloud: "docker" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      if (name === "my-docker") return dockerEntry;
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Should NOT hatch or retire
-      expect(hatchDockerMock).not.toHaveBeenCalled();
-      expect(hatchLocalMock).not.toHaveBeenCalled();
-      expect(retireLocalMock).not.toHaveBeenCalled();
-      expect(retireDockerMock).not.toHaveBeenCalled();
-      expect(removeAssistantEntryMock).not.toHaveBeenCalled();
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Full flow tests
-// ---------------------------------------------------------------------------
-
-describe("teleport full flow", () => {
-  test("hatch and import: --from my-local --docker", async () => {
-    setArgv("--from", "my-local", "--docker");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-    const dockerEntry = makeEntry("new-docker", { cloud: "docker" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    loadAllAssistantsMock.mockImplementation(() => {
-      if (hatchDockerMock.mock.calls.length > 0) {
-        return [localEntry, dockerEntry];
-      }
-      return [localEntry];
-    });
-
-    const originalFetch = globalThis.fetch;
-    const fetchMock = createFetchMock();
-    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Verify sequence: export, hatch, import, retire
-      expect(hatchDockerMock).toHaveBeenCalled();
-      expect(retireLocalMock).toHaveBeenCalledWith("my-local", localEntry);
-      expect(removeAssistantEntryMock).toHaveBeenCalledWith("my-local");
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("existing target overwrite: --from my-local --docker my-existing", async () => {
-    setArgv("--from", "my-local", "--docker", "my-existing");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-    const dockerEntry = makeEntry("my-existing", { cloud: "docker" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      if (name === "my-existing") return dockerEntry;
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    const fetchMock = createFetchMock();
-    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // No hatch should happen — existing target is used
-      expect(hatchDockerMock).not.toHaveBeenCalled();
-      // Source should still be retired
-      expect(retireLocalMock).toHaveBeenCalledWith("my-local", localEntry);
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("legacy --to flag shows deprecation message", async () => {
-    setArgv("--from", "source", "--to", "target");
-
-    await expect(teleport()).rejects.toThrow("process.exit:1");
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("--to is deprecated"),
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Signed-URL upload tests
-// ---------------------------------------------------------------------------
-
-describe("signed-URL upload flow", () => {
-  test("happy path: signed URL upload succeeds → GCS-based import used", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Signed-URL flow should be used
-      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
-      expect(platformUploadToSignedUrlMock).toHaveBeenCalled();
-      expect(platformImportBundleFromGcsMock).toHaveBeenCalledWith(
-        "bundle-key-123",
-        "platform-token",
-        "https://platform.vellum.ai",
-      );
-      // Inline import should NOT be called
-      expect(platformImportBundleMock).not.toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("happy path dry-run: signed URL upload succeeds → GCS-based preflight used", async () => {
-    setArgv(
-      "--from",
-      "my-local",
-      "--platform",
-      "existing-platform",
-      "--dry-run",
-    );
+  test("dry-run with existing platform target runs preflight-from-gcs", async () => {
+    setArgv("--from", "my-local", "--platform", "existing-platform", "--dry-run");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
     const platformEntry = makeEntry("existing-platform", {
@@ -1306,690 +1334,21 @@ describe("signed-URL upload flow", () => {
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
-
-      // Signed-URL flow should be used for preflight
-      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
-      expect(platformUploadToSignedUrlMock).toHaveBeenCalled();
       expect(platformImportPreflightFromGcsMock).toHaveBeenCalledWith(
         "bundle-key-123",
         "platform-token",
         "https://platform.vellum.ai",
       );
-      // Inline preflight should NOT be called
-      expect(platformImportPreflightMock).not.toHaveBeenCalled();
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("fallback: platformRequestUploadUrl throws 503 → falls back to inline import", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Simulate 503 — "not available" in the error message
-    platformRequestUploadUrlMock.mockRejectedValue(
-      new Error("Signed uploads are not available on this platform instance"),
-    );
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Should fall back to inline import
-      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
-      expect(platformUploadToSignedUrlMock).not.toHaveBeenCalled();
-      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
-      expect(platformImportBundleMock).toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("fallback: platformRequestUploadUrl throws 404 → falls back to inline import", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Simulate 404 — endpoint doesn't exist on older platform versions
-    platformRequestUploadUrlMock.mockRejectedValue(
-      new Error("Signed uploads are not available on this platform instance"),
-    );
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Should fall back to inline import
-      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
-      expect(platformUploadToSignedUrlMock).not.toHaveBeenCalled();
-      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
-      expect(platformImportBundleMock).toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("upload error: platformUploadToSignedUrl throws → error propagates", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Upload succeeds at getting URL but fails during PUT
-    platformUploadToSignedUrlMock.mockRejectedValue(
-      new Error("Upload to signed URL failed: 500 Internal Server Error"),
-    );
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow(
-        "Upload to signed URL failed: 500 Internal Server Error",
-      );
-      // Should NOT fall back to inline import
-      expect(platformImportBundleMock).not.toHaveBeenCalled();
-      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("413 from GCS import: error message includes 'too large'", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // GCS import returns 413
-    platformImportBundleFromGcsMock.mockRejectedValue(
-      new Error("Bundle too large to import"),
-    );
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("too large");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Platform teleport org ID and reordered flow tests
-// ---------------------------------------------------------------------------
-
-describe("platform teleport org ID and reordered flow", () => {
-  test("hatchAssistant is called without orgId (authHeaders fetches it internally)", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // hatchAssistant should be called with just the token (orgId is resolved internally by authHeaders)
-      expect(hatchAssistantMock).toHaveBeenCalledWith("platform-token");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("upload to GCS happens before hatchAssistant for platform targets", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    const callOrder: string[] = [];
-
-    platformRequestUploadUrlMock.mockImplementation(async () => {
-      callOrder.push("platformRequestUploadUrl");
-      return {
-        uploadUrl: "https://storage.googleapis.com/bucket/signed-upload-url",
-        bundleKey: "bundle-key-123",
-        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
-      };
-    });
-
-    platformUploadToSignedUrlMock.mockImplementation(async () => {
-      callOrder.push("platformUploadToSignedUrl");
-    });
-
-    hatchAssistantMock.mockImplementation(async () => {
-      callOrder.push("hatchAssistant");
-      return {
-        assistant: {
-          id: "platform-new-id",
-          name: "platform-new",
-          status: "active",
-        },
-        reusedExisting: false,
-      };
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Verify ordering: upload steps come before hatch
-      const uploadUrlIdx = callOrder.indexOf("platformRequestUploadUrl");
-      const uploadIdx = callOrder.indexOf("platformUploadToSignedUrl");
-      const hatchIdx = callOrder.indexOf("hatchAssistant");
-
-      expect(uploadUrlIdx).toBeGreaterThanOrEqual(0);
-      expect(uploadIdx).toBeGreaterThanOrEqual(0);
-      expect(hatchIdx).toBeGreaterThanOrEqual(0);
-      expect(uploadUrlIdx).toBeLessThan(hatchIdx);
-      expect(uploadIdx).toBeLessThan(hatchIdx);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("signed-URL fallback: when platformRequestUploadUrl throws 'not available', falls back to inline upload via importToAssistant", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Simulate 503 — signed uploads not available
-    platformRequestUploadUrlMock.mockRejectedValue(
-      new Error("Signed uploads are not available on this platform instance"),
-    );
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Upload URL was attempted but failed
-      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
-      // No signed URL upload should have happened
-      expect(platformUploadToSignedUrlMock).not.toHaveBeenCalled();
-      // Should NOT use GCS-based import
-      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
-      // Should fall back to inline import
-      expect(platformImportBundleMock).toHaveBeenCalled();
-      // Hatch should still succeed
-      expect(hatchAssistantMock).toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("bundleKey from pre-upload is forwarded to platformImportBundleFromGcs", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Return a specific bundle key from the pre-upload step
-    platformRequestUploadUrlMock.mockResolvedValue({
-      uploadUrl: "https://storage.googleapis.com/bucket/signed-upload-url",
-      bundleKey: "pre-uploaded-key-789",
-      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // The bundle key from the pre-upload step should be forwarded to GCS import
-      expect(platformImportBundleFromGcsMock).toHaveBeenCalledWith(
-        "pre-uploaded-key-789",
-        "platform-token",
-        expect.any(String),
-      );
-      // Inline import should NOT be used since signed upload succeeded
-      expect(platformImportBundleMock).not.toHaveBeenCalled();
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Pre-check: block teleport to platform when existing assistant detected
-// ---------------------------------------------------------------------------
-
-describe("pre-check: block teleport to platform when existing assistant detected", () => {
-  test("blocks BEFORE GCS upload when pre-check finds existing assistant", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Pre-check returns an existing assistant
-    checkExistingPlatformAssistantMock.mockResolvedValue({
-      id: "existing-platform-id",
-      name: "existing-platform",
-      status: "active",
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-
-      // Pre-check should have been called
-      expect(checkExistingPlatformAssistantMock).toHaveBeenCalledWith(
-        "platform-token",
-        undefined,
-      );
-
-      // GCS upload should NOT have been attempted
-      expect(platformRequestUploadUrlMock).not.toHaveBeenCalled();
-      expect(platformUploadToSignedUrlMock).not.toHaveBeenCalled();
-
-      // Hatch should NOT have been called
       expect(hatchAssistantMock).not.toHaveBeenCalled();
-
-      // Error message should be actionable
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("already have a platform assistant"),
-      );
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Retire it first"),
-      );
-
-      // The existing assistant is saved to the lockfile
-      expect(saveAssistantEntryMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          assistantId: "existing-platform-id",
-          cloud: "vellum",
-        }),
-      );
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
 
-  test("skips pre-check when targeting an existing named assistant", async () => {
-    setArgv("--from", "my-local", "--platform", "existing-platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-    const platformEntry = makeEntry("existing-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      if (name === "existing-platform") return platformEntry;
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Pre-check should NOT be called when targeting a known named assistant
-      expect(checkExistingPlatformAssistantMock).not.toHaveBeenCalled();
-
-      // Upload should proceed normally
-      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("pre-check failure is non-fatal — teleport proceeds", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Pre-check returns null (no existing assistant or API failed gracefully)
-    checkExistingPlatformAssistantMock.mockResolvedValue(null);
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Pre-check was called
-      expect(checkExistingPlatformAssistantMock).toHaveBeenCalled();
-
-      // Upload and hatch should proceed normally
-      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
-      expect(hatchAssistantMock).toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Version guard: block platform→non-platform when target is behind
-// ---------------------------------------------------------------------------
-
-describe("version guard: block platform→non-platform when target is behind", () => {
-  test("blocks platform→local when local version is behind platform", async () => {
-    setArgv("--from", "my-platform", "--local", "my-local");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Source (platform) is on 0.7.0, target (local) is on 0.6.0
-    fetchCurrentVersionMock.mockImplementation((url: string) => {
-      if (url === "https://platform.vellum.ai") return Promise.resolve("0.7.0");
-      return Promise.resolve("0.6.0");
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("is running 0.6.0"),
-      );
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Upgrade your local assistant first"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("allows platform→local when versions are equal", async () => {
-    setArgv("--from", "my-platform", "--local", "my-local");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Both on 0.7.0
-    fetchCurrentVersionMock.mockResolvedValue("0.7.0");
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("allows platform→local when local is ahead of platform", async () => {
-    setArgv("--from", "my-platform", "--local", "my-local");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Source (platform) is on 0.7.0, target (local) is on 0.8.0
-    fetchCurrentVersionMock.mockImplementation((url: string) => {
-      if (url === "https://platform.vellum.ai") return Promise.resolve("0.7.0");
-      return Promise.resolve("0.8.0");
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("allows teleport when source version cannot be fetched (best-effort)", async () => {
-    setArgv("--from", "my-platform", "--local", "my-local");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Source (platform) is unreachable, target (local) is on 0.6.0
-    fetchCurrentVersionMock.mockImplementation((url: string) => {
-      if (url === "https://platform.vellum.ai")
-        return Promise.resolve(undefined);
-      return Promise.resolve("0.6.0");
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("allows teleport when target version cannot be fetched (best-effort)", async () => {
-    setArgv("--from", "my-platform", "--local", "my-local");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Source (platform) is on 0.7.0, target (local) is unreachable
-    fetchCurrentVersionMock.mockImplementation((url: string) => {
-      if (url === "https://platform.vellum.ai") return Promise.resolve("0.7.0");
-      return Promise.resolve(undefined);
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("pre-release target is behind release source: 0.7.0-local.xxx < 0.7.0", async () => {
-    setArgv("--from", "my-platform", "--local", "my-local");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Per semver, pre-release < release for same core version
-    fetchCurrentVersionMock.mockImplementation((url: string) => {
-      if (url === "https://platform.vellum.ai") return Promise.resolve("0.7.0");
-      return Promise.resolve("0.7.0-local.20260411.abc123");
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("is running 0.7.0-local.20260411.abc123"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("blocks platform→docker when docker version is behind platform", async () => {
-    setArgv("--from", "my-platform", "--docker", "my-docker");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const dockerEntry = makeEntry("my-docker", { cloud: "docker" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-docker") return dockerEntry;
-      return null;
-    });
-
-    // Source (platform) is on 0.7.0, target (docker) is on 0.5.0
-    fetchCurrentVersionMock.mockImplementation((url: string) => {
-      if (url === "https://platform.vellum.ai") return Promise.resolve("0.7.0");
-      return Promise.resolve("0.5.0");
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("is running 0.5.0"),
-      );
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Upgrade your docker assistant first"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("dry-run: blocks platform→local when local version is behind", async () => {
+  test("dry-run against local target fails fast (no preflight-from-gcs runtime endpoint yet)", async () => {
     setArgv("--from", "my-platform", "--local", "my-local", "--dry-run");
 
     const platformEntry = makeEntry("my-platform", {
@@ -2004,28 +1363,134 @@ describe("version guard: block platform→non-platform when target is behind", (
       return null;
     });
 
-    // Source (platform) is on 0.7.0, target (local) is on 0.6.0
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "bundle-key-from-platform",
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "--dry-run is not yet supported for local or docker targets",
+        ),
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre-check: block teleport to platform when existing assistant detected
+// ---------------------------------------------------------------------------
+
+describe("pre-check: existing platform assistant", () => {
+  test("blocks before any work when pre-check finds existing assistant", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    checkExistingPlatformAssistantMock.mockResolvedValue({
+      id: "existing-platform-id",
+      name: "existing-platform",
+      status: "active",
+    });
+
+    await expect(teleport()).rejects.toThrow("process.exit:1");
+
+    expect(checkExistingPlatformAssistantMock).toHaveBeenCalledWith(
+      "platform-token",
+      undefined,
+    );
+    // No signed-URL or runtime calls
+    expect(platformRequestSignedUrlMock).not.toHaveBeenCalled();
+    expect(localRuntimeExportToGcsMock).not.toHaveBeenCalled();
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("already have a platform assistant"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Version guard
+// ---------------------------------------------------------------------------
+
+describe("version guard", () => {
+  test("blocks platform→local when local version is behind", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
     fetchCurrentVersionMock.mockImplementation((url: string) => {
       if (url === "https://platform.vellum.ai") return Promise.resolve("0.7.0");
       return Promise.resolve("0.6.0");
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await expect(teleport()).rejects.toThrow("process.exit:1");
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining("is running 0.6.0"),
       );
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
+    }
+  });
+
+  test("allows equal versions", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    fetchCurrentVersionMock.mockResolvedValue("0.7.0");
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "b",
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Teleport complete"),
+      );
+    } finally {
+      restoreFetch();
     }
   });
 
   test("newly hatched target is cleaned up when version check fails", async () => {
-    // No existing local target — teleport will hatch a new one, then
-    // the version guard should retire it to avoid orphans.
     setArgv("--from", "my-platform", "--local");
 
     const platformEntry = makeEntry("my-platform", {
@@ -2034,12 +1499,10 @@ describe("version guard: block platform→non-platform when target is behind", (
     });
     const newLocalEntry = makeEntry("new-local", { cloud: "local" });
 
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      return null;
-    });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-platform" ? platformEntry : null,
+    );
 
-    // Simulate hatch creating a new local entry
     loadAllAssistantsMock.mockImplementation(() => {
       if (hatchLocalMock.mock.calls.length > 0) {
         return [platformEntry, newLocalEntry];
@@ -2047,70 +1510,42 @@ describe("version guard: block platform→non-platform when target is behind", (
       return [platformEntry];
     });
 
-    // Source (platform) is on 0.7.0, newly hatched local is on 0.6.0
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "b",
+    });
+
     fetchCurrentVersionMock.mockImplementation((url: string) => {
       if (url === "https://platform.vellum.ai") return Promise.resolve("0.7.0");
       return Promise.resolve("0.6.0");
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await expect(teleport()).rejects.toThrow("process.exit:1");
-      // Should have hatched a new local assistant
       expect(hatchLocalMock).toHaveBeenCalled();
-      // Should retire the orphaned assistant
       expect(retireLocalMock).toHaveBeenCalledWith("new-local", newLocalEntry);
       expect(removeAssistantEntryMock).toHaveBeenCalledWith("new-local");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Cleaning up newly hatched assistant"),
-      );
     } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("does not check versions for local→platform direction", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      // fetchCurrentVersion should NOT be called for local→platform
-      expect(fetchCurrentVersionMock).not.toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
 });
 
 // ---------------------------------------------------------------------------
-// Credential import display tests
+// Credential import display
 // ---------------------------------------------------------------------------
 
 describe("credential import display", () => {
-  test("prints credential counts when credentialsImported is present", async () => {
+  test("prints credential counts when credentialsImported is present (platform target)", async () => {
     setArgv("--from", "my-local", "--platform");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
 
     platformImportBundleFromGcsMock.mockResolvedValue({
       statusCode: 200,
@@ -2132,47 +1567,24 @@ describe("credential import display", () => {
       },
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
       expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 5/5");
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
 
-  test("does not print credential line when credentialsImported is absent (old server)", async () => {
+  test("does not print credential line when absent", async () => {
     setArgv("--from", "my-local", "--platform");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
 
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Mock the GCS import path (used by default since platformRequestUploadUrl
-    // succeeds) with a response that has no credentialsImported field, simulating
-    // an older server.
-    platformImportBundleFromGcsMock.mockResolvedValue({
-      statusCode: 200,
-      body: {
-        success: true,
-        summary: {
-          total_files: 3,
-          files_created: 2,
-          files_overwritten: 1,
-          files_skipped: 0,
-          backups_created: 1,
-        },
-      },
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
       const allLogCalls = consoleLogSpy.mock.calls.map((c: unknown[]) => c[0]);
@@ -2182,98 +1594,7 @@ describe("credential import display", () => {
       );
       expect(credentialLines).toHaveLength(0);
     } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("lists failed credential accounts individually", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    platformImportBundleFromGcsMock.mockResolvedValue({
-      statusCode: 200,
-      body: {
-        success: true,
-        summary: {
-          total_files: 3,
-          files_created: 2,
-          files_overwritten: 1,
-          files_skipped: 0,
-          backups_created: 1,
-        },
-        credentialsImported: {
-          total: 5,
-          succeeded: 3,
-          failed: 2,
-          failedAccounts: ["google:user@example.com", "github:octocat"],
-        },
-      },
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 3/5");
-      expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials failed:  2");
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        "    - google:user@example.com",
-      );
-      expect(consoleLogSpy).toHaveBeenCalledWith("    - github:octocat");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("shows platform credentials skipped count", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    platformImportBundleFromGcsMock.mockResolvedValue({
-      statusCode: 200,
-      body: {
-        success: true,
-        summary: {
-          total_files: 3,
-          files_created: 2,
-          files_overwritten: 1,
-          files_skipped: 0,
-          backups_created: 1,
-        },
-        credentialsImported: {
-          total: 5,
-          succeeded: 5,
-          failed: 0,
-          failedAccounts: [],
-          skippedPlatform: 3,
-        },
-      },
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 5/5");
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        "  Platform credentials skipped: 3",
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
 });
@@ -2282,7 +1603,7 @@ describe("credential import display", () => {
 // Platform credential injection after teleport
 // ---------------------------------------------------------------------------
 
-describe("teleport platform credential injection", () => {
+describe("platform credential injection", () => {
   test("platform→local teleport calls ensureSelfHostedLocalRegistration and injectCredentialsIntoAssistant", async () => {
     setArgv("--from", "my-platform", "--local", "my-local");
 
@@ -2301,9 +1622,14 @@ describe("teleport platform credential injection", () => {
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "bundle-xyz",
+    });
 
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
       expect(ensureSelfHostedLocalRegistrationMock).toHaveBeenCalledWith(
@@ -2323,49 +1649,12 @@ describe("teleport platform credential injection", () => {
         userId: "user-1",
         webhookSecret: "webhook-secret-123",
       });
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        "  Platform credentials injected.",
-      );
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
 
-  test("platform→docker teleport also calls credential injection", async () => {
-    setArgv("--from", "my-platform", "--docker", "my-docker");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const dockerEntry = makeEntry("my-docker", {
-      cloud: "docker",
-      runtimeUrl: "http://localhost:8821",
-      bearerToken: "docker-bearer",
-    });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-docker") return dockerEntry;
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(ensureSelfHostedLocalRegistrationMock).toHaveBeenCalled();
-      expect(injectCredentialsIntoAssistantMock).toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        "  Platform credentials injected.",
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("local→local teleport does NOT call credential injection", async () => {
+  test("local→docker teleport does NOT call credential injection", async () => {
     setArgv("--from", "my-local", "--docker", "my-docker");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
@@ -2380,63 +1669,28 @@ describe("teleport platform credential injection", () => {
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
       expect(ensureSelfHostedLocalRegistrationMock).not.toHaveBeenCalled();
       expect(injectCredentialsIntoAssistantMock).not.toHaveBeenCalled();
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
+});
 
-  test("if user is not logged in (readPlatformToken returns null), injection is skipped gracefully", async () => {
-    setArgv("--from", "my-platform", "--local", "my-local");
+// ---------------------------------------------------------------------------
+// Misc: legacy --to deprecation
+// ---------------------------------------------------------------------------
 
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const localEntry = makeEntry("my-local", { cloud: "local" });
+describe("misc", () => {
+  test("legacy --to flag shows deprecation message", async () => {
+    setArgv("--from", "source", "--to", "target");
 
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // The readPlatformToken mock is called twice during teleport:
-    // once during the platform export flow and once during credential injection.
-    // We need the first call to return a token (for the export to work)
-    // and the second call to return null (to test the skip path).
-    let callCount = 0;
-    readPlatformTokenMock.mockImplementation(() => {
-      callCount++;
-      // The platform export path calls readPlatformToken first;
-      // the credential injection helper calls it after import.
-      // Return null only on the last call (the injection helper).
-      if (callCount <= 1) return "platform-token";
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(ensureSelfHostedLocalRegistrationMock).not.toHaveBeenCalled();
-      expect(injectCredentialsIntoAssistantMock).not.toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        "  Skipped platform credential injection (not logged in).",
-      );
-      // Teleport still succeeds
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await expect(teleport()).rejects.toThrow("process.exit:1");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("--to is deprecated"),
+    );
   });
 });

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -1863,6 +1863,174 @@ describe("platform credential injection", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Auth / transient-error resilience (Codex P1/P2 regression guards)
+// ---------------------------------------------------------------------------
+
+describe("auth + transient-error resilience", () => {
+  test("runtime 401 on export kickoff triggers token refresh and retry", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    // First kickoff call fails with 401, second succeeds.
+    localRuntimeExportToGcsMock.mockImplementationOnce(async () => {
+      throw new Error("Local runtime export-to-gcs failed (401): stale token");
+    });
+    localRuntimeExportToGcsMock.mockImplementationOnce(async () => ({
+      jobId: "local-export-job-after-refresh",
+    }));
+
+    // Ensure the refresh path returns a distinguishable token.
+    leaseGuardianTokenMock.mockResolvedValueOnce({
+      accessToken: "refreshed-token",
+      accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    } as unknown as Awaited<
+      ReturnType<typeof guardianToken.leaseGuardianToken>
+    >);
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+    } finally {
+      restoreFetch();
+    }
+
+    // Kickoff was attempted twice: once with the cached token, once after
+    // a forced refresh lease.
+    expect(localRuntimeExportToGcsMock).toHaveBeenCalledTimes(2);
+
+    const firstTokenArg = localRuntimeExportToGcsMock.mock.calls[0][1];
+    const secondTokenArg = localRuntimeExportToGcsMock.mock.calls[1][1];
+    expect(firstTokenArg).toBe("local-token");
+    expect(secondTokenArg).toBe("refreshed-token");
+
+    // A fresh lease was requested exactly once (the forceRefresh path).
+    expect(leaseGuardianTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("runtime 401 on import kickoff triggers token refresh and retry", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "b-key",
+    });
+
+    localRuntimeImportFromGcsMock.mockImplementationOnce(async () => {
+      throw new Error(
+        "Local runtime import-from-gcs failed (401): stale token",
+      );
+    });
+    localRuntimeImportFromGcsMock.mockImplementationOnce(async () => ({
+      jobId: "local-import-after-refresh",
+    }));
+
+    leaseGuardianTokenMock.mockResolvedValueOnce({
+      accessToken: "refreshed-import-token",
+      accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    } as unknown as Awaited<
+      ReturnType<typeof guardianToken.leaseGuardianToken>
+    >);
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+    } finally {
+      restoreFetch();
+    }
+
+    expect(localRuntimeImportFromGcsMock).toHaveBeenCalledTimes(2);
+    expect(localRuntimeImportFromGcsMock.mock.calls[0][1]).toBe("local-token");
+    expect(localRuntimeImportFromGcsMock.mock.calls[1][1]).toBe(
+      "refreshed-import-token",
+    );
+  });
+
+  test("runtime non-401 errors do NOT trigger token refresh", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    localRuntimeExportToGcsMock.mockRejectedValue(
+      new Error("Local runtime export-to-gcs failed (500): boom"),
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow(/500.*boom/);
+    } finally {
+      restoreFetch();
+    }
+
+    // One attempt, no forced-refresh lease.
+    expect(localRuntimeExportToGcsMock).toHaveBeenCalledTimes(1);
+    expect(leaseGuardianTokenMock).not.toHaveBeenCalled();
+  });
+
+  test("transient poll error does not abort teleport (job completes after retry)", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    // Throw once with a 503 (transient), then succeed with terminal complete.
+    let pollCalls = 0;
+    localRuntimePollJobStatusMock.mockImplementation(
+      async (_runtimeUrl, _token, jobId) => {
+        pollCalls += 1;
+        if (pollCalls === 1) {
+          throw new Error(
+            "Local job status check failed: 503 Service Unavailable",
+          );
+        }
+        return {
+          jobId,
+          type: "export" as const,
+          status: "complete" as const,
+          result: undefined,
+        };
+      },
+    );
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const restoreFetch = installTrackingFetch();
+    try {
+      // Should NOT reject — a single transient 503 is retried, not fatal.
+      await teleport();
+      expect(pollCalls).toBeGreaterThanOrEqual(2);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("polling failed, retrying"),
+      );
+    } finally {
+      restoreFetch();
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Misc: legacy --to deprecation
 // ---------------------------------------------------------------------------
 

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -453,9 +453,13 @@ beforeEach(() => {
   computeDeviceIdMock.mockReturnValue("device-id-123");
 
   localRuntimeExportToGcsMock.mockReset();
-  localRuntimeExportToGcsMock.mockResolvedValue({ jobId: "local-export-job-1" });
+  localRuntimeExportToGcsMock.mockResolvedValue({
+    jobId: "local-export-job-1",
+  });
   localRuntimeImportFromGcsMock.mockReset();
-  localRuntimeImportFromGcsMock.mockResolvedValue({ jobId: "local-import-job-1" });
+  localRuntimeImportFromGcsMock.mockResolvedValue({
+    jobId: "local-import-job-1",
+  });
   localRuntimePollJobStatusMock.mockReset();
   localRuntimePollJobStatusMock.mockImplementation(defaultLocalRuntimePollImpl);
 
@@ -516,11 +520,13 @@ function makeEntry(
  */
 function installTrackingFetch(): () => void {
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
-    const urlStr = typeof url === "string" ? url : url.toString();
-    fetchCalls.push({ url: urlStr, body: init?.body });
-    return new Response("not found", { status: 404 });
-  }) as unknown as typeof globalThis.fetch;
+  globalThis.fetch = mock(
+    async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      fetchCalls.push({ url: urlStr, body: init?.body });
+      return new Response("not found", { status: 404 });
+    },
+  ) as unknown as typeof globalThis.fetch;
   return () => {
     globalThis.fetch = originalFetch;
   };
@@ -1266,7 +1272,7 @@ describe("polling", () => {
 // ---------------------------------------------------------------------------
 
 describe("MigrationInProgressError handling", () => {
-  test("local-runtime export already in flight → poll the existing job", async () => {
+  test("local-runtime export already in flight → fail fast with existing job id", async () => {
     setArgv("--from", "my-local", "--platform");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
@@ -1283,12 +1289,74 @@ describe("MigrationInProgressError handling", () => {
 
     const restoreFetch = installTrackingFetch();
     try {
-      await teleport();
-      // Should have polled the existing job id.
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+
+      // Must not have polled the existing job — the existing job's bundle
+      // lives at a different GCS key (its caller's signed URL), so polling
+      // it would leave the teleport pointing at an empty/unrelated bundle.
       const polledIds = localRuntimePollJobStatusMock.mock.calls.map(
         (call: unknown[]) => call[2],
       );
-      expect(polledIds).toContain("existing-job-42");
+      expect(polledIds).not.toContain("existing-job-42");
+
+      // Error must mention the existing job id so the user can act on it.
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("existing-job-42"),
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("already in progress"),
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("local-runtime import already in flight → fail fast with existing job id", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "bundle-key-from-platform",
+    });
+
+    localRuntimeImportFromGcsMock.mockRejectedValue(
+      new localRuntimeClient.MigrationInProgressError(
+        "import_in_progress",
+        "existing-import-99",
+      ),
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+
+      // Must not poll the existing import — it's importing somebody else's
+      // bundle, not ours, so reporting on it would be misleading.
+      const polledIds = localRuntimePollJobStatusMock.mock.calls.map(
+        (call: unknown[]) => call[2],
+      );
+      expect(polledIds).not.toContain("existing-import-99");
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("existing-import-99"),
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("already in progress"),
+      );
     } finally {
       restoreFetch();
     }
@@ -1320,7 +1388,13 @@ describe("dry-run", () => {
   });
 
   test("dry-run with existing platform target runs preflight-from-gcs", async () => {
-    setArgv("--from", "my-local", "--platform", "existing-platform", "--dry-run");
+    setArgv(
+      "--from",
+      "my-local",
+      "--platform",
+      "existing-platform",
+      "--dry-run",
+    );
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
     const platformEntry = makeEntry("existing-platform", {
@@ -1378,6 +1452,12 @@ describe("dry-run", () => {
           "--dry-run is not yet supported for local or docker targets",
         ),
       );
+
+      // Must fail BEFORE any export work — no signed URL request, no platform
+      // export initiation, nothing that costs time or bandwidth.
+      expect(platformRequestSignedUrlMock).not.toHaveBeenCalled();
+      expect(platformInitiateExportMock).not.toHaveBeenCalled();
+      expect(localRuntimeExportToGcsMock).not.toHaveBeenCalled();
     } finally {
       restoreFetch();
     }

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -223,11 +223,17 @@ async function getAccessToken(
   runtimeUrl: string,
   assistantId: string,
   displayName: string,
+  options?: { forceRefresh?: boolean },
 ): Promise<string> {
-  const tokenData = loadGuardianToken(assistantId);
+  // When forceRefresh is set (e.g. after a runtime 401 on the cached token)
+  // we skip the cache and lease a brand-new token from the gateway, so a
+  // stale-but-unexpired token can't keep failing on every retry.
+  if (!options?.forceRefresh) {
+    const tokenData = loadGuardianToken(assistantId);
 
-  if (tokenData && new Date(tokenData.accessTokenExpiresAt) > new Date()) {
-    return tokenData.accessToken;
+    if (tokenData && new Date(tokenData.accessTokenExpiresAt) > new Date()) {
+      return tokenData.accessToken;
+    }
   }
 
   try {
@@ -243,6 +249,47 @@ async function getAccessToken(
       process.exit(1);
     }
     throw err;
+  }
+}
+
+/**
+ * Detect a 401 Unauthorized raised by `localRuntimeExportToGcs` /
+ * `localRuntimeImportFromGcs`. Both throw Error with a message of the form
+ * `"Local runtime <op> failed (401): ..."` when the gateway rejects the
+ * cached guardian token.
+ */
+function isRuntime401(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /Local runtime [^(]*failed \(401\)/.test(msg);
+}
+
+/**
+ * Run a runtime kickoff (`localRuntimeExportToGcs` / `localRuntimeImportFromGcs`)
+ * with a one-shot refresh-and-retry on 401. Matches the pre-rewrite
+ * `exportViaHttp`/`importViaHttp` behavior: if the cached guardian token is
+ * stale-but-unexpired and the runtime returns 401, we lease a fresh token
+ * and retry once. Any other error — or a repeated 401 on the refreshed token
+ * — propagates to the caller.
+ */
+async function callRuntimeWithAuthRetry<T>(
+  runtimeUrl: string,
+  assistantId: string,
+  fn: (token: string) => Promise<T>,
+): Promise<T> {
+  const firstToken = await getAccessToken(runtimeUrl, assistantId, assistantId);
+  try {
+    return await fn(firstToken);
+  } catch (err) {
+    if (!isRuntime401(err)) {
+      throw err;
+    }
+    const refreshedToken = await getAccessToken(
+      runtimeUrl,
+      assistantId,
+      assistantId,
+      { forceRefresh: true },
+    );
+    return await fn(refreshedToken);
   }
 }
 
@@ -331,20 +378,27 @@ async function exportFromAssistant(
       bundlePlatformUrl,
     );
 
-    const accessToken = await getAccessToken(
-      entry.runtimeUrl,
-      entry.assistantId,
-      entry.assistantId,
-    );
-
+    // Wrap the kickoff in a one-shot refresh-and-retry helper so a stale-but-
+    // unexpired cached guardian token surfaces as 401 → re-lease → retry
+    // rather than a terminal failure. `accessToken` below is whichever token
+    // succeeded on the kickoff; we reuse it for polling so the runtime sees a
+    // consistent credential throughout the migration.
     let jobId: string;
+    let accessToken: string;
     try {
-      const result = await localRuntimeExportToGcs(
+      const result = await callRuntimeWithAuthRetry(
         entry.runtimeUrl,
-        accessToken,
-        { uploadUrl, description: "teleport export" },
+        entry.assistantId,
+        async (token) => {
+          const r = await localRuntimeExportToGcs(entry.runtimeUrl, token, {
+            uploadUrl,
+            description: "teleport export",
+          });
+          return { jobId: r.jobId, token };
+        },
       );
       jobId = result.jobId;
+      accessToken = result.token;
     } catch (err) {
       if (err instanceof MigrationInProgressError) {
         // Fail fast — the existing job is writing to a different GCS object
@@ -559,22 +613,23 @@ async function importToAssistant(
       bundlePlatformUrl,
     );
 
-    const accessToken = await getAccessToken(
-      entry.runtimeUrl,
-      entry.assistantId,
-      entry.assistantId,
-    );
-
     console.log("Importing data...");
 
     let jobId: string;
+    let accessToken: string;
     try {
-      const result = await localRuntimeImportFromGcs(
+      const result = await callRuntimeWithAuthRetry(
         entry.runtimeUrl,
-        accessToken,
-        { bundleUrl },
+        entry.assistantId,
+        async (token) => {
+          const r = await localRuntimeImportFromGcs(entry.runtimeUrl, token, {
+            bundleUrl,
+          });
+          return { jobId: r.jobId, token };
+        },
       );
       jobId = result.jobId;
+      accessToken = result.token;
     } catch (err) {
       if (err instanceof MigrationInProgressError) {
         // Fail fast — the existing job is importing someone else's bundle

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -309,6 +309,7 @@ interface ImportResponse {
 async function exportFromAssistant(
   entry: AssistantEntry,
   cloud: string,
+  bundlePlatformUrl?: string,
 ): Promise<{ bundleKey: string }> {
   const platformToken = readPlatformToken();
   if (!platformToken) {
@@ -319,11 +320,15 @@ async function exportFromAssistant(
   }
 
   if (cloud === "local" || cloud === "docker") {
-    // Request a signed upload URL from the platform, then hand it to the
-    // local/docker runtime so it can stream the bundle straight into GCS.
+    // Request a signed upload URL from the platform instance that will
+    // eventually own the bundle (i.e. the one the importer will read from).
+    // Passing the target's runtime URL here keeps upload and download on
+    // the same platform — otherwise a non-default/stale platform URL would
+    // cause the import to look at an empty object.
     const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
       { operation: "upload" },
       platformToken,
+      bundlePlatformUrl,
     );
 
     const accessToken = await getAccessToken(
@@ -417,6 +422,7 @@ async function importToAssistant(
   cloud: string,
   bundleKey: string,
   dryRun: boolean,
+  bundlePlatformUrl?: string,
 ): Promise<void> {
   const platformToken = readPlatformToken();
   if (!platformToken) {
@@ -544,10 +550,13 @@ async function importToAssistant(
 
     // Ask the platform for a signed download URL and hand it to the local
     // runtime. The runtime streams the bundle straight out of GCS — the CLI
-    // never touches the bytes.
+    // never touches the bytes. The URL must target the same platform the
+    // bundle was uploaded to; otherwise the object won't exist on this
+    // platform's GCS bucket.
     const { url: bundleUrl } = await platformRequestSignedUrl(
       { operation: "download", bundleKey },
       platformToken,
+      bundlePlatformUrl,
     );
 
     const accessToken = await getAccessToken(
@@ -1019,10 +1028,31 @@ export async function teleport(): Promise<void> {
         }
       }
 
+      // Pin both upload and download to the same platform instance. For
+      // platform targets the bundle is owned by the target platform; for
+      // platform sources it's owned by the source platform. Only one of
+      // these branches applies at a time (same-env was rejected earlier).
+      const bundlePlatformUrl =
+        toCloud === "vellum"
+          ? existingTarget.runtimeUrl
+          : fromCloud === "vellum"
+            ? fromEntry.runtimeUrl
+            : undefined;
+
       console.log(`Exporting from ${from} (${fromCloud})...`);
-      const { bundleKey } = await exportFromAssistant(fromEntry, fromCloud);
+      const { bundleKey } = await exportFromAssistant(
+        fromEntry,
+        fromCloud,
+        bundlePlatformUrl,
+      );
       console.log(`Importing to ${existingTarget.assistantId} (${toCloud})...`);
-      await importToAssistant(existingTarget, toCloud, bundleKey, true);
+      await importToAssistant(
+        existingTarget,
+        toCloud,
+        bundleKey,
+        true,
+        bundlePlatformUrl,
+      );
     } else {
       // No existing target — just describe what would happen
       console.log("Dry run summary:");
@@ -1093,8 +1123,17 @@ export async function teleport(): Promise<void> {
     // Export — for local/docker sources this uploads straight into GCS via
     // the platform's signed URL; for platform sources this runs a server-side
     // export and we read the resulting bundle_key.
+    // The signed upload URL must be requested from the same platform instance
+    // where the import will run. For existing targets that's the lockfile's
+    // runtimeUrl; for fresh hatches it's getPlatformUrl() (which is what
+    // resolveOrHatchTarget writes to the new entry).
     console.log(`Exporting from ${from} (${fromCloud})...`);
-    const { bundleKey } = await exportFromAssistant(fromEntry, fromCloud);
+    const bundlePlatformUrl = targetPlatformUrl ?? getPlatformUrl();
+    const { bundleKey } = await exportFromAssistant(
+      fromEntry,
+      fromCloud,
+      bundlePlatformUrl,
+    );
 
     // Hatch (export succeeded — safe to create the target)
     const toEntry = await resolveOrHatchTarget(targetEnv, targetName);
@@ -1102,7 +1141,13 @@ export async function teleport(): Promise<void> {
 
     // Import from GCS
     console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
-    await importToAssistant(toEntry, toCloud, bundleKey, false);
+    await importToAssistant(
+      toEntry,
+      toCloud,
+      bundleKey,
+      false,
+      bundlePlatformUrl,
+    );
 
     console.log(`Teleport complete: ${from} → ${toEntry.assistantId}`);
     return;
@@ -1144,9 +1189,21 @@ export async function teleport(): Promise<void> {
     }
   }
 
+  // Pin the bundle's platform instance so upload and download land on the
+  // same GCS bucket. For platform sources the bundle is owned by the source
+  // platform. For local/docker→local/docker the bundle lives on whatever
+  // platform getPlatformUrl() currently resolves to — we resolve it once
+  // here so a lockfile change mid-teleport can't split export and import.
+  const bundlePlatformUrl =
+    fromCloud === "vellum" ? fromEntry.runtimeUrl : getPlatformUrl();
+
   // Export from source (bundle lives in GCS after this returns).
   console.log(`Exporting from ${from} (${fromCloud})...`);
-  const { bundleKey } = await exportFromAssistant(fromEntry, fromCloud);
+  const { bundleKey } = await exportFromAssistant(
+    fromEntry,
+    fromCloud,
+    bundlePlatformUrl,
+  );
 
   if (sourceIsLocalOrDocker && targetIsLocalOrDocker && !keepSource) {
     console.log(`Stopping source assistant '${from}' to free ports...`);
@@ -1215,7 +1272,13 @@ export async function teleport(): Promise<void> {
 
   // Import to target (also GCS-driven)
   console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
-  await importToAssistant(toEntry, toCloud, bundleKey, false);
+  await importToAssistant(
+    toEntry,
+    toCloud,
+    bundleKey,
+    false,
+    bundlePlatformUrl,
+  );
 
   // After successful import, inject fresh platform credentials if the
   // user is logged in — replaces the source's stale vellum:* credentials

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -17,15 +17,10 @@ import {
   hatchAssistant,
   checkExistingPlatformAssistant,
   platformInitiateExport,
-  platformPollExportStatus,
-  platformDownloadExport,
-  platformImportPreflight,
-  platformImportBundle,
-  platformRequestUploadUrl,
-  platformUploadToSignedUrl,
-  platformImportPreflightFromGcs,
+  platformPollJobStatus,
   platformImportBundleFromGcs,
-  platformPollImportStatus,
+  platformImportPreflightFromGcs,
+  platformRequestSignedUrl,
   ensureSelfHostedLocalRegistration,
   readGatewayCredential,
   reprovisionAssistantApiKey,
@@ -33,6 +28,13 @@ import {
   fetchCurrentUser,
   fetchOrganizationId,
 } from "../lib/platform-client.js";
+import {
+  localRuntimeExportToGcs,
+  localRuntimeImportFromGcs,
+  localRuntimePollJobStatus,
+  MigrationInProgressError,
+} from "../lib/local-runtime-client.js";
+import { pollJobUntilDone } from "../lib/job-polling.js";
 import {
   hatchDocker,
   retireDocker,
@@ -245,335 +247,7 @@ async function getAccessToken(
 }
 
 // ---------------------------------------------------------------------------
-// HTTP-based export/import helpers (shared by local and docker)
-// ---------------------------------------------------------------------------
-
-async function exportViaHttp(
-  entry: AssistantEntry,
-): Promise<Uint8Array<ArrayBuffer>> {
-  let accessToken = await getAccessToken(
-    entry.runtimeUrl,
-    entry.assistantId,
-    entry.assistantId,
-  );
-
-  let response: Response;
-  try {
-    response = await fetch(`${entry.runtimeUrl}/v1/migrations/export`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ description: "teleport export" }),
-      signal: AbortSignal.timeout(120_000),
-    });
-
-    // Retry once with a fresh token on 401
-    if (response.status === 401) {
-      let refreshedToken: string | null = null;
-      try {
-        const freshToken = await leaseGuardianToken(
-          entry.runtimeUrl,
-          entry.assistantId,
-        );
-        refreshedToken = freshToken.accessToken;
-      } catch {
-        // If token refresh fails, fall through to the error handler below
-      }
-      if (refreshedToken) {
-        accessToken = refreshedToken;
-        response = await fetch(`${entry.runtimeUrl}/v1/migrations/export`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ description: "teleport export" }),
-          signal: AbortSignal.timeout(120_000),
-        });
-      }
-    }
-  } catch (err) {
-    if (err instanceof Error && err.name === "TimeoutError") {
-      console.error("Error: Export request timed out after 2 minutes.");
-      process.exit(1);
-    }
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("ECONNREFUSED") || msg.includes("fetch failed")) {
-      console.error(
-        `Error: Could not connect to assistant '${entry.assistantId}'. Is it running?`,
-      );
-      console.error(`Try: vellum wake ${entry.assistantId}`);
-      process.exit(1);
-    }
-    throw err;
-  }
-
-  if (response.status === 401 || response.status === 403) {
-    console.error("Authentication failed.");
-    process.exit(1);
-  }
-
-  if (response.status === 404) {
-    console.error("Assistant not found or not running.");
-    process.exit(1);
-  }
-
-  if (
-    response.status === 502 ||
-    response.status === 503 ||
-    response.status === 504
-  ) {
-    console.error(
-      `Assistant is unreachable. Try 'vellum wake ${entry.assistantId}'.`,
-    );
-    process.exit(1);
-  }
-
-  if (!response.ok) {
-    const body = await response.text();
-    console.error(`Error: Export failed (${response.status}): ${body}`);
-    process.exit(1);
-  }
-
-  const arrayBuffer = await response.arrayBuffer();
-  return new Uint8Array(arrayBuffer);
-}
-
-async function importViaHttp(
-  entry: AssistantEntry,
-  bundleData: Uint8Array<ArrayBuffer>,
-  dryRun: boolean,
-): Promise<void> {
-  let accessToken = await getAccessToken(
-    entry.runtimeUrl,
-    entry.assistantId,
-    entry.assistantId,
-  );
-
-  if (dryRun) {
-    console.log("Running preflight analysis...\n");
-
-    let response: Response;
-    try {
-      response = await fetch(
-        `${entry.runtimeUrl}/v1/migrations/import-preflight`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            "Content-Type": "application/octet-stream",
-          },
-          body: new Blob([bundleData]),
-          signal: AbortSignal.timeout(120_000),
-        },
-      );
-
-      // Retry once with a fresh token on 401
-      if (response.status === 401) {
-        let refreshedToken: string | null = null;
-        try {
-          const freshToken = await leaseGuardianToken(
-            entry.runtimeUrl,
-            entry.assistantId,
-          );
-          refreshedToken = freshToken.accessToken;
-        } catch {
-          // If token refresh fails, fall through to the error handler below
-        }
-        if (refreshedToken) {
-          accessToken = refreshedToken;
-          response = await fetch(
-            `${entry.runtimeUrl}/v1/migrations/import-preflight`,
-            {
-              method: "POST",
-              headers: {
-                Authorization: `Bearer ${accessToken}`,
-                "Content-Type": "application/octet-stream",
-              },
-              body: new Blob([bundleData]),
-              signal: AbortSignal.timeout(120_000),
-            },
-          );
-        }
-      }
-    } catch (err) {
-      if (err instanceof Error && err.name === "TimeoutError") {
-        console.error("Error: Preflight request timed out after 2 minutes.");
-        process.exit(1);
-      }
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("ECONNREFUSED") || msg.includes("fetch failed")) {
-        console.error(
-          `Error: Could not connect to assistant '${entry.assistantId}'. Is it running?`,
-        );
-        console.error(`Try: vellum wake ${entry.assistantId}`);
-        process.exit(1);
-      }
-      throw err;
-    }
-
-    handleLocalResponseErrors(response, entry.assistantId);
-
-    const result = (await response.json()) as PreflightResponse;
-    printPreflightSummary(result);
-    return;
-  }
-
-  // Actual import
-  console.log("Importing data...");
-
-  let response: Response;
-  try {
-    response = await fetch(`${entry.runtimeUrl}/v1/migrations/import`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/octet-stream",
-      },
-      body: new Blob([bundleData]),
-      signal: AbortSignal.timeout(300_000),
-    });
-
-    // Retry once with a fresh token on 401
-    if (response.status === 401) {
-      let refreshedToken: string | null = null;
-      try {
-        const freshToken = await leaseGuardianToken(
-          entry.runtimeUrl,
-          entry.assistantId,
-        );
-        refreshedToken = freshToken.accessToken;
-      } catch {
-        // If token refresh fails, fall through to the error handler below
-      }
-      if (refreshedToken) {
-        accessToken = refreshedToken;
-        response = await fetch(`${entry.runtimeUrl}/v1/migrations/import`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            "Content-Type": "application/octet-stream",
-          },
-          body: new Blob([bundleData]),
-          signal: AbortSignal.timeout(300_000),
-        });
-      }
-    }
-  } catch (err) {
-    if (err instanceof Error && err.name === "TimeoutError") {
-      console.error("Error: Import request timed out after 5 minutes.");
-      process.exit(1);
-    }
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("ECONNREFUSED") || msg.includes("fetch failed")) {
-      console.error(
-        `Error: Could not connect to assistant '${entry.assistantId}'. Is it running?`,
-      );
-      console.error(`Try: vellum wake ${entry.assistantId}`);
-      process.exit(1);
-    }
-    throw err;
-  }
-
-  handleLocalResponseErrors(response, entry.assistantId);
-
-  const result = (await response.json()) as ImportResponse;
-  printImportSummary(result);
-}
-
-// ---------------------------------------------------------------------------
-// Export from source assistant
-// ---------------------------------------------------------------------------
-
-async function exportFromAssistant(
-  entry: AssistantEntry,
-  cloud: string,
-): Promise<Uint8Array<ArrayBuffer>> {
-  if (cloud === "vellum") {
-    // Platform source — use Django async export
-    const token = readPlatformToken();
-    if (!token) {
-      console.error("Not logged in. Run 'vellum login' first.");
-      process.exit(1);
-    }
-
-    // Initiate export job
-    const { jobId } = await platformInitiateExport(
-      token,
-      "teleport export",
-      entry.runtimeUrl,
-    );
-
-    console.log(`Export started (job ${jobId})...`);
-
-    // Poll for completion
-    const POLL_INTERVAL_MS = 2_000;
-    const TIMEOUT_MS = 5 * 60 * 1_000;
-    const deadline = Date.now() + TIMEOUT_MS;
-    let downloadUrl: string | undefined;
-
-    while (Date.now() < deadline) {
-      let status: { status: string; downloadUrl?: string; error?: string };
-      try {
-        status = await platformPollExportStatus(jobId, token, entry.runtimeUrl);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("not found")) {
-          throw err;
-        }
-        // Re-throw permanent 4xx errors (auth, forbidden, etc.)
-        // but retry transient 5xx errors
-        const statusMatch = msg.match(/status check failed: (\d+)/);
-        if (statusMatch) {
-          const statusCode = parseInt(statusMatch[1], 10);
-          if (statusCode >= 400 && statusCode < 500) {
-            throw err;
-          }
-        }
-        // Transient error — retry
-        console.warn(`Polling failed, retrying... (${msg})`);
-        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-        continue;
-      }
-
-      if (status.status === "complete") {
-        downloadUrl = status.downloadUrl;
-        break;
-      }
-
-      if (status.status === "failed") {
-        console.error(`Export failed: ${status.error ?? "unknown error"}`);
-        process.exit(1);
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-    }
-
-    if (!downloadUrl) {
-      console.error("Export timed out after 5 minutes.");
-      process.exit(1);
-    }
-
-    // Download the bundle
-    const response = await platformDownloadExport(downloadUrl);
-    const arrayBuffer = await response.arrayBuffer();
-    return new Uint8Array(arrayBuffer);
-  }
-
-  if (cloud === "local" || cloud === "docker") {
-    return exportViaHttp(entry);
-  }
-
-  console.error(
-    "Teleport only supports local, docker, and platform assistants as source.",
-  );
-  process.exit(1);
-}
-
-// ---------------------------------------------------------------------------
-// Import into target assistant
+// Summary response shapes (reused by the GCS job result payload)
 // ---------------------------------------------------------------------------
 
 interface PreflightFileEntry {
@@ -625,86 +299,156 @@ interface ImportResponse {
   };
 }
 
-async function importToAssistant(
+// ---------------------------------------------------------------------------
+// Export from source — unified GCS flow
+//
+// Every source (local, docker, platform) produces a `bundleKey` referring to
+// a bundle sitting in GCS. The CLI never holds the bundle bytes.
+// ---------------------------------------------------------------------------
+
+async function exportFromAssistant(
   entry: AssistantEntry,
   cloud: string,
-  bundleData: Uint8Array<ArrayBuffer>,
-  dryRun: boolean,
-  preUploadedBundleKey?: string | null,
-): Promise<void> {
-  if (cloud === "vellum") {
-    // Platform target
-    const token = readPlatformToken();
-    if (!token) {
-      console.error("Not logged in. Run 'vellum login' first.");
+): Promise<{ bundleKey: string }> {
+  const platformToken = readPlatformToken();
+  if (!platformToken) {
+    console.error(
+      "Not logged in. Run 'vellum login' first (required for GCS-based teleport).",
+    );
+    process.exit(1);
+  }
+
+  if (cloud === "local" || cloud === "docker") {
+    // Request a signed upload URL from the platform, then hand it to the
+    // local/docker runtime so it can stream the bundle straight into GCS.
+    const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
+      { operation: "upload" },
+      platformToken,
+    );
+
+    const accessToken = await getAccessToken(
+      entry.runtimeUrl,
+      entry.assistantId,
+      entry.assistantId,
+    );
+
+    let jobId: string;
+    try {
+      const result = await localRuntimeExportToGcs(
+        entry.runtimeUrl,
+        accessToken,
+        { uploadUrl, description: "teleport export" },
+      );
+      jobId = result.jobId;
+    } catch (err) {
+      if (err instanceof MigrationInProgressError) {
+        console.log(
+          `An export is already in progress on '${entry.assistantId}' (job ${err.existingJobId}); polling it instead.`,
+        );
+        jobId = err.existingJobId;
+      } else {
+        throw err;
+      }
+    }
+
+    console.log(`Export started (job ${jobId})...`);
+
+    const terminal = await pollJobUntilDone({
+      label: "local-runtime export",
+      poll: () =>
+        localRuntimePollJobStatus(entry.runtimeUrl, accessToken, jobId),
+    });
+
+    if (terminal.status === "failed") {
+      console.error(`Export failed: ${terminal.error}`);
       process.exit(1);
     }
 
-    // Use pre-uploaded bundle key if provided (string), skip upload if null
-    // (signals signed URLs were already tried and unavailable), or try
-    // signed-URL upload if undefined (never attempted).
-    let bundleKey: string | undefined =
-      preUploadedBundleKey === null ? undefined : preUploadedBundleKey;
-    if (preUploadedBundleKey === undefined) {
-      try {
-        const { uploadUrl, bundleKey: key } = await platformRequestUploadUrl(
-          token,
-          entry.runtimeUrl,
-        );
-        bundleKey = key;
-        console.log("Uploading bundle...");
-        await platformUploadToSignedUrl(uploadUrl, bundleData);
-      } catch (err) {
-        // If signed uploads unavailable (503), fall back to inline upload
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("not available")) {
-          bundleKey = undefined;
-        } else {
-          throw err;
-        }
-      }
+    return { bundleKey };
+  }
+
+  if (cloud === "vellum") {
+    // Platform source — initiate a server-side export. The platform writes
+    // the bundle to its own `exports/<org>/<id>.vbundle` key; we discover
+    // that key via the unified job-status endpoint's `bundle_key` field.
+    const { jobId } = await platformInitiateExport(
+      platformToken,
+      "teleport export",
+      entry.runtimeUrl,
+    );
+
+    console.log(`Export started (job ${jobId})...`);
+
+    const terminal = await pollJobUntilDone({
+      label: "platform export",
+      poll: () => platformPollJobStatus(jobId, platformToken, entry.runtimeUrl),
+    });
+
+    if (terminal.status === "failed") {
+      console.error(`Export failed: ${terminal.error}`);
+      process.exit(1);
     }
 
+    if (!terminal.bundleKey) {
+      console.error(
+        "Export completed but the platform did not return a bundle_key. Is the platform up to date?",
+      );
+      process.exit(1);
+    }
+
+    return { bundleKey: terminal.bundleKey };
+  }
+
+  console.error(
+    "Teleport only supports local, docker, and platform assistants as source.",
+  );
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Import into target — unified GCS flow
+// ---------------------------------------------------------------------------
+
+async function importToAssistant(
+  entry: AssistantEntry,
+  cloud: string,
+  bundleKey: string,
+  dryRun: boolean,
+): Promise<void> {
+  const platformToken = readPlatformToken();
+  if (!platformToken) {
+    console.error(
+      "Not logged in. Run 'vellum login' first (required for GCS-based teleport).",
+    );
+    process.exit(1);
+  }
+
+  if (cloud === "vellum") {
+    // Platform target — the bundle is already in GCS; kick off preflight or
+    // async import via the unified job-status endpoint.
     if (dryRun) {
       console.log("Running preflight analysis...\n");
 
-      let preflightResult: {
-        statusCode: number;
-        body: Record<string, unknown>;
-      };
-      try {
-        preflightResult = bundleKey
-          ? await platformImportPreflightFromGcs(
-              bundleKey,
-              token,
-              entry.runtimeUrl,
-            )
-          : await platformImportPreflight(bundleData, token, entry.runtimeUrl);
-      } catch (err) {
-        if (err instanceof Error && err.name === "TimeoutError") {
-          console.error("Error: Preflight request timed out after 2 minutes.");
-          process.exit(1);
-        }
-        throw err;
-      }
+      const preflight = await platformImportPreflightFromGcs(
+        bundleKey,
+        platformToken,
+        entry.runtimeUrl,
+      );
 
-      if (
-        preflightResult.statusCode === 401 ||
-        preflightResult.statusCode === 403
-      ) {
+      if (preflight.statusCode === 401 || preflight.statusCode === 403) {
         console.error("Authentication failed. Run 'vellum login' to refresh.");
         process.exit(1);
       }
 
-      if (preflightResult.statusCode === 404) {
+      if (preflight.statusCode === 404) {
         console.error("Assistant not found or not running.");
         process.exit(1);
       }
 
       if (
-        preflightResult.statusCode === 502 ||
-        preflightResult.statusCode === 503 ||
-        preflightResult.statusCode === 504
+        preflight.statusCode === 502 ||
+        preflight.statusCode === 503 ||
+        preflight.statusCode === 504
       ) {
         console.error(
           `Assistant is unreachable. Try 'vellum wake ${entry.assistantId}'.`,
@@ -712,35 +456,53 @@ async function importToAssistant(
         process.exit(1);
       }
 
-      if (preflightResult.statusCode !== 200) {
+      if (preflight.statusCode !== 200) {
         console.error(
-          `Error: Preflight check failed (${preflightResult.statusCode}): ${JSON.stringify(preflightResult.body)}`,
+          `Error: Preflight check failed (${preflight.statusCode}): ${JSON.stringify(preflight.body)}`,
         );
         process.exit(1);
       }
 
-      const result = preflightResult.body as unknown as PreflightResponse;
+      const result = preflight.body as unknown as PreflightResponse;
       printPreflightSummary(result);
       return;
     }
 
-    // Actual import
     console.log("Importing data...");
 
-    let importResult: { statusCode: number; body: Record<string, unknown> };
-    try {
-      importResult = bundleKey
-        ? await platformImportBundleFromGcs(bundleKey, token, entry.runtimeUrl)
-        : await platformImportBundle(bundleData, token, entry.runtimeUrl);
-    } catch (err) {
-      if (err instanceof Error && err.name === "TimeoutError") {
-        console.error("Error: Import request timed out.");
-        process.exit(1);
-      }
-      throw err;
+    const importResult = await platformImportBundleFromGcs(
+      bundleKey,
+      platformToken,
+      entry.runtimeUrl,
+    );
+
+    if (importResult.statusCode === 401 || importResult.statusCode === 403) {
+      console.error("Authentication failed. Run 'vellum login' to refresh.");
+      process.exit(1);
     }
 
-    handleImportStatusErrors(importResult.statusCode, entry.assistantId);
+    if (importResult.statusCode === 404) {
+      console.error("Assistant not found or not running.");
+      process.exit(1);
+    }
+
+    if (
+      importResult.statusCode === 502 ||
+      importResult.statusCode === 503 ||
+      importResult.statusCode === 504
+    ) {
+      console.error(
+        `Assistant is unreachable. Try 'vellum wake ${entry.assistantId}'.`,
+      );
+      process.exit(1);
+    }
+
+    if (importResult.statusCode !== 202 && importResult.statusCode !== 200) {
+      console.error(`Error: Import failed (${importResult.statusCode})`);
+      process.exit(1);
+    }
+
+    let finalBody: Record<string, unknown> = importResult.body;
 
     if (importResult.statusCode === 202) {
       const jobId = (importResult.body as { job_id?: string }).job_id;
@@ -749,74 +511,84 @@ async function importToAssistant(
         process.exit(1);
       }
 
-      const POLL_INTERVAL_MS = 5_000;
-      const TIMEOUT_MS = 10 * 60 * 1_000; // 10 minutes (platform staleness is 930s)
-      const startTime = Date.now();
-      const deadline = startTime + TIMEOUT_MS;
+      const terminal = await pollJobUntilDone({
+        label: "platform import",
+        poll: () =>
+          platformPollJobStatus(jobId, platformToken, entry.runtimeUrl),
+      });
 
-      while (Date.now() < deadline) {
-        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-
-        let status: {
-          status: string;
-          result?: Record<string, unknown>;
-          error?: string;
-        };
-        try {
-          status = await platformPollImportStatus(
-            jobId,
-            token,
-            entry.runtimeUrl,
-          );
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          if (msg.includes("not found")) {
-            throw err;
-          }
-          // Re-throw permanent 4xx errors (auth, forbidden, etc.)
-          // but retry transient 5xx errors
-          const statusMatch = msg.match(/status check failed: (\d+)/);
-          if (statusMatch) {
-            const statusCode = parseInt(statusMatch[1], 10);
-            if (statusCode >= 400 && statusCode < 500) {
-              throw err;
-            }
-          }
-          // Transient error — retry
-          console.warn(`Polling failed, retrying... (${msg})`);
-          continue;
-        }
-
-        if (status.status === "complete") {
-          importResult = { statusCode: 200, body: status.result ?? {} };
-          break;
-        }
-
-        if (status.status === "failed") {
-          console.error(`Import failed: ${status.error ?? "unknown error"}`);
-          process.exit(1);
-        }
-
-        const elapsed = Math.round((Date.now() - startTime) / 1000);
-        process.stdout.write(`\rImporting... ${elapsed}s elapsed`);
-      }
-
-      // Clear the progress line
-      process.stdout.write("\r" + " ".repeat(40) + "\r");
-
-      if (importResult.statusCode === 202) {
-        console.error("Import timed out after 10 minutes.");
+      if (terminal.status === "failed") {
+        console.error(`Import failed: ${terminal.error}`);
         process.exit(1);
       }
+
+      finalBody = (terminal.result as Record<string, unknown>) ?? {};
     }
 
-    const result = importResult.body as unknown as ImportResponse;
+    const result = finalBody as unknown as ImportResponse;
     printImportSummary(result);
     return;
   }
 
   if (cloud === "local" || cloud === "docker") {
-    await importViaHttp(entry, bundleData, dryRun);
+    if (dryRun) {
+      // TODO(cli): support dry-run against local targets
+      console.error(
+        "Error: --dry-run is not yet supported for local or docker targets (no preflight-from-gcs endpoint on the runtime).",
+      );
+      process.exit(1);
+    }
+
+    // Ask the platform for a signed download URL and hand it to the local
+    // runtime. The runtime streams the bundle straight out of GCS — the CLI
+    // never touches the bytes.
+    const { url: bundleUrl } = await platformRequestSignedUrl(
+      { operation: "download", bundleKey },
+      platformToken,
+    );
+
+    const accessToken = await getAccessToken(
+      entry.runtimeUrl,
+      entry.assistantId,
+      entry.assistantId,
+    );
+
+    console.log("Importing data...");
+
+    let jobId: string;
+    try {
+      const result = await localRuntimeImportFromGcs(
+        entry.runtimeUrl,
+        accessToken,
+        { bundleUrl },
+      );
+      jobId = result.jobId;
+    } catch (err) {
+      if (err instanceof MigrationInProgressError) {
+        console.log(
+          `An import is already in progress on '${entry.assistantId}' (job ${err.existingJobId}); polling it instead.`,
+        );
+        jobId = err.existingJobId;
+      } else {
+        throw err;
+      }
+    }
+
+    const terminal = await pollJobUntilDone({
+      label: "local-runtime import",
+      poll: () =>
+        localRuntimePollJobStatus(entry.runtimeUrl, accessToken, jobId),
+    });
+
+    if (terminal.status === "failed") {
+      console.error(`Import failed: ${terminal.error}`);
+      process.exit(1);
+    }
+
+    const result =
+      ((terminal.result as Record<string, unknown>) ??
+        {}) as unknown as ImportResponse;
+    printImportSummary(result);
     return;
   }
 
@@ -950,68 +722,6 @@ export async function resolveOrHatchTarget(
 
   console.error(`Error: Unknown target environment '${targetEnv}'.`);
   process.exit(1);
-}
-
-// ---------------------------------------------------------------------------
-// Error handling helpers
-// ---------------------------------------------------------------------------
-
-function handleLocalResponseErrors(
-  response: Response,
-  assistantName: string,
-): void {
-  if (response.status === 401 || response.status === 403) {
-    console.error("Authentication failed.");
-    process.exit(1);
-  }
-
-  if (response.status === 404) {
-    console.error("Assistant not found or not running.");
-    process.exit(1);
-  }
-
-  if (
-    response.status === 502 ||
-    response.status === 503 ||
-    response.status === 504
-  ) {
-    console.error(
-      `Assistant is unreachable. Try 'vellum wake ${assistantName}'.`,
-    );
-    process.exit(1);
-  }
-
-  if (!response.ok) {
-    console.error(`Error: Request failed (${response.status})`);
-    process.exit(1);
-  }
-}
-
-function handleImportStatusErrors(
-  statusCode: number,
-  assistantName: string,
-): void {
-  if (statusCode === 401 || statusCode === 403) {
-    console.error("Authentication failed. Run 'vellum login' to refresh.");
-    process.exit(1);
-  }
-
-  if (statusCode === 404) {
-    console.error("Assistant not found or not running.");
-    process.exit(1);
-  }
-
-  if (statusCode === 502 || statusCode === 503 || statusCode === 504) {
-    console.error(
-      `Assistant is unreachable. Try 'vellum wake ${assistantName}'.`,
-    );
-    process.exit(1);
-  }
-
-  if (statusCode < 200 || statusCode >= 300) {
-    console.error(`Error: Import failed (${statusCode})`);
-    process.exit(1);
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1293,40 +1003,27 @@ export async function teleport(): Promise<void> {
       }
 
       console.log(`Exporting from ${from} (${fromCloud})...`);
-      const bundleData = await exportFromAssistant(fromEntry, fromCloud);
+      const { bundleKey } = await exportFromAssistant(fromEntry, fromCloud);
       console.log(`Importing to ${existingTarget.assistantId} (${toCloud})...`);
-      await importToAssistant(existingTarget, toCloud, bundleData, true);
+      await importToAssistant(existingTarget, toCloud, bundleKey, true);
     } else {
       // No existing target — just describe what would happen
       console.log("Dry run summary:");
       console.log(`  Would export data from: ${from} (${fromCloud})`);
-      if (targetEnv === "platform") {
-        // For platform targets, reflect the reordered flow
-        console.log(`  Would upload bundle via signed URL (if available)`);
-        console.log(
-          `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
-        );
-        console.log(`  Would import data into the new assistant`);
-      } else {
-        console.log(
-          `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
-        );
-        console.log(`  Would import data into the new assistant`);
-      }
+      console.log(`  Would upload bundle via signed URL`);
+      console.log(
+        `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
+      );
+      console.log(`  Would import data into the new assistant`);
     }
 
     console.log(`Dry run complete — no changes were made.`);
     return;
   }
 
-  // Export from source
-  console.log(`Exporting from ${from} (${fromCloud})...`);
-  const bundleData = await exportFromAssistant(fromEntry, fromCloud);
-
   // Platform target: reordered flow — upload to GCS before hatching so that
-  // if upload fails, no empty assistant is left dangling on the platform.
+  // if export/upload fails, no empty assistant is left dangling on the platform.
   if (targetEnv === "platform") {
-    // Step B — Auth
     const token = readPlatformToken();
     if (!token) {
       console.error("Not logged in. Run 'vellum login' first.");
@@ -1334,7 +1031,7 @@ export async function teleport(): Promise<void> {
     }
 
     // If targeting an existing assistant, validate cloud match early — before
-    // uploading — so we don't waste a GCS upload on an invalid command.
+    // exporting — so we don't waste work on an invalid command.
     const existingTarget = targetName ? findAssistantByName(targetName) : null;
     if (existingTarget) {
       const existingCloud = resolveCloud(existingTarget);
@@ -1347,12 +1044,12 @@ export async function teleport(): Promise<void> {
       }
     }
 
-    // Use the existing target's runtimeUrl for all platform calls so upload
-    // and import hit the same instance.
+    // Use the existing target's runtimeUrl for all platform calls so the
+    // export, upload, and import all hit the same instance.
     const targetPlatformUrl = existingTarget?.runtimeUrl;
 
-    // Step B2 — Pre-check: block if the user already has a platform assistant.
-    // This runs BEFORE the expensive GCS upload so we don't waste bandwidth.
+    // Pre-check: block if the user already has a platform assistant. This
+    // runs BEFORE the expensive export so we don't waste the upload.
     if (!existingTarget) {
       const existing = await checkExistingPlatformAssistant(
         token,
@@ -1376,43 +1073,25 @@ export async function teleport(): Promise<void> {
       }
     }
 
-    // Step C — Upload to GCS
-    // bundleKey: string = uploaded successfully, null = tried but unavailable,
-    // undefined would mean "never tried" (not used here).
-    let bundleKey: string | null = null;
-    try {
-      const { uploadUrl, bundleKey: key } = await platformRequestUploadUrl(
-        token,
-        targetPlatformUrl,
-      );
-      bundleKey = key;
-      console.log("Uploading bundle to GCS...");
-      await platformUploadToSignedUrl(uploadUrl, bundleData);
-    } catch (err) {
-      // If signed uploads unavailable (503), fall back to inline upload later
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("not available")) {
-        bundleKey = null;
-      } else {
-        throw err;
-      }
-    }
+    // Export — for local/docker sources this uploads straight into GCS via
+    // the platform's signed URL; for platform sources this runs a server-side
+    // export and we read the resulting bundle_key.
+    console.log(`Exporting from ${from} (${fromCloud})...`);
+    const { bundleKey } = await exportFromAssistant(fromEntry, fromCloud);
 
-    // Step D — Hatch (upload succeeded or fallback to inline — safe to hatch)
+    // Hatch (export succeeded — safe to create the target)
     const toEntry = await resolveOrHatchTarget(targetEnv, targetName);
     const toCloud = resolveCloud(toEntry);
 
-    // Step E — Import from GCS (or inline fallback)
-    // Pass bundleKey (string) or null to signal "already tried, use inline".
+    // Import from GCS
     console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
-    await importToAssistant(toEntry, toCloud, bundleData, false, bundleKey);
+    await importToAssistant(toEntry, toCloud, bundleKey, false);
 
-    // Success summary
     console.log(`Teleport complete: ${from} → ${toEntry.assistantId}`);
     return;
   }
 
-  // Non-platform targets (local/docker): existing flow unchanged
+  // Non-platform targets (local/docker)
   // For local<->docker transfers, stop (sleep) the source to free up ports
   // before hatching the target. We do NOT retire yet — if hatch or import
   // fails, the user can recover by running `vellum wake <source>`.
@@ -1447,6 +1126,10 @@ export async function teleport(): Promise<void> {
       versionGuardPassed = true;
     }
   }
+
+  // Export from source (bundle lives in GCS after this returns).
+  console.log(`Exporting from ${from} (${fromCloud})...`);
+  const { bundleKey } = await exportFromAssistant(fromEntry, fromCloud);
 
   if (sourceIsLocalOrDocker && targetIsLocalOrDocker && !keepSource) {
     console.log(`Stopping source assistant '${from}' to free ports...`);
@@ -1513,9 +1196,9 @@ export async function teleport(): Promise<void> {
     }
   }
 
-  // Import to target
+  // Import to target (also GCS-driven)
   console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
-  await importToAssistant(toEntry, toCloud, bundleData, false);
+  await importToAssistant(toEntry, toCloud, bundleKey, false);
 
   // After successful import, inject fresh platform credentials if the
   // user is logged in — replaces the source's stale vellum:* credentials
@@ -1540,6 +1223,5 @@ export async function teleport(): Promise<void> {
     }
   }
 
-  // Success summary
   console.log(`Teleport complete: ${from} → ${toEntry.assistantId}`);
 }

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -342,13 +342,16 @@ async function exportFromAssistant(
       jobId = result.jobId;
     } catch (err) {
       if (err instanceof MigrationInProgressError) {
-        console.log(
-          `An export is already in progress on '${entry.assistantId}' (job ${err.existingJobId}); polling it instead.`,
+        // Fail fast — the existing job is writing to a different GCS object
+        // (its caller's signed URL, not ours), so polling it would leave us
+        // pointing at an empty/unrelated bundle. Surface the existing job id
+        // so the user can decide whether to wait or investigate.
+        console.error(
+          `Error: Another teleport export is already in progress on '${entry.assistantId}' (job ${err.existingJobId}). Wait for it to finish or check its status, then re-run.`,
         );
-        jobId = err.existingJobId;
-      } else {
-        throw err;
+        process.exit(1);
       }
+      throw err;
     }
 
     console.log(`Export started (job ${jobId})...`);
@@ -565,13 +568,15 @@ async function importToAssistant(
       jobId = result.jobId;
     } catch (err) {
       if (err instanceof MigrationInProgressError) {
-        console.log(
-          `An import is already in progress on '${entry.assistantId}' (job ${err.existingJobId}); polling it instead.`,
+        // Fail fast — the existing job is importing someone else's bundle
+        // (the original caller's), not ours. Polling it would report success
+        // on an import that wasn't the one we just kicked off.
+        console.error(
+          `Error: Another teleport import is already in progress on '${entry.assistantId}' (job ${err.existingJobId}). Wait for it to finish or check its status, then re-run.`,
         );
-        jobId = err.existingJobId;
-      } else {
-        throw err;
+        process.exit(1);
       }
+      throw err;
     }
 
     const terminal = await pollJobUntilDone({
@@ -585,9 +590,8 @@ async function importToAssistant(
       process.exit(1);
     }
 
-    const result =
-      ((terminal.result as Record<string, unknown>) ??
-        {}) as unknown as ImportResponse;
+    const result = ((terminal.result as Record<string, unknown>) ??
+      {}) as unknown as ImportResponse;
     printImportSummary(result);
     return;
   }
@@ -976,6 +980,19 @@ export async function teleport(): Promise<void> {
       if (normalizedSourceEnv === normalizedTargetEnv) {
         console.error(
           `Cannot teleport between two ${normalizedTargetEnv} assistants. Teleport transfers data across different environments.`,
+        );
+        process.exit(1);
+      }
+
+      // Dry-run feasibility check — reject local/docker targets BEFORE any
+      // export work. The local runtime has no preflight-from-gcs endpoint yet,
+      // so we can't actually run a dry-run against it; burning a GCS upload
+      // just to fail afterwards would be wasteful.
+      // TODO(cli): support dry-run against local targets (needs a
+      // preflight-from-gcs endpoint on the runtime).
+      if (toCloud === "local" || toCloud === "docker") {
+        console.error(
+          "Error: --dry-run is not yet supported for local or docker targets (no preflight-from-gcs endpoint on the runtime).",
         );
         process.exit(1);
       }

--- a/cli/src/lib/__tests__/job-polling.test.ts
+++ b/cli/src/lib/__tests__/job-polling.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import { pollJobUntilDone } from "../job-polling.js";
 import type { UnifiedJobStatus } from "../platform-client.js";
@@ -74,5 +74,129 @@ describe("pollJobUntilDone", () => {
       label: "defaults test",
     });
     expect(result.status).toBe("complete");
+  });
+
+  describe("transient-error retry", () => {
+    let warnSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+      warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    test("retries N-1 transient errors then returns terminal status", async () => {
+      const maxTransientErrors = 3;
+      let calls = 0;
+      const result = await pollJobUntilDone({
+        label: "flaky export",
+        intervalMs: 1,
+        timeoutMs: 1_000,
+        maxTransientErrors,
+        poll: async () => {
+          calls += 1;
+          if (calls < maxTransientErrors) {
+            throw new Error(
+              `Local job status check failed: 503 Service Unavailable`,
+            );
+          }
+          return {
+            jobId: "j5",
+            type: "export",
+            status: "complete",
+          } as UnifiedJobStatus;
+        },
+      });
+      expect(result.status).toBe("complete");
+      expect(calls).toBe(maxTransientErrors);
+      // One warning per retried transient error (first two attempts).
+      expect(warnSpy).toHaveBeenCalledTimes(maxTransientErrors - 1);
+    });
+
+    test("propagates the last error once maxTransientErrors is exceeded", async () => {
+      const maxTransientErrors = 2;
+      let calls = 0;
+      await expect(
+        pollJobUntilDone({
+          label: "always broken",
+          intervalMs: 1,
+          timeoutMs: 1_000,
+          maxTransientErrors,
+          poll: async () => {
+            calls += 1;
+            throw new Error(`Local job status check failed: 502 Bad Gateway`);
+          },
+        }),
+      ).rejects.toThrow(/502 Bad Gateway/);
+      // Helper makes `maxTransientErrors + 1` attempts before giving up: the
+      // first attempt plus N retries, counted against the budget.
+      expect(calls).toBe(maxTransientErrors + 1);
+    });
+
+    test("permanent 4xx errors (except 429) propagate immediately", async () => {
+      let calls = 0;
+      await expect(
+        pollJobUntilDone({
+          label: "auth broken",
+          intervalMs: 1,
+          timeoutMs: 1_000,
+          maxTransientErrors: 5,
+          poll: async () => {
+            calls += 1;
+            throw new Error(`Local job status check failed: 403 Forbidden`);
+          },
+        }),
+      ).rejects.toThrow(/403 Forbidden/);
+      expect(calls).toBe(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test("429 rate-limit is retried as transient", async () => {
+      let calls = 0;
+      const result = await pollJobUntilDone({
+        label: "rate limited",
+        intervalMs: 1,
+        timeoutMs: 1_000,
+        maxTransientErrors: 3,
+        poll: async () => {
+          calls += 1;
+          if (calls === 1) {
+            throw new Error(`Local job status check failed: 429 Too Many`);
+          }
+          return {
+            jobId: "j6",
+            type: "export",
+            status: "complete",
+          } as UnifiedJobStatus;
+        },
+      });
+      expect(result.status).toBe("complete");
+      expect(calls).toBe(2);
+    });
+
+    test("unclassified network-style errors are treated as transient", async () => {
+      let calls = 0;
+      const result = await pollJobUntilDone({
+        label: "network blip",
+        intervalMs: 1,
+        timeoutMs: 1_000,
+        maxTransientErrors: 3,
+        poll: async () => {
+          calls += 1;
+          if (calls === 1) {
+            throw new Error("fetch failed");
+          }
+          return {
+            jobId: "j7",
+            type: "export",
+            status: "complete",
+          } as UnifiedJobStatus;
+        },
+      });
+      expect(result.status).toBe("complete");
+      expect(calls).toBe(2);
+    });
   });
 });

--- a/cli/src/lib/job-polling.ts
+++ b/cli/src/lib/job-polling.ts
@@ -18,13 +18,54 @@ export interface PollJobUntilDoneOptions {
   timeoutMs?: number;
   /** Human-readable label used in the timeout error message (e.g. "export job"). */
   label: string;
+  /**
+   * Maximum consecutive transient (retryable) poll errors tolerated before
+   * the last error is propagated. Transient errors (5xx / network) between
+   * successful polls reset the counter. Defaults to 5.
+   */
+  maxTransientErrors?: number;
 }
 
 const DEFAULT_INTERVAL_MS = 2_000;
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_MAX_TRANSIENT_ERRORS = 5;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Heuristic classification used by {@link pollJobUntilDone} to decide whether
+ * to retry a failed poll.
+ *
+ * - 5xx responses and unclassifiable network-style errors (fetch failed,
+ *   ECONNRESET, etc.) are treated as transient.
+ * - 4xx responses are treated as permanent, except 429 (rate limited) which is
+ *   transient.
+ * - "not found" errors are permanent — they indicate the job id is wrong and
+ *   retrying won't help.
+ *
+ * The poll helpers (`platformPollJobStatus`, `localRuntimePollJobStatus`)
+ * raise errors whose message contains the HTTP status (e.g. `"Local job
+ * status check failed: 503 Service Unavailable"`), so we parse that out when
+ * available and default to "retry" when unsure.
+ */
+function isTransientPollError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+
+  if (msg.includes("not found")) return false;
+
+  const match = msg.match(/(?:status check failed|failed)[^\d]*(\d{3})/i);
+  if (match) {
+    const code = parseInt(match[1], 10);
+    if (code === 429) return true;
+    if (code >= 400 && code < 500) return false;
+    if (code >= 500) return true;
+  }
+
+  // Unclassifiable (e.g. "fetch failed", ECONNRESET) — treat as transient so
+  // a single network hiccup doesn't abort a long-running migration.
+  return true;
 }
 
 /**
@@ -33,19 +74,52 @@ function sleep(ms: number): Promise<void> {
  *
  * On terminal status, returns the status object — including the `failed`
  * case. The caller decides how to treat a failed terminal status (e.g.
- * print the `error` field and exit). Only timeouts throw.
+ * print the `error` field and exit). Timeouts throw.
+ *
+ * Transient errors raised by `poll()` (5xx, network hiccups, rate-limits) are
+ * retried up to `maxTransientErrors` times before the last error propagates,
+ * matching the pre-rewrite `platformPollExportStatus` loop's behavior so a
+ * single flaky poll doesn't abort a migration that may still be running.
  */
 export async function pollJobUntilDone(
   options: PollJobUntilDoneOptions,
 ): Promise<TerminalJobStatus> {
   const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxTransientErrors =
+    options.maxTransientErrors ?? DEFAULT_MAX_TRANSIENT_ERRORS;
   const deadline = Date.now() + timeoutMs;
+
+  let consecutiveTransientErrors = 0;
 
   // First poll happens immediately so fast-path completions don't wait
   // one interval before returning.
   while (true) {
-    const status = await options.poll();
+    let status: UnifiedJobStatus;
+    try {
+      status = await options.poll();
+      consecutiveTransientErrors = 0;
+    } catch (err) {
+      if (!isTransientPollError(err)) {
+        throw err;
+      }
+      consecutiveTransientErrors += 1;
+      if (consecutiveTransientErrors > maxTransientErrors) {
+        throw err;
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`${options.label} polling failed, retrying... (${msg})`);
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Timed out waiting for ${options.label} after ${Math.round(
+            timeoutMs / 1000,
+          )}s`,
+        );
+      }
+      await sleep(intervalMs);
+      continue;
+    }
+
     if (status.status === "complete" || status.status === "failed") {
       return status;
     }


### PR DESCRIPTION
## Summary
- Teleport now uploads every source's export to GCS via a platform-signed upload URL, then polls the unified job-status endpoint on whichever side owns the job.
- For local/docker targets, the CLI fetches a platform-signed download URL and hands it to the runtime's import-from-gcs endpoint, then polls the runtime job. The bundle never passes through CLI memory.
- Deletes exportViaHttp, importViaHttp, and the bundleData buffer.

Part of plan: teleport-gcs-unify.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
