### PR TITLE
refactor(security): final Socket doc + workflow trims

### DIFF
--- a/.github/workflows/socket-autofix.yml
+++ b/.github/workflows/socket-autofix.yml
@@ -21,11 +21,7 @@ jobs:
     if: github.repository == 'vellum-ai/vellum-assistant'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # This is a multi-workspace Bun monorepo with NO root-level package.json.
-    # Socket's `fix` needs a resolved dependency tree (node_modules) per
-    # workspace, so we matrix over the runtime-relevant workspaces that each
-    # have their own bun.lock. `meta` and `scripts` (dev tooling) are skipped
-    # to conserve scan quota (~1,000 scans/month on Socket Free).
+    # Multi-workspace monorepo (no root package.json). See docs/socket.md.
     strategy:
       fail-fast: false
       matrix:
@@ -56,14 +52,10 @@ jobs:
         with:
           bun-version: '1.3.11'
 
-      # --ignore-scripts: Socket only needs the resolved dep tree; skipping
-      # postinstall hooks avoids cross-workspace mutations polluting diffs.
+      # See docs/socket.md for rationale (cross-workspace postinstall side-effects).
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
-      # --pr-limit 3: cap per matrix leg (12 × 3 = 36 PRs/week ceiling).
-      # --minimum-release-age 1w: skip versions <7 days old — defense against
-      # malware-via-update (compromised maintainer poisoned patch release).
       - name: Run socket fix
         run: bunx @socketsecurity/cli fix --autopilot --pr-limit 3 --minimum-release-age 1w
         env:

--- a/docs/socket.md
+++ b/docs/socket.md
@@ -42,7 +42,7 @@ Because this is a multi-workspace Bun monorepo with **no root-level `package.jso
   - `--pr-limit 3` — cap per matrix leg (12 × 3 = 36 PRs/week ceiling).
   - `--minimum-release-age 1w` — skip versions published in the last 7 days. Defense against malware-via-update (compromised maintainer pushing a poisoned patch release).
 
-Socket Certified Patches (`socket-patch`) are deferred pending a `socket-patch setup` postinstall-hook rollout across all workspaces — see "Follow-ups / deferred" below.
+Socket Certified Patches (`socket-patch`) are deferred: `socket-patch apply` modifies files in `node_modules/`, which don't persist across `bun install`. Adoption requires running `bunx @socketsecurity/socket-patch setup` per workspace to install a `postinstall: socket-patch apply` hook — a cross-workspace install-time dependency added to every workspace's `package.json`. File as a follow-up when the team is ready to take on that rollout.
 
 ## Policy file
 
@@ -148,11 +148,7 @@ Open a small PR that touches `assistant/package.json` (or any dependency manifes
 
 ## Scan-count watch
 
-Socket Free has ~1,000 scans/month. Each PR with a manifest/lockfile touch consumes 1 scan; each weekly `Socket Fix` run consumes one scan per matrix leg (12) plus extra per fix opened. Check monthly usage at the Socket dashboard. If usage hits **70% (~700 scans) for two consecutive months**, lower the cron cadence or upgrade to Team tier, and file a Linear ticket the first time the threshold is reached. POSIX cron can't express biweekly cleanly — switch to monthly (`cron: '0 9 1 * *'`) or gate with `github.run_number % 2`.
-
-## Follow-ups / deferred
-
-- **Socket Certified Patches** — deferred. `socket-patch apply` modifies files in `node_modules/`, which don't persist across `bun install`. Adoption requires running `bunx @socketsecurity/socket-patch setup` per workspace to install a `postinstall` hook; this rolls out an install-time dependency on every workspace's `package.json`. File as a follow-up when the team is ready to take on that cross-workspace change.
+Socket Free has ~1,000 scans/month. Each PR with a manifest/lockfile touch consumes 1 scan; each weekly `Socket Fix` run consumes one scan per matrix leg (12) plus extra per fix opened. Check monthly usage at the Socket dashboard. If usage hits **70% (~700 scans) for two consecutive months**, lower the cron cadence or upgrade to Team tier, and file a Linear ticket the first time the threshold is reached. POSIX cron can't express true biweekly cleanly. If cadence needs to drop, switch to monthly: `cron: '0 9 1 * *'` (09:00 UTC on the first of each month). A bash step gating on `$(( GITHUB_RUN_NUMBER % 2 ))` works too but lives in `run:` scripts, not `if:` expressions — document and test before relying on it.
 
 ## See also
 


### PR DESCRIPTION
## Summary
- Fix misleading `github.run_number % 2` Actions-expression guidance in the Scan-count watch section (% isn't supported in expression syntax).
- Fold `## Follow-ups / deferred` into the inline Certified-Patches deferral note — single bullet, doesn't warrant its own H2.
- Trim flag-rationale comments in `socket-autofix.yml` that restated what `docs/socket.md` already explains.

Final cleanup pass from round-3 self-review on socket-enforcement.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
