### PR TITLE
fix(cli/skills): tag plugin-source skills as [bundled] in search output

### DIFF
--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -369,7 +369,10 @@ Examples:
           log.info(`Bundled & installed skills (${bundledMatches.length}):\n`);
           for (const s of bundledMatches) {
             const emoji = s.emoji ? `${s.emoji} ` : "";
-            const tag = s.source === "bundled" ? " [bundled]" : " [installed]";
+            const tag =
+              s.source === "bundled" || s.source === "plugin"
+                ? " [bundled]"
+                : " [installed]";
             log.info(`  ${emoji}${s.displayName}${tag}`);
             if (s.displayName !== s.id) {
               log.info(`    ID: ${s.id}`);


### PR DESCRIPTION
## Summary

The `skills search` command only checked `source === "bundled"` when picking the `[bundled]` vs `[installed]` tag, so plugin-source skills (already grouped under "Bundled & installed skills") fell through to `[installed]`. This matches the treatment in the `list` command (line ~82) where plugin-source skills are categorized as bundled.

Addresses review feedback on #27628.

## Test plan
- [x] Verified file contents and line numbers
- [x] Searched skills.ts for other `source === "bundled"` checks — none found
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
