### PR TITLE
Use catalog-aware context windows in conversation budgeting

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -10,6 +10,7 @@ import {
   getSummaryFromContextMessage,
   stripCompactionOnlyInjections,
 } from "../context/window-manager.js";
+import { resolveEffectiveContextWindowTokens } from "../providers/model-context.js";
 import type {
   ContentBlock,
   Message,
@@ -55,6 +56,34 @@ function message(role: "user" | "assistant", text: string): Message {
 }
 
 describe("ContextWindowManager", () => {
+  test("resolves effective max input tokens as min of catalog and config", () => {
+    expect(
+      resolveEffectiveContextWindowTokens({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        configuredMaxInputTokens: 500_000,
+      }),
+    ).toBe(200_000);
+
+    expect(
+      resolveEffectiveContextWindowTokens({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        configuredMaxInputTokens: 150_000,
+      }),
+    ).toBe(150_000);
+  });
+
+  test("keeps configured max input tokens for unknown models", () => {
+    expect(
+      resolveEffectiveContextWindowTokens({
+        provider: "anthropic",
+        model: "custom-model",
+        configuredMaxInputTokens: 123_456,
+      }),
+    ).toBe(123_456);
+  });
+
   test("skips compaction when estimated tokens are below threshold", async () => {
     const provider = createProvider(() => {
       throw new Error("should not be called");

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -16,8 +16,8 @@ mock.module("../util/logger.js", () => ({
     new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
 }));
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({
+function makeMockConfig() {
+  return {
     llm: {
       default: {
         provider: "mock-provider",
@@ -49,7 +49,13 @@ mock.module("../config/loader.js", () => ({
     rateLimit: { maxRequestsPerMinute: 0 },
     workspaceGit: { turnCommitMaxWaitMs: 10 },
     ui: {},
-  }),
+  };
+}
+
+let mockConfig = makeMockConfig();
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},
   invalidateConfigCache: () => {},
@@ -501,6 +507,7 @@ function makeCtx(
 // ── Tests ────────────────────────────────────────────────────────────
 
 beforeEach(() => {
+  mockConfig = makeMockConfig();
   mockEstimateTokens = 1000;
   mockReducerStepFn = null;
   mockOverflowAction = "fail_gracefully";
@@ -1474,6 +1481,64 @@ describe("session-agent-loop", () => {
       expect(agentLoopCalls).toBe(1);
       const complete = events.find((e) => e.type === "message_complete");
       expect(complete).toBeDefined();
+    });
+
+    test("preflight budget uses catalog context window when lower than config", async () => {
+      mockConfig.llm.default.provider = "anthropic";
+      mockConfig.llm.default.model = "claude-opus-4-6";
+      mockConfig.llm.default.contextWindow.maxInputTokens = 500_000;
+      mockEstimateTokens = 191_000;
+
+      let reducerContextWindowMax: number | undefined;
+      mockReducerStepFn = (msgs: Message[], cfg: unknown) => {
+        reducerContextWindowMax = (
+          cfg as { contextWindow: { maxInputTokens: number } }
+        ).contextWindow.maxInputTokens;
+        return {
+          messages: msgs,
+          tier: "forced_compaction",
+          state: {
+            appliedTiers: ["forced_compaction"],
+            injectionMode: "full",
+            exhausted: true,
+          },
+          estimatedTokens: 100_000,
+        };
+      };
+
+      const ctx = makeCtx();
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      expect(reducerContextWindowMax).toBe(200_000);
+    });
+
+    test("preflight budget keeps config override when lower than catalog", async () => {
+      mockConfig.llm.default.provider = "anthropic";
+      mockConfig.llm.default.model = "claude-opus-4-6";
+      mockConfig.llm.default.contextWindow.maxInputTokens = 150_000;
+      mockEstimateTokens = 143_000;
+
+      let reducerContextWindowMax: number | undefined;
+      mockReducerStepFn = (msgs: Message[], cfg: unknown) => {
+        reducerContextWindowMax = (
+          cfg as { contextWindow: { maxInputTokens: number } }
+        ).contextWindow.maxInputTokens;
+        return {
+          messages: msgs,
+          tier: "forced_compaction",
+          state: {
+            appliedTiers: ["forced_compaction"],
+            injectionMode: "full",
+            exhausted: true,
+          },
+          estimatedTokens: 75_000,
+        };
+      };
+
+      const ctx = makeCtx();
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      expect(reducerContextWindowMax).toBe(150_000);
     });
   });
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -27,6 +27,7 @@ import type {
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
+import type { AssistantConfig, ContextWindowConfig } from "../config/types.js";
 import {
   derefToolResultReReads,
   postTurnTruncateToolResults,
@@ -98,6 +99,7 @@ import type {
   TurnContext as PluginTurnContext,
 } from "../plugins/types.js";
 import { PluginExecutionError, PluginTimeoutError } from "../plugins/types.js";
+import { resolveEffectiveContextWindowTokens } from "../providers/model-context.js";
 import type {
   ContentBlock,
   Message,
@@ -197,6 +199,21 @@ const TOOL_FRIENDLY_LABEL: Record<string, string> = {
 type GitServiceInitializer = {
   ensureInitialized(): Promise<void>;
 };
+
+export function resolveEffectiveDefaultContextWindowConfig(
+  config: AssistantConfig,
+): ContextWindowConfig {
+  const defaultLlm = config.llm.default;
+  const contextWindow = defaultLlm.contextWindow;
+  return {
+    ...contextWindow,
+    maxInputTokens: resolveEffectiveContextWindowTokens({
+      provider: defaultLlm.provider,
+      model: defaultLlm.model,
+      configuredMaxInputTokens: contextWindow.maxInputTokens,
+    }),
+  };
+}
 
 // ── Compaction circuit-breaker pipeline helpers ─────────────────────
 //
@@ -1293,8 +1310,10 @@ export async function runAgentLoopImpl(
     // and proactively invoke the reducer if already above budget. This avoids
     // a wasted provider round-trip that would just fail with context_too_large.
     const config = getConfig();
-    const overflowRecovery = config.llm.default.contextWindow.overflowRecovery;
-    const providerMaxTokens = config.llm.default.contextWindow.maxInputTokens;
+    const effectiveContextWindow =
+      resolveEffectiveDefaultContextWindowConfig(config);
+    const overflowRecovery = effectiveContextWindow.overflowRecovery;
+    const providerMaxTokens = effectiveContextWindow.maxInputTokens;
     // Widen safety margin for large conversations where estimation error
     // compounds across many messages with tool results.
     const baseSafetyMargin = overflowRecovery.safetyMarginRatio;
@@ -1376,7 +1395,7 @@ export async function runAgentLoopImpl(
         runMessages,
         systemPrompt: ctx.systemPrompt,
         providerName: estimationProviderName,
-        contextWindow: config.llm.default.contextWindow,
+        contextWindow: effectiveContextWindow,
         preflightBudget,
         toolTokenBudget,
         maxAttempts: overflowRecovery.maxAttempts,
@@ -2001,7 +2020,7 @@ export async function runAgentLoopImpl(
           {
             providerName: estimationProviderName,
             systemPrompt: ctx.systemPrompt,
-            contextWindow: config.llm.default.contextWindow,
+            contextWindow: effectiveContextWindow,
             targetTokens: correctedTarget,
             toolTokenBudget,
           },
@@ -2420,7 +2439,7 @@ export async function runAgentLoopImpl(
       state.exchangeLlmCallCount,
       {
         tokens: state.lastCallInputTokens,
-        maxTokens: config.llm.default.contextWindow.maxInputTokens,
+        maxTokens: effectiveContextWindow.maxInputTokens,
       },
     );
 

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -74,6 +74,7 @@ import { getLogger } from "../util/logger.js";
 import type { AssistantAttachmentDraft } from "./assistant-attachments.js";
 import {
   applyCompactionResult,
+  resolveEffectiveDefaultContextWindowConfig,
   runAgentLoopImpl,
   trackCompactionOutcome,
 } from "./conversation-agent-loop.js";
@@ -517,13 +518,15 @@ export class Conversation {
     const fastModeEnabled = isAssistantFeatureFlagEnabled("fast-mode", config);
     const resolvedSpeed = speedOverride ?? config.llm.default.speed;
     const llmDefault = config.llm.default;
+    const effectiveContextWindow =
+      resolveEffectiveDefaultContextWindowConfig(config);
 
     this.agentLoop = new AgentLoop(
       provider,
       systemPrompt,
       {
         maxTokens,
-        maxInputTokens: llmDefault.contextWindow.maxInputTokens,
+        maxInputTokens: effectiveContextWindow.maxInputTokens,
         thinking: llmDefault.thinking,
         effort: llmDefault.effort,
         ...(fastModeEnabled && resolvedSpeed === "fast"
@@ -539,7 +542,7 @@ export class Conversation {
     this.contextWindowManager = new ContextWindowManager({
       provider,
       systemPrompt: () => resolveSystemPromptCallback([]).systemPrompt,
-      config: llmDefault.contextWindow,
+      config: effectiveContextWindow,
       toolTokenBudget: this.agentLoop.getToolTokenBudget(),
     });
   }


### PR DESCRIPTION
## Summary
- Apply catalog-aware effective context windows to conversation budgeting.
- Cover catalog-vs-config budget behavior in focused tests.

Part of plan: shared-model-catalog-assistant.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
