### PR TITLE
ci: pause native iOS release during Capacitor migration (LUM-1125)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2440,7 +2440,21 @@ jobs:
   # As with the macOS builds, `needs:` gates on GCR manifests only because
   # this job runs in staging too; the Docker Hub gate lives on `release-ios`
   # (prod-only), which is the sole external publisher of this .ipa.
+  #
+  # -------------------------------------------------------------------------
+  # PAUSED during the Capacitor iOS migration (LUM-1125).
+  # iOS releases are handled manually out of `vellum-assistant-platform`'s
+  # Capacitor shell while the replacement CI workflow is being designed.
+  # Both pipelines cannot upload to the same bundle ID
+  # (`ai.vocify-inc.vellum-assistant-ios`) simultaneously — App Store
+  # Connect rejects duplicate build numbers, so we skip this one.
+  #
+  # To re-enable either for a fallback native-iOS release, or if the
+  # Capacitor migration is abandoned: remove `if: false` from here and
+  # from `release-ios` below.
+  # -------------------------------------------------------------------------
   build-ios:
+    if: false
     needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     runs-on: macos-15
     timeout-minutes: 30
@@ -2478,9 +2492,13 @@ jobs:
         working-directory: clients/ios
         run: ./build.sh test
 
+  # PAUSED during the Capacitor iOS migration (LUM-1125) — see note on
+  # `build-ios` above. To re-enable, delete the `if: false` line and
+  # restore the original staging gate:
+  #   if: ${{ needs.extract-version.outputs.is_staging != 'true' }}
   release-ios:
+    if: false
     needs: [extract-version, build-ios, push-dockerhub-image]
-    if: ${{ needs.extract-version.outputs.is_staging != 'true' }}
     runs-on: macos-15
     timeout-minutes: 30
     env:


### PR DESCRIPTION
## Why

The Capacitor iOS shell in `vellum-assistant-platform` now targets the same bundle ID as this repo's native iOS app (`ai.vocify-inc.vellum-assistant-ios`). If both release pipelines run on the same release cycle, they race to upload to App Store Connect — whichever reaches `altool` first wins, and the second gets rejected on duplicate / lower build number. Until the Capacitor CI workflow lands (tracked in [LUM-1125](https://linear.app/vellum/issue/LUM-1125), currently Planned), iOS releases are being driven manually out of `vellum-assistant-platform` via Xcode Archive → Transporter.

This PR pauses the two iOS jobs in the release workflow so they skip on every run and don't race with the manual upload.

## What

- `build-ios` (line 2443) gets `if: false`
- `release-ios` (line 2481) gets `if: false` (original staging gate preserved in a comment so re-enabling is obvious)
- Comment block above `build-ios` documenting the reason + re-enable instructions

Job bodies are left intact so the rollback is trivial — delete the two `if: false` lines and restore the original `if: ${{ needs.extract-version.outputs.is_staging != 'true' }}` on `release-ios` (noted inline).

## Safety

- **Downstream jobs' `needs:` arrays still resolve.** A skipped job is a valid result for `needs:`; dependent jobs keep running.
- **Slack notification step (line ~2857)** renders the skipped state via the existing `ci_icon` helper — no code change needed.
- **macOS / Docker / Chrome extension / desktop / CLI release paths are untouched.** Only the two iOS jobs skip.
- **Staging releases unaffected** — `release-ios` was already gated on `is_staging != 'true'` (production-only), and staging never ran `altool`, so no behavior change there either.

## Rollback

Delete the `if: false` on both jobs and restore the original staging gate on `release-ios`. The inline comment documents the exact line to restore.

## Related

- [LUM-1125](https://linear.app/vellum/issue/LUM-1125) — Capacitor TestFlight CI workflow (Planned)
- Capacitor scaffold PR: vellum-ai/vellum-assistant-platform#4737 (merged)
- NativeAuth plugin PR: vellum-ai/vellum-assistant-platform#4744 (merged)
- Safe-area insets PR (in flight): vellum-ai/vellum-assistant-platform#4821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
