### PR TITLE
feat: conversations defer — deferred self-wakes for conversation orchestration

### DIFF
--- a/assistant/src/__tests__/conversations-defer-cli.test.ts
+++ b/assistant/src/__tests__/conversations-defer-cli.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseDuration } from "../cli/commands/conversations-defer.js";
+
+describe("parseDuration", () => {
+  test("bare number treated as seconds", () => {
+    expect(parseDuration("60")).toBe(60);
+  });
+
+  test("seconds suffix", () => {
+    expect(parseDuration("60s")).toBe(60);
+  });
+
+  test("minutes suffix", () => {
+    expect(parseDuration("5m")).toBe(300);
+  });
+
+  test("hours suffix", () => {
+    expect(parseDuration("1h")).toBe(3600);
+  });
+
+  test("composite hours and minutes", () => {
+    expect(parseDuration("1h30m")).toBe(5400);
+  });
+
+  test("seconds only with suffix", () => {
+    expect(parseDuration("90s")).toBe(90);
+  });
+
+  test("throws on invalid string", () => {
+    expect(() => parseDuration("invalid")).toThrow(
+      'Invalid duration: "invalid"',
+    );
+  });
+
+  test("throws on empty string", () => {
+    expect(() => parseDuration("")).toThrow('Invalid duration: ""');
+  });
+});

--- a/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
+++ b/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
@@ -44,6 +44,7 @@ describe("schedule_syntax column migration", () => {
         quiet INTEGER NOT NULL DEFAULT 0,
         reuse_conversation INTEGER NOT NULL DEFAULT 0,
         script TEXT,
+        wake_conversation_id TEXT,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       )

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -405,17 +405,6 @@ function getPatchHandler() {
   return route.handler;
 }
 
-function getListHandler() {
-  const route = scheduleRouteDefinitions({
-    sendMessageDeps: {} as never,
-  }).find(
-    (candidate) =>
-      candidate.endpoint === "schedules" && candidate.method === "GET",
-  );
-  if (!route) throw new Error("GET schedules route not found");
-  return route.handler;
-}
-
 describe("wake mode in schedule routes", () => {
   beforeEach(() => {
     clearTables();

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -391,3 +391,97 @@ describe("schedule runs list — limit handling", () => {
     expect((body as { runs: unknown[] }).runs).toHaveLength(2);
   });
 });
+
+// ── Wake mode support ─────────────────────────────────────────────────────
+
+function getPatchHandler() {
+  const route = scheduleRouteDefinitions({
+    sendMessageDeps: {} as never,
+  }).find(
+    (candidate) =>
+      candidate.endpoint === "schedules/:id" && candidate.method === "PATCH",
+  );
+  if (!route) throw new Error("PATCH schedule route not found");
+  return route.handler;
+}
+
+function getListHandler() {
+  const route = scheduleRouteDefinitions({
+    sendMessageDeps: {} as never,
+  }).find(
+    (candidate) =>
+      candidate.endpoint === "schedules" && candidate.method === "GET",
+  );
+  if (!route) throw new Error("GET schedules route not found");
+  return route.handler;
+}
+
+describe("wake mode in schedule routes", () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  test("PATCH accepts 'wake' as a valid mode", async () => {
+    const schedule = createSchedule({
+      name: "Wake test",
+      cronExpression: "* * * * *",
+      message: "check deferred",
+      syntax: "cron",
+    });
+
+    const handler = getPatchHandler();
+    const urlStr = `http://localhost/v1/schedules/${schedule.id}`;
+    const response = await handler({
+      req: new Request(urlStr, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "wake", wakeConversationId: "conv-xyz" }),
+      }),
+      url: new URL(urlStr),
+      server: {} as never,
+      authContext: {} as never,
+      params: { id: schedule.id },
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      schedules: Array<{
+        id: string;
+        mode: string;
+        wakeConversationId: string | null;
+      }>;
+    };
+    const updated = body.schedules.find((s) => s.id === schedule.id);
+    expect(updated).toBeDefined();
+    expect(updated!.mode).toBe("wake");
+    expect(updated!.wakeConversationId).toBe("conv-xyz");
+  });
+
+  test("list schedules includes wakeConversationId", async () => {
+    createSchedule({
+      name: "Wake schedule",
+      cronExpression: "0 9 * * *",
+      message: "morning wake",
+      syntax: "cron",
+      mode: "wake",
+      wakeConversationId: "conv-abc",
+    });
+
+    const handler = getListHandler();
+    const response = await handler({
+      req: new Request("http://localhost/v1/schedules"),
+      url: new URL("http://localhost/v1/schedules"),
+      server: {} as never,
+      authContext: {} as never,
+      params: {},
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      schedules: Array<{ name: string; wakeConversationId: string | null }>;
+    };
+    const wakeSchedule = body.schedules.find((s) => s.name === "Wake schedule");
+    expect(wakeSchedule).toBeDefined();
+    expect(wakeSchedule!.wakeConversationId).toBe("conv-abc");
+  });
+});

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -164,6 +164,108 @@ describe("schedule run-now trust propagation", () => {
   });
 });
 
