### PR TITLE
fix(ipc/host-providers): thread callSite to sendMessage + clear config spy

### DIFF
--- a/assistant/src/ipc/skill-routes/__tests__/providers.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/providers.test.ts
@@ -84,6 +84,7 @@ beforeEach(() => {
   sttSupportsBoundarySpy.mockClear();
   getTtsProviderSpy.mockClear();
   resolveTtsConfigSpy.mockClear();
+  getConfigSpy.mockClear();
   getProviderKeyAsyncSpy.mockClear();
 });
 

--- a/assistant/src/ipc/skill-routes/__tests__/providers.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/providers.test.ts
@@ -144,7 +144,10 @@ describe("host.providers.llm.complete", () => {
     ];
     expect(Array.isArray(call[1])).toBe(true);
     expect((call[1] as unknown[]).length).toBe(1);
-    expect(call[3]?.config).toEqual({ model: "override-model" });
+    expect(call[3]?.config).toEqual({
+      model: "override-model",
+      callSite: "mainAgent",
+    });
   });
 
   test("rejects an unknown callSite", async () => {

--- a/assistant/src/ipc/skill-routes/providers.ts
+++ b/assistant/src/ipc/skill-routes/providers.ts
@@ -80,7 +80,7 @@ async function handleLlmComplete(params?: Record<string, unknown>) {
     messages as Message[],
     tools as ToolDefinition[] | undefined,
     systemPrompt,
-    config ? { config: config as SendMessageConfig } : undefined,
+    { config: { ...((config as SendMessageConfig) ?? {}), callSite } },
   );
 }
 


### PR DESCRIPTION
Addresses Codex + Devin feedback on PR #27872. The llm.complete handler parsed a top-level callSite but didn't forward it to provider.sendMessage, so skills that omitted config.callSite fell back to default-model routing. Tests also missed a mockClear() on getConfigSpy in beforeEach, which made toHaveBeenCalled assertions cumulative.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
