### PR TITLE
feat(gateway): add arg parser and command registry for risk classification

### DIFF
--- a/gateway/src/risk/arg-parser.test.ts
+++ b/gateway/src/risk/arg-parser.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseArgs } from "./arg-parser.js";
+
+describe("parseArgs", () => {
+  test("boolean flags", () => {
+    const result = parseArgs(["-v", "-f"], {});
+    expect(result.flags.get("-v")).toBe(true);
+    expect(result.flags.get("-f")).toBe(true);
+    expect(result.positionals).toEqual([]);
+    expect(result.pathArgs).toEqual([]);
+    expect(result.sawDoubleDash).toBe(false);
+  });
+
+  test("value-consuming flags", () => {
+    const result = parseArgs(["-o", "out.txt", "in.txt"], {
+      valueFlags: ["-o"],
+    });
+    expect(result.flags.get("-o")).toBe("out.txt");
+    expect(result.positionals).toEqual(["in.txt"]);
+    // Default positionals mode is "paths", so in.txt is a path.
+    expect(result.pathArgs).toEqual(["in.txt"]);
+  });
+
+  test("path flags", () => {
+    const result = parseArgs(["-t", "/tmp/dir", "file.txt"], {
+      valueFlags: ["-t"],
+      pathFlags: { "-t": true },
+    });
+    expect(result.flags.get("-t")).toBe("/tmp/dir");
+    expect(result.positionals).toEqual(["file.txt"]);
+    // /tmp/dir from pathFlag + file.txt from default positional "paths" mode.
+    expect(result.pathArgs).toEqual(["/tmp/dir", "file.txt"]);
+  });
+
+  test("-- terminator", () => {
+    const result = parseArgs(["--", "-notaflag"], {});
+    expect(result.sawDoubleDash).toBe(true);
+    expect(result.positionals).toEqual(["-notaflag"]);
+    expect(result.pathArgs).toEqual(["-notaflag"]);
+    expect(result.flags.size).toBe(0);
+  });
+
+  test("respectsDoubleDash: false", () => {
+    const result = parseArgs(["--", "-notaflag"], {
+      respectsDoubleDash: false,
+    });
+    // `--` is treated as a boolean flag, not a terminator.
+    expect(result.sawDoubleDash).toBe(false);
+    expect(result.flags.get("--")).toBe(true);
+    expect(result.flags.get("-notaflag")).toBe(true);
+    expect(result.positionals).toEqual([]);
+  });
+
+  test("positionals 'paths' (default) — all positionals in pathArgs", () => {
+    const result = parseArgs(["a.txt", "b.txt"], {});
+    expect(result.positionals).toEqual(["a.txt", "b.txt"]);
+    expect(result.pathArgs).toEqual(["a.txt", "b.txt"]);
+  });
+
+  test("positionals 'paths' (explicit) — all positionals in pathArgs", () => {
+    const result = parseArgs(["a.txt", "b.txt"], { positionals: "paths" });
+    expect(result.positionals).toEqual(["a.txt", "b.txt"]);
+    expect(result.pathArgs).toEqual(["a.txt", "b.txt"]);
+  });
+
+  test("positionals 'none' — no positionals in pathArgs", () => {
+    const result = parseArgs(["a.txt", "b.txt"], { positionals: "none" });
+    expect(result.positionals).toEqual(["a.txt", "b.txt"]);
+    expect(result.pathArgs).toEqual([]);
+  });
+
+  test("mixed positionals (array) with rest descriptor", () => {
+    const result = parseArgs(["pattern", "file1.txt", "file2.txt"], {
+      positionals: [{ role: "pattern" }, { role: "path", rest: true }],
+    });
+    expect(result.positionals).toEqual(["pattern", "file1.txt", "file2.txt"]);
+    // "pattern" has role "pattern" → not a path.
+    // "file1.txt" at index 1 has role "path" with rest → path.
+    // "file2.txt" at index 2 exceeds array but rest descriptor applies → path.
+    expect(result.pathArgs).toEqual(["file1.txt", "file2.txt"]);
+  });
+
+  test("positional array without rest — excess positionals default to path", () => {
+    const result = parseArgs(["script", "extra1", "extra2"], {
+      positionals: [{ role: "script" }],
+    });
+    expect(result.positionals).toEqual(["script", "extra1", "extra2"]);
+    // "script" → role "script" → not a path.
+    // "extra1", "extra2" → no descriptor, no rest → conservative default → path.
+    expect(result.pathArgs).toEqual(["extra1", "extra2"]);
+  });
+
+  test("empty args", () => {
+    const result = parseArgs([], {});
+    expect(result.flags.size).toBe(0);
+    expect(result.positionals).toEqual([]);
+    expect(result.pathArgs).toEqual([]);
+    expect(result.sawDoubleDash).toBe(false);
+  });
+
+  test("value-consuming flag at end of args with no next token — treated as boolean", () => {
+    const result = parseArgs(["-o"], { valueFlags: ["-o"] });
+    expect(result.flags.get("-o")).toBe(true);
+    expect(result.positionals).toEqual([]);
+    expect(result.pathArgs).toEqual([]);
+  });
+
+  test("positionals after -- are still classified by positional descriptors", () => {
+    const result = parseArgs(["--", "pattern", "file.txt"], {
+      positionals: [{ role: "pattern" }, { role: "path" }],
+    });
+    expect(result.sawDoubleDash).toBe(true);
+    expect(result.positionals).toEqual(["pattern", "file.txt"]);
+    // "pattern" at index 0 → role "pattern" → not a path.
+    // "file.txt" at index 1 → role "path" → path.
+    expect(result.pathArgs).toEqual(["file.txt"]);
+  });
+
+  test("value flag value is not added to pathArgs unless flag is in pathFlags", () => {
+    const result = parseArgs(["-o", "/some/path"], {
+      valueFlags: ["-o"],
+      positionals: "none",
+    });
+    expect(result.flags.get("-o")).toBe("/some/path");
+    // -o is not in pathFlags, so the value is not a path.
+    expect(result.pathArgs).toEqual([]);
+  });
+
+  test("multiple path flags accumulate in pathArgs", () => {
+    const result = parseArgs(["-I", "/include1", "-I", "/include2", "src.c"], {
+      valueFlags: ["-I"],
+      pathFlags: { "-I": true },
+    });
+    expect(result.flags.get("-I")).toBe("/include2"); // last value wins in Map
+    expect(result.positionals).toEqual(["src.c"]);
+    expect(result.pathArgs).toEqual(["/include1", "/include2", "src.c"]);
+  });
+
+  test("--flag=value syntax with path flag", () => {
+    const result = parseArgs(["--target-directory=/tmp/dir", "file.txt"], {
+      valueFlags: ["--target-directory"],
+      pathFlags: { "--target-directory": true },
+    });
+    expect(result.flags.get("--target-directory")).toBe("/tmp/dir");
+    expect(result.positionals).toEqual(["file.txt"]);
+    // /tmp/dir from pathFlag + file.txt from default positional "paths" mode.
+    expect(result.pathArgs).toEqual(["/tmp/dir", "file.txt"]);
+  });
+
+  test("--flag=value syntax with non-path value flag", () => {
+    const result = parseArgs(["--output=out.txt", "in.txt"], {
+      valueFlags: ["--output"],
+    });
+    expect(result.flags.get("--output")).toBe("out.txt");
+    expect(result.positionals).toEqual(["in.txt"]);
+    // --output is not in pathFlags, so out.txt is not a path arg.
+    // in.txt is a positional with default "paths" mode → path.
+    expect(result.pathArgs).toEqual(["in.txt"]);
+  });
+});

