### PR TITLE
feat(daemon): add core host IPC routes (log, config, identity, platform)

### DIFF
--- a/assistant/src/ipc/skill-routes/__tests__/config.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/config.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for the `host.config.*` skill IPC routes. Mocks the loader and
+ * feature-flag resolver so the routes can be exercised without touching the
+ * real config file or defaults registry.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock config loader + feature-flag resolver
+// ---------------------------------------------------------------------------
+
+let mockConfig: Record<string, unknown> = {};
+let mockFlagValues: Record<string, boolean> = {};
+const flagCalls: string[] = [];
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  // Reimplement so we don't depend on the real module's behavior.
+  getNestedValue: (obj: Record<string, unknown>, path: string) => {
+    const keys = path.split(".");
+    let current: unknown = obj;
+    for (const key of keys) {
+      if (current == null || typeof current !== "object") return undefined;
+      current = (current as Record<string, unknown>)[key];
+    }
+    return current;
+  },
+}));
+
+mock.module("../../../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string) => {
+    flagCalls.push(key);
+    return mockFlagValues[key] ?? true;
+  },
+}));
+
+const {
+  hostConfigGetSectionRoute,
+  hostConfigIsFeatureFlagEnabledRoute,
+  configRoutes,
+} = await import("../config.js");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockConfig = {};
+  mockFlagValues = {};
+  flagCalls.length = 0;
+});
+
+afterEach(() => {
+  mockConfig = {};
+  mockFlagValues = {};
+  flagCalls.length = 0;
+});
+
+describe("host.config.getSection IPC route", () => {
+  test("method is host.config.getSection", () => {
+    expect(hostConfigGetSectionRoute.method).toBe("host.config.getSection");
+  });
+
+  test("returns a shallow section", async () => {
+    mockConfig = { llm: { default: { provider: "anthropic" } } };
+
+    const result = await hostConfigGetSectionRoute.handler({ path: "llm" });
+
+    expect(result).toEqual({ default: { provider: "anthropic" } });
+  });
+
+  test("returns a nested section by dot-path", async () => {
+    mockConfig = { llm: { default: { provider: "anthropic" } } };
+
+    const result = await hostConfigGetSectionRoute.handler({
+      path: "llm.default.provider",
+    });
+
+    expect(result).toBe("anthropic");
+  });
+
+  test("returns null for a missing path", async () => {
+    mockConfig = {};
+
+    const result = await hostConfigGetSectionRoute.handler({
+      path: "does.not.exist",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("rejects missing path", () => {
+    expect(() => hostConfigGetSectionRoute.handler({})).toThrow();
+  });
+
+  test("rejects empty path", () => {
+    expect(() => hostConfigGetSectionRoute.handler({ path: "" })).toThrow();
+  });
+});
+
+describe("host.config.isFeatureFlagEnabled IPC route", () => {
+  test("method is host.config.isFeatureFlagEnabled", () => {
+    expect(hostConfigIsFeatureFlagEnabledRoute.method).toBe(
+      "host.config.isFeatureFlagEnabled",
+    );
+  });
+
+  test("delegates to the feature-flag resolver and returns true", async () => {
+    mockFlagValues = { browser: true };
+
+    const result = await hostConfigIsFeatureFlagEnabledRoute.handler({
+      key: "browser",
+    });
+
+    expect(result).toBe(true);
+    expect(flagCalls).toEqual(["browser"]);
+  });
+
+  test("returns false when the resolver says the flag is off", async () => {
+    mockFlagValues = { "ces-tools": false };
+
+    const result = await hostConfigIsFeatureFlagEnabledRoute.handler({
+      key: "ces-tools",
+    });
+
+    expect(result).toBe(false);
+  });
+
+  test("rejects missing key", () => {
+    expect(() => hostConfigIsFeatureFlagEnabledRoute.handler({})).toThrow();
+  });
+
+  test("rejects empty key", () => {
+    expect(() =>
+      hostConfigIsFeatureFlagEnabledRoute.handler({ key: "" }),
+    ).toThrow();
+  });
+});
+
+describe("configRoutes", () => {
+  test("exports both config routes", () => {
+    expect(configRoutes).toContain(hostConfigGetSectionRoute);
+    expect(configRoutes).toContain(hostConfigIsFeatureFlagEnabledRoute);
+  });
+});

--- a/assistant/src/ipc/skill-routes/__tests__/identity.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/identity.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the `host.identity.*` skill IPC routes. Mocks
+ * `getAssistantName()` so we can assert both the resolved-name and
+ * missing-name paths, and pins the internal assistant ID to the
+ * canonical "self" constant.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock identity helper
+// ---------------------------------------------------------------------------
+
+let mockName: string | null = null;
+
+mock.module("../../../daemon/identity-helpers.js", () => ({
+  getAssistantName: () => mockName,
+}));
+
+const {
+  hostIdentityGetAssistantNameRoute,
+  hostIdentityGetInternalAssistantIdRoute,
+  identityRoutes,
+} = await import("../identity.js");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockName = null;
+});
+
+afterEach(() => {
+  mockName = null;
+});
+
+describe("host.identity.getAssistantName IPC route", () => {
+  test("method is host.identity.getAssistantName", () => {
+    expect(hostIdentityGetAssistantNameRoute.method).toBe(
+      "host.identity.getAssistantName",
+    );
+  });
+
+  test("returns the name resolved by the daemon identity helper", async () => {
+    mockName = "Example Assistant";
+
+    const result = await hostIdentityGetAssistantNameRoute.handler();
+
+    expect(result).toBe("Example Assistant");
+  });
+
+  test("returns null when the daemon helper returns null", async () => {
+    mockName = null;
+
+    const result = await hostIdentityGetAssistantNameRoute.handler();
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("host.identity.getInternalAssistantId IPC route", () => {
+  test("method is host.identity.getInternalAssistantId", () => {
+    expect(hostIdentityGetInternalAssistantIdRoute.method).toBe(
+      "host.identity.getInternalAssistantId",
+    );
+  });
+
+  test("returns the daemon internal assistant id constant", async () => {
+    const result = await hostIdentityGetInternalAssistantIdRoute.handler();
+
+    expect(result).toBe("self");
+  });
+});
+
+describe("identityRoutes", () => {
+  test("exports both identity routes", () => {
+    expect(identityRoutes).toContain(hostIdentityGetAssistantNameRoute);
+    expect(identityRoutes).toContain(hostIdentityGetInternalAssistantIdRoute);
+  });
+});

--- a/assistant/src/ipc/skill-routes/__tests__/log.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/log.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for the `host.log` skill IPC route. Mocks the daemon logger
+ * factory so we can assert that the route forwards each level, normalizes
+ * the `(msg, meta?)` call shape to pino's `(meta, msg)` shape, and handles
+ * missing/non-object meta safely.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock the daemon logger
+// ---------------------------------------------------------------------------
+
+let calls: Array<{
+  name: string;
+  level: "debug" | "info" | "warn" | "error";
+  meta: Record<string, unknown>;
+  msg: string;
+}> = [];
+
+function makeMockLogger(name: string) {
+  return {
+    debug: (meta: Record<string, unknown>, msg: string) =>
+      calls.push({ name, level: "debug", meta, msg }),
+    info: (meta: Record<string, unknown>, msg: string) =>
+      calls.push({ name, level: "info", meta, msg }),
+    warn: (meta: Record<string, unknown>, msg: string) =>
+      calls.push({ name, level: "warn", meta, msg }),
+    error: (meta: Record<string, unknown>, msg: string) =>
+      calls.push({ name, level: "error", meta, msg }),
+  };
+}
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: (name: string) => makeMockLogger(name),
+}));
+
+const { hostLogRoute, logRoutes } = await import("../log.js");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  calls = [];
+});
+
+afterEach(() => {
+  calls = [];
+});
+
+describe("host.log IPC route", () => {
+  test("method is host.log", () => {
+    expect(hostLogRoute.method).toBe("host.log");
+  });
+
+  test("is registered in logRoutes", () => {
+    expect(logRoutes).toContain(hostLogRoute);
+  });
+
+  test("forwards info-level messages with (meta, msg) shape", async () => {
+    const result = await hostLogRoute.handler({
+      level: "info",
+      msg: "hello world",
+      name: "skill:meet-join",
+      meta: { conversationId: "conv-1" },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      name: "skill:meet-join",
+      level: "info",
+      meta: { conversationId: "conv-1" },
+      msg: "hello world",
+    });
+  });
+
+  test("forwards each level correctly", async () => {
+    for (const level of ["debug", "info", "warn", "error"] as const) {
+      await hostLogRoute.handler({
+        level,
+        msg: `msg-${level}`,
+        name: "skill:test",
+      });
+    }
+    expect(calls.map((c) => c.level)).toEqual([
+      "debug",
+      "info",
+      "warn",
+      "error",
+    ]);
+  });
+
+  test("defaults to 'skill' logger scope when name is omitted", async () => {
+    await hostLogRoute.handler({ level: "info", msg: "no scope" });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].name).toBe("skill");
+  });
+
+  test("treats missing meta as an empty object", async () => {
+    await hostLogRoute.handler({ level: "warn", msg: "no meta" });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].meta).toEqual({});
+  });
+
+  test("treats non-object meta (e.g. array) as an empty object", async () => {
+    await hostLogRoute.handler({
+      level: "warn",
+      msg: "weird meta",
+      meta: ["not", "an", "object"],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].meta).toEqual({});
+  });
+
+  test("rejects missing level", () => {
+    expect(() => hostLogRoute.handler({ msg: "no level" })).toThrow();
+  });
+
+  test("rejects unknown level", () => {
+    expect(() =>
+      hostLogRoute.handler({ level: "fatal", msg: "bad level" }),
+    ).toThrow();
+  });
+
+  test("rejects missing msg", () => {
+    expect(() => hostLogRoute.handler({ level: "info" })).toThrow();
+  });
+});

