### PR TITLE
test: guard that skills/ does not import from assistant/

### DIFF
--- a/assistant/src/__tests__/skill-boundary-guard.test.ts
+++ b/assistant/src/__tests__/skill-boundary-guard.test.ts
@@ -1,0 +1,102 @@
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Guard tests for the skill-isolation boundary. See CLAUDE.md "Skill
+ * Isolation". The end state is zero relative imports across `assistant/` ↔
+ * `skills/` in both directions.
+ *
+ * The assistant → skills direction is currently `test.todo` because
+ * `assistant/src/daemon/external-skills-bootstrap.ts` is a sanctioned
+ * static import (required so `bun --compile` traces the first-party
+ * meet-join skill into the binary). It converts to an active `test(...)`
+ * once the bootstrap is deleted. Keeping it as `test.todo` rather than an
+ * active assertion is required by CLAUDE.md's "Never commit
+ * normally-failing `test(...)` cases" rule.
+ */
+
+/** Resolve repo root (tests run from `assistant/`). */
+function getRepoRoot(): string {
+  return join(process.cwd(), "..");
+}
+
+/**
+ * Run `git grep -lE <pattern> -- <globs>` from the repo root and return the
+ * list of matching file paths. Treats exit code 1 ("no matches") as the
+ * happy path and returns an empty array.
+ */
+function gitGrepFiles(pattern: string, globs: string[]): string[] {
+  try {
+    const output = execFileSync(
+      "git",
+      ["grep", "-lE", pattern, "--", ...globs],
+      { encoding: "utf-8", cwd: getRepoRoot() },
+    ).trim();
+    return output.length > 0 ? output.split("\n") : [];
+  } catch (err) {
+    if ((err as { status?: number }).status === 1) return [];
+    throw err;
+  }
+}
+
+/**
+ * Matches TypeScript imports (including side-effect `import "..."` and
+ * dynamic `import("...")`) whose module specifier starts with one or more
+ * `../` segments and then a `<dir>/` segment. We anchor on the quote so
+ * line-comments that merely mention the pattern in prose do not match.
+ *
+ * The `<dir>` placeholder is interpolated per-test (either `assistant` or
+ * `skills`).
+ */
+function relativeImportPattern(dir: string): string {
+  return `(from|import)[[:space:]]*\\(?["'](\\.\\./)+${dir}/`;
+}
+
+describe("skill-isolation boundary", () => {
+  test("no skills/** TypeScript file imports from assistant/** via relative path", () => {
+    const violations = gitGrepFiles(relativeImportPattern("assistant"), [
+      "skills/**/*.ts",
+    ]);
+
+    if (violations.length > 0) {
+      const message = [
+        "Found skills/ files that import assistant/ via relative path.",
+        'Skills must wire into the daemon through a SkillHost — see CLAUDE.md "Skill Isolation".',
+        "",
+        "Violations:",
+        ...violations.map((f) => `  - ${f}`),
+        "",
+        "To fix: inject the needed capability through `SkillHost` (logger,",
+        "events, registries, providers, etc.) instead of reaching into",
+        "`assistant/` directly.",
+      ].join("\n");
+
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  // Deferred until `external-skills-bootstrap.ts` is deleted — see the
+  // file-level doc block. Body is pre-written so the flip is a `.todo` → `test`
+  // edit rather than a behavior change.
+  test.todo(
+    "no assistant/src/** TypeScript file imports from skills/** via relative path",
+    () => {
+      const violations = gitGrepFiles(relativeImportPattern("skills"), [
+        "assistant/src/**/*.ts",
+      ]);
+
+      if (violations.length > 0) {
+        const message = [
+          "Found assistant/src/ files that import skills/ via relative path.",
+          'Assistants must not reach into skills/ — see CLAUDE.md "Skill Isolation".',
+          "",
+          "Violations:",
+          ...violations.map((f) => `  - ${f}`),
+        ].join("\n");
+
+        expect(violations, message).toEqual([]);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- Adds assistant/src/__tests__/skill-boundary-guard.test.ts.
- Active assertion: no TypeScript file under skills/ imports from assistant/ via relative paths.
- Deferred assertion (test.todo): no TypeScript file under assistant/src/ imports from skills/ — activated in PR 34 after external-skills-bootstrap.ts is deleted.

Part of plan: skill-isolation.md (PR 19 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
