### PR TITLE
docs(plugins): rewrite llm-call pipeline comments in present tense

### DIFF
--- a/assistant/src/__tests__/llm-call-pipeline.test.ts
+++ b/assistant/src/__tests__/llm-call-pipeline.test.ts
@@ -198,13 +198,12 @@ describe("llmCall pipeline", () => {
   });
 
   test("default registered first does not shadow later-registered user middleware", async () => {
-    // Regression for a shadowing bug where `defaultLlmCallPlugin` called
-    // `provider.sendMessage` directly instead of `next(args)`. Because the
-    // default registers at module load (before `bootstrapPlugins()` loads
-    // user plugins), it sat at the outermost layer in production — any
-    // user-registered `llmCall` middleware would have been silently skipped.
-    // This test locks in the fix by registering the default FIRST (matching
-    // production ordering) and asserting a user-registered spy still runs.
+    // The default plugin registers at module load (before `bootstrapPlugins()`
+    // loads user plugins), so it sits at the outermost layer in the onion.
+    // This test registers the default FIRST (matching production ordering)
+    // and asserts that a user-registered spy still runs — confirming that
+    // the outermost middleware forwards via `next(args)` rather than
+    // short-circuiting the chain.
     const observed: LLMCallArgs[] = [];
     const spyPlugin: Plugin = {
       manifest: {

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -494,14 +494,13 @@ export class AgentLoop {
         // Wrap the provider call in the `llmCall` pipeline so middleware
         // contributed by plugins may observe, rewrite, short-circuit, or
         // post-process every LLM request. The terminal below is the real
-        // `provider.sendMessage(...)` call; middleware that call `next(args)`
-        // eventually reach it. The default `defaultLlmCallPlugin` contributes
-        // only a passthrough middleware that forwards to `next(args)` —
-        // registered at module load, it sits at the outermost layer in the
-        // onion, so short-circuiting there would silently disable every
-        // user-registered `llmCall` middleware. Timeout is `null`
-        // (`DEFAULT_TIMEOUTS.llmCall`) — the provider layer already enforces
-        // its own HTTP-level budgets.
+        // `provider.sendMessage(...)` call; middleware reach it by calling
+        // `next(args)`. The default `defaultLlmCallPlugin` contributes a
+        // passthrough middleware that forwards to `next(args)` — it
+        // registers at module load and sits at the outermost onion layer,
+        // so it must yield to keep user-registered `llmCall` middleware
+        // reachable. Timeout is `null` (`DEFAULT_TIMEOUTS.llmCall`) — the
+        // provider layer already enforces its own HTTP-level budgets.
         //
         // The `onEvent` wrapping is kept inside `args.options` so substitution
         // and streaming behavior exactly match the pre-pipeline call site.

--- a/assistant/src/plugins/defaults/llm-call.ts
+++ b/assistant/src/plugins/defaults/llm-call.ts
@@ -1,6 +1,6 @@
 /**
- * Default `llmCall` plugin — a true passthrough that declares the pipeline
- * surface and always yields to downstream middleware.
+ * Default `llmCall` plugin — a passthrough that declares the pipeline
+ * surface and yields to downstream middleware.
  *
  * The plugin system wraps every LLM request in the `llmCall` pipeline. The
  * actual call to {@link Provider.sendMessage} lives in the `runPipeline`
@@ -8,13 +8,10 @@
  * contribute the manifest (`provides.llmCall: "v1"`) so other plugins can
  * negotiate against the pipeline surface.
  *
- * Because this plugin is registered at module load — BEFORE user plugins are
- * loaded by `bootstrapPlugins()` — it sits at the outermost layer in
- * `composeMiddleware`'s onion ordering. If its middleware called
- * `provider.sendMessage` directly (instead of `next(args)`) it would
- * short-circuit the chain and silently disable every user-registered
- * `llmCall` middleware in production. The middleware therefore just forwards
- * to `next(args)`.
+ * This plugin registers at module load — before user plugins are loaded by
+ * `bootstrapPlugins()` — so it sits at the outermost layer in
+ * `composeMiddleware`'s onion ordering. To keep user-registered middleware
+ * reachable, the middleware forwards unconditionally via `next(args)`.
  *
  * Registered from `daemon/external-plugins-bootstrap.ts` via a side-effect
  * import so the plugin is present in the registry before


### PR DESCRIPTION
## Summary
- Addresses Devin's feedback on #27633: comments in the llm-call pipeline narrated the history of a fixed bug ("Regression for...", "it sat at", "would have been silently skipped", "locks in the fix") rather than describing current behavior.
- Rewrote the regression-test comment, the default plugin's file header, and the call-site comment in `agent/loop.ts` to describe what the code does today and why — no references to the prior bug or fix.

## Test plan
- [x] `bun test src/__tests__/llm-call-pipeline.test.ts` — unchanged behavior, comment-only
- [x] `bunx tsc --noEmit` — clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
