### PR TITLE
Teleport GCS consolidation: unified signed-URL, async jobs, and job-status endpoints (CLI side)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5772,6 +5772,73 @@ paths:
                     the importer.
               required:
                 - url
+  /v1/migrations/import-from-gcs:
+    post:
+      operationId: migrations_importfromgcs_post
+      summary: Start an async .vbundle import from a signed GCS URL
+      description:
+        Schedule a background import job that fetches the bundle at `bundle_url` and streams it through the
+        importer. Returns 202 with a `job_id`; poll `GET /v1/migrations/jobs/{job_id}` for status. 409 if another import
+        is already in flight.
+      tags:
+        - migrations
+      responses:
+        "202":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  job_id:
+                    type: string
+                  status:
+                    type: string
+                    const: pending
+                  type:
+                    type: string
+                    const: import
+                required:
+                  - job_id
+                  - status
+                  - type
+                additionalProperties: false
+        "409":
+          description:
+            "Another import job is already pending or running. Body shape: { error: { code: 'import_in_progress',
+            job_id: string } }."
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - import_in_progress
+                      job_id:
+                        type: string
+                    required:
+                      - code
+                      - job_id
+                required:
+                  - error
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                bundle_url:
+                  type: string
+                  format: uri
+              required:
+                - bundle_url
+              additionalProperties: false
   /v1/migrations/import-preflight:
     post:
       operationId: migrations_importpreflight_post

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5633,6 +5633,54 @@ paths:
               required:
                 - description
               additionalProperties: false
+  /v1/migrations/export-to-gcs:
+    post:
+      operationId: migrations_exporttogcs_post
+      summary: Start an async export streamed to a GCS signed URL
+      description:
+        Kick off a background export job that PUTs a freshly-built .vbundle archive to the supplied GCS signed URL.
+        Returns 202 with a job_id the caller can poll via the job-status endpoint. Fails fast with 409 if another export
+        job is already pending or running.
+      tags:
+        - migrations
+      responses:
+        "202":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  job_id:
+                    type: string
+                  status:
+                    type: string
+                    const: pending
+                  type:
+                    type: string
+                    const: export
+                required:
+                  - job_id
+                  - status
+                  - type
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                upload_url:
+                  type: string
+                  format: uri
+                  description: Signed GCS PUT URL that receives the exported bundle.
+                description:
+                  description: Human-readable export description.
+                  type: string
+              required:
+                - upload_url
+              additionalProperties: false
   /v1/migrations/import:
     post:
       operationId: migrations_import_post

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5762,6 +5762,111 @@ paths:
                   - conflicts
                   - manifest
                 additionalProperties: false
+  /v1/migrations/jobs/{job_id}:
+    get:
+      operationId: migrations_jobs_by_job_id_get
+      summary: Get migration job status
+      description:
+        "Return the current status of an async migration job (export or import). The response discriminates on
+        `status`: `processing` (pending or running), `complete` (with `result`), or `failed` (with `error`,
+        `error_code`, optional `upstream_status`). The `processing` value mirrors the platform's transport shape so CLI
+        clients can share a single parser across the platform and the daemon."
+      tags:
+        - migrations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    properties:
+                      job_id:
+                        type: string
+                      type:
+                        type: string
+                        enum:
+                          - export
+                          - import
+                      status:
+                        type: string
+                        const: processing
+                    required:
+                      - job_id
+                      - type
+                      - status
+                    additionalProperties: false
+                  - type: object
+                    properties:
+                      job_id:
+                        type: string
+                      type:
+                        type: string
+                        enum:
+                          - export
+                          - import
+                      status:
+                        type: string
+                        const: complete
+                      result: {}
+                    required:
+                      - job_id
+                      - type
+                      - status
+                      - result
+                    additionalProperties: false
+                  - type: object
+                    properties:
+                      job_id:
+                        type: string
+                      type:
+                        type: string
+                        enum:
+                          - export
+                          - import
+                      status:
+                        type: string
+                        const: failed
+                      error:
+                        type: string
+                      error_code:
+                        type: string
+                      upstream_status:
+                        type: integer
+                        minimum: -9007199254740991
+                        maximum: 9007199254740991
+                    required:
+                      - job_id
+                      - type
+                      - status
+                      - error
+                      - error_code
+                    additionalProperties: false
+        "404":
+          description: "No job matches the given id. Body shape: { error: { code: 'job_not_found' } }."
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - job_not_found
+                    required:
+                      - code
+                required:
+                  - error
+      parameters:
+        - name: job_id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/migrations/validate:
     post:
       operationId: migrations_validate_post

--- a/assistant/scripts/generate-openapi.ts
+++ b/assistant/scripts/generate-openapi.ts
@@ -83,9 +83,11 @@ const RouteEntrySchema = z.object({
   requestBody: RouteBodySchemaSchema.optional(),
   /** Multi-content-type request body variants (overrides `requestBody` when present). */
   requestBodies: z.array(RouteRequestBodyVariantSchema).optional(),
-  /** JSON Schema for the 200 response body. */
+  /** JSON Schema for the success response body. */
   responseBody: RouteBodySchemaSchema.optional(),
-  /** Extra non-200 responses documented in the spec. */
+  /** HTTP status code for the success response. Defaults to "200". */
+  responseStatus: z.string().optional(),
+  /** Extra response codes documented in the spec. */
   additionalResponses: z
     .record(z.string(), RouteAdditionalResponseSchema)
     .optional(),
@@ -431,14 +433,17 @@ function buildSpec(
           ? [deriveTagFromModule(entry.sourceModule)]
           : undefined;
 
-    // Build the operation
+    // Build the operation. Default success status is 200; async endpoints
+    // that enqueue a job and return immediately set responseStatus: "202"
+    // so the generated spec matches the handler's actual response code.
+    const successStatus = entry.responseStatus ?? "200";
     const operation: OpenApiOperation = {
       operationId,
       ...(entry.summary ? { summary: entry.summary } : {}),
       ...(entry.description ? { description: entry.description } : {}),
       ...(tags ? { tags } : {}),
       responses: {
-        "200": entry.responseBody
+        [successStatus]: entry.responseBody
           ? {
               description: "Successful response",
               content: {

--- a/assistant/src/__tests__/migration-export-to-gcs.test.ts
+++ b/assistant/src/__tests__/migration-export-to-gcs.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Integration tests for POST /v1/migrations/export-to-gcs.
+ *
+ * Covered:
+ * - Happy path: the handler returns 202 + job_id, the background job
+ *   PUTs a valid .vbundle to the fixture server, and the final job
+ *   record carries a matching result payload.
+ * - Concurrency: a second export-to-gcs while the first is still
+ *   pending/running returns 409 `export_in_progress`.
+ * - Upload failure: when the PUT server responds 500, the job ends
+ *   `failed` with `error.code === "upload_failed"` and
+ *   `upstreamStatus: 500`.
+ * - Invalid URL: non-https, wrong host, and path-traversal URLs are
+ *   rejected at the handler (400) with the validator's reason code
+ *   in `error.reason`.
+ *
+ * The .vbundle bytes observed by the fixture server are cross-checked
+ * against `validateVBundle` to prove the upload body matches what
+ * `streamExportVBundle()` would produce.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const testDir = process.env.VELLUM_WORKSPACE_DIR!;
+const testDbDir = join(testDir, "data", "db");
+const testDbPath = join(testDbDir, "assistant.db");
+const testConfigPath = join(testDir, "config.json");
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  getAllRules: () => [],
+  isStarterBundleAccepted: () => false,
+  clearCache: () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+  invalidateConfigCache: () => {},
+}));
+
+// Force the credential collector onto the unreachable branch so the
+// handler treats it as "export without credentials" (fast, no CES).
+mock.module("../security/secure-keys.js", () => ({
+  listSecureKeysAsync: async () => ({ accounts: [], unreachable: true }),
+  getSecureKeyAsync: async () => undefined,
+  getSecureKeyResultAsync: async () => ({
+    value: undefined,
+    unreachable: true,
+  }),
+  bulkSetSecureKeysAsync: async () => [],
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks so module-level code picks up the stubs)
+// ---------------------------------------------------------------------------
+
+import { migrationJobs } from "../runtime/migrations/job-registry.js";
+import { validateVBundle } from "../runtime/migrations/vbundle-validator.js";
+import {
+  _setUrlImportValidatorOptionsForTests,
+  handleMigrationExportToGcs,
+} from "../runtime/routes/migration-routes.js";
+
+// ---------------------------------------------------------------------------
+// Fixture workspace: write a minimal SQLite file + config so the exporter
+// has real data to walk.
+// ---------------------------------------------------------------------------
+
+const SQLITE_HEADER = new Uint8Array([
+  0x53, 0x51, 0x4c, 0x69, 0x74, 0x65, 0x20, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74,
+  0x20, 0x33, 0x00,
+]);
+const TEST_CONFIG = { provider: "anthropic", model: "test-model" };
+
+beforeAll(() => {
+  mkdirSync(testDbDir, { recursive: true });
+  writeFileSync(testDbPath, SQLITE_HEADER);
+  writeFileSync(testConfigPath, JSON.stringify(TEST_CONFIG, null, 2));
+
+  // Widen the URL validator allowlist so the handler accepts a URL
+  // pointing at the local fixture server.
+  _setUrlImportValidatorOptionsForTests({
+    allowedHosts: ["127.0.0.1", "storage.googleapis.com"],
+  });
+});
+
+afterAll(() => {
+  _setUrlImportValidatorOptionsForTests(undefined);
+});
+
+// Drop stale job records between tests so concurrency assertions are
+// deterministic (a `failed` job from a previous test must not collide
+// with the next test's `startJob("export", …)` call — the registry only
+// rejects while the prior job is still pending/running, but evicting the
+// entry defensively keeps log output clean too).
+afterEach(async () => {
+  // Wait a tick so any in-flight runners can finalize their state.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  // Force-evict any remaining terminal records by tightening the TTL.
+  const savedTtl = migrationJobs.completedJobTtlMs;
+  migrationJobs.completedJobTtlMs = 0;
+  migrationJobs.sweep();
+  migrationJobs.completedJobTtlMs = savedTtl;
+});
+
+// ---------------------------------------------------------------------------
+// Local http fixture server that captures PUT bodies
+// ---------------------------------------------------------------------------
+
+interface FixtureServer {
+  server: Server;
+  port: number;
+  close: () => Promise<void>;
+}
+
+async function startFixtureServer(
+  handler: (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
+  ) => void,
+): Promise<FixtureServer> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fixture server bound to unexpected address");
+  }
+  return {
+    server,
+    port: address.port,
+    close: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+function makeFakeSignedUploadUrl(port: number): string {
+  // `validateGcsSignedUrl` requires a signature query param; pin a dummy.
+  return `http://127.0.0.1:${port}/upload/bundle?X-Goog-Signature=fake`;
+}
+
+/** Read the full body of an incoming request into a Buffer. */
+function collectBody(
+  req: import("node:http").IncomingMessage,
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+/** Poll `migrationJobs.getJob(id)` until the job reaches a terminal state. */
+async function waitForJobTerminal(
+  id: string,
+  { timeoutMs = 10_000 }: { timeoutMs?: number } = {},
+): Promise<NonNullable<ReturnType<typeof migrationJobs.getJob>>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const job = migrationJobs.getJob(id);
+    if (job && (job.status === "complete" || job.status === "failed")) {
+      return job;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Job ${id} did not reach a terminal state in time`);
+}
+
+// ---------------------------------------------------------------------------
+// Response shape types
+// ---------------------------------------------------------------------------
+
+interface AcceptedResponse {
+  job_id: string;
+  status: "pending";
+  type: "export";
+}
+
+interface ErrorEnvelope {
+  error: {
+    code: string;
+    reason?: string;
+    job_id?: string;
+    message?: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("handleMigrationExportToGcs — happy path", () => {
+  test("202 + job completes with a valid .vbundle PUT to the upload URL", async () => {
+    let capturedBody: Buffer | undefined;
+    let capturedContentType: string | undefined;
+
+    const fixture = await startFixtureServer(async (req, res) => {
+      if (req.method !== "PUT") {
+        res.writeHead(405);
+        res.end();
+        return;
+      }
+      capturedContentType = req.headers["content-type"];
+      capturedBody = await collectBody(req);
+      res.writeHead(200);
+      res.end();
+    });
+
+    try {
+      const req = new Request("http://localhost/v1/migrations/export-to-gcs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          upload_url: makeFakeSignedUploadUrl(fixture.port),
+          description: "happy-path export",
+        }),
+      });
+
+      const res = await handleMigrationExportToGcs(req);
+      expect(res.status).toBe(202);
+
+      const body = (await res.json()) as AcceptedResponse;
+      expect(body.status).toBe("pending");
+      expect(body.type).toBe("export");
+      expect(body.job_id).toBeDefined();
+      expect(typeof body.job_id).toBe("string");
+
+      const terminal = await waitForJobTerminal(body.job_id);
+      expect(terminal.status).toBe("complete");
+      expect(terminal.error).toBeUndefined();
+
+      const result = terminal.result as {
+        size: number;
+        sha256: string;
+        schemaVersion: string;
+        credentialsIncluded: number;
+      };
+      expect(result.size).toBeGreaterThan(0);
+      expect(typeof result.sha256).toBe("string");
+      expect(result.sha256.length).toBeGreaterThan(0);
+      expect(result.schemaVersion).toBeDefined();
+      expect(result.credentialsIncluded).toBe(0);
+
+      expect(capturedContentType).toBe("application/octet-stream");
+      expect(capturedBody).toBeDefined();
+      expect(capturedBody!.byteLength).toBe(result.size);
+
+      // The uploaded body is a real .vbundle — validate it.
+      const validation = validateVBundle(new Uint8Array(capturedBody!));
+      expect(validation.is_valid).toBe(true);
+      expect(validation.errors).toHaveLength(0);
+      expect(validation.manifest?.manifest_sha256).toBe(result.sha256);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+});
+
+describe("handleMigrationExportToGcs — concurrency", () => {
+  test("second export while first is running returns 409 export_in_progress", async () => {
+    // First fixture: deliberately slow so the first job stays pending long
+    // enough for the second request to collide with it.
+    let release: () => void = () => {};
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const slow = await startFixtureServer(async (req, res) => {
+      if (req.method !== "PUT") {
+        res.writeHead(405);
+        res.end();
+        return;
+      }
+      // Consume the body but defer the response until the test says so.
+      await collectBody(req);
+      await released;
+      res.writeHead(200);
+      res.end();
+    });
+
+    // Second fixture: never hit in this test — but we still need a valid
+    // URL shape so the handler gets past URL validation on the second
+    // call. We point the second request at the same fixture URL; the
+    // handler rejects before the URL is fetched.
+    try {
+      const firstReq = new Request(
+        "http://localhost/v1/migrations/export-to-gcs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            upload_url: makeFakeSignedUploadUrl(slow.port),
+          }),
+        },
+      );
+      const firstRes = await handleMigrationExportToGcs(firstReq);
+      expect(firstRes.status).toBe(202);
+      const firstBody = (await firstRes.json()) as AcceptedResponse;
+
+      // Yield to the microtask queue so the first job's runner actually
+      // transitions from pending → running before we try to start a
+      // second one.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const secondReq = new Request(
+        "http://localhost/v1/migrations/export-to-gcs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            upload_url: makeFakeSignedUploadUrl(slow.port),
+          }),
+        },
+      );
+      const secondRes = await handleMigrationExportToGcs(secondReq);
+      expect(secondRes.status).toBe(409);
+      const secondBody = (await secondRes.json()) as ErrorEnvelope;
+      expect(secondBody.error.code).toBe("export_in_progress");
+      expect(secondBody.error.job_id).toBe(firstBody.job_id);
+
+      // Unblock the first fixture so the first job can finalize and the
+      // afterEach cleanup sweeps it out.
+      release();
+      await waitForJobTerminal(firstBody.job_id);
+    } finally {
+      release();
+      await slow.close();
+    }
+  }, 20_000);
+});
+
+describe("handleMigrationExportToGcs — upload failure", () => {
+  test("PUT server responds 500 → job failed with upload_failed + upstreamStatus", async () => {
+    const fixture = await startFixtureServer(async (req, res) => {
+      // Drain the body so the client side completes its write before we
+      // send the 500 response. Without this, fetch may surface the 500 as
+      // a transport-level error instead of a non-2xx response.
+      await collectBody(req);
+      res.writeHead(500);
+      res.end("upload rejected");
+    });
+
+    try {
+      const req = new Request("http://localhost/v1/migrations/export-to-gcs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          upload_url: makeFakeSignedUploadUrl(fixture.port),
+        }),
+      });
+
+      const res = await handleMigrationExportToGcs(req);
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as AcceptedResponse;
+
+      const terminal = await waitForJobTerminal(body.job_id);
+      expect(terminal.status).toBe("failed");
+      expect(terminal.error).toBeDefined();
+      expect(terminal.error?.code).toBe("upload_failed");
+      expect(terminal.error?.upstreamStatus).toBe(500);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+});
+
+describe("handleMigrationExportToGcs — redirect handling", () => {
+  test("PUT server responds with a 302 redirect → job failed (no SSRF follow)", async () => {
+    // If the upstream "storage.googleapis.com" responded with a 3xx to an
+    // attacker-controlled host, default fetch would follow and PUT bytes
+    // there. `redirect: "error"` on the fetch must surface the redirect
+    // as a transport failure instead — the job must end `failed` rather
+    // than `complete`, and no bytes must reach the redirect target.
+    let redirectTargetHit = false;
+    const redirectTarget = await startFixtureServer(async (_req, res) => {
+      redirectTargetHit = true;
+      res.writeHead(200);
+      res.end();
+    });
+    const fixture = await startFixtureServer(async (_req, res) => {
+      res.writeHead(302, {
+        Location: `http://127.0.0.1:${redirectTarget.port}/attacker`,
+      });
+      res.end();
+    });
+
+    try {
+      const req = new Request("http://localhost/v1/migrations/export-to-gcs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          upload_url: makeFakeSignedUploadUrl(fixture.port),
+        }),
+      });
+
+      const res = await handleMigrationExportToGcs(req);
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as AcceptedResponse;
+
+      const terminal = await waitForJobTerminal(body.job_id);
+      expect(terminal.status).toBe("failed");
+      expect(redirectTargetHit).toBe(false);
+    } finally {
+      await fixture.close();
+      await redirectTarget.close();
+    }
+  }, 15_000);
+});
+
+describe("handleMigrationExportToGcs — URL validation", () => {
+  test("rejects non-https scheme when allowlist is default (400)", async () => {
+    // Temporarily reset the validator to production defaults so this
+    // assertion exercises the strict scheme check.
+    _setUrlImportValidatorOptionsForTests(undefined);
+    try {
+      const req = new Request("http://localhost/v1/migrations/export-to-gcs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          upload_url: "http://storage.googleapis.com/b/o?X-Goog-Signature=fake",
+        }),
+      });
+      const res = await handleMigrationExportToGcs(req);
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as ErrorEnvelope;
+      expect(body.error.code).toBe("invalid_upload_url");
+      expect(body.error.reason).toBe("scheme");
+    } finally {
+      _setUrlImportValidatorOptionsForTests({
+        allowedHosts: ["127.0.0.1", "storage.googleapis.com"],
+      });
+    }
+  });
+
+  test("rejects wrong host (400)", async () => {
+    const req = new Request("http://localhost/v1/migrations/export-to-gcs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        upload_url: "https://evil.example.com/bucket/obj?X-Goog-Signature=fake",
+      }),
+    });
+    const res = await handleMigrationExportToGcs(req);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ErrorEnvelope;
+    expect(body.error.code).toBe("invalid_upload_url");
+    expect(body.error.reason).toBe("host");
+  });
+
+  test("rejects path traversal (400)", async () => {
+    const req = new Request("http://localhost/v1/migrations/export-to-gcs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        upload_url:
+          "https://storage.googleapis.com/bucket/..%2Fother?X-Goog-Signature=fake",
+      }),
+    });
+    const res = await handleMigrationExportToGcs(req);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ErrorEnvelope;
+    expect(body.error.code).toBe("invalid_upload_url");
+    expect(body.error.reason).toBe("path_traversal");
+  });
+});

--- a/assistant/src/__tests__/migration-import-from-gcs.test.ts
+++ b/assistant/src/__tests__/migration-import-from-gcs.test.ts
@@ -285,6 +285,10 @@ interface BadRequestResponse {
   error: { code: string; message: string };
 }
 
+interface InvalidBundleUrlResponse {
+  error: { code: "invalid_bundle_url"; reason: string };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -455,6 +459,57 @@ describe("POST /v1/migrations/import-from-gcs", () => {
       if (firstJobId !== undefined) {
         await pollJobUntilDone(firstJobId);
       }
+    }
+  }, 30_000);
+
+  test("invalid bundle_url (disallowed host) returns 400 without consuming the in-flight slot", async () => {
+    // Disallowed host — syntactically a valid URL (passes zod), but
+    // `validateGcsSignedUrl` must reject it synchronously so the single
+    // in-flight import slot is NOT taken. Without the preflight, this
+    // would return 202 + job_id and then only fail inside the async
+    // runner, blocking a correct retry until the doomed job cleared.
+    const badReq = new Request(
+      "http://localhost/v1/migrations/import-from-gcs",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          bundle_url: "http://evil.example.com/bundle?X-Goog-Signature=fake",
+        }),
+      },
+    );
+    const badRes = await handleMigrationImportFromGcs(badReq);
+    expect(badRes.status).toBe(400);
+    const badBody = (await badRes.json()) as InvalidBundleUrlResponse;
+    expect(badBody.error.code).toBe("invalid_bundle_url");
+    expect(typeof badBody.error.reason).toBe("string");
+    expect(badBody.error.reason.length).toBeGreaterThan(0);
+
+    // A follow-up valid request must still be able to start a job — proving
+    // the doomed request did not occupy the concurrency slot.
+    const bundlePath = makeSmallValidBundlePath(testParent);
+    const fixture = await startFixtureServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/octet-stream" });
+      createReadStream(bundlePath).pipe(res);
+    });
+    try {
+      const goodReq = new Request(
+        "http://localhost/v1/migrations/import-from-gcs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
+        },
+      );
+      const goodRes = await handleMigrationImportFromGcs(goodReq);
+      expect(goodRes.status).toBe(202);
+      const goodBody = (await goodRes.json()) as AcceptedResponse;
+      expect(goodBody.type).toBe("import");
+
+      // Drain the job so subsequent tests start from a clean registry.
+      await pollJobUntilDone(goodBody.job_id);
+    } finally {
+      await fixture.close();
     }
   }, 30_000);
 

