### PR TITLE
feat(home): wire email draft detail panel with to/subject/body fields (JARVIS-579)

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -155,6 +155,14 @@ export async function run(
             title: "Email Draft Created",
             summary: `Drafted reply to ${recipientSummary}.`,
             dedupKey: `email-draft:${draft.id}`,
+            detailPanel: {
+              kind: "emailDraft",
+              data: {
+                to: toList.join(", "),
+                subject: replySubject ?? "",
+                body: text,
+              },
+            },
           }).catch((err) => {
             log.warn({ err }, "Failed to emit email draft feed event");
           });
@@ -183,6 +191,14 @@ export async function run(
           title: "Email Draft Created",
           summary: `Drafted reply to ${recipientSummary}.`,
           dedupKey: `email-draft:${draft.id}`,
+          detailPanel: {
+            kind: "emailDraft",
+            data: {
+              to: toList.join(", "),
+              subject: replySubject ?? "",
+              body: text,
+            },
+          },
         }).catch((err) => {
           log.warn({ err }, "Failed to emit email draft feed event");
         });
@@ -217,6 +233,14 @@ export async function run(
           title: "Email Draft Created",
           summary: "Created an email draft.",
           dedupKey: `email-draft:${draft.id}`,
+          detailPanel: {
+            kind: "emailDraft",
+            data: {
+              to: conversationId,
+              subject: subject ?? "",
+              body: text,
+            },
+          },
         }).catch((err) => {
           log.warn({ err }, "Failed to emit email draft feed event");
         });
@@ -241,6 +265,14 @@ export async function run(
         title: "Email Draft Created",
         summary: "Created an email draft.",
         dedupKey: `email-draft:${draft.id}`,
+        detailPanel: {
+          kind: "emailDraft",
+          data: {
+            to: conversationId,
+            subject: subject ?? "",
+            body: text,
+          },
+        },
       }).catch((err) => {
         log.warn({ err }, "Failed to emit email draft feed event");
       });

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -271,15 +271,24 @@ extension MainWindowView {
                         onCardAction: { _, _ in }
                     )
                 case .emailDraft(let item):
-                    HomeDetailPanel(
-                        icon: nil,
-                        title: item.title,
-                        onDismiss: { activeHomeDetailPanel = nil }
-                    ) {
-                        Text(item.summary)
-                            .font(VFont.bodyMediumDefault)
-                            .foregroundStyle(VColor.contentSecondary)
-                            .padding(VSpacing.lg)
+                    if let panelData = EmailDraftPanelData.from(item.detailPanel?.data) {
+                        HomeEmailDraftDetailView(
+                            item: item,
+                            panelData: panelData,
+                            feedStore: feedStore,
+                            onDismiss: { activeHomeDetailPanel = nil }
+                        )
+                    } else {
+                        HomeDetailPanel(
+                            icon: nil,
+                            title: item.title,
+                            onDismiss: { activeHomeDetailPanel = nil }
+                        ) {
+                            Text(item.summary)
+                                .font(VFont.bodyMediumDefault)
+                                .foregroundStyle(VColor.contentSecondary)
+                                .padding(VSpacing.lg)
+                        }
                     }
                 case .documentPreview(let item):
                     HomeDetailPanel(
@@ -1095,6 +1104,68 @@ private struct AppLoadingView: View {
             if !Task.isCancelled {
                 timedOut = true
             }
+        }
+    }
+}
+
+// MARK: - Email Draft Detail View
+
+/// Structured email draft detail panel that renders to/subject/body
+/// fields from server-provided `EmailDraftPanelData` and exposes
+/// Discard / Send footer buttons. Action wiring through `feedStore`
+/// is a follow-up — the buttons are visible but currently dismiss
+/// the panel.
+struct HomeEmailDraftDetailView: View {
+    let item: FeedItem
+    let panelData: EmailDraftPanelData
+    let feedStore: HomeFeedStore
+    let onDismiss: () -> Void
+
+    @State private var toAddress: String
+    @State private var subject: String
+    @State private var bodyText: String
+
+    init(
+        item: FeedItem,
+        panelData: EmailDraftPanelData,
+        feedStore: HomeFeedStore,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.item = item
+        self.panelData = panelData
+        self.feedStore = feedStore
+        self.onDismiss = onDismiss
+        self._toAddress = State(initialValue: panelData.to)
+        self._subject = State(initialValue: panelData.subject)
+        self._bodyText = State(initialValue: panelData.body)
+    }
+
+    var body: some View {
+        HomeDetailPanel(
+            icon: nil,
+            title: item.title,
+            onDismiss: onDismiss,
+            scrollable: false
+        ) {
+            HomeEmailEditor(
+                toAddress: $toAddress,
+                subject: $subject,
+                bodyText: $bodyText,
+                attachments: [],
+                onAttachmentTap: { _ in },
+                onSend: {
+                    Task {
+                        _ = await feedStore.triggerAction(itemId: item.id, actionId: "send")
+                    }
+                    onDismiss()
+                },
+                onDiscard: {
+                    Task {
+                        _ = await feedStore.triggerAction(itemId: item.id, actionId: "discard")
+                    }
+                    onDismiss()
+                }
+            )
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -278,6 +278,7 @@ extension MainWindowView {
                             feedStore: feedStore,
                             onDismiss: { activeHomeDetailPanel = nil }
                         )
+                        .id(item.id)
                     } else {
                         HomeDetailPanel(
                             icon: nil,
@@ -1154,15 +1155,11 @@ struct HomeEmailDraftDetailView: View {
                 attachments: [],
                 onAttachmentTap: { _ in },
                 onSend: {
-                    Task {
-                        _ = await feedStore.triggerAction(itemId: item.id, actionId: "send")
-                    }
+                    // Action wiring is a follow-up — just dismiss for now.
                     onDismiss()
                 },
                 onDiscard: {
-                    Task {
-                        _ = await feedStore.triggerAction(itemId: item.id, actionId: "discard")
-                    }
+                    // Action wiring is a follow-up — just dismiss for now.
                     onDismiss()
                 }
             )


### PR DESCRIPTION
## Summary
- Populate detailPanel.data with to/subject/body on email draft feed events in messaging-send.ts
- Parse EmailDraftPanelData in PanelCoordinator and render structured email fields
- Add Discard and Send footer action buttons
- Fall back to summary text when data is nil

Part of plan: home-feed-detail-panel-data.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
