### PR TITLE
feat(clients): rewire V3RuleEditorModal save to v3 trust rules API

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -850,7 +850,10 @@ private struct ToolCallStepDetailRow: View {
                                 tool: rule.toolName,
                                 pattern: rule.pattern,
                                 risk: rule.riskLevel,
-                                description: tc.reasonDescription ?? "\(rule.toolName) — \(rule.pattern)"
+                                description: {
+                                    let desc = tc.reasonDescription ?? ""
+                                    return desc.isEmpty ? "\(rule.toolName) — \(rule.pattern)" : desc
+                                }()
                             )
                         }
                     },

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -750,6 +750,7 @@ private struct ToolCallStepDetailRow: View {
     /// Shared across all rows — `TrustRuleClient` is a stateless HTTP client,
     /// so a single static instance avoids re-creation on every view rebuild.
     private static let trustRuleClient: TrustRuleClientProtocol = TrustRuleClient()
+    private static let trustRuleV3Client = TrustRuleV3Client()
 
     private static let coloredOutputCache: NSCache<NSString, StepDetailAttributedStringCacheEntry> = {
         let cache = NSCache<NSString, StepDetailAttributedStringCacheEntry>()
@@ -845,13 +846,11 @@ private struct ToolCallStepDetailRow: View {
                     scopeOptions: Self.v3ScopeOptions(from: tc),
                     onSave: { rule in
                         Task {
-                            try? await Self.trustRuleClient.addTrustRule(
-                                toolName: rule.toolName,
+                            try? await Self.trustRuleV3Client.createRule(
+                                tool: rule.toolName,
                                 pattern: rule.pattern,
-                                scope: rule.scope,
-                                decision: "allow",
-                                executionTarget: nil,
-                                riskLevel: rule.riskLevel
+                                risk: rule.riskLevel,
+                                description: tc.reasonDescription ?? "\(rule.toolName) — \(rule.pattern)"
                             )
                         }
                     },


### PR DESCRIPTION
## Summary
- V3RuleEditorModal save now calls TrustRuleV3Client.createRule() when permission-controls-v3 is on
- Sends tool, pattern, risk, and description to /v1/trust-rules-v3
- v1 addTrustRule path unchanged when flag is off

Part of plan: v3-trust-rules-client.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
