### PR TITLE
fix(macOS): update VNotification gallery header description to reflect multi-line support

### DIFF
--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -244,7 +244,7 @@ struct FeedbackGallerySection: View {
                 // MARK: - VNotification
                 GallerySectionHeader(
                     title: "VNotification",
-                    description: "Compact single-line feedback bar. Supports 4 tones × 2 styles, with optional leading icon, action label, and dismiss button."
+                    description: "Compact feedback bar that wraps long messages to multiple lines. Supports 4 tones × 2 styles, with optional leading icon, action label, and dismiss button."
                 )
 
                 VCard {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan self-review for vnotif-multiline.md.

**Gap:** Gallery section header description still claims 'single-line'
**What was expected:** Header description should match the multi-line capability (already documented in the type's doc comment and shown via the new Multi-line subsection).
**What was found:** `GallerySectionHeader(description:)` at FeedbackGallerySection.swift:247 still read 'Compact single-line feedback bar.'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
