### PR TITLE
feat(clients): add V3TrustRulesView trust rules manager

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/V3TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/V3TrustRulesView.swift
@@ -1,0 +1,350 @@
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - V3 Trust Rules View
+
+struct V3TrustRulesView: View {
+    let trustRuleV3Client: TrustRuleV3ClientProtocol
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var rules: [TrustRuleV3] = []
+    @State private var isLoading = true
+    @State private var showAllDefaults = false
+    @State private var editingRule: TrustRuleV3? = nil
+    @State private var ruleToDelete: TrustRuleV3? = nil
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Trust Rules")
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+                Spacer()
+                VToggle(isOn: $showAllDefaults, label: "Show all defaults")
+                VButton(label: "Done", style: .outlined) {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+            }
+            .padding()
+
+            SettingsDivider()
+
+            // Content
+            if isLoading {
+                Spacer()
+                ProgressView()
+                Spacer()
+            } else if rules.isEmpty {
+                Spacer()
+                VStack(spacing: VSpacing.sm) {
+                    VIconView(.shieldCheck, size: 32)
+                        .foregroundStyle(VColor.contentTertiary)
+                    Text("No trust rules yet. Rules are created when you classify actions from permission prompts.")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 320)
+                }
+                Spacer()
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(rules) { rule in
+                            V3TrustRuleRow(
+                                rule: rule,
+                                onEdit: { editingRule = rule },
+                                onDelete: { ruleToDelete = rule }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        .frame(width: 600, minHeight: 500)
+        .task { await loadRules() }
+        .onChange(of: showAllDefaults) { await loadRules() }
+        .sheet(item: $editingRule) { rule in
+            V3TrustRuleEditSheet(
+                rule: rule,
+                trustRuleV3Client: trustRuleV3Client,
+                onSave: { await loadRules() }
+            )
+        }
+        .alert("Delete Trust Rule?", isPresented: Binding(
+            get: { ruleToDelete != nil },
+            set: { if !$0 { ruleToDelete = nil } }
+        )) {
+            Button("Cancel", role: .cancel) { ruleToDelete = nil }
+            Button("Delete", role: .destructive) {
+                if let rule = ruleToDelete {
+                    Task { await deleteRule(rule: rule) }
+                    ruleToDelete = nil
+                }
+            }
+        } message: {
+            if let rule = ruleToDelete {
+                Text("Remove the trust rule for \(rule.tool) matching \"\(rule.pattern)\"?")
+            }
+        }
+    }
+
+    // MARK: - Data Loading
+
+    @MainActor
+    private func loadRules() async {
+        isLoading = true
+        do {
+            if showAllDefaults {
+                // Fetch all default rules plus user-relevant rules, merge and deduplicate
+                async let defaultRules = trustRuleV3Client.listRules(origin: "default", tool: nil, includeDeleted: nil)
+                async let userRules = trustRuleV3Client.listRules(origin: nil, tool: nil, includeDeleted: nil)
+                let allDefaults = (try? await defaultRules) ?? []
+                let allUser = (try? await userRules) ?? []
+                var seen = Set<String>()
+                var merged: [TrustRuleV3] = []
+                for rule in allUser {
+                    if seen.insert(rule.id).inserted {
+                        merged.append(rule)
+                    }
+                }
+                for rule in allDefaults {
+                    if seen.insert(rule.id).inserted {
+                        merged.append(rule)
+                    }
+                }
+                rules = merged.sorted { lhs, rhs in
+                    if lhs.tool != rhs.tool { return lhs.tool < rhs.tool }
+                    return lhs.description < rhs.description
+                }
+            } else {
+                let fetched = try await trustRuleV3Client.listRules(origin: nil, tool: nil, includeDeleted: nil)
+                rules = fetched.sorted { lhs, rhs in
+                    if lhs.tool != rhs.tool { return lhs.tool < rhs.tool }
+                    return lhs.description < rhs.description
+                }
+            }
+        } catch {
+            // Fetch failed — keep previous rules visible
+        }
+        isLoading = false
+    }
+
+    // MARK: - Delete
+
+    @MainActor
+    private func deleteRule(rule: TrustRuleV3) async {
+        try? await trustRuleV3Client.deleteRule(id: rule.id)
+        withAnimation {
+            rules.removeAll { $0.id == rule.id }
+        }
+    }
+}
+
+// MARK: - V3 Trust Rule Row
+
+private struct V3TrustRuleRow: View {
+    let rule: TrustRuleV3
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+
+    private func riskColor(_ risk: String) -> Color {
+        switch risk.lowercased() {
+        case "low": return VColor.systemPositiveStrong
+        case "medium": return VColor.systemMidStrong
+        case "high": return VColor.systemNegativeStrong
+        default: return VColor.contentTertiary
+        }
+    }
+
+    /// Allow deleting user-defined rules and modified defaults; hide delete for unmodified defaults.
+    private var canDelete: Bool {
+        !(rule.origin == "default" && !rule.userModified)
+    }
+
+    var body: some View {
+        HStack(spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(rule.description)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(2)
+                Text(rule.tool)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+
+            Spacer()
+
+            // Risk badge
+            Text(rule.risk.lowercased())
+                .font(VFont.labelDefault)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 2)
+                .background(riskColor(rule.risk).opacity(0.15))
+                .foregroundStyle(riskColor(rule.risk))
+                .clipShape(Capsule())
+
+            // Origin / modified indicators
+            if rule.origin == "default" {
+                Text("Default")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+
+            if rule.userModified {
+                Text("Modified")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.systemMidStrong)
+            }
+
+            // Edit button
+            Button {
+                onEdit()
+            } label: {
+                VIconView(.pencil, size: 14)
+            }
+            .buttonStyle(.borderless)
+
+            // Delete button (only for user-defined or modified defaults)
+            if canDelete {
+                Button {
+                    onDelete()
+                } label: {
+                    VIconView(.trash, size: 14)
+                        .foregroundStyle(VColor.systemNegativeStrong)
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .contentShape(Rectangle())
+        .onTapGesture { onEdit() }
+    }
+}
+
+// MARK: - V3 Trust Rule Edit Sheet
+
+private struct V3TrustRuleEditSheet: View {
+    let rule: TrustRuleV3
+    let trustRuleV3Client: TrustRuleV3ClientProtocol
+    let onSave: @Sendable () async -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedRisk: String = ""
+    @State private var isSaving = false
+
+    var body: some View {
+        VStack(spacing: VSpacing.lg) {
+            // Title
+            Text("Edit Trust Rule")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+
+            // Pattern
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text("Pattern")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                Text(rule.pattern)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                    .textSelection(.enabled)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Description
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text("Description")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                Text(rule.description)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Risk level picker
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("Risk Level")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+
+                HStack(spacing: VSpacing.sm) {
+                    riskLevelButton(label: "Low", value: "low", color: VColor.systemPositiveStrong)
+                    riskLevelButton(label: "Medium", value: "medium", color: VColor.systemMidStrong)
+                    riskLevelButton(label: "High", value: "high", color: VColor.systemNegativeStrong)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Reset to Default button (only for modified defaults)
+            if rule.origin == "default" && rule.userModified {
+                VButton(label: "Reset to Default", style: .outlined) {
+                    Task {
+                        try? await trustRuleV3Client.resetRule(id: rule.id)
+                        await onSave()
+                        dismiss()
+                    }
+                }
+            }
+
+            Spacer()
+
+            // Buttons row
+            HStack {
+                Spacer()
+                VButton(label: "Cancel", style: .ghost) {
+                    dismiss()
+                }
+                VButton(
+                    label: "Save",
+                    style: .primary,
+                    isDisabled: selectedRisk == rule.risk || isSaving
+                ) {
+                    isSaving = true
+                    Task {
+                        try? await trustRuleV3Client.updateRule(id: rule.id, risk: selectedRisk, description: nil)
+                        await onSave()
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .frame(width: 400)
+        .onAppear {
+            selectedRisk = rule.risk
+        }
+    }
+
+    @ViewBuilder
+    private func riskLevelButton(label: String, value: String, color: Color) -> some View {
+        Button {
+            selectedRisk = value
+        } label: {
+            HStack(spacing: VSpacing.xs) {
+                Circle()
+                    .fill(color)
+                    .frame(width: 8, height: 8)
+                Text(label)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(selectedRisk == value ? VColor.auxWhite : color)
+            }
+            .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
+            .background(
+                selectedRisk == value
+                    ? color
+                    : Color.clear
+            )
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .strokeBorder(color, lineWidth: selectedRisk == value ? 0 : 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/V3TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/V3TrustRulesView.swift
@@ -64,7 +64,7 @@ struct V3TrustRulesView: View {
         }
         .frame(width: 600, minHeight: 500)
         .task { await loadRules() }
-        .onChange(of: showAllDefaults) { await loadRules() }
+        .onChange(of: showAllDefaults) { _, _ in await loadRules() }
         .sheet(item: $editingRule) { rule in
             V3TrustRuleEditSheet(
                 rule: rule,
@@ -100,8 +100,8 @@ struct V3TrustRulesView: View {
                 // Fetch all default rules plus user-relevant rules, merge and deduplicate
                 async let defaultRules = trustRuleV3Client.listRules(origin: "default", tool: nil, includeDeleted: nil)
                 async let userRules = trustRuleV3Client.listRules(origin: nil, tool: nil, includeDeleted: nil)
-                let allDefaults = (try? await defaultRules) ?? []
-                let allUser = (try? await userRules) ?? []
+                let allDefaults = try await defaultRules
+                let allUser = try await userRules
                 var seen = Set<String>()
                 var merged: [TrustRuleV3] = []
                 for rule in allUser {
@@ -135,9 +135,13 @@ struct V3TrustRulesView: View {
 
     @MainActor
     private func deleteRule(rule: TrustRuleV3) async {
-        try? await trustRuleV3Client.deleteRule(id: rule.id)
-        withAnimation {
-            rules.removeAll { $0.id == rule.id }
+        do {
+            try await trustRuleV3Client.deleteRule(id: rule.id)
+            withAnimation {
+                rules.removeAll { $0.id == rule.id }
+            }
+        } catch {
+            // Delete failed — keep the rule visible
         }
     }
 }
@@ -180,8 +184,7 @@ private struct V3TrustRuleRow: View {
             // Risk badge
             Text(rule.risk.lowercased())
                 .font(VFont.labelDefault)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 2)
+                .padding(EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 8))
                 .background(riskColor(rule.risk).opacity(0.15))
                 .foregroundStyle(riskColor(rule.risk))
                 .clipShape(Capsule())
@@ -206,6 +209,7 @@ private struct V3TrustRuleRow: View {
                 VIconView(.pencil, size: 14)
             }
             .buttonStyle(.borderless)
+            .accessibilityLabel("Edit \(rule.description) trust rule")
 
             // Delete button (only for user-defined or modified defaults)
             if canDelete {
@@ -216,12 +220,21 @@ private struct V3TrustRuleRow: View {
                         .foregroundStyle(VColor.systemNegativeStrong)
                 }
                 .buttonStyle(.borderless)
+                .accessibilityLabel("Delete \(rule.description) trust rule")
             }
         }
-        .padding(.horizontal, VSpacing.lg)
-        .padding(.vertical, VSpacing.sm)
+        .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.lg, bottom: VSpacing.sm, trailing: VSpacing.lg))
         .contentShape(Rectangle())
-        .onTapGesture { onEdit() }
+        .background {
+            Button("") { onEdit() }
+                .buttonStyle(.plain)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .accessibilityHidden(true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(rule.description)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction { onEdit() }
     }
 }
 
@@ -235,6 +248,7 @@ private struct V3TrustRuleEditSheet: View {
     @Environment(\.dismiss) private var dismiss
     @State private var selectedRisk: String = ""
     @State private var isSaving = false
+    @State private var saveError: String? = nil
 
     var body: some View {
         VStack(spacing: VSpacing.lg) {
@@ -283,12 +297,27 @@ private struct V3TrustRuleEditSheet: View {
             // Reset to Default button (only for modified defaults)
             if rule.origin == "default" && rule.userModified {
                 VButton(label: "Reset to Default", style: .outlined) {
+                    isSaving = true
+                    saveError = nil
                     Task {
-                        try? await trustRuleV3Client.resetRule(id: rule.id)
-                        await onSave()
-                        dismiss()
+                        do {
+                            try await trustRuleV3Client.resetRule(id: rule.id)
+                            await onSave()
+                            dismiss()
+                        } catch {
+                            saveError = error.localizedDescription
+                            isSaving = false
+                        }
                     }
                 }
+            }
+
+            // Error message
+            if let saveError {
+                Text(saveError)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             Spacer()
@@ -305,10 +334,16 @@ private struct V3TrustRuleEditSheet: View {
                     isDisabled: selectedRisk == rule.risk || isSaving
                 ) {
                     isSaving = true
+                    saveError = nil
                     Task {
-                        try? await trustRuleV3Client.updateRule(id: rule.id, risk: selectedRisk, description: nil)
-                        await onSave()
-                        dismiss()
+                        do {
+                            try await trustRuleV3Client.updateRule(id: rule.id, risk: selectedRisk, description: nil)
+                            await onSave()
+                            dismiss()
+                        } catch {
+                            saveError = error.localizedDescription
+                            isSaving = false
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- V3TrustRulesView with list of trust rules, toggle for defaults, edit/delete
- V3TrustRuleEditSheet with risk level capsule picker, reset to default
- Risk badges (Low green, Medium yellow, High red), origin/modified indicators

Part of plan: v3-trust-rules-client.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
