### PR TITLE
feat(schedule): add `wake_conversation_id` column to `cron_jobs`

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -147,6 +147,7 @@ import {
   migrateScheduleQuietFlag,
   migrateScheduleReuseConversation,
   migrateScheduleScriptColumn,
+  migrateScheduleWakeConversationId,
   migrateSchemaIndexesAndColumns,
   migrateScrubCorruptedImageAttachments,
   migrateStripIntegrationPrefixFromProviderKeys,
@@ -380,6 +381,7 @@ export function initializeDb(): void {
     migrateStripPlaceholderSentinelsFromMessages,
     migrateOAuthProvidersManagedServiceIsPaid,
     migrateOAuthProvidersAvailableScopes,
+    migrateScheduleWakeConversationId,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/226-schedule-wake-conversation-id.ts
+++ b/assistant/src/memory/migrations/226-schedule-wake-conversation-id.ts
@@ -1,0 +1,11 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateScheduleWakeConversationId(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(`ALTER TABLE cron_jobs ADD COLUMN wake_conversation_id TEXT`);
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -171,6 +171,7 @@ export { migrateStripPlaceholderSentinelsFromMessages } from "./222-strip-placeh
 export { migrateScheduleScriptColumn } from "./223-schedule-script-column.js";
 export { migrateOAuthProvidersManagedServiceIsPaid } from "./224-oauth-providers-managed-service-is-paid.js";
 export { migrateOAuthProvidersAvailableScopes } from "./225-oauth-providers-available-scopes.js";
+export { migrateScheduleWakeConversationId } from "./226-schedule-wake-conversation-id.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -29,6 +29,7 @@ export const cronJobs = sqliteTable("cron_jobs", {
     .notNull()
     .default(false), // reuse the same conversation across runs
   script: text("script"), // shell command for script mode (nullable, only used when mode = 'script')
+  wakeConversationId: text("wake_conversation_id"), // target conversation for wake mode (nullable)
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -145,6 +145,7 @@ export function createSchedule(params: {
     timezone,
     message: params.message,
     script: params.script ?? null,
+    wakeConversationId: null as string | null,
     nextRunAt,
     lastRunAt: null as number | null,
     lastStatus: null as string | null,


### PR DESCRIPTION
## Summary
- Add nullable `wake_conversation_id` TEXT column to `cron_jobs` table (Drizzle schema + SQLite migration)
- Register migration in both `index.ts` and `db-init.ts`

Part of plan: conv-defer.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
