### PR TITLE
feat(home): add typed `data` field and scheduled/nudge kinds to FeedItemDetailPanel (JARVIS-579)

### DIFF
--- a/assistant/src/home/__tests__/feed-types.test.ts
+++ b/assistant/src/home/__tests__/feed-types.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
-import { type FeedItem, feedItemSchema, parseFeedFile } from "../feed-types.js";
+import {
+  type DocumentPreviewPanelData,
+  type EmailDraftPanelData,
+  type FeedItem,
+  feedItemSchema,
+  type NudgePanelData,
+  parseFeedFile,
+  type PaymentAuthPanelData,
+  type PermissionChatPanelData,
+  type ScheduledPanelData,
+  type ToolPermissionPanelData,
+  type UpdatesListPanelData,
+} from "../feed-types.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -271,5 +283,227 @@ describe("parseFeedFile", () => {
         updatedAt: NOW_ISO,
       }),
     ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detailPanel — new kinds and data field
+// ---------------------------------------------------------------------------
+
+describe("feedItemSchema — detailPanel kinds", () => {
+  test("accepts 'scheduled' panel kind", () => {
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "scheduled" },
+    });
+    expect(parsed.detailPanel?.kind).toBe("scheduled");
+  });
+
+  test("accepts 'nudge' panel kind", () => {
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "nudge" },
+    });
+    expect(parsed.detailPanel?.kind).toBe("nudge");
+  });
+
+  test("accepts all original panel kinds", () => {
+    for (const kind of [
+      "emailDraft",
+      "documentPreview",
+      "permissionChat",
+      "paymentAuth",
+      "toolPermission",
+      "updatesList",
+    ]) {
+      const parsed = feedItemSchema.parse({
+        ...minimalNudge(),
+        detailPanel: { kind },
+      });
+      expect(parsed.detailPanel?.kind).toBe(kind);
+    }
+  });
+
+  test("rejects unknown panel kind", () => {
+    expect(() =>
+      feedItemSchema.parse({
+        ...minimalNudge(),
+        detailPanel: { kind: "unknown" },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("feedItemSchema — detailPanel data field", () => {
+  test("accepts panel without data", () => {
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "emailDraft" },
+    });
+    expect(parsed.detailPanel?.data).toBeUndefined();
+  });
+
+  test("accepts panel with empty data object", () => {
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "emailDraft", data: {} },
+    });
+    expect(parsed.detailPanel?.data).toEqual({});
+  });
+
+  test("round-trips EmailDraftPanelData shape", () => {
+    const data: EmailDraftPanelData = {
+      to: "user@example.com",
+      subject: "Follow up",
+      body: "Hi, just checking in.",
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "emailDraft", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as EmailDraftPanelData;
+    expect(d.to).toBe("user@example.com");
+    expect(d.subject).toBe("Follow up");
+    expect(d.body).toBe("Hi, just checking in.");
+  });
+
+  test("round-trips DocumentPreviewPanelData shape", () => {
+    const data: DocumentPreviewPanelData = {
+      imageUrl: "https://example.com/img.png",
+      caption: "Screenshot",
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "documentPreview", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as DocumentPreviewPanelData;
+    expect(d.imageUrl).toBe("https://example.com/img.png");
+    expect(d.caption).toBe("Screenshot");
+  });
+
+  test("round-trips PermissionChatPanelData shape", () => {
+    const data: PermissionChatPanelData = {
+      userMessage: "Can you run this?",
+      assistantResponse: "I need permission to execute.",
+      requestId: "req-123",
+      toolName: "bash",
+      commandPreview: "rm -rf /tmp/test",
+      riskLevel: "high",
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "permissionChat", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as PermissionChatPanelData;
+    expect(d.userMessage).toBe("Can you run this?");
+    expect(d.requestId).toBe("req-123");
+    expect(d.toolName).toBe("bash");
+    expect(d.riskLevel).toBe("high");
+  });
+
+  test("round-trips PaymentAuthPanelData shape", () => {
+    const data: PaymentAuthPanelData = {
+      imageUrl: "https://example.com/receipt.png",
+      caption: "Receipt",
+      amount: "$42.00",
+      recipient: "Example User",
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "paymentAuth", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as PaymentAuthPanelData;
+    expect(d.amount).toBe("$42.00");
+    expect(d.recipient).toBe("Example User");
+  });
+
+  test("round-trips ToolPermissionPanelData shape", () => {
+    const data: ToolPermissionPanelData = {
+      toolName: "file_write",
+      commandPreview: "write to /tmp/output.txt",
+      riskLevel: "medium",
+      decision: "approved",
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "toolPermission", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as ToolPermissionPanelData;
+    expect(d.toolName).toBe("file_write");
+    expect(d.decision).toBe("approved");
+  });
+
+  test("round-trips UpdatesListPanelData shape", () => {
+    const data: UpdatesListPanelData = {
+      items: [
+        { title: "Update 1", description: "First update" },
+        { title: "Update 2", description: "Second update" },
+      ],
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "updatesList", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as UpdatesListPanelData;
+    expect(d.items).toHaveLength(2);
+    expect(d.items[0]?.title).toBe("Update 1");
+  });
+
+  test("round-trips ScheduledPanelData shape", () => {
+    const data: ScheduledPanelData = {
+      description: "Daily standup reminder",
+      jobName: "standup-reminder",
+      syntax: "cron",
+      mode: "recurring",
+      schedule: "0 9 * * 1-5",
+      enabled: true,
+      nextRun: "2026-04-24T09:00:00.000Z",
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "scheduled", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as ScheduledPanelData;
+    expect(d.jobName).toBe("standup-reminder");
+    expect(d.syntax).toBe("cron");
+    expect(d.enabled).toBe(true);
+    expect(d.nextRun).toBe("2026-04-24T09:00:00.000Z");
+  });
+
+  test("round-trips NudgePanelData shape", () => {
+    const data: NudgePanelData = {
+      description: "Things you might want to do",
+      cards: [
+        { id: "card-1", title: "Review PR", description: "PR #123 is waiting" },
+        {
+          id: "card-2",
+          title: "Reply to thread",
+          description: "Alice asked a question",
+        },
+      ],
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "nudge", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as NudgePanelData;
+    expect(d.description).toBe("Things you might want to do");
+    expect(d.cards).toHaveLength(2);
+    expect(d.cards[0]?.id).toBe("card-1");
+  });
+
+  test("existing items without data field decode without error", () => {
+    // Simulate a legacy item with detailPanel but no data
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "emailDraft" },
+    });
+    expect(parsed.detailPanel?.kind).toBe("emailDraft");
+    expect(parsed.detailPanel?.data).toBeUndefined();
+  });
+
+  test("items without detailPanel still parse", () => {
+    const parsed = feedItemSchema.parse(minimalNudge());
+    expect(parsed.detailPanel).toBeUndefined();
   });
 });

--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -74,11 +74,80 @@ export type FeedItemDetailPanelKind =
   | "permissionChat"
   | "paymentAuth"
   | "toolPermission"
-  | "updatesList";
+  | "updatesList"
+  | "scheduled"
+  | "nudge";
 
-/** Server-driven detail panel descriptor attached to a feed item. */
+// ---------------------------------------------------------------------------
+// Per-kind panel data interfaces
+// ---------------------------------------------------------------------------
+
+export interface EmailDraftPanelData {
+  to: string;
+  subject: string;
+  body: string;
+}
+
+export interface DocumentPreviewPanelData {
+  imageUrl?: string;
+  caption?: string;
+}
+
+export interface PermissionChatPanelData {
+  userMessage: string;
+  assistantResponse: string;
+  requestId: string;
+  toolName: string;
+  commandPreview?: string;
+  riskLevel?: string;
+}
+
+export interface PaymentAuthPanelData {
+  imageUrl?: string;
+  caption?: string;
+  amount?: string;
+  recipient?: string;
+}
+
+export interface ToolPermissionPanelData {
+  toolName: string;
+  commandPreview?: string;
+  riskLevel?: string;
+  decision?: string;
+}
+
+export interface UpdatesListPanelData {
+  items: Array<{ title: string; description: string }>;
+}
+
+export interface ScheduledPanelData {
+  description?: string;
+  jobName: string;
+  syntax: string;
+  mode: string;
+  schedule?: string;
+  enabled: boolean;
+  nextRun?: string;
+}
+
+export interface NudgePanelData {
+  description?: string;
+  cards: Array<{
+    id: string;
+    title: string;
+    description: string;
+  }>;
+}
+
+/**
+ * Server-driven detail panel descriptor attached to a feed item.
+ *
+ * `data` is an untyped dictionary on the wire — kind-specific parsing
+ * happens at the consumer via the per-kind interfaces above.
+ */
 export interface FeedItemDetailPanel {
   kind: FeedItemDetailPanelKind;
+  data?: Record<string, unknown>;
 }
 
 /**
@@ -200,10 +269,13 @@ const feedItemDetailPanelKindSchema = z.enum([
   "paymentAuth",
   "toolPermission",
   "updatesList",
+  "scheduled",
+  "nudge",
 ]);
 
 const feedItemDetailPanelSchema = z.object({
   kind: feedItemDetailPanelKindSchema,
+  data: z.record(z.unknown()).optional(),
 });
 
 /**

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanelKind.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanelKind.swift
@@ -32,6 +32,8 @@ enum HomeDetailPanelKind: Equatable {
             case .paymentAuth: return .paymentAuth(item)
             case .toolPermission: return .toolPermission(item)
             case .updatesList: return .updatesList(item)
+            case .scheduled: return .scheduled(item)
+            case .nudge: return .nudge(item)
             }
         }
 

--- a/clients/shared/Network/FeedItem.swift
+++ b/clients/shared/Network/FeedItem.swift
@@ -113,7 +113,7 @@ public struct FeedItemDetailPanel: Codable, Sendable {
 
 extension FeedItemDetailPanel: Equatable {
     public static func == (lhs: FeedItemDetailPanel, rhs: FeedItemDetailPanel) -> Bool {
-        lhs.kind == rhs.kind
+        lhs.kind == rhs.kind && lhs.data == rhs.data
     }
 }
 

--- a/clients/shared/Network/FeedItem.swift
+++ b/clients/shared/Network/FeedItem.swift
@@ -101,13 +101,25 @@ public enum FeedItemDetailPanelKind: String, Codable, Sendable, Hashable {
 ///
 /// `data` is an untyped dictionary on the wire — kind-specific parsing
 /// happens at the consumer via the per-kind data structs below.
-public struct FeedItemDetailPanel: Codable, Sendable, Hashable {
+public struct FeedItemDetailPanel: Codable, Sendable {
     public let kind: FeedItemDetailPanelKind
     public let data: [String: AnyCodable]?
 
     public init(kind: FeedItemDetailPanelKind, data: [String: AnyCodable]? = nil) {
         self.kind = kind
         self.data = data
+    }
+}
+
+extension FeedItemDetailPanel: Equatable {
+    public static func == (lhs: FeedItemDetailPanel, rhs: FeedItemDetailPanel) -> Bool {
+        lhs.kind == rhs.kind
+    }
+}
+
+extension FeedItemDetailPanel: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(kind)
     }
 }
 

--- a/clients/shared/Network/FeedItem.swift
+++ b/clients/shared/Network/FeedItem.swift
@@ -93,12 +93,196 @@ public enum FeedItemDetailPanelKind: String, Codable, Sendable, Hashable {
     case paymentAuth
     case toolPermission
     case updatesList
+    case scheduled
+    case nudge
 }
 
 /// Server-driven detail panel descriptor attached to a feed item.
+///
+/// `data` is an untyped dictionary on the wire — kind-specific parsing
+/// happens at the consumer via the per-kind data structs below.
 public struct FeedItemDetailPanel: Codable, Sendable, Hashable {
     public let kind: FeedItemDetailPanelKind
-    public init(kind: FeedItemDetailPanelKind) { self.kind = kind }
+    public let data: [String: AnyCodable]?
+
+    public init(kind: FeedItemDetailPanelKind, data: [String: AnyCodable]? = nil) {
+        self.kind = kind
+        self.data = data
+    }
+}
+
+// MARK: - Per-kind panel data structs
+
+/// Data for the `emailDraft` detail panel kind.
+public struct EmailDraftPanelData: Sendable, Hashable {
+    public let to: String
+    public let subject: String
+    public let body: String
+
+    public static func from(_ data: [String: AnyCodable]?) -> EmailDraftPanelData? {
+        guard let data,
+              let to = data["to"]?.value as? String,
+              let subject = data["subject"]?.value as? String,
+              let body = data["body"]?.value as? String else { return nil }
+        return EmailDraftPanelData(to: to, subject: subject, body: body)
+    }
+}
+
+/// Data for the `documentPreview` detail panel kind.
+public struct DocumentPreviewPanelData: Sendable, Hashable {
+    public let imageUrl: String?
+    public let caption: String?
+
+    public static func from(_ data: [String: AnyCodable]?) -> DocumentPreviewPanelData? {
+        guard let data else { return nil }
+        return DocumentPreviewPanelData(
+            imageUrl: data["imageUrl"]?.value as? String,
+            caption: data["caption"]?.value as? String
+        )
+    }
+}
+
+/// Data for the `permissionChat` detail panel kind.
+public struct PermissionChatPanelData: Sendable, Hashable {
+    public let userMessage: String
+    public let assistantResponse: String
+    public let requestId: String
+    public let toolName: String
+    public let commandPreview: String?
+    public let riskLevel: String?
+
+    public static func from(_ data: [String: AnyCodable]?) -> PermissionChatPanelData? {
+        guard let data,
+              let userMessage = data["userMessage"]?.value as? String,
+              let assistantResponse = data["assistantResponse"]?.value as? String,
+              let requestId = data["requestId"]?.value as? String,
+              let toolName = data["toolName"]?.value as? String else { return nil }
+        return PermissionChatPanelData(
+            userMessage: userMessage,
+            assistantResponse: assistantResponse,
+            requestId: requestId,
+            toolName: toolName,
+            commandPreview: data["commandPreview"]?.value as? String,
+            riskLevel: data["riskLevel"]?.value as? String
+        )
+    }
+}
+
+/// Data for the `paymentAuth` detail panel kind.
+public struct PaymentAuthPanelData: Sendable, Hashable {
+    public let imageUrl: String?
+    public let caption: String?
+    public let amount: String?
+    public let recipient: String?
+
+    public static func from(_ data: [String: AnyCodable]?) -> PaymentAuthPanelData? {
+        guard let data else { return nil }
+        return PaymentAuthPanelData(
+            imageUrl: data["imageUrl"]?.value as? String,
+            caption: data["caption"]?.value as? String,
+            amount: data["amount"]?.value as? String,
+            recipient: data["recipient"]?.value as? String
+        )
+    }
+}
+
+/// Data for the `toolPermission` detail panel kind.
+public struct ToolPermissionPanelData: Sendable, Hashable {
+    public let toolName: String
+    public let commandPreview: String?
+    public let riskLevel: String?
+    public let decision: String?
+
+    public static func from(_ data: [String: AnyCodable]?) -> ToolPermissionPanelData? {
+        guard let data,
+              let toolName = data["toolName"]?.value as? String else { return nil }
+        return ToolPermissionPanelData(
+            toolName: toolName,
+            commandPreview: data["commandPreview"]?.value as? String,
+            riskLevel: data["riskLevel"]?.value as? String,
+            decision: data["decision"]?.value as? String
+        )
+    }
+}
+
+/// Data for the `updatesList` detail panel kind.
+public struct UpdatesListPanelData: Sendable, Hashable {
+    public struct Item: Sendable, Hashable {
+        public let title: String
+        public let description: String
+    }
+
+    public let items: [Item]
+
+    public static func from(_ data: [String: AnyCodable]?) -> UpdatesListPanelData? {
+        guard let data,
+              let rawItems = data["items"]?.value as? [Any] else { return nil }
+        var parsed: [Item] = []
+        for rawItem in rawItems {
+            guard let dict = rawItem as? [String: Any],
+                  let title = dict["title"] as? String,
+                  let description = dict["description"] as? String else { continue }
+            parsed.append(Item(title: title, description: description))
+        }
+        return UpdatesListPanelData(items: parsed)
+    }
+}
+
+/// Data for the `scheduled` detail panel kind.
+public struct ScheduledPanelData: Sendable, Hashable {
+    public let description: String?
+    public let jobName: String
+    public let syntax: String
+    public let mode: String
+    public let schedule: String?
+    public let enabled: Bool
+    public let nextRun: String?
+
+    public static func from(_ data: [String: AnyCodable]?) -> ScheduledPanelData? {
+        guard let data,
+              let jobName = data["jobName"]?.value as? String,
+              let syntax = data["syntax"]?.value as? String,
+              let mode = data["mode"]?.value as? String,
+              let enabled = data["enabled"]?.value as? Bool else { return nil }
+        return ScheduledPanelData(
+            description: data["description"]?.value as? String,
+            jobName: jobName,
+            syntax: syntax,
+            mode: mode,
+            schedule: data["schedule"]?.value as? String,
+            enabled: enabled,
+            nextRun: data["nextRun"]?.value as? String
+        )
+    }
+}
+
+/// Data for the `nudge` detail panel kind.
+public struct NudgePanelData: Sendable, Hashable {
+    public struct Card: Sendable, Hashable {
+        public let id: String
+        public let title: String
+        public let description: String
+    }
+
+    public let description: String?
+    public let cards: [Card]
+
+    public static func from(_ data: [String: AnyCodable]?) -> NudgePanelData? {
+        guard let data,
+              let rawCards = data["cards"]?.value as? [Any] else { return nil }
+        var parsed: [Card] = []
+        for rawCard in rawCards {
+            guard let dict = rawCard as? [String: Any],
+                  let id = dict["id"] as? String,
+                  let title = dict["title"] as? String,
+                  let description = dict["description"] as? String else { continue }
+            parsed.append(Card(id: id, title: title, description: description))
+        }
+        return NudgePanelData(
+            description: data["description"]?.value as? String,
+            cards: parsed
+        )
+    }
 }
 
 // MARK: - FeedItem


### PR DESCRIPTION
## Summary
- Add per-kind data interfaces (EmailDraft, DocumentPreview, PermissionChat, PaymentAuth, ToolPermission, UpdatesList, Scheduled, Nudge) and typed `data` field to FeedItemDetailPanel
- Add `scheduled` and `nudge` panel kinds to TS union, Zod schema, and Swift enum
- Add Swift panel data structs with `from(_:)` factory methods and tests

Part of plan: home-feed-detail-panel-data.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
