### PR TITLE
fix(subagent): inherit parent conversation trust context

### DIFF
--- a/assistant/src/__tests__/subagent-trust-context-inheritance.test.ts
+++ b/assistant/src/__tests__/subagent-trust-context-inheritance.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Regression test: SubagentManager.spawn() must inherit the parent
+ * conversation's trust context onto the child. Without this, the child
+ * defaults to trustClass === "unknown" and guardian-gated tools (e.g.
+ * web_fetch) fail closed even when the parent was guardian-authenticated.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+
+type CapturedTrustContext = { trustClass: string; sourceChannel: string };
+
+const setTrustContextCalls: (CapturedTrustContext | null)[] = [];
+
+class FakeConversation {
+  hasSystemPromptOverride = false;
+  messages: unknown[] = [];
+  usageStats = { inputTokens: 0, outputTokens: 0, estimatedCost: 0 };
+
+  constructor(
+    _id: string,
+    _provider: unknown,
+    _systemPrompt: string,
+    _maxTokens: number,
+    _sendToClient: (msg: ServerMessage) => void,
+  ) {}
+
+  updateClient(): void {}
+  setIsSubagent(): void {}
+  setTrustContext(ctx: CapturedTrustContext | null): void {
+    setTrustContextCalls.push(ctx);
+  }
+  setSubagentAllowedTools(): void {}
+  setPreactivatedSkillIds(): void {}
+  enqueueMessage() {
+    return { rejected: false, queued: true };
+  }
+  abort(): void {}
+  dispose(): void {}
+  sendToClient(): void {}
+  loadFromDb(): Promise<void> {
+    return Promise.resolve();
+  }
+  persistUserMessage(): string {
+    return "msg-id";
+  }
+  runAgentLoop(): Promise<void> {
+    return Promise.resolve();
+  }
+  getCurrentSystemPrompt(): string {
+    return "system";
+  }
+  injectInheritedContext(): void {}
+}
+
+mock.module("../daemon/conversation.js", () => ({
+  Conversation: FakeConversation,
+}));
+
+mock.module("../memory/conversation-bootstrap.js", () => ({
+  bootstrapConversation: () => ({ id: "conv-id" }),
+}));
+
+mock.module("../providers/registry.js", () => ({
+  getProvider: () => ({ name: "anthropic" }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    llm: { default: { provider: "anthropic", maxTokens: 4096 } },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+import { SubagentManager } from "../subagent/manager.js";
+
+describe("SubagentManager — trust context inheritance", () => {
+  afterEach(() => {
+    setTrustContextCalls.length = 0;
+  });
+
+  test("copies the parent conversation's trust context onto the child", async () => {
+    const manager = new SubagentManager();
+    const parentTrustContext = {
+      trustClass: "guardian" as const,
+      sourceChannel: "slack" as const,
+    };
+    manager.resolveParentConversation = ((id: string) => {
+      if (id === "parent-1") {
+        return { trustContext: parentTrustContext } as never;
+      }
+      return undefined;
+    }) as typeof manager.resolveParentConversation;
+
+    await manager.spawn(
+      {
+        parentConversationId: "parent-1",
+        label: "test",
+        objective: "test objective",
+      },
+      () => {},
+    );
+
+    expect(setTrustContextCalls).toEqual([parentTrustContext]);
+  });
+
+  test("does not set trust context when parent cannot be resolved", async () => {
+    const manager = new SubagentManager();
+    manager.resolveParentConversation = (() =>
+      undefined) as typeof manager.resolveParentConversation;
+
+    await manager.spawn(
+      {
+        parentConversationId: "parent-missing",
+        label: "test",
+        objective: "test objective",
+      },
+      () => {},
+    );
+
+    expect(setTrustContextCalls).toEqual([]);
+  });
+
+  test("does not set trust context when parent has none", async () => {
+    const manager = new SubagentManager();
+    manager.resolveParentConversation = (() =>
+      ({
+        trustContext: undefined,
+      }) as never) as typeof manager.resolveParentConversation;
+
+    await manager.spawn(
+      {
+        parentConversationId: "parent-untrusted",
+        label: "test",
+        objective: "test objective",
+      },
+      () => {},
+    );
+
+    expect(setTrustContextCalls).toEqual([]);
+  });
+});

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -236,15 +236,18 @@ export class SubagentManager {
       );
     }
 
+    // Resolve the parent conversation once: forks read its system prompt,
+    // and every spawn inherits its trust context below.
+    const parentConv = this.resolveParentConversation?.(
+      config.parentConversationId,
+    );
+
     let systemPrompt: string;
     if (isFork) {
       // Forks use the parent's system prompt directly — no subagent preamble.
       if (config.parentSystemPrompt) {
         systemPrompt = config.parentSystemPrompt;
       } else if (this.resolveParentConversation) {
-        const parentConv = this.resolveParentConversation(
-          config.parentConversationId,
-        );
         const resolved = parentConv?.getCurrentSystemPrompt();
         if (!resolved) {
           throw new Error(
@@ -338,6 +341,13 @@ export class SubagentManager {
     // This ensures interactive prompts (host attachment reads) fail fast.
     conversation.updateClient(wrappedSendToClient, true);
     conversation.setIsSubagent(true);
+
+    // Inherit parent trust context so guardian-gated tools evaluate the
+    // subagent against the parent's actor trust class instead of defaulting
+    // to "unknown" and failing closed.
+    if (parentConv?.trustContext) {
+      conversation.setTrustContext(parentConv.trustContext);
+    }
 
     if (isFork) {
       // Force the fork to use the parent's system prompt as-is without dynamic rebuild.


### PR DESCRIPTION
## Summary
- Subagents created via `SubagentManager.spawn()` now inherit the parent conversation's `trustContext`, so guardian-gated tools (e.g. `web_fetch`) evaluate the child against the parent's actor trust class instead of defaulting to `"unknown"` and failing closed with "requires guardian approval from a verified channel identity".
- Hoisted the `resolveParentConversation()` lookup to a single call at the top of `spawn()` so the existing fork-system-prompt path and the new trust-context path share one resolver hit.
- Added `subagent-trust-context-inheritance.test.ts` covering parent-with-trust, parent-unresolvable, and parent-without-trust.

## Original prompt
fix that and automerge the fix once you've addressed review feedback
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
