### PR TITLE
docs(tools/executor): rewrite history-narrating comments (PR #27651 review)

### DIFF
--- a/assistant/src/__tests__/tool-execute-pipeline.test.ts
+++ b/assistant/src/__tests__/tool-execute-pipeline.test.ts
@@ -334,14 +334,12 @@ describe("ToolExecutor.execute → toolExecute pipeline", () => {
   });
 
   test("slow middleware does not trip a pipeline-level timeout", async () => {
-    // Regression: `ToolExecutor.execute` used to pass the per-tool timeout
-    // to `runPipeline`, which made the pipeline race everything upstream of
-    // the tool call (permission checks, approval waits, middleware) against
-    // the same budget. A slow human clicking "allow" produced a
-    // `PluginTimeoutError` thrown past `executeInternal`'s catch block,
-    // breaking the `execute()` never-throws contract. The pipeline is now
-    // untimed; `executeWithTimeout` inside `executeInternal` is the sole
-    // enforcer of the per-tool budget and only wraps the actual tool call.
+    // Regression: the pipeline must NOT arm a timer — `executeWithTimeout`
+    // inside `executeInternal` is the sole enforcer of the per-tool budget
+    // and only wraps the actual tool call. Upstream phases (permission
+    // checks, approval waits, middleware) must not race the tool budget,
+    // because that would break the `execute()` never-throws contract when
+    // a slow phase (e.g. a human clicking "allow") exceeds the budget.
     const slow: Middleware<ToolExecuteArgs, ToolExecuteResult> =
       async function slowMw(args, next) {
         await new Promise((resolve) => setTimeout(resolve, 50));

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -60,16 +60,14 @@ export class ToolExecutor {
      * middleware registered on the `toolExecute` pipeline sees the same
      * context every other pipeline slot uses. When omitted (CLI/test
      * invocations that call `ToolExecutor.execute` directly), the executor
-     * synthesizes a fallback context from the {@link ToolContext}, which
-     * keeps pre-threading behavior intact for legacy callers.
+     * synthesizes a fallback context from the {@link ToolContext}.
      */
     turnContext?: TurnContext,
   ): Promise<ToolExecutionResult> {
     // Prefer the orchestrator-supplied `turnContext` so the pipeline sees
     // the real conversation identity, per-turn trust, and context-window
     // manager. When absent (CLI / test invocations that bypass the agent
-    // loop), synthesize a minimal context from the `ToolContext` — the
-    // same fallback the executor has used since the pipeline was added.
+    // loop), synthesize a minimal context from the `ToolContext`.
     const turnCtx: TurnContext = turnContext ?? {
       requestId: context.requestId ?? "",
       conversationId: context.conversationId,
@@ -85,14 +83,11 @@ export class ToolExecutor {
 
     // No pipeline-level timeout: `executeInternal` already wraps the real
     // tool invocation in `executeWithTimeout`, which is the sole enforcer
-    // of the per-tool budget. Propagating `perToolTimeoutMs` to
-    // `runPipeline` made the pipeline race everything upstream of the
-    // tool call — permission checks, approval waits, middleware — against
-    // the same budget, so a slow human clicking "allow" produced a
-    // `PluginTimeoutError` thrown past `executeInternal`'s catch block,
-    // breaking the `execute()` never-throws contract. Letting the pipeline
-    // run untimed keeps the contract intact; runaway middleware is a
-    // plugin-health concern handled by per-plugin timeouts, not here.
+    // of the per-tool budget. The pipeline itself runs untimed so that
+    // upstream phases (permission checks, approval waits, middleware) are
+    // not racing the tool budget — only the actual tool call is. Runaway
+    // middleware is a plugin-health concern handled by per-plugin timeouts,
+    // not here.
     return runPipeline<ToolExecuteArgs, ToolExecuteResult>(
       "toolExecute",
       middlewares,


### PR DESCRIPTION
## Summary

Addresses review feedback on #27651 — rewrites history-narrating comments in `assistant/src/tools/executor.ts` and `assistant/src/__tests__/tool-execute-pipeline.test.ts` as present-tense descriptions of current behavior.

## Test plan

- [x] Comments-only change; no behavior affected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
