### PR TITLE
refactor(assistant): migrate gateway IPC reads (feature flags, thresholds, contacts) to @vellumai/gateway-client

### DIFF
--- a/assistant/src/__tests__/mock-gateway-ipc.ts
+++ b/assistant/src/__tests__/mock-gateway-ipc.ts
@@ -1,5 +1,6 @@
 /**
- * Global test utility for mocking gateway IPC calls via `node:net`.
+ * Global test utility for mocking gateway IPC calls via
+ * `@vellumai/gateway-client/ipc-client`.
  *
  * Usage:
  *   import { mockGatewayIpc, resetMockGatewayIpc } from "../__tests__/mock-gateway-ipc.js";
@@ -23,10 +24,10 @@
  * a real gateway socket. Call `mockGatewayIpc()` to configure specific
  * responses when the test cares about the IPC result.
  *
- * Mocks `node:net` at the socket level, but ONLY intercepts connections to
- * `gateway.sock` paths. All other `node:net` exports and non-gateway
- * `connect()` calls pass through to the real implementation so that proxy /
- * tunnel tests continue to work.
+ * Mocks `@vellumai/gateway-client/ipc-client` at the package level so the
+ * assistant's thin wrapper in `ipc/gateway-client.ts` (which delegates to
+ * the package) gets the fake implementation. Non-gateway IPC paths (e.g.
+ * CLI IPC) are unaffected since they don't import from the package.
  */
 
 import { EventEmitter } from "node:events";
@@ -39,35 +40,26 @@ import { mock } from "bun:test";
 /** IPC result the fake gateway will return (keyed by method name). */
 let ipcResults: Record<string, unknown> = {};
 
-/** Whether the fake socket should simulate a connection error. */
+/** Whether the fake ipcCall should simulate a connection error. */
 let simulateError = false;
 
-/** Error code to use when simulating an error. */
-let simulateErrorCode = "ENOENT";
-
 // ---------------------------------------------------------------------------
-// FakeSocket — simulates the gateway IPC protocol
+// FakePersistentIpcClient — mirrors PersistentIpcClient API
 // ---------------------------------------------------------------------------
 
