### PR TITLE
fix: clear stale loadedImage before re-fetching in document/payment panels

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDocumentPreviewPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDocumentPreviewPanel.swift
@@ -47,6 +47,7 @@ struct HomeDocumentPreviewPanel: View {
     }
 
     private func loadImageIfNeeded() async {
+        loadedImage = nil
         guard let urlString = panelData?.imageUrl,
               let url = URL(string: urlString) else { return }
         do {

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePaymentAuthPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePaymentAuthPanel.swift
@@ -59,6 +59,7 @@ struct HomePaymentAuthPanel: View {
     }
 
     private func loadImageIfNeeded() async {
+        loadedImage = nil
         guard let urlString = panelData?.imageUrl,
               let url = URL(string: urlString) else { return }
         do {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for home-feed-detail-panel-data.md.

**Gap:** Stale loadedImage in document/payment panels
**What was expected:** Old image cleared before loading new one
**What was found:** loadImageIfNeeded() does not reset loadedImage = nil before fetching
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
