### PR TITLE
feat(gateway): seed trust_rules table from DEFAULT_COMMAND_REGISTRY on startup

### DIFF
--- a/gateway/src/__tests__/seed-trust-rules-v3.test.ts
+++ b/gateway/src/__tests__/seed-trust-rules-v3.test.ts
@@ -51,11 +51,7 @@ describe("seedTrustRuleV3sFromRegistry()", () => {
   });
 
   test("count is > 200 for the current registry size", () => {
-    // Seed on a fresh store to get the count directly
-    resetGatewayDb();
-    // Re-init without seeding to get a clean count
-    // Actually initGatewayDb seeds automatically, so we check via list
-    // The rules were already seeded by initGatewayDb in beforeEach
+    // Rules were already seeded by initGatewayDb in beforeEach
     const rules = store.list({ origin: "default" });
     expect(rules.length).toBeGreaterThan(200);
   });

--- a/gateway/src/__tests__/seed-trust-rules-v3.test.ts
+++ b/gateway/src/__tests__/seed-trust-rules-v3.test.ts
@@ -1,0 +1,154 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
+import { seedTrustRuleV3sFromRegistry } from "../db/seed-trust-rules-v3.js";
+import { TrustRuleV3Store } from "../db/trust-rule-v3-store.js";
+import "./test-preload.js";
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let store: TrustRuleV3Store;
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  store = new TrustRuleV3Store();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+// ---------------------------------------------------------------------------
+// Basic seeding
+// ---------------------------------------------------------------------------
+
+describe("seedTrustRuleV3sFromRegistry()", () => {
+  test("creates rows for all registry entries (top-level + subcommands)", () => {
+    // initGatewayDb() already seeds, so just check the result
+    const rules = store.list({ origin: "default" });
+    expect(rules.length).toBeGreaterThan(0);
+
+    // Spot-check a top-level command
+    const lsRule = rules.find((r) => r.pattern === "ls");
+    expect(lsRule).toBeDefined();
+    expect(lsRule!.tool).toBe("bash");
+    expect(lsRule!.risk).toBe("low");
+    expect(lsRule!.id).toBe("default:bash:ls");
+
+    // Spot-check a subcommand
+    const gitPush = rules.find((r) => r.pattern === "git push");
+    expect(gitPush).toBeDefined();
+    expect(gitPush!.risk).toBe("medium");
+    expect(gitPush!.id).toBe("default:bash:git-push");
+
+    // Spot-check a nested subcommand (git stash drop)
+    const gitStashDrop = rules.find((r) => r.pattern === "git stash drop");
+    expect(gitStashDrop).toBeDefined();
+    expect(gitStashDrop!.risk).toBe("high");
+    expect(gitStashDrop!.id).toBe("default:bash:git-stash-drop");
+  });
+
+  test("count is > 200 for the current registry size", () => {
+    // Seed on a fresh store to get the count directly
+    resetGatewayDb();
+    // Re-init without seeding to get a clean count
+    // Actually initGatewayDb seeds automatically, so we check via list
+    // The rules were already seeded by initGatewayDb in beforeEach
+    const rules = store.list({ origin: "default" });
+    expect(rules.length).toBeGreaterThan(200);
+  });
+
+  test("re-seeding is idempotent — same number of active rules", () => {
+    const rulesBefore = store.list({ origin: "default" });
+    const countBefore = rulesBefore.length;
+
+    // Seed again
+    const count = seedTrustRuleV3sFromRegistry(store);
+
+    const rulesAfter = store.list({ origin: "default" });
+    expect(rulesAfter.length).toBe(countBefore);
+    expect(count).toBe(countBefore);
+  });
+
+  test("deterministic IDs are consistent across re-seeds", () => {
+    const rulesBefore = store.list({ origin: "default" });
+    const idsBefore = new Set(rulesBefore.map((r) => r.id));
+
+    // Seed again
+    seedTrustRuleV3sFromRegistry(store);
+
+    const rulesAfter = store.list({ origin: "default" });
+    const idsAfter = new Set(rulesAfter.map((r) => r.id));
+
+    expect(idsAfter).toEqual(idsBefore);
+  });
+
+  test("deterministic IDs follow default:bash:<slug> format", () => {
+    const rules = store.list({ origin: "default" });
+    for (const rule of rules) {
+      expect(rule.id).toMatch(/^default:bash:/);
+      // Slug portion should not contain spaces
+      const slug = rule.id.replace("default:bash:", "");
+      expect(slug).not.toContain(" ");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Three-guard protection
+// ---------------------------------------------------------------------------
+
+describe("three-guard upsert protection", () => {
+  test("user-modified rule is NOT overwritten on re-seed", () => {
+    // Modify a seeded rule's risk
+    const lsRule = store.getById("default:bash:ls")!;
+    expect(lsRule.risk).toBe("low");
+
+    store.update("default:bash:ls", { risk: "high" });
+
+    const modified = store.getById("default:bash:ls")!;
+    expect(modified.risk).toBe("high");
+    expect(modified.userModified).toBe(true);
+
+    // Re-seed
+    seedTrustRuleV3sFromRegistry(store);
+
+    // Verify the modified rule was NOT overwritten
+    const afterReseed = store.getById("default:bash:ls")!;
+    expect(afterReseed.risk).toBe("high");
+    expect(afterReseed.userModified).toBe(true);
+  });
+
+  test("soft-deleted rule is NOT restored on re-seed", () => {
+    // Soft-delete a seeded rule
+    store.remove("default:bash:ls");
+
+    const deleted = store.getById("default:bash:ls")!;
+    expect(deleted.deleted).toBe(true);
+
+    // Re-seed
+    seedTrustRuleV3sFromRegistry(store);
+
+    // Verify the deleted rule was NOT restored
+    const afterReseed = store.getById("default:bash:ls")!;
+    expect(afterReseed.deleted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Description generation
+// ---------------------------------------------------------------------------
+
+describe("description generation", () => {
+  test("uses spec.reason when present", () => {
+    const sudoRule = store.getById("default:bash:sudo")!;
+    expect(sudoRule.description).toContain("Elevates to superuser privileges");
+  });
+
+  test("generates default description when no reason", () => {
+    const lsRule = store.getById("default:bash:ls")!;
+    expect(lsRule.description).toBe("ls (default)");
+  });
+});

--- a/gateway/src/__tests__/trust-rule-v3-store.test.ts
+++ b/gateway/src/__tests__/trust-rule-v3-store.test.ts
@@ -9,10 +9,23 @@ import "./test-preload.js";
 
 let store: TrustRuleV3Store;
 
+/**
+ * Baseline counts captured after initGatewayDb() seeds the registry defaults.
+ * Tests that assert counts use these as a starting point.
+ */
+let seededDefaultCount: number;
+let seededBashCount: number;
+let seededTotalCount: number;
+
 beforeEach(async () => {
   resetGatewayDb();
   await initGatewayDb();
   store = new TrustRuleV3Store();
+
+  // Capture baselines — initGatewayDb() seeds DEFAULT_COMMAND_REGISTRY
+  seededDefaultCount = store.list({ origin: "default" }).length;
+  seededBashCount = store.list({ tool: "bash" }).length;
+  seededTotalCount = store.list().length;
 });
 
 afterEach(() => {
@@ -52,7 +65,7 @@ describe("create()", () => {
     const before = new Date().toISOString();
     const rule = store.create({
       tool: "bash",
-      pattern: "ls",
+      pattern: "my-custom-ls",
       risk: "low",
       description: "test",
     });
@@ -84,7 +97,7 @@ describe("list()", () => {
     });
 
     const rules = store.list();
-    expect(rules).toHaveLength(2);
+    expect(rules).toHaveLength(seededTotalCount + 2);
   });
 
   test("filters by origin", () => {
@@ -107,8 +120,8 @@ describe("list()", () => {
     expect(userRules[0].origin).toBe("user_defined");
 
     const defaultRules = store.list({ origin: "default" });
-    expect(defaultRules).toHaveLength(1);
-    expect(defaultRules[0].origin).toBe("default");
+    expect(defaultRules).toHaveLength(seededDefaultCount + 1);
+    expect(defaultRules.every((r) => r.origin === "default")).toBe(true);
   });
 
   test("filters by tool", () => {
@@ -126,8 +139,8 @@ describe("list()", () => {
     });
 
     const bashRules = store.list({ tool: "bash" });
-    expect(bashRules).toHaveLength(1);
-    expect(bashRules[0].tool).toBe("bash");
+    expect(bashRules).toHaveLength(seededBashCount + 1);
+    expect(bashRules.every((r) => r.tool === "bash")).toBe(true);
   });
 
   test("excludes soft-deleted rules by default", () => {
@@ -141,7 +154,9 @@ describe("list()", () => {
     store.remove("default:bash:danger");
 
     const rules = store.list();
-    expect(rules).toHaveLength(0);
+    // Should have the seeded rules but not the soft-deleted one
+    expect(rules).toHaveLength(seededTotalCount);
+    expect(rules.find((r) => r.id === "default:bash:danger")).toBeUndefined();
   });
 
   test("includes soft-deleted rules when includeDeleted is true", () => {
@@ -155,8 +170,10 @@ describe("list()", () => {
     store.remove("default:bash:danger");
 
     const rules = store.list({ includeDeleted: true });
-    expect(rules).toHaveLength(1);
-    expect(rules[0].deleted).toBe(true);
+    expect(rules).toHaveLength(seededTotalCount + 1);
+    const deleted = rules.find((r) => r.id === "default:bash:danger");
+    expect(deleted).toBeDefined();
+    expect(deleted!.deleted).toBe(true);
   });
 });
 
@@ -210,17 +227,17 @@ describe("update()", () => {
 
   test("sets userModified=true for default rules", () => {
     store.upsertDefault({
-      id: "default:bash:test",
+      id: "default:bash:test-update",
       tool: "bash",
-      pattern: "test",
+      pattern: "test-update",
       risk: "low",
       description: "Default rule",
     });
 
-    const rule = store.getById("default:bash:test")!;
+    const rule = store.getById("default:bash:test-update")!;
     expect(rule.userModified).toBe(false);
 
-    const updated = store.update("default:bash:test", { risk: "high" });
+    const updated = store.update("default:bash:test-update", { risk: "high" });
     expect(updated.userModified).toBe(true);
   });
 
@@ -269,22 +286,24 @@ describe("remove()", () => {
 
   test("soft-deletes default rules", () => {
     store.upsertDefault({
-      id: "default:bash:test",
+      id: "default:bash:test-remove",
       tool: "bash",
-      pattern: "test",
+      pattern: "test-remove",
       risk: "low",
       description: "Default rule",
     });
 
-    const result = store.remove("default:bash:test");
+    const result = store.remove("default:bash:test-remove");
     expect(result).toBe(true);
 
-    // Should not appear in default list
+    // Should not appear in default list (without includeDeleted)
     const rules = store.list();
-    expect(rules).toHaveLength(0);
+    expect(
+      rules.find((r) => r.id === "default:bash:test-remove"),
+    ).toBeUndefined();
 
     // Should still exist as soft-deleted
-    const found = store.getById("default:bash:test");
+    const found = store.getById("default:bash:test-remove");
     expect(found).not.toBeNull();
     expect(found!.deleted).toBe(true);
   });
@@ -303,24 +322,24 @@ describe("remove()", () => {
 describe("reset()", () => {
   test("clears userModified and deleted, restores risk", () => {
     store.upsertDefault({
-      id: "default:bash:test",
+      id: "default:bash:test-reset",
       tool: "bash",
-      pattern: "test",
+      pattern: "test-reset",
       risk: "low",
       description: "Default rule",
     });
 
     // Modify and delete
-    store.update("default:bash:test", { risk: "high" });
-    store.remove("default:bash:test");
+    store.update("default:bash:test-reset", { risk: "high" });
+    store.remove("default:bash:test-reset");
 
-    const beforeReset = store.getById("default:bash:test")!;
+    const beforeReset = store.getById("default:bash:test-reset")!;
     expect(beforeReset.userModified).toBe(true);
     expect(beforeReset.deleted).toBe(true);
     expect(beforeReset.risk).toBe("high");
 
     // Reset
-    const resetRule = store.reset("default:bash:test", "low");
+    const resetRule = store.reset("default:bash:test-reset", "low");
     expect(resetRule.userModified).toBe(false);
     expect(resetRule.deleted).toBe(false);
     expect(resetRule.risk).toBe("low");
@@ -354,14 +373,14 @@ describe("reset()", () => {
 describe("upsertDefault()", () => {
   test("inserts a new default rule", () => {
     store.upsertDefault({
-      id: "default:bash:test",
+      id: "default:bash:test-upsert",
       tool: "bash",
-      pattern: "test",
+      pattern: "test-upsert",
       risk: "low",
       description: "Default rule",
     });
 
-    const rule = store.getById("default:bash:test");
+    const rule = store.getById("default:bash:test-upsert");
     expect(rule).not.toBeNull();
     expect(rule!.origin).toBe("default");
     expect(rule!.userModified).toBe(false);
@@ -371,53 +390,53 @@ describe("upsertDefault()", () => {
 
   test("updates unmodified default rule on conflict", () => {
     store.upsertDefault({
-      id: "default:bash:test",
+      id: "default:bash:test-upsert-conflict",
       tool: "bash",
-      pattern: "test",
+      pattern: "test-upsert-conflict",
       risk: "low",
       description: "Original",
     });
 
     // Re-upsert with updated risk and description
     store.upsertDefault({
-      id: "default:bash:test",
+      id: "default:bash:test-upsert-conflict",
       tool: "bash",
-      pattern: "test",
+      pattern: "test-upsert-conflict",
       risk: "medium",
       description: "Updated",
     });
 
-    const rule = store.getById("default:bash:test")!;
+    const rule = store.getById("default:bash:test-upsert-conflict")!;
     expect(rule.risk).toBe("medium");
     expect(rule.description).toBe("Updated");
   });
 
   test("three-guard: does NOT overwrite user-modified rule", () => {
     store.upsertDefault({
-      id: "default:bash:test",
+      id: "default:bash:test-3g-modified",
       tool: "bash",
-      pattern: "test",
+      pattern: "test-3g-modified",
       risk: "low",
       description: "Original",
     });
 
     // User modifies the rule
-    store.update("default:bash:test", { risk: "high" });
+    store.update("default:bash:test-3g-modified", { risk: "high" });
 
-    const modified = store.getById("default:bash:test")!;
+    const modified = store.getById("default:bash:test-3g-modified")!;
     expect(modified.userModified).toBe(true);
     expect(modified.risk).toBe("high");
 
     // Re-upsert should NOT overwrite because userModified=true
     store.upsertDefault({
-      id: "default:bash:test",
+      id: "default:bash:test-3g-modified",
       tool: "bash",
-      pattern: "test",
+      pattern: "test-3g-modified",
       risk: "low",
       description: "Should not overwrite",
     });
 
-    const afterUpsert = store.getById("default:bash:test")!;
+    const afterUpsert = store.getById("default:bash:test-3g-modified")!;
     expect(afterUpsert.risk).toBe("high");
     expect(afterUpsert.description).toBe("Original");
     expect(afterUpsert.userModified).toBe(true);
@@ -425,29 +444,29 @@ describe("upsertDefault()", () => {
 
   test("three-guard: does NOT overwrite soft-deleted rule", () => {
     store.upsertDefault({
-      id: "default:bash:test",
+      id: "default:bash:test-3g-deleted",
       tool: "bash",
-      pattern: "test",
+      pattern: "test-3g-deleted",
       risk: "low",
       description: "Original",
     });
 
     // Soft-delete the rule
-    store.remove("default:bash:test");
+    store.remove("default:bash:test-3g-deleted");
 
-    const deleted = store.getById("default:bash:test")!;
+    const deleted = store.getById("default:bash:test-3g-deleted")!;
     expect(deleted.deleted).toBe(true);
 
     // Re-upsert should NOT overwrite because deleted=true
     store.upsertDefault({
-      id: "default:bash:test",
+      id: "default:bash:test-3g-deleted",
       tool: "bash",
-      pattern: "test",
+      pattern: "test-3g-deleted",
       risk: "medium",
       description: "Should not overwrite",
     });
 
-    const afterUpsert = store.getById("default:bash:test")!;
+    const afterUpsert = store.getById("default:bash:test-3g-deleted")!;
     expect(afterUpsert.risk).toBe("low");
     expect(afterUpsert.description).toBe("Original");
     expect(afterUpsert.deleted).toBe(true);
@@ -474,10 +493,11 @@ describe("upsertDefault()", () => {
 
     // The user-defined rule should remain unchanged
     const rules = store.list({ tool: "bash" });
-    expect(rules).toHaveLength(1);
-    expect(rules[0].origin).toBe("user_defined");
-    expect(rules[0].risk).toBe("high");
-    expect(rules[0].description).toBe("User created");
+    const customRule = rules.find((r) => r.pattern === "custom-pattern");
+    expect(customRule).toBeDefined();
+    expect(customRule!.origin).toBe("user_defined");
+    expect(customRule!.risk).toBe("high");
+    expect(customRule!.description).toBe("User created");
   });
 });
 
@@ -503,8 +523,10 @@ describe("listActive()", () => {
     store.remove("default:bash:danger");
 
     const active = store.listActive();
-    expect(active).toHaveLength(1);
-    expect(active[0].pattern).toBe("echo *");
+    // Seeded rules + 1 user rule, but NOT the soft-deleted danger rule
+    expect(active).toHaveLength(seededTotalCount + 1);
+    expect(active.find((r) => r.pattern === "echo *")).toBeDefined();
+    expect(active.find((r) => r.pattern === "danger")).toBeUndefined();
   });
 
   test("filters by tool", () => {
@@ -522,8 +544,8 @@ describe("listActive()", () => {
     });
 
     const bashRules = store.listActive("bash");
-    expect(bashRules).toHaveLength(1);
-    expect(bashRules[0].tool).toBe("bash");
+    expect(bashRules).toHaveLength(seededBashCount + 1);
+    expect(bashRules.every((r) => r.tool === "bash")).toBe(true);
 
     const fileRules = store.listActive("file_read");
     expect(fileRules).toHaveLength(1);
@@ -545,6 +567,6 @@ describe("listActive()", () => {
     });
 
     const allActive = store.listActive();
-    expect(allActive).toHaveLength(2);
+    expect(allActive).toHaveLength(seededTotalCount + 2);
   });
 });

--- a/gateway/src/db/connection.ts
+++ b/gateway/src/db/connection.ts
@@ -5,6 +5,8 @@ import { join } from "node:path";
 import { getGatewaySecurityDir, getLegacyRootDir } from "../paths.js";
 import { runDataMigrations } from "./data-migrations/index.js";
 import * as schema from "./schema.js";
+import { seedTrustRuleV3sFromRegistry } from "./seed-trust-rules-v3.js";
+import { TrustRuleV3Store } from "./trust-rule-v3-store.js";
 
 export type GatewayDb = ReturnType<typeof drizzle<typeof schema>>;
 
@@ -79,6 +81,9 @@ export async function initGatewayDb(): Promise<void> {
   }
 
   runDataMigrations(getRawDb(db));
+
+  const trustRuleV3Store = new TrustRuleV3Store(db);
+  seedTrustRuleV3sFromRegistry(trustRuleV3Store);
 }
 
 /**

--- a/gateway/src/db/seed-trust-rules-v3.ts
+++ b/gateway/src/db/seed-trust-rules-v3.ts
@@ -1,0 +1,92 @@
+/**
+ * Seeds the trust_rules table from the DEFAULT_COMMAND_REGISTRY.
+ *
+ * Walks the registry and produces one row per top-level command and one row
+ * per subcommand (recursively). Uses deterministic IDs of the form
+ * `default:bash:<command-slug>` so re-seeding is idempotent for unmodified
+ * rules, while the three-guard upsert protects user modifications.
+ */
+
+import { DEFAULT_COMMAND_REGISTRY } from "../risk/command-registry.js";
+import type { CommandRiskSpec } from "../risk/risk-types.js";
+import type {
+  TrustRuleV3Store,
+  UpsertDefaultInput,
+} from "./trust-rule-v3-store.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a deterministic ID from a command pattern.
+ * Spaces are replaced with hyphens: "git push" -> "default:bash:git-push"
+ */
+function makeId(pattern: string): string {
+  return `default:bash:${pattern.replace(/ /g, "-")}`;
+}
+
+/**
+ * Build a human-readable description for a registry entry.
+ * Uses `spec.reason` when available, otherwise generates a default.
+ */
+function makeDescription(pattern: string, spec: CommandRiskSpec): string {
+  if (spec.reason) {
+    return `${pattern} \u2014 ${spec.reason}`;
+  }
+  return `${pattern} (default)`;
+}
+
+/**
+ * Recursively collect upsert inputs from a CommandRiskSpec and its subcommands.
+ */
+function collectEntries(
+  pattern: string,
+  spec: CommandRiskSpec,
+  results: UpsertDefaultInput[],
+): void {
+  // Add entry for this command/subcommand
+  results.push({
+    id: makeId(pattern),
+    tool: "bash",
+    pattern,
+    risk: spec.baseRisk,
+    description: makeDescription(pattern, spec),
+  });
+
+  // Recurse into subcommands
+  if (spec.subcommands) {
+    for (const [sub, subSpec] of Object.entries(spec.subcommands)) {
+      collectEntries(`${pattern} ${sub}`, subSpec, results);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Seed the trust_rules table from DEFAULT_COMMAND_REGISTRY.
+ *
+ * Produces one row per top-level command and one row per subcommand
+ * (recursively). Uses `store.upsertDefault()` so that:
+ * - New entries are inserted
+ * - Unmodified entries are updated (risk/description may change across versions)
+ * - User-modified or soft-deleted entries are NOT overwritten (three-guard)
+ *
+ * @returns The number of entries upserted (for logging).
+ */
+export function seedTrustRuleV3sFromRegistry(store: TrustRuleV3Store): number {
+  const entries: UpsertDefaultInput[] = [];
+
+  for (const [command, spec] of Object.entries(DEFAULT_COMMAND_REGISTRY)) {
+    collectEntries(command, spec, entries);
+  }
+
+  for (const entry of entries) {
+    store.upsertDefault(entry);
+  }
+
+  return entries.length;
+}


### PR DESCRIPTION
## Summary
- Walk DEFAULT_COMMAND_REGISTRY and produce one trust_rules row per command/subcommand
- Deterministic IDs (default:bash:<slug>), three-guard upsert protects user modifications
- Wired into initGatewayDb() for automatic seeding on every startup
- Tests for idempotency, three-guard protection, and row count

Part of plan: v3-trust-rules-table.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
