### PR TITLE
test(credential-security): allow ipc/skill-routes/providers.ts to import secure-keys

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -216,6 +216,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "providers/speech-to-text/resolve.ts", // STT provider API key lookup
       "daemon/lifecycle.ts", // CES client injection into secure-keys at startup
       "daemon/daemon-skill-host.ts", // SkillHost secureKeys facet adapter (delegates to getProviderKeyAsync)
+      "ipc/skill-routes/providers.ts", // host.providers.secureKeys.getProviderKey IPC route (out-of-process SkillHost companion)
       "daemon/external-plugins-bootstrap.ts", // reads credentials at plugin init (manifest.requiresCredential) via the CES-mediated getSecureKeyAsync path
       "inbound/platform-callback-registration.ts", // managed credential lookup for platform base URL, assistant ID, and API key
       "tts/providers/elevenlabs-provider.ts", // ElevenLabs TTS API key lookup


### PR DESCRIPTION
## Summary

- PR #27879 added `ipc/skill-routes/providers.ts`, which implements the `host.providers.secureKeys.getProviderKey` IPC route and imports `getProviderKeyAsync` from `secure-keys`. The allowlist in `credential-security-invariants.test.ts` hadn't been updated, so the "secure-keys is only imported by authorized modules" invariant started failing on main.
- Add `ipc/skill-routes/providers.ts` to `ALLOWED_IMPORTERS`; it is the out-of-process companion to `daemon/daemon-skill-host.ts`, which is already on the list.

## Original prompt

--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24862925977/job/72792459910
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
