### PR TITLE
feat(host-transfer): register host_file_transfer permissions and risk classification

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -795,6 +795,7 @@ describe("Trust Store", () => {
         "host_bash",
         "host_file_edit",
         "host_file_read",
+        "host_file_transfer",
         "host_file_write",
         "recall",
         "scaffold_managed_skill",

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -353,7 +353,8 @@ async function buildCommandCandidates(
   if (
     toolName === "host_file_read" ||
     toolName === "host_file_write" ||
-    toolName === "host_file_edit"
+    toolName === "host_file_edit" ||
+    toolName === "host_file_transfer"
   ) {
     const resolved = fileTarget ? resolve(fileTarget) : fileTarget;
     const normalized =
@@ -452,6 +453,7 @@ export async function classifyRisk(
       "host_file_read",
       "host_file_write",
       "host_file_edit",
+      "host_file_transfer",
     ].includes(toolName)
   ) {
     const filePath = getStringField(input, "path", "file_path");
@@ -463,7 +465,8 @@ export async function classifyRisk(
         | "file_edit"
         | "host_file_read"
         | "host_file_write"
-        | "host_file_edit",
+        | "host_file_edit"
+        | "host_file_transfer",
       filePath,
       workingDir: isHostTool ? "/" : (workingDir ?? process.cwd()),
     });
@@ -763,6 +766,7 @@ const TOOL_DISPLAY_NAMES: Record<string, string> = {
   host_file_read: "host file reads",
   host_file_write: "host file writes",
   host_file_edit: "host file edits",
+  host_file_transfer: "host file transfers",
   web_fetch: "URL fetches",
   network_request: "network requests",
 };
@@ -971,6 +975,7 @@ const ALLOWLIST_STRATEGIES: Record<string, AllowlistStrategy> = {
   host_file_read: fileAllowlistStrategy,
   host_file_write: fileAllowlistStrategy,
   host_file_edit: fileAllowlistStrategy,
+  host_file_transfer: fileAllowlistStrategy,
   web_fetch: urlAllowlistStrategy,
   network_request: urlAllowlistStrategy,
   scaffold_managed_skill: managedSkillAllowlistStrategy,
@@ -1035,6 +1040,7 @@ export const SCOPE_AWARE_TOOLS = new Set([
   "host_file_read",
   "host_file_write",
   "host_file_edit",
+  "host_file_transfer",
 ]);
 
 export function generateScopeOptions(

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -36,6 +36,7 @@ const HOST_FILE_TOOLS: readonly ScopedTrustRule["tool"][] = [
   "host_file_read",
   "host_file_write",
   "host_file_edit",
+  "host_file_transfer",
 ] as const;
 const COMPUTER_USE_TOOLS = [
   "computer_use_observe",

--- a/assistant/src/permissions/file-risk-classifier.test.ts
+++ b/assistant/src/permissions/file-risk-classifier.test.ts
@@ -391,6 +391,62 @@ describe("FileRiskClassifier", () => {
     });
   });
 
+  // ── host_file_transfer ──────────────────────────────────────────────────
+
+  describe("host_file_transfer", () => {
+    test("default risk is medium", async () => {
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: "/tmp/output.txt",
+      });
+      expect(result.riskLevel).toBe("medium");
+      expect(result.reason).toBe("Host file transfer (default)");
+      expect(result.matchType).toBe("registry");
+    });
+
+    test("empty filePath is medium", async () => {
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: "",
+      });
+      expect(result.riskLevel).toBe("medium");
+    });
+
+    test("skill source path is high", async () => {
+      const absSkillPath = "/home/user/skills/evil-skill/SKILL.md";
+      skillSourcePaths.add(resolve(absSkillPath));
+      try {
+        const result = await classifyInput({
+          toolName: "host_file_transfer",
+          filePath: absSkillPath,
+        });
+        expect(result.riskLevel).toBe("high");
+        expect(result.reason).toBe("Transfers to skill source code");
+      } finally {
+        skillSourcePaths.delete(resolve(absSkillPath));
+      }
+    });
+
+    test("hooks directory is high", async () => {
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: MOCK_HOOKS_DIR,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Transfers to hooks directory");
+    });
+
+    test("file inside hooks directory is high", async () => {
+      const hookFile = join(MOCK_HOOKS_DIR, "pre-tool-use.sh");
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: hookFile,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Transfers to hooks directory");
+    });
+  });
+
   // ── Singleton export ─────────────────────────────────────────────────────
 
   describe("singleton", () => {

--- a/assistant/src/permissions/file-risk-classifier.ts
+++ b/assistant/src/permissions/file-risk-classifier.ts
@@ -1,8 +1,9 @@
 /**
  * File risk classifier — path-based risk classification for file tools.
  *
- * Implements RiskClassifier<FileClassifierInput> for all six file tool types:
- * file_read, file_write, file_edit, host_file_read, host_file_write, host_file_edit.
+ * Implements RiskClassifier<FileClassifierInput> for all seven file tool types:
+ * file_read, file_write, file_edit, host_file_read, host_file_write,
+ * host_file_edit, host_file_transfer.
  *
  * Risk escalation paths:
  * - file_read: Low by default, High if targeting the actor token signing key.
@@ -11,6 +12,8 @@
  * - host_file_read: Medium (tool registry default; no special escalation).
  * - host_file_write / host_file_edit: Medium by default, High if targeting
  *   skill source code or the workspace hooks directory.
+ * - host_file_transfer: Medium by default, High if the destination path
+ *   targets skill source code or the workspace hooks directory.
  */
 
 import { homedir } from "node:os";
@@ -40,7 +43,8 @@ export interface FileClassifierInput {
     | "file_edit"
     | "host_file_read"
     | "host_file_write"
-    | "host_file_edit";
+    | "host_file_edit"
+    | "host_file_transfer";
   filePath: string;
   workingDir: string;
 }
@@ -90,6 +94,7 @@ const FILE_TOOL_DISPLAY_NAMES: Record<string, string> = {
   host_file_read: "host file reads",
   host_file_write: "host file writes",
   host_file_edit: "host file edits",
+  host_file_transfer: "host file transfers",
 };
 
 function friendlyBasename(filePath: string): string {
@@ -231,7 +236,11 @@ export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
       }
 
       case "host_file_write":
-      case "host_file_edit": {
+      case "host_file_edit":
+      case "host_file_transfer": {
+        // "Writes" for write/edit (both mutate files), "Transfers" for transfer.
+        const actionVerb =
+          toolName === "host_file_transfer" ? "Transfers" : "Writes";
         if (filePath) {
           // Host file tools resolve paths without workingDir — resolve(filePath)
           // treats the path as absolute or relative to cwd.
@@ -241,7 +250,7 @@ export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
           ) {
             return {
               riskLevel: "high",
-              reason: "Writes to skill source code",
+              reason: `${actionVerb} to skill source code`,
               scopeOptions: [],
               matchType: "registry",
               allowlistOptions,
@@ -250,7 +259,7 @@ export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
           if (isHooksPath(resolvedPath)) {
             return {
               riskLevel: "high",
-              reason: "Writes to hooks directory",
+              reason: `${actionVerb} to hooks directory`,
               scopeOptions: [],
               matchType: "registry",
               allowlistOptions,
@@ -258,9 +267,15 @@ export class FileRiskClassifier implements RiskClassifier<FileClassifierInput> {
           }
         }
         // Fall through to tool registry default (Medium).
+        const defaultLabel =
+          toolName === "host_file_write"
+            ? "write"
+            : toolName === "host_file_edit"
+              ? "edit"
+              : "transfer";
         return {
           riskLevel: "medium",
-          reason: `Host file ${toolName === "host_file_write" ? "write" : "edit"} (default)`,
+          reason: `Host file ${defaultLabel} (default)`,
           scopeOptions: [],
           matchType: "registry",
           allowlistOptions,

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -63,6 +63,7 @@ const HOST_TOOLS = new Set([
   "host_file_read",
   "host_file_write",
   "host_file_edit",
+  "host_file_transfer",
   "host_bash",
   "computer_use_run_applescript",
 ]);

--- a/assistant/src/tools/tool-input-summary.ts
+++ b/assistant/src/tools/tool-input-summary.ts
@@ -49,7 +49,8 @@ export function summarizeToolInput(
     case "file_edit":
     case "host_file_read":
     case "host_file_write":
-    case "host_file_edit": {
+    case "host_file_edit":
+    case "host_file_transfer": {
       const path = extractString(input, "file_path", "path");
       return path ? path.trim() : "";
     }

--- a/packages/ces-contracts/src/trust-rules.ts
+++ b/packages/ces-contracts/src/trust-rules.ts
@@ -11,7 +11,7 @@
  * - **Scoped**: tools whose candidates include a filesystem path and obey
  *   directory-boundary scope constraints (`file_read`, `file_write`,
  *   `file_edit`, `host_file_read`, `host_file_write`, `host_file_edit`,
- *   `bash`, `host_bash`).
+ *   `host_file_transfer`, `bash`, `host_bash`).
  * - **URL**: tools whose candidates include a URL (`web_fetch`,
  *   `network_request`).
  * - **Managed skill**: tools that manage first-party skill packages
@@ -44,6 +44,7 @@ export const SCOPED_TOOLS = [
   "host_file_read",
   "host_file_write",
   "host_file_edit",
+  "host_file_transfer",
   "bash",
   "host_bash",
 ] as const;


### PR DESCRIPTION
## Summary
- Add host_file_transfer to SCOPED_TOOLS in ces-contracts for type compatibility
- Add host_file_transfer to HOST_FILE_TOOLS for default ask permission rule
- Add host_file_transfer to FileRiskClassifier with destination-path-based risk escalation
- Existing host file tool permissions unchanged

Part of plan: host-file-transfer.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
