### PR TITLE
fix(macos): restore Finder/DMG icon & add per-environment icon infrastructure

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1339,12 +1339,30 @@ cat > "$CONTENTS/Info.plist" <<PLIST
 </plist>
 PLIST
 
+# Resolve per-environment icon source. Falls back to production if no
+# environment-specific override exists.
+ICONS_DIR="$SCRIPT_DIR/vellum-assistant/Resources/icons"
+if [ -d "$ICONS_DIR/$VELLUM_ENVIRONMENT" ]; then
+    ICON_SOURCE_DIR="$ICONS_DIR/$VELLUM_ENVIRONMENT"
+elif [ -d "$ICONS_DIR/production" ]; then
+    ICON_SOURCE_DIR="$ICONS_DIR/production"
+else
+    ICON_SOURCE_DIR=""
+fi
+
 # Always compile asset catalog (fast, ensures AppIcon changes are picked up)
 # AppIcon.icon is a Xcode-26 Icon Composer bundle — actool reads it alongside
 # the xcassets and emits both the layered Liquid Glass iconstack for macOS Tahoe
 # and backward-compatible raster fallbacks for macOS 15 into Assets.car.
 XCASSETS="$SCRIPT_DIR/vellum-assistant/Resources/Assets.xcassets"
 APP_ICON="$SCRIPT_DIR/vellum-assistant/Resources/AppIcon.icon"
+
+# Overlay environment-specific icon into the .icon bundle so both actool
+# (Assets.car / Liquid Glass) and the .icns generation use the correct source.
+if [ -n "$ICON_SOURCE_DIR" ]; then
+    cp "$ICON_SOURCE_DIR/icon.json" "$APP_ICON/icon.json"
+    cp -R "$ICON_SOURCE_DIR/Assets/" "$APP_ICON/Assets/"
+fi
 if [ -d "$XCASSETS" ]; then
     ACTOOL_INPUTS=("$XCASSETS")
     if [ -d "$APP_ICON" ]; then
@@ -1372,7 +1390,9 @@ fi
 # actool with .icon bundles only emits into Assets.car — it does not produce a
 # standalone .icns.  Finder and create-dmg rely on CFBundleIconFile → .icns,
 # so we render one from the same SVG source that Icon Composer uses.
-if [ ! -f "$RESOURCES_DIR/AppIcon.icns" ] && [ -d "$APP_ICON" ]; then
+# Always regenerate when an icon source directory is resolved — the Swift
+# script is fast and this avoids stale icns after environment switches.
+if [ -d "$APP_ICON" ] && [ -n "$ICON_SOURCE_DIR" ]; then
     echo "Generating AppIcon.icns from SVG..."
 
     ICONSET_DIR=$(mktemp -d)/AppIcon.iconset

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1350,13 +1350,217 @@ if [ -d "$XCASSETS" ]; then
     if [ -d "$APP_ICON" ]; then
         ACTOOL_INPUTS+=("$APP_ICON")
     fi
