### PR TITLE
fix(meet-join/observer): cancel LLM-ask timeout in finally to prevent orphan timers

### DIFF
--- a/skills/meet-join/daemon/consent-monitor.ts
+++ b/skills/meet-join/daemon/consent-monitor.ts
@@ -775,28 +775,32 @@ function createDefaultLlmAsk(host: SkillHost): ObjectionLLMAsk {
     }
 
     const controller = host.providers.llm.createTimeout(CONSENT_LLM_TIMEOUT_MS);
-    const response = await provider.sendMessage(
-      [host.providers.llm.userMessage(prompt)],
-      [OBJECTION_TOOL],
-      "You are a strict JSON classifier. Only respond via the report_objection tool.",
-      {
-        config: {
-          callSite: "meetConsentMonitor",
-          max_tokens: CONSENT_LLM_MAX_TOKENS,
-          tool_choice: { type: "tool" as const, name: OBJECTION_TOOL.name },
+    try {
+      const response = await provider.sendMessage(
+        [host.providers.llm.userMessage(prompt)],
+        [OBJECTION_TOOL],
+        "You are a strict JSON classifier. Only respond via the report_objection tool.",
+        {
+          config: {
+            callSite: "meetConsentMonitor",
+            max_tokens: CONSENT_LLM_MAX_TOKENS,
+            tool_choice: { type: "tool" as const, name: OBJECTION_TOOL.name },
+          },
+          signal: controller.signal,
         },
-        signal: controller.signal,
-      },
-    );
-    const tool = host.providers.llm.extractToolUse(response) as {
-      input?: { objected?: unknown; reason?: unknown };
-    } | null;
-    if (!tool) return { objected: false, reason: "" };
-    const input = tool.input ?? {};
-    return {
-      objected: input.objected === true,
-      reason: typeof input.reason === "string" ? input.reason : "",
-    };
+      );
+      const tool = host.providers.llm.extractToolUse(response) as {
+        input?: { objected?: unknown; reason?: unknown };
+      } | null;
+      if (!tool) return { objected: false, reason: "" };
+      const input = tool.input ?? {};
+      return {
+        objected: input.objected === true,
+        reason: typeof input.reason === "string" ? input.reason : "",
+      };
+    } finally {
+      controller.abort();
+    }
   };
 }
 


### PR DESCRIPTION
Addresses Devin feedback on PR #27798. createDefaultLlmAsk never aborted the controller or cleared the setTimeout after a successful call, so orphan timers accumulated across calls (self-cleaning after 5s but a regression vs pre-migration try/finally behavior).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