+// ── GET /schedules — exclude_created_by filtering ─────────────────────────
+
+function getListHandler() {
+  const route = scheduleRouteDefinitions({
+    sendMessageDeps: {} as never,
+  }).find(
+    (candidate) =>
+      candidate.endpoint === "schedules" && candidate.method === "GET",
+  );
+  if (!route) throw new Error("List schedules route not found");
+  return route.handler;
+}
+
+async function callListHandler(
+  excludeCreatedBy?: string,
+): Promise<{ status: number; body: { schedules: Array<{ id: string }> } }> {
+  const handler = getListHandler();
+  const suffix = excludeCreatedBy
+    ? `?exclude_created_by=${excludeCreatedBy}`
+    : "";
+  const urlStr = `http://localhost/v1/schedules${suffix}`;
+  const response = await handler({
+    req: new Request(urlStr),
+    url: new URL(urlStr),
+    server: {} as never,
+    authContext: {} as never,
+    params: {},
+  });
+  return {
+    status: response.status,
+    body: (await response.json()) as { schedules: Array<{ id: string }> },
+  };
+}
+
+describe("GET /schedules — exclude_created_by filtering", () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  test("returns all schedules when no exclude_created_by param", async () => {
+    createSchedule({
+      name: "Agent schedule",
+      cronExpression: "* * * * *",
+      message: "hello",
+      syntax: "cron",
+    });
+    createSchedule({
+      name: "Deferred wake",
+      cronExpression: "0 9 * * *",
+      message: "wake up",
+      syntax: "cron",
+      createdBy: "defer",
+    });
+
+    const { status, body } = await callListHandler();
+    expect(status).toBe(200);
+    expect(body.schedules).toHaveLength(2);
+  });
+
+  test("filters out deferred wakes when exclude_created_by=defer", async () => {
+    createSchedule({
+      name: "Agent schedule",
+      cronExpression: "* * * * *",
+      message: "hello",
+      syntax: "cron",
+    });
+    const deferred = createSchedule({
+      name: "Deferred wake",
+      cronExpression: "0 9 * * *",
+      message: "wake up",
+      syntax: "cron",
+      createdBy: "defer",
+    });
+
+    const { status, body } = await callListHandler("defer");
+    expect(status).toBe(200);
+    expect(body.schedules).toHaveLength(1);
+    expect(body.schedules.every((s) => s.id !== deferred.id)).toBe(true);
+  });
+
+  test("returns empty list when all schedules match exclusion", async () => {
+    createSchedule({
+      name: "Deferred 1",
+      cronExpression: "* * * * *",
+      message: "a",
+      syntax: "cron",
+      createdBy: "defer",
+    });
+    createSchedule({
+      name: "Deferred 2",
+      cronExpression: "0 9 * * *",
+      message: "b",
+      syntax: "cron",
+      createdBy: "defer",
+    });
+
+    const { status, body } = await callListHandler("defer");
+    expect(status).toBe(200);
+    expect(body.schedules).toHaveLength(0);
+  });
+});
+
 // ── schedules/:id/runs limit handling ─────────────────────────────────────
 
 function getRunsHandler() {
@@ -171,8 +273,7 @@ function getRunsHandler() {
     sendMessageDeps: {} as never,
   }).find(
     (candidate) =>
-      candidate.endpoint === "schedules/:id/runs" &&
-      candidate.method === "GET",
+      candidate.endpoint === "schedules/:id/runs" && candidate.method === "GET",
   );
   if (!route) throw new Error("Runs schedule route not found");
   return route.handler;

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -972,6 +972,123 @@ describe("listSchedules filters", () => {
   });
 });
 
