### PR TITLE
feat(daemon): add host IPC event routes including long-lived subscribe stream

### DIFF
--- a/assistant/src/ipc/skill-routes/__tests__/events-ipc.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/events-ipc.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Integration tests for the `host.events.*` skill IPC routes.
+ *
+ * Exercises the three routes registered in `skill-routes/events.ts`
+ * against a live `SkillIpcServer` on a temporary socket path:
+ *
+ * - `host.events.publish` — publishes an event and verifies it reaches the
+ *   daemon's `assistantEventHub` exactly as an in-process publish would.
+ * - `host.events.buildEvent` — verifies deterministic envelope construction
+ *   under `DAEMON_INTERNAL_ASSISTANT_ID`.
+ * - `host.events.subscribe` — long-lived stream: confirms open ack, filtered
+ *   delivery (match vs. mismatch), explicit close, and cleanup on client
+ *   disconnect (including that the hub releases its subscription slot).
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { connect, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { AssistantEvent } from "../../../runtime/assistant-event.js";
+import { assistantEventHub } from "../../../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../runtime/assistant-scope.js";
+import { SkillIpcServer } from "../../skill-server.js";
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+let tempDir: string | null = null;
+let server: SkillIpcServer | null = null;
+let socketPath = "";
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "events-ipc-test-"));
+  socketPath = join(tempDir, "assistant-skill.sock");
+  server = new SkillIpcServer({ socketPath });
+  server.start();
+});
+
+afterEach(async () => {
+  server?.stop();
+  server = null;
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+  // Give the event loop a tick to fully release resources.
+  await new Promise((resolve) => setTimeout(resolve, 10));
+});
+
+type Frame =
+  | { id: string; result?: unknown; error?: string }
+  | { id: string; event: "delivery"; payload: unknown };
+
+interface TestClient {
+  socket: Socket;
+  nextFrame(): Promise<Frame>;
+  send(payload: Record<string, unknown>): void;
+  close(): void;
+}
+
+async function openClient(): Promise<TestClient> {
+  const socket = connect(socketPath);
+  await new Promise<void>((resolve, reject) => {
+    socket.once("connect", () => resolve());
+    socket.once("error", (err) => reject(err));
+  });
+
+  let buffer = "";
+  const pending: Frame[] = [];
+  const waiters: Array<(frame: Frame) => void> = [];
+
+  socket.on("data", (chunk) => {
+    buffer += chunk.toString();
+    let idx: number;
+    while ((idx = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.slice(0, idx).trim();
+      buffer = buffer.slice(idx + 1);
+      if (!line) continue;
+      const frame = JSON.parse(line) as Frame;
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter(frame);
+      } else {
+        pending.push(frame);
+      }
+    }
+  });
+
+  return {
+    socket,
+    nextFrame: () =>
+      new Promise<Frame>((resolve, reject) => {
+        const buffered = pending.shift();
+        if (buffered) {
+          resolve(buffered);
+          return;
+        }
+        const timer = setTimeout(() => {
+          const idx = waiters.indexOf(settle);
+          if (idx >= 0) waiters.splice(idx, 1);
+          reject(new Error("Timed out waiting for frame"));
+        }, 1000);
+        const settle = (frame: Frame) => {
+          clearTimeout(timer);
+          resolve(frame);
+        };
+        waiters.push(settle);
+      }),
+    send: (payload) => {
+      socket.write(JSON.stringify(payload) + "\n");
+    },
+    close: () => {
+      socket.destroy();
+    },
+  };
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 30));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("host.events.publish", () => {
+  test("publish round-trip reaches assistantEventHub subscribers", async () => {
+    const received: AssistantEvent[] = [];
+    const subscription = assistantEventHub.subscribe(
+      { assistantId: "test-asst" },
+      (evt) => {
+        received.push(evt);
+      },
+    );
+
+    try {
+      const client = await openClient();
+      const event = {
+        id: "evt-1",
+        assistantId: "test-asst",
+        conversationId: "conv-1",
+        emittedAt: new Date().toISOString(),
+        message: { type: "test_message", foo: "bar" },
+      };
+      client.send({
+        id: "req-1",
+        method: "host.events.publish",
+        params: { event },
+      });
+
+      const frame = await client.nextFrame();
+      expect("result" in frame && frame.result).toEqual({ published: true });
+
+      expect(received).toHaveLength(1);
+      expect(received[0]?.id).toBe("evt-1");
+      expect(received[0]?.assistantId).toBe("test-asst");
+      expect((received[0]?.message as { foo: string }).foo).toBe("bar");
+
+      client.close();
+    } finally {
+      subscription.dispose();
+    }
+  });
+
+  test("publish rejects malformed events", async () => {
+    const client = await openClient();
+    client.send({
+      id: "req-bad",
+      method: "host.events.publish",
+      params: { event: { id: "x" } },
+    });
+
+    const frame = await client.nextFrame();
+    expect("error" in frame && frame.error).toBeTruthy();
+
+    client.close();
+  });
+});
+
+describe("host.events.buildEvent", () => {
+  test("returns an envelope attributed to DAEMON_INTERNAL_ASSISTANT_ID", async () => {
+    const client = await openClient();
+    const conversationId = "conv-xyz";
+    const message = { type: "assistant_text_delta", text: "hi" };
+    client.send({
+      id: "req-1",
+      method: "host.events.buildEvent",
+      params: { message, conversationId },
+    });
+
+    const frame = await client.nextFrame();
+    expect("result" in frame).toBe(true);
+    const built = (frame as { result: AssistantEvent }).result;
+    expect(built.assistantId).toBe(DAEMON_INTERNAL_ASSISTANT_ID);
+    expect(built.conversationId).toBe(conversationId);
+    expect(typeof built.id).toBe("string");
+    expect(typeof built.emittedAt).toBe("string");
+    expect(built.message).toEqual(message);
+
+    client.close();
+  });
+});
+
+describe("host.events.subscribe", () => {
+  test("opens ack, delivers matching events, filters non-matching", async () => {
+    const baseSubscribers = assistantEventHub.subscriberCount();
+    const client = await openClient();
+    client.send({
+      id: "sub-1",
+      method: "host.events.subscribe",
+      params: {
+        filter: {
+          assistantId: "asst-a",
+          conversationId: "conv-a",
+        },
+      },
+    });
+
+    // Open acknowledgement.
+    const ack = await client.nextFrame();
+    expect("result" in ack && ack.result).toEqual({ subscribed: true });
+    expect(assistantEventHub.subscriberCount()).toBe(baseSubscribers + 1);
+
+    // Matching event.
+    await assistantEventHub.publish({
+      id: "e1",
+      assistantId: "asst-a",
+      conversationId: "conv-a",
+      emittedAt: new Date().toISOString(),
+      message: { type: "t1" },
+    } as never);
+
+    const delivery = await client.nextFrame();
+    expect("event" in delivery && delivery.event).toBe("delivery");
+    expect(
+      "payload" in delivery && (delivery.payload as AssistantEvent).id,
+    ).toBe("e1");
+
+    // Non-matching event on a different conversation.
+    await assistantEventHub.publish({
+      id: "e2",
+      assistantId: "asst-a",
+      conversationId: "conv-b",
+      emittedAt: new Date().toISOString(),
+      message: { type: "t2" },
+    } as never);
+
+    // Non-matching event on a different assistant.
+    await assistantEventHub.publish({
+      id: "e3",
+      assistantId: "asst-b",
+      conversationId: "conv-a",
+      emittedAt: new Date().toISOString(),
+      message: { type: "t3" },
+    } as never);
+
+    // Confirm no delivery frame arrives for the non-matching events by
+    // publishing another matching event and asserting ordering.
+    await assistantEventHub.publish({
+      id: "e4",
+      assistantId: "asst-a",
+      conversationId: "conv-a",
+      emittedAt: new Date().toISOString(),
+      message: { type: "t4" },
+    } as never);
+
+    const nextDelivery = await client.nextFrame();
+    expect(
+      "payload" in nextDelivery && (nextDelivery.payload as AssistantEvent).id,
+    ).toBe("e4");
+
+    client.close();
+    await tick();
+    expect(assistantEventHub.subscriberCount()).toBe(baseSubscribers);
+  });
+
+  test("explicit subscribe-close releases the hub subscription", async () => {
+    const baseSubscribers = assistantEventHub.subscriberCount();
+    const client = await openClient();
+    client.send({
+      id: "sub-2",
+      method: "host.events.subscribe",
+      params: { filter: { assistantId: "asst-close" } },
+    });
+    await client.nextFrame(); // ack
+    expect(assistantEventHub.subscriberCount()).toBe(baseSubscribers + 1);
+
+    client.send({
+      id: "ctrl-1",
+      method: "host.events.subscribe.close",
+      params: { subscribeId: "sub-2" },
+    });
+
+    const closeAck = await client.nextFrame();
+    expect("result" in closeAck && closeAck.result).toEqual({ closed: true });
+    expect(assistantEventHub.subscriberCount()).toBe(baseSubscribers);
+
+    client.close();
+  });
+
+  test("client disconnect releases the hub subscription", async () => {
+    const baseSubscribers = assistantEventHub.subscriberCount();
+    const client = await openClient();
+    client.send({
+      id: "sub-3",
+      method: "host.events.subscribe",
+      params: { filter: { assistantId: "asst-leak" } },
+    });
+    await client.nextFrame(); // ack
+    expect(assistantEventHub.subscriberCount()).toBe(baseSubscribers + 1);
+
+    client.close();
+    await tick();
+    expect(assistantEventHub.subscriberCount()).toBe(baseSubscribers);
+
+    // Further publishes do not reach the disposed subscription. If the
+    // subscription had leaked, the hub would invoke a callback whose
+    // stream reference is destroyed — and we would see either an error
+    // log or a thrown aggregate from `publish`. Both would surface here
+    // because `publish` re-throws subscriber errors.
+    await assistantEventHub.publish({
+      id: "post",
+      assistantId: "asst-leak",
+      emittedAt: new Date().toISOString(),
+      message: { type: "post" },
+    } as never);
+  });
+
+  test("server shutdown tears down streams", async () => {
+    const baseSubscribers = assistantEventHub.subscriberCount();
+    const client = await openClient();
+    client.send({
+      id: "sub-4",
+      method: "host.events.subscribe",
+      params: { filter: { assistantId: "asst-stop" } },
+    });
+    await client.nextFrame(); // ack
+    expect(assistantEventHub.subscriberCount()).toBe(baseSubscribers + 1);
+
+    server?.stop();
+    server = null;
+    await tick();
+    expect(assistantEventHub.subscriberCount()).toBe(baseSubscribers);
+
+    // Clean up the client socket; the server already destroyed it.
+    client.close();
+  });
+
+  test("rejects duplicate subscribe id on the same socket", async () => {
+    const client = await openClient();
+    client.send({
+      id: "sub-dup",
+      method: "host.events.subscribe",
+      params: { filter: { assistantId: "asst-dup" } },
+    });
+    const ack = await client.nextFrame();
+    expect("result" in ack && ack.result).toEqual({ subscribed: true });
+
+    client.send({
+      id: "sub-dup",
+      method: "host.events.subscribe",
+      params: { filter: { assistantId: "asst-dup" } },
+    });
+    const err = await client.nextFrame();
+    expect("error" in err && err.error).toContain("sub-dup");
+
+    client.close();
+  });
+
+  test("subscribe-close on unknown id still acks", async () => {
+    const client = await openClient();
+    client.send({
+      id: "ctrl-nop",
+      method: "host.events.subscribe.close",
+      params: { subscribeId: "does-not-exist" },
+    });
+    const frame = await client.nextFrame();
+    expect("result" in frame && frame.result).toEqual({ closed: true });
+
+    client.close();
+  });
+});