--- a/assistant/src/ipc/skill-routes/__tests__/platform.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/platform.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the `host.platform.*` skill IPC routes. Mocks the platform
+ * path helpers and runtime-mode resolver so route behavior is verified
+ * independently of the real filesystem or `IS_CONTAINERIZED` env setting.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { DaemonRuntimeMode } from "../../../runtime/runtime-mode.js";
+
+// ---------------------------------------------------------------------------
+// Mock platform + runtime-mode helpers
+// ---------------------------------------------------------------------------
+
+let mockWorkspaceDir = "/tmp/workspace";
+let mockVellumRoot = "/tmp/.vellum";
+let mockRuntimeMode: DaemonRuntimeMode = "bare-metal";
+
+mock.module("../../../util/platform.js", () => ({
+  getWorkspaceDir: () => mockWorkspaceDir,
+  vellumRoot: () => mockVellumRoot,
+}));
+
+mock.module("../../../runtime/runtime-mode.js", () => ({
+  getDaemonRuntimeMode: () => mockRuntimeMode,
+}));
+
+const {
+  hostPlatformWorkspaceDirRoute,
+  hostPlatformVellumRootRoute,
+  hostPlatformRuntimeModeRoute,
+  platformRoutes,
+} = await import("../platform.js");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockWorkspaceDir = "/tmp/workspace";
+  mockVellumRoot = "/tmp/.vellum";
+  mockRuntimeMode = "bare-metal";
+});
+
+afterEach(() => {
+  mockWorkspaceDir = "/tmp/workspace";
+  mockVellumRoot = "/tmp/.vellum";
+  mockRuntimeMode = "bare-metal";
+});
+
+describe("host.platform.workspaceDir IPC route", () => {
+  test("method is host.platform.workspaceDir", () => {
+    expect(hostPlatformWorkspaceDirRoute.method).toBe(
+      "host.platform.workspaceDir",
+    );
+  });
+
+  test("returns the workspace directory from the platform helper", async () => {
+    mockWorkspaceDir = "/Users/alice/.vellum/workspace";
+
+    const result = await hostPlatformWorkspaceDirRoute.handler();
+
+    expect(result).toBe("/Users/alice/.vellum/workspace");
+  });
+});
+
+describe("host.platform.vellumRoot IPC route", () => {
+  test("method is host.platform.vellumRoot", () => {
+    expect(hostPlatformVellumRootRoute.method).toBe("host.platform.vellumRoot");
+  });
+
+  test("returns the vellum root from the platform helper", async () => {
+    mockVellumRoot = "/Users/alice/.vellum";
+
+    const result = await hostPlatformVellumRootRoute.handler();
+
+    expect(result).toBe("/Users/alice/.vellum");
+  });
+});
+
+describe("host.platform.runtimeMode IPC route", () => {
+  test("method is host.platform.runtimeMode", () => {
+    expect(hostPlatformRuntimeModeRoute.method).toBe(
+      "host.platform.runtimeMode",
+    );
+  });
+
+  test("returns 'bare-metal' when the daemon runs outside a container", async () => {
+    mockRuntimeMode = "bare-metal";
+
+    const result = await hostPlatformRuntimeModeRoute.handler();
+
+    expect(result).toBe("bare-metal");
+  });
+
+  test("returns 'docker' when the daemon runs inside a container", async () => {
+    mockRuntimeMode = "docker";
+
+    const result = await hostPlatformRuntimeModeRoute.handler();
+
+    expect(result).toBe("docker");
+  });
+});
+
+describe("platformRoutes", () => {
+  test("exports all three platform routes", () => {
+    expect(platformRoutes).toContain(hostPlatformWorkspaceDirRoute);
+    expect(platformRoutes).toContain(hostPlatformVellumRootRoute);
+    expect(platformRoutes).toContain(hostPlatformRuntimeModeRoute);
+  });
+});

