### PR TITLE
feat(home): wire document preview and payment auth detail panels (JARVIS-579)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeAuthDetailCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeAuthDetailCard.swift
@@ -1,17 +1,53 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Stub body component for payment-authorization detail panels.
-/// Will be replaced with a rich approval UI when the daemon surfaces
-/// structured payment-auth fields on `FeedItem`.
+/// Body component for payment-authorization detail panels.
+///
+/// Renders structured payment info — amount, recipient, and an optional
+/// caption — as a compact card above the document/invoice preview. When
+/// no structured data is available the component renders nothing, letting
+/// the parent panel fall back to the default placeholder.
 struct HomeAuthDetailCard: View {
-    let item: FeedItem
+    let amount: String?
+    let recipient: String?
+    let caption: String?
 
     var body: some View {
-        Text(item.title)
-            .font(VFont.bodyMediumDefault)
-            .foregroundStyle(VColor.contentSecondary)
+        let hasContent = amount != nil || recipient != nil || caption != nil
+        if hasContent {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                if let amount {
+                    HStack(spacing: VSpacing.xs) {
+                        Text("Amount")
+                            .font(VFont.bodyMediumLighter)
+                            .foregroundStyle(VColor.contentTertiary)
+                        Spacer()
+                        Text(amount)
+                            .font(VFont.bodyMediumEmphasised)
+                            .foregroundStyle(VColor.contentEmphasized)
+                    }
+                }
+
+                if let recipient {
+                    HStack(spacing: VSpacing.xs) {
+                        Text("Recipient")
+                            .font(VFont.bodyMediumLighter)
+                            .foregroundStyle(VColor.contentTertiary)
+                        Spacer()
+                        Text(recipient)
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                    }
+                }
+
+                if let caption {
+                    Text(caption)
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
             .padding(VSpacing.lg)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDocumentPreviewPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDocumentPreviewPanel.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Wrapper panel for the document preview detail panel kind.
+///
+/// Parses `DocumentPreviewPanelData` from the feed item's `detailPanel.data`.
+/// When an `imageUrl` is present, loads the image asynchronously and renders
+/// it via `HomeDocumentPreview`. Falls back to the placeholder caption when
+/// the URL is absent or the download fails.
+struct HomeDocumentPreviewPanel: View {
+    let item: FeedItem
+    let onClose: () -> Void
+
+    @State private var loadedImage: NSImage?
+
+    private var panelData: DocumentPreviewPanelData? {
+        DocumentPreviewPanelData.from(item.detailPanel?.data)
+    }
+
+    var body: some View {
+        HomeDetailPanel(
+            icon: nil,
+            title: item.title,
+            onDismiss: onClose,
+            scrollable: false
+        ) {
+            HomeDocumentPreview(
+                image: loadedImage,
+                placeholderCaption: panelData?.caption ?? item.summary,
+                actions: [
+                    HomeDocumentPreview.Action(
+                        label: "Action",
+                        style: .outlined,
+                        action: { onClose() }
+                    ),
+                    HomeDocumentPreview.Action(
+                        label: "Action",
+                        style: .primary,
+                        action: { onClose() }
+                    ),
+                ]
+            )
+        }
+        .task(id: panelData?.imageUrl) {
+            await loadImageIfNeeded()
+        }
+    }
+
+    private func loadImageIfNeeded() async {
+        guard let urlString = panelData?.imageUrl,
+              let url = URL(string: urlString) else { return }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            guard !Task.isCancelled else { return }
+            if let image = NSImage(data: data) {
+                loadedImage = image
+            }
+        } catch {
+            // Download failed — leave loadedImage nil so the placeholder renders.
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePaymentAuthPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePaymentAuthPanel.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Wrapper panel for the payment authorization detail panel kind.
+///
+/// Parses `PaymentAuthPanelData` from the feed item's `detailPanel.data`.
+/// When an `imageUrl` is present (invoice/document image), loads and renders
+/// it via `HomeDocumentPreview` with amount and recipient shown as
+/// supplementary text above the image. Falls back gracefully to a text-only
+/// card when data is nil or the image cannot be loaded.
+struct HomePaymentAuthPanel: View {
+    let item: FeedItem
+    let onClose: () -> Void
+
+    @State private var loadedImage: NSImage?
+
+    private var panelData: PaymentAuthPanelData? {
+        PaymentAuthPanelData.from(item.detailPanel?.data)
+    }
+
+    var body: some View {
+        HomeDetailPanel(
+            icon: nil,
+            title: item.title,
+            onDismiss: onClose,
+            scrollable: false
+        ) {
+            VStack(alignment: .leading, spacing: 0) {
+                // Supplementary amount/recipient info above the preview
+                if panelData?.amount != nil || panelData?.recipient != nil {
+                    HomeAuthDetailCard(
+                        amount: panelData?.amount,
+                        recipient: panelData?.recipient,
+                        caption: panelData?.caption
+                    )
+                }
+
+                HomeDocumentPreview(
+                    image: loadedImage,
+                    placeholderCaption: panelData?.caption ?? item.summary,
+                    actions: [
+                        HomeDocumentPreview.Action(
+                            label: "Action",
+                            style: .outlined,
+                            action: { onClose() }
+                        ),
+                        HomeDocumentPreview.Action(
+                            label: "Action",
+                            style: .primary,
+                            action: { onClose() }
+                        ),
+                    ]
+                )
+            }
+        }
+        .task(id: panelData?.imageUrl) {
+            await loadImageIfNeeded()
+        }
+    }
+
+    private func loadImageIfNeeded() async {
+        guard let urlString = panelData?.imageUrl,
+              let url = URL(string: urlString) else { return }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            guard !Task.isCancelled else { return }
+            if let image = NSImage(data: data) {
+                loadedImage = image
+            }
+        } catch {
+            // Download failed — leave loadedImage nil so the placeholder renders.
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -282,16 +282,10 @@ extension MainWindowView {
                             .padding(VSpacing.lg)
                     }
                 case .documentPreview(let item):
-                    HomeDetailPanel(
-                        icon: nil,
-                        title: item.title,
-                        onDismiss: { activeHomeDetailPanel = nil }
-                    ) {
-                        Text(item.summary)
-                            .font(VFont.bodyMediumDefault)
-                            .foregroundStyle(VColor.contentSecondary)
-                            .padding(VSpacing.lg)
-                    }
+                    HomeDocumentPreviewPanel(
+                        item: item,
+                        onClose: { activeHomeDetailPanel = nil }
+                    )
                 case .permissionChat(let item):
                     HomeDetailPanel(
                         icon: nil,
@@ -304,13 +298,10 @@ extension MainWindowView {
                             .padding(VSpacing.lg)
                     }
                 case .paymentAuth(let item):
-                    HomeDetailPanel(
-                        icon: nil,
-                        title: item.title,
-                        onDismiss: { activeHomeDetailPanel = nil }
-                    ) {
-                        HomeAuthDetailCard(item: item)
-                    }
+                    HomePaymentAuthPanel(
+                        item: item,
+                        onClose: { activeHomeDetailPanel = nil }
+                    )
                 case .toolPermission(let item):
                     HomeDetailPanel(
                         icon: nil,


### PR DESCRIPTION
## Summary
- Parse DocumentPreviewPanelData and PaymentAuthPanelData in PanelCoordinator
- Render images from URLs via HomeDocumentPreview when available
- Update HomeAuthDetailCard to show amount, recipient, and caption
- Add footer action buttons to both panels, fall back to text when data is nil

Part of plan: home-feed-detail-panel-data.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
