### PR TITLE
refactor(meet-join): migrate observer modules (barge-in, chat-opportunity, consent, session-event-router, storage-writer) to SkillHost

### DIFF
--- a/skills/meet-join/daemon/barge-in-watcher.ts
+++ b/skills/meet-join/daemon/barge-in-watcher.ts
@@ -37,6 +37,14 @@
  */
 
 import type {
+  AssistantEvent,
+  AssistantEventCallback,
+  Logger,
+  SkillHost,
+  Subscription as AssistantEventSubscription,
+} from "@vellumai/skill-host-contracts";
+
+import type {
   MeetBotEvent,
   ParticipantChangeEvent,
   SpeakerChangeEvent,
@@ -44,19 +52,31 @@ import type {
 } from "../contracts/index.js";
 
 import {
-  type AssistantEventCallback,
-  type AssistantEventSubscription,
-  assistantEventHub,
-} from "../../../assistant/src/runtime/assistant-event-hub.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../assistant/src/runtime/assistant-scope.js";
-import { getLogger } from "../../../assistant/src/util/logger.js";
-import {
   type MeetEventSubscriber,
   type MeetEventUnsubscribe,
   subscribeToMeetingEvents,
 } from "./event-publisher.js";
+import { registerSubModule } from "./modules-registry.js";
 
-const log = getLogger("meet-barge-in-watcher");
+export type { AssistantEventCallback, AssistantEventSubscription };
+
+/**
+ * Fallback logger used when the watcher is constructed without a host-
+ * sourced logger. Keeps the class callable from unit tests that build it
+ * directly without supplying a full {@link SkillHost} stub.
+ */
+const consoleLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: (msg, meta) => {
+    // eslint-disable-next-line no-console
+    console.warn(msg, meta ?? {});
+  },
+  error: (msg, meta) => {
+    // eslint-disable-next-line no-console
+    console.error(msg, meta ?? {});
+  },
+};
 
 // ---------------------------------------------------------------------------
 // Tunables
