### PR TITLE
fix(meet-join): close AUTH handshake oversize bypass

### DIFF
--- a/skills/meet-join/daemon/audio-ingest.ts
+++ b/skills/meet-join/daemon/audio-ingest.ts
@@ -513,12 +513,12 @@ export class MeetAudioIngest {
       if (settled) return;
       buffer = Buffer.concat([buffer, chunk]);
       const newline = buffer.indexOf(0x0a);
-      if (newline === -1) {
-        if (buffer.length > MAX_HANDSHAKE_BYTES) {
-          finish(() => callbacks.onReject("handshake-too-long"));
-        }
+      const handshakeLen = newline === -1 ? buffer.length : newline;
+      if (handshakeLen > MAX_HANDSHAKE_BYTES) {
+        finish(() => callbacks.onReject("handshake-too-long"));
         return;
       }
+      if (newline === -1) return;
       const line = buffer.subarray(0, newline).toString("utf8");
       const residual =
         newline + 1 < buffer.length ? buffer.subarray(newline + 1) : null;


### PR DESCRIPTION
Codex P2 from #27652.

`authenticateConnection` only enforced `MAX_HANDSHAKE_BYTES` when no newline had been seen yet. A peer could send a newline-terminated first chunk whose handshake portion already exceeded the cap and bypass the guard — the code would then UTF-8 decode and buffer the oversized line before rejecting on token mismatch.

Fix: compute the handshake-line length (bytes before the newline if present, else full buffer) and reject early if it exceeds `MAX_HANDSHAKE_BYTES`, before any decode or token comparison.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
