### PR TITLE
test(injector-chain): align third-party injector test title and order

### DIFF
--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -365,22 +365,22 @@ describe("injector chain", () => {
     );
   });
 
-  test("third-party injector at order 25 lands between unified-turn-context (20) and pkb-context (30) in the final message", async () => {
+  test("third-party prepend injector at order 15 lands between workspace (10) and unified-turn-context (20) in the final message", async () => {
     // Proves the extensibility contract end-to-end: a plugin-registered
-    // injector at `order: 25` with `placement: "prepend-user-tail"` slots
-    // between the unified-turn prepend (order 20, executes just before
-    // workspace) and the PKB after-memory splice (order 30). Because it
-    // uses prepend-user-tail placement it becomes a third prepend,
-    // landing between workspace (topmost) and unified-turn.
+    // injector at `order: 15` with `placement: "prepend-user-tail"` slots
+    // between the workspace prepend (order 10) and the unified-turn
+    // prepend (order 20). Because descending-order application for
+    // prepends puts the lowest-`order` injector topmost, workspace ends
+    // up on top, then plugin@15, then unified-turn.
     registerPlugin(defaultInjectorsPlugin);
     registerPlugin(
-      wrapInPlugin("third-party-25-prepend", [
+      wrapInPlugin("third-party-15-prepend", [
         {
-          name: "plugin-25",
+          name: "plugin-15",
           order: 15, // between workspace (10) and unified-turn (20)
           async produce(): Promise<InjectionBlock> {
             return {
-              id: "plugin-25",
+              id: "plugin-15",
               text: "<plugin_block_15/>",
               placement: "prepend-user-tail",
             };


### PR DESCRIPTION
Addresses Devin feedback on PR #27791: test at injector-chain.test.ts:368 labeled 'order 25' but created an injector at order 15. The scenario at line 368 actually covers a different case — a prepend-user-tail injector at order 15 landing between workspace (10) and unified-turn (20). Order 25 is already covered at line 117. Renamed the test title, comment block, plugin/block identifiers to match the actual order (15).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
