### PR TITLE
fix(macos): silence 'var chars' build warning in build.sh

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1458,7 +1458,7 @@ let svgHeight = vbParts[3]
 // --- Build CGPath from SVG path data ---
 func parseSVGPath(_ d: String) -> CGPath {
     let path = CGMutablePath()
-    var chars = Array(d)
+    let chars = Array(d)
     var i = 0
     var currentX: CGFloat = 0
     var currentY: CGFloat = 0


### PR DESCRIPTION
## Summary
- Changed `var chars` to `let chars` in the inline Swift `parseSVGPath` function within `clients/macos/build.sh` since the array is never mutated
- Silences the Swift compiler warning: "variable 'chars' was never mutated; consider changing to 'let' constant"

## Original prompt
fix this macos build warning:

<stdin>:57:9: warning: variable 'chars' was never mutated; consider changing to 'let' constant
 55 | func parseSVGPath(_ d: String) -> CGPath {
 56 |     let path = CGMutablePath()
 57 |     var chars = Array(d)
    |         `- warning: variable 'chars' was never mutated; consider changing to 'let' constant
 58 |     var i = 0
 59 |     var currentX: CGFloat = 0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
