### PR TITLE
refactor(assistant): migrate gateway delivery and trust HTTP clients to @vellumai/gateway-client

### DIFF
--- a/assistant/src/permissions/trust-client.ts
+++ b/assistant/src/permissions/trust-client.ts
@@ -1,207 +1,53 @@
 /**
- * HTTP client for the gateway's trust rule endpoints.
+ * Assistant-side trust rule client.
  *
- * Provides CRUD operations over trust rules stored in the gateway,
- * replacing direct filesystem access to trust.json when the assistant
- * runs in a containerized environment.
+ * Delegates transport logic to `@vellumai/gateway-client/http-trust-rules`
+ * (`TrustRulesClient` class) while preserving the free-function API that
+ * existing call sites (trust-store.ts) expect.
  *
- * Both async and synchronous variants are exported. The sync variants
- * use `Bun.spawnSync` + `curl` to make blocking HTTP calls — acceptable
- * for user-initiated write operations that are infrequent.
- *
- * All rule-returning endpoints parse response payloads through the shared
- * `parseTrustRule` canonical parser so the client never returns unparsed
- * or untyped raw rule objects.
+ * Auth context (token minting, gateway base URL) is injected from the
+ * assistant's own config/auth modules so the package stays transport-focused.
  */
 
 import type { TrustRule } from "@vellumai/ces-contracts";
-import { parseTrustRule } from "@vellumai/ces-contracts";
+import {
+  type AcceptStarterBundleResult,
+  TrustRulesClient,
+} from "@vellumai/gateway-client/http-trust-rules";
 
 import { getGatewayInternalBaseUrl } from "../config/env.js";
 import { mintEdgeRelayToken } from "../runtime/auth/token-service.js";
 import { getLogger } from "../util/logger.js";
 
+// Re-export the result type so existing import sites are unchanged.
+export type { AcceptStarterBundleResult };
+
 const log = getLogger("trust-client");
 
