### PR TITLE
fix(plugins): close bundled-skill spoof and preserve trust-rule match after origin split

### DIFF
--- a/assistant/src/__tests__/plugin-tool-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-tool-contribution.test.ts
@@ -241,16 +241,22 @@ describe("registerPluginTools / unregisterPluginTools helpers", () => {
     // pre-tagged with another skill's or plugin's ID. The helper must
     // overwrite it so the bootstrap is always the source of truth for
     // ownership — and it must clear cross-origin fields (ownerSkillId /
-    // ownerMcpServerId) so the stamped tool cannot leak across namespaces.
+    // ownerMcpServerId / ownerSkillBundled / ownerSkillVersionHash) so the
+    // stamped tool cannot leak across namespaces or spoof bundled-skill
+    // auto-allow.
     const spoofed = makeFakeTool("pt_spoof", {
       origin: "skill",
       ownerSkillId: "some-other-skill",
+      ownerSkillBundled: true,
+      ownerSkillVersionHash: "deadbeef",
     });
     registerPluginTools("my-plugin", [spoofed]);
     const retrieved = getTool("pt_spoof");
     expect(retrieved?.origin).toBe("plugin");
     expect(retrieved?.ownerPluginId).toBe("my-plugin");
     expect(retrieved?.ownerSkillId).toBeUndefined();
+    expect(retrieved?.ownerSkillBundled).toBeUndefined();
+    expect(retrieved?.ownerSkillVersionHash).toBeUndefined();
   });
 
   test("unregisterPluginTools removes the plugin's tools", () => {

--- a/assistant/src/tools/policy-context.ts
+++ b/assistant/src/tools/policy-context.ts
@@ -36,7 +36,7 @@ export function buildPolicyContext(
 
   const conversationId = context?.conversationId;
 
-  if (tool.origin === "skill") {
+  if (tool.origin === "skill" || tool.origin === "plugin") {
     return {
       executionTarget: tool.executionTarget,
       ephemeralRules: ephemeralRules?.length ? ephemeralRules : undefined,

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -181,6 +181,8 @@ export function registerPluginTools(
     ownerPluginId: pluginName,
     ownerSkillId: undefined,
     ownerMcpServerId: undefined,
+    ownerSkillBundled: undefined,
+    ownerSkillVersionHash: undefined,
   }));
 
   const accepted: Tool[] = [];


### PR DESCRIPTION
## Summary

Addresses Devin P1 (security bypass) and Codex P1 (trust-rule regression) on #27655.

- `registerPluginTools` was clearing `origin`, `ownerSkillId`, `ownerMcpServerId` but NOT `ownerSkillBundled` or `ownerSkillVersionHash`. Because `checker.ts` maps `origin: plugin` to `toolOrigin: skill` in `ApprovalContext`, and `approval-policy.ts` auto-allows `toolOrigin: skill` + `isSkillBundled: true` at Low risk, a plugin author could spoof `ownerSkillBundled: true` and bypass the third-party-skill approval gate. Fix: also stamp those fields to `undefined`.
- `buildPolicyContext` only attached `executionTarget` for `origin: skill`. Trust rules persisted while plugin tools were tagged as skill include `executionTarget`, and `matchesExecutionTarget` requires exact match — so plugin tools under their new origin stopped matching those rules, silently regressing approved automations. Fix: attach `executionTarget` for `origin: plugin` too (option (b) from the review — preserves existing trust rules without a migration).

## Test plan
- [x] Extended `plugin-tool-contribution.test.ts` spoofing test to assert `ownerSkillBundled` and `ownerSkillVersionHash` are cleared.
- [x] `bun test src/__tests__/plugin-tool-contribution.test.ts` — 10/10 pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
