### PR TITLE
fix(runtime): scope bootstrap-secret gate to Docker-only mode

### DIFF
--- a/assistant/src/config/env-registry.ts
+++ b/assistant/src/config/env-registry.ts
@@ -52,6 +52,28 @@ export function getIsContainerized(): boolean {
 }
 
 /**
+ * VELLUM_CLOUD — string, default: undefined
+ * Identifies the deployment topology when running containerized.
+ * Known values: "docker" (CLI-spawned Docker stack), "apple-container"
+ * (macOS Apple-container pod), "platform" (managed cloud).
+ */
+export function getVellumCloud(): string | undefined {
+  return str("VELLUM_CLOUD");
+}
+
+/**
+ * True iff this assistant is running under the Docker topology where the
+ * runtime HTTP port is published on the host (`-p host:container`). This is
+ * the only mode where host-local processes can reach the runtime endpoint
+ * directly, bypassing the gateway — so Docker mode requires the additional
+ * x-bootstrap-secret gate. Other containerized topologies (Apple containers,
+ * platform pods) keep the runtime port inside the pod network.
+ */
+export function isDockerCloud(): boolean {
+  return getVellumCloud() === "docker";
+}
+
+/**
  * IS_PLATFORM — boolean, default: false
  * When true, indicates the assistant is running as a platform-managed
  * remote instance. Controls platform-specific behaviors like webhook

--- a/assistant/src/runtime/routes/__tests__/guardian-bootstrap-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/guardian-bootstrap-routes.test.ts
@@ -56,6 +56,7 @@ function makeRequest(headers: Record<string, string> = {}): Request {
 
 const ENV_KEYS = [
   "IS_CONTAINERIZED",
+  "VELLUM_CLOUD",
   "GUARDIAN_BOOTSTRAP_SECRET",
   "DISABLE_HTTP_AUTH",
   "VELLUM_UNSAFE_AUTH_BYPASS",
@@ -76,9 +77,10 @@ afterEach(() => {
   }
 });
 
-describe("handleGuardianBootstrap — containerized mode secret enforcement", () => {
+describe("handleGuardianBootstrap — Docker mode secret enforcement", () => {
   beforeEach(() => {
     process.env.IS_CONTAINERIZED = "true";
+    process.env.VELLUM_CLOUD = "docker";
   });
 
   test("rejects with 403 when GUARDIAN_BOOTSTRAP_SECRET env is unset (fail-closed)", async () => {
@@ -145,6 +147,31 @@ describe("handleGuardianBootstrap — containerized mode secret enforcement", ()
     const res = await handleGuardianBootstrap(
       makeRequest(),
       makeServer("192.168.1.10"),
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("handleGuardianBootstrap — non-Docker containerized modes", () => {
+  // Apple-container pods and managed platform pods set IS_CONTAINERIZED=true
+  // but keep the runtime port inside the pod network. They do not need (or
+  // set) GUARDIAN_BOOTSTRAP_SECRET, so the gate must not fire for them.
+
+  test("Apple-container pod accepts loopback peer without a bootstrap secret", async () => {
+    process.env.IS_CONTAINERIZED = "true";
+    process.env.VELLUM_CLOUD = "apple-container";
+    const res = await handleGuardianBootstrap(
+      makeRequest(),
+      makeServer("127.0.0.1"),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("containerized without VELLUM_CLOUD accepts a private-network peer without a secret", async () => {
+    process.env.IS_CONTAINERIZED = "true";
+    const res = await handleGuardianBootstrap(
+      makeRequest(),
+      makeServer("172.17.0.1"),
     );
     expect(res.status).toBe(200);
   });

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -28,7 +28,10 @@ type ServerWithRequestIP = {
   ): { address: string; family: string; port: number } | null;
 };
 import { isHttpAuthDisabled } from "../../config/env.js";
-import { getIsContainerized } from "../../config/env-registry.js";
+import {
+  getIsContainerized,
+  isDockerCloud,
+} from "../../config/env-registry.js";
 
 const log = getLogger("guardian-bootstrap");
 
@@ -132,11 +135,13 @@ export async function handleGuardianBootstrap(
     return httpError("FORBIDDEN", "Bootstrap endpoint is local-only", 403);
   }
 
-  // In containerized mode, require a valid bootstrap secret — this closes
-  // the bypass where a host-local client could hit the published runtime
-  // port directly and skip the gateway's gate. Fails closed if the env var
-  // is unset in containerized deployments.
-  if (containerized && !isHttpAuthDisabled()) {
+  // In Docker mode specifically, require a valid bootstrap secret — this
+  // closes the bypass where a host-local client could hit the published
+  // runtime port directly and skip the gateway's gate. Fails closed if the
+  // env var is unset. Other containerized topologies (Apple-container pods,
+  // managed platform pods) keep the runtime port inside the pod network and
+  // do not need this additional gate.
+  if (isDockerCloud() && !isHttpAuthDisabled()) {
     if (!isBootstrapSecretValid(req)) {
       log.warn(
         { peerIp },


### PR DESCRIPTION
## Summary

Addresses Codex P1 feedback on #27620.

The new bootstrap-secret gate fired for any container that set `IS_CONTAINERIZED=true`, including the Apple-container path where `GUARDIAN_BOOTSTRAP_SECRET` is intentionally not propagated. Result: gateway-forwarded bootstrap requests in Apple-container mode always returned 403.

The bypass that motivated the gate is specific to the Docker topology, where the runtime HTTP port is host-published (`-p host:container`) so sibling Meet-bot containers can reach it via `host.docker.internal`. Other containerized topologies (Apple-container pods, managed platform pods) keep the runtime port inside the pod network and don't need the additional gate.

## Changes

- Add `getVellumCloud()` and `isDockerCloud()` helpers in `assistant/src/config/env-registry.ts`.
- Narrow the bootstrap-secret check in `guardian-bootstrap-routes.ts` from `containerized` to `isDockerCloud()`.
- Update tests: rename the existing block to "Docker mode secret enforcement" and set `VELLUM_CLOUD=docker` in its setup. Add a new block covering Apple-container mode (200 with no secret) and containerized-without-cloud (200 with no secret).

The peer-IP gate and `x-forwarded-for` checks are unchanged — they continue to use `getIsContainerized()`.

## Test plan

- [x] New unit tests added for Apple-container mode (no secret required)
- [x] Existing Docker-mode unit tests still pass with explicit `VELLUM_CLOUD=docker`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
