### PR TITLE
feat(host-transfer): add Swift message types and SSE routing for host file transfer

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -407,6 +407,11 @@ extension AppDelegate {
                 case .hostBrowserCancel(let msg):
                     self.hostBrowserExecutor.cancel(msg.requestId)
 
+                case .hostTransferRequest(let msg):
+                    HostToolExecutor.executeHostTransferRequest(msg)
+                case .hostTransferCancel(let msg):
+                    HostToolExecutor.cancelHostTransferRequest(msg.requestId)
+
                 case .hostBashCancel(let msg):
                     HostToolExecutor.cancelHostBashRequest(msg.requestId)
                 case .hostFileCancel(let msg):

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -606,6 +606,10 @@ public final class EventStreamClient {
             if locallyOwnedConversationIds.contains(msg.conversationId) { return false }
             log.warning("Ignoring host_browser_request for non-local conversation \(msg.conversationId, privacy: .public)")
             return true
+        case .hostTransferRequest(let msg):
+            if locallyOwnedConversationIds.contains(msg.conversationId) { return false }
+            log.warning("Ignoring host_transfer_request for non-local conversation \(msg.conversationId, privacy: .public)")
+            return true
         default:
             return false
         }

--- a/clients/shared/Network/HostToolExecutor.swift
+++ b/clients/shared/Network/HostToolExecutor.swift
@@ -472,6 +472,22 @@ public enum HostToolExecutor {
         return nil
     }
 
+    // MARK: - Host Transfer (stub — PR 7)
+
+    /// Execute a host file transfer request locally.
+    // TODO: implement in host-file-xfer/pr-7
+    @MainActor
+    public static func executeHostTransferRequest(_ request: HostTransferRequest) {
+        log.warning("executeHostTransferRequest not yet implemented — requestId=\(request.requestId, privacy: .public)")
+    }
+
+    /// Cancel an in-flight host file transfer request.
+    // TODO: implement in host-file-xfer/pr-7
+    public static func cancelHostTransferRequest(_ requestId: String) {
+        markCancelled(requestId)
+        log.warning("cancelHostTransferRequest not yet implemented — requestId=\(requestId, privacy: .public)")
+    }
+
     private enum FileOperationError: LocalizedError {
         case noMatch
         case multipleMatches(Int)

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -61,6 +61,12 @@ import Foundation
 // │                                 │ decoded from flat fields               │
 // │ SkillsshOriginMeta             │ Payload struct for skillssh origin;    │
 // │                                 │ decoded from flat fields               │
+// │ HostTransferRequest            │ Hand-maintained alongside              │
+// │                                 │ HostTransferCancelRequest              │
+// │ HostTransferCancelRequest      │ Hand-maintained alongside              │
+// │                                 │ HostTransferRequest                    │
+// │ HostTransferResultPayload      │ Posted back to daemon; hand-maintained │
+// │                                 │ alongside HostTransferRequest          │
 // └─────────────────────────────────┴──────────────────────────────────────────┘
 //
 // **Do not add new manual structs** without documenting the reason here.
@@ -1739,6 +1745,47 @@ public struct HostBrowserResultPayload: Codable, Sendable {
     }
 }
 
+// MARK: - Host File Transfer
+
+/// Request from the daemon to transfer a file between the sandbox and the host
+/// machine. `direction` is either `"to_host"` (sandbox → host) or `"to_sandbox"`
+/// (host → sandbox). The client decodes this to keep the SSE stream healthy and
+/// routes it to the executor for processing.
+public struct HostTransferRequest: Decodable, Sendable {
+    public let type: String
+    public let requestId: String
+    public let conversationId: String
+    public let direction: String
+    public let transferId: String
+    public let destPath: String?
+    public let sourcePath: String?
+    public let sizeBytes: Int?
+    public let sha256: String?
+    public let overwrite: Bool?
+}
+
+/// Cancellation signal from the daemon telling the client to abort an in-flight
+/// host file transfer identified by `requestId`.
+public struct HostTransferCancelRequest: Decodable, Sendable {
+    public let type: String
+    public let requestId: String
+}
+
+/// Payload posted back to the daemon with the result of a host file transfer.
+public struct HostTransferResultPayload: Codable, Sendable {
+    public let requestId: String
+    public let isError: Bool
+    public let bytesWritten: Int?
+    public let errorMessage: String?
+
+    public init(requestId: String, isError: Bool, bytesWritten: Int?, errorMessage: String?) {
+        self.requestId = requestId
+        self.isError = isError
+        self.bytesWritten = bytesWritten
+        self.errorMessage = errorMessage
+    }
+}
+
 // MARK: - Meet (live meeting state)
 
 /// A single participant in a meeting as broadcast by the Meet-bot.
@@ -2617,6 +2664,8 @@ public enum ServerMessage: Decodable, Sendable {
     case hostCuCancel(HostCuCancelRequest)
     case hostBrowserRequest(HostBrowserRequest)
     case hostBrowserCancel(HostBrowserCancelRequest)
+    case hostTransferRequest(HostTransferRequest)
+    case hostTransferCancel(HostTransferCancelRequest)
     case meetJoining(MeetJoiningMessage)
     case meetJoined(MeetJoinedMessage)
     case meetParticipantChanged(MeetParticipantChangedMessage)
@@ -3111,6 +3160,12 @@ public enum ServerMessage: Decodable, Sendable {
         case "host_browser_cancel":
             let message = try HostBrowserCancelRequest(from: decoder)
             self = .hostBrowserCancel(message)
+        case "host_transfer_request":
+            let message = try HostTransferRequest(from: decoder)
+            self = .hostTransferRequest(message)
+        case "host_transfer_cancel":
+            let message = try HostTransferCancelRequest(from: decoder)
+            self = .hostTransferCancel(message)
         case "context_compacted":
             let message = try ContextCompacted(from: decoder)
             self = .contextCompacted(message)

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1762,6 +1762,15 @@ public struct HostTransferRequest: Decodable, Sendable {
     public let sizeBytes: Int?
     public let sha256: String?
     public let overwrite: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case type, requestId, conversationId, direction
+        case transferId = "transfer_id"
+        case destPath = "dest_path"
+        case sourcePath = "source_path"
+        case sizeBytes = "size_bytes"
+        case sha256, overwrite
+    }
 }
 
 /// Cancellation signal from the daemon telling the client to abort an in-flight


### PR DESCRIPTION
## Summary
- Add HostTransferRequest, HostTransferCancelRequest, and HostTransferResultPayload Swift structs
- Add ServerMessage enum cases and decoder for host_transfer_request/cancel
- Route SSE messages to stub executor methods in AppDelegate
- Add stub methods in HostToolExecutor (to be replaced by PR 7)

Part of plan: host-file-transfer.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