--- a/assistant/src/ipc/skill-routes/__tests__/events-ipc.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/events-ipc.test.ts
@@ -157,7 +157,9 @@ describe("host.events.publish", () => {
       expect(received).toHaveLength(1);
       expect(received[0]?.id).toBe("evt-1");
       expect(received[0]?.assistantId).toBe("test-asst");
-      expect((received[0]?.message as { foo: string }).foo).toBe("bar");
+      expect((received[0]?.message as unknown as { foo: string }).foo).toBe(
+        "bar",
+      );
 
       client.close();
     } finally {
@@ -198,7 +200,7 @@ describe("host.events.buildEvent", () => {
     expect(built.conversationId).toBe(conversationId);
     expect(typeof built.id).toBe("string");
     expect(typeof built.emittedAt).toBe("string");
-    expect(built.message).toEqual(message);
+    expect(built.message).toEqual(message as typeof built.message);
 
     client.close();
   });

--- a/assistant/src/ipc/skill-routes/events.ts
+++ b/assistant/src/ipc/skill-routes/events.ts
@@ -1,0 +1,122 @@
+/**
+ * Skill IPC routes for `host.events.*`.
+ *
+ * Exposes the daemon's `assistantEventHub` to out-of-process skills so they
+ * can publish, subscribe to, and construct `AssistantEvent` envelopes
+ * without linking against `assistant/` directly. Mirrors the in-process
+ * `EventsFacet` surface defined in `@vellumai/skill-host-contracts` and
+ * implemented for in-process callers by `DaemonSkillHost`.
+ *
+ * ### Routes
+ *
+ * - `host.events.publish` — one-shot RPC. Params `{ event: AssistantEvent }`.
+ *   Forwards to `assistantEventHub.publish(event)` and resolves once all
+ *   matching subscribers have been dispatched.
+ *
+ * - `host.events.subscribe` — long-lived stream. Params
+ *   `{ filter: AssistantEventFilter }`. The server opens a subscription on
+ *   `assistantEventHub` and streams each matching event back as a delivery
+ *   frame (`{ id, event: "delivery", payload }`) until the client
+ *   disconnects or sends the `host.events.subscribe.close` control method.
+ *   Teardown is wired through the IPC server's per-socket subscription map
+ *   so daemon shutdown also evicts every active subscriber.
+ *
+ * - `host.events.buildEvent` — deterministic helper. Params
+ *   `{ message, conversationId? }`. Returns the `AssistantEvent` envelope a
+ *   skill would otherwise construct via `DAEMON_INTERNAL_ASSISTANT_ID` —
+ *   keeping event-id allocation and timestamp generation on the daemon side
+ *   so skill processes do not drift on UUID / clock sources.
+ */
+
+import { z } from "zod";
+
+import { buildAssistantEvent } from "../../runtime/assistant-event.js";
+import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
+import type { IpcRoute } from "../cli-server.js";
+import type { SkillIpcStreamingRoute } from "../skill-server.js";
+
+// ---------------------------------------------------------------------------
+// Param schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * `AssistantEvent` wire shape accepted by `host.events.publish`. The
+ * envelope fields (`id`, `assistantId`, `emittedAt`, `message`) are
+ * required; `conversationId` is optional. The `message` payload is an
+ * opaque JSON object — the daemon does not narrow it before handing it to
+ * `assistantEventHub.publish`, matching the in-process hub contract.
+ */
+const AssistantEventSchema = z.object({
+  id: z.string().min(1),
+  assistantId: z.string().min(1),
+  conversationId: z.string().optional(),
+  emittedAt: z.string().min(1),
+  message: z.record(z.string(), z.unknown()),
+});
+
+const PublishParams = z.object({
+  event: AssistantEventSchema,
+});
+
+const FilterSchema = z.object({
+  assistantId: z.string().min(1),
+  conversationId: z.string().optional(),
+});
+
+const SubscribeParams = z.object({
+  filter: FilterSchema,
+});
+
+const BuildEventParams = z.object({
+  message: z.record(z.string(), z.unknown()),
+  conversationId: z.string().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async function handlePublish(
+  params?: Record<string, unknown>,
+): Promise<{ published: true }> {
+  const { event } = PublishParams.parse(params);
+  // Contract types the hub as `AssistantEvent<ServerMessage>`; the wire-level
+  // message is an opaque record that satisfies the `ServerMessage` structural
+  // shape (`{ type: string; [key: string]: unknown }`). Cast at the boundary.
+  await assistantEventHub.publish(event as never);
+  return { published: true };
+}
+
+function handleBuildEvent(params?: Record<string, unknown>): unknown {
+  const { message, conversationId } = BuildEventParams.parse(params);
+  return buildAssistantEvent(
+    DAEMON_INTERNAL_ASSISTANT_ID,
+    message as never,
+    conversationId,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Route exports
+// ---------------------------------------------------------------------------
+
+export const eventsRoutes: IpcRoute[] = [
+  { method: "host.events.publish", handler: handlePublish },
+  { method: "host.events.buildEvent", handler: handleBuildEvent },
+];
+
+export const eventsStreamingRoutes: SkillIpcStreamingRoute[] = [
+  {
+    method: "host.events.subscribe",
+    handler: (stream, params) => {
+      const { filter } = SubscribeParams.parse(params);
+      const subscription = assistantEventHub.subscribe(filter, (event) => {
+        stream.send(event);
+      });
+      return () => {
+        subscription.dispose();
+      };
+    },
+  },
+];

--- a/assistant/src/ipc/skill-routes/index.ts
+++ b/assistant/src/ipc/skill-routes/index.ts
@@ -1,5 +1,7 @@
 import type { IpcRoute } from "../cli-server.js";
+import type { SkillIpcStreamingRoute } from "../skill-server.js";
 import { configRoutes } from "./config.js";
+import { eventsRoutes, eventsStreamingRoutes } from "./events.js";
 import { identityRoutes } from "./identity.js";
 import { logRoutes } from "./log.js";
 import { memorySkillRoutes } from "./memory.js";
@@ -23,4 +25,13 @@ export const skillIpcRoutes: IpcRoute[] = [
   ...memorySkillRoutes,
   ...providerSkillRoutes,
   ...registriesRoutes,
+  ...eventsRoutes,
+];
+
+/**
+ * Long-lived streaming skill IPC routes. Handlers return a dispose callback
+ * invoked on client disconnect, explicit close, or daemon shutdown.
+ */
+export const skillIpcStreamingRoutes: SkillIpcStreamingRoute[] = [
+  ...eventsStreamingRoutes,
 ];

--- a/assistant/src/ipc/skill-server.ts
+++ b/assistant/src/ipc/skill-server.ts
@@ -7,8 +7,19 @@
  * evolve its own long-lived subscribe streams.
  *
  * Protocol: newline-delimited JSON over a Unix domain socket.
+ *
+ * One-shot RPC:
  * - Request:  { "id": string, "method": string, "params"?: Record<string, unknown> }
  * - Response: { "id": string, "result"?: unknown, "error"?: string }
+ *
+ * Streaming RPC (e.g. `host.events.subscribe`):
+ * - Request:    { "id": string, "method": string, "params"?: Record<string, unknown> }
+ * - Open ack:   { "id": string, "result": { "subscribed": true } }
+ * - Deliveries: { "id": string, "event": "delivery", "payload": <data> } (0..N)
+ * - Error:      { "id": string, "error": string } (terminal)
+ * - Close req:  { "id": "<ctrl-id>", "method": "host.events.subscribe.close",
+ *                 "params": { "subscribeId": "<original-id>" } }
+ * - Close ack:  { "id": "<ctrl-id>", "result": { "closed": true } }
  *
  * The preferred socket path is `{workspaceDir}/assistant-skill.sock`. On
  * platforms with strict AF_UNIX path limits (notably macOS), the server falls
@@ -25,10 +36,55 @@ import type {
   IpcRequest,
   IpcResponse,
 } from "./cli-server.js";
-import { skillIpcRoutes } from "./skill-routes/index.js";
+import {
+  skillIpcRoutes,
+  skillIpcStreamingRoutes,
+} from "./skill-routes/index.js";
 import { resolveSkillIpcSocketPath } from "./skill-socket-path.js";
 
 const log = getLogger("skill-ipc-server");
+
+// ---------------------------------------------------------------------------
+// Streaming
+// ---------------------------------------------------------------------------
+
+/**
+ * Well-known control method the client sends to close an open stream. The
+ * server also tears down on socket close / daemon shutdown, so this is only
+ * needed when the client wants to keep the socket but end one subscription.
+ */
+export const SKILL_IPC_SUBSCRIBE_CLOSE_METHOD =
+  "host.events.subscribe.close" as const;
+
+/** Stream handle passed to streaming-handler implementations. */
+export interface SkillIpcStream {
+  /** The original request id that opened this stream (used as the stream id). */
+  readonly id: string;
+  /**
+   * Send a delivery frame to the client. No-op after the stream has been
+   * closed (client disconnect, explicit close, or server shutdown).
+   */
+  send(payload: unknown): void;
+  /** True until the stream has been disposed. */
+  readonly active: boolean;
+}
+
+/**
+ * Handler signature for long-lived streaming methods (e.g.
+ * `host.events.subscribe`). Runs synchronously with the opening request and
+ * returns a dispose callback that the server invokes on client disconnect,
+ * explicit close, or server shutdown.
+ */
+export type SkillIpcStreamingHandler = (
+  stream: SkillIpcStream,
+  params?: Record<string, unknown>,
+) => () => void;
+
+/** Long-lived streaming route — method name + handler function. */
+export type SkillIpcStreamingRoute = {
+  method: string;
+  handler: SkillIpcStreamingHandler;
+};
 
 // ---------------------------------------------------------------------------
 // Server
@@ -43,6 +99,13 @@ export class SkillIpcServer {
   private server: Server | null = null;
   private clients = new Set<Socket>();
   private methods = new Map<string, IpcMethodHandler>();
+  private streamingMethods = new Map<string, SkillIpcStreamingHandler>();
+  /**
+   * Per-socket subscription registry. Keyed by the request id that opened
+   * the stream so the close-control message and socket-close teardown can
+   * locate the matching dispose callback.
+   */
+  private subscriptions = new WeakMap<Socket, Map<string, () => void>>();
   private socketPath: string;
 
   constructor(options: SkillIpcServerOptions = {}) {
@@ -66,11 +129,22 @@ export class SkillIpcServer {
     for (const route of skillIpcRoutes) {
       this.methods.set(route.method, route.handler);
     }
+    for (const route of skillIpcStreamingRoutes) {
+      this.streamingMethods.set(route.method, route.handler);
+    }
   }
 
   /** Register an additional method handler after construction. */
   registerMethod(method: string, handler: IpcMethodHandler): void {
     this.methods.set(method, handler);
+  }
+
+  /** Register an additional streaming handler after construction. */
+  registerStreamingMethod(
+    method: string,
+    handler: SkillIpcStreamingHandler,
+  ): void {
+    this.streamingMethods.set(method, handler);
   }
 
   /** Start listening on the Unix domain socket. */
@@ -110,12 +184,14 @@ export class SkillIpcServer {
 
       socket.on("close", () => {
         this.clients.delete(socket);
+        this.teardownSubscriptions(socket);
         log.debug("Skill IPC client disconnected");
       });
 
       socket.on("error", (err) => {
         log.warn({ err }, "Skill IPC client socket error");
         this.clients.delete(socket);
+        this.teardownSubscriptions(socket);
       });
     });
 
@@ -131,6 +207,7 @@ export class SkillIpcServer {
   /** Stop the server and disconnect all clients. */
   stop(): void {
     for (const client of this.clients) {
+      this.teardownSubscriptions(client);
       if (!client.destroyed) client.destroy();
     }
     this.clients.clear();
@@ -189,6 +266,18 @@ export class SkillIpcServer {
       return;
     }
 
+    // Subscribe-close is a built-in control message handled by the server.
+    if (req.method === SKILL_IPC_SUBSCRIBE_CLOSE_METHOD) {
+      this.handleSubscribeClose(socket, req);
+      return;
+    }
+
+    const streamingHandler = this.streamingMethods.get(req.method);
+    if (streamingHandler) {
+      this.handleStreamingRequest(socket, req, streamingHandler);
+      return;
+    }
+
     const handler = this.methods.get(req.method);
     if (!handler) {
       this.sendResponse(socket, {
@@ -222,6 +311,115 @@ export class SkillIpcServer {
         error: String(err),
       });
     }
+  }
+
+  private handleStreamingRequest(
+    socket: Socket,
+    req: IpcRequest,
+    handler: SkillIpcStreamingHandler,
+  ): void {
+    // Reject duplicate stream ids on the same socket so late deliveries
+    // on a zombie id never confuse the client's correlation table.
+    const existing = this.subscriptions.get(socket);
+    if (existing?.has(req.id)) {
+      this.sendResponse(socket, {
+        id: req.id,
+        error: `Stream id already active: ${req.id}`,
+      });
+      return;
+    }
+
+    let active = true;
+    const stream: SkillIpcStream = {
+      id: req.id,
+      get active() {
+        return active;
+      },
+      send: (payload) => {
+        if (!active || socket.destroyed) return;
+        socket.write(
+          JSON.stringify({
+            id: req.id,
+            event: "delivery",
+            payload,
+          }) + "\n",
+        );
+      },
+    };
+
+    let dispose: () => void;
+    try {
+      dispose = handler(stream, req.params);
+    } catch (err) {
+      log.warn(
+        { err, method: req.method },
+        "Skill IPC streaming handler error",
+      );
+      this.sendResponse(socket, { id: req.id, error: String(err) });
+      return;
+    }
+
+    const map = existing ?? new Map<string, () => void>();
+    if (!existing) this.subscriptions.set(socket, map);
+    map.set(req.id, () => {
+      if (!active) return;
+      active = false;
+      try {
+        dispose();
+      } catch (err) {
+        log.warn(
+          { err, method: req.method },
+          "Skill IPC streaming dispose error",
+        );
+      }
+    });
+
+    // Acknowledge the subscription open so the client can flip its
+    // correlation entry from "pending" to "streaming" before deliveries
+    // start arriving.
+    this.sendResponse(socket, {
+      id: req.id,
+      result: { subscribed: true },
+    });
+  }
+
+  private handleSubscribeClose(socket: Socket, req: IpcRequest): void {
+    const subscribeId =
+      req.params && typeof req.params.subscribeId === "string"
+        ? req.params.subscribeId
+        : null;
+    if (!subscribeId) {
+      this.sendResponse(socket, {
+        id: req.id,
+        error: "Missing 'subscribeId' param",
+      });
+      return;
+    }
+
+    const map = this.subscriptions.get(socket);
+    const dispose = map?.get(subscribeId);
+    if (dispose) {
+      dispose();
+      map!.delete(subscribeId);
+    }
+    this.sendResponse(socket, {
+      id: req.id,
+      result: { closed: true },
+    });
+  }
+
+  private teardownSubscriptions(socket: Socket): void {
+    const map = this.subscriptions.get(socket);
+    if (!map) return;
+    for (const dispose of map.values()) {
+      try {
+        dispose();
+      } catch (err) {
+        log.warn({ err }, "Skill IPC teardown dispose error");
+      }
+    }
+    map.clear();
+    this.subscriptions.delete(socket);
   }
 
   private sendResponse(socket: Socket, response: IpcResponse): void {


### PR DESCRIPTION
## Summary
- host.events.publish forwards to assistantEventHub.
- host.events.subscribe is a long-lived stream that delivers matching events until the client disconnects.
- host.events.buildEvent is a deterministic helper for constructing events.

Part of plan: skill-isolation.md (PR 23 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
