### PR TITLE
docs: rewrite remaining pre-migration comment references in present tense

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1723,15 +1723,11 @@ const DEFAULT_PLACEMENT: InjectionPlacement = "append-user-tail";
  * Count leading memory-prefix blocks on a user message's `content`.
  *
  * Delegates to {@link countMemoryPrefixBlocks} from
- * `memory/graph/conversation-graph-memory.js` — the same state-machine the
- * pre-migration PKB-reminder branch used to find its splice point. The
- * pre-migration `injectPkbContext` and `injectNowScratchpad` helpers used
- * slightly simpler rules inline; reusing the canonical counter here
- * collapses the three near-identical splice rules into one source of truth
- * so the ordering of PKB-context / PKB-reminder / NOW blocks relative to
- * any memory prefix is stable and testable. For the common case (just
- * `<memory __injected>` text, no images), the output is byte-identical to
- * the pre-migration helpers.
+ * `memory/graph/conversation-graph-memory.js` — the canonical state-machine
+ * for locating the memory-prefix boundary. Reusing it here keeps the
+ * PKB-context / PKB-reminder / NOW splice rules aligned on a single source
+ * of truth so their ordering relative to any memory prefix is stable and
+ * testable.
  */
 function countMemoryPrefixBlocksOnContent(content: ContentBlock[]): number {
   return countMemoryPrefixBlocks(content);
@@ -1739,19 +1735,15 @@ function countMemoryPrefixBlocksOnContent(content: ContentBlock[]): number {
 
 /**
  * Apply one injector block to a `runMessages` array according to its
- * declared {@link InjectionPlacement}.
- *
- * Preserves the byte-for-byte positional semantics of the pre-migration
- * `inject*` helpers:
+ * declared {@link InjectionPlacement}:
  *  - `"prepend-user-tail"` — prepend to the tail user message's content.
  *  - `"append-user-tail"`  — append to the tail user message's content.
  *  - `"after-memory-prefix"` — splice immediately after any leading memory
- *    prefix blocks (mirrors `injectPkbContext` / `injectNowScratchpad`).
+ *    prefix blocks.
  *  - `"replace-run-messages"` — replace `runMessages` wholesale with
  *    `block.messagesOverride`.
  *
- * Blocks with empty `text` on non-replace placements are no-ops (the
- * pre-migration branches also short-circuited on empty strings).
+ * Blocks with empty `text` on non-replace placements are no-ops.
  */
 function applyInjectionBlock(
   runMessages: Message[],
@@ -2053,9 +2045,7 @@ export async function applyRuntimeInjections(
   //
   // The capture is gated on the tail actually being a user message — if it
   // isn't, `applyInjectionBlock` no-ops the block and no content is actually
-  // injected, so the persisted metadata must be undefined (matches
-  // pre-migration behaviour where the `inject*` helpers short-circuited the
-  // same way).
+  // injected, so the persisted metadata must be undefined.
   let turnContextCaptured: string | undefined;
   let workspaceCaptured: string | undefined;
   let nowScratchpadCaptured: string | undefined;
@@ -2086,10 +2076,8 @@ export async function applyRuntimeInjections(
   }
 
   // Compose the block text into a single informational string for
-  // `injectorChainBlock`. Matches the pre-migration behaviour where the
-  // field captured the composed view of every third-party injector on
-  // the turn. We include default injectors here too so downstream
-  // observers see the full set.
+  // `injectorChainBlock` — a composed view of every injector that fired on
+  // the turn, including defaults, so downstream observers see the full set.
   const injectorChainPieces: string[] = [];
   for (const block of chainBlocks) {
     if (block.text.length > 0) injectorChainPieces.push(block.text);

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -157,10 +157,10 @@ export const unifiedTurnContextInjector: Injector = {
  * yielding `[...memory, <system_reminder>, <knowledge_base>, ...user text]`.
  *
  * Emitting context and reminder as two separate blocks (rather than a single
- * concatenated text) preserves the pre-migration two-ContentBlock shape that
- * the rehydration path in `conversation-lifecycle.ts` recreates — keeping
- * fresh-injection and rehydrated-history structurally identical so
- * Anthropic's prefix cache matches across reloads.
+ * concatenated text) produces the two-ContentBlock shape that the rehydration
+ * path in `conversation-lifecycle.ts` recreates — keeping fresh-injection and
+ * rehydrated-history structurally identical so Anthropic's prefix cache
+ * matches across reloads.
  *
  * Gating:
  *  - `mode === "full"`.
@@ -189,7 +189,7 @@ export const pkbContextInjector: Injector = {
  * hints) as its own after-memory-prefix splice. Higher `order` than
  * `pkb-context` so the reminder splices second and ends up immediately
  * after the memory prefix, pushing `<knowledge_base>` one slot further
- * down — matching the pre-migration [reminder, context] ordering.
+ * down — producing a [reminder, context] ordering.
  *
  * Gating:
  *  - `mode === "full"`.
@@ -215,9 +215,7 @@ export const pkbReminderInjector: Injector = {
 /**
  * Render the PKB context block — wraps the raw content in
  * `<knowledge_base>...</knowledge_base>` while escaping any closing tags
- * inside the content that would break out of the XML wrapper. Mirrors the
- * body of the pre-migration `injectPkbContext` helper exactly so the emitted
- * bytes match.
+ * inside the content that would break out of the XML wrapper.
  */
 function buildPkbContextBlock(content: string): string {
   const escaped = content.replace(
@@ -367,10 +365,9 @@ export const subagentStatusInjector: Injector = {
  * orchestrator builds the transcript via `loadSlackChronologicalMessages`
  * before the chain runs.
  *
- * The injector preserves the pre-migration memory-block prepending
- * behaviour: `extractMemoryPrefixBlocks` is re-applied to the Slack
- * transcript's tail user message inside `applyRuntimeInjections` when the
- * replacement fires.
+ * Memory-block prepending is preserved across the replacement:
+ * `extractMemoryPrefixBlocks` is re-applied to the Slack transcript's tail
+ * user message inside `applyRuntimeInjections` when the replacement fires.
  *
  * Active in both `full` and `minimal` mode — Slack transcript replacement
  * is not a high-token optional block, it's the canonical view of Slack


### PR DESCRIPTION
## Summary

Follow-up to #27653 (Devin review feedback). That PR replaced the inline `inject*` helpers with a default-injector chain but left several doc comments referring to "pre-migration" behavior. Rewrite those comments to describe the current behavior directly.

Files:
- `assistant/src/plugins/defaults/injectors.ts` — pkb-context, pkb-reminder, buildPkbContextBlock, slack-messages docblocks.
- `assistant/src/daemon/conversation-runtime-assembly.ts` — countMemoryPrefixBlocksOnContent, applyInjectionBlock, metadata-capture and injectorChainBlock comments.

No behavior changes.

## Test plan

- [x] `bunx tsc --noEmit` — edited files clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
