### PR TITLE
fix(config): restore strict image-gen prefix + inline migration helper

### DIFF
--- a/assistant/src/media/types.ts
+++ b/assistant/src/media/types.ts
@@ -34,12 +34,12 @@ export const MAX_VARIANTS = 4;
 
 /**
  * Derive the image-generation provider from a model identifier by prefix.
- * Canonical mapping shared between the runtime model setter
- * (`setImageGenModel`) and workspace migration 006-services-config so the
- * two cannot drift. Unknown models fall through to "gemini".
+ * Shared with the runtime dispatcher `providerForModel` in
+ * `image-service.ts`; prefixes must stay in sync with that function.
+ * Unknown models fall through to "gemini".
  */
 export function providerForImageModelPrefix(model: string): ImageGenProvider {
-  if (model.startsWith("gpt") || model.startsWith("dall-e")) {
+  if (model.startsWith("gpt-") || model.startsWith("dall-e-")) {
     return "openai";
   }
   return "gemini";

--- a/assistant/src/workspace/migrations/006-services-config.ts
+++ b/assistant/src/workspace/migrations/006-services-config.ts
@@ -1,13 +1,22 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { providerForImageModelPrefix } from "../../media/types.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
   getProviderKeyAsync,
   getSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import type { WorkspaceMigration } from "./types.js";
+
+// Inlined per workspace-migration self-containment rule (see migrations
+// AGENTS.md). Mirrors the runtime prefix logic in `media/types.ts` and
+// `media/image-service.ts`; kept strict (`gpt-`/`dall-e-`) to match.
+function providerForImageModelPrefix(model: string): "gemini" | "openai" {
+  if (model.startsWith("gpt-") || model.startsWith("dall-e-")) {
+    return "openai";
+  }
+  return "gemini";
+}
 
 export const servicesConfigMigration: WorkspaceMigration = {
   id: "006-services-config",


### PR DESCRIPTION
## Summary
- **Migration self-containment**: `assistant/src/workspace/migrations/006-services-config.ts` was importing `providerForImageModelPrefix` from `../../media/types.js`, which violates the self-containment rule in `assistant/src/workspace/migrations/AGENTS.md` (migrations must duplicate shared helpers, not import them). Inline the 5-line helper directly in the migration.
- **Prefix consistency**: The shared `providerForImageModelPrefix` had been relaxed from `gpt-`/`dall-e-` to `gpt`/`dall-e`, diverging from the runtime dispatcher `providerForModel` in `image-service.ts` (still strict). Restore strict prefixes in both the shared helper and the inlined migration copy so all three provider-for-model paths match. No existing callers/tests use hyphenless model IDs, so behavior is unchanged for real inputs.

Addresses Codex P1 + Devin review feedback on #27647.

## Test plan
- [x] `bunx tsc --noEmit` (no new errors in changed files)
- [x] Existing tests for migration 006 and `setImageGenModel` use hyphenated model IDs (`gpt-4o`, `dall-e-3`, `dall-e-2`, `gemini-2.5-flash-image`) and continue to pass with strict prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
