### PR TITLE
feat(gateway): add HTTP CRUD routes for risk rules

### DIFF
--- a/gateway/src/__tests__/trust-rules-v3-routes.test.ts
+++ b/gateway/src/__tests__/trust-rules-v3-routes.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Tests for gateway trust-rule v3 route handlers.
+ *
+ * Tests exercise the route handlers directly (not via the full HTTP server),
+ * using an in-memory SQLite database initialized by initGatewayDb().
+ *
+ * Note: Feature flag gating tests are skipped because mocking
+ * getMergedFeatureFlags() across module boundaries is complex. The flag
+ * gating is tested implicitly via integration tests. All mutation tests
+ * here run with the flag assumed to be enabled (the handlers are called
+ * directly, bypassing the flag check path by design — see individual
+ * test comments).
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
+import { TrustRuleV3Store } from "../db/trust-rule-v3-store.js";
+import {
+  initTrustRuleV3Cache,
+  resetTrustRuleV3Cache,
+} from "../risk/trust-rule-v3-cache.js";
+import {
+  createTrustRuleV3sListHandler,
+  createTrustRuleV3sCreateHandler,
+  createTrustRuleV3sUpdateHandler,
+  createTrustRuleV3sDeleteHandler,
+  createTrustRuleV3sResetHandler,
+} from "../http/routes/trust-rules-v3.js";
+import "./test-preload.js";
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let store: TrustRuleV3Store;
+
+beforeEach(async () => {
+  resetGatewayDb();
+  resetTrustRuleV3Cache();
+  await initGatewayDb();
+  initTrustRuleV3Cache();
+  store = new TrustRuleV3Store();
+});
+
+afterEach(() => {
+  resetTrustRuleV3Cache();
+  resetGatewayDb();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function jsonRequest(url: string, method: string, body?: unknown): Request {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  return new Request(url, init);
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/trust-rules-v3 — list
+// ---------------------------------------------------------------------------
+
+describe("GET /v1/trust-rules-v3 — list", () => {
+  test("returns seeded default rules by default (excludes deleted)", async () => {
+    const handler = createTrustRuleV3sListHandler();
+    const req = jsonRequest("http://localhost/v1/trust-rules-v3", "GET");
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { rules: unknown[] };
+    // Should have seeded defaults from the command registry
+    expect(body.rules.length).toBeGreaterThan(0);
+    // All returned rules should not be deleted
+    for (const rule of body.rules as Array<{ deleted: boolean }>) {
+      expect(rule.deleted).toBe(false);
+    }
+  });
+
+  test("filters by origin=default", async () => {
+    // Create a user-defined rule so there's a mix
+    store.create({
+      tool: "bash",
+      pattern: "my-custom-command",
+      risk: "low",
+      description: "test rule",
+    });
+
+    const handler = createTrustRuleV3sListHandler();
+    const req = jsonRequest(
+      "http://localhost/v1/trust-rules-v3?origin=default",
+      "GET",
+    );
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      rules: Array<{ origin: string }>;
+    };
+    for (const rule of body.rules) {
+      expect(rule.origin).toBe("default");
+    }
+  });
+
+  test("filters by tool=bash", async () => {
+    const handler = createTrustRuleV3sListHandler();
+    const req = jsonRequest(
+      "http://localhost/v1/trust-rules-v3?tool=bash",
+      "GET",
+    );
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      rules: Array<{ tool: string }>;
+    };
+    expect(body.rules.length).toBeGreaterThan(0);
+    for (const rule of body.rules) {
+      expect(rule.tool).toBe("bash");
+    }
+  });
+
+  test("includes deleted rules when include_deleted=true", async () => {
+    // Soft-delete a default rule
+    const defaults = store.list({ origin: "default" });
+    expect(defaults.length).toBeGreaterThan(0);
+    const targetRule = defaults[0];
+    store.remove(targetRule.id);
+
+    const handler = createTrustRuleV3sListHandler();
+
+    // Without include_deleted, the deleted rule should not appear
+    const reqExclude = jsonRequest("http://localhost/v1/trust-rules-v3", "GET");
+    const resExclude = await handler(reqExclude);
+    const bodyExclude = (await resExclude.json()) as {
+      rules: Array<{ id: string }>;
+    };
+    const deletedInExclude = bodyExclude.rules.find(
+      (r) => r.id === targetRule.id,
+    );
+    expect(deletedInExclude).toBeUndefined();
+
+    // With include_deleted=true, the deleted rule should appear
+    const reqInclude = jsonRequest(
+      "http://localhost/v1/trust-rules-v3?include_deleted=true",
+      "GET",
+    );
+    const resInclude = await handler(reqInclude);
+    const bodyInclude = (await resInclude.json()) as {
+      rules: Array<{ id: string; deleted: boolean }>;
+    };
+    const deletedInInclude = bodyInclude.rules.find(
+      (r) => r.id === targetRule.id,
+    );
+    expect(deletedInInclude).toBeDefined();
+    expect(deletedInInclude!.deleted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/trust-rules-v3 — create
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/trust-rules-v3 — create", () => {
+  test("creates a rule with valid body (201)", async () => {
+    const handler = createTrustRuleV3sCreateHandler();
+    const req = jsonRequest("http://localhost/v1/trust-rules-v3", "POST", {
+      tool: "bash",
+      pattern: "echo hello",
+      risk: "low",
+      description: "Allow echo hello",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as {
+      rule: {
+        tool: string;
+        pattern: string;
+        risk: string;
+        description: string;
+        origin: string;
+      };
+    };
+    expect(body.rule.tool).toBe("bash");
+    expect(body.rule.pattern).toBe("echo hello");
+    expect(body.rule.risk).toBe("low");
+    expect(body.rule.description).toBe("Allow echo hello");
+    expect(body.rule.origin).toBe("user_defined");
+  });
+
+  test("returns 400 for missing fields", async () => {
+    const handler = createTrustRuleV3sCreateHandler();
+
+    // Missing tool
+    const res1 = await handler(
+      jsonRequest("http://localhost/v1/trust-rules-v3", "POST", {
+        pattern: "echo",
+        risk: "low",
+        description: "test",
+      }),
+    );
+    expect(res1.status).toBe(400);
+
+    // Missing pattern
+    const res2 = await handler(
+      jsonRequest("http://localhost/v1/trust-rules-v3", "POST", {
+        tool: "bash",
+        risk: "low",
+        description: "test",
+      }),
+    );
+    expect(res2.status).toBe(400);
+
+    // Missing risk
+    const res3 = await handler(
+      jsonRequest("http://localhost/v1/trust-rules-v3", "POST", {
+        tool: "bash",
+        pattern: "echo",
+        description: "test",
+      }),
+    );
+    expect(res3.status).toBe(400);
+
+    // Missing description
+    const res4 = await handler(
+      jsonRequest("http://localhost/v1/trust-rules-v3", "POST", {
+        tool: "bash",
+        pattern: "echo",
+        risk: "low",
+      }),
+    );
+    expect(res4.status).toBe(400);
+  });
+
+  test("returns 400 for invalid risk value", async () => {
+    const handler = createTrustRuleV3sCreateHandler();
+    const req = jsonRequest("http://localhost/v1/trust-rules-v3", "POST", {
+      tool: "bash",
+      pattern: "echo",
+      risk: "critical",
+      description: "test",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("risk");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /v1/trust-rules-v3/:id — update
+// ---------------------------------------------------------------------------
+
+describe("PATCH /v1/trust-rules-v3/:id — update", () => {
+  test("updates risk and description (200)", async () => {
+    const created = store.create({
+      tool: "bash",
+      pattern: "test-update",
+      risk: "low",
+      description: "original",
+    });
+
+    const handler = createTrustRuleV3sUpdateHandler();
+    const req = jsonRequest(
+      `http://localhost/v1/trust-rules-v3/${created.id}`,
+      "PATCH",
+      { risk: "high", description: "updated" },
+    );
+    const res = await handler(req, created.id);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      rule: { risk: string; description: string };
+    };
+    expect(body.rule.risk).toBe("high");
+    expect(body.rule.description).toBe("updated");
+  });
+
+  test("returns 404 for non-existent rule", async () => {
+    const handler = createTrustRuleV3sUpdateHandler();
+    const fakeId = "00000000-0000-4000-8000-000000000000";
+    const req = jsonRequest(
+      `http://localhost/v1/trust-rules-v3/${fakeId}`,
+      "PATCH",
+      { risk: "high" },
+    );
+    const res = await handler(req, fakeId);
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/trust-rules-v3/:id — delete
+// ---------------------------------------------------------------------------
+
+describe("DELETE /v1/trust-rules-v3/:id — delete", () => {
+  test("deletes a user-defined rule (200)", async () => {
+    const created = store.create({
+      tool: "bash",
+      pattern: "test-delete",
+      risk: "low",
+      description: "to be deleted",
+    });
+
+    const handler = createTrustRuleV3sDeleteHandler();
+    const req = jsonRequest(
+      `http://localhost/v1/trust-rules-v3/${created.id}`,
+      "DELETE",
+    );
+    const res = await handler(req, created.id);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { success: boolean };
+    expect(body.success).toBe(true);
+
+    // Should be gone from list
+    const found = store.getById(created.id);
+    expect(found).toBeNull();
+  });
+
+  test("returns 404 for non-existent rule", async () => {
+    const handler = createTrustRuleV3sDeleteHandler();
+    const fakeId = "00000000-0000-4000-8000-000000000000";
+    const req = jsonRequest(
+      `http://localhost/v1/trust-rules-v3/${fakeId}`,
+      "DELETE",
+    );
+    const res = await handler(req, fakeId);
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/trust-rules-v3/:id/reset — reset default rule
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/trust-rules-v3/:id/reset — reset", () => {
+  test("resets a modified default rule to original risk (200)", async () => {
+    // Find a default rule seeded from the registry (e.g. "ls" which is "low")
+    const defaults = store.list({ origin: "default" });
+    const lsRule = defaults.find((r) => r.pattern === "ls");
+    // Skip if "ls" not in defaults (shouldn't happen, but defensive)
+    if (!lsRule) return;
+
+    // Modify it to a different risk
+    store.update(lsRule.id, { risk: "high" });
+    const modified = store.getById(lsRule.id)!;
+    expect(modified.risk).toBe("high");
+    expect(modified.userModified).toBe(true);
+
+    const handler = createTrustRuleV3sResetHandler();
+    const req = jsonRequest(
+      `http://localhost/v1/trust-rules-v3/${lsRule.id}/reset`,
+      "POST",
+    );
+    const res = await handler(req, lsRule.id);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      rule: { risk: string; userModified: boolean; deleted: boolean };
+    };
+    expect(body.rule.risk).toBe("low");
+    expect(body.rule.userModified).toBe(false);
+    expect(body.rule.deleted).toBe(false);
+  });
+
+  test("returns 404 for non-existent rule", async () => {
+    const handler = createTrustRuleV3sResetHandler();
+    const fakeId = "00000000-0000-4000-8000-000000000000";
+    const req = jsonRequest(
+      `http://localhost/v1/trust-rules-v3/${fakeId}/reset`,
+      "POST",
+    );
+    const res = await handler(req, fakeId);
+    expect(res.status).toBe(404);
+  });
+
+  test("returns 400 for non-default (user_defined) rule", async () => {
+    const created = store.create({
+      tool: "bash",
+      pattern: "test-no-reset",
+      risk: "low",
+      description: "user-defined, cannot reset",
+    });
+
+    const handler = createTrustRuleV3sResetHandler();
+    const req = jsonRequest(
+      `http://localhost/v1/trust-rules-v3/${created.id}/reset`,
+      "POST",
+    );
+    const res = await handler(req, created.id);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("default");
+  });
+});

--- a/gateway/src/http/routes/trust-rules-v3.ts
+++ b/gateway/src/http/routes/trust-rules-v3.ts
@@ -1,0 +1,331 @@
+/**
+ * Trust rule v3 CRUD endpoints for the gateway.
+ *
+ * All mutation endpoints are gated behind the `permission-controls-v3`
+ * feature flag. Read endpoints (list) are always available so the UI
+ * can display rules regardless of the flag state.
+ *
+ * Mutations invalidate the in-memory risk rule cache so subsequent
+ * classifications reflect the change immediately.
+ */
+
+import { TrustRuleV3Store } from "../../db/trust-rule-v3-store.js";
+import { invalidateTrustRuleV3Cache } from "../../risk/trust-rule-v3-cache.js";
+import { getMergedFeatureFlags } from "../../ipc/feature-flag-handlers.js";
+import { DEFAULT_COMMAND_REGISTRY } from "../../risk/command-registry.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("trust-rules-v3");
+
+const VALID_RISK_VALUES = new Set(["low", "medium", "high"]);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Check the `permission-controls-v3` feature flag.
+ * Returns a 403 Response if the flag is disabled, or null if enabled.
+ */
+function requireV3Flag(): Response | null {
+  if (!getMergedFeatureFlags()["permission-controls-v3"]) {
+    return Response.json({ error: "Feature not enabled" }, { status: 403 });
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/trust-rules-v3 — list rules
+// ---------------------------------------------------------------------------
+
+export function createTrustRuleV3sListHandler() {
+  const store = new TrustRuleV3Store();
+
+  return async (req: Request): Promise<Response> => {
+    try {
+      const url = new URL(req.url);
+      const origin = url.searchParams.get("origin") ?? undefined;
+      const tool = url.searchParams.get("tool") ?? undefined;
+      const includeDeleted = url.searchParams.get("include_deleted") === "true";
+
+      const rules = store.list({ origin, tool, includeDeleted });
+      return Response.json({ rules });
+    } catch (err) {
+      log.error({ err }, "Failed to list v3 trust rules");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/trust-rules-v3 — create rule
+// ---------------------------------------------------------------------------
+
+export function createTrustRuleV3sCreateHandler() {
+  const store = new TrustRuleV3Store();
+
+  return async (req: Request): Promise<Response> => {
+    const flagResponse = requireV3Flag();
+    if (flagResponse) return flagResponse;
+
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json(
+        { error: "Request body must be valid JSON" },
+        { status: 400 },
+      );
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return Response.json(
+        { error: "Request body must be a JSON object" },
+        { status: 400 },
+      );
+    }
+
+    const { tool, pattern, risk, description } = body as Record<
+      string,
+      unknown
+    >;
+
+    if (typeof tool !== "string" || !tool) {
+      return Response.json(
+        { error: '"tool" must be a non-empty string' },
+        { status: 400 },
+      );
+    }
+    if (typeof pattern !== "string" || !pattern) {
+      return Response.json(
+        { error: '"pattern" must be a non-empty string' },
+        { status: 400 },
+      );
+    }
+    if (typeof risk !== "string" || !VALID_RISK_VALUES.has(risk)) {
+      return Response.json(
+        { error: '"risk" must be one of: low, medium, high' },
+        { status: 400 },
+      );
+    }
+    if (typeof description !== "string" || !description) {
+      return Response.json(
+        { error: '"description" must be a non-empty string' },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const rule = store.create({ tool, pattern, risk, description });
+      invalidateTrustRuleV3Cache();
+      return Response.json({ rule }, { status: 201 });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Internal server error";
+      log.error({ err }, "Failed to create v3 trust rule");
+      return Response.json({ error: message }, { status: 400 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /v1/trust-rules-v3/:id — update rule
+// ---------------------------------------------------------------------------
+
+export function createTrustRuleV3sUpdateHandler() {
+  const store = new TrustRuleV3Store();
+
+  return async (req: Request, ruleId: string): Promise<Response> => {
+    const flagResponse = requireV3Flag();
+    if (flagResponse) return flagResponse;
+
+    if (!ruleId) {
+      return Response.json({ error: "Rule ID is required" }, { status: 400 });
+    }
+
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json(
+        { error: "Request body must be valid JSON" },
+        { status: 400 },
+      );
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return Response.json(
+        { error: "Request body must be a JSON object" },
+        { status: 400 },
+      );
+    }
+
+    const { risk, description } = body as Record<string, unknown>;
+
+    if (
+      risk !== undefined &&
+      (typeof risk !== "string" || !VALID_RISK_VALUES.has(risk))
+    ) {
+      return Response.json(
+        { error: '"risk" must be one of: low, medium, high' },
+        { status: 400 },
+      );
+    }
+
+    if (description !== undefined && typeof description !== "string") {
+      return Response.json(
+        { error: '"description" must be a string' },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const rule = store.update(ruleId, {
+        risk: risk as string | undefined,
+        description: description as string | undefined,
+      });
+      invalidateTrustRuleV3Cache();
+      return Response.json({ rule });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Internal server error";
+      if (message.includes("not found")) {
+        return Response.json({ error: message }, { status: 404 });
+      }
+      log.error({ err }, "Failed to update v3 trust rule");
+      return Response.json({ error: message }, { status: 400 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/trust-rules-v3/:id — delete rule
+// ---------------------------------------------------------------------------
+
+export function createTrustRuleV3sDeleteHandler() {
+  const store = new TrustRuleV3Store();
+
+  return async (_req: Request, ruleId: string): Promise<Response> => {
+    const flagResponse = requireV3Flag();
+    if (flagResponse) return flagResponse;
+
+    if (!ruleId) {
+      return Response.json({ error: "Rule ID is required" }, { status: 400 });
+    }
+
+    try {
+      store.remove(ruleId);
+      invalidateTrustRuleV3Cache();
+      return Response.json({ success: true });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Internal server error";
+      if (message.includes("not found")) {
+        return Response.json({ error: message }, { status: 404 });
+      }
+      log.error({ err }, "Failed to delete v3 trust rule");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/trust-rules-v3/:id/reset — reset default rule
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up the original base risk for a default rule by parsing its pattern
+ * against the DEFAULT_COMMAND_REGISTRY.
+ *
+ * For simple commands (e.g. "ls"), looks up `registry.ls.baseRisk`.
+ * For subcommands (e.g. "git push"), looks up `registry.git.subcommands.push.baseRisk`.
+ */
+function lookupOriginalRisk(pattern: string): string | null {
+  const parts = pattern.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return null;
+
+  const command = parts[0];
+  const spec = (DEFAULT_COMMAND_REGISTRY as Record<string, unknown>)[command];
+  if (!spec || typeof spec !== "object") return null;
+
+  const typed = spec as {
+    baseRisk: string;
+    subcommands?: Record<
+      string,
+      { baseRisk: string; subcommands?: Record<string, { baseRisk: string }> }
+    >;
+  };
+
+  // Walk subcommand chain
+  if (parts.length > 1 && typed.subcommands) {
+    let current: {
+      baseRisk: string;
+      subcommands?: Record<
+        string,
+        { baseRisk: string; subcommands?: Record<string, { baseRisk: string }> }
+      >;
+    } = typed;
+    for (let i = 1; i < parts.length; i++) {
+      const sub = current.subcommands?.[parts[i]];
+      if (!sub) break;
+      current = sub as typeof current;
+    }
+    return current.baseRisk;
+  }
+
+  return typed.baseRisk;
+}
+
+export function createTrustRuleV3sResetHandler() {
+  const store = new TrustRuleV3Store();
+
+  return async (_req: Request, ruleId: string): Promise<Response> => {
+    const flagResponse = requireV3Flag();
+    if (flagResponse) return flagResponse;
+
+    if (!ruleId) {
+      return Response.json({ error: "Rule ID is required" }, { status: 400 });
+    }
+
+    // Look up the rule first to validate origin
+    const existing = store.getById(ruleId);
+    if (!existing) {
+      return Response.json(
+        { error: `Trust rule not found: ${ruleId}` },
+        { status: 404 },
+      );
+    }
+
+    if (existing.origin !== "default") {
+      return Response.json(
+        { error: "Can only reset default rules" },
+        { status: 400 },
+      );
+    }
+
+    // Determine original risk from the command registry
+    const originalRisk = lookupOriginalRisk(existing.pattern);
+    if (!originalRisk) {
+      return Response.json(
+        {
+          error: `Cannot determine original risk for pattern: ${existing.pattern}`,
+        },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const rule = store.reset(ruleId, originalRisk);
+      invalidateTrustRuleV3Cache();
+      return Response.json({ rule });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Internal server error";
+      if (message.includes("not found")) {
+        return Response.json({ error: message }, { status: 404 });
+      }
+      log.error({ err }, "Failed to reset v3 trust rule");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -97,6 +97,14 @@ import {
   createTrustRulesMatchHandler,
   createTrustRulesStarterBundleHandler,
 } from "./http/routes/trust-rules.js";
+import {
+  createTrustRuleV3sListHandler,
+  createTrustRuleV3sCreateHandler,
+  createTrustRuleV3sUpdateHandler,
+  createTrustRuleV3sDeleteHandler,
+  createTrustRuleV3sResetHandler,
+} from "./http/routes/trust-rules-v3.js";
+import { initTrustRuleV3Cache } from "./risk/trust-rule-v3-cache.js";
 import { getLogger, initLogger } from "./logger.js";
 import { getPlatformBaseUrl } from "./platform-url.js";
 import {
@@ -239,6 +247,7 @@ async function main() {
   log.info("JWT signing key initialized");
 
   await initGatewayDb();
+  initTrustRuleV3Cache();
 
   // ── TTL caches ──
   // Instantiate caches for credential and config file reads.
@@ -391,6 +400,11 @@ async function main() {
   const handleTrustRulesClear = createTrustRulesClearHandler();
   const handleTrustRulesMatch = createTrustRulesMatchHandler();
   const handleTrustRulesStarterBundle = createTrustRulesStarterBundleHandler();
+  const handleTrustRuleV3sList = createTrustRuleV3sListHandler();
+  const handleTrustRuleV3sCreate = createTrustRuleV3sCreateHandler();
+  const handleTrustRuleV3sUpdate = createTrustRuleV3sUpdateHandler();
+  const handleTrustRuleV3sDelete = createTrustRuleV3sDeleteHandler();
+  const handleTrustRuleV3sReset = createTrustRuleV3sResetHandler();
 
   const audioProxy = createAudioProxyHandler(config);
 
@@ -1178,6 +1192,39 @@ async function main() {
       auth: "edge",
       handler: (req, params, getClientIp) =>
         handleLogExport(req, params, getClientIp),
+    },
+
+    // ── Trust rules v3 ──
+    {
+      path: "/v1/trust-rules-v3",
+      method: "GET",
+      auth: "edge",
+      handler: (req) => handleTrustRuleV3sList(req),
+    },
+    {
+      path: "/v1/trust-rules-v3",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => handleTrustRuleV3sCreate(req),
+    },
+    {
+      // Reset must be registered before the /:id catch-all regex
+      path: /^\/v1\/trust-rules-v3\/([^/]+)\/reset$/,
+      method: "POST",
+      auth: "edge",
+      handler: (req, params) => handleTrustRuleV3sReset(req, params[0]),
+    },
+    {
+      path: /^\/v1\/trust-rules-v3\/([^/]+)$/,
+      method: "PATCH",
+      auth: "edge",
+      handler: (req, params) => handleTrustRuleV3sUpdate(req, params[0]),
+    },
+    {
+      path: /^\/v1\/trust-rules-v3\/([^/]+)$/,
+      method: "DELETE",
+      auth: "edge",
+      handler: (req, params) => handleTrustRuleV3sDelete(req, params[0]),
     },
 
     // ── Trust rules ──


### PR DESCRIPTION
## Summary
- GET /v1/trust-rules-v3 (list with origin/tool/include_deleted filters)
- POST /v1/trust-rules-v3 (create, flag-gated)
- PATCH /v1/trust-rules-v3/:id (update, flag-gated)
- DELETE /v1/trust-rules-v3/:id (delete, flag-gated)
- POST /v1/trust-rules-v3/:id/reset (reset default, flag-gated)
- Cache invalidation on all mutations
- Wired into gateway index.ts

Part of plan: v3-trust-rules-table.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
