### PR TITLE
fix(plugins): make MemoryArgs.signal required

### DIFF
--- a/assistant/src/__tests__/memory-retrieval-pipeline.test.ts
+++ b/assistant/src/__tests__/memory-retrieval-pipeline.test.ts
@@ -66,6 +66,7 @@ function makeMemoryArgs(overrides: Partial<MemoryArgs> = {}): MemoryArgs {
     conversationId: "conv-test",
     trustContext: trust,
     turnIndex: 0,
+    signal: new AbortController().signal,
     ...overrides,
   };
 }
@@ -329,13 +330,10 @@ describe("memoryRetrieval pipeline — default vs custom plugin", () => {
   });
 
   test("pipeline timeout aborts the signal threaded into prepareMemory", async () => {
-    // Regression for the cancellation gap: before `MemoryArgs.signal` was
-    // swapped by the pipeline's abort-linker, a pipeline timeout rejected
-    // the race but left `prepareMemory` running — mutating graph state
-    // after the turn had already errored. This test wires a long-running
-    // `prepareMemory` fake, arms a tight budget, and asserts the signal
-    // the terminal actually received reports `aborted === true` once the
-    // timer fires.
+    // Verifies that the pipeline's abort-linker swaps `MemoryArgs.signal`
+    // for a linked signal so a pipeline timeout aborts `prepareMemory`
+    // and prevents graph-state mutation / event emission after the
+    // pipeline has already errored.
     let capturedSignal: AbortSignal | undefined;
     const hangingPrepare = mock(
       (

--- a/assistant/src/plugins/defaults/memory-retrieval.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval.ts
@@ -121,15 +121,10 @@ export async function runDefaultMemoryRetrieval(
     };
   }
 
-  // `prepareMemory` requires a non-optional signal. In production the agent
-  // loop always threads one via `args.signal`; the fallback `AbortController`
-  // keeps direct callers (e.g. tests that skip the pipeline) working without
-  // forcing every call site to synthesize a dummy signal.
-  const abortSignal = args.signal ?? new AbortController().signal;
   const graphResult = await deps.graphMemory.prepareMemory(
     deps.messages,
     deps.config,
-    abortSignal,
+    args.signal,
     deps.onEvent,
   );
 

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -236,7 +236,7 @@ export interface MemoryArgs {
   readonly conversationId: string;
   readonly trustContext: TrustContext | undefined;
   readonly turnIndex: number;
-  readonly signal?: AbortSignal;
+  readonly signal: AbortSignal;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Make `MemoryArgs.signal` non-optional so middleware cannot rebuild args without a signal and silently make cancellation best-effort
- Drop the `new AbortController().signal` fallback in `runDefaultMemoryRetrieval`
- Update the `memory-retrieval-pipeline` test fixture to supply a default signal
- Replace the history-narrating regression-test comment with a present-tense description of the behavior under test

Addresses review feedback on #27643.

## Test plan
- [x] `bun test src/__tests__/memory-retrieval-pipeline.test.ts` (12 pass)
- [x] `bunx tsc --noEmit` (no new errors)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
