### PR TITLE
feat(home): wire heartbeat nudge detail panel with real issue cards (JARVIS-579)

### DIFF
--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -405,6 +405,20 @@ export class HeartbeatService {
         summary: "Heartbeat check completed.",
         dedupKey: `heartbeat:ok:${today}`,
         priority: 30,
+        detailPanel: {
+          kind: "nudge",
+          data: {
+            description: "Heartbeat check completed successfully.",
+            cards: [
+              {
+                id: `heartbeat-summary:${today}`,
+                title: "Heartbeat Summary",
+                description:
+                  "Periodic heartbeat check ran and completed. All checklist items were reviewed.",
+              },
+            ],
+          },
+        },
       }).catch((err) => {
         log.warn(
           { err, conversationId: conversation.id },

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -256,18 +256,51 @@ extension MainWindowView {
                         onSecondaryAction: { activeHomeDetailPanel = nil }
                     )
                 case .nudge(let item):
+                    let nudgeData = NudgePanelData.from(item.detailPanel?.data)
+                    let nudgeCards: [HomeNudgeDetailPanel.Card] = nudgeData.map { data in
+                        data.cards.map { card in
+                            HomeNudgeDetailPanel.Card(
+                                id: card.id,
+                                title: card.title,
+                                description: card.description,
+                                actions: []
+                            )
+                        }
+                    } ?? HomeNudgeDetailPanelPlaceholders.sampleCards
+                    let nudgeDescription = nudgeData?.description ?? "Found some issues."
                     HomeNudgeDetailPanel(
                         title: item.title,
                         icon: .heart,
                         iconForeground: VColor.feedNudgeStrong,
                         iconBackground: VColor.feedNudgeWeak,
-                        description: "Found some issues.",
-                        cards: HomeNudgeDetailPanelPlaceholders.sampleCards,
+                        description: nudgeDescription,
+                        cards: nudgeCards,
                         primaryActionLabel: "Resolve All",
                         secondaryActionLabel: "Clear All",
                         onClose: { activeHomeDetailPanel = nil },
-                        onPrimaryAction: { activeHomeDetailPanel = nil },
-                        onSecondaryAction: { activeHomeDetailPanel = nil },
+                        onPrimaryAction: {
+                            if let firstAction = item.actions?.first {
+                                Task {
+                                    _ = await feedStore.triggerAction(
+                                        itemId: item.id,
+                                        actionId: firstAction.id
+                                    )
+                                    await MainActor.run {
+                                        activeHomeDetailPanel = nil
+                                    }
+                                }
+                            } else {
+                                activeHomeDetailPanel = nil
+                            }
+                        },
+                        onSecondaryAction: {
+                            Task {
+                                await feedStore.dismiss(itemId: item.id)
+                                await MainActor.run {
+                                    activeHomeDetailPanel = nil
+                                }
+                            }
+                        },
                         onCardAction: { _, _ in }
                     )
                 case .emailDraft(let item):


### PR DESCRIPTION
## Summary
- Set detailPanel.kind to nudge with NudgePanelData on heartbeat feed events
- Parse NudgePanelData in PanelCoordinator and map cards to HomeNudgeDetailPanel.Card
- Wire Clear All / Resolve All buttons, fall back to placeholder when data is nil

Part of plan: home-feed-detail-panel-data.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
