### PR TITLE
feat(daemon): add MeetHostSupervisor for lazy meet-host spawn lifecycle

### DIFF
--- a/assistant/src/daemon/__tests__/meet-host-supervisor.test.ts
+++ b/assistant/src/daemon/__tests__/meet-host-supervisor.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Unit tests for `MeetHostSupervisor`. The tests replace
+ * `child_process.spawn` and `net.connect` with in-memory stubs so the
+ * supervisor can be exercised end-to-end without touching real
+ * subprocesses or Unix sockets.
+ *
+ * Coverage:
+ *   1. First `ensureRunning()` spawns; a concurrent second call shares
+ *      the in-flight promise (no double-spawn).
+ *   2. Session counter behaviour: `reportSessionStarted` cancels the
+ *      idle timer; returning to zero sessions arms it; timer expiry
+ *      triggers a graceful shutdown path.
+ *   3. Hash-mismatch rejects the `ensureRunning()` promise with a
+ *      clear error and leaves the supervisor ready to re-spawn on the
+ *      next call.
+ *   4. Crash after successful startup nulls the handle; the next
+ *      `ensureRunning()` call spawns again.
+ */
+
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import type { Socket } from "node:net";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Stub the config loader before importing the module under test so the
+// idle-timeout reader doesn't walk into the real workspace loader.
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({}),
+  getNestedValue: () => undefined,
+}));
+
+// Stub the logger to keep test output clean.
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+// Stub the skill-socket-path helper so tests don't touch the real
+// workspace directory.
+mock.module("../../ipc/skill-socket-path.js", () => ({
+  getSkillSocketPath: () => "/tmp/test-skill.sock",
+  resolveSkillIpcSocketPath: () => ({ path: "/tmp/test-skill.sock" }),
+}));
+
+const { MeetHostSupervisor } = await import("../meet-host-supervisor.js");
+
+// ---------------------------------------------------------------------------
+// Fake child process + fake socket
+// ---------------------------------------------------------------------------
+
+class FakeChild extends EventEmitter {
+  killed = false;
+  exitCode: number | null = null;
+  pid = 12345;
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  kill = mock((_signal?: NodeJS.Signals | number) => {
+    // Simulate the process exiting almost immediately on signal.
+    queueMicrotask(() => {
+      if (this.exitCode == null) {
+        this.exitCode = 143;
+        this.killed = true;
+        this.emit("exit", 143, _signal ?? "SIGTERM");
+      }
+    });
+    return true;
+  });
+
+  /** Force-exit the child with a given code (simulated crash). */
+  simulateExit(code: number | null, signal: NodeJS.Signals | null = null) {
+    if (this.exitCode != null) return;
+    this.exitCode = code ?? 0;
+    this.emit("exit", code, signal);
+  }
+}
+
+class FakeSocket extends EventEmitter {
+  write = mock((_data: string, cb?: (err?: Error) => void) => {
+    if (cb) cb();
+    return true;
+  });
+  destroy = mock(() => {
+    // Intentionally silent.
+  });
+  /** Simulate async "connect" event firing on the next tick. */
+  triggerConnect() {
+    queueMicrotask(() => this.emit("connect"));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+interface Harness {
+  child: FakeChild;
+  supervisor: InstanceType<typeof MeetHostSupervisor>;
+  spawnFn: ReturnType<typeof mock>;
+  connectFn: ReturnType<typeof mock>;
+}
+
+function makeHarness(
+  overrides: {
+    manifestHash?: string;
+    idleTimeoutMs?: number;
+    gracefulExitGraceMs?: number;
+    sigkillGraceMs?: number;
+  } = {},
+): Harness {
+  const child = new FakeChild();
+  const spawnFn = mock(() => child as unknown as ChildProcess);
+  const connectFn = mock(() => {
+    const sock = new FakeSocket();
+    sock.triggerConnect();
+    return sock as unknown as Socket;
+  });
+  const supervisor = new MeetHostSupervisor({
+    skillRuntimePath: "/fake/skills/meet-join",
+    bunBinaryPath: "/fake/bin/bun",
+    skillSocketPath: "/tmp/test-skill.sock",
+    manifest: { sourceHash: overrides.manifestHash ?? "hash-abc" },
+    spawnFn,
+    connectFn,
+    idleTimeoutMsOverride: overrides.idleTimeoutMs ?? 60_000,
+    gracefulExitGraceMs: overrides.gracefulExitGraceMs ?? 5,
+    sigkillGraceMs: overrides.sigkillGraceMs ?? 5,
+  });
+  return { child, supervisor, spawnFn, connectFn };
+}
+
+/** Drain pending I/O callbacks so queued handshake promises settle. */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MeetHostSupervisor", () => {
+  let harness: Harness;
+
+  afterEach(async () => {
+    // Make sure no supervisor lingers with a live timer between tests.
+    try {
+      await harness?.supervisor.shutdown();
+    } catch {
+      // Shutdown during tests may already have been triggered.
+    }
+  });
+
+  beforeEach(() => {
+    // Replaced per-test via makeHarness; initialize to undefined so
+    // afterEach's optional chain is safe on tests that throw early.
+    harness = undefined as unknown as Harness;
+  });
+
+  test("first ensureRunning() spawns; concurrent second call shares the promise", async () => {
+    harness = makeHarness();
+    const { supervisor, spawnFn } = harness;
+
+    const p1 = supervisor.ensureRunning();
+    const p2 = supervisor.ensureRunning();
+
+    // Both promises should be the same in-flight spawn — only one spawn call.
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+
+    // Deliver the handshake after both callers have subscribed.
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "hash-abc" });
+
+    await Promise.all([p1, p2]);
+    expect(supervisor.isRunning).toBe(true);
+
+    // A third call after the child is up must not re-spawn.
+    await supervisor.ensureRunning();
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+
+    // Sanity: spawn was called with our bun binary + register.ts.
+    const [, args] = spawnFn.mock.calls[0] as [string, readonly string[]];
+    expect(args[0]).toBe("run");
+    expect(args[1]).toBe("/fake/skills/meet-join/register.ts");
+    expect(args.some((a) => a.startsWith("--ipc="))).toBe(true);
+    expect(args).toContain("--skill-id=meet-join");
+  });
+
+  test("hash mismatch rejects ensureRunning with a clear error and allows re-spawn", async () => {
+    harness = makeHarness({ manifestHash: "expected-hash" });
+    const { supervisor, spawnFn } = harness;
+
+    const p = supervisor.ensureRunning();
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "wrong-hash" });
+
+    await expect(p).rejects.toThrow(/source hash mismatch/);
+    await expect(p).rejects.toThrow(/Regenerate the meet-join manifest/);
+
+    // After a rejected handshake the supervisor should be ready to try again.
+    expect(supervisor.isRunning).toBe(false);
+
+    const p2 = supervisor.ensureRunning();
+    expect(spawnFn).toHaveBeenCalledTimes(2);
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "expected-hash" });
+    await p2;
+    expect(supervisor.isRunning).toBe(true);
+  });
+
+  test("session counter + idle timeout: timer arms at zero, cancels on new session, fires on expiry", async () => {
+    harness = makeHarness({
+      idleTimeoutMs: 20,
+      gracefulExitGraceMs: 5,
+      sigkillGraceMs: 5,
+    });
+    const { supervisor, connectFn, child } = harness;
+
+    const p = supervisor.ensureRunning();
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "hash-abc" });
+    await p;
+
+    // Start + end two sessions, cancelling/arming the timer.
+    supervisor.reportSessionStarted("s1");
+    supervisor.reportSessionStarted("s2");
+    expect(supervisor.activeSessionCount).toBe(2);
+
+    supervisor.reportSessionEnded("s1");
+    // s2 still active — idle timer must NOT be armed.
+    expect(supervisor.activeSessionCount).toBe(1);
+
+    supervisor.reportSessionEnded("s2");
+    expect(supervisor.activeSessionCount).toBe(0);
+
+    // A second start before the timer fires must cancel it.
+    supervisor.reportSessionStarted("s3");
+    supervisor.reportSessionEnded("s3");
+    // Timer re-armed — wait past its expiry.
+    await new Promise((r) => setTimeout(r, 40));
+
+    // After idle expiry the supervisor should try to send skill.shutdown
+    // over the control socket; our fake socket records that write.
+    expect(connectFn).toHaveBeenCalled();
+    // Let the kill / exit microtasks settle.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(child.exitCode).not.toBeNull();
+  });
+
+  test("crash after startup nulls the handle; next ensureRunning re-spawns", async () => {
+    harness = makeHarness();
+    const { supervisor, spawnFn, child: firstChild } = harness;
+
+    const p = supervisor.ensureRunning();
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "hash-abc" });
+    await p;
+    expect(supervisor.isRunning).toBe(true);
+
+    // Simulate an unexpected crash of the first child.
+    firstChild.simulateExit(137, "SIGKILL");
+    expect(supervisor.isRunning).toBe(false);
+
+    // Next ensureRunning must spawn a fresh child. Swap the spawn
+    // factory so a distinct FakeChild shows up for the second call.
+    const secondChild = new FakeChild();
+    spawnFn.mockImplementation(() => secondChild as unknown as ChildProcess);
+
+    const p2 = supervisor.ensureRunning();
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "hash-abc" });
+    await p2;
+    expect(spawnFn).toHaveBeenCalledTimes(2);
+    expect(supervisor.isRunning).toBe(true);
+  });
+
+  test("shutdown stops the child and is safe to call twice", async () => {
+    harness = makeHarness();
+    const { supervisor, child } = harness;
+
+    const p = supervisor.ensureRunning();
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "hash-abc" });
+    await p;
+
+    await supervisor.shutdown();
+    expect(child.exitCode).not.toBeNull();
+
+    // A second shutdown is a no-op.
+    await supervisor.shutdown();
+    // ensureRunning after shutdown should reject — supervisor is done.
+    await expect(supervisor.ensureRunning()).rejects.toThrow(/shutting down/);
+  });
+});

