### PR TITLE
fix(cli): drop trailing period in image-gen keys-set hint

### DIFF
--- a/assistant/src/cli/commands/image-generation.ts
+++ b/assistant/src/cli/commands/image-generation.ts
@@ -172,7 +172,7 @@ Examples:
       const hint =
         svc.mode === "managed"
           ? `${baseHint}\n  Run 'assistant auth login' to authenticate, or set services.image-generation.mode to 'your-own' in config.`
-          : `Run: assistant keys set ${provider} <key>.\n${baseHint}`;
+          : `Run: assistant keys set ${provider} <key>\n${baseHint}`;
       if (jsonOutput) {
         process.stdout.write(JSON.stringify({ ok: false, error: hint }) + "\n");
       } else {


### PR DESCRIPTION
Users copy-pasted the trailing period into their API key value, breaking downstream auth.

Addresses Codex P2 on #27657.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
