### PR TITLE
feat(ipc): add `defer_create`, `defer_list`, `defer_cancel` IPC routes

### DIFF
--- a/assistant/src/ipc/routes/defer.ts
+++ b/assistant/src/ipc/routes/defer.ts
@@ -1,0 +1,137 @@
+import { z } from "zod";
+
+import {
+  cancelSchedule,
+  createSchedule,
+  listSchedules,
+} from "../../schedule/schedule-store.js";
+import type { IpcRoute } from "../cli-server.js";
+
+// ---------------------------------------------------------------------------
+// defer_create
+// ---------------------------------------------------------------------------
+
+const DeferCreateParams = z
+  .object({
+    conversationId: z.string().min(1),
+    hint: z.string().min(1),
+    delaySeconds: z.number().optional(),
+    fireAt: z.number().optional(),
+    name: z.string().optional(),
+  })
+  .refine((p) => p.delaySeconds != null || p.fireAt != null, {
+    message: "Either delaySeconds or fireAt must be provided",
+  });
+
+const deferCreateRoute: IpcRoute = {
+  method: "defer_create",
+  handler: async (params) => {
+    const { conversationId, hint, delaySeconds, fireAt, name } =
+      DeferCreateParams.parse(params);
+
+    const resolvedFireAt = fireAt ?? Date.now() + delaySeconds! * 1000;
+
+    const job = createSchedule({
+      name: name ?? "Deferred wake",
+      message: hint,
+      mode: "wake",
+      wakeConversationId: conversationId,
+      nextRunAt: resolvedFireAt,
+      quiet: true,
+      createdBy: "defer",
+    });
+
+    return {
+      id: job.id,
+      name: job.name,
+      fireAt: resolvedFireAt,
+      conversationId,
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// defer_list
+// ---------------------------------------------------------------------------
+
+const DeferListParams = z.object({
+  conversationId: z.string().optional(),
+});
+
+const deferListRoute: IpcRoute = {
+  method: "defer_list",
+  handler: async (params) => {
+    const { conversationId } = DeferListParams.parse(params ?? {});
+
+    const jobs = listSchedules({
+      mode: "wake",
+      createdBy: "defer",
+      conversationId,
+    });
+
+    const active = jobs.filter(
+      (j) => j.status === "active" || j.status === "firing",
+    );
+
+    return {
+      defers: active.map((j) => ({
+        id: j.id,
+        name: j.name,
+        hint: j.message,
+        conversationId: j.wakeConversationId,
+        fireAt: j.nextRunAt,
+        status: j.status,
+      })),
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// defer_cancel
+// ---------------------------------------------------------------------------
+
+const DeferCancelParams = z.object({
+  id: z.string().optional(),
+  all: z.boolean().optional(),
+  conversationId: z.string().optional(),
+});
+
+const deferCancelRoute: IpcRoute = {
+  method: "defer_cancel",
+  handler: async (params) => {
+    const { id, all, conversationId } = DeferCancelParams.parse(params);
+
+    if (id) {
+      const ok = cancelSchedule(id);
+      return { cancelled: ok ? 1 : 0 };
+    }
+
+    if (all) {
+      const jobs = listSchedules({
+        mode: "wake",
+        createdBy: "defer",
+        conversationId,
+      });
+
+      let count = 0;
+      for (const j of jobs) {
+        if (j.status === "active" || j.status === "firing") {
+          if (cancelSchedule(j.id)) count++;
+        }
+      }
+      return { cancelled: count };
+    }
+
+    throw new Error("Either 'id' or 'all' must be provided to defer_cancel");
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const deferRoutes: IpcRoute[] = [
+  deferCreateRoute,
+  deferListRoute,
+  deferCancelRoute,
+];

--- a/assistant/src/ipc/routes/index.ts
+++ b/assistant/src/ipc/routes/index.ts
@@ -2,6 +2,7 @@ import type { IpcRoute } from "../cli-server.js";
 import { attachmentRoutes } from "./attachment.js";
 import { browserExecuteRoute } from "./browser.js";
 import { cacheRoutes } from "./cache.js";
+import { deferRoutes } from "./defer.js";
 import { getContactRoute } from "./get-contact.js";
 import { listClientsRoute } from "./list-clients.js";
 import { mergeContactsRoute } from "./merge-contacts.js";
@@ -19,6 +20,7 @@ import { watcherRoutes } from "./watcher.js";
 export const cliIpcRoutes: IpcRoute[] = [
   ...attachmentRoutes,
   browserExecuteRoute,
+  ...deferRoutes,
   getContactRoute,
   listClientsRoute,
   mergeContactsRoute,


### PR DESCRIPTION
## Summary
- Add three new IPC routes for deferred wake management
- `defer_create`: creates a wake schedule targeting a conversation
- `defer_list`: lists active/firing deferred wakes
- `defer_cancel`: cancels single or all pending wakes
- Register routes in IPC index

Part of plan: conv-defer.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
