### PR TITLE
fix(ci): matrix Socket autofix over bun.lock workspaces + fix scan/apply contract

### DIFF
--- a/.github/workflows/socket-autofix.yml
+++ b/.github/workflows/socket-autofix.yml
@@ -11,6 +11,8 @@ permissions:
 
 concurrency:
   group: socket-autofix
+  # Don't cancel mid-run: socket-fix and socket-patch open PRs as they go;
+  # cancelling leaves half-created branches / partial manifest state.
   cancel-in-progress: false
 
 jobs:
@@ -19,6 +21,30 @@ jobs:
     if: github.repository == 'vellum-ai/vellum-assistant'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # This is a multi-workspace Bun monorepo with NO root-level package.json.
+    # Socket's `fix` needs a resolved dependency tree (node_modules) per
+    # workspace, so we matrix over the runtime-relevant workspaces that each
+    # have their own bun.lock. `meta` and `scripts` (dev tooling) are skipped
+    # to conserve scan quota (~1,000 scans/month on Socket Free).
+    strategy:
+      fail-fast: false
+      matrix:
+        workspace:
+          - assistant
+          - cli
+          - credential-executor
+          - gateway
+          - clients/chrome-extension
+          - clients/chrome-extension/native-host
+          - packages/ces-contracts
+          - packages/credential-storage
+          - packages/egress-proxy
+          - skills/meet-join
+          - skills/meet-join/bot
+          - skills/meet-join/meet-controller-ext
+    defaults:
+      run:
+        working-directory: ${{ matrix.workspace }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -29,6 +55,9 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: '1.3.11'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       # Flags (verified against https://docs.socket.dev/docs/socket-fix):
       #   --autopilot              headless CI mode; enables auto-merge on PRs Socket opens.
@@ -49,6 +78,27 @@ jobs:
     if: github.repository == 'vellum-ai/vellum-assistant'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Same matrix rationale as socket-fix above: socket-patch operates on a
+    # resolved node_modules tree, and there's no root manifest to install from.
+    strategy:
+      fail-fast: false
+      matrix:
+        workspace:
+          - assistant
+          - cli
+          - credential-executor
+          - gateway
+          - clients/chrome-extension
+          - clients/chrome-extension/native-host
+          - packages/ces-contracts
+          - packages/credential-storage
+          - packages/egress-proxy
+          - skills/meet-join
+          - skills/meet-join/bot
+          - skills/meet-join/meet-controller-ext
+    defaults:
+      run:
+        working-directory: ${{ matrix.workspace }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -60,19 +110,63 @@ jobs:
         with:
           bun-version: '1.3.11'
 
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       # socket-patch is the standalone Certified Patches CLI
       # (https://github.com/SocketDev/socket-patch). It works without a Socket
       # API token on the Free tier; paid-tier patches are silently skipped
       # (expected). Package name verified against the npm registry and the
       # upstream README at authoring time — re-verify if upgrading.
       #
-      # `apply` has no `--yes` flag; per upstream docs, interactive prompts
-      # auto-proceed when stdin is not a TTY (i.e. in CI), so no flag needed.
+      # Canonical sequence per upstream README (verified against
+      # raw.githubusercontent.com/SocketDev/socket-patch/main/README.md):
+      #   1. `scan --json`  — discover available patches (no filesystem side
+      #      effects; emits a JSON report).
+      #   2. `get <id>`     — download each patch into .socket/manifest.json.
+      #      `get` requires a single identifier (UUID/CVE/GHSA/PURL/package)
+      #      per invocation, so we drive it from the scan output via jq.
+      #   3. `apply`        — consume .socket/manifest.json and patch
+      #      node_modules in place. `apply` returns status="no_manifest" if
+      #      nothing was staged — treated as a no-op success.
+      #
+      # Interactive prompts auto-proceed when stdin is not a TTY (i.e. CI),
+      # so no --yes flag is needed.
       - name: Scan for available patches
-        run: bunx @socketsecurity/socket-patch scan --json > /tmp/socket-patch-scan.json
+        run: bunx @socketsecurity/socket-patch scan --json > /tmp/socket-patch-scan-${{ strategy.job-index }}.json
+        continue-on-error: true
+
+      - name: Download patches into manifest
+        run: |
+          scan_file="/tmp/socket-patch-scan-${{ strategy.job-index }}.json"
+          if [ ! -s "$scan_file" ]; then
+            echo "No scan output — nothing to get."
+            exit 0
+          fi
+          # Extract patch identifiers from scan output. Schema isn't fully
+          # documented upstream; try common shapes (uuid, id, patchId) and
+          # dedupe. If jq finds nothing, the loop body never runs and apply
+          # returns no_manifest, which is fine.
+          ids=$(jq -r '
+            [ ..
+              | objects
+              | (.uuid? // .id? // .patchId?)
+              | select(. != null and . != "")
+            ] | unique | .[]
+          ' "$scan_file" 2>/dev/null || true)
+          if [ -z "$ids" ]; then
+            echo "No patch identifiers found in scan output."
+            exit 0
+          fi
+          echo "$ids" | while read -r id; do
+            [ -z "$id" ] && continue
+            echo "Fetching patch: $id"
+            bunx @socketsecurity/socket-patch get "$id" --save-only || echo "  (failed, continuing)"
+          done
 
       - name: Apply patches
         run: bunx @socketsecurity/socket-patch apply
+        continue-on-error: true
 
       - name: Detect changes
         id: diff
@@ -89,21 +183,24 @@ jobs:
         run: |
           # Random delimiter prevents GITHUB_OUTPUT injection if scan JSON contains 'EOF' on its own line.
           delimiter="ghadelim_$(openssl rand -hex 16)"
+          scan_file="/tmp/socket-patch-scan-${{ strategy.job-index }}.json"
           {
             echo "body<<${delimiter}"
-            echo 'Applied Socket Certified Patches for the week.'
+            echo "Applied Socket Certified Patches for workspace \`${{ matrix.workspace }}\`."
             echo ''
             echo 'Socket is on the Free tier — paid-tier patches are silently skipped.'
             echo ''
             echo '### Scan output'
             echo ''
             echo '```json'
-            cat /tmp/socket-patch-scan.json
+            if [ -s "$scan_file" ]; then
+              cat "$scan_file"
+            else
+              echo '(no scan output)'
+            fi
             echo '```'
             echo ''
             echo 'See [docs/socket.md](docs/socket.md) for the runbook.'
-            echo ''
-            echo 'Part of ATL-106.'
             echo "${delimiter}"
           } >> "$GITHUB_OUTPUT"
 
@@ -111,12 +208,9 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
-          branch: socket-patch/weekly-${{ github.run_number }}
-          title: "chore(deps): apply Socket Certified Patches (weekly)"
+          branch: socket-patch/weekly-${{ github.run_number }}-${{ strategy.job-index }}
+          title: "chore(deps): apply Socket Certified Patches (${{ matrix.workspace }})"
           body: ${{ steps.body.outputs.body }}
-          commit-message: |
-            chore(deps): apply Socket Certified Patches
-
-            Part of ATL-106
+          commit-message: "chore(deps): apply Socket Certified Patches (${{ matrix.workspace }})"
           labels: dependencies,security,socket-patch
           delete-branch: true

--- a/docs/socket.md
+++ b/docs/socket.md
@@ -36,12 +36,14 @@ Both are gated by `socket.yml` at the repo root.
 
 ### `Socket Autofix` workflow (weekly Monday 09:00 UTC)
 
-`.github/workflows/socket-autofix.yml` runs on `cron: '0 9 * * 1'` plus `workflow_dispatch`. It contains two **independent** jobs (no `needs:` between them) that run in parallel:
+`.github/workflows/socket-autofix.yml` runs on `cron: '0 9 * * 1'` plus `workflow_dispatch`. It contains two **independent** jobs (no `needs:` between them) that run in parallel.
 
-- **`socket-fix`** — opens one PR per fixable GHSA/CVE. Flags:
+Because this is a multi-workspace Bun monorepo with **no root-level `package.json`**, both jobs use `strategy.matrix` over the runtime-relevant workspaces that each own a `bun.lock` (`assistant`, `cli`, `credential-executor`, `gateway`, the two `clients/chrome-extension*` workspaces, the three `packages/*` workspaces, and the three `skills/meet-join*` workspaces). Each matrix leg sets `defaults.run.working-directory` to its workspace and runs `bun install --frozen-lockfile` before invoking the Socket CLI — Socket's `fix` and `socket-patch apply` both operate on a resolved `node_modules` tree, so skipping the install leaves them with nothing to scan. `meta` and `scripts` (dev tooling only) are deliberately excluded to conserve the Free tier's ~1,000 scans/month budget.
+
+- **`socket-fix`** — opens one PR per fixable GHSA/CVE, per workspace. Flags:
   - `--pr-limit 10` — cap per-run PR volume. Socket's current default, pinned explicitly for reviewer visibility and future-default stability.
   - `--minimum-release-age 1w` — skip versions published in the last 7 days. Defense against malware-via-update (compromised maintainer pushing a poisoned patch release).
-- **`socket-patch`** — applies Socket Certified Patches, bundled into one PR. Paid-tier patches are silently skipped on Free (expected — no PR opened those weeks).
+- **`socket-patch`** — applies Socket Certified Patches per workspace. The canonical CLI sequence is `scan --json` → `get <id>` (one call per patch identifier, fed from the scan output via `jq`; `get` writes `.socket/manifest.json`) → `apply` (consumes the manifest). `apply` returns `status="no_manifest"` when no patches were staged, which is treated as a no-op success. Paid-tier patches are silently skipped on Free (expected — no PR opened those weeks).
 
 ## Policy file
 


### PR DESCRIPTION
## Summary
- Fixes a silent no-op: the previous workflow ran from the repo root with no `bun install`, so Socket tools had nothing to scan.
- Matrixes both `socket-fix` and `socket-patch` jobs over the workspaces with their own `bun.lock`.
- Adds `bun install --frozen-lockfile` per workspace before the Socket CLI invocation.
- Restructures `socket-patch` to the canonical `scan → get → apply` sequence (previous code skipped the manifest-population step).
- Minor polish: comment on `cancel-in-progress: false`, drop duplicate ATL-106 trailer in weekly autofix commit message.
- Updates `docs/socket.md` runbook to describe the matrix structure.

## Why it matters
Socket's `fix` and `socket-patch apply` both require a resolved dependency tree (node_modules) to operate. In a multi-workspace monorepo with no root manifest, the workflow has to be scoped per workspace or it silently finds nothing. Before this fix, every Monday's scheduled run did nothing visible.

Fixes gaps identified during plan self-review for socket-enforcement.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
