### PR TITLE
refactor(meet-join): migrate event-publisher + conversation-bridge to SkillHost

### DIFF
--- a/skills/meet-join/daemon/__tests__/avatar-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/avatar-e2e.test.ts
@@ -56,13 +56,18 @@ import type { VideoDeviceHandle } from "../../bot/src/media/video-device.js";
 import { BotState } from "../../bot/src/control/state.js";
 import { FakeAvatarRenderer } from "../../bot/__tests__/avatar-interface.test.js";
 
-import { meetEventDispatcher } from "../event-publisher.js";
+import {
+  _resetEventPublisherForTests,
+  createEventPublisher,
+  meetEventDispatcher,
+} from "../event-publisher.js";
 import { __resetMeetSessionEventRouterForTests } from "../session-event-router.js";
 import {
   _createMeetSessionManagerForTests,
   MEET_BOT_INTERNAL_PORT,
   type MeetAudioIngestLike,
 } from "../session-manager.js";
+import { installSessionManagerTestHost } from "./test-host.js";
 
 // ---------------------------------------------------------------------------
 // Shared fixtures — the "fake bot" stands up a real `createHttpServer`
@@ -357,6 +362,8 @@ const fakeBotRef: { current: FakeBotServer | null } = { current: null };
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "avatar-e2e-"));
   __resetMeetSessionEventRouterForTests();
+  _resetEventPublisherForTests();
+  createEventPublisher(installSessionManagerTestHost());
   meetEventDispatcher._resetForTests();
   // Wipe the registry so tests can't leak factories across each other.
   // The `"fake"` id is re-registered inside the lazy runner below, once

--- a/skills/meet-join/daemon/__tests__/chat-send-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/chat-send-e2e.test.ts
@@ -46,8 +46,13 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { AssistantEvent } from "../../../../assistant/src/runtime/assistant-event.js";
 import { assistantEventHub } from "../../../../assistant/src/runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../assistant/src/runtime/assistant-scope.js";
-import { meetEventDispatcher } from "../event-publisher.js";
+import {
+  _resetEventPublisherForTests,
+  createEventPublisher,
+  meetEventDispatcher,
+} from "../event-publisher.js";
 import { __resetMeetSessionEventRouterForTests } from "../session-event-router.js";
+import { installSessionManagerTestHost } from "./test-host.js";
 import {
   _createMeetSessionManagerForTests,
   MEET_BOT_INTERNAL_PORT,
@@ -198,6 +203,8 @@ let fakeBot: FakeBotServer;
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "chat-send-e2e-"));
   __resetMeetSessionEventRouterForTests();
+  _resetEventPublisherForTests();
+  createEventPublisher(installSessionManagerTestHost());
   meetEventDispatcher._resetForTests();
   fakeBot = startFakeBot();
 });

--- a/skills/meet-join/daemon/__tests__/dind-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/dind-e2e.test.ts
@@ -47,8 +47,13 @@ import {
   dockerSocketUnreachableMessage,
   resetSocketReachabilityCacheForTests,
 } from "../docker-runner.js";
-import { meetEventDispatcher } from "../event-publisher.js";
+import {
+  _resetEventPublisherForTests,
+  createEventPublisher,
+  meetEventDispatcher,
+} from "../event-publisher.js";
 import { __resetMeetSessionEventRouterForTests } from "../session-event-router.js";
+import { installSessionManagerTestHost } from "./test-host.js";
 import {
   _createMeetSessionManagerForTests,
   MEET_BOT_INTERNAL_PORT,
@@ -209,6 +214,8 @@ let engine: DockerEngineMock | null;
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "dind-e2e-ws-"));
   __resetMeetSessionEventRouterForTests();
+  _resetEventPublisherForTests();
+  createEventPublisher(installSessionManagerTestHost());
   meetEventDispatcher._resetForTests();
   // The `/_ping` cache is module-scoped; tempdir sockets are unique so
   // cross-test pollution shouldn't happen, but reset defensively.

--- a/skills/meet-join/daemon/__tests__/docker-mode-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/docker-mode-e2e.test.ts
@@ -45,7 +45,11 @@ import {
   HOST_GATEWAY_ALIAS,
   resetSocketReachabilityCacheForTests,
 } from "../docker-runner.js";
-import { meetEventDispatcher } from "../event-publisher.js";
+import {
+  _resetEventPublisherForTests,
+  createEventPublisher,
+  meetEventDispatcher,
+} from "../event-publisher.js";
 import { __resetMeetSessionEventRouterForTests } from "../session-event-router.js";
 import {
   _createMeetSessionManagerForTests,
@@ -55,6 +59,7 @@ import {
   type MeetConversationBridgeLike,
   type MeetStorageWriterLike,
 } from "../session-manager.js";
+import { installSessionManagerTestHost } from "./test-host.js";
 
 // ---------------------------------------------------------------------------
 // Mock Docker Engine — a real HTTP server bound to a tempdir unix socket.
@@ -239,6 +244,8 @@ let engine: DockerEngineMock | null;
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "docker-mode-e2e-ws-"));
   __resetMeetSessionEventRouterForTests();
+  _resetEventPublisherForTests();
+  createEventPublisher(installSessionManagerTestHost());
   meetEventDispatcher._resetForTests();
   // The `/_ping` reachability cache is module-scoped so it survives
   // per-test teardown; tempdir socket paths are unique so cross-test

--- a/skills/meet-join/daemon/__tests__/e2e-smoke.test.ts
+++ b/skills/meet-join/daemon/__tests__/e2e-smoke.test.ts
@@ -67,6 +67,8 @@ import {
   MeetConversationBridge,
 } from "../conversation-bridge.js";
 import {
+  _resetEventPublisherForTests,
+  createEventPublisher,
   meetEventDispatcher,
   subscribeToMeetingEvents,
 } from "../event-publisher.js";
@@ -81,6 +83,7 @@ import {
   type MeetAudioIngestLike,
 } from "../session-manager.js";
 import { MeetStorageWriter } from "../storage-writer.js";
+import { installSessionManagerTestHost } from "./test-host.js";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -339,6 +342,8 @@ let workspaceDir: string;
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "meet-e2e-"));
   __resetMeetSessionEventRouterForTests();
+  _resetEventPublisherForTests();
+  createEventPublisher(installSessionManagerTestHost());
   meetEventDispatcher._resetForTests();
 });
 

--- a/skills/meet-join/daemon/__tests__/event-publisher.test.ts
+++ b/skills/meet-join/daemon/__tests__/event-publisher.test.ts
@@ -3,7 +3,7 @@
  *
  * Covers:
  *   - `publishMeetEvent` builds a proper `AssistantEvent` and hands it to
- *     `assistantEventHub.publish` with the expected `type` + `meetingId` +
+ *     the host's event hub with the expected `type` + `meetingId` +
  *     payload fields.
  *   - `MeetEventDispatcher` supports multiple subscribers per meeting with
  *     independent unsubscribe, and tolerates a throwing subscriber.
@@ -11,16 +11,28 @@
  *     router-delivered bot events into the right `meet.*` event kinds.
  *   - Interim transcript chunks are dropped; finals are published with the
  *     full payload.
+ *
+ * The tests install a minimal stub {@link SkillHost} before each case so
+ * the module-level exports are wired to a recordable hub. A future PR
+ * introduces a shared `buildTestHost()` helper — for now the shim below
+ * is narrow enough to live inline.
  */
 
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import type {
+  AssistantEvent,
+  ServerMessage,
+  SkillHost,
+  Subscription,
+} from "@vellumai/skill-host-contracts";
+import { buildAssistantEvent } from "@vellumai/skill-host-contracts";
+
 import type { MeetBotEvent } from "../../contracts/index.js";
 
