### PR TITLE
chore(security): add socket.yml policy for supply-chain enforcement

### DIFF
--- a/docs/socket.md
+++ b/docs/socket.md
@@ -1,0 +1,10 @@
+# Socket.dev at Vellum Assistant
+
+This file is a stub. The full Socket.dev runbook — covering the `socket-security` App checks, the `socket.yml` policy, the weekly `Socket Autofix` workflow, token provenance, and the `gh api` command to wire Socket into the `main` branch-protection ruleset — lands in the follow-up PR of the same plan (ATL-106 / `socket-enforcement`).
+
+Until that PR merges, see:
+
+- `socket.yml` at the repo root — committed alert policy (boolean `issueRules` map per the Socket config schema).
+- `SECURITY.md` — vulnerability reporting policy.
+- [Socket docs](https://docs.socket.dev/docs/socket-yml) — canonical `socket.yml` schema reference.
+- Socket dashboard Security Policies — graduated block/warn/ignore severity mapping (not expressible in `socket.yml`).

--- a/socket.yml
+++ b/socket.yml
@@ -1,10 +1,20 @@
 # Socket.dev supply-chain policy.
 # Gates the `socket-security` GitHub App checks that run on every PR.
 # Free tier only: no reachability, no priority scoring, no Slack, no org-wide rules.
-# Layering: fail (action: error) > warn (action: warn) > allow (action: ignore).
+#
+# Shape: `<alertName>: true` enables the alert (severity and block-vs-warn
+# are determined by Socket's default severity mapping plus the Socket
+# dashboard Security Policy). `<alertName>: false` suppresses the alert
+# entirely. Three-state (block/warn/ignore) granularity lives in the
+# dashboard policy, not in this file — see docs/socket.md.
+#
+# Package-specific exceptions: add under the relevant alert with a rationale
+# comment (why suppressing, who approved, date, expiry if any). Reviewers
+# block suppressions without rationale.
+#
 # Alert names below verified against https://docs.socket.dev/docs/socket-yml
 # and https://socket.dev/alerts in 2026-04; re-verify on next edit.
-# Runbook: docs/socket.md.
+# Runbook: docs/socket.md (lands in PR 3 of the same plan — ATL-106).
 
 version: 2
 
@@ -19,23 +29,27 @@ projectIgnorePaths:
   - "**/*.bun-build"
 
 issueRules:
-  # --- FAIL (blocks the check) ---
-  malware: { action: error }
-  gptMalware: { action: error }
-  didYouMean: { action: error }
-  installScripts: { action: error }
-  hasNativeCode: { action: error }
-  shellAccess: { action: error }
+  # Supply-chain-attack signals — always on (reported and, per Socket default
+  # severity, block the check).
+  malware: true
+  gptMalware: true
+  didYouMean: true
+  installScripts: true
+  hasNativeCode: true
+  shellAccess: true
 
-  # --- WARN (surfaces but does not fail) ---
-  unpublishedLicense: { action: warn }
-  deprecated: { action: warn }
-  unmaintained: { action: warn }
-  dynamicRequire: { action: warn }
-  criticalCVE: { action: warn }
-  highCVE: { action: warn }
+  # Hygiene / trust signals — on (reported; block-vs-warn is controlled by
+  # Socket dashboard Security Policies, not this YAML).
+  unpublishedLicense: true
+  deprecated: true
+  unmaintained: true
+  dynamicRequire: true
 
-  # Allow medium/low CVEs by default. Package-specific allow entries added
-  # here MUST carry a rationale comment (why, who, date, expiry).
-  mediumCVE: { action: ignore }
-  lowCVE: { action: ignore }
+  # CVEs — critical and high are on (block per Socket default severity).
+  # Medium/low suppressed here; surface them via dashboard policy if we want
+  # to gate on them later. Package-specific exceptions go here with a
+  # rationale comment (why, who, date, expiry).
+  criticalCVE: true
+  highCVE: true
+  mediumCVE: false
+  lowCVE: false

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,41 @@
+# Socket.dev supply-chain policy.
+# Gates the `socket-security` GitHub App checks that run on every PR.
+# Free tier only: no reachability, no priority scoring, no Slack, no org-wide rules.
+# Layering: fail (action: error) > warn (action: warn) > allow (action: ignore).
+# Alert names below verified against https://docs.socket.dev/docs/socket-yml
+# and https://socket.dev/alerts in 2026-04; re-verify on next edit.
+# Runbook: docs/socket.md.
+
+version: 2
+
+projectIgnorePaths:
+  - "**/node_modules/**"
+  - "**/.build/**"
+  - "clients/.build/**"
+  - "**/dist/**"
+  - "**/build/**"
+  - "**/.build-ios/**"
+  - "**/*.tsbuildinfo"
+  - "**/*.bun-build"
+
+issueRules:
+  # --- FAIL (blocks the check) ---
+  malware: { action: error }
+  gptMalware: { action: error }
+  didYouMean: { action: error }
+  installScripts: { action: error }
+  hasNativeCode: { action: error }
+  shellAccess: { action: error }
+
+  # --- WARN (surfaces but does not fail) ---
+  unpublishedLicense: { action: warn }
+  deprecated: { action: warn }
+  unmaintained: { action: warn }
+  dynamicRequire: { action: warn }
+  criticalCVE: { action: warn }
+  highCVE: { action: warn }
+
+  # Allow medium/low CVEs by default. Package-specific allow entries added
+  # here MUST carry a rationale comment (why, who, date, expiry).
+  mediumCVE: { action: ignore }
+  lowCVE: { action: ignore }


### PR DESCRIPTION
## Summary
- Add `socket.yml` at the repo root to gate the `socket-security` GitHub App checks.
- Curated alert-category layering: fail on supply-chain-attack signals, warn on hygiene issues, allow low/medium CVEs (with allow-with-rationale rule documented inline).
- `projectIgnorePaths` excludes `node_modules`, Swift `.build`, and build artifacts.

Part of plan: socket-enforcement.md (PR 1 of 3)
Part of ATL-106
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
