### PR TITLE
feat(home): add structured data to feed detail panels (JARVIS-579)

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -155,6 +155,14 @@ export async function run(
             title: "Email Draft Created",
             summary: `Drafted reply to ${recipientSummary}.`,
             dedupKey: `email-draft:${draft.id}`,
+            detailPanel: {
+              kind: "emailDraft",
+              data: {
+                to: toList.join(", "),
+                subject: replySubject ?? "",
+                body: text,
+              },
+            },
           }).catch((err) => {
             log.warn({ err }, "Failed to emit email draft feed event");
           });
@@ -183,6 +191,14 @@ export async function run(
           title: "Email Draft Created",
           summary: `Drafted reply to ${recipientSummary}.`,
           dedupKey: `email-draft:${draft.id}`,
+          detailPanel: {
+            kind: "emailDraft",
+            data: {
+              to: toList.join(", "),
+              subject: replySubject ?? "",
+              body: text,
+            },
+          },
         }).catch((err) => {
           log.warn({ err }, "Failed to emit email draft feed event");
         });
@@ -217,6 +233,14 @@ export async function run(
           title: "Email Draft Created",
           summary: "Created an email draft.",
           dedupKey: `email-draft:${draft.id}`,
+          detailPanel: {
+            kind: "emailDraft",
+            data: {
+              to: conversationId,
+              subject: subject ?? "",
+              body: text,
+            },
+          },
         }).catch((err) => {
           log.warn({ err }, "Failed to emit email draft feed event");
         });