--- a/gateway/src/risk/arg-parser.ts
+++ b/gateway/src/risk/arg-parser.ts
@@ -1,0 +1,141 @@
+import type { ArgSchema, ParsedArgs, PositionalDesc } from "./risk-types.js";
+
+/**
+ * Parse a command's arguments according to an {@link ArgSchema}.
+ *
+ * Classifies each token as a flag, positional, or path argument. The
+ * resulting {@link ParsedArgs} is consumed by downstream path-resolution
+ * and sandbox-policy checks.
+ */
+export function parseArgs(args: string[], schema: ArgSchema): ParsedArgs {
+  const valueFlagSet = new Set(schema.valueFlags);
+  const pathFlagSet = new Set(
+    schema.pathFlags ? Object.keys(schema.pathFlags) : [],
+  );
+
+  const flags = new Map<string, string | true>();
+  const positionals: string[] = [];
+  const pathArgs: string[] = [];
+  let sawDoubleDash = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const token = args[i]!;
+
+    // After `--`, everything is positional.
+    if (sawDoubleDash) {
+      positionals.push(token);
+      addIfPath(token, positionals.length - 1, schema.positionals, pathArgs);
+      i++;
+      continue;
+    }
+
+    // Double-dash terminator.
+    if (token === "--" && schema.respectsDoubleDash !== false) {
+      sawDoubleDash = true;
+      i++;
+      continue;
+    }
+
+    // Value-consuming flag: consume next token as the flag's value.
+    if (token.startsWith("-") && valueFlagSet.has(token)) {
+      const nextIndex = i + 1;
+      if (nextIndex < args.length) {
+        const value = args[nextIndex]!;
+        flags.set(token, value);
+        if (pathFlagSet.has(token)) {
+          pathArgs.push(value);
+        }
+        i += 2;
+      } else {
+        // Flag at end of args with no next token — treat as boolean.
+        flags.set(token, true);
+        i++;
+      }
+      continue;
+    }
+
+    // --flag=value form: split on the first `=` and check if the flag
+    // name is a value-consuming flag. This handles e.g.
+    // `--target-directory=/tmp/` or `--output=out.txt`.
+    if (token.startsWith("-") && token.includes("=")) {
+      const eqIndex = token.indexOf("=");
+      const flagName = token.slice(0, eqIndex);
+      const flagValue = token.slice(eqIndex + 1);
+
+      if (valueFlagSet.has(flagName)) {
+        flags.set(flagName, flagValue);
+        if (pathFlagSet.has(flagName)) {
+          pathArgs.push(flagValue);
+        }
+        i++;
+        continue;
+      }
+    }
+
+    // Boolean flag (starts with `-` but not a value-consuming flag).
+    if (token.startsWith("-")) {
+      flags.set(token, true);
+      i++;
+      continue;
+    }
+
+    // Positional argument.
+    positionals.push(token);
+    addIfPath(token, positionals.length - 1, schema.positionals, pathArgs);
+    i++;
+  }
+
+  return { flags, positionals, pathArgs, sawDoubleDash };
+}
+
+/**
+ * Determine whether a positional at the given index is a path and, if so,
+ * add it to `pathArgs`.
+ */
+function addIfPath(
+  token: string,
+  index: number,
+  positionalsDef: ArgSchema["positionals"],
+  pathArgs: string[],
+): void {
+  if (positionalsDef === undefined || positionalsDef === "paths") {
+    // Default: all positionals are paths.
+    pathArgs.push(token);
+    return;
+  }
+
+  if (positionalsDef === "none") {
+    // Explicitly not paths.
+    return;
+  }
+
+  // Array of PositionalDesc — look up by index.
+  const descs: PositionalDesc[] = positionalsDef;
+
+  // Find the applicable descriptor: either the one at this index, or a
+  // previous `rest: true` descriptor that covers all subsequent positions.
+  let desc: PositionalDesc | undefined;
+
+  if (index < descs.length) {
+    desc = descs[index];
+  } else {
+    // Look backwards for the last `rest: true` descriptor.
+    for (let j = descs.length - 1; j >= 0; j--) {
+      if (descs[j]!.rest) {
+        desc = descs[j];
+        break;
+      }
+    }
+  }
+
+  if (desc) {
+    if (desc.role === "path") {
+      pathArgs.push(token);
+    }
+    // Other roles (pattern, script, value, command) → not a path.
+  } else {
+    // No descriptor and no rest — conservative default: treat as path.
+    pathArgs.push(token);
+  }
+}

