### PR TITLE
refactor(meet-join): migrate meet-internal route to SkillHost

### DIFF
--- a/skills/meet-join/__tests__/register.test.ts
+++ b/skills/meet-join/__tests__/register.test.ts
@@ -28,7 +28,11 @@ import { afterAll, describe, expect, mock, test } from "bun:test";
 let lastHandlerMeetingId: string | null = null;
 mock.module("../routes/meet-internal.js", () => ({
   MEET_INTERNAL_EVENTS_PATH_RE: /^\/v1\/internal\/meet\/([^/]+)\/events$/,
-  handleMeetInternalEvents: async (_req: Request, meetingId: string) => {
+  handleMeetInternalEvents: async (
+    _host: SkillHost,
+    _req: Request,
+    meetingId: string,
+  ) => {
     lastHandlerMeetingId = meetingId;
     return new Response(null, { status: 204 });
   },

--- a/skills/meet-join/register.ts
+++ b/skills/meet-join/register.ts
@@ -79,7 +79,7 @@ export function register(host: SkillHost): void {
           ),
         );
       }
-      return handleMeetInternalEvents(req, meetingId);
+      return handleMeetInternalEvents(host, req, meetingId);
     },
   });
 

--- a/skills/meet-join/routes/__tests__/meet-internal.test.ts
+++ b/skills/meet-join/routes/__tests__/meet-internal.test.ts
@@ -10,10 +10,38 @@
 
 import { describe, expect, test } from "bun:test";
 
+import type { SkillHost } from "@vellumai/skill-host-contracts";
+
 import type { MeetBotEvent } from "../../contracts/index.js";
 
 import { MeetSessionEventRouter } from "../../daemon/session-event-router.js";
 import { handleMeetInternalEvents } from "../meet-internal.js";
+
+/**
+ * Minimal host stub covering just the surface `handleMeetInternalEvents`
+ * touches today — logger access. Extended to a full `SkillHost` via a
+ * throwing proxy so any unexpected facet access fails loudly rather than
+ * silently returning `undefined`.
+ */
+function buildTestHost(): SkillHost {
+  const noopLogger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+  const throwing = (name: string): never => {
+    throw new Error(`unexpected host.${name} access in meet-internal test`);
+  };
+  return new Proxy({} as SkillHost, {
+    get: (_t, prop) => {
+      if (prop === "logger") return { get: () => noopLogger };
+      return throwing(String(prop));
+    },
+  });
+}
+
+const host: SkillHost = buildTestHost();
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -99,7 +127,7 @@ describe("handleMeetInternalEvents — auth", () => {
       body: [lifecycleEvent("m1")],
     });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(401);
     const body = (await res.json()) as { error: { code: string } };
@@ -110,7 +138,7 @@ describe("handleMeetInternalEvents — auth", () => {
     const { router } = makeRouterWithToken("m1", "secret");
     const req = buildRequest("m1", { body: [lifecycleEvent("m1")] });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(401);
   });
@@ -122,7 +150,7 @@ describe("handleMeetInternalEvents — auth", () => {
       body: [lifecycleEvent("m1")],
     });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(401);
   });
@@ -138,7 +166,7 @@ describe("handleMeetInternalEvents — auth", () => {
       body: JSON.stringify([lifecycleEvent("m1")]),
     });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(401);
   });
@@ -158,7 +186,7 @@ describe("handleMeetInternalEvents — success path", () => {
     ];
     const req = buildRequest("m1", { bearer: "tok-1", body: batch });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(204);
     expect(received).toEqual(batch);
@@ -172,7 +200,7 @@ describe("handleMeetInternalEvents — success path", () => {
 
     const req = buildRequest("m1", { bearer: "tok-1", body: [] });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(204);
     expect(received).toEqual([]);
@@ -188,7 +216,7 @@ describe("handleMeetInternalEvents — success path", () => {
       body: [lifecycleEvent("m1")],
     });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(204);
   });
@@ -208,7 +236,7 @@ describe("handleMeetInternalEvents — success path", () => {
       body: JSON.stringify([lifecycleEvent("m1")]),
     });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(204);
     expect(received).toHaveLength(1);
@@ -220,7 +248,7 @@ describe("handleMeetInternalEvents — body validation", () => {
     const { router } = makeRouterWithToken("m1", "tok");
     const req = buildRequest("m1", { bearer: "tok", rawBody: "not-json{" });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: { code: string } };
@@ -234,7 +262,7 @@ describe("handleMeetInternalEvents — body validation", () => {
       body: { not: "an array" },
     });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(400);
   });
@@ -252,7 +280,7 @@ describe("handleMeetInternalEvents — body validation", () => {
       ],
     });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(400);
   });
@@ -272,7 +300,7 @@ describe("handleMeetInternalEvents — body validation", () => {
       ],
     });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(400);
   });
@@ -291,7 +319,7 @@ describe("handleMeetInternalEvents — body validation", () => {
       ],
     });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(400);
     // Importantly: the valid event was NOT dispatched — we reject the
@@ -314,7 +342,7 @@ describe("handleMeetInternalEvents — body validation", () => {
       body: [lifecycleEvent("m1"), lifecycleEvent("m2")],
     });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(400);
     // Atomic rejection: a mid-batch mismatch aborts the whole batch and
