### PR TITLE
fix(macos/settings): scope API key text clear to matching provider in image gen save

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -201,6 +201,7 @@ struct ImageGenerationServiceCard: View {
                 // re-query so the displayed state reflects the now-visible provider.
                 if provider == currentProvider {
                     imageGenHasKey = true
+                    keyTextBinding.wrappedValue = ""
                 } else {
                     hasKeyTask?.cancel()
                     let targetProvider = currentProvider
@@ -208,7 +209,6 @@ struct ImageGenerationServiceCard: View {
                         await refreshHasKey(for: targetProvider)
                     }
                 }
-                keyTextBinding.wrappedValue = ""
                 showToast("\(provider == "openai" ? "OpenAI" : "Gemini") API key saved", .success)
             })
         }


### PR DESCRIPTION
## Summary

Move `keyTextBinding.wrappedValue = ""` inside the `provider == currentProvider` branch of `save()`'s onSuccess in `ImageGenerationServiceCard.swift`. Previously the clear ran unconditionally, so if the user saved a key for provider A, switched to provider B, and started typing a new key, provider A's successful onSuccess would wipe provider B's in-progress key text.

In the else branch (provider changed), the text was already cleared by the `onChange(of: draftModel)` handler when the user switched — so no clear is needed there. If the user has begun typing a new key for the new provider, we must NOT wipe it.

Addresses Devin review feedback on #27659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
