### PR TITLE
docs(tool-error): rewrite comments in present tense

### DIFF
--- a/assistant/src/__tests__/tool-error-pipeline.test.ts
+++ b/assistant/src/__tests__/tool-error-pipeline.test.ts
@@ -190,11 +190,11 @@ describe("toolError pipeline", () => {
       expect(decision.action).toBe("skip");
     });
 
-    test("terminal still produces the legacy nudge when no plugin is registered", async () => {
-      // No registerPlugin call — the registry is empty for this slot. Since
-      // `agent/loop.ts` now passes `defaultToolErrorTerminal` as the pipeline
-      // terminal (rather than an inline `() => skip`), direct AgentLoop
-      // callers that skip `bootstrapPlugins()` still get the legacy nudge.
+    test("terminal produces the nudge when no plugin is registered", async () => {
+      // No registerPlugin call — the registry is empty for this slot. The
+      // pipeline terminal is `defaultToolErrorTerminal`, so direct AgentLoop
+      // callers that skip `bootstrapPlugins()` still get the nudge even
+      // without any registered middleware.
       const decision = await runToolErrorPipeline({
         hasToolError: true,
         consecutiveErrorTurns: 1,

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1016,8 +1016,7 @@ export class AgentLoop {
           // middleware is a passthrough (so later-registered user plugins
           // aren't shadowed), so this terminal is what actually produces
           // the decision when no user plugin overrides it. Wiring the
-          // decision here — rather than inside the default plugin's
-          // middleware — also preserves the legacy nudge for direct
+          // decision here also ensures the nudge fires for direct
           // AgentLoop callers (tests, benchmarks) that skip
           // `bootstrapPlugins()` and therefore never register the default.
           async (args) => defaultToolErrorTerminal(args),


### PR DESCRIPTION
Addresses review feedback on #27642. Rewrites two comments and a test name to describe current behavior instead of narrating the change from the previous implementation.

- `tool-error-pipeline.test.ts`: test name and comment drop "still", "legacy", "now passes", and "rather than an inline \`() => skip\`".
- `agent/loop.ts`: comment drops "preserves the legacy nudge" and the "rather than inside the default plugin's middleware" contrast.

Per `assistant/AGENTS.md`: comments describe current state, not history.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
