### PR TITLE
fix: address 5 review findings in service communication matrix

### DIFF
--- a/docs/service-communication-matrix.md
+++ b/docs/service-communication-matrix.md
@@ -18,19 +18,26 @@ This document enumerates every observed communication permutation between the th
 | 6 | Gateway -> Assistant | `http` | JWT Bearer (service token) | OAuth callback forwarding |
 | 7 | Gateway -> Assistant | `http` | JWT Bearer (service token) | Runtime proxy |
 | 8 | Gateway -> Assistant | `http` | JWT Bearer (service token) | Log export (daemon logs) |
-| 9 | Gateway -> Assistant | `websocket` | JWT Bearer (edge relay token, query param) | Twilio ConversationRelay WebSocket proxy |
-| 10 | Assistant -> Gateway | `http` | JWT Bearer (daemon delivery token) | Channel reply delivery (Telegram) |
-| 11 | Assistant -> Gateway | `http` | JWT Bearer (daemon delivery token) | Channel reply delivery (WhatsApp) |
-| 12 | Assistant -> Gateway | `http` | JWT Bearer (daemon delivery token) | Channel reply delivery (Slack) |
-| 13 | Assistant -> Gateway | `http` | JWT Bearer (edge relay token) | Trust rules CRUD |
-| 14 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Feature flags IPC |
-| 15 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Contact data IPC |
-| 16 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Risk classification IPC |
-| 17 | Assistant -> CES | `stdio-ndjson` | none (child process) | CES RPC (local mode) |
-| 18 | Assistant -> CES | `unix-socket-ndjson` | none (bootstrap socket) | CES RPC (managed mode) |
-| 19 | Assistant -> CES | `http` | CES_SERVICE_TOKEN Bearer | CES credential CRUD (HTTP) |
-| 20 | Gateway -> CES | `http` | CES_SERVICE_TOKEN Bearer | Gateway credential reads (HTTP) |
-| 21 | Gateway -> CES | `http` | CES_SERVICE_TOKEN Bearer | Gateway CES log export (HTTP) |
+| 9 | Gateway -> Assistant | `http` | none (audioId capability token) | Audio proxy |
+| 10 | Gateway -> Assistant | `http` | JWT Bearer (service token) | Health probe (migration state) |
+| 11 | Gateway -> Assistant | `http` | none | Readiness probe |
+| 12 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only) | Twilio ConversationRelay WebSocket proxy |
+| 13 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param) | Browser relay WebSocket proxy |
+| 14 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only) | Twilio MediaStream WebSocket proxy |
+| 15 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param) | STT stream WebSocket proxy |
+| 16 | Assistant -> Gateway | `http` | JWT Bearer (daemon delivery token) | Channel reply delivery (Telegram) |
+| 17 | Assistant -> Gateway | `http` | JWT Bearer (daemon delivery token) | Channel reply delivery (WhatsApp) |
+| 18 | Assistant -> Gateway | `http` | JWT Bearer (daemon delivery token) | Channel reply delivery (Slack) |
+| 19 | Assistant -> Gateway | `http` | JWT Bearer (edge relay token) | Trust rules CRUD |
+| 20 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Feature flags IPC |
+| 21 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Contact data IPC |
+| 22 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Risk classification IPC |
+| 23 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Threshold IPC |
+| 24 | Assistant -> CES | `stdio-ndjson` | none (child process) | CES RPC (local mode) |
+| 25 | Assistant -> CES | `unix-socket-ndjson` | none (bootstrap socket) | CES RPC (managed mode) |
+| 26 | Assistant -> CES | `http` | CES_SERVICE_TOKEN Bearer | CES credential CRUD (HTTP) |
+| 27 | Gateway -> CES | `http` | CES_SERVICE_TOKEN Bearer | Gateway credential reads (HTTP) |
+| 28 | Gateway -> CES | `http` | CES_SERVICE_TOKEN Bearer | Gateway CES log export (HTTP) |
 
 ## Gateway -> Assistant
 
@@ -130,10 +137,46 @@ This document enumerates every observed communication permutation between the th
 **Callee files:**
 - `assistant/src/runtime/http-server.ts`
 
