### PR TITLE
feat(macOS): VNotification multi-line wrapping

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -37,7 +37,7 @@ public struct VNotification: View {
                 HStack(alignment: .top, spacing: VSpacing.xs) {
                     VIconView(leadingIcon, size: 12)
                         .foregroundStyle(iconColor)
-                        .padding(.top, 1)
+                        .padding(.top, 3)
                         .accessibilityHidden(true)
                     Text(message)
                         .font(textFont)

--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Compact single-line notification bar with optional action and dismiss. Positioned inline or pinned above content. See FeedbackGallerySection for variants.
+/// Compact notification bar with optional action and dismiss. Wraps long messages to multiple lines; short messages render as a single-line compact bar. See FeedbackGallerySection for variants.
 public struct VNotification: View {
     public enum Tone { case positive, negative, warning, neutral }
     public enum Style { case weak, strong }
@@ -32,24 +32,23 @@ public struct VNotification: View {
     }
 
     public var body: some View {
-        HStack(alignment: .center, spacing: 0) {
+        HStack(alignment: .top, spacing: 0) {
             if showsLeadingIcon {
-                HStack(spacing: VSpacing.xs) {
+                HStack(alignment: .top, spacing: VSpacing.xs) {
                     VIconView(leadingIcon, size: 12)
                         .foregroundStyle(iconColor)
+                        .padding(.top, 1)
                         .accessibilityHidden(true)
                     Text(message)
                         .font(textFont)
                         .foregroundStyle(textColor)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             } else {
                 Text(message)
                     .font(textFont)
                     .foregroundStyle(textColor)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             Spacer()
@@ -83,7 +82,7 @@ public struct VNotification: View {
                 }
             }
         }
-        .frame(height: 32)
+        .padding(.vertical, 7)
         .padding(.horizontal, VSpacing.sm)
         .background(backgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))

--- a/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VNotification.swift
@@ -37,7 +37,7 @@ public struct VNotification: View {
                 HStack(alignment: .top, spacing: VSpacing.xs) {
                     VIconView(leadingIcon, size: 12)
                         .foregroundStyle(iconColor)
-                        .padding(.top, 3)
+                        .frame(height: 18)
                         .accessibilityHidden(true)
                     Text(message)
                         .font(textFont)

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -244,7 +244,7 @@ struct FeedbackGallerySection: View {
                 // MARK: - VNotification
                 GallerySectionHeader(
                     title: "VNotification",
-                    description: "Compact single-line feedback bar. Supports 4 tones × 2 styles, with optional leading icon, action label, and dismiss button."
+                    description: "Compact feedback bar that wraps long messages to multiple lines. Supports 4 tones × 2 styles, with optional leading icon, action label, and dismiss button."
                 )
 
                 VCard {

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -379,6 +379,32 @@ struct FeedbackGallerySection: View {
                                 )
                             }
                         }
+
+                        Divider().background(VColor.borderBase)
+
+                        // Multi-line
+                        Text("Multi-line")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                        VStack(alignment: .leading, spacing: VSpacing.sm) {
+                            VNotification(
+                                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                                tone: .negative,
+                                style: .strong,
+                                actionLabel: "Action",
+                                onAction: {},
+                                onDismiss: {}
+                            )
+                            .frame(maxWidth: 420, alignment: .leading)
+
+                            VNotification(
+                                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                                tone: .positive,
+                                style: .weak,
+                                onDismiss: {}
+                            )
+                            .frame(maxWidth: 420, alignment: .leading)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Update VNotification to wrap long messages across multiple lines per the Figma multi-line mock (node 3816:60658). Short messages still render as the compact single-line bar (padding-driven sizing: 7pt top + 18pt line-height + 7pt bottom = 32pt). Adds a Multi-line subsection to the Feedback gallery with two wrapped variants.

## Self-review result
GAPS FOUND → 1 gap fixed across 1 fix PR → re-review PASS.

## PRs merged into feature branch
- #27820: feat(macOS): VNotification wraps long messages to multiple lines
- #27833: fix(macOS): update VNotification gallery header description to reflect multi-line support

Part of plan: vnotif-multiline.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
