### PR TITLE
feat(assistant): add persistent IPC connection for hot-path gateway calls

### DIFF
--- a/assistant/src/ipc/gateway-client.test.ts
+++ b/assistant/src/ipc/gateway-client.test.ts
@@ -1,0 +1,250 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import {
+  PersistentIpcClient,
+  resetPersistentClient,
+} from "./gateway-client.js";
+
+// ---------------------------------------------------------------------------
+// Mock gateway Unix socket server
+// ---------------------------------------------------------------------------
+
+let server: Server;
+let socketPath: string;
+let tmpDir: string;
+let serverConnections: Socket[] = [];
+
+/** Handler for incoming IPC requests. Override per-test as needed. */
+let requestHandler: (
+  req: { id: string; method: string; params?: Record<string, unknown> },
+  sock: Socket,
+) => void;
+
+function defaultHandler(
+  req: { id: string; method: string; params?: Record<string, unknown> },
+  sock: Socket,
+): void {
+  sock.write(
+    JSON.stringify({ id: req.id, result: { echo: req.method } }) + "\n",
+  );
+}
+
+beforeAll(async () => {
+  tmpDir = realpathSync(mkdtempSync(join(tmpdir(), "ipc-test-")));
+  socketPath = join(tmpDir, "persistent-ipc-test.sock");
+  requestHandler = defaultHandler;
+
+  await new Promise<void>((resolve) => {
+    server = createServer((sock) => {
+      serverConnections.push(sock);
+      let buffer = "";
+      sock.on("data", (chunk) => {
+        buffer += chunk.toString();
+        let idx: number;
+        while ((idx = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, idx).trim();
+          buffer = buffer.slice(idx + 1);
+          if (!line) continue;
+          try {
+            const req = JSON.parse(line);
+            requestHandler(req, sock);
+          } catch {
+            // ignore malformed
+          }
+        }
+      });
+    });
+    server.listen(socketPath, resolve);
+  });
+});
+
+afterEach(() => {
+  requestHandler = defaultHandler;
+  resetPersistentClient();
+});
+
+afterAll(() => {
+  for (const conn of serverConnections) {
+    conn.destroy();
+  }
+  serverConnections = [];
+  server.close();
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PersistentIpcClient", () => {
+  test("connects and sends correctly formatted JSON", async () => {
+    const receivedRequests: unknown[] = [];
+    requestHandler = (req, sock) => {
+      receivedRequests.push(req);
+      sock.write(JSON.stringify({ id: req.id, result: "ok" }) + "\n");
+    };
+
+    const client = new PersistentIpcClient(socketPath);
+    try {
+      const result = await client.call("test_method", { key: "value" });
+
+      expect(result).toBe("ok");
+      expect(receivedRequests).toHaveLength(1);
+
+      const sent = receivedRequests[0] as {
+        id: string;
+        method: string;
+        params: Record<string, unknown>;
+      };
+      expect(sent.id).toBeDefined();
+      expect(sent.method).toBe("test_method");
+      expect(sent.params).toEqual({ key: "value" });
+    } finally {
+      client.destroy();
+    }
+  });
+
+  test("routes responses to the correct pending request by ID", async () => {
+    // Delay responses so multiple requests are in-flight simultaneously.
+    requestHandler = (req, sock) => {
+      setTimeout(() => {
+        sock.write(
+          JSON.stringify({ id: req.id, result: `result-for-${req.method}` }) +
+            "\n",
+        );
+      }, 10);
+    };
+
+    const client = new PersistentIpcClient(socketPath);
+    try {
+      const [r1, r2, r3] = await Promise.all([
+        client.call("method_a"),
+        client.call("method_b"),
+        client.call("method_c"),
+      ]);
+
+      expect(r1).toBe("result-for-method_a");
+      expect(r2).toBe("result-for-method_b");
+      expect(r3).toBe("result-for-method_c");
+    } finally {
+      client.destroy();
+    }
+  });
+
+  test("reconnects after socket close", async () => {
+    let callCount = 0;
+    requestHandler = (req, sock) => {
+      callCount++;
+      sock.write(
+        JSON.stringify({ id: req.id, result: `call-${callCount}` }) + "\n",
+      );
+    };
+
+    const client = new PersistentIpcClient(socketPath);
+    try {
+      // First call — establishes connection.
+      const r1 = await client.call("first");
+      expect(r1).toBe("call-1");
+
+      // Force-close all server-side connections to simulate a disconnect.
+      for (const conn of serverConnections) {
+        conn.destroy();
+      }
+      serverConnections = [];
+
+      // Allow the close event to propagate.
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Second call — should reconnect automatically.
+      const r2 = await client.call("second");
+      expect(r2).toBe("call-2");
+    } finally {
+      client.destroy();
+    }
+  });
+
+  test("rejects pending request on timeout", async () => {
+    // Never respond, so the call should time out.
+    requestHandler = () => {
+      /* silence */
+    };
+
+    // Use a very short timeout so the test doesn't hang.
+    const client = new PersistentIpcClient(socketPath, 100);
+    try {
+      await expect(client.call("slow_method")).rejects.toThrow(/timed out/);
+    } finally {
+      client.destroy();
+    }
+  });
+
+  test("rejects pending requests when socket errors", async () => {
+    requestHandler = (req, sock) => {
+      // Simulate server-side error by destroying the connection.
+      sock.destroy();
+    };
+
+    const client = new PersistentIpcClient(socketPath);
+    try {
+      await expect(client.call("will_error")).rejects.toThrow(/disconnected/);
+    } finally {
+      client.destroy();
+    }
+  });
+
+  test("rejects with error message from server", async () => {
+    requestHandler = (req, sock) => {
+      sock.write(
+        JSON.stringify({ id: req.id, error: "something went wrong" }) + "\n",
+      );
+    };
+
+    const client = new PersistentIpcClient(socketPath);
+    try {
+      await expect(client.call("bad_call")).rejects.toThrow(
+        "something went wrong",
+      );
+    } finally {
+      client.destroy();
+    }
+  });
+
+  test("destroy rejects all pending requests", async () => {
+    requestHandler = () => {
+      /* never respond */
+    };
+
+    const client = new PersistentIpcClient(socketPath, 10_000);
+    const promise = client.call("pending_forever");
+    // Give time for the request to be sent.
+    await new Promise((r) => setTimeout(r, 20));
+    client.destroy();
+
+    await expect(promise).rejects.toThrow(/destroyed/);
+  });
+
+  test("connection failure rejects the call", async () => {
+    const badPath = join(tmpDir, "nonexistent.sock");
+    const client = new PersistentIpcClient(badPath);
+    try {
+      await expect(client.call("unreachable")).rejects.toThrow();
+    } finally {
+      client.destroy();
+    }
+  });
+});