+### Audio proxy
+
+- **Protocol:** `http`
+- **Auth:** none (audioId capability token)
+- **Description:** Gateway proxies Twilio TTS audio fetch requests to the assistant's /v1/audio/:audioId endpoint. The audioId is an unguessable UUID acting as a capability token.
+
+**Caller files:**
+- `gateway/src/http/routes/audio-proxy.ts`
+
+**Callee files:**
+- `assistant/src/runtime/routes/audio-routes.ts`
+
+### Health probe (migration state)
+
+- **Protocol:** `http`
+- **Auth:** JWT Bearer (service token)
+- **Description:** Gateway forwards /healthz?include=migrations to the assistant's /v1/health endpoint to surface migration state.
+
+**Caller files:**
+- `gateway/src/index.ts`
+
+**Callee files:**
+- `assistant/src/runtime/http-server.ts`
+
+### Readiness probe
+
+- **Protocol:** `http`
+- **Auth:** none
+- **Description:** Gateway forwards /readyz to the assistant's /readyz endpoint for full-stack readiness checks.
+
+**Caller files:**
+- `gateway/src/index.ts`
+
+**Callee files:**
+- `assistant/src/runtime/http-server.ts`
+
 ### Twilio ConversationRelay WebSocket proxy
 
 - **Protocol:** `websocket`
-- **Auth:** JWT Bearer (edge relay token, query param)
+- **Auth:** JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only)
 - **Description:** Gateway proxies Twilio ConversationRelay WebSocket frames to the assistant's /v1/calls/relay endpoint.
 
 **Caller files:**
@@ -141,6 +184,42 @@ This document enumerates every observed communication permutation between the th
 
 **Callee files:**
 - `assistant/src/calls/relay-server.ts`
+
+### Browser relay WebSocket proxy
+
+- **Protocol:** `websocket`
+- **Auth:** JWT Bearer (service token, query param)
+- **Description:** Gateway proxies Chrome extension browser-relay WebSocket frames to the assistant's /v1/browser-relay endpoint.
+
+**Caller files:**
+- `gateway/src/http/routes/browser-relay-websocket.ts`
+
+**Callee files:**
+- `assistant/src/runtime/http-server.ts`
+
+### Twilio MediaStream WebSocket proxy
+
+- **Protocol:** `websocket`
+- **Auth:** JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only)
+- **Description:** Gateway proxies Twilio MediaStream WebSocket frames to the assistant's /v1/calls/media-stream endpoint.
+
+**Caller files:**
+- `gateway/src/http/routes/twilio-media-websocket.ts`
+
+**Callee files:**
+- `assistant/src/calls/media-stream-server.ts`
+
+### STT stream WebSocket proxy
+
+- **Protocol:** `websocket`
+- **Auth:** JWT Bearer (service token, query param)
+- **Description:** Gateway proxies speech-to-text audio streams to the assistant's /v1/stt/stream WebSocket endpoint.
+
+**Caller files:**
+- `gateway/src/http/routes/stt-stream-websocket.ts`
+
+**Callee files:**
+- `assistant/src/runtime/http-server.ts`
 
 ## Assistant -> Gateway
 
@@ -193,7 +272,7 @@ This document enumerates every observed communication permutation between the th
 - `assistant/src/permissions/trust-client.ts`
 
 **Callee files:**
-- `gateway/src/ipc/trust-rule-handlers.ts`
+- `gateway/src/http/routes/trust-rules.ts`
 - `gateway/src/trust-store.ts`
 
 ### Feature flags IPC
@@ -232,6 +311,20 @@ This document enumerates every observed communication permutation between the th
 - `assistant/src/ipc/gateway-client.ts`
 
 **Callee files:**
+- `gateway/src/ipc/risk-classification-handlers.ts`
+- `gateway/src/ipc/server.ts`
+
+### Threshold IPC
+
+- **Protocol:** `ipc-unix-ndjson`
+- **Auth:** none (local socket)
+- **Description:** Assistant reads auto-approve threshold configuration from the gateway via IPC (get_global_thresholds, get_conversation_threshold methods).
+
+**Caller files:**
+- `assistant/src/permissions/gateway-threshold-reader.ts`
+
+**Callee files:**
+- `gateway/src/ipc/threshold-handlers.ts`
 - `gateway/src/ipc/server.ts`
 
 ## Assistant -> CES
@@ -285,6 +378,7 @@ This document enumerates every observed communication permutation between the th
 
 **Caller files:**
 - `gateway/src/credential-reader.ts`
+- `gateway/src/credential-watcher.ts`
 
 **Callee files:**
 - `credential-executor/src/http/*.ts`

--- a/docs/service-communication-matrix.md
+++ b/docs/service-communication-matrix.md
@@ -21,9 +21,9 @@ This document enumerates every observed communication permutation between the th
 | 9 | Gateway -> Assistant | `http` | none (audioId capability token) | Audio proxy |
 | 10 | Gateway -> Assistant | `http` | JWT Bearer (service token) | Health probe (migration state) |
 | 11 | Gateway -> Assistant | `http` | none | Readiness probe |
-| 12 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only) | Twilio ConversationRelay WebSocket proxy |
+| 12 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param; unverified) | Twilio ConversationRelay WebSocket proxy |
 | 13 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param) | Browser relay WebSocket proxy |
