### PR TITLE
feat(daemon): add memory and provider host IPC routes

### DIFF
--- a/assistant/src/ipc/skill-routes/__tests__/memory.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/memory.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for the `host.memory.*` skill IPC routes.
+ *
+ * Every daemon delegate is mocked with `mock.module` so the test exercises
+ * only the route layer — param parsing, delegate call shape, return shape.
+ * Deep behavioral coverage for `addMessage` / `wakeAgentForOpportunity`
+ * lives in their own modules.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module-level stubs — installed before importing the module under test
+// ---------------------------------------------------------------------------
+
+const addMessageSpy = mock(
+  async (
+    _conversationId: string,
+    _role: string,
+    _content: string,
+    _metadata?: Record<string, unknown>,
+    _opts?: { skipIndexing?: boolean },
+  ) => ({ id: "msg-xyz", createdAt: 123 }),
+);
+mock.module("../../../memory/conversation-crud.js", () => ({
+  addMessage: addMessageSpy,
+}));
+
+const wakeAgentSpy = mock(
+  async (_opts: { conversationId: string; hint: string; source: string }) => ({
+    invoked: true,
+    producedToolCalls: false,
+  }),
+);
+mock.module("../../../runtime/agent-wake.js", () => ({
+  wakeAgentForOpportunity: wakeAgentSpy,
+}));
+
+// ---------------------------------------------------------------------------
+// Module under test — imported after every stub is in place
+// ---------------------------------------------------------------------------
+
+import {
+  memoryAddMessageRoute,
+  memorySkillRoutes,
+  memoryWakeAgentForOpportunityRoute,
+} from "../memory.js";
+
+beforeEach(() => {
+  addMessageSpy.mockClear();
+  wakeAgentSpy.mockClear();
+});
+
+describe("memorySkillRoutes registry", () => {
+  test("exposes both canonical method names", () => {
+    const methods = memorySkillRoutes.map((r) => r.method).sort();
+    expect(methods).toEqual([
+      "host.memory.addMessage",
+      "host.memory.wakeAgentForOpportunity",
+    ]);
+  });
+});
+
+describe("host.memory.addMessage", () => {
+  test("forwards all positional args to addMessage and returns its result", async () => {
+    const result = await memoryAddMessageRoute.handler({
+      conversationId: "conv-1",
+      role: "user",
+      content: "hello",
+      metadata: { foo: "bar" },
+      opts: { skipIndexing: true },
+    });
+
+    expect(addMessageSpy).toHaveBeenCalledTimes(1);
+    const call = addMessageSpy.mock.calls[0];
+    expect(call[0]).toBe("conv-1");
+    expect(call[1]).toBe("user");
+    expect(call[2]).toBe("hello");
+    expect(call[3]).toEqual({ foo: "bar" });
+    expect(call[4]).toEqual({ skipIndexing: true });
+    expect(result).toEqual({ id: "msg-xyz", createdAt: 123 });
+  });
+
+  test("accepts omitted metadata + opts", async () => {
+    await memoryAddMessageRoute.handler({
+      conversationId: "conv-2",
+      role: "assistant",
+      content: "ack",
+    });
+
+    expect(addMessageSpy).toHaveBeenCalledTimes(1);
+    const call = addMessageSpy.mock.calls[0];
+    expect(call[3]).toBeUndefined();
+    expect(call[4]).toBeUndefined();
+  });
+
+  test("rejects missing conversationId", async () => {
+    await expect(
+      memoryAddMessageRoute.handler({ role: "user", content: "x" }),
+    ).rejects.toThrow();
+  });
+
+  test("rejects empty conversationId", async () => {
+    await expect(
+      memoryAddMessageRoute.handler({
+        conversationId: "",
+        role: "user",
+        content: "x",
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("rejects missing role", async () => {
+    await expect(
+      memoryAddMessageRoute.handler({
+        conversationId: "c",
+        content: "x",
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("rejects missing content", async () => {
+    await expect(
+      memoryAddMessageRoute.handler({
+        conversationId: "c",
+        role: "user",
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("host.memory.wakeAgentForOpportunity", () => {
+  test("forwards WakeOptions and returns void (drops WakeResult)", async () => {
+    const result = await memoryWakeAgentForOpportunityRoute.handler({
+      conversationId: "conv-1",
+      hint: "new email arrived",
+      source: "skill-test",
+    });
+
+    expect(wakeAgentSpy).toHaveBeenCalledTimes(1);
+    expect(wakeAgentSpy.mock.calls[0]?.[0]).toEqual({
+      conversationId: "conv-1",
+      hint: "new email arrived",
+      source: "skill-test",
+    });
+    // Contract is `void` — daemon's WakeResult is discarded on purpose.
+    expect(result).toBeUndefined();
+  });
+
+  test("rejects missing conversationId", async () => {
+    await expect(
+      memoryWakeAgentForOpportunityRoute.handler({
+        hint: "h",
+        source: "s",
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("rejects empty hint", async () => {
+    await expect(
+      memoryWakeAgentForOpportunityRoute.handler({
+        conversationId: "c",
+        hint: "",
+        source: "s",
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("rejects empty source", async () => {
+    await expect(
+      memoryWakeAgentForOpportunityRoute.handler({
+        conversationId: "c",
+        hint: "h",
+        source: "",
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/assistant/src/ipc/skill-routes/__tests__/providers.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/providers.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Unit tests for the `host.providers.*` skill IPC routes.
+ *
+ * Every daemon delegate is mocked with `mock.module` so the test exercises
+ * only the route layer — param parsing, delegate call shape, return shape.
+ * Deep behavioral coverage lives in each delegate's own module tests.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module-level stubs — installed before importing the module under test
+// ---------------------------------------------------------------------------
+
+const sendMessageSpy = mock(async () => ({
+  content: [{ type: "text", text: "hello" }],
+  model: "stub-model",
+  usage: { inputTokens: 1, outputTokens: 2 },
+  stopReason: "end_turn",
+}));
+const stubProvider: unknown = {
+  name: "stub-provider",
+  sendMessage: sendMessageSpy,
+};
+const getConfiguredProviderSpy = mock(async () => stubProvider);
+mock.module("../../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: getConfiguredProviderSpy,
+}));
+
+const sttListProviderIdsSpy = mock(() => ["openai-whisper", "deepgram"]);
+const sttSupportsBoundarySpy = mock(() => true);
+mock.module("../../../providers/speech-to-text/provider-catalog.js", () => ({
+  listProviderIds: sttListProviderIdsSpy,
+  supportsBoundary: sttSupportsBoundarySpy,
+}));
+
+const getTtsProviderSpy = mock((id: string) => ({
+  id,
+  capabilities: {},
+  synthesize: async () => ({}),
+}));
+mock.module("../../../tts/provider-registry.js", () => ({
+  getTtsProvider: getTtsProviderSpy,
+}));
+
+const resolveTtsConfigSpy = mock(() => ({
+  provider: "elevenlabs",
+  providerConfig: { voiceId: "stub-voice" },
+}));
+mock.module("../../../tts/tts-config-resolver.js", () => ({
+  resolveTtsConfig: resolveTtsConfigSpy,
+}));
+
+const getConfigSpy = mock(() => ({ services: { tts: {} } }));
+mock.module("../../../config/loader.js", () => ({
+  getConfig: getConfigSpy,
+}));
+
+const getProviderKeyAsyncSpy = mock(async (id: string) =>
+  id === "present" ? "secret-key" : undefined,
+);
+mock.module("../../../security/secure-keys.js", () => ({
+  getProviderKeyAsync: getProviderKeyAsyncSpy,
+}));
+
+// ---------------------------------------------------------------------------
+// Module under test — imported after every stub is in place
+// ---------------------------------------------------------------------------
+
+import {
+  providerSkillRoutes,
+  providersLlmCompleteRoute,
+  providersSecureKeysGetProviderKeyRoute,
+  providersSttListProviderIdsRoute,
+  providersSttSupportsBoundaryRoute,
+  providersTtsGetRoute,
+  providersTtsResolveConfigRoute,
+} from "../providers.js";
+
+beforeEach(() => {
+  sendMessageSpy.mockClear();
+  getConfiguredProviderSpy.mockClear();
+  sttListProviderIdsSpy.mockClear();
+  sttSupportsBoundarySpy.mockClear();
+  getTtsProviderSpy.mockClear();
+  resolveTtsConfigSpy.mockClear();
+  getProviderKeyAsyncSpy.mockClear();
+});
+
+describe("providerSkillRoutes registry", () => {
+  test("exposes every documented method name", () => {
+    const methods = providerSkillRoutes.map((r) => r.method).sort();
+    expect(methods).toEqual([
+      "host.providers.llm.complete",
+      "host.providers.secureKeys.getProviderKey",
+      "host.providers.stt.listProviderIds",
+      "host.providers.stt.supportsBoundary",
+      "host.providers.tts.get",
+      "host.providers.tts.resolveConfig",
+    ]);
+  });
+});
+
+describe("host.providers.llm.complete", () => {
+  test("resolves the provider by callSite and forwards request args", async () => {
+    const response = await providersLlmCompleteRoute.handler({
+      callSite: "mainAgent",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      systemPrompt: "you are helpful",
+    });
+
+    expect(getConfiguredProviderSpy).toHaveBeenCalledWith("mainAgent");
+    expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+    const call = sendMessageSpy.mock.calls[0] as unknown as [
+      unknown[],
+      unknown,
+      string | undefined,
+      unknown,
+    ];
+    expect(Array.isArray(call[0])).toBe(true);
+    expect(call[2]).toBe("you are helpful");
+    expect(response).toEqual({
+      content: [{ type: "text", text: "hello" }],
+      model: "stub-model",
+      usage: { inputTokens: 1, outputTokens: 2 },
+      stopReason: "end_turn",
+    });
+  });
+
+  test("passes tools + config through when provided", async () => {
+    await providersLlmCompleteRoute.handler({
+      callSite: "mainAgent",
+      messages: [],
+      tools: [{ name: "echo", description: "", input_schema: {} }],
+      config: { model: "override-model" },
+    });
+
+    const call = sendMessageSpy.mock.calls[0] as unknown as [
+      unknown[],
+      unknown[],
+      string | undefined,
+      { config?: Record<string, unknown> } | undefined,
+    ];
+    expect(Array.isArray(call[1])).toBe(true);
+    expect((call[1] as unknown[]).length).toBe(1);
+    expect(call[3]?.config).toEqual({ model: "override-model" });
+  });
+
+  test("rejects an unknown callSite", async () => {
+    await expect(
+      providersLlmCompleteRoute.handler({
+        callSite: "not-a-callsite",
+        messages: [],
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("throws when no provider is configured for the callSite", async () => {
+    getConfiguredProviderSpy.mockImplementationOnce(async () => null);
+    await expect(
+      providersLlmCompleteRoute.handler({
+        callSite: "mainAgent",
+        messages: [],
+      }),
+    ).rejects.toThrow(/no provider configured/);
+  });
+});
+
+describe("host.providers.stt.listProviderIds", () => {
+  test("returns a fresh array of ids", () => {
+    const result = providersSttListProviderIdsRoute.handler();
+    expect(result).toEqual(["openai-whisper", "deepgram"]);
+    expect(sttListProviderIdsSpy).toHaveBeenCalled();
+  });
+});
+
+describe("host.providers.stt.supportsBoundary", () => {
+  test("delegates with positional (id, boundary) and returns the bool", () => {
+    sttSupportsBoundarySpy.mockImplementationOnce(() => true);
+    const result = providersSttSupportsBoundaryRoute.handler({
+      id: "openai-whisper",
+      boundary: "daemon-streaming",
+    });
+
+    expect(result).toBe(true);
+    const call = sttSupportsBoundarySpy.mock.calls[0] as unknown as [
+      string,
+      string,
+    ];
+    expect(call[0]).toBe("openai-whisper");
+    expect(call[1]).toBe("daemon-streaming");
+  });
+
+  test("rejects missing id", () => {
+    expect(() =>
+      providersSttSupportsBoundaryRoute.handler({ boundary: "x" }),
+    ).toThrow();
+  });
+
+  test("rejects missing boundary", () => {
+    expect(() =>
+      providersSttSupportsBoundaryRoute.handler({ id: "y" }),
+    ).toThrow();
+  });
+});
+
+describe("host.providers.tts.resolveConfig", () => {
+  test("returns a serializable config object from resolveTtsConfig(getConfig())", () => {
+    const result = providersTtsResolveConfigRoute.handler();
+    expect(result).toEqual({
+      provider: "elevenlabs",
+      providerConfig: { voiceId: "stub-voice" },
+    });
+    expect(getConfigSpy).toHaveBeenCalled();
+    expect(resolveTtsConfigSpy).toHaveBeenCalled();
+  });
+});
+
+describe("host.providers.tts.get", () => {
+  test("returns a handle serialized as { id } after resolving the provider", () => {
+    const result = providersTtsGetRoute.handler({ id: "elevenlabs" });
+    expect(result).toEqual({ id: "elevenlabs" });
+    expect(getTtsProviderSpy).toHaveBeenCalledWith("elevenlabs");
+  });
+
+  test("propagates unknown-id errors from the registry", () => {
+    getTtsProviderSpy.mockImplementationOnce(() => {
+      throw new Error('Unknown TTS provider "ghost".');
+    });
+    expect(() => providersTtsGetRoute.handler({ id: "ghost" })).toThrow(
+      /Unknown TTS provider/,
+    );
+  });
+
+  test("rejects empty id", () => {
+    expect(() => providersTtsGetRoute.handler({ id: "" })).toThrow();
+  });
+});
+
+describe("host.providers.secureKeys.getProviderKey", () => {
+  test("returns the stored key for a known provider", async () => {
+    const result = await providersSecureKeysGetProviderKeyRoute.handler({
+      id: "present",
+    });
+    expect(result).toBe("secret-key");
+    expect(getProviderKeyAsyncSpy).toHaveBeenCalledWith("present");
+  });
+
+  test("normalizes daemon's undefined to null for absent keys", async () => {
+    const result = await providersSecureKeysGetProviderKeyRoute.handler({
+      id: "absent",
+    });
+    expect(result).toBeNull();
+  });
+
+  test("rejects empty id", async () => {
+    await expect(
+      providersSecureKeysGetProviderKeyRoute.handler({ id: "" }),
+    ).rejects.toThrow();
+  });
+});

--- a/assistant/src/ipc/skill-routes/index.ts
+++ b/assistant/src/ipc/skill-routes/index.ts
@@ -1,11 +1,16 @@
 import type { IpcRoute } from "../cli-server.js";
+import { memorySkillRoutes } from "./memory.js";
+import { providerSkillRoutes } from "./providers.js";
 
 /**
  * Skill IPC routes — host capabilities exposed to first-party skill processes
  * over the `assistant-skill.sock` socket.
  *
- * Populated by subsequent PRs in the skill-isolation plan (host.log,
+ * Populated incrementally by the skill-isolation plan PRs (host.log,
  * host.config.*, host.identity.*, host.platform.*, host.memory.*,
  * host.providers.*, host.events.*, host.registries.*).
  */
-export const skillIpcRoutes: IpcRoute[] = [];
+export const skillIpcRoutes: IpcRoute[] = [
+  ...memorySkillRoutes,
+  ...providerSkillRoutes,
+];

--- a/assistant/src/ipc/skill-routes/memory.ts
+++ b/assistant/src/ipc/skill-routes/memory.ts
@@ -1,0 +1,76 @@
+/**
+ * Skill IPC routes for the `host.memory.*` facet.
+ *
+ * These mirror the in-process delegates used by `DaemonSkillHost`
+ * (see `assistant/src/daemon/daemon-skill-host.ts`). Every handler is a
+ * thin pass-through to the underlying daemon module, with schema-validated
+ * params and a serializable return shape.
+ */
+
+import { z } from "zod";
+
+import { addMessage } from "../../memory/conversation-crud.js";
+import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
+import type { IpcRoute } from "../cli-server.js";
+
+// -- Param schemas --------------------------------------------------------
+
+/**
+ * Shape mirrors the daemon's `addMessage()` positional signature:
+ * `(conversationId, role, content, metadata?, opts?)`. Metadata is a
+ * free-form record (validated downstream by `messageMetadataSchema` with a
+ * warn-and-store fallback). Only `skipIndexing` is recognised in `opts`.
+ */
+const MemoryAddMessageParams = z.object({
+  conversationId: z.string().min(1),
+  role: z.string().min(1),
+  content: z.string(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  opts: z
+    .object({
+      skipIndexing: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+/** Mirrors `WakeOptions` from `runtime/agent-wake.ts`. */
+const MemoryWakeOpportunityParams = z.object({
+  conversationId: z.string().min(1),
+  hint: z.string().min(1),
+  source: z.string().min(1),
+});
+
+// -- Handlers -------------------------------------------------------------
+
+async function handleAddMessage(params?: Record<string, unknown>) {
+  const { conversationId, role, content, metadata, opts } =
+    MemoryAddMessageParams.parse(params);
+  return addMessage(conversationId, role, content, metadata, opts);
+}
+
+async function handleWakeAgentForOpportunity(
+  params?: Record<string, unknown>,
+): Promise<void> {
+  const opts = MemoryWakeOpportunityParams.parse(params);
+  // Contract exposes `void` even though the daemon returns a `WakeResult` —
+  // the skill surface does not need the producedToolCalls / reason fields.
+  await wakeAgentForOpportunity(opts);
+}
+
+// -- Route definitions ----------------------------------------------------
+
+export const memoryAddMessageRoute: IpcRoute = {
+  method: "host.memory.addMessage",
+  handler: handleAddMessage,
+};
+
+export const memoryWakeAgentForOpportunityRoute: IpcRoute = {
+  method: "host.memory.wakeAgentForOpportunity",
+  handler: handleWakeAgentForOpportunity,
+};
+
+/** All `host.memory.*` IPC routes. */
+export const memorySkillRoutes: IpcRoute[] = [
+  memoryAddMessageRoute,
+  memoryWakeAgentForOpportunityRoute,
+];

--- a/assistant/src/ipc/skill-routes/providers.ts
+++ b/assistant/src/ipc/skill-routes/providers.ts
@@ -1,0 +1,163 @@
+/**
+ * Skill IPC routes for the `host.providers.*` facet.
+ *
+ * These mirror the in-process delegates used by `DaemonSkillHost`
+ * (see `assistant/src/daemon/daemon-skill-host.ts`). Every handler is a
+ * thin pass-through to the underlying daemon module, with schema-validated
+ * params and a serializable return shape.
+ *
+ * Sub-facets:
+ * - `host.providers.llm.complete`
+ * - `host.providers.stt.listProviderIds`
+ * - `host.providers.stt.supportsBoundary`
+ * - `host.providers.tts.resolveConfig`
+ * - `host.providers.tts.get`         (returns a handle-as-id; synthesis
+ *                                     happens in-skill via the returned config)
+ * - `host.providers.secureKeys.getProviderKey`
+ */
+
+import { z } from "zod";
+
+import { getConfig } from "../../config/loader.js";
+import { LLMCallSiteEnum } from "../../config/schemas/llm.js";
+import { getConfiguredProvider } from "../../providers/provider-send-message.js";
+import {
+  listProviderIds as sttListProviderIds,
+  supportsBoundary as sttSupportsBoundary,
+} from "../../providers/speech-to-text/provider-catalog.js";
+import type {
+  Message,
+  SendMessageConfig,
+  ToolDefinition,
+} from "../../providers/types.js";
+import { getProviderKeyAsync } from "../../security/secure-keys.js";
+import { getTtsProvider } from "../../tts/provider-registry.js";
+import { resolveTtsConfig } from "../../tts/tts-config-resolver.js";
+import type { IpcRoute } from "../cli-server.js";
+
+// -- Param schemas --------------------------------------------------------
+
+/**
+ * LLM completion request. The IPC surface only accepts the serializable
+ * subset of `Provider.sendMessage(messages, tools?, systemPrompt?, options?)`.
+ * Non-serializable fields (`onEvent`, `signal`) are intentionally omitted —
+ * streaming deltas and per-call cancellation belong on future streaming
+ * routes, not this one-shot RPC.
+ */
+const ProvidersLlmCompleteParams = z.object({
+  callSite: LLMCallSiteEnum,
+  messages: z.array(z.unknown()),
+  tools: z.array(z.unknown()).optional(),
+  systemPrompt: z.string().optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
+});
+
+const ProvidersSttSupportsBoundaryParams = z.object({
+  id: z.string().min(1),
+  boundary: z.string().min(1),
+});
+
+const ProvidersTtsGetParams = z.object({
+  id: z.string().min(1),
+});
+
+const ProvidersSecureKeysGetParams = z.object({
+  id: z.string().min(1),
+});
+
+// -- Handlers -------------------------------------------------------------
+
+async function handleLlmComplete(params?: Record<string, unknown>) {
+  const { callSite, messages, tools, systemPrompt, config } =
+    ProvidersLlmCompleteParams.parse(params);
+  const provider = await getConfiguredProvider(callSite);
+  if (!provider) {
+    throw new Error(
+      `host.providers.llm.complete: no provider configured for callSite '${callSite}'`,
+    );
+  }
+  return provider.sendMessage(
+    messages as Message[],
+    tools as ToolDefinition[] | undefined,
+    systemPrompt,
+    config ? { config: config as SendMessageConfig } : undefined,
+  );
+}
+
+function handleSttListProviderIds(): string[] {
+  return [...sttListProviderIds()];
+}
+
+function handleSttSupportsBoundary(params?: Record<string, unknown>): boolean {
+  const { id, boundary } = ProvidersSttSupportsBoundaryParams.parse(params);
+  // Unknown ids return `false`, so the narrowing cast is safe.
+  return sttSupportsBoundary(id as never, boundary as never);
+}
+
+function handleTtsResolveConfig(): ReturnType<typeof resolveTtsConfig> {
+  return resolveTtsConfig(getConfig());
+}
+
+/**
+ * Return a serializable handle for a TTS provider. The actual `TtsProvider`
+ * object holds method closures that cannot cross the IPC boundary — skills
+ * identify the provider by id and do synthesis via the config returned from
+ * `resolveConfig`. We still invoke `getTtsProvider(id)` here so an invalid
+ * id surfaces as an error rather than a silently invalid handle.
+ */
+function handleTtsGet(params?: Record<string, unknown>): { id: string } {
+  const { id } = ProvidersTtsGetParams.parse(params);
+  const provider = getTtsProvider(id as never);
+  return { id: provider.id };
+}
+
+async function handleSecureKeysGetProviderKey(
+  params?: Record<string, unknown>,
+): Promise<string | null> {
+  const { id } = ProvidersSecureKeysGetParams.parse(params);
+  // Daemon helper returns `undefined` for absent keys; the contract returns
+  // `null`. Normalize at the boundary.
+  return (await getProviderKeyAsync(id)) ?? null;
+}
+
+// -- Route definitions ----------------------------------------------------
+
+export const providersLlmCompleteRoute: IpcRoute = {
+  method: "host.providers.llm.complete",
+  handler: handleLlmComplete,
+};
+
+export const providersSttListProviderIdsRoute: IpcRoute = {
+  method: "host.providers.stt.listProviderIds",
+  handler: handleSttListProviderIds,
+};
+
+export const providersSttSupportsBoundaryRoute: IpcRoute = {
+  method: "host.providers.stt.supportsBoundary",
+  handler: handleSttSupportsBoundary,
+};
+
+export const providersTtsResolveConfigRoute: IpcRoute = {
+  method: "host.providers.tts.resolveConfig",
+  handler: handleTtsResolveConfig,
+};
+
+export const providersTtsGetRoute: IpcRoute = {
+  method: "host.providers.tts.get",
+  handler: handleTtsGet,
+};
+
+export const providersSecureKeysGetProviderKeyRoute: IpcRoute = {
+  method: "host.providers.secureKeys.getProviderKey",
+  handler: handleSecureKeysGetProviderKey,
+};
+
+/** All `host.providers.*` IPC routes. */
+export const providerSkillRoutes: IpcRoute[] = [
+  providersLlmCompleteRoute,
+  providersSttListProviderIdsRoute,
+  providersSttSupportsBoundaryRoute,
+  providersTtsResolveConfigRoute,
+  providersTtsGetRoute,
+  providersSecureKeysGetProviderKeyRoute,
+];


### PR DESCRIPTION
## Summary
- Adds host.memory.*, host.providers.llm.complete, host.providers.stt.*, host.providers.tts.*, host.providers.secureKeys.getProviderKey IPC routes.
- Each delegates to existing daemon modules.

Part of plan: skill-isolation.md (PR 22 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
