### PR TITLE
fix(cli): refresh token on 401 during long-running migration polls

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -1987,6 +1987,66 @@ describe("auth + transient-error resilience", () => {
     expect(leaseGuardianTokenMock).not.toHaveBeenCalled();
   });
 
+  test("runtime poll 401 mid-migration triggers forceRefresh lease and completes", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    // Export kickoff succeeds with the cached "local-token".
+    // During polling, the first status check fails with 401 (token expired
+    // mid-migration), the poll loop calls refreshOn401 → leaseGuardianToken,
+    // then the next poll succeeds with the new token.
+    const tokensSeenByPoll: string[] = [];
+    localRuntimePollJobStatusMock.mockImplementation(
+      async (_runtimeUrl, token, jobId) => {
+        tokensSeenByPoll.push(token);
+        if (tokensSeenByPoll.length === 1) {
+          throw new Error("Local job status check failed: 401 Unauthorized");
+        }
+        return {
+          jobId,
+          type: "export" as const,
+          status: "complete" as const,
+          result: undefined,
+        };
+      },
+    );
+
+    leaseGuardianTokenMock.mockResolvedValueOnce({
+      accessToken: "poll-refreshed-token",
+      accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    } as unknown as Awaited<
+      ReturnType<typeof guardianToken.leaseGuardianToken>
+    >);
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      // The first poll used the cached token; the second (post-refresh) poll
+      // used the freshly leased one.
+      expect(tokensSeenByPoll.length).toBeGreaterThanOrEqual(2);
+      expect(tokensSeenByPoll[0]).toBe("local-token");
+      expect(tokensSeenByPoll[1]).toBe("poll-refreshed-token");
+
+      // leaseGuardianToken was invoked for the forceRefresh path.
+      expect(leaseGuardianTokenMock).toHaveBeenCalledTimes(1);
+
+      // The 401 branch emits its own warning — distinct from the generic
+      // transient-error warning — so this asserts the refresh path fired.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("refreshing auth"),
+      );
+    } finally {
+      restoreFetch();
+      warnSpy.mockRestore();
+    }
+  });
+
   test("transient poll error does not abort teleport (job completes after retry)", async () => {
     setArgv("--from", "my-local", "--platform");
 

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -419,6 +419,17 @@ async function exportFromAssistant(
       label: "local-runtime export",
       poll: () =>
         localRuntimePollJobStatus(entry.runtimeUrl, accessToken, jobId),
+      // Large exports can take longer than a guardian-token lease. If the
+      // runtime returns 401 mid-poll, re-lease a fresh token and rebind the
+      // closure variable so the next poll uses it.
+      refreshOn401: async () => {
+        accessToken = await getAccessToken(
+          entry.runtimeUrl,
+          entry.assistantId,
+          entry.assistantId,
+          { forceRefresh: true },
+        );
+      },
     });
 
     if (terminal.status === "failed") {
@@ -441,9 +452,24 @@ async function exportFromAssistant(
 
     console.log(`Export started (job ${jobId})...`);
 
+    let exportPlatformToken = platformToken;
     const terminal = await pollJobUntilDone({
       label: "platform export",
-      poll: () => platformPollJobStatus(jobId, platformToken, entry.runtimeUrl),
+      poll: () =>
+        platformPollJobStatus(jobId, exportPlatformToken, entry.runtimeUrl),
+      // The platform token is normally static per-process, but re-reading the
+      // on-disk credential covers the case where the user ran `vellum login`
+      // in another terminal during a long migration. A persistent 401 after
+      // a re-read surfaces to the caller with a clear next step.
+      refreshOn401: async () => {
+        const refreshed = readPlatformToken();
+        if (!refreshed) {
+          throw new Error(
+            "Platform auth expired during export and no credential was found on disk. Run 'vellum login' and retry.",
+          );
+        }
+        exportPlatformToken = refreshed;
+      },
     });
 
     if (terminal.status === "failed") {
@@ -574,10 +600,20 @@ async function importToAssistant(
         process.exit(1);
       }
 
+      let importPlatformToken = platformToken;
       const terminal = await pollJobUntilDone({
         label: "platform import",
         poll: () =>
-          platformPollJobStatus(jobId, platformToken, entry.runtimeUrl),
+          platformPollJobStatus(jobId, importPlatformToken, entry.runtimeUrl),
+        refreshOn401: async () => {
+          const refreshed = readPlatformToken();
+          if (!refreshed) {
+            throw new Error(
+              "Platform auth expired during import and no credential was found on disk. Run 'vellum login' and retry.",
+            );
+          }
+          importPlatformToken = refreshed;
+        },
       });
 
       if (terminal.status === "failed") {
@@ -647,6 +683,14 @@ async function importToAssistant(
       label: "local-runtime import",
       poll: () =>
         localRuntimePollJobStatus(entry.runtimeUrl, accessToken, jobId),
+      refreshOn401: async () => {
+        accessToken = await getAccessToken(
+          entry.runtimeUrl,
+          entry.assistantId,
+          entry.assistantId,
+          { forceRefresh: true },
+        );
+      },
     });
 
     if (terminal.status === "failed") {

--- a/cli/src/lib/__tests__/job-polling.test.ts
+++ b/cli/src/lib/__tests__/job-polling.test.ts
@@ -176,6 +176,82 @@ describe("pollJobUntilDone", () => {
       expect(calls).toBe(2);
     });
 
+    test("refreshOn401 is invoked on 401 and polling continues after refresh", async () => {
+      let calls = 0;
+      let refreshes = 0;
+      const result = await pollJobUntilDone({
+        label: "expiring auth",
+        intervalMs: 1,
+        timeoutMs: 1_000,
+        maxTransientErrors: 0,
+        refreshOn401: async () => {
+          refreshes += 1;
+        },
+        poll: async () => {
+          calls += 1;
+          if (calls === 1) {
+            throw new Error("Local job status check failed: 401 Unauthorized");
+          }
+          return {
+            jobId: "j401",
+            type: "export",
+            status: "complete",
+          } as UnifiedJobStatus;
+        },
+      });
+      expect(result.status).toBe("complete");
+      expect(refreshes).toBe(1);
+      expect(calls).toBe(2);
+      // The 401 branch logs its own distinct warning (not the generic
+      // "polling failed, retrying" one) so operators can distinguish an
+      // auth refresh from a transient-error retry in the output.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("refreshing auth"),
+      );
+    });
+
+    test("propagates 401 once maxAuthRefreshes is exceeded", async () => {
+      const maxAuthRefreshes = 2;
+      let calls = 0;
+      let refreshes = 0;
+      await expect(
+        pollJobUntilDone({
+          label: "persistently unauthorized",
+          intervalMs: 1,
+          timeoutMs: 1_000,
+          maxAuthRefreshes,
+          refreshOn401: async () => {
+            refreshes += 1;
+          },
+          poll: async () => {
+            calls += 1;
+            throw new Error("Local job status check failed: 401 Unauthorized");
+          },
+        }),
+      ).rejects.toThrow(/401 Unauthorized/);
+      // Helper allows `maxAuthRefreshes` successful refresh-and-retry cycles
+      // (each counted against the budget after the poll fails), plus one
+      // final attempt on the refreshed token that exceeds the budget.
+      expect(calls).toBe(maxAuthRefreshes + 1);
+      expect(refreshes).toBe(maxAuthRefreshes);
+    });
+
+    test("without refreshOn401, 401 still propagates as a permanent 4xx", async () => {
+      let calls = 0;
+      await expect(
+        pollJobUntilDone({
+          label: "no refresh hook",
+          intervalMs: 1,
+          timeoutMs: 1_000,
+          poll: async () => {
+            calls += 1;
+            throw new Error("Local job status check failed: 401 Unauthorized");
+          },
+        }),
+      ).rejects.toThrow(/401 Unauthorized/);
+      expect(calls).toBe(1);
+    });
+
     test("unclassified network-style errors are treated as transient", async () => {
       let calls = 0;
       const result = await pollJobUntilDone({

--- a/cli/src/lib/job-polling.ts
+++ b/cli/src/lib/job-polling.ts
@@ -24,11 +24,36 @@ export interface PollJobUntilDoneOptions {
    * successful polls reset the counter. Defaults to 5.
    */
   maxTransientErrors?: number;
+  /**
+   * Optional async hook invoked when `poll()` throws an error containing a
+   * `401` HTTP status. The callback is expected to refresh whatever
+   * credential the poll closure reads (e.g. re-lease a guardian token), then
+   * return. The polling loop will retry the poll after the callback resolves
+   * instead of propagating the 401.
+   *
+   * Used by long-running migrations where the cached access token may expire
+   * mid-poll. Without this hook, 4xx errors (except 429) are permanent and
+   * would abandon a migration that's still running on the server.
+   */
+  refreshOn401?: () => Promise<void>;
+  /**
+   * Maximum consecutive 401 refreshes tolerated before the last 401 is
+   * propagated. Tracked separately from {@link maxTransientErrors} because
+   * a persistent 401 after a refresh usually means the underlying credential
+   * is revoked, not a transient network issue. Defaults to 3.
+   */
+  maxAuthRefreshes?: number;
 }
 
 const DEFAULT_INTERVAL_MS = 2_000;
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_MAX_TRANSIENT_ERRORS = 5;
+const DEFAULT_MAX_AUTH_REFRESHES = 3;
+
+function is401Error(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /\b401\b/.test(msg);
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -88,9 +113,12 @@ export async function pollJobUntilDone(
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxTransientErrors =
     options.maxTransientErrors ?? DEFAULT_MAX_TRANSIENT_ERRORS;
+  const maxAuthRefreshes =
+    options.maxAuthRefreshes ?? DEFAULT_MAX_AUTH_REFRESHES;
   const deadline = Date.now() + timeoutMs;
 
   let consecutiveTransientErrors = 0;
+  let consecutiveAuthRefreshes = 0;
 
   // First poll happens immediately so fast-path completions don't wait
   // one interval before returning.
@@ -99,7 +127,33 @@ export async function pollJobUntilDone(
     try {
       status = await options.poll();
       consecutiveTransientErrors = 0;
+      consecutiveAuthRefreshes = 0;
     } catch (err) {
+      // 401 Unauthorized takes precedence over the generic transient
+      // classifier: when a refresh callback is registered, a long-running
+      // poll loop can re-lease its credential and keep going instead of
+      // abandoning a migration that's still running on the server.
+      if (options.refreshOn401 && is401Error(err)) {
+        consecutiveAuthRefreshes += 1;
+        if (consecutiveAuthRefreshes > maxAuthRefreshes) {
+          throw err;
+        }
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `${options.label} polling got 401, refreshing auth and retrying... (${msg})`,
+        );
+        await options.refreshOn401();
+        if (Date.now() >= deadline) {
+          throw new Error(
+            `Timed out waiting for ${options.label} after ${Math.round(
+              timeoutMs / 1000,
+            )}s`,
+          );
+        }
+        await sleep(intervalMs);
+        continue;
+      }
+
       if (!isTransientPollError(err)) {
         throw err;
       }


### PR DESCRIPTION
## Summary
- pollJobUntilDone now accepts a refreshOn401 callback. When the poll throws a 401 error, the callback runs once and the loop continues instead of propagating.
- teleport.ts wires runtime polls to re-lease the guardian token (getAccessToken with forceRefresh) and platform polls to re-read the platform token.

Self-review gap from teleport-gcs-unify.md plan execution.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