--- a/assistant/src/ipc/skill-routes/config.ts
+++ b/assistant/src/ipc/skill-routes/config.ts
@@ -1,0 +1,47 @@
+/**
+ * Skill IPC routes: `host.config.getSection` and `host.config.isFeatureFlagEnabled`.
+ *
+ * Expose the daemon config and feature-flag resolver to out-of-process skills.
+ * `getSection` returns a nested value looked up by dot-path (e.g. `"llm.default"`);
+ * `isFeatureFlagEnabled` consults the standard assistant flag resolver so skills
+ * observe the same overrides and remote values the in-process code does.
+ */
+
+import { z } from "zod";
+
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import { getConfig, getNestedValue } from "../../config/loader.js";
+import type { IpcRoute } from "../cli-server.js";
+
+const GetSectionParams = z.object({
+  path: z.string().min(1),
+});
+
+const IsFeatureFlagEnabledParams = z.object({
+  key: z.string().min(1),
+});
+
+export const hostConfigGetSectionRoute: IpcRoute = {
+  method: "host.config.getSection",
+  handler: (params) => {
+    const { path } = GetSectionParams.parse(params);
+    const value = getNestedValue(
+      getConfig() as unknown as Record<string, unknown>,
+      path,
+    );
+    return value ?? null;
+  },
+};
+
+export const hostConfigIsFeatureFlagEnabledRoute: IpcRoute = {
+  method: "host.config.isFeatureFlagEnabled",
+  handler: (params) => {
+    const { key } = IsFeatureFlagEnabledParams.parse(params);
+    return isAssistantFeatureFlagEnabled(key, getConfig());
+  },
+};
+
+export const configRoutes: IpcRoute[] = [
+  hostConfigGetSectionRoute,
+  hostConfigIsFeatureFlagEnabledRoute,
+];

