### PR TITLE
fix(tests): set GUARDIAN_BOOTSTRAP_SECRET in containerized bootstrap test

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -740,15 +740,20 @@ describe("bootstrap private-network guard", () => {
   });
 
   test("accepts LAN peer in containerized mode", async () => {
-    const prev = process.env.IS_CONTAINERIZED;
+    const prevContainerized = process.env.IS_CONTAINERIZED;
+    const prevSecret = process.env.GUARDIAN_BOOTSTRAP_SECRET;
     process.env.IS_CONTAINERIZED = "true";
+    process.env.GUARDIAN_BOOTSTRAP_SECRET = "test-bootstrap-secret";
     try {
       const { handleGuardianBootstrap } =
         await import("../runtime/routes/guardian-bootstrap-routes.js");
 
       const req = new Request("http://localhost/v1/guardian/init", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "x-bootstrap-secret": "test-bootstrap-secret",
+        },
         body: JSON.stringify({
           platform: "macos",
           deviceId: "test-device-docker",
@@ -758,10 +763,15 @@ describe("bootstrap private-network guard", () => {
       const res = await handleGuardianBootstrap(req, lanPeerServer);
       expect(res.status).toBe(200);
     } finally {
-      if (prev === undefined) {
+      if (prevContainerized === undefined) {
         delete process.env.IS_CONTAINERIZED;
       } else {
-        process.env.IS_CONTAINERIZED = prev;
+        process.env.IS_CONTAINERIZED = prevContainerized;
+      }
+      if (prevSecret === undefined) {
+        delete process.env.GUARDIAN_BOOTSTRAP_SECRET;
+      } else {
+        process.env.GUARDIAN_BOOTSTRAP_SECRET = prevSecret;
       }
     }
   });


### PR DESCRIPTION
## Summary

- The "accepts LAN peer in containerized mode" test in `actor-token-service.test.ts` expected HTTP 200 but was returning 403 on main.
- Commit 3d136102d6 added `x-bootstrap-secret` enforcement in containerized mode to close a Docker port-publish bypass, but did not update this older sibling test — only the new `guardian-bootstrap-routes.test.ts` exercises the new contract.
- Set `GUARDIAN_BOOTSTRAP_SECRET` env var and send the matching `x-bootstrap-secret` header so the test reflects the current gate while still verifying LAN peers are accepted in containerized mode.

## Original prompt

--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24855077933/job/72765660568
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
