### PR TITLE
feat(macos): add per-environment icon colors for staging, dev, and local

### DIFF
--- a/clients/macos/build-resources/icons/dev/Assets/white-V.svg
+++ b/clients/macos/build-resources/icons/dev/Assets/white-V.svg
@@ -1,0 +1,3 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M37.7717 25L50 51.2728L62.1797 25L74.4565 25L49.9029 75L25.5435 25H37.7717Z" fill="white"/>
+</svg>

--- a/clients/macos/build-resources/icons/dev/icon.json
+++ b/clients/macos/build-resources/icons/dev/icon.json
@@ -1,0 +1,47 @@
+{
+  "fill" : {
+    "solid" : "display-p3:1.00000,0.53333,0.78824,1.00000"
+  },
+  "groups" : [
+    {
+      "blend-mode" : "normal",
+      "layers" : [
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "dark",
+              "value" : "none"
+            }
+          ],
+          "glass" : false,
+          "image-name" : "white-V.svg",
+          "name" : "white-V",
+          "position" : {
+            "scale" : 11,
+            "translation-in-points" : [
+              0,
+              12
+            ]
+          }
+        }
+      ],
+      "lighting" : "individual",
+      "name" : "Group",
+      "shadow" : {
+        "kind" : "neutral",
+        "opacity" : 0.5
+      },
+      "specular" : true,
+      "translucency" : {
+        "enabled" : true,
+        "value" : 0.5
+      }
+    }
+  ],
+  "supported-platforms" : {
+    "circles" : [
+      "watchOS"
+    ],
+    "squares" : "shared"
+  }
+}

--- a/clients/macos/build-resources/icons/local/Assets/white-V.svg
+++ b/clients/macos/build-resources/icons/local/Assets/white-V.svg
@@ -1,0 +1,3 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M37.7717 25L50 51.2728L62.1797 25L74.4565 25L49.9029 75L25.5435 25H37.7717Z" fill="white"/>
+</svg>

--- a/clients/macos/build-resources/icons/local/icon.json
+++ b/clients/macos/build-resources/icons/local/icon.json
@@ -1,0 +1,47 @@
+{
+  "fill" : {
+    "solid" : "display-p3:1.00000,0.53333,0.78824,1.00000"
+  },
+  "groups" : [
+    {
+      "blend-mode" : "normal",
+      "layers" : [
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "dark",
+              "value" : "none"
+            }
+          ],
+          "glass" : false,
+          "image-name" : "white-V.svg",
+          "name" : "white-V",
+          "position" : {
+            "scale" : 11,
+            "translation-in-points" : [
+              0,
+              12
+            ]
+          }
+        }
+      ],
+      "lighting" : "individual",
+      "name" : "Group",
+      "shadow" : {
+        "kind" : "neutral",
+        "opacity" : 0.5
+      },
+      "specular" : true,
+      "translucency" : {
+        "enabled" : true,
+        "value" : 0.5
+      }
+    }
+  ],
+  "supported-platforms" : {
+    "circles" : [
+      "watchOS"
+    ],
+    "squares" : "shared"
+  }
+}

--- a/clients/macos/build-resources/icons/staging/Assets/white-V.svg
+++ b/clients/macos/build-resources/icons/staging/Assets/white-V.svg
@@ -1,0 +1,3 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M37.7717 25L50 51.2728L62.1797 25L74.4565 25L49.9029 75L25.5435 25H37.7717Z" fill="white"/>
+</svg>

--- a/clients/macos/build-resources/icons/staging/icon.json
+++ b/clients/macos/build-resources/icons/staging/icon.json
@@ -1,0 +1,47 @@
+{
+  "fill" : {
+    "solid" : "display-p3:0.91373,0.78824,0.10196,1.00000"
+  },
+  "groups" : [
+    {
+      "blend-mode" : "normal",
+      "layers" : [
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "dark",
+              "value" : "none"
+            }
+          ],
+          "glass" : false,
+          "image-name" : "white-V.svg",
+          "name" : "white-V",
+          "position" : {
+            "scale" : 11,
+            "translation-in-points" : [
+              0,
+              12
+            ]
+          }
+        }
+      ],
+      "lighting" : "individual",
+      "name" : "Group",
+      "shadow" : {
+        "kind" : "neutral",
+        "opacity" : 0.5
+      },
+      "specular" : true,
+      "translucency" : {
+        "enabled" : true,
+        "value" : 0.5
+      }
+    }
+  ],
+  "supported-platforms" : {
+    "circles" : [
+      "watchOS"
+    ],
+    "squares" : "shared"
+  }
+}


### PR DESCRIPTION
## Summary
- Add yellow icon for staging builds (`#E9C91A`) and pink icon for dev/local builds (`#FF88C9`)
- Uses the per-environment icon infrastructure from PR #27733, with Icon Composer manifests and foreground SVGs for each environment
- Production icon remains unchanged (green)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
