### PR TITLE
feat(gateway): add risk type definitions and tree-sitter dependencies

### DIFF
--- a/gateway/bun.lock
+++ b/gateway/bun.lock
@@ -12,7 +12,9 @@
         "minimatch": "10.2.4",
         "pino": "9.14.0",
         "pino-pretty": "13.1.3",
+        "tree-sitter-bash": "0.25.1",
         "uuid": "13.0.0",
+        "web-tree-sitter": "0.26.5",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -350,6 +352,10 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "node-addon-api": ["node-addon-api@8.7.0", "", {}, "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -434,6 +440,8 @@
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
+    "tree-sitter-bash": ["tree-sitter-bash@0.25.1", "", { "dependencies": { "node-addon-api": "^8.2.1", "node-gyp-build": "^4.8.2" }, "peerDependencies": { "tree-sitter": "^0.25.0" }, "optionalPeers": ["tree-sitter"] }, "sha512-7hMytuYIMoXOq24yRulgIxthE9YmggZIOHCyPTTuJcu6EU54tYD+4G39cUb28kxC6jMf/AbPfWGLQtgPTdh3xw=="],
+
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -453,6 +461,8 @@
     "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
+
+    "web-tree-sitter": ["web-tree-sitter@0.26.5", "", {}, "sha512-u9sl+q21VSKX2T8dhpQw8bMGGqNfwaIyuoYE3kdOQGVDrOqrmcS9GmaQoCS602iaFnuokn3WCHW374c7GAnuaQ=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -31,7 +31,9 @@
     "minimatch": "10.2.4",
     "pino": "9.14.0",
     "pino-pretty": "13.1.3",
+    "tree-sitter-bash": "0.25.1",
     "uuid": "13.0.0",
+    "web-tree-sitter": "0.26.5",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/gateway/src/risk/risk-types.ts
+++ b/gateway/src/risk/risk-types.ts
@@ -1,0 +1,319 @@
+/**
+ * Types for the data-driven command risk classifier.
+ *
+ * All types are JSON-serializable — no native RegExp, no function references.
+ * Regex patterns are stored as strings (use `String.raw` for ergonomics in TS).
+ * This constraint exists because the registry will eventually be persisted to a
+ * DB with per-user/per-org overrides that need to round-trip cleanly.
+ *
+ * Ported from assistant/src/permissions/risk-types.ts with all assistant-specific
+ * imports inlined for gateway self-containment.
+ */
+
+// ── Risk level enum (inlined from skill-host-contracts) ──────────────────────
+
+export enum RiskLevel {
+  Low = "low",
+  Medium = "medium",
+  High = "high",
+}
+
+// ── Risk levels ──────────────────────────────────────────────────────────────
+
+/**
+ * Risk level for a classified command or tool invocation.
+ *
+ * - `"low"`: Read-only, no side effects (auto-allow in most policies)
+ * - `"medium"`: Writes to filesystem, network access, state changes (confirm)
+ * - `"high"`: Destructive, privilege escalation, force ops, arbitrary code exec
+ * - `"unknown"`: Not in registry, unrecognized command or arg pattern
+ */
+export type Risk = "low" | "medium" | "high" | "unknown";
+
+/**
+ * Risk levels that can be assigned to commands in the registry.
+ * Excludes "unknown" — that's a classifier output, not a registry value.
+ */
+export type RegistryRisk = "low" | "medium" | "high";
+
+// ── Allowlist option (inlined from skill-host-contracts) ─────────────────────
+
+export interface AllowlistOption {
+  label: string;
+  description: string;
+  pattern: string;
+}
+
+// ── Risk assessment output ───────────────────────────────────────────────────
+
+/** A scope option presented to the user when classifying an unknown command. */
+export interface ScopeOption {
+  /** Stored in DB if user saves (always regex internally). */
+  pattern: string;
+  /** Human-readable description shown in UI. */
+  label: string;
+}
+
+/**
+ * The output of a risk classifier. Tool-agnostic — every classifier
+ * (bash, file_write, web_fetch, etc.) produces this same shape.
+ */
+export interface RiskAssessment {
+  /** Computed risk level. */
+  riskLevel: Risk;
+  /** Human-readable explanation of why this risk level was assigned. */
+  reason: string;
+  /** Scope options for the "save this classification" UI, narrowest to broadest. */
+  scopeOptions: ScopeOption[];
+  /** How the risk was determined. */
+  matchType: "user_rule" | "registry" | "unknown";
+  /**
+   * Allowlist options for the permission prompt "always allow" scope ladder.
+   * Populated by classifiers that unify risk classification and scope option
+   * generation. When present, `generateAllowlistOptions()` returns these
+   * directly instead of calling the per-tool strategy function.
+   */
+  allowlistOptions?: AllowlistOption[];
+}
+
+// ── Classifier interface ─────────────────────────────────────────────────────
+
+/**
+ * Generic risk classifier interface. Each tool type (bash, file_write, etc.)
+ * implements this with a tool-specific input type.
+ */
+export interface RiskClassifier<TInput> {
+  classify(input: TInput): Promise<RiskAssessment>;
+}
+
+// ── Bash classifier input ────────────────────────────────────────────────────
+
+/** Input to the bash risk classifier. */
+export interface BashClassifierInput {
+  /** The raw command string. */
+  command: string;
+  /** Which tool is being invoked. */
+  toolName: "bash" | "host_bash";
+  /** Working directory (for path resolution in arg rules). */
+  workingDir?: string;
+}
+
+// ── Command registry types ───────────────────────────────────────────────────
+
+/**
+ * A single arg-level risk rule within a command spec.
+ *
+ * Evaluated per arg token. If `flags` is set, the rule only fires when the
+ * arg matches one of those flags. If `valuePattern` is set, the arg (or the
+ * flag's consumed value) must match the regex.
+ */
+export interface ArgRule {
+  /**
+   * Stable ID for DB references, partial overrides, and audit trails.
+   * Convention: `"command:descriptor"` (e.g. `"curl:upload-file"`, `"rm:recursive-force"`).
+   */
+  id: string;
+  /**
+   * Flag(s) that trigger this rule. Omit for positional/any-arg matching.
+   * Combined short flags are listed as literals (e.g. `"-rf"`, `"-fr"`).
+   */
+  flags?: string[];
+  /**
+   * Regex string matched against the arg value. Omit if flag presence alone
+   * triggers the rule. Stored as a string (not a native RegExp) for JSON
+   * serialization.
+   */
+  valuePattern?: string;
+  /** Risk level when this rule fires. */
+  risk: RegistryRisk;
+  /** Human-readable reason (shown in permission prompt). */
+  reason: string;
+}
+
+/**
+ * Risk specification for a single command (or subcommand).
+ *
+ * The registry is a `Record<string, CommandRiskSpec>` mapping program names
+ * to their specs. Subcommands nest recursively.
+ */
+export interface CommandRiskSpec {
+  /** Base risk when no arg rules match. */
+  baseRisk: RegistryRisk;
+  /**
+   * Subcommand-level overrides. Keys are subcommand names
+   * (e.g. `{ push: { baseRisk: "medium", ... } }` under `git`).
+   * Subcommands can nest further (e.g. `git stash drop`).
+   */
+  subcommands?: Record<string, CommandRiskSpec>;
+  /** Arg-level rules, evaluated per arg. First match per arg wins. */
+  argRules?: ArgRule[];
+  /**
+   * Is this a wrapper command? (sudo, env, nice, etc.)
+   * When true, the classifier unwraps to find the inner command and
+   * takes the max of the wrapper's baseRisk and the inner command's risk.
+   */
+  isWrapper?: boolean;
+  /**
+   * Flags that put a wrapper into a non-exec mode (e.g. command -v, env -0).
+   * When the first arg matches a non-exec flag, skip unwrapping and classify
+   * the wrapper standalone against its own arg rules.
+   */
+  nonExecFlags?: string[];
+  /**
+   * Does this command have non-standard syntax where intermediate scope
+   * options would be confusing? (find, xargs, awk, etc.)
+   * When true, the scope ladder only offers exact match and command-level wildcard.
+   */
+  complexSyntax?: boolean;
+  /** Human-readable reason for the base risk (shown when no arg rule matches). */
+  reason?: string;
+  /**
+   * When true, this command auto-approves in the assistant's workspace
+   * without consulting the user's autoApproveUpTo threshold.
+   */
+  sandboxAutoApprove?: boolean;
+  /**
+   * Arg-parsing schema for extracting structured argument information.
+   * Used by `parseArgs()` to classify args into flags, positionals, and
+   * path arguments for downstream path-based policy checks.
+   */
+  argSchema?: ArgSchema;
+}
+
+// ── Arg schema types ─────────────────────────────────────────────────────────
+
+/** Describes the role of a positional argument in a command. */
+export interface PositionalDesc {
+  /** The semantic role of this positional argument. */
+  role: "path" | "pattern" | "script" | "value" | "command";
+  /**
+   * When true, this descriptor applies to all subsequent positionals too
+   * (i.e. the remaining args are all of this role).
+   */
+  rest?: boolean;
+}
+
+/**
+ * Schema for parsing a command's arguments into structured data.
+ *
+ * Drives the `parseArgs()` utility to classify each token as a flag,
+ * positional, or path argument.
+ */
+export interface ArgSchema {
+  /** Flags that consume the next token as a value (e.g. `-o`, `--output`). */
+  valueFlags?: string[];
+  /**
+   * Describes how positional arguments should be interpreted:
+   * - `"paths"` (or omitted): all positionals are filesystem paths
+   * - `"none"`: no positionals are filesystem paths
+   * - `PositionalDesc[]`: per-index role descriptors
+   */
+  positionals?: "paths" | "none" | PositionalDesc[];
+  /** Flag names whose consumed values are filesystem paths (e.g. `{ "-t": true }`). */
+  pathFlags?: Record<string, true>;
+  /**
+   * Whether `--` ends flag parsing (everything after is positional).
+   * Defaults to `true` when omitted.
+   */
+  respectsDoubleDash?: boolean;
+}
+
+/**
+ * The result of parsing a command's arguments via `parseArgs()`.
+ */
+export interface ParsedArgs {
+  /** Flag name to value (`true` for boolean flags, string for value-consuming flags). */
+  flags: Map<string, string | true>;
+  /** All positional arguments in order. */
+  positionals: string[];
+  /** Subset of positionals and flag values that are filesystem paths. */
+  pathArgs: string[];
+  /** Whether a `--` double-dash terminator was encountered. */
+  sawDoubleDash: boolean;
+}
+
+// ── User rule types ──────────────────────────────────────────────────────────
+
+/**
+ * A user-created risk classification rule.
+ *
+ * Created via the scope ladder UI (from permission prompts) or manually
+ * in settings. Stored in the user's DB.
+ */
+export interface UserRule {
+  /** Auto-generated unique ID. */
+  id: string;
+  /** Regex pattern (converted from glob at creation time). */
+  pattern: string;
+  /** User-assigned risk level. */
+  risk: RegistryRisk;
+  /** Human-readable label (shown in settings UI). */
+  label: string;
+  /** ISO 8601 timestamp of when the rule was created. */
+  createdAt: string;
+  /** How the rule was created. */
+  source: "scope_ladder" | "manual";
+}
+
+// ── Dangerous pattern types (from shell parser) ──────────────────────────────
+
+export type DangerousPatternType =
+  | "pipe_to_shell"
+  | "base64_execute"
+  | "process_substitution"
+  | "sensitive_redirect"
+  | "dangerous_substitution"
+  | "env_injection";
+
+export interface DangerousPattern {
+  type: DangerousPatternType;
+  description: string;
+  text: string;
+}
+
+// ── Risk ordering helpers ────────────────────────────────────────────────────
+
+const RISK_ORD: Record<Risk, number> = {
+  low: 0,
+  medium: 1,
+  unknown: 2,
+  high: 3,
+};
+
+/**
+ * Numeric ordering for risk comparison.
+ *
+ * `high` outranks `unknown`: if any segment is definitively high-risk, the
+ * overall command is high — the known-dangerous signal dominates. `unknown`
+ * sits between medium and high: an unrecognized command is riskier than a
+ * known-medium one, but not as definitive as a known-high one.
+ */
+export function riskOrd(risk: Risk): number {
+  return RISK_ORD[risk];
+}
+
+/** Return the higher of two risk levels. */
+export function maxRisk(a: Risk, b: Risk): Risk {
+  return riskOrd(a) >= riskOrd(b) ? a : b;
+}
+
+// ── Risk → RiskLevel mapping ─────────────────────────────────────────────────
+
+/**
+ * Map a classifier `Risk` value to the permission system's `RiskLevel` enum.
+ *
+ * `"unknown"` maps to `RiskLevel.Medium` — matching the existing checker.ts
+ * behavior where unrecognized commands are treated as medium-risk.
+ */
+export function riskToRiskLevel(risk: Risk): RiskLevel {
+  switch (risk) {
+    case "low":
+      return RiskLevel.Low;
+    case "medium":
+      return RiskLevel.Medium;
+    case "high":
+      return RiskLevel.High;
+    case "unknown":
+      return RiskLevel.Medium;
+  }
+}


### PR DESCRIPTION
## Summary
- Add web-tree-sitter and tree-sitter-bash dependencies to gateway
- Create gateway/src/risk/risk-types.ts with all risk classification types ported from assistant
- Inline RiskLevel enum to eliminate assistant-specific imports

Part of plan: move-risk-pipeline-to-gateway.md (PR 1 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
