### PR TITLE
ci(assistant): install gateway deps in main CI workflow

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -44,6 +44,7 @@ jobs:
         run: |
           cd ../packages/ces-contracts && bun install --frozen-lockfile
           cd ../../skills/meet-join && bun install --frozen-lockfile
+          cd ../../gateway && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
@@ -82,6 +83,7 @@ jobs:
         run: |
           cd ../packages/ces-contracts && bun install --frozen-lockfile
           cd ../../skills/meet-join && bun install --frozen-lockfile
+          cd ../../gateway && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
@@ -120,6 +122,7 @@ jobs:
         run: |
           cd ../packages/ces-contracts && bun install --frozen-lockfile
           cd ../../skills/meet-join && bun install --frozen-lockfile
+          cd ../../gateway && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
@@ -184,6 +187,7 @@ jobs:
         run: |
           cd ../packages/ces-contracts && bun install --frozen-lockfile
           cd ../../skills/meet-join && bun install --frozen-lockfile
+          cd ../../gateway && bun install --frozen-lockfile
 
       - name: Check OpenAPI spec is up to date
         run: bun run generate:openapi -- --check


### PR DESCRIPTION
## Summary
- Main-branch typecheck was failing because \`assistant/\` tsc follows \`src/__tests__/helpers/gateway-classify-mock.ts\` into \`gateway/src/ipc/risk-classification-handlers.ts\`, and gateway's \`node_modules\` wasn't installed — so zod, pino, pino-pretty, and web-tree-sitter couldn't be resolved.
- PR workflow (\`pr-assistant.yaml\`) already installs gateway deps in all four jobs; main workflow (\`ci-main-assistant.yaml\`) had drifted. Adds the missing \`cd ../../gateway && bun install --frozen-lockfile\` line to lint, typecheck, test, and openapi-check jobs so they match.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24862659681/job/72791608801
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
