### PR TITLE
fix(plugins): close plugin-registration window after loadUserPlugins returns

### DIFF
--- a/assistant/src/__tests__/plugin-registry.test.ts
+++ b/assistant/src/__tests__/plugin-registry.test.ts
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
   ASSISTANT_API_VERSIONS,
+  closeRegistration,
   getInjectors,
   getMiddlewaresFor,
   getRegisteredPlugins,
@@ -62,6 +63,35 @@ describe("plugin registry", () => {
     );
     expect(() => registerPlugin(buildPlugin("alpha"))).toThrow(
       "already registered",
+    );
+  });
+
+  test("rejects a late `registerPlugin` call after `closeRegistration`", () => {
+    // Models the user-plugin hang: `loadUserPlugins()` timed out awaiting the
+    // plugin's dynamic import, called `closeRegistration()`, and returned.
+    // The plugin's module evaluation later completes and still tries to
+    // register. The latch must reject it so the registry doesn't gain an
+    // entry after `bootstrapPlugins()` has walked it.
+    closeRegistration();
+
+    expect(() => registerPlugin(buildPlugin("late-arrival"))).toThrow(
+      PluginExecutionError,
+    );
+    expect(() => registerPlugin(buildPlugin("late-arrival"))).toThrow(
+      "registration is closed",
+    );
+    expect(getRegisteredPlugins().map((p) => p.manifest.name)).not.toContain(
+      "late-arrival",
+    );
+  });
+
+  test("`resetPluginRegistryForTests` re-opens the registration window", () => {
+    closeRegistration();
+    resetPluginRegistryForTests();
+    // Without the reset reopening the latch, this registration would throw.
+    expect(() => registerPlugin(buildPlugin("after-reset"))).not.toThrow();
+    expect(getRegisteredPlugins().map((p) => p.manifest.name)).toContain(
+      "after-reset",
     );
   });
 

--- a/assistant/src/__tests__/user-plugin-loader.test.ts
+++ b/assistant/src/__tests__/user-plugin-loader.test.ts
@@ -178,6 +178,48 @@ registerPlugin({
     expect(names).not.toContain("hanging-plugin");
   });
 
