### PR TITLE
feat(host-transfer): add SSE message types and pending interaction kind

### DIFF
--- a/assistant/src/__tests__/host-transfer-pending-interactions.test.ts
+++ b/assistant/src/__tests__/host-transfer-pending-interactions.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for host_transfer message types and pending interaction
+ * registration.
+ *
+ * Verifies:
+ * - HostTransferRequest and HostTransferCancelRequest are part of ServerMessage
+ * - "host_transfer" is a valid PendingInteraction kind
+ * - host_transfer interactions survive removeByConversation (not auto-denied)
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { Conversation } from "../daemon/conversation.js";
+import type {
+  HostTransferCancelRequest,
+  HostTransferRequest,
+  HostTransferToHostRequest,
+  HostTransferToSandboxRequest,
+  ServerMessage,
+} from "../daemon/message-protocol.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function stubConversation(id: string): Conversation {
+  return { id } as unknown as Conversation;
+}
+
+// ---------------------------------------------------------------------------
+// Message type compilation checks
+// ---------------------------------------------------------------------------
+
+describe("HostTransfer message types", () => {
+  test("HostTransferToHostRequest is assignable to ServerMessage", () => {
+    const msg: HostTransferToHostRequest = {
+      type: "host_transfer_request",
+      requestId: "req-1",
+      conversationId: "conv-1",
+      direction: "to_host",
+      transferId: "xfer-1",
+      destPath: "/tmp/file.txt",
+      sizeBytes: 1024,
+      sha256: "abc123",
+      overwrite: false,
+    };
+    const _sm: ServerMessage = msg;
+    expect(_sm.type).toBe("host_transfer_request");
+  });
+
+  test("HostTransferToSandboxRequest is assignable to ServerMessage", () => {
+    const msg: HostTransferToSandboxRequest = {
+      type: "host_transfer_request",
+      requestId: "req-2",
+      conversationId: "conv-1",
+      direction: "to_sandbox",
+      transferId: "xfer-2",
+      sourcePath: "/home/user/file.txt",
+    };
+    const _sm: ServerMessage = msg;
+    expect(_sm.type).toBe("host_transfer_request");
+  });
+
+  test("HostTransferCancelRequest is assignable to ServerMessage", () => {
+    const msg: HostTransferCancelRequest = {
+      type: "host_transfer_cancel",
+      requestId: "req-3",
+    };
+    const _sm: ServerMessage = msg;
+    expect(_sm.type).toBe("host_transfer_cancel");
+  });
+
+  test("HostTransferRequest union covers both directions", () => {
+    const toHost: HostTransferRequest = {
+      type: "host_transfer_request",
+      requestId: "req-4",
+      conversationId: "conv-1",
+      direction: "to_host",
+      transferId: "xfer-3",
+      destPath: "/tmp/out.bin",
+      sizeBytes: 512,
+      sha256: "def456",
+      overwrite: true,
+    };
+    const toSandbox: HostTransferRequest = {
+      type: "host_transfer_request",
+      requestId: "req-5",
+      conversationId: "conv-1",
+      direction: "to_sandbox",
+      transferId: "xfer-4",
+      sourcePath: "/data/input.csv",
+    };
+    expect(toHost.direction).toBe("to_host");
+    expect(toSandbox.direction).toBe("to_sandbox");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pending interaction registration
+// ---------------------------------------------------------------------------
+
+describe("host_transfer pending interactions", () => {
+  beforeEach(() => {
+    pendingInteractions.clear();
+  });
+
+  test("host_transfer can be registered as a pending interaction", () => {
+    const conv = stubConversation("conv-1");
+    pendingInteractions.register("req-1", {
+      conversation: conv,
+      conversationId: "conv-1",
+      kind: "host_transfer",
+    });
+
+    const interaction = pendingInteractions.get("req-1");
+    expect(interaction).toBeDefined();
+    expect(interaction!.kind).toBe("host_transfer");
+    expect(interaction!.conversationId).toBe("conv-1");
+  });
+
+  test("host_transfer interactions survive removeByConversation", () => {
+    const conv = stubConversation("conv-1");
+
+    // Register a confirmation (should be removed) and a host_transfer (should survive)
+    pendingInteractions.register("confirm-1", {
+      conversation: conv,
+      conversationId: "conv-1",
+      kind: "confirmation",
+    });
+    pendingInteractions.register("transfer-1", {
+      conversation: conv,
+      conversationId: "conv-1",
+      kind: "host_transfer",
+    });
+
+    pendingInteractions.removeByConversation(conv);
+
+    // Confirmation should be gone
+    expect(pendingInteractions.get("confirm-1")).toBeUndefined();
+    // host_transfer should survive
+    expect(pendingInteractions.get("transfer-1")).toBeDefined();
+    expect(pendingInteractions.get("transfer-1")!.kind).toBe("host_transfer");
+  });
+
+  test("host_transfer interactions can be resolved", () => {
+    const conv = stubConversation("conv-1");
+    pendingInteractions.register("req-1", {
+      conversation: conv,
+      conversationId: "conv-1",
+      kind: "host_transfer",
+    });
+
+    const resolved = pendingInteractions.resolve("req-1");
+    expect(resolved).toBeDefined();
+    expect(resolved!.kind).toBe("host_transfer");
+
+    // After resolve, it should be gone
+    expect(pendingInteractions.get("req-1")).toBeUndefined();
+  });
+});

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -27,6 +27,7 @@ export * from "./message-types/host-bash.js";
 export * from "./message-types/host-browser.js";
 export * from "./message-types/host-cu.js";
 export * from "./message-types/host-file.js";
+export * from "./message-types/host-transfer.js";
 export * from "./message-types/inbox.js";
 export * from "./message-types/integrations.js";
 export * from "./message-types/meet.js";
@@ -87,6 +88,7 @@ import type {
 } from "./message-types/host-browser.js";
 import type { _HostCuServerMessages } from "./message-types/host-cu.js";
 import type { _HostFileServerMessages } from "./message-types/host-file.js";
+import type { _HostTransferServerMessages } from "./message-types/host-transfer.js";
 import type {
   _InboxClientMessages,
   _InboxServerMessages,
@@ -200,6 +202,7 @@ export type ServerMessage =
   | _HostBrowserServerMessages
   | _HostCuServerMessages
   | _HostFileServerMessages
+  | _HostTransferServerMessages
   | _MeetServerMessages
   | _MemoryServerMessages
   | _WorkspaceServerMessages

--- a/assistant/src/daemon/message-types/host-transfer.ts
+++ b/assistant/src/daemon/message-types/host-transfer.ts
@@ -1,0 +1,41 @@
+// Host transfer proxy types.
+// Enables bidirectional file transfer between sandbox and host machine
+// when running as a managed assistant.
+
+// === Server → Client ===
+
+export interface HostTransferToHostRequest {
+  type: "host_transfer_request";
+  requestId: string;
+  conversationId: string;
+  direction: "to_host";
+  transferId: string;
+  destPath: string;
+  sizeBytes: number;
+  sha256: string;
+  overwrite: boolean;
+}
+
+export interface HostTransferToSandboxRequest {
+  type: "host_transfer_request";
+  requestId: string;
+  conversationId: string;
+  direction: "to_sandbox";
+  transferId: string;
+  sourcePath: string;
+}
+
+export type HostTransferRequest =
+  | HostTransferToHostRequest
+  | HostTransferToSandboxRequest;
+
+export interface HostTransferCancelRequest {
+  type: "host_transfer_cancel";
+  requestId: string;
+}
+
+// --- Domain-level union aliases (consumed by the barrel file) ---
+
+export type _HostTransferServerMessages =
+  | HostTransferRequest
+  | HostTransferCancelRequest;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -292,6 +292,12 @@ function makePendingInteractionRegistrar(
         conversationId,
         kind: "host_cu",
       });
+    } else if (msg.type === "host_transfer_request") {
+      pendingInteractions.register(msg.requestId, {
+        conversation,
+        conversationId,
+        kind: "host_transfer",
+      });
     }
   };
 }

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -1,11 +1,12 @@
 /**
  * In-memory tracker that maps requestId to conversation info for pending
- * confirmation, secret, host_bash, host_file, host_cu, and host_browser
- * interactions.
+ * confirmation, secret, host_bash, host_file, host_cu, host_browser, and
+ * host_transfer interactions.
  *
  * When the agent loop emits a confirmation_request, secret_request,
- * host_bash_request, host_file_request, host_cu_request, or
- * host_browser_request, the onEvent callback registers the interaction here.
+ * host_bash_request, host_file_request, host_cu_request,
+ * host_browser_request, or host_transfer_request, the onEvent callback
+ * registers the interaction here.
  * Standalone HTTP endpoints (/v1/confirm, /v1/secret, /v1/trust-rules,
  * /v1/host-bash-result, /v1/host-file-result, /v1/host-cu-result,
  * /v1/host-browser-result) look up the conversation from this tracker to
@@ -48,6 +49,7 @@ export interface PendingInteraction {
     | "host_file"
     | "host_cu"
     | "host_browser"
+    | "host_transfer"
     | "acp_confirmation";
   confirmationDetails?: ConfirmationDetails;
   /** For ACP permissions: resolves directly without a Conversation object. */
@@ -103,13 +105,13 @@ export function getByConversation(
  * Remove pending confirmation and secret interactions for a given conversation.
  * Used when auto-denying all pending interactions (e.g. new user message).
  *
- * host_bash, host_file, host_cu, and host_browser interactions are
- * intentionally skipped — they represent in-flight tool executions proxied to
- * the client, not confirmations to auto-deny. Removing them would orphan the
- * request: the client would POST to /v1/host-bash-result,
- * /v1/host-file-result, /v1/host-cu-result, or /v1/host-browser-result after
- * completing the operation, get a 404, and the proxy timer would fire with a
- * spurious timeout error.
+ * host_bash, host_file, host_cu, host_browser, and host_transfer interactions
+ * are intentionally skipped — they represent in-flight tool executions proxied
+ * to the client, not confirmations to auto-deny. Removing them would orphan
+ * the request: the client would POST to /v1/host-bash-result,
+ * /v1/host-file-result, /v1/host-cu-result, /v1/host-browser-result, or
+ * /v1/host-transfer-result after completing the operation, get a 404, and the
+ * proxy timer would fire with a spurious timeout error.
  */
 export function removeByConversation(conversation: Conversation): void {
   for (const [requestId, interaction] of pending) {
@@ -119,6 +121,7 @@ export function removeByConversation(conversation: Conversation): void {
       interaction.kind !== "host_file" &&
       interaction.kind !== "host_cu" &&
       interaction.kind !== "host_browser" &&
+      interaction.kind !== "host_transfer" &&
       interaction.kind !== "acp_confirmation"
     ) {
       pending.delete(requestId);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1227,6 +1227,14 @@ function registerHostProxyPendingInteraction(
     });
     return msg.requestId;
   }
+  if (msg.type === "host_transfer_request") {
+    pendingInteractions.register(msg.requestId, {
+      conversation,
+      conversationId,
+      kind: "host_transfer",
+    });
+    return msg.requestId;
+  }
   return undefined;
 }
 


### PR DESCRIPTION
## Summary
- Add HostTransferRequest and HostTransferCancelRequest message types for the host_file_transfer SSE protocol
- Register host_transfer as a pending interaction kind that survives new user messages
- Wire pending interaction registration in both daemon server and HTTP conversation routes

Part of plan: host-file-transfer.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
