### PR TITLE
feat(host-transfer): implement Swift executor for pull/push file transfer with SHA-256 verification

### DIFF
--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -350,12 +350,24 @@ public enum GatewayHTTPClient {
     /// - Parameters:
     ///   - path: Path segment after `/v1/`.
     ///   - body: Optional HTTP body data.
+    ///   - params: Optional query parameters. Keys and values are percent-encoded
+    ///     using a restricted character set that escapes `&`, `=`, `+`, and `#`.
+    ///   - contentType: Optional Content-Type header value. Overrides the default `application/json`.
+    ///   - extraHeaders: Optional additional headers to include in the request.
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func put(path: String, body: Data? = nil, timeout: TimeInterval = 30) async throws -> Response {
-        return try await executeWithRetry(path: path, method: "PUT", timeout: timeout) { request in
+    public static func put(path: String, body: Data? = nil, params: [String: String]? = nil, contentType: String? = nil, extraHeaders: [String: String]? = nil, timeout: TimeInterval = 30) async throws -> Response {
+        return try await executeWithRetry(path: path, params: params, method: "PUT", timeout: timeout) { request in
             request.httpBody = body
+            if let contentType {
+                request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+            }
+            if let extraHeaders {
+                for (key, value) in extraHeaders {
+                    request.setValue(value, forHTTPHeaderField: key)
+                }
+            }
         }
     }
 

--- a/clients/shared/Network/HostProxyClient.swift
+++ b/clients/shared/Network/HostProxyClient.swift
@@ -135,14 +135,12 @@ public struct HostProxyClient: HostProxyClientProtocol {
     public func pushTransferContent(transferId: String, data: Data, sha256: String, sourcePath: String) async throws -> Bool {
         // Scale timeout by data size: ~5s per MB with a 30s minimum.
         let timeout: TimeInterval = max(30, TimeInterval(data.count) / (1024 * 1024) * 5 + 30)
-        // Encode SHA-256 and source path as query parameters since the PUT
-        // method does not support custom headers directly.
-        let encodedSha = sha256.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? sha256
-        let encodedPath = sourcePath.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? sourcePath
-        let path = "assistants/{assistantId}/transfers/\(transferId)/content?sha256=\(encodedSha)&sourcePath=\(encodedPath)"
         let response = try await GatewayHTTPClient.put(
-            path: path,
+            path: "assistants/{assistantId}/transfers/\(transferId)/content",
             body: data,
+            params: ["sourcePath": sourcePath],
+            contentType: "application/octet-stream",
+            extraHeaders: ["X-Transfer-SHA256": sha256],
             timeout: timeout
         )
         guard response.isSuccess else {

--- a/clients/shared/Network/HostProxyClient.swift
+++ b/clients/shared/Network/HostProxyClient.swift
@@ -9,6 +9,9 @@ public protocol HostProxyClientProtocol {
     func postFileResult(_ result: HostFileResultPayload) async -> Bool
     func postCuResult(_ result: HostCuResultPayload) async -> Bool
     func postBrowserResult(_ result: HostBrowserResultPayload) async -> Bool
+    func postTransferResult(_ result: HostTransferResultPayload) async -> Bool
+    func pullTransferContent(transferId: String) async throws -> Data
+    func pushTransferContent(transferId: String, data: Data, sha256: String, sourcePath: String) async throws -> Bool
 }
 
 /// Gateway-backed implementation of ``HostProxyClientProtocol``.
@@ -93,6 +96,70 @@ public struct HostProxyClient: HostProxyClientProtocol {
         } catch {
             log.error("postBrowserResult error: \(error.localizedDescription)")
             return false
+        }
+    }
+
+    public func postTransferResult(_ result: HostTransferResultPayload) async -> Bool {
+        do {
+            let body = try JSONEncoder().encode(result)
+            // Scale timeout based on payload size for large transfer results.
+            let timeout: TimeInterval = max(30, TimeInterval(body.count) / (1024 * 1024) * 5 + 30)
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/host-transfer-result",
+                body: body,
+                timeout: timeout
+            )
+            guard response.isSuccess else {
+                log.error("postTransferResult failed (HTTP \(response.statusCode))")
+                return false
+            }
+            return true
+        } catch {
+            log.error("postTransferResult error: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    public func pullTransferContent(transferId: String) async throws -> Data {
+        // Use a generous timeout — large files may take a while to download.
+        let response = try await GatewayHTTPClient.get(
+            path: "assistants/{assistantId}/transfers/\(transferId)/content",
+            timeout: 300
+        )
+        guard response.isSuccess else {
+            throw TransferError.pullFailed(statusCode: response.statusCode)
+        }
+        return response.data
+    }
+
+    public func pushTransferContent(transferId: String, data: Data, sha256: String, sourcePath: String) async throws -> Bool {
+        // Scale timeout by data size: ~5s per MB with a 30s minimum.
+        let timeout: TimeInterval = max(30, TimeInterval(data.count) / (1024 * 1024) * 5 + 30)
+        // Encode SHA-256 and source path as query parameters since the PUT
+        // method does not support custom headers directly.
+        let encodedSha = sha256.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? sha256
+        let encodedPath = sourcePath.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? sourcePath
+        let path = "assistants/{assistantId}/transfers/\(transferId)/content?sha256=\(encodedSha)&sourcePath=\(encodedPath)"
+        let response = try await GatewayHTTPClient.put(
+            path: path,
+            body: data,
+            timeout: timeout
+        )
+        guard response.isSuccess else {
+            log.error("pushTransferContent failed (HTTP \(response.statusCode))")
+            return false
+        }
+        return true
+    }
+
+    enum TransferError: LocalizedError {
+        case pullFailed(statusCode: Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .pullFailed(let statusCode):
+                return "Failed to pull transfer content (HTTP \(statusCode))"
+            }
         }
     }
 }

--- a/clients/shared/Network/HostToolExecutor.swift
+++ b/clients/shared/Network/HostToolExecutor.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import os
 
@@ -472,20 +473,304 @@ public enum HostToolExecutor {
         return nil
     }
 
-    // MARK: - Host Transfer (stub — PR 7)
+    // MARK: - Host Transfer Execution
 
-    /// Execute a host file transfer request locally.
-    // TODO: implement in host-file-xfer/pr-7
+    /// Execute a host file transfer request locally and post the result back to the daemon.
+    /// Dispatches by direction: `to_host` (pull from sandbox) or `to_sandbox` (push to sandbox).
     @MainActor
     public static func executeHostTransferRequest(_ request: HostTransferRequest) {
-        log.warning("executeHostTransferRequest not yet implemented — requestId=\(request.requestId, privacy: .public)")
+        Task.detached {
+            // Pre-cancellation check
+            if isCancelledAndConsume(request.requestId) {
+                log.debug("Host transfer skipped (pre-cancelled) — requestId=\(request.requestId, privacy: .public)")
+                return
+            }
+
+            switch request.direction {
+            case "to_host":
+                await executeToHostTransfer(request)
+            case "to_sandbox":
+                await executeToSandboxTransfer(request)
+            default:
+                log.error("Unknown transfer direction: \(request.direction, privacy: .public)")
+                let result = HostTransferResultPayload(
+                    requestId: request.requestId,
+                    isError: true,
+                    bytesWritten: nil,
+                    errorMessage: "Unknown transfer direction: \(request.direction)"
+                )
+                if !isCancelledAndConsume(request.requestId) {
+                    _ = await HostProxyClient().postTransferResult(result)
+                }
+            }
+        }
     }
 
     /// Cancel an in-flight host file transfer request.
-    // TODO: implement in host-file-xfer/pr-7
     public static func cancelHostTransferRequest(_ requestId: String) {
         markCancelled(requestId)
-        log.warning("cancelHostTransferRequest not yet implemented — requestId=\(requestId, privacy: .public)")
+        log.info("Cancelling host transfer — requestId=\(requestId, privacy: .public)")
+    }
+
+    // MARK: - Transfer Direction Handlers
+
+    /// Pull a file from the sandbox to the host (to_host direction).
+    /// Downloads the file content via GET, writes to destPath, and verifies SHA-256.
+    private static func executeToHostTransfer(_ request: HostTransferRequest) async {
+        guard let destPath = request.destPath, !destPath.isEmpty else {
+            let result = HostTransferResultPayload(
+                requestId: request.requestId,
+                isError: true,
+                bytesWritten: nil,
+                errorMessage: "destPath is required for to_host transfers"
+            )
+            if !isCancelledAndConsume(request.requestId) {
+                _ = await HostProxyClient().postTransferResult(result)
+            }
+            return
+        }
+
+        let transferId = request.transferId
+
+        // Check overwrite: if overwrite is not true and file already exists, fail early.
+        if request.overwrite != true, FileManager.default.fileExists(atPath: destPath) {
+            let result = HostTransferResultPayload(
+                requestId: request.requestId,
+                isError: true,
+                bytesWritten: nil,
+                errorMessage: "File already exists at \(destPath) and overwrite is not enabled"
+            )
+            if !isCancelledAndConsume(request.requestId) {
+                _ = await HostProxyClient().postTransferResult(result)
+            }
+            return
+        }
+
+        // Create parent directories
+        let destURL = URL(fileURLWithPath: destPath)
+        let parentDir = destURL.deletingLastPathComponent().path
+        do {
+            try FileManager.default.createDirectory(
+                atPath: parentDir,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+        } catch {
+            let result = HostTransferResultPayload(
+                requestId: request.requestId,
+                isError: true,
+                bytesWritten: nil,
+                errorMessage: "Failed to create parent directory: \(error.localizedDescription)"
+            )
+            if !isCancelledAndConsume(request.requestId) {
+                _ = await HostProxyClient().postTransferResult(result)
+            }
+            return
+        }
+
+        // Check cancellation before downloading
+        if isCancelledAndConsume(request.requestId) {
+            log.debug("Host transfer cancelled before download — requestId=\(request.requestId, privacy: .public)")
+            return
+        }
+
+        // Pull file content from the daemon
+        let data: Data
+        do {
+            data = try await HostProxyClient().pullTransferContent(transferId: transferId)
+        } catch {
+            let result = HostTransferResultPayload(
+                requestId: request.requestId,
+                isError: true,
+                bytesWritten: nil,
+                errorMessage: "Failed to pull transfer content: \(error.localizedDescription)"
+            )
+            if !isCancelledAndConsume(request.requestId) {
+                _ = await HostProxyClient().postTransferResult(result)
+            }
+            return
+        }
+
+        // Check cancellation after download
+        if isCancelledAndConsume(request.requestId) {
+            log.debug("Host transfer cancelled after download — requestId=\(request.requestId, privacy: .public)")
+            return
+        }
+
+        // Write data to destination
+        do {
+            try data.write(to: destURL)
+        } catch {
+            let result = HostTransferResultPayload(
+                requestId: request.requestId,
+                isError: true,
+                bytesWritten: nil,
+                errorMessage: "Failed to write file to \(destPath): \(error.localizedDescription)"
+            )
+            if !isCancelledAndConsume(request.requestId) {
+                _ = await HostProxyClient().postTransferResult(result)
+            }
+            return
+        }
+
+        // Verify SHA-256 if expected hash is provided
+        if let expectedSha = request.sha256, !expectedSha.isEmpty {
+            let actualSha = sha256Hex(data)
+            if actualSha != expectedSha {
+                // Mismatch — delete the written file and post error
+                try? FileManager.default.removeItem(at: destURL)
+                let result = HostTransferResultPayload(
+                    requestId: request.requestId,
+                    isError: true,
+                    bytesWritten: nil,
+                    errorMessage: "SHA-256 mismatch: expected \(expectedSha), got \(actualSha)"
+                )
+                if !isCancelledAndConsume(request.requestId) {
+                    _ = await HostProxyClient().postTransferResult(result)
+                }
+                return
+            }
+        }
+
+        log.debug("Host transfer to_host completed — requestId=\(request.requestId, privacy: .public) bytes=\(data.count)")
+
+        // Post success
+        let result = HostTransferResultPayload(
+            requestId: request.requestId,
+            isError: false,
+            bytesWritten: data.count,
+            errorMessage: nil
+        )
+        if !isCancelledAndConsume(request.requestId) {
+            _ = await HostProxyClient().postTransferResult(result)
+        }
+    }
+
+    /// Push a file from the host to the sandbox (to_sandbox direction).
+    /// Reads the source file, computes SHA-256, and uploads via PUT.
+    private static func executeToSandboxTransfer(_ request: HostTransferRequest) async {
+        guard let sourcePath = request.sourcePath, !sourcePath.isEmpty else {
+            let result = HostTransferResultPayload(
+                requestId: request.requestId,
+                isError: true,
+                bytesWritten: nil,
+                errorMessage: "sourcePath is required for to_sandbox transfers"
+            )
+            if !isCancelledAndConsume(request.requestId) {
+                _ = await HostProxyClient().postTransferResult(result)
+            }
+            return
+        }
+
+        let transferId = request.transferId
+
+        // Validate source exists and is a file (not directory)
+        let sourceURL = URL(fileURLWithPath: sourcePath)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: sourcePath, isDirectory: &isDirectory) else {
+            let result = HostTransferResultPayload(
+                requestId: request.requestId,
+                isError: true,
+                bytesWritten: nil,
+                errorMessage: "Source file does not exist: \(sourcePath)"
+            )
+            if !isCancelledAndConsume(request.requestId) {
+                _ = await HostProxyClient().postTransferResult(result)
+            }
+            return
+        }
+        guard !isDirectory.boolValue else {
+            let result = HostTransferResultPayload(
+                requestId: request.requestId,
+                isError: true,
+                bytesWritten: nil,
+                errorMessage: "Source path is a directory, not a file: \(sourcePath)"
+            )
+            if !isCancelledAndConsume(request.requestId) {
+                _ = await HostProxyClient().postTransferResult(result)
+            }
+            return
+        }
+
+        // Read file data
+        let data: Data
+        do {
+            data = try Data(contentsOf: sourceURL)
+        } catch {
+            let result = HostTransferResultPayload(
+                requestId: request.requestId,
+                isError: true,
+                bytesWritten: nil,
+                errorMessage: "Failed to read source file: \(error.localizedDescription)"
+            )
+            if !isCancelledAndConsume(request.requestId) {
+                _ = await HostProxyClient().postTransferResult(result)
+            }
+            return
+        }
+
+        // Check cancellation before uploading
+        if isCancelledAndConsume(request.requestId) {
+            log.debug("Host transfer cancelled before upload — requestId=\(request.requestId, privacy: .public)")
+            return
+        }
+
+        // Compute SHA-256
+        let sha = sha256Hex(data)
+
+        // Push via PUT
+        do {
+            let success = try await HostProxyClient().pushTransferContent(
+                transferId: transferId,
+                data: data,
+                sha256: sha,
+                sourcePath: sourcePath
+            )
+            guard success else {
+                let result = HostTransferResultPayload(
+                    requestId: request.requestId,
+                    isError: true,
+                    bytesWritten: nil,
+                    errorMessage: "Failed to push transfer content"
+                )
+                if !isCancelledAndConsume(request.requestId) {
+                    _ = await HostProxyClient().postTransferResult(result)
+                }
+                return
+            }
+        } catch {
+            let result = HostTransferResultPayload(
+                requestId: request.requestId,
+                isError: true,
+                bytesWritten: nil,
+                errorMessage: "Failed to push transfer content: \(error.localizedDescription)"
+            )
+            if !isCancelledAndConsume(request.requestId) {
+                _ = await HostProxyClient().postTransferResult(result)
+            }
+            return
+        }
+
+        log.debug("Host transfer to_sandbox completed — requestId=\(request.requestId, privacy: .public) bytes=\(data.count)")
+
+        // Post success
+        let result = HostTransferResultPayload(
+            requestId: request.requestId,
+            isError: false,
+            bytesWritten: data.count,
+            errorMessage: nil
+        )
+        if !isCancelledAndConsume(request.requestId) {
+            _ = await HostProxyClient().postTransferResult(result)
+        }
+    }
+
+    // MARK: - SHA-256 Helper
+
+    /// Compute the lowercase hex-encoded SHA-256 digest of the given data.
+    private static func sha256Hex(_ data: Data) -> String {
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
     }
 
     private enum FileOperationError: LocalizedError {


### PR DESCRIPTION
## Summary
- Replace stub methods with full to_host (pull) and to_sandbox (push) transfer executors
- Add HostProxyClient methods for pullTransferContent, pushTransferContent, postTransferResult
- SHA-256 integrity verification with partial file cleanup on mismatch
- Pre-transfer overwrite and source validation checks

Part of plan: host-file-transfer.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
