### PR TITLE
Cherry-pick fixes into release/v0.6.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2438,7 +2438,21 @@ jobs:
   # As with the macOS builds, `needs:` gates on GCR manifests only because
   # this job runs in staging too; the Docker Hub gate lives on `release-ios`
   # (prod-only), which is the sole external publisher of this .ipa.
+  #
+  # -------------------------------------------------------------------------
+  # PAUSED during the Capacitor iOS migration (LUM-1125).
+  # iOS releases are handled manually out of `vellum-assistant-platform`'s
+  # Capacitor shell while the replacement CI workflow is being designed.
+  # Both pipelines cannot upload to the same bundle ID
+  # (`ai.vocify-inc.vellum-assistant-ios`) simultaneously — App Store
+  # Connect rejects duplicate build numbers, so we skip this one.
+  #
+  # To re-enable either for a fallback native-iOS release, or if the
+  # Capacitor migration is abandoned: remove `if: false` from here and
+  # from `release-ios` below.
+  # -------------------------------------------------------------------------
   build-ios:
+    if: false
     needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     runs-on: macos-15
     timeout-minutes: 30
@@ -2476,9 +2490,13 @@ jobs:
         working-directory: clients/ios
         run: ./build.sh test
 
+  # PAUSED during the Capacitor iOS migration (LUM-1125) — see note on
+  # `build-ios` above. To re-enable, delete the `if: false` line and
+  # restore the original staging gate:
+  #   if: ${{ needs.extract-version.outputs.is_staging != 'true' }}
   release-ios:
+    if: false
     needs: [extract-version, build-ios, push-dockerhub-image]
-    if: ${{ needs.extract-version.outputs.is_staging != 'true' }}
     runs-on: macos-15
     timeout-minutes: 30
     env:

--- a/assistant/AGENTS.md
+++ b/assistant/AGENTS.md
@@ -14,7 +14,13 @@ When you introduce a new env var that the assistant process needs to read at run
 
 ## Daemon startup philosophy
 
-The daemon must **never** block startup under *any circumstance*. All possible errors should be logged so that the assistant can recover from it's corrupted state after the fact.
+The daemon must **never** block startup under _any circumstance_. All possible errors should be logged so that the assistant can recover from it's corrupted state after the fact.
+
+## Post-execution hooks
+
+Tool post-execution hooks (`src/daemon/tool-side-effects.ts`) run after a tool executor returns. Treat the executor's output as authoritative: hooks must not re-do work the executor already completed, especially destructive work like wiping and rebuilding a generated-output directory. If the hook needs to recover from a failed executor step, gate the recovery on an explicit failure signal in the tool result (e.g. a `compile_errors` field) rather than running unconditionally.
+
+Shared mutable resources written by more than one caller (e.g. `dist/` directories produced by `compileApp()`) must be serialised per-resource so concurrent callers cannot race on `rm -rf` + write sequences.
 
 ## Code comments
 

--- a/assistant/AGENTS.md
+++ b/assistant/AGENTS.md
@@ -18,7 +18,9 @@ The daemon must **never** block startup under _any circumstance_. All possible e
 
 ## Post-execution hooks
 
-Tool post-execution hooks (`src/daemon/tool-side-effects.ts`) run after a tool executor returns. Treat the executor's output as authoritative: hooks must not re-do work the executor already completed, especially destructive work like wiping and rebuilding a generated-output directory. If the hook needs to recover from a failed executor step, gate the recovery on an explicit failure signal in the tool result (e.g. a `compile_errors` field) rather than running unconditionally.
+Tool post-execution hooks (`src/daemon/tool-side-effects.ts`) run after a tool executor returns. They are an **observation-and-notification layer** only: refresh client-side state, broadcast events, kick off orthogonal background work (e.g. icon generation). Hooks must not re-do work the executor already performed, and must not attempt recovery when the executor failed — failures surface in the tool result for the LLM to act on.
+
+Do not coordinate hook behaviour by re-parsing the tool's JSON response to infer what the executor did (e.g. "if field X is missing, retry step Y"). That couples the LLM-facing response shape to internal daemon logic and breaks silently when the response shape evolves. Keep the hook's logic independent of the result payload, or if the hook genuinely needs executor-internal state, pass it through a typed side channel — never through a JSON round-trip.
 
 Shared mutable resources written by more than one caller (e.g. `dist/` directories produced by `compileApp()`) must be serialised per-resource so concurrent callers cannot race on `rm -rf` + write sequences.
 

