### PR TITLE
refactor(meet-join): migrate all meet tool files to SkillHost

### DIFF
--- a/skills/meet-join/register.ts
+++ b/skills/meet-join/register.ts
@@ -19,10 +19,12 @@
  * single sanctioned named import in
  * `assistant/src/daemon/external-skills-bootstrap.ts`.
  *
- * Later PRs (Waves 6+) migrate the individual tool and route modules
- * onto the same host contract. Until those land, the tool / route
- * implementations retain their current relative imports into
- * `assistant/`; only this entry point's signature changes in this PR.
+ * Tool modules under `./tools/` now expose `create<Name>Tool(host)`
+ * factories that take the same `SkillHost` and return a neutral-typed
+ * `Tool`. Route modules follow once PR 15 migrates `meet-internal.ts`.
+ * The remaining `assistant/` imports under this skill will disappear
+ * as the later Wave-6 PRs migrate the daemon-side sub-modules onto
+ * the same contract.
  *
  * ## Feature-flag semantics
  *
@@ -44,20 +46,26 @@
  * would reject the bot's opaque bearer token as a malformed JWT).
  */
 
-import type { SkillHost, Tool } from "@vellumai/skill-host-contracts";
+import type { SkillHost } from "@vellumai/skill-host-contracts";
 
 import {
   handleMeetInternalEvents,
   MEET_INTERNAL_EVENTS_PATH_RE,
 } from "./routes/meet-internal.js";
 import {
-  meetDisableAvatarTool,
-  meetEnableAvatarTool,
+  createMeetDisableAvatarTool,
+  createMeetEnableAvatarTool,
 } from "./tools/meet-avatar-tool.js";
-import { MEET_FLAG_KEY, meetJoinTool } from "./tools/meet-join-tool.js";
-import { meetLeaveTool } from "./tools/meet-leave-tool.js";
-import { meetSendChatTool } from "./tools/meet-send-chat-tool.js";
-import { meetCancelSpeakTool, meetSpeakTool } from "./tools/meet-speak-tool.js";
+import {
+  MEET_FLAG_KEY,
+  createMeetJoinTool,
+} from "./tools/meet-join-tool.js";
+import { createMeetLeaveTool } from "./tools/meet-leave-tool.js";
+import { createMeetSendChatTool } from "./tools/meet-send-chat-tool.js";
+import {
+  createMeetCancelSpeakTool,
+  createMeetSpeakTool,
+} from "./tools/meet-speak-tool.js";
 
 export function register(host: SkillHost): void {
   host.registries.registerSkillRoute({
@@ -95,22 +103,14 @@ export function register(host: SkillHost): void {
       return [];
     }
 
-    // The concrete tool objects are still typed via `assistant/src/tools/types`
-    // (migration lands in Wave 6 / PR 14). The host contract's `Tool` is a
-    // structurally-leaner overlay of the same shape; the daemon-side
-    // `DaemonSkillHost.registerTools` narrows back to the assistant flavor
-    // at its boundary (see `daemon-skill-host.ts`). Cast here so the
-    // contract-typed signature accepts the assistant-typed values until
-    // each tool is individually migrated to import its types from the
-    // neutral package.
     return [
-      meetJoinTool,
-      meetLeaveTool,
-      meetSendChatTool,
-      meetSpeakTool,
-      meetCancelSpeakTool,
-      meetEnableAvatarTool,
-      meetDisableAvatarTool,
-    ] as unknown as Tool[];
+      createMeetJoinTool(host),
+      createMeetLeaveTool(host),
+      createMeetSendChatTool(host),
+      createMeetSpeakTool(host),
+      createMeetCancelSpeakTool(host),
+      createMeetEnableAvatarTool(host),
+      createMeetDisableAvatarTool(host),
+    ];
   });
 }

--- a/skills/meet-join/tools/__tests__/meet-avatar-tool.test.ts
+++ b/skills/meet-join/tools/__tests__/meet-avatar-tool.test.ts
@@ -6,8 +6,13 @@
  * sessions), explicit-id pass-through, and error propagation from the
  * session manager. Mirrors the mocking style used in the sibling
  * `meet-send-chat-tool.test.ts` / `meet-speak-tool.test.ts`.
+ *
+ * The tools are now constructed via factories (`createMeetEnableAvatarTool`,
+ * `createMeetDisableAvatarTool`) taking a `SkillHost`; the test builds a
+ * minimal fake host (feature-flag reads, no-op logger) to drive them.
  */
 
+import type { SkillHost, Tool } from "@vellumai/skill-host-contracts";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 let flagEnabled = true;
@@ -79,41 +84,51 @@ mock.module("../../daemon/session-manager.js", () => ({
   MeetBotChatError: FakeMeetBotChatError,
 }));
 
-mock.module(
-  "../../../../assistant/src/config/assistant-feature-flags.js",
-  () => ({
-    isAssistantFeatureFlagEnabled: (key: string) => {
-      if (key === "meet") return flagEnabled;
-      return true;
-    },
-  }),
-);
-
-mock.module("../../../../assistant/src/config/loader.js", () => ({
-  getConfig: () => ({
-    services: { meet: { consentMessage: "unused-in-avatar-tests" } },
-  }),
-}));
-
-mock.module("../../../../assistant/src/util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
-}));
-
-const { meetEnableAvatarTool, meetDisableAvatarTool } =
+const { createMeetEnableAvatarTool, createMeetDisableAvatarTool } =
   await import("../meet-avatar-tool.js");
 
-import type { ToolContext } from "../../../../assistant/src/tools/types.js";
+function makeHost(): SkillHost {
+  const unreachable = (path: string): never => {
+    throw new Error(
+      `meet-avatar-tool.test: fake SkillHost facet ${path} was unexpectedly accessed`,
+    );
+  };
+  const throwingProxy = (path: string) =>
+    new Proxy({}, { get: (_t, p) => unreachable(`${path}.${String(p)}`) });
 
-function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    logger: {
+      get: () =>
+        new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+    } as SkillHost["logger"],
+    config: {
+      isFeatureFlagEnabled: (key: string) =>
+        key === "meet" ? flagEnabled : true,
+      getSection: () => undefined,
+    },
+    identity: throwingProxy("identity") as SkillHost["identity"],
+    platform: throwingProxy("platform") as SkillHost["platform"],
+    providers: throwingProxy("providers") as SkillHost["providers"],
+    memory: throwingProxy("memory") as SkillHost["memory"],
+    events: throwingProxy("events") as SkillHost["events"],
+    registries: throwingProxy("registries") as SkillHost["registries"],
+    speakers: throwingProxy("speakers") as SkillHost["speakers"],
+  };
+}
+
+let meetEnableAvatarTool: Tool;
+let meetDisableAvatarTool: Tool;
+
+function makeContext(): {
+  workingDir: string;
+  conversationId: string;
+  trustClass: string;
+} {
   return {
     workingDir: "/tmp",
     conversationId: "conv-test",
     trustClass: "guardian",
-    ...overrides,
-  } as ToolContext;
+  };
 }
 
 function fakeSession(meetingId: string) {
@@ -142,6 +157,9 @@ beforeEach(() => {
     disabled: true,
     wasActive: false,
   }));
