### PR TITLE
feat(home): wire real schedule metadata into scheduled detail panel (JARVIS-579)

### DIFF
--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -20,6 +20,7 @@ import {
   failOneShot,
   getLastScheduleConversationId,
   type RoutingIntent,
+  type ScheduleJob,
 } from "./schedule-store.js";
 
 const log = getLogger("scheduler");
@@ -149,6 +150,7 @@ async function runScheduleOnce(
             title: job.name,
             summary: "Reminder fired.",
             dedupKey: `schedule-notify-oneshot:${job.id}`,
+            job,
           });
         } else {
           // Track recurring notify-mode success so lastStatus resets to ok
@@ -159,6 +161,7 @@ async function runScheduleOnce(
             title: job.name,
             summary: "Scheduled notification fired.",
             dedupKey: `schedule-run:${runId}`,
+            job,
           });
         }
       } catch (err) {
@@ -208,6 +211,7 @@ async function runScheduleOnce(
               title: job.name,
               summary: "Script ran.",
               dedupKey: `schedule-run:${runId}`,
+              job,
             });
           }
           if (isOneShot) completeOneShot(job.id);
@@ -287,6 +291,7 @@ async function runScheduleOnce(
               title: job.name,
               summary: "Scheduled task ran.",
               dedupKey: `schedule-run:${runId}`,
+              job,
             });
           }
           if (isOneShot) completeOneShot(job.id);
@@ -385,6 +390,7 @@ async function runScheduleOnce(
           title: job.name,
           summary: isOneShot ? "One-shot reminder ran." : "Scheduled job ran.",
           dedupKey: `schedule-run:${runId}`,
+          job,
         });
       }
       if (isOneShot) completeOneShot(job.id);
@@ -464,17 +470,36 @@ async function runScheduleOnce(
  * record is created) so each run lands as its own entry in the
  * activity log — the writer's per-source cap keeps total volume
  * bounded.
+ *
+ * When a {@link ScheduleJob} is provided, the emitted feed item
+ * includes a `detailPanel` with real schedule metadata so the macOS
+ * client can render the scheduled detail panel without placeholders.
  */
 function emitScheduleFeedEvent(params: {
   title: string;
   summary: string;
   dedupKey: string;
+  job?: ScheduleJob;
 }): void {
   void emitFeedEvent({
     source: "assistant",
     title: params.title,
     summary: params.summary,
     dedupKey: params.dedupKey,
+    detailPanel: params.job
+      ? {
+          kind: "scheduled",
+          data: {
+            jobName: params.job.name,
+            syntax: params.job.syntax,
+            mode: params.job.mode,
+            schedule: params.job.expression ?? undefined,
+            enabled: params.job.enabled,
+            nextRun: new Date(params.job.nextRunAt).toISOString(),
+            description: params.job.message.slice(0, 200),
+          },
+        }
+      : undefined,
   }).catch((err) => {
     log.warn(
       { err, dedupKey: params.dedupKey },

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -234,10 +234,6 @@ extension MainWindowView {
             detailPanel: {
                 switch activeHomeDetailPanel {
                 case .scheduled(let item):
-                    // Parse real schedule metadata from the daemon's
-                    // detailPanel.data when available; fall back to
-                    // placeholder values when the data is nil or
-                    // malformed so the panel always renders.
                     let details: HomeScheduledDetails = {
                         guard let panelData = ScheduledPanelData.from(item.detailPanel?.data) else {
                             return HomeScheduledDetails.placeholder

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -234,15 +234,33 @@ extension MainWindowView {
             detailPanel: {
                 switch activeHomeDetailPanel {
                 case .scheduled(let item):
-                    let details = HomeScheduledDetails.placeholder
-                    // Surface the tapped item's title so distinct scheduled
-                    // rows render distinct panel headers while the rest of
-                    // the schedule metadata still uses placeholder data
-                    // (Devin feedback on PR #27475).
-                    // TODO: replace placeholder data with real schedule
-                    // metadata when the daemon surfaces scheduled-item
-                    // fields on FeedItem (see .private/plans/home-feed-groups.md
-                    // follow-up).
+                    // Parse real schedule metadata from the daemon's
+                    // detailPanel.data when available; fall back to
+                    // placeholder values when the data is nil or
+                    // malformed so the panel always renders.
+                    let details: HomeScheduledDetails = {
+                        guard let panelData = ScheduledPanelData.from(item.detailPanel?.data) else {
+                            return HomeScheduledDetails.placeholder
+                        }
+                        let nextRunDate: Date = {
+                            guard let iso = panelData.nextRun else { return Date() }
+                            let formatter = ISO8601DateFormatter()
+                            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                            return formatter.date(from: iso)
+                                ?? ISO8601DateFormatter().date(from: iso)
+                                ?? Date()
+                        }()
+                        return HomeScheduledDetails(
+                            name: panelData.jobName,
+                            syntax: panelData.syntax,
+                            mode: panelData.mode,
+                            schedule: panelData.schedule ?? "—",
+                            enabled: panelData.enabled,
+                            nextRun: nextRunDate,
+                            nextRunTimeZone: .current,
+                            description: panelData.description ?? item.summary
+                        )
+                    }()
                     HomeScheduledDetailPanel(
                         title: item.title,
                         description: details.description,


### PR DESCRIPTION
## Summary
- Populate detailPanel.data with real job metadata (name, syntax, mode, schedule, enabled, nextRun) in emitScheduleFeedEvent
- Parse ScheduledPanelData in PanelCoordinator to render real values in HomeScheduledDetailPanel
- Fall back to placeholder when data is nil or malformed

Part of plan: home-feed-detail-panel-data.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
