### PR TITLE
fix(meet-join/reaper): align ReaperLogger to (msg, meta?) signature

### DIFF
--- a/skills/meet-join/daemon/docker-runner.ts
+++ b/skills/meet-join/daemon/docker-runner.ts
@@ -1109,16 +1109,20 @@ export const REAPER_TERM_KILL_GRACE_MS = 10_000;
  *   `docker rm` it manually once.
  */
 /**
- * Structural subset of a pino-style structured logger — the reaper only
- * emits info/warn/debug lines and doesn't want a hard dep on pino's type
- * export from this module. The daemon's real logger (`pino.Logger`) is
- * assignable to this shape.
+ * Structural subset of the SkillHost `Logger` contract — the reaper only
+ * emits info/warn/debug lines and doesn't want a hard dep on the full
+ * contract re-export from this module. Signature matches
+ * `@vellumai/skill-host-contracts` `Logger`: `(msg: string, meta?: unknown)`.
+ *
+ * Do not restore pino-style `(obj, msg?)` here: TypeScript's bivariant
+ * method checking would accept a `Logger` in this slot and silently swap
+ * the arguments at runtime.
  */
 export interface ReaperLogger {
-  info(obj: Record<string, unknown>, msg?: string): void;
-  warn(obj: Record<string, unknown>, msg?: string): void;
-  error?(obj: Record<string, unknown>, msg?: string): void;
-  debug(obj: Record<string, unknown>, msg?: string): void;
+  info(msg: string, meta?: unknown): void;
+  warn(msg: string, meta?: unknown): void;
+  error?(msg: string, meta?: unknown): void;
+  debug(msg: string, meta?: unknown): void;
 }
 
 export async function reapOrphanedMeetBots(opts: {
@@ -1150,7 +1154,7 @@ export async function reapOrphanedMeetBots(opts: {
       all: false,
     });
   } catch (err) {
-    logger.warn({ err }, "reapOrphanedMeetBots: listContainers failed");
+    logger.warn("reapOrphanedMeetBots: listContainers failed", { err });
     return { killed, kept, skippedUnlabeled };
   }
 
@@ -1167,8 +1171,8 @@ export async function reapOrphanedMeetBots(opts: {
     // container is actually stale.
     if (containerInstance === undefined) {
       logger.debug(
-        { containerId, meetingId },
         "reapOrphanedMeetBots: skipping pre-label container (missing vellum.meet.instance)",
+        { containerId, meetingId },
       );
       skippedUnlabeled.push(containerId);
       continue;
@@ -1207,21 +1211,23 @@ export async function reapOrphanedMeetBots(opts: {
       setTimeout(() => {
         docker.kill(containerId, "SIGKILL").catch((err: unknown) => {
           logger.debug(
-            { err, containerId, meetingId },
             "reapOrphanedMeetBots: delayed SIGKILL failed (container likely already dead)",
+            { err, containerId, meetingId },
           );
         });
       }, REAPER_TERM_KILL_GRACE_MS).unref?.();
-      logger.info(
-        { containerId, meetingId, reason: "orphan" },
-        "orphan meet-bot reaped",
-      );
+      logger.info("orphan meet-bot reaped", {
+        containerId,
+        meetingId,
+        reason: "orphan",
+      });
       killed.push(containerId);
     } catch (err) {
-      logger.warn(
-        { err, containerId, meetingId },
-        "reapOrphanedMeetBots: kill failed — continuing sweep",
-      );
+      logger.warn("reapOrphanedMeetBots: kill failed — continuing sweep", {
+        err,
+        containerId,
+        meetingId,
+      });
     }
   }
 

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -123,7 +123,6 @@ import type {
   DockerRunner,
   DockerRunResult,
   DockerWaitResult,
-  ReaperLogger,
 } from "./docker-runner.js";
 import {
   meetEventDispatcher,
@@ -1020,7 +1019,7 @@ class MeetSessionManagerImpl {
         },
         instanceHash: getMeetBotInstanceHash(),
         createdBefore: daemonStartEpochSeconds,
-        logger: adaptContractLoggerToReaperLogger(reaperLog),
+        logger: reaperLog,
       }).catch((err: unknown) => {
         reaperLog.warn(
           "Startup orphan-reaper sweep threw — continuing",
@@ -2722,21 +2721,6 @@ function resolveSubModuleFactory<F extends SubModuleFactory>(name: string): F {
     );
   }
   return factory as F;
-}
-
-/**
- * Adapter: wrap a skill-host-contracts {@link Logger} (contract shape
- * `(msg, meta)`) so it satisfies the pino-style {@link ReaperLogger}
- * shape (`(obj, msg)`) consumed by {@link reapOrphanedMeetBots}. Keeping
- * the reaper's pino shape avoids churn in the docker-runner module.
- */
-function adaptContractLoggerToReaperLogger(log: Logger): ReaperLogger {
-  return {
-    info: (obj, msg) => log.info(msg ?? "", obj),
-    warn: (obj, msg) => log.warn(msg ?? "", obj),
-    error: (obj, msg) => log.error(msg ?? "", obj),
-    debug: (obj, msg) => log.debug(msg ?? "", obj),
-  };
 }
 
 /**


### PR DESCRIPTION
Addresses Devin feedback on PR #27784: ReaperLogger pino-style (obj, msg?) silently swaps args at runtime when a SkillHost Logger is substituted due to TS bivariant method checking.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
