### PR TITLE
fix(daemon/skill-ipc): probe-connect before unlinking live socket path

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -908,7 +908,7 @@ export class DaemonServer {
     // socket to access host capabilities (host.log, host.config.*,
     // host.events.*, host.registries.*). Route registry is populated by
     // subsequent PRs in the skill-isolation plan.
-    this.skillIpc.start();
+    await this.skillIpc.start();
 
     // Wire the launchConversation helper to daemon-side state so
     // handleSurfaceAction can spawn conversations through it.

--- a/assistant/src/ipc/__tests__/skill-server.test.ts
+++ b/assistant/src/ipc/__tests__/skill-server.test.ts
@@ -35,7 +35,7 @@ afterEach(() => {
 
 async function startServerAt(socketPath: string): Promise<SkillIpcServer> {
   const srv = new SkillIpcServer({ socketPath });
-  srv.start();
+  await srv.start();
   // Give the listener a tick to bind.
   await new Promise((resolve) => setTimeout(resolve, 50));
   return srv;

--- a/assistant/src/ipc/skill-routes/__tests__/events-ipc.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/events-ipc.test.ts
@@ -32,11 +32,11 @@ let tempDir: string | null = null;
 let server: SkillIpcServer | null = null;
 let socketPath = "";
 
-beforeEach(() => {
+beforeEach(async () => {
   tempDir = mkdtempSync(join(tmpdir(), "events-ipc-test-"));
   socketPath = join(tempDir, "assistant-skill.sock");
   server = new SkillIpcServer({ socketPath });
-  server.start();
+  await server.start();
 });
 
 afterEach(async () => {

--- a/assistant/src/ipc/skill-server.ts
+++ b/assistant/src/ipc/skill-server.ts
@@ -27,7 +27,7 @@
  */
 
 import { existsSync, mkdirSync, unlinkSync } from "node:fs";
-import { createServer, type Server, type Socket } from "node:net";
+import { connect, createServer, type Server, type Socket } from "node:net";
 import { dirname } from "node:path";
 
 import { getLogger } from "../util/logger.js";
@@ -148,21 +148,19 @@ export class SkillIpcServer {
   }
 
   /** Start listening on the Unix domain socket. */
-  start(): void {
+  async start(): Promise<void> {
     // Ensure the parent directory exists before listening.
     const socketDir = dirname(this.socketPath);
     if (!existsSync(socketDir)) {
       mkdirSync(socketDir, { recursive: true, mode: 0o700 });
     }
 
-    // Clean up stale socket file from a previous run
-    if (existsSync(this.socketPath)) {
-      try {
-        unlinkSync(this.socketPath);
-      } catch {
-        // Ignore — may already be gone
-      }
-    }
+    // Probe-connect before unlinking: Unix sockets can be unlinked while still
+    // bound, so a blind `unlinkSync` on a live path would silently orphan
+    // another daemon's listener. Only unlink when the connect fails with
+    // ECONNREFUSED (stale file from a previous crash) / ENOENT (race with
+    // removal) — fail fast on a successful connect.
+    await ensureSocketPathFree(this.socketPath);
 
     this.server = createServer((socket) => {
       this.clients.add(socket);
@@ -427,4 +425,35 @@ export class SkillIpcServer {
       socket.write(JSON.stringify(response) + "\n");
     }
   }
+}
+
+/**
+ * Probe-connect to `socketPath`. If a live listener answers, reject so the
+ * caller can surface `EADDRINUSE`-style errors instead of silently hijacking
+ * the path. If the connect fails with `ECONNREFUSED`/`ENOENT`, the file is a
+ * stale leftover and we unlink it. Any other error propagates.
+ */
+async function ensureSocketPathFree(socketPath: string): Promise<void> {
+  if (!existsSync(socketPath)) return;
+  await new Promise<void>((resolve, reject) => {
+    const client = connect(socketPath);
+    client.once("connect", () => {
+      client.end();
+      reject(
+        new Error(`EADDRINUSE: another daemon is listening at ${socketPath}`),
+      );
+    });
+    client.once("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "ECONNREFUSED" || err.code === "ENOENT") {
+        try {
+          unlinkSync(socketPath);
+        } catch {
+          // Ignore — may already be gone
+        }
+        resolve();
+      } else {
+        reject(err);
+      }
+    });
+  });
 }


### PR DESCRIPTION
Addresses Codex P1 feedback on PR #27839.

`SkillIpcServer.start()` previously called `unlinkSync(socketPath)` whenever the pathname existed. Unix sockets can be unlinked while still bound, so two daemons targeting the same workspace could silently orphan each other's listener and break skill IPC with no error surfaced.

The fix probe-connects to the path first: if a live listener answers, fail fast with `EADDRINUSE: another daemon is listening at <path>`; only unlink on `ECONNREFUSED`/`ENOENT` (stale file from a previous crash).

Note: the second review comment (Devin — drop `getSkillSocketPath` as dead code) is no longer actionable. PR #27870 added `MeetHostSupervisor` which now imports `getSkillSocketPath`, so the function has a real caller and AGENTS.md's dead-code rule no longer applies.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