-    xcrun actool "${ACTOOL_INPUTS[@]}" \
+    # Capture actool output; suppress warnings but surface real failures
+    ACTOOL_OUTPUT=$(xcrun actool "${ACTOOL_INPUTS[@]}" \
         --compile "$RESOURCES_DIR" \
         --platform macosx \
         --minimum-deployment-target 14.0 \
         --app-icon AppIcon \
         --output-partial-info-plist /dev/null \
-        > /dev/null 2>&1 || true
+        2>&1) || {
+        # Filter out warning lines and check if there are real errors
+        ACTOOL_ERRORS=$(echo "$ACTOOL_OUTPUT" | grep -iv 'warning:' || true)
+        if [ -n "$ACTOOL_ERRORS" ]; then
+            echo "actool failed:"
+            echo "$ACTOOL_ERRORS"
+            exit 1
+        fi
+    }
+fi
+
+# Generate AppIcon.icns from SVG source for Finder/DMG icon display.
+# actool with .icon bundles only emits into Assets.car — it does not produce a
+# standalone .icns.  Finder and create-dmg rely on CFBundleIconFile → .icns,
+# so we render one from the same SVG source that Icon Composer uses.
+if [ ! -f "$RESOURCES_DIR/AppIcon.icns" ] && [ -d "$APP_ICON" ]; then
+    echo "Generating AppIcon.icns from SVG..."
+
+    ICONSET_DIR=$(mktemp -d)/AppIcon.iconset
+    mkdir -p "$ICONSET_DIR"
+
+    # Render a 1024x1024 master PNG using an inline Swift script.
+    # This is consistent with how dmg/generate-background.swift works.
+    MASTER_PNG=$(mktemp /tmp/appicon-master-XXXXXX.png)
+    swift - "$APP_ICON/Assets/white-V.svg" "$APP_ICON/icon.json" "$MASTER_PNG" <<'SWIFT_SCRIPT'
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+let svgPath = CommandLine.arguments[1]
+let jsonPath = CommandLine.arguments[2]
+let outputPath = CommandLine.arguments[3]
+
+// --- Parse fill color from icon.json ---
+let jsonData = try! Data(contentsOf: URL(fileURLWithPath: jsonPath))
+let json = try! JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+let fillDict = json["fill"] as! [String: Any]
+let solidStr = fillDict["solid"] as! String  // "display-p3:0.12941,0.42353,0.21569,1.00000"
+
+let colorParts = solidStr.split(separator: ":")[1].split(separator: ",").map { CGFloat(Double($0)!) }
+let fillColor = CGColor(
+    colorSpace: CGColorSpace(name: CGColorSpace.displayP3)!,
+    components: colorParts
+)!
+
+// --- Parse SVG path ---
+let svgString = try! String(contentsOfFile: svgPath, encoding: .utf8)
+// Extract the path d attribute from the SVG
+let dRange = svgString.range(of: "d=\"")!
+let afterD = svgString[dRange.upperBound...]
+let closingQuote = afterD.firstIndex(of: "\"")!
+let pathData = String(afterD[..<closingQuote])
+
+// Parse SVG viewBox for coordinate mapping
+let vbRange = svgString.range(of: "viewBox=\"")!
+let afterVB = svgString[vbRange.upperBound...]
+let vbClose = afterVB.firstIndex(of: "\"")!
+let vbParts = String(afterVB[..<vbClose]).split(separator: " ").map { CGFloat(Double($0)!) }
+let svgWidth = vbParts[2]
+let svgHeight = vbParts[3]
+
+// --- Build CGPath from SVG path data ---
+func parseSVGPath(_ d: String) -> CGPath {
+    let path = CGMutablePath()
+    var chars = Array(d)
+    var i = 0
+    var currentX: CGFloat = 0
+    var currentY: CGFloat = 0
+
+    func skipWhitespaceAndCommas() {
+        while i < chars.count && (chars[i] == " " || chars[i] == "," || chars[i] == "\n" || chars[i] == "\r" || chars[i] == "\t") {
+            i += 1
+        }
+    }
+
+    func parseNumber() -> CGFloat {
+        skipWhitespaceAndCommas()
+        var numStr = ""
+        if i < chars.count && (chars[i] == "-" || chars[i] == "+") {
+            numStr.append(chars[i]); i += 1
+        }
+        while i < chars.count && (chars[i] >= "0" && chars[i] <= "9" || chars[i] == ".") {
+            numStr.append(chars[i]); i += 1
+        }
+        return CGFloat(Double(numStr) ?? 0)
+    }
+
+    while i < chars.count {
+        skipWhitespaceAndCommas()
+        if i >= chars.count { break }
+        let cmd = chars[i]
+        if cmd.isLetter { i += 1 }
+        switch cmd {
+        case "M":
+            let x = parseNumber(); let y = parseNumber()
+            path.move(to: CGPoint(x: x, y: y))
+            currentX = x; currentY = y
+        case "m":
+            let dx = parseNumber(); let dy = parseNumber()
+            currentX += dx; currentY += dy
+            path.move(to: CGPoint(x: currentX, y: currentY))
+        case "L":
+            let x = parseNumber(); let y = parseNumber()
+            path.addLine(to: CGPoint(x: x, y: y))
+            currentX = x; currentY = y
+        case "l":
+            let dx = parseNumber(); let dy = parseNumber()
+            currentX += dx; currentY += dy
+            path.addLine(to: CGPoint(x: currentX, y: currentY))
+        case "Z", "z":
+            path.closeSubpath()
+        default:
+            break
+        }
+    }
+    return path
+}
+
+// --- Render 1024x1024 PNG ---
+let size = 1024
+let colorSpace = CGColorSpace(name: CGColorSpace.displayP3)!
+
+guard let ctx = CGContext(
+    data: nil, width: size, height: size,
+    bitsPerComponent: 8, bytesPerRow: 0,
+    space: colorSpace,
+    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+) else { fatalError("Failed to create bitmap context") }
+
+let s = CGFloat(size)
+
+// Draw macOS squircle rounded-rect background with the green fill.
+// Apple's macOS icon shape uses ~22.37% corner radius (continuous corners).
+let iconRect = CGRect(x: 0, y: 0, width: s, height: s)
+let cornerRadius = s * 0.2237
+let bgPath = CGPath(roundedRect: iconRect, cornerWidth: cornerRadius, cornerHeight: cornerRadius, transform: nil)
+ctx.addPath(bgPath)
+ctx.setFillColor(fillColor)
+ctx.fillPath()
+
+// Draw the white V centered with scale=6 and translation=[0, 25] from icon.json.
+// Icon Composer coordinates: origin is center of the 1024x1024 canvas,
+// Y-axis points up, and scale is relative to the SVG's native size.
+let scale: CGFloat = 6
+let txPoints: CGFloat = 0
+let tyPoints: CGFloat = 25
+
+// Scale from points to pixels (icon.json uses a 1024-point canvas)
+let svgPixelWidth = svgWidth * scale
+let svgPixelHeight = svgHeight * scale
+
+// Center the scaled SVG on the canvas, then apply translation
+let offsetX = (s - svgPixelWidth) / 2.0 + txPoints
+// Flip Y: CGContext uses bottom-left origin with Y-up, but SVG uses top-left
+// origin with Y-down. Flip the context to match SVG coordinate convention.
+// icon.json translation Y=25 means 25pt upward in Icon Composer;
+// in our now-flipped top-left-origin context, upward = negative Y.
+let offsetY = (s - svgPixelHeight) / 2.0 - tyPoints
+
+ctx.saveGState()
+// Flip to top-left origin (matching SVG coordinates)
+ctx.translateBy(x: 0, y: s)
+ctx.scaleBy(x: 1, y: -1)
+// Move to where the SVG should be drawn, then scale the SVG coordinates
+ctx.translateBy(x: offsetX, y: offsetY)
+ctx.scaleBy(x: scale, y: scale)
+let vPath = parseSVGPath(pathData)
+ctx.addPath(vPath)
+ctx.setFillColor(.white)
+ctx.fillPath()
+ctx.restoreGState()
+
+// Write PNG
+guard let image = ctx.makeImage() else { fatalError("Failed to create CGImage") }
+let url = URL(fileURLWithPath: outputPath)
+guard let dest = CGImageDestinationCreateWithURL(
+    url as CFURL, UTType.png.identifier as CFString, 1, nil
+) else { fatalError("Failed to create image destination") }
+CGImageDestinationAddImage(dest, image, nil)
+guard CGImageDestinationFinalize(dest) else { fatalError("Failed to write PNG") }
+SWIFT_SCRIPT
+
+    if [ ! -f "$MASTER_PNG" ]; then
+        echo "Error: Failed to generate master icon PNG"
+        exit 1
+    fi
+
+    # Generate all required icon sizes from the 1024x1024 master.
+    # iconutil requires: 16, 32, 128, 256, 512 at 1x and 2x (10 files).
+    for SIZE in 16 32 128 256 512; do
+        DOUBLE=$((SIZE * 2))
+        sips -z "$SIZE" "$SIZE" "$MASTER_PNG" --out "$ICONSET_DIR/icon_${SIZE}x${SIZE}.png" > /dev/null
+        sips -z "$DOUBLE" "$DOUBLE" "$MASTER_PNG" --out "$ICONSET_DIR/icon_${SIZE}x${SIZE}@2x.png" > /dev/null
+    done
+
+    # Produce the .icns file
+    iconutil --convert icns --output "$RESOURCES_DIR/AppIcon.icns" "$ICONSET_DIR"
+
+    # Clean up
+    rm -rf "$(dirname "$ICONSET_DIR")"
+    rm -f "$MASTER_PNG"
+
+    echo "Generated AppIcon.icns"
 fi
 
 # Copy document type icon for .vellum UTI

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1506,7 +1506,9 @@ func parseSVGPath(_ d: String) -> CGPath {
         case "Z", "z":
             path.closeSubpath()
         default:
-            break
+            // Skip unknown commands by advancing past their numeric arguments
+            // to avoid an infinite loop on unsupported SVG path commands (C, H, V, etc.)
+            while i < chars.count && !chars[i].isLetter { i += 1 }
         }
     }
     return path

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1481,11 +1481,24 @@ func parseSVGPath(_ d: String) -> CGPath {
         return CGFloat(Double(numStr) ?? 0)
     }
 
