### PR TITLE
feat(gateway): refactor bash classifier to read base risk from risk rule cache

### DIFF
--- a/gateway/src/__tests__/bash-risk-classifier.test.ts
+++ b/gateway/src/__tests__/bash-risk-classifier.test.ts
@@ -1,0 +1,209 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
+import { TrustRuleV3Store } from "../db/trust-rule-v3-store.js";
+import {
+  initTrustRuleV3Cache,
+  resetTrustRuleV3Cache,
+} from "../risk/trust-rule-v3-cache.js";
+import { classifySegment } from "../risk/bash-risk-classifier.js";
+import { DEFAULT_COMMAND_REGISTRY } from "../risk/command-registry.js";
+import type { CommandSegment } from "../risk/shell-parser.js";
+import "./test-preload.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal CommandSegment for testing. */
+function segment(command: string): CommandSegment {
+  const parts = command.split(/\s+/);
+  return {
+    command,
+    program: parts[0],
+    args: parts.slice(1),
+    operator: "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Risk rule cache integration
+// ---------------------------------------------------------------------------
+
+describe("risk rule cache integration", () => {
+  let store: TrustRuleV3Store;
+
+  beforeEach(async () => {
+    resetGatewayDb();
+    await initGatewayDb();
+    store = new TrustRuleV3Store();
+  });
+
+  afterEach(() => {
+    resetTrustRuleV3Cache();
+    resetGatewayDb();
+  });
+
+  test("user-modified risk override changes baseRisk", () => {
+    // Seed a default rule for "git push" and then modify its risk to "low"
+    store.upsertDefault({
+      id: "test-git-push",
+      tool: "bash",
+      pattern: "git push",
+      risk: "medium",
+      description: "Git push",
+    });
+    store.update("test-git-push", { risk: "low" });
+
+    initTrustRuleV3Cache(store);
+
+    const result = classifySegment(
+      segment("git push"),
+      [],
+      DEFAULT_COMMAND_REGISTRY,
+    );
+
+    expect(result.risk).toBe("low");
+  });
+
+  test("matchType is user_rule when a user-modified rule determines risk", () => {
+    // Create a default rule and modify it — userModified becomes true
+    store.upsertDefault({
+      id: "test-git-push-mt",
+      tool: "bash",
+      pattern: "git push",
+      risk: "medium",
+      description: "Git push",
+    });
+    store.update("test-git-push-mt", { risk: "low" });
+
+    initTrustRuleV3Cache(store);
+
+    const result = classifySegment(
+      segment("git push"),
+      [],
+      DEFAULT_COMMAND_REGISTRY,
+    );
+
+    expect(result.matchType).toBe("user_rule");
+  });
+
+  test("matchType is user_rule when a user-defined rule determines risk", () => {
+    // Create a user-defined rule (origin = "user_defined")
+    store.create({
+      tool: "bash",
+      pattern: "my-custom-cmd",
+      risk: "low",
+      description: "Custom command",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    // my-custom-cmd is not in the registry, so it would normally be "unknown".
+    // But with the cache, the risk is overridden. However, the classifier
+    // checks the registry first — if there's no registry entry, it returns
+    // "unknown" before reaching the cache. So use a known command instead.
+    store.create({
+      tool: "bash",
+      pattern: "ls",
+      risk: "low",
+      description: "List files — user override",
+    });
+
+    // Reinitialize cache with the new rule
+    resetTrustRuleV3Cache();
+    initTrustRuleV3Cache(store);
+
+    const result = classifySegment(segment("ls"), [], DEFAULT_COMMAND_REGISTRY);
+
+    expect(result.matchType).toBe("user_rule");
+  });
+
+  test("arg rules still escalate on top of cached baseRisk", () => {
+    // Set git push base risk to "low" via cache
+    store.upsertDefault({
+      id: "test-git-push-esc",
+      tool: "bash",
+      pattern: "git push",
+      risk: "medium",
+      description: "Git push",
+    });
+    store.update("test-git-push-esc", { risk: "low" });
+
+    initTrustRuleV3Cache(store);
+
+    // git push --force should still escalate via arg rules (--force → high)
+    const result = classifySegment(
+      segment("git push --force"),
+      [],
+      DEFAULT_COMMAND_REGISTRY,
+    );
+
+    expect(result.risk).toBe("high");
+  });
+
+  test("fallback when cache is not initialized — classifier uses registry", () => {
+    // Don't initialize the cache — resetTrustRuleV3Cache() was called in afterEach
+    // and we haven't called initTrustRuleV3Cache() here
+    resetTrustRuleV3Cache();
+
+    const result = classifySegment(
+      segment("git push"),
+      [],
+      DEFAULT_COMMAND_REGISTRY,
+    );
+
+    // Should still work using registry baseRisk
+    expect(result.risk).toBe("medium");
+    expect(result.matchType).toBe("registry");
+  });
+
+  test("subcommand resolution — git push looks up 'git push' in cache, not just 'git'", () => {
+    // Create rules for both "git" and "git push" with different risks
+    store.create({
+      tool: "bash",
+      pattern: "git",
+      risk: "low",
+      description: "Git base",
+    });
+    store.create({
+      tool: "bash",
+      pattern: "git push",
+      risk: "high",
+      description: "Git push — elevated",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const result = classifySegment(
+      segment("git push"),
+      [],
+      DEFAULT_COMMAND_REGISTRY,
+    );
+
+    // The cache should match "git push" (the more specific subcommand pattern),
+    // not just "git"
+    expect(result.risk).toBe("high");
+  });
+
+  test("cache override does not affect matchType when rule is not user-modified", () => {
+    // A default rule that has NOT been user-modified
+    store.upsertDefault({
+      id: "test-git-default",
+      tool: "bash",
+      pattern: "git",
+      risk: "low",
+      description: "Git default",
+    });
+
+    initTrustRuleV3Cache(store);
+
+    const result = classifySegment(
+      segment("git status"),
+      [],
+      DEFAULT_COMMAND_REGISTRY,
+    );
+
+    // Default rule, not user-modified — matchType should remain "registry"
+    expect(result.matchType).toBe("registry");
+  });
+});

--- a/gateway/src/__tests__/bash-risk-classifier.test.ts
+++ b/gateway/src/__tests__/bash-risk-classifier.test.ts
@@ -32,6 +32,12 @@ function segment(command: string): CommandSegment {
 describe("risk rule cache integration", () => {
   let store: TrustRuleV3Store;
 
+  // initGatewayDb() seeds the trust_rules table from DEFAULT_COMMAND_REGISTRY
+  // via seedTrustRuleV3sFromRegistry(). Tests that modify existing patterns
+  // (like "git push") must update the seeded rows rather than creating new ones.
+  // Seeded IDs follow the pattern: default:bash:<command-with-hyphens>
+  // e.g., "git push" -> "default:bash:git-push"
+
   beforeEach(async () => {
     resetGatewayDb();
     await initGatewayDb();
@@ -44,15 +50,8 @@ describe("risk rule cache integration", () => {
   });
 
   test("user-modified risk override changes baseRisk", () => {
-    // Seed a default rule for "git push" and then modify its risk to "low"
-    store.upsertDefault({
-      id: "test-git-push",
-      tool: "bash",
-      pattern: "git push",
-      risk: "medium",
-      description: "Git push",
-    });
-    store.update("test-git-push", { risk: "low" });
+    // Modify the seeded "git push" rule's risk to "low"
+    store.update("default:bash:git-push", { risk: "low" });
 
     initTrustRuleV3Cache(store);
 
@@ -66,15 +65,8 @@ describe("risk rule cache integration", () => {
   });
 
   test("matchType is user_rule when a user-modified rule determines risk", () => {
-    // Create a default rule and modify it — userModified becomes true
-    store.upsertDefault({
-      id: "test-git-push-mt",
-      tool: "bash",
-      pattern: "git push",
-      risk: "medium",
-      description: "Git push",
-    });
-    store.update("test-git-push-mt", { risk: "low" });
+    // Modify the seeded "git push" rule — userModified becomes true
+    store.update("default:bash:git-push", { risk: "low" });
 
     initTrustRuleV3Cache(store);
 
@@ -88,29 +80,10 @@ describe("risk rule cache integration", () => {
   });
 
   test("matchType is user_rule when a user-defined rule determines risk", () => {
-    // Create a user-defined rule (origin = "user_defined")
-    store.create({
-      tool: "bash",
-      pattern: "my-custom-cmd",
-      risk: "low",
-      description: "Custom command",
-    });
+    // Modify the seeded "ls" rule — sets userModified and origin stays "default"
+    // but userModified=true triggers user_rule matchType
+    store.update("default:bash:ls", { risk: "low" });
 
-    initTrustRuleV3Cache(store);
-
-    // my-custom-cmd is not in the registry, so it would normally be "unknown".
-    // But with the cache, the risk is overridden. However, the classifier
-    // checks the registry first — if there's no registry entry, it returns
-    // "unknown" before reaching the cache. So use a known command instead.
-    store.create({
-      tool: "bash",
-      pattern: "ls",
-      risk: "low",
-      description: "List files — user override",
-    });
-
-    // Reinitialize cache with the new rule
-    resetTrustRuleV3Cache();
     initTrustRuleV3Cache(store);
 
     const result = classifySegment(segment("ls"), [], DEFAULT_COMMAND_REGISTRY);
@@ -119,15 +92,8 @@ describe("risk rule cache integration", () => {
   });
 
   test("arg rules still escalate on top of cached baseRisk", () => {
-    // Set git push base risk to "low" via cache
-    store.upsertDefault({
-      id: "test-git-push-esc",
-      tool: "bash",
-      pattern: "git push",
-      risk: "medium",
-      description: "Git push",
-    });
-    store.update("test-git-push-esc", { risk: "low" });
+    // Set git push base risk to "low" via cache update
+    store.update("default:bash:git-push", { risk: "low" });
 
     initTrustRuleV3Cache(store);
 
@@ -158,19 +124,11 @@ describe("risk rule cache integration", () => {
   });
 
   test("subcommand resolution — git push looks up 'git push' in cache, not just 'git'", () => {
-    // Create rules for both "git" and "git push" with different risks
-    store.create({
-      tool: "bash",
-      pattern: "git",
-      risk: "low",
-      description: "Git base",
-    });
-    store.create({
-      tool: "bash",
-      pattern: "git push",
-      risk: "high",
-      description: "Git push — elevated",
-    });
+    // Modify the seeded "git" to low, keep "git push" at its seeded risk.
+    // Then modify "git push" to high. The classifier should find "git push"
+    // (the more specific pattern), not "git".
+    store.update("default:bash:git", { risk: "low" });
+    store.update("default:bash:git-push", { risk: "high" });
 
     initTrustRuleV3Cache(store);
 
@@ -186,14 +144,8 @@ describe("risk rule cache integration", () => {
   });
 
   test("cache override does not affect matchType when rule is not user-modified", () => {
-    // A default rule that has NOT been user-modified
-    store.upsertDefault({
-      id: "test-git-default",
-      tool: "bash",
-      pattern: "git",
-      risk: "low",
-      description: "Git default",
-    });
+    // The seeded "git" rule has NOT been user-modified — it's a default rule.
+    // Don't call store.update() so userModified stays false.
 
     initTrustRuleV3Cache(store);
 
@@ -204,6 +156,66 @@ describe("risk rule cache integration", () => {
     );
 
     // Default rule, not user-modified — matchType should remain "registry"
+    expect(result.matchType).toBe("registry");
+  });
+
+  test("multi-level subcommand — git stash drop looks up 'git stash drop' in cache", () => {
+    // Modify the seeded "git stash drop" rule (ID: default:bash:git-stash-drop)
+    // to "low". The classifier should build the full subcommand path
+    // "git stash drop" and find this specific rule in the cache.
+    store.update("default:bash:git-stash-drop", { risk: "low" });
+
+    initTrustRuleV3Cache(store);
+
+    const result = classifySegment(
+      segment("git stash drop"),
+      [],
+      DEFAULT_COMMAND_REGISTRY,
+    );
+
+    // The cache should match the full path "git stash drop", overriding
+    // the registry's high baseRisk for git stash drop.
+    expect(result.risk).toBe("low");
+    expect(result.matchType).toBe("user_rule");
+  });
+
+  test("multi-level subcommand — falls back to parent when specific sub not cached", () => {
+    // Modify the seeded "git stash" rule to "low", but leave "git stash drop"
+    // at its seeded value. Then soft-delete "git stash drop" so the cache
+    // falls back to the parent "git stash" pattern.
+    store.update("default:bash:git-stash", { risk: "low" });
+    store.remove("default:bash:git-stash-drop");
+
+    initTrustRuleV3Cache(store);
+
+    // "git stash drop" should look up "git stash drop" first, not find it
+    // (soft-deleted), then the cache's findBaseRisk falls back to "git stash"
+    const result = classifySegment(
+      segment("git stash drop"),
+      [],
+      DEFAULT_COMMAND_REGISTRY,
+    );
+
+    expect(result.risk).toBe("low");
+    expect(result.matchType).toBe("user_rule");
+  });
+
+  test("matchType resets to registry when arg rules escalate above cached base risk", () => {
+    // Set git push base risk to "low" via a user-modified cache rule
+    store.update("default:bash:git-push", { risk: "low" });
+
+    initTrustRuleV3Cache(store);
+
+    // git push --force: cache sets base to "low" (user_rule matchType),
+    // but --force arg rule escalates to "high". Since the registry's arg
+    // rules determined the final risk, matchType should be "registry".
+    const result = classifySegment(
+      segment("git push --force"),
+      [],
+      DEFAULT_COMMAND_REGISTRY,
+    );
+
+    expect(result.risk).toBe("high");
     expect(result.matchType).toBe("registry");
   });
 });

--- a/gateway/src/risk/bash-risk-classifier.ts
+++ b/gateway/src/risk/bash-risk-classifier.ts
@@ -330,20 +330,28 @@ export function classifySegment(
   let effectiveMatchType: RiskAssessment["matchType"] = "registry";
 
   try {
-    // Build the subcommand pattern (e.g., "git push") to look up in cache.
-    // Determine the subcommand name the same way resolveSubcommand does.
-    let subcommand: string | undefined;
-    if (spec.subcommands && segment.args.length > 0) {
-      const valueFlagsList = spec.argSchema?.valueFlags;
-      const valueFlags = valueFlagsList ? new Set(valueFlagsList) : undefined;
-      subcommand = firstPositionalArg(segment.args, valueFlags);
-      if (subcommand && !spec.subcommands[subcommand]) {
-        subcommand = undefined;
+    // Build the full subcommand pattern (e.g., "git stash drop") to look up in
+    // cache. Walk the subcommand tree the same way resolveSubcommand does,
+    // collecting each traversed subcommand name to build the complete chain.
+    const subcommandChain: string[] = [];
+    {
+      let walkSpec: CommandRiskSpec = spec;
+      let walkArgs: string[] = segment.args;
+      while (walkSpec.subcommands && walkArgs.length > 0) {
+        const valueFlagsList = walkSpec.argSchema?.valueFlags;
+        const valueFlags = valueFlagsList ? new Set(valueFlagsList) : undefined;
+        const subName = firstPositionalArg(walkArgs, valueFlags);
+        if (!subName || !walkSpec.subcommands[subName]) break;
+        subcommandChain.push(subName);
+        const subIdx = walkArgs.indexOf(subName);
+        walkArgs = walkArgs.slice(subIdx + 1);
+        walkSpec = walkSpec.subcommands[subName];
       }
     }
-    const subcommandPattern = subcommand
-      ? `${programName} ${subcommand}`
-      : programName;
+    const subcommandPattern =
+      subcommandChain.length > 0
+        ? `${programName} ${subcommandChain.join(" ")}`
+        : programName;
     const cachedRule = getTrustRuleV3Cache().findBaseRisk(
       "bash",
       subcommandPattern,
@@ -560,11 +568,17 @@ export function classifySegment(
         // Escalation: always apply (matched rule is >= baseRisk)
         risk = argRuleMaxRisk;
         reason = argRuleReason;
+        // The registry's arg rules determined the final risk, not the user's
+        // cached base risk override. Reset matchType to "registry".
+        effectiveMatchType = "registry";
       } else if (!hasUnmatchedNonFlagArg) {
         // De-escalation: only safe when ALL non-flag args matched rules.
         // Every arg is accounted for, so the lower risk is justified.
         risk = argRuleMaxRisk;
         reason = argRuleReason;
+        // Arg rules de-escalated — the registry's arg rules determined the
+        // final risk, so matchType should reflect the registry, not the cache.
+        effectiveMatchType = "registry";
       }
       // Otherwise: some args matched low rules but other args went unmatched.
       // Keep baseRisk as the floor — can't safely de-escalate.

--- a/gateway/src/risk/bash-risk-classifier.ts
+++ b/gateway/src/risk/bash-risk-classifier.ts
@@ -28,6 +28,7 @@ import {
   type UserRule,
 } from "./risk-types.js";
 import { cachedParse } from "./shell-identity.js";
+import { getTrustRuleV3Cache } from "./trust-rule-v3-cache.js";
 
 // ── Risk ordering helpers ────────────────────────────────────────────────────
 
@@ -322,6 +323,41 @@ export function classifySegment(
   const { spec: resolvedSpec, remainingArgs: _remainingArgs } =
     resolveSubcommand(spec, segment.args);
 
+  // 4b. Check TrustRuleV3Cache for base risk overrides.
+  // The cache overrides ONLY baseRisk — structural data (argRules, subcommands,
+  // isWrapper, sandboxAutoApprove, argSchema) still comes from the registry.
+  let effectiveBaseRisk: Risk = resolvedSpec.baseRisk;
+  let effectiveMatchType: RiskAssessment["matchType"] = "registry";
+
+  try {
+    // Build the subcommand pattern (e.g., "git push") to look up in cache.
+    // Determine the subcommand name the same way resolveSubcommand does.
+    let subcommand: string | undefined;
+    if (spec.subcommands && segment.args.length > 0) {
+      const valueFlagsList = spec.argSchema?.valueFlags;
+      const valueFlags = valueFlagsList ? new Set(valueFlagsList) : undefined;
+      subcommand = firstPositionalArg(segment.args, valueFlags);
+      if (subcommand && !spec.subcommands[subcommand]) {
+        subcommand = undefined;
+      }
+    }
+    const subcommandPattern = subcommand
+      ? `${programName} ${subcommand}`
+      : programName;
+    const cachedRule = getTrustRuleV3Cache().findBaseRisk(
+      "bash",
+      subcommandPattern,
+    );
+    if (cachedRule) {
+      effectiveBaseRisk = cachedRule.risk;
+      if (cachedRule.userModified || cachedRule.origin === "user_defined") {
+        effectiveMatchType = "user_rule";
+      }
+    }
+  } catch {
+    // Cache not initialized (e.g., in tests) — use registry baseRisk
+  }
+
   // 5. Evaluate arg rules
   //
   // Arg rules can both escalate AND de-escalate from baseRisk.
@@ -334,7 +370,7 @@ export function classifySegment(
   //
   // Escalation always applies — any matched rule that's higher than baseRisk
   // raises the risk regardless of unmatched args.
-  let risk: Risk = resolvedSpec.baseRisk;
+  let risk: Risk = effectiveBaseRisk;
   let reason = resolvedSpec.reason || `${segment.program} (default)`;
 
   const argRules = resolvedSpec.argRules;
@@ -541,7 +577,7 @@ export function classifySegment(
   // Example: `curl http://localhost:$PORT` — arg rule de-escalates to low,
   // but baseRisk=medium is the floor, so escalateOne(medium) → high.
   if (segment.args.some((a) => a.includes("$"))) {
-    const escalationBase = maxRisk(risk, resolvedSpec.baseRisk);
+    const escalationBase = maxRisk(risk, effectiveBaseRisk);
     const escalated = escalateOne(escalationBase);
     if (riskOrd(escalated) > riskOrd(risk)) {
       risk = escalated;
@@ -570,7 +606,7 @@ export function classifySegment(
     }
   }
 
-  return { risk, reason, matchType: "registry" };
+  return { risk, reason, matchType: effectiveMatchType };
 }
 
 // ── Scope option generation ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- classifySegment() checks TrustRuleV3Cache for base risk overrides after registry lookup
- Cache only overrides baseRisk — structural data (argRules, subcommands, isWrapper) still from registry
- matchType is user_rule when cache determines risk from user-modified or user-defined rule
- Graceful fallback when cache is not initialized
- Tests for cache integration, arg rule escalation, subcommand resolution

Part of plan: v3-trust-rules-table.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