-| 14 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only) | Twilio MediaStream WebSocket proxy |
+| 14 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param; unverified) | Twilio MediaStream WebSocket proxy |
 | 15 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param) | STT stream WebSocket proxy |
 | 16 | Assistant -> Gateway | `http` | JWT Bearer (daemon delivery token) | Channel reply delivery (Telegram) |
 | 17 | Assistant -> Gateway | `http` | JWT Bearer (daemon delivery token) | Channel reply delivery (WhatsApp) |
@@ -176,7 +176,7 @@ This document enumerates every observed communication permutation between the th
 ### Twilio ConversationRelay WebSocket proxy
 
 - **Protocol:** `websocket`
-- **Auth:** JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only)
+- **Auth:** JWT Bearer (service token, query param; unverified)
 - **Description:** Gateway proxies Twilio ConversationRelay WebSocket frames to the assistant's /v1/calls/relay endpoint.
 
 **Caller files:**
@@ -200,7 +200,7 @@ This document enumerates every observed communication permutation between the th
 ### Twilio MediaStream WebSocket proxy
 
 - **Protocol:** `websocket`
-- **Auth:** JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only)
+- **Auth:** JWT Bearer (service token, query param; unverified)
 - **Description:** Gateway proxies Twilio MediaStream WebSocket frames to the assistant's /v1/calls/media-stream endpoint.
 
 **Caller files:**

