### PR TITLE
revert(cd): restore CRX upload to Chrome Web Store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,7 +298,16 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - name: Download extension zip
+      - name: Download extension CRX
+        id: download-crx
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        continue-on-error: true
+        with:
+          name: chrome-extension-crx
+          path: /tmp/chrome-extension
+
+      - name: Download extension zip (fallback)
+        if: steps.download-crx.outcome != 'success'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: chrome-extension-zip
@@ -314,8 +323,8 @@ jobs:
           CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
         run: |
-          # CWS Items API only accepts zip files, not signed CRX packages
-          UPLOAD_FILE=$(ls /tmp/chrome-extension/*.zip)
+          # Prefer signed CRX if available, fall back to zip
+          UPLOAD_FILE=$(ls /tmp/chrome-extension/*.crx 2>/dev/null || ls /tmp/chrome-extension/*.zip)
           echo "Uploading: $UPLOAD_FILE"
           chrome-webstore-upload upload \
             --source "$UPLOAD_FILE" \


### PR DESCRIPTION
## Summary

Reverts the upload-format change from #27302 which switched to ZIP-only uploads.

**Root cause:** [Verified CRX Uploads](https://developer.chrome.com/blog/verified-uploads-cws) is enabled for our extension, so CWS requires signed CRX packages. Uploading a ZIP produces `PKG_MUST_UPDATE_AS_CRX`.

The original failure that prompted #27302 was actually `ITEM_NOT_UPDATABLE` (extension stuck in "pending review" status), not a format issue. This restores the CRX-first-with-ZIP-fallback approach.

**Note:** The extension is currently stuck in pending review/ready-to-publish status in the CWS Developer Dashboard. Someone with dashboard access needs to publish or discard that pending submission before the next release will succeed — otherwise it will fail with `ITEM_NOT_UPDATABLE` again.

## Test plan
- [ ] Merge this PR
- [ ] Clear the stuck submission in the [Chrome Developer Dashboard](https://chrome.google.com/webstore/devconsole)
- [ ] Next release with chrome extension changes should upload the signed CRX successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
