### PR TITLE
refactor(gateway): migrate secondary control-plane/runtime-health proxy routes to assistant client

### DIFF
--- a/gateway/src/http/routes/channel-readiness-proxy.ts
+++ b/gateway/src/http/routes/channel-readiness-proxy.ts
@@ -5,11 +5,12 @@
  * disabled, so skills and clients can use gateway URLs exclusively.
  */
 
+import { proxyForwardToResponse } from "@vellumai/assistant-client";
+
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
-import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("channel-readiness-proxy");
 
@@ -20,79 +21,34 @@ export function createChannelReadinessProxyHandler(config: GatewayConfig) {
     upstreamSearch: string,
   ): Promise<Response> {
     const start = performance.now();
-    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
-
-    const reqHeaders = stripHopByHop(new Headers(req.headers));
-    reqHeaders.delete("host");
-    reqHeaders.delete("authorization");
-
-    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
-
-    const hasBody = req.method !== "GET" && req.method !== "HEAD";
-    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
-    if (bodyBuffer !== null) {
-      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
-    }
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort(
-        new DOMException(
-          "The operation was aborted due to timeout",
-          "TimeoutError",
-        ),
-      );
-    }, config.runtimeTimeoutMs);
-
-    let response: Response;
-    try {
-      response = await fetchImpl(upstream, {
-        method: req.method,
-        headers: reqHeaders,
-        body: bodyBuffer,
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-    } catch (err) {
-      clearTimeout(timeoutId);
-      const duration = Math.round(performance.now() - start);
-      if (err instanceof DOMException && err.name === "TimeoutError") {
-        log.error(
-          { path: upstreamPath, duration },
-          "Channel readiness proxy upstream timed out",
-        );
-        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
-      }
-      log.error(
-        { err, path: upstreamPath, duration },
-        "Channel readiness proxy upstream connection failed",
-      );
-      return Response.json({ error: "Bad Gateway" }, { status: 502 });
-    }
-
-    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const response = await proxyForwardToResponse(req, {
+      baseUrl: config.assistantRuntimeBaseUrl,
+      path: upstreamPath,
+      search: upstreamSearch || undefined,
+      serviceToken: mintServiceToken(),
+      timeoutMs: config.runtimeTimeoutMs,
+      fetchImpl,
+    });
     const duration = Math.round(performance.now() - start);
 
-    if (response.status >= 400) {
-      const body = await response.text();
+    if (response.status >= 500) {
+      log.error(
+        { path: upstreamPath, status: response.status, duration },
+        "Channel readiness proxy upstream error",
+      );
+    } else if (response.status >= 400) {
       log.warn(
         { path: upstreamPath, status: response.status, duration },
         "Channel readiness proxy upstream error",
       );
-      return new Response(body, {
-        status: response.status,
-        headers: resHeaders,
-      });
+    } else {
+      log.info(
+        { path: upstreamPath, status: response.status, duration },
+        "Channel readiness proxy completed",
+      );
     }
 
-    log.info(
-      { path: upstreamPath, status: response.status, duration },
-      "Channel readiness proxy completed",
-    );
-    return new Response(response.body, {
-      status: response.status,
-      headers: resHeaders,
-    });
+    return response;
   }
 
   return {

--- a/gateway/src/http/routes/channel-verification-session-proxy.test.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import type { GatewayConfig } from "../../config.js";
+
+// --- Mocks -------------------------------------------------------------------
+
+let capturedFetchHeaders: Headers | undefined;
+let capturedFetchUrl: string | undefined;
+let fetchResponse = new Response(JSON.stringify({ ok: true }), { status: 200 });
+
+// Mock mintServiceToken before importing the module under test
+mock.module("../../auth/token-exchange.js", () => ({
+  mintServiceToken: () => "test-service-token",
+}));
+
+mock.module("../../fetch.js", () => ({
+  fetchImpl: async (url: string | URL | Request, init?: RequestInit) => {
+    capturedFetchUrl = String(url);
+    capturedFetchHeaders = new Headers(init?.headers as HeadersInit);
+    return fetchResponse;
+  },
+}));
+
+mock.module("../../paths.js", () => ({
+  getGatewaySecurityDir: () => "/tmp/test-gateway-sec",
+}));
+
+// Import after mocks are registered
+const { createChannelVerificationSessionProxyHandler } =
+  await import("./channel-verification-session-proxy.js");
+
+// --- Helpers -----------------------------------------------------------------
+
+function makeConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    runtimeTimeoutMs: 30_000,
+    ...overrides,
+  } as GatewayConfig;
+}
+
+// --- Tests -------------------------------------------------------------------
+
+describe("channel-verification-session-proxy x-forwarded-for handling", () => {
+  beforeEach(() => {
+    capturedFetchHeaders = undefined;
+    capturedFetchUrl = undefined;
+    fetchResponse = new Response(JSON.stringify({ ok: true }), { status: 200 });
+  });
+
+  it("strips x-forwarded-for for loopback client IP", async () => {
+    const config = makeConfig();
+    const handler = createChannelVerificationSessionProxyHandler(config);
+
+    const req = new Request("http://gateway/v1/channel-verification-sessions", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-for": "should-be-stripped",
+      },
+      body: JSON.stringify({ channel: "test" }),
+    });
+
+    // proxyToRuntime is called without clientIp from handleCreateVerificationSession,
+    // so x-forwarded-for should be stripped
+    await handler.handleCreateVerificationSession(req);
+
+    expect(capturedFetchHeaders).toBeDefined();
+    expect(capturedFetchHeaders!.has("x-forwarded-for")).toBe(false);
+  });
+
+  it("injects service token as Bearer authorization", async () => {
+    const config = makeConfig();
+    const handler = createChannelVerificationSessionProxyHandler(config);
+
+    const req = new Request("http://gateway/v1/channel-verification-sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel: "test" }),
+    });
+
+    await handler.handleCreateVerificationSession(req);
+
+    expect(capturedFetchHeaders).toBeDefined();
+    expect(capturedFetchHeaders!.get("authorization")).toBe(
+      "Bearer test-service-token",
+    );
+  });
+
+  it("forwards query params for status endpoint", async () => {
+    const config = makeConfig();
+    const handler = createChannelVerificationSessionProxyHandler(config);
+
+    const req = new Request(
+      "http://gateway/v1/channel-verification-sessions/status?channel=telegram&id=123",
+      { method: "GET" },
+    );
+
+    await handler.handleGetVerificationStatus(req);
+
+    expect(capturedFetchUrl).toBeDefined();
+    expect(capturedFetchUrl).toContain(
+      "/v1/channel-verification-sessions/status",
+    );
+    expect(capturedFetchUrl).toContain("channel=telegram");
+    expect(capturedFetchUrl).toContain("id=123");
+  });
+
+  it("strips hop-by-hop headers from forwarded request", async () => {
+    const config = makeConfig();
+    const handler = createChannelVerificationSessionProxyHandler(config);
+
+    const req = new Request("http://gateway/v1/channel-verification-sessions", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        connection: "keep-alive",
+        "keep-alive": "timeout=5",
+      },
+      body: JSON.stringify({ channel: "test" }),
+    });
+
+    await handler.handleCreateVerificationSession(req);
+
+    expect(capturedFetchHeaders).toBeDefined();
+    expect(capturedFetchHeaders!.has("connection")).toBe(false);
+    expect(capturedFetchHeaders!.has("keep-alive")).toBe(false);
+    expect(capturedFetchHeaders!.get("content-type")).toBe("application/json");
+  });
+
+  it("removes incoming host and authorization headers", async () => {
+    const config = makeConfig();
+    const handler = createChannelVerificationSessionProxyHandler(config);
+
+    const req = new Request("http://gateway/v1/channel-verification-sessions", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        host: "gateway.example.com",
+        authorization: "Bearer old-edge-token",
+      },
+      body: JSON.stringify({ channel: "test" }),
+    });
+
+    await handler.handleCreateVerificationSession(req);
+
+    expect(capturedFetchHeaders).toBeDefined();
+    expect(capturedFetchHeaders!.has("host")).toBe(false);
+    // authorization should be the service token, not the edge token
+    expect(capturedFetchHeaders!.get("authorization")).toBe(
+      "Bearer test-service-token",
+    );
+  });
+});
+
+describe("channel-verification-session-proxy guardian init", () => {
+  beforeEach(() => {
+    capturedFetchHeaders = undefined;
+    capturedFetchUrl = undefined;
+    fetchResponse = new Response(JSON.stringify({ ok: true }), { status: 200 });
+    // Clear bootstrap secret env
+    delete process.env.GUARDIAN_BOOTSTRAP_SECRET;
+  });
+
+  it("rejects handleResetBootstrap from non-loopback IP", async () => {
+    const config = makeConfig();
+    const handler = createChannelVerificationSessionProxyHandler(config);
+
+    const response = await handler.handleResetBootstrap("192.168.1.100");
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe("Loopback-only endpoint");
+  });
+
+  it("allows handleResetBootstrap from loopback IP", async () => {
+    const config = makeConfig();
+    const handler = createChannelVerificationSessionProxyHandler(config);
+
+    const response = await handler.handleResetBootstrap("127.0.0.1");
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("allows handleResetBootstrap from IPv6 loopback", async () => {
+    const config = makeConfig();
+    const handler = createChannelVerificationSessionProxyHandler(config);
+
+    const response = await handler.handleResetBootstrap("::1");
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("rejects handleResetBootstrap in containerized mode", async () => {
+    process.env.GUARDIAN_BOOTSTRAP_SECRET = "secret-abc";
+    const config = makeConfig();
+    const handler = createChannelVerificationSessionProxyHandler(config);
+
+    const response = await handler.handleResetBootstrap("127.0.0.1");
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe("Reset not available in containerized mode");
+  });
+});

--- a/gateway/src/http/routes/channel-verification-session-proxy.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.ts
@@ -8,13 +8,14 @@
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { proxyForwardToResponse } from "@vellumai/assistant-client";
+
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import { getGatewaySecurityDir } from "../../paths.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
 import { isLoopbackAddress } from "../../util/is-loopback-address.js";
-import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("channel-verification-session-proxy");
 
@@ -41,6 +42,31 @@ function parseBootstrapSecrets(): string[] {
     .filter((s) => s.length > 0);
 }
 
+/**
+ * Build a request with the correct `x-forwarded-for` header for upstream
+ * forwarding. The runtime uses this header to enforce loopback-only checks
+ * in bare-metal mode and rejects it outright when a bootstrap secret is
+ * present (Docker mode).
+ *
+ * - If `clientIp` is provided and is not loopback, set the header.
+ * - Otherwise, strip any client-supplied value to prevent spoofing.
+ */
+function withForwardedFor(req: Request, clientIp?: string): Request {
+  const headers = new Headers(req.headers);
+  if (clientIp && !isLoopbackAddress(clientIp)) {
+    headers.set("x-forwarded-for", clientIp);
+  } else {
+    headers.delete("x-forwarded-for");
+  }
+  return new Request(req.url, {
+    method: req.method,
+    headers,
+    body: req.body,
+    // @ts-expect-error -- Bun supports duplex on Request but the types lag
+    duplex: "half",
+  });
+}
+
 export function createChannelVerificationSessionProxyHandler(
   config: GatewayConfig,
 ) {
@@ -54,93 +80,36 @@ export function createChannelVerificationSessionProxyHandler(
     upstreamSearch: string,
     clientIp?: string,
   ): Promise<Response> {
+    const prepared = withForwardedFor(req, clientIp);
     const start = performance.now();
-    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
-
-    const reqHeaders = stripHopByHop(new Headers(req.headers));
-    reqHeaders.delete("host");
-    reqHeaders.delete("authorization");
-
-    // Inject the real client IP so the runtime can enforce loopback-only
-    // checks, overwriting any client-supplied value to prevent spoofing.
-    // Strip the header for loopback peers: the runtime rejects any request
-    // with x-forwarded-for in bare-metal mode, and forwarding 127.0.0.1
-    // conveys no useful information.
-    if (clientIp && !isLoopbackAddress(clientIp)) {
-      reqHeaders.set("x-forwarded-for", clientIp);
-    } else {
-      reqHeaders.delete("x-forwarded-for");
-    }
-
-    // Mint a short-lived service token for gateway->runtime auth.
-    // The token itself proves gateway origin (aud=vellum-daemon).
-    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
-
-    const hasBody = req.method !== "GET" && req.method !== "HEAD";
-    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
-    if (bodyBuffer !== null) {
-      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
-    }
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort(
-        new DOMException(
-          "The operation was aborted due to timeout",
-          "TimeoutError",
-        ),
-      );
-    }, config.runtimeTimeoutMs);
-
-    let response: Response;
-    try {
-      response = await fetchImpl(upstream, {
-        method: req.method,
-        headers: reqHeaders,
-        body: bodyBuffer,
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-    } catch (err) {
-      clearTimeout(timeoutId);
-      const duration = Math.round(performance.now() - start);
-      if (err instanceof DOMException && err.name === "TimeoutError") {
-        log.error(
-          { path: upstreamPath, duration },
-          "Channel verification session proxy upstream timed out",
-        );
-        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
-      }
-      log.error(
-        { err, path: upstreamPath, duration },
-        "Channel verification session proxy upstream connection failed",
-      );
-      return Response.json({ error: "Bad Gateway" }, { status: 502 });
-    }
-
-    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const response = await proxyForwardToResponse(prepared, {
+      baseUrl: config.assistantRuntimeBaseUrl,
+      path: upstreamPath,
+      search: upstreamSearch || undefined,
+      serviceToken: mintServiceToken(),
+      timeoutMs: config.runtimeTimeoutMs,
+      fetchImpl,
+    });
     const duration = Math.round(performance.now() - start);
 
-    if (response.status >= 400) {
-      const body = await response.text();
+    if (response.status >= 500) {
+      log.error(
+        { path: upstreamPath, status: response.status, duration },
+        "Channel verification session proxy upstream error",
+      );
+    } else if (response.status >= 400) {
       log.warn(
         { path: upstreamPath, status: response.status, duration },
         "Channel verification session proxy upstream error",
       );
-      return new Response(body, {
-        status: response.status,
-        headers: resHeaders,
-      });
+    } else {
+      log.info(
+        { path: upstreamPath, status: response.status, duration },
+        "Channel verification session proxy completed",
+      );
     }
 
-    log.info(
-      { path: upstreamPath, status: response.status, duration },
-      "Channel verification session proxy completed",
-    );
-    return new Response(response.body, {
-      status: response.status,
-      headers: resHeaders,
-    });
+    return response;
   }
 
   return {

--- a/gateway/src/http/routes/oauth-apps-proxy.ts
+++ b/gateway/src/http/routes/oauth-apps-proxy.ts
@@ -5,11 +5,12 @@
  * disabled, so skills and clients can use gateway URLs exclusively.
  */
 
+import { proxyForwardToResponse } from "@vellumai/assistant-client";
+
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
-import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("oauth-apps-proxy");
 
@@ -20,79 +21,34 @@ export function createOAuthAppsProxyHandler(config: GatewayConfig) {
     upstreamSearch: string,
   ): Promise<Response> {
     const start = performance.now();
-    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
-
-    const reqHeaders = stripHopByHop(new Headers(req.headers));
-    reqHeaders.delete("host");
-    reqHeaders.delete("authorization");
-
-    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
-
-    const hasBody = req.method !== "GET" && req.method !== "HEAD";
-    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
-    if (bodyBuffer !== null) {
-      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
-    }
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort(
-        new DOMException(
-          "The operation was aborted due to timeout",
-          "TimeoutError",
-        ),
-      );
-    }, config.runtimeTimeoutMs);
-
-    let response: Response;
-    try {
-      response = await fetchImpl(upstream, {
-        method: req.method,
-        headers: reqHeaders,
-        body: bodyBuffer,
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-    } catch (err) {
-      clearTimeout(timeoutId);
-      const duration = Math.round(performance.now() - start);
-      if (err instanceof DOMException && err.name === "TimeoutError") {
-        log.error(
-          { path: upstreamPath, duration },
-          "OAuth apps proxy upstream timed out",
-        );
-        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
-      }
-      log.error(
-        { err, path: upstreamPath, duration },
-        "OAuth apps proxy upstream connection failed",
-      );
-      return Response.json({ error: "Bad Gateway" }, { status: 502 });
-    }
-
-    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const response = await proxyForwardToResponse(req, {
+      baseUrl: config.assistantRuntimeBaseUrl,
+      path: upstreamPath,
+      search: upstreamSearch || undefined,
+      serviceToken: mintServiceToken(),
+      timeoutMs: config.runtimeTimeoutMs,
+      fetchImpl,
+    });
     const duration = Math.round(performance.now() - start);
 
-    if (response.status >= 400) {
-      const body = await response.text();
+    if (response.status >= 500) {
+      log.error(
+        { path: upstreamPath, status: response.status, duration },
+        "OAuth apps proxy upstream error",
+      );
+    } else if (response.status >= 400) {
       log.warn(
         { path: upstreamPath, status: response.status, duration },
         "OAuth apps proxy upstream error",
       );
-      return new Response(body, {
-        status: response.status,
-        headers: resHeaders,
-      });
+    } else {
+      log.info(
+        { path: upstreamPath, status: response.status, duration },
+        "OAuth apps proxy completed",
+      );
     }
 
-    log.info(
-      { path: upstreamPath, status: response.status, duration },
-      "OAuth apps proxy completed",
-    );
-    return new Response(response.body, {
-      status: response.status,
-      headers: resHeaders,
-    });
+    return response;
   }
 
   return {

--- a/gateway/src/http/routes/oauth-providers-proxy.ts
+++ b/gateway/src/http/routes/oauth-providers-proxy.ts
@@ -5,11 +5,12 @@
  * disabled, so skills and clients can use gateway URLs exclusively.
  */
 
+import { proxyForwardToResponse } from "@vellumai/assistant-client";
+
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
-import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("oauth-providers-proxy");
 
@@ -20,79 +21,34 @@ export function createOAuthProvidersProxyHandler(config: GatewayConfig) {
     upstreamSearch: string,
   ): Promise<Response> {
     const start = performance.now();
-    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
-
-    const reqHeaders = stripHopByHop(new Headers(req.headers));
-    reqHeaders.delete("host");
-    reqHeaders.delete("authorization");
-
-    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
-
-    const hasBody = req.method !== "GET" && req.method !== "HEAD";
-    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
-    if (bodyBuffer !== null) {
-      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
-    }
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort(
-        new DOMException(
-          "The operation was aborted due to timeout",
-          "TimeoutError",
-        ),
-      );
-    }, config.runtimeTimeoutMs);
-
-    let response: Response;
-    try {
-      response = await fetchImpl(upstream, {
-        method: req.method,
-        headers: reqHeaders,
-        body: bodyBuffer,
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-    } catch (err) {
-      clearTimeout(timeoutId);
-      const duration = Math.round(performance.now() - start);
-      if (err instanceof DOMException && err.name === "TimeoutError") {
-        log.error(
-          { path: upstreamPath, duration },
-          "OAuth providers proxy upstream timed out",
-        );
-        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
-      }
-      log.error(
-        { err, path: upstreamPath, duration },
-        "OAuth providers proxy upstream connection failed",
-      );
-      return Response.json({ error: "Bad Gateway" }, { status: 502 });
-    }
-
-    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const response = await proxyForwardToResponse(req, {
+      baseUrl: config.assistantRuntimeBaseUrl,
+      path: upstreamPath,
+      search: upstreamSearch || undefined,
+      serviceToken: mintServiceToken(),
+      timeoutMs: config.runtimeTimeoutMs,
+      fetchImpl,
+    });
     const duration = Math.round(performance.now() - start);
 
-    if (response.status >= 400) {
-      const body = await response.text();
+    if (response.status >= 500) {
+      log.error(
+        { path: upstreamPath, status: response.status, duration },
+        "OAuth providers proxy upstream error",
+      );
+    } else if (response.status >= 400) {
       log.warn(
         { path: upstreamPath, status: response.status, duration },
         "OAuth providers proxy upstream error",
       );
-      return new Response(body, {
-        status: response.status,
-        headers: resHeaders,
-      });
+    } else {
+      log.info(
+        { path: upstreamPath, status: response.status, duration },
+        "OAuth providers proxy completed",
+      );
     }
 
-    log.info(
-      { path: upstreamPath, status: response.status, duration },
-      "OAuth providers proxy completed",
-    );
-    return new Response(response.body, {
-      status: response.status,
-      headers: resHeaders,
-    });
+    return response;
   }
 
   return {

--- a/gateway/src/http/routes/pairing-proxy.test.ts
+++ b/gateway/src/http/routes/pairing-proxy.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import type { GatewayConfig } from "../../config.js";
+
+// --- Mocks -------------------------------------------------------------------
+
+let capturedFetchHeaders: Headers | undefined;
+let capturedFetchUrl: string | undefined;
+let fetchResponse = new Response(JSON.stringify({ ok: true }), { status: 200 });
+
+mock.module("../../auth/token-exchange.js", () => ({
+  mintServiceToken: () => "test-service-token",
+}));
+
+mock.module("../../fetch.js", () => ({
+  fetchImpl: async (url: string | URL | Request, init?: RequestInit) => {
+    capturedFetchUrl = String(url);
+    capturedFetchHeaders = new Headers(init?.headers as HeadersInit);
+    return fetchResponse;
+  },
+}));
+
+// Import after mocks are registered
+const { createPairingProxyHandler } = await import("./pairing-proxy.js");
+
+// --- Helpers -----------------------------------------------------------------
+
+function makeConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    runtimeTimeoutMs: 30_000,
+    ...overrides,
+  } as GatewayConfig;
+}
+
+// --- Tests -------------------------------------------------------------------
+
+describe("pairing-proxy", () => {
+  beforeEach(() => {
+    capturedFetchHeaders = undefined;
+    capturedFetchUrl = undefined;
+    fetchResponse = new Response(JSON.stringify({ ok: true }), { status: 200 });
+  });
+
+  it("proxies POST /pairing/register to runtime", async () => {
+    const config = makeConfig();
+    const handler = createPairingProxyHandler(config);
+
+    const body = JSON.stringify({ pairingSecret: "abc123" });
+    const req = new Request("http://gateway/v1/pairing/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+
+    const response = await handler.handlePairingRegister(req);
+
+    expect(response.status).toBe(200);
+    expect(capturedFetchUrl).toContain("/v1/pairing/register");
+    expect(capturedFetchHeaders!.get("authorization")).toBe(
+      "Bearer test-service-token",
+    );
+  });
+
+  it("forwards query params for status endpoint", async () => {
+    const config = makeConfig();
+    const handler = createPairingProxyHandler(config);
+
+    const req = new Request(
+      "http://gateway/v1/pairing/status?pairingSecret=abc123",
+      { method: "GET" },
+    );
+
+    await handler.handlePairingStatus(req);
+
+    expect(capturedFetchUrl).toBeDefined();
+    expect(capturedFetchUrl).toContain("/v1/pairing/status");
+    expect(capturedFetchUrl).toContain("pairingSecret=abc123");
+  });
+
+  it("rejects payloads exceeding size limit via Content-Length", async () => {
+    const config = makeConfig();
+    const handler = createPairingProxyHandler(config);
+
+    const req = new Request("http://gateway/v1/pairing/register", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(128 * 1024), // 128 KB > 64 KB limit
+      },
+      body: JSON.stringify({ data: "x" }),
+    });
+
+    const response = await handler.handlePairingRegister(req);
+
+    expect(response.status).toBe(413);
+    const body = await response.json();
+    expect(body.error).toBe("Payload too large");
+    // Should NOT have forwarded to upstream
+    expect(capturedFetchUrl).toBeUndefined();
+  });
+
+  it("allows payloads within size limit", async () => {
+    const config = makeConfig();
+    const handler = createPairingProxyHandler(config);
+
+    const payload = JSON.stringify({ pairingSecret: "abc123" });
+    const req = new Request("http://gateway/v1/pairing/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: payload,
+    });
+
+    const response = await handler.handlePairingRegister(req);
+
+    expect(response.status).toBe(200);
+    expect(capturedFetchUrl).toContain("/v1/pairing/register");
+  });
+
+  it("strips hop-by-hop headers from forwarded request", async () => {
+    const config = makeConfig();
+    const handler = createPairingProxyHandler(config);
+
+    const req = new Request("http://gateway/v1/pairing/status?secret=abc", {
+      method: "GET",
+      headers: {
+        connection: "keep-alive",
+        "keep-alive": "timeout=5",
+      },
+    });
+
+    await handler.handlePairingStatus(req);
+
+    expect(capturedFetchHeaders).toBeDefined();
+    expect(capturedFetchHeaders!.has("connection")).toBe(false);
+    expect(capturedFetchHeaders!.has("keep-alive")).toBe(false);
+  });
+
+  it("removes incoming host and authorization headers", async () => {
+    const config = makeConfig();
+    const handler = createPairingProxyHandler(config);
+
+    const req = new Request("http://gateway/v1/pairing/status?secret=abc", {
+      method: "GET",
+      headers: {
+        host: "gateway.example.com",
+        authorization: "Bearer old-token",
+      },
+    });
+
+    await handler.handlePairingStatus(req);
+
+    expect(capturedFetchHeaders).toBeDefined();
+    expect(capturedFetchHeaders!.has("host")).toBe(false);
+    expect(capturedFetchHeaders!.get("authorization")).toBe(
+      "Bearer test-service-token",
+    );
+  });
+});

--- a/gateway/src/http/routes/pairing-proxy.ts
+++ b/gateway/src/http/routes/pairing-proxy.ts
@@ -6,11 +6,12 @@
  * The gateway simply proxies to the daemon's pairing endpoints.
  */
 
+import { proxyForwardToResponse } from "@vellumai/assistant-client";
+
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
-import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("pairing-proxy");
 
@@ -25,23 +26,12 @@ export function createPairingProxyHandler(config: GatewayConfig) {
     upstreamPath: string,
     upstreamSearch: string,
   ): Promise<Response> {
-    const start = performance.now();
-    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
-
-    const reqHeaders = stripHopByHop(new Headers(req.headers));
-    reqHeaders.delete("host");
-    reqHeaders.delete("authorization");
-
-    // Mint a short-lived service token for gateway->runtime auth
-    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
-
-    const hasBody = req.method !== "GET" && req.method !== "HEAD";
-
     // Payload size guard — primary defense: reject via Content-Length before
     // reading the body into memory. This is the main protection against
     // oversized requests because Bun's Request.arrayBuffer() buffers the
     // entire body with no streaming-limit API, so once we call it the
     // memory is already allocated.
+    const hasBody = req.method !== "GET" && req.method !== "HEAD";
     if (hasBody) {
       const contentLength = req.headers.get("content-length");
       if (contentLength) {
@@ -56,10 +46,12 @@ export function createPairingProxyHandler(config: GatewayConfig) {
       }
     }
 
-    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
-    // Belt-and-suspenders: verify actual size after read in case
-    // Content-Length was absent (chunked) or spoofed.
-    if (bodyBuffer !== null) {
+    // Belt-and-suspenders: peek at the actual body size before forwarding.
+    // We need to buffer it here anyway for the size check, then wrap it in
+    // a new Request so proxyForwardToResponse can re-buffer it without a
+    // double-consume error.
+    if (hasBody) {
+      const bodyBuffer = await req.arrayBuffer();
       if (bodyBuffer.byteLength > MAX_PAIRING_PAYLOAD_BYTES) {
         log.warn(
           { bodyLength: bodyBuffer.byteLength },
@@ -67,68 +59,45 @@ export function createPairingProxyHandler(config: GatewayConfig) {
         );
         return Response.json({ error: "Payload too large" }, { status: 413 });
       }
-      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
-    }
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort(
-        new DOMException(
-          "The operation was aborted due to timeout",
-          "TimeoutError",
-        ),
-      );
-    }, TIMEOUT_MS);
-
-    let response: Response;
-    try {
-      response = await fetchImpl(upstream, {
+      // Rebuild the request with the buffered body so the shared helper
+      // can consume it without hitting a "body already used" error.
+      req = new Request(req.url, {
         method: req.method,
-        headers: reqHeaders,
+        headers: req.headers,
         body: bodyBuffer,
-        signal: controller.signal,
       });
-      clearTimeout(timeoutId);
-    } catch (err) {
-      clearTimeout(timeoutId);
-      const duration = Math.round(performance.now() - start);
-      if (err instanceof DOMException && err.name === "TimeoutError") {
-        log.error(
-          { path: upstreamPath, duration },
-          "Pairing proxy upstream timed out",
-        );
-        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
-      }
-      log.error(
-        { err, path: upstreamPath, duration },
-        "Pairing proxy upstream connection failed",
-      );
-      return Response.json({ error: "Bad Gateway" }, { status: 502 });
     }
 
-    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const start = performance.now();
+    const response = await proxyForwardToResponse(req, {
+      baseUrl: config.assistantRuntimeBaseUrl,
+      path: upstreamPath,
+      search: upstreamSearch || undefined,
+      serviceToken: mintServiceToken(),
+      timeoutMs: TIMEOUT_MS,
+      fetchImpl,
+    });
     const duration = Math.round(performance.now() - start);
 
-    if (response.status >= 400) {
-      const body = await response.text();
+    if (response.status >= 500) {
+      log.error(
+        { path: upstreamPath, status: response.status, duration },
+        "Pairing proxy upstream error",
+      );
+    } else if (response.status >= 400) {
       log.warn(
         { path: upstreamPath, status: response.status, duration },
         "Pairing proxy upstream error",
       );
-      return new Response(body, {
-        status: response.status,
-        headers: resHeaders,
-      });
+    } else {
+      log.info(
+        { path: upstreamPath, status: response.status, duration },
+        "Pairing proxy completed",
+      );
     }
 
-    log.info(
-      { path: upstreamPath, status: response.status, duration },
-      "Pairing proxy completed",
-    );
-    return new Response(response.body, {
-      status: response.status,
-      headers: resHeaders,
-    });
+    return response;
   }
 
   return {

--- a/gateway/src/http/routes/runtime-health-proxy.ts
+++ b/gateway/src/http/routes/runtime-health-proxy.ts
@@ -5,80 +5,45 @@
  * proxy is disabled.
  */
 
+import { proxyForwardToResponse } from "@vellumai/assistant-client";
+
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
-import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("runtime-health-proxy");
 
 export function createRuntimeHealthProxyHandler(config: GatewayConfig) {
   async function handleRuntimeHealth(req: Request): Promise<Response> {
     const start = performance.now();
-    const upstream = `${config.assistantRuntimeBaseUrl}/v1/health`;
-
-    const reqHeaders = stripHopByHop(new Headers(req.headers));
-    reqHeaders.delete("host");
-    reqHeaders.delete("authorization");
-
-    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort(
-        new DOMException(
-          "The operation was aborted due to timeout",
-          "TimeoutError",
-        ),
-      );
-    }, config.runtimeTimeoutMs);
-
-    let response: Response;
-    try {
-      response = await fetchImpl(upstream, {
-        method: "GET",
-        headers: reqHeaders,
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-    } catch (err) {
-      clearTimeout(timeoutId);
-      const duration = Math.round(performance.now() - start);
-      if (err instanceof DOMException && err.name === "TimeoutError") {
-        log.error({ duration }, "Runtime health proxy upstream timed out");
-        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
-      }
-      log.error(
-        { err, duration },
-        "Runtime health proxy upstream connection failed",
-      );
-      return Response.json({ error: "Bad Gateway" }, { status: 502 });
-    }
-
-    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const response = await proxyForwardToResponse(req, {
+      baseUrl: config.assistantRuntimeBaseUrl,
+      path: "/v1/health",
+      serviceToken: mintServiceToken(),
+      timeoutMs: config.runtimeTimeoutMs,
+      fetchImpl,
+    });
     const duration = Math.round(performance.now() - start);
 
-    if (response.status >= 400) {
-      const body = await response.text();
+    if (response.status >= 500) {
+      log.error(
+        { status: response.status, duration },
+        "Runtime health proxy upstream error",
+      );
+    } else if (response.status >= 400) {
       log.warn(
         { status: response.status, duration },
         "Runtime health proxy upstream error",
       );
-      return new Response(body, {
-        status: response.status,
-        headers: resHeaders,
-      });
+    } else {
+      log.info(
+        { status: response.status, duration },
+        "Runtime health proxy completed",
+      );
     }
 
-    log.info(
-      { status: response.status, duration },
-      "Runtime health proxy completed",
-    );
-    return new Response(response.body, {
-      status: response.status,
-      headers: resHeaders,
-    });
+    return response;
   }
 
   return { handleRuntimeHealth };

--- a/gateway/src/http/routes/slack-control-plane-proxy.ts
+++ b/gateway/src/http/routes/slack-control-plane-proxy.ts
@@ -5,11 +5,12 @@
  * disabled, so skills and clients can use gateway URLs exclusively.
  */
 
+import { proxyForwardToResponse } from "@vellumai/assistant-client";
+
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
-import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("slack-control-plane-proxy");
 
@@ -28,80 +29,35 @@ export function createSlackControlPlaneProxyHandler(config: GatewayConfig) {
     options?: { timeoutMs?: number },
   ): Promise<Response> {
     const start = performance.now();
-    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
     const timeoutMs = options?.timeoutMs ?? config.runtimeTimeoutMs;
-
-    const reqHeaders = stripHopByHop(new Headers(req.headers));
-    reqHeaders.delete("host");
-    reqHeaders.delete("authorization");
-
-    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
-
-    const hasBody = req.method !== "GET" && req.method !== "HEAD";
-    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
-    if (bodyBuffer !== null) {
-      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
-    }
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort(
-        new DOMException(
-          "The operation was aborted due to timeout",
-          "TimeoutError",
-        ),
-      );
-    }, timeoutMs);
-
-    let response: Response;
-    try {
-      response = await fetchImpl(upstream, {
-        method: req.method,
-        headers: reqHeaders,
-        body: bodyBuffer,
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-    } catch (err) {
-      clearTimeout(timeoutId);
-      const duration = Math.round(performance.now() - start);
-      if (err instanceof DOMException && err.name === "TimeoutError") {
-        log.error(
-          { path: upstreamPath, duration },
-          "Slack control-plane proxy upstream timed out",
-        );
-        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
-      }
-      log.error(
-        { err, path: upstreamPath, duration },
-        "Slack control-plane proxy upstream connection failed",
-      );
-      return Response.json({ error: "Bad Gateway" }, { status: 502 });
-    }
-
-    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const response = await proxyForwardToResponse(req, {
+      baseUrl: config.assistantRuntimeBaseUrl,
+      path: upstreamPath,
+      search: upstreamSearch || undefined,
+      serviceToken: mintServiceToken(),
+      timeoutMs,
+      fetchImpl,
+    });
     const duration = Math.round(performance.now() - start);
 
-    if (response.status >= 400) {
-      const body = await response.text();
+    if (response.status >= 500) {
+      log.error(
+        { path: upstreamPath, status: response.status, duration },
+        "Slack control-plane proxy upstream error",
+      );
+    } else if (response.status >= 400) {
       log.warn(
         { path: upstreamPath, status: response.status, duration },
         "Slack control-plane proxy upstream error",
       );
-      return new Response(body, {
-        status: response.status,
-        headers: resHeaders,
-      });
+    } else {
+      log.info(
+        { path: upstreamPath, status: response.status, duration },
+        "Slack control-plane proxy completed",
+      );
     }
 
-    log.info(
-      { path: upstreamPath, status: response.status, duration },
-      "Slack control-plane proxy completed",
-    );
-    return new Response(response.body, {
-      status: response.status,
-      headers: resHeaders,
-    });
+    return response;
   }
 
   return {


### PR DESCRIPTION
## Summary
- Migrates 7 secondary proxy routes to @vellumai/assistant-client shared helpers
- Preserves verification/pairing special header handling and bootstrap security logic
- Maintains health/readiness availability under runtime-proxy-disabled configs

Part of plan: service-comm-clients.md (PR 5 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
