### PR TITLE
feat(assistant): add ipcClassifyRisk typed helper for gateway classification

### DIFF
--- a/assistant/src/ipc/gateway-client.ts
+++ b/assistant/src/ipc/gateway-client.ts
@@ -11,6 +11,10 @@
 
 import { connect, type Socket } from "node:net";
 
+import type {
+  ClassificationResult,
+  ClassifyRiskParams,
+} from "../permissions/ipc-risk-types.js";
 import { getLogger } from "../util/logger.js";
 import { resolveIpcSocketPath } from "./socket-path.js";
 
@@ -400,6 +404,52 @@ export async function ipcGetFeatureFlags(): Promise<Record<string, boolean>> {
     return filtered;
   }
   return {};
+}
+
+/**
+ * Classify risk for a tool invocation via the gateway's persistent IPC
+ * connection.
+ *
+ * Uses `ipcCallPersistent` (not the one-shot `ipcCall`) because risk
+ * classification is on the hot path for every tool invocation and the
+ * persistent connection avoids per-call connect overhead.
+ *
+ * Returns `undefined` when the gateway is unreachable, the response is
+ * malformed, or the call fails for any reason — callers should fall back
+ * to local classification.
+ */
+export async function ipcClassifyRisk(
+  params: ClassifyRiskParams,
+): Promise<ClassificationResult | undefined> {
+  try {
+    const result = await ipcCallPersistent(
+      "classify_risk",
+      params as unknown as Record<string, unknown>,
+    );
+
+    // Validate the response has at minimum a `risk` field
+    if (!result || typeof result !== "object" || Array.isArray(result)) {
+      log.warn(
+        { result },
+        "ipcClassifyRisk: gateway returned non-object response",
+      );
+      return undefined;
+    }
+
+    const obj = result as Record<string, unknown>;
+    if (typeof obj.risk !== "string") {
+      log.warn(
+        { result },
+        "ipcClassifyRisk: gateway response missing 'risk' field",
+      );
+      return undefined;
+    }
+
+    return result as ClassificationResult;
+  } catch (err) {
+    log.warn({ err }, "ipcClassifyRisk: persistent IPC call failed");
+    return undefined;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/permissions/ipc-risk-types.ts
+++ b/assistant/src/permissions/ipc-risk-types.ts
@@ -1,0 +1,88 @@
+/**
+ * Types for gateway IPC risk classification.
+ *
+ * These types mirror the gateway's classify_risk IPC response shape
+ * (gateway/src/ipc/risk-classification-handlers.ts) and request parameters.
+ * Keep them in sync when the gateway response evolves.
+ */
+
+import type { AllowlistOption, ScopeOption } from "./types.js";
+
+// ── Dangerous pattern (mirrors gateway wire format) ─────────────────────────
+
+export interface DangerousPattern {
+  type: string;
+  description: string;
+  text: string;
+}
+
+// ── Gateway response type ───────────────────────────────────────────────────
+
+/**
+ * The response returned by the gateway's `classify_risk` IPC method.
+ *
+ * Mirrors the `ClassificationResult` in
+ * `gateway/src/ipc/risk-classification-handlers.ts`.
+ */
+export interface ClassificationResult {
+  risk: "low" | "medium" | "high" | "unknown";
+  reason: string;
+  matchType: "user_rule" | "registry" | "unknown";
+  scopeOptions: ScopeOption[];
+  allowlistOptions?: AllowlistOption[];
+  actionKeys?: string[];
+  commandCandidates?: string[];
+  dangerousPatterns?: DangerousPattern[];
+  opaqueConstructs?: boolean;
+  isComplexSyntax?: boolean;
+  sandboxAutoApprove?: boolean;
+}
+
+// ── Gateway request type ────────────────────────────────────────────────────
+
+/**
+ * File classifier context pre-resolved by the assistant and forwarded
+ * to the gateway so it can run file-risk classification without importing
+ * assistant-specific path helpers.
+ */
+export interface FileContext {
+  protectedDir: string;
+  hooksDir: string;
+  actorTokenSigningKeyPath: string;
+  skillSourceDirs: string[];
+}
+
+/**
+ * Skill metadata pre-resolved by the assistant and forwarded to the
+ * gateway for skill-load risk classification.
+ */
+export interface SkillMetadata {
+  skillId: string;
+  selector: string;
+  versionHash: string;
+  transitiveHash?: string;
+  hasInlineExpansions: boolean;
+  isDynamic: boolean;
+}
+
+/**
+ * Parameters for the `classify_risk` IPC request.
+ *
+ * Mirrors the Zod schema in
+ * `gateway/src/ipc/risk-classification-handlers.ts`.
+ */
+export interface ClassifyRiskParams {
+  tool: string;
+  command?: string;
+  url?: string;
+  path?: string;
+  skill?: string;
+  mode?: string;
+  script?: string;
+  workingDir?: string;
+  allowPrivateNetwork?: boolean;
+  networkMode?: string;
+  isContainerized?: boolean;
+  fileContext?: FileContext;
+  skillMetadata?: SkillMetadata;
+}


### PR DESCRIPTION
## Summary
- Create ipc-risk-types.ts with ClassificationResult and ClassifyRiskParams types
- Add ipcClassifyRisk() helper using persistent IPC connection
- Response validation with warnings on malformed gateway responses

Part of plan: move-risk-pipeline-to-gateway.md (PR 8 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
