### PR TITLE
feat(gateway): add TrustRuleV3Store with SQLite CRUD operations

### DIFF
--- a/gateway/src/__tests__/trust-rule-v3-store.test.ts
+++ b/gateway/src/__tests__/trust-rule-v3-store.test.ts
@@ -1,0 +1,550 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
+import { TrustRuleV3Store } from "../db/trust-rule-v3-store.js";
+import "./test-preload.js";
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let store: TrustRuleV3Store;
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  store = new TrustRuleV3Store();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+// ---------------------------------------------------------------------------
+// create()
+// ---------------------------------------------------------------------------
+
+describe("create()", () => {
+  test("creates a user-defined rule with all fields", () => {
+    const rule = store.create({
+      tool: "bash",
+      pattern: "echo *",
+      risk: "low",
+      description: "Allow echo commands",
+    });
+
+    expect(rule.id).toBeTruthy();
+    // Should be a valid UUID format
+    expect(rule.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+    expect(rule.tool).toBe("bash");
+    expect(rule.pattern).toBe("echo *");
+    expect(rule.risk).toBe("low");
+    expect(rule.description).toBe("Allow echo commands");
+    expect(rule.origin).toBe("user_defined");
+    expect(rule.userModified).toBe(false);
+    expect(rule.deleted).toBe(false);
+    expect(rule.createdAt).toBeTruthy();
+    expect(rule.updatedAt).toBeTruthy();
+  });
+
+  test("sets createdAt and updatedAt to ISO 8601 UTC", () => {
+    const before = new Date().toISOString();
+    const rule = store.create({
+      tool: "bash",
+      pattern: "ls",
+      risk: "low",
+      description: "test",
+    });
+    const after = new Date().toISOString();
+
+    expect(rule.createdAt >= before).toBe(true);
+    expect(rule.createdAt <= after).toBe(true);
+    expect(rule.updatedAt).toBe(rule.createdAt);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list()
+// ---------------------------------------------------------------------------
+
+describe("list()", () => {
+  test("returns all non-deleted rules by default", () => {
+    store.create({
+      tool: "bash",
+      pattern: "echo *",
+      risk: "low",
+      description: "Rule 1",
+    });
+    store.create({
+      tool: "file_read",
+      pattern: "/tmp/**",
+      risk: "medium",
+      description: "Rule 2",
+    });
+
+    const rules = store.list();
+    expect(rules).toHaveLength(2);
+  });
+
+  test("filters by origin", () => {
+    store.create({
+      tool: "bash",
+      pattern: "echo *",
+      risk: "low",
+      description: "User rule",
+    });
+    store.upsertDefault({
+      id: "default:bash:rm-rf",
+      tool: "bash",
+      pattern: "rm -rf *",
+      risk: "high",
+      description: "Default rule",
+    });
+
+    const userRules = store.list({ origin: "user_defined" });
+    expect(userRules).toHaveLength(1);
+    expect(userRules[0].origin).toBe("user_defined");
+
+    const defaultRules = store.list({ origin: "default" });
+    expect(defaultRules).toHaveLength(1);
+    expect(defaultRules[0].origin).toBe("default");
+  });
+
+  test("filters by tool", () => {
+    store.create({
+      tool: "bash",
+      pattern: "echo *",
+      risk: "low",
+      description: "Bash rule",
+    });
+    store.create({
+      tool: "file_read",
+      pattern: "/tmp/**",
+      risk: "medium",
+      description: "File rule",
+    });
+
+    const bashRules = store.list({ tool: "bash" });
+    expect(bashRules).toHaveLength(1);
+    expect(bashRules[0].tool).toBe("bash");
+  });
+
+  test("excludes soft-deleted rules by default", () => {
+    store.upsertDefault({
+      id: "default:bash:danger",
+      tool: "bash",
+      pattern: "danger",
+      risk: "high",
+      description: "Danger",
+    });
+    store.remove("default:bash:danger");
+
+    const rules = store.list();
+    expect(rules).toHaveLength(0);
+  });
+
+  test("includes soft-deleted rules when includeDeleted is true", () => {
+    store.upsertDefault({
+      id: "default:bash:danger",
+      tool: "bash",
+      pattern: "danger",
+      risk: "high",
+      description: "Danger",
+    });
+    store.remove("default:bash:danger");
+
+    const rules = store.list({ includeDeleted: true });
+    expect(rules).toHaveLength(1);
+    expect(rules[0].deleted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getById()
+// ---------------------------------------------------------------------------
+
+describe("getById()", () => {
+  test("returns rule when found", () => {
+    const created = store.create({
+      tool: "bash",
+      pattern: "echo *",
+      risk: "low",
+      description: "Test",
+    });
+
+    const found = store.getById(created.id);
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(created.id);
+    expect(found!.tool).toBe("bash");
+  });
+
+  test("returns null when not found", () => {
+    const found = store.getById("nonexistent-id");
+    expect(found).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update()
+// ---------------------------------------------------------------------------
+
+describe("update()", () => {
+  test("updates risk and description", () => {
+    const created = store.create({
+      tool: "bash",
+      pattern: "echo *",
+      risk: "low",
+      description: "Original",
+    });
+
+    const updated = store.update(created.id, {
+      risk: "high",
+      description: "Updated",
+    });
+
+    expect(updated.risk).toBe("high");
+    expect(updated.description).toBe("Updated");
+    expect(updated.updatedAt > created.updatedAt).toBe(true);
+  });
+
+  test("sets userModified=true for default rules", () => {
+    store.upsertDefault({
+      id: "default:bash:test",
+      tool: "bash",
+      pattern: "test",
+      risk: "low",
+      description: "Default rule",
+    });
+
+    const rule = store.getById("default:bash:test")!;
+    expect(rule.userModified).toBe(false);
+
+    const updated = store.update("default:bash:test", { risk: "high" });
+    expect(updated.userModified).toBe(true);
+  });
+
+  test("does not set userModified for user_defined rules", () => {
+    const created = store.create({
+      tool: "bash",
+      pattern: "echo *",
+      risk: "low",
+      description: "User rule",
+    });
+
+    const updated = store.update(created.id, { risk: "high" });
+    expect(updated.userModified).toBe(false);
+  });
+
+  test("throws if rule not found", () => {
+    expect(() => store.update("nonexistent", { risk: "high" })).toThrow(
+      "Trust rule not found: nonexistent",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// remove()
+// ---------------------------------------------------------------------------
+
+describe("remove()", () => {
+  test("hard-deletes user_defined rules", () => {
+    const created = store.create({
+      tool: "bash",
+      pattern: "echo *",
+      risk: "low",
+      description: "User rule",
+    });
+
+    const result = store.remove(created.id);
+    expect(result).toBe(true);
+
+    // Should be completely gone, even with includeDeleted
+    const found = store.getById(created.id);
+    expect(found).toBeNull();
+
+    const allRules = store.list({ includeDeleted: true });
+    expect(allRules.find((r) => r.id === created.id)).toBeUndefined();
+  });
+
+  test("soft-deletes default rules", () => {
+    store.upsertDefault({
+      id: "default:bash:test",
+      tool: "bash",
+      pattern: "test",
+      risk: "low",
+      description: "Default rule",
+    });
+
+    const result = store.remove("default:bash:test");
+    expect(result).toBe(true);
+
+    // Should not appear in default list
+    const rules = store.list();
+    expect(rules).toHaveLength(0);
+
+    // Should still exist as soft-deleted
+    const found = store.getById("default:bash:test");
+    expect(found).not.toBeNull();
+    expect(found!.deleted).toBe(true);
+  });
+
+  test("throws if rule not found", () => {
+    expect(() => store.remove("nonexistent")).toThrow(
+      "Trust rule not found: nonexistent",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reset()
+// ---------------------------------------------------------------------------
+
+describe("reset()", () => {
+  test("clears userModified and deleted, restores risk", () => {
+    store.upsertDefault({
+      id: "default:bash:test",
+      tool: "bash",
+      pattern: "test",
+      risk: "low",
+      description: "Default rule",
+    });
+
+    // Modify and delete
+    store.update("default:bash:test", { risk: "high" });
+    store.remove("default:bash:test");
+
+    const beforeReset = store.getById("default:bash:test")!;
+    expect(beforeReset.userModified).toBe(true);
+    expect(beforeReset.deleted).toBe(true);
+    expect(beforeReset.risk).toBe("high");
+
+    // Reset
+    const resetRule = store.reset("default:bash:test", "low");
+    expect(resetRule.userModified).toBe(false);
+    expect(resetRule.deleted).toBe(false);
+    expect(resetRule.risk).toBe("low");
+    expect(resetRule.updatedAt > beforeReset.updatedAt).toBe(true);
+  });
+
+  test("throws if rule not found", () => {
+    expect(() => store.reset("nonexistent", "low")).toThrow(
+      "Trust rule not found: nonexistent",
+    );
+  });
+
+  test("throws if origin is not default", () => {
+    const created = store.create({
+      tool: "bash",
+      pattern: "echo *",
+      risk: "low",
+      description: "User rule",
+    });
+
+    expect(() => store.reset(created.id, "low")).toThrow(
+      `Cannot reset non-default rule: ${created.id}`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertDefault()
+// ---------------------------------------------------------------------------
+
+describe("upsertDefault()", () => {
+  test("inserts a new default rule", () => {
+    store.upsertDefault({
+      id: "default:bash:test",
+      tool: "bash",
+      pattern: "test",
+      risk: "low",
+      description: "Default rule",
+    });
+
+    const rule = store.getById("default:bash:test");
+    expect(rule).not.toBeNull();
+    expect(rule!.origin).toBe("default");
+    expect(rule!.userModified).toBe(false);
+    expect(rule!.deleted).toBe(false);
+    expect(rule!.risk).toBe("low");
+  });
+
+  test("updates unmodified default rule on conflict", () => {
+    store.upsertDefault({
+      id: "default:bash:test",
+      tool: "bash",
+      pattern: "test",
+      risk: "low",
+      description: "Original",
+    });
+
+    // Re-upsert with updated risk and description
+    store.upsertDefault({
+      id: "default:bash:test",
+      tool: "bash",
+      pattern: "test",
+      risk: "medium",
+      description: "Updated",
+    });
+
+    const rule = store.getById("default:bash:test")!;
+    expect(rule.risk).toBe("medium");
+    expect(rule.description).toBe("Updated");
+  });
+
+  test("three-guard: does NOT overwrite user-modified rule", () => {
+    store.upsertDefault({
+      id: "default:bash:test",
+      tool: "bash",
+      pattern: "test",
+      risk: "low",
+      description: "Original",
+    });
+
+    // User modifies the rule
+    store.update("default:bash:test", { risk: "high" });
+
+    const modified = store.getById("default:bash:test")!;
+    expect(modified.userModified).toBe(true);
+    expect(modified.risk).toBe("high");
+
+    // Re-upsert should NOT overwrite because userModified=true
+    store.upsertDefault({
+      id: "default:bash:test",
+      tool: "bash",
+      pattern: "test",
+      risk: "low",
+      description: "Should not overwrite",
+    });
+
+    const afterUpsert = store.getById("default:bash:test")!;
+    expect(afterUpsert.risk).toBe("high");
+    expect(afterUpsert.description).toBe("Original");
+    expect(afterUpsert.userModified).toBe(true);
+  });
+
+  test("three-guard: does NOT overwrite soft-deleted rule", () => {
+    store.upsertDefault({
+      id: "default:bash:test",
+      tool: "bash",
+      pattern: "test",
+      risk: "low",
+      description: "Original",
+    });
+
+    // Soft-delete the rule
+    store.remove("default:bash:test");
+
+    const deleted = store.getById("default:bash:test")!;
+    expect(deleted.deleted).toBe(true);
+
+    // Re-upsert should NOT overwrite because deleted=true
+    store.upsertDefault({
+      id: "default:bash:test",
+      tool: "bash",
+      pattern: "test",
+      risk: "medium",
+      description: "Should not overwrite",
+    });
+
+    const afterUpsert = store.getById("default:bash:test")!;
+    expect(afterUpsert.risk).toBe("low");
+    expect(afterUpsert.description).toBe("Original");
+    expect(afterUpsert.deleted).toBe(true);
+  });
+
+  test("three-guard: does NOT overwrite user_defined origin rule on conflict", () => {
+    // Create a user-defined rule first
+    store.create({
+      tool: "bash",
+      pattern: "custom-pattern",
+      risk: "high",
+      description: "User created",
+    });
+
+    // Upsert a default with same tool+pattern should NOT overwrite
+    // because origin != 'default'
+    store.upsertDefault({
+      id: "default:bash:custom-pattern",
+      tool: "bash",
+      pattern: "custom-pattern",
+      risk: "low",
+      description: "Default version",
+    });
+
+    // The user-defined rule should remain unchanged
+    const rules = store.list({ tool: "bash" });
+    expect(rules).toHaveLength(1);
+    expect(rules[0].origin).toBe("user_defined");
+    expect(rules[0].risk).toBe("high");
+    expect(rules[0].description).toBe("User created");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listActive()
+// ---------------------------------------------------------------------------
+
+describe("listActive()", () => {
+  test("returns only non-deleted rules", () => {
+    store.create({
+      tool: "bash",
+      pattern: "echo *",
+      risk: "low",
+      description: "Active user rule",
+    });
+    store.upsertDefault({
+      id: "default:bash:danger",
+      tool: "bash",
+      pattern: "danger",
+      risk: "high",
+      description: "Deleted default",
+    });
+    store.remove("default:bash:danger");
+
+    const active = store.listActive();
+    expect(active).toHaveLength(1);
+    expect(active[0].pattern).toBe("echo *");
+  });
+
+  test("filters by tool", () => {
+    store.create({
+      tool: "bash",
+      pattern: "echo *",
+      risk: "low",
+      description: "Bash rule",
+    });
+    store.create({
+      tool: "file_read",
+      pattern: "/tmp/**",
+      risk: "medium",
+      description: "File rule",
+    });
+
+    const bashRules = store.listActive("bash");
+    expect(bashRules).toHaveLength(1);
+    expect(bashRules[0].tool).toBe("bash");
+
+    const fileRules = store.listActive("file_read");
+    expect(fileRules).toHaveLength(1);
+    expect(fileRules[0].tool).toBe("file_read");
+  });
+
+  test("returns all active rules when no tool filter is provided", () => {
+    store.create({
+      tool: "bash",
+      pattern: "echo *",
+      risk: "low",
+      description: "Bash rule",
+    });
+    store.create({
+      tool: "file_read",
+      pattern: "/tmp/**",
+      risk: "medium",
+      description: "File rule",
+    });
+
+    const allActive = store.listActive();
+    expect(allActive).toHaveLength(2);
+  });
+});

--- a/gateway/src/db/trust-rule-v3-store.ts
+++ b/gateway/src/db/trust-rule-v3-store.ts
@@ -1,0 +1,282 @@
+import { and, eq, sql } from "drizzle-orm";
+import { type GatewayDb, getGatewayDb } from "./connection.js";
+import { trustRulesV3 } from "./schema.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TrustRuleV3 {
+  id: string;
+  tool: string;
+  pattern: string;
+  risk: "low" | "medium" | "high";
+  description: string;
+  origin: "default" | "user_defined";
+  userModified: boolean;
+  deleted: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ListFilters {
+  origin?: string;
+  tool?: string;
+  includeDeleted?: boolean;
+}
+
+export interface CreateInput {
+  tool: string;
+  pattern: string;
+  risk: string;
+  description: string;
+}
+
+export interface UpdateInput {
+  risk?: string;
+  description?: string;
+}
+
+export interface UpsertDefaultInput {
+  id: string;
+  tool: string;
+  pattern: string;
+  risk: string;
+  description: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function nowISO(): string {
+  return new Date().toISOString();
+}
+
+function toTrustRuleV3(row: typeof trustRulesV3.$inferSelect): TrustRuleV3 {
+  return {
+    id: row.id,
+    tool: row.tool,
+    pattern: row.pattern,
+    risk: row.risk as TrustRuleV3["risk"],
+    description: row.description,
+    origin: row.origin as TrustRuleV3["origin"],
+    userModified: row.userModified,
+    deleted: row.deleted,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export class TrustRuleV3Store {
+  private injectedDb?: GatewayDb;
+
+  constructor(db?: GatewayDb) {
+    this.injectedDb = db;
+  }
+
+  private get db(): GatewayDb {
+    return this.injectedDb ?? getGatewayDb();
+  }
+
+  /**
+   * List trust rules with optional filters.
+   * By default excludes soft-deleted rules.
+   */
+  list(filters?: ListFilters): TrustRuleV3[] {
+    const conditions = [];
+
+    if (!filters?.includeDeleted) {
+      conditions.push(eq(trustRulesV3.deleted, false));
+    }
+    if (filters?.origin !== undefined) {
+      conditions.push(eq(trustRulesV3.origin, filters.origin));
+    }
+    if (filters?.tool !== undefined) {
+      conditions.push(eq(trustRulesV3.tool, filters.tool));
+    }
+
+    const query = this.db.select().from(trustRulesV3);
+    const rows =
+      conditions.length > 0
+        ? query.where(and(...conditions)).all()
+        : query.all();
+
+    return rows.map(toTrustRuleV3);
+  }
+
+  /**
+   * Fetch a single rule by ID. Returns null if not found.
+   */
+  getById(id: string): TrustRuleV3 | null {
+    const row = this.db
+      .select()
+      .from(trustRulesV3)
+      .where(eq(trustRulesV3.id, id))
+      .get();
+    return row ? toTrustRuleV3(row) : null;
+  }
+
+  /**
+   * Create a user-defined trust rule. Generates a UUIDv4 id.
+   */
+  create(input: CreateInput): TrustRuleV3 {
+    const now = nowISO();
+    const id = crypto.randomUUID();
+
+    this.db
+      .insert(trustRulesV3)
+      .values({
+        id,
+        tool: input.tool,
+        pattern: input.pattern,
+        risk: input.risk,
+        description: input.description,
+        origin: "user_defined",
+        userModified: false,
+        deleted: false,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    return this.getById(id)!;
+  }
+
+  /**
+   * Update an existing rule's risk and/or description.
+   * If the rule has origin="default", sets userModified=true.
+   * Throws if not found.
+   */
+  update(id: string, updates: UpdateInput): TrustRuleV3 {
+    const existing = this.getById(id);
+    if (!existing) {
+      throw new Error(`Trust rule not found: ${id}`);
+    }
+
+    const setValues: Record<string, unknown> = {
+      updatedAt: nowISO(),
+    };
+
+    if (updates.risk !== undefined) {
+      setValues.risk = updates.risk;
+    }
+    if (updates.description !== undefined) {
+      setValues.description = updates.description;
+    }
+
+    // If this is a default rule, mark as user-modified
+    if (existing.origin === "default") {
+      setValues.userModified = true;
+    }
+
+    this.db
+      .update(trustRulesV3)
+      .set(setValues)
+      .where(eq(trustRulesV3.id, id))
+      .run();
+
+    return this.getById(id)!;
+  }
+
+  /**
+   * Remove a trust rule.
+   * - user_defined rules: hard-delete (DELETE FROM)
+   * - default rules: soft-delete (set deleted=true)
+   * Throws if not found.
+   */
+  remove(id: string): boolean {
+    const existing = this.getById(id);
+    if (!existing) {
+      throw new Error(`Trust rule not found: ${id}`);
+    }
+
+    if (existing.origin === "user_defined") {
+      // Hard-delete
+      this.db.delete(trustRulesV3).where(eq(trustRulesV3.id, id)).run();
+    } else {
+      // Soft-delete for default rules
+      this.db
+        .update(trustRulesV3)
+        .set({ deleted: true, updatedAt: nowISO() })
+        .where(eq(trustRulesV3.id, id))
+        .run();
+    }
+
+    return true;
+  }
+
+  /**
+   * Reset a default rule to its original state.
+   * Clears userModified and deleted, restores risk to originalRisk.
+   * Throws if not found or if origin is not "default".
+   */
+  reset(id: string, originalRisk: string): TrustRuleV3 {
+    const existing = this.getById(id);
+    if (!existing) {
+      throw new Error(`Trust rule not found: ${id}`);
+    }
+    if (existing.origin !== "default") {
+      throw new Error(`Cannot reset non-default rule: ${id}`);
+    }
+
+    this.db
+      .update(trustRulesV3)
+      .set({
+        userModified: false,
+        deleted: false,
+        risk: originalRisk,
+        updatedAt: nowISO(),
+      })
+      .where(eq(trustRulesV3.id, id))
+      .run();
+
+    return this.getById(id)!;
+  }
+
+  /**
+   * Insert or update a default rule. On conflict (tool, pattern), updates
+   * risk and description ONLY IF origin='default' AND user_modified=0 AND
+   * deleted=0. This implements the three-guard upsert.
+   *
+   * Uses raw SQL because Drizzle ORM doesn't support conditional ON CONFLICT
+   * updates natively.
+   */
+  upsertDefault(input: UpsertDefaultInput): void {
+    const now = nowISO();
+
+    this.db.run(sql`
+      INSERT INTO trust_rules (id, tool, pattern, risk, description, origin, user_modified, deleted, created_at, updated_at)
+      VALUES (${input.id}, ${input.tool}, ${input.pattern}, ${input.risk}, ${input.description}, 'default', 0, 0, ${now}, ${now})
+      ON CONFLICT (tool, pattern) DO UPDATE SET
+        risk = excluded.risk,
+        description = excluded.description,
+        updated_at = excluded.updated_at
+      WHERE origin = 'default' AND user_modified = 0 AND deleted = 0
+    `);
+  }
+
+  /**
+   * Return all active (non-deleted) rules, optionally filtered by tool.
+   * This is the query the cache will use.
+   */
+  listActive(tool?: string): TrustRuleV3[] {
+    const conditions = [eq(trustRulesV3.deleted, false)];
+
+    if (tool !== undefined) {
+      conditions.push(eq(trustRulesV3.tool, tool));
+    }
+
+    const rows = this.db
+      .select()
+      .from(trustRulesV3)
+      .where(and(...conditions))
+      .all();
+
+    return rows.map(toTrustRuleV3);
+  }
+}

--- a/gateway/src/db/trust-rule-v3-store.ts
+++ b/gateway/src/db/trust-rule-v3-store.ts
@@ -49,16 +49,37 @@ export interface UpsertDefaultInput {
 // Helpers
 // ---------------------------------------------------------------------------
 
+const VALID_RISK_VALUES: ReadonlySet<string> = new Set([
+  "low",
+  "medium",
+  "high",
+]);
+
+function assertValidRisk(value: string): asserts value is TrustRuleV3["risk"] {
+  if (!VALID_RISK_VALUES.has(value)) {
+    throw new Error(
+      `Invalid risk value: "${value}". Must be one of: low, medium, high`,
+    );
+  }
+}
+
 function nowISO(): string {
   return new Date().toISOString();
 }
 
 function toTrustRuleV3(row: typeof trustRulesV3.$inferSelect): TrustRuleV3 {
+  // Belt-and-suspenders: validate the DB risk value. The schema constraint
+  // should prevent invalid values, but default to the raw cast if somehow
+  // one slips through.
+  const risk = VALID_RISK_VALUES.has(row.risk)
+    ? (row.risk as TrustRuleV3["risk"])
+    : (row.risk as TrustRuleV3["risk"]);
+
   return {
     id: row.id,
     tool: row.tool,
     pattern: row.pattern,
-    risk: row.risk as TrustRuleV3["risk"],
+    risk,
     description: row.description,
     origin: row.origin as TrustRuleV3["origin"],
     userModified: row.userModified,
@@ -125,6 +146,8 @@ export class TrustRuleV3Store {
    * Create a user-defined trust rule. Generates a UUIDv4 id.
    */
   create(input: CreateInput): TrustRuleV3 {
+    assertValidRisk(input.risk);
+
     const now = nowISO();
     const id = crypto.randomUUID();
 
@@ -156,6 +179,15 @@ export class TrustRuleV3Store {
     const existing = this.getById(id);
     if (!existing) {
       throw new Error(`Trust rule not found: ${id}`);
+    }
+
+    // Early return if no fields to update — don't mark userModified for a no-op
+    if (updates.risk === undefined && updates.description === undefined) {
+      return existing;
+    }
+
+    if (updates.risk !== undefined) {
+      assertValidRisk(updates.risk);
     }
 
     const setValues: Record<string, unknown> = {


### PR DESCRIPTION
## Summary
- Add TrustRuleV3Store class with full CRUD: list, getById, create, update, remove, reset, upsertDefault, listActive
- Three-guard upsert for default rules (origin=default AND user_modified=0 AND deleted=0)
- Soft-delete for defaults, hard-delete for user-defined rules
- Comprehensive test suite

Part of plan: v3-trust-rules-table.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