--- a/assistant/src/__tests__/app-compiler.test.ts
+++ b/assistant/src/__tests__/app-compiler.test.ts
@@ -355,6 +355,63 @@ console.log("styled");`,
     const r2 = await compileApp(appDir2);
     expect(r2.ok).toBe(true);
   }, 30_000);
+
+  test("concurrent callers during an in-flight compile coalesce to at most one follow-up", async () => {
+    const appDir = await scaffold("concurrent-dedup", {
+      "main.tsx": `console.log("hello");`,
+      "index.html": MINIMAL_HTML,
+    });
+
+    // Kick off three concurrent compiles. Serialisation guarantees the
+    // first runs to completion alone; callers 2 and 3 coalesce into a
+    // single follow-up compile that begins after the first settles.
+    const [r1, r2, r3] = await Promise.all([
+      compileApp(appDir),
+      compileApp(appDir),
+      compileApp(appDir),
+    ]);
+
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    expect(r3.ok).toBe(true);
+
+    // Callers 2 and 3 share the coalesced follow-up promise.
+    expect(r2).toBe(r3);
+    // Caller 1 ran a distinct compile from the coalesced follow-up.
+    expect(r1).not.toBe(r2);
+
+    // Final dist/ output must be intact regardless of how many compiles
+    // ran: main.js non-empty and index.html has the injected script tag.
+    const js = await readFile(join(appDir, "dist", "main.js"), "utf-8");
+    expect(js.length).toBeGreaterThan(0);
+    const html = await readFile(join(appDir, "dist", "index.html"), "utf-8");
+    expect(html).toContain('src="main.js"');
+  });
+
+  test("source edit during an in-flight compile is picked up by the follow-up", async () => {
+    const appDir = await scaffold("mid-build-edit", {
+      "main.tsx": `console.log("original");`,
+      "index.html": MINIMAL_HTML,
+    });
+
+    // Start the first compile but do not await it yet.
+    const first = compileApp(appDir);
+
+    // Mutate the source while the first compile is still running, then
+    // request another compile. The follow-up must read the updated source
+    // rather than silently reusing the first compile's (now stale) output.
+    await writeFile(join(appDir, "src", "main.tsx"), `console.log("updated");`);
+    const second = compileApp(appDir);
+
+    const [r1, r2] = await Promise.all([first, second]);
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    expect(r1).not.toBe(r2);
+
+    const js = await readFile(join(appDir, "dist", "main.js"), "utf-8");
+    expect(js).toContain("updated");
+    expect(js).not.toContain("original");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
@@ -44,7 +44,9 @@ mock.module("../tools/browser/browser-screencast.js", () => ({
   registerConversationSender: mock(() => {}),
 }));
 
-// Mock app-store functions used by handleAppChange in tool-side-effects
+// Stub app-store functions used by other modules (e.g. app-source-watcher,
+// conversation-surfaces) so tool-side-effects' hooks can run without touching
+// the real app store during tests.
 mock.module("../memory/app-store.js", () => ({
   getApp: mock(() => null),
   getAppDirPath: mock(() => "/tmp/test-apps/dummy"),
@@ -286,6 +288,44 @@ describe("session-tool-setup app refresh side effects", () => {
 
       expect(broadcastSpy).not.toHaveBeenCalled();
     });
+
+    test("fires notify side effects regardless of compile outcome reported in payload", async () => {
+      // The hook observes the tool result but does not branch on compile
+      // status fields inside it. Whether the executor reports a successful
+      // compile or returns compile_errors, the hook still refreshes
+      // surfaces and broadcasts — compile retries are the LLM's
+      // responsibility via a follow-up tool call, not the hook's.
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: JSON.stringify({
+          id: "new-app-err",
+          name: "Busted",
+          compiled: false,
+          compile_errors: [{ text: "syntax error" }],
+        }),
+        isError: false,
+      });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+        broadcastSpy,
+      );
+
+      await toolFn("app_create", { name: "Busted", html: "" });
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(broadcastSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+      expect((broadcastSpy.mock.calls as unknown[][])[0][0]).toEqual({
+        type: "app_files_changed",
+        appId: "new-app-err",
+      });
+      expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   // ── app_delete side effects ────────────────────────────────────────
@@ -435,5 +475,4 @@ describe("session-tool-setup app refresh side effects", () => {
       expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
     });
   });
-
 });

--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -269,13 +269,96 @@ async function resolveAppImports(srcDir: string): Promise<void> {
 }
 
 /**
+ * Per-appDir compile serialisation.
+ *
+ * compileApp() begins by `rm -rf dist/`, so two concurrent compiles on the
+ * same appDir can wipe each other's intermediate output. To prevent that
+ * while still picking up source edits that arrive mid-build, we track a
+ * two-slot queue per appDir:
+ *
+ * - `current`: the compile that is currently writing to dist/.
+ * - `pending`: at most one coalesced follow-up compile queued because a new
+ *   caller arrived while `current` was running. Additional callers arriving
+ *   during that window share `pending` — they do not spawn yet another run.
+ *   Once `current` settles, `pending` is promoted to `current` and begins
+ *   executing; new callers arriving after promotion queue a fresh `pending`.
+ *
+ * This keeps dist/ consistent under concurrency while guaranteeing that any
+ * source mutation observed after a compile starts will be reflected in a
+ * subsequent compile pass rather than silently dropped.
+ */
+interface CompileSlot {
+  current: Promise<CompileResult>;
+  pending?: Promise<CompileResult>;
+}
+
+const compileSlots = new Map<string, CompileSlot>();
+
+/**
  * Compile a TSX app from appDir/src/ into appDir/dist/.
  *
  * Expects appDir/src/main.tsx as the entry point and appDir/src/index.html
  * as the HTML shell. Produces appDir/dist/main.js and appDir/dist/index.html
  * (with script and optional stylesheet tags injected).
+ *
+ * Concurrent calls for the same appDir are serialised (see `compileSlots`
+ * above). Callers never see a partial or racing dist/ write; callers that
+ * represent work requested after a compile started always get a subsequent
+ * fresh compile.
  */
-export async function compileApp(appDir: string): Promise<CompileResult> {
+export function compileApp(appDir: string): Promise<CompileResult> {
+  const slot = compileSlots.get(appDir);
+
+  if (!slot) {
+    const current = runCompile(appDir);
+    const onSettled = () => slotCompileSettled(appDir, current);
+    current.then(onSettled, onSettled);
+    compileSlots.set(appDir, { current });
+    return current;
+  }
+
+  if (slot.pending) return slot.pending;
+
+  // A second distinct caller arrived while `current` is running. Queue a
+  // follow-up that starts once `current` settles (success or failure) so
+  // any source edits that happened mid-build still get compiled.
+  const rerun = async (): Promise<CompileResult> => {
+    try {
+      await slot.current;
+    } catch {
+      // Ignore: we want to rerun regardless of the prior compile's outcome.
+    }
+    return runCompile(appDir);
+  };
+  const pending = rerun();
+  const onSettled = () => slotCompileSettled(appDir, pending);
+  pending.then(onSettled, onSettled);
+  slot.pending = pending;
+  return pending;
+}
+
+function slotCompileSettled(
+  appDir: string,
+  finished: Promise<CompileResult>,
+): void {
+  const slot = compileSlots.get(appDir);
+  if (!slot) return;
+
+  if (slot.current !== finished) {
+    // finished is a rerun that hasn't been promoted yet, or a stale entry.
+    // Promotion happens below when `current` settles; there is nothing to do
+    // here because a subsequent slotCompileSettled(current) will run first.
+    return;
+  }
+
+  if (slot.pending) {
+    compileSlots.set(appDir, { current: slot.pending });
+  } else {
+    compileSlots.delete(appDir);
+  }
+}
+
+async function runCompile(appDir: string): Promise<CompileResult> {
   const start = performance.now();
   const srcDir = join(appDir, "src");
   const distDir = join(appDir, "dist");

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -108,6 +108,7 @@ registerHook(
         id?: string;
         name?: string;
         description?: string;
+        compile_errors?: unknown;
       };
       if (parsed.id) {
         // The apps directory may have just been created — ensure the
@@ -115,7 +116,27 @@ registerHook(
         // trigger live reload.
         ensureAppSourceWatcher();
 
-        handleAppChange(ctx, parsed.id, broadcastToAllClients);
+        // executeAppCreate compiles multifile apps inline and populates
+        // dist/ before returning. handleAppChange would otherwise start
+        // a second compile that begins with `rm -rf dist/`, so we only
+        // invoke it when the executor left compile_errors — i.e. the
+        // authoritative compile did not succeed and a retry is wanted.
+        const app = getApp(parsed.id);
+        const executorCompiled =
+          app != null &&
+          isMultifileApp(app) &&
+          parsed.compile_errors === undefined;
+
+        if (executorCompiled) {
+          refreshSurfacesForApp(ctx, parsed.id);
+          broadcastToAllClients?.({
+            type: "app_files_changed",
+            appId: parsed.id,
+          });
+          void updatePublishedAppDeployment(parsed.id);
+        } else {
+          handleAppChange(ctx, parsed.id, broadcastToAllClients);
+        }
 
         // Fire-and-forget: generate an app icon in the background.
         // When complete, broadcast again so clients pick up the new icon.

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -7,9 +7,7 @@
  * registry entry instead of another if/else branch.
  */
 
-import { compileApp } from "../bundler/app-compiler.js";
 import { generateAppIcon } from "../media/app-icon-generator.js";
-import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
 import { findActiveSession } from "../runtime/channel-verification-service.js";
 import { deliverVerificationSlack } from "../runtime/verification-outbound-actions.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
@@ -39,41 +37,22 @@ export type PostExecutionHook = (
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-/** Shared logic for refreshing app surfaces, broadcasting changes, and triggering auto-deploy. */
-function handleAppChange(
+/**
+ * Propagate an app change to connected clients and the publish pipeline.
+ *
+ * Compilation is the responsibility of the tool executor (see
+ * `executeAppCreate`, `executeAppRefresh`): executors own the source→dist
+ * transform and surface `compile_errors` in their result when it fails.
+ * Post-execution hooks only observe the outcome and notify — they must
+ * not re-run a compile because `compileApp()` begins with `rm -rf dist/`
+ * and would race with the executor's own output (LUM-1153).
+ */
+function notifyAppChanged(
   ctx: ToolSetupContext,
   appId: string,
   broadcastToAllClients: ((msg: ServerMessage) => void) | undefined,
   opts?: { fileChange?: boolean; status?: string },
 ): void {
-  const app = getApp(appId);
-
-  // Multifile apps need a recompile before refreshing surfaces so the
-  // WebView picks up the latest compiled output.
-  if (app && isMultifileApp(app)) {
-    const appDir = getAppDirPath(appId);
-    void compileApp(appDir)
-      .then((result) => {
-        if (!result.ok) {
-          log.warn(
-            { appId, errors: result.errors },
-            "Recompile failed on app change, serving stale dist/",
-          );
-        }
-        refreshSurfacesForApp(ctx, appId, opts);
-        broadcastToAllClients?.({ type: "app_files_changed", appId });
-        void updatePublishedAppDeployment(appId);
-      })
-      .catch((err) => {
-        log.warn({ appId, err }, "Recompile threw on app change");
-        // Still refresh surfaces with stale output
-        refreshSurfacesForApp(ctx, appId, opts);
-        broadcastToAllClients?.({ type: "app_files_changed", appId });
-        void updatePublishedAppDeployment(appId);
-      });
-    return;
-  }
-
   refreshSurfacesForApp(ctx, appId, opts);
   broadcastToAllClients?.({ type: "app_files_changed", appId });
   void updatePublishedAppDeployment(appId);
@@ -108,7 +87,6 @@ registerHook(
         id?: string;
         name?: string;
         description?: string;
-        compile_errors?: unknown;
       };
       if (parsed.id) {
         // The apps directory may have just been created — ensure the
@@ -116,27 +94,7 @@ registerHook(
         // trigger live reload.
         ensureAppSourceWatcher();
 
-        // executeAppCreate compiles multifile apps inline and populates
-        // dist/ before returning. handleAppChange would otherwise start
-        // a second compile that begins with `rm -rf dist/`, so we only
-        // invoke it when the executor left compile_errors — i.e. the
-        // authoritative compile did not succeed and a retry is wanted.
-        const app = getApp(parsed.id);
-        const executorCompiled =
-          app != null &&
-          isMultifileApp(app) &&
-          parsed.compile_errors === undefined;
-
-        if (executorCompiled) {
-          refreshSurfacesForApp(ctx, parsed.id);
-          broadcastToAllClients?.({
-            type: "app_files_changed",
-            appId: parsed.id,
-          });
-          void updatePublishedAppDeployment(parsed.id);
-        } else {
-          handleAppChange(ctx, parsed.id, broadcastToAllClients);
-        }
+        notifyAppChanged(ctx, parsed.id, broadcastToAllClients);
 
         // Fire-and-forget: generate an app icon in the background.
         // When complete, broadcast again so clients pick up the new icon.
@@ -186,33 +144,12 @@ registerHook(
 );
 
 // Trigger surface refresh + broadcast when an app is refreshed.
-// If the executor already compiled (multifile path), skip the redundant
-// recompile and just refresh surfaces / broadcast / deploy directly.
 registerHook(
   "app_refresh",
-  (_name, input, result, { ctx, broadcastToAllClients }) => {
+  (_name, input, _result, { ctx, broadcastToAllClients }) => {
     const appId = input.app_id as string | undefined;
     if (!appId) return;
-
-    // executeAppRefresh already compiled multifile apps and included a
-    // "compiled" field in the result. Skip the expensive recompile and
-    // go straight to surface refresh + broadcast + deploy.
-    let alreadyCompiled = false;
-    try {
-      const parsed = JSON.parse(result.content) as { compiled?: boolean };
-      alreadyCompiled = parsed.compiled !== undefined;
-    } catch {
-      // Result wasn't valid JSON — fall through to handleAppChange.
-    }
-
-    if (alreadyCompiled) {
-      const opts = { fileChange: true };
-      refreshSurfacesForApp(ctx, appId, opts);
-      broadcastToAllClients?.({ type: "app_files_changed", appId });
-      void updatePublishedAppDeployment(appId);
-    } else {
-      handleAppChange(ctx, appId, broadcastToAllClients, { fileChange: true });
-    }
+    notifyAppChanged(ctx, appId, broadcastToAllClients, { fileChange: true });
   },
 );
 

--- a/clients/chrome-extension/manifest.json
+++ b/clients/chrome-extension/manifest.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "minimum_chrome_version": "116",
   "description": "Bridges the Vellum assistant to your live browser session via Chrome DevTools Protocol (CDP) through chrome.debugger.",
+  "homepage_url": "https://www.vellum.ai",
 
   "permissions": [
     "debugger",

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1339,24 +1339,315 @@ cat > "$CONTENTS/Info.plist" <<PLIST
 </plist>
 PLIST
 
+# Resolve per-environment icon source. Falls back to production if no
+# environment-specific override exists.
+ICONS_DIR="$SCRIPT_DIR/vellum-assistant/Resources/icons"
+if [ -d "$ICONS_DIR/$VELLUM_ENVIRONMENT" ]; then
+    ICON_SOURCE_DIR="$ICONS_DIR/$VELLUM_ENVIRONMENT"
+elif [ -d "$ICONS_DIR/production" ]; then
+    ICON_SOURCE_DIR="$ICONS_DIR/production"
+else
+    ICON_SOURCE_DIR=""
+fi
+
 # Always compile asset catalog (fast, ensures AppIcon changes are picked up)
 # AppIcon.icon is a Xcode-26 Icon Composer bundle — actool reads it alongside
 # the xcassets and emits both the layered Liquid Glass iconstack for macOS Tahoe
 # and backward-compatible raster fallbacks for macOS 15 into Assets.car.
 XCASSETS="$SCRIPT_DIR/vellum-assistant/Resources/Assets.xcassets"
 APP_ICON="$SCRIPT_DIR/vellum-assistant/Resources/AppIcon.icon"
+
+# Overlay environment-specific icon into the .icon bundle so both actool
+# (Assets.car / Liquid Glass) and the .icns generation use the correct source.
+if [ -n "$ICON_SOURCE_DIR" ]; then
+    cp "$ICON_SOURCE_DIR/icon.json" "$APP_ICON/icon.json"
+    cp -R "$ICON_SOURCE_DIR/Assets/" "$APP_ICON/Assets/"
+fi
 if [ -d "$XCASSETS" ]; then
     ACTOOL_INPUTS=("$XCASSETS")
     if [ -d "$APP_ICON" ]; then
         ACTOOL_INPUTS+=("$APP_ICON")
     fi
-    xcrun actool "${ACTOOL_INPUTS[@]}" \
+    # Capture actool output; suppress warnings but surface real failures
+    ACTOOL_OUTPUT=$(xcrun actool "${ACTOOL_INPUTS[@]}" \
         --compile "$RESOURCES_DIR" \
         --platform macosx \
         --minimum-deployment-target 14.0 \
         --app-icon AppIcon \
         --output-partial-info-plist /dev/null \
-        > /dev/null 2>&1 || true
+        2>&1) || {
+        # Filter out warning lines and check if there are real errors
+        ACTOOL_ERRORS=$(echo "$ACTOOL_OUTPUT" | grep -iv 'warning:' || true)
+        if [ -n "$ACTOOL_ERRORS" ]; then
+            echo "actool failed:"
+            echo "$ACTOOL_ERRORS"
+            exit 1
+        fi
+    }
+fi
+
+# Generate AppIcon.icns from SVG source for Finder/DMG icon display.
+# actool with .icon bundles only emits into Assets.car — it does not produce a
+# standalone .icns.  Finder and create-dmg rely on CFBundleIconFile → .icns,
+# so we render one from the same SVG source that Icon Composer uses.
+# Always regenerate when an icon source directory is resolved — the Swift
+# script is fast and this avoids stale icns after environment switches.
+if [ -d "$APP_ICON" ] && [ -n "$ICON_SOURCE_DIR" ]; then
+    echo "Generating AppIcon.icns from SVG..."
+
+    ICONSET_DIR=$(mktemp -d)/AppIcon.iconset
+    mkdir -p "$ICONSET_DIR"
+
+    # Render a 1024x1024 master PNG using an inline Swift script.
+    # This is consistent with how dmg/generate-background.swift works.
+    MASTER_PNG=$(mktemp /tmp/appicon-master-XXXXXX).png
+    swift - "$APP_ICON" "$MASTER_PNG" <<'SWIFT_SCRIPT'
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+let iconDir = CommandLine.arguments[1]
+let outputPath = CommandLine.arguments[2]
+
+// --- Parse icon.json ---
+let jsonPath = iconDir + "/icon.json"
+let jsonData = try! Data(contentsOf: URL(fileURLWithPath: jsonPath))
+let json = try! JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+
+// Fill color
+let fillDict = json["fill"] as! [String: Any]
+let solidStr = fillDict["solid"] as! String  // "display-p3:0.12941,0.42353,0.21569,1.00000"
+
+let colorParts = solidStr.split(separator: ":")[1].split(separator: ",").map { CGFloat(Double($0)!) }
+let fillColor = CGColor(
+    colorSpace: CGColorSpace(name: CGColorSpace.displayP3)!,
+    components: colorParts
+)!
+
+// Layer position: scale and translation
+let groups = json["groups"] as! [[String: Any]]
+let layers = groups[0]["layers"] as! [[String: Any]]
+let layer = layers[0]
+let position = layer["position"] as! [String: Any]
+let scale = CGFloat(position["scale"] as! Double)
+let translationPts = position["translation-in-points"] as! [Double]
+let txPoints = CGFloat(translationPts[0])
+let tyPoints = CGFloat(translationPts[1])
+
+// SVG filename from layer image-name
+let imageName = layer["image-name"] as! String
+let svgPath = iconDir + "/Assets/" + imageName
+
+// --- Parse SVG path ---
+let svgString = try! String(contentsOfFile: svgPath, encoding: .utf8)
+// Extract the path d attribute from the SVG
+let dRange = svgString.range(of: "d=\"")!
+let afterD = svgString[dRange.upperBound...]
+let closingQuote = afterD.firstIndex(of: "\"")!
+let pathData = String(afterD[..<closingQuote])
+
+// Parse SVG viewBox for coordinate mapping
+let vbRange = svgString.range(of: "viewBox=\"")!
+let afterVB = svgString[vbRange.upperBound...]
+let vbClose = afterVB.firstIndex(of: "\"")!
+let vbParts = String(afterVB[..<vbClose]).split(separator: " ").map { CGFloat(Double($0)!) }
+let svgWidth = vbParts[2]
+let svgHeight = vbParts[3]
+
+// --- Build CGPath from SVG path data ---
+func parseSVGPath(_ d: String) -> CGPath {
+    let path = CGMutablePath()
+    var chars = Array(d)
+    var i = 0
+    var currentX: CGFloat = 0
+    var currentY: CGFloat = 0
+
+    func skipWhitespaceAndCommas() {
+        while i < chars.count && (chars[i] == " " || chars[i] == "," || chars[i] == "\n" || chars[i] == "\r" || chars[i] == "\t") {
+            i += 1
+        }
+    }
+
+    func parseNumber() -> CGFloat {
+        skipWhitespaceAndCommas()
+        var numStr = ""
+        if i < chars.count && (chars[i] == "-" || chars[i] == "+") {
+            numStr.append(chars[i]); i += 1
+        }
+        while i < chars.count && (chars[i] >= "0" && chars[i] <= "9" || chars[i] == ".") {
+            numStr.append(chars[i]); i += 1
+        }
+        return CGFloat(Double(numStr) ?? 0)
+    }
+
+    var lastCmd: Character = " "
+
+    while i < chars.count {
+        skipWhitespaceAndCommas()
+        if i >= chars.count { break }
+
+        // Determine the command: explicit letter or implicit repetition
+        var cmd: Character
+        if chars[i].isLetter {
+            cmd = chars[i]; i += 1
+        } else {
+            // Implicit repetition: reuse last command (M promotes to L per SVG spec)
+            cmd = lastCmd
+            if cmd == "M" { cmd = "L" }
+            if cmd == "m" { cmd = "l" }
+        }
+        lastCmd = cmd
+
+        switch cmd {
+        case "M":
+            let x = parseNumber(); let y = parseNumber()
+            path.move(to: CGPoint(x: x, y: y))
+            currentX = x; currentY = y
+        case "m":
+            let dx = parseNumber(); let dy = parseNumber()
+            currentX += dx; currentY += dy
+            path.move(to: CGPoint(x: currentX, y: currentY))
+        case "L":
+            let x = parseNumber(); let y = parseNumber()
+            path.addLine(to: CGPoint(x: x, y: y))
+            currentX = x; currentY = y
+        case "l":
+            let dx = parseNumber(); let dy = parseNumber()
+            currentX += dx; currentY += dy
+            path.addLine(to: CGPoint(x: currentX, y: currentY))
+        case "H":
+            currentX = parseNumber()
+            path.addLine(to: CGPoint(x: currentX, y: currentY))
+        case "h":
+            currentX += parseNumber()
+            path.addLine(to: CGPoint(x: currentX, y: currentY))
+        case "V":
+            currentY = parseNumber()
+            path.addLine(to: CGPoint(x: currentX, y: currentY))
+        case "v":
+            currentY += parseNumber()
+            path.addLine(to: CGPoint(x: currentX, y: currentY))
+        case "C":
+            let x1 = parseNumber(); let y1 = parseNumber()
+            let x2 = parseNumber(); let y2 = parseNumber()
+            let x = parseNumber(); let y = parseNumber()
+            path.addCurve(to: CGPoint(x: x, y: y),
+                          control1: CGPoint(x: x1, y: y1),
+                          control2: CGPoint(x: x2, y: y2))
+            currentX = x; currentY = y
+        case "c":
+            let dx1 = parseNumber(); let dy1 = parseNumber()
+            let dx2 = parseNumber(); let dy2 = parseNumber()
+            let dx = parseNumber(); let dy = parseNumber()
+            path.addCurve(to: CGPoint(x: currentX + dx, y: currentY + dy),
+                          control1: CGPoint(x: currentX + dx1, y: currentY + dy1),
+                          control2: CGPoint(x: currentX + dx2, y: currentY + dy2))
+            currentX += dx; currentY += dy
+        case "Q":
+            let x1 = parseNumber(); let y1 = parseNumber()
+            let x = parseNumber(); let y = parseNumber()
+            path.addQuadCurve(to: CGPoint(x: x, y: y),
+                              control: CGPoint(x: x1, y: y1))
+            currentX = x; currentY = y
+        case "q":
+            let dx1 = parseNumber(); let dy1 = parseNumber()
+            let dx = parseNumber(); let dy = parseNumber()
+            path.addQuadCurve(to: CGPoint(x: currentX + dx, y: currentY + dy),
+                              control: CGPoint(x: currentX + dx1, y: currentY + dy1))
+            currentX += dx; currentY += dy
+        case "Z", "z":
+            path.closeSubpath()
+        default:
+            // Skip unrecognized commands by advancing past their arguments
+            while i < chars.count && !chars[i].isLetter { i += 1 }
+        }
+    }
+    return path
+}
+
+// --- Render 1024x1024 PNG ---
+let size = 1024
+let colorSpace = CGColorSpace(name: CGColorSpace.displayP3)!
+
+guard let ctx = CGContext(
+    data: nil, width: size, height: size,
+    bitsPerComponent: 8, bytesPerRow: 0,
+    space: colorSpace,
+    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+) else { fatalError("Failed to create bitmap context") }
+
+let s = CGFloat(size)
+
+// Draw macOS squircle rounded-rect background with the green fill.
+// Apple's macOS icon shape uses ~22.37% corner radius (continuous corners).
+let iconRect = CGRect(x: 0, y: 0, width: s, height: s)
+let cornerRadius = s * 0.2237
+let bgPath = CGPath(roundedRect: iconRect, cornerWidth: cornerRadius, cornerHeight: cornerRadius, transform: nil)
+ctx.addPath(bgPath)
+ctx.setFillColor(fillColor)
+ctx.fillPath()
+
+// Draw the white V centered with scale and translation from icon.json.
+// Icon Composer coordinates: origin is center of the 1024x1024 canvas,
+// Y-axis points up, and scale is relative to the SVG's native size.
+
+// Scale from points to pixels (icon.json uses a 1024-point canvas)
+let svgPixelWidth = svgWidth * scale
+let svgPixelHeight = svgHeight * scale
+
+// Center the scaled SVG on the canvas, then apply translation
+let offsetX = (s - svgPixelWidth) / 2.0 + txPoints
+// Flip Y: CGContext uses bottom-left origin with Y-up, but SVG uses top-left
+// origin with Y-down. Flip the context to match SVG coordinate convention.
+// icon.json translation Y=25 means 25pt upward in Icon Composer;
+// in our now-flipped top-left-origin context, upward = negative Y.
+let offsetY = (s - svgPixelHeight) / 2.0 - tyPoints
+
+ctx.saveGState()
+// Flip to top-left origin (matching SVG coordinates)
+ctx.translateBy(x: 0, y: s)
+ctx.scaleBy(x: 1, y: -1)
+// Move to where the SVG should be drawn, then scale the SVG coordinates
+ctx.translateBy(x: offsetX, y: offsetY)
+ctx.scaleBy(x: scale, y: scale)
+let vPath = parseSVGPath(pathData)
+ctx.addPath(vPath)
+ctx.setFillColor(.white)
+ctx.fillPath()
+ctx.restoreGState()
+
+// Write PNG
+guard let image = ctx.makeImage() else { fatalError("Failed to create CGImage") }
+let url = URL(fileURLWithPath: outputPath)
+guard let dest = CGImageDestinationCreateWithURL(
+    url as CFURL, UTType.png.identifier as CFString, 1, nil
+) else { fatalError("Failed to create image destination") }
+CGImageDestinationAddImage(dest, image, nil)
+guard CGImageDestinationFinalize(dest) else { fatalError("Failed to write PNG") }
+SWIFT_SCRIPT
+
+    if [ ! -f "$MASTER_PNG" ]; then
+        echo "Error: Failed to generate master icon PNG"
+        exit 1
+    fi
+
+    # Generate all required icon sizes from the 1024x1024 master.
+    # iconutil requires: 16, 32, 128, 256, 512 at 1x and 2x (10 files).
+    for SIZE in 16 32 128 256 512; do
+        DOUBLE=$((SIZE * 2))
+        sips -z "$SIZE" "$SIZE" "$MASTER_PNG" --out "$ICONSET_DIR/icon_${SIZE}x${SIZE}.png" > /dev/null
+        sips -z "$DOUBLE" "$DOUBLE" "$MASTER_PNG" --out "$ICONSET_DIR/icon_${SIZE}x${SIZE}@2x.png" > /dev/null
+    done
+
+    # Produce the .icns file
+    iconutil --convert icns --output "$RESOURCES_DIR/AppIcon.icns" "$ICONSET_DIR"
+
+    # Clean up
+    rm -rf "$(dirname "$ICONSET_DIR")"
+    rm -f "$MASTER_PNG"
+
+    echo "Generated AppIcon.icns"
 fi
 
 # Copy document type icon for .vellum UTI

--- a/clients/macos/vellum-assistant/Resources/icons/README.md
+++ b/clients/macos/vellum-assistant/Resources/icons/README.md
@@ -1,0 +1,54 @@
+# Per-Environment App Icons
+
+This directory contains per-environment icon sources for the macOS app.
+Each subdirectory corresponds to a `VELLUM_ENVIRONMENT` value and holds the
+Icon Composer assets that `build.sh` copies into `AppIcon.icon/` before the
+build compiles them.
+
+## Directory structure
+
+```
+icons/
+  README.md
+  production/          # VELLUM_ENVIRONMENT=production (canonical/default)
+    icon.json          # Icon Composer manifest (fill color, layer definitions)
+    Assets/
+      white-V.svg      # Foreground SVG layer
+  staging/             # (example) VELLUM_ENVIRONMENT=staging
+    icon.json
+    Assets/
+      white-V.svg
+```
+
+One subdirectory per environment: `local`, `dev`, `staging`, `production`.
+If no directory exists for the current `VELLUM_ENVIRONMENT`, the build falls
+back to `production/`.
+
+## Adding a new environment icon
+
+1. Create a directory matching the environment name (e.g. `staging/`).
+2. Copy `production/icon.json` and `production/Assets/white-V.svg` into it.
+3. Edit `icon.json` to change the `fill.solid` color. This controls the
+   background tint of the app icon. The color format is
+   `display-p3:<red>,<green>,<blue>,<alpha>` with values between 0 and 1.
+4. Optionally replace `Assets/white-V.svg` with a different foreground SVG.
+5. Build with `VELLUM_ENVIRONMENT=staging ./build.sh run` (or whichever
+   environment you added) and verify the icon.
+
+The easiest customization is changing just the `fill.solid` color in
+`icon.json` to give each environment a distinct background tint while keeping
+the same white-V foreground.
+
+## How it works
+
+`build.sh` resolves the icon source directory at build time:
+
+1. Checks for `icons/$VELLUM_ENVIRONMENT/`.
+2. Falls back to `icons/production/` if the environment directory is missing.
+3. Copies `icon.json` and `Assets/` from the resolved directory into
+   `AppIcon.icon/`, overwriting its contents.
+4. `actool` and the `.icns` generation step then read from `AppIcon.icon/`,
+   so both Liquid Glass and Finder/DMG icons reflect the environment color.
+
+`AppIcon.icon/` in the source tree is treated as a working copy that gets
+overwritten at build time -- it is not the source of truth.

--- a/clients/macos/vellum-assistant/Resources/icons/production/Assets/white-V.svg
+++ b/clients/macos/vellum-assistant/Resources/icons/production/Assets/white-V.svg
@@ -1,0 +1,3 @@
+<svg width="92" height="92" viewBox="0 0 92 92" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.5 0L46 48.342L68.4107 0L91 0L45.8214 92L1 0L23.5 0Z" fill="white"/>
+</svg>

--- a/clients/macos/vellum-assistant/Resources/icons/production/icon.json
+++ b/clients/macos/vellum-assistant/Resources/icons/production/icon.json
@@ -1,0 +1,47 @@
+{
+  "fill" : {
+    "solid" : "display-p3:0.12941,0.42353,0.21569,1.00000"
+  },
+  "groups" : [
+    {
+      "blend-mode" : "normal",
+      "layers" : [
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "dark",
+              "value" : "none"
+            }
+          ],
+          "glass" : false,
+          "image-name" : "white-V.svg",
+          "name" : "white-V",
+          "position" : {
+            "scale" : 6,
+            "translation-in-points" : [
+              0,
+              25
+            ]
+          }
+        }
+      ],
+      "lighting" : "individual",
+      "name" : "Group",
+      "shadow" : {
+        "kind" : "neutral",
+        "opacity" : 0.5
+      },
+      "specular" : true,
+      "translucency" : {
+        "enabled" : true,
+        "value" : 0.5
+      }
+    }
+  ],
+  "supported-platforms" : {
+    "circles" : [
+      "watchOS"
+    ],
+    "squares" : "shared"
+  }
+}

--- a/clients/macos/vellum-assistantTests/AppListManagerSyncTests.swift
+++ b/clients/macos/vellum-assistantTests/AppListManagerSyncTests.swift
@@ -9,7 +9,7 @@ import XCTest
 ///
 /// The chain under test:
 ///   app_create tool runs
-///   → handleAppChange in tool-side-effects.ts broadcasts app_files_changed
+///   → notifyAppChanged in tool-side-effects.ts broadcasts app_files_changed
 ///   → macOS client calls /v1/apps, receives updated list
 ///   → AppListManager.syncFromDaemon() is called with the new list
 ///   → manager.apps contains the new app


### PR DESCRIPTION
## Summary
Cherry-picks the following commits into `release/v0.6.6`:

- `4d355fe` — Add homepage_url to Chrome extension manifest (#27707)
- `82b287d` — ci: pause native iOS release during Capacitor migration (#27711)
- `a1cd254` — fix(macos): restore Finder/DMG icon & add per-environment icon infrastructure (#27733)
- `f7e19c9` — fix(app_create): stop redundant recompile racing with executor output (#27736)
- `0bddd86` — refactor(tool-side-effects): decouple app hooks from executor payload (#27743)

## Test plan
- All commits were previously merged to main and tested via CI
- Cherry-picks applied cleanly with no conflicts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
