### PR TITLE
feat(macos): add per-environment app icon infrastructure

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1342,8 +1342,13 @@ PLIST
 # Resolve per-environment icon source. Falls back to production if no
 # environment-specific override exists.
 ICONS_DIR="$SCRIPT_DIR/vellum-assistant/Resources/icons"
+ICON_ENV_OVERRIDE=false
 if [ -d "$ICONS_DIR/$VELLUM_ENVIRONMENT" ]; then
     ICON_SOURCE_DIR="$ICONS_DIR/$VELLUM_ENVIRONMENT"
+    # Only force icns regeneration for non-production environments
+    if [ "$VELLUM_ENVIRONMENT" != "production" ]; then
+        ICON_ENV_OVERRIDE=true
+    fi
 elif [ -d "$ICONS_DIR/production" ]; then
     ICON_SOURCE_DIR="$ICONS_DIR/production"
 else
@@ -1390,9 +1395,9 @@ fi
 # actool with .icon bundles only emits into Assets.car — it does not produce a
 # standalone .icns.  Finder and create-dmg rely on CFBundleIconFile → .icns,
 # so we render one from the same SVG source that Icon Composer uses.
-# Always regenerate when an environment icon source is set (to pick up
+# Force regeneration for non-production environment overrides (to pick up
 # environment-specific colors), otherwise generate only if missing.
-if [ -d "$APP_ICON" ] && { [ -n "$ICON_SOURCE_DIR" ] || [ ! -f "$RESOURCES_DIR/AppIcon.icns" ]; }; then
+if [ -d "$APP_ICON" ] && { [ "$ICON_ENV_OVERRIDE" = true ] || [ ! -f "$RESOURCES_DIR/AppIcon.icns" ]; }; then
     echo "Generating AppIcon.icns from SVG..."
 
     ICONSET_DIR=$(mktemp -d)/AppIcon.iconset

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1339,12 +1339,30 @@ cat > "$CONTENTS/Info.plist" <<PLIST
 </plist>
 PLIST
 
+# Resolve per-environment icon source. Falls back to production if no
+# environment-specific override exists.
+ICONS_DIR="$SCRIPT_DIR/vellum-assistant/Resources/icons"
+if [ -d "$ICONS_DIR/$VELLUM_ENVIRONMENT" ]; then
+    ICON_SOURCE_DIR="$ICONS_DIR/$VELLUM_ENVIRONMENT"
+elif [ -d "$ICONS_DIR/production" ]; then
+    ICON_SOURCE_DIR="$ICONS_DIR/production"
+else
+    ICON_SOURCE_DIR=""
+fi
+
 # Always compile asset catalog (fast, ensures AppIcon changes are picked up)
 # AppIcon.icon is a Xcode-26 Icon Composer bundle — actool reads it alongside
 # the xcassets and emits both the layered Liquid Glass iconstack for macOS Tahoe
 # and backward-compatible raster fallbacks for macOS 15 into Assets.car.
 XCASSETS="$SCRIPT_DIR/vellum-assistant/Resources/Assets.xcassets"
 APP_ICON="$SCRIPT_DIR/vellum-assistant/Resources/AppIcon.icon"
+
+# Overlay environment-specific icon into the .icon bundle so both actool
+# (Assets.car / Liquid Glass) and the .icns generation use the correct source.
+if [ -n "$ICON_SOURCE_DIR" ]; then
+    cp "$ICON_SOURCE_DIR/icon.json" "$APP_ICON/icon.json"
+    cp -R "$ICON_SOURCE_DIR/Assets/" "$APP_ICON/Assets/"
+fi
 if [ -d "$XCASSETS" ]; then
     ACTOOL_INPUTS=("$XCASSETS")
     if [ -d "$APP_ICON" ]; then
@@ -1372,7 +1390,9 @@ fi
 # actool with .icon bundles only emits into Assets.car — it does not produce a
 # standalone .icns.  Finder and create-dmg rely on CFBundleIconFile → .icns,
 # so we render one from the same SVG source that Icon Composer uses.
-if [ ! -f "$RESOURCES_DIR/AppIcon.icns" ] && [ -d "$APP_ICON" ]; then
+# Always regenerate when an environment icon source is set (to pick up
+# environment-specific colors), otherwise generate only if missing.
+if [ -d "$APP_ICON" ] && { [ -n "$ICON_SOURCE_DIR" ] || [ ! -f "$RESOURCES_DIR/AppIcon.icns" ]; }; then
     echo "Generating AppIcon.icns from SVG..."
 
     ICONSET_DIR=$(mktemp -d)/AppIcon.iconset

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1342,13 +1342,8 @@ PLIST
 # Resolve per-environment icon source. Falls back to production if no
 # environment-specific override exists.
 ICONS_DIR="$SCRIPT_DIR/vellum-assistant/Resources/icons"
-ICON_ENV_OVERRIDE=false
 if [ -d "$ICONS_DIR/$VELLUM_ENVIRONMENT" ]; then
     ICON_SOURCE_DIR="$ICONS_DIR/$VELLUM_ENVIRONMENT"
-    # Only force icns regeneration for non-production environments
-    if [ "$VELLUM_ENVIRONMENT" != "production" ]; then
-        ICON_ENV_OVERRIDE=true
-    fi
 elif [ -d "$ICONS_DIR/production" ]; then
     ICON_SOURCE_DIR="$ICONS_DIR/production"
 else
