### PR TITLE
feat(schedule): accept `wake` mode in HTTP schedule routes and daemon message types

### DIFF
--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -171,8 +171,7 @@ function getRunsHandler() {
     sendMessageDeps: {} as never,
   }).find(
     (candidate) =>
-      candidate.endpoint === "schedules/:id/runs" &&
-      candidate.method === "GET",
+      candidate.endpoint === "schedules/:id/runs" && candidate.method === "GET",
   );
   if (!route) throw new Error("Runs schedule route not found");
   return route.handler;
@@ -288,5 +287,99 @@ describe("schedule runs list — limit handling", () => {
     const { status, body } = await callRunsHandler(job.id, "2.7");
     expect(status).toBe(200);
     expect((body as { runs: unknown[] }).runs).toHaveLength(2);
+  });
+});
+
+// ── Wake mode support ─────────────────────────────────────────────────────
+
+function getPatchHandler() {
+  const route = scheduleRouteDefinitions({
+    sendMessageDeps: {} as never,
+  }).find(
+    (candidate) =>
+      candidate.endpoint === "schedules/:id" && candidate.method === "PATCH",
+  );
+  if (!route) throw new Error("PATCH schedule route not found");
+  return route.handler;
+}
+
+function getListHandler() {
+  const route = scheduleRouteDefinitions({
+    sendMessageDeps: {} as never,
+  }).find(
+    (candidate) =>
+      candidate.endpoint === "schedules" && candidate.method === "GET",
+  );
+  if (!route) throw new Error("GET schedules route not found");
+  return route.handler;
+}
+
+describe("wake mode in schedule routes", () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  test("PATCH accepts 'wake' as a valid mode", async () => {
+    const schedule = createSchedule({
+      name: "Wake test",
+      cronExpression: "* * * * *",
+      message: "check deferred",
+      syntax: "cron",
+    });
+
+    const handler = getPatchHandler();
+    const urlStr = `http://localhost/v1/schedules/${schedule.id}`;
+    const response = await handler({
+      req: new Request(urlStr, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "wake", wakeConversationId: "conv-xyz" }),
+      }),
+      url: new URL(urlStr),
+      server: {} as never,
+      authContext: {} as never,
+      params: { id: schedule.id },
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      schedules: Array<{
+        id: string;
+        mode: string;
+        wakeConversationId: string | null;
+      }>;
+    };
+    const updated = body.schedules.find((s) => s.id === schedule.id);
+    expect(updated).toBeDefined();
+    expect(updated!.mode).toBe("wake");
+    expect(updated!.wakeConversationId).toBe("conv-xyz");
+  });
+
+  test("list schedules includes wakeConversationId", async () => {
+    createSchedule({
+      name: "Wake schedule",
+      cronExpression: "0 9 * * *",
+      message: "morning wake",
+      syntax: "cron",
+      mode: "wake",
+      wakeConversationId: "conv-abc",
+    });
+
+    const handler = getListHandler();
+    const response = await handler({
+      req: new Request("http://localhost/v1/schedules"),
+      url: new URL("http://localhost/v1/schedules"),
+      server: {} as never,
+      authContext: {} as never,
+      params: {},
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      schedules: Array<{ name: string; wakeConversationId: string | null }>;
+    };
+    const wakeSchedule = body.schedules.find((s) => s.name === "Wake schedule");
+    expect(wakeSchedule).toBeDefined();
+    expect(wakeSchedule!.wakeConversationId).toBe("conv-abc");
   });
 });

--- a/assistant/src/daemon/message-types/schedules.ts
+++ b/assistant/src/daemon/message-types/schedules.ts
@@ -84,6 +84,7 @@ export interface SchedulesListResponse {
     status: string;
     routingIntent: string;
     reuseConversation: boolean;
+    wakeConversationId: string | null;
     isOneShot: boolean;
   }>;
 }

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -60,6 +60,7 @@ function handleListSchedules(): Response {
       status: j.status,
       routingIntent: j.routingIntent,
       reuseConversation: j.reuseConversation,
+      wakeConversationId: j.wakeConversationId,
       isOneShot: j.cronExpression == null,
     })),
   });
@@ -111,7 +112,7 @@ function handleCancelSchedule(id: string): Response {
   return handleListSchedules();
 }
 
-const VALID_MODES = ["notify", "execute", "script"] as const;
+const VALID_MODES = ["notify", "execute", "script", "wake"] as const;
 const VALID_ROUTING_INTENTS = [
   "single_channel",
   "multi_channel",
@@ -157,6 +158,7 @@ function handleUpdateSchedule(
     "routingIntent",
     "quiet",
     "reuseConversation",
+    "wakeConversationId",
   ] as const) {
     if (key in body) {
       updates[key] = body[key];
@@ -309,6 +311,31 @@ async function handleRunScheduleNow(
       });
       const runId = createScheduleRun(schedule.id, fallbackConversation.id);
       completeScheduleRun(runId, { status: "error", error: message });
+    }
+    return handleListSchedules();
+  }
+
+  // ── Wake mode (resume an existing conversation, no new message) ────
+  if (schedule.mode === "wake") {
+    if (!schedule.wakeConversationId) {
+      return httpError(
+        "BAD_REQUEST",
+        "Wake schedule has no target conversation",
+        400,
+      );
+    }
+    const { wakeAgentForOpportunity } =
+      await import("../../runtime/agent-wake.js");
+    try {
+      await wakeAgentForOpportunity({
+        conversationId: schedule.wakeConversationId,
+        hint: schedule.message,
+        source: "defer",
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn({ err, jobId: schedule.id }, "Manual wake execution failed");
+      return httpError("INTERNAL_ERROR", message, 500);
     }
     return handleListSchedules();
   }

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -250,6 +250,7 @@ export function updateSchedule(
     routingHints?: Record<string, unknown>;
     quiet?: boolean;
     reuseConversation?: boolean;
+    wakeConversationId?: string | null;
   },
 ): ScheduleJob | null {
   const db = getDb();
@@ -308,6 +309,8 @@ export function updateSchedule(
   if (updates.quiet !== undefined) set.quiet = updates.quiet;
   if (updates.reuseConversation !== undefined)
     set.reuseConversation = updates.reuseConversation;
+  if (updates.wakeConversationId !== undefined)
+    set.wakeConversationId = updates.wakeConversationId;
 
   // Recompute nextRunAt if schedule timing may have changed (only for recurring)
   if (


### PR DESCRIPTION
## Summary
- Add `wake` to `VALID_MODES` in schedule routes
- Include `wakeConversationId` in list response and update passthrough
- Add wake-mode branch to run-now handler
- Add `wakeConversationId` to `SchedulesListResponse` type
- Add tests for wake mode in schedule routes

Part of plan: conv-defer.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