+  const host = makeHost();
+  meetEnableAvatarTool = createMeetEnableAvatarTool(host);
+  meetDisableAvatarTool = createMeetDisableAvatarTool(host);
 });
 
 afterAll(() => {
@@ -155,8 +173,12 @@ afterAll(() => {
 describe("meet_enable_avatar feature-flag gating", () => {
   test("returns an error when the meet flag is off", async () => {
     flagEnabled = false;
+    meetEnableAvatarTool = createMeetEnableAvatarTool(makeHost());
     activeSessionsValue = [fakeSession("m1")];
-    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    const result = await meetEnableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("meet feature is disabled");
     expect(enableAvatarMock).not.toHaveBeenCalled();
@@ -172,7 +194,7 @@ describe("meet_enable_avatar input validation", () => {
     activeSessionsValue = [fakeSession("solo")];
     const result = await meetEnableAvatarTool.execute(
       { meetingId: 123 },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(enableAvatarMock).not.toHaveBeenCalled();
@@ -182,7 +204,7 @@ describe("meet_enable_avatar input validation", () => {
     activeSessionsValue = [fakeSession("solo")];
     const result = await meetEnableAvatarTool.execute(
       { meetingId: "  " },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(enableAvatarMock).not.toHaveBeenCalled();
@@ -196,7 +218,10 @@ describe("meet_enable_avatar input validation", () => {
 describe("meet_enable_avatar disambiguation", () => {
   test("errors when no active sessions exist", async () => {
     activeSessionsValue = [];
-    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    const result = await meetEnableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content.toLowerCase()).toContain("no active meet session");
     expect(enableAvatarMock).not.toHaveBeenCalled();
@@ -210,7 +235,10 @@ describe("meet_enable_avatar disambiguation", () => {
       active: true,
       devicePath: "/dev/video10",
     }));
-    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    const result = await meetEnableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(false);
     expect(enableAvatarMock).toHaveBeenCalledTimes(1);
     expect(enableAvatarMock.mock.calls[0][0]).toBe("solo");
@@ -232,7 +260,10 @@ describe("meet_enable_avatar disambiguation", () => {
 
   test("errors when multiple active sessions and meetingId is omitted", async () => {
     activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
-    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    const result = await meetEnableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("multiple active");
     expect(result.content).toContain("m1");
@@ -244,7 +275,7 @@ describe("meet_enable_avatar disambiguation", () => {
     activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
     const result = await meetEnableAvatarTool.execute(
       { meetingId: "m2" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(false);
     expect(enableAvatarMock).toHaveBeenCalledTimes(1);
@@ -262,7 +293,10 @@ describe("meet_enable_avatar error propagation", () => {
     enableAvatarMock.mockImplementationOnce(async () => {
       throw new FakeMeetSessionNotFoundError("no session");
     });
-    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    const result = await meetEnableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("no active Meet session");
     expect(result.content).toContain("solo");
@@ -273,7 +307,10 @@ describe("meet_enable_avatar error propagation", () => {
     enableAvatarMock.mockImplementationOnce(async () => {
       throw new FakeMeetSessionUnreachableError("connect ECONNREFUSED");
     });
-    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    const result = await meetEnableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("meet bot unreachable");
     expect(result.content).toContain("ECONNREFUSED");
@@ -284,7 +321,10 @@ describe("meet_enable_avatar error propagation", () => {
     enableAvatarMock.mockImplementationOnce(async () => {
       throw new FakeMeetBotAvatarError("renderer unavailable", 503);
     });
-    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    const result = await meetEnableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("status 503");
     expect(result.content).toContain("renderer unavailable");
@@ -295,7 +335,10 @@ describe("meet_enable_avatar error propagation", () => {
     enableAvatarMock.mockImplementationOnce(async () => {
       throw new Error("something exploded");
     });
-    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    const result = await meetEnableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("failed to enable Meet avatar");
     expect(result.content).toContain("something exploded");
@@ -309,8 +352,12 @@ describe("meet_enable_avatar error propagation", () => {
 describe("meet_disable_avatar feature-flag gating", () => {
   test("returns an error when the meet flag is off", async () => {
     flagEnabled = false;
+    meetDisableAvatarTool = createMeetDisableAvatarTool(makeHost());
     activeSessionsValue = [fakeSession("m1")];
-    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    const result = await meetDisableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("meet feature is disabled");
     expect(disableAvatarMock).not.toHaveBeenCalled();
@@ -324,7 +371,10 @@ describe("meet_disable_avatar feature-flag gating", () => {
 describe("meet_disable_avatar disambiguation", () => {
   test("errors when no active sessions exist", async () => {
     activeSessionsValue = [];
-    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    const result = await meetDisableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content.toLowerCase()).toContain("no active meet session");
     expect(disableAvatarMock).not.toHaveBeenCalled();
@@ -337,7 +387,10 @@ describe("meet_disable_avatar disambiguation", () => {
       wasActive: true,
       cameraChanged: true,
     }));
-    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    const result = await meetDisableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(false);
     expect(disableAvatarMock).toHaveBeenCalledTimes(1);
     expect(disableAvatarMock.mock.calls[0][0]).toBe("solo");
@@ -357,7 +410,10 @@ describe("meet_disable_avatar disambiguation", () => {
 
   test("errors when multiple active sessions and meetingId is omitted", async () => {
     activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
-    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    const result = await meetDisableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("multiple active");
     expect(disableAvatarMock).not.toHaveBeenCalled();
@@ -367,7 +423,7 @@ describe("meet_disable_avatar disambiguation", () => {
     activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
     const result = await meetDisableAvatarTool.execute(
       { meetingId: "m1" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(false);
     expect(disableAvatarMock).toHaveBeenCalledTimes(1);
@@ -385,7 +441,10 @@ describe("meet_disable_avatar error propagation", () => {
     disableAvatarMock.mockImplementationOnce(async () => {
       throw new FakeMeetSessionNotFoundError("no session");
     });
-    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    const result = await meetDisableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("no active Meet session");
     expect(result.content).toContain("solo");
@@ -396,7 +455,10 @@ describe("meet_disable_avatar error propagation", () => {
     disableAvatarMock.mockImplementationOnce(async () => {
       throw new FakeMeetSessionUnreachableError("connect ECONNREFUSED");
     });
-    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    const result = await meetDisableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("meet bot unreachable");
     expect(result.content).toContain("ECONNREFUSED");
@@ -407,7 +469,10 @@ describe("meet_disable_avatar error propagation", () => {
     disableAvatarMock.mockImplementationOnce(async () => {
       throw new FakeMeetBotAvatarError("teardown failed", 500);
     });
-    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    const result = await meetDisableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("status 500");
     expect(result.content).toContain("teardown failed");
@@ -418,7 +483,10 @@ describe("meet_disable_avatar error propagation", () => {
     disableAvatarMock.mockImplementationOnce(async () => {
       throw new Error("kernel panic");
     });
-    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    const result = await meetDisableAvatarTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("failed to disable Meet avatar");
     expect(result.content).toContain("kernel panic");

--- a/skills/meet-join/tools/__tests__/meet-join-tool.test.ts
+++ b/skills/meet-join/tools/__tests__/meet-join-tool.test.ts
@@ -3,24 +3,23 @@
  *
  * Exercises URL validation, feature-flag gating, `{assistantName}`
  * substitution, and the happy-path call into `MeetSessionManager.join`.
- * The session manager is swapped via `mock.module` rather than
- * constructor injection so the tool under test continues to import the
- * real singleton path — the same one production code uses — without
- * having to thread a parameter through just for tests.
+ * The session manager is swapped via `mock.module` so the tool under
+ * test continues to import the real singleton path — the same one
+ * production code uses — without having to thread a parameter through
+ * just for tests.
+ *
+ * The tool itself now takes a `SkillHost` at construction time, so the
+ * test builds a minimal fake host (feature-flag reads, logger, assistant
+ * name) rather than mocking into `assistant/src/...` directly.
  */
 
+import type { SkillHost, Tool } from "@vellumai/skill-host-contracts";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ----- Mocks wired BEFORE importing the tool ---------------------------------
-//
-// The tool pulls `MeetSessionManager` at module-eval time, so these mock
-// installations must precede the `await import(...)` of the tool module.
-// That ordering is why we keep mutable state (`flagEnabled`,
-// `assistantNameValue`, etc.) in module-scope closures: each test can
-// adjust them without having to re-invoke `mock.module`.
 
 let flagEnabled = true;
-let assistantNameValue: string | null = "Nova";
+let assistantNameValue: string | undefined = "Nova";
 let consentTemplate =
   "Hi, I'm {assistantName}, an AI assistant joining to take notes. Let me know if you'd prefer I leave.";
 
@@ -61,50 +60,71 @@ mock.module("../../daemon/session-manager.js", () => ({
   },
 }));
 
-mock.module(
-  "../../../../assistant/src/config/assistant-feature-flags.js",
-  () => ({
-    isAssistantFeatureFlagEnabled: (key: string) => {
-      if (key === "meet") return flagEnabled;
-      return true;
-    },
-  }),
-);
-
 mock.module("../../meet-config.js", () => ({
   getMeetConfig: () => ({
     consentMessage: consentTemplate,
   }),
 }));
 
-mock.module("../../../../assistant/src/daemon/identity-helpers.js", () => ({
-  getAssistantName: () => assistantNameValue,
-}));
-
-mock.module("../../../../assistant/src/util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
-}));
-
 // Import AFTER the module mocks are installed.
 const {
-  meetJoinTool,
+  createMeetJoinTool,
   MEET_URL_REGEX,
   substituteAssistantName,
   DEFAULT_ASSISTANT_NAME,
 } = await import("../meet-join-tool.js");
 
-import type { ToolContext } from "../../../../assistant/src/tools/types.js";
+/**
+ * Minimal fake `SkillHost` exposing only the facets `createMeetJoinTool`
+ * reads: logger, config.isFeatureFlagEnabled, identity.getAssistantName.
+ * Every other facet is a throwing proxy so drift into un-plumbed host
+ * surfaces fails loudly instead of silently no-opping.
+ */
+function makeHost(): SkillHost {
+  const unreachable = (path: string): never => {
+    throw new Error(
+      `meet-join-tool.test: fake SkillHost facet ${path} was unexpectedly accessed`,
+    );
+  };
+  const throwingProxy = (path: string) =>
+    new Proxy({}, { get: (_t, p) => unreachable(`${path}.${String(p)}`) });
 
-function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    logger: {
+      get: () =>
+        new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+    } as SkillHost["logger"],
+    config: {
+      isFeatureFlagEnabled: (key: string) =>
+        key === "meet" ? flagEnabled : true,
+      getSection: () => undefined,
+    },
+    identity: {
+      getAssistantName: () => assistantNameValue,
+      internalAssistantId: "self",
+    },
+    platform: throwingProxy("platform") as SkillHost["platform"],
+    providers: throwingProxy("providers") as SkillHost["providers"],
+    memory: throwingProxy("memory") as SkillHost["memory"],
+    events: throwingProxy("events") as SkillHost["events"],
+    registries: throwingProxy("registries") as SkillHost["registries"],
+    speakers: throwingProxy("speakers") as SkillHost["speakers"],
+  };
+}
+
+let meetJoinTool: Tool;
+
+/** Minimal `ToolContext` covering the fields the tool actually reads. */
+function makeContext(overrides: { conversationId?: string } = {}): {
+  workingDir: string;
+  conversationId: string;
+  trustClass: string;
+} {
   return {
     workingDir: "/tmp",
-    conversationId: "conv-test",
+    conversationId: overrides.conversationId ?? "conv-test",
     trustClass: "guardian",
-    ...overrides,
-  } as ToolContext;
+  };
 }
 
 beforeEach(() => {
@@ -113,6 +133,7 @@ beforeEach(() => {
   consentTemplate =
     "Hi, I'm {assistantName}, an AI assistant joining to take notes. Let me know if you'd prefer I leave.";
   joinMock.mockClear();
+  meetJoinTool = createMeetJoinTool(makeHost());
 });
 
 afterAll(() => {
@@ -176,9 +197,10 @@ describe("substituteAssistantName", () => {
 describe("meet_join feature-flag gating", () => {
   test("returns an error when the meet flag is off", async () => {
     flagEnabled = false;
+    meetJoinTool = createMeetJoinTool(makeHost());
     const result = await meetJoinTool.execute(
       { url: "https://meet.google.com/abc-defg-hij" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("meet feature is disabled");
@@ -187,9 +209,10 @@ describe("meet_join feature-flag gating", () => {
 
   test("proceeds to the session manager when the meet flag is on", async () => {
     flagEnabled = true;
+    meetJoinTool = createMeetJoinTool(makeHost());
     const result = await meetJoinTool.execute(
       { url: "https://meet.google.com/abc-defg-hij" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(false);
     expect(joinMock).toHaveBeenCalledTimes(1);
@@ -202,7 +225,7 @@ describe("meet_join feature-flag gating", () => {
 
 describe("meet_join input validation", () => {
   test("rejects a missing url", async () => {
-    const result = await meetJoinTool.execute({}, makeContext());
+    const result = await meetJoinTool.execute({}, makeContext() as never);
     expect(result.isError).toBe(true);
     // Zod reports "expected string, received undefined" for a missing url;
     // assert the error surfaces as an Error: … payload rather than leaking
@@ -214,7 +237,7 @@ describe("meet_join input validation", () => {
   test("rejects a non-Meet url", async () => {
     const result = await meetJoinTool.execute(
       { url: "https://zoom.us/j/12345" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Google Meet");
@@ -224,7 +247,7 @@ describe("meet_join input validation", () => {
   test("accepts a valid Meet url", async () => {
     const result = await meetJoinTool.execute(
       { url: "https://meet.google.com/abc-defg-hij" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(false);
   });
@@ -237,9 +260,10 @@ describe("meet_join input validation", () => {
 describe("meet_join session-manager delegation", () => {
   test("substitutes {assistantName} into the consent message before joining", async () => {
     assistantNameValue = "Aria";
+    meetJoinTool = createMeetJoinTool(makeHost());
     const result = await meetJoinTool.execute(
       { url: "https://meet.google.com/abc-defg-hij" },
-      makeContext({ conversationId: "conv-123" }),
+      makeContext({ conversationId: "conv-123" }) as never,
     );
 
     expect(result.isError).toBe(false);
@@ -256,10 +280,11 @@ describe("meet_join session-manager delegation", () => {
   });
 
   test("falls back to the default assistant name when IDENTITY.md is missing", async () => {
-    assistantNameValue = null;
+    assistantNameValue = undefined;
+    meetJoinTool = createMeetJoinTool(makeHost());
     await meetJoinTool.execute(
       { url: "https://meet.google.com/abc-defg-hij" },
-      makeContext(),
+      makeContext() as never,
     );
     const call = joinMock.mock.calls[0][0];
     expect(call.consentMessage).toContain(DEFAULT_ASSISTANT_NAME);
@@ -269,7 +294,7 @@ describe("meet_join session-manager delegation", () => {
   test("returns the generated meetingId and joining status", async () => {
     const result = await meetJoinTool.execute(
       { url: "https://meet.google.com/abc-defg-hij" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(false);
     const payload = JSON.parse(result.content) as {
@@ -286,7 +311,7 @@ describe("meet_join session-manager delegation", () => {
     });
     const result = await meetJoinTool.execute(
       { url: "https://meet.google.com/abc-defg-hij" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("docker is not running");

--- a/skills/meet-join/tools/__tests__/meet-leave-tool.test.ts
+++ b/skills/meet-join/tools/__tests__/meet-leave-tool.test.ts
@@ -5,8 +5,13 @@
  * `meetingId` (0 / 1 / many active sessions), explicit-id pass-through,
  * and reason-default behavior. Mirrors the mocking style used in the
  * sibling `meet-join-tool.test.ts`.
+ *
+ * The tool is now constructed via `createMeetLeaveTool(host)`, so the
+ * test builds a minimal fake host (feature-flag reads, no-op logger) to
+ * drive it.
  */
 
+import type { SkillHost, Tool } from "@vellumai/skill-host-contracts";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 let flagEnabled = true;
@@ -49,41 +54,50 @@ mock.module("../../daemon/session-manager.js", () => ({
   },
 }));
 
-mock.module(
-  "../../../../assistant/src/config/assistant-feature-flags.js",
-  () => ({
-    isAssistantFeatureFlagEnabled: (key: string) => {
-      if (key === "meet") return flagEnabled;
-      return true;
-    },
-  }),
-);
-
-mock.module("../../../../assistant/src/config/loader.js", () => ({
-  getConfig: () => ({
-    services: { meet: { consentMessage: "unused-in-leave-tests" } },
-  }),
-}));
-
-mock.module("../../../../assistant/src/util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
-}));
-
-const { meetLeaveTool, DEFAULT_LEAVE_REASON } =
+const { createMeetLeaveTool, DEFAULT_LEAVE_REASON } =
   await import("../meet-leave-tool.js");
 
-import type { ToolContext } from "../../../../assistant/src/tools/types.js";
+function makeHost(): SkillHost {
+  const unreachable = (path: string): never => {
+    throw new Error(
+      `meet-leave-tool.test: fake SkillHost facet ${path} was unexpectedly accessed`,
+    );
+  };
+  const throwingProxy = (path: string) =>
+    new Proxy({}, { get: (_t, p) => unreachable(`${path}.${String(p)}`) });
 
-function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    logger: {
+      get: () =>
+        new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+    } as SkillHost["logger"],
+    config: {
+      isFeatureFlagEnabled: (key: string) =>
+        key === "meet" ? flagEnabled : true,
+      getSection: () => undefined,
+    },
+    identity: throwingProxy("identity") as SkillHost["identity"],
+    platform: throwingProxy("platform") as SkillHost["platform"],
+    providers: throwingProxy("providers") as SkillHost["providers"],
+    memory: throwingProxy("memory") as SkillHost["memory"],
+    events: throwingProxy("events") as SkillHost["events"],
+    registries: throwingProxy("registries") as SkillHost["registries"],
+    speakers: throwingProxy("speakers") as SkillHost["speakers"],
+  };
+}
+
+let meetLeaveTool: Tool;
+
+function makeContext(): {
+  workingDir: string;
+  conversationId: string;
+  trustClass: string;
+} {
   return {
     workingDir: "/tmp",
     conversationId: "conv-test",
     trustClass: "guardian",
-    ...overrides,
-  } as ToolContext;
+  };
 }
 
 function fakeSession(meetingId: string) {
@@ -103,6 +117,7 @@ beforeEach(() => {
   activeSessionsValue = [];
   leaveMock.mockClear();
   getSessionMock.mockClear();
+  meetLeaveTool = createMeetLeaveTool(makeHost());
 });
 
 afterAll(() => {
@@ -116,8 +131,9 @@ afterAll(() => {
 describe("meet_leave feature-flag gating", () => {
   test("returns an error when the meet flag is off", async () => {
     flagEnabled = false;
+    meetLeaveTool = createMeetLeaveTool(makeHost());
     activeSessionsValue = [fakeSession("m1")];
-    const result = await meetLeaveTool.execute({}, makeContext());
+    const result = await meetLeaveTool.execute({}, makeContext() as never);
     expect(result.isError).toBe(true);
     expect(result.content).toContain("meet feature is disabled");
     expect(leaveMock).not.toHaveBeenCalled();
@@ -131,7 +147,7 @@ describe("meet_leave feature-flag gating", () => {
 describe("meet_leave disambiguation", () => {
   test("errors when no active sessions exist", async () => {
     activeSessionsValue = [];
-    const result = await meetLeaveTool.execute({}, makeContext());
+    const result = await meetLeaveTool.execute({}, makeContext() as never);
     expect(result.isError).toBe(true);
     expect(result.content.toLowerCase()).toContain("no active meet session");
     expect(leaveMock).not.toHaveBeenCalled();
@@ -141,7 +157,7 @@ describe("meet_leave disambiguation", () => {
     activeSessionsValue = [fakeSession("solo")];
     const result = await meetLeaveTool.execute(
       { reason: "user-requested" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(false);
     expect(leaveMock).toHaveBeenCalledTimes(1);
@@ -157,7 +173,7 @@ describe("meet_leave disambiguation", () => {
 
   test("errors when multiple active sessions and meetingId is omitted", async () => {
     activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
-    const result = await meetLeaveTool.execute({}, makeContext());
+    const result = await meetLeaveTool.execute({}, makeContext() as never);
     expect(result.isError).toBe(true);
     expect(result.content).toContain("multiple active");
     expect(result.content).toContain("m1");
@@ -169,7 +185,7 @@ describe("meet_leave disambiguation", () => {
     activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
     const result = await meetLeaveTool.execute(
       { meetingId: "m2" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(false);
     expect(leaveMock).toHaveBeenCalledTimes(1);
@@ -178,13 +194,13 @@ describe("meet_leave disambiguation", () => {
 
   test("defaults the reason to DEFAULT_LEAVE_REASON when none provided", async () => {
     activeSessionsValue = [fakeSession("solo")];
-    await meetLeaveTool.execute({}, makeContext());
+    await meetLeaveTool.execute({}, makeContext() as never);
     expect(leaveMock.mock.calls[0][1]).toBe(DEFAULT_LEAVE_REASON);
   });
 
   test("trims whitespace-only reasons and falls back to the default", async () => {
     activeSessionsValue = [fakeSession("solo")];
-    await meetLeaveTool.execute({ reason: "   " }, makeContext());
+    await meetLeaveTool.execute({ reason: "   " }, makeContext() as never);
     expect(leaveMock.mock.calls[0][1]).toBe(DEFAULT_LEAVE_REASON);
   });
 
@@ -195,7 +211,7 @@ describe("meet_leave disambiguation", () => {
     activeSessionsValue = [];
     const result = await meetLeaveTool.execute(
       { meetingId: "unknown" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(false);
     const payload = JSON.parse(result.content) as {
@@ -218,7 +234,7 @@ describe("meet_leave error surfacing", () => {
     leaveMock.mockImplementationOnce(async () => {
       throw new Error("container stop timed out");
     });
-    const result = await meetLeaveTool.execute({}, makeContext());
+    const result = await meetLeaveTool.execute({}, makeContext() as never);
     expect(result.isError).toBe(true);
     expect(result.content).toContain("container stop timed out");
   });

--- a/skills/meet-join/tools/__tests__/meet-send-chat-tool.test.ts
+++ b/skills/meet-join/tools/__tests__/meet-send-chat-tool.test.ts
@@ -5,8 +5,13 @@
  * caller omits `meetingId` (0 / 1 / many active sessions), explicit-id
  * pass-through, and error propagation from the session manager. Mirrors
  * the mocking style used in the sibling `meet-leave-tool.test.ts`.
+ *
+ * The tool is now constructed via `createMeetSendChatTool(host)`, so the
+ * test builds a minimal fake host (feature-flag reads, no-op logger) to
+ * drive it.
  */
 
+import type { SkillHost, Tool } from "@vellumai/skill-host-contracts";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 let flagEnabled = true;
@@ -53,40 +58,49 @@ mock.module("../../daemon/session-manager.js", () => ({
   MeetBotChatError: FakeMeetBotChatError,
 }));
 
-mock.module(
-  "../../../../assistant/src/config/assistant-feature-flags.js",
-  () => ({
-    isAssistantFeatureFlagEnabled: (key: string) => {
-      if (key === "meet") return flagEnabled;
-      return true;
+const { createMeetSendChatTool } = await import("../meet-send-chat-tool.js");
+
+function makeHost(): SkillHost {
+  const unreachable = (path: string): never => {
+    throw new Error(
+      `meet-send-chat-tool.test: fake SkillHost facet ${path} was unexpectedly accessed`,
+    );
+  };
+  const throwingProxy = (path: string) =>
+    new Proxy({}, { get: (_t, p) => unreachable(`${path}.${String(p)}`) });
+
+  return {
+    logger: {
+      get: () =>
+        new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+    } as SkillHost["logger"],
+    config: {
+      isFeatureFlagEnabled: (key: string) =>
+        key === "meet" ? flagEnabled : true,
+      getSection: () => undefined,
     },
-  }),
-);
+    identity: throwingProxy("identity") as SkillHost["identity"],
+    platform: throwingProxy("platform") as SkillHost["platform"],
+    providers: throwingProxy("providers") as SkillHost["providers"],
+    memory: throwingProxy("memory") as SkillHost["memory"],
+    events: throwingProxy("events") as SkillHost["events"],
+    registries: throwingProxy("registries") as SkillHost["registries"],
+    speakers: throwingProxy("speakers") as SkillHost["speakers"],
+  };
+}
 
-mock.module("../../../../assistant/src/config/loader.js", () => ({
-  getConfig: () => ({
-    services: { meet: { consentMessage: "unused-in-send-chat-tests" } },
-  }),
-}));
+let meetSendChatTool: Tool;
 
-mock.module("../../../../assistant/src/util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
-}));
-
-const { meetSendChatTool } = await import("../meet-send-chat-tool.js");
-
-import type { ToolContext } from "../../../../assistant/src/tools/types.js";
-
-function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+function makeContext(): {
+  workingDir: string;
+  conversationId: string;
+  trustClass: string;
+} {
   return {
     workingDir: "/tmp",
     conversationId: "conv-test",
     trustClass: "guardian",
-    ...overrides,
-  } as ToolContext;
+  };
 }
 
 function fakeSession(meetingId: string) {
@@ -106,6 +120,7 @@ beforeEach(() => {
   activeSessionsValue = [];
   sendChatMock.mockClear();
   sendChatMock.mockImplementation(async () => {});
+  meetSendChatTool = createMeetSendChatTool(makeHost());
 });
 
 afterAll(() => {
@@ -119,10 +134,11 @@ afterAll(() => {
 describe("meet_send_chat feature-flag gating", () => {
   test("returns an error when the meet flag is off", async () => {
     flagEnabled = false;
+    meetSendChatTool = createMeetSendChatTool(makeHost());
     activeSessionsValue = [fakeSession("m1")];
     const result = await meetSendChatTool.execute(
       { text: "hello" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("meet feature is disabled");
@@ -137,7 +153,7 @@ describe("meet_send_chat feature-flag gating", () => {
 describe("meet_send_chat input validation", () => {
   test("rejects missing text", async () => {
     activeSessionsValue = [fakeSession("solo")];
-    const result = await meetSendChatTool.execute({}, makeContext());
+    const result = await meetSendChatTool.execute({}, makeContext() as never);
     expect(result.isError).toBe(true);
     expect(result.content).toMatch(/^Error:/);
     expect(sendChatMock).not.toHaveBeenCalled();
@@ -145,7 +161,10 @@ describe("meet_send_chat input validation", () => {
 
   test("rejects empty text", async () => {
     activeSessionsValue = [fakeSession("solo")];
-    const result = await meetSendChatTool.execute({ text: "" }, makeContext());
+    const result = await meetSendChatTool.execute(
+      { text: "" },
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("text");
     expect(sendChatMock).not.toHaveBeenCalled();
@@ -153,7 +172,10 @@ describe("meet_send_chat input validation", () => {
 
   test("rejects non-string text", async () => {
     activeSessionsValue = [fakeSession("solo")];
-    const result = await meetSendChatTool.execute({ text: 123 }, makeContext());
+    const result = await meetSendChatTool.execute(
+      { text: 123 },
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(sendChatMock).not.toHaveBeenCalled();
   });
@@ -168,7 +190,7 @@ describe("meet_send_chat disambiguation", () => {
     activeSessionsValue = [];
     const result = await meetSendChatTool.execute(
       { text: "hi there" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(result.content.toLowerCase()).toContain("no active meet session");
@@ -179,7 +201,7 @@ describe("meet_send_chat disambiguation", () => {
     activeSessionsValue = [fakeSession("solo")];
     const result = await meetSendChatTool.execute(
       { text: "hello team" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(false);
     expect(sendChatMock).toHaveBeenCalledTimes(1);
@@ -197,7 +219,7 @@ describe("meet_send_chat disambiguation", () => {
     activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
     const result = await meetSendChatTool.execute(
       { text: "hi" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("multiple active");
@@ -210,7 +232,7 @@ describe("meet_send_chat disambiguation", () => {
     activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
     const result = await meetSendChatTool.execute(
       { meetingId: "m2", text: "hi m2" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(false);
     expect(sendChatMock).toHaveBeenCalledTimes(1);
@@ -231,7 +253,7 @@ describe("meet_send_chat error propagation", () => {
     });
     const result = await meetSendChatTool.execute(
       { text: "hello" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("no active Meet session");
@@ -245,7 +267,7 @@ describe("meet_send_chat error propagation", () => {
     });
     const result = await meetSendChatTool.execute(
       { text: "hello" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("meet bot unreachable");
@@ -259,7 +281,7 @@ describe("meet_send_chat error propagation", () => {
     });
     const result = await meetSendChatTool.execute(
       { text: "hello" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("status 502");
@@ -273,7 +295,7 @@ describe("meet_send_chat error propagation", () => {
     });
     const result = await meetSendChatTool.execute(
       { text: "hello" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("failed to send Meet chat");

--- a/skills/meet-join/tools/__tests__/meet-speak-tool.test.ts
+++ b/skills/meet-join/tools/__tests__/meet-speak-tool.test.ts
@@ -6,8 +6,13 @@
  * `meetingId` (0 / 1 / many active sessions), explicit-id pass-through,
  * and error propagation from the session manager. Mirrors the mocking
  * style used in the sibling `meet-send-chat-tool.test.ts`.
+ *
+ * The tools are now constructed via factories (`createMeetSpeakTool`,
+ * `createMeetCancelSpeakTool`) taking a `SkillHost`; the test builds a
+ * minimal fake host (feature-flag reads, no-op logger) to drive them.
  */
 
+import type { SkillHost, Tool } from "@vellumai/skill-host-contracts";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 let flagEnabled = true;
@@ -64,41 +69,54 @@ mock.module("../../daemon/session-manager.js", () => ({
   MeetBotChatError: FakeMeetBotChatError,
 }));
 
-mock.module(
-  "../../../../assistant/src/config/assistant-feature-flags.js",
-  () => ({
-    isAssistantFeatureFlagEnabled: (key: string) => {
-      if (key === "meet") return flagEnabled;
-      return true;
+const {
+  createMeetSpeakTool,
+  createMeetCancelSpeakTool,
+  MEET_SPEAK_MAX_TEXT_LENGTH,
+} = await import("../meet-speak-tool.js");
+
+function makeHost(): SkillHost {
+  const unreachable = (path: string): never => {
+    throw new Error(
+      `meet-speak-tool.test: fake SkillHost facet ${path} was unexpectedly accessed`,
+    );
+  };
+  const throwingProxy = (path: string) =>
+    new Proxy({}, { get: (_t, p) => unreachable(`${path}.${String(p)}`) });
+
+  return {
+    logger: {
+      get: () =>
+        new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+    } as SkillHost["logger"],
+    config: {
+      isFeatureFlagEnabled: (key: string) =>
+        key === "meet" ? flagEnabled : true,
+      getSection: () => undefined,
     },
-  }),
-);
+    identity: throwingProxy("identity") as SkillHost["identity"],
+    platform: throwingProxy("platform") as SkillHost["platform"],
+    providers: throwingProxy("providers") as SkillHost["providers"],
+    memory: throwingProxy("memory") as SkillHost["memory"],
+    events: throwingProxy("events") as SkillHost["events"],
+    registries: throwingProxy("registries") as SkillHost["registries"],
+    speakers: throwingProxy("speakers") as SkillHost["speakers"],
+  };
+}
 
-mock.module("../../../../assistant/src/config/loader.js", () => ({
-  getConfig: () => ({
-    services: { meet: { consentMessage: "unused-in-speak-tests" } },
-  }),
-}));
+let meetSpeakTool: Tool;
+let meetCancelSpeakTool: Tool;
 
-mock.module("../../../../assistant/src/util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
-}));
-
-const { meetSpeakTool, meetCancelSpeakTool, MEET_SPEAK_MAX_TEXT_LENGTH } =
-  await import("../meet-speak-tool.js");
-
-import type { ToolContext } from "../../../../assistant/src/tools/types.js";
-
-function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+function makeContext(): {
+  workingDir: string;
+  conversationId: string;
+  trustClass: string;
+} {
   return {
     workingDir: "/tmp",
     conversationId: "conv-test",
     trustClass: "guardian",
-    ...overrides,
-  } as ToolContext;
+  };
 }
 
 function fakeSession(meetingId: string) {
@@ -120,6 +138,9 @@ beforeEach(() => {
   speakMock.mockImplementation(async () => ({ streamId: "stream-default" }));
   cancelSpeakMock.mockClear();
   cancelSpeakMock.mockImplementation(async () => {});
+  const host = makeHost();
+  meetSpeakTool = createMeetSpeakTool(host);
+  meetCancelSpeakTool = createMeetCancelSpeakTool(host);
 });
 
 afterAll(() => {
@@ -133,10 +154,11 @@ afterAll(() => {
 describe("meet_speak feature-flag gating", () => {
   test("returns an error when the meet flag is off", async () => {
     flagEnabled = false;
+    meetSpeakTool = createMeetSpeakTool(makeHost());
     activeSessionsValue = [fakeSession("m1")];
     const result = await meetSpeakTool.execute(
       { text: "hello" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("meet feature is disabled");
@@ -151,7 +173,7 @@ describe("meet_speak feature-flag gating", () => {
 describe("meet_speak input validation", () => {
   test("rejects missing text", async () => {
     activeSessionsValue = [fakeSession("solo")];
-    const result = await meetSpeakTool.execute({}, makeContext());
+    const result = await meetSpeakTool.execute({}, makeContext() as never);
     expect(result.isError).toBe(true);
     expect(result.content).toMatch(/^Error:/);
     expect(speakMock).not.toHaveBeenCalled();
@@ -159,7 +181,10 @@ describe("meet_speak input validation", () => {
 
   test("rejects empty text", async () => {
     activeSessionsValue = [fakeSession("solo")];
-    const result = await meetSpeakTool.execute({ text: "" }, makeContext());
+    const result = await meetSpeakTool.execute(
+      { text: "" },
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("text");
     expect(speakMock).not.toHaveBeenCalled();
@@ -167,7 +192,10 @@ describe("meet_speak input validation", () => {
 
   test("rejects non-string text", async () => {
     activeSessionsValue = [fakeSession("solo")];
-    const result = await meetSpeakTool.execute({ text: 123 }, makeContext());
+    const result = await meetSpeakTool.execute(
+      { text: 123 },
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(speakMock).not.toHaveBeenCalled();
   });
@@ -175,7 +203,10 @@ describe("meet_speak input validation", () => {
   test("accepts text exactly at the soft length cap", async () => {
     activeSessionsValue = [fakeSession("solo")];
     const text = "a".repeat(MEET_SPEAK_MAX_TEXT_LENGTH);
-    const result = await meetSpeakTool.execute({ text }, makeContext());
+    const result = await meetSpeakTool.execute(
+      { text },
+      makeContext() as never,
+    );
     expect(result.isError).toBe(false);
     expect(speakMock).toHaveBeenCalledTimes(1);
     expect(speakMock.mock.calls[0][1].text.length).toBe(
@@ -186,7 +217,10 @@ describe("meet_speak input validation", () => {
   test("rejects text exceeding the soft length cap", async () => {
     activeSessionsValue = [fakeSession("solo")];
     const text = "a".repeat(MEET_SPEAK_MAX_TEXT_LENGTH + 1);
-    const result = await meetSpeakTool.execute({ text }, makeContext());
+    const result = await meetSpeakTool.execute(
+      { text },
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain(`${MEET_SPEAK_MAX_TEXT_LENGTH}`);
     expect(result.content.toLowerCase()).toContain("meet_send_chat");
@@ -197,7 +231,7 @@ describe("meet_speak input validation", () => {
     activeSessionsValue = [fakeSession("solo")];
     const result = await meetSpeakTool.execute(
       { text: "hi", voice: "  " },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(speakMock).not.toHaveBeenCalled();
@@ -210,7 +244,7 @@ describe("meet_speak input validation", () => {
     }));
     const result = await meetSpeakTool.execute(
       { text: "hi there", voice: "alloy" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(false);
     expect(speakMock).toHaveBeenCalledTimes(1);
@@ -230,7 +264,7 @@ describe("meet_speak disambiguation", () => {
     activeSessionsValue = [];
     const result = await meetSpeakTool.execute(
       { text: "anyone there?" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(result.content.toLowerCase()).toContain("no active meet session");
@@ -244,7 +278,7 @@ describe("meet_speak disambiguation", () => {
     }));
     const result = await meetSpeakTool.execute(
       { text: "hello team" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(false);
     expect(speakMock).toHaveBeenCalledTimes(1);
@@ -260,7 +294,10 @@ describe("meet_speak disambiguation", () => {
 
   test("errors when multiple active sessions and meetingId is omitted", async () => {
     activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
-    const result = await meetSpeakTool.execute({ text: "hi" }, makeContext());
+    const result = await meetSpeakTool.execute(
+      { text: "hi" },
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("multiple active");
     expect(result.content).toContain("m1");
@@ -275,7 +312,7 @@ describe("meet_speak disambiguation", () => {
     }));
     const result = await meetSpeakTool.execute(
       { meetingId: "m2", text: "hi m2" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(false);
     expect(speakMock).toHaveBeenCalledTimes(1);
@@ -296,7 +333,7 @@ describe("meet_speak error propagation", () => {
     });
     const result = await meetSpeakTool.execute(
       { text: "hello" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("no active Meet session");
@@ -310,7 +347,7 @@ describe("meet_speak error propagation", () => {
     });
     const result = await meetSpeakTool.execute(
       { text: "hello" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("failed to speak into Meet");
@@ -325,8 +362,12 @@ describe("meet_speak error propagation", () => {
 describe("meet_cancel_speak feature-flag gating", () => {
   test("returns an error when the meet flag is off", async () => {
     flagEnabled = false;
+    meetCancelSpeakTool = createMeetCancelSpeakTool(makeHost());
     activeSessionsValue = [fakeSession("m1")];
-    const result = await meetCancelSpeakTool.execute({}, makeContext());
+    const result = await meetCancelSpeakTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("meet feature is disabled");
     expect(cancelSpeakMock).not.toHaveBeenCalled();
@@ -340,7 +381,10 @@ describe("meet_cancel_speak feature-flag gating", () => {
 describe("meet_cancel_speak disambiguation", () => {
   test("errors when no active sessions exist", async () => {
     activeSessionsValue = [];
-    const result = await meetCancelSpeakTool.execute({}, makeContext());
+    const result = await meetCancelSpeakTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content.toLowerCase()).toContain("no active meet session");
     expect(cancelSpeakMock).not.toHaveBeenCalled();
@@ -348,7 +392,10 @@ describe("meet_cancel_speak disambiguation", () => {
 
   test("cancels the single active session when meetingId is omitted", async () => {
     activeSessionsValue = [fakeSession("solo")];
-    const result = await meetCancelSpeakTool.execute({}, makeContext());
+    const result = await meetCancelSpeakTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(false);
     expect(cancelSpeakMock).toHaveBeenCalledTimes(1);
     expect(cancelSpeakMock.mock.calls[0][0]).toBe("solo");
@@ -361,7 +408,10 @@ describe("meet_cancel_speak disambiguation", () => {
 
   test("errors when multiple active sessions and meetingId is omitted", async () => {
     activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
-    const result = await meetCancelSpeakTool.execute({}, makeContext());
+    const result = await meetCancelSpeakTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("multiple active");
     expect(cancelSpeakMock).not.toHaveBeenCalled();
@@ -371,7 +421,7 @@ describe("meet_cancel_speak disambiguation", () => {
     activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
     const result = await meetCancelSpeakTool.execute(
       { meetingId: "m1" },
-      makeContext(),
+      makeContext() as never,
     );
     expect(result.isError).toBe(false);
     expect(cancelSpeakMock).toHaveBeenCalledTimes(1);
@@ -389,7 +439,10 @@ describe("meet_cancel_speak error propagation", () => {
     cancelSpeakMock.mockImplementationOnce(async () => {
       throw new FakeMeetSessionNotFoundError("no session");
     });
-    const result = await meetCancelSpeakTool.execute({}, makeContext());
+    const result = await meetCancelSpeakTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("no active Meet session");
     expect(result.content).toContain("solo");
@@ -400,7 +453,10 @@ describe("meet_cancel_speak error propagation", () => {
     cancelSpeakMock.mockImplementationOnce(async () => {
       throw new Error("bridge cancel failed");
     });
-    const result = await meetCancelSpeakTool.execute({}, makeContext());
+    const result = await meetCancelSpeakTool.execute(
+      {},
+      makeContext() as never,
+    );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("failed to cancel Meet speech");
     expect(result.content).toContain("bridge cancel failed");

--- a/skills/meet-join/tools/meet-avatar-tool.ts
+++ b/skills/meet-join/tools/meet-avatar-tool.ts
@@ -18,18 +18,16 @@
  * place.
  */
 
-import { z } from "zod";
-
-import { isAssistantFeatureFlagEnabled } from "../../../assistant/src/config/assistant-feature-flags.js";
-import { getConfig } from "../../../assistant/src/config/loader.js";
-import { RiskLevel } from "../../../assistant/src/permissions/types.js";
-import type { ToolDefinition } from "../../../assistant/src/providers/types.js";
 import type {
+  SkillHost,
   Tool,
   ToolContext,
+  ToolDefinition,
   ToolExecutionResult,
-} from "../../../assistant/src/tools/types.js";
-import { getLogger } from "../../../assistant/src/util/logger.js";
+} from "@vellumai/skill-host-contracts";
+import { RiskLevel } from "@vellumai/skill-host-contracts";
+import { z } from "zod";
+
 import {
   MeetBotAvatarError,
   MeetSessionManager,
@@ -37,8 +35,6 @@ import {
   MeetSessionUnreachableError,
 } from "../daemon/session-manager.js";
 import { MEET_FLAG_KEY } from "./meet-join-tool.js";
-
-const log = getLogger("meet-avatar-tool");
 
 const MeetAvatarInputSchema = z.object({
   meetingId: z.string().trim().min(1).optional(),
@@ -74,201 +70,211 @@ function resolveTargetMeetingId(
   return { ok: true, meetingId: active[0].meetingId };
 }
 
-class MeetEnableAvatarTool implements Tool {
-  name = "meet_enable_avatar";
-  description =
-    "Turn on the assistant's video avatar in an active Google Meet call. The avatar lip-syncs to meet_speak output; it is off by default on join and must be explicitly enabled. See the Video avatar section of the meet-join SKILL.md for when to use this. When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.";
-  category = "meet";
-  // Low: consent for on-camera participation is established meeting-wide
-  // by `meet_join` (High) and the join-consent message; flipping the
-  // avatar within that bounded session is within the user's expressed
-  // consent envelope. Idempotent on the bot side (calling enable when
-  // already on returns `alreadyRunning: true`), so a stray retry is
-  // harmless. Aligns with the other in-meeting verbs (also Low).
-  defaultRiskLevel = RiskLevel.Low;
+/**
+ * Build the `meet_enable_avatar` tool, wired to the supplied `SkillHost`
+ * for feature-flag reads and logging.
+ */
+export function createMeetEnableAvatarTool(host: SkillHost): Tool {
+  const log = host.logger.get("meet-avatar-tool");
 
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: "object",
-        properties: {
-          meetingId: {
-            type: "string",
-            description:
-              "The id of the meeting to enable the avatar in, as returned by meet_join. Optional when exactly one session is active.",
+  return {
+    name: "meet_enable_avatar",
+    description:
+      "Turn on the assistant's video avatar in an active Google Meet call. The avatar lip-syncs to meet_speak output; it is off by default on join and must be explicitly enabled. See the Video avatar section of the meet-join SKILL.md for when to use this. When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.",
+    category: "meet",
+    // Low: consent for on-camera participation is established meeting-wide
+    // by `meet_join` (High) and the join-consent message; flipping the
+    // avatar within that bounded session is within the user's expressed
+    // consent envelope. Idempotent on the bot side (calling enable when
+    // already on returns `alreadyRunning: true`), so a stray retry is
+    // harmless. Aligns with the other in-meeting verbs (also Low).
+    defaultRiskLevel: RiskLevel.Low,
+
+    getDefinition(): ToolDefinition {
+      return {
+        name: this.name,
+        description: this.description,
+        input_schema: {
+          type: "object",
+          properties: {
+            meetingId: {
+              type: "string",
+              description:
+                "The id of the meeting to enable the avatar in, as returned by meet_join. Optional when exactly one session is active.",
+            },
           },
         },
-      },
-    };
-  }
-
-  async execute(
-    input: Record<string, unknown>,
-    _context: ToolContext,
-  ): Promise<ToolExecutionResult> {
-    // 1. Feature-flag gate — symmetric with the other meet_* tools.
-    const config = getConfig();
-    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
-      return {
-        content:
-          "Error: the meet feature is disabled. Enable the `meet` feature flag to manage Google Meet calls.",
-        isError: true,
       };
-    }
+    },
 
-    // 2. Input validation. All fields are optional so a bare `{}` is valid;
-    //    Zod still catches wrong-type submissions.
-    const parsed = MeetAvatarInputSchema.safeParse(input);
-    if (!parsed.success) {
-      const message =
-        parsed.error.issues[0]?.message ?? "invalid meet_enable_avatar input";
-      return { content: `Error: ${message}`, isError: true };
-    }
-    const { meetingId: explicitId } = parsed.data;
-
-    // 3. Disambiguate target session.
-    const target = resolveTargetMeetingId(explicitId);
-    if (!target.ok) {
-      return { content: target.content, isError: true };
-    }
-    const targetMeetingId = target.meetingId;
-
-    // 4. Delegate.
-    try {
-      const body = await MeetSessionManager.enableAvatar(targetMeetingId);
-      return {
-        content: JSON.stringify({ meetingId: targetMeetingId, ...body }),
-        isError: false,
-      };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.warn(
-        { err, meetingId: targetMeetingId },
-        "meet_enable_avatar tool failed",
-      );
-      if (err instanceof MeetSessionNotFoundError) {
+    async execute(
+      input: Record<string, unknown>,
+      _context: ToolContext,
+    ): Promise<ToolExecutionResult> {
+      // 1. Feature-flag gate — symmetric with the other meet_* tools.
+      if (!host.config.isFeatureFlagEnabled(MEET_FLAG_KEY)) {
         return {
-          content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
+          content:
+            "Error: the meet feature is disabled. Enable the `meet` feature flag to manage Google Meet calls.",
           isError: true,
         };
       }
-      if (err instanceof MeetSessionUnreachableError) {
+
+      // 2. Input validation. All fields are optional so a bare `{}` is valid;
+      //    Zod still catches wrong-type submissions.
+      const parsed = MeetAvatarInputSchema.safeParse(input);
+      if (!parsed.success) {
+        const message =
+          parsed.error.issues[0]?.message ?? "invalid meet_enable_avatar input";
+        return { content: `Error: ${message}`, isError: true };
+      }
+      const { meetingId: explicitId } = parsed.data;
+
+      // 3. Disambiguate target session.
+      const target = resolveTargetMeetingId(explicitId);
+      if (!target.ok) {
+        return { content: target.content, isError: true };
+      }
+      const targetMeetingId = target.meetingId;
+
+      // 4. Delegate.
+      try {
+        const body = await MeetSessionManager.enableAvatar(targetMeetingId);
         return {
-          content: `Error: meet bot unreachable — ${message}`,
+          content: JSON.stringify({ meetingId: targetMeetingId, ...body }),
+          isError: false,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn("meet_enable_avatar tool failed", {
+          err,
+          meetingId: targetMeetingId,
+        });
+        if (err instanceof MeetSessionNotFoundError) {
+          return {
+            content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
+            isError: true,
+          };
+        }
+        if (err instanceof MeetSessionUnreachableError) {
+          return {
+            content: `Error: meet bot unreachable — ${message}`,
+            isError: true,
+          };
+        }
+        if (err instanceof MeetBotAvatarError) {
+          return {
+            content: `Error: meet bot rejected avatar enable (status ${err.status}) — ${message}`,
+            isError: true,
+          };
+        }
+        return {
+          content: `Error: failed to enable Meet avatar — ${message}`,
           isError: true,
         };
       }
-      if (err instanceof MeetBotAvatarError) {
-        return {
-          content: `Error: meet bot rejected avatar enable (status ${err.status}) — ${message}`,
-          isError: true,
-        };
-      }
-      return {
-        content: `Error: failed to enable Meet avatar — ${message}`,
-        isError: true,
-      };
-    }
-  }
+    },
+  };
 }
 
-class MeetDisableAvatarTool implements Tool {
-  name = "meet_disable_avatar";
-  description =
-    "Turn off the assistant's video avatar in an active Google Meet call. See the Video avatar section of the meet-join SKILL.md for when to use this (notably: disable during long stretches of silence so participants don't read the avatar as watching). When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.";
-  category = "meet";
-  // Low: turning the assistant's own camera off is strictly less invasive
-  // than turning it on, and idempotent on the bot side.
-  defaultRiskLevel = RiskLevel.Low;
+/**
+ * Build the `meet_disable_avatar` tool, wired to the supplied `SkillHost`
+ * for feature-flag reads and logging.
+ */
+export function createMeetDisableAvatarTool(host: SkillHost): Tool {
+  const log = host.logger.get("meet-avatar-tool");
 
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: "object",
-        properties: {
-          meetingId: {
-            type: "string",
-            description:
-              "The id of the meeting to disable the avatar in, as returned by meet_join. Optional when exactly one session is active.",
+  return {
+    name: "meet_disable_avatar",
+    description:
+      "Turn off the assistant's video avatar in an active Google Meet call. See the Video avatar section of the meet-join SKILL.md for when to use this (notably: disable during long stretches of silence so participants don't read the avatar as watching). When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.",
+    category: "meet",
+    // Low: turning the assistant's own camera off is strictly less invasive
+    // than turning it on, and idempotent on the bot side.
+    defaultRiskLevel: RiskLevel.Low,
+
+    getDefinition(): ToolDefinition {
+      return {
+        name: this.name,
+        description: this.description,
+        input_schema: {
+          type: "object",
+          properties: {
+            meetingId: {
+              type: "string",
+              description:
+                "The id of the meeting to disable the avatar in, as returned by meet_join. Optional when exactly one session is active.",
+            },
           },
         },
-      },
-    };
-  }
-
-  async execute(
-    input: Record<string, unknown>,
-    _context: ToolContext,
-  ): Promise<ToolExecutionResult> {
-    // 1. Feature-flag gate.
-    const config = getConfig();
-    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
-      return {
-        content:
-          "Error: the meet feature is disabled. Enable the `meet` feature flag to manage Google Meet calls.",
-        isError: true,
       };
-    }
+    },
 
-    // 2. Input validation.
-    const parsed = MeetAvatarInputSchema.safeParse(input);
-    if (!parsed.success) {
-      const message =
-        parsed.error.issues[0]?.message ?? "invalid meet_disable_avatar input";
-      return { content: `Error: ${message}`, isError: true };
-    }
-    const { meetingId: explicitId } = parsed.data;
-
-    // 3. Disambiguate target session.
-    const target = resolveTargetMeetingId(explicitId);
-    if (!target.ok) {
-      return { content: target.content, isError: true };
-    }
-    const targetMeetingId = target.meetingId;
-
-    // 4. Delegate. `disableAvatar` is idempotent on the bot side.
-    try {
-      const body = await MeetSessionManager.disableAvatar(targetMeetingId);
-      return {
-        content: JSON.stringify({ meetingId: targetMeetingId, ...body }),
-        isError: false,
-      };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.warn(
-        { err, meetingId: targetMeetingId },
-        "meet_disable_avatar tool failed",
-      );
-      if (err instanceof MeetSessionNotFoundError) {
+    async execute(
+      input: Record<string, unknown>,
+      _context: ToolContext,
+    ): Promise<ToolExecutionResult> {
+      // 1. Feature-flag gate.
+      if (!host.config.isFeatureFlagEnabled(MEET_FLAG_KEY)) {
         return {
-          content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
+          content:
+            "Error: the meet feature is disabled. Enable the `meet` feature flag to manage Google Meet calls.",
           isError: true,
         };
       }
-      if (err instanceof MeetSessionUnreachableError) {
+
+      // 2. Input validation.
+      const parsed = MeetAvatarInputSchema.safeParse(input);
+      if (!parsed.success) {
+        const message =
+          parsed.error.issues[0]?.message ?? "invalid meet_disable_avatar input";
+        return { content: `Error: ${message}`, isError: true };
+      }
+      const { meetingId: explicitId } = parsed.data;
+
+      // 3. Disambiguate target session.
+      const target = resolveTargetMeetingId(explicitId);
+      if (!target.ok) {
+        return { content: target.content, isError: true };
+      }
+      const targetMeetingId = target.meetingId;
+
+      // 4. Delegate. `disableAvatar` is idempotent on the bot side.
+      try {
+        const body = await MeetSessionManager.disableAvatar(targetMeetingId);
         return {
-          content: `Error: meet bot unreachable — ${message}`,
+          content: JSON.stringify({ meetingId: targetMeetingId, ...body }),
+          isError: false,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn("meet_disable_avatar tool failed", {
+          err,
+          meetingId: targetMeetingId,
+        });
+        if (err instanceof MeetSessionNotFoundError) {
+          return {
+            content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
+            isError: true,
+          };
+        }
+        if (err instanceof MeetSessionUnreachableError) {
+          return {
+            content: `Error: meet bot unreachable — ${message}`,
+            isError: true,
+          };
+        }
+        if (err instanceof MeetBotAvatarError) {
+          return {
+            content: `Error: meet bot rejected avatar disable (status ${err.status}) — ${message}`,
+            isError: true,
+          };
+        }
+        return {
+          content: `Error: failed to disable Meet avatar — ${message}`,
           isError: true,
         };
       }
-      if (err instanceof MeetBotAvatarError) {
-        return {
-          content: `Error: meet bot rejected avatar disable (status ${err.status}) — ${message}`,
-          isError: true,
-        };
-      }
-      return {
-        content: `Error: failed to disable Meet avatar — ${message}`,
-        isError: true,
-      };
-    }
-  }
+    },
+  };
 }
-
-/** Exported singletons so the tool registry can re-register after test resets. */
-export const meetEnableAvatarTool = new MeetEnableAvatarTool();
-export const meetDisableAvatarTool = new MeetDisableAvatarTool();

--- a/skills/meet-join/tools/meet-join-tool.ts
+++ b/skills/meet-join/tools/meet-join-tool.ts
@@ -21,23 +21,18 @@
 
 import { randomUUID } from "node:crypto";
 
-import { z } from "zod";
-
-import { isAssistantFeatureFlagEnabled } from "../../../assistant/src/config/assistant-feature-flags.js";
-import { getConfig } from "../../../assistant/src/config/loader.js";
-import { getAssistantName } from "../../../assistant/src/daemon/identity-helpers.js";
-import { RiskLevel } from "../../../assistant/src/permissions/types.js";
-import type { ToolDefinition } from "../../../assistant/src/providers/types.js";
 import type {
+  SkillHost,
   Tool,
   ToolContext,
+  ToolDefinition,
   ToolExecutionResult,
-} from "../../../assistant/src/tools/types.js";
-import { getLogger } from "../../../assistant/src/util/logger.js";
+} from "@vellumai/skill-host-contracts";
+import { RiskLevel } from "@vellumai/skill-host-contracts";
+import { z } from "zod";
+
 import { getMeetConfig } from "../meet-config.js";
 import { MeetSessionManager } from "../daemon/session-manager.js";
-
-const log = getLogger("meet-join-tool");
 
 /** Feature-flag key that gates the Meet joining bot end-to-end. */
 export const MEET_FLAG_KEY = "meet" as const;
@@ -77,117 +72,120 @@ export function substituteAssistantName(
   return template.split("{assistantName}").join(assistantName);
 }
 
-class MeetJoinTool implements Tool {
-  name = "meet_join";
-  description =
-    "Join a Google Meet call as an AI note-taker. The bot announces itself in the meeting chat, captures a live transcript, and can be asked to leave at any time. Only call this when the user explicitly asks the assistant to join a specific Meet URL.";
-  category = "meet";
-  defaultRiskLevel = RiskLevel.High;
+/**
+ * Build the `meet_join` tool, wired to the supplied `SkillHost` for
+ * feature-flag reads, assistant identity, and logging.
+ */
+export function createMeetJoinTool(host: SkillHost): Tool {
+  const log = host.logger.get("meet-join-tool");
 
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: "object",
-        properties: {
-          url: {
-            type: "string",
-            description:
-              "The Google Meet URL to join, e.g. https://meet.google.com/xxx-yyyy-zzz.",
-          },
-          note: {
-            type: "string",
-            description:
-              "Optional free-form note about why the assistant is joining (recorded alongside the session for later reference).",
-          },
-        },
-        required: ["url"],
-      },
-    };
-  }
+  return {
+    name: "meet_join",
+    description:
+      "Join a Google Meet call as an AI note-taker. The bot announces itself in the meeting chat, captures a live transcript, and can be asked to leave at any time. Only call this when the user explicitly asks the assistant to join a specific Meet URL.",
+    category: "meet",
+    defaultRiskLevel: RiskLevel.High,
 
-  async execute(
-    input: Record<string, unknown>,
-    context: ToolContext,
-  ): Promise<ToolExecutionResult> {
-    // 1. Feature-flag gate. Keep the error wording stable so the skill can
-    //    relay it verbatim to the user without surprises.
-    const config = getConfig();
-    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
+    getDefinition(): ToolDefinition {
       return {
-        content:
-          "Error: the meet feature is disabled. Enable the `meet` feature flag to join Google Meet calls.",
-        isError: true,
+        name: this.name,
+        description: this.description,
+        input_schema: {
+          type: "object",
+          properties: {
+            url: {
+              type: "string",
+              description:
+                "The Google Meet URL to join, e.g. https://meet.google.com/xxx-yyyy-zzz.",
+            },
+            note: {
+              type: "string",
+              description:
+                "Optional free-form note about why the assistant is joining (recorded alongside the session for later reference).",
+            },
+          },
+          required: ["url"],
+        },
       };
-    }
+    },
 
-    // 2. Input validation.
-    const parsed = MeetJoinInputSchema.safeParse(input);
-    if (!parsed.success) {
-      const message =
-        parsed.error.issues[0]?.message ?? "invalid meet_join input";
-      return { content: `Error: ${message}`, isError: true };
-    }
-    const { url, note } = parsed.data;
+    async execute(
+      input: Record<string, unknown>,
+      context: ToolContext,
+    ): Promise<ToolExecutionResult> {
+      // 1. Feature-flag gate. Keep the error wording stable so the skill can
+      //    relay it verbatim to the user without surprises.
+      if (!host.config.isFeatureFlagEnabled(MEET_FLAG_KEY)) {
+        return {
+          content:
+            "Error: the meet feature is disabled. Enable the `meet` feature flag to join Google Meet calls.",
+          isError: true,
+        };
+      }
 
-    // 3. Consent-message substitution. We resolve `{assistantName}` here so
-    //    the substituted string reaches the bot container via the session
-    //    manager — keeping the substitution in the tool lets the config
-    //    value remain a template (stable across renames) while the bot
-    //    sees a human-readable greeting.
-    const meetConfig = getMeetConfig();
-    const rawTemplate = meetConfig.consentMessage;
-    const assistantName = getAssistantName() ?? DEFAULT_ASSISTANT_NAME;
-    const consentMessage = substituteAssistantName(rawTemplate, assistantName);
+      // 2. Input validation.
+      const parsed = MeetJoinInputSchema.safeParse(input);
+      if (!parsed.success) {
+        const message =
+          parsed.error.issues[0]?.message ?? "invalid meet_join input";
+        return { content: `Error: ${message}`, isError: true };
+      }
+      const { url, note } = parsed.data;
 
-    // 4. Generate a fresh meeting id. UUIDs give us the cryptographic
-    //    uniqueness the session manager's per-meeting token resolver
-    //    expects without having to coordinate ids across subsystems.
-    const meetingId = randomUUID();
+      // 3. Consent-message substitution. We resolve `{assistantName}` here so
+      //    the substituted string reaches the bot container via the session
+      //    manager — keeping the substitution in the tool lets the config
+      //    value remain a template (stable across renames) while the bot
+      //    sees a human-readable greeting.
+      const meetConfig = getMeetConfig();
+      const rawTemplate = meetConfig.consentMessage;
+      const assistantName =
+        host.identity.getAssistantName() ?? DEFAULT_ASSISTANT_NAME;
+      const consentMessage = substituteAssistantName(rawTemplate, assistantName);
 
-    // 5. Delegate to the session manager. Failures surface as tool errors
-    //    rather than throwing, so the agent loop can re-prompt the user
-    //    with a clear message instead of marking the whole turn as an
-    //    unexpected failure.
-    try {
-      const session = await MeetSessionManager.join({
-        url,
-        meetingId,
-        conversationId: context.conversationId,
-        consentMessage,
-      });
+      // 4. Generate a fresh meeting id. UUIDs give us the cryptographic
+      //    uniqueness the session manager's per-meeting token resolver
+      //    expects without having to coordinate ids across subsystems.
+      const meetingId = randomUUID();
 
-      log.info(
-        {
+      // 5. Delegate to the session manager. Failures surface as tool errors
+      //    rather than throwing, so the agent loop can re-prompt the user
+      //    with a clear message instead of marking the whole turn as an
+      //    unexpected failure.
+      try {
+        const session = await MeetSessionManager.join({
+          url,
+          meetingId,
+          conversationId: context.conversationId,
+          consentMessage,
+        });
+
+        log.info("meet_join tool spawned a Meet session", {
           meetingId: session.meetingId,
           conversationId: session.conversationId,
           containerId: session.containerId,
           note: note ? "[present]" : undefined,
-        },
-        "meet_join tool spawned a Meet session",
-      );
+        });
 
-      return {
-        content: JSON.stringify({
-          meetingId: session.meetingId,
-          status: "joining",
-        }),
-        isError: false,
-      };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.warn(
-        { err, meetingId, url },
-        "meet_join tool failed to start a Meet session",
-      );
-      return {
-        content: `Error: failed to join Meet — ${message}`,
-        isError: true,
-      };
-    }
-  }
+        return {
+          content: JSON.stringify({
+            meetingId: session.meetingId,
+            status: "joining",
+          }),
+          isError: false,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn("meet_join tool failed to start a Meet session", {
+          err,
+          meetingId,
+          url,
+        });
+        return {
+          content: `Error: failed to join Meet — ${message}`,
+          isError: true,
+        };
+      }
+    },
+  };
 }
-
-/** Exported singleton so the tool registry can re-register it after test resets. */
-export const meetJoinTool = new MeetJoinTool();

--- a/skills/meet-join/tools/meet-leave-tool.ts
+++ b/skills/meet-join/tools/meet-leave-tool.ts
@@ -10,22 +10,18 @@
  * routing.
  */
 
-import { z } from "zod";
-
-import { isAssistantFeatureFlagEnabled } from "../../../assistant/src/config/assistant-feature-flags.js";
-import { getConfig } from "../../../assistant/src/config/loader.js";
-import { RiskLevel } from "../../../assistant/src/permissions/types.js";
-import type { ToolDefinition } from "../../../assistant/src/providers/types.js";
 import type {
+  SkillHost,
   Tool,
   ToolContext,
+  ToolDefinition,
   ToolExecutionResult,
-} from "../../../assistant/src/tools/types.js";
-import { getLogger } from "../../../assistant/src/util/logger.js";
+} from "@vellumai/skill-host-contracts";
+import { RiskLevel } from "@vellumai/skill-host-contracts";
+import { z } from "zod";
+
 import { MeetSessionManager } from "../daemon/session-manager.js";
 import { MEET_FLAG_KEY } from "./meet-join-tool.js";
-
-const log = getLogger("meet-leave-tool");
 
 /** Default reason recorded when the caller doesn't supply one. */
 export const DEFAULT_LEAVE_REASON = "requested";
@@ -37,125 +33,130 @@ const MeetLeaveInputSchema = z.object({
 
 export type MeetLeaveInput = z.infer<typeof MeetLeaveInputSchema>;
 
-class MeetLeaveTool implements Tool {
-  name = "meet_leave";
-  description =
-    "Leave an active Google Meet call that the assistant previously joined. When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.";
-  category = "meet";
-  defaultRiskLevel = RiskLevel.Low;
+/**
+ * Build the `meet_leave` tool, wired to the supplied `SkillHost` for
+ * feature-flag reads and logging.
+ */
+export function createMeetLeaveTool(host: SkillHost): Tool {
+  const log = host.logger.get("meet-leave-tool");
 
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: "object",
-        properties: {
-          meetingId: {
-            type: "string",
-            description:
-              "The id of the meeting to leave, as returned by meet_join. Optional when exactly one session is active.",
-          },
-          reason: {
-            type: "string",
-            description:
-              "Free-form reason recorded with the leave event (e.g. 'user-requested', 'task-complete'). Defaults to 'requested'.",
+  return {
+    name: "meet_leave",
+    description:
+      "Leave an active Google Meet call that the assistant previously joined. When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.",
+    category: "meet",
+    defaultRiskLevel: RiskLevel.Low,
+
+    getDefinition(): ToolDefinition {
+      return {
+        name: this.name,
+        description: this.description,
+        input_schema: {
+          type: "object",
+          properties: {
+            meetingId: {
+              type: "string",
+              description:
+                "The id of the meeting to leave, as returned by meet_join. Optional when exactly one session is active.",
+            },
+            reason: {
+              type: "string",
+              description:
+                "Free-form reason recorded with the leave event (e.g. 'user-requested', 'task-complete'). Defaults to 'requested'.",
+            },
           },
         },
-      },
-    };
-  }
-
-  async execute(
-    input: Record<string, unknown>,
-    _context: ToolContext,
-  ): Promise<ToolExecutionResult> {
-    // 1. Feature-flag gate — symmetric with meet_join so that disabling
-    //    the feature blocks both sides of the lifecycle instead of
-    //    leaking a half-working interface.
-    const config = getConfig();
-    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
-      return {
-        content:
-          "Error: the meet feature is disabled. Enable the `meet` feature flag to manage Google Meet calls.",
-        isError: true,
       };
-    }
+    },
 
-    // 2. Input validation. All fields are optional so a bare `{}` is valid;
-    //    Zod still catches wrong-type submissions and we surface the first
-    //    issue verbatim for debuggability.
-    const parsed = MeetLeaveInputSchema.safeParse(input);
-    if (!parsed.success) {
-      const message =
-        parsed.error.issues[0]?.message ?? "invalid meet_leave input";
-      return { content: `Error: ${message}`, isError: true };
-    }
-    const { meetingId: explicitId, reason } = parsed.data;
-
-    // 3. Disambiguate the target session when no id is supplied. Ambiguity
-    //    (zero or multiple active sessions) is a caller error: we refuse
-    //    rather than guess, so the skill can prompt the user for the
-    //    specific meeting.
-    let targetMeetingId: string;
-    if (explicitId) {
-      targetMeetingId = explicitId;
-    } else {
-      const active = MeetSessionManager.activeSessions();
-      if (active.length === 0) {
+    async execute(
+      input: Record<string, unknown>,
+      _context: ToolContext,
+    ): Promise<ToolExecutionResult> {
+      // 1. Feature-flag gate — symmetric with meet_join so that disabling
+      //    the feature blocks both sides of the lifecycle instead of
+      //    leaking a half-working interface.
+      if (!host.config.isFeatureFlagEnabled(MEET_FLAG_KEY)) {
         return {
-          content: "Error: no active Meet session to leave.",
+          content:
+            "Error: the meet feature is disabled. Enable the `meet` feature flag to manage Google Meet calls.",
           isError: true,
         };
       }
-      if (active.length > 1) {
-        const ids = active.map((s) => s.meetingId).join(", ");
-        return {
-          content: `Error: multiple active Meet sessions (${ids}). Pass meetingId explicitly.`,
-          isError: true,
-        };
+
+      // 2. Input validation. All fields are optional so a bare `{}` is valid;
+      //    Zod still catches wrong-type submissions and we surface the first
+      //    issue verbatim for debuggability.
+      const parsed = MeetLeaveInputSchema.safeParse(input);
+      if (!parsed.success) {
+        const message =
+          parsed.error.issues[0]?.message ?? "invalid meet_leave input";
+        return { content: `Error: ${message}`, isError: true };
       }
-      targetMeetingId = active[0].meetingId;
-    }
+      const { meetingId: explicitId, reason } = parsed.data;
 
-    // 4. Delegate. `leave()` is idempotent for unknown meeting ids, so we
-    //    don't need a pre-flight existence check — but we do call it out
-    //    in the response when nothing matched, to avoid telling the
-    //    model "left" for a no-op.
-    const sessionBefore = MeetSessionManager.getSession(targetMeetingId);
-    const leaveReason = reason?.trim() ? reason.trim() : DEFAULT_LEAVE_REASON;
+      // 3. Disambiguate the target session when no id is supplied. Ambiguity
+      //    (zero or multiple active sessions) is a caller error: we refuse
+      //    rather than guess, so the skill can prompt the user for the
+      //    specific meeting.
+      let targetMeetingId: string;
+      if (explicitId) {
+        targetMeetingId = explicitId;
+      } else {
+        const active = MeetSessionManager.activeSessions();
+        if (active.length === 0) {
+          return {
+            content: "Error: no active Meet session to leave.",
+            isError: true,
+          };
+        }
+        if (active.length > 1) {
+          const ids = active.map((s) => s.meetingId).join(", ");
+          return {
+            content: `Error: multiple active Meet sessions (${ids}). Pass meetingId explicitly.`,
+            isError: true,
+          };
+        }
+        targetMeetingId = active[0].meetingId;
+      }
 
-    try {
-      await MeetSessionManager.leave(targetMeetingId, leaveReason);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.warn(
-        { err, meetingId: targetMeetingId, reason: leaveReason },
-        "meet_leave tool failed",
-      );
-      return {
-        content: `Error: failed to leave Meet — ${message}`,
-        isError: true,
-      };
-    }
+      // 4. Delegate. `leave()` is idempotent for unknown meeting ids, so we
+      //    don't need a pre-flight existence check — but we do call it out
+      //    in the response when nothing matched, to avoid telling the
+      //    model "left" for a no-op.
+      const sessionBefore = MeetSessionManager.getSession(targetMeetingId);
+      const leaveReason = reason?.trim() ? reason.trim() : DEFAULT_LEAVE_REASON;
 
-    if (!sessionBefore) {
-      return {
-        content: JSON.stringify({
-          left: false,
+      try {
+        await MeetSessionManager.leave(targetMeetingId, leaveReason);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn("meet_leave tool failed", {
+          err,
           meetingId: targetMeetingId,
-          note: "no active session matched that meetingId",
-        }),
+          reason: leaveReason,
+        });
+        return {
+          content: `Error: failed to leave Meet — ${message}`,
+          isError: true,
+        };
+      }
+
+      if (!sessionBefore) {
+        return {
+          content: JSON.stringify({
+            left: false,
+            meetingId: targetMeetingId,
+            note: "no active session matched that meetingId",
+          }),
+          isError: false,
+        };
+      }
+
+      return {
+        content: JSON.stringify({ left: true, meetingId: targetMeetingId }),
         isError: false,
       };
-    }
-
-    return {
-      content: JSON.stringify({ left: true, meetingId: targetMeetingId }),
-      isError: false,
-    };
-  }
+    },
+  };
 }
-
-/** Exported singleton so the tool registry can re-register it after test resets. */
-export const meetLeaveTool = new MeetLeaveTool();

--- a/skills/meet-join/tools/meet-send-chat-tool.ts
+++ b/skills/meet-join/tools/meet-send-chat-tool.ts
@@ -9,18 +9,16 @@
  * session-manager state.
  */
 
-import { z } from "zod";
-
-import { isAssistantFeatureFlagEnabled } from "../../../assistant/src/config/assistant-feature-flags.js";
-import { getConfig } from "../../../assistant/src/config/loader.js";
-import { RiskLevel } from "../../../assistant/src/permissions/types.js";
-import type { ToolDefinition } from "../../../assistant/src/providers/types.js";
 import type {
+  SkillHost,
   Tool,
   ToolContext,
+  ToolDefinition,
   ToolExecutionResult,
-} from "../../../assistant/src/tools/types.js";
-import { getLogger } from "../../../assistant/src/util/logger.js";
+} from "@vellumai/skill-host-contracts";
+import { RiskLevel } from "@vellumai/skill-host-contracts";
+import { z } from "zod";
+
 import {
   MeetBotChatError,
   MeetSessionManager,
@@ -29,8 +27,6 @@ import {
 } from "../daemon/session-manager.js";
 import { MEET_FLAG_KEY } from "./meet-join-tool.js";
 
-const log = getLogger("meet-send-chat-tool");
-
 const MeetSendChatInputSchema = z.object({
   meetingId: z.string().trim().min(1).optional(),
   text: z.string().min(1, "text is required"),
@@ -38,126 +34,131 @@ const MeetSendChatInputSchema = z.object({
 
 export type MeetSendChatInput = z.infer<typeof MeetSendChatInputSchema>;
 
-class MeetSendChatTool implements Tool {
-  name = "meet_send_chat";
-  description =
-    "Post a message into the chat of an active Google Meet call. When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.";
-  category = "meet";
-  // Low: consent is established meeting-wide by `meet_join` (High) and the
-  // Phase 1 join-consent message announcing the bot. Chat posts within that
-  // bounded session are within the user's expressed consent envelope, and
-  // proactive-chat wakes run on client-less conversations where a Medium-risk
-  // approval prompt would hang forever. Aligns with `meet_leave` (also Low).
-  defaultRiskLevel = RiskLevel.Low;
+/**
+ * Build the `meet_send_chat` tool, wired to the supplied `SkillHost` for
+ * feature-flag reads and logging.
+ */
+export function createMeetSendChatTool(host: SkillHost): Tool {
+  const log = host.logger.get("meet-send-chat-tool");
 
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: "object",
-        properties: {
-          meetingId: {
-            type: "string",
-            description:
-              "The id of the meeting to send chat to, as returned by meet_join. Optional when exactly one session is active.",
+  return {
+    name: "meet_send_chat",
+    description:
+      "Post a message into the chat of an active Google Meet call. When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.",
+    category: "meet",
+    // Low: consent is established meeting-wide by `meet_join` (High) and the
+    // Phase 1 join-consent message announcing the bot. Chat posts within that
+    // bounded session are within the user's expressed consent envelope, and
+    // proactive-chat wakes run on client-less conversations where a Medium-risk
+    // approval prompt would hang forever. Aligns with `meet_leave` (also Low).
+    defaultRiskLevel: RiskLevel.Low,
+
+    getDefinition(): ToolDefinition {
+      return {
+        name: this.name,
+        description: this.description,
+        input_schema: {
+          type: "object",
+          properties: {
+            meetingId: {
+              type: "string",
+              description:
+                "The id of the meeting to send chat to, as returned by meet_join. Optional when exactly one session is active.",
+            },
+            text: {
+              type: "string",
+              description:
+                "The message text to post into the meeting chat. Keep it concise and conversational.",
+            },
           },
-          text: {
-            type: "string",
-            description:
-              "The message text to post into the meeting chat. Keep it concise and conversational.",
-          },
+          required: ["text"],
         },
-        required: ["text"],
-      },
-    };
-  }
-
-  async execute(
-    input: Record<string, unknown>,
-    _context: ToolContext,
-  ): Promise<ToolExecutionResult> {
-    // 1. Feature-flag gate — symmetric with meet_join / meet_leave.
-    const config = getConfig();
-    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
-      return {
-        content:
-          "Error: the meet feature is disabled. Enable the `meet` feature flag to send chat in Google Meet calls.",
-        isError: true,
       };
-    }
+    },
 
-    // 2. Input validation.
-    const parsed = MeetSendChatInputSchema.safeParse(input);
-    if (!parsed.success) {
-      const message =
-        parsed.error.issues[0]?.message ?? "invalid meet_send_chat input";
-      return { content: `Error: ${message}`, isError: true };
-    }
-    const { meetingId: explicitId, text } = parsed.data;
+    async execute(
+      input: Record<string, unknown>,
+      _context: ToolContext,
+    ): Promise<ToolExecutionResult> {
+      // 1. Feature-flag gate — symmetric with meet_join / meet_leave.
+      if (!host.config.isFeatureFlagEnabled(MEET_FLAG_KEY)) {
+        return {
+          content:
+            "Error: the meet feature is disabled. Enable the `meet` feature flag to send chat in Google Meet calls.",
+          isError: true,
+        };
+      }
 
-    // 3. Disambiguate target session when no id is supplied. Zero or >1
-    //    active sessions is a caller error — refuse rather than guess.
-    let targetMeetingId: string;
-    if (explicitId) {
-      targetMeetingId = explicitId;
-    } else {
-      const active = MeetSessionManager.activeSessions();
-      if (active.length === 0) {
-        return {
-          content: "Error: no active Meet session to send chat to.",
-          isError: true,
-        };
+      // 2. Input validation.
+      const parsed = MeetSendChatInputSchema.safeParse(input);
+      if (!parsed.success) {
+        const message =
+          parsed.error.issues[0]?.message ?? "invalid meet_send_chat input";
+        return { content: `Error: ${message}`, isError: true };
       }
-      if (active.length > 1) {
-        const ids = active.map((s) => s.meetingId).join(", ");
-        return {
-          content: `Error: multiple active Meet sessions (${ids}). Pass meetingId explicitly.`,
-          isError: true,
-        };
-      }
-      targetMeetingId = active[0].meetingId;
-    }
+      const { meetingId: explicitId, text } = parsed.data;
 
-    // 4. Delegate.
-    try {
-      await MeetSessionManager.sendChat(targetMeetingId, text);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.warn(
-        { err, meetingId: targetMeetingId, textLength: text.length },
-        "meet_send_chat tool failed",
-      );
-      if (err instanceof MeetSessionNotFoundError) {
+      // 3. Disambiguate target session when no id is supplied. Zero or >1
+      //    active sessions is a caller error — refuse rather than guess.
+      let targetMeetingId: string;
+      if (explicitId) {
+        targetMeetingId = explicitId;
+      } else {
+        const active = MeetSessionManager.activeSessions();
+        if (active.length === 0) {
+          return {
+            content: "Error: no active Meet session to send chat to.",
+            isError: true,
+          };
+        }
+        if (active.length > 1) {
+          const ids = active.map((s) => s.meetingId).join(", ");
+          return {
+            content: `Error: multiple active Meet sessions (${ids}). Pass meetingId explicitly.`,
+            isError: true,
+          };
+        }
+        targetMeetingId = active[0].meetingId;
+      }
+
+      // 4. Delegate.
+      try {
+        await MeetSessionManager.sendChat(targetMeetingId, text);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn("meet_send_chat tool failed", {
+          err,
+          meetingId: targetMeetingId,
+          textLength: text.length,
+        });
+        if (err instanceof MeetSessionNotFoundError) {
+          return {
+            content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
+            isError: true,
+          };
+        }
+        if (err instanceof MeetSessionUnreachableError) {
+          return {
+            content: `Error: meet bot unreachable — ${message}`,
+            isError: true,
+          };
+        }
+        if (err instanceof MeetBotChatError) {
+          return {
+            content: `Error: meet bot rejected the chat (status ${err.status}) — ${message}`,
+            isError: true,
+          };
+        }
         return {
-          content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
+          content: `Error: failed to send Meet chat — ${message}`,
           isError: true,
         };
       }
-      if (err instanceof MeetSessionUnreachableError) {
-        return {
-          content: `Error: meet bot unreachable — ${message}`,
-          isError: true,
-        };
-      }
-      if (err instanceof MeetBotChatError) {
-        return {
-          content: `Error: meet bot rejected the chat (status ${err.status}) — ${message}`,
-          isError: true,
-        };
-      }
+
       return {
-        content: `Error: failed to send Meet chat — ${message}`,
-        isError: true,
+        content: JSON.stringify({ sent: true, meetingId: targetMeetingId }),
+        isError: false,
       };
-    }
-
-    return {
-      content: JSON.stringify({ sent: true, meetingId: targetMeetingId }),
-      isError: false,
-    };
-  }
+    },
+  };
 }
-
-/** Exported singleton so the tool registry can re-register it after test resets. */
-export const meetSendChatTool = new MeetSendChatTool();

--- a/skills/meet-join/tools/meet-speak-tool.ts
+++ b/skills/meet-join/tools/meet-speak-tool.ts
@@ -17,25 +17,21 @@
  * monologue — so we refuse here and let the agent re-plan.
  */
 
-import { z } from "zod";
-
-import { isAssistantFeatureFlagEnabled } from "../../../assistant/src/config/assistant-feature-flags.js";
-import { getConfig } from "../../../assistant/src/config/loader.js";
-import { RiskLevel } from "../../../assistant/src/permissions/types.js";
-import type { ToolDefinition } from "../../../assistant/src/providers/types.js";
 import type {
+  SkillHost,
   Tool,
   ToolContext,
+  ToolDefinition,
   ToolExecutionResult,
-} from "../../../assistant/src/tools/types.js";
-import { getLogger } from "../../../assistant/src/util/logger.js";
+} from "@vellumai/skill-host-contracts";
+import { RiskLevel } from "@vellumai/skill-host-contracts";
+import { z } from "zod";
+
 import {
   MeetSessionManager,
   MeetSessionNotFoundError,
 } from "../daemon/session-manager.js";
 import { MEET_FLAG_KEY } from "./meet-join-tool.js";
-
-const log = getLogger("meet-speak-tool");
 
 /**
  * Soft cap on the synthesized text length. Anything longer should be sent
@@ -92,207 +88,215 @@ function resolveTargetMeetingId(
   return { ok: true, meetingId: active[0].meetingId };
 }
 
-class MeetSpeakTool implements Tool {
-  name = "meet_speak";
-  description =
-    "Speak synthesized audio into an active Google Meet call. Use this to reply out loud during a meeting; for long-form answers prefer meet_send_chat. When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.";
-  category = "meet";
-  // Low: consent for audio output is established meeting-wide by `meet_join`
-  // (High) and the join-consent message announcing the bot. Speaking within
-  // that bounded session is within the user's expressed consent envelope,
-  // and proactive-speech wakes run on client-less conversations where a
-  // Medium-risk approval prompt would hang forever. Aligns with `meet_leave`
-  // and `meet_send_chat` (also Low).
-  defaultRiskLevel = RiskLevel.Low;
+/**
+ * Build the `meet_speak` tool, wired to the supplied `SkillHost` for
+ * feature-flag reads and logging.
+ */
+export function createMeetSpeakTool(host: SkillHost): Tool {
+  const log = host.logger.get("meet-speak-tool");
 
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: "object",
-        properties: {
-          meetingId: {
-            type: "string",
-            description:
-              "The id of the meeting to speak into, as returned by meet_join. Optional when exactly one session is active.",
-          },
-          text: {
-            type: "string",
-            description: `The text to synthesize and play. Keep it conversational and under ${MEET_SPEAK_MAX_TEXT_LENGTH} characters — longer replies should be sent via meet_send_chat.`,
-          },
-          voice: {
-            type: "string",
-            description:
-              "Optional provider-specific voice identifier. Falls back to the configured default voice when omitted.",
-          },
-        },
-        required: ["text"],
-      },
-    };
-  }
+  return {
+    name: "meet_speak",
+    description:
+      "Speak synthesized audio into an active Google Meet call. Use this to reply out loud during a meeting; for long-form answers prefer meet_send_chat. When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.",
+    category: "meet",
+    // Low: consent for audio output is established meeting-wide by `meet_join`
+    // (High) and the join-consent message announcing the bot. Speaking within
+    // that bounded session is within the user's expressed consent envelope,
+    // and proactive-speech wakes run on client-less conversations where a
+    // Medium-risk approval prompt would hang forever. Aligns with `meet_leave`
+    // and `meet_send_chat` (also Low).
+    defaultRiskLevel: RiskLevel.Low,
 
-  async execute(
-    input: Record<string, unknown>,
-    _context: ToolContext,
-  ): Promise<ToolExecutionResult> {
-    // 1. Feature-flag gate — symmetric with the other meet_* tools.
-    const config = getConfig();
-    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
+    getDefinition(): ToolDefinition {
       return {
-        content:
-          "Error: the meet feature is disabled. Enable the `meet` feature flag to speak in Google Meet calls.",
-        isError: true,
+        name: this.name,
+        description: this.description,
+        input_schema: {
+          type: "object",
+          properties: {
+            meetingId: {
+              type: "string",
+              description:
+                "The id of the meeting to speak into, as returned by meet_join. Optional when exactly one session is active.",
+            },
+            text: {
+              type: "string",
+              description: `The text to synthesize and play. Keep it conversational and under ${MEET_SPEAK_MAX_TEXT_LENGTH} characters — longer replies should be sent via meet_send_chat.`,
+            },
+            voice: {
+              type: "string",
+              description:
+                "Optional provider-specific voice identifier. Falls back to the configured default voice when omitted.",
+            },
+          },
+          required: ["text"],
+        },
       };
-    }
+    },
 
-    // 2. Input validation.
-    const parsed = MeetSpeakInputSchema.safeParse(input);
-    if (!parsed.success) {
-      const message =
-        parsed.error.issues[0]?.message ?? "invalid meet_speak input";
-      return { content: `Error: ${message}`, isError: true };
-    }
-    const { meetingId: explicitId, text, voice } = parsed.data;
+    async execute(
+      input: Record<string, unknown>,
+      _context: ToolContext,
+    ): Promise<ToolExecutionResult> {
+      // 1. Feature-flag gate — symmetric with the other meet_* tools.
+      if (!host.config.isFeatureFlagEnabled(MEET_FLAG_KEY)) {
+        return {
+          content:
+            "Error: the meet feature is disabled. Enable the `meet` feature flag to speak in Google Meet calls.",
+          isError: true,
+        };
+      }
 
-    // 3. Disambiguate target session when no id is supplied.
-    const target = resolveTargetMeetingId(explicitId);
-    if (!target.ok) {
-      return { content: target.content, isError: true };
-    }
-    const targetMeetingId = target.meetingId;
+      // 2. Input validation.
+      const parsed = MeetSpeakInputSchema.safeParse(input);
+      if (!parsed.success) {
+        const message =
+          parsed.error.issues[0]?.message ?? "invalid meet_speak input";
+        return { content: `Error: ${message}`, isError: true };
+      }
+      const { meetingId: explicitId, text, voice } = parsed.data;
 
-    // 4. Delegate.
-    try {
-      const result = await MeetSessionManager.speak(targetMeetingId, {
-        text,
-        voice,
-      });
-      log.info(
-        {
+      // 3. Disambiguate target session when no id is supplied.
+      const target = resolveTargetMeetingId(explicitId);
+      if (!target.ok) {
+        return { content: target.content, isError: true };
+      }
+      const targetMeetingId = target.meetingId;
+
+      // 4. Delegate.
+      try {
+        const result = await MeetSessionManager.speak(targetMeetingId, {
+          text,
+          voice,
+        });
+        log.info("meet_speak tool started a TTS stream", {
           meetingId: targetMeetingId,
           streamId: result.streamId,
           textLength: text.length,
           voice: voice ?? "default",
+        });
+        return {
+          content: JSON.stringify({
+            meetingId: targetMeetingId,
+            streamId: result.streamId,
+          }),
+          isError: false,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn("meet_speak tool failed", {
+          err,
+          meetingId: targetMeetingId,
+          textLength: text.length,
+        });
+        if (err instanceof MeetSessionNotFoundError) {
+          return {
+            content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
+            isError: true,
+          };
+        }
+        return {
+          content: `Error: failed to speak into Meet — ${message}`,
+          isError: true,
+        };
+      }
+    },
+  };
+}
+
+/**
+ * Build the `meet_cancel_speak` tool, wired to the supplied `SkillHost`
+ * for feature-flag reads and logging.
+ */
+export function createMeetCancelSpeakTool(host: SkillHost): Tool {
+  const log = host.logger.get("meet-speak-tool");
+
+  return {
+    name: "meet_cancel_speak",
+    description:
+      "Cancel any in-flight synthesized speech in an active Google Meet call so the assistant can voluntarily stop talking (e.g. when interrupted by a participant). When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.",
+    category: "meet",
+    // Low: cancelling the assistant's own audio output is strictly less
+    // invasive than speaking — no new sound is emitted, and idempotent
+    // when nothing is currently playing.
+    defaultRiskLevel: RiskLevel.Low,
+
+    getDefinition(): ToolDefinition {
+      return {
+        name: this.name,
+        description: this.description,
+        input_schema: {
+          type: "object",
+          properties: {
+            meetingId: {
+              type: "string",
+              description:
+                "The id of the meeting whose in-flight speech should be cancelled. Optional when exactly one session is active.",
+            },
+          },
         },
-        "meet_speak tool started a TTS stream",
-      );
+      };
+    },
+
+    async execute(
+      input: Record<string, unknown>,
+      _context: ToolContext,
+    ): Promise<ToolExecutionResult> {
+      // 1. Feature-flag gate.
+      if (!host.config.isFeatureFlagEnabled(MEET_FLAG_KEY)) {
+        return {
+          content:
+            "Error: the meet feature is disabled. Enable the `meet` feature flag to manage Google Meet calls.",
+          isError: true,
+        };
+      }
+
+      // 2. Input validation. All fields are optional so a bare `{}` is valid;
+      //    Zod still catches wrong-type submissions.
+      const parsed = MeetCancelSpeakInputSchema.safeParse(input);
+      if (!parsed.success) {
+        const message =
+          parsed.error.issues[0]?.message ?? "invalid meet_cancel_speak input";
+        return { content: `Error: ${message}`, isError: true };
+      }
+      const { meetingId: explicitId } = parsed.data;
+
+      // 3. Disambiguate target session.
+      const target = resolveTargetMeetingId(explicitId);
+      if (!target.ok) {
+        return { content: target.content, isError: true };
+      }
+      const targetMeetingId = target.meetingId;
+
+      // 4. Delegate. `cancelSpeak` is idempotent when nothing is in flight.
+      try {
+        await MeetSessionManager.cancelSpeak(targetMeetingId);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn("meet_cancel_speak tool failed", {
+          err,
+          meetingId: targetMeetingId,
+        });
+        if (err instanceof MeetSessionNotFoundError) {
+          return {
+            content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
+            isError: true,
+          };
+        }
+        return {
+          content: `Error: failed to cancel Meet speech — ${message}`,
+          isError: true,
+        };
+      }
+
       return {
         content: JSON.stringify({
+          cancelled: true,
           meetingId: targetMeetingId,
-          streamId: result.streamId,
         }),
         isError: false,
       };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.warn(
-        { err, meetingId: targetMeetingId, textLength: text.length },
-        "meet_speak tool failed",
-      );
-      if (err instanceof MeetSessionNotFoundError) {
-        return {
-          content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
-          isError: true,
-        };
-      }
-      return {
-        content: `Error: failed to speak into Meet — ${message}`,
-        isError: true,
-      };
-    }
-  }
+    },
+  };
 }
-
-class MeetCancelSpeakTool implements Tool {
-  name = "meet_cancel_speak";
-  description =
-    "Cancel any in-flight synthesized speech in an active Google Meet call so the assistant can voluntarily stop talking (e.g. when interrupted by a participant). When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.";
-  category = "meet";
-  // Low: cancelling the assistant's own audio output is strictly less
-  // invasive than speaking — no new sound is emitted, and idempotent
-  // when nothing is currently playing.
-  defaultRiskLevel = RiskLevel.Low;
-
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: "object",
-        properties: {
-          meetingId: {
-            type: "string",
-            description:
-              "The id of the meeting whose in-flight speech should be cancelled. Optional when exactly one session is active.",
-          },
-        },
-      },
-    };
-  }
-
-  async execute(
-    input: Record<string, unknown>,
-    _context: ToolContext,
-  ): Promise<ToolExecutionResult> {
-    // 1. Feature-flag gate.
-    const config = getConfig();
-    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
-      return {
-        content:
-          "Error: the meet feature is disabled. Enable the `meet` feature flag to manage Google Meet calls.",
-        isError: true,
-      };
-    }
-
-    // 2. Input validation. All fields are optional so a bare `{}` is valid;
-    //    Zod still catches wrong-type submissions.
-    const parsed = MeetCancelSpeakInputSchema.safeParse(input);
-    if (!parsed.success) {
-      const message =
-        parsed.error.issues[0]?.message ?? "invalid meet_cancel_speak input";
-      return { content: `Error: ${message}`, isError: true };
-    }
-    const { meetingId: explicitId } = parsed.data;
-
-    // 3. Disambiguate target session.
-    const target = resolveTargetMeetingId(explicitId);
-    if (!target.ok) {
-      return { content: target.content, isError: true };
-    }
-    const targetMeetingId = target.meetingId;
-
-    // 4. Delegate. `cancelSpeak` is idempotent when nothing is in flight.
-    try {
-      await MeetSessionManager.cancelSpeak(targetMeetingId);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.warn(
-        { err, meetingId: targetMeetingId },
-        "meet_cancel_speak tool failed",
-      );
-      if (err instanceof MeetSessionNotFoundError) {
-        return {
-          content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
-          isError: true,
-        };
-      }
-      return {
-        content: `Error: failed to cancel Meet speech — ${message}`,
-        isError: true,
-      };
-    }
-
-    return {
-      content: JSON.stringify({
-        cancelled: true,
-        meetingId: targetMeetingId,
-      }),
-      isError: false,
-    };
-  }
-}
-
-/** Exported singletons so the tool registry can re-register after test resets. */
-export const meetSpeakTool = new MeetSpeakTool();
-export const meetCancelSpeakTool = new MeetCancelSpeakTool();


### PR DESCRIPTION
## Summary
- Converts meet-join, meet-leave, meet-speak, meet-send-chat, and meet-avatar tool files from singleton exports to createXTool(host: SkillHost) factories.
- All 5 tool files now use host.config.*, host.logger.get, and contracts-package tool types; zero assistant/ imports.
- register.ts tool provider callback updated to invoke the factories.

Part of plan: skill-isolation.md (PR 14 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