@@ -1395,9 +1390,9 @@ fi
 # actool with .icon bundles only emits into Assets.car — it does not produce a
 # standalone .icns.  Finder and create-dmg rely on CFBundleIconFile → .icns,
 # so we render one from the same SVG source that Icon Composer uses.
-# Force regeneration for non-production environment overrides (to pick up
-# environment-specific colors), otherwise generate only if missing.
-if [ -d "$APP_ICON" ] && { [ "$ICON_ENV_OVERRIDE" = true ] || [ ! -f "$RESOURCES_DIR/AppIcon.icns" ]; }; then
+# Always regenerate when an icon source directory is resolved — the Swift
+# script is fast and this avoids stale icns after environment switches.
+if [ -d "$APP_ICON" ] && [ -n "$ICON_SOURCE_DIR" ]; then
     echo "Generating AppIcon.icns from SVG..."
 
     ICONSET_DIR=$(mktemp -d)/AppIcon.iconset

--- a/clients/macos/vellum-assistant/Resources/icons/README.md
+++ b/clients/macos/vellum-assistant/Resources/icons/README.md
@@ -1,0 +1,54 @@
+# Per-Environment App Icons
+
+This directory contains per-environment icon sources for the macOS app.
+Each subdirectory corresponds to a `VELLUM_ENVIRONMENT` value and holds the
+Icon Composer assets that `build.sh` copies into `AppIcon.icon/` before the
+build compiles them.
+
+## Directory structure
+
+```
+icons/
+  README.md
+  production/          # VELLUM_ENVIRONMENT=production (canonical/default)
+    icon.json          # Icon Composer manifest (fill color, layer definitions)
+    Assets/
+      white-V.svg      # Foreground SVG layer
+  staging/             # (example) VELLUM_ENVIRONMENT=staging
+    icon.json
+    Assets/
+      white-V.svg
+```
+
+One subdirectory per environment: `local`, `dev`, `staging`, `production`.
+If no directory exists for the current `VELLUM_ENVIRONMENT`, the build falls
+back to `production/`.
+
+## Adding a new environment icon
+
+1. Create a directory matching the environment name (e.g. `staging/`).
+2. Copy `production/icon.json` and `production/Assets/white-V.svg` into it.
+3. Edit `icon.json` to change the `fill.solid` color. This controls the
+   background tint of the app icon. The color format is
+   `display-p3:<red>,<green>,<blue>,<alpha>` with values between 0 and 1.
+4. Optionally replace `Assets/white-V.svg` with a different foreground SVG.
+5. Build with `VELLUM_ENVIRONMENT=staging ./build.sh run` (or whichever
+   environment you added) and verify the icon.
+
+The easiest customization is changing just the `fill.solid` color in
+`icon.json` to give each environment a distinct background tint while keeping
+the same white-V foreground.
+
+## How it works
+
+`build.sh` resolves the icon source directory at build time:
+
+1. Checks for `icons/$VELLUM_ENVIRONMENT/`.
+2. Falls back to `icons/production/` if the environment directory is missing.
+3. Copies `icon.json` and `Assets/` from the resolved directory into
+   `AppIcon.icon/`, overwriting its contents.
+4. `actool` and the `.icns` generation step then read from `AppIcon.icon/`,
+   so both Liquid Glass and Finder/DMG icons reflect the environment color.
+
+`AppIcon.icon/` in the source tree is treated as a working copy that gets
+overwritten at build time -- it is not the source of truth.

--- a/clients/macos/vellum-assistant/Resources/icons/production/Assets/white-V.svg
+++ b/clients/macos/vellum-assistant/Resources/icons/production/Assets/white-V.svg
@@ -1,0 +1,3 @@
+<svg width="92" height="92" viewBox="0 0 92 92" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.5 0L46 48.342L68.4107 0L91 0L45.8214 92L1 0L23.5 0Z" fill="white"/>
+</svg>

--- a/clients/macos/vellum-assistant/Resources/icons/production/icon.json
+++ b/clients/macos/vellum-assistant/Resources/icons/production/icon.json
@@ -1,0 +1,47 @@
+{
+  "fill" : {
+    "solid" : "display-p3:0.12941,0.42353,0.21569,1.00000"
+  },
+  "groups" : [
+    {
+      "blend-mode" : "normal",
+      "layers" : [
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "dark",
+              "value" : "none"
+            }
+          ],
+          "glass" : false,
+          "image-name" : "white-V.svg",
+          "name" : "white-V",
+          "position" : {
+            "scale" : 6,
+            "translation-in-points" : [
+              0,
+              25
+            ]
+          }
+        }
+      ],
+      "lighting" : "individual",
+      "name" : "Group",
+      "shadow" : {
+        "kind" : "neutral",
+        "opacity" : 0.5
+      },
+      "specular" : true,
+      "translucency" : {
+        "enabled" : true,
+        "value" : 0.5
+      }
+    }
+  ],
+  "supported-platforms" : {
+    "circles" : [
+      "watchOS"
+    ],
+    "squares" : "shared"
+  }
+}


### PR DESCRIPTION
## Summary
- Creates per-environment icon directory structure under Resources/icons/ with production as the canonical source
- Adds environment-aware icon resolution in build.sh that overlays the correct icon assets before actool and icns generation
- Updates icns generation guard to always regenerate when an environment icon source is available

Part of plan: fix-macos-app-icon.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
