### PR TITLE
fix: align playground compaction readouts

### DIFF
--- a/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
@@ -8,7 +8,23 @@
  * into interesting states without having to wait for three real summary
  * LLM failures.
  */
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({
+    llm: {
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        contextWindow: {
+          enabled: true,
+          maxInputTokens: 500_000,
+          compactThreshold: 0.8,
+        },
+      },
+    },
+  }),
+}));
 
 import type { Conversation } from "../../../../daemon/conversation.js";
 import type { ServerMessage } from "../../../../daemon/message-protocol.js";
@@ -282,6 +298,8 @@ describe("POST /v1/conversations/:id/playground/inject-compaction-failures", () 
       expect(body).toHaveProperty(key);
     }
     expect(body.consecutiveCompactionFailures).toBe(2);
+    expect(body.maxInputTokens).toBe(200_000);
+    expect(body.thresholdTokens).toBe(160_000);
     expect(body.isCircuitOpen).toBe(false);
     expect(body.compactionCircuitOpenUntil).toBeNull();
     expect(typeof body.estimatedInputTokens).toBe("number");

--- a/assistant/src/runtime/routes/playground/__tests__/state.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/state.test.ts
@@ -4,9 +4,11 @@ mock.module("../../../../config/loader.js", () => ({
   getConfig: () => ({
     llm: {
       default: {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
         contextWindow: {
           enabled: true,
-          maxInputTokens: 200_000,
+          maxInputTokens: 500_000,
           compactThreshold: 0.8,
         },
       },

--- a/assistant/src/runtime/routes/playground/inject-failures.ts
+++ b/assistant/src/runtime/routes/playground/inject-failures.ts
@@ -20,6 +20,7 @@ import { z } from "zod";
 import { getConfig } from "../../../config/loader.js";
 import { estimatePromptTokens } from "../../../context/token-estimator.js";
 import type { Conversation } from "../../../daemon/conversation.js";
+import { resolveEffectiveDefaultContextWindowConfig } from "../../../providers/model-context.js";
 import { httpError } from "../../http-errors.js";
 import type { RouteDefinition } from "../../http-router.js";
 import { conversationNotFoundResponse } from "./conversation-not-found.js";
@@ -131,7 +132,7 @@ export interface CompactionStateResponse {
 function buildCompactionState(
   conversation: Conversation,
 ): CompactionStateResponse {
-  const ctxConfig = getConfig().llm.default.contextWindow;
+  const ctxConfig = resolveEffectiveDefaultContextWindowConfig(getConfig());
   const maxInputTokens = ctxConfig.maxInputTokens;
   const compactThresholdRatio = ctxConfig.compactThreshold;
   const isCompactionEnabled = ctxConfig.enabled;

--- a/assistant/src/runtime/routes/playground/state.ts
+++ b/assistant/src/runtime/routes/playground/state.ts
@@ -14,6 +14,7 @@
 import { getConfig } from "../../../config/loader.js";
 import { estimatePromptTokens } from "../../../context/token-estimator.js";
 import type { Conversation } from "../../../daemon/conversation.js";
+import { resolveEffectiveDefaultContextWindowConfig } from "../../../providers/model-context.js";
 import type { RouteDefinition } from "../../http-router.js";
 import { conversationNotFoundResponse } from "./conversation-not-found.js";
 import { assertPlaygroundEnabled, type PlaygroundRouteDeps } from "./index.js";
@@ -30,7 +31,7 @@ import { assertPlaygroundEnabled, type PlaygroundRouteDeps } from "./index.js";
 export function buildCompactionStateResponse(conversation: Conversation) {
   const messages = conversation.getMessages();
   const estimatedInputTokens = estimatePromptTokens(messages);
-  const cfg = getConfig().llm.default.contextWindow;
+  const cfg = resolveEffectiveDefaultContextWindowConfig(getConfig());
   const maxInputTokens = cfg.maxInputTokens;
   const compactThresholdRatio = cfg.compactThreshold;
   const thresholdTokens = Math.floor(maxInputTokens * compactThresholdRatio);


### PR DESCRIPTION
## Summary
- Use effective catalog-aware context-window config in remaining playground compaction readouts.
- Cover compaction-state and inject-failures responses with catalog-capped max token assertions.

Fixes gap identified during plan review for shared-model-catalog-assistant.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
