### PR TITLE
fix(plugins): always adopt historyRepair pipeline output, gate only logging on stats

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1583,18 +1583,24 @@ export async function runAgentLoopImpl(
         throw err;
       }
     }
-    if (
-      preRunRepair !== null &&
-      (preRunRepair.stats.assistantToolResultsMigrated > 0 ||
+    if (preRunRepair !== null) {
+      // Always adopt the pipeline's output history — a user `historyRepair`
+      // middleware may rewrite `messages` (e.g. provider-specific
+      // normalization) without incrementing any of the built-in repair
+      // counters. Gating the assignment on `stats` would silently discard
+      // those edits and send the un-rewritten history to the provider.
+      runMessages = preRunRepair.messages;
+      if (
+        preRunRepair.stats.assistantToolResultsMigrated > 0 ||
         preRunRepair.stats.missingToolResultsInserted > 0 ||
         preRunRepair.stats.orphanToolResultsDowngraded > 0 ||
-        preRunRepair.stats.consecutiveSameRoleMerged > 0)
-    ) {
-      rlog.warn(
-        { phase: "pre_run", ...preRunRepair.stats },
-        "Repaired runtime history before provider call",
-      );
-      runMessages = preRunRepair.messages;
+        preRunRepair.stats.consecutiveSameRoleMerged > 0
+      ) {
+        rlog.warn(
+          { phase: "pre_run", ...preRunRepair.stats },
+          "Repaired runtime history before provider call",
+        );
+      }
     }
 
     // Replace historical web_search_tool_result blocks with text summaries.


### PR DESCRIPTION
## Summary

Codex P1 on #27635: the post-pipeline guard in `conversation-agent-loop.ts` only assigned the pipeline's output to `runMessages` when one of the built-in repair counters (`stats`) was non-zero. A user `historyRepair` middleware that rewrites `messages` (e.g. provider-specific normalization) without touching the built-in counters had its result silently discarded — the provider call saw the unmodified history.

## Fix

- Assign `runMessages = preRunRepair.messages` whenever the pipeline succeeds.
- Use the `stats` check only to gate the telemetry `rlog.warn(...)`.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] Logging semantics preserved: warn still fires iff any built-in counter > 0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
