### PR TITLE
fix(overflow-reduce): classify throwIfAborted cancellation, add test awaits, drop history comments

### DIFF
--- a/assistant/src/__tests__/overflow-reduce-pipeline.test.ts
+++ b/assistant/src/__tests__/overflow-reduce-pipeline.test.ts
@@ -591,7 +591,7 @@ describe("overflow-reduce pipeline", () => {
         },
       };
 
-      expect(
+      await expect(
         defaultOverflowReduceMiddleware(
           aborting,
           async () => {
@@ -600,8 +600,6 @@ describe("overflow-reduce pipeline", () => {
           makeTurnContext(),
         ),
       ).rejects.toThrow();
-      // Give the event loop a tick to resolve the rejected promise.
-      await Promise.resolve();
       // Exactly one iteration ran; the abort gate stopped the next round.
       expect(estimateCalls).toBe(1);
     });
@@ -616,7 +614,7 @@ describe("overflow-reduce pipeline", () => {
         abortSignal: controller.signal,
       };
 
-      expect(
+      await expect(
         defaultOverflowReduceMiddleware(
           args,
           async () => {
@@ -625,7 +623,6 @@ describe("overflow-reduce pipeline", () => {
           makeTurnContext(),
         ),
       ).rejects.toThrow();
-      await Promise.resolve();
       // Reducer never ran — zero compaction and reinject callbacks observed.
       expect(build.compactionResults).toHaveLength(0);
       expect(build.reinjectCalls).toHaveLength(0);

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1450,8 +1450,8 @@ export async function runAgentLoopImpl(
           // When THIS iteration compacted, it stripped existing NOW.md /
           // PKB blocks — so we re-inject current content. A later iteration
           // that only truncates or downgrades must NOT re-force PKB/NOW,
-          // or each round would grow the token count. Matches the
-          // pre-PR-23 per-iteration `step.compactionResult?.compacted` gate.
+          // or each round would grow the token count.
+          // Gate: only the iteration that actually compacted re-injects.
           const injection = await applyRuntimeInjections(reducedMessages, {
             ...injectionOpts,
             ...(stepCompacted && { pkbContext: currentPkbContent }),

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -125,7 +125,10 @@ export interface ErrorContext {
  * which erases the `AbortError` name. To compensate, the daemon tags every
  * `controller.abort(reason)` call with an `AbortReason` object — when the
  * wrapped `ProviderError` carries that tagged reason, we treat it as a user
- * cancellation regardless of error class.
+ * cancellation regardless of error class. The same tagged object can also
+ * surface directly (e.g. when code calls `AbortSignal.throwIfAborted()`,
+ * which throws `signal.reason` verbatim), so a bare `AbortReason` is
+ * recognized as cancellation too.
  */
 export function isUserCancellation(error: unknown, ctx: ErrorContext): boolean {
   if (!ctx.aborted) return false;
@@ -134,6 +137,7 @@ export function isUserCancellation(error: unknown, ctx: ErrorContext): boolean {
   if (error instanceof ProviderError && isAbortReason(error.abortReason)) {
     return true;
   }
+  if (isAbortReason(error)) return true;
   return false;
 }
 

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -411,7 +411,7 @@ export interface OverflowReduceArgs {
    * mutable shared state. Returns the new `runMessages`.
    *
    * Two distinct "did compact" signals are passed so the orchestrator can
-   * match the pre-PR-23 semantics:
+   * apply the correct per-iteration vs sticky gating:
    * - `stepCompacted` — whether THIS iteration's reducer step produced a
    *   fresh compaction. Gates PKB / NOW re-injection: compaction strips the
    *   existing blocks, so only iterations that just compacted need the


### PR DESCRIPTION
## Summary
Addresses review feedback on #27641.

- **Codex P1 — `throwIfAborted()` cancellation classification.** `AbortSignal.throwIfAborted()` throws `signal.reason` verbatim. Conversation abort signals carry a tagged `AbortReason` object, which `isUserCancellation` did not previously recognize as a bare value — so a user stop during overflow reduction was classified as a conversation error rather than a cancellation. Extended `isUserCancellation` in `assistant/src/daemon/conversation-error.ts` to recognize a bare `AbortReason` alongside the existing `AbortError` / wrapped-`ProviderError` shapes. Fixes classification upstream so any future `throwIfAborted()` call site on a conversation abort signal routes correctly.
- **Devin bugs 1 & 2 — missing `await` on `expect(...).rejects.toThrow()`.** The two abort-signal tests in `overflow-reduce-pipeline.test.ts` were fire-and-forget, so the rejection assertions passed vacuously. Added `await` and removed the now-unnecessary `await Promise.resolve()` tick.
- **Devin bugs 3 & 4 — drop "pre-PR-23" references.** Two newly added comments narrated removed code, violating `assistant/AGENTS.md`'s code-comments rule. Rewrote each in present tense describing current behavior (in `conversation-agent-loop.ts` and `plugins/types.ts`).

## Test plan
- [x] `bun test src/__tests__/overflow-reduce-pipeline.test.ts src/__tests__/conversation-error.test.ts` — 115 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
