### PR TITLE
Socket.dev supply-chain enforcement + autofix (ATL-106)

### DIFF
--- a/.github/workflows/socket-autofix.yml
+++ b/.github/workflows/socket-autofix.yml
@@ -21,11 +21,7 @@ jobs:
     if: github.repository == 'vellum-ai/vellum-assistant'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # This is a multi-workspace Bun monorepo with NO root-level package.json.
-    # Socket's `fix` needs a resolved dependency tree (node_modules) per
-    # workspace, so we matrix over the runtime-relevant workspaces that each
-    # have their own bun.lock. `meta` and `scripts` (dev tooling) are skipped
-    # to conserve scan quota (~1,000 scans/month on Socket Free).
+    # Multi-workspace monorepo (no root package.json). See docs/socket.md.
     strategy:
       fail-fast: false
       matrix:
@@ -56,14 +52,10 @@ jobs:
         with:
           bun-version: '1.3.11'
 
-      # --ignore-scripts: Socket only needs the resolved dep tree; skipping
-      # postinstall hooks avoids cross-workspace mutations polluting diffs.
+      # See docs/socket.md for rationale (cross-workspace postinstall side-effects).
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
-      # --pr-limit 3: cap per matrix leg (12 × 3 = 36 PRs/week ceiling).
-      # --minimum-release-age 1w: skip versions <7 days old — defense against
-      # malware-via-update (compromised maintainer poisoned patch release).
       - name: Run socket fix
         run: bunx @socketsecurity/cli fix --autopilot --pr-limit 3 --minimum-release-age 1w
         env:

--- a/.github/workflows/socket-autofix.yml
+++ b/.github/workflows/socket-autofix.yml
@@ -11,6 +11,8 @@ permissions:
 
 concurrency:
   group: socket-autofix
+  # Don't cancel mid-run: socket-fix and socket-patch open PRs as they go;
+  # cancelling leaves half-created branches / partial manifest state.
   cancel-in-progress: false
 
 jobs:
@@ -19,6 +21,30 @@ jobs:
     if: github.repository == 'vellum-ai/vellum-assistant'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # This is a multi-workspace Bun monorepo with NO root-level package.json.
