### PR TITLE
fix: guard nextRunAt > 0 to avoid epoch date in scheduled panel

### DIFF
--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -495,7 +495,10 @@ function emitScheduleFeedEvent(params: {
             mode: params.job.mode,
             schedule: params.job.expression ?? undefined,
             enabled: params.job.enabled,
-            nextRun: new Date(params.job.nextRunAt).toISOString(),
+            nextRun:
+              params.job.nextRunAt > 0
+                ? new Date(params.job.nextRunAt).toISOString()
+                : undefined,
             description: params.job.message.slice(0, 200),
           },
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for home-feed-detail-panel-data.md.

**Gap:** Epoch date for exhausted schedules
**What was expected:** nextRun should be undefined when nextRunAt is 0
**What was found:** Produces 1970-01-01 when nextRunAt is 0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
