### PR TITLE
refactor(skill-host-contracts): move AssistantEvent types into neutral package

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -17,6 +17,7 @@
         "@vellumai/ces-contracts": "file:../packages/ces-contracts",
         "@vellumai/credential-storage": "file:../packages/credential-storage",
         "@vellumai/egress-proxy": "file:../packages/egress-proxy",
+        "@vellumai/skill-host-contracts": "file:../packages/skill-host-contracts",
         "archiver": "7.0.1",
         "commander": "13.1.0",
         "croner": "10.0.1",
@@ -390,6 +391,8 @@
     "@vellumai/credential-storage": ["@vellumai/credential-storage@file:../packages/credential-storage", { "devDependencies": { "@types/bun": "^1.2.4", "typescript": "^5.7.3" } }],
 
     "@vellumai/egress-proxy": ["@vellumai/egress-proxy@file:../packages/egress-proxy", { "devDependencies": { "@types/bun": "^1.2.4", "typescript": "^5.7.3" } }],
+
+    "@vellumai/skill-host-contracts": ["@vellumai/skill-host-contracts@file:../packages/skill-host-contracts", { "devDependencies": { "@types/bun": "1.3.10", "typescript": "5.9.3" } }],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -41,6 +41,7 @@
     "@vellumai/ces-contracts": "file:../packages/ces-contracts",
     "@vellumai/credential-storage": "file:../packages/credential-storage",
     "@vellumai/egress-proxy": "file:../packages/egress-proxy",
+    "@vellumai/skill-host-contracts": "file:../packages/skill-host-contracts",
     "archiver": "7.0.1",
     "commander": "13.1.0",
     "croner": "10.0.1",