+// ── Wake mode ───────────────────────────────────────────────────────
+
+describe("createSchedule (wake mode)", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  test("creates a wake schedule with wakeConversationId", () => {
+    const job = createSchedule({
+      name: "Wake conv",
+      message: "resume conversation",
+      nextRunAt: Date.now() + 60_000,
+      mode: "wake",
+      wakeConversationId: "conv-123",
+    });
+
+    expect(job.mode).toBe("wake");
+    expect(job.wakeConversationId).toBe("conv-123");
+    expect(job.status).toBe("active");
+
+    const retrieved = getSchedule(job.id);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.wakeConversationId).toBe("conv-123");
+  });
+
+  test("throws when creating wake schedule without wakeConversationId", () => {
+    expect(() =>
+      createSchedule({
+        name: "Bad wake",
+        message: "no conv id",
+        nextRunAt: Date.now() + 60_000,
+        mode: "wake",
+      }),
+    ).toThrow("Wake schedules require wakeConversationId");
+  });
+});
+
+// ── listSchedules new filters ───────────────────────────────────────
+
+describe("listSchedules new filters", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  test("mode filter returns only schedules with matching mode", () => {
+    createSchedule({
+      name: "Execute schedule",
+      message: "execute",
+      nextRunAt: Date.now() + 60_000,
+      mode: "execute",
+    });
+    createSchedule({
+      name: "Wake schedule",
+      message: "wake",
+      nextRunAt: Date.now() + 60_000,
+      mode: "wake",
+      wakeConversationId: "conv-abc",
+    });
+
+    const wakeOnly = listSchedules({ mode: "wake" });
+    expect(wakeOnly.length).toBe(1);
+    expect(wakeOnly[0].name).toBe("Wake schedule");
+    expect(wakeOnly[0].mode).toBe("wake");
+  });
+
+  test("createdBy filter returns only schedules with matching creator", () => {
+    createSchedule({
+      name: "Agent schedule",
+      message: "by agent",
+      nextRunAt: Date.now() + 60_000,
+      createdBy: "agent",
+    });
+    createSchedule({
+      name: "Defer schedule",
+      message: "by defer",
+      nextRunAt: Date.now() + 60_000,
+      createdBy: "defer",
+    });
+
+    const deferOnly = listSchedules({ createdBy: "defer" });
+    expect(deferOnly.length).toBe(1);
+    expect(deferOnly[0].name).toBe("Defer schedule");
+    expect(deferOnly[0].createdBy).toBe("defer");
+  });
+
+  test("conversationId filter returns only wakes targeting that conversation", () => {
+    createSchedule({
+      name: "Wake for conv-123",
+      message: "wake conv-123",
+      nextRunAt: Date.now() + 60_000,
+      mode: "wake",
+      wakeConversationId: "conv-123",
+    });
+    createSchedule({
+      name: "Wake for conv-456",
+      message: "wake conv-456",
+      nextRunAt: Date.now() + 60_000,
+      mode: "wake",
+      wakeConversationId: "conv-456",
+    });
+    createSchedule({
+      name: "Regular schedule",
+      message: "no wake",
+      nextRunAt: Date.now() + 60_000,
+    });
+
+    const conv123Only = listSchedules({ conversationId: "conv-123" });
+    expect(conv123Only.length).toBe(1);
+    expect(conv123Only[0].name).toBe("Wake for conv-123");
+    expect(conv123Only[0].wakeConversationId).toBe("conv-123");
+  });
+});
+
 // ── describeCronExpression ──────────────────────────────────────────
 
 describe("describeCronExpression", () => {

--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -1,0 +1,262 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  truncateForLog: (value: string) => value,
+}));
+
+const mockWakeAgentForOpportunity = mock(() =>
+  Promise.resolve({ invoked: true, producedToolCalls: false }),
+);
+mock.module("../runtime/agent-wake.js", () => ({
+  wakeAgentForOpportunity: mockWakeAgentForOpportunity,
+}));
+
+const mockEmitFeedEvent = mock(() => Promise.resolve());
+mock.module("../home/emit-feed-event.js", () => ({
+  emitFeedEvent: mockEmitFeedEvent,
+}));
+
+import { getDb, initializeDb } from "../memory/db.js";
+import { createSchedule } from "../schedule/schedule-store.js";
+import { startScheduler } from "../schedule/scheduler.js";
+
+initializeDb();
+
+/** Access the underlying bun:sqlite Database for raw parameterized queries. */
+function getRawDb(): import("bun:sqlite").Database {
+  return (getDb() as unknown as { $client: import("bun:sqlite").Database })
+    .$client;
+}
+
+/** Force a schedule to be due by setting next_run_at in the past. */
+function forceScheduleDue(scheduleId: string): void {
+  getRawDb().run("UPDATE cron_jobs SET next_run_at = ? WHERE id = ?", [
+    Date.now() - 1000,
+    scheduleId,
+  ]);
+}
+
+// Replace setTimeout with a fast-forward version so the scheduler
+// wait calls fire quickly instead of waiting real time.
+let origSetTimeout: typeof globalThis.setTimeout;
+
+describe("scheduler wake mode", () => {
+  beforeAll(() => {
+    origSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = ((
+      fn: TimerHandler,
+      _ms?: number,
+      ...args: unknown[]
+    ) => {
+      return origSetTimeout(fn, 200, ...args);
+    }) as typeof setTimeout;
+  });
+
+  afterAll(() => {
+    globalThis.setTimeout = origSetTimeout;
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+    db.run("DELETE FROM task_runs");
+    db.run("DELETE FROM tasks");
+    db.run("DELETE FROM messages");
+    db.run("DELETE FROM conversations");
+    mockWakeAgentForOpportunity.mockClear();
+    mockEmitFeedEvent.mockClear();
+  });
+
+  test("wake schedule calls wakeAgentForOpportunity with correct args", async () => {
+    // GIVEN a one-shot wake schedule with a conversation ID
+    const schedule = createSchedule({
+      name: "Wake Test",
+      message: "Check back on this",
+      mode: "wake",
+      wakeConversationId: "conv-xyz",
+      nextRunAt: Date.now() - 1000,
+    });
+    forceScheduleDue(schedule.id);
+
+    const processMessage = mock(() => Promise.resolve());
+
+    // WHEN the scheduler fires
+    const scheduler = startScheduler(processMessage, () => {});
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    // THEN wakeAgentForOpportunity is called with the correct arguments
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledWith({
+      conversationId: "conv-xyz",
+      hint: "Check back on this",
+      source: "defer",
+    });
+
+    // AND processMessage is never called (wake mode doesn't use it)
+    expect(processMessage).not.toHaveBeenCalled();
+  });
+
+  test("missing wakeConversationId logs warning and completes (not fails)", async () => {
+    // GIVEN a one-shot wake schedule WITHOUT a conversation ID
+    // We need to create it with a wakeConversationId first (validation requires it),
+    // then clear it at the DB level to simulate a missing value at runtime.
+    const schedule = createSchedule({
+      name: "Wake No Conv",
+      message: "Missing conv",
+      mode: "wake",
+      wakeConversationId: "conv-placeholder",
+      nextRunAt: Date.now() - 1000,
+    });
+    getRawDb().run(
+      "UPDATE cron_jobs SET wake_conversation_id = NULL WHERE id = ?",
+      [schedule.id],
+    );
+    forceScheduleDue(schedule.id);
+
+    const processMessage = mock(() => Promise.resolve());
+
+    // WHEN the scheduler fires
+    const scheduler = startScheduler(processMessage, () => {});
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    // THEN wakeAgentForOpportunity is NOT called
+    expect(mockWakeAgentForOpportunity).not.toHaveBeenCalled();
+
+    // AND the one-shot is completed (not failed) — check status is 'fired' not 'cancelled'
+    const row = getRawDb()
+      .query("SELECT status FROM cron_jobs WHERE id = ?")
+      .get(schedule.id) as { status: string } | null;
+    expect(row?.status).toBe("fired");
+  });
+
+  test("successful wake marks one-shot as completed", async () => {
+    // GIVEN a one-shot wake schedule
+    mockWakeAgentForOpportunity.mockResolvedValueOnce({
+      invoked: true,
+      producedToolCalls: false,
+    });
+
+    const schedule = createSchedule({
+      name: "Wake Complete",
+      message: "Should complete",
+      mode: "wake",
+      wakeConversationId: "conv-abc",
+      nextRunAt: Date.now() - 1000,
+    });
+    forceScheduleDue(schedule.id);
+
+    // WHEN the scheduler fires
+    const scheduler = startScheduler(
+      mock(() => Promise.resolve()),
+      () => {},
+    );
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    // THEN the one-shot is marked as completed (status = 'fired')
+    const row = getRawDb()
+      .query("SELECT status FROM cron_jobs WHERE id = ?")
+      .get(schedule.id) as { status: string } | null;
+    expect(row?.status).toBe("fired");
+  });
+
+  test("failed wake marks one-shot as failed", async () => {
+    // GIVEN a one-shot wake schedule where wakeAgentForOpportunity throws
+    mockWakeAgentForOpportunity.mockRejectedValueOnce(new Error("Wake failed"));
+
+    const schedule = createSchedule({
+      name: "Wake Fail",
+      message: "Should fail",
+      mode: "wake",
+      wakeConversationId: "conv-fail",
+      nextRunAt: Date.now() - 1000,
+    });
+    forceScheduleDue(schedule.id);
+
+    // WHEN the scheduler fires
+    const scheduler = startScheduler(
+      mock(() => Promise.resolve()),
+      () => {},
+    );
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    // THEN the one-shot is reverted to 'active' for retry (failOneShot behavior)
+    const row = getRawDb()
+      .query("SELECT status FROM cron_jobs WHERE id = ?")
+      .get(schedule.id) as { status: string } | null;
+    expect(row?.status).toBe("active");
+  });
+
+  test("quiet: true suppresses feed event", async () => {
+    // GIVEN a one-shot wake schedule with quiet: true
+    const schedule = createSchedule({
+      name: "Wake Quiet",
+      message: "Quiet wake",
+      mode: "wake",
+      wakeConversationId: "conv-quiet",
+      quiet: true,
+      nextRunAt: Date.now() - 1000,
+    });
+    forceScheduleDue(schedule.id);
+
+    // WHEN the scheduler fires
+    const scheduler = startScheduler(
+      mock(() => Promise.resolve()),
+      () => {},
+    );
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    // THEN wakeAgentForOpportunity is called
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+
+    // AND no feed event is emitted
+    expect(mockEmitFeedEvent).not.toHaveBeenCalled();
+  });
+
+  test("quiet: false emits feed event on success", async () => {
+    // GIVEN a one-shot wake schedule with quiet: false (default)
+    const schedule = createSchedule({
+      name: "Wake Loud",
+      message: "Loud wake",
+      mode: "wake",
+      wakeConversationId: "conv-loud",
+      nextRunAt: Date.now() - 1000,
+    });
+    forceScheduleDue(schedule.id);
+
+    // WHEN the scheduler fires
+    const scheduler = startScheduler(
+      mock(() => Promise.resolve()),
+      () => {},
+    );
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    // THEN a feed event IS emitted
+    expect(mockEmitFeedEvent).toHaveBeenCalledTimes(1);
+    expect(mockEmitFeedEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "assistant",
+        title: "Wake Loud",
+        summary: "Deferred wake fired.",
+      }),
+    );
+  });
+});