-class FakeSocket extends EventEmitter {
-  unref() {
-    /* no-op */
-  }
-  destroy() {
-    /* no-op */
-  }
-  write(data: string) {
-    try {
-      const req = JSON.parse(data.trim());
-      const result =
-        req.method in ipcResults ? ipcResults[req.method] : undefined;
-      const response = JSON.stringify({ id: req.id, result });
-      queueMicrotask(() => {
-        this.emit("data", Buffer.from(response + "\n"));
-      });
-    } catch {
-      // Malformed request — ignore
+class FakePersistentIpcClient extends EventEmitter {
+  async call(
+    method: string,
+    _params?: Record<string, unknown>,
+  ): Promise<unknown> {
+    if (simulateError) {
+      throw new Error("Mock IPC socket error");
     }
+    return method in ipcResults ? ipcResults[method] : undefined;
+  }
+
+  destroy(): void {
+    /* no-op */
   }
 }
 
@@ -76,39 +68,19 @@ class FakeSocket extends EventEmitter {
 // ---------------------------------------------------------------------------
 
 export function installGatewayIpcMock(): void {
-  // Snapshot the real node:net exports BEFORE mock.module replaces them.
-  // require() returns the current (real) module synchronously; after
-  // mock.module() the namespace is replaced for all future importers
-  // (like gateway-client.ts), but our captured references stay real.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports -- require() is intentional: we need a synchronous snapshot of the real module before mock.module() replaces it
-  const realNet = require("node:net") as typeof import("node:net");
-  const realConnect = realNet.connect;
-
-  mock.module("node:net", () => ({
-    ...realNet,
-    connect(...args: unknown[]) {
-      // Only intercept Unix domain socket connections to gateway.sock.
-      // Everything else (TCP ports, other Unix sockets) passes through
-      // to the real node:net so proxy / tunnel tests keep working.
-      if (
-        typeof args[0] === "string" &&
-        (args[0] as string).endsWith("gateway.sock")
-      ) {
-        const socket = new FakeSocket();
-        queueMicrotask(() => {
-          if (simulateError) {
-            const err = new Error(simulateErrorCode) as NodeJS.ErrnoException;
-            err.code = simulateErrorCode;
-            socket.emit("error", err);
-            socket.emit("close");
-          } else {
-            socket.emit("connect");
-          }
-        });
-        return socket;
+  mock.module("@vellumai/gateway-client/ipc-client", () => ({
+    ipcCall: async (
+      _socketPath: string,
+      method: string,
+      _params?: Record<string, unknown>,
+    ): Promise<unknown> => {
+      if (simulateError) {
+        // Real ipcCall returns undefined on failure — mirror that behavior.
+        return undefined;
       }
-      return realConnect(...(args as Parameters<typeof realConnect>));
+      return method in ipcResults ? ipcResults[method] : undefined;
     },
+    PersistentIpcClient: FakePersistentIpcClient,
   }));
 }
 
@@ -122,8 +94,8 @@ export function installGatewayIpcMock(): void {
  * @param flags — feature flag map returned by `get_feature_flags`. Pass
  *   `null` to skip setting a result (useful when only simulating errors).
  * @param opts.error — simulate a socket connection error
- * @param opts.code — error code (default "ENOENT")
- * @param opts.results — raw method→result map for arbitrary IPC methods
+ * @param opts.code — error code (kept for API compat, unused by package mock)
+ * @param opts.results — raw method->result map for arbitrary IPC methods
  */
 export function mockGatewayIpc(
   flags?: Record<string, boolean> | null,
@@ -137,7 +109,6 @@ export function mockGatewayIpc(
   }
   if (opts?.error) {
     simulateError = true;
-    simulateErrorCode = opts.code ?? "ENOENT";
   }
 }
 
@@ -147,5 +118,4 @@ export function mockGatewayIpc(
 export function resetMockGatewayIpc(): void {
   ipcResults = {};
   simulateError = false;
-  simulateErrorCode = "ENOENT";
 }

--- a/assistant/src/ipc/gateway-client.test.ts
+++ b/assistant/src/ipc/gateway-client.test.ts
@@ -1,250 +1,131 @@
-import { mkdtempSync, realpathSync, rmSync } from "node:fs";
-import { createServer, type Server, type Socket } from "node:net";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  test,
-} from "bun:test";
+/**
+ * Tests for the assistant's gateway IPC wrapper layer.
+ *
+ * Transport-level behavior (NDJSON framing, reconnection, timeout) is
+ * covered by the @vellumai/gateway-client package tests. These tests
+ * verify the assistant-specific wrapper: singleton lifecycle, feature
+ * flag parsing, and socket path resolution.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
 
 import {
-  PersistentIpcClient,
+  mockGatewayIpc,
+  resetMockGatewayIpc,
+} from "../__tests__/mock-gateway-ipc.js";
+import {
+  ipcCall,
+  ipcCallPersistent,
+  ipcGetFeatureFlags,
   resetPersistentClient,
 } from "./gateway-client.js";
 
-// ---------------------------------------------------------------------------
-// Mock gateway Unix socket server
-// ---------------------------------------------------------------------------
-
-let server: Server;
-let socketPath: string;
-let tmpDir: string;
-let serverConnections: Socket[] = [];
-
-/** Handler for incoming IPC requests. Override per-test as needed. */
-let requestHandler: (
-  req: { id: string; method: string; params?: Record<string, unknown> },
-  sock: Socket,
-) => void;
-
-function defaultHandler(
-  req: { id: string; method: string; params?: Record<string, unknown> },
-  sock: Socket,
-): void {
-  sock.write(
-    JSON.stringify({ id: req.id, result: { echo: req.method } }) + "\n",
-  );
-}
-
-beforeAll(async () => {
-  tmpDir = realpathSync(mkdtempSync(join(tmpdir(), "ipc-test-")));
-  socketPath = join(tmpDir, "persistent-ipc-test.sock");
-  requestHandler = defaultHandler;
-
-  await new Promise<void>((resolve) => {
-    server = createServer((sock) => {
-      serverConnections.push(sock);
-      let buffer = "";
-      sock.on("data", (chunk) => {
-        buffer += chunk.toString();
-        let idx: number;
-        while ((idx = buffer.indexOf("\n")) !== -1) {
-          const line = buffer.slice(0, idx).trim();
-          buffer = buffer.slice(idx + 1);
-          if (!line) continue;
-          try {
-            const req = JSON.parse(line);
-            requestHandler(req, sock);
-          } catch {
-            // ignore malformed
-          }
-        }
-      });
-    });
-    server.listen(socketPath, resolve);
-  });
-});
-
 afterEach(() => {
-  requestHandler = defaultHandler;
   resetPersistentClient();
-});
-
-afterAll(() => {
-  for (const conn of serverConnections) {
-    conn.destroy();
-  }
-  serverConnections = [];
-  server.close();
-  try {
-    rmSync(tmpDir, { recursive: true, force: true });
-  } catch {
-    /* best-effort */
-  }
+  resetMockGatewayIpc();
 });
 
 // ---------------------------------------------------------------------------
-// Tests
+// ipcCall wrapper
 // ---------------------------------------------------------------------------
 
-describe("PersistentIpcClient", () => {
-  test("connects and sends correctly formatted JSON", async () => {
-    const receivedRequests: unknown[] = [];
-    requestHandler = (req, sock) => {
-      receivedRequests.push(req);
-      sock.write(JSON.stringify({ id: req.id, result: "ok" }) + "\n");
-    };
+describe("ipcCall", () => {
+  test("delegates to package ipcCall and returns result", async () => {
+    mockGatewayIpc(null, {
+      results: { test_method: { key: "value" } },
+    });
 
-    const client = new PersistentIpcClient(socketPath);
-    try {
-      const result = await client.call("test_method", { key: "value" });
-
-      expect(result).toBe("ok");
-      expect(receivedRequests).toHaveLength(1);
-
-      const sent = receivedRequests[0] as {
-        id: string;
-        method: string;
-        params: Record<string, unknown>;
-      };
-      expect(sent.id).toBeDefined();
-      expect(sent.method).toBe("test_method");
-      expect(sent.params).toEqual({ key: "value" });
-    } finally {
-      client.destroy();
-    }
+    const result = await ipcCall("test_method");
+    expect(result).toEqual({ key: "value" });
   });
 
-  test("routes responses to the correct pending request by ID", async () => {
-    // Delay responses so multiple requests are in-flight simultaneously.
-    requestHandler = (req, sock) => {
-      setTimeout(() => {
-        sock.write(
-          JSON.stringify({ id: req.id, result: `result-for-${req.method}` }) +
-            "\n",
-        );
-      }, 10);
-    };
+  test("returns undefined when mock simulates error", async () => {
+    mockGatewayIpc(null, { error: true });
 
-    const client = new PersistentIpcClient(socketPath);
-    try {
-      const [r1, r2, r3] = await Promise.all([
-        client.call("method_a"),
-        client.call("method_b"),
-        client.call("method_c"),
-      ]);
-
-      expect(r1).toBe("result-for-method_a");
-      expect(r2).toBe("result-for-method_b");
-      expect(r3).toBe("result-for-method_c");
-    } finally {
-      client.destroy();
-    }
+    const result = await ipcCall("test_method");
+    expect(result).toBeUndefined();
   });
 
-  test("reconnects after socket close", async () => {
-    let callCount = 0;
-    requestHandler = (req, sock) => {
-      callCount++;
-      sock.write(
-        JSON.stringify({ id: req.id, result: `call-${callCount}` }) + "\n",
-      );
-    };
+  test("returns undefined for unconfigured methods", async () => {
+    const result = await ipcCall("unconfigured_method");
+    expect(result).toBeUndefined();
+  });
+});
 
-    const client = new PersistentIpcClient(socketPath);
-    try {
-      // First call — establishes connection.
-      const r1 = await client.call("first");
-      expect(r1).toBe("call-1");
+// ---------------------------------------------------------------------------
+// ipcCallPersistent singleton
+// ---------------------------------------------------------------------------
 
-      // Force-close all server-side connections to simulate a disconnect.
-      for (const conn of serverConnections) {
-        conn.destroy();
-      }
-      serverConnections = [];
+describe("ipcCallPersistent", () => {
+  test("returns result from persistent client", async () => {
+    mockGatewayIpc(null, {
+      results: { persistent_test: "persistent-result" },
+    });
 
-      // Allow the close event to propagate.
-      await new Promise((r) => setTimeout(r, 50));
-
-      // Second call — should reconnect automatically.
-      const r2 = await client.call("second");
-      expect(r2).toBe("call-2");
-    } finally {
-      client.destroy();
-    }
+    const result = await ipcCallPersistent("persistent_test");
+    expect(result).toBe("persistent-result");
   });
 
-  test("rejects pending request on timeout", async () => {
-    // Never respond, so the call should time out.
-    requestHandler = () => {
-      /* silence */
-    };
+  test("throws when mock simulates error", async () => {
+    mockGatewayIpc(null, { error: true });
 
-    // Use a very short timeout so the test doesn't hang.
-    const client = new PersistentIpcClient(socketPath, 100);
-    try {
-      await expect(client.call("slow_method")).rejects.toThrow(/timed out/);
-    } finally {
-      client.destroy();
-    }
+    await expect(ipcCallPersistent("any_method")).rejects.toThrow(
+      /Mock IPC socket error/,
+    );
   });
 
-  test("rejects pending requests when socket errors", async () => {
-    requestHandler = (req, sock) => {
-      // Simulate server-side error by destroying the connection.
-      sock.destroy();
-    };
+  test("resetPersistentClient does not throw when no client exists", () => {
+    // Should be a no-op when called before any ipcCallPersistent.
+    expect(() => resetPersistentClient()).not.toThrow();
+  });
+});
 
-    const client = new PersistentIpcClient(socketPath);
-    try {
-      await expect(client.call("will_error")).rejects.toThrow(/disconnected/);
-    } finally {
-      client.destroy();
-    }
+// ---------------------------------------------------------------------------
+// ipcGetFeatureFlags
+// ---------------------------------------------------------------------------
+
+describe("ipcGetFeatureFlags", () => {
+  test("parses boolean flag values from IPC response", async () => {
+    mockGatewayIpc({ "flag-a": true, "flag-b": false });
+
+    const flags = await ipcGetFeatureFlags();
+    expect(flags).toEqual({ "flag-a": true, "flag-b": false });
   });
 
-  test("rejects with error message from server", async () => {
-    requestHandler = (req, sock) => {
-      sock.write(
-        JSON.stringify({ id: req.id, error: "something went wrong" }) + "\n",
-      );
-    };
+  test("filters non-boolean values from response", async () => {
+    mockGatewayIpc(null, {
+      results: {
+        get_feature_flags: {
+          valid: true,
+          number: 42,
+          string: "yes",
+          nested: { deep: true },
+        },
+      },
+    });
 
-    const client = new PersistentIpcClient(socketPath);
-    try {
-      await expect(client.call("bad_call")).rejects.toThrow(
-        "something went wrong",
-      );
-    } finally {
-      client.destroy();
-    }
+    const flags = await ipcGetFeatureFlags();
+    expect(flags).toEqual({ valid: true });
   });
 
-  test("destroy rejects all pending requests", async () => {
-    requestHandler = () => {
-      /* never respond */
-    };
-
-    const client = new PersistentIpcClient(socketPath, 10_000);
-    const promise = client.call("pending_forever");
-    // Give time for the request to be sent.
-    await new Promise((r) => setTimeout(r, 20));
-    client.destroy();
-
-    await expect(promise).rejects.toThrow(/destroyed/);
+  test("returns empty record when IPC returns undefined", async () => {
+    // No mock configured — ipcCall returns undefined
+    const flags = await ipcGetFeatureFlags();
+    expect(flags).toEqual({});
   });
 
-  test("connection failure rejects the call", async () => {
-    const badPath = join(tmpDir, "nonexistent.sock");
-    const client = new PersistentIpcClient(badPath);
-    try {
-      await expect(client.call("unreachable")).rejects.toThrow();
-    } finally {
-      client.destroy();
-    }
+  test("returns empty record when IPC returns array", async () => {
+    mockGatewayIpc(null, {
+      results: { get_feature_flags: [true, false] },
+    });
+
+    const flags = await ipcGetFeatureFlags();
+    expect(flags).toEqual({});
+  });
+
+  test("returns empty record on error", async () => {
+    mockGatewayIpc(null, { error: true });
+
+    const flags = await ipcGetFeatureFlags();
+    expect(flags).toEqual({});
   });
 });

--- a/assistant/src/ipc/gateway-client.ts
+++ b/assistant/src/ipc/gateway-client.ts
@@ -1,43 +1,33 @@
 /**
  * Assistant-side IPC client for communicating with the gateway.
  *
- * Connects to the gateway's Unix domain socket and provides typed methods
- * for reading gateway-owned data. Protocol: newline-delimited JSON
- * (same as gateway/src/ipc/server.ts).
+ * Thin wrapper over `@vellumai/gateway-client/ipc-client` that resolves
+ * the gateway socket path and injects the assistant logger. All transport
+ * logic lives in the shared package; this module provides the same public
+ * API the rest of the assistant codebase expects.
  *
  * The preferred socket path is `{workspaceDir}/gateway.sock`, with a
  * deterministic fallback for long AF_UNIX paths.
  */
 
-import { connect, type Socket } from "node:net";
+import {
+  ipcCall as packageIpcCall,
+  PersistentIpcClient as PackagePersistentIpcClient,
+} from "@vellumai/gateway-client/ipc-client";
 
 import { getLogger } from "../util/logger.js";
 import { resolveIpcSocketPath } from "./socket-path.js";
 
 const log = getLogger("gateway-ipc-client");
 
-// ---------------------------------------------------------------------------
-// Types (mirror gateway/src/ipc/server.ts protocol)
-// ---------------------------------------------------------------------------
-
-type IpcRequest = {
-  id: string;
-  method: string;
-  params?: Record<string, unknown>;
-};
-
-type IpcResponse = {
-  id: string;
-  result?: unknown;
-  error?: string;
-};
+// Re-export the package's PersistentIpcClient under the same name so
+// existing test imports (`import { PersistentIpcClient } from ...`) and
+// direct instantiations continue to work without changes.
+export { PackagePersistentIpcClient as PersistentIpcClient };
 
 // ---------------------------------------------------------------------------
-// Client
+// One-shot IPC call
 // ---------------------------------------------------------------------------
-
-const DEFAULT_CALL_TIMEOUT_MS = 5_000;
-const CONNECT_TIMEOUT_MS = 3_000;
 
 /**
  * One-shot IPC helper: connect, call a method, disconnect.
@@ -51,306 +41,14 @@ export async function ipcCall(
   params?: Record<string, unknown>,
 ): Promise<unknown> {
   const socketPath = getGatewaySocketPath();
-
-  return new Promise<unknown>((resolve) => {
-    let settled = false;
-    let callTimer: ReturnType<typeof setTimeout> | undefined;
-
-    const finish = (value: unknown) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(connectTimer);
-      if (callTimer) clearTimeout(callTimer);
-      socket.destroy();
-      resolve(value);
-    };
-
-    const connectTimer = setTimeout(() => {
-      log.warn(
-        { method, socketPath, timeoutMs: CONNECT_TIMEOUT_MS },
-        "IPC connect timed out",
-      );
-      finish(undefined);
-    }, CONNECT_TIMEOUT_MS);
-
-    const socket: Socket = connect(socketPath);
-    // Prevent the socket from keeping the process alive (important for
-    // one-shot CLI commands that must exit after the call completes).
-    socket.unref();
-
-    let buffer = "";
-    const reqId = "1";
-
-    socket.on("connect", () => {
-      clearTimeout(connectTimer);
-      const req: IpcRequest = { id: reqId, method, params };
-      socket.write(JSON.stringify(req) + "\n");
-
-      // Call timeout — if the gateway doesn't respond in time, give up.
-      // Keep this timer ref'd (not unref'd) so the process waits for the
-      // response or timeout before exiting — the socket itself is unref'd.
-      callTimer = setTimeout(() => {
-        log.warn(
-          { method, socketPath, timeoutMs: DEFAULT_CALL_TIMEOUT_MS },
-          "IPC call timed out waiting for response",
-        );
-        finish(undefined);
-      }, DEFAULT_CALL_TIMEOUT_MS);
-
-      socket.on("data", (chunk) => {
-        buffer += chunk.toString();
-        let newlineIdx: number;
-        while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
-          const line = buffer.slice(0, newlineIdx).trim();
-          buffer = buffer.slice(newlineIdx + 1);
-          if (!line) continue;
-
-          try {
-            const msg = JSON.parse(line) as IpcResponse;
-            if (msg.id === reqId) {
-              if (msg.error) {
-                log.warn(
-                  { error: msg.error, method },
-                  "IPC call returned error",
-                );
-                finish(undefined);
-              } else {
-                finish(msg.result);
-              }
-              return;
-            }
-          } catch {
-            // Ignore malformed lines
-          }
-        }
-      });
-    });
-
-    socket.on("error", (err) => {
-      log.warn(
-        {
-          err,
-          code: (err as NodeJS.ErrnoException).code,
-          method,
-          socketPath,
-        },
-        "Gateway IPC socket error",
-      );
-      finish(undefined);
-    });
-
-    socket.on("close", () => {
-      if (!settled) {
-        log.warn(
-          { method, socketPath },
-          "Gateway IPC socket closed before response",
-        );
-      }
-      finish(undefined);
-    });
-  });
-}
-
-// ---------------------------------------------------------------------------
-// Persistent IPC client
-// ---------------------------------------------------------------------------
-
-type PendingRequest = {
-  resolve: (value: unknown) => void;
-  reject: (reason: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
-};
-
-/**
- * Maintains a single Unix socket connection to the gateway, with automatic
- * reconnection on failure. Multiplexes requests by ID so many concurrent
- * callers can share one socket.
- *
- * Designed for hot-path calls (e.g. classify_risk) where connecting per call
- * adds unacceptable overhead.
- */
-export class PersistentIpcClient {
-  private socket: Socket | null = null;
-  private pending = new Map<string, PendingRequest>();
-  private nextId = 1;
-  private buffer = "";
-  private connecting: Promise<void> | null = null;
-  private readonly socketPath: string;
-  private readonly callTimeoutMs: number;
-
-  constructor(socketPath: string, callTimeoutMs = DEFAULT_CALL_TIMEOUT_MS) {
-    this.socketPath = socketPath;
-    this.callTimeoutMs = callTimeoutMs;
-  }
-
-  /**
-   * Send an IPC request over the persistent connection.
-   *
-   * Connects on first use. If the socket is closed or errored, the next call
-   * re-establishes the connection automatically.
-   */
-  async call(
-    method: string,
-    params?: Record<string, unknown>,
-  ): Promise<unknown> {
-    await this.ensureConnected();
-
-    const id = String(this.nextId++);
-    const req: IpcRequest = { id, method, params };
-
-    return new Promise<unknown>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        const entry = this.pending.get(id);
-        if (entry) {
-          this.pending.delete(id);
-          entry.reject(
-            new Error(
-              `IPC call "${method}" timed out after ${this.callTimeoutMs}ms`,
-            ),
-          );
-        }
-      }, this.callTimeoutMs);
-      // Don't let the timeout timer keep the process alive.
-      timer.unref();
-
-      this.pending.set(id, { resolve, reject, timer });
-
-      try {
-        this.socket!.write(JSON.stringify(req) + "\n");
-      } catch (err) {
-        this.pending.delete(id);
-        clearTimeout(timer);
-        reject(err instanceof Error ? err : new Error(String(err)));
-      }
-    });
-  }
-
-  /** Explicitly close the connection and reject all pending requests. */
-  destroy(): void {
-    this.rejectAllPending(new Error("PersistentIpcClient destroyed"));
-    if (this.socket) {
-      this.socket.destroy();
-      this.socket = null;
-    }
-    this.connecting = null;
-    this.buffer = "";
-  }
-
-  // -------------------------------------------------------------------------
-  // Internals
-  // -------------------------------------------------------------------------
-
-  private async ensureConnected(): Promise<void> {
-    if (this.socket) return;
-    if (this.connecting) return this.connecting;
-
-    this.connecting = new Promise<void>((resolve, reject) => {
-      const sock: Socket = connect(this.socketPath);
-      sock.unref();
-
-      const connectTimer = setTimeout(() => {
-        sock.destroy();
-        reject(
-          new Error(
-            `IPC persistent connect timed out after ${CONNECT_TIMEOUT_MS}ms`,
-          ),
-        );
-      }, CONNECT_TIMEOUT_MS);
-      connectTimer.unref();
-
-      sock.on("connect", () => {
-        clearTimeout(connectTimer);
-        this.socket = sock;
-        this.buffer = "";
-        this.connecting = null;
-        this.wireDataHandler(sock);
-        resolve();
-      });
-
-      sock.on("error", (err) => {
-        clearTimeout(connectTimer);
-        log.warn(
-          {
-            err,
-            code: (err as NodeJS.ErrnoException).code,
-            socketPath: this.socketPath,
-          },
-          "Persistent IPC socket error",
-        );
-        this.handleDisconnect();
-        reject(err);
-      });
-
-      // If close fires during connect (before "connect" event), reject.
-      sock.on("close", () => {
-        clearTimeout(connectTimer);
-        if (!this.socket) {
-          this.connecting = null;
-          reject(new Error("Socket closed before connect"));
-        }
-      });
-    });
-
-    return this.connecting;
-  }
-
-  private wireDataHandler(sock: Socket): void {
-    sock.on("data", (chunk) => {
-      this.buffer += chunk.toString();
-      let newlineIdx: number;
-      while ((newlineIdx = this.buffer.indexOf("\n")) !== -1) {
-        const line = this.buffer.slice(0, newlineIdx).trim();
-        this.buffer = this.buffer.slice(newlineIdx + 1);
-        if (!line) continue;
-
-        try {
-          const msg = JSON.parse(line) as IpcResponse;
-          const entry = this.pending.get(msg.id);
-          if (entry) {
-            this.pending.delete(msg.id);
-            clearTimeout(entry.timer);
-            if (msg.error) {
-              entry.reject(new Error(msg.error));
-            } else {
-              entry.resolve(msg.result);
-            }
-          }
-        } catch {
-          // Ignore malformed lines
-        }
-      }
-    });
-
-    sock.on("error", () => {
-      this.handleDisconnect();
-    });
-
-    sock.on("close", () => {
-      this.handleDisconnect();
-    });
-  }
-
-  private handleDisconnect(): void {
-    this.rejectAllPending(new Error("IPC socket disconnected"));
-    this.socket = null;
-    this.connecting = null;
-    this.buffer = "";
-  }
-
-  private rejectAllPending(reason: Error): void {
-    for (const [id, entry] of this.pending) {
-      clearTimeout(entry.timer);
-      entry.reject(reason);
-      this.pending.delete(id);
-    }
-  }
+  return packageIpcCall(socketPath, method, params, log);
 }
 
 // ---------------------------------------------------------------------------
 // Singleton persistent client
 // ---------------------------------------------------------------------------
 
-let persistentClient: PersistentIpcClient | null = null;
+let persistentClient: PackagePersistentIpcClient | null = null;
 
 /**
  * Persistent IPC call — singleton wrapper around PersistentIpcClient.
@@ -366,7 +64,11 @@ export async function ipcCallPersistent(
   params?: Record<string, unknown>,
 ): Promise<unknown> {
   if (!persistentClient) {
-    persistentClient = new PersistentIpcClient(getGatewaySocketPath());
+    persistentClient = new PackagePersistentIpcClient(
+      getGatewaySocketPath(),
+      undefined,
+      log,
+    );
   }
   return persistentClient.call(method, params);
 }


### PR DESCRIPTION
## Summary
- Migrates assistant IPC socket implementation to @vellumai/gateway-client/ipc-client
- Preserves method names, failure semantics, and cache/TTL logic
- Updates mocking utilities for clean package-level hooks

Part of plan: service-comm-clients.md (PR 9 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
