### PR TITLE
feat(home): render permissionChat detail panel with real tool/command data (JARVIS-579)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionDetailCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionDetailCard.swift
@@ -1,17 +1,118 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Stub body component for tool-permission detail panels.
-/// Will be replaced with a rich permission approval UI when the daemon
-/// surfaces structured permission fields on `FeedItem`.
+/// Body component for tool-permission detail panels.
+///
+/// Renders structured permission fields (tool name, command preview, risk
+/// level, decision) from `ToolPermissionPanelData` as a compact details
+/// card. Falls back to the feed item's title when no structured data is
+/// available.
 struct HomePermissionDetailCard: View {
     let item: FeedItem
 
+    private var panelData: ToolPermissionPanelData? {
+        ToolPermissionPanelData.from(item.detailPanel?.data)
+    }
+
     var body: some View {
-        Text(item.title)
-            .font(VFont.bodyMediumDefault)
-            .foregroundStyle(VColor.contentSecondary)
-            .padding(VSpacing.lg)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        if let data = panelData {
+            structuredContent(data)
+        } else {
+            Text(item.title)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .padding(VSpacing.lg)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        }
+    }
+
+    // MARK: - Structured Content
+
+    @ViewBuilder
+    private func structuredContent(_ data: ToolPermissionPanelData) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            if let decision = data.decision {
+                decisionBadge(decision)
+            }
+
+            detailsCard(data)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    @ViewBuilder
+    private func decisionBadge(_ decision: String) -> some View {
+        let isApproved = decision.lowercased().contains("allow") || decision.lowercased().contains("approve")
+        HStack(spacing: VSpacing.xs) {
+            VIconView(isApproved ? .check : .x, size: 14)
+            Text(decision.capitalized)
+                .font(VFont.bodyMediumEmphasised)
+        }
+        .foregroundStyle(isApproved ? VColor.systemPositiveStrong : VColor.systemNegativeStrong)
+    }
+
+    private func detailsCard(_ data: ToolPermissionPanelData) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Details")
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(VColor.contentEmphasized)
+                .accessibilityAddTraits(.isHeader)
+
+            detailRow(key: "Tool", value: data.toolName)
+
+            if let command = data.commandPreview {
+                detailRow(key: "Command", value: command)
+            }
+
+            if let risk = data.riskLevel {
+                HStack {
+                    Text("Risk")
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentTertiary)
+                    Spacer()
+                    Text(risk.capitalized)
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(riskColor(for: risk))
+                }
+            }
+        }
+        .padding(EdgeInsets(
+            top: VSpacing.md,
+            leading: VSpacing.md,
+            bottom: VSpacing.lg,
+            trailing: VSpacing.md
+        ))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg, style: .continuous)
+                .fill(VColor.surfaceOverlay)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg, style: .continuous)
+                .strokeBorder(VColor.borderHover, lineWidth: 1)
+        )
+    }
+
+    private func detailRow(key: String, value: String) -> some View {
+        HStack {
+            Text(key)
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentTertiary)
+            Spacer()
+            Text(value)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentDefault)
+                .lineLimit(2)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+
+    private func riskColor(for level: String) -> Color {
+        switch level.lowercased() {
+        case "high":   return VColor.systemNegativeStrong
+        case "medium": return VColor.systemMidStrong
+        default:       return VColor.contentDefault
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionDetailCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionDetailCard.swift
@@ -10,12 +10,23 @@ import VellumAssistantShared
 struct HomePermissionDetailCard: View {
     let item: FeedItem
 
-    private var panelData: ToolPermissionPanelData? {
-        ToolPermissionPanelData.from(item.detailPanel?.data)
+    private var toolData: ToolPermissionPanelData? {
+        if let data = ToolPermissionPanelData.from(item.detailPanel?.data) {
+            return data
+        }
+        if let chat = PermissionChatPanelData.from(item.detailPanel?.data) {
+            return ToolPermissionPanelData(
+                toolName: chat.toolName,
+                commandPreview: chat.commandPreview,
+                riskLevel: chat.riskLevel,
+                decision: nil
+            )
+        }
+        return nil
     }
 
     var body: some View {
-        if let data = panelData {
+        if let data = toolData {
             structuredContent(data)
         } else {
             Text(item.title)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -344,35 +344,8 @@ extension MainWindowView {
                         onClose: { activeHomeDetailPanel = nil }
                     )
                 case .permissionChat(let item):
-                    if let chatData = PermissionChatPanelData.from(item.detailPanel?.data) {
-                        HomeDetailPanel(
-                            icon: nil,
-                            title: item.title,
-                            onGoToThread: item.conversationId.flatMap { id in
-                                UUID(uuidString: id).map { uuid in
-                                    {
-                                        activeHomeDetailPanel = nil
-                                        windowState.selection = .conversation(uuid)
-                                    }
-                                }
-                            },
-                            onDismiss: { activeHomeDetailPanel = nil }
-                        ) {
-                            HomePermissionChatPreview(
-                                userMessage: chatData.userMessage,
-                                assistantResponse: chatData.assistantResponse,
-                                confirmation: ToolConfirmationData(
-                                    requestId: chatData.requestId,
-                                    toolName: chatData.toolName,
-                                    riskLevel: chatData.riskLevel ?? "medium",
-                                    persistentDecisionsAllowed: false
-                                ),
-                                onAllow: { activeHomeDetailPanel = nil },
-                                onDeny: { activeHomeDetailPanel = nil },
-                                onAlwaysAllow: { _, _, _, _ in activeHomeDetailPanel = nil }
-                            )
-                        }
-                    } else if ToolPermissionPanelData.from(item.detailPanel?.data) != nil {
+                    if PermissionChatPanelData.from(item.detailPanel?.data) != nil ||
+                       ToolPermissionPanelData.from(item.detailPanel?.data) != nil {
                         HomeDetailPanel(
                             icon: nil,
                             title: item.title,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -344,15 +344,53 @@ extension MainWindowView {
                         onClose: { activeHomeDetailPanel = nil }
                     )
                 case .permissionChat(let item):
-                    HomeDetailPanel(
-                        icon: nil,
-                        title: item.title,
-                        onDismiss: { activeHomeDetailPanel = nil }
-                    ) {
-                        Text(item.summary)
-                            .font(VFont.bodyMediumDefault)
-                            .foregroundStyle(VColor.contentSecondary)
-                            .padding(VSpacing.lg)
+                    if let chatData = PermissionChatPanelData.from(item.detailPanel?.data) {
+                        HomeDetailPanel(
+                            icon: nil,
+                            title: item.title,
+                            onGoToThread: item.conversationId.flatMap { id in
+                                UUID(uuidString: id).map { uuid in
+                                    {
+                                        activeHomeDetailPanel = nil
+                                        windowState.selection = .conversation(uuid)
+                                    }
+                                }
+                            },
+                            onDismiss: { activeHomeDetailPanel = nil }
+                        ) {
+                            HomePermissionChatPreview(
+                                userMessage: chatData.userMessage,
+                                assistantResponse: chatData.assistantResponse,
+                                confirmation: ToolConfirmationData(
+                                    requestId: chatData.requestId,
+                                    toolName: chatData.toolName,
+                                    riskLevel: chatData.riskLevel ?? "medium",
+                                    persistentDecisionsAllowed: false
+                                ),
+                                onAllow: { activeHomeDetailPanel = nil },
+                                onDeny: { activeHomeDetailPanel = nil },
+                                onAlwaysAllow: { _, _, _, _ in activeHomeDetailPanel = nil }
+                            )
+                        }
+                    } else if ToolPermissionPanelData.from(item.detailPanel?.data) != nil {
+                        HomeDetailPanel(
+                            icon: nil,
+                            title: item.title,
+                            onDismiss: { activeHomeDetailPanel = nil }
+                        ) {
+                            HomePermissionDetailCard(item: item)
+                        }
+                    } else {
+                        HomeDetailPanel(
+                            icon: nil,
+                            title: item.title,
+                            onDismiss: { activeHomeDetailPanel = nil }
+                        ) {
+                            Text(item.summary)
+                                .font(VFont.bodyMediumDefault)
+                                .foregroundStyle(VColor.contentSecondary)
+                                .padding(VSpacing.lg)
+                        }
                     }
                 case .paymentAuth(let item):
                     HomePaymentAuthPanel(


### PR DESCRIPTION
## Summary
- Parse PermissionChatPanelData in PanelCoordinator for .permissionChat case, showing tool name, command preview, and risk level
- Update HomePermissionDetailCard to render structured fields from panel data
- Parse ToolPermissionPanelData for .toolPermission case with structured approval/denial info
- Fall back to summary text when data is nil

Part of plan: home-feed-detail-panel-data.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