--- a/assistant/src/__tests__/migration-import-from-gcs.test.ts
+++ b/assistant/src/__tests__/migration-import-from-gcs.test.ts
@@ -294,7 +294,7 @@ interface InvalidBundleUrlResponse {
 // ---------------------------------------------------------------------------
 
 describe("POST /v1/migrations/import-from-gcs", () => {
-  test("happy path: 202 → job completes with result.report.summary", async () => {
+  test("happy path: 202 → job completes with flat result.summary", async () => {
     const bundlePath = makeSmallValidBundlePath(testParent);
 
     const fixture = await startFixtureServer((_req, res) => {
@@ -323,18 +323,23 @@ describe("POST /v1/migrations/import-from-gcs", () => {
       const finalJob = await pollJobUntilDone(body.job_id);
       expect(finalJob.status).toBe("complete");
 
-      const summary = finalJob.result as {
-        report: {
-          summary: {
-            total_files: number;
-            files_created: number;
-          };
+      // The job result must match the wire shape the CLI expects when it
+      // casts `terminal.result` to `ImportResponse`: `success` and `summary`
+      // live at the top level, NOT under a nested `report` field. Asserting
+      // here is what locks in the fix for the async-vs-sync shape drift
+      // that was misreporting successful imports as failed.
+      const result = finalJob.result as {
+        success: boolean;
+        summary: {
+          total_files: number;
+          files_created: number;
         };
       };
-      expect(summary).toBeDefined();
-      expect(summary.report).toBeDefined();
-      expect(summary.report.summary.total_files).toBeGreaterThan(0);
-      expect(summary.report.summary.files_created).toBeGreaterThan(0);
+      expect(result).toBeDefined();
+      expect(result.success).toBe(true);
+      expect(result.summary).toBeDefined();
+      expect(result.summary.total_files).toBeGreaterThan(0);
+      expect(result.summary.files_created).toBeGreaterThan(0);
 
       // Workspace was swapped into place.
       expect(

--- a/assistant/src/__tests__/migration-import-from-gcs.test.ts
+++ b/assistant/src/__tests__/migration-import-from-gcs.test.ts
@@ -1,0 +1,472 @@
+/**
+ * Integration tests for POST /v1/migrations/import-from-gcs.
+ *
+ * The endpoint kicks off an async import job that fetches a .vbundle from
+ * a signed GCS URL and streams it through the importer. The handler returns
+ * 202 with a `job_id`; the test then polls the in-process
+ * `migrationJobs` registry directly (no separate status endpoint yet — PR 4
+ * adds that) to assert the job progresses through `pending`/`running` to a
+ * terminal `complete` or `failed` state with the expected result / error
+ * mapping.
+ *
+ * Covered cases:
+ * - Happy path: 202 → poll → `complete` with `result.report.summary`.
+ * - Upstream fetch failure (HTTP 500): job ends `failed` with
+ *   `error.code === "fetch_failed"` and `error.upstreamStatus === 500`.
+ * - Validation failure (corrupt bundle): job ends `failed` with
+ *   `error.code === "validation_failed"`.
+ * - Concurrency: second import while the first is in flight → 409 with
+ *   `error.code === "import_in_progress"`.
+ */
+
+import {
+  createReadStream,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Test isolation: per-file workspace root.
+//
+// The streaming importer renames the workspace dir itself, so each test
+// needs a fresh tmp dir that the importer can swap into place.
+// ---------------------------------------------------------------------------
+
+const originalWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+
+function freshWorkspaceRoot(): string {
+  const parent = realpathSync(
+    mkdtempSync(join(tmpdir(), "migration-import-from-gcs-")),
+  );
+  const workspaceDir = join(parent, "workspace");
+  mkdirSync(workspaceDir, { recursive: true });
+  return workspaceDir;
+}
+
+function setWorkspaceDir(dir: string): void {
+  process.env.VELLUM_WORKSPACE_DIR = dir;
+}
+
+// ---------------------------------------------------------------------------
+// Mocks (mirrors migration-import-from-url.test.ts)
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  getAllRules: () => [],
+  isStarterBundleAccepted: () => false,
+  clearCache: () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  getGatewayPort: () => 7830,
+  getRuntimeHttpPort: () => 7821,
+  getRuntimeHttpHost: () => "127.0.0.1",
+  getRuntimeGatewayOriginSecret: () => undefined,
+  getIngressPublicBaseUrl: () => undefined,
+  setIngressPublicBaseUrl: () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks so module-level code picks up the stubs)
+// ---------------------------------------------------------------------------
+
+import {
+  type MigrationJob,
+  migrationJobs,
+} from "../runtime/migrations/job-registry.js";
+import { buildVBundle } from "../runtime/migrations/vbundle-builder.js";
+import {
+  _setUrlImportValidatorOptionsForTests,
+  handleMigrationImportFromGcs,
+} from "../runtime/routes/migration-routes.js";
+
+// ---------------------------------------------------------------------------
+// Local http fixture server
+// ---------------------------------------------------------------------------
+
+interface FixtureServer {
+  server: Server;
+  port: number;
+  close: () => Promise<void>;
+}
+
+async function startFixtureServer(
+  handler: (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
+  ) => void,
+): Promise<FixtureServer> {
+  const server = createServer(handler);
+  // Track every connection so `close()` can forcibly tear them down. Tests
+  // that intentionally hang the response body (to simulate an in-flight
+  // upstream fetch) would otherwise deadlock `server.close()`, which waits
+  // for clients to disconnect on their own.
+  const sockets = new Set<import("node:net").Socket>();
+  server.on("connection", (sock) => {
+    sockets.add(sock);
+    sock.on("close", () => sockets.delete(sock));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fixture server bound to unexpected address");
+  }
+  const port = address.port;
+  return {
+    server,
+    port,
+    close: async () => {
+      for (const sock of sockets) {
+        try {
+          sock.destroy();
+        } catch {
+          /* best effort */
+        }
+      }
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+function makeFakeSignedUrl(port: number): string {
+  // `validateGcsSignedUrl` requires a signature query param; pin a dummy.
+  return `http://127.0.0.1:${port}/bundle?X-Goog-Signature=fake`;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeSmallValidBundlePath(parent: string): string {
+  const { archive } = buildVBundle({
+    files: [
+      {
+        path: "workspace/data/db/assistant.db",
+        data: new TextEncoder().encode("SQLite format 3\0"),
+      },
+      {
+        path: "workspace/config.json",
+        data: new TextEncoder().encode(
+          JSON.stringify({ provider: "anthropic", model: "test-model" }),
+        ),
+      },
+    ],
+  });
+  const bundlePath = join(parent, "fixture-small.vbundle");
+  writeFileSync(bundlePath, archive);
+  return bundlePath;
+}
+
+function makeCorruptBundlePath(parent: string): string {
+  // Random bytes — not a gzip stream, not a tar, nothing the importer can
+  // parse. Drives `validation_failed` inside `streamCommitImport`.
+  const payload = new Uint8Array(4096);
+  for (let i = 0; i < payload.length; i += 1) {
+    payload[i] = Math.floor(Math.random() * 256);
+  }
+  const bundlePath = join(parent, "fixture-corrupt.vbundle");
+  writeFileSync(bundlePath, payload);
+  return bundlePath;
+}
+
+// ---------------------------------------------------------------------------
+// Poll helpers — the registry is in-process so we peek at `getJob` directly
+// until the job leaves the pending/running states.
+// ---------------------------------------------------------------------------
+
+async function pollJobUntilDone(
+  jobId: string,
+  timeoutMs = 30_000,
+): Promise<MigrationJob> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const job = migrationJobs.getJob(jobId);
+    if (!job) {
+      throw new Error(`Job ${jobId} disappeared from the registry`);
+    }
+    if (job.status === "complete" || job.status === "failed") {
+      return job;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Job ${jobId} did not finish within ${timeoutMs}ms`);
+}
+
+// ---------------------------------------------------------------------------
+// Global test-only allowlist: widen the URL validator to accept 127.0.0.1.
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  _setUrlImportValidatorOptionsForTests({
+    allowedHosts: ["127.0.0.1", "storage.googleapis.com"],
+  });
+});
+
+afterAll(() => {
+  _setUrlImportValidatorOptionsForTests(undefined);
+  if (originalWorkspaceDir !== undefined) {
+    process.env.VELLUM_WORKSPACE_DIR = originalWorkspaceDir;
+  }
+});
+
+// Each test gets its own workspace dir so the streaming importer's atomic
+// swap doesn't leak state across tests.
+let testWorkspaceRoot: string;
+let testParent: string;
+
+beforeEach(() => {
+  testWorkspaceRoot = freshWorkspaceRoot();
+  testParent = join(testWorkspaceRoot, "..");
+  setWorkspaceDir(testWorkspaceRoot);
+});
+
+afterEach(() => {
+  try {
+    rmSync(testParent, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Response shape types
+// ---------------------------------------------------------------------------
+
+interface AcceptedResponse {
+  job_id: string;
+  status: "pending";
+  type: "import";
+}
+
+interface ConflictResponse {
+  error: { code: "import_in_progress"; job_id: string };
+}
+
+interface BadRequestResponse {
+  error: { code: string; message: string };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/migrations/import-from-gcs", () => {
+  test("happy path: 202 → job completes with result.report.summary", async () => {
+    const bundlePath = makeSmallValidBundlePath(testParent);
+
+    const fixture = await startFixtureServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/octet-stream" });
+      createReadStream(bundlePath).pipe(res);
+    });
+
+    try {
+      const req = new Request(
+        "http://localhost/v1/migrations/import-from-gcs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
+        },
+      );
+
+      const res = await handleMigrationImportFromGcs(req);
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as AcceptedResponse;
+      expect(body.type).toBe("import");
+      expect(body.status).toBe("pending");
+      expect(typeof body.job_id).toBe("string");
+      expect(body.job_id.length).toBeGreaterThan(0);
+
+      const finalJob = await pollJobUntilDone(body.job_id);
+      expect(finalJob.status).toBe("complete");
+
+      const summary = finalJob.result as {
+        report: {
+          summary: {
+            total_files: number;
+            files_created: number;
+          };
+        };
+      };
+      expect(summary).toBeDefined();
+      expect(summary.report).toBeDefined();
+      expect(summary.report.summary.total_files).toBeGreaterThan(0);
+      expect(summary.report.summary.files_created).toBeGreaterThan(0);
+
+      // Workspace was swapped into place.
+      expect(
+        existsSync(join(testWorkspaceRoot, "data", "db", "assistant.db")),
+      ).toBe(true);
+      expect(existsSync(join(testWorkspaceRoot, "config.json"))).toBe(true);
+    } finally {
+      await fixture.close();
+    }
+  }, 30_000);
+
+  test("upstream 500: job ends failed with fetch_failed + upstreamStatus 500", async () => {
+    const fixture = await startFixtureServer((_req, res) => {
+      res.writeHead(500);
+      res.end("oh no");
+    });
+
+    try {
+      const req = new Request(
+        "http://localhost/v1/migrations/import-from-gcs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
+        },
+      );
+
+      const res = await handleMigrationImportFromGcs(req);
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as AcceptedResponse;
+
+      const finalJob = await pollJobUntilDone(body.job_id);
+      expect(finalJob.status).toBe("failed");
+      expect(finalJob.error?.code).toBe("fetch_failed");
+      expect(finalJob.error?.upstreamStatus).toBe(500);
+    } finally {
+      await fixture.close();
+    }
+  }, 30_000);
+
+  test("corrupt bundle: job ends failed with validation_failed", async () => {
+    const bundlePath = makeCorruptBundlePath(testParent);
+
+    const fixture = await startFixtureServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/octet-stream" });
+      createReadStream(bundlePath).pipe(res);
+    });
+
+    try {
+      const req = new Request(
+        "http://localhost/v1/migrations/import-from-gcs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
+        },
+      );
+
+      const res = await handleMigrationImportFromGcs(req);
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as AcceptedResponse;
+
+      const finalJob = await pollJobUntilDone(body.job_id);
+      expect(finalJob.status).toBe("failed");
+      // The streaming importer maps a mangled archive to
+      // `extraction_failed` (gunzip throws on the random payload before the
+      // tar layer even sees it). Parity with the URL-body path: that path
+      // returns 500 `{ reason: "extraction_failed" }` for the same input,
+      // and `runGcsImport` re-throws it as a `GcsImportError` carrying the
+      // same code.
+      expect(finalJob.error?.code).toBe("extraction_failed");
+    } finally {
+      await fixture.close();
+    }
+  }, 30_000);
+
+  test("second import while first is in flight returns 409", async () => {
+    // A fixture that never responds keeps the first job stuck in `pending`
+    // (the runner is scheduled on a microtask, but the handler's `fetch`
+    // hangs on the open socket). Even `pending` counts as in-flight for
+    // the concurrency check, so the 409 is deterministic regardless of
+    // event-loop timing.
+    const fixture = await startFixtureServer((_req, _res) => {
+      // Intentionally no response — hold the socket open.
+    });
+
+    let firstJobId: string | undefined;
+    try {
+      const firstReq = new Request(
+        "http://localhost/v1/migrations/import-from-gcs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
+        },
+      );
+      const firstRes = await handleMigrationImportFromGcs(firstReq);
+      expect(firstRes.status).toBe(202);
+      const firstBody = (await firstRes.json()) as AcceptedResponse;
+      firstJobId = firstBody.job_id;
+
+      const secondReq = new Request(
+        "http://localhost/v1/migrations/import-from-gcs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
+        },
+      );
+      const secondRes = await handleMigrationImportFromGcs(secondReq);
+      expect(secondRes.status).toBe(409);
+      const secondBody = (await secondRes.json()) as ConflictResponse;
+      expect(secondBody.error.code).toBe("import_in_progress");
+      expect(secondBody.error.job_id).toBe(firstBody.job_id);
+    } finally {
+      // Close the server — this destroys every tracked socket, which
+      // unblocks the first job's `fetch` and lets the runner settle into
+      // `failed`. Wait for that before returning so subsequent tests can
+      // start their own `"import"` job without tripping the registry's
+      // single-in-flight invariant.
+      await fixture.close();
+      if (firstJobId !== undefined) {
+        await pollJobUntilDone(firstJobId);
+      }
+    }
+  }, 30_000);
+
+  test("malformed body (missing bundle_url) returns 400", async () => {
+    const req = new Request("http://localhost/v1/migrations/import-from-gcs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const res = await handleMigrationImportFromGcs(req);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as BadRequestResponse;
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+});

--- a/assistant/src/__tests__/migration-jobs-status.test.ts
+++ b/assistant/src/__tests__/migration-jobs-status.test.ts
@@ -1,0 +1,179 @@
+/**
+ * HTTP-layer tests for GET /v1/migrations/jobs/:job_id.
+ *
+ * Covered:
+ * - 404 `{ error: { code: "job_not_found" } }` for an unknown id.
+ * - `processing` response shape for a job that is still running (runner
+ *   blocked on a deferred gate).
+ * - `complete` response shape including the runner's `result`.
+ * - `failed` response shape — confirms `error_code`, `error` message, and
+ *   the optional `upstream_status` field are all populated when the runner
+ *   throws a `kFetchBodyError`-tagged error with `upstreamStatus`.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  getGatewayPort: () => 7830,
+  getRuntimeHttpPort: () => 7821,
+  getRuntimeHttpHost: () => "127.0.0.1",
+  getRuntimeGatewayOriginSecret: () => undefined,
+  getIngressPublicBaseUrl: () => undefined,
+  setIngressPublicBaseUrl: () => {},
+}));
+
+import { migrationJobs } from "../runtime/migrations/job-registry.js";
+import { handleMigrationJobStatus } from "../runtime/routes/migration-routes.js";
+
+const kFetchBodyError = Symbol.for("vellum.migrationImport.fetchBodyError");
+
+/** Spin the microtask queue so `queueMicrotask`-scheduled work runs. */
+async function flushMicrotasks(n = 4): Promise<void> {
+  for (let i = 0; i < n; i++) {
+    await Promise.resolve();
+  }
+}
+
+function makeRequest(): Request {
+  return new Request("http://127.0.0.1/v1/migrations/jobs/any");
+}
+
+describe("GET /v1/migrations/jobs/:job_id", () => {
+  test("404 job_not_found for unknown id", async () => {
+    const response = await handleMigrationJobStatus(makeRequest(), {
+      job_id: "00000000-0000-0000-0000-000000000000",
+    });
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("job_not_found");
+  });
+
+  test("processing status while the runner is still running", async () => {
+    // Keep the runner blocked so the job stays in `running` state.
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const job = migrationJobs.startJob("export", async () => {
+      await gate;
+      return { ok: true };
+    });
+    // Let `queueMicrotask` flip status from `pending` to `running`.
+    await flushMicrotasks();
+
+    try {
+      const response = await handleMigrationJobStatus(makeRequest(), {
+        job_id: job.id,
+      });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        job_id: string;
+        type: string;
+        status: string;
+      };
+      expect(body.job_id).toBe(job.id);
+      expect(body.type).toBe("export");
+      expect(body.status).toBe("processing");
+    } finally {
+      // Release the runner so the registry's in-flight slot frees up for
+      // other tests (and the job transitions to complete cleanly).
+      release();
+      await flushMicrotasks();
+    }
+  });
+
+  test("complete status includes the runner's result", async () => {
+    const resultPayload = { files_written: 3, manifest: { schema: "vbundle/1" } };
+
+    const job = migrationJobs.startJob("export", async () => resultPayload);
+    await flushMicrotasks();
+
+    const response = await handleMigrationJobStatus(makeRequest(), {
+      job_id: job.id,
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      job_id: string;
+      type: string;
+      status: string;
+      result: unknown;
+    };
+    expect(body.job_id).toBe(job.id);
+    expect(body.type).toBe("export");
+    expect(body.status).toBe("complete");
+    expect(body.result).toEqual(resultPayload);
+  });
+
+  test("failed status exposes error, error_code, and upstream_status", async () => {
+    const job = migrationJobs.startJob("import", async () => {
+      const err = new Error("upstream hung up") as Error & {
+        upstreamStatus?: number;
+      };
+      (err as unknown as Record<symbol, boolean>)[kFetchBodyError] = true;
+      err.upstreamStatus = 502;
+      throw err;
+    });
+    await flushMicrotasks();
+
+    const response = await handleMigrationJobStatus(makeRequest(), {
+      job_id: job.id,
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      job_id: string;
+      type: string;
+      status: string;
+      error: string;
+      error_code: string;
+      upstream_status?: number;
+    };
+    expect(body.job_id).toBe(job.id);
+    expect(body.type).toBe("import");
+    expect(body.status).toBe("failed");
+    expect(body.error).toBe("upstream hung up");
+    expect(body.error_code).toBe("fetch_failed");
+    expect(body.upstream_status).toBe(502);
+  });
+
+  test("failed status omits upstream_status when the runner error has none", async () => {
+    const job = migrationJobs.startJob("export", async () => {
+      const err = new Error("invalid manifest") as Error & { code: string };
+      err.code = "invalid_manifest";
+      throw err;
+    });
+    await flushMicrotasks();
+
+    const response = await handleMigrationJobStatus(makeRequest(), {
+      job_id: job.id,
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("failed");
+    expect(body.error).toBe("invalid manifest");
+    expect(body.error_code).toBe("invalid_manifest");
+    expect(body.upstream_status).toBeUndefined();
+  });
+});

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -445,6 +445,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "migrations/export", scopes: ["settings.write"] },
   { endpoint: "migrations/import-preflight", scopes: ["settings.write"] },
   { endpoint: "migrations/import", scopes: ["settings.write"] },
+  { endpoint: "migrations/jobs", scopes: ["settings.read"] },
 
   // Backups
   { endpoint: "backups", scopes: ["settings.read"] },

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -443,6 +443,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Migrations
   { endpoint: "migrations/validate", scopes: ["settings.read"] },
   { endpoint: "migrations/export", scopes: ["settings.write"] },
+  { endpoint: "migrations/export-to-gcs", scopes: ["settings.write"] },
   { endpoint: "migrations/import-preflight", scopes: ["settings.write"] },
   { endpoint: "migrations/import", scopes: ["settings.write"] },
   { endpoint: "migrations/jobs", scopes: ["settings.read"] },

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -446,6 +446,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "migrations/export-to-gcs", scopes: ["settings.write"] },
   { endpoint: "migrations/import-preflight", scopes: ["settings.write"] },
   { endpoint: "migrations/import", scopes: ["settings.write"] },
+  { endpoint: "migrations/import-from-gcs", scopes: ["settings.write"] },
   { endpoint: "migrations/jobs", scopes: ["settings.read"] },
 
   // Backups

--- a/assistant/src/runtime/http-router.ts
+++ b/assistant/src/runtime/http-router.ts
@@ -106,9 +106,16 @@ export interface RouteDefinition {
    * raw bytes OR JSON URL).
    */
   requestBodies?: RouteRequestBodyVariant[];
-  /** Zod schema for the 200 response body. */
+  /** Zod schema for the success response body. */
   responseBody?: RouteBodySchema;
-  /** Additional non-200 responses documented in the generated OpenAPI spec. */
+  /**
+   * HTTP status code for the documented success response. Defaults to 200.
+   * Set to "202" for async endpoints that enqueue a job and return
+   * immediately — this keeps the generated OpenAPI spec aligned with the
+   * handler's actual `status:` value.
+   */
+  responseStatus?: string;
+  /** Additional response codes documented in the generated OpenAPI spec. */
   additionalResponses?: Record<string, RouteAdditionalResponse>;
 }
 

--- a/assistant/src/runtime/migrations/__tests__/job-registry.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/job-registry.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tests for the in-memory migration job registry.
+ *
+ * Covered:
+ * - Happy path: start -> poll pending -> poll running -> poll complete with result.
+ * - Failure path: runner throws -> job ends in `failed` with mapped error.
+ * - `kFetchBodyError` path: tagged thrown object maps to `fetch_failed` with
+ *   optional `upstreamStatus` preserved.
+ * - Concurrent limit: second export while one is pending/running rejects with
+ *   `JobAlreadyInProgressError`; a job of the other type is allowed alongside.
+ * - TTL sweep: completed job older than the TTL is evicted; job that is not
+ *   yet past TTL is retained.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  JobAlreadyInProgressError,
+  type MigrationJob,
+  MigrationJobRegistry,
+} from "../job-registry.js";
+
+const kFetchBodyError = Symbol.for("vellum.migrationImport.fetchBodyError");
+
+/** Spin the microtask queue N times so `queueMicrotask`-scheduled work runs. */
+async function flushMicrotasks(n = 4): Promise<void> {
+  for (let i = 0; i < n; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("MigrationJobRegistry", () => {
+  test("happy path: pending -> running -> complete with result", async () => {
+    const registry = new MigrationJobRegistry();
+
+    let release: (value: string) => void = () => {};
+    const gate = new Promise<string>((resolve) => {
+      release = resolve;
+    });
+
+    const job = registry.startJob("export", async (): Promise<string> => {
+      return await gate;
+    });
+
+    // Returned synchronously in pending state.
+    expect(job.status).toBe("pending");
+    expect(job.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(job.type).toBe("export");
+    expect(job.createdAt).toBeGreaterThan(0);
+    expect(job.startedAt).toBeUndefined();
+    expect(job.completedAt).toBeUndefined();
+
+    // Let the microtask run -> status flips to running with `startedAt` set.
+    await flushMicrotasks();
+    const running = registry.getJob(job.id);
+    expect(running).not.toBeNull();
+    expect(running!.status).toBe("running");
+    expect(running!.startedAt).toBeGreaterThanOrEqual(running!.createdAt);
+
+    // Resolve the runner and let it settle.
+    release("the-result");
+    await flushMicrotasks();
+
+    const done = registry.getJob(job.id);
+    expect(done).not.toBeNull();
+    expect(done!.status).toBe("complete");
+    expect(done!.result).toBe("the-result");
+    expect(done!.completedAt).toBeGreaterThanOrEqual(done!.startedAt ?? 0);
+    expect(done!.error).toBeUndefined();
+
+    // `listJobs` sees it too.
+    expect(registry.listJobs().map((j) => j.id)).toContain(job.id);
+  });
+
+  test("failure path: runner throws -> failed with mapped error", async () => {
+    const registry = new MigrationJobRegistry();
+    const job = registry.startJob("export", async () => {
+      throw new Error("boom");
+    });
+
+    await flushMicrotasks();
+
+    const done = registry.getJob(job.id);
+    expect(done).not.toBeNull();
+    expect(done!.status).toBe("failed");
+    expect(done!.error).toEqual({ code: "unknown", message: "boom" });
+    expect(done!.result).toBeUndefined();
+    expect(done!.completedAt).toBeGreaterThanOrEqual(done!.startedAt ?? 0);
+  });
+
+  test("runner-provided `code` overrides the default `unknown`", async () => {
+    const registry = new MigrationJobRegistry();
+    const job = registry.startJob("import", async () => {
+      const err = new Error("invalid manifest") as Error & { code: string };
+      err.code = "invalid_manifest";
+      throw err;
+    });
+
+    await flushMicrotasks();
+
+    const done = registry.getJob(job.id);
+    expect(done!.status).toBe("failed");
+    expect(done!.error).toEqual({
+      code: "invalid_manifest",
+      message: "invalid manifest",
+    });
+  });
+
+  test("kFetchBodyError path: tagged error maps to `fetch_failed`", async () => {
+    const registry = new MigrationJobRegistry();
+    const job = registry.startJob("import", async () => {
+      const err = new Error("upstream hung up") as Error & {
+        upstreamStatus?: number;
+      };
+      (err as unknown as Record<symbol, boolean>)[kFetchBodyError] = true;
+      err.upstreamStatus = 502;
+      throw err;
+    });
+
+    await flushMicrotasks();
+
+    const done = registry.getJob(job.id);
+    expect(done).not.toBeNull();
+    expect(done!.status).toBe("failed");
+    expect(done!.error).toEqual({
+      code: "fetch_failed",
+      message: "upstream hung up",
+      upstreamStatus: 502,
+    });
+  });
+
+  test("kFetchBodyError without upstreamStatus omits the field", async () => {
+    const registry = new MigrationJobRegistry();
+    const job = registry.startJob("import", async () => {
+      const err = new Error("aborted") as Error;
+      (err as unknown as Record<symbol, boolean>)[kFetchBodyError] = true;
+      throw err;
+    });
+
+    await flushMicrotasks();
+
+    const done = registry.getJob(job.id)!;
+    expect(done.status).toBe("failed");
+    expect(done.error).toEqual({
+      code: "fetch_failed",
+      message: "aborted",
+    });
+    expect(done.error?.upstreamStatus).toBeUndefined();
+  });
+
+  test("concurrent limit: second same-type job rejects; other type is allowed", async () => {
+    const registry = new MigrationJobRegistry();
+
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    // First export is pending (microtask hasn't run yet) — second export
+    // immediately rejects on the still-pending first job.
+    const first = registry.startJob("export", async () => {
+      await gate;
+    });
+    expect(first.status).toBe("pending");
+
+    expect(() => registry.startJob("export", async () => {})).toThrow(
+      JobAlreadyInProgressError,
+    );
+
+    // Advance to running — a same-type attempt still rejects.
+    await flushMicrotasks();
+    expect(registry.getJob(first.id)!.status).toBe("running");
+
+    let caught: unknown = null;
+    try {
+      registry.startJob("export", async () => {});
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(JobAlreadyInProgressError);
+    expect((caught as JobAlreadyInProgressError).existingJobId).toBe(first.id);
+
+    // A job of the *other* type is allowed in parallel.
+    const importJob = registry.startJob("import", async () => "ok");
+    expect(importJob.type).toBe("import");
+    expect(importJob.id).not.toBe(first.id);
+
+    // Settle both before leaving the test so no promises leak.
+    release();
+    await flushMicrotasks();
+    expect(registry.getJob(first.id)!.status).toBe("complete");
+    expect(registry.getJob(importJob.id)!.status).toBe("complete");
+
+    // And now a new export is allowed since nothing is in flight.
+    const third = registry.startJob("export", async () => "again");
+    expect(third.status).toBe("pending");
+    await flushMicrotasks();
+    expect(registry.getJob(third.id)!.status).toBe("complete");
+  });
+
+  test("returned job snapshots are decoupled from internal registry state", async () => {
+    const registry = new MigrationJobRegistry();
+
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const first = registry.startJob("export", async () => {
+      await gate;
+    });
+
+    // The synchronous return of startJob must be a snapshot, not the
+    // internal record. Mutating it (e.g. to simulate a caller stomping on
+    // `status`) must not unblock the single-in-flight invariant while the
+    // runner is still active.
+    first.status = "complete";
+    first.completedAt = Date.now();
+
+    await flushMicrotasks();
+    // Internal state is still running — the snapshot mutation did not leak.
+    expect(registry.getJob(first.id)!.status).toBe("running");
+
+    // Attempting a second same-type job must still reject.
+    expect(() => registry.startJob("export", async () => {})).toThrow(
+      JobAlreadyInProgressError,
+    );
+
+    // getJob snapshots are also decoupled: mutating the return value of
+    // getJob does not leak into listJobs or subsequent getJob calls.
+    const polled = registry.getJob(first.id)!;
+    polled.status = "failed";
+    expect(registry.getJob(first.id)!.status).toBe("running");
+    expect(registry.listJobs().find((j) => j.id === first.id)!.status).toBe(
+      "running",
+    );
+
+    // Settle.
+    release();
+    await flushMicrotasks();
+    expect(registry.getJob(first.id)!.status).toBe("complete");
+  });
+
+  test("TTL sweep: completed jobs older than TTL are evicted", async () => {
+    const registry = new MigrationJobRegistry();
+    registry.completedJobTtlMs = 1_000; // 1s for test purposes
+
+    const job = registry.startJob("export", async () => "done");
+    await flushMicrotasks();
+    const completed = registry.getJob(job.id)!;
+    expect(completed.status).toBe("complete");
+
+    // Before TTL: sweep is a no-op.
+    const originalNow = Date.now;
+    try {
+      Date.now = () => (completed.completedAt ?? 0) + 500;
+      registry.sweep();
+      expect(registry.getJob(job.id)).not.toBeNull();
+      expect(registry.listJobs().map((j) => j.id)).toContain(job.id);
+
+      // Past TTL: sweep evicts the completed job.
+      Date.now = () => (completed.completedAt ?? 0) + 2_000;
+      registry.sweep();
+      expect(registry.getJob(job.id)).toBeNull();
+      expect(registry.listJobs().map((j) => j.id)).not.toContain(job.id);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  test("TTL sweep: failed jobs are also evicted past TTL", async () => {
+    const registry = new MigrationJobRegistry();
+    registry.completedJobTtlMs = 500;
+
+    const job = registry.startJob("import", async () => {
+      throw new Error("nope");
+    });
+    await flushMicrotasks();
+    const failed = registry.getJob(job.id)!;
+    expect(failed.status).toBe("failed");
+
+    const originalNow = Date.now;
+    try {
+      Date.now = () => (failed.completedAt ?? 0) + 10_000;
+      registry.sweep();
+      expect(registry.getJob(job.id)).toBeNull();
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  test("TTL sweep: running jobs are never evicted", async () => {
+    const registry = new MigrationJobRegistry();
+    registry.completedJobTtlMs = 1;
+
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const job = registry.startJob("export", async () => {
+      await gate;
+    });
+    await flushMicrotasks();
+    expect(registry.getJob(job.id)!.status).toBe("running");
+
+    const originalNow = Date.now;
+    try {
+      Date.now = () => Number.MAX_SAFE_INTEGER;
+      registry.sweep();
+      expect(registry.getJob(job.id)).not.toBeNull();
+    } finally {
+      Date.now = originalNow;
+    }
+
+    // Cleanup: let the runner resolve.
+    release();
+    await flushMicrotasks();
+  });
+
+  test("getJob returns null for unknown ids", () => {
+    const registry = new MigrationJobRegistry();
+    expect(registry.getJob("nope")).toBeNull();
+  });
+
+  test("JobAlreadyInProgressError carries the existing job id", () => {
+    const err = new JobAlreadyInProgressError("export", "abc-123");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("JobAlreadyInProgressError");
+    expect(err.existingJobId).toBe("abc-123");
+    expect(err.message).toContain("export");
+    expect(err.message).toContain("abc-123");
+  });
+
+  test("MigrationJob interface shape is preserved on success", async () => {
+    const registry = new MigrationJobRegistry();
+    const job = registry.startJob("export", async () => ({ bytes: 42 }));
+    await flushMicrotasks();
+    const done: MigrationJob = registry.getJob(job.id)!;
+    expect(done.id).toBe(job.id);
+    expect(done.type).toBe("export");
+    expect(done.status).toBe("complete");
+    expect(done.result).toEqual({ bytes: 42 });
+  });
+});

--- a/assistant/src/runtime/migrations/job-registry.ts
+++ b/assistant/src/runtime/migrations/job-registry.ts
@@ -1,0 +1,281 @@
+/**
+ * In-memory registry for async migration jobs (export/import).
+ *
+ * Each job has a UUID, a type, a lifecycle (`pending` -> `running` ->
+ * `complete`/`failed`), and optional result/error payloads. Runners are
+ * scheduled with `queueMicrotask` so `startJob` returns synchronously and
+ * callers can immediately poll the job record.
+ *
+ * At most one job of each `MigrationJobType` may be in-flight at a time;
+ * attempting to start a second one while another is pending or running
+ * rejects with `JobAlreadyInProgressError`.
+ *
+ * Completed/failed jobs are kept for `completedJobTtlMs` (default 10
+ * minutes) so clients can still fetch the final status after the runner
+ * finishes, then evicted by `sweep()` which is wired to a periodic
+ * `setInterval` on the singleton. The interval is `unref()`'d so it does
+ * not block process shutdown.
+ */
+
+import { randomUUID } from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type MigrationJobType = "export" | "import";
+
+export type MigrationJobStatus = "pending" | "running" | "complete" | "failed";
+
+export interface MigrationJobError {
+  code: string;
+  message: string;
+  upstreamStatus?: number;
+}
+
+export interface MigrationJob {
+  id: string;
+  type: MigrationJobType;
+  status: MigrationJobStatus;
+  createdAt: number;
+  startedAt?: number;
+  completedAt?: number;
+  error?: MigrationJobError;
+  result?: unknown;
+}
+
+/**
+ * Thrown by `MigrationJobRegistry.startJob` when a job of the same type
+ * is already pending or running.
+ */
+export class JobAlreadyInProgressError extends Error {
+  public readonly existingJobId: string;
+
+  constructor(type: MigrationJobType, existingJobId: string) {
+    super(
+      `A ${type} migration job is already in progress (id=${existingJobId}).`,
+    );
+    this.name = "JobAlreadyInProgressError";
+    this.existingJobId = existingJobId;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// kFetchBodyError — preserve the tag convention used by the URL-body import
+// path in `routes/migration-routes.ts`. An error object carrying this symbol
+// was thrown from a failed upstream fetch body; we translate it into
+// `error.code = "fetch_failed"` for clients.
+// ---------------------------------------------------------------------------
+
+const kFetchBodyError = Symbol.for("vellum.migrationImport.fetchBodyError");
+
+function isFetchBodyError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  return (err as unknown as Record<symbol, boolean>)[kFetchBodyError] === true;
+}
+
+function extractUpstreamStatus(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  const status = (err as { upstreamStatus?: unknown }).upstreamStatus;
+  return typeof status === "number" ? status : undefined;
+}
+
+function mapError(err: unknown): MigrationJobError {
+  const message =
+    err instanceof Error
+      ? err.message
+      : typeof err === "object" &&
+          err !== null &&
+          "message" in err &&
+          typeof (err as { message?: unknown }).message === "string"
+        ? (err as { message: string }).message
+        : String(err);
+
+  if (isFetchBodyError(err)) {
+    const mapped: MigrationJobError = {
+      code: "fetch_failed",
+      message,
+    };
+    const upstreamStatus = extractUpstreamStatus(err);
+    if (upstreamStatus !== undefined) {
+      mapped.upstreamStatus = upstreamStatus;
+    }
+    return mapped;
+  }
+
+  // Runner-provided override: `err.code` wins over the `"unknown"` default
+  // so callers that throw typed errors get their codes preserved.
+  const overrideCode =
+    typeof err === "object" &&
+    err !== null &&
+    typeof (err as { code?: unknown }).code === "string"
+      ? (err as { code: string }).code
+      : undefined;
+
+  const mapped: MigrationJobError = {
+    code: overrideCode ?? "unknown",
+    message,
+  };
+  const upstreamStatus = extractUpstreamStatus(err);
+  if (upstreamStatus !== undefined) {
+    mapped.upstreamStatus = upstreamStatus;
+  }
+  return mapped;
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Default TTL for completed/failed jobs before `sweep()` evicts them.
+ * Exposed as a class field so tests can override the singleton's value.
+ */
+const DEFAULT_COMPLETED_JOB_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Return a shallow clone of a `MigrationJob` that is decoupled from the
+ * internal registry record. The optional `error` object is spread so
+ * callers cannot mutate the stored error either. `result` is `unknown` by
+ * design — callers that pass mutable values in and then mutate them
+ * externally are already outside the registry's invariants.
+ */
+function cloneJob(job: MigrationJob): MigrationJob {
+  const snapshot: MigrationJob = {
+    id: job.id,
+    type: job.type,
+    status: job.status,
+    createdAt: job.createdAt,
+  };
+  if (job.startedAt !== undefined) snapshot.startedAt = job.startedAt;
+  if (job.completedAt !== undefined) snapshot.completedAt = job.completedAt;
+  if (job.error !== undefined) snapshot.error = { ...job.error };
+  if (job.result !== undefined) snapshot.result = job.result;
+  return snapshot;
+}
+
+export class MigrationJobRegistry {
+  private readonly jobs = new Map<string, MigrationJob>();
+  /** Tracks the single in-flight (pending or running) job id per type. */
+  private readonly inFlight = new Map<MigrationJobType, string>();
+
+  /** TTL for completed/failed jobs; mutable so tests can tighten it. */
+  public completedJobTtlMs: number = DEFAULT_COMPLETED_JOB_TTL_MS;
+
+  /**
+   * Start a new migration job. Returns a snapshot of the `MigrationJob`
+   * record synchronously (status `"pending"`); the runner is scheduled via
+   * `queueMicrotask` so the caller can poll via `getJob(id)` immediately.
+   *
+   * The returned object is a shallow clone decoupled from the internal
+   * record so that external mutation cannot violate the single-in-flight
+   * invariant (e.g. flipping a running job's status to `"complete"` must
+   * not unblock a same-type `startJob` while the runner is still active).
+   *
+   * Throws `JobAlreadyInProgressError` if another job of the same type is
+   * already pending or running.
+   */
+  public startJob<T>(
+    type: MigrationJobType,
+    runner: (job: MigrationJob) => Promise<T>,
+  ): MigrationJob {
+    const existingId = this.inFlight.get(type);
+    if (existingId !== undefined) {
+      const existing = this.jobs.get(existingId);
+      if (
+        existing &&
+        (existing.status === "pending" || existing.status === "running")
+      ) {
+        throw new JobAlreadyInProgressError(type, existingId);
+      }
+      // Stale entry (e.g. sweep raced with a new start) — clear it.
+      this.inFlight.delete(type);
+    }
+
+    const job: MigrationJob = {
+      id: randomUUID(),
+      type,
+      status: "pending",
+      createdAt: Date.now(),
+    };
+    this.jobs.set(job.id, job);
+    this.inFlight.set(type, job.id);
+
+    queueMicrotask(() => {
+      job.status = "running";
+      job.startedAt = Date.now();
+      Promise.resolve()
+        .then(() => runner(job))
+        .then(
+          (result) => {
+            job.status = "complete";
+            job.completedAt = Date.now();
+            job.result = result;
+            if (this.inFlight.get(type) === job.id) {
+              this.inFlight.delete(type);
+            }
+          },
+          (err: unknown) => {
+            job.status = "failed";
+            job.completedAt = Date.now();
+            job.error = mapError(err);
+            if (this.inFlight.get(type) === job.id) {
+              this.inFlight.delete(type);
+            }
+          },
+        );
+    });
+
+    return cloneJob(job);
+  }
+
+  public getJob(id: string): MigrationJob | null {
+    const job = this.jobs.get(id);
+    return job ? cloneJob(job) : null;
+  }
+
+  public listJobs(): MigrationJob[] {
+    return Array.from(this.jobs.values(), cloneJob);
+  }
+
+  /**
+   * Drop completed/failed jobs whose `completedAt` is older than
+   * `completedJobTtlMs`. Pending/running jobs are always retained.
+   */
+  public sweep(): void {
+    const now = Date.now();
+    for (const [id, job] of this.jobs) {
+      if (job.status !== "complete" && job.status !== "failed") continue;
+      const completedAt = job.completedAt;
+      if (completedAt === undefined) continue;
+      if (now - completedAt >= this.completedJobTtlMs) {
+        this.jobs.delete(id);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton + sweep interval
+// ---------------------------------------------------------------------------
+
+/** Process-wide registry used by migration routes. */
+export const migrationJobs = new MigrationJobRegistry();
+
+/**
+ * How often the sweep runs. The singleton wires this via `setInterval`;
+ * the interval is `unref()`'d so it does not keep the event loop alive
+ * during shutdown. Tests that need to stop the interval can call
+ * `clearInterval(sweepIntervalId)`.
+ */
+const SWEEP_INTERVAL_MS = 60 * 1000;
+
+export const sweepIntervalId: NodeJS.Timeout = setInterval(() => {
+  migrationJobs.sweep();
+}, SWEEP_INTERVAL_MS);
+
+// `.unref()` exists on Node/Bun Timeout objects. Guard defensively in case
+// an alternative runtime returns a plain number.
+if (typeof (sweepIntervalId as { unref?: () => void }).unref === "function") {
+  (sweepIntervalId as { unref: () => void }).unref();
+}

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -47,6 +47,7 @@ import {
   validateGcsSignedUrl,
   type ValidateGcsSignedUrlOptions,
 } from "../migrations/gcs-signed-url.js";
+import { migrationJobs } from "../migrations/job-registry.js";
 import { streamExportVBundle } from "../migrations/vbundle-builder.js";
 import {
   analyzeImport,
@@ -1134,6 +1135,70 @@ function importCommitFailureResponse(
 }
 
 // ---------------------------------------------------------------------------
+// GET /v1/migrations/jobs/:job_id
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /v1/migrations/jobs/:job_id
+ *
+ * Returns the current status of a migration job tracked by
+ * `MigrationJobRegistry`. The response shape is a discriminated union on
+ * `status`:
+ *
+ *   - `{ job_id, type, status: "processing" }`
+ *     Covers both the internal `pending` and `running` states — collapsed
+ *     into a single wire value to match the platform's transport shape used
+ *     by `ExportStatusProcessingSerializer` / `ImportStatusProcessingSerializer`.
+ *   - `{ job_id, type, status: "complete", result }`
+ *   - `{ job_id, type, status: "failed", error, error_code, upstream_status? }`
+ *
+ * 404 `{ error: { code: "job_not_found" } }` when no job matches the id.
+ */
+export async function handleMigrationJobStatus(
+  _req: Request,
+  params: { job_id: string },
+): Promise<Response> {
+  const job = migrationJobs.getJob(params.job_id);
+  if (job === null) {
+    return Response.json(
+      { error: { code: "job_not_found" } },
+      { status: 404 },
+    );
+  }
+
+  if (job.status === "complete") {
+    return Response.json({
+      job_id: job.id,
+      type: job.type,
+      status: "complete",
+      result: job.result,
+    });
+  }
+
+  if (job.status === "failed") {
+    const error = job.error;
+    const body: Record<string, unknown> = {
+      job_id: job.id,
+      type: job.type,
+      status: "failed",
+      error: error?.message ?? "unknown",
+      error_code: error?.code ?? "unknown",
+    };
+    if (error?.upstreamStatus !== undefined) {
+      body.upstream_status = error.upstreamStatus;
+    }
+    return Response.json(body);
+  }
+
+  // pending or running — collapse to the platform's "processing" wire value.
+  return Response.json({
+    job_id: job.id,
+    type: job.type,
+    status: "processing",
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
 
@@ -1250,6 +1315,56 @@ export function migrationRouteDefinitions(): RouteDefinition[] {
         warnings: z.array(z.unknown()),
       }),
       handler: async ({ req }) => handleMigrationImport(req),
+    },
+    {
+      endpoint: "migrations/jobs/:job_id",
+      method: "GET",
+      summary: "Get migration job status",
+      description:
+        "Return the current status of an async migration job (export or import). The response discriminates on `status`: `processing` (pending or running), `complete` (with `result`), or `failed` (with `error`, `error_code`, optional `upstream_status`). The `processing` value mirrors the platform's transport shape so CLI clients can share a single parser across the platform and the daemon.",
+      tags: ["migrations"],
+      responseBody: z.discriminatedUnion("status", [
+        z.object({
+          job_id: z.string(),
+          type: z.enum(["export", "import"]),
+          status: z.literal("processing"),
+        }),
+        z.object({
+          job_id: z.string(),
+          type: z.enum(["export", "import"]),
+          status: z.literal("complete"),
+          result: z.unknown(),
+        }),
+        z.object({
+          job_id: z.string(),
+          type: z.enum(["export", "import"]),
+          status: z.literal("failed"),
+          error: z.string(),
+          error_code: z.string(),
+          upstream_status: z.number().int().optional(),
+        }),
+      ]),
+      additionalResponses: {
+        "404": {
+          description:
+            "No job matches the given id. Body shape: { error: { code: 'job_not_found' } }.",
+          schema: {
+            type: "object",
+            properties: {
+              error: {
+                type: "object",
+                properties: {
+                  code: { type: "string", enum: ["job_not_found"] },
+                },
+                required: ["code"],
+              },
+            },
+            required: ["error"],
+          },
+        },
+      },
+      handler: ({ req, params }) =>
+        handleMigrationJobStatus(req, { job_id: params.job_id }),
     },
   ];
 }

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -935,12 +935,14 @@ export function _setUrlImportValidatorOptionsForTests(
 }
 
 /**
- * Successful outcome of `runGcsImport`. Mirrors the inputs that
- * `importCommitSuccessResponse` expects so callers can feed it straight
- * into a Response builder OR return it as an async-job `result`.
+ * Successful outcome of `runGcsImport`. Mirrors the wire shape produced by
+ * `importCommitSuccessResponse` (report fields spread at the top level, with
+ * an optional `credentialsImported` summary alongside) so the same value can
+ * be serialized directly as a Response body OR stashed as an async-job
+ * `result` — both the sync endpoint and the async job-status endpoint then
+ * hand the CLI a single, identical `ImportResponse`-compatible shape.
  */
-export interface ImportSummary {
-  report: ImportCommitReport;
+export interface ImportSummary extends ImportCommitReport {
   credentialsImported?: CredentialImportSummary;
 }
 
@@ -1312,8 +1314,8 @@ export async function runGcsImport(
   );
 
   return credentialsImported
-    ? { report: result.report, credentialsImported }
-    : { report: result.report };
+    ? { ...result.report, credentialsImported }
+    : { ...result.report };
 }
 
 /**
@@ -1347,10 +1349,8 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
 
   try {
     const summary = await runGcsImport(parsed.data.url);
-    return importCommitSuccessResponse(
-      summary.report,
-      summary.credentialsImported,
-    );
+    const { credentialsImported, ...report } = summary;
+    return importCommitSuccessResponse(report, credentialsImported);
   } catch (err) {
     return gcsImportErrorToUrlBodyResponse(err);
   }

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -1452,6 +1452,29 @@ export async function handleMigrationImportFromGcs(
 
   const { bundle_url } = parsed.data;
 
+  // Synchronously validate the GCS URL before consuming the single
+  // in-flight import slot. Mirrors `handleMigrationExportToGcs`: an
+  // invalid-but-syntactically-valid URL (wrong host/scheme, missing
+  // signature) must be rejected with 400 here so a correct retry isn't
+  // blocked behind a doomed async job that only fails once the runner
+  // re-validates inside `runGcsImport`. Never log the raw URL.
+  const validated = validateGcsSignedUrl(bundle_url, urlValidatorOptions);
+  if (!validated.ok) {
+    log.warn(
+      { reason: validated.reason },
+      "Rejected migration import-from-gcs bundle URL",
+    );
+    return Response.json(
+      {
+        error: {
+          code: "invalid_bundle_url",
+          reason: validated.reason,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
   try {
     const job = migrationJobs.startJob("import", async (jobRecord) =>
       runGcsImport(bundle_url, jobRecord.id),

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -47,7 +47,10 @@ import {
   validateGcsSignedUrl,
   type ValidateGcsSignedUrlOptions,
 } from "../migrations/gcs-signed-url.js";
-import { migrationJobs } from "../migrations/job-registry.js";
+import {
+  JobAlreadyInProgressError,
+  migrationJobs,
+} from "../migrations/job-registry.js";
 import { streamExportVBundle } from "../migrations/vbundle-builder.js";
 import {
   analyzeImport,
@@ -315,6 +318,291 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
       500,
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/migrations/export-to-gcs — async export streamed to a signed URL
+// ---------------------------------------------------------------------------
+
+/** 60 minutes — matches the URL-body import fetch deadline. */
+const EXPORT_TO_GCS_PUT_TIMEOUT_MS = 60 * 60 * 1000;
+
+const MigrationExportToGcsBody = z.object({
+  upload_url: z.string().url(),
+  description: z.string().optional(),
+});
+
+/**
+ * Collected credentials plus a warning marker if the credential store was
+ * unreachable. The caller surfaces the warning in logs; production callers
+ * fail closed on errors (a thrown exception → 500) to avoid shipping a
+ * bundle with partial credentials. An unreachable store is NOT an error —
+ * `handleMigrationExport` treats that case as "export without credentials".
+ */
+interface CollectedCredentials {
+  credentials: Array<{ account: string; value: string }>;
+  unreachable: boolean;
+}
+
+/**
+ * Mirror of the credential-collection block inside `handleMigrationExport`.
+ * Factored out so the new async export-to-gcs handler can share the exact
+ * same behavior. Throws if the credential store raises an unexpected error —
+ * the caller translates that into a 500 (fail closed on credential errors).
+ */
+async function collectExportCredentials(): Promise<CollectedCredentials> {
+  const credentialList = await listSecureKeysAsync();
+  if (credentialList.unreachable) {
+    log.warn(
+      "Credential store is unreachable — export will not include credentials",
+    );
+    return { credentials: [], unreachable: true };
+  }
+  const credentials: Array<{ account: string; value: string }> = [];
+  for (const account of credentialList.accounts) {
+    const result = await getSecureKeyResultAsync(account);
+    if (result.unreachable) {
+      log.warn(
+        { account },
+        "Credential store unreachable when reading credential — skipping",
+      );
+    } else if (result.value != null) {
+      credentials.push({ account, value: result.value });
+    }
+  }
+  return { credentials, unreachable: false };
+}
+
+/**
+ * POST /v1/migrations/export-to-gcs
+ *
+ * Starts an async export job that streams a freshly-built .vbundle archive
+ * to a GCS signed PUT URL. Returns `202 Accepted` with a `job_id` the caller
+ * can poll via the job-status endpoint; the bundle upload runs in the
+ * background via `migrationJobs`.
+ *
+ * Request body (JSON):
+ *   { upload_url: string, description?: string }
+ *
+ * Responses:
+ *   202: { job_id, status: "pending", type: "export" }
+ *   400: { error: { code: "invalid_upload_url", reason } } — URL failed
+ *        `validateGcsSignedUrl` (scheme/host/signature/traversal).
+ *   409: { error: { code: "export_in_progress", job_id } } — another export
+ *        job is already pending or running.
+ *   500: Standard error envelope for credential-collection failures or
+ *        other unexpected errors before the job is enqueued.
+ *
+ * Terminal job state (surfaced via the job-status endpoint once poll lands):
+ *   result: { size, sha256, schemaVersion, credentialsIncluded }
+ *   error.code = "upload_failed" with `upstreamStatus` on non-2xx PUT
+ *   error.code = "fetch_failed" on transport errors from the PUT itself.
+ *
+ * Auth: settings.write scope (matches `migrations/export`).
+ */
+export async function handleMigrationExportToGcs(
+  req: Request,
+): Promise<Response> {
+  // ── 1. Parse JSON body ────────────────────────────────────────────────
+  let rawBody: unknown;
+  try {
+    rawBody = await req.json();
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to parse JSON body on migration export-to-gcs request",
+    );
+    return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+  }
+
+  const parsed = MigrationExportToGcsBody.safeParse(rawBody);
+  if (!parsed.success) {
+    return httpError(
+      "BAD_REQUEST",
+      "Request body must be { upload_url: string, description?: string } with a valid URL",
+      400,
+    );
+  }
+
+  // ── 2. Validate the upload URL. Never log `parsed.data.upload_url`.
+  const validated = validateGcsSignedUrl(
+    parsed.data.upload_url,
+    urlValidatorOptions,
+  );
+  if (!validated.ok) {
+    log.warn(
+      { reason: validated.reason },
+      "Rejected migration export-to-gcs upload URL",
+    );
+    return Response.json(
+      {
+        error: {
+          code: "invalid_upload_url",
+          reason: validated.reason,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  log.info(
+    { host: validated.host, path: validated.path },
+    "migration export to GCS starting",
+  );
+
+  // ── 3. Collect credentials up front. Fail closed → 500.
+  let collected: CollectedCredentials;
+  try {
+    collected = await collectExportCredentials();
+  } catch (err) {
+    log.error({ err }, "Failed to collect credentials for export-to-gcs");
+    return httpError(
+      "INTERNAL_ERROR",
+      err instanceof Error ? err.message : "Failed to collect credentials",
+      500,
+    );
+  }
+
+  const description = parsed.data.description;
+  const uploadUrl = parsed.data.upload_url;
+
+  // ── 4. Enqueue the job. The runner captures the collected credentials.
+  let job;
+  try {
+    job = migrationJobs.startJob("export", async () => {
+      let cleanup: (() => Promise<void>) | undefined;
+      try {
+        const result = await streamExportVBundle({
+          workspaceDir: getWorkspaceDir(),
+          source: "runtime-export",
+          description,
+          credentials: collected.credentials,
+          checkpoint: () => {
+            const dbPath = getDbPath();
+            try {
+              const db = new Database(dbPath);
+              try {
+                db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+              } finally {
+                db.close();
+              }
+            } catch (err) {
+              log.warn(
+                { err },
+                "WAL checkpoint failed — exporting without checkpoint",
+              );
+            }
+          },
+        });
+
+        cleanup = result.cleanup;
+        const { tempPath, size, manifest } = result;
+
+        // Stream the temp file to GCS via PUT. Using Node's ReadableStream
+        // bridge keeps peak memory bounded — we do NOT load the archive
+        // into memory.
+        const fileStream = createReadStream(tempPath);
+        const webBody = Readable.toWeb(
+          fileStream,
+        ) as unknown as ReadableStream<Uint8Array>;
+
+        let response: Response;
+        try {
+          response = await fetch(uploadUrl, {
+            method: "PUT",
+            body: webBody,
+            // `duplex: "half"` is required when sending a streaming body
+            // via fetch in Node/Bun — without it the platform rejects the
+            // request as "duplex option is required when body is a
+            // ReadableStream".
+            duplex: "half",
+            // `validateGcsSignedUrl` only vets the initial URL. If the
+            // upstream responds with a 3xx, default fetch would follow
+            // the redirect and PUT bytes to an attacker-controlled host.
+            // Refuse redirects so the signed URL's origin is the only
+            // destination for the export archive.
+            redirect: "error",
+            headers: {
+              "Content-Type": "application/octet-stream",
+              "Content-Length": String(size),
+            },
+            signal: AbortSignal.timeout(EXPORT_TO_GCS_PUT_TIMEOUT_MS),
+          } as RequestInit & { duplex: "half" });
+        } catch (err) {
+          // Transport-level fetch failures (DNS, reset, abort) — tag them
+          // with the fetch-body marker so the registry maps them to
+          // `error.code = "fetch_failed"` and logs stay consistent with
+          // the import URL path.
+          const wrapped = err instanceof Error ? err : new Error(String(err));
+          tagFetchBodyError(wrapped as NodeJS.ErrnoException);
+          (wrapped as { code?: string }).code = "fetch_failed";
+          throw wrapped;
+        }
+
+        if (!response.ok) {
+          // Drain so the socket is released promptly. Ignore drain errors.
+          try {
+            await response.body?.cancel();
+          } catch {
+            /* best-effort */
+          }
+          const uploadErr = new Error(
+            `Upload to GCS failed with status ${response.status}`,
+          );
+          (uploadErr as { code?: string }).code = "upload_failed";
+          (uploadErr as { upstreamStatus?: number }).upstreamStatus =
+            response.status;
+          throw uploadErr;
+        }
+
+        return {
+          size,
+          sha256: manifest.manifest_sha256,
+          schemaVersion: manifest.schema_version,
+          credentialsIncluded: collected.credentials.length,
+        };
+      } finally {
+        // Mirror the raw-bytes export cleanup pattern: the stream's
+        // `close` listener is the happy-path cleanup in that handler, but
+        // here we keep everything in the async block, so a finally is the
+        // right place to evict the temp file regardless of outcome.
+        if (cleanup) {
+          try {
+            await cleanup();
+          } catch (err) {
+            log.warn({ err }, "Failed to clean up export-to-gcs temp file");
+          }
+        }
+      }
+    });
+  } catch (err) {
+    if (err instanceof JobAlreadyInProgressError) {
+      return Response.json(
+        {
+          error: {
+            code: "export_in_progress",
+            job_id: err.existingJobId,
+          },
+        },
+        { status: 409 },
+      );
+    }
+    log.error({ err }, "Unexpected error while enqueueing export-to-gcs job");
+    return httpError(
+      "INTERNAL_ERROR",
+      err instanceof Error ? err.message : "Unexpected export-to-gcs error",
+      500,
+    );
+  }
+
+  return Response.json(
+    {
+      job_id: job.id,
+      status: "pending" as const,
+      type: "export" as const,
+    },
+    { status: 202 },
+  );
 }
 
 /**
@@ -1315,6 +1603,31 @@ export function migrationRouteDefinitions(): RouteDefinition[] {
         warnings: z.array(z.unknown()),
       }),
       handler: async ({ req }) => handleMigrationImport(req),
+    },
+    {
+      endpoint: "migrations/export-to-gcs",
+      method: "POST",
+      summary: "Start an async export streamed to a GCS signed URL",
+      description:
+        "Kick off a background export job that PUTs a freshly-built .vbundle archive to the supplied GCS signed URL. Returns 202 with a job_id the caller can poll via the job-status endpoint. Fails fast with 409 if another export job is already pending or running.",
+      tags: ["migrations"],
+      requestBody: z.object({
+        upload_url: z
+          .string()
+          .url()
+          .describe("Signed GCS PUT URL that receives the exported bundle."),
+        description: z
+          .string()
+          .optional()
+          .describe("Human-readable export description."),
+      }),
+      responseStatus: "202",
+      responseBody: z.object({
+        job_id: z.string(),
+        status: z.literal("pending"),
+        type: z.literal("export"),
+      }),
+      handler: async ({ req }) => handleMigrationExportToGcs(req),
     },
     {
       endpoint: "migrations/jobs/:job_id",

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -869,13 +869,16 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
 }
 
 // ---------------------------------------------------------------------------
-// URL-body variant of POST /v1/migrations/import
+// GCS URL import pipeline — shared by the URL-body branch of
+// POST /v1/migrations/import and POST /v1/migrations/import-from-gcs.
 // ---------------------------------------------------------------------------
 
 /** 60 minutes — matches the gateway's upstream fetch deadline. */
 const URL_FETCH_TIMEOUT_MS = 60 * 60 * 1000;
 
 const MigrationImportUrlBody = z.object({ url: z.string().min(1) });
+
+const MigrationImportFromGcsBody = z.object({ bundle_url: z.string().url() });
 
 /**
  * Marker attached to errors that originate from the upstream HTTP body
@@ -932,43 +935,96 @@ export function _setUrlImportValidatorOptionsForTests(
 }
 
 /**
- * Handle a JSON `{ "url": "..." }` body on POST /v1/migrations/import.
- *
- * Fetches the signed URL, pipes the response body through the streaming
- * importer, and returns the same response shapes as the raw-bytes path.
- * The signed URL is never logged or included in error responses — only the
- * extracted host and path make it into logs.
+ * Successful outcome of `runGcsImport`. Mirrors the inputs that
+ * `importCommitSuccessResponse` expects so callers can feed it straight
+ * into a Response builder OR return it as an async-job `result`.
  */
-async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
-  // ── 1. Parse JSON body ────────────────────────────────────────────────
-  let rawBody: unknown;
-  try {
-    rawBody = await req.json();
-  } catch (err) {
-    log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
-      "Failed to parse JSON body on migration import URL request",
-    );
-    return httpError("BAD_REQUEST", "Invalid JSON body", 400);
-  }
+export interface ImportSummary {
+  report: ImportCommitReport;
+  credentialsImported?: CredentialImportSummary;
+}
 
-  const parsed = MigrationImportUrlBody.safeParse(rawBody);
-  if (!parsed.success) {
-    return httpError(
-      "BAD_REQUEST",
-      "Request body must be { url: string } with a non-empty url",
-      400,
-    );
-  }
+/**
+ * Structured error thrown by `runGcsImport`. Carries the information needed
+ * to reconstruct the URL-body handler's legacy Response shapes and for the
+ * async-job registry to map to `error.code`/`upstreamStatus`.
+ */
+interface GcsImportErrorInit {
+  code:
+    | "invalid_url"
+    | "fetch_failed"
+    | "validation_failed"
+    | "extraction_failed"
+    | "write_failed";
+  message: string;
+  upstreamStatus?: number;
+  reason?: string;
+  errors?: Array<{ code: string; message: string; path?: string }>;
+  partial_report?: ImportCommitReport;
+}
 
-  // ── 2. Validate the URL (defense-in-depth; never log `parsed.data.url`).
-  const validated = validateGcsSignedUrl(parsed.data.url, urlValidatorOptions);
+class GcsImportError extends Error {
+  public readonly code: GcsImportErrorInit["code"];
+  public readonly upstreamStatus?: number;
+  public readonly reason?: string;
+  public readonly errors?: GcsImportErrorInit["errors"];
+  public readonly partial_report?: ImportCommitReport;
+
+  constructor(init: GcsImportErrorInit) {
+    super(init.message);
+    this.name = "GcsImportError";
+    this.code = init.code;
+    if (init.upstreamStatus !== undefined) {
+      this.upstreamStatus = init.upstreamStatus;
+    }
+    if (init.reason !== undefined) {
+      this.reason = init.reason;
+    }
+    if (init.errors !== undefined) {
+      this.errors = init.errors;
+    }
+    if (init.partial_report !== undefined) {
+      this.partial_report = init.partial_report;
+    }
+  }
+}
+
+/**
+ * Fetch a .vbundle from a signed GCS URL and commit it via the streaming
+ * importer. On success, returns an `ImportSummary` the caller can serialize
+ * into a Response or stash as an async-job `result`. On failure, throws a
+ * `GcsImportError`:
+ *
+ *   - `invalid_url`        → URL failed `validateGcsSignedUrl` (pre-fetch).
+ *   - `fetch_failed`       → upstream fetch error, non-2xx response, missing
+ *                            body, OR a mid-stream body teardown tagged via
+ *                            `kFetchBodyError`. `upstreamStatus` is populated
+ *                            for non-2xx responses.
+ *   - `validation_failed`  → the bundle failed schema/structural validation
+ *                            inside `streamCommitImport`; `errors` carries
+ *                            the per-issue list.
+ *   - `extraction_failed`  → bundle extraction threw (malformed archive, hash
+ *                            mismatch, etc.) that was NOT an upstream tear-
+ *                            down. `reason` carries the importer's string.
+ *   - `write_failed`       → post-extraction disk write error; `partial_report`
+ *                            is attached when the importer produced one.
+ *
+ * The signed URL is never echoed into errors or logs — only the extracted
+ * `host`/`path` are.
+ */
+export async function runGcsImport(
+  url: string,
+  _correlationId?: string,
+): Promise<ImportSummary> {
+  // ── 1. Validate the URL (defense-in-depth; never log the raw URL).
+  const validated = validateGcsSignedUrl(url, urlValidatorOptions);
   if (!validated.ok) {
-    // `reason` is a stable enum string and safe to include. The raw URL is
-    // not — it may contain a live signature. Callers get the reason so they
-    // can correct the URL without leaking anything into observability.
     log.warn({ reason: validated.reason }, "Rejected migration import URL");
-    return httpError("BAD_REQUEST", `Invalid URL: ${validated.reason}`, 400);
+    throw new GcsImportError({
+      code: "invalid_url",
+      message: `Invalid URL: ${validated.reason}`,
+      reason: validated.reason,
+    });
   }
 
   log.info(
@@ -978,10 +1034,10 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
 
   const startedAt = Date.now();
 
-  // ── 3. Fetch the URL ──────────────────────────────────────────────────
+  // ── 2. Fetch the URL ──────────────────────────────────────────────────
   let upstream: Response;
   try {
-    upstream = await fetch(parsed.data.url, {
+    upstream = await fetch(url, {
       signal: AbortSignal.timeout(URL_FETCH_TIMEOUT_MS),
       // SSRF guard: `validateGcsSignedUrl` only vetted the initial URL.
       // Default fetch behavior follows 3xx responses, which would let a
@@ -999,10 +1055,10 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
       },
       "Failed to fetch migration import URL",
     );
-    return Response.json(
-      { success: false, reason: "fetch_failed" },
-      { status: 502 },
-    );
+    throw new GcsImportError({
+      code: "fetch_failed",
+      message: err instanceof Error ? err.message : String(err),
+    });
   }
 
   if (!upstream.ok) {
@@ -1020,14 +1076,11 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
     } catch {
       /* best effort */
     }
-    return Response.json(
-      {
-        success: false,
-        reason: "fetch_failed",
-        upstream_status: upstream.status,
-      },
-      { status: 502 },
-    );
+    throw new GcsImportError({
+      code: "fetch_failed",
+      message: `Upstream fetch returned ${upstream.status}`,
+      upstreamStatus: upstream.status,
+    });
   }
 
   if (!upstream.body) {
@@ -1035,13 +1088,13 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
       { host: validated.host, path: validated.path },
       "Migration import URL fetch returned no body",
     );
-    return Response.json(
-      { success: false, reason: "fetch_failed" },
-      { status: 502 },
-    );
+    throw new GcsImportError({
+      code: "fetch_failed",
+      message: "Upstream fetch returned no body",
+    });
   }
 
-  // ── 4. Stream the response through the importer ──────────────────────
+  // ── 3. Stream the response through the importer ──────────────────────
   // Convert the WHATWG ReadableStream from fetch() into a Node Readable so
   // the tar-stream / gunzip / hash-verifier pipeline inside
   // streamCommitImport can consume it via `.pipe()`.
@@ -1053,8 +1106,8 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
   // from the upstream HTTP body (peer reset, abort mid-stream, etc.) with a
   // known symbol. When that tagged error surfaces out of
   // streamCommitImport's gunzip/tar pipeline, we can distinguish it from a
-  // legitimate bundle-format failure and map it to 502 fetch_failed instead
-  // of 500 extraction_failed — matching the OpenAPI contract for the URL
+  // legitimate bundle-format failure and map it to `fetch_failed` instead
+  // of `extraction_failed` — matching the OpenAPI contract for the URL
   // body shape. We also propagate errors from the wrapper back to the
   // upstream stream so its underlying connection is torn down cleanly.
   //
@@ -1070,7 +1123,7 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
   // `taggedSource`. The subsequent `close` on `upstreamNodeStream` is then a
   // cascaded effect of our own teardown, NOT a real upstream failure — so
   // we must NOT tag it as a fetch-body error, or local validation /
-  // extraction errors would be masked as 502 fetch_failed.
+  // extraction errors would be masked as fetch_failed.
   let localTeardownInitiated = false;
   upstreamNodeStream.on("end", () => {
     upstreamEnded = true;
@@ -1106,8 +1159,8 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
   // (malformed bundle, hash mismatch, size cap, etc.). We set
   // `localTeardownInitiated` BEFORE destroying upstream so the resulting
   // cascaded `close` on `upstreamNodeStream` isn't misclassified as a real
-  // upstream failure (which would return 502 fetch_failed and mask the
-  // actual validation error).
+  // upstream failure (which would return fetch_failed and mask the actual
+  // validation error).
   taggedSource.on("close", () => {
     if (!upstreamNodeStream.destroyed) {
       localTeardownInitiated = true;
@@ -1156,10 +1209,10 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
         },
         "Upstream body stream failed mid-import",
       );
-      return Response.json(
-        { success: false, reason: "fetch_failed" },
-        { status: 502 },
-      );
+      throw new GcsImportError({
+        code: "fetch_failed",
+        message: err instanceof Error ? err.message : String(err),
+      });
     }
     log.error(
       {
@@ -1169,11 +1222,10 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
       },
       "streamCommitImport threw during URL-body import",
     );
-    return httpError(
-      "INTERNAL_ERROR",
-      err instanceof Error ? err.message : "Unexpected import error",
-      500,
-    );
+    throw new GcsImportError({
+      code: "extraction_failed",
+      message: err instanceof Error ? err.message : "Unexpected import error",
+    });
   }
 
   if (!result.ok) {
@@ -1191,10 +1243,10 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
         },
         "Upstream body stream failed mid-import (detected via result)",
       );
-      return Response.json(
-        { success: false, reason: "fetch_failed" },
-        { status: 502 },
-      );
+      throw new GcsImportError({
+        code: "fetch_failed",
+        message: "Upstream body stream failed mid-import",
+      });
     }
     log.warn(
       {
@@ -1204,7 +1256,28 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
       },
       "streamCommitImport returned failure during URL-body import",
     );
-    return importCommitFailureResponse(result);
+    if (result.reason === "validation_failed") {
+      throw new GcsImportError({
+        code: "validation_failed",
+        message: "Bundle validation failed",
+        reason: result.reason,
+        errors: result.errors,
+      });
+    }
+    if (result.reason === "extraction_failed") {
+      throw new GcsImportError({
+        code: "extraction_failed",
+        message: result.message,
+        reason: result.reason,
+      });
+    }
+    // write_failed
+    throw new GcsImportError({
+      code: "write_failed",
+      message: result.message,
+      reason: result.reason,
+      partial_report: result.partial_report,
+    });
   }
 
   // Merge any warnings accumulated by the credential-import callback into
@@ -1238,7 +1311,174 @@ async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
     "Migration import from URL complete",
   );
 
-  return importCommitSuccessResponse(result.report, credentialsImported);
+  return credentialsImported
+    ? { report: result.report, credentialsImported }
+    : { report: result.report };
+}
+
+/**
+ * Handle a JSON `{ "url": "..." }` body on POST /v1/migrations/import.
+ *
+ * Thin wrapper around `runGcsImport` that preserves the legacy synchronous
+ * Response shapes. `handleMigrationImportFromGcs` below uses the same helper
+ * asynchronously via the migration-job registry.
+ */
+async function handleMigrationImportFromUrl(req: Request): Promise<Response> {
+  // ── 1. Parse JSON body ────────────────────────────────────────────────
+  let rawBody: unknown;
+  try {
+    rawBody = await req.json();
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to parse JSON body on migration import URL request",
+    );
+    return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+  }
+
+  const parsed = MigrationImportUrlBody.safeParse(rawBody);
+  if (!parsed.success) {
+    return httpError(
+      "BAD_REQUEST",
+      "Request body must be { url: string } with a non-empty url",
+      400,
+    );
+  }
+
+  try {
+    const summary = await runGcsImport(parsed.data.url);
+    return importCommitSuccessResponse(
+      summary.report,
+      summary.credentialsImported,
+    );
+  } catch (err) {
+    return gcsImportErrorToUrlBodyResponse(err);
+  }
+}
+
+/**
+ * Map a `runGcsImport` error (or any other thrown value) back to the
+ * legacy URL-body Response shapes. Kept here so both the URL-body handler
+ * and any future callers of `runGcsImport` that want the same wire shape
+ * can reuse the mapping.
+ */
+function gcsImportErrorToUrlBodyResponse(err: unknown): Response {
+  if (err instanceof GcsImportError) {
+    if (err.code === "invalid_url") {
+      return httpError("BAD_REQUEST", err.message, 400);
+    }
+    if (err.code === "fetch_failed") {
+      const body: {
+        success: false;
+        reason: "fetch_failed";
+        upstream_status?: number;
+      } = {
+        success: false,
+        reason: "fetch_failed",
+      };
+      if (err.upstreamStatus !== undefined) {
+        body.upstream_status = err.upstreamStatus;
+      }
+      return Response.json(body, { status: 502 });
+    }
+    if (err.code === "validation_failed") {
+      return Response.json({
+        success: false,
+        reason: "validation_failed",
+        errors: err.errors ?? [],
+      });
+    }
+    if (err.code === "extraction_failed") {
+      return Response.json(
+        {
+          success: false,
+          reason: "extraction_failed",
+          message: err.message,
+        },
+        { status: 500 },
+      );
+    }
+    // write_failed
+    return Response.json(
+      {
+        success: false,
+        reason: "write_failed",
+        message: err.message,
+        ...(err.partial_report ? { partial_report: err.partial_report } : {}),
+      },
+      { status: 500 },
+    );
+  }
+
+  log.error({ err }, "Unexpected error from runGcsImport");
+  return httpError(
+    "INTERNAL_ERROR",
+    err instanceof Error ? err.message : "Unexpected import error",
+    500,
+  );
+}
+
+/**
+ * POST /v1/migrations/import-from-gcs
+ *
+ * Kick off an async bundle import from a signed GCS URL. Returns 202 with a
+ * `job_id` the caller can poll via `GET /v1/migrations/jobs/:job_id`
+ * (PR 4). 409 if another import is already pending or running.
+ *
+ * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, svc_daemon, local.
+ */
+export async function handleMigrationImportFromGcs(
+  req: Request,
+): Promise<Response> {
+  let rawBody: unknown;
+  try {
+    rawBody = await req.json();
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to parse JSON body on migration import-from-gcs request",
+    );
+    return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+  }
+
+  const parsed = MigrationImportFromGcsBody.safeParse(rawBody);
+  if (!parsed.success) {
+    return httpError(
+      "BAD_REQUEST",
+      "Request body must be { bundle_url: string } with a valid URL",
+      400,
+    );
+  }
+
+  const { bundle_url } = parsed.data;
+
+  try {
+    const job = migrationJobs.startJob("import", async (jobRecord) =>
+      runGcsImport(bundle_url, jobRecord.id),
+    );
+    return Response.json(
+      { job_id: job.id, status: "pending", type: "import" },
+      { status: 202 },
+    );
+  } catch (err) {
+    if (err instanceof JobAlreadyInProgressError) {
+      return Response.json(
+        {
+          error: {
+            code: "import_in_progress",
+            job_id: err.existingJobId,
+          },
+        },
+        { status: 409 },
+      );
+    }
+    log.error({ err }, "Unexpected error scheduling import-from-gcs job");
+    return httpError(
+      "INTERNAL_ERROR",
+      err instanceof Error ? err.message : "Unexpected import error",
+      500,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1448,10 +1688,7 @@ export async function handleMigrationJobStatus(
 ): Promise<Response> {
   const job = migrationJobs.getJob(params.job_id);
   if (job === null) {
-    return Response.json(
-      { error: { code: "job_not_found" } },
-      { status: 404 },
-    );
+    return Response.json({ error: { code: "job_not_found" } }, { status: 404 });
   }
 
   if (job.status === "complete") {
@@ -1628,6 +1865,44 @@ export function migrationRouteDefinitions(): RouteDefinition[] {
         type: z.literal("export"),
       }),
       handler: async ({ req }) => handleMigrationExportToGcs(req),
+    },
+    {
+      endpoint: "migrations/import-from-gcs",
+      method: "POST",
+      summary: "Start an async .vbundle import from a signed GCS URL",
+      description:
+        "Schedule a background import job that fetches the bundle at `bundle_url` and streams it through the importer. Returns 202 with a `job_id`; poll `GET /v1/migrations/jobs/{job_id}` for status. 409 if another import is already in flight.",
+      tags: ["migrations"],
+      requestBody: z.object({
+        bundle_url: z.string().url(),
+      }),
+      responseStatus: "202",
+      responseBody: z.object({
+        job_id: z.string(),
+        status: z.literal("pending"),
+        type: z.literal("import"),
+      }),
+      additionalResponses: {
+        "409": {
+          description:
+            "Another import job is already pending or running. Body shape: { error: { code: 'import_in_progress', job_id: string } }.",
+          schema: {
+            type: "object",
+            properties: {
+              error: {
+                type: "object",
+                properties: {
+                  code: { type: "string", enum: ["import_in_progress"] },
+                  job_id: { type: "string" },
+                },
+                required: ["code", "job_id"],
+              },
+            },
+            required: ["error"],
+          },
+        },
+      },
+      handler: async ({ req }) => handleMigrationImportFromGcs(req),
     },
     {
       endpoint: "migrations/jobs/:job_id",

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 // ---------------------------------------------------------------------------
-// Temp directory for lockfile isolation (same pattern as assistant-config.test.ts)
+// Temp directory for lockfile isolation
 // ---------------------------------------------------------------------------
 
 const testDir = mkdtempSync(join(tmpdir(), "cli-teleport-test-"));
@@ -23,16 +23,10 @@ process.env.VELLUM_LOCKFILE_DIR = testDir;
 // Mocks — must be set up before importing the module under test
 // ---------------------------------------------------------------------------
 
-// Import the real modules — do NOT mock them with mock.module() because
-// Bun's mock.module() replaces modules globally and the replacement leaks
-// into other test files (e.g. platform-client.test.ts, guardian-token.test.ts,
-// multi-local.test.ts) running in the same process with no way to unmock.
-// Instead, we use spyOn() on the imported module namespace objects — these
-// mutate only the current process's live binding and are restored via
-// mockRestore() in afterAll.
 import * as assistantConfig from "../lib/assistant-config.js";
 import * as guardianToken from "../lib/guardian-token.js";
 import * as platformClient from "../lib/platform-client.js";
+import * as localRuntimeClient from "../lib/local-runtime-client.js";
 
 const findAssistantByNameMock = spyOn(
   assistantConfig,
@@ -101,88 +95,31 @@ const platformInitiateExportMock = spyOn(
   platformClient,
   "platformInitiateExport",
 ).mockResolvedValue({
-  jobId: "job-1",
+  jobId: "platform-export-job-1",
   status: "pending",
 });
 
-const platformPollExportStatusMock = spyOn(
+const platformPollJobStatusMock = spyOn(
   platformClient,
-  "platformPollExportStatus",
+  "platformPollJobStatus",
 ).mockResolvedValue({
-  status: "complete" as string,
-  downloadUrl: "https://cdn.example.com/bundle.tar.gz",
+  jobId: "platform-job-1",
+  type: "export",
+  status: "complete",
+  bundleKey: "platform-bundle-key-abc",
 });
 
-const platformDownloadExportMock = spyOn(
+const platformRequestSignedUrlMock = spyOn(
   platformClient,
-  "platformDownloadExport",
-).mockImplementation(async () => {
-  const data = new Uint8Array([10, 20, 30]);
-  return new Response(data, { status: 200 });
-});
-
-const platformImportPreflightMock = spyOn(
-  platformClient,
-  "platformImportPreflight",
-).mockResolvedValue({
-  statusCode: 200,
-  body: {
-    can_import: true,
-    summary: {
-      files_to_create: 2,
-      files_to_overwrite: 1,
-      files_unchanged: 0,
-      total_files: 3,
-    },
-  } as Record<string, unknown>,
-});
-
-const platformImportBundleMock = spyOn(
-  platformClient,
-  "platformImportBundle",
-).mockResolvedValue({
-  statusCode: 200,
-  body: {
-    success: true,
-    summary: {
-      total_files: 3,
-      files_created: 2,
-      files_overwritten: 1,
-      files_skipped: 0,
-      backups_created: 1,
-    },
-  } as Record<string, unknown>,
-});
-
-const platformRequestUploadUrlMock = spyOn(
-  platformClient,
-  "platformRequestUploadUrl",
-).mockResolvedValue({
-  uploadUrl: "https://storage.googleapis.com/bucket/signed-upload-url",
-  bundleKey: "bundle-key-123",
+  "platformRequestSignedUrl",
+).mockImplementation(async (params) => ({
+  url:
+    params.operation === "upload"
+      ? "https://storage.googleapis.com/bucket/signed-upload"
+      : "https://storage.googleapis.com/bucket/signed-download",
+  bundleKey: params.bundleKey ?? "bundle-key-123",
   expiresAt: new Date(Date.now() + 3600_000).toISOString(),
-});
-
-const platformUploadToSignedUrlMock = spyOn(
-  platformClient,
-  "platformUploadToSignedUrl",
-).mockResolvedValue(undefined);
-
-const platformImportPreflightFromGcsMock = spyOn(
-  platformClient,
-  "platformImportPreflightFromGcs",
-).mockResolvedValue({
-  statusCode: 200,
-  body: {
-    can_import: true,
-    summary: {
-      files_to_create: 2,
-      files_to_overwrite: 1,
-      files_unchanged: 0,
-      total_files: 3,
-    },
-  } as Record<string, unknown>,
-});
+}));
 
 const platformImportBundleFromGcsMock = spyOn(
   platformClient,
@@ -197,6 +134,22 @@ const platformImportBundleFromGcsMock = spyOn(
       files_overwritten: 1,
       files_skipped: 0,
       backups_created: 1,
+    },
+  } as Record<string, unknown>,
+});
+
+const platformImportPreflightFromGcsMock = spyOn(
+  platformClient,
+  "platformImportPreflightFromGcs",
+).mockResolvedValue({
+  statusCode: 200,
+  body: {
+    can_import: true,
+    summary: {
+      files_to_create: 2,
+      files_to_overwrite: 1,
+      files_unchanged: 0,
+      total_files: 3,
     },
   } as Record<string, unknown>,
 });
@@ -240,6 +193,35 @@ const fetchOrganizationIdMock = spyOn(
   platformClient,
   "fetchOrganizationId",
 ).mockResolvedValue("org-1");
+
+const localRuntimeExportToGcsMock = spyOn(
+  localRuntimeClient,
+  "localRuntimeExportToGcs",
+).mockResolvedValue({ jobId: "local-export-job-1" });
+
+const localRuntimeImportFromGcsMock = spyOn(
+  localRuntimeClient,
+  "localRuntimeImportFromGcs",
+).mockResolvedValue({ jobId: "local-import-job-1" });
+
+const localRuntimePollJobStatusMock = spyOn(
+  localRuntimeClient,
+  "localRuntimePollJobStatus",
+).mockImplementation(async (_runtimeUrl, _token, jobId) => ({
+  jobId,
+  type: jobId.includes("import") ? "import" : "export",
+  status: "complete",
+  result: {
+    success: true,
+    summary: {
+      total_files: 3,
+      files_created: 2,
+      files_overwritten: 1,
+      files_skipped: 0,
+      backups_created: 1,
+    },
+  },
+}));
 
 const hatchLocalMock = mock(async () => {});
 
@@ -313,19 +295,18 @@ afterAll(() => {
   hatchAssistantMock.mockRestore();
   checkExistingPlatformAssistantMock.mockRestore();
   platformInitiateExportMock.mockRestore();
-  platformPollExportStatusMock.mockRestore();
-  platformDownloadExportMock.mockRestore();
-  platformImportPreflightMock.mockRestore();
-  platformImportBundleMock.mockRestore();
-  platformRequestUploadUrlMock.mockRestore();
-  platformUploadToSignedUrlMock.mockRestore();
-  platformImportPreflightFromGcsMock.mockRestore();
+  platformPollJobStatusMock.mockRestore();
+  platformRequestSignedUrlMock.mockRestore();
   platformImportBundleFromGcsMock.mockRestore();
+  platformImportPreflightFromGcsMock.mockRestore();
   ensureSelfHostedLocalRegistrationMock.mockRestore();
   injectCredentialsIntoAssistantMock.mockRestore();
   fetchCurrentUserMock.mockRestore();
   fetchOrganizationIdMock.mockRestore();
   computeDeviceIdMock.mockRestore();
+  localRuntimeExportToGcsMock.mockRestore();
+  localRuntimeImportFromGcsMock.mockRestore();
+  localRuntimePollJobStatusMock.mockRestore();
   rmSync(testDir, { recursive: true, force: true });
   delete process.env.VELLUM_LOCKFILE_DIR;
 });
@@ -335,11 +316,39 @@ let exitMock: ReturnType<typeof mock>;
 let originalExit: typeof process.exit;
 let consoleLogSpy: ReturnType<typeof spyOn>;
 let consoleErrorSpy: ReturnType<typeof spyOn>;
+let fetchCalls: Array<{ url: string; body: unknown }>;
+
+function defaultLocalRuntimePollImpl(
+  _runtimeUrl: string,
+  _token: string,
+  jobId: string,
+): Promise<{
+  jobId: string;
+  type: "export" | "import";
+  status: "complete";
+  result: Record<string, unknown>;
+}> {
+  return Promise.resolve({
+    jobId,
+    type: jobId.includes("import") ? "import" : "export",
+    status: "complete",
+    result: {
+      success: true,
+      summary: {
+        total_files: 3,
+        files_created: 2,
+        files_overwritten: 1,
+        files_skipped: 0,
+        backups_created: 1,
+      },
+    },
+  });
+}
 
 beforeEach(() => {
   originalArgv = [...process.argv];
+  fetchCalls = [];
 
-  // Reset all mocks
   findAssistantByNameMock.mockReset();
   findAssistantByNameMock.mockReturnValue(null);
   saveAssistantEntryMock.mockReset();
@@ -371,66 +380,25 @@ beforeEach(() => {
   });
   platformInitiateExportMock.mockReset();
   platformInitiateExportMock.mockResolvedValue({
-    jobId: "job-1",
+    jobId: "platform-export-job-1",
     status: "pending",
   });
-  platformPollExportStatusMock.mockReset();
-  platformPollExportStatusMock.mockResolvedValue({
+  platformPollJobStatusMock.mockReset();
+  platformPollJobStatusMock.mockResolvedValue({
+    jobId: "platform-job-1",
+    type: "export",
     status: "complete",
-    downloadUrl: "https://cdn.example.com/bundle.tar.gz",
+    bundleKey: "platform-bundle-key-abc",
   });
-  platformDownloadExportMock.mockReset();
-  platformDownloadExportMock.mockResolvedValue(
-    new Response(new Uint8Array([10, 20, 30]), { status: 200 }),
-  );
-  platformImportPreflightMock.mockReset();
-  platformImportPreflightMock.mockResolvedValue({
-    statusCode: 200,
-    body: {
-      can_import: true,
-      summary: {
-        files_to_create: 2,
-        files_to_overwrite: 1,
-        files_unchanged: 0,
-        total_files: 3,
-      },
-    },
-  });
-  platformImportBundleMock.mockReset();
-  platformImportBundleMock.mockResolvedValue({
-    statusCode: 200,
-    body: {
-      success: true,
-      summary: {
-        total_files: 3,
-        files_created: 2,
-        files_overwritten: 1,
-        files_skipped: 0,
-        backups_created: 1,
-      },
-    },
-  });
-  platformRequestUploadUrlMock.mockReset();
-  platformRequestUploadUrlMock.mockResolvedValue({
-    uploadUrl: "https://storage.googleapis.com/bucket/signed-upload-url",
-    bundleKey: "bundle-key-123",
+  platformRequestSignedUrlMock.mockReset();
+  platformRequestSignedUrlMock.mockImplementation(async (params) => ({
+    url:
+      params.operation === "upload"
+        ? "https://storage.googleapis.com/bucket/signed-upload"
+        : "https://storage.googleapis.com/bucket/signed-download",
+    bundleKey: params.bundleKey ?? "bundle-key-123",
     expiresAt: new Date(Date.now() + 3600_000).toISOString(),
-  });
-  platformUploadToSignedUrlMock.mockReset();
-  platformUploadToSignedUrlMock.mockResolvedValue(undefined);
-  platformImportPreflightFromGcsMock.mockReset();
-  platformImportPreflightFromGcsMock.mockResolvedValue({
-    statusCode: 200,
-    body: {
-      can_import: true,
-      summary: {
-        files_to_create: 2,
-        files_to_overwrite: 1,
-        files_unchanged: 0,
-        total_files: 3,
-      },
-    },
-  });
+  }));
   platformImportBundleFromGcsMock.mockReset();
   platformImportBundleFromGcsMock.mockResolvedValue({
     statusCode: 200,
@@ -442,6 +410,19 @@ beforeEach(() => {
         files_overwritten: 1,
         files_skipped: 0,
         backups_created: 1,
+      },
+    },
+  });
+  platformImportPreflightFromGcsMock.mockReset();
+  platformImportPreflightFromGcsMock.mockResolvedValue({
+    statusCode: 200,
+    body: {
+      can_import: true,
+      summary: {
+        files_to_create: 2,
+        files_to_overwrite: 1,
+        files_unchanged: 0,
+        total_files: 3,
       },
     },
   });
@@ -470,6 +451,17 @@ beforeEach(() => {
   fetchOrganizationIdMock.mockResolvedValue("org-1");
   computeDeviceIdMock.mockReset();
   computeDeviceIdMock.mockReturnValue("device-id-123");
+
+  localRuntimeExportToGcsMock.mockReset();
+  localRuntimeExportToGcsMock.mockResolvedValue({
+    jobId: "local-export-job-1",
+  });
+  localRuntimeImportFromGcsMock.mockReset();
+  localRuntimeImportFromGcsMock.mockResolvedValue({
+    jobId: "local-import-job-1",
+  });
+  localRuntimePollJobStatusMock.mockReset();
+  localRuntimePollJobStatusMock.mockImplementation(defaultLocalRuntimePollImpl);
 
   hatchLocalMock.mockReset();
   hatchLocalMock.mockResolvedValue(undefined);
@@ -505,7 +497,6 @@ afterEach(() => {
 });
 
 function setArgv(...args: string[]): void {
-  // teleport reads process.argv.slice(3)
   process.argv = ["bun", "vellum", "teleport", ...args];
 }
 
@@ -521,44 +512,24 @@ function makeEntry(
   };
 }
 
-/** Create a mock fetch that handles export and import endpoints. */
-function createFetchMock() {
-  return mock(async (url: string | URL | Request) => {
-    const urlStr = typeof url === "string" ? url : url.toString();
-    if (urlStr.includes("/export")) {
-      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
-    }
-    if (urlStr.includes("/import-preflight")) {
-      return new Response(
-        JSON.stringify({
-          can_import: true,
-          summary: {
-            files_to_create: 1,
-            files_to_overwrite: 0,
-            files_unchanged: 0,
-            total_files: 1,
-          },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
-    }
-    if (urlStr.includes("/import")) {
-      return new Response(
-        JSON.stringify({
-          success: true,
-          summary: {
-            total_files: 1,
-            files_created: 1,
-            files_overwritten: 0,
-            files_skipped: 0,
-            backups_created: 0,
-          },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
-    }
-    return new Response("not found", { status: 404 });
-  });
+/**
+ * Tracking fetch mock — records every call so tests can verify that the CLI
+ * never sends a bundle-sized request body. With the new GCS-unified flow
+ * all bundle bytes travel between the runtime and GCS directly, so the CLI
+ * should make zero fetch calls carrying binary payloads.
+ */
+function installTrackingFetch(): () => void {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = mock(
+    async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      fetchCalls.push({ url: urlStr, body: init?.body });
+      return new Response("not found", { status: 404 });
+    },
+  ) as unknown as typeof globalThis.fetch;
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -663,20 +634,13 @@ describe("same-environment rejection", () => {
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Cannot teleport between two local assistants"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await expect(teleport()).rejects.toThrow("process.exit:1");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Cannot teleport between two local assistants"),
+    );
   });
 
-  test("source docker, target docker -> error (after resolving target)", async () => {
+  test("source docker, target docker -> error", async () => {
     setArgv("--from", "src", "--docker", "dst");
 
     const srcEntry = makeEntry("src", { cloud: "docker" });
@@ -688,22 +652,13 @@ describe("same-environment rejection", () => {
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Cannot teleport between two docker assistants",
-        ),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await expect(teleport()).rejects.toThrow("process.exit:1");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Cannot teleport between two docker assistants"),
+    );
   });
 
-  test("source vellum, target platform -> error (after resolving target)", async () => {
+  test("source vellum, target platform -> error", async () => {
     setArgv("--from", "src", "--platform", "dst");
 
     const srcEntry = makeEntry("src", {
@@ -721,19 +676,12 @@ describe("same-environment rejection", () => {
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Cannot teleport between two platform assistants",
-        ),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await expect(teleport()).rejects.toThrow("process.exit:1");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Cannot teleport between two platform assistants",
+      ),
+    );
   });
 
   test("same-env rejection happens before hatching (no orphaned assistants)", async () => {
@@ -749,59 +697,15 @@ describe("same-environment rejection", () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Cannot teleport between two local assistants"),
     );
-    // Crucially: no hatch should have been called — the early guard fires first
-    expect(hatchLocalMock).not.toHaveBeenCalled();
-    expect(hatchDockerMock).not.toHaveBeenCalled();
-    expect(hatchAssistantMock).not.toHaveBeenCalled();
-  });
-
-  test("same-env rejection before hatching for docker", async () => {
-    setArgv("--from", "my-docker", "--docker");
-
-    const dockerEntry = makeEntry("my-docker", { cloud: "docker" });
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-docker") return dockerEntry;
-      return null;
-    });
-
-    await expect(teleport()).rejects.toThrow("process.exit:1");
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Cannot teleport between two docker assistants"),
-    );
-    expect(hatchLocalMock).not.toHaveBeenCalled();
-    expect(hatchDockerMock).not.toHaveBeenCalled();
-    expect(hatchAssistantMock).not.toHaveBeenCalled();
-  });
-
-  test("same-env rejection before hatching for platform (vellum cloud)", async () => {
-    setArgv("--from", "my-cloud", "--platform");
-
-    const platformEntry = makeEntry("my-cloud", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-cloud") return platformEntry;
-      return null;
-    });
-
-    await expect(teleport()).rejects.toThrow("process.exit:1");
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "Cannot teleport between two platform assistants",
-      ),
-    );
     expect(hatchLocalMock).not.toHaveBeenCalled();
     expect(hatchDockerMock).not.toHaveBeenCalled();
     expect(hatchAssistantMock).not.toHaveBeenCalled();
   });
 
   test("flag says docker but resolved target is local -> rejects cloud mismatch", async () => {
-    // User passes --docker but the named target is actually a local assistant
     setArgv("--from", "src", "--docker", "misidentified");
 
     const srcEntry = makeEntry("src", { cloud: "vellum" });
-    // Target is actually local despite the --docker flag
     const dstEntry = makeEntry("misidentified", { cloud: "local" });
 
     findAssistantByNameMock.mockImplementation((name: string) => {
@@ -832,16 +736,11 @@ describe("resolveOrHatchTarget", () => {
     const result = await resolveOrHatchTarget("docker", "my-docker");
     expect(result).toBe(dockerEntry);
     expect(hatchDockerMock).not.toHaveBeenCalled();
-    expect(consoleLogSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Target: my-docker (docker)"),
-    );
   });
 
   test("name not found -> hatch docker", async () => {
     const newEntry = makeEntry("new-one", { cloud: "docker" });
     findAssistantByNameMock.mockImplementation((name: string) => {
-      // First call: lookup by name -> not found
-      // Second call: after hatch -> found
       if (name === "new-one" && hatchDockerMock.mock.calls.length > 0) {
         return newEntry;
       }
@@ -859,12 +758,10 @@ describe("resolveOrHatchTarget", () => {
     expect(result).toBe(newEntry);
   });
 
-  test("no name -> hatch local with null name, discovers via diff", async () => {
+  test("no name -> hatch local, discovers via diff", async () => {
     const existingEntry = makeEntry("existing-local", { cloud: "local" });
     const newEntry = makeEntry("auto-generated", { cloud: "local" });
 
-    // Before hatch: only the existing entry
-    // After hatch: existing + new entry
     loadAllAssistantsMock.mockImplementation(() => {
       if (hatchLocalMock.mock.calls.length > 0) {
         return [existingEntry, newEntry];
@@ -873,13 +770,7 @@ describe("resolveOrHatchTarget", () => {
     });
 
     const result = await resolveOrHatchTarget("local");
-    expect(hatchLocalMock).toHaveBeenCalledWith(
-      "vellum",
-      null,
-      false,
-      false,
-      {},
-    );
+    expect(hatchLocalMock).toHaveBeenCalled();
     expect(result).toBe(newEntry);
   });
 
@@ -903,16 +794,10 @@ describe("resolveOrHatchTarget", () => {
 
     const result = await resolveOrHatchTarget("platform", "nonexistent");
     expect(hatchAssistantMock).toHaveBeenCalledWith("platform-token");
-    expect(saveAssistantEntryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        assistantId: "platform-new-id",
-        cloud: "vellum",
-      }),
-    );
     expect(result.assistantId).toBe("platform-new-id");
   });
 
-  test("platform with no name -> blocks when hatch returns reusedExisting (defensive safety net)", async () => {
+  test("platform with no name -> blocks when hatch returns reusedExisting", async () => {
     findAssistantByNameMock.mockReturnValue(null);
     hatchAssistantMock.mockResolvedValue({
       assistant: {
@@ -923,24 +808,11 @@ describe("resolveOrHatchTarget", () => {
       reusedExisting: true,
     });
 
-    // Defensive safety net: even though the pre-check in teleport() should
-    // catch this first, resolveOrHatchTarget still blocks on reusedExisting
-    // to guard against a TOCTOU race (matching the Swift client behavior).
     await expect(resolveOrHatchTarget("platform", undefined)).rejects.toThrow(
       "process.exit:1",
     );
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("already have a platform assistant"),
-    );
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Retire it first"),
-    );
-    // The existing assistant is saved to the lockfile so `vellum retire` can find it
-    expect(saveAssistantEntryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        assistantId: "existing-platform-id",
-        cloud: "vellum",
-      }),
     );
   });
 
@@ -973,33 +845,139 @@ describe("resolveOrHatchTarget", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Auto-retire tests
+// Unified GCS teleport flow — the four directions
 // ---------------------------------------------------------------------------
 
-describe("auto-retire", () => {
-  test("local -> docker: stops source before hatch, retires after import", async () => {
-    setArgv("--from", "my-local", "--docker");
+describe("unified GCS flow — four directions", () => {
+  test("local → platform: requests upload URL, drives local runtime export, imports from GCS", async () => {
+    setArgv("--from", "my-local", "--platform");
 
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      // Signed-URL request for upload — pinned to the platform target's URL
+      // so upload and download land on the same platform.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        expect.objectContaining({ operation: "upload" }),
+        "platform-token",
+        "https://platform.vellum.ai",
+      );
+
+      // Runtime export-to-gcs kicked off with the signed upload URL
+      expect(localRuntimeExportToGcsMock).toHaveBeenCalledWith(
+        "http://localhost:7821",
+        "local-token",
+        expect.objectContaining({
+          uploadUrl: "https://storage.googleapis.com/bucket/signed-upload",
+        }),
+      );
+
+      // Poll continued until complete
+      expect(localRuntimePollJobStatusMock).toHaveBeenCalled();
+
+      // Import via GCS with the bundleKey returned from signed-URL request
+      expect(platformImportBundleFromGcsMock).toHaveBeenCalledWith(
+        "bundle-key-123",
+        "platform-token",
+        expect.any(String),
+      );
+
+      // No download-URL request on the import side (platform target pulls
+      // directly from GCS).
+      const downloadOps = platformRequestSignedUrlMock.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as { operation: string }).operation === "download",
+      );
+      expect(downloadOps.length).toBe(0);
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("platform → local: drives platform export, reads bundle_key, requests download URL for runtime import", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
     const localEntry = makeEntry("my-local", {
       cloud: "local",
-      resources: {
-        instanceDir: "/home/test",
-        pidFile: "/home/test/.vellum/assistant.pid",
-        signingKey: "key",
-        daemonPort: 7821,
-        gatewayPort: 7830,
-        qdrantPort: 6333,
-        cesPort: 8090,
-      },
+      bearerToken: "local-bearer",
     });
-    const dockerEntry = makeEntry("new-docker", { cloud: "docker" });
 
     findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
       if (name === "my-local") return localEntry;
       return null;
     });
 
-    // Simulate hatch creating a new docker entry
+    // Platform poll returns export-complete with a bundle_key.
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "platform-exports/org-1/bundle-abc.vbundle",
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      // Platform side: initiated server export and polled the unified status.
+      expect(platformInitiateExportMock).toHaveBeenCalled();
+      expect(platformPollJobStatusMock).toHaveBeenCalled();
+
+      // For the local target we request a download URL keyed by the
+      // platform's bundle_key. The URL must target the SOURCE platform
+      // (where the bundle was written) — pinned so a lockfile change
+      // can't split upload and download across instances.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        {
+          operation: "download",
+          bundleKey: "platform-exports/org-1/bundle-abc.vbundle",
+        },
+        "platform-token",
+        "https://platform.vellum.ai",
+      );
+
+      // Runtime import-from-gcs was kicked off with that URL.
+      expect(localRuntimeImportFromGcsMock).toHaveBeenCalledWith(
+        "http://localhost:7821",
+        "local-token",
+        expect.objectContaining({
+          bundleUrl: "https://storage.googleapis.com/bucket/signed-download",
+        }),
+      );
+      expect(localRuntimePollJobStatusMock).toHaveBeenCalled();
+
+      // No legacy inline-import helpers were touched.
+      // (Verified by the absence of fetch calls carrying bundle bodies —
+      // see "never buffers bundle bytes" assertion below.)
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("local → docker: export via upload URL, import via download URL", async () => {
+    setArgv("--from", "my-local", "--docker");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    const dockerEntry = makeEntry("new-docker", {
+      cloud: "docker",
+      runtimeUrl: "http://localhost:7822",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
     loadAllAssistantsMock.mockImplementation(() => {
       if (hatchDockerMock.mock.calls.length > 0) {
         return [localEntry, dockerEntry];
@@ -1007,31 +985,60 @@ describe("auto-retire", () => {
       return [localEntry];
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
-      // Source should be stopped (slept) before hatch
-      expect(stopProcessByPidFileMock).toHaveBeenCalled();
-      // Retire happens after successful import
+
+      // Export and import must pin the same platform URL so the bundle
+      // lives in one place end-to-end. For local→docker neither side is
+      // platform, so we default to getPlatformUrl() (resolved once).
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        expect.objectContaining({ operation: "upload" }),
+        "platform-token",
+        "https://platform.vellum.ai",
+      );
+      expect(localRuntimeExportToGcsMock).toHaveBeenCalled();
+
+      // Import: download-URL for the docker target, then runtime import.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        {
+          operation: "download",
+          bundleKey: "bundle-key-123",
+        },
+        "platform-token",
+        "https://platform.vellum.ai",
+      );
+      expect(localRuntimeImportFromGcsMock).toHaveBeenCalledWith(
+        "http://localhost:7822",
+        "local-token",
+        expect.objectContaining({
+          bundleUrl: "https://storage.googleapis.com/bucket/signed-download",
+        }),
+      );
+
+      // Source retirement still happens on success for local↔docker.
       expect(retireLocalMock).toHaveBeenCalledWith("my-local", localEntry);
       expect(removeAssistantEntryMock).toHaveBeenCalledWith("my-local");
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
 
-  test("docker -> local: sleeps containers before hatch, retires after import", async () => {
+  test("docker → local: export via upload URL, import via download URL", async () => {
     setArgv("--from", "my-docker", "--local");
 
-    const dockerEntry = makeEntry("my-docker", { cloud: "docker" });
-    const localEntry = makeEntry("new-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-docker") return dockerEntry;
-      return null;
+    const dockerEntry = makeEntry("my-docker", {
+      cloud: "docker",
+      runtimeUrl: "http://localhost:7822",
     });
+    const localEntry = makeEntry("new-local", {
+      cloud: "local",
+      runtimeUrl: "http://localhost:7823",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-docker" ? dockerEntry : null,
+    );
 
     loadAllAssistantsMock.mockImplementation(() => {
       if (hatchLocalMock.mock.calls.length > 0) {
@@ -1040,252 +1047,449 @@ describe("auto-retire", () => {
       return [dockerEntry];
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
-      // Docker source should be slept (containers stopped) before hatch
+
+      // Docker source should be put to sleep first.
       expect(sleepContainersMock).toHaveBeenCalled();
-      // Retire happens after successful import
+
+      // Export leg: upload-URL (pinned to the same platform as import),
+      // then runtime export.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        expect.objectContaining({ operation: "upload" }),
+        "platform-token",
+        "https://platform.vellum.ai",
+      );
+      expect(localRuntimeExportToGcsMock).toHaveBeenCalledWith(
+        "http://localhost:7822",
+        "local-token",
+        expect.objectContaining({
+          uploadUrl: "https://storage.googleapis.com/bucket/signed-upload",
+        }),
+      );
+
+      // Import leg: download-URL targets the new local runtime
+      expect(localRuntimeImportFromGcsMock).toHaveBeenCalledWith(
+        "http://localhost:7823",
+        "local-token",
+        expect.anything(),
+      );
+
+      // Source retirement
       expect(retireDockerMock).toHaveBeenCalledWith("my-docker");
       expect(removeAssistantEntryMock).toHaveBeenCalledWith("my-docker");
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Target-platform URL threading: signed URL must be requested from the same
+// platform instance the import will run against. Codex P2 regression guard.
+// ---------------------------------------------------------------------------
+
+describe("signed-URL request targets the bundle-owning platform", () => {
+  test("local → existing platform target with non-default runtimeUrl: upload URL pinned to target's runtimeUrl", async () => {
+    setArgv("--from", "my-local", "--platform", "existing-platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    // Crucially, the target's runtimeUrl is NOT the default getPlatformUrl()
+    // return value — this is the regression case Codex flagged.
+    const platformEntry = makeEntry("existing-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://staging-platform.vellum.ai",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      if (name === "existing-platform") return platformEntry;
+      return null;
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      // The signed-URL request for upload MUST target the existing
+      // platform assistant's runtimeUrl, not the default platform URL.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        expect.objectContaining({ operation: "upload" }),
+        "platform-token",
+        "https://staging-platform.vellum.ai",
+      );
+
+      // And the import must run against the same platform.
+      expect(platformImportBundleFromGcsMock).toHaveBeenCalledWith(
+        "bundle-key-123",
+        "platform-token",
+        "https://staging-platform.vellum.ai",
+      );
+
+      // Assert none of the signed-URL calls used the default URL — if any
+      // did, upload and download would hit different platforms.
+      for (const call of platformRequestSignedUrlMock.mock.calls) {
+        expect(call[2]).toBe("https://staging-platform.vellum.ai");
+      }
+    } finally {
+      restoreFetch();
     }
   });
 
-  test("--keep-source skips retire and removeAssistantEntry", async () => {
-    setArgv("--from", "my-local", "--docker", "--keep-source");
+  test("platform → local with non-default source runtimeUrl: download URL pinned to source's runtimeUrl", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
 
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://dev-platform.vellum.ai",
+    });
     const localEntry = makeEntry("my-local", { cloud: "local" });
-    const dockerEntry = makeEntry("new-docker", { cloud: "docker" });
 
     findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
       if (name === "my-local") return localEntry;
       return null;
     });
 
-    loadAllAssistantsMock.mockImplementation(() => {
-      if (hatchDockerMock.mock.calls.length > 0) {
-        return [localEntry, dockerEntry];
-      }
-      return [localEntry];
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "dev-bundle-key",
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
-      expect(retireLocalMock).not.toHaveBeenCalled();
-      expect(retireDockerMock).not.toHaveBeenCalled();
-      expect(removeAssistantEntryMock).not.toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("kept (--keep-source)"),
+
+      // The download URL must be requested from the SOURCE platform (where
+      // the bundle was written by the server-side export), not the default.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        { operation: "download", bundleKey: "dev-bundle-key" },
+        "platform-token",
+        "https://dev-platform.vellum.ai",
       );
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
+});
 
-  test("platform transfers skip retire", async () => {
+// ---------------------------------------------------------------------------
+// Invariants: CLI never buffers bundle bytes
+// ---------------------------------------------------------------------------
+
+describe("CLI never buffers bundle bytes", () => {
+  // A teleport bundle is always > 1 KiB in practice; anything near that size
+  // would mean the CLI is shuttling bytes when it shouldn't.
+  const BUNDLE_BODY_THRESHOLD_BYTES = 1024;
+
+  function bodySize(body: unknown): number {
+    if (typeof body === "string") return body.length;
+    if (body instanceof Uint8Array) return body.byteLength;
+    if (body instanceof ArrayBuffer) return body.byteLength;
+    if (body instanceof Blob) return body.size;
+    return 0;
+  }
+
+  test("local → platform: no fetch call carries a bundle-sized body", async () => {
     setArgv("--from", "my-local", "--platform");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      for (const call of fetchCalls) {
+        expect(bodySize(call.body)).toBeLessThan(BUNDLE_BODY_THRESHOLD_BYTES);
+      }
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("platform → local: no fetch call carries a bundle-sized body", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
 
     findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
       if (name === "my-local") return localEntry;
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "platform-exports/org-1/bundle.vbundle",
+    });
 
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
-      expect(retireLocalMock).not.toHaveBeenCalled();
-      expect(retireDockerMock).not.toHaveBeenCalled();
-      expect(removeAssistantEntryMock).not.toHaveBeenCalled();
+
+      for (const call of fetchCalls) {
+        expect(bodySize(call.body)).toBeLessThan(BUNDLE_BODY_THRESHOLD_BYTES);
+      }
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Polling behavior
+// ---------------------------------------------------------------------------
+
+describe("polling", () => {
+  test("local-runtime export poll continues until complete", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    let callIdx = 0;
+    localRuntimePollJobStatusMock.mockImplementation(
+      async (_runtimeUrl, _token, jobId) => {
+        callIdx++;
+        if (callIdx < 3) {
+          return {
+            jobId,
+            type: "export" as const,
+            status: "processing" as const,
+          };
+        }
+        return {
+          jobId,
+          type: "export" as const,
+          status: "complete" as const,
+          result: undefined,
+        };
+      },
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+      expect(callIdx).toBeGreaterThanOrEqual(3);
+    } finally {
+      restoreFetch();
     }
   });
 
+  test("local-runtime export failure → teleport exits 1", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    localRuntimePollJobStatusMock.mockResolvedValue({
+      jobId: "local-export-job-1",
+      type: "export",
+      status: "failed",
+      error: "simulated failure",
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("simulated failure"),
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("local-runtime import failure → teleport exits 1", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "key-1",
+    });
+
+    localRuntimePollJobStatusMock.mockImplementation(
+      async (_runtimeUrl, _token, jobId) => {
+        if (jobId.includes("import")) {
+          return {
+            jobId,
+            type: "import" as const,
+            status: "failed" as const,
+            error: "import blew up",
+          };
+        }
+        return {
+          jobId,
+          type: "export" as const,
+          status: "complete" as const,
+          result: undefined,
+        };
+      },
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("import blew up"),
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MigrationInProgressError handling
+// ---------------------------------------------------------------------------
+
+describe("MigrationInProgressError handling", () => {
+  test("local-runtime export already in flight → fail fast with existing job id", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    localRuntimeExportToGcsMock.mockRejectedValue(
+      new localRuntimeClient.MigrationInProgressError(
+        "export_in_progress",
+        "existing-job-42",
+      ),
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+
+      // Must not have polled the existing job — the existing job's bundle
+      // lives at a different GCS key (its caller's signed URL), so polling
+      // it would leave the teleport pointing at an empty/unrelated bundle.
+      const polledIds = localRuntimePollJobStatusMock.mock.calls.map(
+        (call: unknown[]) => call[2],
+      );
+      expect(polledIds).not.toContain("existing-job-42");
+
+      // Error must mention the existing job id so the user can act on it.
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("existing-job-42"),
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("already in progress"),
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("local-runtime import already in flight → fail fast with existing job id", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "bundle-key-from-platform",
+    });
+
+    localRuntimeImportFromGcsMock.mockRejectedValue(
+      new localRuntimeClient.MigrationInProgressError(
+        "import_in_progress",
+        "existing-import-99",
+      ),
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+
+      // Must not poll the existing import — it's importing somebody else's
+      // bundle, not ours, so reporting on it would be misleading.
+      const polledIds = localRuntimePollJobStatusMock.mock.calls.map(
+        (call: unknown[]) => call[2],
+      );
+      expect(polledIds).not.toContain("existing-import-99");
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("existing-import-99"),
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("already in progress"),
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dry-run behavior
+// ---------------------------------------------------------------------------
+
+describe("dry-run", () => {
   test("dry-run without existing target does not hatch or export", async () => {
     setArgv("--from", "my-local", "--docker", "--dry-run");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
 
     await teleport();
 
-    // Should NOT hatch, export, import, or retire
     expect(hatchDockerMock).not.toHaveBeenCalled();
     expect(hatchLocalMock).not.toHaveBeenCalled();
     expect(hatchAssistantMock).not.toHaveBeenCalled();
     expect(retireLocalMock).not.toHaveBeenCalled();
     expect(retireDockerMock).not.toHaveBeenCalled();
-    expect(removeAssistantEntryMock).not.toHaveBeenCalled();
+    expect(localRuntimeExportToGcsMock).not.toHaveBeenCalled();
+    expect(localRuntimeImportFromGcsMock).not.toHaveBeenCalled();
   });
 
-  test("dry-run with existing target runs preflight without hatching", async () => {
-    setArgv("--from", "my-local", "--docker", "my-docker", "--dry-run");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-    const dockerEntry = makeEntry("my-docker", { cloud: "docker" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      if (name === "my-docker") return dockerEntry;
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Should NOT hatch or retire
-      expect(hatchDockerMock).not.toHaveBeenCalled();
-      expect(hatchLocalMock).not.toHaveBeenCalled();
-      expect(retireLocalMock).not.toHaveBeenCalled();
-      expect(retireDockerMock).not.toHaveBeenCalled();
-      expect(removeAssistantEntryMock).not.toHaveBeenCalled();
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Full flow tests
-// ---------------------------------------------------------------------------
-
-describe("teleport full flow", () => {
-  test("hatch and import: --from my-local --docker", async () => {
-    setArgv("--from", "my-local", "--docker");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-    const dockerEntry = makeEntry("new-docker", { cloud: "docker" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    loadAllAssistantsMock.mockImplementation(() => {
-      if (hatchDockerMock.mock.calls.length > 0) {
-        return [localEntry, dockerEntry];
-      }
-      return [localEntry];
-    });
-
-    const originalFetch = globalThis.fetch;
-    const fetchMock = createFetchMock();
-    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Verify sequence: export, hatch, import, retire
-      expect(hatchDockerMock).toHaveBeenCalled();
-      expect(retireLocalMock).toHaveBeenCalledWith("my-local", localEntry);
-      expect(removeAssistantEntryMock).toHaveBeenCalledWith("my-local");
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("existing target overwrite: --from my-local --docker my-existing", async () => {
-    setArgv("--from", "my-local", "--docker", "my-existing");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-    const dockerEntry = makeEntry("my-existing", { cloud: "docker" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      if (name === "my-existing") return dockerEntry;
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    const fetchMock = createFetchMock();
-    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // No hatch should happen — existing target is used
-      expect(hatchDockerMock).not.toHaveBeenCalled();
-      // Source should still be retired
-      expect(retireLocalMock).toHaveBeenCalledWith("my-local", localEntry);
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("legacy --to flag shows deprecation message", async () => {
-    setArgv("--from", "source", "--to", "target");
-
-    await expect(teleport()).rejects.toThrow("process.exit:1");
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("--to is deprecated"),
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Signed-URL upload tests
-// ---------------------------------------------------------------------------
-
-describe("signed-URL upload flow", () => {
-  test("happy path: signed URL upload succeeds → GCS-based import used", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Signed-URL flow should be used
-      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
-      expect(platformUploadToSignedUrlMock).toHaveBeenCalled();
-      expect(platformImportBundleFromGcsMock).toHaveBeenCalledWith(
-        "bundle-key-123",
-        "platform-token",
-        "https://platform.vellum.ai",
-      );
-      // Inline import should NOT be called
-      expect(platformImportBundleMock).not.toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("happy path dry-run: signed URL upload succeeds → GCS-based preflight used", async () => {
+  test("dry-run with existing platform target runs preflight-from-gcs", async () => {
     setArgv(
       "--from",
       "my-local",
@@ -1306,690 +1510,21 @@ describe("signed-URL upload flow", () => {
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
-
-      // Signed-URL flow should be used for preflight
-      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
-      expect(platformUploadToSignedUrlMock).toHaveBeenCalled();
       expect(platformImportPreflightFromGcsMock).toHaveBeenCalledWith(
         "bundle-key-123",
         "platform-token",
         "https://platform.vellum.ai",
       );
-      // Inline preflight should NOT be called
-      expect(platformImportPreflightMock).not.toHaveBeenCalled();
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("fallback: platformRequestUploadUrl throws 503 → falls back to inline import", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Simulate 503 — "not available" in the error message
-    platformRequestUploadUrlMock.mockRejectedValue(
-      new Error("Signed uploads are not available on this platform instance"),
-    );
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Should fall back to inline import
-      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
-      expect(platformUploadToSignedUrlMock).not.toHaveBeenCalled();
-      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
-      expect(platformImportBundleMock).toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("fallback: platformRequestUploadUrl throws 404 → falls back to inline import", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Simulate 404 — endpoint doesn't exist on older platform versions
-    platformRequestUploadUrlMock.mockRejectedValue(
-      new Error("Signed uploads are not available on this platform instance"),
-    );
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Should fall back to inline import
-      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
-      expect(platformUploadToSignedUrlMock).not.toHaveBeenCalled();
-      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
-      expect(platformImportBundleMock).toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("upload error: platformUploadToSignedUrl throws → error propagates", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Upload succeeds at getting URL but fails during PUT
-    platformUploadToSignedUrlMock.mockRejectedValue(
-      new Error("Upload to signed URL failed: 500 Internal Server Error"),
-    );
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow(
-        "Upload to signed URL failed: 500 Internal Server Error",
-      );
-      // Should NOT fall back to inline import
-      expect(platformImportBundleMock).not.toHaveBeenCalled();
-      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("413 from GCS import: error message includes 'too large'", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // GCS import returns 413
-    platformImportBundleFromGcsMock.mockRejectedValue(
-      new Error("Bundle too large to import"),
-    );
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("too large");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Platform teleport org ID and reordered flow tests
-// ---------------------------------------------------------------------------
-
-describe("platform teleport org ID and reordered flow", () => {
-  test("hatchAssistant is called without orgId (authHeaders fetches it internally)", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // hatchAssistant should be called with just the token (orgId is resolved internally by authHeaders)
-      expect(hatchAssistantMock).toHaveBeenCalledWith("platform-token");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("upload to GCS happens before hatchAssistant for platform targets", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    const callOrder: string[] = [];
-
-    platformRequestUploadUrlMock.mockImplementation(async () => {
-      callOrder.push("platformRequestUploadUrl");
-      return {
-        uploadUrl: "https://storage.googleapis.com/bucket/signed-upload-url",
-        bundleKey: "bundle-key-123",
-        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
-      };
-    });
-
-    platformUploadToSignedUrlMock.mockImplementation(async () => {
-      callOrder.push("platformUploadToSignedUrl");
-    });
-
-    hatchAssistantMock.mockImplementation(async () => {
-      callOrder.push("hatchAssistant");
-      return {
-        assistant: {
-          id: "platform-new-id",
-          name: "platform-new",
-          status: "active",
-        },
-        reusedExisting: false,
-      };
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Verify ordering: upload steps come before hatch
-      const uploadUrlIdx = callOrder.indexOf("platformRequestUploadUrl");
-      const uploadIdx = callOrder.indexOf("platformUploadToSignedUrl");
-      const hatchIdx = callOrder.indexOf("hatchAssistant");
-
-      expect(uploadUrlIdx).toBeGreaterThanOrEqual(0);
-      expect(uploadIdx).toBeGreaterThanOrEqual(0);
-      expect(hatchIdx).toBeGreaterThanOrEqual(0);
-      expect(uploadUrlIdx).toBeLessThan(hatchIdx);
-      expect(uploadIdx).toBeLessThan(hatchIdx);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("signed-URL fallback: when platformRequestUploadUrl throws 'not available', falls back to inline upload via importToAssistant", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Simulate 503 — signed uploads not available
-    platformRequestUploadUrlMock.mockRejectedValue(
-      new Error("Signed uploads are not available on this platform instance"),
-    );
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Upload URL was attempted but failed
-      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
-      // No signed URL upload should have happened
-      expect(platformUploadToSignedUrlMock).not.toHaveBeenCalled();
-      // Should NOT use GCS-based import
-      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
-      // Should fall back to inline import
-      expect(platformImportBundleMock).toHaveBeenCalled();
-      // Hatch should still succeed
-      expect(hatchAssistantMock).toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("bundleKey from pre-upload is forwarded to platformImportBundleFromGcs", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Return a specific bundle key from the pre-upload step
-    platformRequestUploadUrlMock.mockResolvedValue({
-      uploadUrl: "https://storage.googleapis.com/bucket/signed-upload-url",
-      bundleKey: "pre-uploaded-key-789",
-      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // The bundle key from the pre-upload step should be forwarded to GCS import
-      expect(platformImportBundleFromGcsMock).toHaveBeenCalledWith(
-        "pre-uploaded-key-789",
-        "platform-token",
-        expect.any(String),
-      );
-      // Inline import should NOT be used since signed upload succeeded
-      expect(platformImportBundleMock).not.toHaveBeenCalled();
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Pre-check: block teleport to platform when existing assistant detected
-// ---------------------------------------------------------------------------
-
-describe("pre-check: block teleport to platform when existing assistant detected", () => {
-  test("blocks BEFORE GCS upload when pre-check finds existing assistant", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Pre-check returns an existing assistant
-    checkExistingPlatformAssistantMock.mockResolvedValue({
-      id: "existing-platform-id",
-      name: "existing-platform",
-      status: "active",
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-
-      // Pre-check should have been called
-      expect(checkExistingPlatformAssistantMock).toHaveBeenCalledWith(
-        "platform-token",
-        undefined,
-      );
-
-      // GCS upload should NOT have been attempted
-      expect(platformRequestUploadUrlMock).not.toHaveBeenCalled();
-      expect(platformUploadToSignedUrlMock).not.toHaveBeenCalled();
-
-      // Hatch should NOT have been called
       expect(hatchAssistantMock).not.toHaveBeenCalled();
-
-      // Error message should be actionable
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("already have a platform assistant"),
-      );
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Retire it first"),
-      );
-
-      // The existing assistant is saved to the lockfile
-      expect(saveAssistantEntryMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          assistantId: "existing-platform-id",
-          cloud: "vellum",
-        }),
-      );
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
 
-  test("skips pre-check when targeting an existing named assistant", async () => {
-    setArgv("--from", "my-local", "--platform", "existing-platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-    const platformEntry = makeEntry("existing-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      if (name === "existing-platform") return platformEntry;
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Pre-check should NOT be called when targeting a known named assistant
-      expect(checkExistingPlatformAssistantMock).not.toHaveBeenCalled();
-
-      // Upload should proceed normally
-      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("pre-check failure is non-fatal — teleport proceeds", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Pre-check returns null (no existing assistant or API failed gracefully)
-    checkExistingPlatformAssistantMock.mockResolvedValue(null);
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-
-      // Pre-check was called
-      expect(checkExistingPlatformAssistantMock).toHaveBeenCalled();
-
-      // Upload and hatch should proceed normally
-      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
-      expect(hatchAssistantMock).toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Version guard: block platform→non-platform when target is behind
-// ---------------------------------------------------------------------------
-
-describe("version guard: block platform→non-platform when target is behind", () => {
-  test("blocks platform→local when local version is behind platform", async () => {
-    setArgv("--from", "my-platform", "--local", "my-local");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Source (platform) is on 0.7.0, target (local) is on 0.6.0
-    fetchCurrentVersionMock.mockImplementation((url: string) => {
-      if (url === "https://platform.vellum.ai") return Promise.resolve("0.7.0");
-      return Promise.resolve("0.6.0");
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("is running 0.6.0"),
-      );
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Upgrade your local assistant first"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("allows platform→local when versions are equal", async () => {
-    setArgv("--from", "my-platform", "--local", "my-local");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Both on 0.7.0
-    fetchCurrentVersionMock.mockResolvedValue("0.7.0");
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("allows platform→local when local is ahead of platform", async () => {
-    setArgv("--from", "my-platform", "--local", "my-local");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Source (platform) is on 0.7.0, target (local) is on 0.8.0
-    fetchCurrentVersionMock.mockImplementation((url: string) => {
-      if (url === "https://platform.vellum.ai") return Promise.resolve("0.7.0");
-      return Promise.resolve("0.8.0");
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("allows teleport when source version cannot be fetched (best-effort)", async () => {
-    setArgv("--from", "my-platform", "--local", "my-local");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Source (platform) is unreachable, target (local) is on 0.6.0
-    fetchCurrentVersionMock.mockImplementation((url: string) => {
-      if (url === "https://platform.vellum.ai")
-        return Promise.resolve(undefined);
-      return Promise.resolve("0.6.0");
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("allows teleport when target version cannot be fetched (best-effort)", async () => {
-    setArgv("--from", "my-platform", "--local", "my-local");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Source (platform) is on 0.7.0, target (local) is unreachable
-    fetchCurrentVersionMock.mockImplementation((url: string) => {
-      if (url === "https://platform.vellum.ai") return Promise.resolve("0.7.0");
-      return Promise.resolve(undefined);
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("pre-release target is behind release source: 0.7.0-local.xxx < 0.7.0", async () => {
-    setArgv("--from", "my-platform", "--local", "my-local");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Per semver, pre-release < release for same core version
-    fetchCurrentVersionMock.mockImplementation((url: string) => {
-      if (url === "https://platform.vellum.ai") return Promise.resolve("0.7.0");
-      return Promise.resolve("0.7.0-local.20260411.abc123");
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("is running 0.7.0-local.20260411.abc123"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("blocks platform→docker when docker version is behind platform", async () => {
-    setArgv("--from", "my-platform", "--docker", "my-docker");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const dockerEntry = makeEntry("my-docker", { cloud: "docker" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-docker") return dockerEntry;
-      return null;
-    });
-
-    // Source (platform) is on 0.7.0, target (docker) is on 0.5.0
-    fetchCurrentVersionMock.mockImplementation((url: string) => {
-      if (url === "https://platform.vellum.ai") return Promise.resolve("0.7.0");
-      return Promise.resolve("0.5.0");
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("is running 0.5.0"),
-      );
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Upgrade your docker assistant first"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("dry-run: blocks platform→local when local version is behind", async () => {
+  test("dry-run against local target fails fast (no preflight-from-gcs runtime endpoint yet)", async () => {
     setArgv("--from", "my-platform", "--local", "my-local", "--dry-run");
 
     const platformEntry = makeEntry("my-platform", {
@@ -2004,28 +1539,140 @@ describe("version guard: block platform→non-platform when target is behind", (
       return null;
     });
 
-    // Source (platform) is on 0.7.0, target (local) is on 0.6.0
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "bundle-key-from-platform",
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "--dry-run is not yet supported for local or docker targets",
+        ),
+      );
+
+      // Must fail BEFORE any export work — no signed URL request, no platform
+      // export initiation, nothing that costs time or bandwidth.
+      expect(platformRequestSignedUrlMock).not.toHaveBeenCalled();
+      expect(platformInitiateExportMock).not.toHaveBeenCalled();
+      expect(localRuntimeExportToGcsMock).not.toHaveBeenCalled();
+    } finally {
+      restoreFetch();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre-check: block teleport to platform when existing assistant detected
+// ---------------------------------------------------------------------------
+
+describe("pre-check: existing platform assistant", () => {
+  test("blocks before any work when pre-check finds existing assistant", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    checkExistingPlatformAssistantMock.mockResolvedValue({
+      id: "existing-platform-id",
+      name: "existing-platform",
+      status: "active",
+    });
+
+    await expect(teleport()).rejects.toThrow("process.exit:1");
+
+    expect(checkExistingPlatformAssistantMock).toHaveBeenCalledWith(
+      "platform-token",
+      undefined,
+    );
+    // No signed-URL or runtime calls
+    expect(platformRequestSignedUrlMock).not.toHaveBeenCalled();
+    expect(localRuntimeExportToGcsMock).not.toHaveBeenCalled();
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("already have a platform assistant"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Version guard
+// ---------------------------------------------------------------------------
+
+describe("version guard", () => {
+  test("blocks platform→local when local version is behind", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
     fetchCurrentVersionMock.mockImplementation((url: string) => {
       if (url === "https://platform.vellum.ai") return Promise.resolve("0.7.0");
       return Promise.resolve("0.6.0");
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await expect(teleport()).rejects.toThrow("process.exit:1");
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining("is running 0.6.0"),
       );
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
+    }
+  });
+
+  test("allows equal versions", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    fetchCurrentVersionMock.mockResolvedValue("0.7.0");
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "b",
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Teleport complete"),
+      );
+    } finally {
+      restoreFetch();
     }
   });
 
   test("newly hatched target is cleaned up when version check fails", async () => {
-    // No existing local target — teleport will hatch a new one, then
-    // the version guard should retire it to avoid orphans.
     setArgv("--from", "my-platform", "--local");
 
     const platformEntry = makeEntry("my-platform", {
@@ -2034,12 +1681,10 @@ describe("version guard: block platform→non-platform when target is behind", (
     });
     const newLocalEntry = makeEntry("new-local", { cloud: "local" });
 
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      return null;
-    });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-platform" ? platformEntry : null,
+    );
 
-    // Simulate hatch creating a new local entry
     loadAllAssistantsMock.mockImplementation(() => {
       if (hatchLocalMock.mock.calls.length > 0) {
         return [platformEntry, newLocalEntry];
@@ -2047,70 +1692,42 @@ describe("version guard: block platform→non-platform when target is behind", (
       return [platformEntry];
     });
 
-    // Source (platform) is on 0.7.0, newly hatched local is on 0.6.0
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "b",
+    });
+
     fetchCurrentVersionMock.mockImplementation((url: string) => {
       if (url === "https://platform.vellum.ai") return Promise.resolve("0.7.0");
       return Promise.resolve("0.6.0");
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await expect(teleport()).rejects.toThrow("process.exit:1");
-      // Should have hatched a new local assistant
       expect(hatchLocalMock).toHaveBeenCalled();
-      // Should retire the orphaned assistant
       expect(retireLocalMock).toHaveBeenCalledWith("new-local", newLocalEntry);
       expect(removeAssistantEntryMock).toHaveBeenCalledWith("new-local");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Cleaning up newly hatched assistant"),
-      );
     } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("does not check versions for local→platform direction", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      // fetchCurrentVersion should NOT be called for local→platform
-      expect(fetchCurrentVersionMock).not.toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
 });
 
 // ---------------------------------------------------------------------------
-// Credential import display tests
+// Credential import display
 // ---------------------------------------------------------------------------
 
 describe("credential import display", () => {
-  test("prints credential counts when credentialsImported is present", async () => {
+  test("prints credential counts when credentialsImported is present (platform target)", async () => {
     setArgv("--from", "my-local", "--platform");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
 
     platformImportBundleFromGcsMock.mockResolvedValue({
       statusCode: 200,
@@ -2132,47 +1749,24 @@ describe("credential import display", () => {
       },
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
       expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 5/5");
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
 
-  test("does not print credential line when credentialsImported is absent (old server)", async () => {
+  test("does not print credential line when absent", async () => {
     setArgv("--from", "my-local", "--platform");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
 
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    // Mock the GCS import path (used by default since platformRequestUploadUrl
-    // succeeds) with a response that has no credentialsImported field, simulating
-    // an older server.
-    platformImportBundleFromGcsMock.mockResolvedValue({
-      statusCode: 200,
-      body: {
-        success: true,
-        summary: {
-          total_files: 3,
-          files_created: 2,
-          files_overwritten: 1,
-          files_skipped: 0,
-          backups_created: 1,
-        },
-      },
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
       const allLogCalls = consoleLogSpy.mock.calls.map((c: unknown[]) => c[0]);
@@ -2182,98 +1776,7 @@ describe("credential import display", () => {
       );
       expect(credentialLines).toHaveLength(0);
     } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("lists failed credential accounts individually", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    platformImportBundleFromGcsMock.mockResolvedValue({
-      statusCode: 200,
-      body: {
-        success: true,
-        summary: {
-          total_files: 3,
-          files_created: 2,
-          files_overwritten: 1,
-          files_skipped: 0,
-          backups_created: 1,
-        },
-        credentialsImported: {
-          total: 5,
-          succeeded: 3,
-          failed: 2,
-          failedAccounts: ["google:user@example.com", "github:octocat"],
-        },
-      },
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 3/5");
-      expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials failed:  2");
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        "    - google:user@example.com",
-      );
-      expect(consoleLogSpy).toHaveBeenCalledWith("    - github:octocat");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("shows platform credentials skipped count", async () => {
-    setArgv("--from", "my-local", "--platform");
-
-    const localEntry = makeEntry("my-local", { cloud: "local" });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-local") return localEntry;
-      return null;
-    });
-
-    platformImportBundleFromGcsMock.mockResolvedValue({
-      statusCode: 200,
-      body: {
-        success: true,
-        summary: {
-          total_files: 3,
-          files_created: 2,
-          files_overwritten: 1,
-          files_skipped: 0,
-          backups_created: 1,
-        },
-        credentialsImported: {
-          total: 5,
-          succeeded: 5,
-          failed: 0,
-          failedAccounts: [],
-          skippedPlatform: 3,
-        },
-      },
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 5/5");
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        "  Platform credentials skipped: 3",
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
 });
@@ -2282,7 +1785,7 @@ describe("credential import display", () => {
 // Platform credential injection after teleport
 // ---------------------------------------------------------------------------
 
-describe("teleport platform credential injection", () => {
+describe("platform credential injection", () => {
   test("platform→local teleport calls ensureSelfHostedLocalRegistration and injectCredentialsIntoAssistant", async () => {
     setArgv("--from", "my-platform", "--local", "my-local");
 
@@ -2301,9 +1804,14 @@ describe("teleport platform credential injection", () => {
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "bundle-xyz",
+    });
 
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
       expect(ensureSelfHostedLocalRegistrationMock).toHaveBeenCalledWith(
@@ -2323,49 +1831,12 @@ describe("teleport platform credential injection", () => {
         userId: "user-1",
         webhookSecret: "webhook-secret-123",
       });
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        "  Platform credentials injected.",
-      );
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
 
-  test("platform→docker teleport also calls credential injection", async () => {
-    setArgv("--from", "my-platform", "--docker", "my-docker");
-
-    const platformEntry = makeEntry("my-platform", {
-      cloud: "vellum",
-      runtimeUrl: "https://platform.vellum.ai",
-    });
-    const dockerEntry = makeEntry("my-docker", {
-      cloud: "docker",
-      runtimeUrl: "http://localhost:8821",
-      bearerToken: "docker-bearer",
-    });
-
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "my-platform") return platformEntry;
-      if (name === "my-docker") return dockerEntry;
-      return null;
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await teleport();
-      expect(ensureSelfHostedLocalRegistrationMock).toHaveBeenCalled();
-      expect(injectCredentialsIntoAssistantMock).toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        "  Platform credentials injected.",
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("local→local teleport does NOT call credential injection", async () => {
+  test("local→docker teleport does NOT call credential injection", async () => {
     setArgv("--from", "my-local", "--docker", "my-docker");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
@@ -2380,19 +1851,67 @@ describe("teleport platform credential injection", () => {
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
       expect(ensureSelfHostedLocalRegistrationMock).not.toHaveBeenCalled();
       expect(injectCredentialsIntoAssistantMock).not.toHaveBeenCalled();
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
     }
   });
+});
 
-  test("if user is not logged in (readPlatformToken returns null), injection is skipped gracefully", async () => {
+// ---------------------------------------------------------------------------
+// Auth / transient-error resilience (Codex P1/P2 regression guards)
+// ---------------------------------------------------------------------------
+
+describe("auth + transient-error resilience", () => {
+  test("runtime 401 on export kickoff triggers token refresh and retry", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    // First kickoff call fails with 401, second succeeds.
+    localRuntimeExportToGcsMock.mockImplementationOnce(async () => {
+      throw new Error("Local runtime export-to-gcs failed (401): stale token");
+    });
+    localRuntimeExportToGcsMock.mockImplementationOnce(async () => ({
+      jobId: "local-export-job-after-refresh",
+    }));
+
+    // Ensure the refresh path returns a distinguishable token.
+    leaseGuardianTokenMock.mockResolvedValueOnce({
+      accessToken: "refreshed-token",
+      accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    } as unknown as Awaited<
+      ReturnType<typeof guardianToken.leaseGuardianToken>
+    >);
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+    } finally {
+      restoreFetch();
+    }
+
+    // Kickoff was attempted twice: once with the cached token, once after
+    // a forced refresh lease.
+    expect(localRuntimeExportToGcsMock).toHaveBeenCalledTimes(2);
+
+    const firstTokenArg = localRuntimeExportToGcsMock.mock.calls[0][1];
+    const secondTokenArg = localRuntimeExportToGcsMock.mock.calls[1][1];
+    expect(firstTokenArg).toBe("local-token");
+    expect(secondTokenArg).toBe("refreshed-token");
+
+    // A fresh lease was requested exactly once (the forceRefresh path).
+    expect(leaseGuardianTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("runtime 401 on import kickoff triggers token refresh and retry", async () => {
     setArgv("--from", "my-platform", "--local", "my-local");
 
     const platformEntry = makeEntry("my-platform", {
@@ -2407,36 +1926,121 @@ describe("teleport platform credential injection", () => {
       return null;
     });
 
-    // The readPlatformToken mock is called twice during teleport:
-    // once during the platform export flow and once during credential injection.
-    // We need the first call to return a token (for the export to work)
-    // and the second call to return null (to test the skip path).
-    let callCount = 0;
-    readPlatformTokenMock.mockImplementation(() => {
-      callCount++;
-      // The platform export path calls readPlatformToken first;
-      // the credential injection helper calls it after import.
-      // Return null only on the last call (the injection helper).
-      if (callCount <= 1) return "platform-token";
-      return null;
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "b-key",
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+    localRuntimeImportFromGcsMock.mockImplementationOnce(async () => {
+      throw new Error(
+        "Local runtime import-from-gcs failed (401): stale token",
+      );
+    });
+    localRuntimeImportFromGcsMock.mockImplementationOnce(async () => ({
+      jobId: "local-import-after-refresh",
+    }));
 
+    leaseGuardianTokenMock.mockResolvedValueOnce({
+      accessToken: "refreshed-import-token",
+      accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    } as unknown as Awaited<
+      ReturnType<typeof guardianToken.leaseGuardianToken>
+    >);
+
+    const restoreFetch = installTrackingFetch();
     try {
       await teleport();
-      expect(ensureSelfHostedLocalRegistrationMock).not.toHaveBeenCalled();
-      expect(injectCredentialsIntoAssistantMock).not.toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        "  Skipped platform credential injection (not logged in).",
-      );
-      // Teleport still succeeds
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Teleport complete"),
+    } finally {
+      restoreFetch();
+    }
+
+    expect(localRuntimeImportFromGcsMock).toHaveBeenCalledTimes(2);
+    expect(localRuntimeImportFromGcsMock.mock.calls[0][1]).toBe("local-token");
+    expect(localRuntimeImportFromGcsMock.mock.calls[1][1]).toBe(
+      "refreshed-import-token",
+    );
+  });
+
+  test("runtime non-401 errors do NOT trigger token refresh", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    localRuntimeExportToGcsMock.mockRejectedValue(
+      new Error("Local runtime export-to-gcs failed (500): boom"),
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow(/500.*boom/);
+    } finally {
+      restoreFetch();
+    }
+
+    // One attempt, no forced-refresh lease.
+    expect(localRuntimeExportToGcsMock).toHaveBeenCalledTimes(1);
+    expect(leaseGuardianTokenMock).not.toHaveBeenCalled();
+  });
+
+  test("transient poll error does not abort teleport (job completes after retry)", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    // Throw once with a 503 (transient), then succeed with terminal complete.
+    let pollCalls = 0;
+    localRuntimePollJobStatusMock.mockImplementation(
+      async (_runtimeUrl, _token, jobId) => {
+        pollCalls += 1;
+        if (pollCalls === 1) {
+          throw new Error(
+            "Local job status check failed: 503 Service Unavailable",
+          );
+        }
+        return {
+          jobId,
+          type: "export" as const,
+          status: "complete" as const,
+          result: undefined,
+        };
+      },
+    );
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const restoreFetch = installTrackingFetch();
+    try {
+      // Should NOT reject — a single transient 503 is retried, not fatal.
+      await teleport();
+      expect(pollCalls).toBeGreaterThanOrEqual(2);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("polling failed, retrying"),
       );
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreFetch();
+      warnSpy.mockRestore();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Misc: legacy --to deprecation
+// ---------------------------------------------------------------------------
+
+describe("misc", () => {
+  test("legacy --to flag shows deprecation message", async () => {
+    setArgv("--from", "source", "--to", "target");
+
+    await expect(teleport()).rejects.toThrow("process.exit:1");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("--to is deprecated"),
+    );
   });
 });

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -1987,6 +1987,66 @@ describe("auth + transient-error resilience", () => {
     expect(leaseGuardianTokenMock).not.toHaveBeenCalled();
   });
 
+  test("runtime poll 401 mid-migration triggers forceRefresh lease and completes", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    // Export kickoff succeeds with the cached "local-token".
+    // During polling, the first status check fails with 401 (token expired
+    // mid-migration), the poll loop calls refreshOn401 → leaseGuardianToken,
+    // then the next poll succeeds with the new token.
+    const tokensSeenByPoll: string[] = [];
+    localRuntimePollJobStatusMock.mockImplementation(
+      async (_runtimeUrl, token, jobId) => {
+        tokensSeenByPoll.push(token);
+        if (tokensSeenByPoll.length === 1) {
+          throw new Error("Local job status check failed: 401 Unauthorized");
+        }
+        return {
+          jobId,
+          type: "export" as const,
+          status: "complete" as const,
+          result: undefined,
+        };
+      },
+    );
+
+    leaseGuardianTokenMock.mockResolvedValueOnce({
+      accessToken: "poll-refreshed-token",
+      accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    } as unknown as Awaited<
+      ReturnType<typeof guardianToken.leaseGuardianToken>
+    >);
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      // The first poll used the cached token; the second (post-refresh) poll
+      // used the freshly leased one.
+      expect(tokensSeenByPoll.length).toBeGreaterThanOrEqual(2);
+      expect(tokensSeenByPoll[0]).toBe("local-token");
+      expect(tokensSeenByPoll[1]).toBe("poll-refreshed-token");
+
+      // leaseGuardianToken was invoked for the forceRefresh path.
+      expect(leaseGuardianTokenMock).toHaveBeenCalledTimes(1);
+
+      // The 401 branch emits its own warning — distinct from the generic
+      // transient-error warning — so this asserts the refresh path fired.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("refreshing auth"),
+      );
+    } finally {
+      restoreFetch();
+      warnSpy.mockRestore();
+    }
+  });
+
   test("transient poll error does not abort teleport (job completes after retry)", async () => {
     setArgv("--from", "my-local", "--platform");
 

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -419,6 +419,17 @@ async function exportFromAssistant(
       label: "local-runtime export",
       poll: () =>
         localRuntimePollJobStatus(entry.runtimeUrl, accessToken, jobId),
+      // Large exports can take longer than a guardian-token lease. If the
+      // runtime returns 401 mid-poll, re-lease a fresh token and rebind the
+      // closure variable so the next poll uses it.
+      refreshOn401: async () => {
+        accessToken = await getAccessToken(
+          entry.runtimeUrl,
+          entry.assistantId,
+          entry.assistantId,
+          { forceRefresh: true },
+        );
+      },
     });
 
     if (terminal.status === "failed") {
@@ -441,9 +452,24 @@ async function exportFromAssistant(
 
     console.log(`Export started (job ${jobId})...`);
 
+    let exportPlatformToken = platformToken;
     const terminal = await pollJobUntilDone({
       label: "platform export",
-      poll: () => platformPollJobStatus(jobId, platformToken, entry.runtimeUrl),
+      poll: () =>
+        platformPollJobStatus(jobId, exportPlatformToken, entry.runtimeUrl),
+      // The platform token is normally static per-process, but re-reading the
+      // on-disk credential covers the case where the user ran `vellum login`
+      // in another terminal during a long migration. A persistent 401 after
+      // a re-read surfaces to the caller with a clear next step.
+      refreshOn401: async () => {
+        const refreshed = readPlatformToken();
+        if (!refreshed) {
+          throw new Error(
+            "Platform auth expired during export and no credential was found on disk. Run 'vellum login' and retry.",
+          );
+        }
+        exportPlatformToken = refreshed;
+      },
     });
 
     if (terminal.status === "failed") {
@@ -574,10 +600,20 @@ async function importToAssistant(
         process.exit(1);
       }
 
+      let importPlatformToken = platformToken;
       const terminal = await pollJobUntilDone({
         label: "platform import",
         poll: () =>
-          platformPollJobStatus(jobId, platformToken, entry.runtimeUrl),
+          platformPollJobStatus(jobId, importPlatformToken, entry.runtimeUrl),
+        refreshOn401: async () => {
+          const refreshed = readPlatformToken();
+          if (!refreshed) {
+            throw new Error(
+              "Platform auth expired during import and no credential was found on disk. Run 'vellum login' and retry.",
+            );
+          }
+          importPlatformToken = refreshed;
+        },
       });
 
       if (terminal.status === "failed") {
@@ -647,6 +683,14 @@ async function importToAssistant(
       label: "local-runtime import",
       poll: () =>
         localRuntimePollJobStatus(entry.runtimeUrl, accessToken, jobId),
+      refreshOn401: async () => {
+        accessToken = await getAccessToken(
+          entry.runtimeUrl,
+          entry.assistantId,
+          entry.assistantId,
+          { forceRefresh: true },
+        );
+      },
     });
 
     if (terminal.status === "failed") {

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -17,15 +17,10 @@ import {
   hatchAssistant,
   checkExistingPlatformAssistant,
   platformInitiateExport,
-  platformPollExportStatus,
-  platformDownloadExport,
-  platformImportPreflight,
-  platformImportBundle,
-  platformRequestUploadUrl,
-  platformUploadToSignedUrl,
-  platformImportPreflightFromGcs,
+  platformPollJobStatus,
   platformImportBundleFromGcs,
-  platformPollImportStatus,
+  platformImportPreflightFromGcs,
+  platformRequestSignedUrl,
   ensureSelfHostedLocalRegistration,
   readGatewayCredential,
   reprovisionAssistantApiKey,
@@ -33,6 +28,13 @@ import {
   fetchCurrentUser,
   fetchOrganizationId,
 } from "../lib/platform-client.js";
+import {
+  localRuntimeExportToGcs,
+  localRuntimeImportFromGcs,
+  localRuntimePollJobStatus,
+  MigrationInProgressError,
+} from "../lib/local-runtime-client.js";
+import { pollJobUntilDone } from "../lib/job-polling.js";
 import {
   hatchDocker,
   retireDocker,
@@ -221,11 +223,17 @@ async function getAccessToken(
   runtimeUrl: string,
   assistantId: string,
   displayName: string,
+  options?: { forceRefresh?: boolean },
 ): Promise<string> {
-  const tokenData = loadGuardianToken(assistantId);
+  // When forceRefresh is set (e.g. after a runtime 401 on the cached token)
+  // we skip the cache and lease a brand-new token from the gateway, so a
+  // stale-but-unexpired token can't keep failing on every retry.
+  if (!options?.forceRefresh) {
+    const tokenData = loadGuardianToken(assistantId);
 
-  if (tokenData && new Date(tokenData.accessTokenExpiresAt) > new Date()) {
-    return tokenData.accessToken;
+    if (tokenData && new Date(tokenData.accessTokenExpiresAt) > new Date()) {
+      return tokenData.accessToken;
+    }
   }
 
   try {
@@ -244,336 +252,49 @@ async function getAccessToken(
   }
 }
 
-// ---------------------------------------------------------------------------
-// HTTP-based export/import helpers (shared by local and docker)
-// ---------------------------------------------------------------------------
-
-async function exportViaHttp(
-  entry: AssistantEntry,
-): Promise<Uint8Array<ArrayBuffer>> {
-  let accessToken = await getAccessToken(
-    entry.runtimeUrl,
-    entry.assistantId,
-    entry.assistantId,
-  );
-
-  let response: Response;
-  try {
-    response = await fetch(`${entry.runtimeUrl}/v1/migrations/export`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ description: "teleport export" }),
-      signal: AbortSignal.timeout(120_000),
-    });
-
-    // Retry once with a fresh token on 401
-    if (response.status === 401) {
-      let refreshedToken: string | null = null;
-      try {
-        const freshToken = await leaseGuardianToken(
-          entry.runtimeUrl,
-          entry.assistantId,
-        );
-        refreshedToken = freshToken.accessToken;
-      } catch {
-        // If token refresh fails, fall through to the error handler below
-      }
-      if (refreshedToken) {
-        accessToken = refreshedToken;
-        response = await fetch(`${entry.runtimeUrl}/v1/migrations/export`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ description: "teleport export" }),
-          signal: AbortSignal.timeout(120_000),
-        });
-      }
-    }
-  } catch (err) {
-    if (err instanceof Error && err.name === "TimeoutError") {
-      console.error("Error: Export request timed out after 2 minutes.");
-      process.exit(1);
-    }
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("ECONNREFUSED") || msg.includes("fetch failed")) {
-      console.error(
-        `Error: Could not connect to assistant '${entry.assistantId}'. Is it running?`,
-      );
-      console.error(`Try: vellum wake ${entry.assistantId}`);
-      process.exit(1);
-    }
-    throw err;
-  }
-
-  if (response.status === 401 || response.status === 403) {
-    console.error("Authentication failed.");
-    process.exit(1);
-  }
-
-  if (response.status === 404) {
-    console.error("Assistant not found or not running.");
-    process.exit(1);
-  }
-
-  if (
-    response.status === 502 ||
-    response.status === 503 ||
-    response.status === 504
-  ) {
-    console.error(
-      `Assistant is unreachable. Try 'vellum wake ${entry.assistantId}'.`,
-    );
-    process.exit(1);
-  }
-
-  if (!response.ok) {
-    const body = await response.text();
-    console.error(`Error: Export failed (${response.status}): ${body}`);
-    process.exit(1);
-  }
-
-  const arrayBuffer = await response.arrayBuffer();
-  return new Uint8Array(arrayBuffer);
+/**
+ * Detect a 401 Unauthorized raised by `localRuntimeExportToGcs` /
+ * `localRuntimeImportFromGcs`. Both throw Error with a message of the form
+ * `"Local runtime <op> failed (401): ..."` when the gateway rejects the
+ * cached guardian token.
+ */
+function isRuntime401(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /Local runtime [^(]*failed \(401\)/.test(msg);
 }
 
-async function importViaHttp(
-  entry: AssistantEntry,
-  bundleData: Uint8Array<ArrayBuffer>,
-  dryRun: boolean,
-): Promise<void> {
-  let accessToken = await getAccessToken(
-    entry.runtimeUrl,
-    entry.assistantId,
-    entry.assistantId,
-  );
-
-  if (dryRun) {
-    console.log("Running preflight analysis...\n");
-
-    let response: Response;
-    try {
-      response = await fetch(
-        `${entry.runtimeUrl}/v1/migrations/import-preflight`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            "Content-Type": "application/octet-stream",
-          },
-          body: new Blob([bundleData]),
-          signal: AbortSignal.timeout(120_000),
-        },
-      );
-
-      // Retry once with a fresh token on 401
-      if (response.status === 401) {
-        let refreshedToken: string | null = null;
-        try {
-          const freshToken = await leaseGuardianToken(
-            entry.runtimeUrl,
-            entry.assistantId,
-          );
-          refreshedToken = freshToken.accessToken;
-        } catch {
-          // If token refresh fails, fall through to the error handler below
-        }
-        if (refreshedToken) {
-          accessToken = refreshedToken;
-          response = await fetch(
-            `${entry.runtimeUrl}/v1/migrations/import-preflight`,
-            {
-              method: "POST",
-              headers: {
-                Authorization: `Bearer ${accessToken}`,
-                "Content-Type": "application/octet-stream",
-              },
-              body: new Blob([bundleData]),
-              signal: AbortSignal.timeout(120_000),
-            },
-          );
-        }
-      }
-    } catch (err) {
-      if (err instanceof Error && err.name === "TimeoutError") {
-        console.error("Error: Preflight request timed out after 2 minutes.");
-        process.exit(1);
-      }
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("ECONNREFUSED") || msg.includes("fetch failed")) {
-        console.error(
-          `Error: Could not connect to assistant '${entry.assistantId}'. Is it running?`,
-        );
-        console.error(`Try: vellum wake ${entry.assistantId}`);
-        process.exit(1);
-      }
+/**
+ * Run a runtime kickoff (`localRuntimeExportToGcs` / `localRuntimeImportFromGcs`)
+ * with a one-shot refresh-and-retry on 401. Matches the pre-rewrite
+ * `exportViaHttp`/`importViaHttp` behavior: if the cached guardian token is
+ * stale-but-unexpired and the runtime returns 401, we lease a fresh token
+ * and retry once. Any other error — or a repeated 401 on the refreshed token
+ * — propagates to the caller.
+ */
+async function callRuntimeWithAuthRetry<T>(
+  runtimeUrl: string,
+  assistantId: string,
+  fn: (token: string) => Promise<T>,
+): Promise<T> {
+  const firstToken = await getAccessToken(runtimeUrl, assistantId, assistantId);
+  try {
+    return await fn(firstToken);
+  } catch (err) {
+    if (!isRuntime401(err)) {
       throw err;
     }
-
-    handleLocalResponseErrors(response, entry.assistantId);
-
-    const result = (await response.json()) as PreflightResponse;
-    printPreflightSummary(result);
-    return;
-  }
-
-  // Actual import
-  console.log("Importing data...");
-
-  let response: Response;
-  try {
-    response = await fetch(`${entry.runtimeUrl}/v1/migrations/import`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/octet-stream",
-      },
-      body: new Blob([bundleData]),
-      signal: AbortSignal.timeout(300_000),
-    });
-
-    // Retry once with a fresh token on 401
-    if (response.status === 401) {
-      let refreshedToken: string | null = null;
-      try {
-        const freshToken = await leaseGuardianToken(
-          entry.runtimeUrl,
-          entry.assistantId,
-        );
-        refreshedToken = freshToken.accessToken;
-      } catch {
-        // If token refresh fails, fall through to the error handler below
-      }
-      if (refreshedToken) {
-        accessToken = refreshedToken;
-        response = await fetch(`${entry.runtimeUrl}/v1/migrations/import`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            "Content-Type": "application/octet-stream",
-          },
-          body: new Blob([bundleData]),
-          signal: AbortSignal.timeout(300_000),
-        });
-      }
-    }
-  } catch (err) {
-    if (err instanceof Error && err.name === "TimeoutError") {
-      console.error("Error: Import request timed out after 5 minutes.");
-      process.exit(1);
-    }
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("ECONNREFUSED") || msg.includes("fetch failed")) {
-      console.error(
-        `Error: Could not connect to assistant '${entry.assistantId}'. Is it running?`,
-      );
-      console.error(`Try: vellum wake ${entry.assistantId}`);
-      process.exit(1);
-    }
-    throw err;
-  }
-
-  handleLocalResponseErrors(response, entry.assistantId);
-
-  const result = (await response.json()) as ImportResponse;
-  printImportSummary(result);
-}
-
-// ---------------------------------------------------------------------------
-// Export from source assistant
-// ---------------------------------------------------------------------------
-
-async function exportFromAssistant(
-  entry: AssistantEntry,
-  cloud: string,
-): Promise<Uint8Array<ArrayBuffer>> {
-  if (cloud === "vellum") {
-    // Platform source — use Django async export
-    const token = readPlatformToken();
-    if (!token) {
-      console.error("Not logged in. Run 'vellum login' first.");
-      process.exit(1);
-    }
-
-    // Initiate export job
-    const { jobId } = await platformInitiateExport(
-      token,
-      "teleport export",
-      entry.runtimeUrl,
+    const refreshedToken = await getAccessToken(
+      runtimeUrl,
+      assistantId,
+      assistantId,
+      { forceRefresh: true },
     );
-
-    console.log(`Export started (job ${jobId})...`);
-
-    // Poll for completion
-    const POLL_INTERVAL_MS = 2_000;
-    const TIMEOUT_MS = 5 * 60 * 1_000;
-    const deadline = Date.now() + TIMEOUT_MS;
-    let downloadUrl: string | undefined;
-
-    while (Date.now() < deadline) {
-      let status: { status: string; downloadUrl?: string; error?: string };
-      try {
-        status = await platformPollExportStatus(jobId, token, entry.runtimeUrl);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("not found")) {
-          throw err;
-        }
-        // Re-throw permanent 4xx errors (auth, forbidden, etc.)
-        // but retry transient 5xx errors
-        const statusMatch = msg.match(/status check failed: (\d+)/);
-        if (statusMatch) {
-          const statusCode = parseInt(statusMatch[1], 10);
-          if (statusCode >= 400 && statusCode < 500) {
-            throw err;
-          }
-        }
-        // Transient error — retry
-        console.warn(`Polling failed, retrying... (${msg})`);
-        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-        continue;
-      }
-
-      if (status.status === "complete") {
-        downloadUrl = status.downloadUrl;
-        break;
-      }
-
-      if (status.status === "failed") {
-        console.error(`Export failed: ${status.error ?? "unknown error"}`);
-        process.exit(1);
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-    }
-
-    if (!downloadUrl) {
-      console.error("Export timed out after 5 minutes.");
-      process.exit(1);
-    }
-
-    // Download the bundle
-    const response = await platformDownloadExport(downloadUrl);
-    const arrayBuffer = await response.arrayBuffer();
-    return new Uint8Array(arrayBuffer);
+    return await fn(refreshedToken);
   }
-
-  if (cloud === "local" || cloud === "docker") {
-    return exportViaHttp(entry);
-  }
-
-  console.error(
-    "Teleport only supports local, docker, and platform assistants as source.",
-  );
-  process.exit(1);
 }
 
 // ---------------------------------------------------------------------------
-// Import into target assistant
+// Summary response shapes (reused by the GCS job result payload)
 // ---------------------------------------------------------------------------
 
 interface PreflightFileEntry {
@@ -625,86 +346,172 @@ interface ImportResponse {
   };
 }
 
-async function importToAssistant(
+// ---------------------------------------------------------------------------
+// Export from source — unified GCS flow
+//
+// Every source (local, docker, platform) produces a `bundleKey` referring to
+// a bundle sitting in GCS. The CLI never holds the bundle bytes.
+// ---------------------------------------------------------------------------
+
+async function exportFromAssistant(
   entry: AssistantEntry,
   cloud: string,
-  bundleData: Uint8Array<ArrayBuffer>,
-  dryRun: boolean,
-  preUploadedBundleKey?: string | null,
-): Promise<void> {
-  if (cloud === "vellum") {
-    // Platform target
-    const token = readPlatformToken();
-    if (!token) {
-      console.error("Not logged in. Run 'vellum login' first.");
+  bundlePlatformUrl?: string,
+): Promise<{ bundleKey: string }> {
+  const platformToken = readPlatformToken();
+  if (!platformToken) {
+    console.error(
+      "Not logged in. Run 'vellum login' first (required for GCS-based teleport).",
+    );
+    process.exit(1);
+  }
+
+  if (cloud === "local" || cloud === "docker") {
+    // Request a signed upload URL from the platform instance that will
+    // eventually own the bundle (i.e. the one the importer will read from).
+    // Passing the target's runtime URL here keeps upload and download on
+    // the same platform — otherwise a non-default/stale platform URL would
+    // cause the import to look at an empty object.
+    const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
+      { operation: "upload" },
+      platformToken,
+      bundlePlatformUrl,
+    );
+
+    // Wrap the kickoff in a one-shot refresh-and-retry helper so a stale-but-
+    // unexpired cached guardian token surfaces as 401 → re-lease → retry
+    // rather than a terminal failure. `accessToken` below is whichever token
+    // succeeded on the kickoff; we reuse it for polling so the runtime sees a
+    // consistent credential throughout the migration.
+    let jobId: string;
+    let accessToken: string;
+    try {
+      const result = await callRuntimeWithAuthRetry(
+        entry.runtimeUrl,
+        entry.assistantId,
+        async (token) => {
+          const r = await localRuntimeExportToGcs(entry.runtimeUrl, token, {
+            uploadUrl,
+            description: "teleport export",
+          });
+          return { jobId: r.jobId, token };
+        },
+      );
+      jobId = result.jobId;
+      accessToken = result.token;
+    } catch (err) {
+      if (err instanceof MigrationInProgressError) {
+        // Fail fast — the existing job is writing to a different GCS object
+        // (its caller's signed URL, not ours), so polling it would leave us
+        // pointing at an empty/unrelated bundle. Surface the existing job id
+        // so the user can decide whether to wait or investigate.
+        console.error(
+          `Error: Another teleport export is already in progress on '${entry.assistantId}' (job ${err.existingJobId}). Wait for it to finish or check its status, then re-run.`,
+        );
+        process.exit(1);
+      }
+      throw err;
+    }
+
+    console.log(`Export started (job ${jobId})...`);
+
+    const terminal = await pollJobUntilDone({
+      label: "local-runtime export",
+      poll: () =>
+        localRuntimePollJobStatus(entry.runtimeUrl, accessToken, jobId),
+    });
+
+    if (terminal.status === "failed") {
+      console.error(`Export failed: ${terminal.error}`);
       process.exit(1);
     }
 
-    // Use pre-uploaded bundle key if provided (string), skip upload if null
-    // (signals signed URLs were already tried and unavailable), or try
-    // signed-URL upload if undefined (never attempted).
-    let bundleKey: string | undefined =
-      preUploadedBundleKey === null ? undefined : preUploadedBundleKey;
-    if (preUploadedBundleKey === undefined) {
-      try {
-        const { uploadUrl, bundleKey: key } = await platformRequestUploadUrl(
-          token,
-          entry.runtimeUrl,
-        );
-        bundleKey = key;
-        console.log("Uploading bundle...");
-        await platformUploadToSignedUrl(uploadUrl, bundleData);
-      } catch (err) {
-        // If signed uploads unavailable (503), fall back to inline upload
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("not available")) {
-          bundleKey = undefined;
-        } else {
-          throw err;
-        }
-      }
+    return { bundleKey };
+  }
+
+  if (cloud === "vellum") {
+    // Platform source — initiate a server-side export. The platform writes
+    // the bundle to its own `exports/<org>/<id>.vbundle` key; we discover
+    // that key via the unified job-status endpoint's `bundle_key` field.
+    const { jobId } = await platformInitiateExport(
+      platformToken,
+      "teleport export",
+      entry.runtimeUrl,
+    );
+
+    console.log(`Export started (job ${jobId})...`);
+
+    const terminal = await pollJobUntilDone({
+      label: "platform export",
+      poll: () => platformPollJobStatus(jobId, platformToken, entry.runtimeUrl),
+    });
+
+    if (terminal.status === "failed") {
+      console.error(`Export failed: ${terminal.error}`);
+      process.exit(1);
     }
 
+    if (!terminal.bundleKey) {
+      console.error(
+        "Export completed but the platform did not return a bundle_key. Is the platform up to date?",
+      );
+      process.exit(1);
+    }
+
+    return { bundleKey: terminal.bundleKey };
+  }
+
+  console.error(
+    "Teleport only supports local, docker, and platform assistants as source.",
+  );
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Import into target — unified GCS flow
+// ---------------------------------------------------------------------------
+
+async function importToAssistant(
+  entry: AssistantEntry,
+  cloud: string,
+  bundleKey: string,
+  dryRun: boolean,
+  bundlePlatformUrl?: string,
+): Promise<void> {
+  const platformToken = readPlatformToken();
+  if (!platformToken) {
+    console.error(
+      "Not logged in. Run 'vellum login' first (required for GCS-based teleport).",
+    );
+    process.exit(1);
+  }
+
+  if (cloud === "vellum") {
+    // Platform target — the bundle is already in GCS; kick off preflight or
+    // async import via the unified job-status endpoint.
     if (dryRun) {
       console.log("Running preflight analysis...\n");
 
-      let preflightResult: {
-        statusCode: number;
-        body: Record<string, unknown>;
-      };
-      try {
-        preflightResult = bundleKey
-          ? await platformImportPreflightFromGcs(
-              bundleKey,
-              token,
-              entry.runtimeUrl,
-            )
-          : await platformImportPreflight(bundleData, token, entry.runtimeUrl);
-      } catch (err) {
-        if (err instanceof Error && err.name === "TimeoutError") {
-          console.error("Error: Preflight request timed out after 2 minutes.");
-          process.exit(1);
-        }
-        throw err;
-      }
+      const preflight = await platformImportPreflightFromGcs(
+        bundleKey,
+        platformToken,
+        entry.runtimeUrl,
+      );
 
-      if (
-        preflightResult.statusCode === 401 ||
-        preflightResult.statusCode === 403
-      ) {
+      if (preflight.statusCode === 401 || preflight.statusCode === 403) {
         console.error("Authentication failed. Run 'vellum login' to refresh.");
         process.exit(1);
       }
 
-      if (preflightResult.statusCode === 404) {
+      if (preflight.statusCode === 404) {
         console.error("Assistant not found or not running.");
         process.exit(1);
       }
 
       if (
-        preflightResult.statusCode === 502 ||
-        preflightResult.statusCode === 503 ||
-        preflightResult.statusCode === 504
+        preflight.statusCode === 502 ||
+        preflight.statusCode === 503 ||
+        preflight.statusCode === 504
       ) {
         console.error(
           `Assistant is unreachable. Try 'vellum wake ${entry.assistantId}'.`,
@@ -712,35 +519,53 @@ async function importToAssistant(
         process.exit(1);
       }
 
-      if (preflightResult.statusCode !== 200) {
+      if (preflight.statusCode !== 200) {
         console.error(
-          `Error: Preflight check failed (${preflightResult.statusCode}): ${JSON.stringify(preflightResult.body)}`,
+          `Error: Preflight check failed (${preflight.statusCode}): ${JSON.stringify(preflight.body)}`,
         );
         process.exit(1);
       }
 
-      const result = preflightResult.body as unknown as PreflightResponse;
+      const result = preflight.body as unknown as PreflightResponse;
       printPreflightSummary(result);
       return;
     }
 
-    // Actual import
     console.log("Importing data...");
 
-    let importResult: { statusCode: number; body: Record<string, unknown> };
-    try {
-      importResult = bundleKey
-        ? await platformImportBundleFromGcs(bundleKey, token, entry.runtimeUrl)
-        : await platformImportBundle(bundleData, token, entry.runtimeUrl);
-    } catch (err) {
-      if (err instanceof Error && err.name === "TimeoutError") {
-        console.error("Error: Import request timed out.");
-        process.exit(1);
-      }
-      throw err;
+    const importResult = await platformImportBundleFromGcs(
+      bundleKey,
+      platformToken,
+      entry.runtimeUrl,
+    );
+
+    if (importResult.statusCode === 401 || importResult.statusCode === 403) {
+      console.error("Authentication failed. Run 'vellum login' to refresh.");
+      process.exit(1);
     }
 
-    handleImportStatusErrors(importResult.statusCode, entry.assistantId);
+    if (importResult.statusCode === 404) {
+      console.error("Assistant not found or not running.");
+      process.exit(1);
+    }
+
+    if (
+      importResult.statusCode === 502 ||
+      importResult.statusCode === 503 ||
+      importResult.statusCode === 504
+    ) {
+      console.error(
+        `Assistant is unreachable. Try 'vellum wake ${entry.assistantId}'.`,
+      );
+      process.exit(1);
+    }
+
+    if (importResult.statusCode !== 202 && importResult.statusCode !== 200) {
+      console.error(`Error: Import failed (${importResult.statusCode})`);
+      process.exit(1);
+    }
+
+    let finalBody: Record<string, unknown> = importResult.body;
 
     if (importResult.statusCode === 202) {
       const jobId = (importResult.body as { job_id?: string }).job_id;
@@ -749,74 +574,89 @@ async function importToAssistant(
         process.exit(1);
       }
 
-      const POLL_INTERVAL_MS = 5_000;
-      const TIMEOUT_MS = 10 * 60 * 1_000; // 10 minutes (platform staleness is 930s)
-      const startTime = Date.now();
-      const deadline = startTime + TIMEOUT_MS;
+      const terminal = await pollJobUntilDone({
+        label: "platform import",
+        poll: () =>
+          platformPollJobStatus(jobId, platformToken, entry.runtimeUrl),
+      });
 
-      while (Date.now() < deadline) {
-        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-
-        let status: {
-          status: string;
-          result?: Record<string, unknown>;
-          error?: string;
-        };
-        try {
-          status = await platformPollImportStatus(
-            jobId,
-            token,
-            entry.runtimeUrl,
-          );
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          if (msg.includes("not found")) {
-            throw err;
-          }
-          // Re-throw permanent 4xx errors (auth, forbidden, etc.)
-          // but retry transient 5xx errors
-          const statusMatch = msg.match(/status check failed: (\d+)/);
-          if (statusMatch) {
-            const statusCode = parseInt(statusMatch[1], 10);
-            if (statusCode >= 400 && statusCode < 500) {
-              throw err;
-            }
-          }
-          // Transient error — retry
-          console.warn(`Polling failed, retrying... (${msg})`);
-          continue;
-        }
-
-        if (status.status === "complete") {
-          importResult = { statusCode: 200, body: status.result ?? {} };
-          break;
-        }
-
-        if (status.status === "failed") {
-          console.error(`Import failed: ${status.error ?? "unknown error"}`);
-          process.exit(1);
-        }
-
-        const elapsed = Math.round((Date.now() - startTime) / 1000);
-        process.stdout.write(`\rImporting... ${elapsed}s elapsed`);
-      }
-
-      // Clear the progress line
-      process.stdout.write("\r" + " ".repeat(40) + "\r");
-
-      if (importResult.statusCode === 202) {
-        console.error("Import timed out after 10 minutes.");
+      if (terminal.status === "failed") {
+        console.error(`Import failed: ${terminal.error}`);
         process.exit(1);
       }
+
+      finalBody = (terminal.result as Record<string, unknown>) ?? {};
     }
 
-    const result = importResult.body as unknown as ImportResponse;
+    const result = finalBody as unknown as ImportResponse;
     printImportSummary(result);
     return;
   }
 
   if (cloud === "local" || cloud === "docker") {
-    await importViaHttp(entry, bundleData, dryRun);
+    if (dryRun) {
+      // TODO(cli): support dry-run against local targets
+      console.error(
+        "Error: --dry-run is not yet supported for local or docker targets (no preflight-from-gcs endpoint on the runtime).",
+      );
+      process.exit(1);
+    }
+
+    // Ask the platform for a signed download URL and hand it to the local
+    // runtime. The runtime streams the bundle straight out of GCS — the CLI
+    // never touches the bytes. The URL must target the same platform the
+    // bundle was uploaded to; otherwise the object won't exist on this
+    // platform's GCS bucket.
+    const { url: bundleUrl } = await platformRequestSignedUrl(
+      { operation: "download", bundleKey },
+      platformToken,
+      bundlePlatformUrl,
+    );
+
+    console.log("Importing data...");
+
+    let jobId: string;
+    let accessToken: string;
+    try {
+      const result = await callRuntimeWithAuthRetry(
+        entry.runtimeUrl,
+        entry.assistantId,
+        async (token) => {
+          const r = await localRuntimeImportFromGcs(entry.runtimeUrl, token, {
+            bundleUrl,
+          });
+          return { jobId: r.jobId, token };
+        },
+      );
+      jobId = result.jobId;
+      accessToken = result.token;
+    } catch (err) {
+      if (err instanceof MigrationInProgressError) {
+        // Fail fast — the existing job is importing someone else's bundle
+        // (the original caller's), not ours. Polling it would report success
+        // on an import that wasn't the one we just kicked off.
+        console.error(
+          `Error: Another teleport import is already in progress on '${entry.assistantId}' (job ${err.existingJobId}). Wait for it to finish or check its status, then re-run.`,
+        );
+        process.exit(1);
+      }
+      throw err;
+    }
+
+    const terminal = await pollJobUntilDone({
+      label: "local-runtime import",
+      poll: () =>
+        localRuntimePollJobStatus(entry.runtimeUrl, accessToken, jobId),
+    });
+
+    if (terminal.status === "failed") {
+      console.error(`Import failed: ${terminal.error}`);
+      process.exit(1);
+    }
+
+    const result = ((terminal.result as Record<string, unknown>) ??
+      {}) as unknown as ImportResponse;
+    printImportSummary(result);
     return;
   }
 
@@ -950,68 +790,6 @@ export async function resolveOrHatchTarget(
 
   console.error(`Error: Unknown target environment '${targetEnv}'.`);
   process.exit(1);
-}
-
-// ---------------------------------------------------------------------------
-// Error handling helpers
-// ---------------------------------------------------------------------------
-
-function handleLocalResponseErrors(
-  response: Response,
-  assistantName: string,
-): void {
-  if (response.status === 401 || response.status === 403) {
-    console.error("Authentication failed.");
-    process.exit(1);
-  }
-
-  if (response.status === 404) {
-    console.error("Assistant not found or not running.");
-    process.exit(1);
-  }
-
-  if (
-    response.status === 502 ||
-    response.status === 503 ||
-    response.status === 504
-  ) {
-    console.error(
-      `Assistant is unreachable. Try 'vellum wake ${assistantName}'.`,
-    );
-    process.exit(1);
-  }
-
-  if (!response.ok) {
-    console.error(`Error: Request failed (${response.status})`);
-    process.exit(1);
-  }
-}
-
-function handleImportStatusErrors(
-  statusCode: number,
-  assistantName: string,
-): void {
-  if (statusCode === 401 || statusCode === 403) {
-    console.error("Authentication failed. Run 'vellum login' to refresh.");
-    process.exit(1);
-  }
-
-  if (statusCode === 404) {
-    console.error("Assistant not found or not running.");
-    process.exit(1);
-  }
-
-  if (statusCode === 502 || statusCode === 503 || statusCode === 504) {
-    console.error(
-      `Assistant is unreachable. Try 'vellum wake ${assistantName}'.`,
-    );
-    process.exit(1);
-  }
-
-  if (statusCode < 200 || statusCode >= 300) {
-    console.error(`Error: Import failed (${statusCode})`);
-    process.exit(1);
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1270,6 +1048,19 @@ export async function teleport(): Promise<void> {
         process.exit(1);
       }
 
+      // Dry-run feasibility check — reject local/docker targets BEFORE any
+      // export work. The local runtime has no preflight-from-gcs endpoint yet,
+      // so we can't actually run a dry-run against it; burning a GCS upload
+      // just to fail afterwards would be wasteful.
+      // TODO(cli): support dry-run against local targets (needs a
+      // preflight-from-gcs endpoint on the runtime).
+      if (toCloud === "local" || toCloud === "docker") {
+        console.error(
+          "Error: --dry-run is not yet supported for local or docker targets (no preflight-from-gcs endpoint on the runtime).",
+        );
+        process.exit(1);
+      }
+
       // Version guard: block platform→non-platform when target is behind
       if (fromCloud === "vellum" && toCloud !== "vellum") {
         const [sourceVersion, targetVersion] = await Promise.all([
@@ -1292,41 +1083,49 @@ export async function teleport(): Promise<void> {
         }
       }
 
+      // Pin both upload and download to the same platform instance. For
+      // platform targets the bundle is owned by the target platform; for
+      // platform sources it's owned by the source platform. Only one of
+      // these branches applies at a time (same-env was rejected earlier).
+      const bundlePlatformUrl =
+        toCloud === "vellum"
+          ? existingTarget.runtimeUrl
+          : fromCloud === "vellum"
+            ? fromEntry.runtimeUrl
+            : undefined;
+
       console.log(`Exporting from ${from} (${fromCloud})...`);
-      const bundleData = await exportFromAssistant(fromEntry, fromCloud);
+      const { bundleKey } = await exportFromAssistant(
+        fromEntry,
+        fromCloud,
+        bundlePlatformUrl,
+      );
       console.log(`Importing to ${existingTarget.assistantId} (${toCloud})...`);
-      await importToAssistant(existingTarget, toCloud, bundleData, true);
+      await importToAssistant(
+        existingTarget,
+        toCloud,
+        bundleKey,
+        true,
+        bundlePlatformUrl,
+      );
     } else {
       // No existing target — just describe what would happen
       console.log("Dry run summary:");
       console.log(`  Would export data from: ${from} (${fromCloud})`);
-      if (targetEnv === "platform") {
-        // For platform targets, reflect the reordered flow
-        console.log(`  Would upload bundle via signed URL (if available)`);
-        console.log(
-          `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
-        );
-        console.log(`  Would import data into the new assistant`);
-      } else {
-        console.log(
-          `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
-        );
-        console.log(`  Would import data into the new assistant`);
-      }
+      console.log(`  Would upload bundle via signed URL`);
+      console.log(
+        `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
+      );
+      console.log(`  Would import data into the new assistant`);
     }
 
     console.log(`Dry run complete — no changes were made.`);
     return;
   }
 
-  // Export from source
-  console.log(`Exporting from ${from} (${fromCloud})...`);
-  const bundleData = await exportFromAssistant(fromEntry, fromCloud);
-
   // Platform target: reordered flow — upload to GCS before hatching so that
-  // if upload fails, no empty assistant is left dangling on the platform.
+  // if export/upload fails, no empty assistant is left dangling on the platform.
   if (targetEnv === "platform") {
-    // Step B — Auth
     const token = readPlatformToken();
     if (!token) {
       console.error("Not logged in. Run 'vellum login' first.");
@@ -1334,7 +1133,7 @@ export async function teleport(): Promise<void> {
     }
 
     // If targeting an existing assistant, validate cloud match early — before
-    // uploading — so we don't waste a GCS upload on an invalid command.
+    // exporting — so we don't waste work on an invalid command.
     const existingTarget = targetName ? findAssistantByName(targetName) : null;
     if (existingTarget) {
       const existingCloud = resolveCloud(existingTarget);
@@ -1347,12 +1146,12 @@ export async function teleport(): Promise<void> {
       }
     }
 
-    // Use the existing target's runtimeUrl for all platform calls so upload
-    // and import hit the same instance.
+    // Use the existing target's runtimeUrl for all platform calls so the
+    // export, upload, and import all hit the same instance.
     const targetPlatformUrl = existingTarget?.runtimeUrl;
 
-    // Step B2 — Pre-check: block if the user already has a platform assistant.
-    // This runs BEFORE the expensive GCS upload so we don't waste bandwidth.
+    // Pre-check: block if the user already has a platform assistant. This
+    // runs BEFORE the expensive export so we don't waste the upload.
     if (!existingTarget) {
       const existing = await checkExistingPlatformAssistant(
         token,
@@ -1376,43 +1175,40 @@ export async function teleport(): Promise<void> {
       }
     }
 
-    // Step C — Upload to GCS
-    // bundleKey: string = uploaded successfully, null = tried but unavailable,
-    // undefined would mean "never tried" (not used here).
-    let bundleKey: string | null = null;
-    try {
-      const { uploadUrl, bundleKey: key } = await platformRequestUploadUrl(
-        token,
-        targetPlatformUrl,
-      );
-      bundleKey = key;
-      console.log("Uploading bundle to GCS...");
-      await platformUploadToSignedUrl(uploadUrl, bundleData);
-    } catch (err) {
-      // If signed uploads unavailable (503), fall back to inline upload later
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("not available")) {
-        bundleKey = null;
-      } else {
-        throw err;
-      }
-    }
+    // Export — for local/docker sources this uploads straight into GCS via
+    // the platform's signed URL; for platform sources this runs a server-side
+    // export and we read the resulting bundle_key.
+    // The signed upload URL must be requested from the same platform instance
+    // where the import will run. For existing targets that's the lockfile's
+    // runtimeUrl; for fresh hatches it's getPlatformUrl() (which is what
+    // resolveOrHatchTarget writes to the new entry).
+    console.log(`Exporting from ${from} (${fromCloud})...`);
+    const bundlePlatformUrl = targetPlatformUrl ?? getPlatformUrl();
+    const { bundleKey } = await exportFromAssistant(
+      fromEntry,
+      fromCloud,
+      bundlePlatformUrl,
+    );
 
-    // Step D — Hatch (upload succeeded or fallback to inline — safe to hatch)
+    // Hatch (export succeeded — safe to create the target)
     const toEntry = await resolveOrHatchTarget(targetEnv, targetName);
     const toCloud = resolveCloud(toEntry);
 
-    // Step E — Import from GCS (or inline fallback)
-    // Pass bundleKey (string) or null to signal "already tried, use inline".
+    // Import from GCS
     console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
-    await importToAssistant(toEntry, toCloud, bundleData, false, bundleKey);
+    await importToAssistant(
+      toEntry,
+      toCloud,
+      bundleKey,
+      false,
+      bundlePlatformUrl,
+    );
 
-    // Success summary
     console.log(`Teleport complete: ${from} → ${toEntry.assistantId}`);
     return;
   }
 
-  // Non-platform targets (local/docker): existing flow unchanged
+  // Non-platform targets (local/docker)
   // For local<->docker transfers, stop (sleep) the source to free up ports
   // before hatching the target. We do NOT retire yet — if hatch or import
   // fails, the user can recover by running `vellum wake <source>`.
@@ -1447,6 +1243,22 @@ export async function teleport(): Promise<void> {
       versionGuardPassed = true;
     }
   }
+
+  // Pin the bundle's platform instance so upload and download land on the
+  // same GCS bucket. For platform sources the bundle is owned by the source
+  // platform. For local/docker→local/docker the bundle lives on whatever
+  // platform getPlatformUrl() currently resolves to — we resolve it once
+  // here so a lockfile change mid-teleport can't split export and import.
+  const bundlePlatformUrl =
+    fromCloud === "vellum" ? fromEntry.runtimeUrl : getPlatformUrl();
+
+  // Export from source (bundle lives in GCS after this returns).
+  console.log(`Exporting from ${from} (${fromCloud})...`);
+  const { bundleKey } = await exportFromAssistant(
+    fromEntry,
+    fromCloud,
+    bundlePlatformUrl,
+  );
 
   if (sourceIsLocalOrDocker && targetIsLocalOrDocker && !keepSource) {
     console.log(`Stopping source assistant '${from}' to free ports...`);
@@ -1513,9 +1325,15 @@ export async function teleport(): Promise<void> {
     }
   }
 
-  // Import to target
+  // Import to target (also GCS-driven)
   console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
-  await importToAssistant(toEntry, toCloud, bundleData, false);
+  await importToAssistant(
+    toEntry,
+    toCloud,
+    bundleKey,
+    false,
+    bundlePlatformUrl,
+  );
 
   // After successful import, inject fresh platform credentials if the
   // user is logged in — replaces the source's stale vellum:* credentials
@@ -1540,6 +1358,5 @@ export async function teleport(): Promise<void> {
     }
   }
 
-  // Success summary
   console.log(`Teleport complete: ${from} → ${toEntry.assistantId}`);
 }

--- a/cli/src/lib/__tests__/job-polling.test.ts
+++ b/cli/src/lib/__tests__/job-polling.test.ts
@@ -176,6 +176,82 @@ describe("pollJobUntilDone", () => {
       expect(calls).toBe(2);
     });
 
+    test("refreshOn401 is invoked on 401 and polling continues after refresh", async () => {
+      let calls = 0;
+      let refreshes = 0;
+      const result = await pollJobUntilDone({
+        label: "expiring auth",
+        intervalMs: 1,
+        timeoutMs: 1_000,
+        maxTransientErrors: 0,
+        refreshOn401: async () => {
+          refreshes += 1;
+        },
+        poll: async () => {
+          calls += 1;
+          if (calls === 1) {
+            throw new Error("Local job status check failed: 401 Unauthorized");
+          }
+          return {
+            jobId: "j401",
+            type: "export",
+            status: "complete",
+          } as UnifiedJobStatus;
+        },
+      });
+      expect(result.status).toBe("complete");
+      expect(refreshes).toBe(1);
+      expect(calls).toBe(2);
+      // The 401 branch logs its own distinct warning (not the generic
+      // "polling failed, retrying" one) so operators can distinguish an
+      // auth refresh from a transient-error retry in the output.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("refreshing auth"),
+      );
+    });
+
+    test("propagates 401 once maxAuthRefreshes is exceeded", async () => {
+      const maxAuthRefreshes = 2;
+      let calls = 0;
+      let refreshes = 0;
+      await expect(
+        pollJobUntilDone({
+          label: "persistently unauthorized",
+          intervalMs: 1,
+          timeoutMs: 1_000,
+          maxAuthRefreshes,
+          refreshOn401: async () => {
+            refreshes += 1;
+          },
+          poll: async () => {
+            calls += 1;
+            throw new Error("Local job status check failed: 401 Unauthorized");
+          },
+        }),
+      ).rejects.toThrow(/401 Unauthorized/);
+      // Helper allows `maxAuthRefreshes` successful refresh-and-retry cycles
+      // (each counted against the budget after the poll fails), plus one
+      // final attempt on the refreshed token that exceeds the budget.
+      expect(calls).toBe(maxAuthRefreshes + 1);
+      expect(refreshes).toBe(maxAuthRefreshes);
+    });
+
+    test("without refreshOn401, 401 still propagates as a permanent 4xx", async () => {
+      let calls = 0;
+      await expect(
+        pollJobUntilDone({
+          label: "no refresh hook",
+          intervalMs: 1,
+          timeoutMs: 1_000,
+          poll: async () => {
+            calls += 1;
+            throw new Error("Local job status check failed: 401 Unauthorized");
+          },
+        }),
+      ).rejects.toThrow(/401 Unauthorized/);
+      expect(calls).toBe(1);
+    });
+
     test("unclassified network-style errors are treated as transient", async () => {
       let calls = 0;
       const result = await pollJobUntilDone({

--- a/cli/src/lib/__tests__/job-polling.test.ts
+++ b/cli/src/lib/__tests__/job-polling.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import { pollJobUntilDone } from "../job-polling.js";
 import type { UnifiedJobStatus } from "../platform-client.js";
@@ -74,5 +74,129 @@ describe("pollJobUntilDone", () => {
       label: "defaults test",
     });
     expect(result.status).toBe("complete");
+  });
+
+  describe("transient-error retry", () => {
+    let warnSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+      warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    test("retries N-1 transient errors then returns terminal status", async () => {
+      const maxTransientErrors = 3;
+      let calls = 0;
+      const result = await pollJobUntilDone({
+        label: "flaky export",
+        intervalMs: 1,
+        timeoutMs: 1_000,
+        maxTransientErrors,
+        poll: async () => {
+          calls += 1;
+          if (calls < maxTransientErrors) {
+            throw new Error(
+              `Local job status check failed: 503 Service Unavailable`,
+            );
+          }
+          return {
+            jobId: "j5",
+            type: "export",
+            status: "complete",
+          } as UnifiedJobStatus;
+        },
+      });
+      expect(result.status).toBe("complete");
+      expect(calls).toBe(maxTransientErrors);
+      // One warning per retried transient error (first two attempts).
+      expect(warnSpy).toHaveBeenCalledTimes(maxTransientErrors - 1);
+    });
+
+    test("propagates the last error once maxTransientErrors is exceeded", async () => {
+      const maxTransientErrors = 2;
+      let calls = 0;
+      await expect(
+        pollJobUntilDone({
+          label: "always broken",
+          intervalMs: 1,
+          timeoutMs: 1_000,
+          maxTransientErrors,
+          poll: async () => {
+            calls += 1;
+            throw new Error(`Local job status check failed: 502 Bad Gateway`);
+          },
+        }),
+      ).rejects.toThrow(/502 Bad Gateway/);
+      // Helper makes `maxTransientErrors + 1` attempts before giving up: the
+      // first attempt plus N retries, counted against the budget.
+      expect(calls).toBe(maxTransientErrors + 1);
+    });
+
+    test("permanent 4xx errors (except 429) propagate immediately", async () => {
+      let calls = 0;
+      await expect(
+        pollJobUntilDone({
+          label: "auth broken",
+          intervalMs: 1,
+          timeoutMs: 1_000,
+          maxTransientErrors: 5,
+          poll: async () => {
+            calls += 1;
+            throw new Error(`Local job status check failed: 403 Forbidden`);
+          },
+        }),
+      ).rejects.toThrow(/403 Forbidden/);
+      expect(calls).toBe(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test("429 rate-limit is retried as transient", async () => {
+      let calls = 0;
+      const result = await pollJobUntilDone({
+        label: "rate limited",
+        intervalMs: 1,
+        timeoutMs: 1_000,
+        maxTransientErrors: 3,
+        poll: async () => {
+          calls += 1;
+          if (calls === 1) {
+            throw new Error(`Local job status check failed: 429 Too Many`);
+          }
+          return {
+            jobId: "j6",
+            type: "export",
+            status: "complete",
+          } as UnifiedJobStatus;
+        },
+      });
+      expect(result.status).toBe("complete");
+      expect(calls).toBe(2);
+    });
+
+    test("unclassified network-style errors are treated as transient", async () => {
+      let calls = 0;
+      const result = await pollJobUntilDone({
+        label: "network blip",
+        intervalMs: 1,
+        timeoutMs: 1_000,
+        maxTransientErrors: 3,
+        poll: async () => {
+          calls += 1;
+          if (calls === 1) {
+            throw new Error("fetch failed");
+          }
+          return {
+            jobId: "j7",
+            type: "export",
+            status: "complete",
+          } as UnifiedJobStatus;
+        },
+      });
+      expect(result.status).toBe("complete");
+      expect(calls).toBe(2);
+    });
   });
 });

--- a/cli/src/lib/__tests__/job-polling.test.ts
+++ b/cli/src/lib/__tests__/job-polling.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import { pollJobUntilDone } from "../job-polling.js";
+import type { UnifiedJobStatus } from "../platform-client.js";
+
+describe("pollJobUntilDone", () => {
+  test("returns terminal 'complete' after N processing polls", async () => {
+    const statuses: UnifiedJobStatus[] = [
+      { jobId: "j1", type: "export", status: "processing" },
+      { jobId: "j1", type: "export", status: "processing" },
+      {
+        jobId: "j1",
+        type: "export",
+        status: "complete",
+        bundleKey: "bundles/j1.tar.gz",
+      },
+    ];
+    let i = 0;
+    const result = await pollJobUntilDone({
+      poll: async () => statuses[i++]!,
+      intervalMs: 1,
+      timeoutMs: 1_000,
+      label: "test export",
+    });
+
+    expect(result.status).toBe("complete");
+    if (result.status === "complete") {
+      expect(result.bundleKey).toBe("bundles/j1.tar.gz");
+    }
+    expect(i).toBe(3);
+  });
+
+  test("propagates terminal 'failed' status to caller without throwing", async () => {
+    const result = await pollJobUntilDone({
+      poll: async () => ({
+        jobId: "j2",
+        type: "import",
+        status: "failed",
+        error: "bad bundle",
+      }),
+      intervalMs: 1,
+      timeoutMs: 1_000,
+      label: "test import",
+    });
+
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.error).toBe("bad bundle");
+    }
+  });
+
+  test("throws with label when polling exceeds timeoutMs", async () => {
+    let calls = 0;
+    await expect(
+      pollJobUntilDone({
+        poll: async () => {
+          calls += 1;
+          return { jobId: "j3", type: "export", status: "processing" };
+        },
+        intervalMs: 20,
+        timeoutMs: 10,
+        label: "slow export",
+      }),
+    ).rejects.toThrow(/slow export/);
+
+    // The loop does one poll before checking the deadline, so calls ≥ 1.
+    expect(calls).toBeGreaterThanOrEqual(1);
+  });
+
+  test("uses defaults when intervalMs/timeoutMs are omitted (fast path)", async () => {
+    // Fast path: first poll is already terminal so neither default matters.
+    const result = await pollJobUntilDone({
+      poll: async () => ({ jobId: "j4", type: "export", status: "complete" }),
+      label: "defaults test",
+    });
+    expect(result.status).toBe("complete");
+  });
+});

--- a/cli/src/lib/__tests__/local-runtime-client.test.ts
+++ b/cli/src/lib/__tests__/local-runtime-client.test.ts
@@ -1,0 +1,383 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  MigrationInProgressError,
+  localRuntimeExportToGcs,
+  localRuntimeImportFromGcs,
+  localRuntimePollJobStatus,
+} from "../local-runtime-client.js";
+
+const RUNTIME_URL = "http://127.0.0.1:8765";
+const TOKEN = "local-bearer-token";
+
+interface CapturedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function captureFetch(
+  responder: (call: CapturedCall) => Response | Promise<Response>,
+): {
+  calls: CapturedCall[];
+  fetchMock: typeof globalThis.fetch;
+} {
+  const calls: CapturedCall[] = [];
+  const fetchMock = mock(
+    async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      const rawHeaders = (init?.headers ?? {}) as
+        | Record<string, string>
+        | Headers;
+      const headers: Record<string, string> = {};
+      if (rawHeaders instanceof Headers) {
+        rawHeaders.forEach((v, k) => {
+          headers[k] = v;
+        });
+      } else {
+        Object.assign(headers, rawHeaders);
+      }
+      let parsedBody: unknown = undefined;
+      const b = init?.body;
+      if (typeof b === "string") {
+        try {
+          parsedBody = JSON.parse(b);
+        } catch {
+          parsedBody = b;
+        }
+      }
+      const call: CapturedCall = {
+        url: urlStr,
+        method: init?.method ?? "GET",
+        headers,
+        body: parsedBody,
+      };
+      calls.push(call);
+      return responder(call);
+    },
+  );
+  return { calls, fetchMock: fetchMock as unknown as typeof globalThis.fetch };
+}
+
+let originalFetch: typeof globalThis.fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("localRuntimeExportToGcs", () => {
+  test("POSTs {upload_url, description} with Bearer auth and returns job_id on 202", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "export-job-1",
+          status: "pending",
+          type: "export",
+        }),
+        { status: 202, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await localRuntimeExportToGcs(RUNTIME_URL, TOKEN, {
+      uploadUrl: "https://storage.example/signed/abc",
+      description: "teleport export",
+    });
+
+    expect(result.jobId).toBe("export-job-1");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(`${RUNTIME_URL}/v1/migrations/export-to-gcs`);
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(calls[0]!.headers["Content-Type"]).toBe("application/json");
+    expect(calls[0]!.body).toEqual({
+      upload_url: "https://storage.example/signed/abc",
+      description: "teleport export",
+    });
+  });
+
+  test("omits description when not provided", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({ job_id: "j", status: "pending", type: "export" }),
+        { status: 202 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    await localRuntimeExportToGcs(RUNTIME_URL, TOKEN, {
+      uploadUrl: "https://storage.example/signed/abc",
+    });
+
+    expect(calls[0]!.body).toEqual({
+      upload_url: "https://storage.example/signed/abc",
+    });
+  });
+
+  test("409 export_in_progress (nested {error:{code,job_id}}) throws MigrationInProgressError carrying existing job_id", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          error: {
+            code: "export_in_progress",
+            job_id: "existing-export-42",
+          },
+        }),
+        { status: 409 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    try {
+      await localRuntimeExportToGcs(RUNTIME_URL, TOKEN, {
+        uploadUrl: "https://storage.example/signed/abc",
+      });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MigrationInProgressError);
+      const mip = err as MigrationInProgressError;
+      expect(mip.kind).toBe("export_in_progress");
+      expect(mip.existingJobId).toBe("existing-export-42");
+    }
+  });
+
+  test("409 export_in_progress regression: nested job_id 'abc-123' is surfaced (not empty)", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          error: { code: "export_in_progress", job_id: "abc-123" },
+        }),
+        { status: 409 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    try {
+      await localRuntimeExportToGcs(RUNTIME_URL, TOKEN, {
+        uploadUrl: "https://storage.example/signed/abc",
+      });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MigrationInProgressError);
+      const mip = err as MigrationInProgressError;
+      expect(mip.existingJobId).toBe("abc-123");
+      expect(mip.existingJobId).not.toBe("");
+      expect(mip.kind).toBe("export_in_progress");
+    }
+  });
+
+  test("409 export_in_progress with legacy flat shape is still parsed", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          code: "export_in_progress",
+          job_id: "legacy-export-9",
+        }),
+        { status: 409 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    try {
+      await localRuntimeExportToGcs(RUNTIME_URL, TOKEN, {
+        uploadUrl: "https://storage.example/signed/abc",
+      });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MigrationInProgressError);
+      const mip = err as MigrationInProgressError;
+      expect(mip.kind).toBe("export_in_progress");
+      expect(mip.existingJobId).toBe("legacy-export-9");
+    }
+  });
+
+  test("non-202 non-409 responses throw with status + body", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response("boom", { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      localRuntimeExportToGcs(RUNTIME_URL, TOKEN, {
+        uploadUrl: "https://storage.example/signed/abc",
+      }),
+    ).rejects.toThrow(/500/);
+  });
+});
+
+describe("localRuntimeImportFromGcs", () => {
+  test("POSTs {bundle_url} with Bearer auth and returns job_id on 202", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "import-job-1",
+          status: "pending",
+          type: "import",
+        }),
+        { status: 202 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await localRuntimeImportFromGcs(RUNTIME_URL, TOKEN, {
+      bundleUrl: "https://storage.example/signed/dl-xyz",
+    });
+
+    expect(result.jobId).toBe("import-job-1");
+    expect(calls[0]!.url).toBe(`${RUNTIME_URL}/v1/migrations/import-from-gcs`);
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(calls[0]!.body).toEqual({
+      bundle_url: "https://storage.example/signed/dl-xyz",
+    });
+  });
+
+  test("409 import_in_progress (nested {error:{code,job_id}}) throws MigrationInProgressError carrying existing job_id", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          error: {
+            code: "import_in_progress",
+            job_id: "existing-import-7",
+          },
+        }),
+        { status: 409 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    try {
+      await localRuntimeImportFromGcs(RUNTIME_URL, TOKEN, {
+        bundleUrl: "https://storage.example/signed/dl-xyz",
+      });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MigrationInProgressError);
+      const mip = err as MigrationInProgressError;
+      expect(mip.kind).toBe("import_in_progress");
+      expect(mip.existingJobId).toBe("existing-import-7");
+    }
+  });
+
+  test("409 import_in_progress with legacy flat shape is still parsed", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          code: "import_in_progress",
+          job_id: "legacy-import-2",
+        }),
+        { status: 409 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    try {
+      await localRuntimeImportFromGcs(RUNTIME_URL, TOKEN, {
+        bundleUrl: "https://storage.example/signed/dl-xyz",
+      });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MigrationInProgressError);
+      const mip = err as MigrationInProgressError;
+      expect(mip.kind).toBe("import_in_progress");
+      expect(mip.existingJobId).toBe("legacy-import-2");
+    }
+  });
+});
+
+describe("localRuntimePollJobStatus", () => {
+  test("GETs /v1/migrations/jobs/{jobId} with Bearer auth and parses processing", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "poll-1",
+          type: "export",
+          status: "processing",
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const status = await localRuntimePollJobStatus(
+      RUNTIME_URL,
+      TOKEN,
+      "poll-1",
+    );
+
+    expect(status).toEqual({
+      jobId: "poll-1",
+      type: "export",
+      status: "processing",
+    });
+    expect(calls[0]!.url).toBe(`${RUNTIME_URL}/v1/migrations/jobs/poll-1`);
+    expect(calls[0]!.method).toBe("GET");
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  test("parses complete with bundle_key", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "poll-2",
+          type: "export",
+          status: "complete",
+          bundle_key: "bundles/x.tar.gz",
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const status = await localRuntimePollJobStatus(
+      RUNTIME_URL,
+      TOKEN,
+      "poll-2",
+    );
+
+    expect(status.status).toBe("complete");
+    if (status.status === "complete") {
+      expect(status.bundleKey).toBe("bundles/x.tar.gz");
+    }
+  });
+
+  test("parses failed with error", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "poll-3",
+          type: "import",
+          status: "failed",
+          error: "corrupted bundle",
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const status = await localRuntimePollJobStatus(
+      RUNTIME_URL,
+      TOKEN,
+      "poll-3",
+    );
+
+    expect(status.status).toBe("failed");
+    if (status.status === "failed") {
+      expect(status.error).toBe("corrupted bundle");
+    }
+  });
+
+  test("404 → throws 'Migration job not found'", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response("{}", { status: 404 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      localRuntimePollJobStatus(RUNTIME_URL, TOKEN, "missing"),
+    ).rejects.toThrow(/Migration job not found/);
+  });
+});