--- a/assistant/src/cli/commands/conversations-defer.ts
+++ b/assistant/src/cli/commands/conversations-defer.ts
@@ -1,0 +1,352 @@
+import type { Command } from "commander";
+
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import { log } from "../logger.js";
+
+// ---------------------------------------------------------------------------
+// Duration parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a human-friendly duration string into seconds.
+ *
+ * Accepted formats:
+ *   "60"     → 60   (bare number = seconds)
+ *   "60s"    → 60
+ *   "5m"     → 300
+ *   "1h"     → 3600
+ *   "1h30m"  → 5400
+ *   "90s"    → 90
+ */
+export function parseDuration(input: string): number {
+  if (/^\d+$/.test(input)) return parseInt(input, 10);
+
+  let total = 0;
+  const re = /(\d+)(h|m|s)/g;
+  let match;
+  while ((match = re.exec(input)) !== null) {
+    const val = parseInt(match[1], 10);
+    switch (match[2]) {
+      case "h":
+        total += val * 3600;
+        break;
+      case "m":
+        total += val * 60;
+        break;
+      case "s":
+        total += val;
+        break;
+    }
+  }
+  if (total === 0) throw new Error(`Invalid duration: "${input}"`);
+  return total;
+}
+
+// ---------------------------------------------------------------------------
+// Conversation ID resolution
+// ---------------------------------------------------------------------------
+
+function resolveConversationId(positionalArg?: string): string {
+  if (positionalArg) return positionalArg;
+
+  const skillCtxRaw = process.env.__SKILL_CONTEXT_JSON;
+  if (skillCtxRaw) {
+    try {
+      const ctx = JSON.parse(skillCtxRaw) as Record<string, unknown>;
+      if (typeof ctx.conversationId === "string" && ctx.conversationId) {
+        return ctx.conversationId;
+      }
+    } catch {
+      // Ignore malformed JSON
+    }
+  }
+
+  const envConvId = process.env.__CONVERSATION_ID;
+  if (envConvId) return envConvId;
+
+  throw new Error(
+    "No conversation ID provided. Pass it as an argument, or set $__SKILL_CONTEXT_JSON or $__CONVERSATION_ID.",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerConversationsDeferCommand(parent: Command): void {
+  const defer = parent
+    .command("defer [conversationId]")
+    .description("Create a deferred wake for a conversation")
+    .option("--in <duration>", "Delay before firing (e.g. 60, 60s, 5m, 1h)")
+    .option("--at <iso8601>", "Absolute ISO 8601 fire time")
+    .requiredOption("--hint <text>", "Hint message for the wake")
+    .option("--name <text>", "Name for the deferred wake", "Deferred wake")
+    .option("--json", "Output result as JSON")
+    .addHelpText(
+      "after",
+      `
+Create a deferred wake that fires after a delay or at a specific time.
+The conversation ID is resolved from the positional argument, the
+$__SKILL_CONTEXT_JSON env var, or $__CONVERSATION_ID.
+
+Requires the assistant to be running. Communicates via IPC socket.
+
+Examples:
+  $ assistant conversations defer --in 60 --hint "check progress"
+  $ assistant conversations defer conv-123 --in 5m --hint "follow up"
+  $ assistant conversations defer --at 2026-04-23T15:00:00Z --hint "meeting time"
+  $ assistant conversations defer --in 1h30m --hint "remind me" --json`,
+    )
+    .action(
+      async (
+        conversationIdArg: string | undefined,
+        opts: {
+          in?: string;
+          at?: string;
+          hint: string;
+          name: string;
+          json?: boolean;
+        },
+      ) => {
+        let conversationId: string;
+        try {
+          conversationId = resolveConversationId(conversationIdArg);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (opts.json) {
+            log.info(JSON.stringify({ ok: false, error: msg }));
+          } else {
+            log.error(`Error: ${msg}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        if (!opts.in && !opts.at) {
+          const msg = "Either --in or --at must be provided";
+          if (opts.json) {
+            log.info(JSON.stringify({ ok: false, error: msg }));
+          } else {
+            log.error(`Error: ${msg}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        let delaySeconds: number | undefined;
+        let fireAt: number | undefined;
+
+        if (opts.in) {
+          try {
+            delaySeconds = parseDuration(opts.in);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (opts.json) {
+              log.info(JSON.stringify({ ok: false, error: msg }));
+            } else {
+              log.error(`Error: ${msg}`);
+            }
+            process.exitCode = 1;
+            return;
+          }
+        }
+
+        if (opts.at) {
+          fireAt = new Date(opts.at).getTime();
+          if (isNaN(fireAt)) {
+            const msg = `Invalid ISO 8601 date: "${opts.at}"`;
+            if (opts.json) {
+              log.info(JSON.stringify({ ok: false, error: msg }));
+            } else {
+              log.error(`Error: ${msg}`);
+            }
+            process.exitCode = 1;
+            return;
+          }
+          if (fireAt <= Date.now()) {
+            const msg = "The --at time must be in the future";
+            if (opts.json) {
+              log.info(JSON.stringify({ ok: false, error: msg }));
+            } else {
+              log.error(`Error: ${msg}`);
+            }
+            process.exitCode = 1;
+            return;
+          }
+        }
+
+        const result = await cliIpcCall<{
+          id: string;
+          name: string;
+          fireAt: number;
+          conversationId: string;
+        }>("defer_create", {
+          conversationId,
+          hint: opts.hint,
+          delaySeconds,
+          fireAt,
+          name: opts.name,
+        });
+
+        if (!result.ok) {
+          if (opts.json) {
+            log.info(JSON.stringify({ ok: false, error: result.error }));
+          } else {
+            log.error(`Error: ${result.error}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        const created = result.result!;
+        if (opts.json) {
+          log.info(JSON.stringify({ ok: true, ...created }));
+        } else {
+          const fireDate = new Date(created.fireAt).toISOString();
+          log.info(
+            `Created deferred wake "${created.name}" (${created.id}) — fires at ${fireDate}`,
+          );
+        }
+      },
+    );
+
+  // -----------------------------------------------------------------------
+  // defer list
+  // -----------------------------------------------------------------------
+
+  defer
+    .command("list")
+    .description("List pending deferred wakes")
+    .option("--conversation-id <id>", "Filter by conversation ID")
+    .option("--json", "Output result as JSON")
+    .addHelpText(
+      "after",
+      `
+List all pending deferred wakes, optionally filtered by conversation ID.
+
+Requires the assistant to be running. Communicates via IPC socket.
+
+Examples:
+  $ assistant conversations defer list
+  $ assistant conversations defer list --conversation-id conv-123
+  $ assistant conversations defer list --json`,
+    )
+    .action(async (opts: { conversationId?: string; json?: boolean }) => {
+      const result = await cliIpcCall<{
+        defers: Array<{
+          id: string;
+          name: string;
+          hint: string;
+          conversationId: string;
+          fireAt: number;
+          status: string;
+        }>;
+      }>("defer_list", {
+        conversationId: opts.conversationId,
+      });
+
+      if (!result.ok) {
+        if (opts.json) {
+          log.info(JSON.stringify({ ok: false, error: result.error }));
+        } else {
+          log.error(`Error: ${result.error}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      const { defers } = result.result!;
+
+      if (opts.json) {
+        log.info(JSON.stringify({ ok: true, defers }));
+        return;
+      }
+
+      if (defers.length === 0) {
+        log.info("No pending deferred wakes");
+        return;
+      }
+
+      log.info(`${"ID".padEnd(38)}${"Fire At".padEnd(28)}Hint`);
+      log.info("-".repeat(80));
+      for (const d of defers) {
+        const fireDate = new Date(d.fireAt).toISOString();
+        log.info(`${d.id.padEnd(38)}${fireDate.padEnd(28)}${d.hint}`);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // defer cancel
+  // -----------------------------------------------------------------------
+
+  defer
+    .command("cancel [deferId]")
+    .description("Cancel a deferred wake by ID, or all with --all")
+    .option("--all", "Cancel all pending deferred wakes")
+    .option("--conversation-id <id>", "Filter by conversation ID (with --all)")
+    .option("--json", "Output result as JSON")
+    .addHelpText(
+      "after",
+      `
+Cancel a single deferred wake by ID, or all pending wakes with --all.
+
+Requires the assistant to be running. Communicates via IPC socket.
+
+Examples:
+  $ assistant conversations defer cancel <deferId>
+  $ assistant conversations defer cancel --all
+  $ assistant conversations defer cancel --all --conversation-id conv-123
+  $ assistant conversations defer cancel --all --json`,
+    )
+    .action(
+      async (
+        deferId: string | undefined,
+        opts: { all?: boolean; conversationId?: string; json?: boolean },
+      ) => {
+        if (!deferId && !opts.all) {
+          const msg =
+            "Provide a defer ID to cancel, or use --all to cancel all";
+          if (opts.json) {
+            log.info(JSON.stringify({ ok: false, error: msg }));
+          } else {
+            log.error(`Error: ${msg}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        const ipcParams: Record<string, unknown> = {};
+        if (deferId) {
+          ipcParams.id = deferId;
+        }
+        if (opts.all) {
+          ipcParams.all = true;
+          if (opts.conversationId) {
+            ipcParams.conversationId = opts.conversationId;
+          }
+        }
+
+        const result = await cliIpcCall<{ cancelled: number }>(
+          "defer_cancel",
+          ipcParams,
+        );
+
+        if (!result.ok) {
+          if (opts.json) {
+            log.info(JSON.stringify({ ok: false, error: result.error }));
+          } else {
+            log.error(`Error: ${result.error}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        const { cancelled } = result.result!;
+        if (opts.json) {
+          log.info(JSON.stringify({ ok: true, cancelled }));
+        } else {
+          log.info(`Cancelled ${cancelled} deferred wake(s)`);
+        }
+      },
+    );
+}

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -34,6 +34,7 @@ import { deleteSchedule } from "../../schedule/schedule-store.js";
 import { timeAgo } from "../../util/time.js";
 import { initializeDb } from "../db.js";
 import { log } from "../logger.js";
+import { registerConversationsDeferCommand } from "./conversations-defer.js";
 import { registerConversationsImportCommand } from "./conversations-import.js";
 
 export function registerConversationsCommand(program: Command): void {
@@ -42,6 +43,7 @@ export function registerConversationsCommand(program: Command): void {
     .description("Manage conversations");
 
   registerConversationsImportCommand(conversations);
+  registerConversationsDeferCommand(conversations);
 
   conversations.addHelpText(
     "after",

--- a/assistant/src/daemon/message-types/schedules.ts
+++ b/assistant/src/daemon/message-types/schedules.ts
@@ -84,6 +84,7 @@ export interface SchedulesListResponse {
     status: string;
     routingIntent: string;
     reuseConversation: boolean;
+    wakeConversationId: string | null;
     isOneShot: boolean;
   }>;
 }

--- a/assistant/src/ipc/routes/defer.ts
+++ b/assistant/src/ipc/routes/defer.ts
@@ -1,0 +1,137 @@
+import { z } from "zod";
+
+import {
+  cancelSchedule,
+  createSchedule,
+  listSchedules,
+} from "../../schedule/schedule-store.js";
+import type { IpcRoute } from "../cli-server.js";
+
+// ---------------------------------------------------------------------------
+// defer_create
+// ---------------------------------------------------------------------------
+
+const DeferCreateParams = z
+  .object({
+    conversationId: z.string().min(1),
+    hint: z.string().min(1),
+    delaySeconds: z.number().optional(),
+    fireAt: z.number().optional(),
+    name: z.string().optional(),
+  })
+  .refine((p) => p.delaySeconds != null || p.fireAt != null, {
+    message: "Either delaySeconds or fireAt must be provided",
+  });
+
+const deferCreateRoute: IpcRoute = {
+  method: "defer_create",
+  handler: async (params) => {
+    const { conversationId, hint, delaySeconds, fireAt, name } =
+      DeferCreateParams.parse(params);
+
+    const resolvedFireAt = fireAt ?? Date.now() + delaySeconds! * 1000;
+
+    const job = createSchedule({
+      name: name ?? "Deferred wake",
+      message: hint,
+      mode: "wake",
+      wakeConversationId: conversationId,
+      nextRunAt: resolvedFireAt,
+      quiet: true,
+      createdBy: "defer",
+    });
+
+    return {
+      id: job.id,
+      name: job.name,
+      fireAt: resolvedFireAt,
+      conversationId,
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// defer_list
+// ---------------------------------------------------------------------------
+
+const DeferListParams = z.object({
+  conversationId: z.string().optional(),
+});
+
+const deferListRoute: IpcRoute = {
+  method: "defer_list",
+  handler: async (params) => {
+    const { conversationId } = DeferListParams.parse(params ?? {});
+
+    const jobs = listSchedules({
+      mode: "wake",
+      createdBy: "defer",
+      conversationId,
+    });
+
+    const active = jobs.filter(
+      (j) => j.status === "active" || j.status === "firing",
+    );
+
+    return {
+      defers: active.map((j) => ({
+        id: j.id,
+        name: j.name,
+        hint: j.message,
+        conversationId: j.wakeConversationId,
+        fireAt: j.nextRunAt,
+        status: j.status,
+      })),
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// defer_cancel
+// ---------------------------------------------------------------------------
+
+const DeferCancelParams = z.object({
+  id: z.string().optional(),
+  all: z.boolean().optional(),
+  conversationId: z.string().optional(),
+});
+
+const deferCancelRoute: IpcRoute = {
+  method: "defer_cancel",
+  handler: async (params) => {
+    const { id, all, conversationId } = DeferCancelParams.parse(params);
+
+    if (id) {
+      const ok = cancelSchedule(id);
+      return { cancelled: ok ? 1 : 0 };
+    }
+
+    if (all) {
+      const jobs = listSchedules({
+        mode: "wake",
+        createdBy: "defer",
+        conversationId,
+      });
+
+      let count = 0;
+      for (const j of jobs) {
+        if (j.status === "active" || j.status === "firing") {
+          if (cancelSchedule(j.id)) count++;
+        }
+      }
+      return { cancelled: count };
+    }
+
+    throw new Error("Either 'id' or 'all' must be provided to defer_cancel");
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const deferRoutes: IpcRoute[] = [
+  deferCreateRoute,
+  deferListRoute,
+  deferCancelRoute,
+];

--- a/assistant/src/ipc/routes/index.ts
+++ b/assistant/src/ipc/routes/index.ts
@@ -2,6 +2,7 @@ import type { IpcRoute } from "../cli-server.js";
 import { attachmentRoutes } from "./attachment.js";
 import { browserExecuteRoute } from "./browser.js";
 import { cacheRoutes } from "./cache.js";
+import { deferRoutes } from "./defer.js";
 import { getContactRoute } from "./get-contact.js";
 import { listClientsRoute } from "./list-clients.js";
 import { mergeContactsRoute } from "./merge-contacts.js";
@@ -19,6 +20,7 @@ import { watcherRoutes } from "./watcher.js";
 export const cliIpcRoutes: IpcRoute[] = [
   ...attachmentRoutes,
   browserExecuteRoute,
+  ...deferRoutes,
   getContactRoute,
   listClientsRoute,
   mergeContactsRoute,

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -147,6 +147,7 @@ import {
   migrateScheduleQuietFlag,
   migrateScheduleReuseConversation,
   migrateScheduleScriptColumn,
+  migrateScheduleWakeConversationId,
   migrateSchemaIndexesAndColumns,
   migrateScrubCorruptedImageAttachments,
   migrateStripIntegrationPrefixFromProviderKeys,
@@ -380,6 +381,7 @@ export function initializeDb(): void {
     migrateStripPlaceholderSentinelsFromMessages,
     migrateOAuthProvidersManagedServiceIsPaid,
     migrateOAuthProvidersAvailableScopes,
+    migrateScheduleWakeConversationId,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/226-schedule-wake-conversation-id.ts
+++ b/assistant/src/memory/migrations/226-schedule-wake-conversation-id.ts
@@ -1,0 +1,11 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateScheduleWakeConversationId(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(`ALTER TABLE cron_jobs ADD COLUMN wake_conversation_id TEXT`);
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -171,6 +171,7 @@ export { migrateStripPlaceholderSentinelsFromMessages } from "./222-strip-placeh
 export { migrateScheduleScriptColumn } from "./223-schedule-script-column.js";
 export { migrateOAuthProvidersManagedServiceIsPaid } from "./224-oauth-providers-managed-service-is-paid.js";
 export { migrateOAuthProvidersAvailableScopes } from "./225-oauth-providers-available-scopes.js";
+export { migrateScheduleWakeConversationId } from "./226-schedule-wake-conversation-id.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -29,6 +29,7 @@ export const cronJobs = sqliteTable("cron_jobs", {
     .notNull()
     .default(false), // reuse the same conversation across runs
   script: text("script"), // shell command for script mode (nullable, only used when mode = 'script')
+  wakeConversationId: text("wake_conversation_id"), // target conversation for wake mode (nullable)
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -63,6 +63,7 @@ function handleListSchedules(excludeCreatedBy?: string): Response {
       status: j.status,
       routingIntent: j.routingIntent,
       reuseConversation: j.reuseConversation,
+      wakeConversationId: j.wakeConversationId,
       isOneShot: j.cronExpression == null,
     })),
   });
@@ -114,7 +115,7 @@ function handleCancelSchedule(id: string): Response {
   return handleListSchedules();
 }
 
-const VALID_MODES = ["notify", "execute", "script"] as const;
+const VALID_MODES = ["notify", "execute", "script", "wake"] as const;
 const VALID_ROUTING_INTENTS = [
   "single_channel",
   "multi_channel",
@@ -160,6 +161,7 @@ function handleUpdateSchedule(
     "routingIntent",
     "quiet",
     "reuseConversation",
+    "wakeConversationId",
   ] as const) {
     if (key in body) {
       updates[key] = body[key];
@@ -312,6 +314,31 @@ async function handleRunScheduleNow(
       });
       const runId = createScheduleRun(schedule.id, fallbackConversation.id);
       completeScheduleRun(runId, { status: "error", error: message });
+    }
+    return handleListSchedules();
+  }
+
+  // ── Wake mode (resume an existing conversation, no new message) ────
+  if (schedule.mode === "wake") {
+    if (!schedule.wakeConversationId) {
+      return httpError(
+        "BAD_REQUEST",
+        "Wake schedule has no target conversation",
+        400,
+      );
+    }
+    const { wakeAgentForOpportunity } =
+      await import("../../runtime/agent-wake.js");
+    try {
+      await wakeAgentForOpportunity({
+        conversationId: schedule.wakeConversationId,
+        hint: schedule.message,
+        source: "defer",
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn({ err, jobId: schedule.id }, "Manual wake execution failed");
+      return httpError("INTERNAL_ERROR", message, 500);
     }
     return handleListSchedules();
   }

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -36,10 +36,13 @@ const SCHEDULE_GUARDIAN_TRUST_CONTEXT = {
 // Handlers
 // ---------------------------------------------------------------------------
 
-function handleListSchedules(): Response {
+function handleListSchedules(excludeCreatedBy?: string): Response {
   const jobs = listSchedules();
+  const filtered = excludeCreatedBy
+    ? jobs.filter((j) => j.createdBy !== excludeCreatedBy)
+    : jobs;
   return Response.json({
-    schedules: jobs.map((j) => ({
+    schedules: filtered.map((j) => ({
       id: j.id,
       name: j.name,
       enabled: j.enabled,
@@ -391,7 +394,11 @@ export function scheduleRouteDefinitions(deps: {
       responseBody: z.object({
         schedules: z.array(z.unknown()).describe("Schedule objects"),
       }),
-      handler: () => handleListSchedules(),
+      handler: ({ url }) => {
+        const excludeCreatedBy =
+          url.searchParams.get("exclude_created_by") ?? undefined;
+        return handleListSchedules(excludeCreatedBy);
+      },
     },
     {
       endpoint: "schedules/:id/runs",

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -145,6 +145,7 @@ export function createSchedule(params: {
     timezone,
     message: params.message,
     script: params.script ?? null,
+    wakeConversationId: null as string | null,
     nextRunAt,
     lastRunAt: null as number | null,
     lastStatus: null as string | null,

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -250,6 +250,7 @@ export function updateSchedule(
     routingHints?: Record<string, unknown>;
     quiet?: boolean;
     reuseConversation?: boolean;
+    wakeConversationId?: string | null;
   },
 ): ScheduleJob | null {
   const db = getDb();
@@ -308,6 +309,8 @@ export function updateSchedule(
   if (updates.quiet !== undefined) set.quiet = updates.quiet;
   if (updates.reuseConversation !== undefined)
     set.reuseConversation = updates.reuseConversation;
+  if (updates.wakeConversationId !== undefined)
+    set.wakeConversationId = updates.wakeConversationId;
 
   // Recompute nextRunAt if schedule timing may have changed (only for recurring)
   if (

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -14,7 +14,7 @@ import type { ScheduleSyntax } from "./recurrence-types.js";
 
 const logger = getLogger("schedule-store");
 
-export type ScheduleMode = "notify" | "execute" | "script";
+export type ScheduleMode = "notify" | "execute" | "script" | "wake";
 export type RoutingIntent = "single_channel" | "multi_channel" | "all_channels";
 export type ScheduleStatus = "active" | "firing" | "fired" | "cancelled";
 
@@ -28,6 +28,7 @@ export interface ScheduleJob {
   timezone: string | null;
   message: string;
   script: string | null;
+  wakeConversationId: string | null;
   nextRunAt: number;
   lastRunAt: number | null;
   lastStatus: string | null;
@@ -87,6 +88,7 @@ export function createSchedule(params: {
   timezone?: string | null;
   message: string;
   script?: string | null;
+  wakeConversationId?: string | null;
   enabled?: boolean;
   createdBy?: string;
   syntax?: ScheduleSyntax;
@@ -114,6 +116,10 @@ export function createSchedule(params: {
     if (!isValidScheduleExpression(spec)) {
       throw new Error(`Invalid ${syntax} expression: "${expression}"`);
     }
+  }
+
+  if (params.mode === "wake" && !params.wakeConversationId) {
+    throw new Error("Wake schedules require wakeConversationId");
   }
 
   const db = getDb();
@@ -145,7 +151,7 @@ export function createSchedule(params: {
     timezone,
     message: params.message,
     script: params.script ?? null,
-    wakeConversationId: null as string | null,
+    wakeConversationId: params.wakeConversationId ?? null,
     nextRunAt,
     lastRunAt: null as number | null,
     lastStatus: null as string | null,
@@ -192,6 +198,9 @@ export function listSchedules(options?: {
   enabledOnly?: boolean;
   oneShotOnly?: boolean;
   recurringOnly?: boolean;
+  mode?: ScheduleMode;
+  createdBy?: string;
+  conversationId?: string;
 }): ScheduleJob[] {
   const db = getDb();
   const conditions = [];
@@ -203,6 +212,17 @@ export function listSchedules(options?: {
   }
   if (options?.recurringOnly) {
     conditions.push(sql`${scheduleJobs.cronExpression} IS NOT NULL`);
+  }
+  if (options?.mode) {
+    conditions.push(eq(scheduleJobs.mode, options.mode));
+  }
+  if (options?.createdBy) {
+    conditions.push(eq(scheduleJobs.createdBy, options.createdBy));
+  }
+  if (options?.conversationId) {
+    conditions.push(
+      eq(scheduleJobs.wakeConversationId, options.conversationId),
+    );
   }
   const where = conditions.length > 0 ? and(...conditions) : undefined;
   const rows = db
@@ -784,6 +804,7 @@ function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
     timezone: row.timezone,
     message: row.message,
     script: row.script ?? null,
+    wakeConversationId: row.wakeConversationId ?? null,
     nextRunAt: row.nextRunAt,
     lastRunAt: row.lastRunAt,
     lastStatus: row.lastStatus,

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -3,6 +3,7 @@ import { emitFeedEvent } from "../home/emit-feed-event.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { getConversation } from "../memory/conversation-crud.js";
 import { invalidateAssistantInferredItemsForConversation } from "../memory/task-memory-cleanup.js";
+import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
 import { runSequencesOnce } from "../sequence/engine.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -221,6 +222,48 @@ async function runScheduleOnce(
           "Script schedule execution failed",
         );
         completeScheduleRun(runId, { status: "error", error: errorMsg });
+        if (isOneShot) failOneShot(job.id);
+      }
+      processed += 1;
+      continue;
+    }
+
+    // ── Wake mode (resume an existing conversation) ─────────────────
+    if (job.mode === "wake") {
+      const { wakeConversationId } = job;
+      if (!wakeConversationId) {
+        log.warn(
+          { jobId: job.id, name: job.name },
+          "Wake schedule missing wakeConversationId — completing as no-op",
+        );
+        if (isOneShot) completeOneShot(job.id);
+        processed += 1;
+        continue;
+      }
+
+      try {
+        log.info(
+          { jobId: job.id, name: job.name, wakeConversationId, isOneShot },
+          "Executing wake schedule",
+        );
+        await wakeAgentForOpportunity({
+          conversationId: wakeConversationId,
+          hint: job.message,
+          source: "defer",
+        });
+        if (isOneShot) completeOneShot(job.id);
+        if (!job.quiet) {
+          emitScheduleFeedEvent({
+            title: job.name,
+            summary: "Deferred wake fired.",
+            dedupKey: `schedule-wake:${job.id}`,
+          });
+        }
+      } catch (err) {
+        log.warn(
+          { err, jobId: job.id, name: job.name, wakeConversationId, isOneShot },
+          "Wake schedule execution failed",
+        );
         if (isOneShot) failOneShot(job.id);
       }
       processed += 1;

--- a/clients/shared/Network/ScheduleClient.swift
+++ b/clients/shared/Network/ScheduleClient.swift
@@ -34,7 +34,7 @@ public struct ScheduleClient: ScheduleClientProtocol {
 
     public func fetchSchedulesList() async throws -> [ScheduleItem] {
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/schedules", timeout: 10
+            path: "assistants/{assistantId}/schedules?exclude_created_by=defer", timeout: 10
         )
         guard response.isSuccess else {
             log.error("fetchSchedulesList failed (HTTP \(response.statusCode))")


### PR DESCRIPTION
## Summary
Extend the existing schedule system with a `wake` mode that fires `wakeAgentForOpportunity()` on an existing conversation after a delay. This enables the assistant to schedule future work on the current conversation without blocking it — the primary use case is polling Claude Code sessions.

## Changes
- **DB**: Add `wake_conversation_id` column to `cron_jobs` table
- **Schedule store**: Add `wake` mode, `wakeConversationId` field, and `mode`/`createdBy`/`conversationId` list filters
- **Scheduler**: Handle `wake` mode in `runScheduleOnce` — calls `wakeAgentForOpportunity`
- **HTTP routes**: Accept `wake` mode, include `wakeConversationId` in responses, add run-now support
- **IPC routes**: `defer_create`, `defer_list`, `defer_cancel` for CLI communication
- **CLI**: `assistant conversations defer` subcommand with create/list/cancel
- **Settings UI**: Filter deferred wakes from schedule list by default

## PRs merged into feature branch
- #27817: feat(schedule): add `wake_conversation_id` column to `cron_jobs`
- #27821: feat(schedule): add `wake` mode, `wakeConversationId`, and list filters
- #27828: feat(schedule): handle `wake` mode in scheduler `runScheduleOnce`
- #27829: feat(schedule): accept `wake` mode in HTTP schedule routes
- #27827: feat(ipc): add `defer_create`, `defer_list`, `defer_cancel` IPC routes
- #27825: feat(schedule): exclude `createdBy: 'defer'` from default schedule list
- #27831: feat(cli): add `conversations defer` subcommand

Part of plan: conv-defer.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