@@ -330,7 +358,7 @@ describe("handleMeetInternalEvents — method enforcement", () => {
     const { router } = makeRouterWithToken("m1", "tok");
     const req = buildRequest("m1", { method: "GET", bearer: "tok" });
 
-    const res = await handleMeetInternalEvents(req, "m1", router);
+    const res = await handleMeetInternalEvents(host, req, "m1", router);
 
     expect(res.status).toBe(405);
     expect(res.headers.get("allow")).toBe("POST");

--- a/skills/meet-join/routes/meet-internal.ts
+++ b/skills/meet-join/routes/meet-internal.ts
@@ -38,17 +38,14 @@
 
 import { timingSafeEqual } from "node:crypto";
 
-import { MeetBotEventSchema } from "../contracts/index.js";
+import type { SkillHost } from "@vellumai/skill-host-contracts";
 import { z } from "zod";
 
+import { MeetBotEventSchema } from "../contracts/index.js";
 import {
   getMeetSessionEventRouter,
   type MeetSessionEventRouter,
 } from "../daemon/session-event-router.js";
-import { getLogger } from "../../../assistant/src/util/logger.js";
-import { httpError } from "../../../assistant/src/runtime/http-errors.js";
-
-const log = getLogger("meet-internal-routes");
 
 /**
  * Batched-event request body. The bot buffers events briefly and ships
@@ -56,6 +53,28 @@ const log = getLogger("meet-internal-routes");
  */
 export const MeetIngressBatchSchema = z.array(MeetBotEventSchema);
 export type MeetIngressBatch = z.infer<typeof MeetIngressBatchSchema>;
+
+// ── Local HTTP error helper ─────────────────────────────────────────────────
+//
+// The skill no longer imports `httpError` from `assistant/src/runtime/`; the
+// skill-isolation plan (`.private/plans/skill-isolation.md`) bans all
+// `assistant/` reach-ins from `skills/`. The wire envelope below is the
+// exact shape produced by `assistant/src/runtime/http-errors.ts` so clients
+// (the meet bot) observe no change.
+
+type MeetRouteErrorCode = "BAD_REQUEST" | "UNAUTHORIZED";
+
+function meetRouteError(
+  code: MeetRouteErrorCode,
+  message: string,
+  status: number,
+  details?: unknown,
+): Response {
+  const body = {
+    error: { code, message, ...(details !== undefined ? { details } : {}) },
+  };
+  return Response.json(body, { status });
+}
 
 /**
  * Handle `POST /v1/internal/meet/:meetingId/events`.
@@ -67,12 +86,20 @@ export type MeetIngressBatch = z.infer<typeof MeetIngressBatchSchema>;
  *      constant-time comparison. 401 on any mismatch.
  *   3. Dispatch each validated event to the registered session handler.
  *   4. Return 204 on success.
+ *
+ * `host` provides logger access (replacing the former direct import of
+ * `getLogger` from `assistant/`). `router` remains an injectable default
+ * for tests that want to drive a fresh router without hitting the module
+ * singleton.
  */
 export async function handleMeetInternalEvents(
+  host: SkillHost,
   req: Request,
   meetingId: string,
   router: MeetSessionEventRouter = getMeetSessionEventRouter(),
 ): Promise<Response> {
+  const log = host.logger.get("meet-internal-routes");
+
   if (req.method !== "POST") {
     return new Response("method not allowed", {
       status: 405,
@@ -84,19 +111,19 @@ export async function handleMeetInternalEvents(
   const expectedToken = router.resolveBotApiToken(meetingId);
   if (!expectedToken) {
     log.warn(
-      { meetingId },
       "meet-internal: no active session for meetingId; rejecting",
+      { meetingId },
     );
-    return httpError("UNAUTHORIZED", "unauthorized", 401);
+    return meetRouteError("UNAUTHORIZED", "unauthorized", 401);
   }
 
   const presented = parseBearerToken(req.headers.get("authorization"));
   if (!presented || !tokensMatch(presented, expectedToken)) {
     log.warn(
-      { meetingId, tokenPresented: presented !== null },
       "meet-internal: bearer token mismatch; rejecting",
+      { meetingId, tokenPresented: presented !== null },
     );
-    return httpError("UNAUTHORIZED", "unauthorized", 401);
+    return meetRouteError("UNAUTHORIZED", "unauthorized", 401);
   }
 
   // ── Body parse ───────────────────────────────────────────────────────
@@ -104,16 +131,16 @@ export async function handleMeetInternalEvents(
   try {
     rawBody = await req.json();
   } catch {
-    return httpError("BAD_REQUEST", "invalid JSON body", 400);
+    return meetRouteError("BAD_REQUEST", "invalid JSON body", 400);
   }
 
   const parsed = MeetIngressBatchSchema.safeParse(rawBody);
   if (!parsed.success) {
     log.warn(
-      { meetingId, issues: parsed.error.issues },
       "meet-internal: invalid event batch",
+      { meetingId, issues: parsed.error.issues },
     );
-    return httpError(
+    return meetRouteError(
       "BAD_REQUEST",
       "invalid event batch",
       400,
@@ -131,14 +158,14 @@ export async function handleMeetInternalEvents(
   for (const event of parsed.data) {
     if (event.meetingId !== meetingId) {
       log.warn(
+        "meet-internal: event meetingId does not match path",
         {
           pathMeetingId: meetingId,
           eventMeetingId: event.meetingId,
           eventType: event.type,
         },
-        "meet-internal: event meetingId does not match path",
       );
-      return httpError(
+      return meetRouteError(
         "BAD_REQUEST",
         "event meetingId does not match path",
         400,


### PR DESCRIPTION
## Summary
- routes/meet-internal.ts's handlers now accept a SkillHost; assistant/ imports removed.
- register.ts threads the host into the route handler closure.

Part of plan: skill-isolation.md (PR 15 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