-import type { AssistantEvent } from "../../../../assistant/src/runtime/assistant-event.js";
-import { assistantEventHub } from "../../../../assistant/src/runtime/assistant-event-hub.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../assistant/src/runtime/assistant-scope.js";
 import {
+  _resetEventPublisherForTests,
+  createEventPublisher,
   meetEventDispatcher,
   publishMeetEvent,
   registerMeetingDispatcher,
@@ -34,16 +46,121 @@ import {
 } from "../session-event-router.js";
 
 // ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_ASSISTANT_ID = "self";
+
+/**
+ * Minimal stub host — only the facets the publisher actually reads are
+ * wired up. The host's `events.publish` fans out to a local subscriber
+ * set so tests can observe emitted events without touching
+ * `assistantEventHub`. Anything else throws to surface accidental use.
+ */
+function makeTestHost(): {
+  host: SkillHost;
+  subscribe: (cb: (event: AssistantEvent) => void) => Subscription;
+} {
+  const listeners = new Set<(event: AssistantEvent) => void>();
+
+  const subscribe = (cb: (event: AssistantEvent) => void): Subscription => {
+    listeners.add(cb);
+    let active = true;
+    return {
+      dispose: () => {
+        listeners.delete(cb);
+        active = false;
+      },
+      get active() {
+        return active;
+      },
+    };
+  };
+
+  const noopLogger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+
+  const host: SkillHost = {
+    logger: { get: () => noopLogger },
+    config: {
+      isFeatureFlagEnabled: () => false,
+      getSection: () => undefined,
+    },
+    identity: {
+      getAssistantName: () => undefined,
+      internalAssistantId: TEST_ASSISTANT_ID,
+    },
+    platform: {
+      workspaceDir: () => "/tmp/test-workspace",
+      vellumRoot: () => "/tmp/test-vellum",
+      runtimeMode: () => "bare-metal" as never,
+    },
+    providers: {
+      llm: {
+        getConfigured: () => ({}),
+        userMessage: () => ({}),
+        extractToolUse: () => null,
+        createTimeout: () => new AbortController(),
+      },
+      stt: {
+        listProviderIds: () => [],
+        supportsBoundary: () => false,
+        resolveStreamingTranscriber: () => ({}),
+      },
+      tts: {
+        get: () => ({}),
+        resolveConfig: () => ({}),
+      },
+      secureKeys: { getProviderKey: async () => null },
+    },
+    memory: {
+      addMessage: async () => ({}),
+      wakeAgentForOpportunity: async () => {},
+    },
+    events: {
+      publish: async (event: AssistantEvent) => {
+        for (const cb of Array.from(listeners)) {
+          try {
+            cb(event);
+          } catch {
+            // Mirror the hub's behavior — subscriber errors never leak.
+          }
+        }
+      },
+      subscribe: (_filter, cb) =>
+        subscribe(cb as (event: AssistantEvent) => void),
+      buildEvent: (message: ServerMessage, conversationId?: string) =>
+        buildAssistantEvent(TEST_ASSISTANT_ID, message, conversationId),
+    },
+    registries: {
+      registerTools: () => {
+        throw new Error("unexpected");
+      },
+      registerSkillRoute: () => ({}) as never,
+      registerShutdownHook: () => {},
+    },
+    speakers: { createTracker: () => ({}) },
+  };
+
+  return { host, subscribe };
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 /**
- * Subscribe to the event hub for a given assistantId and collect every
- * published event. Returns the collected list + an unsubscribe function.
+ * Capture every event published by the test host — the module-level
+ * publisher writes through `host.events.publish`, so this just reads back
+ * the recorded list from the test host.
  */
-function captureHub(assistantId: string) {
+function captureHub(harness: ReturnType<typeof makeTestHost>) {
   const received: AssistantEvent[] = [];
-  const sub = assistantEventHub.subscribe({ assistantId }, (event) => {
+  const sub = harness.subscribe((event) => {
     received.push(event);
   });
   return { received, dispose: () => sub.dispose() };
@@ -109,8 +226,13 @@ function makeLifecycle(
 // Shared setup
 // ---------------------------------------------------------------------------
 
+let harness: ReturnType<typeof makeTestHost>;
+
 beforeEach(() => {
   __resetMeetSessionEventRouterForTests();
+  _resetEventPublisherForTests();
+  harness = makeTestHost();
+  createEventPublisher(harness.host);
   meetEventDispatcher._resetForTests();
 });
 
@@ -120,29 +242,30 @@ beforeEach(() => {
 
 describe("publishMeetEvent", () => {
   test("wraps payload in a ServerMessage via buildAssistantEvent", async () => {
-    const { received, dispose } = captureHub(DAEMON_INTERNAL_ASSISTANT_ID);
+    const { received, dispose } = captureHub(harness);
     try {
       await publishMeetEvent(
-        DAEMON_INTERNAL_ASSISTANT_ID,
+        TEST_ASSISTANT_ID,
         "m-pub-1",
         "meet.joining",
-        { url: "https://meet.google.com/abc-def-ghi" },
+        { url: "https://meet.example.com/abc-def-ghi" },
       );
 
       expect(received).toHaveLength(1);
       const event = received[0]!;
-      expect(event.assistantId).toBe(DAEMON_INTERNAL_ASSISTANT_ID);
+      expect(event.assistantId).toBe(TEST_ASSISTANT_ID);
       expect(event.id).toMatch(
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
       );
       expect(Number.isNaN(Date.parse(event.emittedAt))).toBe(false);
-      expect(event.message.type).toBe("meet.joining");
-      expect((event.message as { meetingId: string }).meetingId).toBe(
-        "m-pub-1",
-      );
-      expect((event.message as { url: string }).url).toBe(
-        "https://meet.google.com/abc-def-ghi",
-      );
+      const message = event.message as {
+        type: string;
+        meetingId: string;
+        url: string;
+      };
+      expect(message.type).toBe("meet.joining");
+      expect(message.meetingId).toBe("m-pub-1");
+      expect(message.url).toBe("https://meet.example.com/abc-def-ghi");
     } finally {
       dispose();
     }
@@ -150,15 +273,12 @@ describe("publishMeetEvent", () => {
 
   test("does not propagate subscriber failures", async () => {
     // Subscribe with a throwing callback — the publish should still resolve.
-    const sub = assistantEventHub.subscribe(
-      { assistantId: DAEMON_INTERNAL_ASSISTANT_ID },
-      () => {
-        throw new Error("boom");
-      },
-    );
+    const sub = harness.subscribe(() => {
+      throw new Error("boom");
+    });
     try {
       await expect(
-        publishMeetEvent(DAEMON_INTERNAL_ASSISTANT_ID, "m-pub-2", "meet.left", {
+        publishMeetEvent(TEST_ASSISTANT_ID, "m-pub-2", "meet.left", {
           reason: "user-requested",
         }),
       ).resolves.toBeUndefined();
@@ -177,17 +297,14 @@ describe("publishMeetEvent", () => {
       "meet.left",
       "meet.error",
     ] as const;
-    const { received, dispose } = captureHub(DAEMON_INTERNAL_ASSISTANT_ID);
+    const { received, dispose } = captureHub(harness);
     try {
       for (const kind of kinds) {
-        await publishMeetEvent(
-          DAEMON_INTERNAL_ASSISTANT_ID,
-          "m-kinds",
-          kind,
-          {},
-        );
+        await publishMeetEvent(TEST_ASSISTANT_ID, "m-kinds", kind, {});
       }
-      expect(received.map((e) => e.message.type)).toEqual([...kinds]);
+      expect(received.map((e) => (e.message as { type: string }).type)).toEqual(
+        [...kinds],
+      );
     } finally {
       dispose();
     }
@@ -296,11 +413,8 @@ describe("registerMeetingDispatcher / unregisterMeetingDispatcher", () => {
 describe("subscribeEventHubPublisher", () => {
   test("participant.change → meet.participant_changed with joined/left arrays", async () => {
     registerMeetingDispatcher("m-p");
-    const { received, dispose } = captureHub(DAEMON_INTERNAL_ASSISTANT_ID);
-    const unsub = subscribeEventHubPublisher(
-      DAEMON_INTERNAL_ASSISTANT_ID,
-      "m-p",
-    );
+    const { received, dispose } = captureHub(harness);
+    const unsub = subscribeEventHubPublisher(TEST_ASSISTANT_ID, "m-p");
     try {
       const event = makeParticipantChange("m-p");
       getMeetSessionEventRouter().dispatch("m-p", event);
@@ -329,11 +443,8 @@ describe("subscribeEventHubPublisher", () => {
 
   test("speaker.change → meet.speaker_changed with id + name", async () => {
     registerMeetingDispatcher("m-s");
-    const { received, dispose } = captureHub(DAEMON_INTERNAL_ASSISTANT_ID);
-    const unsub = subscribeEventHubPublisher(
-      DAEMON_INTERNAL_ASSISTANT_ID,
-      "m-s",
-    );
+    const { received, dispose } = captureHub(harness);
+    const unsub = subscribeEventHubPublisher(TEST_ASSISTANT_ID, "m-s");
     try {
       getMeetSessionEventRouter().dispatch("m-s", makeSpeakerChange("m-s"));
       await Promise.resolve();
@@ -357,16 +468,13 @@ describe("subscribeEventHubPublisher", () => {
 
   test("final transcript.chunk → meet.transcript_chunk; interims are dropped", async () => {
     registerMeetingDispatcher("m-t");
-    const { received, dispose } = captureHub(DAEMON_INTERNAL_ASSISTANT_ID);
-    const unsub = subscribeEventHubPublisher(
-      DAEMON_INTERNAL_ASSISTANT_ID,
-      "m-t",
-    );
+    const { received, dispose } = captureHub(harness);
+    const unsub = subscribeEventHubPublisher(TEST_ASSISTANT_ID, "m-t");
     try {
       // Interim — should NOT publish.
       getMeetSessionEventRouter().dispatch(
         "m-t",
-        makeTranscript("m-t", false, { text: "interim …" }),
+        makeTranscript("m-t", false, { text: "interim ..." }),
       );
       // Final — SHOULD publish with all optional fields preserved.
       getMeetSessionEventRouter().dispatch(
@@ -406,11 +514,8 @@ describe("subscribeEventHubPublisher", () => {
     // first joined, leave, error). The router-hub bridge must stay quiet on
     // lifecycle or we'd double-publish `meet.joined` etc.
     registerMeetingDispatcher("m-l");
-    const { received, dispose } = captureHub(DAEMON_INTERNAL_ASSISTANT_ID);
-    const unsub = subscribeEventHubPublisher(
-      DAEMON_INTERNAL_ASSISTANT_ID,
-      "m-l",
-    );
+    const { received, dispose } = captureHub(harness);
+    const unsub = subscribeEventHubPublisher(TEST_ASSISTANT_ID, "m-l");
     try {
       getMeetSessionEventRouter().dispatch(
         "m-l",
@@ -430,11 +535,8 @@ describe("subscribeEventHubPublisher", () => {
 
   test("chat.inbound is dropped (not a meet.* event kind)", async () => {
     registerMeetingDispatcher("m-c");
-    const { received, dispose } = captureHub(DAEMON_INTERNAL_ASSISTANT_ID);
-    const unsub = subscribeEventHubPublisher(
-      DAEMON_INTERNAL_ASSISTANT_ID,
-      "m-c",
-    );
+    const { received, dispose } = captureHub(harness);
+    const unsub = subscribeEventHubPublisher(TEST_ASSISTANT_ID, "m-c");
     try {
       getMeetSessionEventRouter().dispatch("m-c", {
         type: "chat.inbound",

--- a/skills/meet-join/daemon/__tests__/proactive-chat-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/proactive-chat-e2e.test.ts
@@ -84,8 +84,13 @@ import type {
   MeetEventSubscriber,
   MeetEventUnsubscribe,
 } from "../event-publisher.js";
-import { meetEventDispatcher } from "../event-publisher.js";
+import {
+  _resetEventPublisherForTests,
+  createEventPublisher,
+  meetEventDispatcher,
+} from "../event-publisher.js";
 import { __resetMeetSessionEventRouterForTests } from "../session-event-router.js";
+import { installSessionManagerTestHost } from "./test-host.js";
 import {
   _createMeetSessionManagerForTests,
   MEET_BOT_INTERNAL_PORT,
@@ -298,6 +303,8 @@ beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "proactive-chat-e2e-"));
   __resetMeetSessionEventRouterForTests();
   __resetWakeChainForTests();
+  _resetEventPublisherForTests();
+  createEventPublisher(installSessionManagerTestHost());
   meetEventDispatcher._resetForTests();
   persistedMessages.length = 0;
   fakeBot = startFakeBot();

--- a/skills/meet-join/daemon/__tests__/session-manager.test.ts
+++ b/skills/meet-join/daemon/__tests__/session-manager.test.ts
@@ -25,11 +25,16 @@ import type {
   ChatOpportunityDecision,
   ChatOpportunityDetectorStats,
 } from "../chat-opportunity-detector.js";
-import { meetEventDispatcher } from "../event-publisher.js";
+import {
+  _resetEventPublisherForTests,
+  createEventPublisher,
+  meetEventDispatcher,
+} from "../event-publisher.js";
 import {
   __resetMeetSessionEventRouterForTests,
   getMeetSessionEventRouter,
 } from "../session-event-router.js";
+import { installSessionManagerTestHost } from "./test-host.js";
 import {
   _createMeetSessionManagerForTests,
   BOT_LEAVE_HTTP_TIMEOUT_MS,
@@ -186,6 +191,12 @@ let workspaceDir: string;
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "session-manager-test-"));
   __resetMeetSessionEventRouterForTests();
+  _resetEventPublisherForTests();
+  // Wire the module-level event publisher to the real `assistantEventHub`
+  // so the existing `captureHub` subscriptions in these tests still receive
+  // events. A follow-up PR introduces a shared `buildTestHost()` helper —
+  // for now the per-test-suite shim lives next to the test file.
+  createEventPublisher(installSessionManagerTestHost());
   meetEventDispatcher._resetForTests();
 });
 

--- a/skills/meet-join/daemon/__tests__/test-host.ts
+++ b/skills/meet-join/daemon/__tests__/test-host.ts
@@ -1,0 +1,109 @@
+/**
+ * Narrow {@link SkillHost} stub for session-manager tests.
+ *
+ * The session-manager test suite still imports `assistantEventHub` directly
+ * so it can capture events published during `join()` / `leave()` / error
+ * paths. This helper returns a minimal host that forwards `events.publish`
+ * to the real `assistantEventHub` and uses the neutral
+ * `buildAssistantEvent` factory for event construction — so every existing
+ * `captureHub` subscription in the test file continues to receive the
+ * events the session manager emits.
+ *
+ * The helper is deliberately test-local: PR 16 of the skill-isolation plan
+ * introduces a shared `buildTestHost()` under `skills/meet-join/__tests__/`
+ * and migrates every meet-join test off direct `assistant/` imports. Until
+ * that PR lands, this file is the smallest possible wiring shim — only the
+ * facets the session manager actually reads at runtime are populated; the
+ * rest intentionally throw so accidental use surfaces as a clear error.
+ */
+
+import type {
+  AssistantEvent,
+  ServerMessage,
+  SkillHost,
+} from "@vellumai/skill-host-contracts";
+import { buildAssistantEvent } from "@vellumai/skill-host-contracts";
+
+import { assistantEventHub } from "../../../../assistant/src/runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../assistant/src/runtime/assistant-scope.js";
+
+/**
+ * Build a stub {@link SkillHost} wired to the real `assistantEventHub`.
+ * Only the `events` facet is functional — the other facets throw on
+ * access so tests that accidentally start depending on them fail loudly.
+ */
+export function installSessionManagerTestHost(): SkillHost {
+  const noopLogger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+
+  return {
+    logger: { get: () => noopLogger },
+    config: {
+      isFeatureFlagEnabled: () => false,
+      getSection: () => undefined,
+    },
+    identity: {
+      getAssistantName: () => undefined,
+      internalAssistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+    },
+    platform: {
+      workspaceDir: () => "/tmp/session-manager-test-workspace",
+      vellumRoot: () => "/tmp/session-manager-test-vellum",
+      runtimeMode: () => "bare-metal" as never,
+    },
+    providers: {
+      llm: {
+        getConfigured: () => {
+          throw new Error("unexpected llm.getConfigured");
+        },
+        userMessage: () => {
+          throw new Error("unexpected llm.userMessage");
+        },
+        extractToolUse: () => null,
+        createTimeout: () => new AbortController(),
+      },
+      stt: {
+        listProviderIds: () => [],
+        supportsBoundary: () => false,
+        resolveStreamingTranscriber: () => {
+          throw new Error("unexpected stt.resolveStreamingTranscriber");
+        },
+      },
+      tts: {
+        get: () => {
+          throw new Error("unexpected tts.get");
+        },
+        resolveConfig: () => ({}),
+      },
+      secureKeys: { getProviderKey: async () => null },
+    },
+    memory: {
+      addMessage: async () => ({}),
+      wakeAgentForOpportunity: async () => {},
+    },
+    events: {
+      publish: (event: AssistantEvent) =>
+        assistantEventHub.publish(event as never),
+      subscribe: (filter, cb) =>
+        assistantEventHub.subscribe(filter, cb as never),
+      buildEvent: (message: ServerMessage, conversationId?: string) =>
+        buildAssistantEvent(
+          DAEMON_INTERNAL_ASSISTANT_ID,
+          message,
+          conversationId,
+        ),
+    },
+    registries: {
+      registerTools: () => {
+        throw new Error("unexpected registries.registerTools");
+      },
+      registerSkillRoute: () => ({}) as never,
+      registerShutdownHook: () => {},
+    },
+    speakers: { createTracker: () => ({}) },
+  };
+}

--- a/skills/meet-join/daemon/conversation-bridge.ts
+++ b/skills/meet-join/daemon/conversation-bridge.ts
@@ -3,70 +3,76 @@
  * messages and live ephemeral updates.
  *
  * The bridge subscribes to a meeting's bot-event stream via
- * {@link subscribeToMeetingEvents} (the PR 19 fan-out dispatcher). It fans
- * incoming {@link MeetBotEvent}s into four sinks:
+ * {@link subscribeToMeetingEvents} and fans incoming {@link MeetBotEvent}s
+ * into four sinks:
  *
- *   1. **Final transcripts** (`transcript.chunk` with `isFinal === true`)
- *      are run through {@link MeetSpeakerResolver} to arbitrate Deepgram
- *      vs DOM speaker attribution, then persisted as `"user"` messages
- *      with a `[<speakerName>]: <text>` attribution. Speaker metadata
+ *   1. Final transcripts (`transcript.chunk` with `isFinal === true`) are
+ *      run through {@link MeetSpeakerResolver} to arbitrate provider vs
+ *      DOM speaker attribution, then persisted as `"user"` messages with
+ *      a `[<speakerName>]: <text>` attribution. Speaker metadata
  *      (`meetSpeakerLabel`, `meetSpeakerId`, `meetSpeakerName`,
  *      `meetSpeakerConfidence`, `meetTimestamp`) rides in the message
  *      metadata so later PRs can surface the raw speaker context without
  *      re-parsing the content.
  *
- *   2. **Interim transcripts** (`transcript.chunk` with `isFinal === false`)
- *      are NOT persisted. They are published via
- *      {@link assistantEventHub} as `meet.transcript_interim` so live
- *      clients can render in-progress text and have it superseded once a
- *      final chunk arrives.
+ *   2. Interim transcripts (`transcript.chunk` with `isFinal === false`)
+ *      are NOT persisted. They are published via the host's event hub as
+ *      `meet.transcript_interim` so live clients can render in-progress
+ *      text and have it superseded once a final chunk arrives.
  *
- *   3. **Inbound chat** (`chat.inbound`) is persisted as a `"user"`
- *      message prefixed with `"[Meet chat] <fromName>: <text>"` — this is
- *      the repo's existing "tag it in the content" pattern used by
- *      pointer / call messages (see `assistant/src/calls/call-pointer-messages.ts`).
+ *   3. Inbound chat (`chat.inbound`) is persisted as a `"user"` message
+ *      prefixed with `"[Meet chat] <fromName>: <text>"` — this is the
+ *      repo's existing "tag it in the content" pattern used by pointer
+ *      and call messages.
  *
- *   4. **Participant changes** (`participant.change`) are persisted as
- *      short `"user"`-role lines (`"[Meeting] <name> joined"` /
+ *   4. Participant changes (`participant.change`) are persisted as short
+ *      `"user"`-role lines (`"[Meeting] <name> joined"` /
  *      `"[Meeting] <name> left"`) with `automated: true` in metadata so
  *      they don't pollute memory indexing. Using `"user"` role keeps
  *      untrusted participant names from carrying assistant-level
  *      authority in model context.
  *
  * `speaker.change` and `lifecycle` are intentionally consumed elsewhere
- * (PR 18 storage writer, PR 19 lifecycle listener, PR 21 speaker
- * resolver); this bridge is a no-op for them at the top level, though
- * the resolver transparently observes `speaker.change` via its own
- * subscription.
+ * (storage writer, lifecycle listener, speaker resolver); this bridge is
+ * a no-op for them at the top level, though the resolver transparently
+ * observes `speaker.change` via its own subscription.
  *
- * Dependency injection keeps the bridge test-friendly: the message-insert
- * function, the dispatcher subscribe, the event hub, and the resolver
- * can all be supplied at construction time so unit tests never need to
- * spin up SQLite or the real singleton.
+ * ## Host-based factory
+ *
+ * The module previously reached into `assistant/` for `buildAssistantEvent`,
+ * `assistantEventHub`, `getLogger`, and `DAEMON_INTERNAL_ASSISTANT_ID`. The
+ * skill-isolation plan replaces those with the runtime-injected
+ * {@link SkillHost}. {@link createConversationBridge} captures a host and
+ * returns a builder that constructs {@link MeetConversationBridge}
+ * instances with host-backed defaults pre-wired; each instance's deps bag
+ * still accepts overrides so tests can inject shims without threading a
+ * full host through.
  */
+
+import type {
+  AssistantEvent,
+  Logger,
+  ServerMessage,
+  SkillHost,
+} from "@vellumai/skill-host-contracts";
+import { buildAssistantEvent } from "@vellumai/skill-host-contracts";
 
 import type { MeetBotEvent } from "../contracts/index.js";
 
-import type { ServerMessage } from "../../../assistant/src/daemon/message-protocol.js";
-import { buildAssistantEvent } from "../../../assistant/src/runtime/assistant-event.js";
-import { assistantEventHub as defaultAssistantEventHub } from "../../../assistant/src/runtime/assistant-event-hub.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../assistant/src/runtime/assistant-scope.js";
-import { getLogger } from "../../../assistant/src/util/logger.js";
 import {
   type MeetEventSubscriber,
   type MeetEventUnsubscribe,
   subscribeToMeetingEvents as defaultSubscribeToMeetingEvents,
 } from "./event-publisher.js";
+import { registerSubModule } from "./modules-registry.js";
 import { MeetSpeakerResolver } from "./speaker-resolver.js";
-
-const log = getLogger("meet-conversation-bridge");
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 /**
- * Narrow shape of `addMessage` from `memory/conversation-crud.ts` — the
+ * Narrow shape of `addMessage` from the assistant's memory module — the
  * bridge only needs the subset of fields that the conversation message
  * insert path actually accepts. Declared locally so tests can supply a
  * recording shim without importing the full database module.
@@ -79,9 +85,9 @@ export type InsertMessageFn = (
   opts?: { skipIndexing?: boolean },
 ) => Promise<{ id: string } & Record<string, unknown>>;
 
-/** Minimal hub surface the bridge depends on — matches `assistantEventHub`. */
+/** Minimal hub surface the bridge depends on — matches `host.events`. */
 export interface AssistantEventPublisher {
-  publish: (event: ReturnType<typeof buildAssistantEvent>) => Promise<void>;
+  publish: (event: AssistantEvent) => Promise<void>;
 }
 
 /**
@@ -93,6 +99,17 @@ export type SubscribeToMeetingEventsFn = (
   cb: MeetEventSubscriber,
 ) => MeetEventUnsubscribe;
 
+/**
+ * Build an {@link AssistantEvent} envelope. The default uses the neutral
+ * `buildAssistantEvent` from `@vellumai/skill-host-contracts`; tests may
+ * inject a recorder.
+ */
+export type BuildEventFn = (
+  assistantId: string,
+  message: ServerMessage,
+  conversationId?: string,
+) => AssistantEvent;
+
 export interface MeetConversationBridgeDeps {
   /** Required: the per-meeting id the dispatcher keys on. */
   meetingId: string;
@@ -102,10 +119,14 @@ export interface MeetConversationBridgeDeps {
   insertMessage: InsertMessageFn;
   /**
    * Optional: override the dispatcher subscribe function. Defaults to the
-   * process singleton {@link subscribeToMeetingEvents}.
+   * legacy module-level thunk from `event-publisher.ts`.
    */
   subscribeToMeetingEvents?: SubscribeToMeetingEventsFn;
-  /** Optional: override the event hub (defaults to the process singleton). */
+  /**
+   * Optional: override the event hub (defaults to whatever
+   * {@link createConversationBridge} captured, or — for tests that build
+   * the class directly — falls back to a no-op implementation).
+   */
   assistantEventHub?: AssistantEventPublisher;
   /**
    * Optional: override the speaker resolver. The bridge constructs a
@@ -114,12 +135,45 @@ export interface MeetConversationBridgeDeps {
    */
   resolver?: MeetSpeakerResolver;
   /**
-   * Optional: override the assistant id on emitted interim events. The
-   * daemon normally uses `DAEMON_INTERNAL_ASSISTANT_ID` ("self"); tests
-   * may want to verify scope behavior.
+   * Optional: override the assistant id on emitted interim events.
+   * Defaults to the host's internal assistant id when the factory is used,
+   * or `"self"` when the class is constructed directly (tests).
    */
   assistantId?: string;
+  /**
+   * Optional: structural logger. Defaults to a host-backed logger when the
+   * factory is used, or a console-wrapping shim when the class is
+   * constructed directly without a host.
+   */
+  log?: Logger;
+  /**
+   * Optional: override the `AssistantEvent` builder. Defaults to the
+   * pure-function {@link buildAssistantEvent} in
+   * `@vellumai/skill-host-contracts`.
+   */
+  buildEvent?: BuildEventFn;
 }
+
+// ---------------------------------------------------------------------------
+// Fallback logger
+// ---------------------------------------------------------------------------
+
+/**
+ * Structural logger used when a bridge is constructed without a host or
+ * explicit `log` dep. The default pipes through `console.*` so test
+ * failures still surface — callers that want structured output wire in a
+ * host-backed logger via the factory.
+ */
+const consoleFallbackLogger: Logger = {
+  // eslint-disable-next-line no-console
+  debug: (msg, meta) => console.debug(msg, meta),
+  // eslint-disable-next-line no-console
+  info: (msg, meta) => console.info(msg, meta),
+  // eslint-disable-next-line no-console
+  warn: (msg, meta) => console.warn(msg, meta),
+  // eslint-disable-next-line no-console
+  error: (msg, meta) => console.error(msg, meta),
+};
 
 // ---------------------------------------------------------------------------
 // Bridge
@@ -130,9 +184,11 @@ export class MeetConversationBridge {
   private readonly conversationId: string;
   private readonly insertMessage: InsertMessageFn;
   private readonly subscribeFn: SubscribeToMeetingEventsFn;
-  private readonly hub: AssistantEventPublisher;
+  private readonly hub: AssistantEventPublisher | null;
   private readonly resolver: MeetSpeakerResolver;
   private readonly assistantId: string;
+  private readonly log: Logger;
+  private readonly buildEvent: BuildEventFn;
   private unsubscribeFn: MeetEventUnsubscribe | null = null;
 
   constructor(deps: MeetConversationBridgeDeps) {
@@ -141,14 +197,22 @@ export class MeetConversationBridge {
     this.insertMessage = deps.insertMessage;
     this.subscribeFn =
       deps.subscribeToMeetingEvents ?? defaultSubscribeToMeetingEvents;
-    this.hub = deps.assistantEventHub ?? defaultAssistantEventHub;
+    // No direct daemon-singleton fallback — callers that don't provide a
+    // hub get a no-op publish so the bridge still installs cleanly.
+    this.hub = deps.assistantEventHub ?? null;
     this.resolver =
       deps.resolver ??
       new MeetSpeakerResolver({
         meetingId: deps.meetingId,
         subscribe: this.subscribeFn,
       });
-    this.assistantId = deps.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
+    // `"self"` is the literal value of `DAEMON_INTERNAL_ASSISTANT_ID`; the
+    // factory ordinarily supplies `host.identity.internalAssistantId`
+    // through the deps bag, but direct test construction keeps a
+    // matching fallback so interim events stay scoped consistently.
+    this.assistantId = deps.assistantId ?? "self";
+    this.log = deps.log ?? consoleFallbackLogger;
+    this.buildEvent = deps.buildEvent ?? buildAssistantEvent;
   }
 
   /**
@@ -162,10 +226,11 @@ export class MeetConversationBridge {
       // Defer to async-aware branch but don't block the dispatcher — late
       // errors are logged, not surfaced.
       void this.handleEvent(event).catch((err) => {
-        log.error(
-          { err, meetingId: this.meetingId, eventType: event.type },
-          "MeetConversationBridge: handler failed",
-        );
+        this.log.error("MeetConversationBridge: handler failed", {
+          err,
+          meetingId: this.meetingId,
+          eventType: event.type,
+        });
       });
     });
   }
@@ -179,9 +244,12 @@ export class MeetConversationBridge {
       try {
         this.unsubscribeFn();
       } catch (err) {
-        log.warn(
-          { err, meetingId: this.meetingId },
+        this.log.warn(
           "MeetConversationBridge: dispatcher unsubscribe threw",
+          {
+            err,
+            meetingId: this.meetingId,
+          },
         );
       }
       this.unsubscribeFn = null;
@@ -216,14 +284,14 @@ export class MeetConversationBridge {
         // bridge itself doesn't need to react to active-speaker changes.
         return;
       case "lifecycle":
-        // PR 19 (lifecycle listener) owns this.
+        // The lifecycle listener owns this.
         return;
       default: {
         const exhaustiveCheck: never = event;
-        log.warn(
-          { meetingId: this.meetingId, event: exhaustiveCheck },
-          "MeetConversationBridge: unknown event type",
-        );
+        this.log.warn("MeetConversationBridge: unknown event type", {
+          meetingId: this.meetingId,
+          event: exhaustiveCheck,
+        });
         return;
       }
     }
@@ -258,7 +326,7 @@ export class MeetConversationBridge {
     if (resolved.speakerId !== undefined) {
       metadata.meetSpeakerId = resolved.speakerId;
     } else if (event.speakerId !== undefined) {
-      // Preserve the raw Deepgram speakerId even when the resolver didn't
+      // Preserve the raw provider speakerId even when the resolver didn't
       // produce a binding — it can still help downstream consumers pair
       // ASR segments to the same opaque speaker.
       metadata.meetSpeakerId = event.speakerId;
@@ -272,7 +340,7 @@ export class MeetConversationBridge {
   ): Promise<void> {
     // Never persisted — interim chunks are hub-only so the UI can render
     // live text that will be superseded by the next final chunk.
-    const message = {
+    const message: ServerMessage = {
       type: "meet.transcript_interim",
       meetingId: this.meetingId,
       conversationId: this.conversationId,
@@ -281,17 +349,19 @@ export class MeetConversationBridge {
       speakerLabel: event.speakerLabel,
       speakerId: event.speakerId,
       confidence: event.confidence,
-    } as unknown as ServerMessage;
+    };
+
+    if (!this.hub) return;
 
     try {
       await this.hub.publish(
-        buildAssistantEvent(this.assistantId, message, this.conversationId),
+        this.buildEvent(this.assistantId, message, this.conversationId),
       );
     } catch (err) {
-      log.warn(
-        { err, meetingId: this.meetingId },
-        "MeetConversationBridge: interim publish failed",
-      );
+      this.log.warn("MeetConversationBridge: interim publish failed", {
+        err,
+        meetingId: this.meetingId,
+      });
     }
   }
 
@@ -314,10 +384,10 @@ export class MeetConversationBridge {
   private async handleParticipantChange(
     event: Extract<MeetBotEvent, { type: "participant.change" }>,
   ): Promise<void> {
-    // Emit one short status line per join/leave so the conversation
-    // stays readable — one batched summary would hide concurrent moves.
-    // Persisted as "user" with `automated: true` so untrusted participant
-    // names never carry assistant-level authority in model context.
+    // Emit one short status line per join/leave so the conversation stays
+    // readable — one batched summary would hide concurrent moves. Persisted
+    // as "user" with `automated: true` so untrusted participant names never
+    // carry assistant-level authority in model context.
     for (const participant of event.joined) {
       const safeName = sanitizeParticipantName(participant.name);
       const line = `[Meeting] ${safeName} joined`;
@@ -356,6 +426,58 @@ export class MeetConversationBridge {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Inputs a caller still needs to supply when building a bridge via the
+ * factory. The factory injects host-derived fields (hub, logger, assistant
+ * id, event builder) so consumers only think about the per-meeting bits.
+ */
+export interface BuildConversationBridgeArgs {
+  meetingId: string;
+  conversationId: string;
+  insertMessage: InsertMessageFn;
+  subscribeToMeetingEvents?: SubscribeToMeetingEventsFn;
+  resolver?: MeetSpeakerResolver;
+}
+
+export interface ConversationBridgeBuilder {
+  (args: BuildConversationBridgeArgs): MeetConversationBridge;
+}
+
+/**
+ * Build the conversation-bridge factory against a {@link SkillHost}. The
+ * returned function is the production entry point: callers pass
+ * per-meeting args and receive a fully wired {@link MeetConversationBridge}
+ * with host-backed publish, log, and identity dependencies.
+ */
+export function createConversationBridge(
+  host: SkillHost,
+): ConversationBridgeBuilder {
+  const log = host.logger.get("meet-conversation-bridge");
+  // `host.events.buildEvent` curries the internal assistant id; the bridge
+  // always publishes as the internal assistant, so we wrap the curried form
+  // in a builder whose `assistantId` argument is accepted but unused.
+  // Passing it through to `buildEvent` would re-curry the same constant.
+  const buildEvent: BuildEventFn = (_assistantId, message, conversationId) =>
+    host.events.buildEvent(message, conversationId);
+
+  return (args) =>
+    new MeetConversationBridge({
+      meetingId: args.meetingId,
+      conversationId: args.conversationId,
+      insertMessage: args.insertMessage,
+      subscribeToMeetingEvents: args.subscribeToMeetingEvents,
+      resolver: args.resolver,
+      assistantEventHub: host.events,
+      assistantId: host.identity.internalAssistantId,
+      log,
+      buildEvent,
+    });
+}
+
 /**
  * Strip control characters and collapse whitespace in a participant display
  * name so it can't inject newlines, tabs, or other formatting tricks when
@@ -369,3 +491,13 @@ function sanitizeParticipantName(raw: string): string {
     .trim()
     .slice(0, 100);
 }
+
+// ---------------------------------------------------------------------------
+// Sub-module registration
+// ---------------------------------------------------------------------------
+//
+// The factory slot here is `createConversationBridge` — consumers (the
+// session manager in PR 17) pull the builder via `getSubModule` instead
+// of taking a static import on this file.
+
+registerSubModule("conversation-bridge", createConversationBridge);

--- a/skills/meet-join/daemon/event-publisher.ts
+++ b/skills/meet-join/daemon/event-publisher.ts
@@ -5,23 +5,35 @@
  *
  * Two concerns live here:
  *
- *  1. {@link publishMeetEvent} — builds a proper {@link AssistantEvent} via
- *     {@link buildAssistantEvent} and hands it to `assistantEventHub.publish`.
+ *  1. {@link publishMeetEvent} — builds a proper `AssistantEvent` via the
+ *     host's `events.buildEvent` and hands it to `host.events.publish`.
  *     Failures are swallowed and logged: a slow/broken SSE subscriber must
  *     never break the meeting.
  *
  *  2. {@link MeetEventDispatcher} — a thin fan-out for per-meeting bot
  *     events. The router upstream (`MeetSessionEventRouter`, PR 9) only
- *     allows *one* handler per meeting, which means the session manager
+ *     allows one handler per meeting, which means the session manager
  *     must own the single registration and multiplex from there. Several
- *     PRs in the plan want to observe the same live event stream (this
- *     publisher for SSE, PR 17 for the conversation bridge, PR 18 for
- *     storage, PR 22 for consent). They all subscribe through this
- *     dispatcher rather than racing to replace each other at the router.
+ *     consumers want to observe the same live event stream (this
+ *     publisher for SSE, conversation bridge, storage, consent). They
+ *     all subscribe through this dispatcher rather than racing to
+ *     replace each other at the router.
  *
- *     The dispatcher is intentionally cheap: a Map<meetingId, Set<cb>>,
+ *     The dispatcher is intentionally cheap: a `Map<meetingId, Set<cb>>`,
  *     synchronous fan-out, handler errors are caught and logged. No
  *     buffering, no async queues — matches the router's ergonomics.
+ *
+ * ## Host-based factory
+ *
+ * The module previously imported `assistantEventHub`, `buildAssistantEvent`,
+ * and `getLogger` directly from `assistant/`. The skill-isolation plan
+ * replaces those with the runtime-injected `SkillHost` supplied by the
+ * assistant's bootstrap. {@link createEventPublisher} captures the host
+ * and wires the module-level singletons that existing consumers (e.g.
+ * the session manager, until PR 17) keep importing. Calling the factory
+ * before those consumers run is a startup ordering requirement — the
+ * module-level thunks throw a clear error if invoked before the host is
+ * installed.
  *
  * Future PRs that want to read the stream should call
  * `subscribeToMeetingEvents(meetingId, cb)` rather than calling
@@ -29,15 +41,12 @@
  * consumer never steps on an existing one.
  */
 
+import type { Logger, SkillHost } from "@vellumai/skill-host-contracts";
+
 import type { MeetBotEvent } from "../contracts/index.js";
 
-import type { ServerMessage } from "../../../assistant/src/daemon/message-protocol.js";
-import { buildAssistantEvent } from "../../../assistant/src/runtime/assistant-event.js";
-import { assistantEventHub } from "../../../assistant/src/runtime/assistant-event-hub.js";
-import { getLogger } from "../../../assistant/src/util/logger.js";
+import { registerSubModule } from "./modules-registry.js";
 import { getMeetSessionEventRouter } from "./session-event-router.js";
-
-const log = getLogger("meet-event-publisher");
 
 // ---------------------------------------------------------------------------
 // Event-kind discriminator
@@ -60,40 +69,6 @@ export type MeetEventKind =
   | "meet.speaking_ended";
 
 // ---------------------------------------------------------------------------
-// publishMeetEvent
-// ---------------------------------------------------------------------------
-
-/**
- * Publish a Meet lifecycle/transcript/participant/speaker event to the
- * in-process `assistantEventHub`. Clients subscribed via SSE receive the
- * event in delivery order.
- *
- * `payload` is merged with `{ type: kind, meetingId }` to form the
- * `ServerMessage` body — callers must not include `type` or `meetingId`
- * in `payload` or they will conflict with the discriminator.
- *
- * Errors from subscribers are logged but never rethrown: a slow or broken
- * consumer on the SSE side must not break the active meeting. Returns a
- * promise that resolves when the publish call settles, for tests that
- * want to await delivery. Production callers can fire-and-forget.
- */
-export function publishMeetEvent(
-  assistantId: string,
-  meetingId: string,
-  kind: MeetEventKind,
-  payload: Record<string, unknown>,
-): Promise<void> {
-  // Narrow the composed literal to `ServerMessage` — every `meet.*` kind
-  // has a matching variant in the `ServerMessage` discriminated union, but
-  // TypeScript can't infer the runtime match from a string-keyed payload.
-  const message = { type: kind, meetingId, ...payload } as ServerMessage;
-  const event = buildAssistantEvent(assistantId, message);
-  return assistantEventHub.publish(event).catch((err) => {
-    log.warn({ err, meetingId, kind }, "Failed to publish meet event");
-  });
-}
-
-// ---------------------------------------------------------------------------
 // MeetEventDispatcher — per-meeting fan-out shim
 // ---------------------------------------------------------------------------
 
@@ -107,9 +82,15 @@ export type MeetEventUnsubscribe = () => void;
  * Process-wide fan-out map for per-meeting bot events. One instance, many
  * subscribers per meeting id. Singleton so cross-cutting subscribers
  * (publisher, bridge, storage, consent) agree on the same dispatch target.
+ *
+ * The dispatcher holds no references to `assistant/` — it uses the
+ * factory-supplied logger for its internal diagnostics, so constructing
+ * it requires a {@link Logger} rather than reaching for a global.
  */
 class MeetEventDispatcher {
   private readonly subs = new Map<string, Set<MeetEventSubscriber>>();
+
+  constructor(private readonly log: Logger) {}
 
   subscribe(meetingId: string, cb: MeetEventSubscriber): MeetEventUnsubscribe {
     let set = this.subs.get(meetingId);
@@ -135,10 +116,11 @@ class MeetEventDispatcher {
       try {
         cb(event);
       } catch (err) {
-        log.error(
-          { err, meetingId, eventType: event.type },
-          "Meet event subscriber threw",
-        );
+        this.log.error("Meet event subscriber threw", {
+          err,
+          meetingId,
+          eventType: event.type,
+        });
       }
     }
   }
@@ -159,41 +141,239 @@ class MeetEventDispatcher {
   }
 }
 
-/** Process-level singleton dispatcher, shared across the meet subsystem. */
-export const meetEventDispatcher = new MeetEventDispatcher();
+// ---------------------------------------------------------------------------
+// EventPublisher facade
+// ---------------------------------------------------------------------------
+
+/**
+ * Bundle returned by {@link createEventPublisher}. Holds the per-meeting
+ * dispatcher and the host-backed publish helpers that previously reached
+ * into `assistant/` via top-level imports.
+ */
+export interface EventPublisher {
+  readonly dispatcher: MeetEventDispatcher;
+  publishMeetEvent(
+    assistantId: string,
+    meetingId: string,
+    kind: MeetEventKind,
+    payload: Record<string, unknown>,
+  ): Promise<void>;
+  subscribeToMeetingEvents(
+    meetingId: string,
+    cb: MeetEventSubscriber,
+  ): MeetEventUnsubscribe;
+  registerMeetingDispatcher(meetingId: string): void;
+  unregisterMeetingDispatcher(meetingId: string): void;
+  subscribeEventHubPublisher(
+    assistantId: string,
+    meetingId: string,
+  ): MeetEventUnsubscribe;
+}
+
+/**
+ * Build the Meet event publisher against a {@link SkillHost}. Called
+ * once by `register(host)` at daemon startup; also stashes the resulting
+ * bundle on a module-level singleton so the legacy module-scoped exports
+ * (imported by `session-manager.ts` pending PR 17) keep working.
+ */
+export function createEventPublisher(host: SkillHost): EventPublisher {
+  const log = host.logger.get("meet-event-publisher");
+  const dispatcher = new MeetEventDispatcher(log);
+
+  const publisher: EventPublisher = {
+    dispatcher,
+
+    publishMeetEvent(
+      // The assistantId is retained in the signature to preserve the API
+      // callers (session-manager) use today, but the host's `buildEvent`
+      // curries `DAEMON_INTERNAL_ASSISTANT_ID` so the argument no longer
+      // influences the emitted event. Callers always pass the internal id.
+      _assistantId: string,
+      meetingId: string,
+      kind: MeetEventKind,
+      payload: Record<string, unknown>,
+    ): Promise<void> {
+      // Narrow the composed literal to the host's wire-level `ServerMessage`
+      // — every `meet.*` kind has a matching variant in the daemon-side
+      // discriminated union, but TypeScript can't infer that from a
+      // string-keyed payload at this boundary.
+      const message = { type: kind, meetingId, ...payload };
+      const event = host.events.buildEvent(message);
+      return host.events.publish(event).catch((err) => {
+        log.warn("Failed to publish meet event", { err, meetingId, kind });
+      });
+    },
+
+    subscribeToMeetingEvents(
+      meetingId: string,
+      cb: MeetEventSubscriber,
+    ): MeetEventUnsubscribe {
+      return dispatcher.subscribe(meetingId, cb);
+    },
+
+    registerMeetingDispatcher(meetingId: string): void {
+      getMeetSessionEventRouter().register(meetingId, (event) => {
+        dispatcher.dispatch(meetingId, event);
+      });
+    },
+
+    unregisterMeetingDispatcher(meetingId: string): void {
+      getMeetSessionEventRouter().unregister(meetingId);
+      dispatcher.clear(meetingId);
+    },
+
+    subscribeEventHubPublisher(
+      assistantId: string,
+      meetingId: string,
+    ): MeetEventUnsubscribe {
+      return publisher.subscribeToMeetingEvents(meetingId, (event) => {
+        switch (event.type) {
+          case "participant.change":
+            void publisher.publishMeetEvent(
+              assistantId,
+              meetingId,
+              "meet.participant_changed",
+              {
+                joined: event.joined,
+                left: event.left,
+              },
+            );
+            return;
+          case "speaker.change":
+            void publisher.publishMeetEvent(
+              assistantId,
+              meetingId,
+              "meet.speaker_changed",
+              {
+                speakerId: event.speakerId,
+                speakerName: event.speakerName,
+              },
+            );
+            return;
+          case "transcript.chunk": {
+            // Interim chunks are noisy and may be superseded by a later
+            // final chunk covering the same time range. Clients only want
+            // stable text.
+            if (!event.isFinal) return;
+            const payload: Record<string, unknown> = { text: event.text };
+            if (event.speakerLabel !== undefined)
+              payload.speakerLabel = event.speakerLabel;
+            if (event.speakerId !== undefined)
+              payload.speakerId = event.speakerId;
+            if (event.confidence !== undefined)
+              payload.confidence = event.confidence;
+            void publisher.publishMeetEvent(
+              assistantId,
+              meetingId,
+              "meet.transcript_chunk",
+              payload,
+            );
+            return;
+          }
+          default:
+            // Ignore event kinds we don't fan out from the router path.
+            // Lifecycle transitions are published by the session manager.
+            // Inbound chat + interim transcripts are intentionally dropped.
+            return;
+        }
+      });
+    },
+  };
+
+  installedPublisher = publisher;
+  return publisher;
+}
+
+// ---------------------------------------------------------------------------
+// Module-scoped thunks for legacy consumers
+// ---------------------------------------------------------------------------
+//
+// Session-manager (pending PR 17) still imports these names directly. They
+// delegate to the singleton that `createEventPublisher(host)` installed at
+// startup. Calling before installation throws a loud error so wiring bugs
+// surface early rather than silently dispatching into the void.
+
+let installedPublisher: EventPublisher | null = null;
+
+function requirePublisher(): EventPublisher {
+  if (!installedPublisher) {
+    throw new Error(
+      "meet-join event-publisher: createEventPublisher(host) was not invoked " +
+        "before a legacy export was accessed. Ensure the skill's register(host) " +
+        "entry point ran during daemon bootstrap.",
+    );
+  }
+  return installedPublisher;
+}
+
+/**
+ * Publish a Meet lifecycle/transcript/participant/speaker event via the
+ * installed host. See {@link EventPublisher.publishMeetEvent}.
+ *
+ * `payload` is merged with `{ type: kind, meetingId }` to form the message
+ * body — callers must not include `type` or `meetingId` in `payload` or
+ * they will conflict with the discriminator.
+ *
+ * Errors from subscribers are logged but never rethrown: a slow or broken
+ * consumer on the SSE side must not break the active meeting.
+ */
+export function publishMeetEvent(
+  assistantId: string,
+  meetingId: string,
+  kind: MeetEventKind,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  return requirePublisher().publishMeetEvent(
+    assistantId,
+    meetingId,
+    kind,
+    payload,
+  );
+}
+
+/**
+ * Process-level singleton dispatcher facade. Delegates to the dispatcher
+ * constructed by {@link createEventPublisher}. Retained so test harnesses
+ * and the session manager can use the same API they used pre-migration.
+ */
+export const meetEventDispatcher = {
+  subscribe(meetingId: string, cb: MeetEventSubscriber): MeetEventUnsubscribe {
+    return requirePublisher().dispatcher.subscribe(meetingId, cb);
+  },
+  dispatch(meetingId: string, event: MeetBotEvent): void {
+    requirePublisher().dispatcher.dispatch(meetingId, event);
+  },
+  clear(meetingId: string): void {
+    requirePublisher().dispatcher.clear(meetingId);
+  },
+  subscriberCount(meetingId: string): number {
+    return requirePublisher().dispatcher.subscriberCount(meetingId);
+  },
+  _resetForTests(): void {
+    // Tolerate tests that reset before any factory has been wired — the
+    // dispatcher is state-free in that case, so there is nothing to clear.
+    installedPublisher?.dispatcher._resetForTests();
+  },
+};
 
 /**
  * Subscribe to raw bot events for a meeting. Safe for multiple callers.
  * Returns an unsubscribe function.
- *
- * Use this from downstream consumers (conversation bridge, storage writer,
- * consent monitor) instead of calling `MeetSessionEventRouter.register`
- * directly — the router allows only one handler per meeting, and the
- * session manager owns that registration.
  */
 export function subscribeToMeetingEvents(
   meetingId: string,
   cb: MeetEventSubscriber,
 ): MeetEventUnsubscribe {
-  return meetEventDispatcher.subscribe(meetingId, cb);
+  return requirePublisher().subscribeToMeetingEvents(meetingId, cb);
 }
-
-// ---------------------------------------------------------------------------
-// Router integration
-// ---------------------------------------------------------------------------
 
 /**
  * Install the single `MeetSessionEventRouter` handler for a meeting. The
- * handler forwards every incoming event into {@link meetEventDispatcher}
- * so multiple subscribers can observe the stream.
- *
- * The session manager calls this once per `join()` and pairs it with
- * {@link unregisterMeetingDispatcher} on `leave()`.
+ * handler forwards every incoming event into the dispatcher so multiple
+ * subscribers can observe the stream.
  */
 export function registerMeetingDispatcher(meetingId: string): void {
-  getMeetSessionEventRouter().register(meetingId, (event) => {
-    meetEventDispatcher.dispatch(meetingId, event);
-  });
+  requirePublisher().registerMeetingDispatcher(meetingId);
 }
 
 /**
@@ -201,74 +381,42 @@ export function registerMeetingDispatcher(meetingId: string): void {
  * meeting. Symmetric with {@link registerMeetingDispatcher}.
  */
 export function unregisterMeetingDispatcher(meetingId: string): void {
-  getMeetSessionEventRouter().unregister(meetingId);
-  meetEventDispatcher.clear(meetingId);
+  requirePublisher().unregisterMeetingDispatcher(meetingId);
 }
-
-// ---------------------------------------------------------------------------
-// Router → event-hub bridge
-// ---------------------------------------------------------------------------
 
 /**
  * Subscribe the event-hub publisher to a meeting's bot-event stream so
  * `participant.change`, `speaker.change`, and final transcript chunks
- * fan out as `meet.participant_changed` / `meet.speaker_changed` /
- * `meet.transcript_chunk` events on `assistantEventHub`.
+ * fan out as the matching `meet.*` events on the host's event hub.
  *
  * Lifecycle transitions are NOT handled here — the session manager
  * publishes `meet.joining`, `meet.joined`, `meet.left`, and `meet.error`
- * directly at the points it controls (join start, first joined lifecycle
- * event, leave, error) since those fire outside the bot-event stream
- * or carry richer context than the wire event provides.
- *
- * Returns an unsubscribe function the caller can invoke on leave.
+ * directly at the points it controls.
  */
 export function subscribeEventHubPublisher(
   assistantId: string,
   meetingId: string,
 ): MeetEventUnsubscribe {
-  return subscribeToMeetingEvents(meetingId, (event) => {
-    switch (event.type) {
-      case "participant.change":
-        void publishMeetEvent(
-          assistantId,
-          meetingId,
-          "meet.participant_changed",
-          {
-            joined: event.joined,
-            left: event.left,
-          },
-        );
-        return;
-      case "speaker.change":
-        void publishMeetEvent(assistantId, meetingId, "meet.speaker_changed", {
-          speakerId: event.speakerId,
-          speakerName: event.speakerName,
-        });
-        return;
-      case "transcript.chunk": {
-        // Interim chunks are noisy and may be superseded by a later final
-        // chunk covering the same time range. Clients only want stable text.
-        if (!event.isFinal) return;
-        const payload: Record<string, unknown> = { text: event.text };
-        if (event.speakerLabel !== undefined)
-          payload.speakerLabel = event.speakerLabel;
-        if (event.speakerId !== undefined) payload.speakerId = event.speakerId;
-        if (event.confidence !== undefined)
-          payload.confidence = event.confidence;
-        void publishMeetEvent(
-          assistantId,
-          meetingId,
-          "meet.transcript_chunk",
-          payload,
-        );
-        return;
-      }
-      default:
-        // Ignore event kinds we don't fan out from the router path.
-        // Lifecycle transitions are published by the session manager.
-        // Inbound chat + interim transcripts are intentionally dropped.
-        return;
-    }
-  });
+  return requirePublisher().subscribeEventHubPublisher(assistantId, meetingId);
 }
+
+/**
+ * Test-only helper. Clears the installed publisher so a fresh host can be
+ * wired in from the next test case. Production code must never call this.
+ */
+export function _resetEventPublisherForTests(): void {
+  installedPublisher = null;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-module registration
+// ---------------------------------------------------------------------------
+//
+// Wave 6+ of the skill-isolation plan wires sub-module factories into a
+// per-skill registry so the session manager can pull them by name without
+// taking a static import on each file (see `modules-registry.ts`). The
+// factory is registered as a side effect of importing this module so any
+// static import from `register.ts` / the session manager is enough to
+// populate the slot.
+
+registerSubModule("event-publisher", createEventPublisher);


### PR DESCRIPTION
## Summary
- Converts event-publisher.ts and conversation-bridge.ts to createX(host) factories.
- Both files now source logger, event hub, and identity constants from SkillHost instead of assistant/.
- Factories registered into modules-registry.ts for session-manager (PR 17) to consume.

Part of plan: skill-isolation.md (PR 9 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
