### PR TITLE
feat(gateway): add trust_rules Drizzle table schema

### DIFF
--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -7,7 +7,13 @@
  */
 
 import { sql } from "drizzle-orm";
-import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import {
+  index,
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
 
 // ---------------------------------------------------------------------------
 // Slack
@@ -109,4 +115,29 @@ export const conversationThresholdOverrides = sqliteTable(
       .notNull()
       .default(sql`(datetime('now'))`),
   },
+);
+
+// ---------------------------------------------------------------------------
+// Trust rules (v3)
+// ---------------------------------------------------------------------------
+
+export const trustRulesV3 = sqliteTable(
+  "trust_rules",
+  {
+    id: text("id").primaryKey(),
+    tool: text("tool").notNull(),
+    pattern: text("pattern").notNull(),
+    risk: text("risk").notNull(), // "low" | "medium" | "high"
+    description: text("description").notNull(),
+    origin: text("origin").notNull(), // "default" | "user_defined"
+    userModified: integer("user_modified", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    deleted: integer("deleted", { mode: "boolean" }).notNull().default(false),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("idx_trust_rules_tool_pattern").on(table.tool, table.pattern),
+  ],
 );


### PR DESCRIPTION
## Summary
- Add trust_rules table definition to gateway Drizzle schema
- 10 columns: id, tool, pattern, risk, description, origin, user_modified, deleted, created_at, updated_at
- Unique index on (tool, pattern)

Part of plan: v3-trust-rules-table.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
