### PR TITLE
Fix subagent permission context inheritance

### DIFF
--- a/assistant/src/__tests__/subagent-call-site-routing.test.ts
+++ b/assistant/src/__tests__/subagent-call-site-routing.test.ts
@@ -21,10 +21,19 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 
 // Capture the provider passed to Conversation.
 let capturedProvider: unknown = undefined;
+interface CapturedConversationState {
+  trustContext: unknown;
+  authContext: unknown;
+  assistantId: string | undefined;
+}
+
+let capturedConversation: CapturedConversationState | undefined = undefined;
 
 // Stub Conversation so spawn() doesn't try to actually run an agent loop —
 // we only care about what provider it was constructed with.
 class FakeConversation {
+  private readonly capturedState: CapturedConversationState;
+
   constructor(
     _id: string,
     provider: unknown,
@@ -33,11 +42,30 @@ class FakeConversation {
     _sendToClient: (msg: ServerMessage) => void,
   ) {
     capturedProvider = provider;
+    this.capturedState = {
+      trustContext: undefined,
+      authContext: undefined,
+      assistantId: undefined,
+    };
+    capturedConversation = this.capturedState;
   }
   updateClient() {}
   setIsSubagent() {}
+  setTrustContext(ctx: unknown) {
+    this.capturedState.trustContext = ctx ?? undefined;
+  }
+  setAuthContext(ctx: unknown) {
+    this.capturedState.authContext = ctx ?? undefined;
+  }
+  getAuthContext() {
+    return this.capturedState.authContext;
+  }
+  setAssistantId(assistantId: string | null) {
+    this.capturedState.assistantId = assistantId ?? undefined;
+  }
   hasSystemPromptOverride = false;
   setSubagentAllowedTools() {}
+  setPreactivatedSkillIds() {}
   preactivateSkills() {}
   preactivateSkillsAsync() {}
   setSpawnHints() {}
@@ -188,6 +216,55 @@ describe("SubagentManager — provider call-site routing", () => {
     expect(capturedProvider).toBeInstanceOf(CallSiteRoutingProvider);
     // Default provider's name surfaces.
     expect((capturedProvider as { name: string }).name).toBe("anthropic");
+  });
+
+  test("copies parent guardian and auth context into spawned conversation", async () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+    });
+
+    const parentTrustContext = {
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+      guardianPrincipalId: "guardian-1",
+      guardianExternalUserId: "guardian-1",
+    };
+    const parentAuthContext = {
+      subject: "local:self:parent-perms",
+      actorPrincipalId: "guardian-1",
+    };
+
+    capturedConversation = undefined;
+    const manager = new SubagentManager();
+    manager.resolveParentConversation = (id) =>
+      id === "parent-perms"
+        ? ({
+            trustContext: parentTrustContext,
+            getAuthContext: () => parentAuthContext,
+            assistantId: "self",
+            getCurrentSystemPrompt: () => "parent system",
+          } as any)
+        : undefined;
+
+    await manager.spawn(
+      {
+        parentConversationId: "parent-perms",
+        label: "permissions",
+        objective: "use web_fetch",
+      },
+      () => {},
+    );
+
+    const createdConversation = capturedConversation;
+    expect(createdConversation).toBeDefined();
+    if (!createdConversation) {
+      throw new Error("Expected subagent conversation to be constructed");
+    }
+    expect(createdConversation.trustContext).toEqual(parentTrustContext);
+    expect(createdConversation.authContext).toEqual(parentAuthContext);
+    expect(createdConversation.assistantId).toBe("self");
+    expect(createdConversation.trustContext).not.toBe(parentTrustContext);
+    expect(createdConversation.authContext).not.toBe(parentAuthContext);
   });
 });
 

--- a/assistant/src/__tests__/subagent-call-site-routing.test.ts
+++ b/assistant/src/__tests__/subagent-call-site-routing.test.ts
@@ -27,7 +27,7 @@ interface CapturedConversationState {
   assistantId: string | undefined;
 }
 
-let capturedConversation: CapturedConversationState | undefined = undefined;
+const capturedConversations: CapturedConversationState[] = [];
 
 // Stub Conversation so spawn() doesn't try to actually run an agent loop —
 // we only care about what provider it was constructed with.
@@ -47,7 +47,7 @@ class FakeConversation {
       authContext: undefined,
       assistantId: undefined,
     };
-    capturedConversation = this.capturedState;
+    capturedConversations.push(this.capturedState);
   }
   updateClient() {}
   setIsSubagent() {}
@@ -234,7 +234,7 @@ describe("SubagentManager — provider call-site routing", () => {
       actorPrincipalId: "guardian-1",
     };
 
-    capturedConversation = undefined;
+    capturedConversations.length = 0;
     const manager = new SubagentManager();
     manager.resolveParentConversation = (id) =>
       id === "parent-perms"
@@ -255,7 +255,7 @@ describe("SubagentManager — provider call-site routing", () => {
       () => {},
     );
 
-    const createdConversation = capturedConversation;
+    const createdConversation = capturedConversations[0];
     expect(createdConversation).toBeDefined();
     if (!createdConversation) {
       throw new Error("Expected subagent conversation to be constructed");

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -236,16 +236,17 @@ export class SubagentManager {
       );
     }
 
+    const parentConversation = this.resolveParentConversation?.(
+      config.parentConversationId,
+    );
+
     let systemPrompt: string;
     if (isFork) {
       // Forks use the parent's system prompt directly — no subagent preamble.
       if (config.parentSystemPrompt) {
         systemPrompt = config.parentSystemPrompt;
       } else if (this.resolveParentConversation) {
-        const parentConv = this.resolveParentConversation(
-          config.parentConversationId,
-        );
-        const resolved = parentConv?.getCurrentSystemPrompt();
+        const resolved = parentConversation?.getCurrentSystemPrompt();
         if (!resolved) {
           throw new Error(
             "Fork spawn requires a parent system prompt but neither config.parentSystemPrompt " +
@@ -338,6 +339,21 @@ export class SubagentManager {
     // This ensures interactive prompts (host attachment reads) fail fast.
     conversation.updateClient(wrappedSendToClient, true);
     conversation.setIsSubagent(true);
+
+    // Subagents execute as background child conversations, but their tool
+    // permissions must still be scoped to the actor that spawned them. Without
+    // this, tool execution falls back to `unknown` trust and guardian-owned
+    // desktop turns get denied as unverified.
+    if (parentConversation?.trustContext) {
+      conversation.setTrustContext({ ...parentConversation.trustContext });
+    }
+    const parentAuthContext = parentConversation?.getAuthContext();
+    if (parentAuthContext) {
+      conversation.setAuthContext({ ...parentAuthContext });
+    }
+    if (parentConversation?.assistantId) {
+      conversation.setAssistantId(parentConversation.assistantId);
+    }
 
     if (isFork) {
       // Force the fork to use the parent's system prompt as-is without dynamic rebuild.


### PR DESCRIPTION
## Summary
- Copy parent trust and auth context into spawned subagent conversations so tool permissions preserve guardian scope.
- Preserve the parent assistant ID for child conversations and reuse the resolved parent for fork prompt lookup.
- Add regression coverage for subagent spawn context inheritance.

## Original prompt
ahh shit, clean this up in the pwd and ship it to a PR from a worktree instead
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
