### PR TITLE
fix(schedule): exclude deferred wakes from mutation responses and validate defer_cancel scope

### DIFF
--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -12,6 +12,7 @@ import { scheduleRouteDefinitions } from "../runtime/routes/schedule-routes.js";
 import {
   createSchedule,
   createScheduleRun,
+  listSchedules,
 } from "../schedule/schedule-store.js";
 import { scheduleTask } from "../tasks/task-scheduler.js";
 import { createTask } from "../tasks/task-store.js";
@@ -164,7 +165,7 @@ describe("schedule run-now trust propagation", () => {
   });
 });
 
-// ── GET /schedules — exclude_created_by filtering ─────────────────────────
+// ── GET /schedules — default defer exclusion ──────────────────────────────
 
 function getListHandler() {
   const route = scheduleRouteDefinitions({
@@ -178,12 +179,10 @@ function getListHandler() {
 }
 
 async function callListHandler(
-  excludeCreatedBy?: string,
+  includeAll?: boolean,
 ): Promise<{ status: number; body: { schedules: Array<{ id: string }> } }> {
   const handler = getListHandler();
-  const suffix = excludeCreatedBy
-    ? `?exclude_created_by=${excludeCreatedBy}`
-    : "";
+  const suffix = includeAll ? "?include_all=true" : "";
   const urlStr = `http://localhost/v1/schedules${suffix}`;
   const response = await handler({
     req: new Request(urlStr),
@@ -198,32 +197,12 @@ async function callListHandler(
   };
 }
 
-describe("GET /schedules — exclude_created_by filtering", () => {
+describe("GET /schedules — default defer exclusion", () => {
   beforeEach(() => {
     clearTables();
   });
 
-  test("returns all schedules when no exclude_created_by param", async () => {
-    createSchedule({
-      name: "Agent schedule",
-      cronExpression: "* * * * *",
-      message: "hello",
-      syntax: "cron",
-    });
-    createSchedule({
-      name: "Deferred wake",
-      cronExpression: "0 9 * * *",
-      message: "wake up",
-      syntax: "cron",
-      createdBy: "defer",
-    });
-
-    const { status, body } = await callListHandler();
-    expect(status).toBe(200);
-    expect(body.schedules).toHaveLength(2);
-  });
-
-  test("filters out deferred wakes when exclude_created_by=defer", async () => {
+  test("excludes deferred wakes by default", async () => {
     createSchedule({
       name: "Agent schedule",
       cronExpression: "* * * * *",
@@ -238,31 +217,71 @@ describe("GET /schedules — exclude_created_by filtering", () => {
       createdBy: "defer",
     });
 
-    const { status, body } = await callListHandler("defer");
+    const { status, body } = await callListHandler();
     expect(status).toBe(200);
     expect(body.schedules).toHaveLength(1);
     expect(body.schedules.every((s) => s.id !== deferred.id)).toBe(true);
   });
 
-  test("returns empty list when all schedules match exclusion", async () => {
+  test("returns all schedules when include_all=true", async () => {
     createSchedule({
-      name: "Deferred 1",
+      name: "Agent schedule",
       cronExpression: "* * * * *",
-      message: "a",
+      message: "hello",
       syntax: "cron",
-      createdBy: "defer",
     });
     createSchedule({
-      name: "Deferred 2",
+      name: "Deferred wake",
       cronExpression: "0 9 * * *",
-      message: "b",
+      message: "wake up",
       syntax: "cron",
       createdBy: "defer",
     });
 
-    const { status, body } = await callListHandler("defer");
+    const { status, body } = await callListHandler(true);
     expect(status).toBe(200);
-    expect(body.schedules).toHaveLength(0);
+    expect(body.schedules).toHaveLength(2);
+  });
+
+  test("mutation responses also exclude deferred wakes", async () => {
+    createSchedule({
+      name: "Agent schedule",
+      cronExpression: "* * * * *",
+      message: "hello",
+      syntax: "cron",
+    });
+    createSchedule({
+      name: "Deferred wake",
+      cronExpression: "0 9 * * *",
+      message: "wake up",
+      syntax: "cron",
+      createdBy: "defer",
+    });
+
+    const toggleHandler = scheduleRouteDefinitions({
+      sendMessageDeps: {} as never,
+    }).find(
+      (r) => r.endpoint === "schedules/:id/toggle" && r.method === "POST",
+    )!.handler;
+
+    const agent = listSchedules().find((j) => j.createdBy === "agent")!;
+    const urlStr = `http://localhost/v1/schedules/${agent.id}/toggle`;
+    const response = await toggleHandler({
+      req: new Request(urlStr, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+      }),
+      url: new URL(urlStr),
+      server: {} as never,
+      authContext: {} as never,
+      params: { id: agent.id },
+    });
+    const body = (await response.json()) as {
+      schedules: Array<{ id: string }>;
+    };
+    expect(body.schedules).toHaveLength(1);
+    expect(body.schedules[0].id).toBe(agent.id);
   });
 });
 

--- a/assistant/src/ipc/routes/defer.ts
+++ b/assistant/src/ipc/routes/defer.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   cancelSchedule,
   createSchedule,
+  getSchedule,
   listSchedules,
 } from "../../schedule/schedule-store.js";
 import type { IpcRoute } from "../cli-server.js";
@@ -102,6 +103,10 @@ const deferCancelRoute: IpcRoute = {
     const { id, all, conversationId } = DeferCancelParams.parse(params);
 
     if (id) {
+      const job = getSchedule(id);
+      if (!job || job.mode !== "wake" || job.createdBy !== "defer") {
+        return { cancelled: 0, error: "Not a deferred wake" };
+      }
       const ok = cancelSchedule(id);
       return { cancelled: ok ? 1 : 0 };
     }

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -36,11 +36,11 @@ const SCHEDULE_GUARDIAN_TRUST_CONTEXT = {
 // Handlers
 // ---------------------------------------------------------------------------
 
-function handleListSchedules(excludeCreatedBy?: string): Response {
+function handleListSchedules(opts?: { includeAll?: boolean }): Response {
   const jobs = listSchedules();
-  const filtered = excludeCreatedBy
-    ? jobs.filter((j) => j.createdBy !== excludeCreatedBy)
-    : jobs;
+  const filtered = opts?.includeAll
+    ? jobs
+    : jobs.filter((j) => j.createdBy !== "defer");
   return Response.json({
     schedules: filtered.map((j) => ({
       id: j.id,
@@ -422,9 +422,8 @@ export function scheduleRouteDefinitions(deps: {
         schedules: z.array(z.unknown()).describe("Schedule objects"),
       }),
       handler: ({ url }) => {
-        const excludeCreatedBy =
-          url.searchParams.get("exclude_created_by") ?? undefined;
-        return handleListSchedules(excludeCreatedBy);
+        const includeAll = url.searchParams.get("include_all") === "true";
+        return handleListSchedules({ includeAll });
       },
     },
     {

--- a/clients/shared/Network/ScheduleClient.swift
+++ b/clients/shared/Network/ScheduleClient.swift
@@ -34,7 +34,7 @@ public struct ScheduleClient: ScheduleClientProtocol {
 
     public func fetchSchedulesList() async throws -> [ScheduleItem] {
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/schedules?exclude_created_by=defer", timeout: 10
+            path: "assistants/{assistantId}/schedules", timeout: 10
         )
         guard response.isSuccess else {
             log.error("fetchSchedulesList failed (HTTP \(response.statusCode))")


### PR DESCRIPTION
## Summary
Addresses two review findings from Devin and Codex on #27832:

**1. Mutation responses bypass defer exclusion filter** (Devin red + Codex P2)
- `handleListSchedules()` now excludes `createdBy=defer` by default
- Added `include_all=true` query param for callers that need unfiltered results
- All mutation handlers (toggle, delete, cancel, update, run-now) now correctly exclude deferred wakes from their responses
- Reverted Swift client to plain `/schedules` path (server handles filtering)
- Added test: mutation responses exclude deferred wakes

**2. `defer_cancel` by ID doesn't validate scope** (Codex P2)
- `defer_cancel` now looks up the schedule and verifies `mode=wake` and `createdBy=defer` before cancelling
- Returns `{ cancelled: 0, error: "Not a deferred wake" }` for non-defer schedules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
