### PR TITLE
Remove Mention of Google in Auth Connect

### DIFF
--- a/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
+++ b/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
@@ -43,10 +43,6 @@ To actually initiate a connection with the OAuth provider, run:
 assistant oauth connect <provider-key> --scopes <scope1> <scope2> ...
 ```
 
-When `--scopes` is provided, the specified scopes replace the provider's defaults entirely. When omitted, the provider's default scopes are used.
-
-If the provider-specific setup skill gives its own browser handoff instructions, follow those instead of the default browser behavior. Google bring-your-own setup on the macOS desktop app is one example: request the auth URL with `--no-browser`, then open it using the provider skill's AppleScript/browser handoff rules.
-
 This will open a new web browser tab where the user can log in to the third-party provider. Upon success, they should be redirected to a confirmation page and told that it's safe to close the browser tab and come back here.
 
 ## Verification


### PR DESCRIPTION
Simply mentioning "google" and "macos" was probably enough to get the LLM to want to read the google.md reference file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
