### PR TITLE
feat(daemon): add skill IPC server at assistant-skill.sock

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -28,6 +28,7 @@ import type { FilingService } from "../filing/filing-service.js";
 import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { CliIpcServer } from "../ipc/cli-server.js";
 import { registerBrowserIpcContextResolver } from "../ipc/routes/browser-context.js";
+import { SkillIpcServer } from "../ipc/skill-server.js";
 import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
 import * as attachmentsStore from "../memory/attachments-store.js";
 import {
@@ -309,6 +310,7 @@ export class DaemonServer {
   private configWatcher = new ConfigWatcher();
   private appSourceWatcher = new AppSourceWatcher();
   private cliIpc = new CliIpcServer();
+  private skillIpc = new SkillIpcServer();
 
   // CES (Credential Execution Service) — process-level singleton.
   // Lifecycle is managed by startCesProcess() in lifecycle.ts; the server
@@ -895,6 +897,12 @@ export class DaemonServer {
     // invoke daemon-side operations that require in-process state.
     this.cliIpc.start();
 
+    // Start the skill IPC server. First-party skill processes connect to this
+    // socket to access host capabilities (host.log, host.config.*,
+    // host.events.*, host.registries.*). Route registry is populated by
+    // subsequent PRs in the skill-isolation plan.
+    this.skillIpc.start();
+
     // Wire the launchConversation helper to daemon-side state so
     // handleSurfaceAction can spawn conversations through it.
     registerLaunchConversationDeps({
@@ -949,6 +957,7 @@ export class DaemonServer {
     this.configWatcher.stop();
     this.appSourceWatcher.stop();
     this.cliIpc.stop();
+    this.skillIpc.stop();
     if (this.unsubscribeContactChange) {
       this.unsubscribeContactChange();
       this.unsubscribeContactChange = null;

--- a/assistant/src/ipc/__tests__/skill-server.test.ts
+++ b/assistant/src/ipc/__tests__/skill-server.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Smoke test for the skill IPC server. Starts the server on a temp socket
+ * path, connects with a raw socket client, and verifies the server dispatches
+ * newline-delimited JSON messages — specifically, that unknown methods return
+ * a structured error response.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { connect, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { SkillIpcServer } from "../skill-server.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tempDir: string | null = null;
+let server: SkillIpcServer | null = null;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "skill-ipc-test-"));
+});
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+});
+
+async function startServerAt(socketPath: string): Promise<SkillIpcServer> {
+  const srv = new SkillIpcServer({ socketPath });
+  srv.start();
+  // Give the listener a tick to bind.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  return srv;
+}
+
+function sendRequest(
+  socketPath: string,
+  payload: Record<string, unknown>,
+): Promise<{ id: string; result?: unknown; error?: string }> {
+  return new Promise((resolve, reject) => {
+    const socket: Socket = connect(socketPath);
+    let buffer = "";
+    let settled = false;
+
+    const finish = (
+      value: { id: string; result?: unknown; error?: string } | Error,
+    ) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      if (value instanceof Error) reject(value);
+      else resolve(value);
+    };
+
+    socket.on("connect", () => {
+      socket.write(JSON.stringify(payload) + "\n");
+    });
+
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString();
+      const newlineIdx = buffer.indexOf("\n");
+      if (newlineIdx === -1) return;
+      const line = buffer.slice(0, newlineIdx).trim();
+      try {
+        finish(JSON.parse(line));
+      } catch (err) {
+        finish(err as Error);
+      }
+    });
+
+    socket.on("error", (err) => finish(err));
+    socket.on("close", () => {
+      if (!settled) finish(new Error("Connection closed before response"));
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SkillIpcServer", () => {
+  test("accepts connections and returns error for unknown methods", async () => {
+    if (!tempDir) throw new Error("tempDir not initialized");
+    const socketPath = join(tempDir, "assistant-skill.sock");
+    server = await startServerAt(socketPath);
+
+    const response = await sendRequest(socketPath, {
+      id: "req-1",
+      method: "host.does.not.exist",
+    });
+
+    expect(response.id).toBe("req-1");
+    expect(response.result).toBeUndefined();
+    expect(response.error).toBeDefined();
+    expect(response.error).toContain("host.does.not.exist");
+  });
+
+  test("returns error for malformed JSON", async () => {
+    if (!tempDir) throw new Error("tempDir not initialized");
+    const socketPath = join(tempDir, "assistant-skill.sock");
+    server = await startServerAt(socketPath);
+
+    const response = await new Promise<{ id: string; error?: string }>(
+      (resolve, reject) => {
+        const socket: Socket = connect(socketPath);
+        let buffer = "";
+        let settled = false;
+        const finish = (
+          value: { id: string; error?: string } | Error,
+        ): void => {
+          if (settled) return;
+          settled = true;
+          socket.destroy();
+          if (value instanceof Error) reject(value);
+          else resolve(value);
+        };
+        socket.on("connect", () => {
+          socket.write("not-valid-json\n");
+        });
+        socket.on("data", (chunk) => {
+          buffer += chunk.toString();
+          const idx = buffer.indexOf("\n");
+          if (idx === -1) return;
+          const line = buffer.slice(0, idx).trim();
+          try {
+            finish(JSON.parse(line));
+          } catch (err) {
+            finish(err as Error);
+          }
+        });
+        socket.on("error", (err) => finish(err));
+      },
+    );
+
+    expect(response.error).toBe("Invalid JSON");
+  });
+
+  test("returns error for missing id/method fields", async () => {
+    if (!tempDir) throw new Error("tempDir not initialized");
+    const socketPath = join(tempDir, "assistant-skill.sock");
+    server = await startServerAt(socketPath);
+
+    const response = await sendRequest(socketPath, { id: "req-2" });
+
+    expect(response.id).toBe("req-2");
+    expect(response.error).toContain("Missing");
+  });
+
+  test("dispatches registered methods and returns result", async () => {
+    if (!tempDir) throw new Error("tempDir not initialized");
+    const socketPath = join(tempDir, "assistant-skill.sock");
+    server = await startServerAt(socketPath);
+    server.registerMethod("test.echo", (params) => ({ echoed: params }));
+
+    const response = await sendRequest(socketPath, {
+      id: "req-3",
+      method: "test.echo",
+      params: { value: 42 },
+    });
+
+    expect(response.id).toBe("req-3");
+    expect(response.error).toBeUndefined();
+    expect(response.result).toEqual({ echoed: { value: 42 } });
+  });
+});

--- a/assistant/src/ipc/skill-routes/index.ts
+++ b/assistant/src/ipc/skill-routes/index.ts
@@ -1,0 +1,11 @@
+import type { IpcRoute } from "../cli-server.js";
+
+/**
+ * Skill IPC routes — host capabilities exposed to first-party skill processes
+ * over the `assistant-skill.sock` socket.
+ *
+ * Populated by subsequent PRs in the skill-isolation plan (host.log,
+ * host.config.*, host.identity.*, host.platform.*, host.memory.*,
+ * host.providers.*, host.events.*, host.registries.*).
+ */
+export const skillIpcRoutes: IpcRoute[] = [];

--- a/assistant/src/ipc/skill-server.ts
+++ b/assistant/src/ipc/skill-server.ts
@@ -1,0 +1,232 @@
+/**
+ * Skill IPC server — exposes daemon (host) capabilities to first-party skill
+ * processes over a Unix domain socket.
+ *
+ * Separate from the CLI IPC server so skill traffic (host.log, host.config.*,
+ * host.events.*, host.registries.*, etc.) stays off the CLI socket and can
+ * evolve its own long-lived subscribe streams.
+ *
+ * Protocol: newline-delimited JSON over a Unix domain socket.
+ * - Request:  { "id": string, "method": string, "params"?: Record<string, unknown> }
+ * - Response: { "id": string, "result"?: unknown, "error"?: string }
+ *
+ * The preferred socket path is `{workspaceDir}/assistant-skill.sock`. On
+ * platforms with strict AF_UNIX path limits (notably macOS), the server falls
+ * back to a shorter deterministic path via the shared socket-path resolver.
+ */
+
+import { existsSync, mkdirSync, unlinkSync } from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
+import { dirname } from "node:path";
+
+import { getLogger } from "../util/logger.js";
+import type {
+  IpcMethodHandler,
+  IpcRequest,
+  IpcResponse,
+} from "./cli-server.js";
+import { skillIpcRoutes } from "./skill-routes/index.js";
+import { resolveSkillIpcSocketPath } from "./skill-socket-path.js";
+
+const log = getLogger("skill-ipc-server");
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+export interface SkillIpcServerOptions {
+  /** Override the socket path (tests). Defaults to the resolver output. */
+  socketPath?: string;
+}
+
+export class SkillIpcServer {
+  private server: Server | null = null;
+  private clients = new Set<Socket>();
+  private methods = new Map<string, IpcMethodHandler>();
+  private socketPath: string;
+
+  constructor(options: SkillIpcServerOptions = {}) {
+    if (options.socketPath) {
+      this.socketPath = options.socketPath;
+    } else {
+      const socketResolution = resolveSkillIpcSocketPath();
+      this.socketPath = socketResolution.path;
+      if (socketResolution.source !== "workspace") {
+        log.warn(
+          {
+            source: socketResolution.source,
+            workspacePath: socketResolution.workspacePath,
+            resolvedPath: socketResolution.path,
+            maxPathBytes: socketResolution.maxPathBytes,
+          },
+          "Skill IPC socket path exceeded platform limit; using fallback path",
+        );
+      }
+    }
+    for (const route of skillIpcRoutes) {
+      this.methods.set(route.method, route.handler);
+    }
+  }
+
+  /** Register an additional method handler after construction. */
+  registerMethod(method: string, handler: IpcMethodHandler): void {
+    this.methods.set(method, handler);
+  }
+
+  /** Start listening on the Unix domain socket. */
+  start(): void {
+    // Ensure the parent directory exists before listening.
+    const socketDir = dirname(this.socketPath);
+    if (!existsSync(socketDir)) {
+      mkdirSync(socketDir, { recursive: true, mode: 0o700 });
+    }
+
+    // Clean up stale socket file from a previous run
+    if (existsSync(this.socketPath)) {
+      try {
+        unlinkSync(this.socketPath);
+      } catch {
+        // Ignore — may already be gone
+      }
+    }
+
+    this.server = createServer((socket) => {
+      this.clients.add(socket);
+      log.debug("Skill IPC client connected");
+
+      let buffer = "";
+
+      socket.on("data", (chunk) => {
+        buffer += chunk.toString();
+        let newlineIdx: number;
+        while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, newlineIdx).trim();
+          buffer = buffer.slice(newlineIdx + 1);
+          if (line) {
+            this.handleMessage(socket, line);
+          }
+        }
+      });
+
+      socket.on("close", () => {
+        this.clients.delete(socket);
+        log.debug("Skill IPC client disconnected");
+      });
+
+      socket.on("error", (err) => {
+        log.warn({ err }, "Skill IPC client socket error");
+        this.clients.delete(socket);
+      });
+    });
+
+    this.server.on("error", (err) => {
+      log.error({ err }, "Skill IPC server error");
+    });
+
+    this.server.listen(this.socketPath, () => {
+      log.info({ path: this.socketPath }, "Skill IPC server listening");
+    });
+  }
+
+  /** Stop the server and disconnect all clients. */
+  stop(): void {
+    for (const client of this.clients) {
+      if (!client.destroyed) client.destroy();
+    }
+    this.clients.clear();
+
+    if (this.server) {
+      this.server.close();
+      this.server = null;
+    }
+
+    if (existsSync(this.socketPath)) {
+      try {
+        unlinkSync(this.socketPath);
+      } catch {
+        // Ignore
+      }
+    }
+  }
+
+  /** Get the socket path (for diagnostics). */
+  getSocketPath(): string {
+    return this.socketPath;
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────────
+
+  private handleMessage(socket: Socket, line: string): void {
+    let req: IpcRequest;
+    try {
+      req = JSON.parse(line) as IpcRequest;
+    } catch {
+      this.sendResponse(socket, {
+        id: "unknown",
+        error: "Invalid JSON",
+      });
+      return;
+    }
+
+    if (
+      !req ||
+      typeof req !== "object" ||
+      Array.isArray(req) ||
+      !req.id ||
+      !req.method
+    ) {
+      const id =
+        req &&
+        typeof req === "object" &&
+        !Array.isArray(req) &&
+        typeof req.id === "string"
+          ? req.id
+          : "unknown";
+      this.sendResponse(socket, {
+        id,
+        error: "Missing 'id' or 'method' field",
+      });
+      return;
+    }
+
+    const handler = this.methods.get(req.method);
+    if (!handler) {
+      this.sendResponse(socket, {
+        id: req.id,
+        error: `Unknown method: ${req.method}`,
+      });
+      return;
+    }
+
+    try {
+      const result = handler(req.params);
+      if (result instanceof Promise) {
+        result
+          .then((value) => {
+            this.sendResponse(socket, { id: req.id, result: value });
+          })
+          .catch((err) => {
+            log.warn({ err, method: req.method }, "Skill IPC handler error");
+            this.sendResponse(socket, {
+              id: req.id,
+              error: String(err),
+            });
+          });
+      } else {
+        this.sendResponse(socket, { id: req.id, result });
+      }
+    } catch (err) {
+      log.warn({ err, method: req.method }, "Skill IPC handler error");
+      this.sendResponse(socket, {
+        id: req.id,
+        error: String(err),
+      });
+    }
+  }
+
+  private sendResponse(socket: Socket, response: IpcResponse): void {
+    if (!socket.destroyed) {
+      socket.write(JSON.stringify(response) + "\n");
+    }
+  }
+}

--- a/assistant/src/ipc/skill-socket-path.ts
+++ b/assistant/src/ipc/skill-socket-path.ts
@@ -1,0 +1,27 @@
+/**
+ * Skill IPC socket-path helper — resolves the path to `assistant-skill.sock`,
+ * the Unix domain socket that first-party skill processes use to talk to the
+ * daemon.
+ *
+ * Delegates to the shared `resolveIpcSocketPath` in `socket-path.ts` so the
+ * same workspace → BASE_DATA_DIR → tmp fallback chain applies for platforms
+ * with strict AF_UNIX path limits.
+ */
+
+import { getWorkspaceDir } from "../util/platform.js";
+import {
+  type IpcSocketPathResolution,
+  resolveIpcSocketPath,
+} from "./socket-path.js";
+
+export const SKILL_IPC_SOCKET_FILE_NAME = "assistant-skill.sock";
+
+export function resolveSkillIpcSocketPath(
+  workspaceDir: string = getWorkspaceDir(),
+): IpcSocketPathResolution {
+  return resolveIpcSocketPath(SKILL_IPC_SOCKET_FILE_NAME, workspaceDir);
+}
+
+export function getSkillSocketPath(): string {
+  return resolveSkillIpcSocketPath().path;
+}


### PR DESCRIPTION
## Summary
- Adds assistant/src/ipc/skill-server.ts modeled on cli-server.ts, listening on <workspaceDir>/assistant-skill.sock.
- Empty route registry (PR 21-24 populate it with host.* routes).
- Daemon server.ts starts/stops SkillIpcServer alongside CliIpcServer.
- Smoke test verifies the server accepts connections and returns structured errors for unknown methods.

Part of plan: skill-isolation.md (PR 20 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
