### PR TITLE
test(gateway-guard): allowlist websocket-upstream.ts for direct runtime URL

### DIFF
--- a/assistant/src/__tests__/gateway-only-guard.test.ts
+++ b/assistant/src/__tests__/gateway-only-guard.test.ts
@@ -48,6 +48,7 @@ const ALLOWLIST = new Set([
 
   // --- Shared client packages (transport helpers that proxy to the runtime by design) ---
   "packages/assistant-client/src/proxy-forward.ts",
+  "packages/assistant-client/src/websocket-upstream.ts",
 ]);
 
 /** Patterns that indicate a direct runtime URL reference via hardcoded port. */


### PR DESCRIPTION
## Summary
- Add `packages/assistant-client/src/websocket-upstream.ts` to the gateway-only guard allowlist — it connects directly to the assistant runtime's WebSocket endpoint by design, not through the gateway

## Original prompt
fix the CI failure in gateway-only-guard.test.ts: packages/assistant-client/src/websocket-upstream.ts references direct runtime URLs (port 7821) but isn't in the ALLOWLIST. Add it to the allowlist since it's an intentional exception — the assistant-client package connects directly to the assistant runtime's WebSocket endpoint, not through the gateway.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
