### PR TITLE
fix(tests): unbreak CI after daemon-skill-host import + git-init stall

### DIFF
--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -387,6 +387,12 @@ mock.module("../agent/loop.js", () => ({
   },
 }));
 
+mock.module("../workspace/git-service.js", () => ({
+  getWorkspaceGitService: () => ({
+    ensureInitialized: async () => {},
+  }),
+}));
+
 mock.module("../memory/canonical-guardian-store.js", () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
   listCanonicalGuardianRequests: () => [],

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -215,6 +215,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/handlers/config-model.ts", // masked provider key display
       "providers/speech-to-text/resolve.ts", // STT provider API key lookup
       "daemon/lifecycle.ts", // CES client injection into secure-keys at startup
+      "daemon/daemon-skill-host.ts", // SkillHost secureKeys facet adapter (delegates to getProviderKeyAsync)
       "daemon/external-plugins-bootstrap.ts", // reads credentials at plugin init (manifest.requiresCredential) via the CES-mediated getSecureKeyAsync path
       "inbound/platform-callback-registration.ts", // managed credential lookup for platform base URL, assistant ID, and API key
       "tts/providers/elevenlabs-provider.ts", // ElevenLabs TTS API key lookup


### PR DESCRIPTION
## Summary
- Add `daemon/daemon-skill-host.ts` to the `secure-keys` allowlist in `credential-security-invariants.test.ts`. The file was added in 10a9e69777 (DaemonSkillHost) and legitimately imports `getProviderKeyAsync` to implement the SkillHost `secureKeys` facet.
- Mock `workspace/git-service.js` in `conversation-provider-retry-repair.test.ts` to prevent a ~4s `git init` stall on `/tmp` in CI from pushing the first test over bun's 5000ms default timeout. Pattern matches what 5 sibling `conversation-*.test.ts` files already do (e.g. `conversation-agent-loop.test.ts`, `conversation-slash-unknown.test.ts`).

Both failures appeared in the job linked in the original prompt (CI Main Assistant Checks on commit 10a9e69777). With these two tweaks the file completes in ~455ms locally vs ~5300ms previously.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24854565116/job/72763839061
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
