### PR TITLE
fix(plugins): unregister flag-gated plugins on bootstrap skip

### DIFF
--- a/assistant/src/__tests__/plugin-bootstrap.test.ts
+++ b/assistant/src/__tests__/plugin-bootstrap.test.ts
@@ -44,10 +44,13 @@ import { runShutdownHooks } from "../daemon/shutdown-registry.js";
 import { RiskLevel } from "../permissions/types.js";
 import {
   ASSISTANT_API_VERSIONS,
+  getInjectors,
+  getMiddlewaresFor,
   registerPlugin,
   resetPluginRegistryForTests,
 } from "../plugins/registry.js";
 import {
+  type PipelineMiddlewareMap,
   type Plugin,
   PluginExecutionError,
   type PluginInitContext,
@@ -454,6 +457,49 @@ describe("plugin bootstrap", () => {
     await bootstrapPlugins(fakeCtx);
 
     expect(initFired).toBe(false);
+  });
+
+  test("requiresFlag disabled: plugin middleware and injectors are dropped from the registry", async () => {
+    // Regression: prior to the unregisterPlugin() call on the flag-gated skip
+    // path, `getMiddlewaresFor()` and `getInjectors()` iterated over every
+    // entry in `registeredPlugins` — so a gated-off plugin's middleware and
+    // injectors still ran on every pipeline invocation and system-prompt
+    // assembly even though `init()` had never fired to set up the state they
+    // depended on.
+    _setOverridesForTesting({ "plugin-middleware-disabled": false });
+
+    const gatedMiddleware: PipelineMiddlewareMap["llmCall"] = async (
+      args,
+      next,
+    ) => next(args);
+    const plugin = buildPlugin(
+      "gated-middleware",
+      {
+        middleware: { llmCall: gatedMiddleware },
+        injectors: [
+          {
+            name: "gated-middleware-injector",
+            order: 100,
+            async produce() {
+              return null;
+            },
+          },
+        ],
+      },
+      { requiresFlag: ["plugin-middleware-disabled"] },
+    );
+    registerPlugin(plugin);
+
+    await bootstrapPlugins(fakeCtx);
+
+    // Neither the middleware slot nor the injector list should expose the
+    // flag-gated plugin's contributions. The default plugins also contribute
+    // llmCall middleware / injectors, so we key on identity rather than
+    // asserting empty lists.
+    expect(getMiddlewaresFor("llmCall")).not.toContain(gatedMiddleware);
+    expect(
+      getInjectors().some((i) => i.name === "gated-middleware-injector"),
+    ).toBe(false);
   });
 
   test("requiresFlag disabled: no shutdown hook entry installed for the skipped plugin", async () => {

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -14,8 +14,11 @@
  * 3. For each plugin, consults `manifest.requiresFlag` against
  *    {@link isAssistantFeatureFlagEnabled}. If any listed flag is disabled,
  *    the plugin is skipped wholesale — no `init()`, no tool/route/skill
- *    contributions, and no entry in the shutdown hook. This is the primary
- *    mechanism for shipping experimental plugins behind a feature flag.
+ *    contributions, no entry in the shutdown hook, and the plugin is also
+ *    dropped from the registry via {@link unregisterPlugin} so its middleware
+ *    and injectors stop participating in pipeline runs and system-prompt
+ *    assembly. This is the primary mechanism for shipping experimental
+ *    plugins behind a feature flag.
  * 4. Resolves the plugin's `manifest.requiresCredential` entries via the
  *    credential store helper ({@link getSecureKeyAsync}). In Docker mode
  *    that helper goes through the CES HTTP API transparently; in local mode
@@ -251,6 +254,12 @@ export async function bootstrapPlugins(ctx: DaemonContext): Promise<void> {
         { plugin: name, flag: disabledFlag },
         `skipping plugin ${name}: feature flag ${disabledFlag} is disabled`,
       );
+      // Drop the plugin from the registry too. `registerPlugin()` added it at
+      // import time, and `getMiddlewaresFor()` / `getInjectors()` iterate over
+      // every registered entry — without this call, the gated plugin's
+      // middleware and injectors would still participate in every pipeline
+      // run and system-prompt assembly despite `init()` never firing.
+      unregisterPlugin(name);
       continue;
     }
 


### PR DESCRIPTION
## Summary

Devin P1 on #27421: when `bootstrapPlugins` skipped a plugin via the `requiresFlag` gate, it correctly suppressed `init()`, tool/route/skill registration, and shutdown-hook installation — but the plugin remained in `registeredPlugins`. Because `getMiddlewaresFor()` and `getInjectors()` walk every registered entry, the gated plugin's middleware and injectors still ran on every pipeline invocation and every system-prompt assembly, contradicting the documented "skipped entirely" intent and risking runtime failures from middleware touching state `init()` never set up.

Fix: call `unregisterPlugin(name)` (introduced in #27638 for the rollback path) on the flag-gated skip branch so the plugin is fully dropped from the registry. Docstring updated to spell the new behavior out.

Also adds a regression test that registers a plugin with disabled `requiresFlag` plus a middleware and injector, boots the plugin layer, and asserts neither appear in `getMiddlewaresFor("llmCall")` or `getInjectors()`.

## Test plan
- [x] `bun test assistant/src/__tests__/plugin-bootstrap.test.ts` — new test passes.
- [x] `bunx tsc --noEmit` — clean for the touched files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