--- a/assistant/src/daemon/meet-host-supervisor.ts
+++ b/assistant/src/daemon/meet-host-supervisor.ts
@@ -1,0 +1,512 @@
+/**
+ * `MeetHostSupervisor` — owns the lifecycle of the lazily-spawned
+ * `bun run skills/meet-join/register.ts` child process (the meet-host).
+ *
+ * The daemon stays skill-agnostic at the process layer: the supervisor
+ * is the one place that knows how to find the bun binary, resolve the
+ * installed skill path, spawn the child, wait for its handshake, count
+ * active sessions, and idle-shut it down. The IPC surface between the
+ * two processes lives in `assistant/src/ipc/skill-server.ts` (PR 20)
+ * and the `host.registries.*` routes that back it (PR 24).
+ *
+ * ## Lifecycle
+ *
+ *   - `ensureRunning()` — idempotent. First caller triggers
+ *     `child_process.spawn`, subsequent concurrent callers await the
+ *     same in-flight promise. Resolves once the child dials
+ *     `assistant-skill.sock` and sends a handshake frame (via
+ *     `notifyHandshake`) whose reported source-tree hash matches the
+ *     shipped manifest's hash. A mismatch kills the spawn and throws
+ *     a clear error pointing the user at regenerating the manifest.
+ *
+ *   - `reportSessionStarted(id)` / `reportSessionEnded(id)` — mutate
+ *     the active-session counter. Called by PR 24's
+ *     `host.registries.report_session_*` IPC routes. The counter is
+ *     tracked by session id (Set of live ids) so duplicate or
+ *     out-of-order `ended` frames can't drop the count below zero.
+ *
+ *   - Idle timer — when the counter reaches zero the supervisor arms
+ *     a 5-minute timer (configurable via
+ *     `services.meet.host.idle_timeout_ms`). On expiry it sends a
+ *     `skill.shutdown` frame over the IPC socket (best-effort — if no
+ *     IPC sink is wired yet the supervisor still falls through to the
+ *     signal path), waits briefly for graceful exit, then
+ *     SIGTERM/SIGKILLs the child. Any new session before the timer
+ *     fires disarms it.
+ *
+ *   - Crash detection — the supervisor listens for the child's `exit`
+ *     event; when it fires unexpectedly the handle is nulled and the
+ *     next `ensureRunning()` call respawns.
+ *
+ *   - `shutdown()` — graceful termination on daemon shutdown.
+ *
+ * PR 27 adds the supervisor only — it does NOT register any IPC
+ * routes or auto-start on daemon boot. PR 28 wires this class into
+ * `meet-manifest-loader.ts` so proxy tool invocations call
+ * `ensureRunning()` before dispatching.
+ */
+
+import {
+  type ChildProcess,
+  spawn as defaultSpawn,
+  type SpawnOptions,
+} from "node:child_process";
+import { connect as defaultConnect, type Socket } from "node:net";
+
+import { getConfig, getNestedValue } from "../config/loader.js";
+import { getSkillSocketPath } from "../ipc/skill-socket-path.js";
+import { getLogger } from "../util/logger.js";
+
+/**
+ * Shipped manifest payload the supervisor needs for handshake
+ * validation. Callers load the JSON manifest (written by
+ * `skills/meet-join/scripts/emit-manifest.ts`) and pass just the
+ * hash through. Accepting the value rather than reading the file
+ * keeps the supervisor free of path assumptions and simplifies
+ * tests.
+ */
+export interface MeetHostManifest {
+  /** SHA-256 of the shipped skill source tree. */
+  sourceHash: string;
+}
+
+/**
+ * Payload the external IPC route handler passes to `notifyHandshake`
+ * when the meet-host sends its `register_tools` / `ready` frame.
+ * Currently just the source hash; additional fields (pid echo,
+ * protocol version) can be threaded through later without a
+ * signature break.
+ */
+export interface MeetHostHandshakePayload {
+  sourceHash: string;
+}
+
+/**
+ * Dependencies the supervisor needs to spawn and supervise the
+ * child. All are optional on construction — production callers
+ * rely on the defaults and tests override one or two at a time.
+ */
+export interface MeetHostSupervisorDeps {
+  /** Absolute path to the shipped `meet-join` skill dir, containing `register.ts`. */
+  skillRuntimePath: string;
+  /** Absolute path to a standalone bun binary, or `"bun"` for PATH lookup. */
+  bunBinaryPath: string;
+  /** Path to the skill IPC socket the child should dial. */
+  skillSocketPath?: string;
+  /** Shipped manifest (source of the hash we check handshake against). */
+  manifest: MeetHostManifest;
+  /** Child-process spawn function (override for tests). */
+  spawnFn?: (
+    command: string,
+    args: readonly string[],
+    options: SpawnOptions,
+  ) => ChildProcess;
+  /**
+   * Socket-connect function used to open an IPC control channel for
+   * sending `skill.shutdown` on idle. Override for tests.
+   */
+  connectFn?: (path: string) => Socket;
+  /** Override for the idle timeout in ms. Falls back to config key then default. */
+  idleTimeoutMsOverride?: number;
+  /** How long (ms) to wait for graceful exit before SIGTERM on idle/shutdown. */
+  gracefulExitGraceMs?: number;
+  /** How long (ms) to wait after SIGTERM before SIGKILL. */
+  sigkillGraceMs?: number;
+}
+
+/** Default idle timeout when no config override is set: 5 minutes. */
+const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+/** Config path for overriding the idle timeout. */
+const IDLE_TIMEOUT_CONFIG_KEY = "services.meet.host.idle_timeout_ms";
+/** Default grace period for a `skill.shutdown` frame to induce clean exit. */
+const DEFAULT_GRACEFUL_EXIT_GRACE_MS = 2_000;
+/** Default grace period between SIGTERM and SIGKILL. */
+const DEFAULT_SIGKILL_GRACE_MS = 1_000;
+
+const log = getLogger("meet-host-supervisor");
+
+/**
+ * Read the idle timeout from config, falling back to the default. The
+ * config-loader `getNestedValue` helper is nullable; we coerce only
+ * finite positive numbers and log + drop any other value so a malformed
+ * config entry can't disable the idle shutdown entirely.
+ */
+function readIdleTimeoutFromConfig(): number {
+  try {
+    const raw = getNestedValue(
+      getConfig() as unknown as Record<string, unknown>,
+      IDLE_TIMEOUT_CONFIG_KEY,
+    );
+    if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) {
+      return raw;
+    }
+    if (raw !== undefined) {
+      log.warn(
+        { configKey: IDLE_TIMEOUT_CONFIG_KEY, value: raw },
+        "Ignoring non-numeric idle timeout override from config",
+      );
+    }
+  } catch (err) {
+    log.warn({ err }, "Failed to read idle timeout config; using default");
+  }
+  return DEFAULT_IDLE_TIMEOUT_MS;
+}
+
+export class MeetHostSupervisor {
+  private readonly skillRuntimePath: string;
+  private readonly bunBinaryPath: string;
+  private readonly skillSocketPath: string;
+  private readonly manifest: MeetHostManifest;
+  private readonly spawnFn: NonNullable<MeetHostSupervisorDeps["spawnFn"]>;
+  private readonly connectFn: NonNullable<MeetHostSupervisorDeps["connectFn"]>;
+  private readonly idleTimeoutMs: number;
+  private readonly gracefulExitGraceMs: number;
+  private readonly sigkillGraceMs: number;
+
+  private child: ChildProcess | null = null;
+  private spawnPromise: Promise<void> | null = null;
+  private handshakeResolve: (() => void) | null = null;
+  private handshakeReject: ((err: Error) => void) | null = null;
+  private readonly activeSessions = new Set<string>();
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
+  private shuttingDown = false;
+
+  constructor(deps: MeetHostSupervisorDeps) {
+    this.skillRuntimePath = deps.skillRuntimePath;
+    this.bunBinaryPath = deps.bunBinaryPath;
+    this.skillSocketPath = deps.skillSocketPath ?? getSkillSocketPath();
+    this.manifest = deps.manifest;
+    this.spawnFn = deps.spawnFn ?? defaultSpawn;
+    this.connectFn = deps.connectFn ?? defaultConnect;
+    this.idleTimeoutMs =
+      deps.idleTimeoutMsOverride ?? readIdleTimeoutFromConfig();
+    this.gracefulExitGraceMs =
+      deps.gracefulExitGraceMs ?? DEFAULT_GRACEFUL_EXIT_GRACE_MS;
+    this.sigkillGraceMs = deps.sigkillGraceMs ?? DEFAULT_SIGKILL_GRACE_MS;
+  }
+
+  /**
+   * Ensure the meet-host child is spawned, the IPC handshake has been
+   * received, and the manifest hash validated. Idempotent: a second
+   * call while the child is already running is a no-op; a second call
+   * during an in-flight spawn awaits the same promise.
+   */
+  ensureRunning(): Promise<void> {
+    if (this.shuttingDown) {
+      return Promise.reject(
+        new Error("MeetHostSupervisor is shutting down; cannot spawn"),
+      );
+    }
+    if (this.child && !this.child.killed && this.child.exitCode == null) {
+      return this.spawnPromise ?? Promise.resolve();
+    }
+    if (this.spawnPromise) return this.spawnPromise;
+
+    this.spawnPromise = this.spawnAndHandshake().catch((err) => {
+      this.spawnPromise = null;
+      this.teardownChild();
+      throw err;
+    });
+    return this.spawnPromise;
+  }
+
+  /**
+   * Called by the IPC route handler when the child sends its
+   * `host.registries.register_tools` / `ready` frame. The supervisor
+   * validates the reported source hash against the shipped manifest
+   * and either resolves or rejects the in-flight `ensureRunning()`
+   * promise accordingly.
+   *
+   * Intentionally public so PR 24's `host.registries.*` route (which
+   * owns the IPC socket) can forward the payload without the
+   * supervisor owning any socket state itself.
+   */
+  notifyHandshake(payload: MeetHostHandshakePayload): void {
+    if (!this.handshakeResolve || !this.handshakeReject) {
+      log.debug("notifyHandshake called with no in-flight spawn; ignoring");
+      return;
+    }
+    if (payload.sourceHash !== this.manifest.sourceHash) {
+      const err = new Error(
+        `meet-join source hash mismatch: handshake reported ${payload.sourceHash} ` +
+          `but manifest expects ${this.manifest.sourceHash}. ` +
+          "Regenerate the meet-join manifest or rebuild the daemon to match.",
+      );
+      this.handshakeReject(err);
+      return;
+    }
+    this.handshakeResolve();
+  }
+
+  /**
+   * Increment the active-session counter. Called by PR 24's
+   * `host.registries.report_session_started` IPC route when a new
+   * meet session is joined. Idempotent for the same id.
+   */
+  reportSessionStarted(sessionId: string): void {
+    this.activeSessions.add(sessionId);
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+      log.debug({ sessionId }, "Idle timer cancelled — new session active");
+    }
+  }
+
+  /**
+   * Decrement the active-session counter. Called by PR 24's
+   * `host.registries.report_session_ended` IPC route when a meet
+   * session completes. When the counter drops to zero the idle
+   * timer is armed.
+   */
+  reportSessionEnded(sessionId: string): void {
+    const had = this.activeSessions.delete(sessionId);
+    if (!had) {
+      log.debug({ sessionId }, "Ignoring report_session_ended for unknown id");
+    }
+    if (this.activeSessions.size === 0) {
+      this.armIdleTimer();
+    }
+  }
+
+  /**
+   * Read-only view of the active session count — exposed for
+   * diagnostics and tests. Not part of the IPC protocol.
+   */
+  get activeSessionCount(): number {
+    return this.activeSessions.size;
+  }
+
+  /** Whether the child is currently running. Exposed for tests. */
+  get isRunning(): boolean {
+    return (
+      this.child != null && !this.child.killed && this.child.exitCode == null
+    );
+  }
+
+  /**
+   * Graceful termination. Cancels the idle timer, sends
+   * `skill.shutdown` to the child, then SIGTERM → SIGKILL on
+   * escalation. Safe to call multiple times.
+   */
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+    await this.stopChild("daemon-shutdown");
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────────
+
+  private async spawnAndHandshake(): Promise<void> {
+    const registerPath = `${this.skillRuntimePath}/register.ts`;
+    log.info(
+      {
+        bun: this.bunBinaryPath,
+        register: registerPath,
+        socket: this.skillSocketPath,
+      },
+      "Spawning meet-host child process",
+    );
+
+    const child = this.spawnFn(
+      this.bunBinaryPath,
+      [
+        "run",
+        registerPath,
+        `--ipc=${this.skillSocketPath}`,
+        "--skill-id=meet-join",
+      ],
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          VELLUM_SKILL_IPC_SOCKET: this.skillSocketPath,
+          VELLUM_SKILL_ID: "meet-join",
+        },
+      },
+    );
+    this.child = child;
+
+    // Forward stdout/stderr to the daemon log so meet-host diagnostics
+    // aren't lost. Best-effort — streams may be null in tests.
+    child.stdout?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString().trim();
+      if (text) log.info({ source: "meet-host-stdout" }, text);
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString().trim();
+      if (text) log.warn({ source: "meet-host-stderr" }, text);
+    });
+
+    child.on("exit", (code, signal) => {
+      log.info({ code, signal }, "meet-host child exited");
+      // Reject any in-flight handshake so callers fail fast instead of
+      // hanging waiting for a frame that will never arrive.
+      if (this.handshakeReject) {
+        this.handshakeReject(
+          new Error(
+            `meet-host exited before handshake (code=${code ?? "null"}, ` +
+              `signal=${signal ?? "null"})`,
+          ),
+        );
+      }
+      this.teardownChild();
+    });
+    child.on("error", (err) => {
+      log.error({ err }, "meet-host spawn error");
+      if (this.handshakeReject) this.handshakeReject(err);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      this.handshakeResolve = () => {
+        this.handshakeResolve = null;
+        this.handshakeReject = null;
+        resolve();
+      };
+      this.handshakeReject = (err) => {
+        this.handshakeResolve = null;
+        this.handshakeReject = null;
+        reject(err);
+      };
+    });
+  }
+
+  /**
+   * Drop references to the current child and any handshake waiters.
+   * Called on `exit`, on hash-mismatch rejection, and during shutdown.
+   */
+  private teardownChild(): void {
+    this.child = null;
+    this.spawnPromise = null;
+    this.handshakeResolve = null;
+    this.handshakeReject = null;
+  }
+
+  private armIdleTimer(): void {
+    if (this.idleTimer) clearTimeout(this.idleTimer);
+    if (!this.isRunning) return;
+    log.debug(
+      { idleTimeoutMs: this.idleTimeoutMs },
+      "No active sessions — arming idle-shutdown timer",
+    );
+    this.idleTimer = setTimeout(() => {
+      this.idleTimer = null;
+      void this.stopChild("idle-timeout").catch((err) => {
+        log.warn({ err }, "Idle-timeout shutdown failed");
+      });
+    }, this.idleTimeoutMs);
+  }
+
+  /**
+   * Stop the child: send `skill.shutdown` over the control socket,
+   * wait briefly, then SIGTERM, then SIGKILL. Safe to call with no
+   * child (no-op). Reason is surfaced in logs for diagnostics.
+   */
+  private async stopChild(reason: string): Promise<void> {
+    const child = this.child;
+    if (!child || child.exitCode != null) {
+      this.teardownChild();
+      return;
+    }
+    log.info({ reason, pid: child.pid }, "Stopping meet-host child");
+
+    // Best-effort graceful shutdown over the IPC socket. If no frame
+    // can be sent (socket closed, control channel not wired yet) we
+    // fall straight through to signals.
+    try {
+      await this.sendShutdownFrame();
+    } catch (err) {
+      log.debug(
+        { err },
+        "skill.shutdown frame could not be delivered; escalating to SIGTERM",
+      );
+    }
+
+    if (await waitForExit(child, this.gracefulExitGraceMs)) return;
+
+    if (child.exitCode == null) {
+      try {
+        child.kill("SIGTERM");
+      } catch (err) {
+        log.warn({ err }, "SIGTERM to meet-host failed");
+      }
+    }
+    if (await waitForExit(child, this.sigkillGraceMs)) return;
+
+    if (child.exitCode == null) {
+      try {
+        child.kill("SIGKILL");
+      } catch (err) {
+        log.warn({ err }, "SIGKILL to meet-host failed");
+      }
+    }
+    this.teardownChild();
+  }
+
+  /**
+   * Open a one-shot socket connection, write a `skill.shutdown`
+   * request frame, close. Errors are surfaced to the caller so
+   * `stopChild` can log + escalate to signals.
+   */
+  private sendShutdownFrame(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      let sock: Socket;
+      try {
+        sock = this.connectFn(this.skillSocketPath);
+      } catch (err) {
+        reject(err instanceof Error ? err : new Error(String(err)));
+        return;
+      }
+      const frame =
+        JSON.stringify({ id: "meet-host-shutdown", method: "skill.shutdown" }) +
+        "\n";
+      let settled = false;
+      const finish = (err?: Error) => {
+        if (settled) return;
+        settled = true;
+        try {
+          sock.destroy();
+        } catch {
+          // Ignore — destroy is best-effort.
+        }
+        if (err) reject(err);
+        else resolve();
+      };
+      sock.once("connect", () => {
+        sock.write(frame, (writeErr) => {
+          if (writeErr) finish(writeErr);
+          else finish();
+        });
+      });
+      sock.once("error", (err) => finish(err));
+    });
+  }
+}
+
+/**
+ * Resolve when the child exits or the given grace period elapses.
+ * Returns `true` if the child exited within the grace window, `false`
+ * if the timeout fired first.
+ */
+function waitForExit(child: ChildProcess, graceMs: number): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    if (child.exitCode != null) {
+      resolve(true);
+      return;
+    }
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve(false);
+    }, graceMs);
+    child.once("exit", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds assistant/src/daemon/meet-host-supervisor.ts — owns the bun run skills/meet-join/register.ts child process lifecycle.
- ensureRunning() is idempotent, spawn-race-safe, and validates the manifest content hash during the handshake.
- Idle timer shuts the child down after 5 minutes with zero active sessions; config key services.meet.host.idle_timeout_ms overrides.
- Crash detection re-spawns on next ensureRunning() when there is inflight work.
- Supervisor is not yet wired to the manifest loader (PR 28) or to the host.registries IPC routes (PR 24's stubs).

Part of plan: skill-isolation.md (PR 27 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
