### PR TITLE
feat(schedule): exclude `createdBy: 'defer'` from default schedule list

### DIFF
--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -164,6 +164,108 @@ describe("schedule run-now trust propagation", () => {
   });
 });
 
+// ── GET /schedules — exclude_created_by filtering ─────────────────────────
+
+function getListHandler() {
+  const route = scheduleRouteDefinitions({
+    sendMessageDeps: {} as never,
+  }).find(
+    (candidate) =>
+      candidate.endpoint === "schedules" && candidate.method === "GET",
+  );
+  if (!route) throw new Error("List schedules route not found");
+  return route.handler;
+}
+
+async function callListHandler(
+  excludeCreatedBy?: string,
+): Promise<{ status: number; body: { schedules: Array<{ id: string }> } }> {
+  const handler = getListHandler();
+  const suffix = excludeCreatedBy
+    ? `?exclude_created_by=${excludeCreatedBy}`
+    : "";
+  const urlStr = `http://localhost/v1/schedules${suffix}`;
+  const response = await handler({
+    req: new Request(urlStr),
+    url: new URL(urlStr),
+    server: {} as never,
+    authContext: {} as never,
+    params: {},
+  });
+  return {
+    status: response.status,
+    body: (await response.json()) as { schedules: Array<{ id: string }> },
+  };
+}
+
+describe("GET /schedules — exclude_created_by filtering", () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  test("returns all schedules when no exclude_created_by param", async () => {
+    createSchedule({
+      name: "Agent schedule",
+      cronExpression: "* * * * *",
+      message: "hello",
+      syntax: "cron",
+    });
+    createSchedule({
+      name: "Deferred wake",
+      cronExpression: "0 9 * * *",
+      message: "wake up",
+      syntax: "cron",
+      createdBy: "defer",
+    });
+
+    const { status, body } = await callListHandler();
+    expect(status).toBe(200);
+    expect(body.schedules).toHaveLength(2);
+  });
+
+  test("filters out deferred wakes when exclude_created_by=defer", async () => {
+    createSchedule({
+      name: "Agent schedule",
+      cronExpression: "* * * * *",
+      message: "hello",
+      syntax: "cron",
+    });
+    const deferred = createSchedule({
+      name: "Deferred wake",
+      cronExpression: "0 9 * * *",
+      message: "wake up",
+      syntax: "cron",
+      createdBy: "defer",
+    });
+
+    const { status, body } = await callListHandler("defer");
+    expect(status).toBe(200);
+    expect(body.schedules).toHaveLength(1);
+    expect(body.schedules.every((s) => s.id !== deferred.id)).toBe(true);
+  });
+
+  test("returns empty list when all schedules match exclusion", async () => {
+    createSchedule({
+      name: "Deferred 1",
+      cronExpression: "* * * * *",
+      message: "a",
+      syntax: "cron",
+      createdBy: "defer",
+    });
+    createSchedule({
+      name: "Deferred 2",
+      cronExpression: "0 9 * * *",
+      message: "b",
+      syntax: "cron",
+      createdBy: "defer",
+    });
+
+    const { status, body } = await callListHandler("defer");
+    expect(status).toBe(200);
+    expect(body.schedules).toHaveLength(0);
+  });
+});
+
 // ── schedules/:id/runs limit handling ─────────────────────────────────────
 
 function getRunsHandler() {
@@ -171,8 +273,7 @@ function getRunsHandler() {
     sendMessageDeps: {} as never,
   }).find(
     (candidate) =>
-      candidate.endpoint === "schedules/:id/runs" &&
-      candidate.method === "GET",
+      candidate.endpoint === "schedules/:id/runs" && candidate.method === "GET",
   );
   if (!route) throw new Error("Runs schedule route not found");
   return route.handler;

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -36,10 +36,13 @@ const SCHEDULE_GUARDIAN_TRUST_CONTEXT = {
 // Handlers
 // ---------------------------------------------------------------------------
 
-function handleListSchedules(): Response {
+function handleListSchedules(excludeCreatedBy?: string): Response {
   const jobs = listSchedules();
+  const filtered = excludeCreatedBy
+    ? jobs.filter((j) => j.createdBy !== excludeCreatedBy)
+    : jobs;
   return Response.json({
-    schedules: jobs.map((j) => ({
+    schedules: filtered.map((j) => ({
       id: j.id,
       name: j.name,
       enabled: j.enabled,
@@ -391,7 +394,11 @@ export function scheduleRouteDefinitions(deps: {
       responseBody: z.object({
         schedules: z.array(z.unknown()).describe("Schedule objects"),
       }),
-      handler: () => handleListSchedules(),
+      handler: ({ url }) => {
+        const excludeCreatedBy =
+          url.searchParams.get("exclude_created_by") ?? undefined;
+        return handleListSchedules(excludeCreatedBy);
+      },
     },
     {
       endpoint: "schedules/:id/runs",

--- a/clients/shared/Network/ScheduleClient.swift
+++ b/clients/shared/Network/ScheduleClient.swift
@@ -34,7 +34,7 @@ public struct ScheduleClient: ScheduleClientProtocol {
 
     public func fetchSchedulesList() async throws -> [ScheduleItem] {
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/schedules", timeout: 10
+            path: "assistants/{assistantId}/schedules?exclude_created_by=defer", timeout: 10
         )
         guard response.isSuccess else {
             log.error("fetchSchedulesList failed (HTTP \(response.statusCode))")


### PR DESCRIPTION
## Summary
- Add `exclude_created_by` query param support to GET /schedules
- Filter deferred wakes from Settings UI schedule list by default (Swift client sends `?exclude_created_by=defer`)
- Non-list handlers continue to return the full list
- Add tests for filtering behavior

Part of plan: conv-defer.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
