### PR TITLE
docs: update stale injector comments to present tense and eight-default count

### DIFF
--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -141,9 +141,8 @@ describe("injector chain", () => {
   });
 
   test("composeInjectorChain returns empty string when every injector opts out", async () => {
-    // The default chain is the golden-path: all seven defaults return `null`
-    // in this PR, so the composed block is an empty string, matching the
-    // pre-PR behavior where no chain existed at all.
+    // The default chain is the golden-path: all eight defaults return `null`
+    // on an empty turn context, so the composed block is an empty string.
     registerPlugin(defaultInjectorsPlugin);
 
     const composed = await composeInjectorChain(makeTurnContext());
@@ -286,13 +285,13 @@ describe("injector chain", () => {
     expect(result.blocks.injectorChainBlock).toBe("THIRD_PARTY_BLOCK");
   });
 
-  // ── G2.1 migration integration tests ────────────────────────────────
+  // ── Integration tests ───────────────────────────────────────────────
   //
   // These assertions exercise the real per-turn injection pipeline with
-  // the default chain active, verifying that each ported injector emits
-  // byte-identical content to the pre-migration output and that a
-  // third-party injector registered at a fractional `order` slots into
-  // the correct position in the final user-tail content.
+  // the default chain active, verifying that each default injector emits
+  // the expected content and that a third-party injector registered at a
+  // fractional `order` slots into the correct position in the final
+  // user-tail content.
 
   test("golden-path: default chain injects workspace + unified-turn + PKB + NOW + subagent in the correct positions", async () => {
     // Canonical golden-path conversation state: full mode, non-Slack

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -71,7 +71,7 @@ const PKB_HINT_THRESHOLD = 0.5;
 const PKB_HINT_ARCHIVE_THRESHOLD = 0.7;
 
 /**
- * Fixed order values for the seven default injectors. Exported so tests —
+ * Fixed order values for the eight default injectors. Exported so tests —
  * and any future integration code — can assert ordering without re-deriving
  * the constants.
  *

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -921,9 +921,8 @@ export interface TurnContext {
  *   user's typed text (e.g. subagent status, slack active-thread focus).
  * - `"after-memory-prefix"` — insert the block immediately after any leading
  *   memory-prefix blocks (`<memory_context>`, `<memory __injected>`) on the
- *   tail user message. Preserves the splice behaviour of `injectPkbContext`
- *   and `injectNowScratchpad` so memory/PKB/NOW ordering matches the
- *   pre-migration output byte-for-byte.
+ *   tail user message. Keeps memory/PKB/NOW in their canonical relative
+ *   order regardless of how many after-memory-prefix blocks are spliced.
  * - `"replace-run-messages"` — replace the full `runMessages` array with the
  *   block's `messagesOverride`. Used by the Slack chronological-transcript
  *   injector (the transcript is a whole new message list rendered from the


### PR DESCRIPTION
Addresses review feedback on #27665.

- `assistant/src/plugins/defaults/injectors.ts:74` — JSDoc for `DEFAULT_INJECTOR_ORDER` said "seven default injectors"; #27665 added `pkb-reminder` bringing the count to eight.
- `assistant/src/__tests__/injector-chain.test.ts:144` — test comment said "all seven defaults" and narrated pre-PR behavior; rewritten in present tense for eight defaults.
- `assistant/src/__tests__/injector-chain.test.ts:289` — "G2.1 migration integration tests" / "byte-identical content to the pre-migration output" → present-tense "Integration tests" describing what the assertions verify today.
- `assistant/src/plugins/types.ts:926` — `after-memory-prefix` docblock narrated "pre-migration output byte-for-byte"; rewritten to describe the ordering invariant directly.

PR #27777 (merged today) already cleaned up the two "pre-migration" references on `injectors.ts:160` and `:192` that were also flagged, so those are no-ops here.

## Test plan

- [x] Comment-only changes; no runtime behavior affected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
