### PR TITLE
refactor(gateway): route runtime client transport through @vellumai/assistant-client

### DIFF
--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -27,6 +27,7 @@ const {
   forwardTwilioVoiceWebhook,
   forwardTwilioStatusWebhook,
   forwardTwilioConnectActionWebhook,
+  CircuitBreakerOpenError,
 } = await import("../runtime/client.js");
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
@@ -106,6 +107,20 @@ describe("forwardToRuntime", () => {
     expect(result.assistantMessage?.content).toBe("Hi there!");
   });
 
+  test("builds correct upstream URL via buildUpstreamUrl", async () => {
+    fetchMock = mock(
+      async () => new Response(JSON.stringify(successBody), { status: 200 }),
+    );
+
+    const config = makeConfig({
+      assistantRuntimeBaseUrl: "http://localhost:9999",
+    });
+    await forwardToRuntime(config, payload);
+
+    const calledUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
+    expect(calledUrl).toBe("http://localhost:9999/v1/channels/inbound");
+  });
+
   test("4xx error throws immediately without retry", async () => {
     fetchMock = mock(async () => new Response("Bad request", { status: 400 }));
 
@@ -183,6 +198,87 @@ describe("forwardToRuntime", () => {
     const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
     const headers = calledInit.headers as Record<string, string>;
     expect(headers["Authorization"]).toMatch(/^Bearer ey/);
+  });
+
+  test("passes abort signal from createTimeoutController", async () => {
+    fetchMock = mock(
+      async () => new Response(JSON.stringify(successBody), { status: 200 }),
+    );
+
+    const config = makeConfig({});
+    await forwardToRuntime(config, payload);
+
+    const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
+    expect(calledInit.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("circuit breaker state transitions", () => {
+  afterEach(() => {
+    fetchMock = mock(async () => new Response());
+  });
+
+  test("4xx errors do not trip the circuit breaker", async () => {
+    fetchMock = mock(async () => new Response("Bad request", { status: 400 }));
+    const config = makeConfig({ runtimeMaxRetries: 0 });
+
+    // Fire multiple 4xx errors — should never trip the breaker
+    for (let i = 0; i < 10; i++) {
+      await forwardToRuntime(config, payload).catch(() => {});
+    }
+
+    // Next call should still go through (not throw CircuitBreakerOpenError)
+    fetchMock = mock(
+      async () => new Response(JSON.stringify(successBody), { status: 200 }),
+    );
+    const result = await forwardToRuntime(config, payload);
+    expect(result.accepted).toBe(true);
+  });
+
+  test("consecutive 5xx errors trip the breaker after threshold", async () => {
+    fetchMock = mock(async () => new Response("Server error", { status: 500 }));
+    const config = makeConfig({ runtimeMaxRetries: 0 });
+
+    // Each call that exhausts retries with 5xx increments the failure counter.
+    // With runtimeMaxRetries=0, each call = 1 failure + cbOnFailure.
+    // Threshold is 5, so after 5 failed calls the breaker opens.
+    for (let i = 0; i < 5; i++) {
+      await forwardToRuntime(config, payload).catch(() => {});
+    }
+
+    // The 6th call should throw CircuitBreakerOpenError
+    await expect(forwardToRuntime(config, payload)).rejects.toBeInstanceOf(
+      CircuitBreakerOpenError,
+    );
+  });
+
+  test("successful call after failures resets the breaker", async () => {
+    const config = makeConfig({ runtimeMaxRetries: 0 });
+
+    // Accumulate some failures (but below threshold)
+    fetchMock = mock(async () => new Response("Server error", { status: 500 }));
+    for (let i = 0; i < 3; i++) {
+      await forwardToRuntime(config, payload).catch(() => {});
+    }
+
+    // Successful call resets the counter
+    fetchMock = mock(
+      async () => new Response(JSON.stringify(successBody), { status: 200 }),
+    );
+    await forwardToRuntime(config, payload);
+
+    // Now we should be able to tolerate another round of failures without tripping
+    fetchMock = mock(async () => new Response("Server error", { status: 500 }));
+    for (let i = 0; i < 4; i++) {
+      await forwardToRuntime(config, payload).catch(() => {});
+    }
+
+    // Still below threshold (4 < 5), so the next call should proceed
+    fetchMock = mock(
+      async () => new Response(JSON.stringify(successBody), { status: 200 }),
+    );
+    const result = await forwardToRuntime(config, payload);
+    expect(result.accepted).toBe(true);
   });
 });
 

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -1,3 +1,8 @@
+import {
+  buildUpstreamUrl,
+  createTimeoutController,
+} from "@vellumai/assistant-client";
+
 import type { ChannelId, InterfaceId } from "../channels/types.js";
 import { mintIngressToken, mintServiceToken } from "../auth/token-exchange.js";
 import type { GatewayConfig } from "../config.js";
@@ -90,29 +95,43 @@ function cbOnFailure(): void {
   }
 }
 
+// ── Transport helpers ────────────────────────────────────────────────
+
 /**
- * Build common headers for runtime requests using JWT auth.
- *
- * Mints a short-lived token (aud=vellum-daemon) per-request. The token
- * itself proves gateway origin — only the gateway holds the signing key
- * needed to mint daemon-audience tokens. No separate origin header needed.
+ * Build headers for ingress requests (webhook-originated traffic).
+ * Mints a short-lived ingress token per-request.
  */
-function runtimeIngressHeaders(
-  config: GatewayConfig,
+function ingressHeaders(
   extra?: Record<string, string>,
 ): Record<string, string> {
-  const headers: Record<string, string> = { ...extra };
-  headers["Authorization"] = `Bearer ${mintIngressToken()}`;
-  return headers;
+  return { ...extra, Authorization: `Bearer ${mintIngressToken()}` };
 }
 
-function runtimeServiceHeaders(
-  config: GatewayConfig,
+/**
+ * Build headers for service requests (gateway-originated traffic).
+ * Mints a short-lived service token per-request.
+ */
+function serviceHeaders(
   extra?: Record<string, string>,
 ): Record<string, string> {
-  const headers: Record<string, string> = { ...extra };
-  headers["Authorization"] = `Bearer ${mintServiceToken()}`;
-  return headers;
+  return { ...extra, Authorization: `Bearer ${mintServiceToken()}` };
+}
+
+async function timedFetch(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const { controller, clear } = createTimeoutController(timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      ...init,
+      signal: controller.signal,
+    });
+    return response;
+  } finally {
+    clear();
+  }
 }
 
 /**
@@ -200,7 +219,10 @@ export async function forwardToRuntime(
 ): Promise<RuntimeInboundResponse> {
   const isHalfOpenProbe = cbBeforeRequest();
 
-  const url = `${config.assistantRuntimeBaseUrl}/v1/channels/inbound`;
+  const url = buildUpstreamUrl(
+    config.assistantRuntimeBaseUrl,
+    "/v1/channels/inbound",
+  );
 
   const extraHeaders: Record<string, string> = {
     "Content-Type": "application/json",
@@ -223,12 +245,15 @@ export async function forwardToRuntime(
     }
 
     try {
-      const response = await fetchImpl(url, {
-        method: "POST",
-        headers: runtimeIngressHeaders(config, extraHeaders),
-        body: JSON.stringify(payload),
-        signal: AbortSignal.timeout(config.runtimeTimeoutMs),
-      });
+      const response = await timedFetch(
+        url,
+        {
+          method: "POST",
+          headers: ingressHeaders(extraHeaders),
+          body: JSON.stringify(payload),
+        },
+        config.runtimeTimeoutMs,
+      );
 
       if (response.status >= 400 && response.status < 500) {
         const body = await response.text();
@@ -281,18 +306,22 @@ export async function resetConversation(
 ): Promise<void> {
   cbBeforeRequest();
 
-  const url = `${config.assistantRuntimeBaseUrl}/v1/channels/conversation`;
+  const url = buildUpstreamUrl(
+    config.assistantRuntimeBaseUrl,
+    "/v1/channels/conversation",
+  );
 
   let response: Response;
   try {
-    response = await fetchImpl(url, {
-      method: "DELETE",
-      headers: runtimeServiceHeaders(config, {
-        "Content-Type": "application/json",
-      }),
-      body: JSON.stringify({ sourceChannel, conversationExternalId }),
-      signal: AbortSignal.timeout(config.runtimeTimeoutMs),
-    });
+    response = await timedFetch(
+      url,
+      {
+        method: "DELETE",
+        headers: serviceHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ sourceChannel, conversationExternalId }),
+      },
+      config.runtimeTimeoutMs,
+    );
   } catch (err) {
     cbOnFailure();
     throw err;
@@ -327,15 +356,19 @@ async function fetchAttachmentContentRaw(
   config: GatewayConfig,
   attachmentId: string,
 ): Promise<Buffer> {
-  const url = `${
-    config.assistantRuntimeBaseUrl
-  }/v1/attachments/${encodeURIComponent(attachmentId)}/content`;
+  const url = buildUpstreamUrl(
+    config.assistantRuntimeBaseUrl,
+    `/v1/attachments/${encodeURIComponent(attachmentId)}/content`,
+  );
 
-  const response = await fetchImpl(url, {
-    method: "GET",
-    headers: runtimeServiceHeaders(config),
-    signal: AbortSignal.timeout(config.runtimeTimeoutMs),
-  });
+  const response = await timedFetch(
+    url,
+    {
+      method: "GET",
+      headers: serviceHeaders(),
+    },
+    config.runtimeTimeoutMs,
+  );
 
   if (!response.ok) {
     const body = await response.text();
@@ -370,17 +403,21 @@ export async function downloadAttachment(
 ): Promise<HydratedAttachmentPayload> {
   cbBeforeRequest();
 
-  const url = `${
-    config.assistantRuntimeBaseUrl
-  }/v1/attachments/${encodeURIComponent(attachmentId)}`;
+  const url = buildUpstreamUrl(
+    config.assistantRuntimeBaseUrl,
+    `/v1/attachments/${encodeURIComponent(attachmentId)}`,
+  );
 
   let response: Response;
   try {
-    response = await fetchImpl(url, {
-      method: "GET",
-      headers: runtimeServiceHeaders(config),
-      signal: AbortSignal.timeout(config.runtimeTimeoutMs),
-    });
+    response = await timedFetch(
+      url,
+      {
+        method: "GET",
+        headers: serviceHeaders(),
+      },
+      config.runtimeTimeoutMs,
+    );
   } catch (err) {
     cbOnFailure();
     throw err;
@@ -445,18 +482,22 @@ export async function forwardTwilioVoiceWebhook(
 ): Promise<TwilioForwardResponse> {
   cbBeforeRequest();
 
-  const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/voice-webhook`;
+  const url = buildUpstreamUrl(
+    config.assistantRuntimeBaseUrl,
+    "/v1/internal/twilio/voice-webhook",
+  );
 
   let response: Response;
   try {
-    response = await fetchImpl(url, {
-      method: "POST",
-      headers: runtimeServiceHeaders(config, {
-        "Content-Type": "application/json",
-      }),
-      body: JSON.stringify({ params, originalUrl }),
-      signal: AbortSignal.timeout(config.runtimeTimeoutMs),
-    });
+    response = await timedFetch(
+      url,
+      {
+        method: "POST",
+        headers: serviceHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ params, originalUrl }),
+      },
+      config.runtimeTimeoutMs,
+    );
   } catch (err) {
     cbOnFailure();
     throw err;
@@ -481,18 +522,22 @@ export async function forwardTwilioStatusWebhook(
 ): Promise<TwilioForwardResponse> {
   cbBeforeRequest();
 
-  const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/status`;
+  const url = buildUpstreamUrl(
+    config.assistantRuntimeBaseUrl,
+    "/v1/internal/twilio/status",
+  );
 
   let response: Response;
   try {
-    response = await fetchImpl(url, {
-      method: "POST",
-      headers: runtimeServiceHeaders(config, {
-        "Content-Type": "application/json",
-      }),
-      body: JSON.stringify({ params }),
-      signal: AbortSignal.timeout(config.runtimeTimeoutMs),
-    });
+    response = await timedFetch(
+      url,
+      {
+        method: "POST",
+        headers: serviceHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ params }),
+      },
+      config.runtimeTimeoutMs,
+    );
   } catch (err) {
     cbOnFailure();
     throw err;
@@ -517,18 +562,22 @@ export async function forwardTwilioConnectActionWebhook(
 ): Promise<TwilioForwardResponse> {
   cbBeforeRequest();
 
-  const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/connect-action`;
+  const url = buildUpstreamUrl(
+    config.assistantRuntimeBaseUrl,
+    "/v1/internal/twilio/connect-action",
+  );
 
   let response: Response;
   try {
-    response = await fetchImpl(url, {
-      method: "POST",
-      headers: runtimeServiceHeaders(config, {
-        "Content-Type": "application/json",
-      }),
-      body: JSON.stringify({ params }),
-      signal: AbortSignal.timeout(config.runtimeTimeoutMs),
-    });
+    response = await timedFetch(
+      url,
+      {
+        method: "POST",
+        headers: serviceHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ params }),
+      },
+      config.runtimeTimeoutMs,
+    );
   } catch (err) {
     cbOnFailure();
     throw err;
@@ -558,18 +607,22 @@ export async function uploadAttachment(
   const isProbe = cbBeforeRequest();
   const recordOutcome = !skipCb || isProbe;
 
-  const url = `${config.assistantRuntimeBaseUrl}/v1/attachments`;
+  const url = buildUpstreamUrl(
+    config.assistantRuntimeBaseUrl,
+    "/v1/attachments",
+  );
 
   let response: Response;
   try {
-    response = await fetchImpl(url, {
-      method: "POST",
-      headers: runtimeServiceHeaders(config, {
-        "Content-Type": "application/json",
-      }),
-      body: JSON.stringify(input),
-      signal: AbortSignal.timeout(config.runtimeTimeoutMs),
-    });
+    response = await timedFetch(
+      url,
+      {
+        method: "POST",
+        headers: serviceHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify(input),
+      },
+      config.runtimeTimeoutMs,
+    );
   } catch (err) {
     if (recordOutcome) cbOnFailure();
     throw err;
@@ -614,18 +667,22 @@ export async function forwardOAuthCallback(
 ): Promise<OAuthCallbackResponse> {
   cbBeforeRequest();
 
-  const url = `${config.assistantRuntimeBaseUrl}/v1/internal/oauth/callback`;
+  const url = buildUpstreamUrl(
+    config.assistantRuntimeBaseUrl,
+    "/v1/internal/oauth/callback",
+  );
 
   let response: Response;
   try {
-    response = await fetchImpl(url, {
-      method: "POST",
-      headers: runtimeServiceHeaders(config, {
-        "Content-Type": "application/json",
-      }),
-      body: JSON.stringify({ state, code, error }),
-      signal: AbortSignal.timeout(config.runtimeTimeoutMs),
-    });
+    response = await timedFetch(
+      url,
+      {
+        method: "POST",
+        headers: serviceHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ state, code, error }),
+      },
+      config.runtimeTimeoutMs,
+    );
   } catch (err) {
     cbOnFailure();
     throw err;


### PR DESCRIPTION
## Summary
- Refactors gateway runtime client to delegate transport/auth/timeout to @vellumai/assistant-client
- Preserves existing API surface and circuit-breaker/retry semantics
- Updates tests for unchanged behavior

Part of plan: service-comm-clients.md (PR 3 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