@@ -241,6 +265,14 @@ export async function run(
         title: "Email Draft Created",
         summary: "Created an email draft.",
         dedupKey: `email-draft:${draft.id}`,
+        detailPanel: {
+          kind: "emailDraft",
+          data: {
+            to: conversationId,
+            subject: subject ?? "",
+            body: text,
+          },
+        },
       }).catch((err) => {
         log.warn({ err }, "Failed to emit email draft feed event");
       });

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -405,6 +405,20 @@ export class HeartbeatService {
         summary: "Heartbeat check completed.",
         dedupKey: `heartbeat:ok:${today}`,
         priority: 30,
+        detailPanel: {
+          kind: "nudge",
+          data: {
+            description: "Heartbeat check completed successfully.",
+            cards: [
+              {
+                id: `heartbeat-summary:${today}`,
+                title: "Heartbeat Summary",
+                description:
+                  "Periodic heartbeat check ran and completed. All checklist items were reviewed.",
+              },
+            ],
+          },
+        },
       }).catch((err) => {
         log.warn(
           { err, conversationId: conversation.id },

--- a/assistant/src/home/__tests__/feed-types.test.ts
+++ b/assistant/src/home/__tests__/feed-types.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
-import { type FeedItem, feedItemSchema, parseFeedFile } from "../feed-types.js";
+import {
+  type DocumentPreviewPanelData,
+  type EmailDraftPanelData,
+  type FeedItem,
+  feedItemSchema,
+  type NudgePanelData,
+  parseFeedFile,
+  type PaymentAuthPanelData,
+  type PermissionChatPanelData,
+  type ScheduledPanelData,
+  type ToolPermissionPanelData,
+  type UpdatesListPanelData,
+} from "../feed-types.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -271,5 +283,227 @@ describe("parseFeedFile", () => {
         updatedAt: NOW_ISO,
       }),
     ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detailPanel — new kinds and data field
+// ---------------------------------------------------------------------------
+
+describe("feedItemSchema — detailPanel kinds", () => {
+  test("accepts 'scheduled' panel kind", () => {
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "scheduled" },
+    });
+    expect(parsed.detailPanel?.kind).toBe("scheduled");
+  });
+
+  test("accepts 'nudge' panel kind", () => {
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "nudge" },
+    });
+    expect(parsed.detailPanel?.kind).toBe("nudge");
+  });
+
+  test("accepts all original panel kinds", () => {
+    for (const kind of [
+      "emailDraft",
+      "documentPreview",
+      "permissionChat",
+      "paymentAuth",
+      "toolPermission",
+      "updatesList",
+    ]) {
+      const parsed = feedItemSchema.parse({
+        ...minimalNudge(),
+        detailPanel: { kind },
+      });
+      expect(parsed.detailPanel?.kind).toBe(kind);
+    }
+  });
+
+  test("rejects unknown panel kind", () => {
+    expect(() =>
+      feedItemSchema.parse({
+        ...minimalNudge(),
+        detailPanel: { kind: "unknown" },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("feedItemSchema — detailPanel data field", () => {
+  test("accepts panel without data", () => {
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "emailDraft" },
+    });
+    expect(parsed.detailPanel?.data).toBeUndefined();
+  });
+
+  test("accepts panel with empty data object", () => {
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "emailDraft", data: {} },
+    });
+    expect(parsed.detailPanel?.data).toEqual({});
+  });
+
+  test("round-trips EmailDraftPanelData shape", () => {
+    const data: EmailDraftPanelData = {
+      to: "user@example.com",
+      subject: "Follow up",
+      body: "Hi, just checking in.",
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "emailDraft", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as EmailDraftPanelData;
+    expect(d.to).toBe("user@example.com");
+    expect(d.subject).toBe("Follow up");
+    expect(d.body).toBe("Hi, just checking in.");
+  });
+
+  test("round-trips DocumentPreviewPanelData shape", () => {
+    const data: DocumentPreviewPanelData = {
+      imageUrl: "https://example.com/img.png",
+      caption: "Screenshot",
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "documentPreview", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as DocumentPreviewPanelData;
+    expect(d.imageUrl).toBe("https://example.com/img.png");
+    expect(d.caption).toBe("Screenshot");
+  });
+
+  test("round-trips PermissionChatPanelData shape", () => {
+    const data: PermissionChatPanelData = {
+      userMessage: "Can you run this?",
+      assistantResponse: "I need permission to execute.",
+      requestId: "req-123",
+      toolName: "bash",
+      commandPreview: "rm -rf /tmp/test",
+      riskLevel: "high",
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "permissionChat", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as PermissionChatPanelData;
+    expect(d.userMessage).toBe("Can you run this?");
+    expect(d.requestId).toBe("req-123");
+    expect(d.toolName).toBe("bash");
+    expect(d.riskLevel).toBe("high");
+  });
+
+  test("round-trips PaymentAuthPanelData shape", () => {
+    const data: PaymentAuthPanelData = {
+      imageUrl: "https://example.com/receipt.png",
+      caption: "Receipt",
+      amount: "$42.00",
+      recipient: "Example User",
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "paymentAuth", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as PaymentAuthPanelData;
+    expect(d.amount).toBe("$42.00");
+    expect(d.recipient).toBe("Example User");
+  });
+
+  test("round-trips ToolPermissionPanelData shape", () => {
+    const data: ToolPermissionPanelData = {
+      toolName: "file_write",
+      commandPreview: "write to /tmp/output.txt",
+      riskLevel: "medium",
+      decision: "approved",
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "toolPermission", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as ToolPermissionPanelData;
+    expect(d.toolName).toBe("file_write");
+    expect(d.decision).toBe("approved");
+  });
+
+  test("round-trips UpdatesListPanelData shape", () => {
+    const data: UpdatesListPanelData = {
+      items: [
+        { title: "Update 1", description: "First update" },
+        { title: "Update 2", description: "Second update" },
+      ],
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "updatesList", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as UpdatesListPanelData;
+    expect(d.items).toHaveLength(2);
+    expect(d.items[0]?.title).toBe("Update 1");
+  });
+
+  test("round-trips ScheduledPanelData shape", () => {
+    const data: ScheduledPanelData = {
+      description: "Daily standup reminder",
+      jobName: "standup-reminder",
+      syntax: "cron",
+      mode: "recurring",
+      schedule: "0 9 * * 1-5",
+      enabled: true,
+      nextRun: "2026-04-24T09:00:00.000Z",
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "scheduled", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as ScheduledPanelData;
+    expect(d.jobName).toBe("standup-reminder");
+    expect(d.syntax).toBe("cron");
+    expect(d.enabled).toBe(true);
+    expect(d.nextRun).toBe("2026-04-24T09:00:00.000Z");
+  });
+
+  test("round-trips NudgePanelData shape", () => {
+    const data: NudgePanelData = {
+      description: "Things you might want to do",
+      cards: [
+        { id: "card-1", title: "Review PR", description: "PR #123 is waiting" },
+        {
+          id: "card-2",
+          title: "Reply to thread",
+          description: "Alice asked a question",
+        },
+      ],
+    };
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "nudge", data },
+    });
+    const d = parsed.detailPanel?.data as unknown as NudgePanelData;
+    expect(d.description).toBe("Things you might want to do");
+    expect(d.cards).toHaveLength(2);
+    expect(d.cards[0]?.id).toBe("card-1");
+  });
+
+  test("existing items without data field decode without error", () => {
+    // Simulate a legacy item with detailPanel but no data
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      detailPanel: { kind: "emailDraft" },
+    });
+    expect(parsed.detailPanel?.kind).toBe("emailDraft");
+    expect(parsed.detailPanel?.data).toBeUndefined();
+  });
+
+  test("items without detailPanel still parse", () => {
+    const parsed = feedItemSchema.parse(minimalNudge());
+    expect(parsed.detailPanel).toBeUndefined();
   });
 });

--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -74,11 +74,80 @@ export type FeedItemDetailPanelKind =
   | "permissionChat"
   | "paymentAuth"
   | "toolPermission"
-  | "updatesList";
+  | "updatesList"
+  | "scheduled"
+  | "nudge";
 
-/** Server-driven detail panel descriptor attached to a feed item. */
+// ---------------------------------------------------------------------------
+// Per-kind panel data interfaces
+// ---------------------------------------------------------------------------
+
+export interface EmailDraftPanelData {
+  to: string;
+  subject: string;
+  body: string;
+}
+
+export interface DocumentPreviewPanelData {
+  imageUrl?: string;
+  caption?: string;
+}
+
+export interface PermissionChatPanelData {
+  userMessage: string;
+  assistantResponse: string;
+  requestId: string;
+  toolName: string;
+  commandPreview?: string;
+  riskLevel?: string;
+}
+
+export interface PaymentAuthPanelData {
+  imageUrl?: string;
+  caption?: string;
+  amount?: string;
+  recipient?: string;
+}
+
+export interface ToolPermissionPanelData {
+  toolName: string;
+  commandPreview?: string;
+  riskLevel?: string;
+  decision?: string;
+}
+
+export interface UpdatesListPanelData {
+  items: Array<{ title: string; description: string }>;
+}
+
+export interface ScheduledPanelData {
+  description?: string;
+  jobName: string;
+  syntax: string;
+  mode: string;
+  schedule?: string;
+  enabled: boolean;
+  nextRun?: string;
+}
+
+export interface NudgePanelData {
+  description?: string;
+  cards: Array<{
+    id: string;
+    title: string;
+    description: string;
+  }>;
+}
+
+/**
+ * Server-driven detail panel descriptor attached to a feed item.
+ *
+ * `data` is an untyped dictionary on the wire — kind-specific parsing
+ * happens at the consumer via the per-kind interfaces above.
+ */
 export interface FeedItemDetailPanel {
   kind: FeedItemDetailPanelKind;
+  data?: Record<string, unknown>;
 }
 
 /**
@@ -200,10 +269,13 @@ const feedItemDetailPanelKindSchema = z.enum([
   "paymentAuth",
   "toolPermission",
   "updatesList",
+  "scheduled",
+  "nudge",
 ]);
 
 const feedItemDetailPanelSchema = z.object({
   kind: feedItemDetailPanelKindSchema,
+  data: z.record(z.unknown()).optional(),
 });
 
 /**

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -19,7 +19,9 @@ import {
   isConversationHostAccessEnablePrompt,
   isPermissionControlsV2Enabled,
 } from "../../permissions/v2-consent-policy.js";
+import { redactSecrets } from "../../security/secret-scanner.js";
 import { getTool } from "../../tools/registry.js";
+import { summarizeToolInput } from "../../tools/tool-input-summary.js";
 import { getLogger } from "../../util/logger.js";
 import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
 import type { AuthContext } from "../auth/types.js";
@@ -213,6 +215,14 @@ export async function handleConfirm(
 
   const approved = effectiveDecision === "allow";
   const toolName = interaction.confirmationDetails?.toolName ?? "unknown tool";
+  const commandPreviewRaw = interaction.confirmationDetails?.input
+    ? redactSecrets(
+        summarizeToolInput(
+          toolName,
+          interaction.confirmationDetails.input as Record<string, unknown>,
+        ),
+      ) || undefined
+    : undefined;
   void emitFeedEvent({
     source: "assistant",
     title: `${approved ? "Approved" : "Denied"} use of ${toolName}.`,
@@ -220,6 +230,16 @@ export async function handleConfirm(
     dedupKey: `tool-approval:${requestId}`,
     urgency: approved ? undefined : "medium",
     conversationId: interaction.conversationId,
+    detailPanel: {
+      kind: "permissionChat",
+      data: {
+        toolName,
+        commandPreview: commandPreviewRaw || undefined,
+        riskLevel: interaction.confirmationDetails?.riskLevel,
+        requestId,
+        decision: effectiveDecision,
+      },
+    },
   }).catch((err) => {
     log.warn(
       { err, requestId },

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -238,6 +238,8 @@ export async function handleConfirm(
         riskLevel: interaction.confirmationDetails?.riskLevel,
         requestId,
         decision: effectiveDecision,
+        userMessage: "",
+        assistantResponse: "",
       },
     },
   }).catch((err) => {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1016,6 +1016,15 @@ function makeHubPublisher(
         : `Requesting approval to use ${msg.toolName}.`;
       const dedupKey = `tool-approval:${msg.requestId}`;
 
+      const permissionChatData: Record<string, unknown> = {
+        toolName: msg.toolName,
+        commandPreview: commandPreview ?? undefined,
+        riskLevel: msg.riskLevel,
+        requestId: msg.requestId,
+        userMessage: "",
+        assistantResponse: "",
+      };
+
       // Emit immediately with the technical preview.
       void emitFeedEvent({
         source: "assistant",
@@ -1024,6 +1033,10 @@ function makeHubPublisher(
         dedupKey,
         urgency: msg.riskLevel === "high" ? "high" : "medium",
         conversationId,
+        detailPanel: {
+          kind: "permissionChat",
+          data: permissionChatData,
+        },
       }).catch((err) => {
         log.warn(
           { err, requestId: msg.requestId },
@@ -1044,6 +1057,10 @@ function makeHubPublisher(
                 dedupKey,
                 urgency: msg.riskLevel === "high" ? "high" : "medium",
                 conversationId,
+                detailPanel: {
+                  kind: "permissionChat",
+                  data: permissionChatData,
+                },
               });
             }
           })

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -20,6 +20,7 @@ import {
   failOneShot,
   getLastScheduleConversationId,
   type RoutingIntent,
+  type ScheduleJob,
 } from "./schedule-store.js";
 
 const log = getLogger("scheduler");
@@ -149,6 +150,7 @@ async function runScheduleOnce(
             title: job.name,
             summary: "Reminder fired.",
             dedupKey: `schedule-notify-oneshot:${job.id}`,
+            job,
           });
         } else {
           // Track recurring notify-mode success so lastStatus resets to ok
@@ -159,6 +161,7 @@ async function runScheduleOnce(
             title: job.name,
             summary: "Scheduled notification fired.",
             dedupKey: `schedule-run:${runId}`,
+            job,
           });
         }
       } catch (err) {
@@ -208,6 +211,7 @@ async function runScheduleOnce(
               title: job.name,
               summary: "Script ran.",
               dedupKey: `schedule-run:${runId}`,
+              job,
             });
           }
           if (isOneShot) completeOneShot(job.id);
@@ -287,6 +291,7 @@ async function runScheduleOnce(
               title: job.name,
               summary: "Scheduled task ran.",
               dedupKey: `schedule-run:${runId}`,
+              job,
             });
           }
           if (isOneShot) completeOneShot(job.id);
@@ -385,6 +390,7 @@ async function runScheduleOnce(
           title: job.name,
           summary: isOneShot ? "One-shot reminder ran." : "Scheduled job ran.",
           dedupKey: `schedule-run:${runId}`,
+          job,
         });
       }
       if (isOneShot) completeOneShot(job.id);
@@ -464,17 +470,36 @@ async function runScheduleOnce(
  * record is created) so each run lands as its own entry in the
  * activity log — the writer's per-source cap keeps total volume
  * bounded.
+ *
+ * When a {@link ScheduleJob} is provided, the emitted feed item
+ * includes a `detailPanel` with real schedule metadata so the macOS
+ * client can render the scheduled detail panel without placeholders.
  */
 function emitScheduleFeedEvent(params: {
   title: string;
   summary: string;
   dedupKey: string;
+  job?: ScheduleJob;
 }): void {
   void emitFeedEvent({
     source: "assistant",
     title: params.title,
     summary: params.summary,
     dedupKey: params.dedupKey,
+    detailPanel: params.job
+      ? {
+          kind: "scheduled",
+          data: {
+            jobName: params.job.name,
+            syntax: params.job.syntax,
+            mode: params.job.mode,
+            schedule: params.job.expression ?? undefined,
+            enabled: params.job.enabled,
+            nextRun: new Date(params.job.nextRunAt).toISOString(),
+            description: params.job.message.slice(0, 200),
+          },
+        }
+      : undefined,
   }).catch((err) => {
     log.warn(
       { err, dedupKey: params.dedupKey },

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -495,7 +495,10 @@ function emitScheduleFeedEvent(params: {
             mode: params.job.mode,
             schedule: params.job.expression ?? undefined,
             enabled: params.job.enabled,
-            nextRun: new Date(params.job.nextRunAt).toISOString(),
+            nextRun:
+              params.job.nextRunAt > 0
+                ? new Date(params.job.nextRunAt).toISOString()
+                : undefined,
             description: params.job.message.slice(0, 200),
           },
         }

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeAuthDetailCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeAuthDetailCard.swift
@@ -1,17 +1,53 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Stub body component for payment-authorization detail panels.
-/// Will be replaced with a rich approval UI when the daemon surfaces
-/// structured payment-auth fields on `FeedItem`.
+/// Body component for payment-authorization detail panels.
+///
+/// Renders structured payment info — amount, recipient, and an optional
+/// caption — as a compact card above the document/invoice preview. When
+/// no structured data is available the component renders nothing, letting
+/// the parent panel fall back to the default placeholder.
 struct HomeAuthDetailCard: View {
-    let item: FeedItem
+    let amount: String?
+    let recipient: String?
+    let caption: String?
 
     var body: some View {
-        Text(item.title)
-            .font(VFont.bodyMediumDefault)
-            .foregroundStyle(VColor.contentSecondary)
+        let hasContent = amount != nil || recipient != nil || caption != nil
+        if hasContent {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                if let amount {
+                    HStack(spacing: VSpacing.xs) {
+                        Text("Amount")
+                            .font(VFont.bodyMediumLighter)
+                            .foregroundStyle(VColor.contentTertiary)
+                        Spacer()
+                        Text(amount)
+                            .font(VFont.bodyMediumEmphasised)
+                            .foregroundStyle(VColor.contentEmphasized)
+                    }
+                }
+
+                if let recipient {
+                    HStack(spacing: VSpacing.xs) {
+                        Text("Recipient")
+                            .font(VFont.bodyMediumLighter)
+                            .foregroundStyle(VColor.contentTertiary)
+                        Spacer()
+                        Text(recipient)
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                    }
+                }
+
+                if let caption {
+                    Text(caption)
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
             .padding(VSpacing.lg)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanelKind.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanelKind.swift
@@ -32,6 +32,8 @@ enum HomeDetailPanelKind: Equatable {
             case .paymentAuth: return .paymentAuth(item)
             case .toolPermission: return .toolPermission(item)
             case .updatesList: return .updatesList(item)
+            case .scheduled: return .scheduled(item)
+            case .nudge: return .nudge(item)
             }
         }
 

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDocumentPreviewPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDocumentPreviewPanel.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Wrapper panel for the document preview detail panel kind.
+///
+/// Parses `DocumentPreviewPanelData` from the feed item's `detailPanel.data`.
+/// When an `imageUrl` is present, loads the image asynchronously and renders
+/// it via `HomeDocumentPreview`. Falls back to the placeholder caption when
+/// the URL is absent or the download fails.
+struct HomeDocumentPreviewPanel: View {
+    let item: FeedItem
+    let onClose: () -> Void
+
+    @State private var loadedImage: NSImage?
+
+    private var panelData: DocumentPreviewPanelData? {
+        DocumentPreviewPanelData.from(item.detailPanel?.data)
+    }
+
+    var body: some View {
+        HomeDetailPanel(
+            icon: nil,
+            title: item.title,
+            onDismiss: onClose,
+            scrollable: false
+        ) {
+            HomeDocumentPreview(
+                image: loadedImage,
+                placeholderCaption: panelData?.caption ?? item.summary,
+                actions: [
+                    HomeDocumentPreview.Action(
+                        label: "Action",
+                        style: .outlined,
+                        action: { onClose() }
+                    ),
+                    HomeDocumentPreview.Action(
+                        label: "Action",
+                        style: .primary,
+                        action: { onClose() }
+                    ),
+                ]
+            )
+        }
+        .task(id: panelData?.imageUrl) {
+            await loadImageIfNeeded()
+        }
+    }
+
+    private func loadImageIfNeeded() async {
+        guard let urlString = panelData?.imageUrl,
+              let url = URL(string: urlString) else { return }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            guard !Task.isCancelled else { return }
+            if let image = NSImage(data: data) {
+                loadedImage = image
+            }
+        } catch {
+            // Download failed — leave loadedImage nil so the placeholder renders.
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDocumentPreviewPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDocumentPreviewPanel.swift
@@ -47,6 +47,7 @@ struct HomeDocumentPreviewPanel: View {
     }
 
     private func loadImageIfNeeded() async {
+        loadedImage = nil
         guard let urlString = panelData?.imageUrl,
               let url = URL(string: urlString) else { return }
         do {

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePaymentAuthPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePaymentAuthPanel.swift
@@ -59,6 +59,7 @@ struct HomePaymentAuthPanel: View {
     }
 
     private func loadImageIfNeeded() async {
+        loadedImage = nil
         guard let urlString = panelData?.imageUrl,
               let url = URL(string: urlString) else { return }
         do {

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePaymentAuthPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePaymentAuthPanel.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Wrapper panel for the payment authorization detail panel kind.
+///
+/// Parses `PaymentAuthPanelData` from the feed item's `detailPanel.data`.
+/// When an `imageUrl` is present (invoice/document image), loads and renders
+/// it via `HomeDocumentPreview` with amount and recipient shown as
+/// supplementary text above the image. Falls back gracefully to a text-only
+/// card when data is nil or the image cannot be loaded.
+struct HomePaymentAuthPanel: View {
+    let item: FeedItem
+    let onClose: () -> Void
+
+    @State private var loadedImage: NSImage?
+
+    private var panelData: PaymentAuthPanelData? {
+        PaymentAuthPanelData.from(item.detailPanel?.data)
+    }
+
+    var body: some View {
+        HomeDetailPanel(
+            icon: nil,
+            title: item.title,
+            onDismiss: onClose,
+            scrollable: false
+        ) {
+            VStack(alignment: .leading, spacing: 0) {
+                // Supplementary amount/recipient info above the preview
+                if panelData?.amount != nil || panelData?.recipient != nil {
+                    HomeAuthDetailCard(
+                        amount: panelData?.amount,
+                        recipient: panelData?.recipient,
+                        caption: panelData?.caption
+                    )
+                }
+
+                HomeDocumentPreview(
+                    image: loadedImage,
+                    placeholderCaption: panelData?.caption ?? item.summary,
+                    actions: [
+                        HomeDocumentPreview.Action(
+                            label: "Action",
+                            style: .outlined,
+                            action: { onClose() }
+                        ),
+                        HomeDocumentPreview.Action(
+                            label: "Action",
+                            style: .primary,
+                            action: { onClose() }
+                        ),
+                    ]
+                )
+            }
+        }
+        .task(id: panelData?.imageUrl) {
+            await loadImageIfNeeded()
+        }
+    }
+
+    private func loadImageIfNeeded() async {
+        guard let urlString = panelData?.imageUrl,
+              let url = URL(string: urlString) else { return }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            guard !Task.isCancelled else { return }
+            if let image = NSImage(data: data) {
+                loadedImage = image
+            }
+        } catch {
+            // Download failed — leave loadedImage nil so the placeholder renders.
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionDetailCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionDetailCard.swift
@@ -1,17 +1,129 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Stub body component for tool-permission detail panels.
-/// Will be replaced with a rich permission approval UI when the daemon
-/// surfaces structured permission fields on `FeedItem`.
+/// Body component for tool-permission detail panels.
+///
+/// Renders structured permission fields (tool name, command preview, risk
+/// level, decision) from `ToolPermissionPanelData` as a compact details
+/// card. Falls back to the feed item's title when no structured data is
+/// available.
 struct HomePermissionDetailCard: View {
     let item: FeedItem
 
+    private var toolData: ToolPermissionPanelData? {
+        if let data = ToolPermissionPanelData.from(item.detailPanel?.data) {
+            return data
+        }
+        if let chat = PermissionChatPanelData.from(item.detailPanel?.data) {
+            return ToolPermissionPanelData(
+                toolName: chat.toolName,
+                commandPreview: chat.commandPreview,
+                riskLevel: chat.riskLevel,
+                decision: nil
+            )
+        }
+        return nil
+    }
+
     var body: some View {
-        Text(item.title)
-            .font(VFont.bodyMediumDefault)
-            .foregroundStyle(VColor.contentSecondary)
-            .padding(VSpacing.lg)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        if let data = toolData {
+            structuredContent(data)
+        } else {
+            Text(item.title)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .padding(VSpacing.lg)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        }
+    }
+
+    // MARK: - Structured Content
+
+    @ViewBuilder
+    private func structuredContent(_ data: ToolPermissionPanelData) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            if let decision = data.decision {
+                decisionBadge(decision)
+            }
+
+            detailsCard(data)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    @ViewBuilder
+    private func decisionBadge(_ decision: String) -> some View {
+        let isApproved = decision.lowercased().contains("allow") || decision.lowercased().contains("approve")
+        HStack(spacing: VSpacing.xs) {
+            VIconView(isApproved ? .check : .x, size: 14)
+            Text(decision.capitalized)
+                .font(VFont.bodyMediumEmphasised)
+        }
+        .foregroundStyle(isApproved ? VColor.systemPositiveStrong : VColor.systemNegativeStrong)
+    }
+
+    private func detailsCard(_ data: ToolPermissionPanelData) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Details")
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(VColor.contentEmphasized)
+                .accessibilityAddTraits(.isHeader)
+
+            detailRow(key: "Tool", value: data.toolName)
+
+            if let command = data.commandPreview {
+                detailRow(key: "Command", value: command)
+            }
+
+            if let risk = data.riskLevel {
+                HStack {
+                    Text("Risk")
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentTertiary)
+                    Spacer()
+                    Text(risk.capitalized)
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(riskColor(for: risk))
+                }
+            }
+        }
+        .padding(EdgeInsets(
+            top: VSpacing.md,
+            leading: VSpacing.md,
+            bottom: VSpacing.lg,
+            trailing: VSpacing.md
+        ))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg, style: .continuous)
+                .fill(VColor.surfaceOverlay)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg, style: .continuous)
+                .strokeBorder(VColor.borderHover, lineWidth: 1)
+        )
+    }
+
+    private func detailRow(key: String, value: String) -> some View {
+        HStack {
+            Text(key)
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentTertiary)
+            Spacer()
+            Text(value)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentDefault)
+                .lineLimit(2)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+
+    private func riskColor(for level: String) -> Color {
+        switch level.lowercased() {
+        case "high":   return VColor.systemNegativeStrong
+        case "medium": return VColor.systemMidStrong
+        default:       return VColor.contentDefault
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -285,15 +285,25 @@ extension MainWindowView {
                         onCardAction: { _, _ in }
                     )
                 case .emailDraft(let item):
-                    HomeDetailPanel(
-                        icon: nil,
-                        title: item.title,
-                        onDismiss: { activeHomeDetailPanel = nil }
-                    ) {
-                        Text(item.summary)
-                            .font(VFont.bodyMediumDefault)
-                            .foregroundStyle(VColor.contentSecondary)
-                            .padding(VSpacing.lg)
+                    if let panelData = EmailDraftPanelData.from(item.detailPanel?.data) {
+                        HomeEmailDraftDetailView(
+                            item: item,
+                            panelData: panelData,
+                            feedStore: feedStore,
+                            onDismiss: { activeHomeDetailPanel = nil }
+                        )
+                        .id(item.id)
+                    } else {
+                        HomeDetailPanel(
+                            icon: nil,
+                            title: item.title,
+                            onDismiss: { activeHomeDetailPanel = nil }
+                        ) {
+                            Text(item.summary)
+                                .font(VFont.bodyMediumDefault)
+                                .foregroundStyle(VColor.contentSecondary)
+                                .padding(VSpacing.lg)
+                        }
                     }
                 case .documentPreview(let item):
                     HomeDetailPanel(
@@ -1109,6 +1119,64 @@ private struct AppLoadingView: View {
             if !Task.isCancelled {
                 timedOut = true
             }
+        }
+    }
+}
+
+// MARK: - Email Draft Detail View
+
+/// Structured email draft detail panel that renders to/subject/body
+/// fields from server-provided `EmailDraftPanelData` and exposes
+/// Discard / Send footer buttons. Action wiring through `feedStore`
+/// is a follow-up — the buttons are visible but currently dismiss
+/// the panel.
+struct HomeEmailDraftDetailView: View {
+    let item: FeedItem
+    let panelData: EmailDraftPanelData
+    let feedStore: HomeFeedStore
+    let onDismiss: () -> Void
+
+    @State private var toAddress: String
+    @State private var subject: String
+    @State private var bodyText: String
+
+    init(
+        item: FeedItem,
+        panelData: EmailDraftPanelData,
+        feedStore: HomeFeedStore,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.item = item
+        self.panelData = panelData
+        self.feedStore = feedStore
+        self.onDismiss = onDismiss
+        self._toAddress = State(initialValue: panelData.to)
+        self._subject = State(initialValue: panelData.subject)
+        self._bodyText = State(initialValue: panelData.body)
+    }
+
+    var body: some View {
+        HomeDetailPanel(
+            icon: nil,
+            title: item.title,
+            onDismiss: onDismiss,
+            scrollable: false
+        ) {
+            HomeEmailEditor(
+                toAddress: $toAddress,
+                subject: $subject,
+                bodyText: $bodyText,
+                attachments: [],
+                onAttachmentTap: { _ in },
+                onSend: {
+                    // Action wiring is a follow-up — just dismiss for now.
+                    onDismiss()
+                },
+                onDiscard: {
+                    // Action wiring is a follow-up — just dismiss for now.
+                    onDismiss()
+                }
+            )
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -234,15 +234,29 @@ extension MainWindowView {
             detailPanel: {
                 switch activeHomeDetailPanel {
                 case .scheduled(let item):
-                    let details = HomeScheduledDetails.placeholder
-                    // Surface the tapped item's title so distinct scheduled
-                    // rows render distinct panel headers while the rest of
-                    // the schedule metadata still uses placeholder data
-                    // (Devin feedback on PR #27475).
-                    // TODO: replace placeholder data with real schedule
-                    // metadata when the daemon surfaces scheduled-item
-                    // fields on FeedItem (see .private/plans/home-feed-groups.md
-                    // follow-up).
+                    let details: HomeScheduledDetails = {
+                        guard let panelData = ScheduledPanelData.from(item.detailPanel?.data) else {
+                            return HomeScheduledDetails.placeholder
+                        }
+                        let nextRunDate: Date = {
+                            guard let iso = panelData.nextRun else { return Date() }
+                            let formatter = ISO8601DateFormatter()
+                            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                            return formatter.date(from: iso)
+                                ?? ISO8601DateFormatter().date(from: iso)
+                                ?? Date()
+                        }()
+                        return HomeScheduledDetails(
+                            name: panelData.jobName,
+                            syntax: panelData.syntax,
+                            mode: panelData.mode,
+                            schedule: panelData.schedule ?? "—",
+                            enabled: panelData.enabled,
+                            nextRun: nextRunDate,
+                            nextRunTimeZone: .current,
+                            description: panelData.description ?? item.summary
+                        )
+                    }()
                     HomeScheduledDetailPanel(
                         title: item.title,
                         description: details.description,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -339,16 +339,10 @@ extension MainWindowView {
                         }
                     }
                 case .documentPreview(let item):
-                    HomeDetailPanel(
-                        icon: nil,
-                        title: item.title,
-                        onDismiss: { activeHomeDetailPanel = nil }
-                    ) {
-                        Text(item.summary)
-                            .font(VFont.bodyMediumDefault)
-                            .foregroundStyle(VColor.contentSecondary)
-                            .padding(VSpacing.lg)
-                    }
+                    HomeDocumentPreviewPanel(
+                        item: item,
+                        onClose: { activeHomeDetailPanel = nil }
+                    )
                 case .permissionChat(let item):
                     HomeDetailPanel(
                         icon: nil,
@@ -361,13 +355,10 @@ extension MainWindowView {
                             .padding(VSpacing.lg)
                     }
                 case .paymentAuth(let item):
-                    HomeDetailPanel(
-                        icon: nil,
-                        title: item.title,
-                        onDismiss: { activeHomeDetailPanel = nil }
-                    ) {
-                        HomeAuthDetailCard(item: item)
-                    }
+                    HomePaymentAuthPanel(
+                        item: item,
+                        onClose: { activeHomeDetailPanel = nil }
+                    )
                 case .toolPermission(let item):
                     HomeDetailPanel(
                         icon: nil,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -344,15 +344,26 @@ extension MainWindowView {
                         onClose: { activeHomeDetailPanel = nil }
                     )
                 case .permissionChat(let item):
-                    HomeDetailPanel(
-                        icon: nil,
-                        title: item.title,
-                        onDismiss: { activeHomeDetailPanel = nil }
-                    ) {
-                        Text(item.summary)
-                            .font(VFont.bodyMediumDefault)
-                            .foregroundStyle(VColor.contentSecondary)
-                            .padding(VSpacing.lg)
+                    if PermissionChatPanelData.from(item.detailPanel?.data) != nil ||
+                       ToolPermissionPanelData.from(item.detailPanel?.data) != nil {
+                        HomeDetailPanel(
+                            icon: nil,
+                            title: item.title,
+                            onDismiss: { activeHomeDetailPanel = nil }
+                        ) {
+                            HomePermissionDetailCard(item: item)
+                        }
+                    } else {
+                        HomeDetailPanel(
+                            icon: nil,
+                            title: item.title,
+                            onDismiss: { activeHomeDetailPanel = nil }
+                        ) {
+                            Text(item.summary)
+                                .font(VFont.bodyMediumDefault)
+                                .foregroundStyle(VColor.contentSecondary)
+                                .padding(VSpacing.lg)
+                        }
                     }
                 case .paymentAuth(let item):
                     HomePaymentAuthPanel(

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -270,18 +270,51 @@ extension MainWindowView {
                         onSecondaryAction: { activeHomeDetailPanel = nil }
                     )
                 case .nudge(let item):
+                    let nudgeData = NudgePanelData.from(item.detailPanel?.data)
+                    let nudgeCards: [HomeNudgeDetailPanel.Card] = nudgeData.map { data in
+                        data.cards.map { card in
+                            HomeNudgeDetailPanel.Card(
+                                id: card.id,
+                                title: card.title,
+                                description: card.description,
+                                actions: []
+                            )
+                        }
+                    } ?? HomeNudgeDetailPanelPlaceholders.sampleCards
+                    let nudgeDescription = nudgeData?.description ?? "Found some issues."
                     HomeNudgeDetailPanel(
                         title: item.title,
                         icon: .heart,
                         iconForeground: VColor.feedNudgeStrong,
                         iconBackground: VColor.feedNudgeWeak,
-                        description: "Found some issues.",
-                        cards: HomeNudgeDetailPanelPlaceholders.sampleCards,
+                        description: nudgeDescription,
+                        cards: nudgeCards,
                         primaryActionLabel: "Resolve All",
                         secondaryActionLabel: "Clear All",
                         onClose: { activeHomeDetailPanel = nil },
-                        onPrimaryAction: { activeHomeDetailPanel = nil },
-                        onSecondaryAction: { activeHomeDetailPanel = nil },
+                        onPrimaryAction: {
+                            if let firstAction = item.actions?.first {
+                                Task {
+                                    _ = await feedStore.triggerAction(
+                                        itemId: item.id,
+                                        actionId: firstAction.id
+                                    )
+                                    await MainActor.run {
+                                        activeHomeDetailPanel = nil
+                                    }
+                                }
+                            } else {
+                                activeHomeDetailPanel = nil
+                            }
+                        },
+                        onSecondaryAction: {
+                            Task {
+                                await feedStore.dismiss(itemId: item.id)
+                                await MainActor.run {
+                                    activeHomeDetailPanel = nil
+                                }
+                            }
+                        },
                         onCardAction: { _, _ in }
                     )
                 case .emailDraft(let item):

--- a/clients/shared/Network/FeedItem.swift
+++ b/clients/shared/Network/FeedItem.swift
@@ -93,12 +93,208 @@ public enum FeedItemDetailPanelKind: String, Codable, Sendable, Hashable {
     case paymentAuth
     case toolPermission
     case updatesList
+    case scheduled
+    case nudge
 }
 
 /// Server-driven detail panel descriptor attached to a feed item.
-public struct FeedItemDetailPanel: Codable, Sendable, Hashable {
+///
+/// `data` is an untyped dictionary on the wire — kind-specific parsing
+/// happens at the consumer via the per-kind data structs below.
+public struct FeedItemDetailPanel: Codable, Sendable {
     public let kind: FeedItemDetailPanelKind
-    public init(kind: FeedItemDetailPanelKind) { self.kind = kind }
+    public let data: [String: AnyCodable]?
+
+    public init(kind: FeedItemDetailPanelKind, data: [String: AnyCodable]? = nil) {
+        self.kind = kind
+        self.data = data
+    }
+}
+
+extension FeedItemDetailPanel: Equatable {
+    public static func == (lhs: FeedItemDetailPanel, rhs: FeedItemDetailPanel) -> Bool {
+        lhs.kind == rhs.kind && lhs.data == rhs.data
+    }
+}
+
+extension FeedItemDetailPanel: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(kind)
+    }
+}
+
+// MARK: - Per-kind panel data structs
+
+/// Data for the `emailDraft` detail panel kind.
+public struct EmailDraftPanelData: Sendable, Hashable {
+    public let to: String
+    public let subject: String
+    public let body: String
+
+    public static func from(_ data: [String: AnyCodable]?) -> EmailDraftPanelData? {
+        guard let data,
+              let to = data["to"]?.value as? String,
+              let subject = data["subject"]?.value as? String,
+              let body = data["body"]?.value as? String else { return nil }
+        return EmailDraftPanelData(to: to, subject: subject, body: body)
+    }
+}
+
+/// Data for the `documentPreview` detail panel kind.
+public struct DocumentPreviewPanelData: Sendable, Hashable {
+    public let imageUrl: String?
+    public let caption: String?
+
+    public static func from(_ data: [String: AnyCodable]?) -> DocumentPreviewPanelData? {
+        guard let data else { return nil }
+        return DocumentPreviewPanelData(
+            imageUrl: data["imageUrl"]?.value as? String,
+            caption: data["caption"]?.value as? String
+        )
+    }
+}
+
+/// Data for the `permissionChat` detail panel kind.
+public struct PermissionChatPanelData: Sendable, Hashable {
+    public let userMessage: String
+    public let assistantResponse: String
+    public let requestId: String
+    public let toolName: String
+    public let commandPreview: String?
+    public let riskLevel: String?
+
+    public static func from(_ data: [String: AnyCodable]?) -> PermissionChatPanelData? {
+        guard let data,
+              let userMessage = data["userMessage"]?.value as? String,
+              let assistantResponse = data["assistantResponse"]?.value as? String,
+              let requestId = data["requestId"]?.value as? String,
+              let toolName = data["toolName"]?.value as? String else { return nil }
+        return PermissionChatPanelData(
+            userMessage: userMessage,
+            assistantResponse: assistantResponse,
+            requestId: requestId,
+            toolName: toolName,
+            commandPreview: data["commandPreview"]?.value as? String,
+            riskLevel: data["riskLevel"]?.value as? String
+        )
+    }
+}
+
+/// Data for the `paymentAuth` detail panel kind.
+public struct PaymentAuthPanelData: Sendable, Hashable {
+    public let imageUrl: String?
+    public let caption: String?
+    public let amount: String?
+    public let recipient: String?
+
+    public static func from(_ data: [String: AnyCodable]?) -> PaymentAuthPanelData? {
+        guard let data else { return nil }
+        return PaymentAuthPanelData(
+            imageUrl: data["imageUrl"]?.value as? String,
+            caption: data["caption"]?.value as? String,
+            amount: data["amount"]?.value as? String,
+            recipient: data["recipient"]?.value as? String
+        )
+    }
+}
+
+/// Data for the `toolPermission` detail panel kind.
+public struct ToolPermissionPanelData: Sendable, Hashable {
+    public let toolName: String
+    public let commandPreview: String?
+    public let riskLevel: String?
+    public let decision: String?
+
+    public static func from(_ data: [String: AnyCodable]?) -> ToolPermissionPanelData? {
+        guard let data,
+              let toolName = data["toolName"]?.value as? String else { return nil }
+        return ToolPermissionPanelData(
+            toolName: toolName,
+            commandPreview: data["commandPreview"]?.value as? String,
+            riskLevel: data["riskLevel"]?.value as? String,
+            decision: data["decision"]?.value as? String
+        )
+    }
+}
+
+/// Data for the `updatesList` detail panel kind.
+public struct UpdatesListPanelData: Sendable, Hashable {
+    public struct Item: Sendable, Hashable {
+        public let title: String
+        public let description: String
+    }
+
+    public let items: [Item]
+
+    public static func from(_ data: [String: AnyCodable]?) -> UpdatesListPanelData? {
+        guard let data,
+              let rawItems = data["items"]?.value as? [Any] else { return nil }
+        var parsed: [Item] = []
+        for rawItem in rawItems {
+            guard let dict = rawItem as? [String: Any],
+                  let title = dict["title"] as? String,
+                  let description = dict["description"] as? String else { continue }
+            parsed.append(Item(title: title, description: description))
+        }
+        return UpdatesListPanelData(items: parsed)
+    }
+}
+
+/// Data for the `scheduled` detail panel kind.
+public struct ScheduledPanelData: Sendable, Hashable {
+    public let description: String?
+    public let jobName: String
+    public let syntax: String
+    public let mode: String
+    public let schedule: String?
+    public let enabled: Bool
+    public let nextRun: String?
+
+    public static func from(_ data: [String: AnyCodable]?) -> ScheduledPanelData? {
+        guard let data,
+              let jobName = data["jobName"]?.value as? String,
+              let syntax = data["syntax"]?.value as? String,
+              let mode = data["mode"]?.value as? String,
+              let enabled = data["enabled"]?.value as? Bool else { return nil }
+        return ScheduledPanelData(
+            description: data["description"]?.value as? String,
+            jobName: jobName,
+            syntax: syntax,
+            mode: mode,
+            schedule: data["schedule"]?.value as? String,
+            enabled: enabled,
+            nextRun: data["nextRun"]?.value as? String
+        )
+    }
+}
+
+/// Data for the `nudge` detail panel kind.
+public struct NudgePanelData: Sendable, Hashable {
+    public struct Card: Sendable, Hashable {
+        public let id: String
+        public let title: String
+        public let description: String
+    }
+
+    public let description: String?
+    public let cards: [Card]
+
+    public static func from(_ data: [String: AnyCodable]?) -> NudgePanelData? {
+        guard let data,
+              let rawCards = data["cards"]?.value as? [Any] else { return nil }
+        var parsed: [Card] = []
+        for rawCard in rawCards {
+            guard let dict = rawCard as? [String: Any],
+                  let id = dict["id"] as? String,
+                  let title = dict["title"] as? String,
+                  let description = dict["description"] as? String else { continue }
+            parsed.append(Card(id: id, title: title, description: description))
+        }
+        return NudgePanelData(
+            description: data["description"]?.value as? String,
+            cards: parsed
+        )
+    }
 }
 
 // MARK: - FeedItem


### PR DESCRIPTION
## Summary
- Add typed `data` field to `FeedItemDetailPanel` (TS + Zod + Swift) with per-kind data interfaces for 8 panel types
- Wire real structured data from 5 backend producers: scheduler, heartbeat, messaging-send, conversation-routes, approval-routes
- Render structured detail panels on macOS: scheduled (job metadata), email draft (to/subject/body), permission chat (tool/command/risk), nudge (issue cards), document preview (image URLs), payment auth (amount/recipient/image)
- All panels fall back gracefully when `data` is nil

## Self-review result
GAPS FOUND — 3 gaps fixed across 3 fix PRs:
1. Guard `nextRunAt > 0` to avoid epoch date in scheduled panel
2. Include required `userMessage`/`assistantResponse` in approval resolution event
3. Clear stale `loadedImage` before re-fetching in document/payment panels

## PRs merged into feature branch
- #27710: feat(home): add typed `data` field and scheduled/nudge kinds to FeedItemDetailPanel
- #27714: feat(home): wire real schedule metadata into scheduled detail panel
- #27713: feat(home): populate permissionChat detail panel data on tool approval events
- #27717: feat(home): wire email draft detail panel with to/subject/body fields
- #27715: feat(home): wire heartbeat nudge detail panel with real issue cards
- #27716: feat(home): wire document preview and payment auth detail panels
- #27734: feat(home): render permissionChat detail panel with real tool/command data

### Fix PRs
- #27738: fix: guard nextRunAt > 0 to avoid epoch date in scheduled panel
- #27739: fix: include required userMessage/assistantResponse in approval resolution feed event
- #27740: fix: clear stale loadedImage before re-fetching in document/payment panels

Part of plan: home-feed-detail-panel-data.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
