### PR TITLE
refactor(meet-join): migrate audio-ingest + speaker-resolver to SkillHost

### DIFF
--- a/skills/meet-join/daemon/__tests__/audio-ingest.test.ts
+++ b/skills/meet-join/daemon/__tests__/audio-ingest.test.ts
@@ -6,28 +6,10 @@
  * network or filesystem socket is opened.
  */
 
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-// `resolveStreamingTranscriber` is imported at file scope (before any mock
-// is installed) so the "default transcriber factory" describe below can
-// restore the real export in its `afterAll`. Bun's `mock.module` is
-// process-global and persists until re-mocked; installing it at file
-// scope bleeds into sibling test files that share a Bun process (e.g.
-// `providers/speech-to-text/__tests__/resolve.test.ts`).
-import { resolveStreamingTranscriber as realResolveStreamingTranscriberImport } from "../../../../assistant/src/providers/speech-to-text/resolve.js";
-import type {
-  StreamingTranscriber,
-  SttStreamServerEvent,
-} from "../../../../assistant/src/stt/types.js";
+import type { SkillHost } from "@vellumai/skill-host-contracts";
+
 import {
   AUDIO_INGEST_AUTH_PREFIX,
   BOT_CONNECT_TIMEOUT_MS,
@@ -35,8 +17,11 @@ import {
   MAX_HANDSHAKE_BYTES,
   MeetAudioIngest,
   MeetAudioIngestError,
+  createAudioIngest,
   type AudioIngestConnection,
   type AudioIngestServer,
+  type StreamingTranscriber,
+  type SttStreamServerEvent,
 } from "../audio-ingest.js";
 
 /**
@@ -49,20 +34,6 @@ import {
   __resetMeetSessionEventRouterForTests,
   getMeetSessionEventRouter,
 } from "../session-event-router.js";
-
-// Copy the imported function reference out of its live binding so it can
-// be used as the restoration target in `afterAll`. ES module named imports
-// are live bindings that `mock.module` rebinds in place, so passing
-// `realResolveStreamingTranscriberImport` directly into the `afterAll`
-// re-mock factory would just hand back the stub. Saving the current
-// callable value breaks that live link.
-const realResolveStreamingTranscriberFn = realResolveStreamingTranscriberImport;
-
-// Shared state for the default-transcriber-factory describe below. Declared
-// here so both the `mock.module` factory (installed in that describe's
-// `beforeAll`) and the tests themselves have access.
-let mockResolveCalls: Array<Record<string, unknown> | undefined> = [];
-let mockResolveResult: StreamingTranscriber | null = null;
 
 // ---------------------------------------------------------------------------
 // In-memory fakes
@@ -273,8 +244,6 @@ function newIngestSetup(): {
 
 beforeEach(() => {
   __resetMeetSessionEventRouterForTests();
-  mockResolveCalls = [];
-  mockResolveResult = null;
 });
 
 afterEach(() => {
@@ -949,84 +918,131 @@ describe("MeetAudioIngest — auth handshake", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Default transcriber factory — diarization wiring
+// Host-backed factory — diarization wiring
+//
+// The default transcriber resolution path lives inside
+// `createAudioIngest(host)` after the PR 10 migration: it reads the
+// configured STT provider via `host.providers.stt.*` instead of importing
+// the assistant-side resolver directly. These tests exercise the host
+// factory's default path by supplying a stubbed `SkillHost`.
 // ---------------------------------------------------------------------------
 
-describe("MeetAudioIngest — default transcriber factory", () => {
-  // Install the module mock only for this describe so it doesn't leak
-  // into sibling test files that share a Bun process (Bun's `mock.module`
-  // is process-global). Restore in `afterAll` by re-mocking with the real
-  // function reference captured at file load time — Bun's `mock.restore()`
-  // doesn't undo `mock.module`, so we have to re-point it at the original
-  // export ourselves.
-  beforeAll(() => {
-    mock.module(
-      "../../../../assistant/src/providers/speech-to-text/resolve.js",
-      () => ({
-        resolveStreamingTranscriber: async (
-          options?: Record<string, unknown>,
-        ) => {
-          mockResolveCalls.push(options);
-          return mockResolveResult;
+describe("createAudioIngest — default transcriber factory", () => {
+  function buildStubHost(options: {
+    resolver: (
+      spec?: Record<string, unknown>,
+    ) => StreamingTranscriber | null | Promise<StreamingTranscriber | null>;
+    providerIds?: string[];
+  }): SkillHost {
+    const noop = () => {};
+    const logger = { debug: noop, info: noop, warn: noop, error: noop };
+    return {
+      logger: { get: () => logger },
+      config: {
+        isFeatureFlagEnabled: () => false,
+        getSection: () => undefined,
+      },
+      identity: {
+        getAssistantName: () => undefined,
+        internalAssistantId: "self",
+      },
+      platform: {
+        workspaceDir: () => "",
+        vellumRoot: () => "",
+        runtimeMode: () => "baremetal" as never,
+      },
+      providers: {
+        llm: {
+          getConfigured: () => undefined,
+          userMessage: () => undefined,
+          extractToolUse: () => null,
+          createTimeout: () => new AbortController(),
         },
-      }),
-    );
-  });
+        stt: {
+          listProviderIds: () => options.providerIds ?? ["deepgram"],
+          supportsBoundary: () => true,
+          resolveStreamingTranscriber: ((spec?: Record<string, unknown>) =>
+            options.resolver(spec)) as never,
+        },
+        tts: {
+          get: () => undefined,
+          resolveConfig: () => undefined,
+        },
+        secureKeys: {
+          getProviderKey: async () => null,
+        },
+      },
+      memory: {
+        addMessage: (async () => undefined) as never,
+        wakeAgentForOpportunity: async () => undefined,
+      },
+      events: {
+        publish: async () => undefined,
+        subscribe: () => ({ dispose: noop, active: true }),
+        buildEvent: () => ({}) as never,
+      },
+      registries: {
+        registerTools: noop,
+        registerSkillRoute: () => ({}) as never,
+        registerShutdownHook: noop,
+      },
+      speakers: {
+        createTracker: () => ({}),
+      },
+    };
+  }
 
-  afterAll(() => {
-    mock.module(
-      "../../../../assistant/src/providers/speech-to-text/resolve.js",
-      () => ({
-        resolveStreamingTranscriber: realResolveStreamingTranscriberFn,
-      }),
-    );
-  });
-
-  test("requests diarize: preferred from the resolver", async () => {
-    // The fake resolver returns a minimal StreamingTranscriber so the
-    // ingest has something to drive. We don't exercise the streaming path
-    // here — we just need start() to reach the resolver call.
+  test("requests diarize: preferred and the meet-bot sample rate", async () => {
+    const resolverCalls: Array<Record<string, unknown> | undefined> = [];
     const fakeSession = new FakeStreamingTranscriber();
-    mockResolveResult = fakeSession;
+    const host = buildStubHost({
+      resolver: (spec) => {
+        resolverCalls.push(spec);
+        return fakeSession;
+      },
+    });
 
-    // No createTranscriber override — exercises the default factory path.
-    const ingest = new MeetAudioIngest({
+    const ingest = createAudioIngest(host)({
       listen: async () => new FakeAudioIngestServer(),
       botConnectTimeoutMs: 1_000,
     });
 
-    // Kick off start(); we don't need it to resolve, just to call the
-    // resolver. Attach a noop rejection handler so the bot-connect timeout
-    // doesn't surface as an unhandled rejection when the test finishes.
+    // Kick off start(); we don't need it to resolve, just to reach the
+    // resolver call. Attach a noop rejection handler so the bot-connect
+    // timeout (never satisfied here) doesn't surface as an unhandled
+    // rejection when the test finishes.
     const { ready } = await ingest.start("m-diarize", TEST_BOT_TOKEN);
-    // Attach a noop rejection handler so the bot-connect timeout (which we
-    // never satisfy in this test) doesn't surface as an unhandled rejection.
     ready.catch(() => {});
     await flushMicrotasks();
 
-    expect(mockResolveCalls).toHaveLength(1);
-    const opts = mockResolveCalls[0];
+    expect(resolverCalls).toHaveLength(1);
+    const opts = resolverCalls[0];
     expect(opts).toBeDefined();
     expect((opts as { diarize?: string }).diarize).toBe("preferred");
-    // Sanity check that the sample rate is still forwarded.
     expect((opts as { sampleRate?: number }).sampleRate).toBeGreaterThan(0);
 
     await ingest.stop();
   });
 
   test("throws MeetAudioIngestError when the resolver returns null", async () => {
-    // Unusable provider configuration — resolver returns null.
-    mockResolveResult = null;
-
-    const ingest = new MeetAudioIngest({
-      listen: async () => new FakeAudioIngestServer(),
+    const host = buildStubHost({
+      resolver: () => null,
+      providerIds: ["deepgram", "google-gemini"],
     });
 
-    await expect(ingest.start("m-null", TEST_BOT_TOKEN)).rejects.toThrow(
-      MeetAudioIngestError,
-    );
-    await expect(ingest.start("m-null2", TEST_BOT_TOKEN)).rejects.toThrow(
-      /configured STT provider is unusable/i,
-    );
+    const make = createAudioIngest(host);
+
+    await expect(
+      make({ listen: async () => new FakeAudioIngestServer() }).start(
+        "m-null",
+        TEST_BOT_TOKEN,
+      ),
+    ).rejects.toBeInstanceOf(MeetAudioIngestError);
+    await expect(
+      make({ listen: async () => new FakeAudioIngestServer() }).start(
+        "m-null2",
+        TEST_BOT_TOKEN,
+      ),
+    ).rejects.toThrow(/configured STT provider is unusable/i);
   });
 });

--- a/skills/meet-join/daemon/audio-ingest.ts
+++ b/skills/meet-join/daemon/audio-ingest.ts
@@ -2,7 +2,7 @@
  * MeetAudioIngest — daemon-side audio ingress for a meet-bot container.
  *
  * Flow:
- *   1. The session manager calls {@link MeetAudioIngest.start} **before** the
+ *   1. The session manager calls {@link MeetAudioIngest.start} before the
  *      bot container is spawned. `start()` opens a Unix-domain-socket server
  *      (the bot connects as the client once it boots) and opens a streaming
  *      STT session via the configured provider (resolved from
@@ -22,16 +22,19 @@
  *     so we do not leave a zombie container running against a dead ingest.
  *
  * Design notes:
- *   - The STT provider is resolved at runtime via
- *     {@link resolveStreamingTranscriber}, which reads
- *     `services.stt.provider` and looks up credentials through the provider
- *     catalog. Meet transcription therefore honors the same provider
- *     selection as the rest of the assistant.
+ *   - The STT provider is resolved at runtime via the `SkillHost` injected
+ *     into {@link createAudioIngest}. That factory reads
+ *     `services.stt.provider` through the host and looks up credentials
+ *     through the provider catalog. Meet transcription therefore honors
+ *     the same provider selection as the rest of the assistant.
  *   - Provider-specific options (e.g. Deepgram's `smartFormatting` /
  *     `interimResults`) are owned by each provider's config schema.
  *   - All external dependencies (transcriber factory, socket listener) are
  *     swapped via constructor-level factories so tests can drive the class
  *     without touching real sockets or a real STT provider account.
+ *   - This file has zero `assistant/` imports — every runtime dependency
+ *     arrives via the {@link SkillHost} contract from
+ *     `@vellumai/skill-host-contracts`.
  */
 
 import { timingSafeEqual } from "node:crypto";
@@ -42,21 +45,11 @@ import {
   type Socket as NetSocket,
 } from "node:net";
 
+import type { Logger, SkillHost } from "@vellumai/skill-host-contracts";
+
 import type { TranscriptChunkEvent } from "../contracts/index.js";
-
-import {
-  listProviderIds,
-  supportsBoundary,
-} from "../../../assistant/src/providers/speech-to-text/provider-catalog.js";
-import { resolveStreamingTranscriber } from "../../../assistant/src/providers/speech-to-text/resolve.js";
-import type {
-  StreamingTranscriber,
-  SttStreamServerEvent,
-} from "../../../assistant/src/stt/types.js";
-import { getLogger } from "../../../assistant/src/util/logger.js";
+import { registerSubModule } from "./modules-registry.js";
 import { getMeetSessionEventRouter } from "./session-event-router.js";
-
-const log = getLogger("meet-audio-ingest");
 
 /**
  * Host the audio-ingest TCP server binds to. Must be all-interfaces
@@ -79,7 +72,7 @@ export const AUDIO_INGEST_BIND_HOST = "0.0.0.0";
  * container.
  *
  * Must be larger than the bot's worst-case prejoin+admission path, not just
- * its connect cost. The bot only opens the audio socket *after* `joinMeet`
+ * its connect cost. The bot only opens the audio socket after `joinMeet`
  * returns, and `joinMeet` may legitimately block for `MEETING_ROOM_TIMEOUT_MS`
  * (90s) while a host admits the bot through the "Ask to join" lobby. Plus
  * cold-start (Chrome launch + Meet page load + modal dismissal) adds another
@@ -137,6 +130,51 @@ export const MAX_HANDSHAKE_BYTES = 256;
  * provider to decode at the wrong rate and produce garbled transcripts.
  */
 const MEET_BOT_SAMPLE_RATE_HZ = 16_000;
+
+// ---------------------------------------------------------------------------
+// Local structural types
+//
+// These mirror a narrow subset of the assistant's STT contract surface so
+// this file does not import from `assistant/` directly. The daemon-side
+// SkillHost implementation narrows the opaque contract types back to their
+// concrete assistant types at its boundary.
+// ---------------------------------------------------------------------------
+
+/**
+ * Streaming transcript event emitted by the STT provider. Mirrors the
+ * narrow set of variants audio ingest actually dispatches (`partial`,
+ * `final`) plus the variants it explicitly ignores (`error`, `closed`).
+ */
+export type SttStreamServerEvent =
+  | {
+      readonly type: "partial";
+      readonly text: string;
+      readonly speakerLabel?: string;
+      readonly confidence?: number;
+    }
+  | {
+      readonly type: "final";
+      readonly text: string;
+      readonly speakerLabel?: string;
+      readonly confidence?: number;
+    }
+  | {
+      readonly type: "error";
+      readonly category: string;
+      readonly message: string;
+    }
+  | { readonly type: "closed" };
+
+/**
+ * Minimal structural view of the streaming transcriber consumed by the
+ * ingest. Any concrete implementation the host returns (`realtime-ws`,
+ * `incremental-batch`) is a structural supertype.
+ */
+export interface StreamingTranscriber {
+  start(onEvent: (event: SttStreamServerEvent) => void): Promise<void>;
+  sendAudio(audio: Buffer, mimeType: string): void;
+  stop(): void;
+}
 
 // ---------------------------------------------------------------------------
 // Error class
@@ -213,8 +251,8 @@ export type AudioIngestListenFn = () => Promise<AudioIngestServer>;
  *
  * Returning a {@link StreamingTranscriber} keeps the audio-ingest code
  * decoupled from any specific provider — production wiring uses the
- * configured provider via {@link resolveStreamingTranscriber}; tests pass
- * an in-memory fake that conforms to the same contract.
+ * configured provider resolved through the injected `SkillHost`; tests
+ * pass an in-memory fake that conforms to the same contract.
  */
 export type StreamingTranscriberFactory = () => Promise<StreamingTranscriber>;
 
@@ -222,8 +260,22 @@ export type StreamingTranscriberFactory = () => Promise<StreamingTranscriber>;
 // MeetAudioIngest
 // ---------------------------------------------------------------------------
 
+/** No-op logger used when deps do not supply one (tests). */
+const NOOP_LOGGER: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
 export interface MeetAudioIngestDeps {
-  /** Override for the streaming-transcriber factory (tests). */
+  /**
+   * Streaming-transcriber factory. Required in production wiring; optional
+   * here so session-manager's legacy `new MeetAudioIngest()` call (replaced
+   * in PR 17 by a host-backed builder) continues to type-check during the
+   * transition. An ingest without a factory throws
+   * {@link MeetAudioIngestError} on the first `start()` attempt.
+   */
   createTranscriber?: StreamingTranscriberFactory;
   /** Override for the audio-ingest TCP listener factory (tests). */
   listen?: AudioIngestListenFn;
@@ -237,6 +289,13 @@ export interface MeetAudioIngestDeps {
    * attribution when diarization was not requested. Defaults to `true`.
    */
   diarize?: boolean;
+  /**
+   * Structural logger used for internal warnings / info. Defaults to a
+   * silent no-op so direct instantiation in tests does not require a
+   * logger; production paths pass `host.logger.get("meet-audio-ingest")`
+   * through {@link createAudioIngest}.
+   */
+  logger?: Logger;
 }
 
 /** Callback invoked for each PCM chunk received from the bot. */
@@ -252,6 +311,7 @@ export class MeetAudioIngest {
   private readonly listen: AudioIngestListenFn;
   private readonly botConnectTimeoutMs: number;
   private readonly diarize: boolean;
+  private readonly log: Logger;
 
   private server: AudioIngestServer | null = null;
   private connection: AudioIngestConnection | null = null;
@@ -268,11 +328,19 @@ export class MeetAudioIngest {
   private readonly pcmSubscribers = new Set<PcmSubscriber>();
 
   constructor(deps: MeetAudioIngestDeps = {}) {
-    this.createTranscriber = deps.createTranscriber ?? defaultCreateTranscriber;
-    this.listen = deps.listen ?? defaultListen;
+    this.createTranscriber =
+      deps.createTranscriber ??
+      (() => {
+        throw new MeetAudioIngestError(
+          "MeetAudioIngest: no streaming-transcriber factory configured. " +
+            "Instantiate via createAudioIngest(host) or pass deps.createTranscriber.",
+        );
+      });
+    this.listen = deps.listen ?? defaultListen(deps.logger ?? NOOP_LOGGER);
     this.botConnectTimeoutMs =
       deps.botConnectTimeoutMs ?? BOT_CONNECT_TIMEOUT_MS;
     this.diarize = deps.diarize ?? true;
+    this.log = deps.logger ?? NOOP_LOGGER;
   }
 
   /**
@@ -377,7 +445,9 @@ export class MeetAudioIngest {
       try {
         await server.close();
       } catch (err) {
-        log.warn({ err }, "MeetAudioIngest: server close after stop threw");
+        this.log.warn("MeetAudioIngest: server close after stop threw", {
+          err,
+        });
       }
       return { port: 0, ready: Promise.resolve() };
     }
@@ -385,7 +455,10 @@ export class MeetAudioIngest {
     const boundPort = server.port;
 
     server.onError((err) => {
-      log.error({ err, meetingId }, "MeetAudioIngest: socket server error");
+      this.log.error("MeetAudioIngest: socket server error", {
+        err,
+        meetingId,
+      });
     });
 
     // Wait for the bot to connect AND successfully complete the
@@ -400,10 +473,11 @@ export class MeetAudioIngest {
       const timer = setTimeout(() => {
         if (settled) return;
         settled = true;
-        log.warn(
-          { meetingId, port: boundPort, timeoutMs: this.botConnectTimeoutMs },
-          "MeetAudioIngest: bot did not connect within timeout",
-        );
+        this.log.warn("MeetAudioIngest: bot did not connect within timeout", {
+          meetingId,
+          port: boundPort,
+          timeoutMs: this.botConnectTimeoutMs,
+        });
         reject(
           new Error(
             `MeetAudioIngest: bot did not connect to *:${boundPort} within ${this.botConnectTimeoutMs}ms`,
@@ -446,19 +520,19 @@ export class MeetAudioIngest {
               // silently drop them.
               this.handlePcmChunk(residual, meetingId);
             }
-            log.info(
-              { meetingId, port: boundPort },
-              "MeetAudioIngest: bot connected and authenticated",
-            );
+            this.log.info("MeetAudioIngest: bot connected and authenticated", {
+              meetingId,
+              port: boundPort,
+            });
             resolve();
           },
           onReject: (reason) => {
             // Drop the peer, keep listening for the real bot. We only
             // log a counter-style field so repeated bad handshakes
             // don't flood logs with duplicate messages.
-            log.warn(
-              { meetingId, port: boundPort, reason },
+            this.log.warn(
               "MeetAudioIngest: rejected unauthenticated audio-ingest peer",
+              { meetingId, port: boundPort, reason },
             );
             try {
               conn.destroy();
@@ -566,7 +640,7 @@ export class MeetAudioIngest {
       try {
         conn.destroy();
       } catch (err) {
-        log.warn({ err }, "MeetAudioIngest: connection destroy threw");
+        this.log.warn("MeetAudioIngest: connection destroy threw", { err });
       }
     }
 
@@ -579,7 +653,7 @@ export class MeetAudioIngest {
       try {
         transcriber.stop();
       } catch (err) {
-        log.warn({ err }, "MeetAudioIngest: transcriber stop threw");
+        this.log.warn("MeetAudioIngest: transcriber stop threw", { err });
       }
     }
 
@@ -590,7 +664,7 @@ export class MeetAudioIngest {
       try {
         await server.close();
       } catch (err) {
-        log.warn({ err }, "MeetAudioIngest: server close threw");
+        this.log.warn("MeetAudioIngest: server close threw", { err });
       }
     }
 
@@ -599,7 +673,7 @@ export class MeetAudioIngest {
     // own (e.g. the storage writer on `stop()`) are already gone.
     this.pcmSubscribers.clear();
 
-    log.info({ meetingId: this.meetingId }, "MeetAudioIngest: stopped");
+    this.log.info("MeetAudioIngest: stopped", { meetingId: this.meetingId });
   }
 
   // ── Internals ──────────────────────────────────────────────────────
@@ -613,11 +687,14 @@ export class MeetAudioIngest {
     conn.onData((chunk) => this.handlePcmChunk(chunk, meetingId));
 
     conn.onClose(() => {
-      log.info({ meetingId }, "MeetAudioIngest: bot connection closed");
+      this.log.info("MeetAudioIngest: bot connection closed", { meetingId });
     });
 
     conn.onError((err) => {
-      log.warn({ err, meetingId }, "MeetAudioIngest: bot connection error");
+      this.log.warn("MeetAudioIngest: bot connection error", {
+        err,
+        meetingId,
+      });
     });
   }
 
@@ -636,10 +713,10 @@ export class MeetAudioIngest {
         // informational for provider adapters; pass a sensible default.
         transcriber.sendAudio(chunk, "audio/pcm");
       } catch (err) {
-        log.warn(
-          { err, meetingId },
-          "MeetAudioIngest: transcriber.sendAudio threw",
-        );
+        this.log.warn("MeetAudioIngest: transcriber.sendAudio threw", {
+          err,
+          meetingId,
+        });
       }
     }
     // Fan the raw bytes out to every PCM subscriber. Snapshot the set so
@@ -650,10 +727,10 @@ export class MeetAudioIngest {
         try {
           subscriber(chunk);
         } catch (err) {
-          log.warn(
-            { err, meetingId },
-            "MeetAudioIngest: PCM subscriber threw — removing",
-          );
+          this.log.warn("MeetAudioIngest: PCM subscriber threw — removing", {
+            err,
+            meetingId,
+          });
           this.pcmSubscribers.delete(subscriber);
         }
       }
@@ -726,7 +803,7 @@ function constantTimeTokenEqual(
 }
 
 // ---------------------------------------------------------------------------
-// Defaults — resolve the configured STT provider + real node:net socket
+// Host-backed factory
 // ---------------------------------------------------------------------------
 
 function formatDisjunction(items: readonly string[]): string {
@@ -737,25 +814,37 @@ function formatDisjunction(items: readonly string[]): string {
 }
 
 /**
- * Default streaming-transcriber factory — resolves the provider via the
- * assistant's STT catalog (reads `services.stt.provider` and looks up
- * credentials centrally).
+ * Options accepted by the per-meeting ingest builder returned from
+ * {@link createAudioIngest}. The session manager injects per-meeting
+ * overrides (diarization toggle, bot-connect timeout) while the factory
+ * provides the host-backed defaults (logger, transcriber resolver).
+ */
+export interface CreateAudioIngestInstanceOptions {
+  /** Override the audio-ingest TCP listener (tests only). */
+  listen?: AudioIngestListenFn;
+  /** Override the bot-connect timeout (tests only). */
+  botConnectTimeoutMs?: number;
+  /**
+   * Whether to enable diarization. When `false`, provider speaker labels
+   * are stripped from emitted transcript events.
+   */
+  diarize?: boolean;
+}
+
+/**
+ * Host-backed factory for {@link MeetAudioIngest}. The session manager
+ * retrieves this factory from the sub-module registry (see
+ * {@link registerSubModule} wiring below) and calls the returned builder
+ * once per meeting.
  *
- * Meet audio ingest always requests diarization so {@link MeetSpeakerResolver}
- * can bind opaque ASR speaker labels to real participant identities.
- * Providers without diarization support silently ignore the flag.
- *
- * Passes the meet-bot's capture sample rate through to the resolver so
- * Meet's audio ingest does not depend on any adapter's per-provider default.
- * All three streaming adapters happen to default to 16 kHz today, but being
- * explicit insulates us from a future adapter changing its default out from
- * under ingest.
- *
- * Requests `diarize: "preferred"` so capable providers (Deepgram) emit
- * speaker labels that the downstream speaker resolver can cross-check
- * against Meet's DOM-sourced active-speaker signal. Providers that
- * don't support diarization (Gemini, Whisper) silently no-op — Meet
- * still works, the DOM remains the only speaker source.
+ * The default transcriber factory closes over `host.providers.stt.*`:
+ *   - Verifies a streaming-capable provider is configured.
+ *   - Resolves the provider's credentials and opens a streaming session
+ *     requesting `diarize: "preferred"` so capable providers emit
+ *     speaker labels that {@link MeetSpeakerResolver} can cross-check
+ *     against Meet's DOM-sourced active-speaker signal. Providers that
+ *     do not support diarization silently no-op — Meet still works;
+ *     the DOM remains the only speaker source.
  *
  * Throws {@link MeetAudioIngestError} when the resolver returns `null`.
  * With `"preferred"` that only happens when the configured STT provider
@@ -764,26 +853,42 @@ function formatDisjunction(items: readonly string[]): string {
  * capability. The error message points the user at
  * `services.stt.provider`.
  */
-async function defaultCreateTranscriber(): Promise<StreamingTranscriber> {
-  const transcriber = await resolveStreamingTranscriber({
-    sampleRate: MEET_BOT_SAMPLE_RATE_HZ,
+export function createAudioIngest(
+  host: SkillHost,
+): (opts?: CreateAudioIngestInstanceOptions) => MeetAudioIngest {
+  const logger = host.logger.get("meet-audio-ingest");
+  const stt = host.providers.stt;
+
+  const createTranscriber: StreamingTranscriberFactory = async () => {
     // `"preferred"`: enable diarization when the configured provider can
     // do it, but don't refuse to start on providers that can't — Meet
     // falls back to DOM-based speaker attribution via MeetSpeakerResolver.
-    diarize: "preferred",
-  });
-  if (!transcriber) {
-    const streamingProviders = listProviderIds().filter((id) =>
-      supportsBoundary(id, "daemon-streaming"),
-    );
-    const providerList = formatDisjunction(streamingProviders);
-    throw new MeetAudioIngestError(
-      "The configured STT provider is unusable for Meet transcription. " +
-        `Set services.stt.provider to ${providerList} ` +
-        "and ensure credentials are present.",
-    );
-  }
-  return transcriber;
+    const transcriber = (await stt.resolveStreamingTranscriber({
+      sampleRate: MEET_BOT_SAMPLE_RATE_HZ,
+      diarize: "preferred",
+    })) as StreamingTranscriber | null;
+    if (!transcriber) {
+      const streamingProviders = stt
+        .listProviderIds()
+        .filter((id) => stt.supportsBoundary(id));
+      const providerList = formatDisjunction(streamingProviders);
+      throw new MeetAudioIngestError(
+        "The configured STT provider is unusable for Meet transcription. " +
+          `Set services.stt.provider to ${providerList} ` +
+          "and ensure credentials are present.",
+      );
+    }
+    return transcriber;
+  };
+
+  return (opts: CreateAudioIngestInstanceOptions = {}) =>
+    new MeetAudioIngest({
+      createTranscriber,
+      logger,
+      listen: opts.listen,
+      botConnectTimeoutMs: opts.botConnectTimeoutMs,
+      diarize: opts.diarize,
+    });
 }
 
 /**
@@ -793,78 +898,82 @@ async function defaultCreateTranscriber(): Promise<StreamingTranscriber> {
  * once `listen()` resolves and exposed on the returned
  * {@link AudioIngestServer} so the session manager can thread it through
  * to the bot container as the `DAEMON_AUDIO_PORT` env var.
+ *
+ * Accepts a logger so listener-internal failures route through the same
+ * logger the class uses instead of a module-level singleton.
  */
-function defaultListen(): Promise<AudioIngestServer> {
-  return new Promise<AudioIngestServer>((resolve, reject) => {
-    let settled = false;
-    const connectionListeners: Array<(conn: AudioIngestConnection) => void> =
-      [];
-    const errorListeners: Array<(err: Error) => void> = [];
+function defaultListen(log: Logger): () => Promise<AudioIngestServer> {
+  return () =>
+    new Promise<AudioIngestServer>((resolve, reject) => {
+      let settled = false;
+      const connectionListeners: Array<(conn: AudioIngestConnection) => void> =
+        [];
+      const errorListeners: Array<(err: Error) => void> = [];
 
-    const netServer: NetServer = netCreateServer((socket) => {
-      const conn = adaptNetSocket(socket);
-      for (const listener of connectionListeners) {
-        try {
-          listener(conn);
-        } catch (err) {
-          log.warn({ err }, "MeetAudioIngest: connection listener threw");
+      const netServer: NetServer = netCreateServer((socket) => {
+        const conn = adaptNetSocket(socket);
+        for (const listener of connectionListeners) {
+          try {
+            listener(conn);
+          } catch (err) {
+            log.warn("MeetAudioIngest: connection listener threw", { err });
+          }
         }
-      }
-    });
+      });
 
-    netServer.on("error", (err) => {
-      if (!settled) {
+      netServer.on("error", (err) => {
+        if (!settled) {
+          settled = true;
+          reject(err);
+          return;
+        }
+        for (const listener of errorListeners) {
+          try {
+            listener(err);
+          } catch (cbErr) {
+            log.warn("MeetAudioIngest: error listener threw", { cbErr });
+          }
+        }
+      });
+
+      netServer.listen({ host: AUDIO_INGEST_BIND_HOST, port: 0 }, () => {
+        if (settled) return;
         settled = true;
-        reject(err);
-        return;
-      }
-      for (const listener of errorListeners) {
-        try {
-          listener(err);
-        } catch (cbErr) {
-          log.warn({ cbErr }, "MeetAudioIngest: error listener threw");
+
+        const address = netServer.address();
+        if (!address || typeof address === "string") {
+          // `netServer.address()` returns `null` only if the server is not
+          // listening, and a `string` only for Unix-domain servers — neither
+          // can occur after a successful TCP `listen()`. Guard anyway so a
+          // future refactor that reintroduces Unix-domain listens (tests,
+          // alternate transports) fails loudly instead of silently passing
+          // `0` as the port.
+          netServer.close();
+          reject(
+            new Error(
+              `MeetAudioIngest: unexpected listen address shape: ${JSON.stringify(address)}`,
+            ),
+          );
+          return;
         }
-      }
+        const port = (address as AddressInfo).port;
+
+        const wrapped: AudioIngestServer = {
+          port,
+          onConnection: (listener) => {
+            connectionListeners.push(listener);
+          },
+          onError: (listener) => {
+            errorListeners.push(listener);
+          },
+          close: () =>
+            new Promise<void>((resolveClose) => {
+              netServer.close(() => resolveClose());
+            }),
+        };
+        resolve(wrapped);
+      });
     });
-
-    netServer.listen({ host: AUDIO_INGEST_BIND_HOST, port: 0 }, () => {
-      if (settled) return;
-      settled = true;
-
-      const address = netServer.address();
-      if (!address || typeof address === "string") {
-        // `netServer.address()` returns `null` only if the server is not
-        // listening, and a `string` only for Unix-domain servers — neither
-        // can occur after a successful TCP `listen()`. Guard anyway so a
-        // future refactor that reintroduces Unix-domain listens (tests,
-        // alternate transports) fails loudly instead of silently passing
-        // `0` as the port.
-        netServer.close();
-        reject(
-          new Error(
-            `MeetAudioIngest: unexpected listen address shape: ${JSON.stringify(address)}`,
-          ),
-        );
-        return;
-      }
-      const port = (address as AddressInfo).port;
-
-      const wrapped: AudioIngestServer = {
-        port,
-        onConnection: (listener) => {
-          connectionListeners.push(listener);
-        },
-        onError: (listener) => {
-          errorListeners.push(listener);
-        },
-        close: () =>
-          new Promise<void>((resolveClose) => {
-            netServer.close(() => resolveClose());
-          }),
-      };
-      resolve(wrapped);
-    });
-  });
 }
 
 /**
@@ -879,3 +988,15 @@ function adaptNetSocket(socket: NetSocket): AudioIngestConnection {
     destroy: () => socket.destroy(),
   };
 }
+
+// ---------------------------------------------------------------------------
+// Sub-module registry wiring
+// ---------------------------------------------------------------------------
+
+/**
+ * Registry key for the audio-ingest factory. The session manager looks
+ * this up via {@link getSubModule} to obtain the per-meeting builder.
+ */
+export const AUDIO_INGEST_SUB_MODULE = "audio-ingest";
+
+registerSubModule(AUDIO_INGEST_SUB_MODULE, createAudioIngest);

--- a/skills/meet-join/daemon/speaker-resolver.ts
+++ b/skills/meet-join/daemon/speaker-resolver.ts
@@ -6,12 +6,12 @@
  *
  * Two signals feed into the resolver:
  *
- *   1. **Provider labels** — opaque strings that are stable *within* a
+ *   1. Provider labels — opaque strings that are stable within a
  *      session but carry no real-world identity. They ride in
  *      `TranscriptChunkEvent.speakerLabel` (and occasionally `speakerId`).
- *   2. **DOM active-speaker events** — real participant ids + names scraped
+ *   2. DOM active-speaker events — real participant ids + names scraped
  *      from the Meet UI, delivered as `SpeakerChangeEvent`s. These are
- *      authoritative for *who* is on camera but arrive independently of
+ *      authoritative for who is on camera but arrive independently of
  *      the audio stream, so they are only useful when correlated with a
  *      transcript's timestamp.
  *
@@ -25,28 +25,28 @@
  * Resolution precedence for a given transcript (all conditional on the
  * provider label being present, unless noted):
  *
- *   - **DOM active-speaker in window (±{@link DOM_CORRELATION_WINDOW_MS}):**
+ *   - DOM active-speaker in window (±{@link DOM_CORRELATION_WINDOW_MS}):
  *     DOM is authoritative — returned with `confidence: "dom-authoritative"`.
  *     Mapping is created on first sight, incremented on agreement, or —
- *     after 3 consecutive disagreements — *replaced* with the new DOM
+ *     after 3 consecutive disagreements — replaced with the new DOM
  *     speaker. A single disagreement is treated as transient DOM flicker:
  *     the mapping is preserved and the resolver returns the mapped identity
  *     with `confidence: "provider-via-mapping"` (a structured
  *     `speaker.mapping_conflict` log captures the divergence for review).
  *
- *   - **No DOM in window, stable mapping exists (`agreementCount >= 3`):**
+ *   - No DOM in window, stable mapping exists (`agreementCount >= 3`):
  *     Use the learned mapping — `confidence: "provider-via-mapping"`.
  *
- *   - **No DOM in window, no stable mapping, but a last-known DOM speaker
- *     exists:** fall back to the last-known DOM speaker with
+ *   - No DOM in window, no stable mapping, but a last-known DOM speaker
+ *     exists: fall back to the last-known DOM speaker with
  *     `confidence: "dom-fallback"`. This handles brief DOM gaps before the
  *     mapping has had a chance to harden.
  *
- *   - **No DOM in window AND no last-known DOM speaker:** the resolver has
+ *   - No DOM in window AND no last-known DOM speaker: the resolver has
  *     no basis for attribution — `confidence: "unknown"` with the default
  *     name.
  *
- * When the provider label is *absent* (non-diarizing provider, or
+ * When the provider label is absent (non-diarizing provider, or
  * diarization disabled), the DOM is the sole source: DOM in window →
  * `dom-authoritative`, else `unknown`.
  *
@@ -54,27 +54,62 @@
  * single structured log line summarizing the learned mappings and the
  * conflict count for post-hoc accuracy review.
  *
- * The resolver **wraps** (not replaces) the shared {@link SpeakerIdentityTracker}
- * from the calls module: each resolved identity is forwarded via
- * `tracker.identifySpeaker` so the cross-surface speaker profile list stays
- * coherent across calls and meetings.
+ * The resolver wraps (not replaces) a shared speaker-identity tracker
+ * provided via `host.speakers.createTracker()`: each resolved identity is
+ * forwarded via `tracker.identifySpeaker` so the cross-surface speaker
+ * profile list stays coherent across calls and meetings.
+ *
+ * This file has zero `assistant/` imports — every runtime dependency
+ * arrives via the {@link SkillHost} contract from
+ * `@vellumai/skill-host-contracts`.
  */
+
+import type { Logger, SkillHost } from "@vellumai/skill-host-contracts";
 
 import type {
   SpeakerChangeEvent,
   TranscriptChunkEvent,
 } from "../contracts/index.js";
 
-import type { PromptSpeakerMetadata } from "../../../assistant/src/calls/speaker-identification.js";
-import { SpeakerIdentityTracker } from "../../../assistant/src/calls/speaker-identification.js";
-import { getLogger } from "../../../assistant/src/util/logger.js";
 import {
   type MeetEventSubscriber,
   type MeetEventUnsubscribe,
   subscribeToMeetingEvents,
 } from "./event-publisher.js";
+import { registerSubModule } from "./modules-registry.js";
 
-const log = getLogger("meet-speaker-resolver");
+// ---------------------------------------------------------------------------
+// Local structural types
+//
+// These mirror the narrow surface of `SpeakerIdentityTracker` and its
+// metadata payload that the resolver actually exercises. Defining them here
+// avoids reaching into `assistant/` directly; the daemon-side SkillHost
+// narrows its concrete tracker type to these structural supertypes at the
+// boundary.
+// ---------------------------------------------------------------------------
+
+/**
+ * Payload passed to {@link SpeakerIdentityTrackerShape.identifySpeaker}.
+ * The resolver only populates `speakerId` + `speakerName`; the tracker
+ * implementation is responsible for merging the remaining fields from
+ * other ingest sites (calls, telephony, etc.).
+ */
+interface PromptSpeakerMetadata {
+  speakerId?: string;
+  speakerLabel?: string;
+  speakerName?: string;
+  speakerConfidence?: number;
+  participantId?: string;
+}
+
+/**
+ * Minimal tracker surface consumed by the resolver. The full
+ * `SpeakerIdentityTracker` exported from `assistant/` is a structural
+ * supertype — passing it here compiles cleanly without a cast.
+ */
+export interface SpeakerIdentityTrackerShape {
+  identifySpeaker(metadata: PromptSpeakerMetadata): unknown;
+}
 
 // ---------------------------------------------------------------------------
 // Tunables
@@ -106,6 +141,23 @@ export const STABLE_MAPPING_THRESHOLD = 3;
 
 /** Returned as `speakerName` when neither signal produced a binding. */
 export const UNKNOWN_SPEAKER_NAME = "Unknown speaker";
+
+/** No-op logger used when deps do not supply one (tests). */
+const NOOP_LOGGER: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+/**
+ * No-op tracker used when deps do not supply one. Keeps the class safely
+ * instantiable outside the host-backed factory (test scenarios that don't
+ * care about cross-surface speaker accounting).
+ */
+const NOOP_TRACKER: SpeakerIdentityTrackerShape = {
+  identifySpeaker: () => undefined,
+};
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -157,11 +209,12 @@ export interface MeetSpeakerResolverDeps {
   /** Meeting id — used to subscribe to the matching event stream. */
   meetingId: string;
   /**
-   * Optional shared {@link SpeakerIdentityTracker}. Defaults to a fresh
-   * per-resolver instance; callers who want the Meet stream to feed the
-   * same tracker used by calls should pass theirs here.
+   * Optional shared speaker-identity tracker. Defaults to a no-op;
+   * callers who want the Meet stream to feed the same tracker used by
+   * calls should pass one here (the host-backed factory threads
+   * `host.speakers.createTracker()` through for production wiring).
    */
-  tracker?: SpeakerIdentityTracker;
+  tracker?: SpeakerIdentityTrackerShape;
   /**
    * Optional correlation-window override (milliseconds). Defaults to
    * {@link DOM_CORRELATION_WINDOW_MS}. Tests set this to 0 to make the
@@ -177,6 +230,12 @@ export interface MeetSpeakerResolverDeps {
     meetingId: string,
     cb: MeetEventSubscriber,
   ) => MeetEventUnsubscribe;
+  /**
+   * Structural logger for internal warnings. Defaults to a silent no-op
+   * so direct instantiation in tests does not require a logger; the
+   * host-backed factory passes `host.logger.get("meet-speaker-resolver")`.
+   */
+  logger?: Logger;
 }
 
 // ---------------------------------------------------------------------------
@@ -197,7 +256,7 @@ interface ActiveSpeakerSnapshot {
  * conflict; crossing {@link MAPPING_REPLACE_THRESHOLD} replaces the mapping.
  *
  * `lastDisagreeSpeakerId` tracks which DOM speaker drove the current
- * disagreement streak. If a *different* DOM speaker disagrees, the counter
+ * disagreement streak. If a different DOM speaker disagrees, the counter
  * resets to 1 with the new challenger — random flicker from multiple
  * speakers should not accumulate toward a mapping replacement.
  */
@@ -215,9 +274,10 @@ interface LabelMapping {
 
 export class MeetSpeakerResolver {
   private readonly meetingId: string;
-  private readonly tracker: SpeakerIdentityTracker;
+  private readonly tracker: SpeakerIdentityTrackerShape;
   private readonly correlationWindowMs: number;
   private readonly unsubscribeFn: MeetEventUnsubscribe;
+  private readonly log: Logger;
 
   /** Most-recent DOM active speaker — updated on every `speaker.change`. */
   private activeSpeaker: ActiveSpeakerSnapshot | null = null;
@@ -238,9 +298,10 @@ export class MeetSpeakerResolver {
 
   constructor(deps: MeetSpeakerResolverDeps) {
     this.meetingId = deps.meetingId;
-    this.tracker = deps.tracker ?? new SpeakerIdentityTracker();
+    this.tracker = deps.tracker ?? NOOP_TRACKER;
     this.correlationWindowMs =
       deps.correlationWindowMs ?? DOM_CORRELATION_WINDOW_MS;
+    this.log = deps.logger ?? NOOP_LOGGER;
 
     const subscribe = deps.subscribe ?? subscribeToMeetingEvents;
     this.unsubscribeFn = subscribe(this.meetingId, (event) => {
@@ -309,7 +370,7 @@ export class MeetSpeakerResolver {
 
     if (!this.summaryFlushed) {
       this.summaryFlushed = true;
-      log.info(summary, "Meet speaker resolver: meeting summary");
+      this.log.info("Meet speaker resolver: meeting summary", summary);
     }
     return summary;
   }
@@ -323,10 +384,10 @@ export class MeetSpeakerResolver {
     try {
       this.unsubscribeFn();
     } catch (err) {
-      log.warn(
-        { err, meetingId: this.meetingId },
-        "MeetSpeakerResolver: unsubscribe threw",
-      );
+      this.log.warn("MeetSpeakerResolver: unsubscribe threw", {
+        err,
+        meetingId: this.meetingId,
+      });
     }
     this.flushSummary();
   }
@@ -394,7 +455,8 @@ export class MeetSpeakerResolver {
       : 1;
 
     this.conflictCount += 1;
-    log.warn(
+    this.log.warn(
+      "Meet speaker resolver: provider-label mapping disagrees with DOM",
       {
         event: "speaker.mapping_conflict",
         meetingId: this.meetingId,
@@ -410,7 +472,6 @@ export class MeetSpeakerResolver {
         },
         consecutiveDisagreements: newDisagreements,
       },
-      "Meet speaker resolver: provider-label mapping disagrees with DOM",
     );
 
     existing.consecutiveDisagreements = newDisagreements;
@@ -496,9 +557,9 @@ export class MeetSpeakerResolver {
   }
 
   /**
-   * Forward the resolved identity to the shared
-   * {@link SpeakerIdentityTracker} so cross-surface profile accounting
-   * (calls + meetings) stays coherent, then return it.
+   * Forward the resolved identity to the shared speaker-identity tracker
+   * so cross-surface profile accounting (calls + meetings) stays
+   * coherent, then return it.
    */
   private emit(resolved: ResolvedSpeaker): ResolvedSpeaker {
     if (resolved.confidence !== "unknown" && resolved.speakerId) {
@@ -509,13 +570,13 @@ export class MeetSpeakerResolver {
       try {
         this.tracker.identifySpeaker(metadata);
       } catch (err) {
-        // SpeakerIdentityTracker is in-memory only, but defend against a
-        // future implementation change — a tracker failure must never
-        // break transcript attribution.
-        log.warn(
-          { err, meetingId: this.meetingId },
-          "MeetSpeakerResolver: tracker.identifySpeaker threw",
-        );
+        // Tracker is typically in-memory, but defend against a future
+        // implementation change — a tracker failure must never break
+        // transcript attribution.
+        this.log.warn("MeetSpeakerResolver: tracker.identifySpeaker threw", {
+          err,
+          meetingId: this.meetingId,
+        });
       }
     }
     return resolved;
@@ -534,3 +595,68 @@ export class MeetSpeakerResolver {
 function parseTimestamp(iso: string): number {
   return Date.parse(iso);
 }
+
+// ---------------------------------------------------------------------------
+// Host-backed factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-meeting overrides accepted by the builder returned from
+ * {@link createSpeakerResolver}. The session manager supplies the
+ * meeting id and (optionally) a per-meeting correlation window; the
+ * factory wires in the host-provided logger and tracker.
+ */
+export interface CreateSpeakerResolverInstanceOptions {
+  meetingId: string;
+  /** Override the correlation window (tests only). */
+  correlationWindowMs?: number;
+  /** Override the event-stream subscribe function (tests only). */
+  subscribe?: (
+    meetingId: string,
+    cb: MeetEventSubscriber,
+  ) => MeetEventUnsubscribe;
+  /**
+   * Supply a pre-constructed tracker instead of the host-default. The
+   * host-backed factory calls `host.speakers.createTracker()` once per
+   * builder call; callers that want to share a tracker across surfaces
+   * (e.g. calls + Meet) can pass their own.
+   */
+  tracker?: SpeakerIdentityTrackerShape;
+}
+
+/**
+ * Host-backed factory for {@link MeetSpeakerResolver}. The session
+ * manager retrieves this factory from the sub-module registry and calls
+ * the returned builder once per meeting.
+ *
+ * The builder consults `host.speakers.createTracker()` for the default
+ * tracker and routes internal warnings through
+ * `host.logger.get("meet-speaker-resolver")`.
+ */
+export function createSpeakerResolver(
+  host: SkillHost,
+): (opts: CreateSpeakerResolverInstanceOptions) => MeetSpeakerResolver {
+  const logger = host.logger.get("meet-speaker-resolver");
+  return (opts) =>
+    new MeetSpeakerResolver({
+      meetingId: opts.meetingId,
+      tracker:
+        opts.tracker ??
+        (host.speakers.createTracker() as SpeakerIdentityTrackerShape),
+      logger,
+      correlationWindowMs: opts.correlationWindowMs,
+      subscribe: opts.subscribe,
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Sub-module registry wiring
+// ---------------------------------------------------------------------------
+
+/**
+ * Registry key for the speaker-resolver factory. The session manager
+ * looks this up via {@link getSubModule} to obtain the per-meeting builder.
+ */
+export const SPEAKER_RESOLVER_SUB_MODULE = "speaker-resolver";
+
+registerSubModule(SPEAKER_RESOLVER_SUB_MODULE, createSpeakerResolver);


### PR DESCRIPTION
## Summary
- audio-ingest.ts now uses host.providers.stt.* and host.logger.get; zero assistant/ imports.
- speaker-resolver.ts now uses host.speakers.createTracker() and host.logger.get; zero assistant/ imports.
- Both factories registered in modules-registry for session-manager (PR 17).

Part of plan: skill-isolation.md (PR 10 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