--- a/assistant/src/ipc/gateway-client.ts
+++ b/assistant/src/ipc/gateway-client.ts
@@ -152,6 +152,237 @@ export async function ipcCall(
 }
 
 // ---------------------------------------------------------------------------
+// Persistent IPC client
+// ---------------------------------------------------------------------------
+
+type PendingRequest = {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+/**
+ * Maintains a single Unix socket connection to the gateway, with automatic
+ * reconnection on failure. Multiplexes requests by ID so many concurrent
+ * callers can share one socket.
+ *
+ * Designed for hot-path calls (e.g. classify_risk) where connecting per call
+ * adds unacceptable overhead.
+ */
+export class PersistentIpcClient {
+  private socket: Socket | null = null;
+  private pending = new Map<string, PendingRequest>();
+  private nextId = 1;
+  private buffer = "";
+  private connecting: Promise<void> | null = null;
+  private readonly socketPath: string;
+  private readonly callTimeoutMs: number;
+
+  constructor(socketPath: string, callTimeoutMs = DEFAULT_CALL_TIMEOUT_MS) {
+    this.socketPath = socketPath;
+    this.callTimeoutMs = callTimeoutMs;
+  }
+
+  /**
+   * Send an IPC request over the persistent connection.
+   *
+   * Connects on first use. If the socket is closed or errored, the next call
+   * re-establishes the connection automatically.
+   */
+  async call(
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<unknown> {
+    await this.ensureConnected();
+
+    const id = String(this.nextId++);
+    const req: IpcRequest = { id, method, params };
+
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const entry = this.pending.get(id);
+        if (entry) {
+          this.pending.delete(id);
+          entry.reject(
+            new Error(
+              `IPC call "${method}" timed out after ${this.callTimeoutMs}ms`,
+            ),
+          );
+        }
+      }, this.callTimeoutMs);
+      // Don't let the timeout timer keep the process alive.
+      timer.unref();
+
+      this.pending.set(id, { resolve, reject, timer });
+
+      try {
+        this.socket!.write(JSON.stringify(req) + "\n");
+      } catch (err) {
+        this.pending.delete(id);
+        clearTimeout(timer);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  /** Explicitly close the connection and reject all pending requests. */
+  destroy(): void {
+    this.rejectAllPending(new Error("PersistentIpcClient destroyed"));
+    if (this.socket) {
+      this.socket.destroy();
+      this.socket = null;
+    }
+    this.connecting = null;
+    this.buffer = "";
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private async ensureConnected(): Promise<void> {
+    if (this.socket) return;
+    if (this.connecting) return this.connecting;
+
+    this.connecting = new Promise<void>((resolve, reject) => {
+      const sock: Socket = connect(this.socketPath);
+      sock.unref();
+
+      const connectTimer = setTimeout(() => {
+        sock.destroy();
+        reject(
+          new Error(
+            `IPC persistent connect timed out after ${CONNECT_TIMEOUT_MS}ms`,
+          ),
+        );
+      }, CONNECT_TIMEOUT_MS);
+      connectTimer.unref();
+
+      sock.on("connect", () => {
+        clearTimeout(connectTimer);
+        this.socket = sock;
+        this.buffer = "";
+        this.connecting = null;
+        this.wireDataHandler(sock);
+        resolve();
+      });
+
+      sock.on("error", (err) => {
+        clearTimeout(connectTimer);
+        log.warn(
+          {
+            err,
+            code: (err as NodeJS.ErrnoException).code,
+            socketPath: this.socketPath,
+          },
+          "Persistent IPC socket error",
+        );
+        this.handleDisconnect();
+        reject(err);
+      });
+
+      // If close fires during connect (before "connect" event), reject.
+      sock.on("close", () => {
+        clearTimeout(connectTimer);
+        if (!this.socket) {
+          this.connecting = null;
+          reject(new Error("Socket closed before connect"));
+        }
+      });
+    });
+
+    return this.connecting;
+  }
+
+  private wireDataHandler(sock: Socket): void {
+    sock.on("data", (chunk) => {
+      this.buffer += chunk.toString();
+      let newlineIdx: number;
+      while ((newlineIdx = this.buffer.indexOf("\n")) !== -1) {
+        const line = this.buffer.slice(0, newlineIdx).trim();
+        this.buffer = this.buffer.slice(newlineIdx + 1);
+        if (!line) continue;
+
+        try {
+          const msg = JSON.parse(line) as IpcResponse;
+          const entry = this.pending.get(msg.id);
+          if (entry) {
+            this.pending.delete(msg.id);
+            clearTimeout(entry.timer);
+            if (msg.error) {
+              entry.reject(new Error(msg.error));
+            } else {
+              entry.resolve(msg.result);
+            }
+          }
+        } catch {
+          // Ignore malformed lines
+        }
+      }
+    });
+
+    sock.on("error", () => {
+      this.handleDisconnect();
+    });
+
+    sock.on("close", () => {
+      this.handleDisconnect();
+    });
+  }
+
+  private handleDisconnect(): void {
+    this.rejectAllPending(new Error("IPC socket disconnected"));
+    this.socket = null;
+    this.connecting = null;
+    this.buffer = "";
+  }
+
+  private rejectAllPending(reason: Error): void {
+    for (const [id, entry] of this.pending) {
+      clearTimeout(entry.timer);
+      entry.reject(reason);
+      this.pending.delete(id);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton persistent client
+// ---------------------------------------------------------------------------
+
+let persistentClient: PersistentIpcClient | null = null;
+
+/**
+ * Persistent IPC call — singleton wrapper around PersistentIpcClient.
+ *
+ * Creates the instance on first call using the gateway socket path.
+ * Unlike `ipcCall()`, this maintains a single connection across calls,
+ * making it suitable for hot-path operations like risk classification.
+ *
+ * Throws on failure (timeout, socket error) — callers must handle errors.
+ */
+export async function ipcCallPersistent(
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<unknown> {
+  if (!persistentClient) {
+    persistentClient = new PersistentIpcClient(getGatewaySocketPath());
+  }
+  return persistentClient.call(method, params);
+}
+
+/**
+ * Destroy and nullify the singleton persistent client.
+ * Exported for testing — ensures no leaked handles between test runs.
+ */
+export function resetPersistentClient(): void {
+  if (persistentClient) {
+    persistentClient.destroy();
+    persistentClient = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Typed helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add PersistentIpcClient class that maintains a single Unix socket connection with request multiplexing
- Add ipcCallPersistent() singleton wrapper for hot-path gateway calls
- Add resetPersistentClient() for test cleanup
- Add unit tests for persistent connection, multiplexing, reconnection, and timeout handling

Part of plan: move-risk-pipeline-to-gateway.md (PR 2 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
