### PR TITLE
fix(runtime): synchronously validate GCS URL on import-from-gcs

### DIFF
--- a/assistant/src/__tests__/migration-import-from-gcs.test.ts
+++ b/assistant/src/__tests__/migration-import-from-gcs.test.ts
@@ -285,6 +285,10 @@ interface BadRequestResponse {
   error: { code: string; message: string };
 }
 
+interface InvalidBundleUrlResponse {
+  error: { code: "invalid_bundle_url"; reason: string };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -455,6 +459,57 @@ describe("POST /v1/migrations/import-from-gcs", () => {
       if (firstJobId !== undefined) {
         await pollJobUntilDone(firstJobId);
       }
+    }
+  }, 30_000);
+
+  test("invalid bundle_url (disallowed host) returns 400 without consuming the in-flight slot", async () => {
+    // Disallowed host — syntactically a valid URL (passes zod), but
+    // `validateGcsSignedUrl` must reject it synchronously so the single
+    // in-flight import slot is NOT taken. Without the preflight, this
+    // would return 202 + job_id and then only fail inside the async
+    // runner, blocking a correct retry until the doomed job cleared.
+    const badReq = new Request(
+      "http://localhost/v1/migrations/import-from-gcs",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          bundle_url: "http://evil.example.com/bundle?X-Goog-Signature=fake",
+        }),
+      },
+    );
+    const badRes = await handleMigrationImportFromGcs(badReq);
+    expect(badRes.status).toBe(400);
+    const badBody = (await badRes.json()) as InvalidBundleUrlResponse;
+    expect(badBody.error.code).toBe("invalid_bundle_url");
+    expect(typeof badBody.error.reason).toBe("string");
+    expect(badBody.error.reason.length).toBeGreaterThan(0);
+
+    // A follow-up valid request must still be able to start a job — proving
+    // the doomed request did not occupy the concurrency slot.
+    const bundlePath = makeSmallValidBundlePath(testParent);
+    const fixture = await startFixtureServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/octet-stream" });
+      createReadStream(bundlePath).pipe(res);
+    });
+    try {
+      const goodReq = new Request(
+        "http://localhost/v1/migrations/import-from-gcs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
+        },
+      );
+      const goodRes = await handleMigrationImportFromGcs(goodReq);
+      expect(goodRes.status).toBe(202);
+      const goodBody = (await goodRes.json()) as AcceptedResponse;
+      expect(goodBody.type).toBe("import");
+
+      // Drain the job so subsequent tests start from a clean registry.
+      await pollJobUntilDone(goodBody.job_id);
+    } finally {
+      await fixture.close();
     }
   }, 30_000);
 

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -1452,6 +1452,29 @@ export async function handleMigrationImportFromGcs(
 
   const { bundle_url } = parsed.data;
 
+  // Synchronously validate the GCS URL before consuming the single
+  // in-flight import slot. Mirrors `handleMigrationExportToGcs`: an
+  // invalid-but-syntactically-valid URL (wrong host/scheme, missing
+  // signature) must be rejected with 400 here so a correct retry isn't
+  // blocked behind a doomed async job that only fails once the runner
+  // re-validates inside `runGcsImport`. Never log the raw URL.
+  const validated = validateGcsSignedUrl(bundle_url, urlValidatorOptions);
+  if (!validated.ok) {
+    log.warn(
+      { reason: validated.reason },
+      "Rejected migration import-from-gcs bundle URL",
+    );
+    return Response.json(
+      {
+        error: {
+          code: "invalid_bundle_url",
+          reason: validated.reason,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
   try {
     const job = migrationJobs.startJob("import", async (jobRecord) =>
       runGcsImport(bundle_url, jobRecord.id),


### PR DESCRIPTION
## Summary
Mirrors the export-to-gcs preflight: validateGcsSignedUrl is now called before startJob so an invalid URL returns 400 immediately and does NOT consume the single in-flight import slot.

Self-review gap from teleport-gcs-unify.md plan execution.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
