### PR TITLE
ci: verify meet-join manifest emission in release workflows

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -145,6 +145,14 @@ jobs:
           path: assistant/.test-durations
           key: test-durations-${{ github.run_id }}
 
+      # Smoke-run the meet-join manifest emitter so an assistant-side
+      # change that breaks the `SkillHost` contract or `register(host)`
+      # fails here instead of only at Docker-build or macOS-packaging
+      # time. Skill-only changes are covered by pr-skills.yaml via
+      # __tests__/emit-manifest.test.ts.
+      - name: Smoke test meet-join manifest emit
+        run: cd .. && bun run skills/meet-join/scripts/emit-manifest.ts --output /tmp/meet-join-manifest.json
+
   openapi-check:
     name: OpenAPI Spec Check
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -137,6 +137,14 @@ jobs:
           EXCLUDE_EXPERIMENTAL: 'true'
           TEST_WORKERS: '8'
 
+      # Smoke-run the meet-join manifest emitter so an assistant-side
+      # change that breaks the `SkillHost` contract or `register(host)`
+      # fails here instead of only at Docker-build or macOS-packaging
+      # time. Skill-only changes are covered by pr-skills.yaml via
+      # __tests__/emit-manifest.test.ts.
+      - name: Smoke test meet-join manifest emit
+        run: cd .. && bun run skills/meet-join/scripts/emit-manifest.ts --output /tmp/meet-join-manifest.json
+
   artifact:
     name: Upload Artifact
     needs: [lint, typecheck, test]


### PR DESCRIPTION
## Summary
- Adds a CI smoke step that runs skills/meet-join/scripts/emit-manifest.ts so regressions in register() fail early.
- Reviews release workflows to confirm the manifest is embedded in each artifact that needs it (Docker image, macOS .app).
- Any new uses: steps pinned to 40-char SHAs per the repo rule.

Part of plan: skill-isolation.md (PR 30 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