--- a/gateway/src/risk/command-registry.test.ts
+++ b/gateway/src/risk/command-registry.test.ts
@@ -1,0 +1,774 @@
+import { describe, expect, test } from "bun:test";
+
+import { DEFAULT_COMMAND_REGISTRY } from "./command-registry.js";
+import type { ArgRule, CommandRiskSpec } from "./risk-types.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Collect all ArgRule ids from a CommandRiskSpec tree (recursive). */
+function collectArgRuleIds(
+  spec: CommandRiskSpec,
+  prefix: string,
+): { id: string; path: string }[] {
+  const results: { id: string; path: string }[] = [];
+  if (spec.argRules) {
+    for (const rule of spec.argRules) {
+      results.push({ id: rule.id, path: prefix });
+    }
+  }
+  if (spec.subcommands) {
+    for (const [sub, subSpec] of Object.entries(spec.subcommands)) {
+      results.push(...collectArgRuleIds(subSpec, `${prefix} ${sub}`));
+    }
+  }
+  return results;
+}
+
+/** Collect all ArgRules from a CommandRiskSpec tree (recursive). */
+function collectArgRules(spec: CommandRiskSpec): ArgRule[] {
+  const results: ArgRule[] = [];
+  if (spec.argRules) {
+    results.push(...spec.argRules);
+  }
+  if (spec.subcommands) {
+    for (const subSpec of Object.values(spec.subcommands)) {
+      results.push(...collectArgRules(subSpec));
+    }
+  }
+  return results;
+}
+
+/** Collect all baseRisk values from a CommandRiskSpec tree (recursive). */
+function collectBaseRisks(spec: CommandRiskSpec): string[] {
+  const results: string[] = [spec.baseRisk];
+  if (spec.subcommands) {
+    for (const subSpec of Object.values(spec.subcommands)) {
+      results.push(...collectBaseRisks(subSpec));
+    }
+  }
+  return results;
+}
+
+// ── LOW_RISK_PROGRAMS from checker.ts ────────────────────────────────────────
+// Replicated here for test validation. Every program in this set must have an
+// entry in the registry.
+const LOW_RISK_PROGRAMS = new Set([
+  "ls",
+  "cat",
+  "head",
+  "tail",
+  "less",
+  "more",
+  "wc",
+  "file",
+  "stat",
+  "grep",
+  "rg",
+  "ag",
+  "ack",
+  "find",
+  "fd",
+  "which",
+  "where",
+  "whereis",
+  "type",
+  "echo",
+  "printf",
+  "date",
+  "cal",
+  "uptime",
+  "whoami",
+  "hostname",
+  "uname",
+  "pwd",
+  "realpath",
+  "dirname",
+  "basename",
+  "git",
+  "node",
+  "bun",
+  "deno",
+  "npm",
+  "npx",
+  "yarn",
+  "pnpm",
+  "python",
+  "python3",
+  "pip",
+  "pip3",
+  "man",
+  "help",
+  "info",
+  "env",
+  "printenv",
+  "set",
+  "diff",
+  "sort",
+  "uniq",
+  "cut",
+  "tr",
+  "tee",
+  "xargs",
+  "jq",
+  "yq",
+  "http",
+  "dig",
+  "nslookup",
+  "ping",
+  "tree",
+  "du",
+  "df",
+]);
+
+// ── HIGH_RISK_PROGRAMS from checker.ts ───────────────────────────────────────
+const HIGH_RISK_PROGRAMS = new Set([
+  "sudo",
+  "su",
+  "doas",
+  "dd",
+  "mkfs",
+  "fdisk",
+  "parted",
+  "mount",
+  "umount",
+  "systemctl",
+  "service",
+  "launchctl",
+  "useradd",
+  "userdel",
+  "usermod",
+  "groupadd",
+  "groupdel",
+  "iptables",
+  "ufw",
+  "firewall-cmd",
+  "reboot",
+  "shutdown",
+  "halt",
+  "poweroff",
+  "kill",
+  "killall",
+  "pkill",
+]);
+
+// ── WRAPPER_PROGRAMS from checker.ts ─────────────────────────────────────────
+const WRAPPER_PROGRAMS = new Set([
+  "env",
+  "nice",
+  "nohup",
+  "time",
+  "command",
+  "exec",
+  "strace",
+  "ltrace",
+  "ionice",
+  "taskset",
+  "timeout",
+]);
+
+// ── LOW_RISK_GIT_SUBCOMMANDS from checker.ts ─────────────────────────────────
+const LOW_RISK_GIT_SUBCOMMANDS = new Set([
+  "status",
+  "log",
+  "diff",
+  "show",
+  "branch",
+  "tag",
+  "remote",
+  "stash",
+  "blame",
+  "shortlog",
+  "describe",
+  "rev-parse",
+  "ls-files",
+  "ls-tree",
+  "cat-file",
+  "reflog",
+]);
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("command-registry", () => {
+  describe("structure validation", () => {
+    test("every entry has a valid baseRisk", () => {
+      const validRisks = new Set(["low", "medium", "high"]);
+      for (const [_name, spec] of Object.entries(DEFAULT_COMMAND_REGISTRY)) {
+        const allRisks = collectBaseRisks(spec);
+        for (const risk of allRisks) {
+          expect(validRisks.has(risk)).toBe(true);
+        }
+      }
+    });
+
+    test("every ArgRule has a unique id across the entire registry", () => {
+      const allIds: { id: string; path: string }[] = [];
+      for (const [name, spec] of Object.entries(DEFAULT_COMMAND_REGISTRY)) {
+        allIds.push(...collectArgRuleIds(spec, name));
+      }
+
+      const seen = new Map<string, string>();
+      const duplicates: string[] = [];
+      for (const { id, path } of allIds) {
+        if (seen.has(id)) {
+          duplicates.push(
+            `"${id}" appears in both "${seen.get(id)}" and "${path}"`,
+          );
+        }
+        seen.set(id, path);
+      }
+
+      expect(duplicates).toEqual([]);
+    });
+
+    test("every valuePattern compiles as valid RegExp", () => {
+      const errors: string[] = [];
+      for (const [name, spec] of Object.entries(DEFAULT_COMMAND_REGISTRY)) {
+        const allRules = collectArgRules(spec);
+        for (const rule of allRules) {
+          if (rule.valuePattern) {
+            try {
+              new RegExp(rule.valuePattern);
+            } catch (e) {
+              errors.push(`${name}/${rule.id}: ${rule.valuePattern} — ${e}`);
+            }
+          }
+        }
+      }
+      expect(errors).toEqual([]);
+    });
+
+    test("every ArgRule risk is a valid RegistryRisk", () => {
+      const validRisks = new Set(["low", "medium", "high"]);
+      for (const [_name, spec] of Object.entries(DEFAULT_COMMAND_REGISTRY)) {
+        const allRules = collectArgRules(spec);
+        for (const rule of allRules) {
+          expect(validRisks.has(rule.risk)).toBe(true);
+        }
+      }
+    });
+  });
+
+  describe("coverage of checker.ts programs", () => {
+    test("every program in LOW_RISK_PROGRAMS has a registry entry", () => {
+      const missing: string[] = [];
+      for (const prog of LOW_RISK_PROGRAMS) {
+        if (!(prog in DEFAULT_COMMAND_REGISTRY)) {
+          missing.push(prog);
+        }
+      }
+      expect(missing).toEqual([]);
+    });
+
+    test("every program in HIGH_RISK_PROGRAMS has a registry entry", () => {
+      const missing: string[] = [];
+      for (const prog of HIGH_RISK_PROGRAMS) {
+        if (!(prog in DEFAULT_COMMAND_REGISTRY)) {
+          missing.push(prog);
+        }
+      }
+      expect(missing).toEqual([]);
+    });
+
+    test("every program in WRAPPER_PROGRAMS has isWrapper: true", () => {
+      const errors: string[] = [];
+      for (const prog of WRAPPER_PROGRAMS) {
+        const spec = (
+          DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>
+        )[prog];
+        if (!spec) {
+          errors.push(`${prog}: missing from registry`);
+        } else if (!spec.isWrapper) {
+          errors.push(`${prog}: isWrapper is not true`);
+        }
+      }
+      expect(errors).toEqual([]);
+    });
+
+    test("every subcommand in LOW_RISK_GIT_SUBCOMMANDS exists under git subcommands", () => {
+      const gitSpec = DEFAULT_COMMAND_REGISTRY.git;
+      expect(gitSpec).toBeDefined();
+      expect(gitSpec.subcommands).toBeDefined();
+
+      const missing: string[] = [];
+      const subs = gitSpec.subcommands! as Record<string, unknown>;
+      for (const sub of LOW_RISK_GIT_SUBCOMMANDS) {
+        if (!subs[sub]) {
+          missing.push(sub);
+        }
+      }
+      expect(missing).toEqual([]);
+    });
+
+    test("every program in HIGH_RISK_PROGRAMS has baseRisk high in the registry", () => {
+      const errors: string[] = [];
+      for (const prog of HIGH_RISK_PROGRAMS) {
+        const spec = (
+          DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>
+        )[prog];
+        if (!spec) {
+          errors.push(`${prog}: missing from registry`);
+        } else if (spec.baseRisk !== "high") {
+          errors.push(
+            `${prog}: expected baseRisk "high", got "${spec.baseRisk}"`,
+          );
+        }
+      }
+      expect(errors).toEqual([]);
+    });
+
+    test("every LOW_RISK_GIT_SUBCOMMAND has baseRisk low in the registry", () => {
+      const gitSpec = DEFAULT_COMMAND_REGISTRY.git;
+      const errors: string[] = [];
+
+      const gitSubs = gitSpec.subcommands! as Record<string, CommandRiskSpec>;
+      for (const sub of LOW_RISK_GIT_SUBCOMMANDS) {
+        const subSpec = gitSubs[sub];
+        if (subSpec && subSpec.baseRisk !== "low") {
+          // stash is an exception — its baseRisk is "medium" (write operation)
+          // but it was in LOW_RISK_GIT_SUBCOMMANDS because `git stash` without
+          // args defaults to `git stash push`, and the checker treated the bare
+          // command as low. Our registry has it as medium with low subcommands.
+          if (sub === "stash") continue;
+          errors.push(
+            `git ${sub}: expected baseRisk "low", got "${subSpec.baseRisk}"`,
+          );
+        }
+      }
+
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe("command and exec special cases", () => {
+    test("command has isWrapper: true and argRule for -v/-V lookup", () => {
+      const spec = DEFAULT_COMMAND_REGISTRY.command;
+      expect(spec.isWrapper).toBe(true);
+      expect(spec.baseRisk).toBe("low");
+      expect(spec.argRules).toBeDefined();
+
+      const lookupRule = spec.argRules!.find((r) => r.id === "command:lookup");
+      expect(lookupRule).toBeDefined();
+      expect(lookupRule!.flags).toContain("-v");
+      expect(lookupRule!.flags).toContain("-V");
+      expect(lookupRule!.risk).toBe("low");
+    });
+
+    test("exec is high risk wrapper (replaces current shell process)", () => {
+      const spec = DEFAULT_COMMAND_REGISTRY.exec;
+      expect(spec.baseRisk).toBe("high");
+      expect(spec.isWrapper).toBe(true);
+      expect(spec.reason).toBe("Replaces current shell process");
+    });
+  });
+
+  describe("registry entry count", () => {
+    test("has at least 90 entries (comprehensive coverage)", () => {
+      const count = Object.keys(DEFAULT_COMMAND_REGISTRY).length;
+      expect(count).toBeGreaterThanOrEqual(90);
+    });
+  });
+
+  // ── assistant subcommand risk levels ─────────────────────────────────────
+  // These tests verify the registry matches classifyAssistantSubcommand()
+  // from checker.ts, covering every branch of that function.
+  describe("assistant subcommand classifications match classifyAssistantSubcommand", () => {
+    const assistantSpec = DEFAULT_COMMAND_REGISTRY.assistant;
+
+    test("assistant (bare) is low risk", () => {
+      expect(assistantSpec.baseRisk).toBe("low");
+    });
+
+    // ── oauth subcommand ──────────────────────────────────────────────────
+    describe("oauth", () => {
+      const oauthSpec = assistantSpec.subcommands!.oauth;
+
+      test("assistant oauth (bare) is low risk", () => {
+        expect(oauthSpec.baseRisk).toBe("low");
+      });
+
+      test("assistant oauth token is high risk", () => {
+        expect(oauthSpec.subcommands!.token.baseRisk).toBe("high");
+      });
+
+      test("assistant oauth mode (bare) is low risk", () => {
+        expect(oauthSpec.subcommands!.mode.baseRisk).toBe("low");
+      });
+
+      test("assistant oauth mode has --set argRule escalating to high", () => {
+        const modeSpec = oauthSpec.subcommands!.mode;
+        expect(modeSpec.argRules).toBeDefined();
+        const setRule = modeSpec.argRules!.find((r) =>
+          r.flags?.includes("--set"),
+        );
+        expect(setRule).toBeDefined();
+        expect(setRule!.risk).toBe("high");
+      });
+
+      test("assistant oauth request is medium risk", () => {
+        expect(oauthSpec.subcommands!.request.baseRisk).toBe("medium");
+      });
+
+      test("assistant oauth connect is medium risk", () => {
+        expect(oauthSpec.subcommands!.connect.baseRisk).toBe("medium");
+      });
+
+      test("assistant oauth disconnect is medium risk", () => {
+        expect(oauthSpec.subcommands!.disconnect.baseRisk).toBe("medium");
+      });
+    });
+
+    // ── credentials subcommand ────────────────────────────────────────────
+    describe("credentials", () => {
+      const credSpec = assistantSpec.subcommands!.credentials;
+
+      test("assistant credentials (bare) is low risk", () => {
+        expect(credSpec.baseRisk).toBe("low");
+      });
+
+      test("assistant credentials reveal is high risk", () => {
+        expect(credSpec.subcommands!.reveal.baseRisk).toBe("high");
+      });
+
+      test("assistant credentials set is high risk", () => {
+        expect(credSpec.subcommands!.set.baseRisk).toBe("high");
+      });
+
+      test("assistant credentials delete is high risk", () => {
+        expect(credSpec.subcommands!.delete.baseRisk).toBe("high");
+      });
+    });
+
+    // ── keys subcommand ───────────────────────────────────────────────────
+    describe("keys", () => {
+      const keysSpec = assistantSpec.subcommands!.keys;
+
+      test("assistant keys (bare) is low risk", () => {
+        expect(keysSpec.baseRisk).toBe("low");
+      });
+
+      test("assistant keys set is high risk", () => {
+        expect(keysSpec.subcommands!.set.baseRisk).toBe("high");
+      });
+
+      test("assistant keys delete is high risk", () => {
+        expect(keysSpec.subcommands!.delete.baseRisk).toBe("high");
+      });
+    });
+
+    // ── trust subcommand ──────────────────────────────────────────────────
+    describe("trust", () => {
+      const trustSpec = assistantSpec.subcommands!.trust;
+
+      test("assistant trust (bare) is low risk", () => {
+        expect(trustSpec.baseRisk).toBe("low");
+      });
+
+      test("assistant trust remove is high risk", () => {
+        expect(trustSpec.subcommands!.remove.baseRisk).toBe("high");
+      });
+
+      test("assistant trust clear is high risk", () => {
+        expect(trustSpec.subcommands!.clear.baseRisk).toBe("high");
+      });
+    });
+
+    // ── low-risk subcommands (no further subcommands) ────────────────────
+    describe("simple low-risk subcommands", () => {
+      test("assistant platform is low risk", () => {
+        expect(assistantSpec.subcommands!.platform.baseRisk).toBe("low");
+      });
+
+      test("assistant backup is low risk", () => {
+        expect(assistantSpec.subcommands!.backup.baseRisk).toBe("low");
+      });
+
+      test("assistant help is low risk", () => {
+        expect(assistantSpec.subcommands!.help.baseRisk).toBe("low");
+      });
+    });
+
+    // ── completeness check ────────────────────────────────────────────────
+    test("all assistant subcommand groups from classifyAssistantSubcommand are present", () => {
+      const requiredSubcommands = ["oauth", "credentials", "keys", "trust"];
+      const actualSubcommands = Object.keys(assistantSpec.subcommands!);
+      for (const sub of requiredSubcommands) {
+        expect(actualSubcommands).toContain(sub);
+      }
+    });
+
+    test("oauth has all expected sub-subcommands", () => {
+      const oauthSubs = Object.keys(
+        assistantSpec.subcommands!.oauth.subcommands!,
+      );
+      expect(oauthSubs).toContain("token");
+      expect(oauthSubs).toContain("mode");
+      expect(oauthSubs).toContain("request");
+      expect(oauthSubs).toContain("connect");
+      expect(oauthSubs).toContain("disconnect");
+    });
+
+    test("credentials has all expected sub-subcommands", () => {
+      const credSubs = Object.keys(
+        assistantSpec.subcommands!.credentials.subcommands!,
+      );
+      expect(credSubs).toContain("reveal");
+      expect(credSubs).toContain("set");
+      expect(credSubs).toContain("delete");
+    });
+
+    test("keys has all expected sub-subcommands", () => {
+      const keysSubs = Object.keys(
+        assistantSpec.subcommands!.keys.subcommands!,
+      );
+      expect(keysSubs).toContain("set");
+      expect(keysSubs).toContain("delete");
+    });
+
+    test("trust has all expected sub-subcommands", () => {
+      const trustSubs = Object.keys(
+        assistantSpec.subcommands!.trust.subcommands!,
+      );
+      expect(trustSubs).toContain("remove");
+      expect(trustSubs).toContain("clear");
+    });
+  });
+
+  // ── sandboxAutoApprove allowlist guard ───────────────────────────────────
+  describe("sandboxAutoApprove allowlist", () => {
+    /** Collect all top-level commands tagged with sandboxAutoApprove: true. */
+    function getSandboxAutoApproveCommands(): string[] {
+      return Object.entries(DEFAULT_COMMAND_REGISTRY)
+        .filter(
+          ([, spec]) => (spec as CommandRiskSpec).sandboxAutoApprove === true,
+        )
+        .map(([name]) => name)
+        .sort();
+    }
+
+    /**
+     * The exact set of commands that should be tagged with sandboxAutoApprove.
+     * This acts as a guard — any addition or removal must be intentional and
+     * update this list.
+     */
+    const EXPECTED_SANDBOX_AUTO_APPROVE = [
+      // Core filesystem (read-only)
+      "ls",
+      "cat",
+      "head",
+      "tail",
+      "less",
+      "more",
+      "wc",
+      "file",
+      "stat",
+      "du",
+      "df",
+      "diff",
+      "tree",
+      "pwd",
+      "realpath",
+      "basename",
+      "dirname",
+      "readlink",
+      // Search / filter / text processing
+      "grep",
+      "rg",
+      "ag",
+      "ack",
+      "sort",
+      "uniq",
+      "cut",
+      "tr",
+      "sed",
+      // awk excluded: system() can execute arbitrary commands
+      // System info / text output
+      "echo",
+      "printf",
+      // Data processing
+      "jq",
+      "yq",
+      // find excluded: -exec/-execdir/-delete can execute arbitrary commands or delete files
+      "fd",
+      // Write commands
+      "cp",
+      "mv",
+      "mkdir",
+      "touch",
+      "ln",
+      "tee",
+      // Delete commands
+      "rm",
+      "rmdir",
+      // Permissions / ownership
+      "chgrp",
+      "chmod",
+      "chown",
+      // Archives
+      "tar",
+      "zip",
+      "unzip",
+      "gzip",
+      "gunzip",
+    ].sort();
+
+    test("sandboxAutoApprove commands match the expected allowlist exactly", () => {
+      const actual = getSandboxAutoApproveCommands();
+      expect(actual).toEqual(EXPECTED_SANDBOX_AUTO_APPROVE);
+    });
+
+    test("network commands are NOT tagged with sandboxAutoApprove", () => {
+      const networkCommands = [
+        "curl",
+        "wget",
+        "http",
+        "ssh",
+        "scp",
+        "rsync",
+        "ping",
+        "dig",
+        "nslookup",
+      ];
+      for (const cmd of networkCommands) {
+        const spec = (
+          DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>
+        )[cmd];
+        expect(spec).toBeDefined();
+        expect(spec.sandboxAutoApprove).not.toBe(true);
+      }
+    });
+
+    test("runtime/language commands are NOT tagged with sandboxAutoApprove", () => {
+      const runtimeCommands = [
+        "node",
+        "deno",
+        "python",
+        "python3",
+        "ruby",
+        "bash",
+        "sh",
+        "zsh",
+      ];
+      for (const cmd of runtimeCommands) {
+        const spec = (
+          DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>
+        )[cmd];
+        expect(spec).toBeDefined();
+        expect(spec.sandboxAutoApprove).not.toBe(true);
+      }
+    });
+
+    test("package manager commands are NOT tagged with sandboxAutoApprove", () => {
+      const packageCommands = [
+        "npm",
+        "npx",
+        "yarn",
+        "pnpm",
+        "bun",
+        "pip",
+        "pip3",
+        "brew",
+        "cargo",
+        "apt-get",
+        "apt",
+        "dnf",
+        "yum",
+        "pacman",
+        "apk",
+      ];
+      for (const cmd of packageCommands) {
+        const spec = (
+          DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>
+        )[cmd];
+        expect(spec).toBeDefined();
+        expect(spec.sandboxAutoApprove).not.toBe(true);
+      }
+    });
+
+    test("every sandboxAutoApprove command must have argSchema defined", () => {
+      const missing: string[] = [];
+      for (const [name, spec] of Object.entries(DEFAULT_COMMAND_REGISTRY)) {
+        if (
+          (spec as CommandRiskSpec).sandboxAutoApprove === true &&
+          (spec as CommandRiskSpec).argSchema === undefined
+        ) {
+          missing.push(name);
+        }
+      }
+      expect(missing).toEqual([]);
+    });
+
+    test("xargs is NOT tagged with sandboxAutoApprove", () => {
+      const spec = (DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>)
+        .xargs;
+      expect(spec).toBeDefined();
+      expect(spec.sandboxAutoApprove).not.toBe(true);
+    });
+
+    test("commands with value-consuming argRule flags have matching argSchema.valueFlags", () => {
+      // When an argRule has both `flags` and `valuePattern`, those flags consume
+      // the next token as a value — the valuePattern matches against that value.
+      // The command's argSchema.valueFlags must include those flags so that
+      // parseArgs() correctly pairs flags with their values.
+      const errors: string[] = [];
+
+      function checkSpec(spec: CommandRiskSpec, path: string): void {
+        if (spec.argRules) {
+          for (const rule of spec.argRules) {
+            if (rule.flags && rule.valuePattern) {
+              // This rule's flags consume a value — check argSchema coverage.
+              const schemaValueFlags = new Set(
+                spec.argSchema?.valueFlags ?? [],
+              );
+              for (const flag of rule.flags) {
+                if (!schemaValueFlags.has(flag)) {
+                  errors.push(
+                    `${path}/${rule.id}: flag "${flag}" consumes a value (has valuePattern) ` +
+                      `but is not listed in argSchema.valueFlags`,
+                  );
+                }
+              }
+            }
+          }
+        }
+        if (spec.subcommands) {
+          for (const [sub, subSpec] of Object.entries(spec.subcommands)) {
+            checkSpec(subSpec, `${path} ${sub}`);
+          }
+        }
+      }
+
+      for (const [name, spec] of Object.entries(DEFAULT_COMMAND_REGISTRY)) {
+        checkSpec(spec as CommandRiskSpec, name);
+      }
+      expect(errors).toEqual([]);
+    });
+
+    test("system/privilege commands are NOT tagged with sandboxAutoApprove", () => {
+      const systemCommands = [
+        "sudo",
+        "su",
+        "doas",
+        "mount",
+        "umount",
+        "systemctl",
+        "service",
+        "launchctl",
+        "reboot",
+        "shutdown",
+        "kill",
+        "killall",
+        "pkill",
+        "dd",
+        "mkfs",
+        "fdisk",
+      ];
+      for (const cmd of systemCommands) {
+        const spec = (
+          DEFAULT_COMMAND_REGISTRY as Record<string, CommandRiskSpec>
+        )[cmd];
+        expect(spec).toBeDefined();
+        expect(spec.sandboxAutoApprove).not.toBe(true);
+      }
+    });
+  });
+});

--- a/gateway/src/risk/command-registry.ts
+++ b/gateway/src/risk/command-registry.ts
@@ -1,0 +1,1005 @@
+/**
+ * Default command registry for the bash risk classifier.
+ *
+ * A data-driven registry of ~100 commands with base risk levels, subcommand
+ * overrides, and arg-level rules. This is the "smart defaults" layer — users
+ * can override any entry via their personal rule store.
+ *
+ * Every program in checker.ts's LOW_RISK_PROGRAMS, HIGH_RISK_PROGRAMS,
+ * WRAPPER_PROGRAMS, and LOW_RISK_GIT_SUBCOMMANDS has a corresponding entry.
+ * Divergences from the existing checker classification are documented inline.
+ *
+ * @see /docs/bash-risk-classifier-design.md Section 6.2
+ */
+
+import type { CommandRiskSpec } from "./risk-types.js";
+
+// ── Shared regex pattern constants ────────────────────────────────────────────
+// These are used across multiple command entries. Stored as strings (not native
+// RegExp) so they round-trip cleanly through JSON serialization.
+
+/** Matches paths containing sensitive directories (.ssh, .gnupg, .aws, .config, .env). */
+const SENSITIVE_PATHS = String.raw`(?:^|/)(?:\.ssh|\.gnupg|\.aws|\.config|\.env)\b`;
+
+/** Matches system paths (/usr, /bin, /sbin, /lib, /boot, /dev, /proc, /sys). */
+const SYSTEM_PATHS = String.raw`^/(?:usr|bin|sbin|lib|boot|dev|proc|sys)\b`;
+
+/** Matches temp/relative paths (/tmp, /var/tmp, ./, ../). */
+const TMP_PATHS = String.raw`^(?:/tmp|/var/tmp|\./|\.\.\/)`;
+
+// ── Default command registry ──────────────────────────────────────────────────
+
+export const DEFAULT_COMMAND_REGISTRY = {
+  // ── Read-only filesystem commands ──────────────────────────────────────────
+  ls: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  cat: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: {},
+    argRules: [
+      {
+        id: "cat:sensitive",
+        valuePattern: SENSITIVE_PATHS,
+        risk: "high",
+        reason: "Reads sensitive file",
+      },
+    ],
+  },
+  head: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  tail: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  less: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  more: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  wc: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  file: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  stat: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  du: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  df: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  diff: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  tree: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  pwd: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: { positionals: "none" },
+  },
+  realpath: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  basename: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  dirname: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  readlink: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+
+  // ── Search / filter / text processing ──────────────────────────────────────
+  grep: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: {
+      positionals: [{ role: "pattern" }, { role: "path", rest: true }],
+    },
+  },
+  rg: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: {
+      positionals: [{ role: "pattern" }, { role: "path", rest: true }],
+    },
+  },
+  ag: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: {
+      positionals: [{ role: "pattern" }, { role: "path", rest: true }],
+    },
+  },
+  ack: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: {
+      positionals: [{ role: "pattern" }, { role: "path", rest: true }],
+    },
+  },
+  sort: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: {
+      valueFlags: ["-o", "--output"],
+      pathFlags: { "-o": true, "--output": true },
+    },
+  },
+  uniq: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  cut: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  tr: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: { positionals: "none" },
+  },
+  sed: {
+    baseRisk: "medium",
+    reason: "Can write files or execute commands via sed scripts",
+    sandboxAutoApprove: true,
+    argSchema: {
+      positionals: [{ role: "script" }, { role: "path", rest: true }],
+    },
+    argRules: [
+      {
+        id: "sed:inplace",
+        flags: ["-i", "--in-place"],
+        risk: "medium",
+        reason: "Edits files in place",
+      },
+    ],
+  },
+  awk: {
+    baseRisk: "medium",
+    argSchema: {
+      positionals: [{ role: "script" }, { role: "path", rest: true }],
+    },
+    complexSyntax: true,
+    reason: "Can execute shell commands via system()",
+  },
+
+  // ── System information (read-only) ─────────────────────────────────────────
+  echo: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: { positionals: "none" },
+  },
+  printf: {
+    baseRisk: "low",
+    sandboxAutoApprove: true,
+    argSchema: { positionals: "none" },
+  },
+  whoami: { baseRisk: "low" },
+  uname: { baseRisk: "low" },
+  uptime: { baseRisk: "low" },
+  hostname: { baseRisk: "low" },
+  date: { baseRisk: "low" },
+  cal: { baseRisk: "low" },
+  id: { baseRisk: "low" },
+  ps: { baseRisk: "low" },
+  free: { baseRisk: "low" },
+  which: { baseRisk: "low" },
+  where: { baseRisk: "low" },
+  whereis: { baseRisk: "low" },
+  type: { baseRisk: "low" },
+  printenv: { baseRisk: "low" },
+  man: { baseRisk: "low" },
+  help: { baseRisk: "low" },
+  info: { baseRisk: "low" },
+
+  // ── Checksum / hex tools ───────────────────────────────────────────────────
+  sha256sum: { baseRisk: "low" },
+  md5sum: { baseRisk: "low" },
+  xxd: { baseRisk: "low" },
+  hexdump: { baseRisk: "low" },
+
+  // ── Data processing ────────────────────────────────────────────────────────
+  jq: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+  yq: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+
+  // ── Find ───────────────────────────────────────────────────────────────────
+  // DIVERGENCE: checker.ts lists `find` as LOW_RISK unconditionally. Our
+  // registry adds arg rules for -exec/-execdir/-delete which escalate to high.
+  find: {
+    baseRisk: "low",
+    argSchema: {
+      valueFlags: [
+        "-name",
+        "-iname",
+        "-path",
+        "-ipath",
+        "-regex",
+        "-iregex",
+        "-maxdepth",
+        "-mindepth",
+        "-newer",
+        "-user",
+        "-group",
+        "-printf",
+        "-fprintf",
+      ],
+    },
+    complexSyntax: true,
+    argRules: [
+      {
+        id: "find:exec",
+        flags: ["-exec", "-execdir"],
+        risk: "high",
+        reason: "Executes arbitrary commands on matched files",
+      },
+      {
+        id: "find:delete",
+        flags: ["-delete"],
+        risk: "high",
+        reason: "Deletes matched files",
+      },
+    ],
+  },
+  fd: { baseRisk: "low", sandboxAutoApprove: true, argSchema: {} },
+
+  // ── Write commands ─────────────────────────────────────────────────────────
+  cp: {
+    baseRisk: "medium",
+    sandboxAutoApprove: true,
+    argSchema: {
+      valueFlags: ["-t", "--target-directory"],
+      pathFlags: { "-t": true, "--target-directory": true },
+    },
+    argRules: [
+      {
+        id: "cp:system",
+        valuePattern: SYSTEM_PATHS,
+        risk: "high",
+        reason: "Copies to system path",
+      },
+    ],
+  },
+  mv: {
+    baseRisk: "medium",
+    sandboxAutoApprove: true,
+    argSchema: {},
+    argRules: [
+      {
+        id: "mv:system",
+        valuePattern: SYSTEM_PATHS,
+        risk: "high",
+        reason: "Moves to system path",
+      },
+    ],
+  },
+  mkdir: { baseRisk: "medium", sandboxAutoApprove: true, argSchema: {} },
+  touch: { baseRisk: "medium", sandboxAutoApprove: true, argSchema: {} },
+  ln: {
+    baseRisk: "medium",
+    sandboxAutoApprove: true,
+    argSchema: {
+      valueFlags: ["-t", "--target-directory"],
+      pathFlags: { "-t": true, "--target-directory": true },
+    },
+  },
+  // DIVERGENCE: checker.ts lists `tee` as LOW_RISK. Our registry classifies
+  // it as medium because it writes to files.
+  tee: { baseRisk: "medium", sandboxAutoApprove: true, argSchema: {} },
+
+  // ── Delete commands ────────────────────────────────────────────────────────
+  rm: {
+    baseRisk: "high",
+    sandboxAutoApprove: true,
+    argSchema: {},
+    argRules: [
+      {
+        id: "rm:recursive-force",
+        flags: ["-rf", "-fr", "-Rf", "-fR"],
+        risk: "high",
+        reason: "Recursive force delete",
+      },
+      {
+        id: "rm:recursive",
+        flags: ["-r", "-R", "--recursive"],
+        risk: "high",
+        reason: "Recursive delete",
+      },
+      {
+        id: "rm:tmp",
+        valuePattern: TMP_PATHS,
+        risk: "medium",
+        reason: "Removes temp files",
+      },
+      {
+        id: "rm:system",
+        valuePattern: SYSTEM_PATHS,
+        risk: "high",
+        reason: "Removes system files",
+      },
+      {
+        id: "rm:sensitive",
+        valuePattern: SENSITIVE_PATHS,
+        risk: "high",
+        reason: "Removes sensitive files",
+      },
+    ],
+  },
+  rmdir: { baseRisk: "high", sandboxAutoApprove: true, argSchema: {} },
+
+  // ── Network commands ───────────────────────────────────────────────────────
+  curl: {
+    baseRisk: "medium",
+    argSchema: {
+      valueFlags: [
+        "-d",
+        "--data",
+        "--data-binary",
+        "--data-raw",
+        "--data-urlencode",
+        "-T",
+        "--upload-file",
+        "-o",
+        "--output",
+        "-H",
+        "--header",
+        "-X",
+        "--request",
+        "-u",
+        "--user",
+        "-A",
+        "--user-agent",
+        "-e",
+        "--referer",
+        "-b",
+        "--cookie",
+        "-c",
+        "--cookie-jar",
+        "--connect-timeout",
+        "-m",
+        "--max-time",
+        "--retry",
+        "-w",
+        "--write-out",
+      ],
+      positionals: "none", // positionals are URLs, not paths
+    },
+    argRules: [
+      {
+        id: "curl:upload-data",
+        flags: ["-d", "--data", "--data-binary", "--data-raw"],
+        valuePattern: String.raw`^@`,
+        risk: "high",
+        reason: "Uploads file contents",
+      },
+      {
+        id: "curl:upload-file",
+        flags: ["-T", "--upload-file"],
+        risk: "high",
+        reason: "Uploads file",
+      },
+      {
+        id: "curl:output-sensitive",
+        flags: ["-o", "--output"],
+        valuePattern: SENSITIVE_PATHS,
+        risk: "high",
+        reason: "Writes to sensitive path",
+      },
+      {
+        id: "curl:localhost",
+        valuePattern: String.raw`^https?://(localhost|127\.0\.0\.1|\[::1\])`,
+        risk: "low",
+        reason: "Local request",
+      },
+    ],
+  },
+  wget: { baseRisk: "medium" },
+  // DIVERGENCE: checker.ts lists `http` (httpie) as LOW_RISK. Our registry
+  // classifies it as medium because it can make network requests with side effects.
+  http: { baseRisk: "medium" },
+  ping: { baseRisk: "low" },
+  dig: { baseRisk: "low" },
+  nslookup: { baseRisk: "low" },
+  ssh: { baseRisk: "high", reason: "Opens remote shell" },
+  scp: { baseRisk: "high", reason: "Remote file transfer" },
+  rsync: { baseRisk: "high", reason: "Remote file sync" },
+
+  // ── Git ────────────────────────────────────────────────────────────────────
+  // Every subcommand in checker.ts's LOW_RISK_GIT_SUBCOMMANDS must appear here.
+  // Divergences are noted inline.
+  git: {
+    baseRisk: "medium",
+    argSchema: {
+      valueFlags: [
+        "-C",
+        "-c",
+        "--git-dir",
+        "--work-tree",
+        "--namespace",
+        "--super-prefix",
+        "--config-env",
+      ],
+    },
+    subcommands: {
+      // LOW_RISK_GIT_SUBCOMMANDS from checker.ts:
+      status: { baseRisk: "low" },
+      log: { baseRisk: "low" },
+      diff: { baseRisk: "low" },
+      show: { baseRisk: "low" },
+      branch: { baseRisk: "low" },
+      tag: {
+        baseRisk: "low",
+        argRules: [
+          {
+            id: "git-tag:delete",
+            flags: ["-d", "--delete"],
+            risk: "high",
+            reason: "Deletes git tag",
+          },
+        ],
+      },
+      remote: { baseRisk: "low" },
+      // DIVERGENCE: checker.ts lists `stash` as LOW_RISK. Our registry classifies
+      // the base stash command as medium (it modifies working tree), with read-only
+      // subcommands (list, show) as low and destructive ones (drop) as high.
+      stash: {
+        baseRisk: "medium",
+        subcommands: {
+          list: { baseRisk: "low" },
+          show: { baseRisk: "low" },
+          drop: {
+            baseRisk: "high",
+            reason: "Permanently drops stashed changes",
+          },
+        },
+      },
+      blame: { baseRisk: "low" },
+      shortlog: { baseRisk: "low" },
+      describe: { baseRisk: "low" },
+      "rev-parse": { baseRisk: "low" },
+      "ls-files": { baseRisk: "low" },
+      "ls-tree": { baseRisk: "low" },
+      "cat-file": { baseRisk: "low" },
+      reflog: { baseRisk: "low" },
+      // Write operations:
+      add: { baseRisk: "medium" },
+      commit: { baseRisk: "medium" },
+      checkout: { baseRisk: "medium" },
+      switch: { baseRisk: "medium" },
+      merge: { baseRisk: "medium" },
+      rebase: {
+        baseRisk: "medium",
+        argRules: [
+          {
+            id: "git-rebase:interactive",
+            flags: ["-i", "--interactive"],
+            risk: "high",
+            reason: "Interactive rebase rewrites history",
+          },
+        ],
+      },
+      push: {
+        baseRisk: "medium",
+        argRules: [
+          {
+            id: "git-push:force",
+            flags: ["--force", "-f", "--force-with-lease"],
+            risk: "high",
+            reason: "Force push rewrites remote history",
+          },
+        ],
+      },
+      pull: { baseRisk: "medium" },
+      fetch: { baseRisk: "low" },
+      reset: {
+        baseRisk: "medium",
+        argRules: [
+          {
+            id: "git-reset:hard",
+            flags: ["--hard"],
+            risk: "high",
+            reason: "Discards uncommitted changes",
+          },
+        ],
+      },
+      clean: { baseRisk: "high", reason: "Removes untracked files" },
+      bisect: { baseRisk: "low" },
+      worktree: { baseRisk: "medium" },
+    },
+  },
+
+  // ── Package managers ───────────────────────────────────────────────────────
+  // DIVERGENCE: checker.ts lists `npm`, `npx`, `yarn`, `pnpm`, `bun`, `pip`,
+  // `pip3` as LOW_RISK. Our registry classifies them as medium (base) because
+  // they download and execute code, with subcommand-level overrides.
+  npm: {
+    baseRisk: "medium",
+    argSchema: {
+      valueFlags: ["--prefix", "--userconfig", "--globalconfig", "--cache"],
+    },
+    subcommands: {
+      ls: { baseRisk: "low" },
+      list: { baseRisk: "low" },
+      outdated: { baseRisk: "low" },
+      view: { baseRisk: "low" },
+      info: { baseRisk: "low" },
+      install: {
+        baseRisk: "medium",
+        reason: "Runs lifecycle scripts, downloads code",
+      },
+      ci: {
+        baseRisk: "medium",
+        reason: "Clean install, runs lifecycle scripts",
+      },
+      test: { baseRisk: "high", reason: "Executes arbitrary package scripts" },
+      run: { baseRisk: "high", reason: "Executes arbitrary package scripts" },
+      publish: { baseRisk: "high", reason: "Publishes package to registry" },
+    },
+  },
+  // DIVERGENCE: checker.ts lists `npx` as LOW_RISK. Our registry classifies it
+  // as high because it downloads and executes arbitrary packages.
+  npx: {
+    baseRisk: "high",
+    reason: "Downloads and executes arbitrary packages",
+  },
+  yarn: {
+    baseRisk: "medium",
+    subcommands: {
+      list: { baseRisk: "low" },
+      info: { baseRisk: "low" },
+      why: { baseRisk: "low" },
+      install: { baseRisk: "medium" },
+      add: { baseRisk: "medium" },
+      test: { baseRisk: "high", reason: "Executes arbitrary package scripts" },
+      run: { baseRisk: "high", reason: "Executes arbitrary package scripts" },
+    },
+  },
+  pnpm: {
+    baseRisk: "medium",
+    subcommands: {
+      list: { baseRisk: "low" },
+      install: { baseRisk: "medium" },
+      add: { baseRisk: "medium" },
+      test: { baseRisk: "high", reason: "Executes arbitrary package scripts" },
+      run: { baseRisk: "high", reason: "Executes arbitrary package scripts" },
+    },
+  },
+  // DIVERGENCE: checker.ts lists `bun` as LOW_RISK. Our registry classifies it
+  // as medium (base) with subcommand overrides because it can execute code.
+  bun: {
+    baseRisk: "medium",
+    subcommands: {
+      install: { baseRisk: "medium" },
+      add: { baseRisk: "medium" },
+      test: { baseRisk: "high", reason: "Executes arbitrary test code" },
+      run: { baseRisk: "high", reason: "Executes arbitrary scripts" },
+    },
+  },
+  pip: {
+    baseRisk: "medium",
+    subcommands: {
+      list: { baseRisk: "low" },
+      show: { baseRisk: "low" },
+      install: { baseRisk: "medium" },
+    },
+  },
+  pip3: {
+    baseRisk: "medium",
+    subcommands: {
+      list: { baseRisk: "low" },
+      show: { baseRisk: "low" },
+      install: { baseRisk: "medium" },
+    },
+  },
+  brew: {
+    baseRisk: "medium",
+    subcommands: {
+      list: { baseRisk: "low" },
+      info: { baseRisk: "low" },
+      search: { baseRisk: "low" },
+      install: { baseRisk: "medium" },
+      uninstall: { baseRisk: "high" },
+    },
+  },
+  cargo: {
+    baseRisk: "medium",
+    subcommands: {
+      build: { baseRisk: "medium" },
+      test: { baseRisk: "high", reason: "Executes arbitrary test code" },
+      run: { baseRisk: "high", reason: "Compiles and executes code" },
+    },
+  },
+
+  // ── Build tools (inherently opaque) ────────────────────────────────────────
+  make: { baseRisk: "high", reason: "Executes arbitrary Makefile targets" },
+
+  // ── Language runtimes ──────────────────────────────────────────────────────
+  // DIVERGENCE: checker.ts lists `node` as LOW_RISK. Our registry classifies it
+  // as high because it executes arbitrary JavaScript.
+  node: {
+    baseRisk: "high",
+    reason: "Executes arbitrary JavaScript",
+    argRules: [
+      {
+        id: "node:version",
+        flags: ["--version", "-v"],
+        risk: "low",
+        reason: "Prints version",
+      },
+      {
+        id: "node:eval",
+        flags: ["-e", "--eval"],
+        risk: "high",
+        reason: "Evaluates inline JavaScript",
+      },
+    ],
+  },
+  // DIVERGENCE: checker.ts lists `deno` as LOW_RISK. Our registry classifies it
+  // as high because it executes arbitrary code.
+  deno: { baseRisk: "high", reason: "Executes arbitrary code" },
+  // DIVERGENCE: checker.ts lists `python` and `python3` as LOW_RISK. Our registry
+  // classifies them as high because they execute arbitrary Python code.
+  python: {
+    baseRisk: "high",
+    reason: "Executes arbitrary Python code",
+    argRules: [
+      {
+        id: "python:version",
+        flags: ["--version", "-V"],
+        risk: "low",
+        reason: "Prints version",
+      },
+    ],
+  },
+  python3: {
+    baseRisk: "high",
+    reason: "Executes arbitrary Python code",
+    argRules: [
+      {
+        id: "python3:version",
+        flags: ["--version", "-V"],
+        risk: "low",
+        reason: "Prints version",
+      },
+    ],
+  },
+  ruby: { baseRisk: "high", reason: "Executes arbitrary Ruby code" },
+  go: {
+    // baseRisk is low (unlike npm's medium) because bare `go` prints help.
+    // Dangerous subcommands (run, test, generate, get) are handled individually.
+    baseRisk: "low",
+    subcommands: {
+      mod: { baseRisk: "low" },
+      vet: { baseRisk: "low" },
+      version: { baseRisk: "low" },
+      build: { baseRisk: "medium" },
+      test: { baseRisk: "high", reason: "Executes arbitrary test code" },
+      run: { baseRisk: "high", reason: "Compiles and executes Go code" },
+      get: {
+        baseRisk: "medium",
+        reason:
+          "Downloads and installs packages; may execute arbitrary code via tool directives",
+      },
+      generate: {
+        baseRisk: "high",
+        reason: "Runs arbitrary commands via //go:generate directives",
+      },
+    },
+  },
+
+  // ── Docker ─────────────────────────────────────────────────────────────────
+  docker: {
+    baseRisk: "medium",
+    argSchema: {
+      valueFlags: ["--host", "-H", "--config", "--context", "--log-level"],
+    },
+    subcommands: {
+      ps: { baseRisk: "low" },
+      images: { baseRisk: "low" },
+      inspect: { baseRisk: "low" },
+      logs: { baseRisk: "low" },
+      info: { baseRisk: "low" },
+      version: { baseRisk: "low" },
+      build: { baseRisk: "medium" },
+      pull: { baseRisk: "medium" },
+      push: { baseRisk: "high", reason: "Pushes image to registry" },
+      run: {
+        baseRisk: "high",
+        argSchema: {
+          valueFlags: [
+            "-v",
+            "--volume",
+            "-p",
+            "--publish",
+            "-e",
+            "--env",
+            "--name",
+            "--network",
+            "-w",
+            "--workdir",
+            "--entrypoint",
+            "--mount",
+            "--cpus",
+            "--memory",
+            "--user",
+            "--platform",
+          ],
+        },
+        reason: "Runs arbitrary container",
+        argRules: [
+          {
+            id: "docker-run:privileged",
+            flags: ["--privileged"],
+            risk: "high",
+            reason: "Privileged container with full host access",
+          },
+          {
+            id: "docker-run:volume-root",
+            flags: ["-v", "--volume"],
+            valuePattern: String.raw`^/:`,
+            risk: "high",
+            reason: "Mounts host root filesystem",
+          },
+        ],
+      },
+      exec: {
+        baseRisk: "high",
+        reason: "Executes command in running container",
+      },
+      rm: { baseRisk: "high" },
+      rmi: { baseRisk: "high" },
+      stop: { baseRisk: "medium" },
+      start: { baseRisk: "medium" },
+    },
+  },
+
+  // ── Privilege / system ─────────────────────────────────────────────────────
+  sudo: {
+    baseRisk: "high",
+    isWrapper: true,
+    reason: "Elevates to superuser privileges",
+  },
+  su: { baseRisk: "high", reason: "Switches user identity" },
+  doas: {
+    baseRisk: "high",
+    isWrapper: true,
+    reason: "Elevates privileges (OpenBSD sudo alternative)",
+  },
+  chmod: {
+    baseRisk: "high",
+    sandboxAutoApprove: true,
+    argSchema: {},
+    reason: "Changes file permissions",
+  },
+  chown: {
+    baseRisk: "high",
+    sandboxAutoApprove: true,
+    argSchema: {},
+    reason: "Changes file ownership",
+  },
+  chgrp: {
+    baseRisk: "high",
+    sandboxAutoApprove: true,
+    argSchema: {},
+    reason: "Changes file group",
+  },
+  mount: { baseRisk: "high", reason: "Mounts filesystem" },
+  umount: { baseRisk: "high", reason: "Unmounts filesystem" },
+  systemctl: { baseRisk: "high", reason: "Controls system services" },
+  service: { baseRisk: "high", reason: "Controls system services" },
+  launchctl: { baseRisk: "high", reason: "Controls macOS services" },
+
+  // ── User management ────────────────────────────────────────────────────────
+  useradd: { baseRisk: "high", reason: "Creates system user" },
+  userdel: { baseRisk: "high", reason: "Deletes system user" },
+  usermod: { baseRisk: "high", reason: "Modifies system user" },
+  groupadd: { baseRisk: "high", reason: "Creates system group" },
+  groupdel: { baseRisk: "high", reason: "Deletes system group" },
+
+  // ── Firewall ───────────────────────────────────────────────────────────────
+  iptables: { baseRisk: "high", reason: "Modifies firewall rules" },
+  ufw: { baseRisk: "high", reason: "Modifies firewall rules" },
+  "firewall-cmd": { baseRisk: "high", reason: "Modifies firewall rules" },
+
+  // ── System lifecycle ───────────────────────────────────────────────────────
+  reboot: { baseRisk: "high", reason: "Reboots the system" },
+  shutdown: { baseRisk: "high", reason: "Shuts down the system" },
+  halt: { baseRisk: "high", reason: "Halts the system" },
+  poweroff: { baseRisk: "high", reason: "Powers off the system" },
+
+  // ── Process management ─────────────────────────────────────────────────────
+  kill: { baseRisk: "high", reason: "Sends signal to process" },
+  killall: { baseRisk: "high", reason: "Kills processes by name" },
+  pkill: { baseRisk: "high", reason: "Kills processes by pattern" },
+
+  // ── Catastrophic ───────────────────────────────────────────────────────────
+  mkfs: { baseRisk: "high", reason: "Formats filesystem — destroys all data" },
+  dd: {
+    baseRisk: "high",
+    reason: "Low-level block device copy — can destroy disks",
+  },
+  fdisk: { baseRisk: "high", reason: "Modifies disk partitions" },
+  parted: { baseRisk: "high", reason: "Modifies disk partitions" },
+
+  // ── Wrapper commands ───────────────────────────────────────────────────────
+  // These unwrap to find and classify the inner command. The classifier takes
+  // max(wrapper.baseRisk, inner.risk).
+  env: { baseRisk: "low", isWrapper: true },
+  nice: { baseRisk: "low", isWrapper: true },
+  nohup: { baseRisk: "low", isWrapper: true },
+  timeout: {
+    baseRisk: "low",
+    isWrapper: true,
+    nonExecFlags: ["--help", "--version"],
+  },
+  time: { baseRisk: "low", isWrapper: true },
+  command: {
+    baseRisk: "low",
+    isWrapper: true,
+    nonExecFlags: ["-v", "-V"],
+    argRules: [
+      {
+        id: "command:lookup",
+        flags: ["-v", "-V"],
+        risk: "low",
+        reason: "Command lookup",
+      },
+    ],
+  },
+  exec: {
+    baseRisk: "high",
+    isWrapper: true,
+    reason: "Replaces current shell process",
+  },
+  strace: {
+    baseRisk: "medium",
+    isWrapper: true,
+    reason: "Traces system calls",
+  },
+  ltrace: {
+    baseRisk: "medium",
+    isWrapper: true,
+    reason: "Traces library calls",
+  },
+  ionice: { baseRisk: "low", isWrapper: true },
+  taskset: { baseRisk: "low", isWrapper: true },
+
+  // ── Shell interpreters ──────────────────────────────────────────────────────
+  // These execute arbitrary code via -c, script files, or stdin.
+  bash: {
+    baseRisk: "high",
+    reason: "Executes arbitrary shell commands",
+    complexSyntax: true,
+  },
+  sh: {
+    baseRisk: "high",
+    reason: "Executes arbitrary shell commands",
+    complexSyntax: true,
+  },
+  zsh: {
+    baseRisk: "high",
+    reason: "Executes arbitrary shell commands",
+    complexSyntax: true,
+  },
+  dash: {
+    baseRisk: "high",
+    reason: "Executes arbitrary shell commands",
+    complexSyntax: true,
+  },
+  fish: {
+    baseRisk: "high",
+    reason: "Executes arbitrary shell commands",
+    complexSyntax: true,
+  },
+
+  // ── Package managers (additional) ──────────────────────────────────────────
+  "apt-get": { baseRisk: "high", reason: "Installs/removes system packages" },
+  apt: { baseRisk: "high", reason: "Installs/removes system packages" },
+  dnf: { baseRisk: "high", reason: "Installs/removes system packages" },
+  yum: { baseRisk: "high", reason: "Installs/removes system packages" },
+  pacman: { baseRisk: "high", reason: "Installs/removes system packages" },
+  apk: { baseRisk: "high", reason: "Installs/removes system packages" },
+
+  // ── Shell builtins ─────────────────────────────────────────────────────────
+  cd: { baseRisk: "low" },
+  pushd: { baseRisk: "low" },
+  popd: { baseRisk: "low" },
+  export: { baseRisk: "low" },
+  unset: { baseRisk: "low" },
+  alias: { baseRisk: "low" },
+  history: { baseRisk: "low" },
+  // DIVERGENCE: checker.ts lists `set` as LOW_RISK. Our registry classifies it
+  // as medium because it can modify shell options and behavior.
+  set: { baseRisk: "medium", reason: "Modifies shell options" },
+  source: { baseRisk: "high", reason: "Executes arbitrary shell script" },
+  eval: { baseRisk: "high", reason: "Evaluates arbitrary shell code" },
+
+  // ── Misc tools ─────────────────────────────────────────────────────────────
+  // DIVERGENCE: checker.ts lists `xargs` as LOW_RISK. Our registry classifies
+  // it as medium because it executes commands with piped arguments.
+  xargs: {
+    baseRisk: "medium",
+    complexSyntax: true,
+    reason: "Executes command with piped arguments",
+  },
+  tar: {
+    baseRisk: "medium",
+    sandboxAutoApprove: true,
+    argSchema: {
+      valueFlags: ["-C", "--directory", "-f", "--file"],
+      pathFlags: {
+        "-C": true,
+        "--directory": true,
+        "-f": true,
+        "--file": true,
+      },
+    },
+    complexSyntax: true,
+  },
+  zip: { baseRisk: "medium", sandboxAutoApprove: true, argSchema: {} },
+  unzip: { baseRisk: "medium", sandboxAutoApprove: true, argSchema: {} },
+  gzip: { baseRisk: "medium", sandboxAutoApprove: true, argSchema: {} },
+  gunzip: { baseRisk: "medium", sandboxAutoApprove: true, argSchema: {} },
+
+  // ── Version control tools ──────────────────────────────────────────────────
+  gh: {
+    baseRisk: "low",
+    argSchema: { valueFlags: ["--repo", "-R"] },
+    subcommands: {
+      pr: {
+        baseRisk: "low",
+        subcommands: {
+          view: { baseRisk: "low" },
+          list: { baseRisk: "low" },
+          create: { baseRisk: "medium" },
+          merge: { baseRisk: "high", reason: "Merges pull request" },
+        },
+      },
+      issue: {
+        baseRisk: "low",
+        subcommands: {
+          view: { baseRisk: "low" },
+          list: { baseRisk: "low" },
+          create: { baseRisk: "medium" },
+        },
+      },
+      repo: {
+        baseRisk: "low",
+        subcommands: {
+          view: { baseRisk: "low" },
+          clone: { baseRisk: "low" },
+          create: { baseRisk: "high" },
+          delete: { baseRisk: "high" },
+        },
+      },
+      api: { baseRisk: "medium", reason: "Makes arbitrary GitHub API calls" },
+    },
+  },
+
+  // ── Vellum assistant CLI ───────────────────────────────────────────────────
+  // Classification matches classifyAssistantSubcommand() from checker.ts exactly.
+  assistant: {
+    baseRisk: "low",
+    subcommands: {
+      platform: { baseRisk: "low" },
+      backup: { baseRisk: "low" },
+      help: { baseRisk: "low" },
+      oauth: {
+        baseRisk: "low",
+        subcommands: {
+          token: { baseRisk: "high", reason: "Exposes OAuth token" },
+          mode: {
+            baseRisk: "low",
+            argRules: [
+              {
+                id: "assistant-oauth-mode:set",
+                flags: ["--set"],
+                risk: "high",
+                reason: "Changes OAuth mode",
+              },
+            ],
+          },
+          request: { baseRisk: "medium", reason: "Makes OAuth request" },
+          connect: { baseRisk: "medium", reason: "Connects OAuth integration" },
+          disconnect: {
+            baseRisk: "medium",
+            reason: "Disconnects OAuth integration",
+          },
+        },
+      },
+      credentials: {
+        baseRisk: "low",
+        subcommands: {
+          reveal: { baseRisk: "high", reason: "Reveals credential value" },
+          set: { baseRisk: "high", reason: "Sets credential value" },
+          delete: { baseRisk: "high", reason: "Deletes credential" },
+        },
+      },
+      keys: {
+        baseRisk: "low",
+        subcommands: {
+          set: { baseRisk: "high", reason: "Sets key value" },
+          delete: { baseRisk: "high", reason: "Deletes key" },
+        },
+      },
+      trust: {
+        baseRisk: "low",
+        subcommands: {
+          remove: { baseRisk: "high", reason: "Removes trust rule" },
+          clear: { baseRisk: "high", reason: "Clears all trust rules" },
+        },
+      },
+    },
+  },
+} satisfies Record<string, CommandRiskSpec>;


### PR DESCRIPTION
## Summary
- Copy arg parser from assistant to gateway with updated imports
- Copy command registry (~290 entries) from assistant to gateway
- Port all tests for both modules

Part of plan: move-risk-pipeline-to-gateway.md (PR 4 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
