### PR TITLE
docs(arch): add assistant-gateway-ces communication matrix and drift guard

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,6 +20,7 @@ This file is the cross-system architecture index. Detailed designs live in domai
 | Environment and data layout | [Environment and Data Layout](#environment-and-data-layout) (this file) |
 | Multi-local instance isolation | [Multi-Local Instance Isolation](#multi-local-instance-isolation) (this file) |
 | Docker volume architecture | [Docker Volume Architecture](#docker-volume-architecture) (this file) |
+| Service communication matrix | [`docs/service-communication-matrix.md`](docs/service-communication-matrix.md) |
 
 ## Cross-Cutting Invariants
 
@@ -215,6 +216,8 @@ Each bot container receives a bind of `/workspace` sourced from the assistant's 
 **Security boundary — single-user local only.** The Docker-in-Docker model requires the assistant container to run with `--privileged`, or at minimum `CAP_SYS_ADMIN` + `CAP_NET_ADMIN`, so the inner `dockerd` can set up cgroups, overlay mounts, and container networks. This is acceptable for single-user local deployments where the assistant already runs with the user's privileges. It is **not** acceptable as-is for managed/multi-tenant mode: Kubernetes deployments must configure Pod Security Admission to allow this privilege level on the assistant pod, or swap in a different bot-spawn model (e.g. a Kubernetes job runner or a dedicated bot-scheduler service) before Meet can ship to managed instances. Managed Meet support is explicitly out of scope for this Docker-in-Docker approach — see [`vellum-assistant-platform`](../vellum-assistant-platform).
 
 ### Cross-Service Access Patterns
+
+For the full inventory of every assistant/gateway/CES communication direction, protocol, and callsite, see the [Service Communication Matrix](docs/service-communication-matrix.md).
 
 In Docker mode (`IS_CONTAINERIZED=true`), services that need data from another service's security domain use HTTP APIs instead of direct filesystem access:
 

--- a/docs/service-communication-matrix.md
+++ b/docs/service-communication-matrix.md
@@ -1,0 +1,302 @@
+# Service Communication Matrix
+
+> **Auto-generated** from `scripts/service-communication/matrix-source.ts`.
+> Do not edit by hand. Run `bun run scripts/service-communication/generate-matrix.ts` to regenerate.
+
+This document enumerates every observed communication permutation between the three core services:
+**Assistant** (daemon), **Gateway** (channel ingress), and **CES** (Credential Execution Service).
+
+## Summary
+
+| # | Direction | Protocol | Auth | Label |
+|---|-----------|----------|------|-------|
+| 1 | Gateway -> Assistant | `http` | JWT Bearer (ingress token) | Channel inbound forwarding |
+| 2 | Gateway -> Assistant | `http` | JWT Bearer (service token) | Conversation reset |
+| 3 | Gateway -> Assistant | `http` | JWT Bearer (service token) | Attachment upload |
+| 4 | Gateway -> Assistant | `http` | JWT Bearer (service token) | Attachment download |
+| 5 | Gateway -> Assistant | `http` | JWT Bearer (service token) | Twilio voice webhook forwarding |
+| 6 | Gateway -> Assistant | `http` | JWT Bearer (service token) | OAuth callback forwarding |
+| 7 | Gateway -> Assistant | `http` | JWT Bearer (service token) | Runtime proxy |
+| 8 | Gateway -> Assistant | `http` | JWT Bearer (service token) | Log export (daemon logs) |
+| 9 | Gateway -> Assistant | `websocket` | JWT Bearer (edge relay token, query param) | Twilio ConversationRelay WebSocket proxy |
+| 10 | Assistant -> Gateway | `http` | JWT Bearer (daemon delivery token) | Channel reply delivery (Telegram) |
+| 11 | Assistant -> Gateway | `http` | JWT Bearer (daemon delivery token) | Channel reply delivery (WhatsApp) |
+| 12 | Assistant -> Gateway | `http` | JWT Bearer (daemon delivery token) | Channel reply delivery (Slack) |
+| 13 | Assistant -> Gateway | `http` | JWT Bearer (edge relay token) | Trust rules CRUD |
+| 14 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Feature flags IPC |
+| 15 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Contact data IPC |
+| 16 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Risk classification IPC |
+| 17 | Assistant -> CES | `stdio-ndjson` | none (child process) | CES RPC (local mode) |
+| 18 | Assistant -> CES | `unix-socket-ndjson` | none (bootstrap socket) | CES RPC (managed mode) |
+| 19 | Assistant -> CES | `http` | CES_SERVICE_TOKEN Bearer | CES credential CRUD (HTTP) |
+| 20 | Gateway -> CES | `http` | CES_SERVICE_TOKEN Bearer | Gateway credential reads (HTTP) |
+| 21 | Gateway -> CES | `http` | CES_SERVICE_TOKEN Bearer | Gateway CES log export (HTTP) |
+
+## Gateway -> Assistant
+
+### Channel inbound forwarding
+
+- **Protocol:** `http`
+- **Auth:** JWT Bearer (ingress token)
+- **Description:** Gateway forwards normalized channel messages (Telegram, WhatsApp, Slack, email) to the assistant's /v1/channels/inbound endpoint.
+
+**Caller files:**
+- `gateway/src/runtime/client.ts`
+
+**Callee files:**
+- `assistant/src/runtime/routes/inbound-stages/*.ts`
+
+### Conversation reset
+
+- **Protocol:** `http`
+- **Auth:** JWT Bearer (service token)
+- **Description:** Gateway resets a channel conversation via DELETE /v1/channels/conversation on the assistant.
+
+**Caller files:**
+- `gateway/src/runtime/client.ts`
+
+**Callee files:**
+- `assistant/src/runtime/routes/inbound-message-handler.ts`
+
+### Attachment upload
+
+- **Protocol:** `http`
+- **Auth:** JWT Bearer (service token)
+- **Description:** Gateway uploads channel attachments to the assistant via POST /v1/attachments.
+
+**Caller files:**
+- `gateway/src/runtime/client.ts`
+
+**Callee files:**
+- `assistant/src/runtime/routes/inbound-message-handler.ts`
+
+### Attachment download
+
+- **Protocol:** `http`
+- **Auth:** JWT Bearer (service token)
+- **Description:** Gateway downloads attachment metadata and content from the assistant for channel delivery.
+
+**Caller files:**
+- `gateway/src/runtime/client.ts`
+
+**Callee files:**
+- `assistant/src/runtime/routes/inbound-message-handler.ts`
+
+### Twilio voice webhook forwarding
+
+- **Protocol:** `http`
+- **Auth:** JWT Bearer (service token)
+- **Description:** Gateway forwards validated Twilio voice/status/connect-action webhooks to the assistant's internal Twilio endpoints.
+
+**Caller files:**
+- `gateway/src/runtime/client.ts`
+
+**Callee files:**
+- `assistant/src/calls/*.ts`
+
+### OAuth callback forwarding
+
+- **Protocol:** `http`
+- **Auth:** JWT Bearer (service token)
+- **Description:** Gateway forwards OAuth callback codes to the assistant's internal OAuth endpoint.
+
+**Caller files:**
+- `gateway/src/runtime/client.ts`
+
+**Callee files:**
+- `assistant/src/runtime/routes/inbound-message-handler.ts`
+
+### Runtime proxy
+
+- **Protocol:** `http`
+- **Auth:** JWT Bearer (service token)
+- **Description:** Gateway proxies authenticated external HTTP requests directly to the assistant runtime.
+
+**Caller files:**
+- `gateway/src/http/routes/runtime-proxy.ts`
+
+**Callee files:**
+- `assistant/src/runtime/http-server.ts`
+
+### Log export (daemon logs)
+
+- **Protocol:** `http`
+- **Auth:** JWT Bearer (service token)
+- **Description:** Gateway collects daemon logs from the assistant via POST /v1/export during log export.
+
+**Caller files:**
+- `gateway/src/http/routes/log-export.ts`
+
+**Callee files:**
+- `assistant/src/runtime/http-server.ts`
+
+### Twilio ConversationRelay WebSocket proxy
+
+- **Protocol:** `websocket`
+- **Auth:** JWT Bearer (edge relay token, query param)
+- **Description:** Gateway proxies Twilio ConversationRelay WebSocket frames to the assistant's /v1/calls/relay endpoint.
+
+**Caller files:**
+- `gateway/src/http/routes/twilio-relay-websocket.ts`
+
+**Callee files:**
+- `assistant/src/calls/relay-server.ts`
+
+## Assistant -> Gateway
+
+### Channel reply delivery (Telegram)
+
+- **Protocol:** `http`
+- **Auth:** JWT Bearer (daemon delivery token)
+- **Description:** Assistant delivers reply messages to Telegram chats via the gateway's /deliver/telegram endpoint.
+
+**Caller files:**
+- `assistant/src/runtime/gateway-client.ts`
+- `assistant/src/notifications/adapters/telegram.ts`
+
+**Callee files:**
+- `gateway/src/http/routes/telegram-deliver.ts`
+
+### Channel reply delivery (WhatsApp)
+
+- **Protocol:** `http`
+- **Auth:** JWT Bearer (daemon delivery token)
+- **Description:** Assistant delivers reply messages to WhatsApp via the gateway's /deliver/whatsapp endpoint.
+
+**Caller files:**
+- `assistant/src/runtime/gateway-client.ts`
+- `assistant/src/messaging/providers/whatsapp/adapter.ts`
+
+**Callee files:**
+- `gateway/src/http/routes/whatsapp-deliver.ts`
+
+### Channel reply delivery (Slack)
+
+- **Protocol:** `http`
+- **Auth:** JWT Bearer (daemon delivery token)
+- **Description:** Assistant delivers reply messages to Slack via the gateway's /deliver/slack endpoint.
+
+**Caller files:**
+- `assistant/src/runtime/gateway-client.ts`
+- `assistant/src/notifications/adapters/slack.ts`
+
+**Callee files:**
+- `gateway/src/http/routes/slack-deliver.ts`
+
+### Trust rules CRUD
+
+- **Protocol:** `http`
+- **Auth:** JWT Bearer (edge relay token)
+- **Description:** Assistant reads/writes trust rules via the gateway's /v1/trust-rules REST API (containerized mode).
+
+**Caller files:**
+- `assistant/src/permissions/trust-client.ts`
+
+**Callee files:**
+- `gateway/src/ipc/trust-rule-handlers.ts`
+- `gateway/src/trust-store.ts`
+
+### Feature flags IPC
+
+- **Protocol:** `ipc-unix-ndjson`
+- **Auth:** none (local socket)
+- **Description:** Assistant fetches merged feature flags from the gateway via the Unix domain socket IPC (get_feature_flags method).
+
+**Caller files:**
+- `assistant/src/ipc/gateway-client.ts`
+
+**Callee files:**
+- `gateway/src/ipc/feature-flag-handlers.ts`
+- `gateway/src/ipc/server.ts`
+
+### Contact data IPC
+
+- **Protocol:** `ipc-unix-ndjson`
+- **Auth:** none (local socket)
+- **Description:** Assistant reads contact auth/authz data from the gateway via IPC (get_contact, list_contacts, get_contact_by_channel, get_channels_for_contact).
+
+**Caller files:**
+- `assistant/src/ipc/gateway-client.ts`
+
+**Callee files:**
+- `gateway/src/ipc/contact-handlers.ts`
+- `gateway/src/ipc/server.ts`
+
+### Risk classification IPC
+
+- **Protocol:** `ipc-unix-ndjson`
+- **Auth:** none (local socket)
+- **Description:** Assistant classifies tool invocation risk via the persistent IPC connection to the gateway (classify_risk method).
+
+**Caller files:**
+- `assistant/src/ipc/gateway-client.ts`
+
+**Callee files:**
+- `gateway/src/ipc/server.ts`
+
+## Assistant -> CES
+
+### CES RPC (local mode)
+
+- **Protocol:** `stdio-ndjson`
+- **Auth:** none (child process)
+- **Description:** Assistant spawns the credential-executor as a child process and communicates via stdio JSON-RPC for tool execution (run_authenticated_command, make_authenticated_request, manage_secure_command_tool).
+
+**Caller files:**
+- `assistant/src/credential-execution/process-manager.ts`
+- `assistant/src/credential-execution/client.ts`
+
+**Callee files:**
+- `credential-executor/src/server.ts`
+- `credential-executor/src/main.ts`
+
+### CES RPC (managed mode)
+
+- **Protocol:** `unix-socket-ndjson`
+- **Auth:** none (bootstrap socket)
+- **Description:** Assistant connects to the CES sidecar's bootstrap Unix socket (CES_BOOTSTRAP_SOCKET) for RPC in managed/Docker mode.
+
+**Caller files:**
+- `assistant/src/credential-execution/process-manager.ts`
+
+**Callee files:**
+- `credential-executor/src/managed-main.ts`
+- `credential-executor/src/server.ts`
+
+### CES credential CRUD (HTTP)
+
+- **Protocol:** `http`
+- **Auth:** CES_SERVICE_TOKEN Bearer
+- **Description:** Assistant performs credential CRUD via the CES HTTP API (CES_CREDENTIAL_URL) in containerized mode.
+
+**Caller files:**
+- `assistant/src/security/ces-credential-client.ts`
+
+**Callee files:**
+- `credential-executor/src/http/*.ts`
+
+## Gateway -> CES
+
+### Gateway credential reads (HTTP)
+
+- **Protocol:** `http`
+- **Auth:** CES_SERVICE_TOKEN Bearer
+- **Description:** Gateway reads credentials from the CES HTTP API (CES_CREDENTIAL_URL) in containerized mode for channel auth (Telegram bot token, Twilio SID, etc.).
+
+**Caller files:**
+- `gateway/src/credential-reader.ts`
+
+**Callee files:**
+- `credential-executor/src/http/*.ts`
+
+### Gateway CES log export (HTTP)
+
+- **Protocol:** `http`
+- **Auth:** CES_SERVICE_TOKEN Bearer
+- **Description:** Gateway fetches CES audit logs during log export via GET /v1/logs/export on the CES HTTP API.
+
+**Caller files:**
+- `gateway/src/http/routes/log-export.ts`
+
+**Callee files:**
+- `credential-executor/src/http/*.ts`

--- a/scripts/service-communication/__tests__/generate-matrix.test.ts
+++ b/scripts/service-communication/__tests__/generate-matrix.test.ts
@@ -1,0 +1,166 @@
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { Glob } from "bun";
+
+import {
+  MATRIX_ENTRIES,
+  type MatrixEntry,
+  type Protocol,
+  type ServiceName,
+} from "../matrix-source.js";
+import { renderMatrix, serviceDisplayName } from "../generate-matrix.js";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..");
+
+const VALID_SERVICES: ServiceName[] = ["assistant", "gateway", "ces"];
+
+const VALID_PROTOCOLS: Protocol[] = [
+  "http",
+  "websocket",
+  "ipc-unix-ndjson",
+  "stdio-ndjson",
+  "unix-socket-ndjson",
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function permutationKey(entry: MatrixEntry): string {
+  return `${entry.caller}->${entry.callee}:${entry.protocol}:${entry.label}`;
+}
+
+/**
+ * Check whether a glob pattern matches at least one file in the repo.
+ * Uses Bun's Glob API for fast native matching.
+ */
+function globMatchesFiles(pattern: string): boolean {
+  const glob = new Glob(pattern);
+  for (const _match of glob.scanSync({ cwd: REPO_ROOT })) {
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("service communication matrix", () => {
+  test("matrix is not empty", () => {
+    expect(MATRIX_ENTRIES.length).toBeGreaterThan(0);
+  });
+
+  test("every entry has a non-empty label", () => {
+    for (const entry of MATRIX_ENTRIES) {
+      expect(entry.label.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every entry uses a valid service name for caller and callee", () => {
+    for (const entry of MATRIX_ENTRIES) {
+      expect(VALID_SERVICES).toContain(entry.caller);
+      expect(VALID_SERVICES).toContain(entry.callee);
+    }
+  });
+
+  test("caller and callee are different services", () => {
+    for (const entry of MATRIX_ENTRIES) {
+      expect(entry.caller).not.toBe(entry.callee);
+    }
+  });
+
+  test("every entry uses a valid protocol", () => {
+    for (const entry of MATRIX_ENTRIES) {
+      expect(VALID_PROTOCOLS).toContain(entry.protocol);
+    }
+  });
+
+  test("every entry has a non-empty auth field", () => {
+    for (const entry of MATRIX_ENTRIES) {
+      expect(entry.auth.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every entry has a non-empty description", () => {
+    for (const entry of MATRIX_ENTRIES) {
+      expect(entry.description.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every entry has at least one caller glob", () => {
+    for (const entry of MATRIX_ENTRIES) {
+      expect(entry.callerGlobs.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every entry has at least one callee glob", () => {
+    for (const entry of MATRIX_ENTRIES) {
+      expect(entry.calleeGlobs.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("no duplicate permutation keys", () => {
+    const keys = MATRIX_ENTRIES.map(permutationKey);
+    const seen = new Set<string>();
+    for (const key of keys) {
+      expect(seen.has(key)).toBe(false);
+      seen.add(key);
+    }
+  });
+
+  test("caller globs reference existing files", () => {
+    const missing: string[] = [];
+    for (const entry of MATRIX_ENTRIES) {
+      for (const pattern of entry.callerGlobs) {
+        if (!globMatchesFiles(pattern)) {
+          missing.push(`[${entry.label}] caller: ${pattern}`);
+        }
+      }
+    }
+    if (missing.length > 0) {
+      throw new Error(
+        `Matrix entries reference missing caller files:\n${missing.join("\n")}`,
+      );
+    }
+  });
+
+  test("callee globs reference existing files", () => {
+    const missing: string[] = [];
+    for (const entry of MATRIX_ENTRIES) {
+      for (const pattern of entry.calleeGlobs) {
+        if (!globMatchesFiles(pattern)) {
+          missing.push(`[${entry.label}] callee: ${pattern}`);
+        }
+      }
+    }
+    if (missing.length > 0) {
+      throw new Error(
+        `Matrix entries reference missing callee files:\n${missing.join("\n")}`,
+      );
+    }
+  });
+
+  test("renderMatrix produces valid markdown", () => {
+    const output = renderMatrix(MATRIX_ENTRIES);
+    expect(output).toContain("# Service Communication Matrix");
+    expect(output).toContain("## Summary");
+    // Verify the summary table has a row for every entry
+    for (const entry of MATRIX_ENTRIES) {
+      expect(output).toContain(entry.label);
+    }
+  });
+
+  test("renderMatrix includes detail sections for every direction", () => {
+    const output = renderMatrix(MATRIX_ENTRIES);
+    const directions = new Set(
+      MATRIX_ENTRIES.map(
+        (e) =>
+          `## ${serviceDisplayName(e.caller)} -> ${serviceDisplayName(e.callee)}`,
+      ),
+    );
+    for (const heading of directions) {
+      expect(output).toContain(heading);
+    }
+  });
+});

--- a/scripts/service-communication/generate-matrix.ts
+++ b/scripts/service-communication/generate-matrix.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env bun
+/**
+ * Renders docs/service-communication-matrix.md from the typed matrix source.
+ *
+ * Usage:
+ *   bun run scripts/service-communication/generate-matrix.ts
+ *
+ * The output is deterministic — re-running produces the same file contents
+ * given the same matrix-source.ts input, so diffs are additive and reviewable.
+ */
+
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { MATRIX_ENTRIES, type MatrixEntry } from "./matrix-source.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function groupBy<T>(items: T[], key: (item: T) => string): Map<string, T[]> {
+  const map = new Map<string, T[]>();
+  for (const item of items) {
+    const k = key(item);
+    const group = map.get(k);
+    if (group) {
+      group.push(item);
+    } else {
+      map.set(k, [item]);
+    }
+  }
+  return map;
+}
+
+function directionKey(entry: MatrixEntry): string {
+  return `${entry.caller} -> ${entry.callee}`;
+}
+
+export function serviceDisplayName(name: string): string {
+  switch (name) {
+    case "assistant":
+      return "Assistant";
+    case "gateway":
+      return "Gateway";
+    case "ces":
+      return "CES";
+    default:
+      return name;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Markdown rendering
+// ---------------------------------------------------------------------------
+
+export function renderMatrix(entries: MatrixEntry[]): string {
+  const lines: string[] = [];
+
+  lines.push("# Service Communication Matrix");
+  lines.push("");
+  lines.push(
+    "> **Auto-generated** from `scripts/service-communication/matrix-source.ts`.",
+  );
+  lines.push("> Do not edit by hand. Run `bun run scripts/service-communication/generate-matrix.ts` to regenerate.");
+  lines.push("");
+  lines.push(
+    "This document enumerates every observed communication permutation between the three core services:",
+  );
+  lines.push(
+    "**Assistant** (daemon), **Gateway** (channel ingress), and **CES** (Credential Execution Service).",
+  );
+  lines.push("");
+
+  // Summary table
+  lines.push("## Summary");
+  lines.push("");
+  lines.push(
+    "| # | Direction | Protocol | Auth | Label |",
+  );
+  lines.push(
+    "|---|-----------|----------|------|-------|",
+  );
+
+  entries.forEach((e, i) => {
+    lines.push(
+      `| ${i + 1} | ${serviceDisplayName(e.caller)} -> ${serviceDisplayName(e.callee)} | \`${e.protocol}\` | ${e.auth} | ${e.label} |`,
+    );
+  });
+
+  lines.push("");
+
+  // Grouped detail sections
+  const grouped = groupBy(entries, directionKey);
+
+  for (const [direction, group] of grouped) {
+    const [callerName, calleeName] = direction.split(" -> ");
+    lines.push(
+      `## ${serviceDisplayName(callerName)} -> ${serviceDisplayName(calleeName)}`,
+    );
+    lines.push("");
+
+    for (const entry of group) {
+      lines.push(`### ${entry.label}`);
+      lines.push("");
+      lines.push(`- **Protocol:** \`${entry.protocol}\``);
+      lines.push(`- **Auth:** ${entry.auth}`);
+      lines.push(`- **Description:** ${entry.description}`);
+      lines.push("");
+      lines.push("**Caller files:**");
+      for (const glob of entry.callerGlobs) {
+        lines.push(`- \`${glob}\``);
+      }
+      lines.push("");
+      lines.push("**Callee files:**");
+      for (const glob of entry.calleeGlobs) {
+        lines.push(`- \`${glob}\``);
+      }
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const repoRoot = join(import.meta.dir, "..", "..");
+  const outputPath = join(repoRoot, "docs", "service-communication-matrix.md");
+
+  const content = renderMatrix(MATRIX_ENTRIES);
+  writeFileSync(outputPath, content, "utf-8");
+
+  // eslint-disable-next-line no-console
+  console.log(`Wrote ${outputPath}`);
+}
+
+main();

--- a/scripts/service-communication/matrix-source.ts
+++ b/scripts/service-communication/matrix-source.ts
@@ -1,0 +1,369 @@
+/**
+ * Typed source-of-truth for all assistant/gateway/CES service-to-service
+ * communication permutations.
+ *
+ * Each entry describes a single direction of communication between two
+ * services, including the protocol, auth mechanism, and concrete source
+ * files that implement the callsite.
+ *
+ * This file is consumed by `generate-matrix.ts` to render the canonical
+ * markdown matrix at `docs/service-communication-matrix.md`.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ServiceName = "assistant" | "gateway" | "ces";
+
+export type Protocol =
+  | "http"
+  | "websocket"
+  | "ipc-unix-ndjson"
+  | "stdio-ndjson"
+  | "unix-socket-ndjson";
+
+export type MatrixEntry = {
+  /** Human-readable label for this communication path. */
+  label: string;
+  /** Service that initiates the communication. */
+  caller: ServiceName;
+  /** Service that receives the communication. */
+  callee: ServiceName;
+  /** Wire protocol used. */
+  protocol: Protocol;
+  /** Auth mechanism (e.g. "JWT Bearer", "CES_SERVICE_TOKEN Bearer", "none"). */
+  auth: string;
+  /** Description of what this communication path does. */
+  description: string;
+  /**
+   * Glob patterns rooted at the repo root that implement the caller side.
+   * Used by the drift guard to detect deleted callsites.
+   */
+  callerGlobs: string[];
+  /**
+   * Glob patterns rooted at the repo root that implement the callee side.
+   * Used by the drift guard to detect deleted callsites.
+   */
+  calleeGlobs: string[];
+};
+
+// ---------------------------------------------------------------------------
+// Matrix entries
+// ---------------------------------------------------------------------------
+
+export const MATRIX_ENTRIES: MatrixEntry[] = [
+  // =========================================================================
+  // Gateway -> Assistant (HTTP)
+  // =========================================================================
+  {
+    label: "Channel inbound forwarding",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "http",
+    auth: "JWT Bearer (ingress token)",
+    description:
+      "Gateway forwards normalized channel messages (Telegram, WhatsApp, Slack, email) to the assistant's /v1/channels/inbound endpoint.",
+    callerGlobs: ["gateway/src/runtime/client.ts"],
+    calleeGlobs: [
+      "assistant/src/runtime/routes/inbound-stages/*.ts",
+    ],
+  },
+  {
+    label: "Conversation reset",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "http",
+    auth: "JWT Bearer (service token)",
+    description:
+      "Gateway resets a channel conversation via DELETE /v1/channels/conversation on the assistant.",
+    callerGlobs: ["gateway/src/runtime/client.ts"],
+    calleeGlobs: [
+      "assistant/src/runtime/routes/inbound-message-handler.ts",
+    ],
+  },
+  {
+    label: "Attachment upload",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "http",
+    auth: "JWT Bearer (service token)",
+    description:
+      "Gateway uploads channel attachments to the assistant via POST /v1/attachments.",
+    callerGlobs: ["gateway/src/runtime/client.ts"],
+    calleeGlobs: [
+      "assistant/src/runtime/routes/inbound-message-handler.ts",
+    ],
+  },
+  {
+    label: "Attachment download",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "http",
+    auth: "JWT Bearer (service token)",
+    description:
+      "Gateway downloads attachment metadata and content from the assistant for channel delivery.",
+    callerGlobs: ["gateway/src/runtime/client.ts"],
+    calleeGlobs: [
+      "assistant/src/runtime/routes/inbound-message-handler.ts",
+    ],
+  },
+  {
+    label: "Twilio voice webhook forwarding",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "http",
+    auth: "JWT Bearer (service token)",
+    description:
+      "Gateway forwards validated Twilio voice/status/connect-action webhooks to the assistant's internal Twilio endpoints.",
+    callerGlobs: ["gateway/src/runtime/client.ts"],
+    calleeGlobs: ["assistant/src/calls/*.ts"],
+  },
+  {
+    label: "OAuth callback forwarding",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "http",
+    auth: "JWT Bearer (service token)",
+    description:
+      "Gateway forwards OAuth callback codes to the assistant's internal OAuth endpoint.",
+    callerGlobs: ["gateway/src/runtime/client.ts"],
+    calleeGlobs: [
+      "assistant/src/runtime/routes/inbound-message-handler.ts",
+    ],
+  },
+  {
+    label: "Runtime proxy",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "http",
+    auth: "JWT Bearer (service token)",
+    description:
+      "Gateway proxies authenticated external HTTP requests directly to the assistant runtime.",
+    callerGlobs: ["gateway/src/http/routes/runtime-proxy.ts"],
+    calleeGlobs: ["assistant/src/runtime/http-server.ts"],
+  },
+  {
+    label: "Log export (daemon logs)",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "http",
+    auth: "JWT Bearer (service token)",
+    description:
+      "Gateway collects daemon logs from the assistant via POST /v1/export during log export.",
+    callerGlobs: ["gateway/src/http/routes/log-export.ts"],
+    calleeGlobs: ["assistant/src/runtime/http-server.ts"],
+  },
+
+  // =========================================================================
+  // Gateway -> Assistant (WebSocket)
+  // =========================================================================
+  {
+    label: "Twilio ConversationRelay WebSocket proxy",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "websocket",
+    auth: "JWT Bearer (edge relay token, query param)",
+    description:
+      "Gateway proxies Twilio ConversationRelay WebSocket frames to the assistant's /v1/calls/relay endpoint.",
+    callerGlobs: [
+      "gateway/src/http/routes/twilio-relay-websocket.ts",
+    ],
+    calleeGlobs: ["assistant/src/calls/relay-server.ts"],
+  },
+
+  // =========================================================================
+  // Assistant -> Gateway (HTTP)
+  // =========================================================================
+  {
+    label: "Channel reply delivery (Telegram)",
+    caller: "assistant",
+    callee: "gateway",
+    protocol: "http",
+    auth: "JWT Bearer (daemon delivery token)",
+    description:
+      "Assistant delivers reply messages to Telegram chats via the gateway's /deliver/telegram endpoint.",
+    callerGlobs: [
+      "assistant/src/runtime/gateway-client.ts",
+      "assistant/src/notifications/adapters/telegram.ts",
+    ],
+    calleeGlobs: ["gateway/src/http/routes/telegram-deliver.ts"],
+  },
+  {
+    label: "Channel reply delivery (WhatsApp)",
+    caller: "assistant",
+    callee: "gateway",
+    protocol: "http",
+    auth: "JWT Bearer (daemon delivery token)",
+    description:
+      "Assistant delivers reply messages to WhatsApp via the gateway's /deliver/whatsapp endpoint.",
+    callerGlobs: [
+      "assistant/src/runtime/gateway-client.ts",
+      "assistant/src/messaging/providers/whatsapp/adapter.ts",
+    ],
+    calleeGlobs: ["gateway/src/http/routes/whatsapp-deliver.ts"],
+  },
+  {
+    label: "Channel reply delivery (Slack)",
+    caller: "assistant",
+    callee: "gateway",
+    protocol: "http",
+    auth: "JWT Bearer (daemon delivery token)",
+    description:
+      "Assistant delivers reply messages to Slack via the gateway's /deliver/slack endpoint.",
+    callerGlobs: [
+      "assistant/src/runtime/gateway-client.ts",
+      "assistant/src/notifications/adapters/slack.ts",
+    ],
+    calleeGlobs: ["gateway/src/http/routes/slack-deliver.ts"],
+  },
+  {
+    label: "Trust rules CRUD",
+    caller: "assistant",
+    callee: "gateway",
+    protocol: "http",
+    auth: "JWT Bearer (edge relay token)",
+    description:
+      "Assistant reads/writes trust rules via the gateway's /v1/trust-rules REST API (containerized mode).",
+    callerGlobs: ["assistant/src/permissions/trust-client.ts"],
+    calleeGlobs: [
+      "gateway/src/ipc/trust-rule-handlers.ts",
+      "gateway/src/trust-store.ts",
+    ],
+  },
+
+  // =========================================================================
+  // Assistant -> Gateway (IPC Unix NDJSON)
+  // =========================================================================
+  {
+    label: "Feature flags IPC",
+    caller: "assistant",
+    callee: "gateway",
+    protocol: "ipc-unix-ndjson",
+    auth: "none (local socket)",
+    description:
+      "Assistant fetches merged feature flags from the gateway via the Unix domain socket IPC (get_feature_flags method).",
+    callerGlobs: ["assistant/src/ipc/gateway-client.ts"],
+    calleeGlobs: [
+      "gateway/src/ipc/feature-flag-handlers.ts",
+      "gateway/src/ipc/server.ts",
+    ],
+  },
+  {
+    label: "Contact data IPC",
+    caller: "assistant",
+    callee: "gateway",
+    protocol: "ipc-unix-ndjson",
+    auth: "none (local socket)",
+    description:
+      "Assistant reads contact auth/authz data from the gateway via IPC (get_contact, list_contacts, get_contact_by_channel, get_channels_for_contact).",
+    callerGlobs: ["assistant/src/ipc/gateway-client.ts"],
+    calleeGlobs: [
+      "gateway/src/ipc/contact-handlers.ts",
+      "gateway/src/ipc/server.ts",
+    ],
+  },
+  {
+    label: "Risk classification IPC",
+    caller: "assistant",
+    callee: "gateway",
+    protocol: "ipc-unix-ndjson",
+    auth: "none (local socket)",
+    description:
+      "Assistant classifies tool invocation risk via the persistent IPC connection to the gateway (classify_risk method).",
+    callerGlobs: ["assistant/src/ipc/gateway-client.ts"],
+    calleeGlobs: [
+      "gateway/src/ipc/server.ts",
+    ],
+  },
+
+  // =========================================================================
+  // Assistant -> CES (stdio NDJSON — local mode)
+  // =========================================================================
+  {
+    label: "CES RPC (local mode)",
+    caller: "assistant",
+    callee: "ces",
+    protocol: "stdio-ndjson",
+    auth: "none (child process)",
+    description:
+      "Assistant spawns the credential-executor as a child process and communicates via stdio JSON-RPC for tool execution (run_authenticated_command, make_authenticated_request, manage_secure_command_tool).",
+    callerGlobs: [
+      "assistant/src/credential-execution/process-manager.ts",
+      "assistant/src/credential-execution/client.ts",
+    ],
+    calleeGlobs: [
+      "credential-executor/src/server.ts",
+      "credential-executor/src/main.ts",
+    ],
+  },
+
+  // =========================================================================
+  // Assistant -> CES (Unix socket NDJSON — managed/Docker mode)
+  // =========================================================================
+  {
+    label: "CES RPC (managed mode)",
+    caller: "assistant",
+    callee: "ces",
+    protocol: "unix-socket-ndjson",
+    auth: "none (bootstrap socket)",
+    description:
+      "Assistant connects to the CES sidecar's bootstrap Unix socket (CES_BOOTSTRAP_SOCKET) for RPC in managed/Docker mode.",
+    callerGlobs: [
+      "assistant/src/credential-execution/process-manager.ts",
+    ],
+    calleeGlobs: [
+      "credential-executor/src/managed-main.ts",
+      "credential-executor/src/server.ts",
+    ],
+  },
+
+  // =========================================================================
+  // Assistant -> CES (HTTP — containerized credential CRUD)
+  // =========================================================================
+  {
+    label: "CES credential CRUD (HTTP)",
+    caller: "assistant",
+    callee: "ces",
+    protocol: "http",
+    auth: "CES_SERVICE_TOKEN Bearer",
+    description:
+      "Assistant performs credential CRUD via the CES HTTP API (CES_CREDENTIAL_URL) in containerized mode.",
+    callerGlobs: [
+      "assistant/src/security/ces-credential-client.ts",
+    ],
+    calleeGlobs: [
+      "credential-executor/src/http/*.ts",
+    ],
+  },
+
+  // =========================================================================
+  // Gateway -> CES (HTTP — credential reads and log export)
+  // =========================================================================
+  {
+    label: "Gateway credential reads (HTTP)",
+    caller: "gateway",
+    callee: "ces",
+    protocol: "http",
+    auth: "CES_SERVICE_TOKEN Bearer",
+    description:
+      "Gateway reads credentials from the CES HTTP API (CES_CREDENTIAL_URL) in containerized mode for channel auth (Telegram bot token, Twilio SID, etc.).",
+    callerGlobs: ["gateway/src/credential-reader.ts"],
+    calleeGlobs: [
+      "credential-executor/src/http/*.ts",
+    ],
+  },
+  {
+    label: "Gateway CES log export (HTTP)",
+    caller: "gateway",
+    callee: "ces",
+    protocol: "http",
+    auth: "CES_SERVICE_TOKEN Bearer",
+    description:
+      "Gateway fetches CES audit logs during log export via GET /v1/logs/export on the CES HTTP API.",
+    callerGlobs: ["gateway/src/http/routes/log-export.ts"],
+    calleeGlobs: [
+      "credential-executor/src/http/*.ts",
+    ],
+  },
+];


### PR DESCRIPTION
## Summary
- Creates docs/service-communication-matrix.md with full inventory of assistant/gateway/CES communication permutations
- Adds generate-matrix scripts and tests to prevent matrix drift
- Links ARCHITECTURE.md to the new matrix as source of truth

Part of plan: service-comm-clients.md (PR 1 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
