### PR TITLE
fix(build): copy tree-sitter WASM assets from gateway instead of assistant

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1839,8 +1839,6 @@ jobs:
           bun build --compile "${DAEMON_FLAGS[@]}" --target=bun-darwin-x64 \
             "$ASSISTANT_SRC_DIR/src/daemon/main.ts" --outfile daemon-bin/vellum-daemon
           chmod +x daemon-bin/vellum-daemon
-          cp "$ASSISTANT_SRC_DIR/node_modules/web-tree-sitter/web-tree-sitter.wasm" daemon-bin/
-          cp "$ASSISTANT_SRC_DIR/node_modules/tree-sitter-bash/tree-sitter-bash.wasm" daemon-bin/
           rm -rf daemon-bin/node_modules
           rm -rf daemon-bin/bundled-skills
           cp -R "$ASSISTANT_SRC_DIR/src/config/bundled-skills" daemon-bin/bundled-skills
@@ -1869,6 +1867,8 @@ jobs:
           bun build --compile --target=bun-darwin-x64 \
             "$GATEWAY_SRC_DIR/src/index.ts" --outfile gateway-bin/vellum-gateway
           chmod +x gateway-bin/vellum-gateway
+          cp "$GATEWAY_SRC_DIR/node_modules/web-tree-sitter/web-tree-sitter.wasm" gateway-bin/
+          cp "$GATEWAY_SRC_DIR/node_modules/tree-sitter-bash/tree-sitter-bash.wasm" gateway-bin/
 
           # Credential-executor (CES)
           (cd "$CES_SRC_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -520,9 +520,10 @@ build_binaries() {
         exit 1
     fi
 
-    # Post-build: copy assets that bun --compile doesn't embed
-    cp "$ASSISTANT_SRC_DIR/node_modules/web-tree-sitter/web-tree-sitter.wasm" "$SCRIPT_DIR/daemon-bin/"
-    cp "$ASSISTANT_SRC_DIR/node_modules/tree-sitter-bash/tree-sitter-bash.wasm" "$SCRIPT_DIR/daemon-bin/"
+    # Post-build: copy WASM assets that bun --compile doesn't embed.
+    # tree-sitter is used by the gateway (risk classification), not the daemon.
+    cp "$GATEWAY_SRC_DIR/node_modules/web-tree-sitter/web-tree-sitter.wasm" "$SCRIPT_DIR/gateway-bin/"
+    cp "$GATEWAY_SRC_DIR/node_modules/tree-sitter-bash/tree-sitter-bash.wasm" "$SCRIPT_DIR/gateway-bin/"
     rm -rf "$SCRIPT_DIR/daemon-bin/node_modules"
     rm -rf "$SCRIPT_DIR/daemon-bin/bundled-skills"
     cp -R "$ASSISTANT_SRC_DIR/src/config/bundled-skills" "$SCRIPT_DIR/daemon-bin/bundled-skills"
@@ -838,8 +839,6 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
     fi
     build_bun_binary "$ASSISTANT_SRC_DIR" "$ASSISTANT_SRC_DIR/src/daemon/main.ts" \
         "$SCRIPT_DIR/daemon-bin" "vellum-daemon" "${local_daemon_flags[@]}"
-    cp "$ASSISTANT_SRC_DIR/node_modules/web-tree-sitter/web-tree-sitter.wasm" "$SCRIPT_DIR/daemon-bin/"
-    cp "$ASSISTANT_SRC_DIR/node_modules/tree-sitter-bash/tree-sitter-bash.wasm" "$SCRIPT_DIR/daemon-bin/"
     # Embedding runtime (onnxruntime-node + @huggingface/transformers) is no longer
     # shipped with the app. It's downloaded post-hatch by EmbeddingRuntimeManager.
     rm -rf "$SCRIPT_DIR/daemon-bin/node_modules"
@@ -963,6 +962,8 @@ fi
 if [ "$GATEWAY_BIN_NEEDS_BUILD" = true ]; then
     build_bun_binary "$GATEWAY_SRC_DIR" "$GATEWAY_SRC_DIR/src/index.ts" \
         "$SCRIPT_DIR/gateway-bin" "vellum-gateway"
+    cp "$GATEWAY_SRC_DIR/node_modules/web-tree-sitter/web-tree-sitter.wasm" "$SCRIPT_DIR/gateway-bin/"
+    cp "$GATEWAY_SRC_DIR/node_modules/tree-sitter-bash/tree-sitter-bash.wasm" "$SCRIPT_DIR/gateway-bin/"
 fi
 
 # Also rebuild if gateway binary changed or newly added
@@ -1047,10 +1048,6 @@ if [ "$NEEDS_REBUILD" = true ]; then
         echo "Bundling daemon binary..."
         cp "$DAEMON_BIN" "$MACOS_DIR/vellum-daemon"
         chmod +x "$MACOS_DIR/vellum-daemon"
-        # Bundle WASM assets into Resources (not embedded by bun --compile)
-        for wasm in "$SCRIPT_DIR/daemon-bin/"*.wasm; do
-            [ -f "$wasm" ] && cp "$wasm" "$RESOURCES_DIR/"
-        done
         # Embedding runtime is now downloaded post-hatch (no bundled node_modules)
         rm -rf "$MACOS_DIR/node_modules"
     else
@@ -1083,6 +1080,11 @@ if [ "$NEEDS_REBUILD" = true ]; then
         echo "Bundling gateway binary..."
         cp "$GATEWAY_BIN" "$MACOS_DIR/vellum-gateway"
         chmod +x "$MACOS_DIR/vellum-gateway"
+        # Bundle WASM assets into Resources (not embedded by bun --compile).
+        # tree-sitter is used by the gateway for risk classification.
+        for wasm in "$SCRIPT_DIR/gateway-bin/"*.wasm; do
+            [ -f "$wasm" ] && cp "$wasm" "$RESOURCES_DIR/"
+        done
     else
         echo "No gateway binary at $GATEWAY_BIN — skipping (dev mode)"
     fi

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -962,6 +962,10 @@ fi
 if [ "$GATEWAY_BIN_NEEDS_BUILD" = true ]; then
     build_bun_binary "$GATEWAY_SRC_DIR" "$GATEWAY_SRC_DIR/src/index.ts" \
         "$SCRIPT_DIR/gateway-bin" "vellum-gateway"
+fi
+# Always refresh WASM assets (not embedded by bun --compile).
+# These must be copied even when the gateway binary is reused from a previous build.
+if [ -d "$SCRIPT_DIR/gateway-bin" ] && [ -d "$GATEWAY_SRC_DIR/node_modules/web-tree-sitter" ]; then
     cp "$GATEWAY_SRC_DIR/node_modules/web-tree-sitter/web-tree-sitter.wasm" "$SCRIPT_DIR/gateway-bin/"
     cp "$GATEWAY_SRC_DIR/node_modules/tree-sitter-bash/tree-sitter-bash.wasm" "$SCRIPT_DIR/gateway-bin/"
 fi


### PR DESCRIPTION
## Summary
- Move WASM asset copy commands (`web-tree-sitter.wasm`, `tree-sitter-bash.wasm`) from `assistant/node_modules/` to `gateway/node_modules/` in both `build.sh` and `release.yml`
- Update destination from `daemon-bin/` to `gateway-bin/` since the shell parser now lives in the gateway
- Move the WASM-to-Resources app-bundle loop from the daemon bundling section to the gateway bundling section

## Original prompt
help fix CI failure at https://github.com/vellum-ai/vellum-assistant/actions/runs/24861442406/job/72787641322
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
