### PR TITLE
feat(home): populate permissionChat detail panel data on tool approval events (JARVIS-579)

### DIFF
--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -19,7 +19,9 @@ import {
   isConversationHostAccessEnablePrompt,
   isPermissionControlsV2Enabled,
 } from "../../permissions/v2-consent-policy.js";
+import { redactSecrets } from "../../security/secret-scanner.js";
 import { getTool } from "../../tools/registry.js";
+import { summarizeToolInput } from "../../tools/tool-input-summary.js";
 import { getLogger } from "../../util/logger.js";
 import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
 import type { AuthContext } from "../auth/types.js";
@@ -213,6 +215,14 @@ export async function handleConfirm(
 
   const approved = effectiveDecision === "allow";
   const toolName = interaction.confirmationDetails?.toolName ?? "unknown tool";
+  const commandPreviewRaw = interaction.confirmationDetails?.input
+    ? redactSecrets(
+        summarizeToolInput(
+          toolName,
+          interaction.confirmationDetails.input as Record<string, unknown>,
+        ),
+      ) || undefined
+    : undefined;
   void emitFeedEvent({
     source: "assistant",
     title: `${approved ? "Approved" : "Denied"} use of ${toolName}.`,
@@ -220,6 +230,16 @@ export async function handleConfirm(
     dedupKey: `tool-approval:${requestId}`,
     urgency: approved ? undefined : "medium",
     conversationId: interaction.conversationId,
+    detailPanel: {
+      kind: "permissionChat",
+      data: {
+        toolName,
+        commandPreview: commandPreviewRaw || undefined,
+        riskLevel: interaction.confirmationDetails?.riskLevel,
+        requestId,
+        decision: effectiveDecision,
+      },
+    },
   }).catch((err) => {
     log.warn(
       { err, requestId },

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1016,6 +1016,15 @@ function makeHubPublisher(
         : `Requesting approval to use ${msg.toolName}.`;
       const dedupKey = `tool-approval:${msg.requestId}`;
 
+      const permissionChatData: Record<string, unknown> = {
+        toolName: msg.toolName,
+        commandPreview: commandPreview ?? undefined,
+        riskLevel: msg.riskLevel,
+        requestId: msg.requestId,
+        userMessage: "",
+        assistantResponse: "",
+      };
+
       // Emit immediately with the technical preview.
       void emitFeedEvent({
         source: "assistant",
@@ -1024,6 +1033,10 @@ function makeHubPublisher(
         dedupKey,
         urgency: msg.riskLevel === "high" ? "high" : "medium",
         conversationId,
+        detailPanel: {
+          kind: "permissionChat",
+          data: permissionChatData,
+        },
       }).catch((err) => {
         log.warn(
           { err, requestId: msg.requestId },
@@ -1044,6 +1057,10 @@ function makeHubPublisher(
                 dedupKey,
                 urgency: msg.riskLevel === "high" ? "high" : "medium",
                 conversationId,
+                detailPanel: {
+                  kind: "permissionChat",
+                  data: permissionChatData,
+                },
               });
             }
           })


### PR DESCRIPTION
## Summary
- Populate detailPanel.data with toolName, commandPreview, riskLevel, requestId on tool approval feed events
- Add decision outcome to approval resolution feed events
- Existing guardian-feed-event tests continue to pass

Part of plan: home-feed-detail-panel-data.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
