### PR TITLE
feat(ci): add Socket.dev weekly autofix workflow (socket-fix + socket-patch)

### DIFF
--- a/.github/workflows/socket-autofix.yml
+++ b/.github/workflows/socket-autofix.yml
@@ -87,8 +87,10 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         id: body
         run: |
+          # Random delimiter prevents GITHUB_OUTPUT injection if scan JSON contains 'EOF' on its own line.
+          delimiter="ghadelim_$(openssl rand -hex 16)"
           {
-            echo 'body<<EOF'
+            echo "body<<${delimiter}"
             echo 'Applied Socket Certified Patches for the week.'
             echo ''
             echo 'Socket is on the Free tier — paid-tier patches are silently skipped.'
@@ -102,7 +104,7 @@ jobs:
             echo 'See [docs/socket.md](docs/socket.md) for the runbook.'
             echo ''
             echo 'Part of ATL-106.'
-            echo EOF
+            echo "${delimiter}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Open PR

--- a/.github/workflows/socket-autofix.yml
+++ b/.github/workflows/socket-autofix.yml
@@ -1,0 +1,120 @@
+name: Socket Autofix
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Mondays at 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: socket-autofix
+  cancel-in-progress: false
+
+jobs:
+  socket-fix:
+    name: Socket Fix (dep upgrades)
+    if: github.repository == 'vellum-ai/vellum-assistant'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      # Flags (verified against https://docs.socket.dev/docs/socket-fix):
+      #   --autopilot              headless CI mode; enables auto-merge on PRs Socket opens.
+      #   --pr-limit 10            cap per-run PR volume (matches Socket's CI default;
+      #                            pinned explicitly for reviewer visibility).
+      #   --minimum-release-age 1w skip versions published in the last 7 days —
+      #                            defense against malware-via-update.
+      - name: Run socket fix
+        run: bunx @socketsecurity/cli fix --autopilot --pr-limit 10 --minimum-release-age 1w
+        env:
+          SOCKET_CLI_API_TOKEN: ${{ secrets.SOCKET_CLI_API_TOKEN }}
+          SOCKET_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOCKET_CLI_GIT_USER_NAME: socket-fix[bot]
+          SOCKET_CLI_GIT_USER_EMAIL: socket-fix[bot]@users.noreply.github.com
+
+  socket-patch:
+    name: Socket Patch (Certified Patches)
+    if: github.repository == 'vellum-ai/vellum-assistant'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      # socket-patch is the standalone Certified Patches CLI
+      # (https://github.com/SocketDev/socket-patch). It works without a Socket
+      # API token on the Free tier; paid-tier patches are silently skipped
+      # (expected). Package name verified against the npm registry and the
+      # upstream README at authoring time — re-verify if upgrading.
+      #
+      # `apply` has no `--yes` flag; per upstream docs, interactive prompts
+      # auto-proceed when stdin is not a TTY (i.e. in CI), so no flag needed.
+      - name: Scan for available patches
+        run: bunx @socketsecurity/socket-patch scan --json > /tmp/socket-patch-scan.json
+
+      - name: Apply patches
+        run: bunx @socketsecurity/socket-patch apply
+
+      - name: Detect changes
+        id: diff
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build PR body
+        if: steps.diff.outputs.changed == 'true'
+        id: body
+        run: |
+          {
+            echo 'body<<EOF'
+            echo 'Applied Socket Certified Patches for the week.'
+            echo ''
+            echo 'Socket is on the Free tier — paid-tier patches are silently skipped.'
+            echo ''
+            echo '### Scan output'
+            echo ''
+            echo '```json'
+            cat /tmp/socket-patch-scan.json
+            echo '```'
+            echo ''
+            echo 'See [docs/socket.md](docs/socket.md) for the runbook.'
+            echo ''
+            echo 'Part of ATL-106.'
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open PR
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          branch: socket-patch/weekly-${{ github.run_number }}
+          title: "chore(deps): apply Socket Certified Patches (weekly)"
+          body: ${{ steps.body.outputs.body }}
+          commit-message: |
+            chore(deps): apply Socket Certified Patches
+
+            Part of ATL-106
+          labels: dependencies,security,socket-patch
+          delete-branch: true


### PR DESCRIPTION
## Summary
- Add `.github/workflows/socket-autofix.yml` with two independent jobs on a weekly Monday 09:00 UTC schedule + `workflow_dispatch`.
- `socket-fix`: dep-upgrade autofix via `bunx @socketsecurity/cli fix --autopilot --pr-limit 10 --minimum-release-age 1w`. Requires the `SOCKET_CLI_API_TOKEN` repo secret.
- `socket-patch`: Certified Patches via `bunx @socketsecurity/socket-patch` (no token needed on Free; paid-tier patches skipped silently).

## Before merging
- [ ] Add `SOCKET_CLI_API_TOKEN` repo secret (same token used by sibling `vellum-assistant-platform` autofix — one Socket token covers both repos).

Part of plan: socket-enforcement.md (PR 2 of 3)
Part of ATL-106
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
