### PR TITLE
fix(cd): upgrade macOS runners to macos-26 and add actool fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1358,7 +1358,7 @@ jobs:
   # for its sibling TestFlight publish.
   build-macos-arm64:
     needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 45
     defaults:
       run:
@@ -1733,7 +1733,7 @@ jobs:
   # Runs in parallel with build-macos-arm64 and does NOT block the release job.
   build-macos-x64:
     needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 45
     continue-on-error: true
     defaults:

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1489,13 +1489,11 @@ if [ -d "$XCASSETS" ]; then
     if [ -d "$APP_ICON" ]; then
         ACTOOL_INPUTS+=("$APP_ICON")
     fi
-    # Capture actool output; a non-zero exit is only a real failure if
-    # Assets.car was not produced. On GitHub-hosted macOS runners actool's
-    # AssetCatalogAgent-AssetRuntime subprocess occasionally crashes (dyld
-    # symbol mismatches against AVFCore / CoreMedia, IBPlatformToolFailure-
-    # Exception). Sometimes Assets.car is written before the crash and we
-    # can continue; sometimes the crash happens early and no output is
-    # produced. Retry a few times to absorb the flaky early-crash case.
+    # Compile the asset catalog. Retry on transient actool crashes
+    # (AssetCatalogAgent-AssetRuntime can segfault on some runner images).
+    # If the .icon bundle causes persistent failures, fall back to
+    # compiling the .xcassets alone — the .icns generation below handles
+    # Finder/DMG icons independently.
     ACTOOL_MAX_ATTEMPTS=3
     ACTOOL_SUCCESS=0
     for attempt in $(seq 1 $ACTOOL_MAX_ATTEMPTS); do
@@ -1517,8 +1515,24 @@ if [ -d "$XCASSETS" ]; then
         fi
         echo "actool attempt $attempt/$ACTOOL_MAX_ATTEMPTS failed without producing Assets.car; retrying."
     done
+    if [ "$ACTOOL_SUCCESS" != "1" ] && [ "${#ACTOOL_INPUTS[@]}" -gt 1 ]; then
+        echo "actool failed with .icon bundle; retrying with .xcassets only."
+        rm -f "$RESOURCES_DIR/Assets.car"
+        if xcrun actool "$XCASSETS" \
+            --compile "$RESOURCES_DIR" \
+            --platform macosx \
+            --minimum-deployment-target 14.0 \
+            --app-icon AppIcon \
+            --output-partial-info-plist /dev/null \
+            2>&1; then
+            ACTOOL_SUCCESS=1
+        elif [ -f "$RESOURCES_DIR/Assets.car" ]; then
+            echo "actool (.xcassets-only) exited non-zero but Assets.car was produced; continuing."
+            ACTOOL_SUCCESS=1
+        fi
+    fi
     if [ "$ACTOOL_SUCCESS" != "1" ]; then
-        echo "actool failed to produce Assets.car after $ACTOOL_MAX_ATTEMPTS attempts:"
+        echo "actool failed to produce Assets.car after all attempts:"
         echo "$ACTOOL_OUTPUT"
         exit 1
     fi


### PR DESCRIPTION
## Summary
- Upgrade `build-macos-arm64` and `build-macos-x64` runners from `macos-15` to `macos-26` — Xcode 26's `actool` crashes on macOS 15 due to missing symbols in system frameworks (`CoreMedia`, `AVFCore`)
- Add a `.xcassets`-only fallback in `build.sh` — if actool fails all 3 retries with the `.icon` bundle, re-attempt without it so the build never breaks over the Liquid Glass icon

## Context
The CD release workflow [failed](https://github.com/vellum-ai/vellum-assistant/actions/runs/24855385754/job/72772933226) on `release/v0.6.6` because `actool`'s `AssetCatalogAgent-AssetRuntime` subprocess crashes with `IBPlatformToolFailureException` when running on a `macos-15` host despite having Xcode 26.2 selected. The dyld symbol mismatches are between Xcode 26's toolchain and macOS 15's system frameworks.

## Test plan
- [ ] Verify `macos-26` runners are available and the build succeeds
- [ ] Confirm the `.xcassets`-only fallback path works if triggered (logged as "actool failed with .icon bundle; retrying with .xcassets only.")
- [ ] Cherry-pick to `release/v0.6.6` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
