### PR TITLE
test(conversation-abort): mock turn-commit + git-service to fix CI timeout

### DIFF
--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -93,6 +93,16 @@ mock.module("../security/secret-allowlist.js", () => ({
   resetAllowlist: () => {},
 }));
 
+mock.module("../workspace/turn-commit.js", () => ({
+  commitTurnChanges: async () => {},
+}));
+
+mock.module("../workspace/git-service.js", () => ({
+  getWorkspaceGitService: () => ({
+    ensureInitialized: async () => {},
+  }),
+}));
+
 // Track all messages persisted to DB
 let persistedMessages: Array<{ role: string; content: string }> = [];
 


### PR DESCRIPTION
## Summary
- Added mocks for `workspace/turn-commit.js` and `workspace/git-service.js` in `conversation-abort-tool-results.test.ts` so the post-turn `commitTurnChanges` race does not eat the 4s default `turnCommitMaxWaitMs` budget on CI's Linux runner.
- Matches the existing mock pattern in `conversation-agent-loop.test.ts`. Without these mocks, the first test timed out at 5s and its deferred `expect` ran after the second test had already reset `persistedMessages = []`, producing `Received: 0`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24856605029/job/72770971376

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
