### PR TITLE
fix(overflow-reduce): catch PluginTimeoutError in reducer compactFn + refresh JSDoc (#27634 review)

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1381,30 +1381,66 @@ export async function runAgentLoopImpl(
         toolTokenBudget,
         maxAttempts: overflowRecovery.maxAttempts,
         abortSignal: abortController.signal,
-        compactFn: async (msgs, signal, opts) =>
+        compactFn: async (msgs, signal, opts) => {
           // Route the reducer's forced-compaction tier through the
           // `compaction` pipeline so registered plugins observe these
           // invocations. Without this, custom compaction middleware only
           // sees the three orchestrator-owned call sites and misses the
           // reducer-initiated forced compactions entirely.
-          (await runPipeline<CompactionArgs, CompactionResult>(
-            "compaction",
-            getMiddlewaresFor("compaction"),
-            (args) =>
-              defaultCompactionTerminal(
-                args,
-                buildPluginTurnContext(ctx, reqId),
-              ),
-            {
-              messages: msgs,
-              signal,
-              options: opts,
-            },
-            buildPluginTurnContext(ctx, reqId),
-            DEFAULT_TIMEOUTS.compaction,
-          )) as Awaited<
-            ReturnType<typeof ctx.contextWindowManager.maybeCompact>
-          >,
+          //
+          // Pipeline timeouts must be caught locally — a `PluginTimeoutError`
+          // bubbling out of here would abort the overflow-reducer tier loop
+          // entirely, skipping fallback tiers (tool-result truncation, media
+          // stubbing, injection downgrade) and bypassing circuit-breaker
+          // bookkeeping. On timeout, record the failure and return a
+          // `compacted: false` result so the reducer falls through to the
+          // next tier.
+          try {
+            return (await runPipeline<CompactionArgs, CompactionResult>(
+              "compaction",
+              getMiddlewaresFor("compaction"),
+              (args) =>
+                defaultCompactionTerminal(
+                  args,
+                  buildPluginTurnContext(ctx, reqId),
+                ),
+              {
+                messages: msgs,
+                signal,
+                options: opts,
+              },
+              buildPluginTurnContext(ctx, reqId),
+              DEFAULT_TIMEOUTS.compaction,
+            )) as Awaited<
+              ReturnType<typeof ctx.contextWindowManager.maybeCompact>
+            >;
+          } catch (err) {
+            if (err instanceof PluginTimeoutError) {
+              rlog.warn(
+                { err, phase: "overflow-reducer-forced-compaction" },
+                "Compaction pipeline timed out — falling through to next reducer tier",
+              );
+              await trackCompactionOutcome(ctx, true, onEvent);
+              return {
+                messages: msgs,
+                compacted: false,
+                previousEstimatedInputTokens: 0,
+                estimatedInputTokens: 0,
+                maxInputTokens: 0,
+                thresholdTokens: 0,
+                compactedMessages: 0,
+                compactedPersistedMessages: 0,
+                summaryCalls: 0,
+                summaryInputTokens: 0,
+                summaryOutputTokens: 0,
+                summaryModel: "",
+                summaryText: "",
+                reason: "compaction pipeline timed out",
+              };
+            }
+            throw err;
+          }
+        },
         emitActivityState: () => {
           ctx.emitActivityState(
             "thinking",

--- a/assistant/src/plugins/defaults/overflow-reduce.ts
+++ b/assistant/src/plugins/defaults/overflow-reduce.ts
@@ -12,11 +12,15 @@
  * callbacks carried on {@link OverflowReduceArgs}; the plugin itself has no
  * access to the agent-loop context object.
  *
- * Internal calls to `ContextWindowManager` remain direct — pipeline layering
- * ends at the top of the reducer, not within the forced-compaction tier.
- * The supplied `compactFn` delegates straight into the context window
- * manager, so only the tier-loop orchestration goes through the pipeline
- * runner.
+ * The forced-compaction tier runs through the orchestrator-supplied
+ * `compactFn`, which routes into the `compaction` plugin pipeline so
+ * registered compaction middleware observes reducer-initiated invocations
+ * alongside the orchestrator-owned call sites. Non-compaction tiers
+ * (tool-result truncation, media stubbing, injection downgrade) remain
+ * in-process: they mutate message arrays directly without crossing a
+ * pipeline boundary. The reducer itself runs under the `overflowReduce`
+ * pipeline, so the full layering is `overflowReduce` → reducer tier loop
+ * → (for the forced-compaction tier only) nested `compaction` pipeline.
  */
 
 import type { ContextWindowCompactOptions } from "../../context/window-manager.js";


### PR DESCRIPTION
Addresses Codex and Devin feedback on #27634.

## Codex P2
The `compactFn` callback passed to the overflow reducer now routes through `runPipeline("compaction", ...)`, but did not catch `PluginTimeoutError`. If a plugin timeout bubbled out, it would abort the overflow-recovery tier loop entirely, skipping the fallback tiers (tool-result truncation, media stubbing, injection downgrade) and bypassing circuit-breaker bookkeeping.

Wrap the pipeline call in the same timeout-degrade pattern used by the start-of-turn, mid-loop, and emergency compaction call sites in the same module: log, record the circuit-breaker failure via `trackCompactionOutcome`, and return a `compacted: false` result so the reducer falls through to the next tier.

## Devin P2
The module-level JSDoc on `overflow-reduce.ts` was stale after the PR changed `compactFn` to route through the `compaction` pipeline. Rewrote it to describe the current layering: `overflowReduce` pipeline → reducer tier loop → (forced-compaction tier only) nested `compaction` pipeline, with non-compaction tiers remaining in-process.

Part of #27634 review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