+  test("plugin whose top-level await resolves AFTER the timeout cannot register late", async () => {
+    // Codex/Devin P1 regression: racing `import(moduleUrl)` against a timeout
+    // only stops the loader from awaiting the module — it does NOT cancel
+    // module evaluation. A plugin whose top-level await eventually resolves
+    // continues running in the background and would otherwise call
+    // `registerPlugin()` after `loadUserPlugins()` has returned (and after
+    // `bootstrapPlugins()` has potentially already walked the registry),
+    // leaving the plugin visible to `getMiddlewaresFor()` / `getInjectors()`
+    // with its `init()` hook never invoked.
+    //
+    // The `closeRegistration()` latch must reject that late arrival so the
+    // registry stays consistent with the bootstrap invariant.
+    writePlugin(
+      "slow-late-plugin",
+      `
+await new Promise((resolve) => setTimeout(resolve, 200));
+registerPlugin({
+  manifest: {
+    name: "slow-late-plugin",
+    version: "0.0.1",
+    requires: { pluginRuntime: "v1" },
+  },
+});
+`,
+    );
+
+    // Time out well before the plugin's top-level await resolves. The loader
+    // returns immediately; the abandoned import keeps evaluating in the
+    // background.
+    await loadUserPlugins({ importTimeoutMs: 25 });
+
+    // Wait long enough for the abandoned import's top-level await to resolve
+    // and try to `registerPlugin()`. The closed-registration latch must
+    // reject the call; the `.catch(() => {})` on the abandoned import must
+    // swallow the resulting rejection so the test does not see an
+    // unhandled-rejection crash.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    const names = getRegisteredPlugins().map((p) => p.manifest.name);
+    expect(names).not.toContain("slow-late-plugin");
+  });
+
   test("subdirectory without register.{ts,js} is silently skipped", async () => {
     // Populate a directory that looks like a plugin but lacks a register
     // file. The loader must skip it without throwing.

--- a/assistant/src/plugins/registry.ts
+++ b/assistant/src/plugins/registry.ts
@@ -78,6 +78,19 @@ export const ASSISTANT_API_VERSIONS: Record<string, string[]> = {
  */
 const registeredPlugins = new Map<string, Plugin>();
 
+/**
+ * Latch that closes the per-boot registration window. Flipped to `true` by
+ * {@link closeRegistration} once `loadUserPlugins()` has returned. After that,
+ * any attempt to register a *new* plugin throws — this is the safety net
+ * against a user plugin whose dynamic `import()` was timed out but whose
+ * top-level `await` later resolves and still tries to call
+ * {@link registerPlugin}. Without the latch such a late arrival would land in
+ * the registry after `bootstrapPlugins()` has already walked it, leaving the
+ * plugin visible to `getMiddlewaresFor()` / `getInjectors()` with its
+ * `init()` hook never invoked.
+ */
+let registrationClosed = false;
+
 // ─── Registration ────────────────────────────────────────────────────────────
 
 /**
@@ -139,10 +152,24 @@ export function registerPlugin(plugin: Plugin): void {
   }
 
   // Duplicate-name check — plugins must be uniquely addressable in logs,
-  // storage paths, and error messages.
+  // storage paths, and error messages. Runs BEFORE the closed-registration
+  // check so `registerDefaultPlugins()` (which replays every default even
+  // after the registration window closes) keeps seeing the familiar
+  // "already registered" error it catches and swallows.
   if (registeredPlugins.has(name)) {
     throw new PluginExecutionError(
       `plugin ${name} is already registered`,
+      name,
+    );
+  }
+
+  // Closed-registration check — rejects a genuinely new plugin that arrives
+  // after {@link closeRegistration}. The canonical offender is a user plugin
+  // whose dynamic `import()` was timed out in `loadUserPlugins()` but whose
+  // module evaluation eventually completes and still calls this function.
+  if (registrationClosed) {
+    throw new PluginExecutionError(
+      `plugin ${name} cannot register: plugin registration is closed (late arrival after loadUserPlugins() returned)`,
       name,
     );
   }
@@ -220,6 +247,23 @@ export function getInjectors(): Injector[] {
 }
 
 /**
+ * Close the per-boot registration window. After this call, any attempt to
+ * register a genuinely new plugin throws a {@link PluginExecutionError}.
+ * Re-registering an already-registered plugin still hits the duplicate-name
+ * check first (so idempotent callers like `registerDefaultPlugins()` keep
+ * working unchanged).
+ *
+ * Called by `loadUserPlugins()` immediately before it returns so the
+ * `bootstrapPlugins()` invariant ("registry has been fully populated for this
+ * boot cycle") cannot be violated by a user plugin whose dynamic `import()`
+ * timed out mid-load but whose top-level `await` resolves later and still
+ * reaches `registerPlugin()`. Idempotent.
+ */
+export function closeRegistration(): void {
+  registrationClosed = true;
+}
+
+/**
  * Remove a plugin from the registry. Invoked from the bootstrap's failure path
  * after {@link Plugin.onShutdown} and contribution teardown have run, so
  * {@link getMiddlewaresFor} and {@link getInjectors} no longer expose a
@@ -250,4 +294,8 @@ export function resetPluginRegistryForTests(): void {
     );
   }
   registeredPlugins.clear();
+  // Re-open the registration window so subsequent tests can register plugins
+  // again. Without this, the latch set by a prior `closeRegistration()` call
+  // would leak across test cases and reject legitimate registrations.
+  registrationClosed = false;
 }

--- a/assistant/src/plugins/user-loader.ts
+++ b/assistant/src/plugins/user-loader.ts
@@ -40,6 +40,7 @@ import { pathToFileURL } from "node:url";
 
 import { getLogger } from "../util/logger.js";
 import { vellumRoot } from "../util/platform.js";
+import { closeRegistration } from "./registry.js";
 
 const log = getLogger("user-plugin-loader");
 
@@ -83,6 +84,10 @@ export async function loadUserPlugins(
       { pluginsDir },
       "loadUserPlugins: no plugins directory — skipping",
     );
+    // Close the registration window even on the fast path so a late arrival
+    // from an unrelated source (e.g. a mis-ordered static import) still can't
+    // slip in after bootstrap walks the registry.
+    closeRegistration();
     return;
   }
 
@@ -97,6 +102,7 @@ export async function loadUserPlugins(
       { err, pluginsDir },
       "loadUserPlugins: failed to read plugins directory",
     );
+    closeRegistration();
     return;
   }
 
@@ -149,8 +155,21 @@ export async function loadUserPlugins(
           importTimeoutMs,
         );
       });
-      const result = await Promise.race([import(moduleUrl), timeoutPromise]);
+      // Retain the import promise so we can attach a terminal `.catch` on the
+      // timeout branch. `Promise.race` does not cancel the losing promise —
+      // the module evaluation keeps running in the background even after we
+      // stop awaiting it, and if it eventually throws (either from the
+      // module body or from the late `registerPlugin()` hitting a closed
+      // registry) an unhandled rejection would crash the daemon.
+      const importPromise = import(moduleUrl);
+      const result = await Promise.race([importPromise, timeoutPromise]);
       if (result === timeoutSentinel) {
+        importPromise.catch(() => {
+          // Abandoned import completed (or threw) after the timeout. The
+          // closed-registration latch in registry.ts guarantees any late
+          // `registerPlugin()` call is rejected, so swallowing the outcome
+          // here is the safe default.
+        });
         log.warn(
           { pluginDir, registerPath, timeoutMs: importTimeoutMs },
           `Timed out loading user plugin ${pluginDir} after ${importTimeoutMs}ms — skipping`,
@@ -174,4 +193,12 @@ export async function loadUserPlugins(
       if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
     }
   }
+
+  // Close the registration window once every candidate plugin has been
+  // awaited (or timed out). The per-plugin try/catch guarantees no throw
+  // escapes the loop, so this line always runs. Any abandoned import that
+  // later resolves and reaches `registerPlugin()` is rejected by the latch,
+  // preserving the `bootstrapPlugins()` invariant that the registry is
+  // fully populated before it is walked.
+  closeRegistration();
 }


### PR DESCRIPTION
Codex P1 + Devin feedback on #27636: racing `import(moduleUrl)` against a timeout does not cancel the import — it only stops awaiting. If a user plugin's top-level `await` resolves *after* `importTimeoutMs`, the module still finishes later and calls `registerPlugin()`, landing the plugin in the registry after `loadUserPlugins()` has returned and potentially after `bootstrapPlugins()` has already walked it. The plugin ends up registered but never initialized — `init()` is never called, yet its middleware and injectors are visible to `getMiddlewaresFor()` / `getInjectors()`.

## Fix

Add a `closeRegistration()` latch in `assistant/src/plugins/registry.ts`. `loadUserPlugins()` flips it before returning (every exit path — fast-path, readdir-failure, and normal completion). After that, `registerPlugin()` throws a `PluginExecutionError` for any genuinely-new plugin. The closed-registration check runs *after* the duplicate-name check, so `registerDefaultPlugins()` (which replays every default inside `bootstrapPlugins()`) keeps seeing the familiar `already registered` error it already catches and swallows.

Also attach `.catch(() => {})` to the abandoned import promise so the eventual throw from `registerPlugin()` hitting the closed registry (or any other module-body throw that lands post-timeout) does not become an unhandled rejection and crash the daemon.

`resetPluginRegistryForTests()` re-opens the latch so the closed state doesn't leak across test cases.

## Tests

Three regression tests:

1. `registry.test.ts`: `registerPlugin` after `closeRegistration()` throws `PluginExecutionError` with `registration is closed` in the message.
2. `registry.test.ts`: `resetPluginRegistryForTests()` re-opens the window.
3. `user-plugin-loader.test.ts`: a plugin whose top-level `await` resolves *after* `importTimeoutMs` does NOT land in the registry (the abandoned import's `registerPlugin()` is rejected by the latch and the resulting rejection is swallowed by the terminal `.catch`).

All 23 tests in the two affected files pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
