### PR TITLE
[codex] Clarify managed Google OAuth skill routing

### DIFF
--- a/skills/vellum-oauth-integrations/SKILL.md
+++ b/skills/vellum-oauth-integrations/SKILL.md
@@ -84,6 +84,18 @@ You can update which mode a given provider should use with:
 assistant oauth mode <provider-key> --set "managed"|"your-own"
 ```
 
+## Choosing the Right Flow
+
+Always determine the provider's supported modes and current mode before reading deeper references.
+
+1. Run `assistant oauth providers get <provider-key>` and `assistant oauth mode <provider-key>`.
+2. If the provider is already set to `managed`, stay on the managed path:
+   - use `references/CONNECTING_ACCOUNTS.md` to connect the account
+   - do **not** send the user into app-registration or credential-setup docs
+   - do **not** switch to `your-own` unless the user explicitly asks for that tradeoff or managed mode is unavailable
+3. If the provider is set to `your-own`, use `references/CONFIGURING_APPLICATIONS.md`, then any relevant `references/provider-app-setups/<provider>.md` guide.
+4. Treat `references/provider-app-setups/<provider>.md` as bring-your-own setup guides unless the file explicitly says otherwise.
+
 # Reference
 
 For detailed information on the following topics, see the reference files:

--- a/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
+++ b/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
@@ -23,6 +23,11 @@ assistant oauth apps list --provider-key <provider-key>
 
 If there are none, they will either need to opt in to using "managed" mode or they will need to create an OAuth app (see [Configuring a New OAuth Application](CONFIGURING_APPLICATIONS.md)).
 
+## Which References Apply
+
+- If the provider is set to `managed`, stay in this document. Do **not** jump into `CONFIGURING_APPLICATIONS.md` or `provider-app-setups/<provider>.md` to invent an app-registration flow.
+- Only use `provider-app-setups/<provider>.md` when the provider is set to `your-own` and you need instructions for creating the user's OAuth app.
+
 ## Initiating the Connection
 
 To actually initiate a connection with the OAuth provider, run:
@@ -33,7 +38,15 @@ assistant oauth connect <provider-key>
 
 **Tip:** You can optionally specify scopes using the `--scopes` flag. This is useful if you know ahead of time what your user is trying to accomplish and want to request the bare minimum scopes needed to accomplish the task at hand.
 
-If the provider-specific setup skill gives its own browser handoff instructions, follow those instead of the default browser behavior. Google bring-your-own setup on the macOS desktop app is one example: request the auth URL with `--no-browser`, then open it using the provider skill's AppleScript/browser handoff rules.
+### Google on macOS desktop
+
+On the macOS desktop app, Google consent should use a Chrome handoff instead of the default browser opener:
+
+1. Run `assistant oauth connect google --no-browser`.
+2. Open the returned authorization URL in the user's existing Google Chrome session.
+3. Never use browser automation or computer-use for the Google consent screen.
+
+This Chrome handoff rule applies when connecting Google in either `managed` or `your-own` mode. Creating Google Cloud credentials is still a `your-own`-only flow.
 
 This will open a new web browser tab where the user can log in to the third-party provider. Upon success, they should be redirected to a confirmation page and told that it's safe to close the browser tab and come back here.
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/google.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/google.md
@@ -1,6 +1,8 @@
-You are helping your user set up Google Cloud OAuth credentials so Gmail and Google Calendar integrations can connect.
+You are helping your user set up Google Cloud OAuth credentials for Google in `your-own` mode so Gmail and Google Calendar integrations can connect.
 
 The included `vellum-oauth-integrations` skill handles the generic parts of the flow (credential collection, app registration, connection, and verification). This file defines only the Google-specific steps.
+
+**Important:** This file is for `your-own` Google setup only. If `assistant oauth mode google` returns `managed`, stop here and use `references/CONNECTING_ACCOUNTS.md` instead. Do not send the user into Google Cloud Console in managed mode.
 
 ## Provider Details
 
@@ -35,7 +37,7 @@ host_bash:
 
 Replace `TARGET_URL` with the actual URL for that step. The point of Path A is to keep the flow in the user's real Chrome profile and avoid automated-browser rejections.
 
-## Google-Specific Flow
+## Google-Specific Flow for Your-Own Mode
 
 The flow has 9 steps total, takes about 3-5 minutes.
 
@@ -190,12 +192,13 @@ Follow the `vellum-oauth-integrations` workflow to collect credentials, register
 
 Google-specific override for macOS desktop app:
 
-1. Before app registration, check the provider mode and set it to `your-own` if needed with `assistant oauth mode google --set your-own`.
-2. Register the OAuth app normally via `assistant oauth apps upsert`.
-3. For authorization, do **not** use the default browser behavior.
-4. Instead, run `assistant oauth connect google --no-browser` so the command returns the authorization URL.
-5. Open that returned authorization URL in Google Chrome using the same `host_bash` + `osascript` pattern as every other `Open:` step in this skill.
-6. Never use browser automation or computer-use for the Google consent screen.
+1. This file assumes the user has already chosen `your-own` mode. If Google is still set to `managed`, only switch it after the user explicitly asks for `your-own` or managed mode is unavailable.
+2. If needed, set the mode with `assistant oauth mode google --set your-own`.
+3. Register the OAuth app normally via `assistant oauth apps upsert`.
+4. For authorization, do **not** use the default browser behavior.
+5. Instead, run `assistant oauth connect google --no-browser` so the command returns the authorization URL.
+6. Open that returned authorization URL in Google Chrome using the same `host_bash` + `osascript` pattern as every other `Open:` step in this skill.
+7. Never use browser automation or computer-use for the Google consent screen.
 
 > I'll start the Google authorization flow now.
 >


### PR DESCRIPTION
## Summary
- route managed providers through the generic connect flow before consulting provider-specific app setup docs
- document the Google macOS managed connect path in `CONNECTING_ACCOUNTS.md`
- mark `provider-app-setups/google.md` as a bring-your-own-only guide

## Why
The current skill stack explains that managed mode is preferred when supported, but the Google provider reference is written as a Google Cloud Console setup guide and explicitly tells the agent to switch to `your-own`. In the captured Gmail setup run, the agent loaded the generic OAuth skill, correctly detected that Google was already `managed`, then still opened the Google-specific guide and let that more specific document bias it toward a BYO interpretation.

## Impact
Managed Google setup should stay on the simple connect flow on macOS desktop, while the Chrome handoff rule remains documented for both modes.

## Validation
- inspected the exported agent trace from the failing Gmail setup run
- manually reviewed the updated skill routing and reference boundaries
