### PR TITLE
fix(macos): retry actool when AssetCatalogAgent crashes early

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1372,22 +1372,35 @@ if [ -d "$XCASSETS" ]; then
     # Assets.car was not produced. On GitHub-hosted macOS runners actool's
     # AssetCatalogAgent-AssetRuntime subprocess occasionally crashes (dyld
     # symbol mismatches against AVFCore / CoreMedia, IBPlatformToolFailure-
-    # Exception) after successfully writing Assets.car, so fall back to an
-    # output-file existence check before failing the build.
-    ACTOOL_OUTPUT=$(xcrun actool "${ACTOOL_INPUTS[@]}" \
-        --compile "$RESOURCES_DIR" \
-        --platform macosx \
-        --minimum-deployment-target 14.0 \
-        --app-icon AppIcon \
-        --output-partial-info-plist /dev/null \
-        2>&1) || {
-        if [ ! -f "$RESOURCES_DIR/Assets.car" ]; then
-            echo "actool failed to produce Assets.car:"
-            echo "$ACTOOL_OUTPUT"
-            exit 1
+    # Exception). Sometimes Assets.car is written before the crash and we
+    # can continue; sometimes the crash happens early and no output is
+    # produced. Retry a few times to absorb the flaky early-crash case.
+    ACTOOL_MAX_ATTEMPTS=3
+    ACTOOL_SUCCESS=0
+    for attempt in $(seq 1 $ACTOOL_MAX_ATTEMPTS); do
+        rm -f "$RESOURCES_DIR/Assets.car"
+        if ACTOOL_OUTPUT=$(xcrun actool "${ACTOOL_INPUTS[@]}" \
+            --compile "$RESOURCES_DIR" \
+            --platform macosx \
+            --minimum-deployment-target 14.0 \
+            --app-icon AppIcon \
+            --output-partial-info-plist /dev/null \
+            2>&1); then
+            ACTOOL_SUCCESS=1
+            break
         fi
-        echo "actool exited non-zero but Assets.car was produced; continuing."
-    }
+        if [ -f "$RESOURCES_DIR/Assets.car" ]; then
+            echo "actool exited non-zero but Assets.car was produced on attempt $attempt; continuing."
+            ACTOOL_SUCCESS=1
+            break
+        fi
+        echo "actool attempt $attempt/$ACTOOL_MAX_ATTEMPTS failed without producing Assets.car; retrying."
+    done
+    if [ "$ACTOOL_SUCCESS" != "1" ]; then
+        echo "actool failed to produce Assets.car after $ACTOOL_MAX_ATTEMPTS attempts:"
+        echo "$ACTOOL_OUTPUT"
+        exit 1
+    fi
 fi
 
 # Generate AppIcon.icns from SVG source for Finder/DMG icon display.


### PR DESCRIPTION
## Summary

- The AssetCatalogAgent-AssetRuntime subprocess invoked by `actool` flakily crashes on GitHub-hosted macOS runners due to a dyld symbol mismatch against AVFCore / CoreMedia. 0c06262a35 tolerated this by checking for `Assets.car` after failure, but when the crash happens early (no output written) the build still fails — which is what happened in [run 24853553319](https://github.com/vellum-ai/vellum-assistant/actions/runs/24853553319/job/72760301076).
- Wrap the `xcrun actool` call in a 3-attempt retry loop. Each attempt clears any partial `Assets.car` before running so the existence check can't be fooled by stale output. Any attempt that produces `Assets.car` (clean or tolerated crash) succeeds; only if all 3 fail without output do we error out.
- Minimal and self-contained — only `clients/macos/build.sh` changes.

## Original prompt

--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24853553319/job/72760301076
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