--- a/scripts/service-communication/matrix-source.ts
+++ b/scripts/service-communication/matrix-source.ts
@@ -198,7 +198,7 @@ export const MATRIX_ENTRIES: MatrixEntry[] = [
     caller: "gateway",
     callee: "assistant",
     protocol: "websocket",
-    auth: "JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only)",
+    auth: "JWT Bearer (service token, query param; unverified)",
     description:
       "Gateway proxies Twilio ConversationRelay WebSocket frames to the assistant's /v1/calls/relay endpoint.",
     callerGlobs: [
@@ -224,7 +224,7 @@ export const MATRIX_ENTRIES: MatrixEntry[] = [
     caller: "gateway",
     callee: "assistant",
     protocol: "websocket",
-    auth: "JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only)",
+    auth: "JWT Bearer (service token, query param; unverified)",
     description:
       "Gateway proxies Twilio MediaStream WebSocket frames to the assistant's /v1/calls/media-stream endpoint.",
     callerGlobs: [

--- a/scripts/service-communication/matrix-source.ts
+++ b/scripts/service-communication/matrix-source.ts
@@ -154,6 +154,41 @@ export const MATRIX_ENTRIES: MatrixEntry[] = [
     callerGlobs: ["gateway/src/http/routes/log-export.ts"],
     calleeGlobs: ["assistant/src/runtime/http-server.ts"],
   },
+  {
+    label: "Audio proxy",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "http",
+    auth: "none (audioId capability token)",
+    description:
+      "Gateway proxies Twilio TTS audio fetch requests to the assistant's /v1/audio/:audioId endpoint. The audioId is an unguessable UUID acting as a capability token.",
+    callerGlobs: ["gateway/src/http/routes/audio-proxy.ts"],
+    calleeGlobs: [
+      "assistant/src/runtime/routes/audio-routes.ts",
+    ],
+  },
+  {
+    label: "Health probe (migration state)",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "http",
+    auth: "JWT Bearer (service token)",
+    description:
+      "Gateway forwards /healthz?include=migrations to the assistant's /v1/health endpoint to surface migration state.",
+    callerGlobs: ["gateway/src/index.ts"],
+    calleeGlobs: ["assistant/src/runtime/http-server.ts"],
+  },
+  {
+    label: "Readiness probe",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "http",
+    auth: "none",
+    description:
+      "Gateway forwards /readyz to the assistant's /readyz endpoint for full-stack readiness checks.",
+    callerGlobs: ["gateway/src/index.ts"],
+    calleeGlobs: ["assistant/src/runtime/http-server.ts"],
+  },
 
   // =========================================================================
   // Gateway -> Assistant (WebSocket)
@@ -163,13 +198,52 @@ export const MATRIX_ENTRIES: MatrixEntry[] = [
     caller: "gateway",
     callee: "assistant",
     protocol: "websocket",
-    auth: "JWT Bearer (edge relay token, query param)",
+    auth: "JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only)",
     description:
       "Gateway proxies Twilio ConversationRelay WebSocket frames to the assistant's /v1/calls/relay endpoint.",
     callerGlobs: [
       "gateway/src/http/routes/twilio-relay-websocket.ts",
     ],
     calleeGlobs: ["assistant/src/calls/relay-server.ts"],
+  },
+  {
+    label: "Browser relay WebSocket proxy",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "websocket",
+    auth: "JWT Bearer (service token, query param)",
+    description:
+      "Gateway proxies Chrome extension browser-relay WebSocket frames to the assistant's /v1/browser-relay endpoint.",
+    callerGlobs: [
+      "gateway/src/http/routes/browser-relay-websocket.ts",
+    ],
+    calleeGlobs: ["assistant/src/runtime/http-server.ts"],
+  },
+  {
+    label: "Twilio MediaStream WebSocket proxy",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "websocket",
+    auth: "JWT Bearer (service token, query param — sent, not verified by callee; private-network guard only)",
+    description:
+      "Gateway proxies Twilio MediaStream WebSocket frames to the assistant's /v1/calls/media-stream endpoint.",
+    callerGlobs: [
+      "gateway/src/http/routes/twilio-media-websocket.ts",
+    ],
+    calleeGlobs: ["assistant/src/calls/media-stream-server.ts"],
+  },
+  {
+    label: "STT stream WebSocket proxy",
+    caller: "gateway",
+    callee: "assistant",
+    protocol: "websocket",
+    auth: "JWT Bearer (service token, query param)",
+    description:
+      "Gateway proxies speech-to-text audio streams to the assistant's /v1/stt/stream WebSocket endpoint.",
+    callerGlobs: [
+      "gateway/src/http/routes/stt-stream-websocket.ts",
+    ],
+    calleeGlobs: ["assistant/src/runtime/http-server.ts"],
   },
 
   // =========================================================================
@@ -227,7 +301,7 @@ export const MATRIX_ENTRIES: MatrixEntry[] = [
       "Assistant reads/writes trust rules via the gateway's /v1/trust-rules REST API (containerized mode).",
     callerGlobs: ["assistant/src/permissions/trust-client.ts"],
     calleeGlobs: [
-      "gateway/src/ipc/trust-rule-handlers.ts",
+      "gateway/src/http/routes/trust-rules.ts",
       "gateway/src/trust-store.ts",
     ],
   },
@@ -273,6 +347,23 @@ export const MATRIX_ENTRIES: MatrixEntry[] = [
       "Assistant classifies tool invocation risk via the persistent IPC connection to the gateway (classify_risk method).",
     callerGlobs: ["assistant/src/ipc/gateway-client.ts"],
     calleeGlobs: [
+      "gateway/src/ipc/risk-classification-handlers.ts",
+      "gateway/src/ipc/server.ts",
+    ],
+  },
+  {
+    label: "Threshold IPC",
+    caller: "assistant",
+    callee: "gateway",
+    protocol: "ipc-unix-ndjson",
+    auth: "none (local socket)",
+    description:
+      "Assistant reads auto-approve threshold configuration from the gateway via IPC (get_global_thresholds, get_conversation_threshold methods).",
+    callerGlobs: [
+      "assistant/src/permissions/gateway-threshold-reader.ts",
+    ],
+    calleeGlobs: [
+      "gateway/src/ipc/threshold-handlers.ts",
       "gateway/src/ipc/server.ts",
     ],
   },
@@ -348,7 +439,10 @@ export const MATRIX_ENTRIES: MatrixEntry[] = [
     auth: "CES_SERVICE_TOKEN Bearer",
     description:
       "Gateway reads credentials from the CES HTTP API (CES_CREDENTIAL_URL) in containerized mode for channel auth (Telegram bot token, Twilio SID, etc.).",
-    callerGlobs: ["gateway/src/credential-reader.ts"],
+    callerGlobs: [
+      "gateway/src/credential-reader.ts",
+      "gateway/src/credential-watcher.ts",
+    ],
     calleeGlobs: [
       "credential-executor/src/http/*.ts",
     ],


### PR DESCRIPTION
## Summary
Addresses 5 review findings from the post-merge review of the service communication matrix (PR #27865):

1. **[P1]** Add 3 missing Gateway→Assistant WS entries (browser-relay, twilio-media, STT stream) and fix auth on existing ConversationRelay entry
2. **[P1]** Add missing Assistant→Gateway threshold IPC entry
3. **[P2]** Fix trust-rules callee globs (pointed to IPC handler instead of HTTP route)
4. **[P2]** Add missing audio-proxy and health/readiness probe HTTP entries (split by auth)
5. **[P3]** Expand drift-guard glob coverage for credential-watcher and risk-classification handlers

## Self-review result
GAPS FOUND — 1 cosmetic gap fixed (verbose auth string shortened)

## PRs merged into feature branch
- #27906: fix: address 5 review findings in service communication matrix

### Fix PRs
- #27907: fix: shorten verbose WS auth strings in matrix

Part of plan: matrix-review-fixes.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