--- a/assistant/src/ipc/skill-routes/identity.ts
+++ b/assistant/src/ipc/skill-routes/identity.ts
@@ -1,0 +1,34 @@
+/**
+ * Skill IPC routes: `host.identity.getAssistantName` and
+ * `host.identity.getInternalAssistantId`.
+ *
+ * Match the `IdentityFacet` surface exposed by `DaemonSkillHost`:
+ * - `getAssistantName` reads the assistant's display name from IDENTITY.md,
+ *   normalizing the daemon helper's `null` to `undefined` (serialized as
+ *   `null` over JSON, which clients translate back to `undefined`).
+ * - `getInternalAssistantId` returns the `DAEMON_INTERNAL_ASSISTANT_ID`
+ *   constant (`"self"`) so skill-side code uses the same internal scope.
+ */
+
+import { getAssistantName } from "../../daemon/identity-helpers.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
+import type { IpcRoute } from "../cli-server.js";
+
+export const hostIdentityGetAssistantNameRoute: IpcRoute = {
+  method: "host.identity.getAssistantName",
+  handler: () => {
+    return getAssistantName() ?? null;
+  },
+};
+
+export const hostIdentityGetInternalAssistantIdRoute: IpcRoute = {
+  method: "host.identity.getInternalAssistantId",
+  handler: () => {
+    return DAEMON_INTERNAL_ASSISTANT_ID;
+  },
+};
+
+export const identityRoutes: IpcRoute[] = [
+  hostIdentityGetAssistantNameRoute,
+  hostIdentityGetInternalAssistantIdRoute,
+];

--- a/assistant/src/ipc/skill-routes/index.ts
+++ b/assistant/src/ipc/skill-routes/index.ts
@@ -1,5 +1,9 @@
 import type { IpcRoute } from "../cli-server.js";
