### PR TITLE
fix: resolve CI failures in schedule tests

### DIFF
--- a/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
+++ b/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
@@ -44,6 +44,7 @@ describe("schedule_syntax column migration", () => {
         quiet INTEGER NOT NULL DEFAULT 0,
         reuse_conversation INTEGER NOT NULL DEFAULT 0,
         script TEXT,
+        wake_conversation_id TEXT,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       )

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -405,17 +405,6 @@ function getPatchHandler() {
   return route.handler;
 }
 
-function getListHandler() {
-  const route = scheduleRouteDefinitions({
-    sendMessageDeps: {} as never,
-  }).find(
-    (candidate) =>
-      candidate.endpoint === "schedules" && candidate.method === "GET",
-  );
-  if (!route) throw new Error("GET schedules route not found");
-  return route.handler;
-}
-
 describe("wake mode in schedule routes", () => {
   beforeEach(() => {
     clearTables();


### PR DESCRIPTION
## Summary
- Remove duplicate `getListHandler` function in `schedule-routes.test.ts` (introduced when PR 4 and PR 7 merged independently)
- Add missing `wake_conversation_id` column to hardcoded schema in `db-schedule-syntax-migration.test.ts`

Fixes CI failures on feature branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