@@ -70,7 +71,8 @@
   "bundledDependencies": [
     "@vellumai/ces-contracts",
     "@vellumai/credential-storage",
-    "@vellumai/egress-proxy"
+    "@vellumai/egress-proxy",
+    "@vellumai/skill-host-contracts"
   ],
   "overrides": {
     "lodash": "4.18.1",

--- a/assistant/src/runtime/assistant-event.ts
+++ b/assistant/src/runtime/assistant-event.ts
@@ -1,83 +1,35 @@
 /**
- * Assistant Events — shared types and SSE framing helpers.
+ * Assistant Events -- thin re-export layer.
  *
- * Fully isolated from daemon/runtime orchestration logic.
- * Import this module from any layer that needs to produce or consume
- * assistant events without creating circular dependencies.
+ * The shared types and SSE framing helpers live in the neutral
+ * `@vellumai/skill-host-contracts` package so isolated skill processes
+ * can consume them without pulling in the daemon. This file pins the
+ * generic payload to the daemon-side `ServerMessage` union so existing
+ * callers continue to get full discriminated-union narrowing.
  */
 
-import { randomUUID } from "node:crypto";
+import type { AssistantEvent as BaseAssistantEvent } from "@vellumai/skill-host-contracts";
+import { buildAssistantEvent as baseBuildAssistantEvent } from "@vellumai/skill-host-contracts";
 
 import type { ServerMessage } from "../daemon/message-protocol.js";
 
-// ── Types ─────────────────────────────────────────────────────────────────────
+export {
+  formatSseFrame,
+  formatSseHeartbeat,
+} from "@vellumai/skill-host-contracts";
 
-/**
- * A single assistant event wrapping a ServerMessage payload.
- * The `message` field preserves the original form so that
- * delta semantics (text deltas, tool input deltas, etc.) are preserved.
- */
-export interface AssistantEvent {
-  /** Globally unique event identifier (UUID). */
-  id: string;
-  /** The assistant this event belongs to. */
-  assistantId: string;
-  /** Resolved conversation id when available. */
-  conversationId?: string;
-  /** ISO-8601 timestamp of when the event was emitted. */
-  emittedAt: string;
-  /** Outbound server message payload. */
-  message: ServerMessage;
-}
+/** Daemon-side specialization of the generic event envelope. */
+export type AssistantEvent = BaseAssistantEvent<ServerMessage>;
 
-// ── Factory ───────────────────────────────────────────────────────────────────
-
-/**
- * Construct an `AssistantEvent` envelope around a `ServerMessage`.
- *
- * @param assistantId  The logical assistant identifier (e.g. from the daemon or HTTP route).
- * @param message      The outbound server message payload.
- * @param conversationId    Optional conversation id — pass when known.
- */
+/** Daemon-side wrapper preserving the original `ServerMessage`-typed signature. */
 export function buildAssistantEvent(
   assistantId: string,
   message: ServerMessage,
   conversationId?: string,
 ): AssistantEvent {
-  return {
-    id: randomUUID(),
+  return baseBuildAssistantEvent<ServerMessage>(
     assistantId,
-    conversationId,
-    emittedAt: new Date().toISOString(),
     message,
-  };
-}
-
-// ── SSE framing ───────────────────────────────────────────────────────────────
-
-/**
- * Format an AssistantEvent as a Server-Sent Events frame.
- *
- * The SSE spec (https://html.spec.whatwg.org/multipage/server-sent-events.html)
- * requires each field on its own line with a trailing blank line.
- *
- * ```
- * event: assistant_event\n
- * id: <event.id>\n
- * data: <JSON>\n
- * \n
- * ```
- */
-export function formatSseFrame(event: AssistantEvent): string {
-  const sanitizedId = event.id.replace(/[\n\r]/g, "");
-  const data = JSON.stringify(event);
-  return `event: assistant_event\nid: ${sanitizedId}\ndata: ${data}\n\n`;
-}
-
-/**
- * Format a keep-alive SSE comment.
- * Clients should ignore comment lines (`:`) per the SSE spec.
- */
-export function formatSseHeartbeat(): string {
-  return ": heartbeat\n\n";
+    conversationId,
+  );
 }

--- a/packages/skill-host-contracts/src/assistant-event.ts
+++ b/packages/skill-host-contracts/src/assistant-event.ts
@@ -1,0 +1,91 @@
+/**
+ * Assistant Events -- shared types and SSE framing helpers.
+ *
+ * This module is intentionally free of imports from `assistant/` or any
+ * other repo-local module so it can be consumed by both the daemon and
+ * isolated skill processes without circular references.
+ *
+ * The `AssistantEvent` interface is generic over the `message` payload so
+ * the neutral package does not need to know about the daemon-side
+ * `ServerMessage` discriminated union. Consumers that want narrower
+ * typing can re-export a specialized alias, e.g.:
+ *
+ *   type AssistantEvent = BaseAssistantEvent<ServerMessage>;
+ */
+
+import { randomUUID } from "node:crypto";
+
+// -- Types ---------------------------------------------------------------------
+
+/**
+ * A single assistant event wrapping an outbound message payload.
+ *
+ * Generic over the payload type so the neutral package has zero dependency
+ * on daemon-side message schemas. The `TMessage` default of `unknown`
+ * keeps the package importable without a type argument when the caller
+ * does not care about message narrowing.
+ */
+export interface AssistantEvent<TMessage = unknown> {
+  /** Globally unique event identifier (UUID). */
+  id: string;
+  /** The assistant this event belongs to. */
+  assistantId: string;
+  /** Resolved conversation id when available. */
+  conversationId?: string;
+  /** ISO-8601 timestamp of when the event was emitted. */
+  emittedAt: string;
+  /** Outbound message payload. */
+  message: TMessage;
+}
+
+// -- Factory -------------------------------------------------------------------
+
+/**
+ * Construct an `AssistantEvent` envelope around a message payload.
+ *
+ * @param assistantId     The logical assistant identifier (e.g. from the daemon or HTTP route).
+ * @param message         The outbound message payload.
+ * @param conversationId  Optional conversation id -- pass when known.
+ */
+export function buildAssistantEvent<TMessage>(
+  assistantId: string,
+  message: TMessage,
+  conversationId?: string,
+): AssistantEvent<TMessage> {
+  return {
+    id: randomUUID(),
+    assistantId,
+    conversationId,
+    emittedAt: new Date().toISOString(),
+    message,
+  };
+}
+
+// -- SSE framing ---------------------------------------------------------------
+
+/**
+ * Format an AssistantEvent as a Server-Sent Events frame.
+ *
+ * The SSE spec (https://html.spec.whatwg.org/multipage/server-sent-events.html)
+ * requires each field on its own line with a trailing blank line.
+ *
+ * ```
+ * event: assistant_event\n
+ * id: <event.id>\n
+ * data: <JSON>\n
+ * \n
+ * ```
+ */
+export function formatSseFrame(event: AssistantEvent): string {
+  const sanitizedId = event.id.replace(/[\n\r]/g, "");
+  const data = JSON.stringify(event);
+  return `event: assistant_event\nid: ${sanitizedId}\ndata: ${data}\n\n`;
+}
+
+/**
+ * Format a keep-alive SSE comment.
+ * Clients should ignore comment lines (`:`) per the SSE spec.
+ */
+export function formatSseHeartbeat(): string {
+  return ": heartbeat\n\n";
+}

--- a/packages/skill-host-contracts/src/index.ts
+++ b/packages/skill-host-contracts/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "./assistant-event.js";


### PR DESCRIPTION
## Summary
- Moves AssistantEvent + buildAssistantEvent types from assistant/src/runtime/assistant-event.ts into @vellumai/skill-host-contracts.
- assistant/src/runtime/assistant-event.ts becomes a thin named re-export. All existing callers keep working.
- Adds @vellumai/skill-host-contracts as a file: dependency of the assistant package.

Part of plan: skill-isolation.md (PR 2 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
