### PR TITLE
fix: include required userMessage/assistantResponse in approval resolution feed event

### DIFF
--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -238,6 +238,8 @@ export async function handleConfirm(
         riskLevel: interaction.confirmationDetails?.riskLevel,
         requestId,
         decision: effectiveDecision,
+        userMessage: "",
+        assistantResponse: "",
       },
     },
   }).catch((err) => {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for home-feed-detail-panel-data.md.

**Gap:** Resolution event drops required permissionChat fields
**What was expected:** Resolution event should include all PermissionChatPanelData fields
**What was found:** userMessage and assistantResponse missing from resolution event data
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
