### PR TITLE
feat(host-transfer): add host_file_transfer tool with local and managed mode execution

### DIFF
--- a/assistant/src/daemon/host-transfer-proxy.ts
+++ b/assistant/src/daemon/host-transfer-proxy.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
@@ -19,6 +20,7 @@ interface PendingTransfer {
   transferId: string;
   direction: "to_host" | "to_sandbox";
   filePath: string;
+  overwrite?: boolean;
   sizeBytes?: number;
   sha256?: string;
   fileBuffer?: Buffer;
@@ -205,6 +207,7 @@ export class HostTransferProxy {
     input: {
       sourcePath: string;
       destPath: string;
+      overwrite?: boolean;
       conversationId: string;
     },
     signal?: AbortSignal,
@@ -267,6 +270,7 @@ export class HostTransferProxy {
         transferId,
         direction: "to_sandbox",
         filePath: input.destPath,
+        overwrite: input.overwrite,
         detachAbort,
       };
       this.pending.set(requestId, entry);
@@ -393,6 +397,17 @@ export class HostTransferProxy {
     }
 
     const { requestId } = entry;
+
+    // Enforce overwrite policy before writing.
+    if (entry.overwrite === false && existsSync(entry.filePath)) {
+      const errorMsg = `Destination file already exists: ${entry.filePath}. Set overwrite to true to replace it.`;
+      clearTimeout(entry.timer);
+      entry.detachAbort();
+      this.pending.delete(requestId);
+      this.transfers.delete(transferId);
+      entry.resolve({ content: errorMsg, isError: true });
+      return { accepted: false, error: errorMsg };
+    }
 
     const cleanup = () => {
       clearTimeout(entry.timer);

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -349,7 +349,13 @@ async function buildCommandCandidates(
     return [...new Set(candidates)];
   }
 
-  const fileTarget = getStringField(input, "path", "file_path");
+  const fileTarget = getStringField(
+    input,
+    "path",
+    "file_path",
+    "dest_path",
+    "source_path",
+  );
   if (
     toolName === "host_file_read" ||
     toolName === "host_file_write" ||
@@ -456,7 +462,13 @@ export async function classifyRisk(
       "host_file_transfer",
     ].includes(toolName)
   ) {
-    const filePath = getStringField(input, "path", "file_path");
+    const filePath = getStringField(
+      input,
+      "path",
+      "file_path",
+      "dest_path",
+      "source_path",
+    );
     const isHostTool = toolName.startsWith("host_");
     const assessment = await fileRiskClassifier.classify({
       toolName: toolName as
@@ -802,7 +814,12 @@ function fileAllowlistStrategy(
   toolName: string,
   input: Record<string, unknown>,
 ): AllowlistOption[] {
-  const filePath = (input.path as string) ?? (input.file_path as string) ?? "";
+  const filePath =
+    (input.path as string) ??
+    (input.file_path as string) ??
+    (input.dest_path as string) ??
+    (input.source_path as string) ??
+    "";
   const toolLabel = TOOL_DISPLAY_NAMES[toolName] ?? toolName;
   const options: AllowlistOption[] = [];
 

--- a/assistant/src/tools/host-filesystem/transfer.ts
+++ b/assistant/src/tools/host-filesystem/transfer.ts
@@ -1,0 +1,206 @@
+import { constants } from "node:fs";
+import { copyFile, lstat, mkdir, realpath } from "node:fs/promises";
+import { dirname, isAbsolute } from "node:path";
+
+import { RiskLevel } from "../../permissions/types.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+
+class HostFileTransferTool implements Tool {
+  name = "host_file_transfer";
+  description =
+    "Copy a file between the assistant's workspace and the user's host machine. Set direction to 'to_host' to send a workspace file to the host, or 'to_sandbox' to pull a host file into the workspace.";
+  category = "host-filesystem";
+  defaultRiskLevel = RiskLevel.Medium;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          source_path: {
+            type: "string",
+            description:
+              "Absolute path to the source file. For to_host, this is a workspace path. For to_sandbox, this is a host path.",
+          },
+          dest_path: {
+            type: "string",
+            description:
+              "Absolute path to the destination. For to_host, this is a host path. For to_sandbox, this is a workspace path.",
+          },
+          direction: {
+            type: "string",
+            enum: ["to_host", "to_sandbox"],
+            description:
+              "Transfer direction: 'to_host' sends a workspace file to the host, 'to_sandbox' pulls a host file into the workspace.",
+          },
+          overwrite: {
+            type: "boolean",
+            description:
+              "Whether to overwrite the destination file if it already exists (default: false)",
+          },
+          activity: {
+            type: "string",
+            description:
+              "Brief description of why the file is being transferred (for audit logging)",
+          },
+        },
+        required: ["source_path", "dest_path", "direction"],
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const sourcePath = input.source_path;
+    if (!sourcePath || typeof sourcePath !== "string") {
+      return {
+        content: "Error: source_path is required and must be a string",
+        isError: true,
+      };
+    }
+
+    const destPath = input.dest_path;
+    if (!destPath || typeof destPath !== "string") {
+      return {
+        content: "Error: dest_path is required and must be a string",
+        isError: true,
+      };
+    }
+
+    const direction = input.direction;
+    if (direction !== "to_host" && direction !== "to_sandbox") {
+      return {
+        content:
+          "Error: direction is required and must be 'to_host' or 'to_sandbox'",
+        isError: true,
+      };
+    }
+
+    const overwrite = input.overwrite === true;
+
+    // Validate that host-side paths are absolute.
+    if (direction === "to_host" && !isAbsolute(destPath)) {
+      return {
+        content: `Error: dest_path must be absolute for host file access: ${destPath}`,
+        isError: true,
+      };
+    }
+    if (direction === "to_sandbox" && !isAbsolute(sourcePath)) {
+      return {
+        content: `Error: source_path must be absolute for host file access: ${sourcePath}`,
+        isError: true,
+      };
+    }
+
+    // Managed mode: delegate to the host transfer proxy when available.
+    if (context.hostTransferProxy?.isAvailable()) {
+      if (direction === "to_host") {
+        return context.hostTransferProxy.requestToHost(
+          {
+            sourcePath,
+            destPath,
+            overwrite,
+            conversationId: context.conversationId,
+          },
+          context.signal,
+        );
+      }
+      return context.hostTransferProxy.requestToSandbox(
+        {
+          sourcePath,
+          destPath,
+          conversationId: context.conversationId,
+        },
+        context.signal,
+      );
+    }
+
+    // Local mode: direct filesystem copy.
+    return this.executeLocal(sourcePath, destPath, overwrite);
+  }
+
+  private async executeLocal(
+    sourcePath: string,
+    destPath: string,
+    overwrite: boolean,
+  ): Promise<ToolExecutionResult> {
+    // Resolve symlinks on the source to ensure we read the real file.
+    let resolvedSource: string;
+    try {
+      resolvedSource = await realpath(sourcePath);
+    } catch {
+      return {
+        content: `Error: source file not found: ${sourcePath}`,
+        isError: true,
+      };
+    }
+
+    // Verify the source is a regular file (not a directory).
+    try {
+      const stat = await lstat(resolvedSource);
+      if (stat.isDirectory()) {
+        return {
+          content: `Error: source path is a directory, not a file: ${sourcePath}. To transfer a directory, archive it first (e.g. tar or zip) and transfer the archive.`,
+          isError: true,
+        };
+      }
+      if (!stat.isFile()) {
+        return {
+          content: `Error: source path is not a regular file: ${sourcePath}`,
+          isError: true,
+        };
+      }
+    } catch (err) {
+      return {
+        content: `Error: cannot stat source file: ${err instanceof Error ? err.message : String(err)}`,
+        isError: true,
+      };
+    }
+
+    // Ensure the destination parent directory exists.
+    try {
+      await mkdir(dirname(destPath), { recursive: true });
+    } catch (err) {
+      return {
+        content: `Error: failed to create destination directory: ${err instanceof Error ? err.message : String(err)}`,
+        isError: true,
+      };
+    }
+
+    // COPYFILE_EXCL makes the call fail atomically if dest exists,
+    // avoiding a TOCTOU race vs. a separate lstat check.
+    try {
+      const flags = overwrite ? 0 : constants.COPYFILE_EXCL;
+      await copyFile(resolvedSource, destPath, flags);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!overwrite && msg.includes("EEXIST")) {
+        return {
+          content: `Error: destination file already exists: ${destPath}. Set overwrite to true to replace it.`,
+          isError: true,
+        };
+      }
+      const hint = msg.includes("EACCES")
+        ? " (permission denied)"
+        : msg.includes("ENOSPC")
+          ? " (no space left on device)"
+          : "";
+      return {
+        content: `Error copying file${hint}: ${msg}`,
+        isError: true,
+      };
+    }
+
+    return {
+      content: `Successfully copied ${sourcePath} to ${destPath}`,
+      isError: false,
+    };
+  }
+}
+
+export const hostFileTransferTool: Tool = new HostFileTransferTool();

--- a/assistant/src/tools/host-filesystem/transfer.ts
+++ b/assistant/src/tools/host-filesystem/transfer.ts
@@ -114,6 +114,7 @@ class HostFileTransferTool implements Tool {
         {
           sourcePath,
           destPath,
+          overwrite,
           conversationId: context.conversationId,
         },
         context.signal,

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -5,6 +5,7 @@ import { registerAppTools } from "./apps/registry.js";
 import { allComputerUseTools } from "./computer-use/definitions.js";
 import { hostFileEditTool } from "./host-filesystem/edit.js";
 import { hostFileReadTool } from "./host-filesystem/read.js";
+import { hostFileTransferTool } from "./host-filesystem/transfer.js";
 import { hostFileWriteTool } from "./host-filesystem/write.js";
 import { hostShellTool } from "./host-terminal/host-shell.js";
 import { registerSystemTools } from "./system/register.js";
@@ -438,6 +439,7 @@ export async function initializeTools(): Promise<void> {
     hostFileReadTool,
     hostFileWriteTool,
     hostFileEditTool,
+    hostFileTransferTool,
     hostShellTool,
   ];
   for (const tool of hostTools) {

--- a/assistant/src/tools/tool-input-summary.ts
+++ b/assistant/src/tools/tool-input-summary.ts
@@ -51,7 +51,13 @@ export function summarizeToolInput(
     case "host_file_write":
     case "host_file_edit":
     case "host_file_transfer": {
-      const path = extractString(input, "file_path", "path");
+      const path = extractString(
+        input,
+        "file_path",
+        "path",
+        "dest_path",
+        "source_path",
+      );
       return path ? path.trim() : "";
     }
     case "web_fetch":


### PR DESCRIPTION
## Summary
- Add host_file_transfer tool definition with JSON schema for direction, paths, overwrite
- Local mode: fs.copyFile with path validation, overwrite protection (atomic COPYFILE_EXCL), symlink resolution
- Managed mode: delegates to HostTransferProxy for streaming transfer
- Register in tool registry

Part of plan: host-file-transfer.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
