### PR TITLE
refactor(gateway): move telegram/twilio/vercel/contacts control-plane proxying to assistant client

### DIFF
--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -209,4 +209,64 @@ describe("contacts control-plane proxy", () => {
     expect(res.status).toBe(504);
     expect(await res.json()).toEqual({ error: "Gateway Timeout" });
   });
+
+  test("returns 502 when runtime is unreachable", async () => {
+    fetchMock = mock(async () => {
+      throw new Error("Connection refused");
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts"),
+    );
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "Bad Gateway" });
+  });
+
+  test("passes through successful response body", async () => {
+    const responsePayload = {
+      contacts: [{ id: "ct_1", name: "Alice" }],
+      total: 1,
+    };
+    fetchMock = mock(async () => {
+      return new Response(JSON.stringify(responsePayload), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(responsePayload);
+    expect(res.headers.get("content-type")).toBe("application/json");
+  });
+
+  test("strips hop-by-hop headers from upstream response", async () => {
+    fetchMock = mock(async () => {
+      return new Response("ok", {
+        status: 200,
+        headers: {
+          "content-type": "text/plain",
+          connection: "keep-alive",
+          "keep-alive": "timeout=5",
+          "x-custom": "preserved",
+        },
+      });
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleUpsertContact(
+      new Request("http://localhost:7830/v1/contacts", { method: "POST" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.has("connection")).toBe(false);
+    expect(res.headers.has("keep-alive")).toBe(false);
+    expect(res.headers.get("x-custom")).toBe("preserved");
+  });
 });

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -5,93 +5,55 @@
  * disabled, so skills and clients can use gateway URLs exclusively.
  */
 
+import { proxyForward } from "@vellumai/assistant-client";
+
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
-import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("contacts-control-plane-proxy");
 
 export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
-  async function proxyToRuntime(
+  async function forward(
     req: Request,
     upstreamPath: string,
-    upstreamSearch: string,
+    upstreamSearch?: string,
   ): Promise<Response> {
     const start = performance.now();
-    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
+    const result = await proxyForward(req, {
+      baseUrl: config.assistantRuntimeBaseUrl,
+      path: upstreamPath,
+      search: upstreamSearch,
+      serviceToken: mintServiceToken(),
+      timeoutMs: config.runtimeTimeoutMs,
+      fetchImpl,
+    });
 
-    const reqHeaders = stripHopByHop(new Headers(req.headers));
-    reqHeaders.delete("host");
-    reqHeaders.delete("authorization");
-
-    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
-
-    const hasBody = req.method !== "GET" && req.method !== "HEAD";
-    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
-    if (bodyBuffer !== null) {
-      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
-    }
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort(
-        new DOMException(
-          "The operation was aborted due to timeout",
-          "TimeoutError",
-        ),
-      );
-    }, config.runtimeTimeoutMs);
-
-    let response: Response;
-    try {
-      response = await fetchImpl(upstream, {
-        method: req.method,
-        headers: reqHeaders,
-        body: bodyBuffer,
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-    } catch (err) {
-      clearTimeout(timeoutId);
-      const duration = Math.round(performance.now() - start);
-      if (err instanceof DOMException && err.name === "TimeoutError") {
-        log.error(
-          { path: upstreamPath, duration },
-          "Ingress control-plane proxy upstream timed out",
-        );
-        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
-      }
-      log.error(
-        { err, path: upstreamPath, duration },
-        "Ingress control-plane proxy upstream connection failed",
-      );
-      return Response.json({ error: "Bad Gateway" }, { status: 502 });
-    }
-
-    const resHeaders = stripHopByHop(new Headers(response.headers));
     const duration = Math.round(performance.now() - start);
 
-    if (response.status >= 400) {
-      const body = await response.text();
+    if (result.gatewayError) {
+      log.error(
+        { path: upstreamPath, duration },
+        result.status === 504
+          ? "Ingress control-plane proxy upstream timed out"
+          : "Ingress control-plane proxy upstream connection failed",
+      );
+    } else if (result.status >= 400) {
       log.warn(
-        { path: upstreamPath, status: response.status, duration },
+        { path: upstreamPath, status: result.status, duration },
         "Ingress control-plane proxy upstream error",
       );
-      return new Response(body, {
-        status: response.status,
-        headers: resHeaders,
-      });
+    } else {
+      log.info(
+        { path: upstreamPath, status: result.status, duration },
+        "Ingress control-plane proxy completed",
+      );
     }
 
-    log.info(
-      { path: upstreamPath, status: response.status, duration },
-      "Ingress control-plane proxy completed",
-    );
-    return new Response(response.body, {
-      status: response.status,
-      headers: resHeaders,
+    return new Response(result.body, {
+      status: result.status,
+      headers: result.headers,
     });
   }
 
@@ -99,62 +61,58 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
     // ── Contact CRUD ──
     async handleListContacts(req: Request): Promise<Response> {
       const url = new URL(req.url);
-      return proxyToRuntime(req, "/v1/contacts", url.search);
+      return forward(req, "/v1/contacts", url.search);
     },
 
     async handleUpsertContact(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/contacts", "");
+      return forward(req, "/v1/contacts");
     },
 
     async handleGetContact(req: Request, contactId: string): Promise<Response> {
-      return proxyToRuntime(req, `/v1/contacts/${contactId}`, "");
+      return forward(req, `/v1/contacts/${contactId}`);
     },
 
     async handleDeleteContact(
       req: Request,
       contactId: string,
     ): Promise<Response> {
-      return proxyToRuntime(req, `/v1/contacts/${contactId}`, "");
+      return forward(req, `/v1/contacts/${contactId}`);
     },
 
     async handleMergeContacts(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/contacts/merge", "");
+      return forward(req, "/v1/contacts/merge");
     },
 
     async handleUpdateContactChannel(
       req: Request,
       contactChannelId: string,
     ): Promise<Response> {
-      return proxyToRuntime(
-        req,
-        `/v1/contact-channels/${contactChannelId}`,
-        "",
-      );
+      return forward(req, `/v1/contact-channels/${contactChannelId}`);
     },
 
     // ── Invite routes ──
     async handleListInvites(req: Request): Promise<Response> {
       const url = new URL(req.url);
-      return proxyToRuntime(req, "/v1/contacts/invites", url.search);
+      return forward(req, "/v1/contacts/invites", url.search);
     },
 
     async handleCreateInvite(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/contacts/invites", "");
+      return forward(req, "/v1/contacts/invites");
     },
 
     async handleRedeemInvite(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/contacts/invites/redeem", "");
+      return forward(req, "/v1/contacts/invites/redeem");
     },
 
     async handleCallInvite(req: Request, inviteId: string): Promise<Response> {
-      return proxyToRuntime(req, `/v1/contacts/invites/${inviteId}/call`, "");
+      return forward(req, `/v1/contacts/invites/${inviteId}/call`);
     },
 
     async handleRevokeInvite(
       req: Request,
       inviteId: string,
     ): Promise<Response> {
-      return proxyToRuntime(req, `/v1/contacts/invites/${inviteId}`, "");
+      return forward(req, `/v1/contacts/invites/${inviteId}`);
     },
   };
 }

--- a/gateway/src/http/routes/telegram-control-plane-proxy.ts
+++ b/gateway/src/http/routes/telegram-control-plane-proxy.ts
@@ -5,115 +5,77 @@
  * disabled, so skills and clients can use gateway URLs exclusively.
  */
 
+import { proxyForward } from "@vellumai/assistant-client";
+
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
-import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("telegram-control-plane-proxy");
 
 export function createTelegramControlPlaneProxyHandler(config: GatewayConfig) {
-  async function proxyToRuntime(
+  async function forward(
     req: Request,
     upstreamPath: string,
-    upstreamSearch: string,
+    upstreamSearch?: string,
   ): Promise<Response> {
     const start = performance.now();
-    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
+    const result = await proxyForward(req, {
+      baseUrl: config.assistantRuntimeBaseUrl,
+      path: upstreamPath,
+      search: upstreamSearch,
+      serviceToken: mintServiceToken(),
+      timeoutMs: config.runtimeTimeoutMs,
+      fetchImpl,
+    });
 
-    const reqHeaders = stripHopByHop(new Headers(req.headers));
-    reqHeaders.delete("host");
-    reqHeaders.delete("authorization");
-
-    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
-
-    const hasBody = req.method !== "GET" && req.method !== "HEAD";
-    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
-    if (bodyBuffer !== null) {
-      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
-    }
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort(
-        new DOMException(
-          "The operation was aborted due to timeout",
-          "TimeoutError",
-        ),
-      );
-    }, config.runtimeTimeoutMs);
-
-    let response: Response;
-    try {
-      response = await fetchImpl(upstream, {
-        method: req.method,
-        headers: reqHeaders,
-        body: bodyBuffer,
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-    } catch (err) {
-      clearTimeout(timeoutId);
-      const duration = Math.round(performance.now() - start);
-      if (err instanceof DOMException && err.name === "TimeoutError") {
-        log.error(
-          { path: upstreamPath, duration },
-          "Telegram control-plane proxy upstream timed out",
-        );
-        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
-      }
-      log.error(
-        { err, path: upstreamPath, duration },
-        "Telegram control-plane proxy upstream connection failed",
-      );
-      return Response.json({ error: "Bad Gateway" }, { status: 502 });
-    }
-
-    const resHeaders = stripHopByHop(new Headers(response.headers));
     const duration = Math.round(performance.now() - start);
 
-    if (response.status >= 400) {
-      const body = await response.text();
+    if (result.gatewayError) {
+      log.error(
+        { path: upstreamPath, duration },
+        result.status === 504
+          ? "Telegram control-plane proxy upstream timed out"
+          : "Telegram control-plane proxy upstream connection failed",
+      );
+    } else if (result.status >= 400) {
       log.warn(
-        { path: upstreamPath, status: response.status, duration },
+        { path: upstreamPath, status: result.status, duration },
         "Telegram control-plane proxy upstream error",
       );
-      return new Response(body, {
-        status: response.status,
-        headers: resHeaders,
-      });
+    } else {
+      log.info(
+        { path: upstreamPath, status: result.status, duration },
+        "Telegram control-plane proxy completed",
+      );
     }
 
-    log.info(
-      { path: upstreamPath, status: response.status, duration },
-      "Telegram control-plane proxy completed",
-    );
-    return new Response(response.body, {
-      status: response.status,
-      headers: resHeaders,
+    return new Response(result.body, {
+      status: result.status,
+      headers: result.headers,
     });
   }
 
   return {
     async handleGetTelegramConfig(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/telegram/config", "");
+      return forward(req, "/v1/integrations/telegram/config");
     },
 
     async handleSetTelegramConfig(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/telegram/config", "");
+      return forward(req, "/v1/integrations/telegram/config");
     },
 
     async handleClearTelegramConfig(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/telegram/config", "");
+      return forward(req, "/v1/integrations/telegram/config");
     },
 
     async handleSetTelegramCommands(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/telegram/commands", "");
+      return forward(req, "/v1/integrations/telegram/commands");
     },
 
     async handleSetupTelegram(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/telegram/setup", "");
+      return forward(req, "/v1/integrations/telegram/setup");
     },
   };
 }

--- a/gateway/src/http/routes/twilio-control-plane-proxy.ts
+++ b/gateway/src/http/routes/twilio-control-plane-proxy.ts
@@ -5,127 +5,85 @@
  * disabled, so skills and clients can use gateway URLs exclusively.
  */
 
+import { proxyForward } from "@vellumai/assistant-client";
+
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
-import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("twilio-control-plane-proxy");
 
 export function createTwilioControlPlaneProxyHandler(config: GatewayConfig) {
-  async function proxyToRuntime(
+  async function forward(
     req: Request,
     upstreamPath: string,
-    upstreamSearch: string,
+    upstreamSearch?: string,
   ): Promise<Response> {
     const start = performance.now();
-    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
+    const result = await proxyForward(req, {
+      baseUrl: config.assistantRuntimeBaseUrl,
+      path: upstreamPath,
+      search: upstreamSearch,
+      serviceToken: mintServiceToken(),
+      timeoutMs: config.runtimeTimeoutMs,
+      fetchImpl,
+    });
 
-    const reqHeaders = stripHopByHop(new Headers(req.headers));
-    reqHeaders.delete("host");
-    reqHeaders.delete("authorization");
-
-    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
-
-    const hasBody = req.method !== "GET" && req.method !== "HEAD";
-    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
-    if (bodyBuffer !== null) {
-      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
-    }
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort(
-        new DOMException(
-          "The operation was aborted due to timeout",
-          "TimeoutError",
-        ),
-      );
-    }, config.runtimeTimeoutMs);
-
-    let response: Response;
-    try {
-      response = await fetchImpl(upstream, {
-        method: req.method,
-        headers: reqHeaders,
-        body: bodyBuffer,
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-    } catch (err) {
-      clearTimeout(timeoutId);
-      const duration = Math.round(performance.now() - start);
-      if (err instanceof DOMException && err.name === "TimeoutError") {
-        log.error(
-          { path: upstreamPath, duration },
-          "Twilio control-plane proxy upstream timed out",
-        );
-        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
-      }
-      log.error(
-        { err, path: upstreamPath, duration },
-        "Twilio control-plane proxy upstream connection failed",
-      );
-      return Response.json({ error: "Bad Gateway" }, { status: 502 });
-    }
-
-    const resHeaders = stripHopByHop(new Headers(response.headers));
     const duration = Math.round(performance.now() - start);
 
-    if (response.status >= 400) {
-      const body = await response.text();
+    if (result.gatewayError) {
+      log.error(
+        { path: upstreamPath, duration },
+        result.status === 504
+          ? "Twilio control-plane proxy upstream timed out"
+          : "Twilio control-plane proxy upstream connection failed",
+      );
+    } else if (result.status >= 400) {
       log.warn(
-        { path: upstreamPath, status: response.status, duration },
+        { path: upstreamPath, status: result.status, duration },
         "Twilio control-plane proxy upstream error",
       );
-      return new Response(body, {
-        status: response.status,
-        headers: resHeaders,
-      });
+    } else {
+      log.info(
+        { path: upstreamPath, status: result.status, duration },
+        "Twilio control-plane proxy completed",
+      );
     }
 
-    log.info(
-      { path: upstreamPath, status: response.status, duration },
-      "Twilio control-plane proxy completed",
-    );
-    return new Response(response.body, {
-      status: response.status,
-      headers: resHeaders,
+    return new Response(result.body, {
+      status: result.status,
+      headers: result.headers,
     });
   }
 
   return {
     async handleGetTwilioConfig(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/twilio/config", "");
+      return forward(req, "/v1/integrations/twilio/config");
     },
 
     async handleSetTwilioCredentials(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/twilio/credentials", "");
+      return forward(req, "/v1/integrations/twilio/credentials");
     },
 
     async handleClearTwilioCredentials(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/twilio/credentials", "");
+      return forward(req, "/v1/integrations/twilio/credentials");
     },
 
     async handleListTwilioNumbers(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/twilio/numbers", "");
+      return forward(req, "/v1/integrations/twilio/numbers");
     },
 
     async handleProvisionTwilioNumber(req: Request): Promise<Response> {
-      return proxyToRuntime(
-        req,
-        "/v1/integrations/twilio/numbers/provision",
-        "",
-      );
+      return forward(req, "/v1/integrations/twilio/numbers/provision");
     },
 
     async handleAssignTwilioNumber(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/twilio/numbers/assign", "");
+      return forward(req, "/v1/integrations/twilio/numbers/assign");
     },
 
     async handleReleaseTwilioNumber(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/twilio/numbers/release", "");
+      return forward(req, "/v1/integrations/twilio/numbers/release");
     },
   };
 }

--- a/gateway/src/http/routes/vercel-control-plane-proxy.ts
+++ b/gateway/src/http/routes/vercel-control-plane-proxy.ts
@@ -6,107 +6,69 @@
  * goes through the gateway as required by AGENTS.md.
  */
 
+import { proxyForward } from "@vellumai/assistant-client";
+
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
-import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("vercel-control-plane-proxy");
 
 export function createVercelControlPlaneProxyHandler(config: GatewayConfig) {
-  async function proxyToRuntime(
+  async function forward(
     req: Request,
     upstreamPath: string,
-    upstreamSearch: string,
+    upstreamSearch?: string,
   ): Promise<Response> {
     const start = performance.now();
-    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
+    const result = await proxyForward(req, {
+      baseUrl: config.assistantRuntimeBaseUrl,
+      path: upstreamPath,
+      search: upstreamSearch,
+      serviceToken: mintServiceToken(),
+      timeoutMs: config.runtimeTimeoutMs,
+      fetchImpl,
+    });
 
-    const reqHeaders = stripHopByHop(new Headers(req.headers));
-    reqHeaders.delete("host");
-    reqHeaders.delete("authorization");
-
-    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
-
-    const hasBody = req.method !== "GET" && req.method !== "HEAD";
-    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
-    if (bodyBuffer !== null) {
-      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
-    }
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort(
-        new DOMException(
-          "The operation was aborted due to timeout",
-          "TimeoutError",
-        ),
-      );
-    }, config.runtimeTimeoutMs);
-
-    let response: Response;
-    try {
-      response = await fetchImpl(upstream, {
-        method: req.method,
-        headers: reqHeaders,
-        body: bodyBuffer,
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-    } catch (err) {
-      clearTimeout(timeoutId);
-      const duration = Math.round(performance.now() - start);
-      if (err instanceof DOMException && err.name === "TimeoutError") {
-        log.error(
-          { path: upstreamPath, duration },
-          "Vercel control-plane proxy upstream timed out",
-        );
-        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
-      }
-      log.error(
-        { err, path: upstreamPath, duration },
-        "Vercel control-plane proxy upstream connection failed",
-      );
-      return Response.json({ error: "Bad Gateway" }, { status: 502 });
-    }
-
-    const resHeaders = stripHopByHop(new Headers(response.headers));
     const duration = Math.round(performance.now() - start);
 
-    if (response.status >= 400) {
-      const body = await response.text();
+    if (result.gatewayError) {
+      log.error(
+        { path: upstreamPath, duration },
+        result.status === 504
+          ? "Vercel control-plane proxy upstream timed out"
+          : "Vercel control-plane proxy upstream connection failed",
+      );
+    } else if (result.status >= 400) {
       log.warn(
-        { path: upstreamPath, status: response.status, duration },
+        { path: upstreamPath, status: result.status, duration },
         "Vercel control-plane proxy upstream error",
       );
-      return new Response(body, {
-        status: response.status,
-        headers: resHeaders,
-      });
+    } else {
+      log.info(
+        { path: upstreamPath, status: result.status, duration },
+        "Vercel control-plane proxy completed",
+      );
     }
 
-    log.info(
-      { path: upstreamPath, status: response.status, duration },
-      "Vercel control-plane proxy completed",
-    );
-    return new Response(response.body, {
-      status: response.status,
-      headers: resHeaders,
+    return new Response(result.body, {
+      status: result.status,
+      headers: result.headers,
     });
   }
 
   return {
     async handleGetVercelConfig(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/vercel/config", "");
+      return forward(req, "/v1/integrations/vercel/config");
     },
 
     async handleSetVercelConfig(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/vercel/config", "");
+      return forward(req, "/v1/integrations/vercel/config");
     },
 
     async handleDeleteVercelConfig(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/vercel/config", "");
+      return forward(req, "/v1/integrations/vercel/config");
     },
   };
 }

--- a/packages/assistant-client/src/proxy-forward.ts
+++ b/packages/assistant-client/src/proxy-forward.ts
@@ -37,7 +37,10 @@ export type ProxyForwardOptions = {
    * Custom fetch implementation. Defaults to the global `fetch`. Useful
    * for testing or when the gateway wraps fetch with instrumentation.
    */
-  fetchImpl?: typeof fetch;
+  fetchImpl?: (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => Promise<Response>;
 };
 
 export type ProxyForwardResult = {


### PR DESCRIPTION
## Summary
- Migrates 4 control-plane proxy routes to use @vellumai/assistant-client shared helpers
- Preserves per-route logging, auth, and error mapping behavior
- Adds/updates tests for shared helper path

Part of plan: service-comm-clients.md (PR 4 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
