### PR TITLE
Add catalog-aware effective context-window resolver

### DIFF
--- a/assistant/src/__tests__/model-context.test.ts
+++ b/assistant/src/__tests__/model-context.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_CONFIGURED_MAX_INPUT_TOKENS,
+  resolveEffectiveContextWindowTokens,
+} from "../providers/model-context.js";
+
+describe("model context", () => {
+  test("uses the catalog context window when it is smaller than config", () => {
+    expect(
+      resolveEffectiveContextWindowTokens({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        configuredMaxInputTokens: 300_000,
+      }),
+    ).toBe(200_000);
+  });
+
+  test("uses configured max input tokens when smaller than the catalog", () => {
+    expect(
+      resolveEffectiveContextWindowTokens({
+        provider: "openai",
+        model: "gpt-5.4",
+        configuredMaxInputTokens: 100_000,
+      }),
+    ).toBe(100_000);
+  });
+
+  test("falls back to configured max input tokens for unknown models", () => {
+    expect(
+      resolveEffectiveContextWindowTokens({
+        provider: "anthropic",
+        model: "custom-model",
+        configuredMaxInputTokens: 123_456,
+      }),
+    ).toBe(123_456);
+  });
+
+  test("falls back to configured max input tokens for unknown providers", () => {
+    expect(
+      resolveEffectiveContextWindowTokens({
+        provider: "provider-proxy",
+        model: "custom-model",
+        configuredMaxInputTokens: 123_456,
+      }),
+    ).toBe(123_456);
+  });
+
+  test("uses catalog context window when configured max input tokens is invalid", () => {
+    expect(
+      resolveEffectiveContextWindowTokens({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        configuredMaxInputTokens: 0,
+      }),
+    ).toBe(200_000);
+  });
+
+  test("uses the config fallback for unknown models with invalid max input tokens", () => {
+    expect(
+      resolveEffectiveContextWindowTokens({
+        provider: "provider-proxy",
+        model: "custom-model",
+        configuredMaxInputTokens: Number.NaN,
+      }),
+    ).toBe(DEFAULT_CONFIGURED_MAX_INPUT_TOKENS);
+  });
+});

--- a/assistant/src/providers/model-context.ts
+++ b/assistant/src/providers/model-context.ts
@@ -1,0 +1,34 @@
+import { PROVIDER_CATALOG } from "./model-catalog.js";
+
+export const DEFAULT_CONFIGURED_MAX_INPUT_TOKENS = 200_000;
+
+export interface ResolveEffectiveContextWindowTokensInput {
+  provider: string;
+  model: string;
+  configuredMaxInputTokens: number;
+}
+
+export function resolveEffectiveContextWindowTokens({
+  provider,
+  model,
+  configuredMaxInputTokens,
+}: ResolveEffectiveContextWindowTokensInput): number {
+  const providerEntry = PROVIDER_CATALOG.find((entry) => entry.id === provider);
+  const catalogModel = providerEntry?.models.find(
+    (entry) => entry.id === model,
+  );
+  const catalogContextWindowTokens = catalogModel?.contextWindowTokens;
+
+  if (
+    !Number.isFinite(configuredMaxInputTokens) ||
+    configuredMaxInputTokens <= 0
+  ) {
+    return catalogContextWindowTokens ?? DEFAULT_CONFIGURED_MAX_INPUT_TOKENS;
+  }
+
+  if (catalogContextWindowTokens === undefined) {
+    return configuredMaxInputTokens;
+  }
+
+  return Math.min(catalogContextWindowTokens, configuredMaxInputTokens);
+}


### PR DESCRIPTION
## Summary
- Add a pure resolver for effective context-window token budgets.
- Cover known and unknown provider/model fallback behavior.

Part of plan: shared-model-catalog-assistant.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
