### PR TITLE
fix: cache test collisions, dead validation, rm matchType reset

### DIFF
--- a/gateway/src/__tests__/trust-rule-v3-cache.test.ts
+++ b/gateway/src/__tests__/trust-rule-v3-cache.test.ts
@@ -28,13 +28,17 @@ afterEach(() => {
 
 // ---------------------------------------------------------------------------
 // findBaseRisk() — exact match
+//
+// Every test uses a unique tool + pattern pair to avoid UNIQUE constraint
+// collisions. The DB file persists across beforeEach resets within a single
+// test file, so patterns must never repeat.
 // ---------------------------------------------------------------------------
 
 describe("findBaseRisk()", () => {
   test("exact match returns the matching rule", () => {
     store.create({
-      tool: "bash",
-      pattern: "rm -rf",
+      tool: "cache_t1",
+      pattern: "exact-match-cmd",
       risk: "high",
       description: "Dangerous remove",
     });
@@ -42,16 +46,16 @@ describe("findBaseRisk()", () => {
     initTrustRuleV3Cache(store);
     const cache = getTrustRuleV3Cache();
 
-    const result = cache.findBaseRisk("bash", "rm -rf");
+    const result = cache.findBaseRisk("cache_t1", "exact-match-cmd");
     expect(result).not.toBeNull();
-    expect(result!.pattern).toBe("rm -rf");
+    expect(result!.pattern).toBe("exact-match-cmd");
     expect(result!.risk).toBe("high");
   });
 
-  test("path-stripped match: /usr/bin/rm matches rule for rm", () => {
+  test("path-stripped match: /usr/bin/prog matches rule for prog", () => {
     store.create({
-      tool: "bash",
-      pattern: "rm",
+      tool: "cache_t2",
+      pattern: "path-strip-prog",
       risk: "high",
       description: "Remove command",
     });
@@ -59,15 +63,15 @@ describe("findBaseRisk()", () => {
     initTrustRuleV3Cache(store);
     const cache = getTrustRuleV3Cache();
 
-    const result = cache.findBaseRisk("bash", "/usr/bin/rm");
+    const result = cache.findBaseRisk("cache_t2", "/usr/bin/path-strip-prog");
     expect(result).not.toBeNull();
-    expect(result!.pattern).toBe("rm");
+    expect(result!.pattern).toBe("path-strip-prog");
   });
 
-  test("path-stripped match with arguments: /usr/bin/git push matches git push", () => {
+  test("path-stripped match with arguments: /usr/bin/prog sub matches prog sub", () => {
     store.create({
-      tool: "bash",
-      pattern: "git push",
+      tool: "cache_t3",
+      pattern: "path-strip-args push",
       risk: "medium",
       description: "Git push command",
     });
@@ -75,56 +79,62 @@ describe("findBaseRisk()", () => {
     initTrustRuleV3Cache(store);
     const cache = getTrustRuleV3Cache();
 
-    const result = cache.findBaseRisk("bash", "/usr/bin/git push");
+    const result = cache.findBaseRisk(
+      "cache_t3",
+      "/usr/bin/path-strip-args push",
+    );
     expect(result).not.toBeNull();
-    expect(result!.pattern).toBe("git push");
+    expect(result!.pattern).toBe("path-strip-args push");
   });
 
-  test("subcommand match: 'git push --force' falls back to 'git push' then 'git'", () => {
+  test("subcommand match: 'prog sub --flag' falls back to 'prog'", () => {
     store.create({
-      tool: "bash",
-      pattern: "git",
+      tool: "cache_t4",
+      pattern: "subcmd-fallback",
       risk: "medium",
-      description: "Git commands",
+      description: "Base command",
     });
 
     initTrustRuleV3Cache(store);
     const cache = getTrustRuleV3Cache();
 
-    // "git push --force" should match "git" via subcommand fallback
-    const result = cache.findBaseRisk("bash", "git push --force");
+    // "subcmd-fallback push --force" should match "subcmd-fallback" via subcommand fallback
+    const result = cache.findBaseRisk(
+      "cache_t4",
+      "subcmd-fallback push --force",
+    );
     expect(result).not.toBeNull();
-    expect(result!.pattern).toBe("git");
+    expect(result!.pattern).toBe("subcmd-fallback");
   });
 
   test("subcommand match prefers longer prefix", () => {
     store.create({
-      tool: "bash",
-      pattern: "git",
+      tool: "cache_t5",
+      pattern: "subcmd-prefer",
       risk: "low",
-      description: "Git base",
+      description: "Base command",
     });
     store.create({
-      tool: "bash",
-      pattern: "git push",
+      tool: "cache_t5",
+      pattern: "subcmd-prefer push",
       risk: "high",
-      description: "Git push",
+      description: "Push subcommand",
     });
 
     initTrustRuleV3Cache(store);
     const cache = getTrustRuleV3Cache();
 
-    // "git push --force" should match "git push" (longer prefix wins)
-    const result = cache.findBaseRisk("bash", "git push --force");
+    // "subcmd-prefer push --force" should match "subcmd-prefer push" (longer prefix wins)
+    const result = cache.findBaseRisk("cache_t5", "subcmd-prefer push --force");
     expect(result).not.toBeNull();
-    expect(result!.pattern).toBe("git push");
+    expect(result!.pattern).toBe("subcmd-prefer push");
     expect(result!.risk).toBe("high");
   });
 
   test("returns null when no match found", () => {
     store.create({
-      tool: "bash",
-      pattern: "echo",
+      tool: "cache_t6",
+      pattern: "no-match-echo",
       risk: "low",
       description: "Echo",
     });
@@ -132,14 +142,17 @@ describe("findBaseRisk()", () => {
     initTrustRuleV3Cache(store);
     const cache = getTrustRuleV3Cache();
 
-    const result = cache.findBaseRisk("bash", "curl");
+    const result = cache.findBaseRisk(
+      "cache_t6",
+      "nonexistent-command-no-match",
+    );
     expect(result).toBeNull();
   });
 
   test("returns null when tool not found", () => {
     store.create({
-      tool: "bash",
-      pattern: "echo",
+      tool: "cache_t7",
+      pattern: "tool-not-found-echo",
       risk: "low",
       description: "Echo",
     });
@@ -147,7 +160,10 @@ describe("findBaseRisk()", () => {
     initTrustRuleV3Cache(store);
     const cache = getTrustRuleV3Cache();
 
-    const result = cache.findBaseRisk("nonexistent_tool", "echo");
+    const result = cache.findBaseRisk(
+      "nonexistent_tool_cache",
+      "tool-not-found-echo",
+    );
     expect(result).toBeNull();
   });
 });
@@ -159,8 +175,8 @@ describe("findBaseRisk()", () => {
 describe("findToolOverride()", () => {
   test("exact match returns the matching rule", () => {
     store.create({
-      tool: "file_read",
-      pattern: "/etc/passwd",
+      tool: "cache_override_t1",
+      pattern: "/etc/override-test",
       risk: "high",
       description: "Sensitive file",
     });
@@ -168,16 +184,19 @@ describe("findToolOverride()", () => {
     initTrustRuleV3Cache(store);
     const cache = getTrustRuleV3Cache();
 
-    const result = cache.findToolOverride("file_read", "/etc/passwd");
+    const result = cache.findToolOverride(
+      "cache_override_t1",
+      "/etc/override-test",
+    );
     expect(result).not.toBeNull();
-    expect(result!.pattern).toBe("/etc/passwd");
+    expect(result!.pattern).toBe("/etc/override-test");
     expect(result!.risk).toBe("high");
   });
 
   test("returns null when pattern not found", () => {
     store.create({
-      tool: "file_read",
-      pattern: "/etc/passwd",
+      tool: "cache_override_t2",
+      pattern: "/etc/override-pattern-miss",
       risk: "high",
       description: "Sensitive file",
     });
@@ -185,14 +204,14 @@ describe("findToolOverride()", () => {
     initTrustRuleV3Cache(store);
     const cache = getTrustRuleV3Cache();
 
-    const result = cache.findToolOverride("file_read", "/tmp/safe");
+    const result = cache.findToolOverride("cache_override_t2", "/tmp/safe");
     expect(result).toBeNull();
   });
 
   test("returns null when tool not found", () => {
     store.create({
-      tool: "file_read",
-      pattern: "/etc/passwd",
+      tool: "cache_override_t3",
+      pattern: "/etc/override-tool-miss",
       risk: "high",
       description: "Sensitive file",
     });
@@ -200,7 +219,10 @@ describe("findToolOverride()", () => {
     initTrustRuleV3Cache(store);
     const cache = getTrustRuleV3Cache();
 
-    const result = cache.findToolOverride("web_fetch", "/etc/passwd");
+    const result = cache.findToolOverride(
+      "nonexistent_override_tool",
+      "/etc/override-tool-miss",
+    );
     expect(result).toBeNull();
   });
 });
@@ -212,20 +234,20 @@ describe("findToolOverride()", () => {
 describe("getAllForTool()", () => {
   test("returns all active rules for a given tool", () => {
     store.create({
-      tool: "bash",
-      pattern: "echo",
+      tool: "cache_getall_t1",
+      pattern: "getall-echo",
       risk: "low",
       description: "Echo",
     });
     store.create({
-      tool: "bash",
-      pattern: "rm",
+      tool: "cache_getall_t1",
+      pattern: "getall-rm",
       risk: "high",
       description: "Remove",
     });
     store.create({
-      tool: "file_read",
-      pattern: "/tmp/**",
+      tool: "cache_getall_other",
+      pattern: "/tmp/getall-other",
       risk: "medium",
       description: "File read",
     });
@@ -233,15 +255,18 @@ describe("getAllForTool()", () => {
     initTrustRuleV3Cache(store);
     const cache = getTrustRuleV3Cache();
 
-    const bashRules = cache.getAllForTool("bash");
-    expect(bashRules).toHaveLength(2);
-    expect(bashRules.map((r) => r.pattern).sort()).toEqual(["echo", "rm"]);
+    const rules = cache.getAllForTool("cache_getall_t1");
+    expect(rules).toHaveLength(2);
+    expect(rules.map((r) => r.pattern).sort()).toEqual([
+      "getall-echo",
+      "getall-rm",
+    ]);
   });
 
   test("returns empty array when tool not found", () => {
     store.create({
-      tool: "bash",
-      pattern: "echo",
+      tool: "cache_getall_t2",
+      pattern: "getall-empty-echo",
       risk: "low",
       description: "Echo",
     });
@@ -249,7 +274,7 @@ describe("getAllForTool()", () => {
     initTrustRuleV3Cache(store);
     const cache = getTrustRuleV3Cache();
 
-    const result = cache.getAllForTool("nonexistent");
+    const result = cache.getAllForTool("nonexistent_getall_tool");
     expect(result).toEqual([]);
   });
 });
@@ -261,8 +286,8 @@ describe("getAllForTool()", () => {
 describe("refresh()", () => {
   test("cache reflects data after refresh", () => {
     store.create({
-      tool: "bash",
-      pattern: "echo",
+      tool: "cache_refresh_t1",
+      pattern: "refresh-echo",
       risk: "low",
       description: "Echo",
     });
@@ -271,30 +296,36 @@ describe("refresh()", () => {
     const cache = getTrustRuleV3Cache();
 
     // Verify initial state
-    expect(cache.findBaseRisk("bash", "echo")).not.toBeNull();
-    expect(cache.findBaseRisk("bash", "curl")).toBeNull();
+    expect(
+      cache.findBaseRisk("cache_refresh_t1", "refresh-echo"),
+    ).not.toBeNull();
+    expect(cache.findBaseRisk("cache_refresh_t1", "refresh-curl")).toBeNull();
 
     // Add a new rule directly to the store (bypassing cache)
     store.create({
-      tool: "bash",
-      pattern: "curl",
+      tool: "cache_refresh_t1",
+      pattern: "refresh-curl",
       risk: "medium",
       description: "Curl",
     });
 
     // Cache should still not have it
-    expect(cache.findBaseRisk("bash", "curl")).toBeNull();
+    expect(cache.findBaseRisk("cache_refresh_t1", "refresh-curl")).toBeNull();
 
     // After refresh, cache should pick it up
     invalidateTrustRuleV3Cache();
-    expect(cache.findBaseRisk("bash", "curl")).not.toBeNull();
-    expect(cache.findBaseRisk("bash", "curl")!.risk).toBe("medium");
+    expect(
+      cache.findBaseRisk("cache_refresh_t1", "refresh-curl"),
+    ).not.toBeNull();
+    expect(cache.findBaseRisk("cache_refresh_t1", "refresh-curl")!.risk).toBe(
+      "medium",
+    );
   });
 
   test("refresh picks up removed rules", () => {
     const rule = store.create({
-      tool: "bash",
-      pattern: "echo",
+      tool: "cache_refresh_t2",
+      pattern: "refresh-remove-echo",
       risk: "low",
       description: "Echo",
     });
@@ -302,17 +333,23 @@ describe("refresh()", () => {
     initTrustRuleV3Cache(store);
     const cache = getTrustRuleV3Cache();
 
-    expect(cache.findBaseRisk("bash", "echo")).not.toBeNull();
+    expect(
+      cache.findBaseRisk("cache_refresh_t2", "refresh-remove-echo"),
+    ).not.toBeNull();
 
     // Remove the rule from the store
     store.remove(rule.id);
 
     // Cache still has old data
-    expect(cache.findBaseRisk("bash", "echo")).not.toBeNull();
+    expect(
+      cache.findBaseRisk("cache_refresh_t2", "refresh-remove-echo"),
+    ).not.toBeNull();
 
     // After refresh, the rule should be gone
     invalidateTrustRuleV3Cache();
-    expect(cache.findBaseRisk("bash", "echo")).toBeNull();
+    expect(
+      cache.findBaseRisk("cache_refresh_t2", "refresh-remove-echo"),
+    ).toBeNull();
   });
 });
 
@@ -329,15 +366,17 @@ describe("singleton functions", () => {
 
   test("initTrustRuleV3Cache() initializes the cache", () => {
     store.create({
-      tool: "bash",
-      pattern: "echo",
+      tool: "cache_singleton_t1",
+      pattern: "singleton-echo",
       risk: "low",
       description: "Echo",
     });
 
     initTrustRuleV3Cache(store);
     const cache = getTrustRuleV3Cache();
-    expect(cache.findBaseRisk("bash", "echo")).not.toBeNull();
+    expect(
+      cache.findBaseRisk("cache_singleton_t1", "singleton-echo"),
+    ).not.toBeNull();
   });
 
   test("resetTrustRuleV3Cache() clears the singleton", () => {

--- a/gateway/src/db/trust-rule-v3-store.ts
+++ b/gateway/src/db/trust-rule-v3-store.ts
@@ -69,11 +69,11 @@ function nowISO(): string {
 
 function toTrustRuleV3(row: typeof trustRulesV3.$inferSelect): TrustRuleV3 {
   // Belt-and-suspenders: validate the DB risk value. The schema constraint
-  // should prevent invalid values, but default to the raw cast if somehow
-  // one slips through.
+  // should prevent invalid values, but default to "high" as a defensive
+  // fallback if somehow one slips through.
   const risk = VALID_RISK_VALUES.has(row.risk)
     ? (row.risk as TrustRuleV3["risk"])
-    : (row.risk as TrustRuleV3["risk"]);
+    : "high";
 
   return {
     id: row.id,

--- a/gateway/src/risk/bash-risk-classifier.ts
+++ b/gateway/src/risk/bash-risk-classifier.ts
@@ -616,6 +616,7 @@ export function classifySegment(
       RM_SAFE_BARE_FILES.has(positionalArgs[0])
     ) {
       risk = "medium";
+      effectiveMatchType = "registry";
       reason = `rm of known safe file: ${positionalArgs[0]}`;
     }
   }


### PR DESCRIPTION
## Summary
Fixes 3 gaps from self-review:
- Cache test patterns changed to non-colliding names (avoid seeded data conflicts)
- toTrustRuleV3 risk validation now defaults to 'high' on invalid DB values
- effectiveMatchType reset to 'registry' on rm safe-file downgrade

Part of plan: v3-trust-rules-table.md (fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
