### PR TITLE
feat(host-transfer): add HTTP endpoints for binary content streaming and result submission

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -188,6 +188,7 @@ import {
 } from "./routes/host-browser-routes.js";
 import { hostCuRouteDefinitions } from "./routes/host-cu-routes.js";
 import { hostFileRouteDefinitions } from "./routes/host-file-routes.js";
+import { hostTransferRouteDefinitions } from "./routes/host-transfer-routes.js";
 import {
   handleHealth,
   handleReadyz,
@@ -2075,6 +2076,7 @@ export class RuntimeHttpServer {
       ...hostBrowserRouteDefinitions(),
       ...hostCuRouteDefinitions(),
       ...hostFileRouteDefinitions(),
+      ...hostTransferRouteDefinitions(),
       ...(this.getSkillContext
         ? skillRouteDefinitions({
             getSkillContext: this.getSkillContext,

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -129,6 +129,21 @@ export function removeByConversation(conversation: Conversation): void {
   }
 }
 
+/**
+ * Return all pending interactions of a given kind.
+ */
+export function getByKind(
+  kind: PendingInteraction["kind"],
+): Array<{ requestId: string } & PendingInteraction> {
+  const results: Array<{ requestId: string } & PendingInteraction> = [];
+  for (const [requestId, interaction] of pending) {
+    if (interaction.kind === kind) {
+      results.push({ requestId, ...interaction });
+    }
+  }
+  return results;
+}
+
 /** Clear all pending interactions. Useful for testing. */
 export function clear(): void {
   pending.clear();

--- a/assistant/src/runtime/routes/host-transfer-routes.ts
+++ b/assistant/src/runtime/routes/host-transfer-routes.ts
@@ -1,0 +1,197 @@
+/**
+ * Route handlers for host file transfer content streaming and result submission.
+ *
+ * - GET  /v1/transfers/:transferId/content — serve file bytes for to_host transfers
+ * - PUT  /v1/transfers/:transferId/content — receive file bytes for to_sandbox transfers
+ * - POST /v1/host-transfer-result          — resolve a pending to_host transfer
+ */
+import { z } from "zod";
+
+import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
+import type { AuthContext } from "../auth/types.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+import * as pendingInteractions from "../pending-interactions.js";
+
+/**
+ * Find the HostTransferProxy that owns a given transferId by scanning
+ * all pending host_transfer interactions.
+ */
+function findProxyByTransferId(transferId: string) {
+  const interactions = pendingInteractions.getByKind("host_transfer");
+  for (const interaction of interactions) {
+    const proxy = interaction.conversation?.getHostTransferProxy();
+    if (proxy?.hasPendingTransfer(transferId)) {
+      return proxy;
+    }
+  }
+  return null;
+}
+
+/**
+ * GET /v1/transfers/:transferId/content — serve raw file bytes for a
+ * to_host transfer. The client downloads these bytes and writes them
+ * to the host filesystem.
+ */
+export function handleTransferContentGet(
+  transferId: string,
+  authContext: AuthContext,
+): Response {
+  const authError = requireBoundGuardian(authContext);
+  if (authError) return authError;
+
+  const proxy = findProxyByTransferId(transferId);
+  if (!proxy) {
+    return httpError("NOT_FOUND", "Unknown or consumed transfer", 404);
+  }
+
+  const content = proxy.getTransferContent(transferId);
+  if (!content) {
+    return httpError("NOT_FOUND", "Unknown or consumed transfer", 404);
+  }
+
+  return new Response(new Uint8Array(content.buffer), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/octet-stream",
+      "Content-Length": content.sizeBytes.toString(),
+      "X-Transfer-SHA256": content.sha256,
+    },
+  });
+}
+
+/**
+ * PUT /v1/transfers/:transferId/content — receive raw file bytes for a
+ * to_sandbox transfer. Verifies SHA-256 integrity and writes to the
+ * sandbox destination path.
+ */
+export async function handleTransferContentPut(
+  transferId: string,
+  req: Request,
+  authContext: AuthContext,
+): Promise<Response> {
+  const authError = requireBoundGuardian(authContext);
+  if (authError) return authError;
+
+  const proxy = findProxyByTransferId(transferId);
+  if (!proxy) {
+    return httpError("NOT_FOUND", "Unknown or consumed transfer", 404);
+  }
+
+  const data = Buffer.from(await req.arrayBuffer());
+  const sha256 = req.headers.get("X-Transfer-SHA256") ?? "";
+
+  const result = await proxy.receiveTransferContent(transferId, data, sha256);
+  if (!result.accepted) {
+    return httpError(
+      "BAD_REQUEST",
+      result.error ?? "Transfer content rejected",
+      400,
+    );
+  }
+
+  return Response.json({ accepted: true });
+}
+
+/**
+ * POST /v1/host-transfer-result — resolve a pending to_host transfer
+ * after the client has downloaded and written the file.
+ */
+export async function handleTransferResult(
+  req: Request,
+  authContext: AuthContext,
+): Promise<Response> {
+  const authError = requireBoundGuardian(authContext);
+  if (authError) return authError;
+
+  const body = (await req.json()) as {
+    requestId?: string;
+    isError?: boolean;
+    bytesWritten?: number;
+    errorMessage?: string;
+  };
+
+  const { requestId } = body;
+
+  if (!requestId || typeof requestId !== "string") {
+    return httpError("BAD_REQUEST", "requestId is required", 400);
+  }
+
+  const peeked = pendingInteractions.get(requestId);
+  if (!peeked) {
+    return httpError(
+      "NOT_FOUND",
+      "No pending interaction found for this requestId",
+      404,
+    );
+  }
+
+  if (peeked.kind !== "host_transfer") {
+    return httpError(
+      "CONFLICT",
+      `Pending interaction is of kind "${peeked.kind}", expected "host_transfer"`,
+      409,
+    );
+  }
+
+  // Validation passed — consume the pending interaction.
+  const interaction = pendingInteractions.resolve(requestId)!;
+
+  interaction.conversation!.resolveHostTransfer(requestId, {
+    isError: body.isError ?? false,
+    bytesWritten: body.bytesWritten,
+    errorMessage: body.errorMessage,
+  });
+
+  return Response.json({ accepted: true });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function hostTransferRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "transfers/:transferId/content",
+      method: "GET",
+      policyKey: "transfers/content",
+      summary: "Get transfer content",
+      description:
+        "Serve raw file bytes for a to_host transfer. Single-use: returns 404 after first consumption.",
+      tags: ["host-transfer"],
+      handler: ({ params, authContext }) =>
+        handleTransferContentGet(params.transferId, authContext),
+    },
+    {
+      endpoint: "transfers/:transferId/content",
+      method: "PUT",
+      policyKey: "transfers/content",
+      summary: "Put transfer content",
+      description:
+        "Receive raw file bytes for a to_sandbox transfer. Verifies SHA-256 integrity via the X-Transfer-SHA256 header.",
+      tags: ["host-transfer"],
+      handler: ({ req, params, authContext }) =>
+        handleTransferContentPut(params.transferId, req, authContext),
+    },
+    {
+      endpoint: "host-transfer-result",
+      method: "POST",
+      summary: "Submit host transfer result",
+      description:
+        "Resolve a pending to_host transfer after the client has downloaded and written the file.",
+      tags: ["host-transfer"],
+      requestBody: z.object({
+        requestId: z.string().describe("Pending transfer request ID"),
+        isError: z.boolean().optional(),
+        bytesWritten: z.number().optional(),
+        errorMessage: z.string().optional(),
+      }),
+      responseBody: z.object({
+        accepted: z.boolean(),
+      }),
+      handler: async ({ req, authContext }) =>
+        handleTransferResult(req, authContext),
+    },
+  ];
+}

--- a/assistant/src/runtime/routes/host-transfer-routes.ts
+++ b/assistant/src/runtime/routes/host-transfer-routes.ts
@@ -15,14 +15,16 @@ import * as pendingInteractions from "../pending-interactions.js";
 
 /**
  * Find the HostTransferProxy that owns a given transferId by scanning
- * all pending host_transfer interactions.
+ * all pending host_transfer interactions. Returns the proxy and the
+ * interaction entry (with its requestId) so callers can resolve the
+ * pending interaction when appropriate.
  */
 function findProxyByTransferId(transferId: string) {
   const interactions = pendingInteractions.getByKind("host_transfer");
   for (const interaction of interactions) {
     const proxy = interaction.conversation?.getHostTransferProxy();
     if (proxy?.hasPendingTransfer(transferId)) {
-      return proxy;
+      return { proxy, interaction };
     }
   }
   return null;
@@ -40,17 +42,17 @@ export function handleTransferContentGet(
   const authError = requireBoundGuardian(authContext);
   if (authError) return authError;
 
-  const proxy = findProxyByTransferId(transferId);
-  if (!proxy) {
+  const match = findProxyByTransferId(transferId);
+  if (!match) {
     return httpError("NOT_FOUND", "Unknown or consumed transfer", 404);
   }
 
-  const content = proxy.getTransferContent(transferId);
+  const content = match.proxy.getTransferContent(transferId);
   if (!content) {
     return httpError("NOT_FOUND", "Unknown or consumed transfer", 404);
   }
 
-  return new Response(new Uint8Array(content.buffer), {
+  return new Response(content.buffer, {
     status: 200,
     headers: {
       "Content-Type": "application/octet-stream",
@@ -73,15 +75,19 @@ export async function handleTransferContentPut(
   const authError = requireBoundGuardian(authContext);
   if (authError) return authError;
 
-  const proxy = findProxyByTransferId(transferId);
-  if (!proxy) {
+  const match = findProxyByTransferId(transferId);
+  if (!match) {
     return httpError("NOT_FOUND", "Unknown or consumed transfer", 404);
   }
 
   const data = Buffer.from(await req.arrayBuffer());
   const sha256 = req.headers.get("X-Transfer-SHA256") ?? "";
 
-  const result = await proxy.receiveTransferContent(transferId, data, sha256);
+  const result = await match.proxy.receiveTransferContent(
+    transferId,
+    data,
+    sha256,
+  );
   if (!result.accepted) {
     return httpError(
       "BAD_REQUEST",
@@ -89,6 +95,12 @@ export async function handleTransferContentPut(
       400,
     );
   }
+
+  // For to_sandbox transfers there is no subsequent /v1/host-transfer-result
+  // callback — the proxy already resolved its internal Promise inside
+  // receiveTransferContent(). Clean up the runtime-level pending interaction
+  // entry so it doesn't leak.
+  pendingInteractions.resolve(match.interaction.requestId);
 
   return Response.json({ accepted: true });
 }


### PR DESCRIPTION
## Summary
- Add GET/PUT /v1/transfers/:transferId/content for binary file streaming
- Add POST /v1/host-transfer-result for to_host result callbacks
- Add getByKind() utility to pending-interactions for proxy lookup
- All routes require bound guardian auth, single-use transferIds return 404

Part of plan: host-file-transfer.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
