### PR TITLE
fix: align context window readouts

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -10,7 +10,6 @@ import {
   getSummaryFromContextMessage,
   stripCompactionOnlyInjections,
 } from "../context/window-manager.js";
-import { resolveEffectiveContextWindowTokens } from "../providers/model-context.js";
 import type {
   ContentBlock,
   Message,
@@ -56,34 +55,6 @@ function message(role: "user" | "assistant", text: string): Message {
 }
 
 describe("ContextWindowManager", () => {
-  test("resolves effective max input tokens as min of catalog and config", () => {
-    expect(
-      resolveEffectiveContextWindowTokens({
-        provider: "anthropic",
-        model: "claude-opus-4-6",
-        configuredMaxInputTokens: 500_000,
-      }),
-    ).toBe(200_000);
-
-    expect(
-      resolveEffectiveContextWindowTokens({
-        provider: "anthropic",
-        model: "claude-opus-4-6",
-        configuredMaxInputTokens: 150_000,
-      }),
-    ).toBe(150_000);
-  });
-
-  test("keeps configured max input tokens for unknown models", () => {
-    expect(
-      resolveEffectiveContextWindowTokens({
-        provider: "anthropic",
-        model: "custom-model",
-        configuredMaxInputTokens: 123_456,
-      }),
-    ).toBe(123_456);
-  });
-
   test("skips compaction when estimated tokens are below threshold", async () => {
     const provider = createProvider(() => {
       throw new Error("should not be called");

--- a/assistant/src/__tests__/model-context.test.ts
+++ b/assistant/src/__tests__/model-context.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   DEFAULT_CONFIGURED_MAX_INPUT_TOKENS,
   resolveEffectiveContextWindowTokens,
+  resolveEffectiveDefaultContextWindowConfig,
 } from "../providers/model-context.js";
 
 describe("model context", () => {
@@ -64,5 +65,34 @@ describe("model context", () => {
         configuredMaxInputTokens: Number.NaN,
       }),
     ).toBe(DEFAULT_CONFIGURED_MAX_INPUT_TOKENS);
+  });
+
+  test("resolves default context window config with catalog cap", () => {
+    const config = {
+      llm: {
+        default: {
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          contextWindow: {
+            enabled: true,
+            maxInputTokens: 500_000,
+            targetBudgetRatio: 0.3,
+            compactThreshold: 0.8,
+            summaryBudgetRatio: 0.05,
+            overflowRecovery: {
+              enabled: true,
+              safetyMarginRatio: 0.05,
+              maxAttempts: 3,
+              interactiveLatestTurnCompression: "summarize",
+              nonInteractiveLatestTurnCompression: "truncate",
+            },
+          },
+        },
+      },
+    } as Parameters<typeof resolveEffectiveDefaultContextWindowConfig>[0];
+
+    expect(
+      resolveEffectiveDefaultContextWindowConfig(config).maxInputTokens,
+    ).toBe(200_000);
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -27,7 +27,6 @@ import type {
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
-import type { AssistantConfig, ContextWindowConfig } from "../config/types.js";
 import {
   derefToolResultReReads,
   postTurnTruncateToolResults,
@@ -99,7 +98,7 @@ import type {
   TurnContext as PluginTurnContext,
 } from "../plugins/types.js";
 import { PluginExecutionError, PluginTimeoutError } from "../plugins/types.js";
-import { resolveEffectiveContextWindowTokens } from "../providers/model-context.js";
+import { resolveEffectiveDefaultContextWindowConfig } from "../providers/model-context.js";
 import type {
   ContentBlock,
   Message,
@@ -199,21 +198,6 @@ const TOOL_FRIENDLY_LABEL: Record<string, string> = {
 type GitServiceInitializer = {
   ensureInitialized(): Promise<void>;
 };
-
-export function resolveEffectiveDefaultContextWindowConfig(
-  config: AssistantConfig,
-): ContextWindowConfig {
-  const defaultLlm = config.llm.default;
-  const contextWindow = defaultLlm.contextWindow;
-  return {
-    ...contextWindow,
-    maxInputTokens: resolveEffectiveContextWindowTokens({
-      provider: defaultLlm.provider,
-      model: defaultLlm.model,
-      configuredMaxInputTokens: contextWindow.maxInputTokens,
-    }),
-  };
-}
 
 // ── Compaction circuit-breaker pipeline helpers ─────────────────────
 //

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -31,6 +31,7 @@ import {
 } from "../memory/conversation-crud.js";
 import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
+import { resolveEffectiveDefaultContextWindowConfig } from "../providers/model-context.js";
 import type { Message } from "../providers/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
 import { getLogger } from "../util/logger.js";
@@ -255,12 +256,14 @@ function buildSlashContext(
   conversation: ProcessConversationContext,
 ): SlashContext {
   const config = getConfig();
+  const effectiveContextWindow =
+    resolveEffectiveDefaultContextWindowConfig(config);
   const turnInterface = conversation.getTurnInterfaceContext();
   return {
     messageCount: conversation.messages.length,
     inputTokens: conversation.usageStats.inputTokens,
     outputTokens: conversation.usageStats.outputTokens,
-    maxInputTokens: config.llm.default.contextWindow.maxInputTokens,
+    maxInputTokens: effectiveContextWindow.maxInputTokens,
     model: config.llm.default.model,
     provider: config.llm.default.provider,
     estimatedCost: conversation.usageStats.estimatedCost,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -60,6 +60,7 @@ import {
 } from "../permissions/v2-consent-policy.js";
 import { resolvePersonaContext } from "../prompts/persona-resolver.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
+import { resolveEffectiveDefaultContextWindowConfig } from "../providers/model-context.js";
 import type { Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
@@ -74,7 +75,6 @@ import { getLogger } from "../util/logger.js";
 import type { AssistantAttachmentDraft } from "./assistant-attachments.js";
 import {
   applyCompactionResult,
-  resolveEffectiveDefaultContextWindowConfig,
   runAgentLoopImpl,
   trackCompactionOutcome,
 } from "./conversation-agent-loop.js";

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -52,6 +52,7 @@ import { getOrCreateConversation } from "../memory/conversation-key-store.js";
 import { syncIdentityNameToPlatform } from "../platform/sync-identity.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import { CallSiteRoutingProvider } from "../providers/call-site-routing.js";
+import { resolveEffectiveDefaultContextWindowConfig } from "../providers/model-context.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
 import { getProvider, initializeProviders } from "../providers/registry.js";
 import {
@@ -1521,12 +1522,14 @@ export class DaemonServer {
       );
 
     const config = getConfig();
+    const effectiveContextWindow =
+      resolveEffectiveDefaultContextWindowConfig(config);
     const serverInterfaceCtx = conversation.getTurnInterfaceContext();
     const slashContext: SlashContext = {
       messageCount: conversation.getMessages().length,
       inputTokens: conversation.usageStats.inputTokens,
       outputTokens: conversation.usageStats.outputTokens,
-      maxInputTokens: config.llm.default.contextWindow.maxInputTokens,
+      maxInputTokens: effectiveContextWindow.maxInputTokens,
       model: config.llm.default.model,
       provider: config.llm.default.provider,
       estimatedCost: conversation.usageStats.estimatedCost,

--- a/assistant/src/providers/model-context.ts
+++ b/assistant/src/providers/model-context.ts
@@ -1,3 +1,4 @@
+import type { AssistantConfig, ContextWindowConfig } from "../config/types.js";
 import { PROVIDER_CATALOG } from "./model-catalog.js";
 
 export const DEFAULT_CONFIGURED_MAX_INPUT_TOKENS = 200_000;
@@ -31,4 +32,19 @@ export function resolveEffectiveContextWindowTokens({
   }
 
   return Math.min(catalogContextWindowTokens, configuredMaxInputTokens);
+}
+
+export function resolveEffectiveDefaultContextWindowConfig(
+  config: AssistantConfig,
+): ContextWindowConfig {
+  const defaultLlm = config.llm.default;
+  const contextWindow = defaultLlm.contextWindow;
+  return {
+    ...contextWindow,
+    maxInputTokens: resolveEffectiveContextWindowTokens({
+      provider: defaultLlm.provider,
+      model: defaultLlm.model,
+      configuredMaxInputTokens: contextWindow.maxInputTokens,
+    }),
+  };
 }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -84,6 +84,7 @@ import {
   getOrCreateConversation,
 } from "../../memory/conversation-key-store.js";
 import { searchConversations } from "../../memory/conversation-queries.js";
+import { resolveEffectiveDefaultContextWindowConfig } from "../../providers/model-context.js";
 import { getConfiguredProvider } from "../../providers/provider-send-message.js";
 import type { Provider } from "../../providers/types.js";
 import { checkIngressForSecrets } from "../../security/secret-ingress.js";
@@ -2075,11 +2076,13 @@ export async function handleSendMessage(
   // Resolve slash commands before persisting or running the agent loop.
   const rawContent = content ?? "";
   const config = getConfig();
+  const effectiveContextWindow =
+    resolveEffectiveDefaultContextWindowConfig(config);
   const slashContext: SlashContext = {
     messageCount: conversation.getMessages().length,
     inputTokens: conversation.usageStats.inputTokens,
     outputTokens: conversation.usageStats.outputTokens,
-    maxInputTokens: config.llm.default.contextWindow.maxInputTokens,
+    maxInputTokens: effectiveContextWindow.maxInputTokens,
     model: config.llm.default.model,
     provider: config.llm.default.provider,
     estimatedCost: conversation.usageStats.estimatedCost,

--- a/assistant/src/runtime/routes/playground/reset-circuit.ts
+++ b/assistant/src/runtime/routes/playground/reset-circuit.ts
@@ -24,6 +24,7 @@
 import { getConfig } from "../../../config/loader.js";
 import { estimatePromptTokens } from "../../../context/token-estimator.js";
 import type { Conversation } from "../../../daemon/conversation.js";
+import { resolveEffectiveDefaultContextWindowConfig } from "../../../providers/model-context.js";
 import type { RouteDefinition } from "../../http-router.js";
 // Import directly from the source modules (not ./index.js) — index.ts imports
 // this file's `resetCircuitRouteDefinitions`, so pulling its re-exports back
@@ -89,7 +90,7 @@ function buildCompactionState(conversation: Conversation): {
   isCompactionEnabled: boolean;
 } {
   const config = getConfig();
-  const contextWindow = config.llm.default.contextWindow;
+  const contextWindow = resolveEffectiveDefaultContextWindowConfig(config);
   const messages = conversation.getMessages();
   const estimatedInputTokens = estimatePromptTokens(messages);
   const maxInputTokens = contextWindow.maxInputTokens;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for shared-model-catalog-assistant.md.

**Gap:** Context-window readouts and helper placement
**What was expected:** Status/readout paths use the same effective context-window budget as enforcement.
**What was found:** Slash status contexts still used the raw configured max input tokens.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
