### PR TITLE
feat(schedule): add `wake` mode, `wakeConversationId`, and list filters to schedule store

### DIFF
--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -972,6 +972,123 @@ describe("listSchedules filters", () => {
   });
 });
 
+// ── Wake mode ───────────────────────────────────────────────────────
+
+describe("createSchedule (wake mode)", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  test("creates a wake schedule with wakeConversationId", () => {
+    const job = createSchedule({
+      name: "Wake conv",
+      message: "resume conversation",
+      nextRunAt: Date.now() + 60_000,
+      mode: "wake",
+      wakeConversationId: "conv-123",
+    });
+
+    expect(job.mode).toBe("wake");
+    expect(job.wakeConversationId).toBe("conv-123");
+    expect(job.status).toBe("active");
+
+    const retrieved = getSchedule(job.id);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.wakeConversationId).toBe("conv-123");
+  });
+
+  test("throws when creating wake schedule without wakeConversationId", () => {
+    expect(() =>
+      createSchedule({
+        name: "Bad wake",
+        message: "no conv id",
+        nextRunAt: Date.now() + 60_000,
+        mode: "wake",
+      }),
+    ).toThrow("Wake schedules require wakeConversationId");
+  });
+});
+
+// ── listSchedules new filters ───────────────────────────────────────
+
+describe("listSchedules new filters", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  test("mode filter returns only schedules with matching mode", () => {
+    createSchedule({
+      name: "Execute schedule",
+      message: "execute",
+      nextRunAt: Date.now() + 60_000,
+      mode: "execute",
+    });
+    createSchedule({
+      name: "Wake schedule",
+      message: "wake",
+      nextRunAt: Date.now() + 60_000,
+      mode: "wake",
+      wakeConversationId: "conv-abc",
+    });
+
+    const wakeOnly = listSchedules({ mode: "wake" });
+    expect(wakeOnly.length).toBe(1);
+    expect(wakeOnly[0].name).toBe("Wake schedule");
+    expect(wakeOnly[0].mode).toBe("wake");
+  });
+
+  test("createdBy filter returns only schedules with matching creator", () => {
+    createSchedule({
+      name: "Agent schedule",
+      message: "by agent",
+      nextRunAt: Date.now() + 60_000,
+      createdBy: "agent",
+    });
+    createSchedule({
+      name: "Defer schedule",
+      message: "by defer",
+      nextRunAt: Date.now() + 60_000,
+      createdBy: "defer",
+    });
+
+    const deferOnly = listSchedules({ createdBy: "defer" });
+    expect(deferOnly.length).toBe(1);
+    expect(deferOnly[0].name).toBe("Defer schedule");
+    expect(deferOnly[0].createdBy).toBe("defer");
+  });
+
+  test("conversationId filter returns only wakes targeting that conversation", () => {
+    createSchedule({
+      name: "Wake for conv-123",
+      message: "wake conv-123",
+      nextRunAt: Date.now() + 60_000,
+      mode: "wake",
+      wakeConversationId: "conv-123",
+    });
+    createSchedule({
+      name: "Wake for conv-456",
+      message: "wake conv-456",
+      nextRunAt: Date.now() + 60_000,
+      mode: "wake",
+      wakeConversationId: "conv-456",
+    });
+    createSchedule({
+      name: "Regular schedule",
+      message: "no wake",
+      nextRunAt: Date.now() + 60_000,
+    });
+
+    const conv123Only = listSchedules({ conversationId: "conv-123" });
+    expect(conv123Only.length).toBe(1);
+    expect(conv123Only[0].name).toBe("Wake for conv-123");
+    expect(conv123Only[0].wakeConversationId).toBe("conv-123");
+  });
+});
+
 // ── describeCronExpression ──────────────────────────────────────────
 
 describe("describeCronExpression", () => {

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -14,7 +14,7 @@ import type { ScheduleSyntax } from "./recurrence-types.js";
 
 const logger = getLogger("schedule-store");
 
-export type ScheduleMode = "notify" | "execute" | "script";
+export type ScheduleMode = "notify" | "execute" | "script" | "wake";
 export type RoutingIntent = "single_channel" | "multi_channel" | "all_channels";
 export type ScheduleStatus = "active" | "firing" | "fired" | "cancelled";
 
@@ -28,6 +28,7 @@ export interface ScheduleJob {
   timezone: string | null;
   message: string;
   script: string | null;
+  wakeConversationId: string | null;
   nextRunAt: number;
   lastRunAt: number | null;
   lastStatus: string | null;
@@ -87,6 +88,7 @@ export function createSchedule(params: {
   timezone?: string | null;
   message: string;
   script?: string | null;
+  wakeConversationId?: string | null;
   enabled?: boolean;
   createdBy?: string;
   syntax?: ScheduleSyntax;
@@ -114,6 +116,10 @@ export function createSchedule(params: {
     if (!isValidScheduleExpression(spec)) {
       throw new Error(`Invalid ${syntax} expression: "${expression}"`);
     }
+  }
+
+  if (params.mode === "wake" && !params.wakeConversationId) {
+    throw new Error("Wake schedules require wakeConversationId");
   }
 
   const db = getDb();
@@ -145,7 +151,7 @@ export function createSchedule(params: {
     timezone,
     message: params.message,
     script: params.script ?? null,
-    wakeConversationId: null as string | null,
+    wakeConversationId: params.wakeConversationId ?? null,
     nextRunAt,
     lastRunAt: null as number | null,
     lastStatus: null as string | null,
@@ -192,6 +198,9 @@ export function listSchedules(options?: {
   enabledOnly?: boolean;
   oneShotOnly?: boolean;
   recurringOnly?: boolean;
+  mode?: ScheduleMode;
+  createdBy?: string;
+  conversationId?: string;
 }): ScheduleJob[] {
   const db = getDb();
   const conditions = [];
@@ -203,6 +212,17 @@ export function listSchedules(options?: {
   }
   if (options?.recurringOnly) {
     conditions.push(sql`${scheduleJobs.cronExpression} IS NOT NULL`);
+  }
+  if (options?.mode) {
+    conditions.push(eq(scheduleJobs.mode, options.mode));
+  }
+  if (options?.createdBy) {
+    conditions.push(eq(scheduleJobs.createdBy, options.createdBy));
+  }
+  if (options?.conversationId) {
+    conditions.push(
+      eq(scheduleJobs.wakeConversationId, options.conversationId),
+    );
   }
   const where = conditions.length > 0 ? and(...conditions) : undefined;
   const rows = db
@@ -784,6 +804,7 @@ function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
     timezone: row.timezone,
     message: row.message,
     script: row.script ?? null,
+    wakeConversationId: row.wakeConversationId ?? null,
     nextRunAt: row.nextRunAt,
     lastRunAt: row.lastRunAt,
     lastStatus: row.lastStatus,


### PR DESCRIPTION
## Summary
- Add `wake` to `ScheduleMode` type and `wakeConversationId` to `ScheduleJob` interface
- Add validation: wake schedules require `wakeConversationId`
- Extend `listSchedules` with `mode`, `createdBy`, and `conversationId` filters
- Add tests for all new functionality

Part of plan: conv-defer.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