+    # Socket's `fix` needs a resolved dependency tree (node_modules) per
+    # workspace, so we matrix over the runtime-relevant workspaces that each
+    # have their own bun.lock. `meta` and `scripts` (dev tooling) are skipped
+    # to conserve scan quota (~1,000 scans/month on Socket Free).
+    strategy:
+      fail-fast: false
+      matrix:
+        workspace:
+          - assistant
+          - cli
+          - credential-executor
+          - gateway
+          - clients/chrome-extension
+          - clients/chrome-extension/native-host
+          - packages/ces-contracts
+          - packages/credential-storage
+          - packages/egress-proxy
+          - skills/meet-join
+          - skills/meet-join/bot
+          - skills/meet-join/meet-controller-ext
+    defaults:
+      run:
+        working-directory: ${{ matrix.workspace }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -29,6 +55,9 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: '1.3.11'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       # Flags (verified against https://docs.socket.dev/docs/socket-fix):
       #   --autopilot              headless CI mode; enables auto-merge on PRs Socket opens.
@@ -49,6 +78,27 @@ jobs:
     if: github.repository == 'vellum-ai/vellum-assistant'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Same matrix rationale as socket-fix above: socket-patch operates on a
+    # resolved node_modules tree, and there's no root manifest to install from.
+    strategy:
+      fail-fast: false
+      matrix:
+        workspace:
+          - assistant
+          - cli
+          - credential-executor
+          - gateway
+          - clients/chrome-extension
+          - clients/chrome-extension/native-host
+          - packages/ces-contracts
+          - packages/credential-storage
+          - packages/egress-proxy
+          - skills/meet-join
+          - skills/meet-join/bot
+          - skills/meet-join/meet-controller-ext
+    defaults:
+      run:
+        working-directory: ${{ matrix.workspace }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -60,19 +110,63 @@ jobs:
         with:
           bun-version: '1.3.11'
 
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       # socket-patch is the standalone Certified Patches CLI
       # (https://github.com/SocketDev/socket-patch). It works without a Socket
       # API token on the Free tier; paid-tier patches are silently skipped
       # (expected). Package name verified against the npm registry and the
       # upstream README at authoring time — re-verify if upgrading.
       #
-      # `apply` has no `--yes` flag; per upstream docs, interactive prompts
-      # auto-proceed when stdin is not a TTY (i.e. in CI), so no flag needed.
+      # Canonical sequence per upstream README (verified against
+      # raw.githubusercontent.com/SocketDev/socket-patch/main/README.md):
+      #   1. `scan --json`  — discover available patches (no filesystem side
+      #      effects; emits a JSON report).
+      #   2. `get <id>`     — download each patch into .socket/manifest.json.
+      #      `get` requires a single identifier (UUID/CVE/GHSA/PURL/package)
+      #      per invocation, so we drive it from the scan output via jq.
+      #   3. `apply`        — consume .socket/manifest.json and patch
+      #      node_modules in place. `apply` returns status="no_manifest" if
+      #      nothing was staged — treated as a no-op success.
+      #
+      # Interactive prompts auto-proceed when stdin is not a TTY (i.e. CI),
+      # so no --yes flag is needed.
       - name: Scan for available patches
-        run: bunx @socketsecurity/socket-patch scan --json > /tmp/socket-patch-scan.json
+        run: bunx @socketsecurity/socket-patch scan --json > /tmp/socket-patch-scan-${{ strategy.job-index }}.json
+        continue-on-error: true
+
+      - name: Download patches into manifest
+        run: |
+          scan_file="/tmp/socket-patch-scan-${{ strategy.job-index }}.json"
+          if [ ! -s "$scan_file" ]; then
+            echo "No scan output — nothing to get."
+            exit 0
+          fi
+          # Extract patch identifiers from scan output. Schema isn't fully
+          # documented upstream; try common shapes (uuid, id, patchId) and
+          # dedupe. If jq finds nothing, the loop body never runs and apply
+          # returns no_manifest, which is fine.
+          ids=$(jq -r '
+            [ ..
+              | objects
+              | (.uuid? // .id? // .patchId?)
+              | select(. != null and . != "")
+            ] | unique | .[]
+          ' "$scan_file" 2>/dev/null || true)
+          if [ -z "$ids" ]; then
+            echo "No patch identifiers found in scan output."
+            exit 0
+          fi
+          echo "$ids" | while read -r id; do
+            [ -z "$id" ] && continue
+            echo "Fetching patch: $id"
+            bunx @socketsecurity/socket-patch get "$id" --save-only || echo "  (failed, continuing)"
+          done
 
       - name: Apply patches
         run: bunx @socketsecurity/socket-patch apply
+        continue-on-error: true
 
       - name: Detect changes
         id: diff
@@ -89,21 +183,24 @@ jobs:
         run: |
           # Random delimiter prevents GITHUB_OUTPUT injection if scan JSON contains 'EOF' on its own line.
           delimiter="ghadelim_$(openssl rand -hex 16)"
+          scan_file="/tmp/socket-patch-scan-${{ strategy.job-index }}.json"
           {
             echo "body<<${delimiter}"
-            echo 'Applied Socket Certified Patches for the week.'
+            echo "Applied Socket Certified Patches for workspace \`${{ matrix.workspace }}\`."
             echo ''
             echo 'Socket is on the Free tier — paid-tier patches are silently skipped.'
             echo ''
             echo '### Scan output'
             echo ''
             echo '```json'
-            cat /tmp/socket-patch-scan.json
+            if [ -s "$scan_file" ]; then
+              cat "$scan_file"
+            else
+              echo '(no scan output)'
+            fi
             echo '```'
             echo ''
             echo 'See [docs/socket.md](docs/socket.md) for the runbook.'
-            echo ''
-            echo 'Part of ATL-106.'
             echo "${delimiter}"
           } >> "$GITHUB_OUTPUT"
 
@@ -111,12 +208,9 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
-          branch: socket-patch/weekly-${{ github.run_number }}
-          title: "chore(deps): apply Socket Certified Patches (weekly)"
+          branch: socket-patch/weekly-${{ github.run_number }}-${{ strategy.job-index }}
+          title: "chore(deps): apply Socket Certified Patches (${{ matrix.workspace }})"
           body: ${{ steps.body.outputs.body }}
-          commit-message: |
-            chore(deps): apply Socket Certified Patches
-
-            Part of ATL-106
+          commit-message: "chore(deps): apply Socket Certified Patches (${{ matrix.workspace }})"
           labels: dependencies,security,socket-patch
           delete-branch: true

--- a/.github/workflows/socket-autofix.yml
+++ b/.github/workflows/socket-autofix.yml
@@ -1,0 +1,122 @@
+name: Socket Autofix
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Mondays at 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: socket-autofix
+  cancel-in-progress: false
+
+jobs:
+  socket-fix:
+    name: Socket Fix (dep upgrades)
+    if: github.repository == 'vellum-ai/vellum-assistant'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      # Flags (verified against https://docs.socket.dev/docs/socket-fix):
+      #   --autopilot              headless CI mode; enables auto-merge on PRs Socket opens.
+      #   --pr-limit 10            cap per-run PR volume (matches Socket's CI default;
+      #                            pinned explicitly for reviewer visibility).
+      #   --minimum-release-age 1w skip versions published in the last 7 days —
+      #                            defense against malware-via-update.
+      - name: Run socket fix
+        run: bunx @socketsecurity/cli fix --autopilot --pr-limit 10 --minimum-release-age 1w
+        env:
+          SOCKET_CLI_API_TOKEN: ${{ secrets.SOCKET_CLI_API_TOKEN }}
+          SOCKET_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOCKET_CLI_GIT_USER_NAME: socket-fix[bot]
+          SOCKET_CLI_GIT_USER_EMAIL: socket-fix[bot]@users.noreply.github.com
+
+  socket-patch:
+    name: Socket Patch (Certified Patches)
+    if: github.repository == 'vellum-ai/vellum-assistant'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      # socket-patch is the standalone Certified Patches CLI
+      # (https://github.com/SocketDev/socket-patch). It works without a Socket
+      # API token on the Free tier; paid-tier patches are silently skipped
+      # (expected). Package name verified against the npm registry and the
+      # upstream README at authoring time — re-verify if upgrading.
+      #
+      # `apply` has no `--yes` flag; per upstream docs, interactive prompts
+      # auto-proceed when stdin is not a TTY (i.e. in CI), so no flag needed.
+      - name: Scan for available patches
+        run: bunx @socketsecurity/socket-patch scan --json > /tmp/socket-patch-scan.json
+
+      - name: Apply patches
+        run: bunx @socketsecurity/socket-patch apply
+
+      - name: Detect changes
+        id: diff
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build PR body
+        if: steps.diff.outputs.changed == 'true'
+        id: body
+        run: |
+          # Random delimiter prevents GITHUB_OUTPUT injection if scan JSON contains 'EOF' on its own line.
+          delimiter="ghadelim_$(openssl rand -hex 16)"
+          {
+            echo "body<<${delimiter}"
+            echo 'Applied Socket Certified Patches for the week.'
+            echo ''
+            echo 'Socket is on the Free tier — paid-tier patches are silently skipped.'
+            echo ''
+            echo '### Scan output'
+            echo ''
+            echo '```json'
+            cat /tmp/socket-patch-scan.json
+            echo '```'
+            echo ''
+            echo 'See [docs/socket.md](docs/socket.md) for the runbook.'
+            echo ''
+            echo 'Part of ATL-106.'
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open PR
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          branch: socket-patch/weekly-${{ github.run_number }}
+          title: "chore(deps): apply Socket Certified Patches (weekly)"
+          body: ${{ steps.body.outputs.body }}
+          commit-message: |
+            chore(deps): apply Socket Certified Patches
+
+            Part of ATL-106
+          labels: dependencies,security,socket-patch
+          delete-branch: true

--- a/.github/workflows/socket-autofix.yml
+++ b/.github/workflows/socket-autofix.yml
@@ -1,4 +1,4 @@
-name: Socket Autofix
+name: Socket Fix
 
 on:
   schedule:
@@ -11,8 +11,8 @@ permissions:
 
 concurrency:
   group: socket-autofix
-  # Don't cancel mid-run: socket-fix and socket-patch open PRs as they go;
-  # cancelling leaves half-created branches / partial manifest state.
+  # Don't cancel mid-run: socket-fix opens PRs as it goes; cancelling leaves
+  # half-created branches / partial manifest state.
   cancel-in-progress: false
 
 jobs:
@@ -56,161 +56,18 @@ jobs:
         with:
           bun-version: '1.3.11'
 
+      # --ignore-scripts: Socket only needs the resolved dep tree; skipping
+      # postinstall hooks avoids cross-workspace mutations polluting diffs.
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
-      # Flags (verified against https://docs.socket.dev/docs/socket-fix):
-      #   --autopilot              headless CI mode; enables auto-merge on PRs Socket opens.
-      #   --pr-limit 10            cap per-run PR volume (matches Socket's CI default;
-      #                            pinned explicitly for reviewer visibility).
-      #   --minimum-release-age 1w skip versions published in the last 7 days —
-      #                            defense against malware-via-update.
+      # --pr-limit 3: cap per matrix leg (12 × 3 = 36 PRs/week ceiling).
+      # --minimum-release-age 1w: skip versions <7 days old — defense against
+      # malware-via-update (compromised maintainer poisoned patch release).
       - name: Run socket fix
-        run: bunx @socketsecurity/cli fix --autopilot --pr-limit 10 --minimum-release-age 1w
+        run: bunx @socketsecurity/cli fix --autopilot --pr-limit 3 --minimum-release-age 1w
         env:
           SOCKET_CLI_API_TOKEN: ${{ secrets.SOCKET_CLI_API_TOKEN }}
           SOCKET_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOCKET_CLI_GIT_USER_NAME: socket-fix[bot]
           SOCKET_CLI_GIT_USER_EMAIL: socket-fix[bot]@users.noreply.github.com
-
-  socket-patch:
-    name: Socket Patch (Certified Patches)
-    if: github.repository == 'vellum-ai/vellum-assistant'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    # Same matrix rationale as socket-fix above: socket-patch operates on a
-    # resolved node_modules tree, and there's no root manifest to install from.
-    strategy:
-      fail-fast: false
-      matrix:
-        workspace:
-          - assistant
-          - cli
-          - credential-executor
-          - gateway
-          - clients/chrome-extension
-          - clients/chrome-extension/native-host
-          - packages/ces-contracts
-          - packages/credential-storage
-          - packages/egress-proxy
-          - skills/meet-join
-          - skills/meet-join/bot
-          - skills/meet-join/meet-controller-ext
-    defaults:
-      run:
-        working-directory: ${{ matrix.workspace }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: '1.3.11'
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      # socket-patch is the standalone Certified Patches CLI
-      # (https://github.com/SocketDev/socket-patch). It works without a Socket
-      # API token on the Free tier; paid-tier patches are silently skipped
-      # (expected). Package name verified against the npm registry and the
-      # upstream README at authoring time — re-verify if upgrading.
-      #
-      # Canonical sequence per upstream README (verified against
-      # raw.githubusercontent.com/SocketDev/socket-patch/main/README.md):
-      #   1. `scan --json`  — discover available patches (no filesystem side
-      #      effects; emits a JSON report).
-      #   2. `get <id>`     — download each patch into .socket/manifest.json.
-      #      `get` requires a single identifier (UUID/CVE/GHSA/PURL/package)
-      #      per invocation, so we drive it from the scan output via jq.
-      #   3. `apply`        — consume .socket/manifest.json and patch
-      #      node_modules in place. `apply` returns status="no_manifest" if
-      #      nothing was staged — treated as a no-op success.
-      #
-      # Interactive prompts auto-proceed when stdin is not a TTY (i.e. CI),
-      # so no --yes flag is needed.
-      - name: Scan for available patches
-        run: bunx @socketsecurity/socket-patch scan --json > /tmp/socket-patch-scan-${{ strategy.job-index }}.json
-        continue-on-error: true
-
-      - name: Download patches into manifest
-        run: |
-          scan_file="/tmp/socket-patch-scan-${{ strategy.job-index }}.json"
-          if [ ! -s "$scan_file" ]; then
-            echo "No scan output — nothing to get."
-            exit 0
-          fi
-          # Extract patch identifiers from scan output. Schema isn't fully
-          # documented upstream; try common shapes (uuid, id, patchId) and
-          # dedupe. If jq finds nothing, the loop body never runs and apply
-          # returns no_manifest, which is fine.
-          ids=$(jq -r '
-            [ ..
-              | objects
-              | (.uuid? // .id? // .patchId?)
-              | select(. != null and . != "")
-            ] | unique | .[]
-          ' "$scan_file" 2>/dev/null || true)
-          if [ -z "$ids" ]; then
-            echo "No patch identifiers found in scan output."
-            exit 0
-          fi
-          echo "$ids" | while read -r id; do
-            [ -z "$id" ] && continue
-            echo "Fetching patch: $id"
-            bunx @socketsecurity/socket-patch get "$id" --save-only || echo "  (failed, continuing)"
-          done
-
-      - name: Apply patches
-        run: bunx @socketsecurity/socket-patch apply
-        continue-on-error: true
-
-      - name: Detect changes
-        id: diff
-        run: |
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Build PR body
-        if: steps.diff.outputs.changed == 'true'
-        id: body
-        run: |
-          # Random delimiter prevents GITHUB_OUTPUT injection if scan JSON contains 'EOF' on its own line.
-          delimiter="ghadelim_$(openssl rand -hex 16)"
-          scan_file="/tmp/socket-patch-scan-${{ strategy.job-index }}.json"
-          {
-            echo "body<<${delimiter}"
-            echo "Applied Socket Certified Patches for workspace \`${{ matrix.workspace }}\`."
-            echo ''
-            echo 'Socket is on the Free tier — paid-tier patches are silently skipped.'
-            echo ''
-            echo '### Scan output'
-            echo ''
-            echo '```json'
-            if [ -s "$scan_file" ]; then
-              cat "$scan_file"
-            else
-              echo '(no scan output)'
-            fi
-            echo '```'
-            echo ''
-            echo 'See [docs/socket.md](docs/socket.md) for the runbook.'
-            echo "${delimiter}"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Open PR
-        if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
-        with:
-          branch: socket-patch/weekly-${{ github.run_number }}-${{ strategy.job-index }}
-          title: "chore(deps): apply Socket Certified Patches (${{ matrix.workspace }})"
-          body: ${{ steps.body.outputs.body }}
-          commit-message: "chore(deps): apply Socket Certified Patches (${{ matrix.workspace }})"
-          labels: dependencies,security,socket-patch
-          delete-branch: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,8 @@ This policy covers the code in this repository, including:
 - The credential execution service (`credential-executor/`)
 - The packages shared between services (`packages/`)
 
+For Socket.dev supply-chain controls and autofix operations, see [docs/socket.md](docs/socket.md).
+
 ## Security Model
 
 For details on Vellum Assistant's security architecture — including sandboxing, credential storage, permission modes, and trust rules — see the [Security Architecture documentation](assistant/docs/architecture/security.md).

--- a/docs/socket.md
+++ b/docs/socket.md
@@ -36,12 +36,14 @@ Both are gated by `socket.yml` at the repo root.
 
 ### `Socket Autofix` workflow (weekly Monday 09:00 UTC)
 
-`.github/workflows/socket-autofix.yml` runs on `cron: '0 9 * * 1'` plus `workflow_dispatch`. It contains two **independent** jobs (no `needs:` between them) that run in parallel:
+`.github/workflows/socket-autofix.yml` runs on `cron: '0 9 * * 1'` plus `workflow_dispatch`. It contains two **independent** jobs (no `needs:` between them) that run in parallel.
 
-- **`socket-fix`** — opens one PR per fixable GHSA/CVE. Flags:
+Because this is a multi-workspace Bun monorepo with **no root-level `package.json`**, both jobs use `strategy.matrix` over the runtime-relevant workspaces that each own a `bun.lock` (`assistant`, `cli`, `credential-executor`, `gateway`, the two `clients/chrome-extension*` workspaces, the three `packages/*` workspaces, and the three `skills/meet-join*` workspaces). Each matrix leg sets `defaults.run.working-directory` to its workspace and runs `bun install --frozen-lockfile` before invoking the Socket CLI — Socket's `fix` and `socket-patch apply` both operate on a resolved `node_modules` tree, so skipping the install leaves them with nothing to scan. `meta` and `scripts` (dev tooling only) are deliberately excluded to conserve the Free tier's ~1,000 scans/month budget.
+
+- **`socket-fix`** — opens one PR per fixable GHSA/CVE, per workspace. Flags:
   - `--pr-limit 10` — cap per-run PR volume. Socket's current default, pinned explicitly for reviewer visibility and future-default stability.
   - `--minimum-release-age 1w` — skip versions published in the last 7 days. Defense against malware-via-update (compromised maintainer pushing a poisoned patch release).
-- **`socket-patch`** — applies Socket Certified Patches, bundled into one PR. Paid-tier patches are silently skipped on Free (expected — no PR opened those weeks).
+- **`socket-patch`** — applies Socket Certified Patches per workspace. The canonical CLI sequence is `scan --json` → `get <id>` (one call per patch identifier, fed from the scan output via `jq`; `get` writes `.socket/manifest.json`) → `apply` (consumes the manifest). `apply` returns `status="no_manifest"` when no patches were staged, which is treated as a no-op success. Paid-tier patches are silently skipped on Free (expected — no PR opened those weeks).
 
 ## Policy file
 

--- a/docs/socket.md
+++ b/docs/socket.md
@@ -1,0 +1,10 @@
+# Socket.dev at Vellum Assistant
+
+This file is a stub. The full Socket.dev runbook — covering the `socket-security` App checks, the `socket.yml` policy, the weekly `Socket Autofix` workflow, token provenance, and the `gh api` command to wire Socket into the `main` branch-protection ruleset — lands in the follow-up PR of the same plan (ATL-106 / `socket-enforcement`).
+
+Until that PR merges, see:
+
+- `socket.yml` at the repo root — committed alert policy (boolean `issueRules` map per the Socket config schema).
+- `SECURITY.md` — vulnerability reporting policy.
+- [Socket docs](https://docs.socket.dev/docs/socket-yml) — canonical `socket.yml` schema reference.
+- Socket dashboard Security Policies — graduated block/warn/ignore severity mapping (not expressible in `socket.yml`).

--- a/docs/socket.md
+++ b/docs/socket.md
@@ -1,10 +1,183 @@
 # Socket.dev at Vellum Assistant
 
-This file is a stub. The full Socket.dev runbook — covering the `socket-security` App checks, the `socket.yml` policy, the weekly `Socket Autofix` workflow, token provenance, and the `gh api` command to wire Socket into the `main` branch-protection ruleset — lands in the follow-up PR of the same plan (ATL-106 / `socket-enforcement`).
+This doc is the operator runbook for Socket.dev on `vellum-ai/vellum-assistant`: what runs in CI, how the policy file is wired, how the weekly autofix works, where the API token comes from, and the manual `gh api` command used to wire Socket checks into `main` branch protection. The sibling repo `vellum-ai/vellum-assistant-platform` uses the **same Socket API token** and has a parallel runbook — rotating the token affects both repos.
 
-Until that PR merges, see:
+## Tier
 
-- `socket.yml` at the repo root — committed alert policy (boolean `issueRules` map per the Socket config schema).
-- `SECURITY.md` — vulnerability reporting policy.
-- [Socket docs](https://docs.socket.dev/docs/socket-yml) — canonical `socket.yml` schema reference.
-- Socket dashboard Security Policies — graduated block/warn/ignore severity mapping (not expressible in `socket.yml`).
+The vellum-ai Socket org is on **Socket Free**.
+
+**Works on Free:**
+
+- `socket-security` GitHub App checks on every PR.
+- `socket.yml` policy file (boolean `issueRules` map).
+- `socket fix` dep-upgrade autofix (requires an API token).
+- Free-tier Socket Certified Patches via `socket-patch` (no token needed).
+- ~1,000 scans/month.
+
+**NOT available on Free:**
+
+- Reachability analysis.
+- Priority scoring.
+- Slack / webhook alert channels.
+- Paid-tier Certified Patches — `socket-patch` silently skips these; expected.
+- Org-wide policy enforcement.
+- Socket Firewall.
+
+## What runs in CI
+
+### `socket-security` GitHub App (per PR)
+
+The `socket-security` App (installed at the vellum-ai org level) emits two check runs on every PR:
+
+- `Socket Security: Project Report` — runs on every PR.
+- `Socket Security: Pull Request Alerts` — runs when a PR touches a manifest or lockfile (`package.json` / `bun.lock`).
+
+Both are gated by `socket.yml` at the repo root.
+
+### `Socket Autofix` workflow (weekly Monday 09:00 UTC)
+
+`.github/workflows/socket-autofix.yml` runs on `cron: '0 9 * * 1'` plus `workflow_dispatch`. It contains two **independent** jobs (no `needs:` between them) that run in parallel:
+
+- **`socket-fix`** — opens one PR per fixable GHSA/CVE. Flags:
+  - `--pr-limit 10` — cap per-run PR volume. Socket's current default, pinned explicitly for reviewer visibility and future-default stability.
+  - `--minimum-release-age 1w` — skip versions published in the last 7 days. Defense against malware-via-update (compromised maintainer pushing a poisoned patch release).
+- **`socket-patch`** — applies Socket Certified Patches, bundled into one PR. Paid-tier patches are silently skipped on Free (expected — no PR opened those weeks).
+
+## Policy file
+
+- **Location:** `socket.yml` at the repo root.
+- **Schema:** `issueRules` is a **boolean map** (`<alertName>: true|false`) per the upstream `@socketsecurity/config` v3 schema (`additionalProperties: { type: "boolean" }`). The `{ action: error|warn|ignore }` object form is **silently rejected** by Socket's config validator and falls back to dashboard defaults — do NOT reintroduce it.
+- **Two states in YAML:** `true` enables the alert (it will surface on the Socket PR check); `false` suppresses it. Block-vs-warn granularity is **not expressible in `socket.yml`** — it lives in the **Socket dashboard Security Policies**. To change whether a specific alert blocks or warns, configure the dashboard policy at the org level rather than editing this file.
+- **Extending the ignore list:** to suppress an alert category repo-wide, set it to `false`. To suppress a *specific package* that triggered an alert (e.g. esbuild for `installScripts`), use Socket's package-scoped override syntax — see https://docs.socket.dev/docs/socket-yml for the current shape. Prefer package-scoped overrides over category-wide `false`; always add a rationale comment above any suppression (why, who approved, date, expiry if any). Reviewers block suppression-without-rationale additions.
+- **Ecosystems:** currently npm/Bun only. The App auto-detects Python manifests if they land; `issueRules` apply across ecosystems, so no YAML change is needed for a new ecosystem unless we want divergent per-ecosystem policy.
+
+## Token provenance
+
+- `SOCKET_CLI_API_TOKEN` is created at **Socket dashboard → Settings → API Tokens** with scopes `full-scans:create` and `packages:list`.
+- Stored as a repo secret at `vellum-ai/vellum-assistant → Settings → Secrets and variables → Actions`.
+- **Same token is used by the sibling `vellum-assistant-platform` repo.** One Socket token covers both repos; rotation means updating the secret in both.
+- **Rotation procedure:**
+  1. In the Socket dashboard, create a new token with the same scopes (`full-scans:create`, `packages:list`).
+  2. Update the repo secret in `vellum-ai/vellum-assistant` → trigger `Socket Autofix` manually → confirm `socket-fix` succeeds.
+  3. Update the repo secret in `vellum-ai/vellum-assistant-platform` → trigger its workflow manually → confirm success.
+  4. Delete the old token in the Socket dashboard.
+- Do NOT rotate during the Monday 09:00 UTC scheduled-run window.
+- Job 2 (`socket-patch`) does NOT consume the token — token rotation cannot break `socket-patch`.
+
+## Interpreting Socket alerts on a PR
+
+`Socket Security: Pull Request Alerts` annotates the PR with any Socket-detected issues for deps touched by the PR. Whether an alert **blocks** the check or shows as a warning is controlled by **two layers**:
+
+1. **`socket.yml`** — `<alertName>: true` enables the alert category; `<alertName>: false` suppresses it entirely.
+2. **Socket dashboard Security Policy** — maps enabled alerts to block / warn / notice severities at the org level. This is where warn-vs-block granularity lives.
+
+Post-ruleset-PATCH (see next section), a Socket check in `error` state (per dashboard policy) **blocks merge** on `main`. A check in `warn` / `notice` surfaces in the PR but does not block.
+
+See `## Policy file` for suppression syntax. Prefer package-scoped overrides over flipping a whole alert category to `false` — the latter weakens the policy for every other dep.
+
+## Ruleset PATCH — wire Socket checks into `main` branch protection
+
+Manual operator step, NOT a code change. Run after PRs 1 and 2 are merged and after a trivial sanity PR (one-line `package.json` edit or `bun.lock` touch) confirms both App checks run green.
+
+Ruleset ID: **`12614752`** ("Main Protection" on `main`).
+
+### Step A — snapshot the existing ruleset
+
+```bash
+gh api /repos/vellum-ai/vellum-assistant/rulesets/12614752 > /tmp/main-ruleset.json
+```
+
+### Step B — verify the pre-PATCH baseline
+
+Expected: review rule present (`approving_review_count=1`, `dismiss_stale_reviews_on_push=true`, `require_last_push_approval=true`); no `required_status_checks` rule.
+
+```bash
+jq '.rules[] | select(.type == "pull_request") | .parameters' /tmp/main-ruleset.json
+
+# Should print nothing — no required_status_checks rule today.
+jq '.rules[] | select(.type == "required_status_checks")' /tmp/main-ruleset.json
+```
+
+### Step C — apply the PATCH
+
+The GitHub ruleset API expects the full ruleset body on PUT. The `jq` filter below rebuilds `{ name, target, enforcement, bypass_actors, conditions, rules }` from the snapshot and only **appends** a new `required_status_checks` rule with both Socket contexts. Review rules, dismiss-stale, and last-push-approval are preserved untouched.
+
+```bash
+jq '
+  .rules += [{
+    "type": "required_status_checks",
+    "parameters": {
+      "strict_required_status_checks_policy": false,
+      "do_not_enforce_on_create": false,
+      "required_status_checks": [
+        { "context": "Socket Security: Pull Request Alerts" },
+        { "context": "Socket Security: Project Report"     }
+      ]
+    }
+  }]
+  | { name, target, enforcement, bypass_actors, conditions, rules }
+' /tmp/main-ruleset.json > /tmp/main-ruleset-patched.json
+
+gh api \
+  --method PUT \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  /repos/vellum-ai/vellum-assistant/rulesets/12614752 \
+  --input /tmp/main-ruleset-patched.json
+```
+
+Payload notes:
+
+- `--method PUT` is required — the ruleset update endpoint is PUT (not PATCH); using PATCH will 404.
+- `strict_required_status_checks_policy: false` — do not require PR branches to be up-to-date with `main` before merging. Matches current behavior; flipping to `true` is a separate follow-up.
+- `do_not_enforce_on_create: false` — apply the rule to branches created after the ruleset is updated.
+- `context` is the check-run name emitted by the `socket-security` App — exact strings. If GitHub returns an app-integration ambiguity error, add `"integration_id": <socket-app-id>` to each entry. Look up the App ID via:
+
+  ```bash
+  gh api /repos/vellum-ai/vellum-assistant/installations \
+    --jq '.installations[] | select(.app_slug == "socket-security") | .app_id'
+  ```
+
+### Step D — verify post-PATCH state
+
+```bash
+# Expected: both Socket contexts listed.
+gh api /repos/vellum-ai/vellum-assistant/rulesets/12614752 | \
+  jq '.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks'
+
+# Expected: review rule unchanged (approving_review_count=1,
+# dismiss_stale_reviews_on_push=true, require_last_push_approval=true).
+gh api /repos/vellum-ai/vellum-assistant/rulesets/12614752 | \
+  jq '.rules[] | select(.type == "pull_request") | .parameters'
+```
+
+### Step E — sanity PR
+
+Open a small PR that touches `assistant/package.json` (or any dependency manifest) and confirm `Socket Security: Pull Request Alerts` now shows as a **required** check on the PR.
+
+## Scan-count watch
+
+Socket Free has ~1,000 scans/month. Consumption sources in this repo:
+
+- Each PR with a manifest/lockfile touch → 1 scan by the App.
+- Each `Socket Autofix` run → multiple scans depending on fix count.
+
+Check monthly usage at the Socket dashboard. If usage hits **70% (~700 scans) for two consecutive months**, revisit by either:
+
+- lowering `Socket Autofix` cadence. Note: POSIX cron has no true biweekly expression — when both day-of-month and day-of-week are constrained, cron ORs them, so `'0 9 */14 * 1'` fires *more* often than weekly, not less. Options: (a) switch to monthly with `cron: '0 9 1 * *'` (runs 09:00 UTC on the 1st of every month); (b) keep the weekly cron and gate the run with a workflow-level `if: (github.run_number % 2) == 0` so only every other run executes; or (c) drive from an external scheduler via `workflow_dispatch`.
+- upgrading to Team tier.
+
+File a Linear ticket the first time the threshold is reached.
+
+## Follow-ups / deferred
+
+- Introduce a GitHub Terraform provider to manage the ruleset declaratively. Today the ruleset is managed by `gh api` only. Track as a separate ticket.
+- Extend `socket.yml` with a Python ecosystem block when/if Python manifests land in this repo (none today).
+- Wire Socket alerts into Slack — requires Team tier; re-evaluate at tier upgrade.
+- Automate scan-count monitoring. Socket does not emit a public usage API on Free, so a monthly manual check is the only option today.
+
+## See also
+
+- `SECURITY.md` — vulnerability reporting policy (the public-facing side).
+- `AGENTS.md` § `Dependencies` — license-compatibility policy (Socket does not enforce license policy; that is still our gate).
+- `AGENTS.md` § `GitHub Actions` — action-pin format rule (why every `uses:` in `socket-autofix.yml` has a 40-char SHA).

--- a/docs/socket.md
+++ b/docs/socket.md
@@ -11,7 +11,6 @@ The vellum-ai Socket org is on **Socket Free**.
 - `socket-security` GitHub App checks on every PR.
 - `socket.yml` policy file (boolean `issueRules` map).
 - `socket fix` dep-upgrade autofix (requires an API token).
-- Free-tier Socket Certified Patches via `socket-patch` (no token needed).
 - ~1,000 scans/month.
 
 **NOT available on Free:**
@@ -19,7 +18,6 @@ The vellum-ai Socket org is on **Socket Free**.
 - Reachability analysis.
 - Priority scoring.
 - Slack / webhook alert channels.
-- Paid-tier Certified Patches — `socket-patch` silently skips these; expected.
 - Org-wide policy enforcement.
 - Socket Firewall.
 
@@ -34,24 +32,24 @@ The `socket-security` App (installed at the vellum-ai org level) emits two check
 
 Both are gated by `socket.yml` at the repo root.
 
-### `Socket Autofix` workflow (weekly Monday 09:00 UTC)
+### `Socket Fix` workflow (weekly Monday 09:00 UTC)
 
-`.github/workflows/socket-autofix.yml` runs on `cron: '0 9 * * 1'` plus `workflow_dispatch`. It contains two **independent** jobs (no `needs:` between them) that run in parallel.
+`.github/workflows/socket-autofix.yml` runs on `cron: '0 9 * * 1'` plus `workflow_dispatch`. (The workflow file name is historical; the workflow `name:` is `Socket Fix`.)
 
-Because this is a multi-workspace Bun monorepo with **no root-level `package.json`**, both jobs use `strategy.matrix` over the runtime-relevant workspaces that each own a `bun.lock` (`assistant`, `cli`, `credential-executor`, `gateway`, the two `clients/chrome-extension*` workspaces, the three `packages/*` workspaces, and the three `skills/meet-join*` workspaces). Each matrix leg sets `defaults.run.working-directory` to its workspace and runs `bun install --frozen-lockfile` before invoking the Socket CLI — Socket's `fix` and `socket-patch apply` both operate on a resolved `node_modules` tree, so skipping the install leaves them with nothing to scan. `meta` and `scripts` (dev tooling only) are deliberately excluded to conserve the Free tier's ~1,000 scans/month budget.
+Because this is a multi-workspace Bun monorepo with **no root-level `package.json`**, the job uses `strategy.matrix` over the runtime-relevant workspaces that each own a `bun.lock` (`assistant`, `cli`, `credential-executor`, `gateway`, the two `clients/chrome-extension*` workspaces, the three `packages/*` workspaces, and the three `skills/meet-join*` workspaces). Each matrix leg sets `defaults.run.working-directory` to its workspace and runs `bun install --frozen-lockfile --ignore-scripts` before invoking the Socket CLI — Socket's `fix` operates on a resolved `node_modules` tree, but postinstall hooks would mutate other workspaces and contaminate the autofix diffs. `meta` and `scripts` (dev tooling only) are deliberately excluded to conserve the Free tier's ~1,000 scans/month budget.
 
 - **`socket-fix`** — opens one PR per fixable GHSA/CVE, per workspace. Flags:
-  - `--pr-limit 10` — cap per-run PR volume. Socket's current default, pinned explicitly for reviewer visibility and future-default stability.
+  - `--pr-limit 3` — cap per matrix leg (12 × 3 = 36 PRs/week ceiling).
   - `--minimum-release-age 1w` — skip versions published in the last 7 days. Defense against malware-via-update (compromised maintainer pushing a poisoned patch release).
-- **`socket-patch`** — applies Socket Certified Patches per workspace. The canonical CLI sequence is `scan --json` → `get <id>` (one call per patch identifier, fed from the scan output via `jq`; `get` writes `.socket/manifest.json`) → `apply` (consumes the manifest). `apply` returns `status="no_manifest"` when no patches were staged, which is treated as a no-op success. Paid-tier patches are silently skipped on Free (expected — no PR opened those weeks).
+
+Socket Certified Patches (`socket-patch`) are deferred pending a `socket-patch setup` postinstall-hook rollout across all workspaces — see "Follow-ups / deferred" below.
 
 ## Policy file
 
 - **Location:** `socket.yml` at the repo root.
 - **Schema:** `issueRules` is a **boolean map** (`<alertName>: true|false`) per the upstream `@socketsecurity/config` v3 schema (`additionalProperties: { type: "boolean" }`). The `{ action: error|warn|ignore }` object form is **silently rejected** by Socket's config validator and falls back to dashboard defaults — do NOT reintroduce it.
-- **Two states in YAML:** `true` enables the alert (it will surface on the Socket PR check); `false` suppresses it. Block-vs-warn granularity is **not expressible in `socket.yml`** — it lives in the **Socket dashboard Security Policies**. To change whether a specific alert blocks or warns, configure the dashboard policy at the org level rather than editing this file.
+- **Dashboard policy layering:** block-vs-warn granularity is **not expressible in `socket.yml`** — it lives in the **Socket dashboard Security Policies**. To change whether a specific alert blocks or warns, configure the dashboard policy at the org level rather than editing this file.
 - **Extending the ignore list:** to suppress an alert category repo-wide, set it to `false`. To suppress a *specific package* that triggered an alert (e.g. esbuild for `installScripts`), use Socket's package-scoped override syntax — see https://docs.socket.dev/docs/socket-yml for the current shape. Prefer package-scoped overrides over category-wide `false`; always add a rationale comment above any suppression (why, who approved, date, expiry if any). Reviewers block suppression-without-rationale additions.
-- **Ecosystems:** currently npm/Bun only. The App auto-detects Python manifests if they land; `issueRules` apply across ecosystems, so no YAML change is needed for a new ecosystem unless we want divergent per-ecosystem policy.
 
 ## Token provenance
 
@@ -60,22 +58,13 @@ Because this is a multi-workspace Bun monorepo with **no root-level `package.jso
 - **Same token is used by the sibling `vellum-assistant-platform` repo.** One Socket token covers both repos; rotation means updating the secret in both.
 - **Rotation procedure:**
   1. In the Socket dashboard, create a new token with the same scopes (`full-scans:create`, `packages:list`).
-  2. Update the repo secret in `vellum-ai/vellum-assistant` → trigger `Socket Autofix` manually → confirm `socket-fix` succeeds.
-  3. Update the repo secret in `vellum-ai/vellum-assistant-platform` → trigger its workflow manually → confirm success.
-  4. Delete the old token in the Socket dashboard.
+  2. Update the repo secret in both `vellum-ai/vellum-assistant` and `vellum-ai/vellum-assistant-platform`, then trigger each repo's Socket workflow manually and confirm success.
+  3. Delete the old token in the Socket dashboard.
 - Do NOT rotate during the Monday 09:00 UTC scheduled-run window.
-- Job 2 (`socket-patch`) does NOT consume the token — token rotation cannot break `socket-patch`.
 
 ## Interpreting Socket alerts on a PR
 
-`Socket Security: Pull Request Alerts` annotates the PR with any Socket-detected issues for deps touched by the PR. Whether an alert **blocks** the check or shows as a warning is controlled by **two layers**:
-
-1. **`socket.yml`** — `<alertName>: true` enables the alert category; `<alertName>: false` suppresses it entirely.
-2. **Socket dashboard Security Policy** — maps enabled alerts to block / warn / notice severities at the org level. This is where warn-vs-block granularity lives.
-
-Post-ruleset-PATCH (see next section), a Socket check in `error` state (per dashboard policy) **blocks merge** on `main`. A check in `warn` / `notice` surfaces in the PR but does not block.
-
-See `## Policy file` for suppression syntax. Prefer package-scoped overrides over flipping a whole alert category to `false` — the latter weakens the policy for every other dep.
+`Socket Security: Pull Request Alerts` annotates the PR with any Socket-detected issues for deps touched by the PR. `socket.yml` decides which alert categories surface; the Socket dashboard Security Policy decides whether each surfaced alert blocks or warns. Post-ruleset-PATCH (see next section), a Socket check in `error` state **blocks merge** on `main`; `warn` / `notice` surfaces in the PR but does not block. Prefer package-scoped overrides over flipping a whole alert category to `false` — the latter weakens the policy for every other dep.
 
 ## Ruleset PATCH — wire Socket checks into `main` branch protection
 
@@ -159,24 +148,11 @@ Open a small PR that touches `assistant/package.json` (or any dependency manifes
 
 ## Scan-count watch
 
-Socket Free has ~1,000 scans/month. Consumption sources in this repo:
-
-- Each PR with a manifest/lockfile touch → 1 scan by the App.
-- Each `Socket Autofix` run → multiple scans depending on fix count.
-
-Check monthly usage at the Socket dashboard. If usage hits **70% (~700 scans) for two consecutive months**, revisit by either:
-
-- lowering `Socket Autofix` cadence. Note: POSIX cron has no true biweekly expression — when both day-of-month and day-of-week are constrained, cron ORs them, so `'0 9 */14 * 1'` fires *more* often than weekly, not less. Options: (a) switch to monthly with `cron: '0 9 1 * *'` (runs 09:00 UTC on the 1st of every month); (b) keep the weekly cron and gate the run with a workflow-level `if: (github.run_number % 2) == 0` so only every other run executes; or (c) drive from an external scheduler via `workflow_dispatch`.
-- upgrading to Team tier.
-
-File a Linear ticket the first time the threshold is reached.
+Socket Free has ~1,000 scans/month. Each PR with a manifest/lockfile touch consumes 1 scan; each weekly `Socket Fix` run consumes one scan per matrix leg (12) plus extra per fix opened. Check monthly usage at the Socket dashboard. If usage hits **70% (~700 scans) for two consecutive months**, lower the cron cadence or upgrade to Team tier, and file a Linear ticket the first time the threshold is reached. POSIX cron can't express biweekly cleanly — switch to monthly (`cron: '0 9 1 * *'`) or gate with `github.run_number % 2`.
 
 ## Follow-ups / deferred
 
-- Introduce a GitHub Terraform provider to manage the ruleset declaratively. Today the ruleset is managed by `gh api` only. Track as a separate ticket.
-- Extend `socket.yml` with a Python ecosystem block when/if Python manifests land in this repo (none today).
-- Wire Socket alerts into Slack — requires Team tier; re-evaluate at tier upgrade.
-- Automate scan-count monitoring. Socket does not emit a public usage API on Free, so a monthly manual check is the only option today.
+- **Socket Certified Patches** — deferred. `socket-patch apply` modifies files in `node_modules/`, which don't persist across `bun install`. Adoption requires running `bunx @socketsecurity/socket-patch setup` per workspace to install a `postinstall` hook; this rolls out an install-time dependency on every workspace's `package.json`. File as a follow-up when the team is ready to take on that cross-workspace change.
 
 ## See also
 

--- a/docs/socket.md
+++ b/docs/socket.md
@@ -42,7 +42,7 @@ Because this is a multi-workspace Bun monorepo with **no root-level `package.jso
   - `--pr-limit 3` — cap per matrix leg (12 × 3 = 36 PRs/week ceiling).
   - `--minimum-release-age 1w` — skip versions published in the last 7 days. Defense against malware-via-update (compromised maintainer pushing a poisoned patch release).
 
-Socket Certified Patches (`socket-patch`) are deferred pending a `socket-patch setup` postinstall-hook rollout across all workspaces — see "Follow-ups / deferred" below.
+Socket Certified Patches (`socket-patch`) are deferred: `socket-patch apply` modifies files in `node_modules/`, which don't persist across `bun install`. Adoption requires running `bunx @socketsecurity/socket-patch setup` per workspace to install a `postinstall: socket-patch apply` hook — a cross-workspace install-time dependency added to every workspace's `package.json`. File as a follow-up when the team is ready to take on that rollout.
 
 ## Policy file
 
@@ -148,11 +148,7 @@ Open a small PR that touches `assistant/package.json` (or any dependency manifes
 
 ## Scan-count watch
 
-Socket Free has ~1,000 scans/month. Each PR with a manifest/lockfile touch consumes 1 scan; each weekly `Socket Fix` run consumes one scan per matrix leg (12) plus extra per fix opened. Check monthly usage at the Socket dashboard. If usage hits **70% (~700 scans) for two consecutive months**, lower the cron cadence or upgrade to Team tier, and file a Linear ticket the first time the threshold is reached. POSIX cron can't express biweekly cleanly — switch to monthly (`cron: '0 9 1 * *'`) or gate with `github.run_number % 2`.
-
-## Follow-ups / deferred
-
-- **Socket Certified Patches** — deferred. `socket-patch apply` modifies files in `node_modules/`, which don't persist across `bun install`. Adoption requires running `bunx @socketsecurity/socket-patch setup` per workspace to install a `postinstall` hook; this rolls out an install-time dependency on every workspace's `package.json`. File as a follow-up when the team is ready to take on that cross-workspace change.
+Socket Free has ~1,000 scans/month. Each PR with a manifest/lockfile touch consumes 1 scan; each weekly `Socket Fix` run consumes one scan per matrix leg (12) plus extra per fix opened. Check monthly usage at the Socket dashboard. If usage hits **70% (~700 scans) for two consecutive months**, lower the cron cadence or upgrade to Team tier, and file a Linear ticket the first time the threshold is reached. POSIX cron can't express true biweekly cleanly. If cadence needs to drop, switch to monthly: `cron: '0 9 1 * *'` (09:00 UTC on the first of each month). A bash step gating on `$(( GITHUB_RUN_NUMBER % 2 ))` works too but lives in `run:` scripts, not `if:` expressions — document and test before relying on it.
 
 ## See also
 

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,55 @@
+# Socket.dev supply-chain policy.
+# Gates the `socket-security` GitHub App checks that run on every PR.
+# Free tier only: no reachability, no priority scoring, no Slack, no org-wide rules.
+#
+# Shape: `<alertName>: true` enables the alert (severity and block-vs-warn
+# are determined by Socket's default severity mapping plus the Socket
+# dashboard Security Policy). `<alertName>: false` suppresses the alert
+# entirely. Three-state (block/warn/ignore) granularity lives in the
+# dashboard policy, not in this file — see docs/socket.md.
+#
+# Package-specific exceptions: add under the relevant alert with a rationale
+# comment (why suppressing, who approved, date, expiry if any). Reviewers
+# block suppressions without rationale.
+#
+# Alert names below verified against https://docs.socket.dev/docs/socket-yml
+# and https://socket.dev/alerts in 2026-04; re-verify on next edit.
+# Runbook: docs/socket.md (lands in PR 3 of the same plan — ATL-106).
+
+version: 2
+
+projectIgnorePaths:
+  - "**/node_modules/**"
+  - "**/.build/**"
+  - "clients/.build/**"
+  - "**/dist/**"
+  - "**/build/**"
+  - "**/.build-ios/**"
+  - "**/*.tsbuildinfo"
+  - "**/*.bun-build"
+
+issueRules:
+  # Supply-chain-attack signals — always on (reported and, per Socket default
+  # severity, block the check).
+  malware: true
+  gptMalware: true
+  didYouMean: true
+  installScripts: true
+  hasNativeCode: true
+  shellAccess: true
+
+  # Hygiene / trust signals — on (reported; block-vs-warn is controlled by
+  # Socket dashboard Security Policies, not this YAML).
+  unpublishedLicense: true
+  deprecated: true
+  unmaintained: true
+  dynamicRequire: true
+
+  # CVEs — critical and high are on (block per Socket default severity).
+  # Medium/low suppressed here; surface them via dashboard policy if we want
+  # to gate on them later. Package-specific exceptions go here with a
+  # rationale comment (why, who, date, expiry).
+  criticalCVE: true
+  highCVE: true
+  mediumCVE: false
+  lowCVE: false

--- a/socket.yml
+++ b/socket.yml
@@ -1,20 +1,7 @@
-# Socket.dev supply-chain policy.
-# Gates the `socket-security` GitHub App checks that run on every PR.
-# Free tier only: no reachability, no priority scoring, no Slack, no org-wide rules.
-#
-# Shape: `<alertName>: true` enables the alert (severity and block-vs-warn
-# are determined by Socket's default severity mapping plus the Socket
-# dashboard Security Policy). `<alertName>: false` suppresses the alert
-# entirely. Three-state (block/warn/ignore) granularity lives in the
-# dashboard policy, not in this file — see docs/socket.md.
-#
-# Package-specific exceptions: add under the relevant alert with a rationale
-# comment (why suppressing, who approved, date, expiry if any). Reviewers
-# block suppressions without rationale.
-#
-# Alert names below verified against https://docs.socket.dev/docs/socket-yml
-# and https://socket.dev/alerts in 2026-04; re-verify on next edit.
-# Runbook: docs/socket.md
+# Socket.dev supply-chain policy. Gates the `socket-security` GitHub App
+# checks on every PR.
+# Schema is booleans — `{ action: ... }` is silently rejected.
+# See docs/socket.md.
 
 version: 2
 
@@ -29,8 +16,6 @@ projectIgnorePaths:
   - "**/*.bun-build"
 
 issueRules:
-  # Supply-chain-attack signals — always on (reported and, per Socket default
-  # severity, block the check).
   malware: true
   gptMalware: true
   didYouMean: true
@@ -38,17 +23,11 @@ issueRules:
   hasNativeCode: true
   shellAccess: true
 
-  # Hygiene / trust signals — on (reported; block-vs-warn is controlled by
-  # Socket dashboard Security Policies, not this YAML).
-  unpublishedLicense: true
+  licenseChange: true
   deprecated: true
   unmaintained: true
   dynamicRequire: true
 
-  # CVEs — critical and high are on (block per Socket default severity).
-  # Medium/low suppressed here; surface them via dashboard policy if we want
-  # to gate on them later. Package-specific exceptions go here with a
-  # rationale comment (why, who, date, expiry).
   criticalCVE: true
   cve: true
   mediumCVE: false

--- a/socket.yml
+++ b/socket.yml
@@ -14,7 +14,7 @@
 #
 # Alert names below verified against https://docs.socket.dev/docs/socket-yml
 # and https://socket.dev/alerts in 2026-04; re-verify on next edit.
-# Runbook: docs/socket.md (lands in PR 3 of the same plan — ATL-106).
+# Runbook: docs/socket.md
 
 version: 2
 
@@ -50,6 +50,6 @@ issueRules:
   # to gate on them later. Package-specific exceptions go here with a
   # rationale comment (why, who, date, expiry).
   criticalCVE: true
-  highCVE: true
+  cve: true
   mediumCVE: false
-  lowCVE: false
+  mildCVE: false


### PR DESCRIPTION
## Summary
Closes two Socket.dev automation gaps on `vellum-ai/vellum-assistant`: commits a `socket.yml` policy, adds a weekly matrixed Socket Fix workflow that opens per-CVE upgrade PRs across all 12 runtime workspaces, and publishes a runbook (`docs/socket.md`) covering operations plus the `gh api` command to wire Socket checks into the `main` branch-protection ruleset. Scoped to Socket Free tier only.

## Self-review result
**PASS** across all four passes after 3 fix cycles. Key mid-flight corrections:
- Boolean `issueRules` schema (Codex P1 — the original `{ action: ... }` shape was silently rejected by `@socketsecurity/config` v3)
- Canonical CVE/license slugs per `socket-cli`'s `alert-translations.json` (`cve`/`mildCVE`/`licenseChange` vs non-canonical `highCVE`/`lowCVE`/`unpublishedLicense`)
- Workflow matrixed over the 12 `bun.lock` workspaces (no root `package.json` in this monorepo); `bun install --frozen-lockfile --ignore-scripts` per leg
- `socket-patch` job DROPPED as theatrical — `apply` writes into gitignored `node_modules/` which doesn't persist across `bun install`. Runbook documents Certified Patches as deferred pending `bunx @socketsecurity/socket-patch setup` rollout
- Heredoc injection fix (random delimiter via `openssl rand -hex 16`)

## PRs merged into feature branch

| # | Title |
|---|-------|
| #27718 | chore(security): add socket.yml policy for supply-chain enforcement |
| #27719 | feat(ci): add Socket.dev weekly autofix workflow |
| #27722 | docs(security): expand Socket.dev runbook (policy, autofix, ruleset wiring) |
| #27729 | fix(security): use Socket's canonical CVE slugs in socket.yml |
| #27730 | fix(ci): matrix Socket autofix over bun.lock workspaces + fix scan/apply contract |
| #27850 | refactor(security): simplify Socket autofix, drop theatrical socket-patch |
| #27851 | refactor(security): final Socket doc + workflow trims |

## Post-merge manual steps (see docs/socket.md)
- [ ] Add `SOCKET_CLI_API_TOKEN` repo secret (same token used by sibling `vellum-assistant-platform` autofix).
- [ ] Run the `gh api --method PUT /repos/vellum-ai/vellum-assistant/rulesets/12614752` ruleset PATCH per the runbook.
- [ ] Verify `required_approving_review_count` / `dismiss_stale_reviews_on_push` / `require_last_push_approval` unchanged from pre-PATCH snapshot.
- [ ] Open a trivial sanity PR touching a `package.json` to confirm both Socket App checks now block on `main`.

Closes ATL-106
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
