### PR TITLE
feat(gateway): add in-memory risk rule cache with invalidation

### DIFF
--- a/gateway/src/__tests__/trust-rule-v3-cache.test.ts
+++ b/gateway/src/__tests__/trust-rule-v3-cache.test.ts
@@ -1,0 +1,359 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
+import { TrustRuleV3Store } from "../db/trust-rule-v3-store.js";
+import {
+  initTrustRuleV3Cache,
+  getTrustRuleV3Cache,
+  invalidateTrustRuleV3Cache,
+  resetTrustRuleV3Cache,
+} from "../risk/trust-rule-v3-cache.js";
+import "./test-preload.js";
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let store: TrustRuleV3Store;
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  store = new TrustRuleV3Store();
+});
+
+afterEach(() => {
+  resetTrustRuleV3Cache();
+  resetGatewayDb();
+});
+
+// ---------------------------------------------------------------------------
+// findBaseRisk() — exact match
+// ---------------------------------------------------------------------------
+
+describe("findBaseRisk()", () => {
+  test("exact match returns the matching rule", () => {
+    store.create({
+      tool: "bash",
+      pattern: "rm -rf",
+      risk: "high",
+      description: "Dangerous remove",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+
+    const result = cache.findBaseRisk("bash", "rm -rf");
+    expect(result).not.toBeNull();
+    expect(result!.pattern).toBe("rm -rf");
+    expect(result!.risk).toBe("high");
+  });
+
+  test("path-stripped match: /usr/bin/rm matches rule for rm", () => {
+    store.create({
+      tool: "bash",
+      pattern: "rm",
+      risk: "high",
+      description: "Remove command",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+
+    const result = cache.findBaseRisk("bash", "/usr/bin/rm");
+    expect(result).not.toBeNull();
+    expect(result!.pattern).toBe("rm");
+  });
+
+  test("path-stripped match with arguments: /usr/bin/git push matches git push", () => {
+    store.create({
+      tool: "bash",
+      pattern: "git push",
+      risk: "medium",
+      description: "Git push command",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+
+    const result = cache.findBaseRisk("bash", "/usr/bin/git push");
+    expect(result).not.toBeNull();
+    expect(result!.pattern).toBe("git push");
+  });
+
+  test("subcommand match: 'git push --force' falls back to 'git push' then 'git'", () => {
+    store.create({
+      tool: "bash",
+      pattern: "git",
+      risk: "medium",
+      description: "Git commands",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+
+    // "git push --force" should match "git" via subcommand fallback
+    const result = cache.findBaseRisk("bash", "git push --force");
+    expect(result).not.toBeNull();
+    expect(result!.pattern).toBe("git");
+  });
+
+  test("subcommand match prefers longer prefix", () => {
+    store.create({
+      tool: "bash",
+      pattern: "git",
+      risk: "low",
+      description: "Git base",
+    });
+    store.create({
+      tool: "bash",
+      pattern: "git push",
+      risk: "high",
+      description: "Git push",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+
+    // "git push --force" should match "git push" (longer prefix wins)
+    const result = cache.findBaseRisk("bash", "git push --force");
+    expect(result).not.toBeNull();
+    expect(result!.pattern).toBe("git push");
+    expect(result!.risk).toBe("high");
+  });
+
+  test("returns null when no match found", () => {
+    store.create({
+      tool: "bash",
+      pattern: "echo",
+      risk: "low",
+      description: "Echo",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+
+    const result = cache.findBaseRisk("bash", "curl");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when tool not found", () => {
+    store.create({
+      tool: "bash",
+      pattern: "echo",
+      risk: "low",
+      description: "Echo",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+
+    const result = cache.findBaseRisk("nonexistent_tool", "echo");
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findToolOverride()
+// ---------------------------------------------------------------------------
+
+describe("findToolOverride()", () => {
+  test("exact match returns the matching rule", () => {
+    store.create({
+      tool: "file_read",
+      pattern: "/etc/passwd",
+      risk: "high",
+      description: "Sensitive file",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+
+    const result = cache.findToolOverride("file_read", "/etc/passwd");
+    expect(result).not.toBeNull();
+    expect(result!.pattern).toBe("/etc/passwd");
+    expect(result!.risk).toBe("high");
+  });
+
+  test("returns null when pattern not found", () => {
+    store.create({
+      tool: "file_read",
+      pattern: "/etc/passwd",
+      risk: "high",
+      description: "Sensitive file",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+
+    const result = cache.findToolOverride("file_read", "/tmp/safe");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when tool not found", () => {
+    store.create({
+      tool: "file_read",
+      pattern: "/etc/passwd",
+      risk: "high",
+      description: "Sensitive file",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+
+    const result = cache.findToolOverride("web_fetch", "/etc/passwd");
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAllForTool()
+// ---------------------------------------------------------------------------
+
+describe("getAllForTool()", () => {
+  test("returns all active rules for a given tool", () => {
+    store.create({
+      tool: "bash",
+      pattern: "echo",
+      risk: "low",
+      description: "Echo",
+    });
+    store.create({
+      tool: "bash",
+      pattern: "rm",
+      risk: "high",
+      description: "Remove",
+    });
+    store.create({
+      tool: "file_read",
+      pattern: "/tmp/**",
+      risk: "medium",
+      description: "File read",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+
+    const bashRules = cache.getAllForTool("bash");
+    expect(bashRules).toHaveLength(2);
+    expect(bashRules.map((r) => r.pattern).sort()).toEqual(["echo", "rm"]);
+  });
+
+  test("returns empty array when tool not found", () => {
+    store.create({
+      tool: "bash",
+      pattern: "echo",
+      risk: "low",
+      description: "Echo",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+
+    const result = cache.getAllForTool("nonexistent");
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refresh() and invalidation
+// ---------------------------------------------------------------------------
+
+describe("refresh()", () => {
+  test("cache reflects data after refresh", () => {
+    store.create({
+      tool: "bash",
+      pattern: "echo",
+      risk: "low",
+      description: "Echo",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+
+    // Verify initial state
+    expect(cache.findBaseRisk("bash", "echo")).not.toBeNull();
+    expect(cache.findBaseRisk("bash", "curl")).toBeNull();
+
+    // Add a new rule directly to the store (bypassing cache)
+    store.create({
+      tool: "bash",
+      pattern: "curl",
+      risk: "medium",
+      description: "Curl",
+    });
+
+    // Cache should still not have it
+    expect(cache.findBaseRisk("bash", "curl")).toBeNull();
+
+    // After refresh, cache should pick it up
+    invalidateTrustRuleV3Cache();
+    expect(cache.findBaseRisk("bash", "curl")).not.toBeNull();
+    expect(cache.findBaseRisk("bash", "curl")!.risk).toBe("medium");
+  });
+
+  test("refresh picks up removed rules", () => {
+    const rule = store.create({
+      tool: "bash",
+      pattern: "echo",
+      risk: "low",
+      description: "Echo",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+
+    expect(cache.findBaseRisk("bash", "echo")).not.toBeNull();
+
+    // Remove the rule from the store
+    store.remove(rule.id);
+
+    // Cache still has old data
+    expect(cache.findBaseRisk("bash", "echo")).not.toBeNull();
+
+    // After refresh, the rule should be gone
+    invalidateTrustRuleV3Cache();
+    expect(cache.findBaseRisk("bash", "echo")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Singleton functions
+// ---------------------------------------------------------------------------
+
+describe("singleton functions", () => {
+  test("getTrustRuleV3Cache() throws if not initialized", () => {
+    expect(() => getTrustRuleV3Cache()).toThrow(
+      "Risk rule cache not initialized",
+    );
+  });
+
+  test("initTrustRuleV3Cache() initializes the cache", () => {
+    store.create({
+      tool: "bash",
+      pattern: "echo",
+      risk: "low",
+      description: "Echo",
+    });
+
+    initTrustRuleV3Cache(store);
+    const cache = getTrustRuleV3Cache();
+    expect(cache.findBaseRisk("bash", "echo")).not.toBeNull();
+  });
+
+  test("resetTrustRuleV3Cache() clears the singleton", () => {
+    initTrustRuleV3Cache(store);
+    // Should work
+    getTrustRuleV3Cache();
+
+    resetTrustRuleV3Cache();
+    // Should throw again
+    expect(() => getTrustRuleV3Cache()).toThrow(
+      "Risk rule cache not initialized",
+    );
+  });
+
+  test("invalidateTrustRuleV3Cache() is safe to call when cache is null", () => {
+    // Should not throw
+    invalidateTrustRuleV3Cache();
+  });
+});

--- a/gateway/src/risk/trust-rule-v3-cache.ts
+++ b/gateway/src/risk/trust-rule-v3-cache.ts
@@ -1,0 +1,138 @@
+import {
+  TrustRuleV3Store,
+  type TrustRuleV3,
+} from "../db/trust-rule-v3-store.js";
+
+// ---------------------------------------------------------------------------
+// Cache class
+// ---------------------------------------------------------------------------
+
+class TrustRuleV3Cache {
+  private store: TrustRuleV3Store;
+  /** Outer key = tool, inner key = pattern */
+  private rules: Map<string, Map<string, TrustRuleV3>> = new Map();
+
+  constructor(store: TrustRuleV3Store) {
+    this.store = store;
+    this.refresh();
+  }
+
+  /**
+   * Clear and reload all active rules from the store.
+   */
+  refresh(): void {
+    this.rules.clear();
+    const active = this.store.listActive();
+    for (const rule of active) {
+      let toolMap = this.rules.get(rule.tool);
+      if (!toolMap) {
+        toolMap = new Map();
+        this.rules.set(rule.tool, toolMap);
+      }
+      toolMap.set(rule.pattern, rule);
+    }
+  }
+
+  /**
+   * Look up the base risk rule for a bash-style (tool, command) pair.
+   *
+   * Resolution order:
+   * 1. Exact match on (tool, command)
+   * 2. Path-stripped match: strip leading path prefix
+   *    (e.g. `/usr/bin/rm` -> `rm`) and retry exact match
+   * 3. Subcommand match: for multi-word commands (e.g. `git push`),
+   *    try progressively shorter prefixes (`"git push"` then `"git"`)
+   */
+  findBaseRisk(tool: string, command: string): TrustRuleV3 | null {
+    const toolMap = this.rules.get(tool);
+    if (!toolMap) return null;
+
+    // 1. Exact match
+    const exact = toolMap.get(command);
+    if (exact) return exact;
+
+    // 2. Path-stripped match: /usr/bin/rm -> rm
+    const stripped = this.stripPath(command);
+    if (stripped !== command) {
+      const strippedMatch = toolMap.get(stripped);
+      if (strippedMatch) return strippedMatch;
+    }
+
+    // 3. Subcommand match: try progressively shorter word prefixes
+    // For "git push --force", try "git push --force", "git push", "git"
+    const resolvedCommand = stripped !== command ? stripped : command;
+    const parts = resolvedCommand.split(/\s+/);
+    for (let i = parts.length - 1; i >= 1; i--) {
+      const subcommand = parts.slice(0, i).join(" ");
+      const match = toolMap.get(subcommand);
+      if (match) return match;
+    }
+
+    return null;
+  }
+
+  /**
+   * Look up a tool override rule by exact (tool, pattern) match.
+   * Used for non-bash classifiers (file, web, skill, schedule).
+   */
+  findToolOverride(tool: string, pattern: string): TrustRuleV3 | null {
+    const toolMap = this.rules.get(tool);
+    if (!toolMap) return null;
+    return toolMap.get(pattern) ?? null;
+  }
+
+  /**
+   * Return all active rules for a given tool.
+   */
+  getAllForTool(tool: string): TrustRuleV3[] {
+    const toolMap = this.rules.get(tool);
+    if (!toolMap) return [];
+    return Array.from(toolMap.values());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Strip leading path components from a command.
+   * `/usr/bin/rm` -> `rm`, `rm` -> `rm`
+   */
+  private stripPath(command: string): string {
+    // Only strip path from the first token (the binary)
+    const spaceIdx = command.indexOf(" ");
+    const binary = spaceIdx === -1 ? command : command.slice(0, spaceIdx);
+    const rest = spaceIdx === -1 ? "" : command.slice(spaceIdx);
+
+    const slashIdx = binary.lastIndexOf("/");
+    if (slashIdx === -1) return command;
+
+    return binary.slice(slashIdx + 1) + rest;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let cache: TrustRuleV3Cache | null = null;
+
+export function initTrustRuleV3Cache(store?: TrustRuleV3Store): void {
+  cache = new TrustRuleV3Cache(store ?? new TrustRuleV3Store());
+}
+
+export function getTrustRuleV3Cache(): TrustRuleV3Cache {
+  if (!cache)
+    throw new Error(
+      "Risk rule cache not initialized \u2014 call initTrustRuleV3Cache() at startup",
+    );
+  return cache;
+}
+
+export function invalidateTrustRuleV3Cache(): void {
+  cache?.refresh();
+}
+
+export function resetTrustRuleV3Cache(): void {
+  cache = null;
+}


### PR DESCRIPTION
## Summary
- TrustRuleV3Cache singleton loaded from TrustRuleV3Store
- findBaseRisk() with exact match, path-stripped, and subcommand pattern support
- findToolOverride() for non-bash classifier user overrides
- invalidateTrustRuleV3Cache() for cache refresh after CRUD mutations
- Tests for all lookup modes and invalidation

Part of plan: v3-trust-rules-table.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
