### PR TITLE
fix(daemon/meet-host-supervisor): kill child on teardown + clear activeSessions + copy fix

### DIFF
--- a/assistant/src/daemon/__tests__/meet-host-supervisor.test.ts
+++ b/assistant/src/daemon/__tests__/meet-host-supervisor.test.ts
@@ -191,7 +191,7 @@ describe("MeetHostSupervisor", () => {
 
   test("hash mismatch rejects ensureRunning with a clear error and allows re-spawn", async () => {
     harness = makeHarness({ manifestHash: "expected-hash" });
-    const { supervisor, spawnFn } = harness;
+    const { supervisor, spawnFn, child: firstChild } = harness;
 
     const p = supervisor.ensureRunning();
     await tick();
@@ -200,8 +200,13 @@ describe("MeetHostSupervisor", () => {
     await expect(p).rejects.toThrow(/source hash mismatch/);
     await expect(p).rejects.toThrow(/Regenerate the meet-join manifest/);
 
+    expect(firstChild.kill).toHaveBeenCalledWith("SIGKILL");
+
     // After a rejected handshake the supervisor should be ready to try again.
     expect(supervisor.isRunning).toBe(false);
+
+    const secondChild = new FakeChild();
+    spawnFn.mockImplementation(() => secondChild as unknown as ChildProcess);
 
     const p2 = supervisor.ensureRunning();
     expect(spawnFn).toHaveBeenCalledTimes(2);

--- a/assistant/src/daemon/meet-host-supervisor.ts
+++ b/assistant/src/daemon/meet-host-supervisor.ts
@@ -230,7 +230,7 @@ export class MeetHostSupervisor {
       const err = new Error(
         `meet-join source hash mismatch: handshake reported ${payload.sourceHash} ` +
           `but manifest expects ${this.manifest.sourceHash}. ` +
-          "Regenerate the meet-join manifest or rebuild the daemon to match.",
+          "Regenerate the meet-join manifest or rebuild the assistant to match.",
       );
       this.handshakeReject(err);
       return;
@@ -376,12 +376,24 @@ export class MeetHostSupervisor {
   /**
    * Drop references to the current child and any handshake waiters.
    * Called on `exit`, on hash-mismatch rejection, and during shutdown.
+   * If the child is still live (e.g. hash-mismatch path aborts before
+   * stopChild runs), SIGKILL it so we don't leak an orphan process on
+   * respawn.
    */
   private teardownChild(): void {
+    const child = this.child;
+    if (child && !child.killed && child.exitCode == null) {
+      try {
+        child.kill("SIGKILL");
+      } catch (err) {
+        log.warn({ err }, "SIGKILL during teardown failed");
+      }
+    }
     this.child = null;
     this.spawnPromise = null;
     this.handshakeResolve = null;
     this.handshakeReject = null;
+    this.activeSessions.clear();
   }
 
   private armIdleTimer(): void {


### PR DESCRIPTION
Addresses review feedback on PR #27870: teardownChild() nulled refs without killing the spawned process (orphan on respawn); activeSessions wasn't cleared (stale IDs blocked idle timer); user-facing error said 'daemon' instead of 'assistant'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
