### PR TITLE
fix: shorten verbose WS auth strings in matrix

### DIFF
--- a/docs/service-communication-matrix.md
+++ b/docs/service-communication-matrix.md
@@ -21,9 +21,9 @@ This document enumerates every observed communication permutation between the th
 | 9 | Gateway -> Assistant | `http` | none (audioId capability token) | Audio proxy |
 | 10 | Gateway -> Assistant | `http` | JWT Bearer (service token) | Health probe (migration state) |
 | 11 | Gateway -> Assistant | `http` | none | Readiness probe |
-| 12 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only) | Twilio ConversationRelay WebSocket proxy |
+| 12 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param; unverified) | Twilio ConversationRelay WebSocket proxy |
 | 13 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param) | Browser relay WebSocket proxy |
-| 14 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only) | Twilio MediaStream WebSocket proxy |
+| 14 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param; unverified) | Twilio MediaStream WebSocket proxy |
 | 15 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param) | STT stream WebSocket proxy |
 | 16 | Assistant -> Gateway | `http` | JWT Bearer (daemon delivery token) | Channel reply delivery (Telegram) |
 | 17 | Assistant -> Gateway | `http` | JWT Bearer (daemon delivery token) | Channel reply delivery (WhatsApp) |
@@ -176,7 +176,7 @@ This document enumerates every observed communication permutation between the th
 ### Twilio ConversationRelay WebSocket proxy
 
 - **Protocol:** `websocket`
-- **Auth:** JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only)
+- **Auth:** JWT Bearer (service token, query param; unverified)
 - **Description:** Gateway proxies Twilio ConversationRelay WebSocket frames to the assistant's /v1/calls/relay endpoint.
 
 **Caller files:**
@@ -200,7 +200,7 @@ This document enumerates every observed communication permutation between the th
 ### Twilio MediaStream WebSocket proxy
 
 - **Protocol:** `websocket`
-- **Auth:** JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only)
+- **Auth:** JWT Bearer (service token, query param; unverified)
 - **Description:** Gateway proxies Twilio MediaStream WebSocket frames to the assistant's /v1/calls/media-stream endpoint.
 
 **Caller files:**

--- a/scripts/service-communication/matrix-source.ts
+++ b/scripts/service-communication/matrix-source.ts
@@ -198,7 +198,7 @@ export const MATRIX_ENTRIES: MatrixEntry[] = [
     caller: "gateway",
     callee: "assistant",
     protocol: "websocket",
-    auth: "JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only)",
+    auth: "JWT Bearer (service token, query param; unverified)",
     description:
       "Gateway proxies Twilio ConversationRelay WebSocket frames to the assistant's /v1/calls/relay endpoint.",
     callerGlobs: [
@@ -224,7 +224,7 @@ export const MATRIX_ENTRIES: MatrixEntry[] = [
     caller: "gateway",
     callee: "assistant",
     protocol: "websocket",
-    auth: "JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only)",
+    auth: "JWT Bearer (service token, query param; unverified)",
     description:
       "Gateway proxies Twilio MediaStream WebSocket frames to the assistant's /v1/calls/media-stream endpoint.",
     callerGlobs: [


### PR DESCRIPTION
## Summary
Shortens the auth description for unverified WS entries from 82 chars to a scannable form.

Fixes gap identified during plan review for matrix-review-fixes.md.

**Gap:** Verbose auth string for unverified WS entries
**What was expected:** Scannable auth field
**What was found:** 82-char auth string hurting readability
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