--- a/cli/src/lib/__tests__/platform-client-signed-url.test.ts
+++ b/cli/src/lib/__tests__/platform-client-signed-url.test.ts
@@ -1,0 +1,405 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  platformPollJobStatus,
+  platformRequestSignedUrl,
+  type UnifiedJobStatus,
+} from "../platform-client.js";
+
+const PLATFORM_URL = "https://platform.example.test";
+const VAK_TOKEN = "vak_test_1234567890"; // API-key path skips org-ID fetch.
+const SESSION_TOKEN = "session_test_1234567890"; // non-vak_ triggers org-ID lookup.
+
+interface CapturedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function captureFetch(
+  responder: (call: CapturedCall) => Response | Promise<Response>,
+): {
+  calls: CapturedCall[];
+  fetchMock: typeof globalThis.fetch;
+} {
+  const calls: CapturedCall[] = [];
+  const fetchMock = mock(
+    async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      const rawHeaders = (init?.headers ?? {}) as
+        | Record<string, string>
+        | Headers;
+      const headers: Record<string, string> = {};
+      if (rawHeaders instanceof Headers) {
+        rawHeaders.forEach((v, k) => {
+          headers[k] = v;
+        });
+      } else {
+        Object.assign(headers, rawHeaders);
+      }
+      let parsedBody: unknown = undefined;
+      const b = init?.body;
+      if (typeof b === "string") {
+        try {
+          parsedBody = JSON.parse(b);
+        } catch {
+          parsedBody = b;
+        }
+      }
+      const call: CapturedCall = {
+        url: urlStr,
+        method: init?.method ?? "GET",
+        headers,
+        body: parsedBody,
+      };
+      calls.push(call);
+      return responder(call);
+    },
+  );
+  return { calls, fetchMock: fetchMock as unknown as typeof globalThis.fetch };
+}
+
+let originalFetch: typeof globalThis.fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("platformRequestSignedUrl", () => {
+  test("upload operation with just operation → posts correct body and parses response", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          url: "https://storage.example/signed/abc",
+          bundle_key: "bundles/abc.tar.gz",
+          expires_at: "2026-04-22T00:00:00Z",
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await platformRequestSignedUrl(
+      { operation: "upload" },
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(result).toEqual({
+      url: "https://storage.example/signed/abc",
+      bundleKey: "bundles/abc.tar.gz",
+      expiresAt: "2026-04-22T00:00:00Z",
+      maxContentLength: undefined,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(`${PLATFORM_URL}/v1/migrations/signed-url/`);
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${VAK_TOKEN}`);
+    expect(calls[0]!.headers["Content-Type"]).toBe("application/json");
+    expect(calls[0]!.body).toEqual({ operation: "upload" });
+  });
+
+  test("upload operation with content_length + content_type passes them through", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          url: "https://storage.example/signed/xyz",
+          bundle_key: "bundles/xyz.tar.gz",
+          expires_at: "2026-04-22T01:00:00Z",
+          max_content_length: 10_000_000,
+        }),
+        { status: 201 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await platformRequestSignedUrl(
+      {
+        operation: "upload",
+        contentType: "application/octet-stream",
+        contentLength: 12345,
+      },
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(result.maxContentLength).toBe(10_000_000);
+    expect(calls[0]!.body).toEqual({
+      operation: "upload",
+      content_type: "application/octet-stream",
+      content_length: 12345,
+    });
+  });
+
+  test("download operation with bundleKey → posts bundle_key and parses response", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          url: "https://storage.example/signed/dl-xyz",
+          bundle_key: "bundles/xyz.tar.gz",
+          expires_at: "2026-04-22T02:00:00Z",
+        }),
+        { status: 201 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await platformRequestSignedUrl(
+      { operation: "download", bundleKey: "bundles/xyz.tar.gz" },
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(result.url).toBe("https://storage.example/signed/dl-xyz");
+    expect(result.bundleKey).toBe("bundles/xyz.tar.gz");
+    expect(calls[0]!.body).toEqual({
+      operation: "download",
+      bundle_key: "bundles/xyz.tar.gz",
+    });
+  });
+
+  test("401 → retries once and returns success on the retry", async () => {
+    let callCount = 0;
+    const { calls, fetchMock } = captureFetch(() => {
+      callCount += 1;
+      if (callCount === 1) {
+        return new Response(JSON.stringify({ detail: "unauthorized" }), {
+          status: 401,
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          url: "https://storage.example/signed/after-retry",
+          bundle_key: "bundles/r.tar.gz",
+          expires_at: "2026-04-22T03:00:00Z",
+        }),
+        { status: 201 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await platformRequestSignedUrl(
+      { operation: "upload" },
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(result.url).toBe("https://storage.example/signed/after-retry");
+    expect(calls).toHaveLength(2);
+  });
+
+  test("401 with session token → invalidates org-ID cache and re-fetches on retry", async () => {
+    // Session tokens (non-vak_) take the org-ID-fetch path. A 401 here
+    // frequently means the cached org ID is stale, so the retry must
+    // clear the cache and re-fetch before the second signed-url POST.
+    const orgIdCalls: string[] = [];
+    const signedUrlCalls: CapturedCall[] = [];
+    let orgIdFetchCount = 0;
+    let signedUrlCount = 0;
+
+    const fetchMock = mock(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        const urlStr = typeof url === "string" ? url : url.toString();
+        const rawHeaders = (init?.headers ?? {}) as
+          | Record<string, string>
+          | Headers;
+        const headers: Record<string, string> = {};
+        if (rawHeaders instanceof Headers) {
+          rawHeaders.forEach((v, k) => {
+            headers[k] = v;
+          });
+        } else {
+          Object.assign(headers, rawHeaders);
+        }
+
+        if (urlStr.endsWith("/v1/organizations/")) {
+          orgIdFetchCount += 1;
+          orgIdCalls.push(urlStr);
+          const orgId = orgIdFetchCount === 1 ? "org-stale" : "org-fresh";
+          return new Response(
+            JSON.stringify({ results: [{ id: orgId, name: "Test Org" }] }),
+            { status: 200 },
+          );
+        }
+
+        if (urlStr.endsWith("/v1/migrations/signed-url/")) {
+          signedUrlCount += 1;
+          let parsedBody: unknown = undefined;
+          const b = init?.body;
+          if (typeof b === "string") {
+            try {
+              parsedBody = JSON.parse(b);
+            } catch {
+              parsedBody = b;
+            }
+          }
+          signedUrlCalls.push({
+            url: urlStr,
+            method: init?.method ?? "GET",
+            headers,
+            body: parsedBody,
+          });
+          if (signedUrlCount === 1) {
+            return new Response(JSON.stringify({ detail: "stale org" }), {
+              status: 401,
+            });
+          }
+          return new Response(
+            JSON.stringify({
+              url: "https://storage.example/signed/fresh",
+              bundle_key: "bundles/fresh.tar.gz",
+              expires_at: "2026-04-22T04:00:00Z",
+            }),
+            { status: 201 },
+          );
+        }
+
+        throw new Error(`Unexpected URL: ${urlStr}`);
+      },
+    );
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const result = await platformRequestSignedUrl(
+      { operation: "upload" },
+      SESSION_TOKEN,
+      PLATFORM_URL,
+    );
+
+    // Both signed-url attempts were made and the retry succeeded.
+    expect(result.url).toBe("https://storage.example/signed/fresh");
+    expect(signedUrlCalls).toHaveLength(2);
+
+    // The cache was cleared after the 401, so the org-ID endpoint was
+    // hit a second time to fetch a fresh ID before the retry.
+    expect(orgIdFetchCount).toBe(2);
+    expect(orgIdCalls).toHaveLength(2);
+
+    // The first signed-url POST used the stale org ID, the second used
+    // the fresh one.
+    expect(signedUrlCalls[0]!.headers["Vellum-Organization-Id"]).toBe(
+      "org-stale",
+    );
+    expect(signedUrlCalls[1]!.headers["Vellum-Organization-Id"]).toBe(
+      "org-fresh",
+    );
+
+    // Session tokens use X-Session-Token, not Bearer.
+    expect(signedUrlCalls[0]!.headers["X-Session-Token"]).toBe(SESSION_TOKEN);
+    expect(signedUrlCalls[0]!.headers.Authorization).toBeUndefined();
+  });
+
+  test("503 → throws so callers can fall back to legacy inline upload", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({ detail: "temporarily down" }), {
+        status: 503,
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      platformRequestSignedUrl(
+        { operation: "upload" },
+        VAK_TOKEN,
+        PLATFORM_URL,
+      ),
+    ).rejects.toThrow(/503/);
+  });
+});
+
+describe("platformPollJobStatus", () => {
+  test("GET /v1/migrations/jobs/{jobId}/ parses processing", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "job-1",
+          type: "export",
+          status: "processing",
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const status = await platformPollJobStatus(
+      "job-1",
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(status).toEqual({
+      jobId: "job-1",
+      type: "export",
+      status: "processing",
+    } satisfies UnifiedJobStatus);
+    expect(calls[0]!.url).toBe(`${PLATFORM_URL}/v1/migrations/jobs/job-1/`);
+    expect(calls[0]!.method).toBe("GET");
+  });
+
+  test("parses complete with bundle_key + result", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "job-2",
+          type: "export",
+          status: "complete",
+          bundle_key: "bundles/done.tar.gz",
+          result: { files: 42 },
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const status = await platformPollJobStatus(
+      "job-2",
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(status.status).toBe("complete");
+    if (status.status === "complete") {
+      expect(status.bundleKey).toBe("bundles/done.tar.gz");
+      expect(status.result).toEqual({ files: 42 });
+    }
+  });
+
+  test("parses failed with error", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          job_id: "job-3",
+          type: "import",
+          status: "failed",
+          error: "bundle corrupt",
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const status = await platformPollJobStatus(
+      "job-3",
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(status.status).toBe("failed");
+    if (status.status === "failed") {
+      expect(status.error).toBe("bundle corrupt");
+    }
+  });
+
+  test("404 → throws 'Migration job not found'", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response("{}", { status: 404 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      platformPollJobStatus("missing", VAK_TOKEN, PLATFORM_URL),
+    ).rejects.toThrow(/Migration job not found/);
+  });
+});

--- a/cli/src/lib/job-polling.ts
+++ b/cli/src/lib/job-polling.ts
@@ -14,7 +14,7 @@ export interface PollJobUntilDoneOptions {
   poll: () => Promise<UnifiedJobStatus>;
   /** Sleep between successive polls. Defaults to 2_000 ms. */
   intervalMs?: number;
-  /** Maximum wall-clock time to wait. Defaults to 30 minutes. */
+  /** Maximum wall-clock time to wait. Defaults to 60 minutes. */
   timeoutMs?: number;
   /** Human-readable label used in the timeout error message (e.g. "export job"). */
   label: string;
@@ -46,7 +46,11 @@ export interface PollJobUntilDoneOptions {
 }
 
 const DEFAULT_INTERVAL_MS = 2_000;
-const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+// Matches the server-side runtime migration window: the GCS upload PUT and
+// the import-URL fetch in assistant/src/runtime/routes/migration-routes.ts
+// use AbortSignal.timeout(60 * 60 * 1000), so a shorter CLI poll cap would
+// abort a job that's still legitimately in progress on the server.
+const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000;
 const DEFAULT_MAX_TRANSIENT_ERRORS = 5;
 const DEFAULT_MAX_AUTH_REFRESHES = 3;
 

--- a/cli/src/lib/job-polling.ts
+++ b/cli/src/lib/job-polling.ts
@@ -24,11 +24,36 @@ export interface PollJobUntilDoneOptions {
    * successful polls reset the counter. Defaults to 5.
    */
   maxTransientErrors?: number;
+  /**
+   * Optional async hook invoked when `poll()` throws an error containing a
+   * `401` HTTP status. The callback is expected to refresh whatever
+   * credential the poll closure reads (e.g. re-lease a guardian token), then
+   * return. The polling loop will retry the poll after the callback resolves
+   * instead of propagating the 401.
+   *
+   * Used by long-running migrations where the cached access token may expire
+   * mid-poll. Without this hook, 4xx errors (except 429) are permanent and
+   * would abandon a migration that's still running on the server.
+   */
+  refreshOn401?: () => Promise<void>;
+  /**
+   * Maximum consecutive 401 refreshes tolerated before the last 401 is
+   * propagated. Tracked separately from {@link maxTransientErrors} because
+   * a persistent 401 after a refresh usually means the underlying credential
+   * is revoked, not a transient network issue. Defaults to 3.
+   */
+  maxAuthRefreshes?: number;
 }
 
 const DEFAULT_INTERVAL_MS = 2_000;
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_MAX_TRANSIENT_ERRORS = 5;
+const DEFAULT_MAX_AUTH_REFRESHES = 3;
+
+function is401Error(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /\b401\b/.test(msg);
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -88,9 +113,12 @@ export async function pollJobUntilDone(
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxTransientErrors =
     options.maxTransientErrors ?? DEFAULT_MAX_TRANSIENT_ERRORS;
+  const maxAuthRefreshes =
+    options.maxAuthRefreshes ?? DEFAULT_MAX_AUTH_REFRESHES;
   const deadline = Date.now() + timeoutMs;
 
   let consecutiveTransientErrors = 0;
+  let consecutiveAuthRefreshes = 0;
 
   // First poll happens immediately so fast-path completions don't wait
   // one interval before returning.
@@ -99,7 +127,33 @@ export async function pollJobUntilDone(
     try {
       status = await options.poll();
       consecutiveTransientErrors = 0;
+      consecutiveAuthRefreshes = 0;
     } catch (err) {
+      // 401 Unauthorized takes precedence over the generic transient
+      // classifier: when a refresh callback is registered, a long-running
+      // poll loop can re-lease its credential and keep going instead of
+      // abandoning a migration that's still running on the server.
+      if (options.refreshOn401 && is401Error(err)) {
+        consecutiveAuthRefreshes += 1;
+        if (consecutiveAuthRefreshes > maxAuthRefreshes) {
+          throw err;
+        }
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `${options.label} polling got 401, refreshing auth and retrying... (${msg})`,
+        );
+        await options.refreshOn401();
+        if (Date.now() >= deadline) {
+          throw new Error(
+            `Timed out waiting for ${options.label} after ${Math.round(
+              timeoutMs / 1000,
+            )}s`,
+          );
+        }
+        await sleep(intervalMs);
+        continue;
+      }
+
       if (!isTransientPollError(err)) {
         throw err;
       }

--- a/cli/src/lib/job-polling.ts
+++ b/cli/src/lib/job-polling.ts
@@ -18,13 +18,54 @@ export interface PollJobUntilDoneOptions {
   timeoutMs?: number;
   /** Human-readable label used in the timeout error message (e.g. "export job"). */
   label: string;
+  /**
+   * Maximum consecutive transient (retryable) poll errors tolerated before
+   * the last error is propagated. Transient errors (5xx / network) between
+   * successful polls reset the counter. Defaults to 5.
+   */
+  maxTransientErrors?: number;
 }
 
 const DEFAULT_INTERVAL_MS = 2_000;
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_MAX_TRANSIENT_ERRORS = 5;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Heuristic classification used by {@link pollJobUntilDone} to decide whether
+ * to retry a failed poll.
+ *
+ * - 5xx responses and unclassifiable network-style errors (fetch failed,
+ *   ECONNRESET, etc.) are treated as transient.
+ * - 4xx responses are treated as permanent, except 429 (rate limited) which is
+ *   transient.
+ * - "not found" errors are permanent — they indicate the job id is wrong and
+ *   retrying won't help.
+ *
+ * The poll helpers (`platformPollJobStatus`, `localRuntimePollJobStatus`)
+ * raise errors whose message contains the HTTP status (e.g. `"Local job
+ * status check failed: 503 Service Unavailable"`), so we parse that out when
+ * available and default to "retry" when unsure.
+ */
+function isTransientPollError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+
+  if (msg.includes("not found")) return false;
+
+  const match = msg.match(/(?:status check failed|failed)[^\d]*(\d{3})/i);
+  if (match) {
+    const code = parseInt(match[1], 10);
+    if (code === 429) return true;
+    if (code >= 400 && code < 500) return false;
+    if (code >= 500) return true;
+  }
+
+  // Unclassifiable (e.g. "fetch failed", ECONNRESET) — treat as transient so
+  // a single network hiccup doesn't abort a long-running migration.
+  return true;
 }
 
 /**
@@ -33,19 +74,52 @@ function sleep(ms: number): Promise<void> {
  *
  * On terminal status, returns the status object — including the `failed`
  * case. The caller decides how to treat a failed terminal status (e.g.
- * print the `error` field and exit). Only timeouts throw.
+ * print the `error` field and exit). Timeouts throw.
+ *
+ * Transient errors raised by `poll()` (5xx, network hiccups, rate-limits) are
+ * retried up to `maxTransientErrors` times before the last error propagates,
+ * matching the pre-rewrite `platformPollExportStatus` loop's behavior so a
+ * single flaky poll doesn't abort a migration that may still be running.
  */
 export async function pollJobUntilDone(
   options: PollJobUntilDoneOptions,
 ): Promise<TerminalJobStatus> {
   const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxTransientErrors =
+    options.maxTransientErrors ?? DEFAULT_MAX_TRANSIENT_ERRORS;
   const deadline = Date.now() + timeoutMs;
+
+  let consecutiveTransientErrors = 0;
 
   // First poll happens immediately so fast-path completions don't wait
   // one interval before returning.
   while (true) {
-    const status = await options.poll();
+    let status: UnifiedJobStatus;
+    try {
+      status = await options.poll();
+      consecutiveTransientErrors = 0;
+    } catch (err) {
+      if (!isTransientPollError(err)) {
+        throw err;
+      }
+      consecutiveTransientErrors += 1;
+      if (consecutiveTransientErrors > maxTransientErrors) {
+        throw err;
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`${options.label} polling failed, retrying... (${msg})`);
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Timed out waiting for ${options.label} after ${Math.round(
+            timeoutMs / 1000,
+          )}s`,
+        );
+      }
+      await sleep(intervalMs);
+      continue;
+    }
+
     if (status.status === "complete" || status.status === "failed") {
       return status;
     }

--- a/cli/src/lib/job-polling.ts
+++ b/cli/src/lib/job-polling.ts
@@ -1,0 +1,63 @@
+import type { UnifiedJobStatus } from "./platform-client.js";
+
+/**
+ * Terminal status returned by {@link pollJobUntilDone}. Callers decide
+ * whether to treat `failed` as a fatal error or retry logic concern.
+ */
+export type TerminalJobStatus = Extract<
+  UnifiedJobStatus,
+  { status: "complete" | "failed" }
+>;
+
+export interface PollJobUntilDoneOptions {
+  /** Async producer that returns the latest job status. */
+  poll: () => Promise<UnifiedJobStatus>;
+  /** Sleep between successive polls. Defaults to 2_000 ms. */
+  intervalMs?: number;
+  /** Maximum wall-clock time to wait. Defaults to 30 minutes. */
+  timeoutMs?: number;
+  /** Human-readable label used in the timeout error message (e.g. "export job"). */
+  label: string;
+}
+
+const DEFAULT_INTERVAL_MS = 2_000;
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll `options.poll` until it returns a terminal status (`complete` or
+ * `failed`), or until `timeoutMs` elapses.
+ *
+ * On terminal status, returns the status object — including the `failed`
+ * case. The caller decides how to treat a failed terminal status (e.g.
+ * print the `error` field and exit). Only timeouts throw.
+ */
+export async function pollJobUntilDone(
+  options: PollJobUntilDoneOptions,
+): Promise<TerminalJobStatus> {
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  // First poll happens immediately so fast-path completions don't wait
+  // one interval before returning.
+  while (true) {
+    const status = await options.poll();
+    if (status.status === "complete" || status.status === "failed") {
+      return status;
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out waiting for ${options.label} after ${Math.round(
+          timeoutMs / 1000,
+        )}s`,
+      );
+    }
+
+    await sleep(intervalMs);
+  }
+}

--- a/cli/src/lib/local-runtime-client.ts
+++ b/cli/src/lib/local-runtime-client.ts
@@ -1,0 +1,178 @@
+import {
+  parseUnifiedJobStatus,
+  type UnifiedJobStatus,
+} from "./platform-client.js";
+
+/**
+ * Thrown when the local runtime returns 409 for an export/import request
+ * because another migration of the same type is already in-flight. The
+ * caller can inspect {@link existingJobId} and decide whether to poll the
+ * existing job instead of retrying.
+ */
+export class MigrationInProgressError extends Error {
+  readonly existingJobId: string;
+  readonly kind: "export_in_progress" | "import_in_progress";
+
+  constructor(
+    kind: "export_in_progress" | "import_in_progress",
+    jobId: string,
+  ) {
+    super(
+      `A migration is already in progress (${kind}); existing job_id=${jobId}`,
+    );
+    this.name = "MigrationInProgressError";
+    this.kind = kind;
+    this.existingJobId = jobId;
+  }
+}
+
+function bearerHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  };
+}
+
+interface Raw409Body {
+  detail?: string;
+  // The runtime's current 409 contract nests the payload under `error`:
+  //   { error: { code: "export_in_progress" | "import_in_progress", job_id } }
+  // We also tolerate a legacy flat shape ({ code, job_id }) for resilience.
+  error?: string | { code?: string; job_id?: string };
+  code?: string;
+  job_id?: string;
+}
+
+/** Common 409 → MigrationInProgressError parsing used by the two POST helpers. */
+async function throwIfInProgress(
+  response: Response,
+  defaultKind: "export_in_progress" | "import_in_progress",
+): Promise<void> {
+  if (response.status !== 409) return;
+  const body = (await response.json().catch(() => ({}))) as Raw409Body;
+  const nested =
+    typeof body.error === "object" && body.error !== null
+      ? body.error
+      : undefined;
+  const jobId = nested?.job_id ?? body.job_id ?? "";
+  const rawKind =
+    nested?.code ??
+    body.code ??
+    (typeof body.error === "string" ? body.error : undefined) ??
+    defaultKind;
+  const kind: "export_in_progress" | "import_in_progress" =
+    rawKind === "export_in_progress" || rawKind === "import_in_progress"
+      ? rawKind
+      : defaultKind;
+  throw new MigrationInProgressError(kind, jobId);
+}
+
+/**
+ * Kick off an async export-to-GCS job on the local runtime.
+ * POSTs to `{runtimeUrl}/v1/migrations/export-to-gcs` and returns the
+ * 202-accepted job_id. On 409 (another export in flight) throws
+ * {@link MigrationInProgressError} with the existing job_id.
+ */
+export async function localRuntimeExportToGcs(
+  runtimeUrl: string,
+  token: string,
+  params: { uploadUrl: string; description?: string },
+): Promise<{ jobId: string }> {
+  const body: Record<string, unknown> = { upload_url: params.uploadUrl };
+  if (params.description !== undefined) {
+    body.description = params.description;
+  }
+
+  const response = await fetch(`${runtimeUrl}/v1/migrations/export-to-gcs`, {
+    method: "POST",
+    headers: bearerHeaders(token),
+    body: JSON.stringify(body),
+  });
+
+  await throwIfInProgress(response, "export_in_progress");
+
+  if (response.status !== 202) {
+    const errText = await response.text().catch(() => "");
+    throw new Error(
+      `Local runtime export-to-gcs failed (${response.status}): ${
+        errText || response.statusText
+      }`,
+    );
+  }
+
+  const json = (await response.json()) as {
+    job_id: string;
+    status?: string;
+    type?: string;
+  };
+  return { jobId: json.job_id };
+}
+
+/**
+ * Kick off an async import-from-GCS job on the local runtime.
+ * POSTs to `{runtimeUrl}/v1/migrations/import-from-gcs` with a signed
+ * download URL. On 409 throws {@link MigrationInProgressError}.
+ */
+export async function localRuntimeImportFromGcs(
+  runtimeUrl: string,
+  token: string,
+  params: { bundleUrl: string },
+): Promise<{ jobId: string }> {
+  const response = await fetch(`${runtimeUrl}/v1/migrations/import-from-gcs`, {
+    method: "POST",
+    headers: bearerHeaders(token),
+    body: JSON.stringify({ bundle_url: params.bundleUrl }),
+  });
+
+  await throwIfInProgress(response, "import_in_progress");
+
+  if (response.status !== 202) {
+    const errText = await response.text().catch(() => "");
+    throw new Error(
+      `Local runtime import-from-gcs failed (${response.status}): ${
+        errText || response.statusText
+      }`,
+    );
+  }
+
+  const json = (await response.json()) as {
+    job_id: string;
+    status?: string;
+    type?: string;
+  };
+  return { jobId: json.job_id };
+}
+
+/**
+ * Poll the local runtime's unified job-status endpoint.
+ * GETs `{runtimeUrl}/v1/migrations/jobs/{jobId}` and parses into
+ * {@link UnifiedJobStatus}.
+ */
+export async function localRuntimePollJobStatus(
+  runtimeUrl: string,
+  token: string,
+  jobId: string,
+): Promise<UnifiedJobStatus> {
+  const response = await fetch(`${runtimeUrl}/v1/migrations/jobs/${jobId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (response.status === 404) {
+    throw new Error("Migration job not found");
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Local job status check failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const raw = (await response.json()) as Parameters<
+    typeof parseUnifiedJobStatus
+  >[0];
+  return parseUnifiedJobStatus(raw);
+}

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -913,3 +913,181 @@ export async function platformPollImportStatus(
     error: body.error,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Unified signed-url + job-status endpoints (teleport-gcs-unify)
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated union representing the unified migration job status shape
+ * returned by `GET /v1/migrations/jobs/{job_id}/` on both the platform and
+ * the local runtime.
+ */
+export type UnifiedJobStatus =
+  | {
+      jobId: string;
+      type: "export" | "import";
+      status: "processing";
+    }
+  | {
+      jobId: string;
+      type: "export" | "import";
+      status: "complete";
+      bundleKey?: string;
+      result?: unknown;
+    }
+  | {
+      jobId: string;
+      type: "export" | "import";
+      status: "failed";
+      error: string;
+    };
+
+interface RawUnifiedJobStatus {
+  job_id: string;
+  type: "export" | "import";
+  status: "processing" | "complete" | "failed";
+  bundle_key?: string;
+  result?: unknown;
+  error?: string;
+}
+
+/**
+ * Normalise the wire-format job-status payload into the TypeScript
+ * discriminated union. Shared between platform and local-runtime helpers
+ * since both endpoints return the same shape.
+ */
+export function parseUnifiedJobStatus(
+  raw: RawUnifiedJobStatus,
+): UnifiedJobStatus {
+  if (raw.status === "processing") {
+    return { jobId: raw.job_id, type: raw.type, status: "processing" };
+  }
+  if (raw.status === "complete") {
+    return {
+      jobId: raw.job_id,
+      type: raw.type,
+      status: "complete",
+      bundleKey: raw.bundle_key,
+      result: raw.result,
+    };
+  }
+  return {
+    jobId: raw.job_id,
+    type: raw.type,
+    status: "failed",
+    error: raw.error ?? "Job failed without an error message",
+  };
+}
+
+/**
+ * Request a signed URL from the platform for either uploading a new bundle
+ * or downloading an existing one. Calls `POST /v1/migrations/signed-url/`.
+ *
+ * - `operation: "upload"` (optionally with `contentType` / `contentLength`)
+ *   returns a URL the CLI can PUT a bundle to.
+ * - `operation: "download"` with a `bundleKey` returns a URL the local
+ *   runtime can GET the bundle from during an import-from-GCS flow.
+ *
+ * Retries once with a fresh org-ID cache on 401 to match the retry pattern
+ * used by other authenticated platform helpers. 503 is bubbled up so
+ * callers can decide to fall back (e.g. legacy inline upload).
+ */
+export async function platformRequestSignedUrl(
+  params: {
+    operation: "upload" | "download";
+    bundleKey?: string;
+    contentType?: string;
+    contentLength?: number;
+  },
+  token: string,
+  platformUrl?: string,
+): Promise<{
+  url: string;
+  bundleKey: string;
+  expiresAt: string;
+  maxContentLength?: number;
+}> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const body: Record<string, unknown> = { operation: params.operation };
+  if (params.bundleKey !== undefined) body.bundle_key = params.bundleKey;
+  if (params.contentType !== undefined) body.content_type = params.contentType;
+  if (params.contentLength !== undefined) {
+    body.content_length = params.contentLength;
+  }
+
+  const doRequest = async (): Promise<Response> =>
+    fetch(`${resolvedUrl}/v1/migrations/signed-url/`, {
+      method: "POST",
+      headers: await authHeaders(token, platformUrl),
+      body: JSON.stringify(body),
+    });
+
+  let response = await doRequest();
+
+  if (response.status === 401) {
+    // Invalidate the cached org-ID (if any) and retry once with a fresh
+    // lookup. For session-token callers, a 401 frequently means the
+    // cached org ID is stale — calling doRequest() again without clearing
+    // the cache would just send the same stale header and fail again.
+    orgIdCache.delete(`${token}::${platformUrl ?? ""}`);
+    response = await doRequest();
+  }
+
+  if (response.status === 201 || response.status === 200) {
+    const json = (await response.json()) as {
+      url: string;
+      bundle_key: string;
+      expires_at: string;
+      max_content_length?: number;
+    };
+    return {
+      url: json.url,
+      bundleKey: json.bundle_key,
+      expiresAt: json.expires_at,
+      maxContentLength: json.max_content_length,
+    };
+  }
+
+  if (response.status === 503) {
+    throw new Error(
+      `Signed URL endpoint unavailable (503) — caller may fall back`,
+    );
+  }
+
+  const errorBody = (await response.json().catch(() => ({}))) as {
+    detail?: string;
+  };
+  throw new Error(
+    errorBody.detail ??
+      `Failed to request signed URL: ${response.status} ${response.statusText}`,
+  );
+}
+
+/**
+ * Poll the unified job-status endpoint on the platform. Calls
+ * `GET /v1/migrations/jobs/{jobId}/` and parses into {@link UnifiedJobStatus}.
+ */
+export async function platformPollJobStatus(
+  jobId: string,
+  token: string,
+  platformUrl?: string,
+): Promise<UnifiedJobStatus> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const response = await fetch(`${resolvedUrl}/v1/migrations/jobs/${jobId}/`, {
+    headers: await authHeaders(token, platformUrl),
+  });
+
+  if (response.status === 404) {
+    throw new Error("Migration job not found");
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Job status check failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const raw = (await response.json()) as RawUnifiedJobStatus;
+  return parseUnifiedJobStatus(raw);
+}

--- a/gateway/src/__tests__/migration-teleport-gcs-proxy.test.ts
+++ b/gateway/src/__tests__/migration-teleport-gcs-proxy.test.ts
@@ -1,0 +1,220 @@
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+import { initSigningKey } from "../auth/token-service.js";
+
+const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
+initSigningKey(TEST_SIGNING_KEY);
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(
+  async () => new Response(),
+);
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const {
+  createMigrationExportToGcsProxyHandler,
+  createMigrationImportFromGcsProxyHandler,
+  createMigrationJobStatusProxyHandler,
+} = await import("../http/routes/migration-proxy.js");
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
+    maxAttachmentConcurrency: 3,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    trustProxy: false,
+    ...overrides,
+  };
+  return merged;
+}
+
+afterEach(() => {
+  fetchMock = mock(async () => new Response());
+});
+
+describe("teleport-gcs migration proxies", () => {
+  test("export-to-gcs: forwards POST body to daemon and returns 202", async () => {
+    let capturedUrl: string | undefined;
+    let capturedMethod: string | undefined;
+    let capturedBody: ArrayBuffer | undefined;
+    let capturedHeaders: Headers | undefined;
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        capturedUrl = String(input);
+        capturedMethod = init?.method;
+        capturedBody = init?.body as ArrayBuffer;
+        capturedHeaders = init?.headers as unknown as Headers;
+        return new Response(
+          JSON.stringify({ job_id: "job-export-1", status: "pending" }),
+          {
+            status: 202,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      },
+    );
+
+    const handler = createMigrationExportToGcsProxyHandler(makeConfig());
+    const bodyText = JSON.stringify({
+      upload_url: "https://storage.example/u",
+      description: "x",
+    });
+    const res = await handler(
+      new Request("http://localhost:7830/v1/migrations/export-to-gcs", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer caller-token",
+          "content-type": "application/json",
+        },
+        body: bodyText,
+      }),
+    );
+
+    expect(res.status).toBe(202);
+    expect(capturedUrl).toBe(
+      "http://localhost:7821/v1/migrations/export-to-gcs",
+    );
+    expect(capturedMethod).toBe("POST");
+    expect(capturedHeaders?.get("authorization")).toMatch(/^Bearer ey/);
+    expect(capturedHeaders?.has("host")).toBe(false);
+    expect(Buffer.from(capturedBody!).toString("utf8")).toBe(bodyText);
+    expect(await res.json()).toEqual({
+      job_id: "job-export-1",
+      status: "pending",
+    });
+  });
+
+  test("import-from-gcs: forwards POST body to daemon and returns 202", async () => {
+    let capturedUrl: string | undefined;
+    let capturedMethod: string | undefined;
+    let capturedHeaders: Headers | undefined;
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        capturedUrl = String(input);
+        capturedMethod = init?.method;
+        capturedHeaders = init?.headers as unknown as Headers;
+        return new Response(
+          JSON.stringify({ job_id: "job-import-1", status: "pending" }),
+          {
+            status: 202,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      },
+    );
+
+    const handler = createMigrationImportFromGcsProxyHandler(makeConfig());
+    const res = await handler(
+      new Request("http://localhost:7830/v1/migrations/import-from-gcs", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer caller-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ bundle_url: "https://storage.example/b" }),
+      }),
+    );
+
+    expect(res.status).toBe(202);
+    expect(capturedUrl).toBe(
+      "http://localhost:7821/v1/migrations/import-from-gcs",
+    );
+    expect(capturedMethod).toBe("POST");
+    expect(capturedHeaders?.get("authorization")).toMatch(/^Bearer ey/);
+  });
+
+  test("jobs/:job_id: forwards GET to daemon with encoded job id", async () => {
+    let capturedUrl: string | undefined;
+    let capturedMethod: string | undefined;
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        capturedUrl = String(input);
+        capturedMethod = init?.method;
+        return new Response(
+          JSON.stringify({
+            job_id: "abc/def",
+            type: "export",
+            status: "processing",
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      },
+    );
+
+    const handler = createMigrationJobStatusProxyHandler(makeConfig());
+    const res = await handler(
+      new Request("http://localhost:7830/v1/migrations/jobs/abc%2Fdef"),
+      "abc/def",
+    );
+
+    expect(res.status).toBe(200);
+    expect(capturedMethod).toBe("GET");
+    expect(capturedUrl).toBe(
+      "http://localhost:7821/v1/migrations/jobs/abc%2Fdef",
+    );
+  });
+
+  test("export-to-gcs: returns 502 on upstream connection failure", async () => {
+    fetchMock = mock(async () => {
+      throw new Error("connection refused");
+    });
+
+    const handler = createMigrationExportToGcsProxyHandler(makeConfig());
+    const res = await handler(
+      new Request("http://localhost:7830/v1/migrations/export-to-gcs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+    );
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "Bad Gateway" });
+  });
+
+  test("jobs/:job_id: forwards upstream non-2xx (e.g. 404 job_not_found)", async () => {
+    fetchMock = mock(
+      async () =>
+        new Response(JSON.stringify({ error: { code: "job_not_found" } }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    const handler = createMigrationJobStatusProxyHandler(makeConfig());
+    const res = await handler(
+      new Request("http://localhost:7830/v1/migrations/jobs/unknown"),
+      "unknown",
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: { code: "job_not_found" } });
+  });
+});

--- a/gateway/src/http/routes/migration-proxy.ts
+++ b/gateway/src/http/routes/migration-proxy.ts
@@ -571,3 +571,152 @@ export function createMigrationImportStatusProxyHandler(
     return Response.json(body, { status: 200 });
   };
 }
+
+// ---------------------------------------------------------------------------
+// Teleport-GCS proxies (POST export-to-gcs / POST import-from-gcs / GET jobs)
+// ---------------------------------------------------------------------------
+
+/**
+ * These three endpoints back the unified teleport-GCS flow on the daemon.
+ * Unlike the legacy `/v1/migrations/import` endpoint, they're already async
+ * by design: POSTs return `202 { job_id }` quickly, and GET `/jobs/:job_id`
+ * is a cheap status lookup. So the gateway just needs to forward the
+ * request transparently — no job-tracking wrapping is required.
+ *
+ * They're registered as explicit routes (rather than relying on the runtime
+ * proxy catch-all) so local/docker teleport works regardless of whether
+ * `runtimeProxyEnabled` is set on the deployment.
+ */
+
+/**
+ * Timeout for the teleport-GCS proxies. Much shorter than
+ * `MIGRATION_TIMEOUT_MS` because the daemon returns 202 immediately on
+ * POST and GET job-status is a cheap in-memory lookup — no multi-GB body
+ * flows through the gateway on this path.
+ */
+const TELEPORT_GCS_TIMEOUT_MS = 60_000;
+
+function createSimpleMigrationProxy(
+  config: GatewayConfig,
+  opts: {
+    method: "POST" | "GET";
+    upstreamPathFor: (pathParam: string | null) => string;
+    logTag: string;
+  },
+) {
+  const { method, upstreamPathFor, logTag } = opts;
+
+  return async function handleSimpleMigrationProxy(
+    req: Request,
+    pathParam: string | null = null,
+  ): Promise<Response> {
+    const start = performance.now();
+    const hasBody = method !== "GET";
+    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
+
+    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPathFor(
+      pathParam,
+    )}`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
+    if (bodyBuffer !== null) {
+      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    }, TELEPORT_GCS_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method,
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ duration }, `${logTag} proxy upstream timed out`);
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error(
+        { err, duration },
+        `${logTag} proxy upstream connection failed`,
+      );
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { status: response.status, duration },
+        `${logTag} proxy upstream error`,
+      );
+      return new Response(body, {
+        status: response.status,
+        headers: resHeaders,
+      });
+    }
+
+    log.info(
+      { status: response.status, duration },
+      `${logTag} proxy completed`,
+    );
+    return new Response(response.body, {
+      status: response.status,
+      headers: resHeaders,
+    });
+  };
+}
+
+/** POST /v1/migrations/export-to-gcs → daemon. Returns 202 { job_id }. */
+export function createMigrationExportToGcsProxyHandler(config: GatewayConfig) {
+  return createSimpleMigrationProxy(config, {
+    method: "POST",
+    upstreamPathFor: () => "/v1/migrations/export-to-gcs",
+    logTag: "Migration export-to-gcs",
+  });
+}
+
+/** POST /v1/migrations/import-from-gcs → daemon. Returns 202 { job_id }. */
+export function createMigrationImportFromGcsProxyHandler(
+  config: GatewayConfig,
+) {
+  return createSimpleMigrationProxy(config, {
+    method: "POST",
+    upstreamPathFor: () => "/v1/migrations/import-from-gcs",
+    logTag: "Migration import-from-gcs",
+  });
+}
+
+/** GET /v1/migrations/jobs/:job_id → daemon. Returns job status JSON. */
+export function createMigrationJobStatusProxyHandler(config: GatewayConfig) {
+  const proxy = createSimpleMigrationProxy(config, {
+    method: "GET",
+    upstreamPathFor: (jobId) =>
+      `/v1/migrations/jobs/${encodeURIComponent(jobId ?? "")}`,
+    logTag: "Migration job-status",
+  });
+  return async function handleMigrationJobStatus(
+    req: Request,
+    jobId: string,
+  ): Promise<Response> {
+    return proxy(req, jobId);
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -81,8 +81,11 @@ import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-pr
 import { createUpgradeBroadcastProxyHandler } from "./http/routes/upgrade-broadcast-proxy.js";
 import {
   createMigrationExportProxyHandler,
+  createMigrationExportToGcsProxyHandler,
+  createMigrationImportFromGcsProxyHandler,
   createMigrationImportProxyHandler,
   createMigrationImportStatusProxyHandler,
+  createMigrationJobStatusProxyHandler,
 } from "./http/routes/migration-proxy.js";
 import { createMigrationRollbackProxyHandler } from "./http/routes/migration-rollback-proxy.js";
 import { createWorkspaceCommitProxyHandler } from "./http/routes/workspace-commit-proxy.js";
@@ -366,6 +369,11 @@ async function main() {
   const migrationImportProxy = createMigrationImportProxyHandler(config);
   const migrationImportStatusProxy =
     createMigrationImportStatusProxyHandler(config);
+  const migrationExportToGcsProxy =
+    createMigrationExportToGcsProxyHandler(config);
+  const migrationImportFromGcsProxy =
+    createMigrationImportFromGcsProxyHandler(config);
+  const migrationJobStatusProxy = createMigrationJobStatusProxyHandler(config);
   const migrationRollbackProxy = createMigrationRollbackProxyHandler(config);
   const workspaceCommitProxy = createWorkspaceCommitProxyHandler(config);
   const brainGraphProxy = createBrainGraphProxyHandler(config);
@@ -944,6 +952,33 @@ async function main() {
       scope: "settings.read",
       handler: (req, params) =>
         migrationImportStatusProxy(req, params[0] ?? ""),
+    },
+
+    // ── Teleport-GCS migration (unified daemon-async flow) ──
+    // These are registered explicitly (not via the runtime-proxy catch-all)
+    // so local/docker teleport works whether or not `runtimeProxyEnabled`
+    // is set. The daemon returns 202 { job_id } on POST and cheap JSON on
+    // GET, so the gateway just transparently forwards without wrapping.
+    {
+      path: "/v1/migrations/export-to-gcs",
+      method: "POST",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req) => migrationExportToGcsProxy(req),
+    },
+    {
+      path: "/v1/migrations/import-from-gcs",
+      method: "POST",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req) => migrationImportFromGcsProxy(req),
+    },
+    {
+      path: /^\/v1\/migrations\/jobs\/([^/]+)\/?$/,
+      method: "GET",
+      auth: "edge-scoped",
+      scope: "settings.read",
+      handler: (req, params) => migrationJobStatusProxy(req, params[0] ?? ""),
     },
 
     // ── Workspace commit ──

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -3848,6 +3848,150 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/migrations/export-to-gcs": {
+        post: {
+          summary: "Kick off an async export-to-GCS job",
+          description:
+            "Transparent proxy to the assistant daemon's `POST /v1/migrations/export-to-gcs` endpoint. The daemon schedules a background export job that streams the workspace backup to the supplied signed GCS upload URL and returns `202 Accepted` with a `job_id`. Callers poll `GET /v1/migrations/jobs/{jobId}` for progress. Registered explicitly (not via the runtime-proxy catch-all) so local/docker teleport works regardless of `runtimeProxyEnabled`.",
+          operationId: "migrationExportToGcs",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "202": {
+              description: "Export job accepted.",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["job_id"],
+                    properties: { job_id: { type: "string" } },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "409": {
+              description: "Another export is already in flight.",
+            },
+            "502": { description: "Failed to reach assistant daemon" },
+            "504": { description: "Assistant daemon request timed out" },
+          },
+        },
+      },
+      "/v1/migrations/import-from-gcs": {
+        post: {
+          summary: "Kick off an async import-from-GCS job",
+          description:
+            "Transparent proxy to the assistant daemon's `POST /v1/migrations/import-from-gcs` endpoint. The daemon schedules a background import job that fetches a `.vbundle` archive at the supplied `bundle_url` and streams it through the importer, returning `202 Accepted` with a `job_id`. Callers poll `GET /v1/migrations/jobs/{jobId}` for progress. Registered explicitly (not via the runtime-proxy catch-all) so local/docker teleport works regardless of `runtimeProxyEnabled`.",
+          operationId: "migrationImportFromGcs",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["bundle_url"],
+                  properties: {
+                    bundle_url: {
+                      type: "string",
+                      format: "uri",
+                      description:
+                        "Signed GCS URL pointing at a .vbundle archive.",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "202": {
+              description: "Import job accepted.",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["job_id"],
+                    properties: { job_id: { type: "string" } },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "409": {
+              description: "Another import is already in flight.",
+            },
+            "502": { description: "Failed to reach assistant daemon" },
+            "504": { description: "Assistant daemon request timed out" },
+          },
+        },
+      },
+      "/v1/migrations/jobs/{jobId}": {
+        get: {
+          summary: "Poll unified migration job status",
+          description:
+            "Transparent proxy to the assistant daemon's `GET /v1/migrations/jobs/{job_id}` endpoint. Returns the current status of an async export-to-GCS or import-from-GCS job tracked by the daemon's migration job registry. Registered explicitly (not via the runtime-proxy catch-all) so local/docker teleport works regardless of `runtimeProxyEnabled`.",
+          operationId: "migrationJobStatus",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              in: "path",
+              name: "jobId",
+              required: true,
+              schema: { type: "string" },
+              description:
+                "The `job_id` returned by the 202 response from `POST /v1/migrations/export-to-gcs` or `POST /v1/migrations/import-from-gcs`.",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Current job status.",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["job_id", "type", "status"],
+                    properties: {
+                      job_id: { type: "string" },
+                      type: {
+                        type: "string",
+                        enum: ["export", "import"],
+                      },
+                      status: {
+                        type: "string",
+                        enum: ["processing", "complete", "failed"],
+                      },
+                      result: {},
+                      error: { type: "string" },
+                      error_code: { type: "string" },
+                      upstream_status: { type: "integer" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "404": {
+              description: "Unknown job_id.",
+            },
+            "502": { description: "Failed to reach assistant daemon" },
+            "504": { description: "Assistant daemon request timed out" },
+          },
+        },
+      },
       "/v1/admin/workspace-commit": {
         post: {
           summary: "Commit workspace changes",


### PR DESCRIPTION
## Summary

Consolidates the teleport command so every direction — local↔platform, local↔docker, platform↔local — routes the bundle through GCS and polls an async job-status endpoint instead of streaming bundle bytes through the CLI. Pairs with vellum-ai/vellum-assistant-platform#4766 which ships the platform-side \`/v1/migrations/signed-url/\` and unified \`/v1/migrations/jobs/{id}/\` endpoints.

## What this unlocks

- **No more bundle buffering in the CLI.** The bundle is uploaded once (source → GCS) and downloaded once (GCS → target). The CLI never holds bundle bytes in memory.
- **One signed-URL endpoint** (\`POST /v1/migrations/signed-url/\` on the platform) serves both upload and download.
- **One job-status shape** across local runtime (\`GET /v1/migrations/jobs/:job_id\`) and platform (\`GET /v1/migrations/jobs/{id}/\`) — both export and import collapse to \`{ status: processing | complete | failed }\`.
- **Async import on the local runtime** via \`POST /v1/migrations/import-from-gcs\` — callers poll instead of holding a connection open.

## Self-review result

PASS with 2 fix PRs merged + 5 documented follow-ups (see below).

## PRs merged into feature branch

**Core implementation**
- #27694 — feat(runtime): add in-memory migration job registry
- #27699 — feat(runtime): add unified migration job status endpoint
- #27701 — feat(runtime): add async import-from-gcs endpoint
- #27702 — feat(runtime): add async export-to-gcs endpoint
- #27705 — feat(cli): add unified signed-url and job-polling client helpers
- #27709 — refactor(cli): route teleport through GCS + async jobs for all sources and targets

**Self-review fixes**
- #27724 — fix(runtime): synchronously validate GCS URL on import-from-gcs (parity with export-to-gcs; prevents a bad URL from occupying the in-flight slot)
- #27725 — fix(cli): refresh token on 401 during long-running migration polls (avoids fatal mid-poll 401 on multi-minute imports)

**Closed (descoped)**
- #27720 — chore: remove URL-body variant of /v1/migrations/import. Closed because the gateway still uses that variant for its async import proxy. Deferred until gateway migrates to \`/v1/migrations/import-from-gcs\`.

## Follow-ups (known gaps, not blocking this PR)

1. **Gateway proxy routes for new endpoints.** The CLI hits the runtime directly via gateway-forwarded ports, so deployments with \`config.runtimeProxyEnabled = false\` will 404 on \`/v1/migrations/{export-to-gcs,import-from-gcs,jobs/:id}\`. Either add explicit gateway routes or document the proxy-enabled requirement.
2. **Structured error metadata through job registry.** \`runGcsImport\` throws \`GcsImportError\` with \`errors[]\` / \`partial_report\`, but the job registry's \`mapError\` only keeps \`code\`/\`message\`/\`upstreamStatus\`. The URL-body path preserves those fields; the import-from-gcs path loses them.
3. **OpenAPI omits 400/409 branches for \`/v1/migrations/export-to-gcs\`.** \`import-from-gcs\` documents its 409; export-to-gcs does not.
4. **503 fallback for older platforms.** If the platform doesn't serve \`/v1/migrations/signed-url/\` yet, teleport errors with \`"Signed URL endpoint unavailable (503) — caller may fall back"\` with no user-friendly guidance.
5. **Per-job ACL on \`/v1/migrations/jobs/:id\`.** Any principal with \`settings.read\` can snoop on any job. Likely fine for single-user daemons but worth a threat-model decision.

## Out-of-scope cleanup

The plan's PR 7 (delete \`platformInitiateExport\`, \`platformDownloadExport\`, \`platformRequestUploadUrl\`) was descoped because those helpers are still used by:
- \`cli/src/commands/backup.ts\`
- \`cli/src/commands/restore.ts\`
- Platform-source branch of \`cli/src/commands/teleport.ts\` (still on the legacy async-export path)

Migrating those commands to the unified signed-URL / job-status flow is a follow-up plan.

Part of plan: teleport-gcs-unify.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
