### PR TITLE
fix(security): use Socket's canonical CVE slugs in socket.yml

### DIFF
--- a/socket.yml
+++ b/socket.yml
@@ -14,7 +14,7 @@
 #
 # Alert names below verified against https://docs.socket.dev/docs/socket-yml
 # and https://socket.dev/alerts in 2026-04; re-verify on next edit.
-# Runbook: docs/socket.md (lands in PR 3 of the same plan — ATL-106).
+# Runbook: docs/socket.md
 
 version: 2
 
@@ -50,6 +50,6 @@ issueRules:
   # to gate on them later. Package-specific exceptions go here with a
   # rationale comment (why, who, date, expiry).
   criticalCVE: true
-  highCVE: true
+  cve: true
   mediumCVE: false
-  lowCVE: false
+  mildCVE: false


### PR DESCRIPTION
## Summary
- Rename `highCVE: true` → `cve: true` (Socket's canonical slug for High).
- Rename `lowCVE: false` → `mildCVE: false` (canonical slug for Low).
- Drop stale PR-3 forward reference from the `docs/socket.md` pointer.

## Why it matters
Socket's @socketsecurity/config v3 validator silently drops unknown alert slugs (`additionalProperties: { type: "boolean" }` with AJV `removeAdditional: 'failing'`). The previous entries had zero effect on Socket's PR check behavior — the file wasn't actually enforcing High/Low CVE policy. After this fix, High CVEs block per Socket default severity and Low CVEs are suppressed.

Fixes gap identified during plan self-review for socket-enforcement.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