+import { configRoutes } from "./config.js";
+import { identityRoutes } from "./identity.js";
+import { logRoutes } from "./log.js";
 import { memorySkillRoutes } from "./memory.js";
+import { platformRoutes } from "./platform.js";
 import { providerSkillRoutes } from "./providers.js";
 import { registriesRoutes } from "./registries.js";
 
@@ -12,6 +16,10 @@ import { registriesRoutes } from "./registries.js";
  * host.providers.*, host.events.*, host.registries.*).
  */
 export const skillIpcRoutes: IpcRoute[] = [
+  ...logRoutes,
+  ...configRoutes,
+  ...identityRoutes,
+  ...platformRoutes,
   ...memorySkillRoutes,
   ...providerSkillRoutes,
   ...registriesRoutes,

--- a/assistant/src/ipc/skill-routes/log.ts
+++ b/assistant/src/ipc/skill-routes/log.ts
@@ -1,0 +1,40 @@
+/**
+ * Skill IPC route: `host.log`.
+ *
+ * Forwards structured log lines from an out-of-process skill to the daemon's
+ * existing logger so skill logs land in the same sink as daemon logs. The
+ * skill-side contract uses `(msg, meta?)`; the daemon's pino loggers use
+ * `(meta, msg)` — this route normalizes the call shape at the boundary,
+ * matching `DaemonSkillHost.logger.get()`.
+ */
+
+import { z } from "zod";
+
+import { getLogger } from "../../util/logger.js";
+import type { IpcRoute } from "../cli-server.js";
+
+const LogParams = z.object({
+  level: z.enum(["debug", "info", "warn", "error"]),
+  msg: z.string(),
+  // Skill-chosen logger scope (mirrors `host.logger.get(name)` on the client
+  // side). Optional so callers that don't thread a scope still get a useful
+  // default instead of failing validation.
+  name: z.string().optional(),
+  meta: z.unknown().optional(),
+});
+
+export const hostLogRoute: IpcRoute = {
+  method: "host.log",
+  handler: (params) => {
+    const { level, msg, name, meta } = LogParams.parse(params);
+    const log = getLogger(name ?? "skill");
+    const metaObj =
+      meta && typeof meta === "object" && !Array.isArray(meta)
+        ? (meta as Record<string, unknown>)
+        : {};
+    log[level](metaObj, msg);
+    return { ok: true };
+  },
+};
+
+export const logRoutes: IpcRoute[] = [hostLogRoute];

--- a/assistant/src/ipc/skill-routes/platform.ts
+++ b/assistant/src/ipc/skill-routes/platform.ts
@@ -1,0 +1,39 @@
+/**
+ * Skill IPC routes: `host.platform.workspaceDir`, `host.platform.vellumRoot`,
+ * and `host.platform.runtimeMode`.
+ *
+ * Surface the platform-path helpers and deployment mode so out-of-process
+ * skills can compute workspace-relative paths and branch on docker vs
+ * bare-metal behavior without reaching into assistant internals.
+ */
+
+import { getDaemonRuntimeMode } from "../../runtime/runtime-mode.js";
+import { getWorkspaceDir, vellumRoot } from "../../util/platform.js";
+import type { IpcRoute } from "../cli-server.js";
+
+export const hostPlatformWorkspaceDirRoute: IpcRoute = {
+  method: "host.platform.workspaceDir",
+  handler: () => {
+    return getWorkspaceDir();
+  },
+};
+
+export const hostPlatformVellumRootRoute: IpcRoute = {
+  method: "host.platform.vellumRoot",
+  handler: () => {
+    return vellumRoot();
+  },
+};
+
+export const hostPlatformRuntimeModeRoute: IpcRoute = {
+  method: "host.platform.runtimeMode",
+  handler: () => {
+    return getDaemonRuntimeMode();
+  },
+};
+
+export const platformRoutes: IpcRoute[] = [
+  hostPlatformWorkspaceDirRoute,
+  hostPlatformVellumRootRoute,
+  hostPlatformRuntimeModeRoute,
+];


### PR DESCRIPTION
## Summary
- Adds host.log, host.config.*, host.identity.*, host.platform.* IPC route handlers.
- Delegates to existing daemon modules.
- Registered alongside memory/providers/registries routes.

Part of plan: skill-isolation.md (PR 21 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
