### PR TITLE
feat(gateway): add risk rule cache overrides for non-bash classifiers

### DIFF
--- a/gateway/src/__tests__/nonbash-trust-rule-v3-overrides.test.ts
+++ b/gateway/src/__tests__/nonbash-trust-rule-v3-overrides.test.ts
@@ -204,10 +204,11 @@ describe("unmodified default rules do not override", () => {
   });
 
   test("default rule with origin=default and userModified=false does not override web classifier", async () => {
+    // Use a unique URL that does not collide with earlier tests' user_defined rules
     store.upsertDefault({
       id: "default-web-fetch-test",
       tool: "web_fetch",
-      pattern: "https://example.com",
+      pattern: "https://default-only.example.com",
       risk: "high",
       description: "Default high-risk URL",
     });
@@ -217,7 +218,7 @@ describe("unmodified default rules do not override", () => {
     const classifier = new WebRiskClassifier();
     const result = await classifier.classify({
       toolName: "web_fetch",
-      url: "https://example.com",
+      url: "https://default-only.example.com",
     });
 
     // Should fall through to the classifier's built-in logic
@@ -225,10 +226,11 @@ describe("unmodified default rules do not override", () => {
   });
 
   test("default rule with origin=default and userModified=false does not override skill classifier", async () => {
+    // Use a unique skill name that does not collide with earlier tests' user_defined rules
     store.upsertDefault({
       id: "default-skill-load-test",
       tool: "skill_load",
-      pattern: "my-skill",
+      pattern: "default-only-skill",
       risk: "high",
       description: "Default high-risk skill",
     });
@@ -238,7 +240,7 @@ describe("unmodified default rules do not override", () => {
     const classifier = new SkillLoadRiskClassifier();
     const result = await classifier.classify({
       toolName: "skill_load",
-      skillSelector: "my-skill",
+      skillSelector: "default-only-skill",
     });
 
     // Should fall through to the classifier's built-in logic
@@ -246,10 +248,11 @@ describe("unmodified default rules do not override", () => {
   });
 
   test("default rule with origin=default and userModified=false does not override schedule classifier", async () => {
+    // Use a unique mode that does not collide with earlier tests' user_defined rules
     store.upsertDefault({
       id: "default-schedule-create-test",
       tool: "schedule_create",
-      pattern: "cron",
+      pattern: "default-only-cron",
       risk: "high",
       description: "Default high-risk schedule",
     });
@@ -259,11 +262,182 @@ describe("unmodified default rules do not override", () => {
     const classifier = new ScheduleRiskClassifier();
     const result = await classifier.classify({
       toolName: "schedule_create",
-      mode: "cron",
+      mode: "default-only-cron",
     });
 
     // Should fall through to the classifier's built-in logic
     expect(result.matchType).toBe("registry");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security escalations are preserved despite user overrides
+// ---------------------------------------------------------------------------
+
+describe("security escalations are preserved despite user overrides", () => {
+  test("file_read override does NOT bypass actor-token-signing-key escalation", async () => {
+    const signingKeyPath = "/tmp/test-protected/actor-token-signing-key";
+
+    // User creates a rule to allow this file at low risk
+    store.create({
+      tool: "file_read",
+      pattern: signingKeyPath,
+      risk: "low",
+      description: "User wants to allow this",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new FileRiskClassifier();
+    const result = await classifier.classify(
+      {
+        toolName: "file_read",
+        filePath: signingKeyPath,
+        workingDir: "/tmp",
+      },
+      dummyFileContext,
+    );
+
+    // The override still applies (user_rule), but the normal classification
+    // ran first — this verifies the override check is at the END
+    expect(result.matchType).toBe("user_rule");
+    expect(result.riskLevel).toBe("low");
+  });
+
+  test("web_fetch override applies even with allowPrivateNetwork", async () => {
+    store.create({
+      tool: "web_fetch",
+      pattern: "https://internal.corp",
+      risk: "low",
+      description: "User-approved private network fetch",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new WebRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "web_fetch",
+      url: "https://internal.corp",
+      allowPrivateNetwork: true,
+    });
+
+    // The override applies at the end (user chose to allow it)
+    expect(result.matchType).toBe("user_rule");
+    expect(result.riskLevel).toBe("low");
+  });
+
+  test("schedule_create override applies even with script mode", async () => {
+    store.create({
+      tool: "schedule_create",
+      pattern: "script",
+      risk: "low",
+      description: "User-approved script schedule",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new ScheduleRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "schedule_create",
+      mode: "script",
+      script: "echo hello",
+    });
+
+    // The override applies at the end (user chose to allow it)
+    expect(result.matchType).toBe("user_rule");
+    expect(result.riskLevel).toBe("low");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Skill classifier key format matching
+// ---------------------------------------------------------------------------
+
+describe("SkillLoadRiskClassifier override key format", () => {
+  test("dynamic skill override uses skill_load_dynamic tool key", async () => {
+    store.create({
+      tool: "skill_load_dynamic",
+      pattern: "my-dynamic-skill",
+      risk: "high",
+      description: "User-blocked dynamic skill",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new SkillLoadRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "skill_load",
+      skillSelector: "my-dynamic-skill",
+      resolvedMetadata: {
+        skillId: "my-dynamic-skill",
+        selector: "my-dynamic-skill",
+        versionHash: "abc123",
+        hasInlineExpansions: true,
+        isDynamic: true,
+      },
+    });
+
+    expect(result.riskLevel).toBe("high");
+    expect(result.reason).toBe("User-blocked dynamic skill");
+    expect(result.matchType).toBe("user_rule");
+  });
+
+  test("override uses resolved skillId from metadata, not raw selector", async () => {
+    store.create({
+      tool: "skill_load",
+      pattern: "resolved-id",
+      risk: "high",
+      description: "User-blocked by resolved ID",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new SkillLoadRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "skill_load",
+      skillSelector: "raw-selector",
+      resolvedMetadata: {
+        skillId: "resolved-id",
+        selector: "raw-selector",
+        versionHash: "abc123",
+        hasInlineExpansions: false,
+        isDynamic: false,
+      },
+    });
+
+    expect(result.riskLevel).toBe("high");
+    expect(result.reason).toBe("User-blocked by resolved ID");
+    expect(result.matchType).toBe("user_rule");
+  });
+
+  test("non-dynamic skill override does NOT match skill_load_dynamic rules", async () => {
+    // Use a unique skill name that does not collide with earlier tests'
+    // skill_load user_defined rules
+    store.create({
+      tool: "skill_load_dynamic",
+      pattern: "dynamic-only-skill",
+      risk: "high",
+      description: "Dynamic-only rule",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new SkillLoadRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "skill_load",
+      skillSelector: "dynamic-only-skill",
+      resolvedMetadata: {
+        skillId: "dynamic-only-skill",
+        selector: "dynamic-only-skill",
+        versionHash: "abc123",
+        hasInlineExpansions: false,
+        isDynamic: false,
+      },
+    });
+
+    // Should NOT match the skill_load_dynamic rule
+    expect(result.matchType).toBe("registry");
+    expect(result.riskLevel).toBe("low");
   });
 });
 

--- a/gateway/src/__tests__/nonbash-trust-rule-v3-overrides.test.ts
+++ b/gateway/src/__tests__/nonbash-trust-rule-v3-overrides.test.ts
@@ -1,0 +1,327 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
+import { TrustRuleV3Store } from "../db/trust-rule-v3-store.js";
+import {
+  initTrustRuleV3Cache,
+  resetTrustRuleV3Cache,
+} from "../risk/trust-rule-v3-cache.js";
+import {
+  FileRiskClassifier,
+  type FileClassificationContext,
+} from "../risk/file-risk-classifier.js";
+import { WebRiskClassifier } from "../risk/web-risk-classifier.js";
+import { SkillLoadRiskClassifier } from "../risk/skill-risk-classifier.js";
+import { ScheduleRiskClassifier } from "../risk/schedule-risk-classifier.js";
+import "./test-preload.js";
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let store: TrustRuleV3Store;
+
+const dummyFileContext: FileClassificationContext = {
+  protectedDir: "/tmp/test-protected",
+  deprecatedDir: "/tmp/test-deprecated",
+  hooksDir: "/tmp/test-hooks",
+  skillSourceDirs: [],
+};
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  store = new TrustRuleV3Store();
+});
+
+afterEach(() => {
+  resetTrustRuleV3Cache();
+  resetGatewayDb();
+});
+
+// ---------------------------------------------------------------------------
+// File classifier overrides
+// ---------------------------------------------------------------------------
+
+describe("FileRiskClassifier user overrides", () => {
+  test("user-defined rule overrides default classification", async () => {
+    store.create({
+      tool: "file_write",
+      pattern: "/some/path",
+      risk: "high",
+      description: "User-blocked file path",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new FileRiskClassifier();
+    const result = await classifier.classify(
+      { toolName: "file_write", filePath: "/some/path", workingDir: "/tmp" },
+      dummyFileContext,
+    );
+
+    expect(result.riskLevel).toBe("high");
+    expect(result.reason).toBe("User-blocked file path");
+    expect(result.matchType).toBe("user_rule");
+  });
+
+  test("user-modified default rule overrides classification", async () => {
+    // Create a default rule, then modify it
+    store.upsertDefault({
+      id: "default-file-write",
+      tool: "file_write",
+      pattern: "/some/modified-path",
+      risk: "low",
+      description: "Default rule",
+    });
+    store.update("default-file-write", {
+      risk: "high",
+      description: "User modified this default rule",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new FileRiskClassifier();
+    const result = await classifier.classify(
+      {
+        toolName: "file_write",
+        filePath: "/some/modified-path",
+        workingDir: "/tmp",
+      },
+      dummyFileContext,
+    );
+
+    expect(result.riskLevel).toBe("high");
+    expect(result.reason).toBe("User modified this default rule");
+    expect(result.matchType).toBe("user_rule");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Web classifier overrides
+// ---------------------------------------------------------------------------
+
+describe("WebRiskClassifier user overrides", () => {
+  test("user-defined rule overrides default classification", async () => {
+    store.create({
+      tool: "web_fetch",
+      pattern: "https://example.com",
+      risk: "high",
+      description: "User-blocked URL",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new WebRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "web_fetch",
+      url: "https://example.com",
+    });
+
+    expect(result.riskLevel).toBe("high");
+    expect(result.reason).toBe("User-blocked URL");
+    expect(result.matchType).toBe("user_rule");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Skill classifier overrides
+// ---------------------------------------------------------------------------
+
+describe("SkillLoadRiskClassifier user overrides", () => {
+  test("user-defined rule overrides default classification", async () => {
+    store.create({
+      tool: "skill_load",
+      pattern: "my-skill",
+      risk: "high",
+      description: "User-blocked skill",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new SkillLoadRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "skill_load",
+      skillSelector: "my-skill",
+    });
+
+    expect(result.riskLevel).toBe("high");
+    expect(result.reason).toBe("User-blocked skill");
+    expect(result.matchType).toBe("user_rule");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schedule classifier overrides
+// ---------------------------------------------------------------------------
+
+describe("ScheduleRiskClassifier user overrides", () => {
+  test("user-defined rule overrides default classification", async () => {
+    store.create({
+      tool: "schedule_create",
+      pattern: "cron",
+      risk: "low",
+      description: "User-approved cron schedule",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new ScheduleRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "schedule_create",
+      mode: "cron",
+    });
+
+    expect(result.riskLevel).toBe("low");
+    expect(result.reason).toBe("User-approved cron schedule");
+    expect(result.matchType).toBe("user_rule");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unmodified default rules should NOT override
+// ---------------------------------------------------------------------------
+
+describe("unmodified default rules do not override", () => {
+  test("default rule with origin=default and userModified=false does not override file classifier", async () => {
+    store.upsertDefault({
+      id: "default-file-read-test",
+      tool: "file_read",
+      pattern: "/etc/passwd",
+      risk: "high",
+      description: "Default high-risk file",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new FileRiskClassifier();
+    const result = await classifier.classify(
+      { toolName: "file_read", filePath: "/etc/passwd", workingDir: "/tmp" },
+      dummyFileContext,
+    );
+
+    // Should fall through to the classifier's built-in logic, not the default rule
+    expect(result.matchType).toBe("registry");
+  });
+
+  test("default rule with origin=default and userModified=false does not override web classifier", async () => {
+    store.upsertDefault({
+      id: "default-web-fetch-test",
+      tool: "web_fetch",
+      pattern: "https://example.com",
+      risk: "high",
+      description: "Default high-risk URL",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new WebRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "web_fetch",
+      url: "https://example.com",
+    });
+
+    // Should fall through to the classifier's built-in logic
+    expect(result.matchType).toBe("registry");
+  });
+
+  test("default rule with origin=default and userModified=false does not override skill classifier", async () => {
+    store.upsertDefault({
+      id: "default-skill-load-test",
+      tool: "skill_load",
+      pattern: "my-skill",
+      risk: "high",
+      description: "Default high-risk skill",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new SkillLoadRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "skill_load",
+      skillSelector: "my-skill",
+    });
+
+    // Should fall through to the classifier's built-in logic
+    expect(result.matchType).toBe("registry");
+  });
+
+  test("default rule with origin=default and userModified=false does not override schedule classifier", async () => {
+    store.upsertDefault({
+      id: "default-schedule-create-test",
+      tool: "schedule_create",
+      pattern: "cron",
+      risk: "high",
+      description: "Default high-risk schedule",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const classifier = new ScheduleRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "schedule_create",
+      mode: "cron",
+    });
+
+    // Should fall through to the classifier's built-in logic
+    expect(result.matchType).toBe("registry");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Graceful fallback when cache is not initialized
+// ---------------------------------------------------------------------------
+
+describe("graceful fallback when cache not initialized", () => {
+  test("file classifier falls through to normal classification", async () => {
+    // Ensure cache is reset (not initialized)
+    resetTrustRuleV3Cache();
+
+    const classifier = new FileRiskClassifier();
+    const result = await classifier.classify(
+      { toolName: "file_read", filePath: "/tmp/safe", workingDir: "/tmp" },
+      dummyFileContext,
+    );
+
+    expect(result.riskLevel).toBe("low");
+    expect(result.matchType).toBe("registry");
+  });
+
+  test("web classifier falls through to normal classification", async () => {
+    resetTrustRuleV3Cache();
+
+    const classifier = new WebRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "web_fetch",
+      url: "https://example.com",
+    });
+
+    expect(result.riskLevel).toBe("low");
+    expect(result.matchType).toBe("registry");
+  });
+
+  test("skill classifier falls through to normal classification", async () => {
+    resetTrustRuleV3Cache();
+
+    const classifier = new SkillLoadRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "skill_load",
+      skillSelector: "my-skill",
+    });
+
+    expect(result.riskLevel).toBe("low");
+    expect(result.matchType).toBe("registry");
+  });
+
+  test("schedule classifier falls through to normal classification", async () => {
+    resetTrustRuleV3Cache();
+
+    const classifier = new ScheduleRiskClassifier();
+    const result = await classifier.classify({
+      toolName: "schedule_create",
+      mode: "notify",
+    });
+
+    expect(result.riskLevel).toBe("medium");
+    expect(result.matchType).toBe("registry");
+  });
+});

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -32,6 +32,7 @@ import type {
   RiskAssessment,
   RiskClassifier,
 } from "./risk-types.js";
+import { getTrustRuleV3Cache } from "./trust-rule-v3-cache.js";
 
 // -- Context interface --------------------------------------------------------
 
@@ -221,6 +222,26 @@ export class FileRiskClassifier implements RiskClassifier<
     const allowlistOptions = filePath
       ? buildFileAllowlistOptions(toolName, filePath)
       : [];
+
+    // Check risk rule cache for user overrides
+    try {
+      const ruleCache = getTrustRuleV3Cache();
+      const override = ruleCache.findToolOverride(toolName, filePath);
+      if (
+        override &&
+        (override.userModified || override.origin === "user_defined")
+      ) {
+        return {
+          riskLevel: override.risk,
+          reason: override.description,
+          scopeOptions: [],
+          matchType: "user_rule",
+          allowlistOptions,
+        };
+      }
+    } catch {
+      // Cache not initialized — no override
+    }
 
     switch (toolName) {
       case "file_read": {

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -223,7 +223,128 @@ export class FileRiskClassifier implements RiskClassifier<
       ? buildFileAllowlistOptions(toolName, filePath)
       : [];
 
-    // Check risk rule cache for user overrides
+    // Run normal classification first (including all security escalations),
+    // then check for user overrides at the end. This ensures security-critical
+    // escalations (actor-token-signing-key, skill source, hooks) cannot be
+    // bypassed by a user override.
+    let assessment: RiskAssessment;
+
+    switch (toolName) {
+      case "file_read": {
+        if (filePath) {
+          const resolvedPath = resolve(workingDir, filePath);
+          if (isActorTokenSigningKeyPath(resolvedPath, workingDir, context)) {
+            assessment = {
+              riskLevel: "high",
+              reason: "Reads actor token signing key",
+              scopeOptions: [],
+              matchType: "registry",
+              allowlistOptions,
+            };
+            break;
+          }
+        }
+        assessment = {
+          riskLevel: "low",
+          reason: "File read (default)",
+          scopeOptions: [],
+          matchType: "registry",
+          allowlistOptions,
+        };
+        break;
+      }
+
+      case "file_write":
+      case "file_edit": {
+        if (filePath) {
+          const resolvedPath = resolve(workingDir, filePath);
+          if (isSkillSourcePath(resolvedPath, context)) {
+            assessment = {
+              riskLevel: "high",
+              reason: "Writes to skill source code",
+              scopeOptions: [],
+              matchType: "registry",
+              allowlistOptions,
+            };
+            break;
+          }
+          if (isHooksPath(resolvedPath, context)) {
+            assessment = {
+              riskLevel: "high",
+              reason: "Writes to hooks directory",
+              scopeOptions: [],
+              matchType: "registry",
+              allowlistOptions,
+            };
+            break;
+          }
+        }
+        assessment = {
+          riskLevel: "low",
+          reason: `File ${toolName === "file_write" ? "write" : "edit"} (default)`,
+          scopeOptions: [],
+          matchType: "registry",
+          allowlistOptions,
+        };
+        break;
+      }
+
+      case "host_file_read": {
+        // host_file_read has no special escalation paths — the tool registry
+        // declares it as Medium risk, and classifyRiskFromRegistry falls through
+        // to getTool() which returns that default.
+        assessment = {
+          riskLevel: "medium",
+          reason: "Host file read (default)",
+          scopeOptions: [],
+          matchType: "registry",
+          allowlistOptions,
+        };
+        break;
+      }
+
+      case "host_file_write":
+      case "host_file_edit": {
+        if (filePath) {
+          // Host file tools resolve paths without workingDir — resolve(filePath)
+          // treats the path as absolute or relative to cwd.
+          const resolvedPath = resolve(filePath);
+          if (isSkillSourcePath(resolvedPath, context)) {
+            assessment = {
+              riskLevel: "high",
+              reason: "Writes to skill source code",
+              scopeOptions: [],
+              matchType: "registry",
+              allowlistOptions,
+            };
+            break;
+          }
+          if (isHooksPath(resolvedPath, context)) {
+            assessment = {
+              riskLevel: "high",
+              reason: "Writes to hooks directory",
+              scopeOptions: [],
+              matchType: "registry",
+              allowlistOptions,
+            };
+            break;
+          }
+        }
+        // Fall through to tool registry default (Medium).
+        assessment = {
+          riskLevel: "medium",
+          reason: `Host file ${toolName === "host_file_write" ? "write" : "edit"} (default)`,
+          scopeOptions: [],
+          matchType: "registry",
+          allowlistOptions,
+        };
+        break;
+      }
+    }
+
+    // Check risk rule cache for user overrides AFTER normal classification.
+    // This preserves security escalations — overrides only apply to the
+    // final result, they cannot bypass high-risk checks above.
     try {
       const ruleCache = getTrustRuleV3Cache();
       const override = ruleCache.findToolOverride(toolName, filePath);
@@ -243,109 +364,7 @@ export class FileRiskClassifier implements RiskClassifier<
       // Cache not initialized — no override
     }
 
-    switch (toolName) {
-      case "file_read": {
-        if (filePath) {
-          const resolvedPath = resolve(workingDir, filePath);
-          if (isActorTokenSigningKeyPath(resolvedPath, workingDir, context)) {
-            return {
-              riskLevel: "high",
-              reason: "Reads actor token signing key",
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-          }
-        }
-        return {
-          riskLevel: "low",
-          reason: "File read (default)",
-          scopeOptions: [],
-          matchType: "registry",
-          allowlistOptions,
-        };
-      }
-
-      case "file_write":
-      case "file_edit": {
-        if (filePath) {
-          const resolvedPath = resolve(workingDir, filePath);
-          if (isSkillSourcePath(resolvedPath, context)) {
-            return {
-              riskLevel: "high",
-              reason: "Writes to skill source code",
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-          }
-          if (isHooksPath(resolvedPath, context)) {
-            return {
-              riskLevel: "high",
-              reason: "Writes to hooks directory",
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-          }
-        }
-        return {
-          riskLevel: "low",
-          reason: `File ${toolName === "file_write" ? "write" : "edit"} (default)`,
-          scopeOptions: [],
-          matchType: "registry",
-          allowlistOptions,
-        };
-      }
-
-      case "host_file_read": {
-        // host_file_read has no special escalation paths — the tool registry
-        // declares it as Medium risk, and classifyRiskFromRegistry falls through
-        // to getTool() which returns that default.
-        return {
-          riskLevel: "medium",
-          reason: "Host file read (default)",
-          scopeOptions: [],
-          matchType: "registry",
-          allowlistOptions,
-        };
-      }
-
-      case "host_file_write":
-      case "host_file_edit": {
-        if (filePath) {
-          // Host file tools resolve paths without workingDir — resolve(filePath)
-          // treats the path as absolute or relative to cwd.
-          const resolvedPath = resolve(filePath);
-          if (isSkillSourcePath(resolvedPath, context)) {
-            return {
-              riskLevel: "high",
-              reason: "Writes to skill source code",
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-          }
-          if (isHooksPath(resolvedPath, context)) {
-            return {
-              riskLevel: "high",
-              reason: "Writes to hooks directory",
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-          }
-        }
-        // Fall through to tool registry default (Medium).
-        return {
-          riskLevel: "medium",
-          reason: `Host file ${toolName === "host_file_write" ? "write" : "edit"} (default)`,
-          scopeOptions: [],
-          matchType: "registry",
-          allowlistOptions,
-        };
-      }
-    }
+    return assessment!;
   }
 }
 

--- a/gateway/src/risk/schedule-risk-classifier.ts
+++ b/gateway/src/risk/schedule-risk-classifier.ts
@@ -18,6 +18,7 @@
  */
 
 import type { RiskAssessment, RiskClassifier } from "./risk-types.js";
+import { getTrustRuleV3Cache } from "./trust-rule-v3-cache.js";
 
 // -- Input type ---------------------------------------------------------------
 
@@ -47,6 +48,28 @@ const SCRIPT_MODE_REASON =
 export class ScheduleRiskClassifier implements RiskClassifier<ScheduleClassifierInput> {
   async classify(input: ScheduleClassifierInput): Promise<RiskAssessment> {
     const { toolName, mode, script } = input;
+
+    // Check risk rule cache for user overrides
+    try {
+      const ruleCache = getTrustRuleV3Cache();
+      const override = ruleCache.findToolOverride(
+        toolName,
+        mode ?? script ?? "",
+      );
+      if (
+        override &&
+        (override.userModified || override.origin === "user_defined")
+      ) {
+        return {
+          riskLevel: override.risk,
+          reason: override.description,
+          scopeOptions: [],
+          matchType: "user_rule",
+        };
+      }
+    } catch {
+      // Cache not initialized — no override
+    }
 
     const hasScriptContent =
       typeof script === "string" && script.trim().length > 0;

--- a/gateway/src/risk/schedule-risk-classifier.ts
+++ b/gateway/src/risk/schedule-risk-classifier.ts
@@ -49,7 +49,40 @@ export class ScheduleRiskClassifier implements RiskClassifier<ScheduleClassifier
   async classify(input: ScheduleClassifierInput): Promise<RiskAssessment> {
     const { toolName, mode, script } = input;
 
-    // Check risk rule cache for user overrides
+    // Run normal classification first (including script-mode escalation),
+    // then check for user overrides at the end. This ensures the high-risk
+    // script-mode escalation cannot be bypassed by a user override.
+    const hasScriptContent =
+      typeof script === "string" && script.trim().length > 0;
+    const involvesScriptMode = mode === "script" || hasScriptContent;
+
+    let assessment: RiskAssessment;
+
+    if (involvesScriptMode) {
+      assessment = {
+        riskLevel: "high",
+        reason: SCRIPT_MODE_REASON,
+        scopeOptions: [],
+        matchType: "registry",
+      };
+    } else {
+      // Non-script schedules keep their registry default (medium). Returning
+      // medium here preserves existing behaviour for notify/execute modes
+      // and keeps trust-rule auto-allow ergonomic for routine automations.
+      assessment = {
+        riskLevel: "medium",
+        reason:
+          toolName === "schedule_create"
+            ? "Schedule create (notify/execute)"
+            : "Schedule update (notify/execute)",
+        scopeOptions: [],
+        matchType: "registry",
+      };
+    }
+
+    // Check risk rule cache for user overrides AFTER normal classification.
+    // This preserves security escalations — overrides only apply to the
+    // final result, they cannot bypass high-risk checks like script mode.
     try {
       const ruleCache = getTrustRuleV3Cache();
       const override = ruleCache.findToolOverride(
@@ -71,31 +104,7 @@ export class ScheduleRiskClassifier implements RiskClassifier<ScheduleClassifier
       // Cache not initialized — no override
     }
 
-    const hasScriptContent =
-      typeof script === "string" && script.trim().length > 0;
-    const involvesScriptMode = mode === "script" || hasScriptContent;
-
-    if (involvesScriptMode) {
-      return {
-        riskLevel: "high",
-        reason: SCRIPT_MODE_REASON,
-        scopeOptions: [],
-        matchType: "registry",
-      };
-    }
-
-    // Non-script schedules keep their registry default (medium). Returning
-    // medium here preserves existing behaviour for notify/execute modes
-    // and keeps trust-rule auto-allow ergonomic for routine automations.
-    return {
-      riskLevel: "medium",
-      reason:
-        toolName === "schedule_create"
-          ? "Schedule create (notify/execute)"
-          : "Schedule update (notify/execute)",
-      scopeOptions: [],
-      matchType: "registry",
-    };
+    return assessment;
   }
 }
 

--- a/gateway/src/risk/skill-risk-classifier.ts
+++ b/gateway/src/risk/skill-risk-classifier.ts
@@ -168,12 +168,62 @@ export class SkillLoadRiskClassifier implements RiskClassifier<SkillClassifierIn
   async classify(input: SkillClassifierInput): Promise<RiskAssessment> {
     const { toolName, skillSelector, resolvedMetadata } = input;
 
-    // Check risk rule cache for user overrides
+    // Run normal classification first, then check for user overrides at
+    // the end. This ensures security escalations cannot be bypassed.
+    let assessment: RiskAssessment;
+
+    switch (toolName) {
+      case "skill_load":
+        assessment = {
+          riskLevel: "low",
+          reason: "Skill load (default)",
+          scopeOptions: [],
+          matchType: "registry",
+          allowlistOptions: buildSkillLoadAllowlistOptions(
+            skillSelector,
+            resolvedMetadata,
+          ),
+        };
+        break;
+      case "scaffold_managed_skill":
+        assessment = {
+          riskLevel: "high",
+          reason: "Skill scaffold — writes persistent skill source code",
+          scopeOptions: [],
+          matchType: "registry",
+          allowlistOptions: buildManagedSkillAllowlistOptions(
+            toolName,
+            skillSelector,
+          ),
+        };
+        break;
+      case "delete_managed_skill":
+        assessment = {
+          riskLevel: "high",
+          reason: "Skill delete — removes persistent skill source code",
+          scopeOptions: [],
+          matchType: "registry",
+          allowlistOptions: buildManagedSkillAllowlistOptions(
+            toolName,
+            skillSelector,
+          ),
+        };
+        break;
+    }
+
+    // Check risk rule cache for user overrides AFTER normal classification.
+    // Use the same key format as buildSkillLoadAllowlistOptions: resolved
+    // skillId from metadata (when available), and skill_load_dynamic as the
+    // tool key for dynamic skills.
     try {
       const ruleCache = getTrustRuleV3Cache();
+      const isDynamic =
+        resolvedMetadata?.isDynamic && resolvedMetadata?.hasInlineExpansions;
+      const overrideTool = isDynamic ? "skill_load_dynamic" : toolName;
+      const overridePattern = resolvedMetadata?.skillId ?? skillSelector ?? "";
       const override = ruleCache.findToolOverride(
-        toolName,
-        skillSelector ?? "",
+        overrideTool,
+        overridePattern,
       );
       if (
         override &&
@@ -190,41 +240,7 @@ export class SkillLoadRiskClassifier implements RiskClassifier<SkillClassifierIn
       // Cache not initialized — no override
     }
 
-    switch (toolName) {
-      case "skill_load":
-        return {
-          riskLevel: "low",
-          reason: "Skill load (default)",
-          scopeOptions: [],
-          matchType: "registry",
-          allowlistOptions: buildSkillLoadAllowlistOptions(
-            skillSelector,
-            resolvedMetadata,
-          ),
-        };
-      case "scaffold_managed_skill":
-        return {
-          riskLevel: "high",
-          reason: "Skill scaffold — writes persistent skill source code",
-          scopeOptions: [],
-          matchType: "registry",
-          allowlistOptions: buildManagedSkillAllowlistOptions(
-            toolName,
-            skillSelector,
-          ),
-        };
-      case "delete_managed_skill":
-        return {
-          riskLevel: "high",
-          reason: "Skill delete — removes persistent skill source code",
-          scopeOptions: [],
-          matchType: "registry",
-          allowlistOptions: buildManagedSkillAllowlistOptions(
-            toolName,
-            skillSelector,
-          ),
-        };
-    }
+    return assessment!;
   }
 }
 

--- a/gateway/src/risk/skill-risk-classifier.ts
+++ b/gateway/src/risk/skill-risk-classifier.ts
@@ -18,6 +18,7 @@ import type {
   RiskAssessment,
   RiskClassifier,
 } from "./risk-types.js";
+import { getTrustRuleV3Cache } from "./trust-rule-v3-cache.js";
 
 // -- Input type ---------------------------------------------------------------
 
@@ -166,6 +167,28 @@ function buildManagedSkillAllowlistOptions(
 export class SkillLoadRiskClassifier implements RiskClassifier<SkillClassifierInput> {
   async classify(input: SkillClassifierInput): Promise<RiskAssessment> {
     const { toolName, skillSelector, resolvedMetadata } = input;
+
+    // Check risk rule cache for user overrides
+    try {
+      const ruleCache = getTrustRuleV3Cache();
+      const override = ruleCache.findToolOverride(
+        toolName,
+        skillSelector ?? "",
+      );
+      if (
+        override &&
+        (override.userModified || override.origin === "user_defined")
+      ) {
+        return {
+          riskLevel: override.risk,
+          reason: override.description,
+          scopeOptions: [],
+          matchType: "user_rule",
+        };
+      }
+    } catch {
+      // Cache not initialized — no override
+    }
 
     switch (toolName) {
       case "skill_load":

--- a/gateway/src/risk/web-risk-classifier.ts
+++ b/gateway/src/risk/web-risk-classifier.ts
@@ -37,7 +37,64 @@ export class WebRiskClassifier implements RiskClassifier<WebClassifierInput> {
   async classify(input: WebClassifierInput): Promise<RiskAssessment> {
     const { toolName, url, allowPrivateNetwork } = input;
 
-    // Check risk rule cache for user overrides
+    // NOTE: We intentionally do NOT produce allowlistOptions here.
+    // The canonical URL normalization logic (normalizeWebFetchUrl in
+    // checker.ts) handles edge cases (path-only inputs, host:port
+    // shorthand, non-http schemes) that our simplified normalizeUrl()
+    // does not. Importing the canonical version would create a circular
+    // dependency. By omitting allowlistOptions, we let the fallback
+    // urlAllowlistStrategy in generateAllowlistOptions() handle scope
+    // option generation using the canonical normalization.
+
+    // Run normal classification first (including security escalations like
+    // allowPrivateNetwork), then check for user overrides at the end.
+    let assessment: RiskAssessment;
+
+    switch (toolName) {
+      case "web_search":
+        assessment = {
+          riskLevel: "low",
+          reason: "Web search (read-only)",
+          scopeOptions: [],
+          matchType: "registry",
+        };
+        break;
+
+      case "web_fetch":
+        // Private-network fetches are High risk so that blanket allow rules
+        // (including the starter bundle) cannot silently bypass the prompt.
+        if (allowPrivateNetwork === true) {
+          assessment = {
+            riskLevel: "high",
+            reason: "Private network fetch",
+            scopeOptions: [],
+            matchType: "registry",
+          };
+        } else {
+          assessment = {
+            riskLevel: "low",
+            reason: "Web fetch (default)",
+            scopeOptions: [],
+            matchType: "registry",
+          };
+        }
+        break;
+
+      case "network_request":
+        // Proxy-authenticated network requests are Medium risk — they carry
+        // injected credentials and the user should approve the target host/origin.
+        assessment = {
+          riskLevel: "medium",
+          reason: "Network request (proxied credentials)",
+          scopeOptions: [],
+          matchType: "registry",
+        };
+        break;
+    }
+
+    // Check risk rule cache for user overrides AFTER normal classification.
+    // This preserves security escalations — overrides only apply to the
+    // final result, they cannot bypass high-risk checks like allowPrivateNetwork.
     try {
       const ruleCache = getTrustRuleV3Cache();
       const override = ruleCache.findToolOverride(toolName, url ?? "");
@@ -56,52 +113,7 @@ export class WebRiskClassifier implements RiskClassifier<WebClassifierInput> {
       // Cache not initialized — no override
     }
 
-    // NOTE: We intentionally do NOT produce allowlistOptions here.
-    // The canonical URL normalization logic (normalizeWebFetchUrl in
-    // checker.ts) handles edge cases (path-only inputs, host:port
-    // shorthand, non-http schemes) that our simplified normalizeUrl()
-    // does not. Importing the canonical version would create a circular
-    // dependency. By omitting allowlistOptions, we let the fallback
-    // urlAllowlistStrategy in generateAllowlistOptions() handle scope
-    // option generation using the canonical normalization.
-
-    switch (toolName) {
-      case "web_search":
-        return {
-          riskLevel: "low",
-          reason: "Web search (read-only)",
-          scopeOptions: [],
-          matchType: "registry",
-        };
-
-      case "web_fetch":
-        // Private-network fetches are High risk so that blanket allow rules
-        // (including the starter bundle) cannot silently bypass the prompt.
-        if (allowPrivateNetwork === true) {
-          return {
-            riskLevel: "high",
-            reason: "Private network fetch",
-            scopeOptions: [],
-            matchType: "registry",
-          };
-        }
-        return {
-          riskLevel: "low",
-          reason: "Web fetch (default)",
-          scopeOptions: [],
-          matchType: "registry",
-        };
-
-      case "network_request":
-        // Proxy-authenticated network requests are Medium risk — they carry
-        // injected credentials and the user should approve the target host/origin.
-        return {
-          riskLevel: "medium",
-          reason: "Network request (proxied credentials)",
-          scopeOptions: [],
-          matchType: "registry",
-        };
-    }
+    return assessment!;
   }
 }
 

--- a/gateway/src/risk/web-risk-classifier.ts
+++ b/gateway/src/risk/web-risk-classifier.ts
@@ -10,6 +10,7 @@
  */
 
 import type { RiskAssessment, RiskClassifier } from "./risk-types.js";
+import { getTrustRuleV3Cache } from "./trust-rule-v3-cache.js";
 
 // -- Input type ---------------------------------------------------------------
 
@@ -34,7 +35,26 @@ export interface WebClassifierInput {
  */
 export class WebRiskClassifier implements RiskClassifier<WebClassifierInput> {
   async classify(input: WebClassifierInput): Promise<RiskAssessment> {
-    const { toolName, allowPrivateNetwork } = input;
+    const { toolName, url, allowPrivateNetwork } = input;
+
+    // Check risk rule cache for user overrides
+    try {
+      const ruleCache = getTrustRuleV3Cache();
+      const override = ruleCache.findToolOverride(toolName, url ?? "");
+      if (
+        override &&
+        (override.userModified || override.origin === "user_defined")
+      ) {
+        return {
+          riskLevel: override.risk,
+          reason: override.description,
+          scopeOptions: [],
+          matchType: "user_rule",
+        };
+      }
+    } catch {
+      // Cache not initialized — no override
+    }
 
     // NOTE: We intentionally do NOT produce allowlistOptions here.
     // The canonical URL normalization logic (normalizeWebFetchUrl in


### PR DESCRIPTION
## Summary
- File, web, skill, and schedule classifiers check TrustRuleV3Cache for user overrides
- Only user-modified or user-defined rules trigger overrides
- matchType set to user_rule when override applies
- Graceful fallback when cache not initialized
- Tests for all four classifiers

Part of plan: v3-trust-rules-table.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
