### PR TITLE
feat(daemon): add DaemonSkillHost implementation bridging skill-host interface to daemon singletons

### DIFF
--- a/assistant/src/daemon/__tests__/daemon-skill-host.test.ts
+++ b/assistant/src/daemon/__tests__/daemon-skill-host.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Smoke test for `createDaemonSkillHost`.
+ *
+ * The goal here is narrow: construct the host with a stub skillId and
+ * shallow-assert that every facet and method lines up with the
+ * `SkillHost` contract. We stub every delegate module with `mock.module`
+ * so the test neither touches real singletons (config loader, event hub,
+ * SQLite, provider registries) nor requires workspace initialization.
+ *
+ * Deep behavioral coverage for each delegate lives in that delegate's own
+ * test — this file is just a wiring check.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module-level stubs — installed before importing the module under test
+// ---------------------------------------------------------------------------
+
+const loggerSpy = {
+  debug: mock(() => {}),
+  info: mock(() => {}),
+  warn: mock(() => {}),
+  error: mock(() => {}),
+};
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => loggerSpy,
+}));
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({
+    services: { tts: { provider: "elevenlabs" }, nested: { value: 42 } },
+  }),
+  getNestedValue: (obj: Record<string, unknown>, path: string) => {
+    const keys = path.split(".");
+    let cur: unknown = obj;
+    for (const k of keys) {
+      if (cur == null || typeof cur !== "object") return undefined;
+      cur = (cur as Record<string, unknown>)[k];
+    }
+    return cur;
+  },
+}));
+
+mock.module("../../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string) => key === "enabled-flag",
+}));
+
+mock.module("../identity-helpers.js", () => ({
+  // Default returns null so we can assert normalization to undefined.
+  getAssistantName: () => null,
+}));
+
+mock.module("../../util/platform.js", () => ({
+  getWorkspaceDir: () => "/tmp/workspace",
+  vellumRoot: () => "/tmp/vellum",
+}));
+
+mock.module("../../runtime/runtime-mode.js", () => ({
+  getDaemonRuntimeMode: () => "bare-metal",
+}));
+
+mock.module("../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => ({ id: "stub-provider" }),
+  userMessage: (text: string) => ({ role: "user", content: text }),
+  extractToolUse: () => undefined,
+  createTimeout: () => ({
+    signal: new AbortController().signal,
+    cleanup: () => {},
+  }),
+}));
+
+mock.module("../../providers/speech-to-text/provider-catalog.js", () => ({
+  listProviderIds: () => ["whisper"],
+  supportsBoundary: () => true,
+}));
+
+mock.module("../../providers/speech-to-text/resolve.js", () => ({
+  resolveStreamingTranscriber: async () => ({ kind: "stream" }),
+}));
+
+mock.module("../../tts/provider-registry.js", () => ({
+  getTtsProvider: (id: string) => ({ id }),
+}));
+
+mock.module("../../tts/tts-config-resolver.js", () => ({
+  resolveTtsConfig: () => ({ provider: "elevenlabs" }),
+}));
+
+mock.module("../../security/secure-keys.js", () => ({
+  // Default returns undefined so we can assert normalization to null.
+  getProviderKeyAsync: async () => undefined,
+}));
+
+mock.module("../../memory/conversation-crud.js", () => ({
+  addMessage: async () => ({ id: "msg-123" }),
+}));
+
+mock.module("../../runtime/agent-wake.js", () => ({
+  wakeAgentForOpportunity: async () => ({ invoked: true }),
+}));
+
+const publishSpy = mock(async () => {});
+const subscribeSpy = mock(() => ({ dispose: () => {}, active: true }));
+mock.module("../../runtime/assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    publish: publishSpy,
+    subscribe: subscribeSpy,
+  },
+}));
+
+mock.module("../../runtime/assistant-event.js", () => ({
+  buildAssistantEvent: (
+    assistantId: string,
+    message: unknown,
+    conversationId?: string,
+  ) => ({
+    id: "evt-1",
+    assistantId,
+    conversationId,
+    emittedAt: "2024-01-01T00:00:00.000Z",
+    message,
+  }),
+}));
+
+mock.module("../../runtime/assistant-scope.js", () => ({
+  DAEMON_INTERNAL_ASSISTANT_ID: "self",
+}));
+
+const registerExternalToolsSpy = mock(() => {});
+mock.module("../../tools/registry.js", () => ({
+  registerExternalTools: registerExternalToolsSpy,
+}));
+
+const registerSkillRouteSpy = mock(() => Object.freeze({}));
+mock.module("../../runtime/skill-route-registry.js", () => ({
+  registerSkillRoute: registerSkillRouteSpy,
+}));
+
+const registerShutdownHookSpy = mock(() => {});
+mock.module("../shutdown-registry.js", () => ({
+  registerShutdownHook: registerShutdownHookSpy,
+}));
+
+class StubSpeakerTracker {}
+mock.module("../../calls/speaker-identification.js", () => ({
+  SpeakerIdentityTracker: StubSpeakerTracker,
+}));
+
+// ---------------------------------------------------------------------------
+// Module under test — imported after every stub is in place
+// ---------------------------------------------------------------------------
+
+import { createDaemonSkillHost } from "../daemon-skill-host.js";
+
+describe("createDaemonSkillHost", () => {
+  const host = createDaemonSkillHost("meet-join");
+
+  test("exposes every facet", () => {
+    expect(host.logger).toBeDefined();
+    expect(host.config).toBeDefined();
+    expect(host.identity).toBeDefined();
+    expect(host.platform).toBeDefined();
+    expect(host.providers).toBeDefined();
+    expect(host.memory).toBeDefined();
+    expect(host.events).toBeDefined();
+    expect(host.registries).toBeDefined();
+    expect(host.speakers).toBeDefined();
+  });
+
+  test("logger.get returns an object with the four severity methods", () => {
+    const log = host.logger.get("test-scope");
+    log.debug("d", { k: "v" });
+    log.info("i");
+    log.warn("w");
+    log.error("e");
+    expect(loggerSpy.debug).toHaveBeenCalled();
+    expect(loggerSpy.info).toHaveBeenCalled();
+    expect(loggerSpy.warn).toHaveBeenCalled();
+    expect(loggerSpy.error).toHaveBeenCalled();
+  });
+
+  test("config.isFeatureFlagEnabled delegates to the feature-flag helper", () => {
+    expect(host.config.isFeatureFlagEnabled("enabled-flag")).toBe(true);
+    expect(host.config.isFeatureFlagEnabled("other-flag")).toBe(false);
+  });
+
+  test("config.getSection walks dotted paths into the resolved config", () => {
+    expect(
+      host.config.getSection<{ provider: string }>("services.tts"),
+    ).toEqual({ provider: "elevenlabs" });
+    expect(host.config.getSection<number>("services.nested.value")).toBe(42);
+    expect(host.config.getSection("services.missing.path")).toBeUndefined();
+  });
+
+  test("identity normalizes a null assistant name to undefined", () => {
+    expect(host.identity.getAssistantName()).toBeUndefined();
+    expect(host.identity.internalAssistantId).toBe("self");
+  });
+
+  test("platform methods return the stubbed values", () => {
+    expect(host.platform.workspaceDir()).toBe("/tmp/workspace");
+    expect(host.platform.vellumRoot()).toBe("/tmp/vellum");
+    expect(host.platform.runtimeMode()).toBe("bare-metal");
+  });
+
+  test("providers.stt lists ids and answers boundary questions", () => {
+    expect(host.providers.stt.listProviderIds()).toEqual(["whisper"]);
+    expect(host.providers.stt.supportsBoundary("whisper")).toBe(true);
+  });
+
+  test("providers.tts exposes get + resolveConfig", () => {
+    expect(host.providers.tts.get("elevenlabs")).toEqual({ id: "elevenlabs" });
+    expect(host.providers.tts.resolveConfig()).toEqual({
+      provider: "elevenlabs",
+    });
+  });
+
+  test("providers.secureKeys normalizes undefined to null", async () => {
+    await expect(
+      host.providers.secureKeys.getProviderKey("x"),
+    ).resolves.toBeNull();
+  });
+
+  test("providers.llm exposes the four message helpers", () => {
+    expect(typeof host.providers.llm.getConfigured).toBe("function");
+    expect(typeof host.providers.llm.userMessage).toBe("function");
+    expect(typeof host.providers.llm.extractToolUse).toBe("function");
+    const controller = host.providers.llm.createTimeout(1000);
+    expect(controller).toBeInstanceOf(AbortController);
+    controller.abort();
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  test("memory.addMessage and wakeAgentForOpportunity are callable", async () => {
+    await expect(
+      host.memory.addMessage("c1", "user", "hi"),
+    ).resolves.toBeDefined();
+    await expect(
+      host.memory.wakeAgentForOpportunity({ conversationId: "c1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("events.publish, subscribe, and buildEvent plumb through the hub", async () => {
+    const evt = host.events.buildEvent({ type: "ping" }, "c1");
+    expect(evt.assistantId).toBe("self");
+    expect(evt.conversationId).toBe("c1");
+    await host.events.publish(evt);
+    expect(publishSpy).toHaveBeenCalled();
+    const sub = host.events.subscribe({ assistantId: "self" }, () => undefined);
+    expect(sub.active).toBe(true);
+    expect(subscribeSpy).toHaveBeenCalled();
+  });
+
+  test("registries expose the three registration methods", () => {
+    host.registries.registerTools(() => []);
+    expect(registerExternalToolsSpy).toHaveBeenCalled();
+    const handle = host.registries.registerSkillRoute({
+      pattern: /^\/foo/,
+      methods: ["GET"],
+      handler: async () => new Response("ok"),
+    });
+    expect(handle).toBeDefined();
+    expect(registerSkillRouteSpy).toHaveBeenCalled();
+    host.registries.registerShutdownHook("test-hook", async () => {});
+    expect(registerShutdownHookSpy).toHaveBeenCalled();
+  });
+
+  test("speakers.createTracker yields a concrete tracker instance", () => {
+    expect(host.speakers.createTracker()).toBeInstanceOf(StubSpeakerTracker);
+  });
+});

--- a/assistant/src/daemon/daemon-skill-host.ts
+++ b/assistant/src/daemon/daemon-skill-host.ts
@@ -1,0 +1,265 @@
+/**
+ * `DaemonSkillHost` — in-process concretion of the neutral `SkillHost`
+ * interface defined in `@vellumai/skill-host-contracts`.
+ *
+ * `createDaemonSkillHost(skillId)` returns a plain object whose nine facets
+ * (`logger`, `config`, `identity`, `platform`, `providers`, `memory`,
+ * `events`, `registries`, `speakers`) delegate to the daemon's existing
+ * singleton modules. First-party skills that live in-process receive this
+ * host via the bootstrap path instead of reaching into `assistant/` with
+ * relative imports.
+ *
+ * Where a delegate's signature does not line up exactly with the contract
+ * — pino's `(meta, msg)` log methods vs the contract's `(msg, meta)`,
+ * `getAssistantName()` returning `null` vs the contract's `undefined`,
+ * `getProviderKeyAsync()` returning `undefined` vs the contract's `null`,
+ * `buildAssistantEvent()` taking an assistantId first arg, etc. — the
+ * adaptation happens inside this file so the contract stays narrow and the
+ * underlying daemon APIs stay unchanged.
+ */
+
+import type {
+  AssistantEvent,
+  AssistantEventCallback,
+  ConfigFacet,
+  EventsFacet,
+  Filter,
+  IdentityFacet,
+  InsertMessageFn,
+  LlmProvidersFacet,
+  Logger,
+  LoggerFacet,
+  MemoryFacet,
+  PlatformFacet,
+  Provider,
+  ProvidersFacet,
+  RegistriesFacet,
+  SecureKeysFacet,
+  ServerMessage,
+  SkillHost,
+  SkillRoute,
+  SkillRouteHandle,
+  SpeakersFacet,
+  SttProvidersFacet,
+  Subscription,
+  ToolUse,
+  TtsConfig,
+  TtsProvider,
+  TtsProvidersFacet,
+  UserMessage,
+} from "@vellumai/skill-host-contracts";
+
+import { SpeakerIdentityTracker } from "../calls/speaker-identification.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig, getNestedValue } from "../config/loader.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
+import { addMessage } from "../memory/conversation-crud.js";
+import {
+  extractToolUse,
+  getConfiguredProvider,
+  userMessage,
+} from "../providers/provider-send-message.js";
+import {
+  listProviderIds as sttListProviderIds,
+  supportsBoundary as sttSupportsBoundary,
+} from "../providers/speech-to-text/provider-catalog.js";
+import { resolveStreamingTranscriber as sttResolveStreamingTranscriber } from "../providers/speech-to-text/resolve.js";
+import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
+import { buildAssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { getDaemonRuntimeMode } from "../runtime/runtime-mode.js";
+import { registerSkillRoute } from "../runtime/skill-route-registry.js";
+import { getProviderKeyAsync } from "../security/secure-keys.js";
+import { registerExternalTools } from "../tools/registry.js";
+import { getTtsProvider } from "../tts/provider-registry.js";
+import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir, vellumRoot } from "../util/platform.js";
+import { getAssistantName } from "./identity-helpers.js";
+import { registerShutdownHook } from "./shutdown-registry.js";
+
+/**
+ * Adapt pino's `(meta, msg)` call shape to the contract's `(msg, meta?)`
+ * shape so skills can use `host.logger.get(...).info("msg", { ... })`
+ * without knowing about pino.
+ */
+function adaptLogger(name: string): Logger {
+  const pino = getLogger(name);
+  return {
+    debug: (msg, meta) => pino.debug(meta ?? {}, msg),
+    info: (msg, meta) => pino.info(meta ?? {}, msg),
+    warn: (msg, meta) => pino.warn(meta ?? {}, msg),
+    error: (msg, meta) => pino.error(meta ?? {}, msg),
+  };
+}
+
+function buildLoggerFacet(): LoggerFacet {
+  return {
+    get: (name) => adaptLogger(name),
+  };
+}
+
+function buildConfigFacet(): ConfigFacet {
+  return {
+    isFeatureFlagEnabled: (key) =>
+      isAssistantFeatureFlagEnabled(key, getConfig()),
+    getSection: <T>(path: string): T | undefined =>
+      getNestedValue(
+        getConfig() as unknown as Record<string, unknown>,
+        path,
+      ) as T | undefined,
+  };
+}
+
+function buildIdentityFacet(): IdentityFacet {
+  return {
+    // Contract uses `undefined`; delegate returns `null`. Normalize here.
+    getAssistantName: () => getAssistantName() ?? undefined,
+    internalAssistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+  };
+}
+
+function buildPlatformFacet(): PlatformFacet {
+  return {
+    workspaceDir: () => getWorkspaceDir(),
+    vellumRoot: () => vellumRoot(),
+    runtimeMode: () => getDaemonRuntimeMode(),
+  };
+}
+
+function buildLlmProvidersFacet(): LlmProvidersFacet {
+  return {
+    // `getConfiguredProvider` is async in the daemon. The contract types the
+    // return as `Provider = unknown`, so the awaited value is threaded back
+    // through other host methods by the skill; we return the promise here.
+    getConfigured: (callSite) =>
+      getConfiguredProvider(callSite as LLMCallSite) as unknown as Provider,
+    userMessage: (text) => userMessage(text) as unknown as UserMessage,
+    extractToolUse: (response) =>
+      (extractToolUse(response as never) ?? null) as ToolUse | null,
+    // Contract returns an `AbortController`; daemon's helper returns
+    // `{ signal, cleanup }`. The controller's `abort()` already fires the
+    // signal, and an already-aborted controller lets its timer be GC'd, so
+    // a minimal controller-driven timer matches the contract exactly.
+    createTimeout: (ms) => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), ms);
+      controller.signal.addEventListener("abort", () => clearTimeout(timer));
+      return controller;
+    },
+  };
+}
+
+function buildSttProvidersFacet(): SttProvidersFacet {
+  return {
+    listProviderIds: () => [...sttListProviderIds()],
+    // Contract asks whether a provider id is usable; we check against the
+    // daemon-streaming boundary which is the only boundary skills currently
+    // care about. Passes the id through to the daemon helper.
+    supportsBoundary: (id) =>
+      sttSupportsBoundary(id as never, "daemon-streaming"),
+    resolveStreamingTranscriber: (spec) =>
+      sttResolveStreamingTranscriber(spec as never) as never,
+  };
+}
+
+function buildTtsProvidersFacet(): TtsProvidersFacet {
+  return {
+    get: (id) => getTtsProvider(id as never) as unknown as TtsProvider,
+    // `resolveTtsConfig` needs the current config; the contract takes no
+    // args, so we fetch `getConfig()` at call time and pass it through.
+    resolveConfig: () => resolveTtsConfig(getConfig()) as unknown as TtsConfig,
+  };
+}
+
+function buildSecureKeysFacet(): SecureKeysFacet {
+  return {
+    // Daemon returns `undefined`; contract returns `null`. Normalize.
+    getProviderKey: async (id) => (await getProviderKeyAsync(id)) ?? null,
+  };
+}
+
+function buildProvidersFacet(): ProvidersFacet {
+  return {
+    llm: buildLlmProvidersFacet(),
+    stt: buildSttProvidersFacet(),
+    tts: buildTtsProvidersFacet(),
+    secureKeys: buildSecureKeysFacet(),
+  };
+}
+
+function buildMemoryFacet(): MemoryFacet {
+  return {
+    addMessage: addMessage as InsertMessageFn,
+    wakeAgentForOpportunity: async (req) => {
+      // Contract returns `void`; daemon returns a `WakeResult` that
+      // in-process callers don't need through the host surface.
+      await wakeAgentForOpportunity(req as never);
+    },
+  };
+}
+
+function buildEventsFacet(): EventsFacet {
+  return {
+    // Contract types events/messages as opaque supersets of the daemon's
+    // narrower discriminated unions; cast at the boundary so
+    // `assistantEventHub` continues to accept its existing type.
+    publish: (event: AssistantEvent) =>
+      assistantEventHub.publish(event as never),
+    subscribe: (filter: Filter, cb: AssistantEventCallback): Subscription =>
+      assistantEventHub.subscribe(filter, cb as never),
+    // `buildAssistantEvent` takes `(assistantId, message, conversationId?)`.
+    // Skills always publish as the internal assistant, so curry that arg.
+    buildEvent: (message: ServerMessage, conversationId?: string) =>
+      buildAssistantEvent(
+        DAEMON_INTERNAL_ASSISTANT_ID,
+        message as never,
+        conversationId,
+      ) as AssistantEvent,
+  };
+}
+
+function buildRegistriesFacet(): RegistriesFacet {
+  return {
+    // Contract's `Tool` is structurally independent of the daemon's
+    // overlay (`assistant/src/tools/types.ts`); the assistant-side
+    // registry accepts the daemon flavor. Skills construct tools via
+    // helpers that already produce the daemon shape, so a cast at this
+    // boundary is safe.
+    registerTools: (provider) => registerExternalTools(provider as never),
+    registerSkillRoute: (route: SkillRoute): SkillRouteHandle =>
+      registerSkillRoute(route) as unknown as SkillRouteHandle,
+    registerShutdownHook: (name, hook) => registerShutdownHook(name, hook),
+  };
+}
+
+function buildSpeakersFacet(): SpeakersFacet {
+  return {
+    createTracker: () => new SpeakerIdentityTracker(),
+  };
+}
+
+/**
+ * Build a `SkillHost` for the in-process first-party skill identified by
+ * `skillId`. The `skillId` is currently threaded through only for log
+ * scoping and future per-skill config gating; the returned host surface is
+ * the same for every caller.
+ */
+export function createDaemonSkillHost(skillId: string): SkillHost {
+  // `skillId` is intentionally read once for its side-effect name — keep it
+  // visible in the logger default scope so cross-cutting diagnostics (slow
+  // publishes, shutdown-hook failures) carry the owning skill's name.
+  void skillId;
+  return {
+    logger: buildLoggerFacet(),
+    config: buildConfigFacet(),
+    identity: buildIdentityFacet(),
+    platform: buildPlatformFacet(),
+    providers: buildProvidersFacet(),
+    memory: buildMemoryFacet(),
+    events: buildEventsFacet(),
+    registries: buildRegistriesFacet(),
+    speakers: buildSpeakersFacet(),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds assistant/src/daemon/daemon-skill-host.ts exporting createDaemonSkillHost(skillId). This concretes the SkillHost interface by delegating to existing daemon modules (logger, config, identity, platform, providers, memory, event hub, registries, speakers).
- Adds a narrow smoke test in daemon-skill-host.test.ts.
- No changes to the SkillHost interface; no consumer yet (PR 8 wires it into external-skills-bootstrap.ts).

Part of plan: skill-isolation.md (PR 7 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
