### PR TITLE
Document assistant pricing estimates as non-hosted-billing data

### DIFF
--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -171,7 +171,7 @@ describe("resolvePricing", () => {
     });
   });
 
-  describe("prefix matching", () => {
+  describe("local estimate prefix matching, not hosted billing", () => {
     test("matches claude-opus-4-6-20260205 via claude-opus-4-6 prefix", () => {
       const result = resolvePricing(
         "anthropic",

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -7,6 +7,10 @@ export interface CatalogModel {
   supportsCaching?: boolean;
   supportsVision?: boolean;
   supportsToolUse?: boolean;
+  /**
+   * Local/public cost estimates for assistant-side display or telemetry only.
+   * Hosted platform billing rates remain authoritative in vellum-assistant-platform.
+   */
   pricing?: {
     inputPer1mTokens: number;
     outputPer1mTokens: number;

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -18,6 +18,9 @@ const ANTHROPIC_FAST_MODE_MULTIPLIER = 6;
 /**
  * Multi-provider pricing catalog keyed by provider then model pattern.
  * Model patterns are matched by exact match first, then by prefix.
+ *
+ * These rates are local/public estimates for assistant-side cost display or
+ * telemetry. Hosted billing rate cards are owned by vellum-assistant-platform.
  */
 const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
   anthropic: {


### PR DESCRIPTION
## Summary
- Clarify that assistant pricing metadata is local estimate data, not hosted billing authority.
- Label the pricing prefix behavior test accordingly.

Part of plan: shared-model-catalog-assistant.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
