### PR TITLE
fix: resolve V3TrustRulesView build warnings and error

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/V3TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/V3TrustRulesView.swift
@@ -62,7 +62,8 @@ struct V3TrustRulesView: View {
                 }
             }
         }
-        .frame(width: 600, minHeight: 500)
+        .frame(width: 600)
+        .frame(minHeight: 500)
         .task(id: showAllDefaults) { await loadRules() }
         .sheet(item: $editingRule) { rule in
             V3TrustRuleEditSheet(
@@ -295,7 +296,7 @@ private struct V3TrustRuleEditSheet: View {
                     saveError = nil
                     Task {
                         do {
-                            try await trustRuleV3Client.resetRule(id: rule.id)
+                            _ = try await trustRuleV3Client.resetRule(id: rule.id)
                             await onSave()
                             dismiss()
                         } catch {
@@ -331,7 +332,7 @@ private struct V3TrustRuleEditSheet: View {
                     saveError = nil
                     Task {
                         do {
-                            try await trustRuleV3Client.updateRule(id: rule.id, risk: selectedRisk, description: nil)
+                            _ = try await trustRuleV3Client.updateRule(id: rule.id, risk: selectedRisk, description: nil)
                             await onSave()
                             dismiss()
                         } catch {


### PR DESCRIPTION
## Summary
- Add `_ =` to discard unused return values from `resetRule(id:)` and `updateRule(id:risk:description:)` calls, fixing two `#no-usage` warnings
- Split `.frame(width: 600, minHeight: 500)` into `.frame(width: 600).frame(minHeight: 500)` to fix the "extra argument 'minHeight' in call" build error (these params belong to different `.frame` overloads)

## Original prompt
Fix mac build warnings for unused results of `resetRule(id:)` and `updateRule(id:risk:description:)`, and the build error from `.frame(width:minHeight:)` in V3TrustRulesView.swift.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
