### PR TITLE
feat(clients): wire V3TrustRulesView into Settings panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -299,7 +299,11 @@ struct SettingsPanel: View {
             bootstrapGeneration += 1
         }
         .sheet(isPresented: $showingTrustRules, onDismiss: { connectionManager?.isTrustRulesSheetOpen = false }) {
-            TrustRulesView(trustRuleClient: TrustRuleClient())
+            if assistantFeatureFlagStore.isEnabled("permission-controls-v3") {
+                V3TrustRulesView(trustRuleV3Client: TrustRuleV3Client())
+            } else {
+                TrustRulesView(trustRuleClient: TrustRuleClient())
+            }
         }
         .onAppear {
             devUnlockMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in


### PR DESCRIPTION
## Summary
- Settings > Privacy & Permissions > Manage shows V3TrustRulesView when permission-controls-v3 is on
- Existing v1 TrustRulesView shown when flag is off

Part of plan: v3-trust-rules-client.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