-const REQUEST_TIMEOUT_MS = 10_000;
-
-// ---------------------------------------------------------------------------
-// Result types (not in ces-contracts — local to the client)
-// ---------------------------------------------------------------------------
-
-export interface AcceptStarterBundleResult {
-  accepted: boolean;
-  rulesAdded: number;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function authHeaders(): Record<string, string> {
-  return {
-    Authorization: `Bearer ${mintEdgeRelayToken()}`,
-    "Content-Type": "application/json",
-  };
-}
-
 /**
- * Execute a fetch request with standard timeout and error handling.
- * Throws a descriptive error on non-OK responses or network failures.
+ * Lazily-created singleton client instance. Constructed on first use so
+ * env resolution and token minting hooks are available.
  */
-async function request<T>(
-  method: string,
-  path: string,
-  body?: unknown,
-): Promise<T> {
-  const url = `${getGatewayInternalBaseUrl()}${path}`;
-  const options: RequestInit = {
-    method,
-    headers: authHeaders(),
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-  };
-  if (body !== undefined) {
-    options.body = JSON.stringify(body);
+let _client: TrustRulesClient | undefined;
+
+function getClient(): TrustRulesClient {
+  if (!_client) {
+    _client = new TrustRulesClient({
+      gatewayBaseUrl: getGatewayInternalBaseUrl(),
+      mintToken: mintEdgeRelayToken,
+      log,
+    });
   }
-
-  let response: Response;
-  try {
-    response = await fetch(url, options);
-  } catch (err) {
-    log.error({ err, method, path }, "Trust rule request failed (network)");
-    throw new Error(
-      `Trust rule request failed: ${method} ${path}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-
-  if (!response.ok) {
-    const text = await response.text().catch(() => "<unreadable>");
-    log.error(
-      { status: response.status, body: text, method, path },
-      "Trust rule request failed",
-    );
-    throw new Error(
-      `Trust rule request failed (${response.status}): ${method} ${path}: ${text}`,
-    );
-  }
-
-  return (await response.json()) as T;
-}
-
-/**
- * Synchronous HTTP request via `Bun.spawnSync` + `curl`.
- *
- * Used by the gateway trust store adapter for write operations that must
- * return synchronously to satisfy the `TrustStoreBackend` interface.
- * Write operations are user-initiated and infrequent, so blocking is acceptable.
- */
-function requestSync<T>(method: string, path: string, body?: unknown): T {
-  const url = `${getGatewayInternalBaseUrl()}${path}`;
-  const headers = authHeaders();
-  const args: string[] = [
-    "curl",
-    "-s",
-    "-S",
-    "-X",
-    method,
-    "--max-time",
-    String(Math.ceil(REQUEST_TIMEOUT_MS / 1000)),
-    "-H",
-    `Authorization: ${headers.Authorization}`,
-    "-H",
-    "Content-Type: application/json",
-    "-w",
-    "\n%{http_code}",
-  ];
-  if (body !== undefined) {
-    args.push("-d", JSON.stringify(body));
-  }
-  args.push(url);
-
-  const proc = Bun.spawnSync(args, {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  if (proc.exitCode !== 0) {
-    const stderr = proc.stderr.toString().trim();
-    log.error(
-      { exitCode: proc.exitCode, stderr, method, path },
-      "Trust rule sync request failed (curl)",
-    );
-    throw new Error(
-      `Trust rule sync request failed: ${method} ${path}: curl exit ${proc.exitCode}: ${stderr}`,
-    );
-  }
-
-  const output = proc.stdout.toString().trim();
-  // curl -w "\n%{http_code}" appends the HTTP status code on the last line
-  const lastNewline = output.lastIndexOf("\n");
-  const responseBody = lastNewline >= 0 ? output.slice(0, lastNewline) : "";
-  const statusCode = parseInt(
-    lastNewline >= 0 ? output.slice(lastNewline + 1) : output,
-    10,
-  );
-
-  if (statusCode < 200 || statusCode >= 300) {
-    log.error(
-      { status: statusCode, body: responseBody, method, path },
-      "Trust rule sync request failed",
-    );
-    throw new Error(
-      `Trust rule sync request failed (${statusCode}): ${method} ${path}: ${responseBody}`,
-    );
-  }
-
-  if (!responseBody) {
-    return {} as T;
-  }
-
-  try {
-    return JSON.parse(responseBody) as T;
-  } catch (err) {
-    log.error(
-      { err, responseBody, method, path },
-      "Failed to parse sync response JSON",
-    );
-    throw new Error(
-      `Trust rule sync request: failed to parse response: ${method} ${path}`,
-    );
-  }
+  return _client;
 }
 
 // ---------------------------------------------------------------------------
-// Response parsing helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Parse a raw rule object from a gateway response through the shared
- * canonical parser. Ensures the trust client never returns unparsed or
- * untyped rule objects, regardless of what the gateway sends back.
- */
-function parseRuleResponse(raw: unknown): TrustRule {
-  if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
-    throw new Error("Trust rule response is not a valid object");
-  }
-  const { rule } = parseTrustRule(raw as Record<string, unknown>);
-  return rule as TrustRule;
-}
-
-/**
- * Parse an array of raw rule objects from a gateway response.
- */
-function parseRulesResponse(raw: unknown[]): TrustRule[] {
-  return raw.map((r) => parseRuleResponse(r));
-}
-
-// ---------------------------------------------------------------------------
-// Public API
+// Public API — preserves existing free-function signatures
 // ---------------------------------------------------------------------------
 
 /** Fetch all trust rules from the gateway. */
 export async function getAllRules(): Promise<TrustRule[]> {
-  const data = await request<{ rules: unknown[] }>("GET", "/v1/trust-rules");
-  return parseRulesResponse(data.rules);
+  return getClient().getAllRules();
 }
 
 /** Create a new trust rule. */
@@ -213,15 +59,7 @@ export async function addRule(params: {
   priority?: number;
   executionTarget?: string;
 }): Promise<TrustRule> {
-  // Only include scope in the request body if provided.
-  const { scope, ...rest } = params;
-  const body = scope != null ? { ...rest, scope } : rest;
-  const data = await request<{ rule: unknown }>(
-    "POST",
-    "/v1/trust-rules",
-    body,
-  );
-  return parseRuleResponse(data.rule);
+  return getClient().addRule(params);
 }
 
 /** Update an existing trust rule by ID. */
@@ -236,26 +74,17 @@ export async function updateRule(
     executionTarget?: string;
   },
 ): Promise<TrustRule> {
-  const data = await request<{ rule: unknown }>(
-    "PATCH",
-    `/v1/trust-rules/${encodeURIComponent(id)}`,
-    updates,
-  );
-  return parseRuleResponse(data.rule);
+  return getClient().updateRule(id, updates);
 }
 
 /** Remove a trust rule by ID. Returns true if the rule was found and deleted. */
 export async function removeRule(id: string): Promise<boolean> {
-  const data = await request<{ success: boolean }>(
-    "DELETE",
-    `/v1/trust-rules/${encodeURIComponent(id)}`,
-  );
-  return data.success;
+  return getClient().removeRule(id);
 }
 
 /** Clear all user trust rules (default rules are preserved by the gateway). */
 export async function clearRules(): Promise<void> {
-  await request<{ success: boolean }>("POST", "/v1/trust-rules/clear");
+  return getClient().clearRules();
 }
 
 /**
@@ -270,24 +99,12 @@ export async function findMatchingRule(
   candidates: string[],
   scope: string,
 ): Promise<TrustRule | null> {
-  const params = new URLSearchParams({
-    tool,
-    commands: candidates.join(","),
-    scope,
-  });
-  const data = await request<{ rule: unknown | null }>(
-    "GET",
-    `/v1/trust-rules/match?${params.toString()}`,
-  );
-  return data.rule != null ? parseRuleResponse(data.rule) : null;
+  return getClient().findMatchingRule(tool, candidates, scope);
 }
 
 /** Accept the starter approval bundle, seeding common low-risk allow rules. */
 export async function acceptStarterBundle(): Promise<AcceptStarterBundleResult> {
-  return request<AcceptStarterBundleResult>(
-    "POST",
-    "/v1/trust-rules/starter-bundle",
-  );
+  return getClient().acceptStarterBundle();
 }
 
 // ---------------------------------------------------------------------------
@@ -296,8 +113,7 @@ export async function acceptStarterBundle(): Promise<AcceptStarterBundleResult> 
 
 /** Fetch all trust rules from the gateway (synchronous). */
 export function getAllRulesSync(): TrustRule[] {
-  const data = requestSync<{ rules: unknown[] }>("GET", "/v1/trust-rules");
-  return parseRulesResponse(data.rules);
+  return getClient().getAllRulesSync();
 }
 
 /** Create a new trust rule (synchronous). */
@@ -309,11 +125,7 @@ export function addRuleSync(params: {
   priority?: number;
   executionTarget?: string;
 }): TrustRule {
-  // Only include scope in the request body if provided.
-  const { scope, ...rest } = params;
-  const body = scope != null ? { ...rest, scope } : rest;
-  const data = requestSync<{ rule: unknown }>("POST", "/v1/trust-rules", body);
-  return parseRuleResponse(data.rule);
+  return getClient().addRuleSync(params);
 }
 
 /** Update an existing trust rule by ID (synchronous). */
@@ -328,32 +140,20 @@ export function updateRuleSync(
     executionTarget?: string;
   },
 ): TrustRule {
-  const data = requestSync<{ rule: unknown }>(
-    "PATCH",
-    `/v1/trust-rules/${encodeURIComponent(id)}`,
-    updates,
-  );
-  return parseRuleResponse(data.rule);
+  return getClient().updateRuleSync(id, updates);
 }
 
 /** Remove a trust rule by ID (synchronous). Returns true if deleted. */
 export function removeRuleSync(id: string): boolean {
-  const data = requestSync<{ success: boolean }>(
-    "DELETE",
-    `/v1/trust-rules/${encodeURIComponent(id)}`,
-  );
-  return data.success;
+  return getClient().removeRuleSync(id);
 }
 
 /** Clear all user trust rules (synchronous). */
 export function clearRulesSync(): void {
-  requestSync<{ success: boolean }>("POST", "/v1/trust-rules/clear");
+  getClient().clearRulesSync();
 }
 
 /** Accept the starter approval bundle (synchronous). */
 export function acceptStarterBundleSync(): AcceptStarterBundleResult {
-  return requestSync<AcceptStarterBundleResult>(
-    "POST",
-    "/v1/trust-rules/starter-bundle",
-  );
+  return getClient().acceptStarterBundleSync();
 }

--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -1,389 +1,37 @@
-import { createHash } from "node:crypto";
+/**
+ * Assistant-side gateway delivery client.
+ *
+ * Delegates transport logic to `@vellumai/gateway-client/http-delivery`
+ * while preserving the exported function signatures used by runtime routes
+ * and notifications. The assistant's pino logger is injected at call sites
+ * so the package stays transport-focused.
+ */
+
+import type {
+  ChannelDeliveryResult,
+  ChannelReplyPayload,
+} from "@vellumai/gateway-client";
+import {
+  ChannelDeliveryError,
+  deliverApprovalPrompt as _deliverApprovalPrompt,
+  deliverChannelReply as _deliverChannelReply,
+} from "@vellumai/gateway-client/http-delivery";
 
 import { getLogger } from "../util/logger.js";
 import type { ApprovalUIMetadata } from "./channel-approval-types.js";
-import type { RuntimeAttachmentMetadata } from "./http-types.js";
 
 const log = getLogger("gateway-client");
 
-/**
- * Error thrown when the gateway returns a non-OK response for channel delivery.
- * Carries the optional `userMessage` field from the gateway so callers can
- * surface actionable error text to end-users.
- */
-export class ChannelDeliveryError extends Error {
-  readonly statusCode: number;
-  /** A user-facing error message from the gateway, if available. */
-  readonly userMessage?: string;
-
-  constructor(statusCode: number, body: string, userMessage?: string) {
-    super(`Channel reply delivery failed (${statusCode}): ${body}`);
-    this.name = "ChannelDeliveryError";
-    this.statusCode = statusCode;
-    this.userMessage = userMessage;
-  }
-}
-
-const DELIVERY_TIMEOUT_MS = 30_000;
-const MANAGED_OUTBOUND_SEND_PATH =
-  "/v1/internal/managed-gateway/outbound-send/";
-const MANAGED_CALLBACK_TOKEN_HEADER = "X-Managed-Gateway-Callback-Token";
-const MANAGED_IDEMPOTENCY_HEADER = "X-Idempotency-Key";
-const MANAGED_OUTBOUND_MAX_ATTEMPTS = 3;
-const MANAGED_OUTBOUND_RETRY_BASE_MS = 150;
-
-export interface ChannelReplyPayload {
-  chatId: string;
-  text?: string;
-  /** Pre-formatted Block Kit blocks for Slack delivery. */
-  blocks?: unknown[];
-  assistantId?: string;
-  attachments?: RuntimeAttachmentMetadata[];
-  approval?: ApprovalUIMetadata;
-  chatAction?: "typing";
-  /**
-   * When true, deliver via `chat.postEphemeral` so only the target `user`
-   * sees the message. Ephemeral messages are fire-and-forget: they cannot
-   * be edited or deleted after posting.
-   */
-  ephemeral?: boolean;
-  /** Slack user ID — required when `ephemeral` is true. */
-  user?: string;
-  /** When provided, instructs the delivery endpoint to update an existing message instead of posting a new one. */
-  messageTs?: string;
-  /** When true, auto-generate Block Kit blocks from text via textToBlocks(). */
-  useBlocks?: boolean;
-  /** When provided, add or remove an emoji reaction on a message. */
-  reaction?: { action: "add" | "remove"; name: string; messageTs: string };
-  /** When provided, set or clear the Slack Assistants API thread status. */
-  assistantThreadStatus?: { channel: string; threadTs: string; status: string };
-}
-
-export interface ChannelDeliveryResult {
-  ok: boolean;
-  /** The message timestamp returned by the delivery endpoint (e.g. Slack message ts). */
-  ts?: string;
-}
-
-interface ManagedOutboundCallbackContext {
-  requestUrl: string;
-  routeId: string;
-  assistantId: string;
-  sourceChannel: "phone";
-  sourceUpdateId?: string;
-  callbackToken?: string;
-}
+// Re-export the error class and types so existing import sites are unchanged.
+export { ChannelDeliveryError };
+export type { ChannelDeliveryResult, ChannelReplyPayload };
 
 export async function deliverChannelReply(
   callbackUrl: string,
   payload: ChannelReplyPayload,
   bearerToken?: string,
 ): Promise<ChannelDeliveryResult> {
-  const managedCallback = parseManagedOutboundCallback(callbackUrl);
-  if (managedCallback) {
-    await deliverManagedOutboundReply(managedCallback, payload, bearerToken);
-    return { ok: true };
-  }
-
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-  if (bearerToken) {
-    headers["Authorization"] = `Bearer ${bearerToken}`;
-  }
-
-  const response = await fetch(callbackUrl, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(DELIVERY_TIMEOUT_MS),
-  });
-
-  if (!response.ok) {
-    const body = await response.text().catch(() => "<unreadable>");
-
-    // Try to extract userMessage from JSON error responses (e.g. from the
-    // Slack delivery endpoint) so callers can surface actionable errors.
-    let userMessage: string | undefined;
-    try {
-      const parsed = JSON.parse(body) as { userMessage?: string };
-      if (typeof parsed.userMessage === "string") {
-        userMessage = parsed.userMessage;
-      }
-    } catch {
-      // Body wasn't JSON — that's fine, userMessage stays undefined.
-    }
-
-    log.error(
-      {
-        status: response.status,
-        body,
-        callbackUrl,
-        chatId: payload.chatId,
-        ...(userMessage && { userMessage }),
-      },
-      "Channel reply delivery failed",
-    );
-    if (userMessage) {
-      log.warn(
-        { chatId: payload.chatId, userMessage },
-        "Gateway returned actionable error for user",
-      );
-    }
-    throw new ChannelDeliveryError(response.status, body, userMessage);
-  }
-
-  const result: ChannelDeliveryResult = { ok: true };
-  try {
-    const responseBody = (await response.json()) as Record<string, unknown>;
-    if (typeof responseBody.ts === "string") {
-      result.ts = responseBody.ts;
-    }
-  } catch {
-    // Response may not be JSON for non-Slack channels; that's fine.
-  }
-
-  if (payload.chatAction) {
-    log.debug(
-      { chatId: payload.chatId, callbackUrl, chatAction: payload.chatAction },
-      "Channel action delivered",
-    );
-  } else {
-    log.info(
-      { chatId: payload.chatId, callbackUrl },
-      "Channel reply delivered",
-    );
-  }
-
-  return result;
-}
-
-function parseManagedOutboundCallback(
-  callbackUrl: string,
-): ManagedOutboundCallbackContext | null {
-  let parsed: URL;
-  try {
-    parsed = new URL(callbackUrl);
-  } catch {
-    return null;
-  }
-
-  const normalizedPath = parsed.pathname.endsWith("/")
-    ? parsed.pathname
-    : `${parsed.pathname}/`;
-  if (normalizedPath !== MANAGED_OUTBOUND_SEND_PATH) {
-    return null;
-  }
-
-  const routeId = parsed.searchParams.get("route_id")?.trim();
-  const assistantId = parsed.searchParams.get("assistant_id")?.trim();
-  const sourceChannel = parsed.searchParams.get("source_channel")?.trim();
-
-  if (!routeId || !assistantId || sourceChannel !== "phone") {
-    throw new Error(
-      "Managed outbound callback URL is missing required route_id, assistant_id, or source_channel.",
-    );
-  }
-
-  const sourceUpdateId = parsed.searchParams.get("source_update_id")?.trim();
-  const callbackToken = parsed.searchParams.get("callback_token")?.trim();
-
-  parsed.searchParams.delete("route_id");
-  parsed.searchParams.delete("assistant_id");
-  parsed.searchParams.delete("source_channel");
-  parsed.searchParams.delete("source_update_id");
-  parsed.searchParams.delete("callback_token");
-
-  return {
-    requestUrl: parsed.toString(),
-    routeId,
-    assistantId,
-    sourceChannel,
-    sourceUpdateId,
-    callbackToken,
-  };
-}
-
-async function deliverManagedOutboundReply(
-  callback: ManagedOutboundCallbackContext,
-  payload: ChannelReplyPayload,
-  bearerToken?: string,
-): Promise<void> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-  if (callback.callbackToken) {
-    headers[MANAGED_CALLBACK_TOKEN_HEADER] = callback.callbackToken;
-  } else if (bearerToken) {
-    headers.Authorization = `Bearer ${bearerToken}`;
-  }
-
-  const hasAttachments =
-    Array.isArray(payload.attachments) && payload.attachments.length > 0;
-  const text = payload.approval?.plainTextFallback ?? payload.text;
-  const normalizedText =
-    typeof text === "string" && text.trim().length > 0 ? text : "";
-  if (!normalizedText) {
-    throw new Error(
-      "Managed outbound delivery requires text or plainTextFallback.",
-    );
-  }
-
-  const requestId = buildManagedOutboundRequestId(
-    callback,
-    payload,
-    normalizedText,
-  );
-  headers[MANAGED_IDEMPOTENCY_HEADER] = requestId;
-
-  const requestBody = JSON.stringify({
-    route_id: callback.routeId,
-    assistant_id: callback.assistantId,
-    normalized_send: {
-      version: "v1",
-      sourceChannel: callback.sourceChannel,
-      message: {
-        to: payload.chatId,
-        content: normalizedText,
-        externalMessageId: requestId,
-      },
-      source: {
-        requestId: requestId,
-      },
-      raw: {
-        chatId: payload.chatId,
-        text: payload.text ?? null,
-        assistantId: payload.assistantId ?? null,
-        chatAction: payload.chatAction ?? null,
-        hasAttachments,
-        sourceUpdateId: callback.sourceUpdateId ?? null,
-      },
-    },
-  });
-
-  for (let attempt = 1; attempt <= MANAGED_OUTBOUND_MAX_ATTEMPTS; attempt++) {
-    let response: Response;
-    try {
-      response = await fetch(callback.requestUrl, {
-        method: "POST",
-        headers,
-        body: requestBody,
-        signal: AbortSignal.timeout(DELIVERY_TIMEOUT_MS),
-      });
-    } catch (error) {
-      if (attempt < MANAGED_OUTBOUND_MAX_ATTEMPTS) {
-        const retryDelayMs = MANAGED_OUTBOUND_RETRY_BASE_MS * attempt;
-        log.warn(
-          {
-            callbackUrl: callback.requestUrl,
-            routeId: callback.routeId,
-            requestId,
-            chatId: payload.chatId,
-            attempt,
-            retryDelayMs,
-            error,
-          },
-          "Managed outbound delivery attempt failed before response; retrying",
-        );
-        await sleep(retryDelayMs);
-        continue;
-      }
-      throw error;
-    }
-
-    if (response.ok) {
-      log.info(
-        {
-          routeId: callback.routeId,
-          assistantId: callback.assistantId,
-          sourceChannel: callback.sourceChannel,
-          requestId,
-          chatId: payload.chatId,
-          attempt,
-        },
-        "Managed outbound delivery accepted",
-      );
-      return;
-    }
-
-    const responseBody = await response.text().catch(() => "<unreadable>");
-    if (
-      response.status >= 500 &&
-      response.status < 600 &&
-      attempt < MANAGED_OUTBOUND_MAX_ATTEMPTS
-    ) {
-      const retryDelayMs = MANAGED_OUTBOUND_RETRY_BASE_MS * attempt;
-      log.warn(
-        {
-          callbackUrl: callback.requestUrl,
-          routeId: callback.routeId,
-          requestId,
-          chatId: payload.chatId,
-          attempt,
-          status: response.status,
-          responseBody,
-          retryDelayMs,
-        },
-        "Managed outbound delivery got retriable upstream response; retrying",
-      );
-      await sleep(retryDelayMs);
-      continue;
-    }
-
-    log.error(
-      {
-        status: response.status,
-        body: responseBody,
-        callbackUrl: callback.requestUrl,
-        routeId: callback.routeId,
-        requestId,
-        chatId: payload.chatId,
-        attempt,
-      },
-      "Managed outbound delivery failed",
-    );
-    throw new Error(
-      `Managed outbound delivery failed (${response.status}): ${responseBody}`,
-    );
-  }
-}
-
-function buildManagedOutboundRequestId(
-  callback: ManagedOutboundCallbackContext,
-  payload: ChannelReplyPayload,
-  normalizedText: string,
-): string {
-  const bodyMaterial = JSON.stringify({
-    callback: {
-      routeId: callback.routeId,
-      assistantId: callback.assistantId,
-      sourceChannel: callback.sourceChannel,
-      sourceUpdateId: callback.sourceUpdateId ?? null,
-    },
-    payload: {
-      chatId: payload.chatId,
-      text: normalizedText,
-      assistantId: payload.assistantId ?? null,
-      chatAction: payload.chatAction ?? null,
-      hasAttachments:
-        Array.isArray(payload.attachments) && payload.attachments.length > 0,
-      approvalRequestId: payload.approval?.requestId ?? null,
-      approvalActions:
-        payload.approval?.actions.map((action) => action.id) ?? null,
-    },
-  });
-
-  const digest = createHash("sha256")
-    .update(bodyMaterial)
-    .digest("hex")
-    .slice(0, 40);
-  return `mgw-send-${digest}`;
-}
-
-async function sleep(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
+  return _deliverChannelReply(callbackUrl, payload, bearerToken, log);
 }
 
 /**
@@ -398,9 +46,13 @@ export async function deliverApprovalPrompt(
   assistantId?: string,
   bearerToken?: string,
 ): Promise<ChannelDeliveryResult> {
-  return deliverChannelReply(
+  return _deliverApprovalPrompt(
     callbackUrl,
-    { chatId, text, approval, assistantId },
+    chatId,
+    text,
+    approval,
+    assistantId,
     bearerToken,
+    log,
   );
 }


### PR DESCRIPTION
## Summary
- Refactors assistant gateway-client and trust-client to delegate transport to @vellumai/gateway-client
- Preserves all exported function signatures and auth context injection
- Updates tests for unchanged error typing and callback behavior

Part of plan: service-comm-clients.md (PR 8 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