+    var lastCmd: Character = " "
+
     while i < chars.count {
         skipWhitespaceAndCommas()
         if i >= chars.count { break }
-        let cmd = chars[i]
-        if cmd.isLetter { i += 1 }
+
+        // Determine the command: explicit letter or implicit repetition
+        var cmd: Character
+        if chars[i].isLetter {
+            cmd = chars[i]; i += 1
+        } else {
+            // Implicit repetition: reuse last command (M promotes to L per SVG spec)
+            cmd = lastCmd
+            if cmd == "M" { cmd = "L" }
+            if cmd == "m" { cmd = "l" }
+        }
+        lastCmd = cmd
+
         switch cmd {
         case "M":
             let x = parseNumber(); let y = parseNumber()
@@ -1503,11 +1516,50 @@ func parseSVGPath(_ d: String) -> CGPath {
             let dx = parseNumber(); let dy = parseNumber()
             currentX += dx; currentY += dy
             path.addLine(to: CGPoint(x: currentX, y: currentY))
+        case "H":
+            currentX = parseNumber()
+            path.addLine(to: CGPoint(x: currentX, y: currentY))
+        case "h":
+            currentX += parseNumber()
+            path.addLine(to: CGPoint(x: currentX, y: currentY))
+        case "V":
+            currentY = parseNumber()
+            path.addLine(to: CGPoint(x: currentX, y: currentY))
+        case "v":
+            currentY += parseNumber()
+            path.addLine(to: CGPoint(x: currentX, y: currentY))
+        case "C":
+            let x1 = parseNumber(); let y1 = parseNumber()
+            let x2 = parseNumber(); let y2 = parseNumber()
+            let x = parseNumber(); let y = parseNumber()
+            path.addCurve(to: CGPoint(x: x, y: y),
+                          control1: CGPoint(x: x1, y: y1),
+                          control2: CGPoint(x: x2, y: y2))
+            currentX = x; currentY = y
+        case "c":
+            let dx1 = parseNumber(); let dy1 = parseNumber()
+            let dx2 = parseNumber(); let dy2 = parseNumber()
+            let dx = parseNumber(); let dy = parseNumber()
+            path.addCurve(to: CGPoint(x: currentX + dx, y: currentY + dy),
+                          control1: CGPoint(x: currentX + dx1, y: currentY + dy1),
+                          control2: CGPoint(x: currentX + dx2, y: currentY + dy2))
+            currentX += dx; currentY += dy
+        case "Q":
+            let x1 = parseNumber(); let y1 = parseNumber()
+            let x = parseNumber(); let y = parseNumber()
+            path.addQuadCurve(to: CGPoint(x: x, y: y),
+                              control: CGPoint(x: x1, y: y1))
+            currentX = x; currentY = y
+        case "q":
+            let dx1 = parseNumber(); let dy1 = parseNumber()
+            let dx = parseNumber(); let dy = parseNumber()
+            path.addQuadCurve(to: CGPoint(x: currentX + dx, y: currentY + dy),
+                              control: CGPoint(x: currentX + dx1, y: currentY + dy1))
+            currentX += dx; currentY += dy
         case "Z", "z":
             path.closeSubpath()
         default:
-            // Skip unknown commands by advancing past their numeric arguments
-            // to avoid an infinite loop on unsupported SVG path commands (C, H, V, etc.)
+            // Skip unrecognized commands by advancing past their arguments
             while i < chars.count && !chars[i].isLetter { i += 1 }
         }
     }

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1400,20 +1400,22 @@ if [ -d "$APP_ICON" ] && [ -n "$ICON_SOURCE_DIR" ]; then
 
     # Render a 1024x1024 master PNG using an inline Swift script.
     # This is consistent with how dmg/generate-background.swift works.
-    MASTER_PNG=$(mktemp /tmp/appicon-master-XXXXXX.png)
-    swift - "$APP_ICON/Assets/white-V.svg" "$APP_ICON/icon.json" "$MASTER_PNG" <<'SWIFT_SCRIPT'
+    MASTER_PNG=$(mktemp /tmp/appicon-master-XXXXXX).png
+    swift - "$APP_ICON" "$MASTER_PNG" <<'SWIFT_SCRIPT'
 import CoreGraphics
 import Foundation
 import ImageIO
 import UniformTypeIdentifiers
 
-let svgPath = CommandLine.arguments[1]
-let jsonPath = CommandLine.arguments[2]
-let outputPath = CommandLine.arguments[3]
+let iconDir = CommandLine.arguments[1]
+let outputPath = CommandLine.arguments[2]
 
-// --- Parse fill color from icon.json ---
+// --- Parse icon.json ---
+let jsonPath = iconDir + "/icon.json"
 let jsonData = try! Data(contentsOf: URL(fileURLWithPath: jsonPath))
 let json = try! JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+
+// Fill color
 let fillDict = json["fill"] as! [String: Any]
 let solidStr = fillDict["solid"] as! String  // "display-p3:0.12941,0.42353,0.21569,1.00000"
 
@@ -1422,6 +1424,20 @@ let fillColor = CGColor(
     colorSpace: CGColorSpace(name: CGColorSpace.displayP3)!,
     components: colorParts
 )!
+
+// Layer position: scale and translation
+let groups = json["groups"] as! [[String: Any]]
+let layers = groups[0]["layers"] as! [[String: Any]]
+let layer = layers[0]
+let position = layer["position"] as! [String: Any]
+let scale = CGFloat(position["scale"] as! Double)
+let translationPts = position["translation-in-points"] as! [Double]
+let txPoints = CGFloat(translationPts[0])
+let tyPoints = CGFloat(translationPts[1])
+
+// SVG filename from layer image-name
+let imageName = layer["image-name"] as! String
+let svgPath = iconDir + "/Assets/" + imageName
 
 // --- Parse SVG path ---
 let svgString = try! String(contentsOfFile: svgPath, encoding: .utf8)
@@ -1518,12 +1534,9 @@ ctx.addPath(bgPath)
 ctx.setFillColor(fillColor)
 ctx.fillPath()
 
-// Draw the white V centered with scale=6 and translation=[0, 25] from icon.json.
+// Draw the white V centered with scale and translation from icon.json.
 // Icon Composer coordinates: origin is center of the 1024x1024 canvas,
 // Y-axis points up, and scale is relative to the SVG's native size.
-let scale: CGFloat = 6
-let txPoints: CGFloat = 0
-let tyPoints: CGFloat = 25
 
 // Scale from points to pixels (icon.json uses a 1024-point canvas)
 let svgPixelWidth = svgWidth * scale

--- a/clients/macos/vellum-assistant/Resources/icons/README.md
+++ b/clients/macos/vellum-assistant/Resources/icons/README.md
@@ -1,0 +1,54 @@
+# Per-Environment App Icons
+
+This directory contains per-environment icon sources for the macOS app.
+Each subdirectory corresponds to a `VELLUM_ENVIRONMENT` value and holds the
+Icon Composer assets that `build.sh` copies into `AppIcon.icon/` before the
+build compiles them.
+
+## Directory structure
+
+```
+icons/
+  README.md
+  production/          # VELLUM_ENVIRONMENT=production (canonical/default)
+    icon.json          # Icon Composer manifest (fill color, layer definitions)
+    Assets/
+      white-V.svg      # Foreground SVG layer
+  staging/             # (example) VELLUM_ENVIRONMENT=staging
+    icon.json
+    Assets/
+      white-V.svg
+```
+
+One subdirectory per environment: `local`, `dev`, `staging`, `production`.
+If no directory exists for the current `VELLUM_ENVIRONMENT`, the build falls
+back to `production/`.
+
+## Adding a new environment icon
+
+1. Create a directory matching the environment name (e.g. `staging/`).
+2. Copy `production/icon.json` and `production/Assets/white-V.svg` into it.
+3. Edit `icon.json` to change the `fill.solid` color. This controls the
+   background tint of the app icon. The color format is
+   `display-p3:<red>,<green>,<blue>,<alpha>` with values between 0 and 1.
+4. Optionally replace `Assets/white-V.svg` with a different foreground SVG.
+5. Build with `VELLUM_ENVIRONMENT=staging ./build.sh run` (or whichever
+   environment you added) and verify the icon.
+
+The easiest customization is changing just the `fill.solid` color in
+`icon.json` to give each environment a distinct background tint while keeping
+the same white-V foreground.
+
+## How it works
+
+`build.sh` resolves the icon source directory at build time:
+
+1. Checks for `icons/$VELLUM_ENVIRONMENT/`.
+2. Falls back to `icons/production/` if the environment directory is missing.
+3. Copies `icon.json` and `Assets/` from the resolved directory into
+   `AppIcon.icon/`, overwriting its contents.
+4. `actool` and the `.icns` generation step then read from `AppIcon.icon/`,
+   so both Liquid Glass and Finder/DMG icons reflect the environment color.
+
+`AppIcon.icon/` in the source tree is treated as a working copy that gets
+overwritten at build time -- it is not the source of truth.

--- a/clients/macos/vellum-assistant/Resources/icons/production/Assets/white-V.svg
+++ b/clients/macos/vellum-assistant/Resources/icons/production/Assets/white-V.svg
@@ -1,0 +1,3 @@
+<svg width="92" height="92" viewBox="0 0 92 92" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.5 0L46 48.342L68.4107 0L91 0L45.8214 92L1 0L23.5 0Z" fill="white"/>
+</svg>

--- a/clients/macos/vellum-assistant/Resources/icons/production/icon.json
+++ b/clients/macos/vellum-assistant/Resources/icons/production/icon.json
@@ -1,0 +1,47 @@
+{
+  "fill" : {
+    "solid" : "display-p3:0.12941,0.42353,0.21569,1.00000"
+  },
+  "groups" : [
+    {
+      "blend-mode" : "normal",
+      "layers" : [
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "dark",
+              "value" : "none"
+            }
+          ],
+          "glass" : false,
+          "image-name" : "white-V.svg",
+          "name" : "white-V",
+          "position" : {
+            "scale" : 6,
+            "translation-in-points" : [
+              0,
+              25
+            ]
+          }
+        }
+      ],
+      "lighting" : "individual",
+      "name" : "Group",
+      "shadow" : {
+        "kind" : "neutral",
+        "opacity" : 0.5
+      },
+      "specular" : true,
+      "translucency" : {
+        "enabled" : true,
+        "value" : 0.5
+      }
+    }
+  ],
+  "supported-platforms" : {
+    "circles" : [
+      "watchOS"
+    ],
+    "squares" : "shared"
+  }
+}


### PR DESCRIPTION
## Summary
Fixes the macOS app icon regression from PR #27022 where migrating to Icon Composer `.icon` bundles broke the Finder/DMG icon (actool no longer generates standalone `.icns`). Adds per-environment icon infrastructure so different environments can use distinct icon assets.

## Self-review result
GAPS FOUND — 2 gaps fixed in 1 fix PR (hardcoded icon.json values, mktemp randomization)

## PRs merged into feature branch
- #27721: fix(macos): generate AppIcon.icns from SVG to restore Finder/DMG icon
- #27727: feat(macos): add per-environment app icon infrastructure

### Fix PRs
- #27732: fix: read scale/translation/image-name from icon.json, fix mktemp randomization

Part of plan: fix-macos-app-icon.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
