### PR TITLE
fix(lint): resolve knip unused file and dependency warnings

### DIFF
--- a/assistant/knip.json
+++ b/assistant/knip.json
@@ -15,7 +15,8 @@
     "../skills/meet-join/meet-controller-ext/src/background.ts",
     "../skills/meet-join/meet-controller-ext/src/content.ts",
     "../skills/meet-join/meet-controller-ext/src/avatar/avatar.ts",
-    "../skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts"
+    "../skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts",
+    "../skills/meet-join/scripts/emit-manifest.ts"
   ],
   "project": [
     "src/**/*.ts",
@@ -29,6 +30,7 @@
     "@vellumai/credential-storage",
     "@vellumai/egress-proxy",
     "@resvg/resvg-js-darwin-arm64",
-    "@resvg/resvg-js-darwin-x64"
+    "@resvg/resvg-js-darwin-x64",
+    "@vellumai/skill-host-contracts"
   ]
 }


### PR DESCRIPTION
## Summary
- Add `../skills/meet-join/scripts/emit-manifest.ts` as a knip entry point — it's a standalone CLI script invoked by Dockerfile, CI, and macOS build, not imported by other source files
- Add `@vellumai/skill-host-contracts` to knip's `ignoreDependencies` — it's used by 7+ source files but knip can't trace the `file:..` link resolution

## Original prompt
fix this lint error:

Run bun run lint:unused
$ knip --include files,dependencies,unlisted
Unused files (1)
../skills/meet-join/scripts/emit-manifest.ts
Unused dependencies (1)
@vellumai/skill-host-contracts  package.json:44:6
error: script "lint:unused" exited with code 1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