@@ -105,8 +125,11 @@ export interface MeetBargeInWatcherDeps {
     cb: MeetEventSubscriber,
   ) => MeetEventUnsubscribe;
   /**
-   * Override the assistant-event-hub subscribe (tests). Defaults to the
-   * process-level {@link assistantEventHub} singleton.
+   * Subscribe to the assistant-event hub. Production callers wire this
+   * via {@link createBargeInWatcher} to `host.events.subscribe`; direct
+   * `new MeetBargeInWatcher` callers (tests) must supply their own
+   * scripted implementation — there is no ambient default since the
+   * watcher no longer imports from `assistant/`.
    */
   subscribeAssistantEvents?: (
     cb: AssistantEventCallback,
@@ -128,6 +151,13 @@ export interface MeetBargeInWatcherDeps {
    * floats.
    */
   interimConfidenceThreshold?: number;
+  /**
+   * Logger used for best-effort error / debug telemetry. Production
+   * callers wire `host.logger.get("meet-barge-in-watcher")` via
+   * {@link createBargeInWatcher}; unit tests get a console-backed
+   * fallback so they don't need to build a full {@link SkillHost}.
+   */
+  logger?: Logger;
 }
 
 // ---------------------------------------------------------------------------
@@ -148,6 +178,7 @@ export class MeetBargeInWatcher {
   private readonly clearTimeoutFn: (handle: unknown) => void;
   private readonly debounceMs: number;
   private readonly interimConfidenceThreshold: number;
+  private readonly log: Logger;
 
   /** Bot's DOM participant id, captured from the first `isSelf` joiner. */
   private botSpeakerId: string | null = null;
@@ -165,13 +196,12 @@ export class MeetBargeInWatcher {
     this.meetingId = deps.meetingId;
     this.sessionManager = deps.sessionManager;
     this.subscribe = deps.subscribe ?? subscribeToMeetingEvents;
+    // Tests that omit this hook get a no-op subscription so `start()` does
+    // not throw; no hub-driven cancels will fire in that mode. Production
+    // wiring comes from {@link createBargeInWatcher}.
     this.subscribeAssistantEvents =
       deps.subscribeAssistantEvents ??
-      ((cb) =>
-        assistantEventHub.subscribe(
-          { assistantId: DAEMON_INTERNAL_ASSISTANT_ID },
-          cb,
-        ));
+      (() => ({ dispose: () => {}, active: false }));
     this.setTimeoutFn = deps.setTimeoutFn ?? ((cb, ms) => setTimeout(cb, ms));
     this.clearTimeoutFn =
       deps.clearTimeoutFn ??
@@ -179,6 +209,7 @@ export class MeetBargeInWatcher {
     this.debounceMs = deps.debounceMs ?? BARGE_IN_DEBOUNCE_MS;
     this.interimConfidenceThreshold =
       deps.interimConfidenceThreshold ?? BARGE_IN_INTERIM_CONFIDENCE_THRESHOLD;
+    this.log = deps.logger ?? consoleLogger;
   }
 
   /**
@@ -207,10 +238,10 @@ export class MeetBargeInWatcher {
       try {
         this.dispatcherUnsubscribe();
       } catch (err) {
-        log.warn(
-          { err, meetingId: this.meetingId },
-          "MeetBargeInWatcher: dispatcher unsubscribe threw",
-        );
+        this.log.warn("MeetBargeInWatcher: dispatcher unsubscribe threw", {
+          err,
+          meetingId: this.meetingId,
+        });
       }
       this.dispatcherUnsubscribe = null;
     }
@@ -219,9 +250,9 @@ export class MeetBargeInWatcher {
       try {
         this.hubSubscription.dispose();
       } catch (err) {
-        log.warn(
-          { err, meetingId: this.meetingId },
+        this.log.warn(
           "MeetBargeInWatcher: assistant-event-hub dispose threw",
+          { err, meetingId: this.meetingId },
         );
       }
       this.hubSubscription = null;
@@ -263,31 +294,36 @@ export class MeetBargeInWatcher {
           return;
       }
     } catch (err) {
-      log.warn(
-        { err, meetingId: this.meetingId, eventType: event.type },
-        "MeetBargeInWatcher: meeting-event handler threw",
-      );
+      this.log.warn("MeetBargeInWatcher: meeting-event handler threw", {
+        err,
+        meetingId: this.meetingId,
+        eventType: event.type,
+      });
     }
   }
 
-  private onAssistantEvent(event: {
-    message: { type: string; meetingId?: string };
-  }): void {
-    const message = event.message;
+  private onAssistantEvent(event: AssistantEvent): void {
+    // The neutral contract's `AssistantEvent` types `message` as unknown;
+    // narrow to the meet-specific shape we care about without introducing
+    // a dependency on the daemon's `ServerMessage` union.
+    const message = event.message as
+      | { type?: string; meetingId?: string; streamId?: string }
+      | undefined;
+    if (!message) return;
     // Filter to our own meeting only — the assistant event hub fans every
     // assistant event to every subscriber, so we have to gate on meetingId
     // ourselves. `meetingId` is part of the `meet.speaking_*` payload shape.
     if (message.meetingId !== this.meetingId) return;
 
     if (message.type === "meet.speaking_started") {
-      const streamId = (message as { streamId?: string }).streamId;
+      const { streamId } = message;
       if (streamId) this.activeSpeakingStreams.add(streamId);
       this.clearPendingCancel();
       return;
     }
 
     if (message.type === "meet.speaking_ended") {
-      const streamId = (message as { streamId?: string }).streamId;
+      const { streamId } = message;
       if (streamId) this.activeSpeakingStreams.delete(streamId);
       if (this.activeSpeakingStreams.size === 0) {
         this.clearPendingCancel();
@@ -372,15 +408,16 @@ export class MeetBargeInWatcher {
       // scheduling and firing, in which case there's nothing to cancel.
       if (this.activeSpeakingStreams.size === 0) return;
 
-      log.info(
-        { meetingId: this.meetingId, trigger },
-        "Meet barge-in: cancelling in-flight TTS",
-      );
+      this.log.info("Meet barge-in: cancelling in-flight TTS", {
+        meetingId: this.meetingId,
+        trigger,
+      });
       void this.sessionManager.cancelSpeak(this.meetingId).catch((err) => {
-        log.warn(
-          { err, meetingId: this.meetingId, trigger },
-          "MeetBargeInWatcher: cancelSpeak rejected",
-        );
+        this.log.warn("MeetBargeInWatcher: cancelSpeak rejected", {
+          err,
+          meetingId: this.meetingId,
+          trigger,
+        });
       });
     }, this.debounceMs);
   }
@@ -390,11 +427,43 @@ export class MeetBargeInWatcher {
     try {
       this.clearTimeoutFn(this.pendingCancelHandle);
     } catch (err) {
-      log.warn(
-        { err, meetingId: this.meetingId },
-        "MeetBargeInWatcher: clearTimeout threw",
-      );
+      this.log.warn("MeetBargeInWatcher: clearTimeout threw", {
+        err,
+        meetingId: this.meetingId,
+      });
     }
     this.pendingCancelHandle = null;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Host-based factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a callable that constructs per-meeting {@link MeetBargeInWatcher}
+ * instances bound to a {@link SkillHost}. The factory wires the host's
+ * logger and the host-scoped assistant-event-hub subscription; per-meeting
+ * deps (`meetingId`, `sessionManager`, etc.) are supplied by the session
+ * manager at construction time.
+ *
+ * Registered under the sub-module slot `"barge-in-watcher"` in
+ * {@link registerSubModule} at module import time; PR 17's session
+ * manager consumes the registration via `getSubModule`.
+ */
+export function createBargeInWatcher(
+  host: SkillHost,
+): (deps: MeetBargeInWatcherDeps) => MeetBargeInWatcher {
+  const logger = host.logger.get("meet-barge-in-watcher");
+  const assistantId = host.identity.internalAssistantId;
+  return (deps) =>
+    new MeetBargeInWatcher({
+      ...deps,
+      subscribeAssistantEvents:
+        deps.subscribeAssistantEvents ??
+        ((cb) => host.events.subscribe({ assistantId }, cb)),
+      logger: deps.logger ?? logger,
+    });
+}
+
+registerSubModule("barge-in-watcher", createBargeInWatcher);

--- a/skills/meet-join/daemon/chat-opportunity-detector.ts
+++ b/skills/meet-join/daemon/chat-opportunity-detector.ts
@@ -55,6 +55,8 @@
  * via `deps.setTimer` / `deps.clearTimer` injections.
  */
 
+import type { Logger, SkillHost } from "@vellumai/skill-host-contracts";
+
 import type {
   InboundChatEvent,
   MeetBotEvent,
@@ -62,14 +64,30 @@ import type {
   TranscriptChunkEvent,
 } from "../contracts/index.js";
 
-import { getLogger } from "../../../assistant/src/util/logger.js";
 import {
   type MeetEventSubscriber,
   type MeetEventUnsubscribe,
   subscribeToMeetingEvents,
 } from "./event-publisher.js";
+import { registerSubModule } from "./modules-registry.js";
 
-const log = getLogger("meet-chat-opportunity-detector");
+/**
+ * Fallback logger used when the detector is constructed without a host-
+ * sourced logger. Keeps the class callable from unit tests that build it
+ * directly without supplying a full {@link SkillHost} stub.
+ */
+const consoleLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: (msg, meta) => {
+    // eslint-disable-next-line no-console
+    console.warn(msg, meta ?? {});
+  },
+  error: (msg, meta) => {
+    // eslint-disable-next-line no-console
+    console.error(msg, meta ?? {});
+  },
+};
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -161,6 +179,13 @@ export interface MeetChatOpportunityDetectorDeps {
    */
   setTimer?: (cb: () => void, ms: number) => TimerHandle;
   clearTimer?: (handle: TimerHandle) => void;
+  /**
+   * Logger used for detector telemetry. Production callers wire
+   * `host.logger.get("meet-chat-opportunity-detector")` via
+   * {@link createChatOpportunityDetector}; unit tests get a console-
+   * backed fallback so they don't need to build a full {@link SkillHost}.
+   */
+  logger?: Logger;
 }
 
 // ---------------------------------------------------------------------------
@@ -200,6 +225,7 @@ function escapeRegex(value: string): string {
 function compilePatterns(
   patterns: readonly string[],
   meetingId: string,
+  log: Logger,
 ): RegExp[] {
   const compiled: RegExp[] = [];
   for (const pattern of patterns) {
@@ -208,8 +234,8 @@ function compilePatterns(
       compiled.push(new RegExp(pattern, "i"));
     } catch (err) {
       log.warn(
-        { err, pattern, meetingId },
         "MeetChatOpportunityDetector: invalid detector regex — skipping",
+        { err, pattern, meetingId },
       );
     }
   }
@@ -234,6 +260,7 @@ export class MeetChatOpportunityDetector {
   private readonly now: () => number;
   private readonly setTimer: (cb: () => void, ms: number) => TimerHandle;
   private readonly clearTimer: (handle: TimerHandle) => void;
+  private readonly log: Logger;
 
   private unsubscribe: MeetEventUnsubscribe | null = null;
   private disposed = false;
@@ -295,6 +322,7 @@ export class MeetChatOpportunityDetector {
       ((handle: TimerHandle): void => {
         clearTimeout(handle as ReturnType<typeof setTimeout>);
       });
+    this.log = deps.logger ?? consoleLogger;
 
     this.patterns = this.config.enabled
       ? this.buildPatterns(
@@ -343,9 +371,9 @@ export class MeetChatOpportunityDetector {
       try {
         this.unsubscribe();
       } catch (err) {
-        log.warn(
-          { err, meetingId: this.meetingId },
+        this.log.warn(
           "MeetChatOpportunityDetector: unsubscribe threw during dispose",
+          { err, meetingId: this.meetingId },
         );
       }
       this.unsubscribe = null;
@@ -384,10 +412,11 @@ export class MeetChatOpportunityDetector {
         return;
       }
     } catch (err) {
-      log.warn(
-        { err, meetingId: this.meetingId, eventType: event.type },
-        "MeetChatOpportunityDetector: event handler threw",
-      );
+      this.log.warn("MeetChatOpportunityDetector: event handler threw", {
+        err,
+        meetingId: this.meetingId,
+        eventType: event.type,
+      });
     }
   }
 
@@ -488,9 +517,9 @@ export class MeetChatOpportunityDetector {
       try {
         patterns.push(new RegExp(`\\b${nameLiteral}\\b`, "i"));
       } catch (err) {
-        log.warn(
-          { err, displayName, meetingId: this.meetingId },
+        this.log.warn(
           "MeetChatOpportunityDetector: failed to build name-mention regex",
+          { err, displayName, meetingId: this.meetingId },
         );
       }
       // Address + question: `(hey|hi|ok|so),? <assistantName>[,.]? … ?`.
@@ -499,13 +528,13 @@ export class MeetChatOpportunityDetector {
           new RegExp(`(hey|hi|ok|so),?\\s+${nameLiteral}[,.]?\\s+.*\\?$`, "i"),
         );
       } catch (err) {
-        log.warn(
-          { err, displayName, meetingId: this.meetingId },
+        this.log.warn(
           "MeetChatOpportunityDetector: failed to build addressed-question regex",
+          { err, displayName, meetingId: this.meetingId },
         );
       }
     }
-    patterns.push(...compilePatterns(extras, this.meetingId));
+    patterns.push(...compilePatterns(extras, this.meetingId, this.log));
     return patterns;
   }
 
@@ -545,14 +574,11 @@ export class MeetChatOpportunityDetector {
       this.lastTier2CallAt !== null &&
       nowMs - this.lastTier2CallAt < this.config.tier2DebounceMs
     ) {
-      log.debug(
-        {
-          event: "chat_opportunity.tier2.debounced",
-          meetingId: this.meetingId,
-          msSinceLast: nowMs - this.lastTier2CallAt,
-        },
-        "MeetChatOpportunityDetector: Tier 2 debounced",
-      );
+      this.log.debug("MeetChatOpportunityDetector: Tier 2 debounced", {
+        event: "chat_opportunity.tier2.debounced",
+        meetingId: this.meetingId,
+        msSinceLast: nowMs - this.lastTier2CallAt,
+      });
       return;
     }
 
@@ -570,15 +596,12 @@ export class MeetChatOpportunityDetector {
       const decision = await this.callDetectorLLM(prompt);
       if (this.disposed) return;
       if (!decision.shouldRespond) {
-        log.debug(
-          {
-            event: "chat_opportunity.tier2.negative",
-            meetingId: this.meetingId,
-            triggerReason,
-            reason: decision.reason,
-          },
-          "MeetChatOpportunityDetector: Tier 2 declined",
-        );
+        this.log.debug("MeetChatOpportunityDetector: Tier 2 declined", {
+          event: "chat_opportunity.tier2.negative",
+          meetingId: this.meetingId,
+          triggerReason,
+          reason: decision.reason,
+        });
         return;
       }
       this.stats.tier2PositiveCount += 1;
@@ -591,10 +614,11 @@ export class MeetChatOpportunityDetector {
       // Restore the debounce clock on failure so the next trigger isn't
       // silently suppressed for the remainder of the debounce window.
       this.lastTier2CallAt = prevTier2CallAt;
-      log.warn(
-        { err, meetingId: this.meetingId, triggerReason },
-        "MeetChatOpportunityDetector: Tier 2 LLM call failed",
-      );
+      this.log.warn("MeetChatOpportunityDetector: Tier 2 LLM call failed", {
+        err,
+        meetingId: this.meetingId,
+        triggerReason,
+      });
     } finally {
       this.tier2InFlight = false;
     }
@@ -649,14 +673,14 @@ export class MeetChatOpportunityDetector {
       nowAfter - this.lastEscalationAt < cooldownMs
     ) {
       this.stats.escalationsSuppressed += 1;
-      log.debug(
+      this.log.debug(
+        "MeetChatOpportunityDetector: escalation suppressed by cooldown",
         {
           event: "chat_opportunity.escalation.suppressed",
           meetingId: this.meetingId,
           kind: opts.kind,
           msSinceLast: nowAfter - this.lastEscalationAt,
         },
-        "MeetChatOpportunityDetector: escalation suppressed by cooldown",
       );
       return;
     }
@@ -664,21 +688,21 @@ export class MeetChatOpportunityDetector {
     this.lastEscalationAt = nowAfter;
     this.stats.escalationsFired += 1;
     if (opts.kind === "voice") this.stats.voiceWakesFired += 1;
-    log.info(
+    this.log.info(
+      "MeetChatOpportunityDetector: firing opportunity callback",
       {
         event: "chat_opportunity.escalation.fired",
         meetingId: this.meetingId,
         kind: opts.kind,
         ...opts.logContext,
       },
-      "MeetChatOpportunityDetector: firing opportunity callback",
     );
     try {
       this.onOpportunity({ reason: opts.reason, kind: opts.kind });
     } catch (err) {
-      log.error(
-        { err, meetingId: this.meetingId, kind: opts.kind },
+      this.log.error(
         "MeetChatOpportunityDetector: onOpportunity callback threw",
+        { err, meetingId: this.meetingId, kind: opts.kind },
       );
     }
   }
@@ -738,3 +762,34 @@ export class MeetChatOpportunityDetector {
     }
   }
 }
+
+// ---------------------------------------------------------------------------
+// Host-based factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a callable that constructs per-meeting
+ * {@link MeetChatOpportunityDetector} instances bound to a
+ * {@link SkillHost}. The factory wires the host's logger; per-meeting
+ * deps (config, voice config, LLM callable, opportunity callback, etc.)
+ * are supplied by the session manager at construction time.
+ *
+ * Registered under the sub-module slot `"chat-opportunity-detector"` in
+ * {@link registerSubModule} at module import time; PR 17's session
+ * manager consumes the registration via `getSubModule`.
+ */
+export function createChatOpportunityDetector(
+  host: SkillHost,
+): (deps: MeetChatOpportunityDetectorDeps) => MeetChatOpportunityDetector {
+  const logger = host.logger.get("meet-chat-opportunity-detector");
+  return (deps) =>
+    new MeetChatOpportunityDetector({
+      ...deps,
+      logger: deps.logger ?? logger,
+    });
+}
+
+registerSubModule(
+  "chat-opportunity-detector",
+  createChatOpportunityDetector,
+);

--- a/skills/meet-join/daemon/consent-monitor.ts
+++ b/skills/meet-join/daemon/consent-monitor.ts
@@ -33,6 +33,8 @@
  * method — the real {@link MeetSessionManager} satisfies this naturally.
  */
 
+import type { Logger, SkillHost } from "@vellumai/skill-host-contracts";
+
 import type {
   InboundChatEvent,
   MeetBotEvent,
@@ -41,23 +43,67 @@ import type {
 } from "../contracts/index.js";
 
 import {
-  createTimeout,
-  extractToolUse,
-  getConfiguredProvider,
-  userMessage,
-} from "../../../assistant/src/providers/provider-send-message.js";
-import type {
-  Provider,
-  ToolDefinition,
-} from "../../../assistant/src/providers/types.js";
-import { getLogger } from "../../../assistant/src/util/logger.js";
-import {
   type MeetEventSubscriber,
   type MeetEventUnsubscribe,
   subscribeToMeetingEvents,
 } from "./event-publisher.js";
+import { registerSubModule } from "./modules-registry.js";
 
-const log = getLogger("meet-consent-monitor");
+/**
+ * Structural overlay of the daemon's `ToolDefinition` used to force the
+ * LLM into a strict-JSON response. The contract's `providers.llm` facet
+ * types its request arguments as `unknown`, so the skill declares the
+ * local shape it actually needs — keeping the concrete daemon type
+ * (`assistant/src/providers/types.ts`) out of this file.
+ */
+interface ObjectionToolDefinition {
+  name: string;
+  description: string;
+  input_schema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required: readonly string[];
+  };
+}
+
+/**
+ * Minimal provider surface the default LLM binding uses. The host's
+ * `providers.llm.getConfigured()` returns an opaque `Provider`, which we
+ * narrow here to the one `sendMessage` method this module calls.
+ */
+interface LlmProviderLike {
+  sendMessage(
+    messages: unknown[],
+    tools: ObjectionToolDefinition[],
+    system: string,
+    opts: {
+      config: {
+        callSite: string;
+        max_tokens: number;
+        tool_choice: { type: "tool"; name: string };
+      };
+      signal: AbortSignal;
+    },
+  ): Promise<unknown>;
+}
+
+/**
+ * Fallback logger used when the monitor is constructed without a host-
+ * sourced logger. Keeps the class callable from unit tests that build it
+ * directly without supplying a full {@link SkillHost} stub.
+ */
+const consoleLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: (msg, meta) => {
+    // eslint-disable-next-line no-console
+    console.warn(msg, meta ?? {});
+  },
+  error: (msg, meta) => {
+    // eslint-disable-next-line no-console
+    console.error(msg, meta ?? {});
+  },
+};
 
 // ---------------------------------------------------------------------------
 // Tunables
@@ -126,10 +172,12 @@ export interface MeetConsentMonitorDeps {
   sessionManager: MeetSessionLeaver;
   config: MeetConsentMonitorConfig;
   /**
-   * Ask the LLM for an objection verdict. Defaults to a wrapper around the
-   * repo-wide provider abstraction using {@link CONSENT_LLM_MAX_TOKENS}
-   * under the `meetConsentMonitor` call site. Tests inject scripted
-   * responses.
+   * Ask the LLM for an objection verdict. Production callers build this
+   * via {@link createConsentMonitor}, which wires the host's
+   * `providers.llm.*` facet; direct `new MeetConsentMonitor(...)` callers
+   * (tests) must supply their own scripted implementation — there is no
+   * ambient default since the monitor no longer imports from
+   * `assistant/`.
    */
   llmAsk?: ObjectionLLMAsk;
   /** Override the dispatcher subscribe (tests). */
@@ -142,6 +190,13 @@ export interface MeetConsentMonitorDeps {
   clearIntervalFn?: (handle: unknown) => void;
   /** Override `Date.now` for tests that want deterministic dedupe timing. */
   now?: () => number;
+  /**
+   * Logger used for monitor telemetry. Production callers wire
+   * `host.logger.get("meet-consent-monitor")` via
+   * {@link createConsentMonitor}; unit tests get a console-backed
+   * fallback so they don't need to build a full {@link SkillHost}.
+   */
+  logger?: Logger;
 }
 
 // ---------------------------------------------------------------------------
@@ -178,6 +233,7 @@ export class MeetConsentMonitor {
   private readonly setIntervalFn: (cb: () => void, ms: number) => unknown;
   private readonly clearIntervalFn: (handle: unknown) => void;
   private readonly now: () => number;
+  private readonly log: Logger;
 
   private unsubscribe: MeetEventUnsubscribe | null = null;
   private timerHandle: unknown = null;
@@ -264,7 +320,12 @@ export class MeetConsentMonitor {
     this.assistantId = deps.assistantId;
     this.sessionManager = deps.sessionManager;
     this.config = deps.config;
-    this.llmAsk = deps.llmAsk ?? defaultLLMAsk;
+    // With the default-LLM binding removed, production callers wire
+    // `deps.llmAsk` via {@link createConsentMonitor}; tests that omit it
+    // get a stub that reports no objection so construction does not throw
+    // but the monitor is effectively a no-op.
+    this.llmAsk =
+      deps.llmAsk ?? (async () => ({ objected: false, reason: "" }));
     this.subscribe = deps.subscribe ?? subscribeToMeetingEvents;
     this.setIntervalFn =
       deps.setIntervalFn ?? ((cb, ms) => setInterval(cb, ms));
@@ -272,6 +333,7 @@ export class MeetConsentMonitor {
       deps.clearIntervalFn ??
       ((handle) => clearInterval(handle as ReturnType<typeof setInterval>));
     this.now = deps.now ?? Date.now;
+    this.log = deps.logger ?? consoleLogger;
   }
 
   /**
@@ -302,10 +364,10 @@ export class MeetConsentMonitor {
       try {
         this.unsubscribe();
       } catch (err) {
-        log.warn(
-          { err, meetingId: this.meetingId },
-          "MeetConsentMonitor: unsubscribe threw during stop",
-        );
+        this.log.warn("MeetConsentMonitor: unsubscribe threw during stop", {
+          err,
+          meetingId: this.meetingId,
+        });
       }
       this.unsubscribe = null;
     }
@@ -313,10 +375,10 @@ export class MeetConsentMonitor {
       try {
         this.clearIntervalFn(this.timerHandle);
       } catch (err) {
-        log.warn(
-          { err, meetingId: this.meetingId },
-          "MeetConsentMonitor: clearInterval threw during stop",
-        );
+        this.log.warn("MeetConsentMonitor: clearInterval threw during stop", {
+          err,
+          meetingId: this.meetingId,
+        });
       }
       this.timerHandle = null;
     }
@@ -340,10 +402,11 @@ export class MeetConsentMonitor {
         return;
       }
     } catch (err) {
-      log.warn(
-        { err, meetingId: this.meetingId, eventType: event.type },
-        "MeetConsentMonitor: event handler threw",
-      );
+      this.log.warn("MeetConsentMonitor: event handler threw", {
+        err,
+        meetingId: this.meetingId,
+        eventType: event.type,
+      });
     }
   }
 
@@ -524,15 +587,12 @@ export class MeetConsentMonitor {
       this.lastLlmCheckAt !== null &&
       now - this.lastLlmCheckAt < LLM_CHECK_DEBOUNCE_MS
     ) {
-      log.debug(
-        {
-          event: "consent_monitor.check.debounced",
-          meetingId: this.meetingId,
-          trigger,
-          msSinceLastCheck: now - this.lastLlmCheckAt,
-        },
-        "MeetConsentMonitor: LLM check debounced",
-      );
+      this.log.debug("MeetConsentMonitor: LLM check debounced", {
+        event: "consent_monitor.check.debounced",
+        meetingId: this.meetingId,
+        trigger,
+        msSinceLastCheck: now - this.lastLlmCheckAt,
+      });
       return;
     }
 
@@ -544,13 +604,13 @@ export class MeetConsentMonitor {
       trigger === "tick" &&
       this.lastContentTimestamp === this.lastLlmCheckContentTimestamp
     ) {
-      log.debug(
+      this.log.debug(
+        "MeetConsentMonitor: timer tick skipped — no new non-bot content",
         {
           event: "consent_monitor.timer.skipped_no_new_content",
           meetingId: this.meetingId,
           lastContentTimestamp: this.lastContentTimestamp,
         },
-        "MeetConsentMonitor: timer tick skipped — no new non-bot content",
       );
       return;
     }
@@ -582,28 +642,22 @@ export class MeetConsentMonitor {
       this.lastLlmCheckContentTimestamp = contentTimestampAtCheck;
 
       if (!decision.objected) {
-        log.debug(
-          {
-            meetingId: this.meetingId,
-            trigger,
-            reason: decision.reason,
-          },
-          "MeetConsentMonitor: LLM confirmed no objection",
-        );
+        this.log.debug("MeetConsentMonitor: LLM confirmed no objection", {
+          meetingId: this.meetingId,
+          trigger,
+          reason: decision.reason,
+        });
         return;
       }
       // Positive verdict — lock the monitor and act.
       this.decided = true;
-      log.info(
-        {
-          meetingId: this.meetingId,
-          assistantId: this.assistantId,
-          trigger,
-          reason: decision.reason,
-          autoLeave: this.config.autoLeaveOnObjection,
-        },
-        "MeetConsentMonitor: objection detected",
-      );
+      this.log.info("MeetConsentMonitor: objection detected", {
+        meetingId: this.meetingId,
+        assistantId: this.assistantId,
+        trigger,
+        reason: decision.reason,
+        autoLeave: this.config.autoLeaveOnObjection,
+      });
       if (this.config.autoLeaveOnObjection) {
         try {
           await this.sessionManager.leave(
@@ -611,10 +665,10 @@ export class MeetConsentMonitor {
             `objection: ${decision.reason}`,
           );
         } catch (err) {
-          log.error(
-            { err, meetingId: this.meetingId },
-            "MeetConsentMonitor: session leave failed",
-          );
+          this.log.error("MeetConsentMonitor: session leave failed", {
+            err,
+            meetingId: this.meetingId,
+          });
         }
       }
     } catch (err) {
@@ -622,9 +676,9 @@ export class MeetConsentMonitor {
       // silently suppressed. The content watermark doesn't need restoring
       // because it's only advanced after a successful LLM call (line above).
       this.lastLlmCheckAt = prevLlmCheckAt;
-      log.warn(
-        { err, meetingId: this.meetingId, trigger },
+      this.log.warn(
         "MeetConsentMonitor: LLM call failed — staying in the meeting",
+        { err, meetingId: this.meetingId, trigger },
       );
     } finally {
       this.llmInFlight = false;
@@ -673,16 +727,16 @@ export class MeetConsentMonitor {
 }
 
 // ---------------------------------------------------------------------------
-// Default LLM binding
+// Default LLM binding (host-scoped)
 // ---------------------------------------------------------------------------
 
 /** Tool schema used to force structured JSON output from the LLM. */
-const OBJECTION_TOOL: ToolDefinition = {
+const OBJECTION_TOOL: ObjectionToolDefinition = {
   name: "report_objection",
   description:
     "Report whether any meeting participant has objected to the AI note-taker's presence.",
   input_schema: {
-    type: "object" as const,
+    type: "object",
     properties: {
       objected: {
         type: "boolean",
@@ -700,27 +754,29 @@ const OBJECTION_TOOL: ToolDefinition = {
 };
 
 /**
- * Default {@link ObjectionLLMAsk} — routes through the repo-wide provider
- * abstraction under the `meetConsentMonitor` call site, times out at
- * {@link CONSENT_LLM_TIMEOUT_MS}, and extracts the tool-use input as the
- * structured verdict.
+ * Build the default {@link ObjectionLLMAsk} bound to a {@link SkillHost}.
+ * Routes through `host.providers.llm.*` under the `meetConsentMonitor`
+ * call site, times out at {@link CONSENT_LLM_TIMEOUT_MS}, and extracts
+ * the tool-use input as the structured verdict.
  *
- * Hidden behind an injectable hook so tests never need to stand up a
- * real provider.
+ * Kept as a factory — rather than a singleton — so tests never need to
+ * stand up a real provider and each host-scoped monitor gets its own
+ * closure over the host's provider accessors.
  */
-async function defaultLLMAsk(prompt: string): Promise<ObjectionDecision> {
-  const provider: Provider | null =
-    await getConfiguredProvider("meetConsentMonitor");
-  if (!provider) {
-    // No provider available — conservatively assume no objection so the
-    // monitor doesn't interrupt a meeting based on missing infra.
-    return { objected: false, reason: "" };
-  }
+function createDefaultLlmAsk(host: SkillHost): ObjectionLLMAsk {
+  return async (prompt) => {
+    const provider = (await host.providers.llm.getConfigured(
+      "meetConsentMonitor",
+    )) as LlmProviderLike | null;
+    if (!provider) {
+      // No provider available — conservatively assume no objection so the
+      // monitor doesn't interrupt a meeting based on missing infra.
+      return { objected: false, reason: "" };
+    }
 
-  const { signal, cleanup } = createTimeout(CONSENT_LLM_TIMEOUT_MS);
-  try {
+    const controller = host.providers.llm.createTimeout(CONSENT_LLM_TIMEOUT_MS);
     const response = await provider.sendMessage(
-      [userMessage(prompt)],
+      [host.providers.llm.userMessage(prompt)],
       [OBJECTION_TOOL],
       "You are a strict JSON classifier. Only respond via the report_objection tool.",
       {
@@ -729,17 +785,51 @@ async function defaultLLMAsk(prompt: string): Promise<ObjectionDecision> {
           max_tokens: CONSENT_LLM_MAX_TOKENS,
           tool_choice: { type: "tool" as const, name: OBJECTION_TOOL.name },
         },
-        signal,
+        signal: controller.signal,
       },
     );
-    const tool = extractToolUse(response);
+    const tool = host.providers.llm.extractToolUse(response) as {
+      input?: { objected?: unknown; reason?: unknown };
+    } | null;
     if (!tool) return { objected: false, reason: "" };
-    const input = tool.input as { objected?: unknown; reason?: unknown };
+    const input = tool.input ?? {};
     return {
       objected: input.objected === true,
       reason: typeof input.reason === "string" ? input.reason : "",
     };
-  } finally {
-    cleanup();
-  }
+  };
 }
+
+// ---------------------------------------------------------------------------
+// Host-based factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a callable that constructs per-meeting {@link MeetConsentMonitor}
+ * instances bound to a {@link SkillHost}. The factory wires the host's
+ * logger and the host-scoped default LLM ask; per-meeting deps
+ * (`meetingId`, `sessionManager`, `config`, etc.) are supplied by the
+ * session manager at construction time.
+ *
+ * Registered under the sub-module slot `"consent-monitor"` in
+ * {@link registerSubModule} at module import time; PR 17's session
+ * manager consumes the registration via `getSubModule`.
+ */
+export function createConsentMonitor(
+  host: SkillHost,
+): (
+  deps: Omit<MeetConsentMonitorDeps, "assistantId"> & { assistantId?: string },
+) => MeetConsentMonitor {
+  const logger = host.logger.get("meet-consent-monitor");
+  const defaultLlmAsk = createDefaultLlmAsk(host);
+  const defaultAssistantId = host.identity.internalAssistantId;
+  return (deps) =>
+    new MeetConsentMonitor({
+      ...deps,
+      assistantId: deps.assistantId ?? defaultAssistantId,
+      llmAsk: deps.llmAsk ?? defaultLlmAsk,
+      logger: deps.logger ?? logger,
+    });
+}
+
+registerSubModule("consent-monitor", createConsentMonitor);

--- a/skills/meet-join/daemon/session-event-router.ts
+++ b/skills/meet-join/daemon/session-event-router.ts
@@ -25,13 +25,20 @@
  * Late events (arriving after `unregister`) are logged and dropped so a
  * slow in-flight POST from a just-terminated bot session can't explode the
  * handler graph.
+ *
+ * ## Host-based factory
+ *
+ * The router no longer imports from `assistant/` directly. Callers build
+ * one via {@link createSessionEventRouter}, passing the `SkillHost` the
+ * skill received from its entry point. The router's only host dependency
+ * is the logger facet, used for handler-error / drop telemetry.
  */
+
+import type { Logger, SkillHost } from "@vellumai/skill-host-contracts";
 
 import type { MeetBotEvent } from "../contracts/index.js";
 
-import { getLogger } from "../../../assistant/src/util/logger.js";
-
-const log = getLogger("meet-session-event-router");
+import { registerSubModule } from "./modules-registry.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -64,6 +71,19 @@ export type BotApiTokenResolver = (meetingId: string) => string | null;
 export class MeetSessionEventRouter {
   private readonly handlers = new Map<string, MeetSessionEventHandler>();
   private resolveBotApiTokenImpl: BotApiTokenResolver = () => null;
+  private readonly log: Logger;
+
+  /**
+   * Construct a router. The optional {@link Logger} is used only for
+   * handler-error / drop telemetry; production callers wire
+   * `host.logger.get("meet-session-event-router")` via
+   * {@link createSessionEventRouter}. Tests that construct the router
+   * directly get a console-backed fallback so they do not need to inject
+   * a logger.
+   */
+  constructor(logger?: Logger) {
+    this.log = logger ?? consoleLogger;
+  }
 
   /**
    * Register a handler for a meeting. Overwrites any existing handler
@@ -73,9 +93,9 @@ export class MeetSessionEventRouter {
    */
   register(meetingId: string, handler: MeetSessionEventHandler): void {
     if (this.handlers.has(meetingId)) {
-      log.warn(
-        { meetingId },
+      this.log.warn(
         "MeetSessionEventRouter: overwriting existing handler registration",
+        { meetingId },
       );
     }
     this.handlers.set(meetingId, handler);
@@ -100,19 +120,20 @@ export class MeetSessionEventRouter {
   dispatch(meetingId: string, event: MeetBotEvent): void {
     const handler = this.handlers.get(meetingId);
     if (!handler) {
-      log.info(
-        { meetingId, eventType: event.type },
+      this.log.info(
         "MeetSessionEventRouter: dropping event for unregistered meeting",
+        { meetingId, eventType: event.type },
       );
       return;
     }
     try {
       handler(event);
     } catch (err) {
-      log.error(
-        { err, meetingId, eventType: event.type },
-        "MeetSessionEventRouter: handler threw",
-      );
+      this.log.error("MeetSessionEventRouter: handler threw", {
+        err,
+        meetingId,
+        eventType: event.type,
+      });
     }
   }
 
@@ -141,14 +162,40 @@ export class MeetSessionEventRouter {
 }
 
 // ---------------------------------------------------------------------------
-// Singleton (matches the style of `ChromeExtensionRegistry` / `assistantEventHub`)
+// Fallback logger for tests / direct-construction paths
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal console-backed logger used when the router is constructed
+ * without a host-supplied logger. Keeps the no-arg `new MeetSessionEventRouter()`
+ * constructor callable from unit tests without forcing them to build a
+ * host stub.
+ */
+const consoleLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: (msg, meta) => {
+    // eslint-disable-next-line no-console
+    console.warn(msg, meta ?? {});
+  },
+  error: (msg, meta) => {
+    // eslint-disable-next-line no-console
+    console.error(msg, meta ?? {});
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Singleton
 // ---------------------------------------------------------------------------
 
 let instance: MeetSessionEventRouter | null = null;
 
 /**
  * Process-level singleton router shared by the ingress route, the session
- * manager, and all event subscribers.
+ * manager, and all event subscribers. Uses the console-backed fallback
+ * logger; callers that want host-scoped logging should construct a
+ * dedicated router via {@link createSessionEventRouter} and pass it
+ * around explicitly.
  */
 export function getMeetSessionEventRouter(): MeetSessionEventRouter {
   if (!instance) instance = new MeetSessionEventRouter();
@@ -172,3 +219,24 @@ export function setBotApiTokenResolver(resolver: BotApiTokenResolver): void {
 export function __resetMeetSessionEventRouterForTests(): void {
   instance = null;
 }
+
+// ---------------------------------------------------------------------------
+// Host-based factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a {@link MeetSessionEventRouter} scoped to a {@link SkillHost}.
+ * The router's logger is sourced from `host.logger.get(...)` so handler-
+ * error and drop telemetry carries the host's log scope.
+ *
+ * Registered under the sub-module slot `"session-event-router"` in
+ * {@link registerSubModule} at module import time; PR 17's session
+ * manager consumes the registration via `getSubModule`.
+ */
+export function createSessionEventRouter(
+  host: SkillHost,
+): MeetSessionEventRouter {
+  return new MeetSessionEventRouter(host.logger.get("meet-session-event-router"));
+}
+
+registerSubModule("session-event-router", createSessionEventRouter);

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -811,7 +811,10 @@ class MeetSessionManagerImpl {
           })),
       storageWriterFactory:
         deps.storageWriterFactory ??
-        ((args) => new MeetStorageWriter(args.meetingId)),
+        ((args) =>
+          new MeetStorageWriter(args.meetingId, {
+            getWorkspaceDir: resolveWorkspaceDir,
+          })),
       resolveAssistantDisplayName:
         deps.resolveAssistantDisplayName ?? getAssistantName,
       insertMessage,

--- a/skills/meet-join/daemon/storage-writer.ts
+++ b/skills/meet-join/daemon/storage-writer.ts
@@ -48,6 +48,8 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
+import type { Logger, SkillHost } from "@vellumai/skill-host-contracts";
+
 import type {
   MeetBotEvent,
   Participant,
@@ -56,15 +58,30 @@ import type {
   TranscriptChunkEvent,
 } from "../contracts/index.js";
 
-import { getLogger } from "../../../assistant/src/util/logger.js";
-import { getWorkspaceDir } from "../../../assistant/src/util/platform.js";
 import {
   type MeetEventSubscriber,
   type MeetEventUnsubscribe,
   subscribeToMeetingEvents,
 } from "./event-publisher.js";
+import { registerSubModule } from "./modules-registry.js";
 
-const log = getLogger("meet-storage-writer");
+/**
+ * Fallback logger for tests / direct `new MeetStorageWriter(...)` calls that
+ * omit the host-sourced logger. Keeps every production caller host-wired
+ * without forcing unit tests to build a full {@link SkillHost} stub.
+ */
+const consoleLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: (msg, meta) => {
+    // eslint-disable-next-line no-console
+    console.warn(msg, meta ?? {});
+  },
+  error: (msg, meta) => {
+    // eslint-disable-next-line no-console
+    console.error(msg, meta ?? {});
+  },
+};
 
 // ---------------------------------------------------------------------------
 // Tuning knobs
@@ -125,7 +142,11 @@ export interface FsPrimitives {
 }
 
 export interface MeetStorageWriterDeps {
-  /** Override workspace directory resolution (tests). */
+  /**
+   * Resolve the workspace directory. Tests pass a tempdir; production
+   * callers construct the writer via {@link createStorageWriter} which
+   * wires this to `host.platform.workspaceDir()`.
+   */
   getWorkspaceDir?: () => string;
   /** Override the `spawn` used to launch ffmpeg (tests). */
   spawn?: SpawnFn;
@@ -142,6 +163,14 @@ export interface MeetStorageWriterDeps {
     meetingId: string,
     cb: MeetEventSubscriber,
   ) => MeetEventUnsubscribe;
+  /**
+   * Logger used for best-effort I/O telemetry. Defaults to a console-
+   * backed fallback so unit tests that construct the writer directly
+   * don't need to supply one. Production callers wire
+   * `host.logger.get("meet-storage-writer")` via
+   * {@link createStorageWriter}.
+   */
+  logger?: Logger;
 }
 
 /**
@@ -187,6 +216,7 @@ export class MeetStorageWriter {
 
   private readonly deps: Required<MeetStorageWriterDeps>;
   private readonly fs: FsPrimitives;
+  private readonly log: Logger;
 
   private segmentsFd: AppendFdState | null = null;
   private transcriptFd: AppendFdState | null = null;
@@ -208,15 +238,26 @@ export class MeetStorageWriter {
     if (!meetingId) {
       throw new Error("MeetStorageWriter: meetingId is required");
     }
+    // No ambient workspace fallback — callers must provide a resolver.
+    // Production wiring comes from {@link createStorageWriter} via
+    // `host.platform.workspaceDir()`; tests/tooling inject a tempdir.
+    const resolveWorkspaceDir = deps.getWorkspaceDir;
+    if (!resolveWorkspaceDir) {
+      throw new Error(
+        "MeetStorageWriter: deps.getWorkspaceDir is required — construct via createStorageWriter(host) or pass an explicit resolver",
+      );
+    }
     this.meetingId = meetingId;
     this.deps = {
-      getWorkspaceDir: deps.getWorkspaceDir ?? getWorkspaceDir,
+      getWorkspaceDir: resolveWorkspaceDir,
       spawn: deps.spawn ?? nodeSpawn,
       fs: deps.fs ?? {},
       now: deps.now ?? Date.now,
       subscribe: deps.subscribe ?? subscribeToMeetingEvents,
+      logger: deps.logger ?? consoleLogger,
     };
     this.fs = { ...DEFAULT_FS, ...(deps.fs ?? {}) };
+    this.log = this.deps.logger;
     this.meetingDir = join(
       this.deps.getWorkspaceDir(),
       "meets",
@@ -259,25 +300,29 @@ export class MeetStorageWriter {
     }) as ChildProcessWithoutNullStreams;
 
     child.on("error", (err) => {
-      log.error(
-        { err, meetingId: this.meetingId },
-        "ffmpeg spawn/runtime error",
-      );
+      this.log.error("ffmpeg spawn/runtime error", {
+        err,
+        meetingId: this.meetingId,
+      });
     });
     child.on("exit", (code, signal) => {
-      log.info({ meetingId: this.meetingId, code, signal }, "ffmpeg exited");
+      this.log.info("ffmpeg exited", {
+        meetingId: this.meetingId,
+        code,
+        signal,
+      });
     });
     child.stderr?.on("data", (chunk: Buffer) => {
-      log.debug(
-        { meetingId: this.meetingId, stderr: chunk.toString("utf8") },
-        "ffmpeg stderr",
-      );
+      this.log.debug("ffmpeg stderr", {
+        meetingId: this.meetingId,
+        stderr: chunk.toString("utf8"),
+      });
     });
     child.stdin.on("error", (err) => {
-      log.debug(
-        { err, meetingId: this.meetingId },
-        "ffmpeg stdin error (suppressed)",
-      );
+      this.log.debug("ffmpeg stdin error (suppressed)", {
+        err,
+        meetingId: this.meetingId,
+      });
     });
 
     this.ffmpegChild = child;
@@ -305,10 +350,10 @@ export class MeetStorageWriter {
       try {
         this.eventUnsubscribe();
       } catch (err) {
-        log.warn(
-          { err, meetingId: this.meetingId },
-          "dispatcher unsubscribe threw during stop",
-        );
+        this.log.warn("dispatcher unsubscribe threw during stop", {
+          err,
+          meetingId: this.meetingId,
+        });
       }
       this.eventUnsubscribe = null;
     }
@@ -322,10 +367,10 @@ export class MeetStorageWriter {
       try {
         this.pcmUnsubscribe();
       } catch (err) {
-        log.warn(
-          { err, meetingId: this.meetingId },
-          "pcm unsubscribe threw during stop",
-        );
+        this.log.warn("pcm unsubscribe threw during stop", {
+          err,
+          meetingId: this.meetingId,
+        });
       }
       this.pcmUnsubscribe = null;
     }
@@ -336,10 +381,10 @@ export class MeetStorageWriter {
       try {
         child.stdin?.end();
       } catch (err) {
-        log.warn(
-          { err, meetingId: this.meetingId },
-          "ffmpeg stdin close threw during stop",
-        );
+        this.log.warn("ffmpeg stdin close threw during stop", {
+          err,
+          meetingId: this.meetingId,
+        });
       }
     }
   }
@@ -374,10 +419,11 @@ export class MeetStorageWriter {
           break;
       }
     } catch (err) {
-      log.error(
-        { err, meetingId: this.meetingId, eventType: event.type },
-        "MeetStorageWriter: handler threw",
-      );
+      this.log.error("MeetStorageWriter: handler threw", {
+        err,
+        meetingId: this.meetingId,
+        eventType: event.type,
+      });
     }
   }
 
@@ -465,10 +511,10 @@ export class MeetStorageWriter {
       try {
         this.fs.fsyncSync(state.fd);
       } catch (err) {
-        log.warn(
-          { err, meetingId: this.meetingId },
-          "fsync failed (non-fatal)",
-        );
+        this.log.warn("fsync failed (non-fatal)", {
+          err,
+          meetingId: this.meetingId,
+        });
       }
       state.writesSinceFlush = 0;
       state.lastFlushAtMs = now;
@@ -480,18 +526,18 @@ export class MeetStorageWriter {
     try {
       this.fs.fsyncSync(state.fd);
     } catch (err) {
-      log.warn(
-        { err, meetingId: this.meetingId },
-        "final fsync failed (non-fatal)",
-      );
+      this.log.warn("final fsync failed (non-fatal)", {
+        err,
+        meetingId: this.meetingId,
+      });
     }
     try {
       this.fs.closeSync(state.fd);
     } catch (err) {
-      log.warn(
-        { err, meetingId: this.meetingId },
-        "fd close failed (non-fatal)",
-      );
+      this.log.warn("fd close failed (non-fatal)", {
+        err,
+        meetingId: this.meetingId,
+      });
     }
   }
 
@@ -544,7 +590,10 @@ export class MeetStorageWriter {
     try {
       child.stdin.write(Buffer.from(bytes));
     } catch (err) {
-      log.warn({ err, meetingId: this.meetingId }, "ffmpeg stdin write failed");
+      this.log.warn("ffmpeg stdin write failed", {
+        err,
+        meetingId: this.meetingId,
+      });
     }
   }
 
@@ -555,7 +604,39 @@ export class MeetStorageWriter {
     try {
       child.stdin?.end();
     } catch (err) {
-      log.warn({ err, meetingId: this.meetingId }, "ffmpeg stdin end failed");
+      this.log.warn("ffmpeg stdin end failed", {
+        err,
+        meetingId: this.meetingId,
+      });
     }
   }
 }
+
+// ---------------------------------------------------------------------------
+// Host-based factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a callable that creates per-meeting {@link MeetStorageWriter}
+ * instances bound to a {@link SkillHost}. Returning a factory (rather
+ * than a single writer) matches how the session manager spins up one
+ * writer per active meeting — all sharing the same host-scoped logger
+ * and workspace-path resolution.
+ *
+ * Registered under the sub-module slot `"storage-writer"` in
+ * {@link registerSubModule} at module import time; PR 17's session
+ * manager consumes the registration via `getSubModule`.
+ */
+export function createStorageWriter(
+  host: SkillHost,
+): (meetingId: string, overrides?: MeetStorageWriterDeps) => MeetStorageWriter {
+  const logger = host.logger.get("meet-storage-writer");
+  return (meetingId, overrides = {}) =>
+    new MeetStorageWriter(meetingId, {
+      getWorkspaceDir: () => host.platform.workspaceDir(),
+      logger,
+      ...overrides,
+    });
+}
+
+registerSubModule("storage-writer", createStorageWriter);


### PR DESCRIPTION
## Summary
- Converts barge-in-watcher, chat-opportunity-detector, consent-monitor, session-event-router, and storage-writer to createX(host) factories.
- All 5 files now source logger, event hub, identity, config from SkillHost; zero assistant/ imports.
- Factories registered in modules-registry for PR 17.

Part of plan: skill-isolation.md (PR 12 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
