### PR TITLE
fix(ipc/host-registries): tool-registry + route-handle + regex-flag fixes

### DIFF
--- a/assistant/src/ipc/cli-server.ts
+++ b/assistant/src/ipc/cli-server.ts
@@ -43,6 +43,7 @@ export type IpcResponse = {
 
 export type IpcMethodHandler = (
   params?: Record<string, unknown>,
+  connection?: unknown,
 ) => unknown | Promise<unknown>;
 
 /** A single IPC route definition — method name + handler function. */

--- a/assistant/src/ipc/skill-routes/__tests__/registries.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/registries.test.ts
@@ -18,7 +18,7 @@ import {
 import {
   __clearExternalToolProvidersForTesting,
   __clearRegistryForTesting,
-  getExternalTools,
+  getTool,
 } from "../../../tools/registry.js";
 import {
   __getActiveSessionCountForTesting,
@@ -69,11 +69,11 @@ describe("host.registries.register_tools", () => {
     })) as { registered: string[] };
 
     expect(result.registered).toEqual(["skill_demo_tool"]);
-    const installed = getExternalTools();
-    expect(installed.map((t) => t.name)).toEqual(["skill_demo_tool"]);
-    expect(installed[0]!.origin).toBe("skill");
-    expect(installed[0]!.ownerSkillId).toBe("demo-skill");
-    expect(installed[0]!.executionMode).toBe("proxy");
+    const installed = getTool("skill_demo_tool");
+    expect(installed).toBeDefined();
+    expect(installed!.origin).toBe("skill");
+    expect(installed!.ownerSkillId).toBe("demo-skill");
+    expect(installed!.executionMode).toBe("proxy");
   });
 
   test("proxy execute throws not-implemented until PR 28 dispatch lands", async () => {
@@ -89,10 +89,10 @@ describe("host.registries.register_tools", () => {
       ],
     });
 
-    const installed = getExternalTools();
-    expect(installed).toHaveLength(1);
+    const installed = getTool("skill_stub_tool");
+    expect(installed).toBeDefined();
     await expect(
-      installed[0]!.execute(
+      installed!.execute(
         {},
         {
           workingDir: "/tmp",

--- a/assistant/src/ipc/skill-routes/registries.ts
+++ b/assistant/src/ipc/skill-routes/registries.ts
@@ -22,7 +22,7 @@ import { z } from "zod";
 
 import { registerShutdownHook } from "../../daemon/shutdown-registry.js";
 import { registerSkillRoute } from "../../runtime/skill-route-registry.js";
-import { registerExternalTools } from "../../tools/registry.js";
+import { registerSkillTools } from "../../tools/registry.js";
 import type {
   ExecutionTarget,
   Tool,
@@ -31,6 +31,7 @@ import type {
 import { RiskLevel } from "../../tools/types.js";
 import { getLogger } from "../../util/logger.js";
 import type { IpcRoute } from "../cli-server.js";
+import type { SkillIpcConnection } from "../skill-server.js";
 
 const log = getLogger("skill-routes-registries");
 
@@ -64,7 +65,11 @@ const RegisterToolsParams = z.object({
 
 const RegisterSkillRouteParams = z.object({
   patternSource: z.string().min(1),
+  // `new RegExp(patternSource)` alone silently drops i/m/g/s/u/y flags from
+  // the skill-side RegExp — keep them as a separate field to survive IPC.
+  patternFlags: z.string().default(""),
   methods: z.array(z.string().min(1)).min(1),
+  skillId: z.string().min(1).optional(),
 });
 
 const RegisterShutdownHookParams = z.object({
@@ -157,34 +162,49 @@ function buildProxyTool(manifest: ToolManifest): Tool {
 // ── Handlers ──────────────────────────────────────────────────────────
 
 async function handleRegisterTools(
-  params?: Record<string, unknown>,
+  params: Record<string, unknown> | undefined,
+  connection?: unknown,
 ): Promise<{ registered: string[] }> {
   const { tools } = RegisterToolsParams.parse(params);
   const proxies = tools.map(buildProxyTool);
-  // `registerExternalTools` takes a provider closure so the tool list is
-  // resolved lazily inside `initializeTools()`; wrap the already-built
-  // proxies in an arrow so registration is observable immediately.
-  registerExternalTools(() => proxies);
+  // `registerExternalTools` is only consumed inside `initializeTools()` at
+  // daemon boot; IPC children connect after boot, so route through
+  // `registerSkillTools` into the live registry the agent-loop reads from.
+  const accepted = registerSkillTools(proxies);
+
+  const conn = connection as SkillIpcConnection | undefined;
+  if (conn) {
+    const ownerIds = new Set<string>();
+    for (const tool of accepted) {
+      if (tool.ownerSkillId) ownerIds.add(tool.ownerSkillId);
+    }
+    for (const skillId of ownerIds) {
+      conn.addSkillToolsOwner(skillId);
+    }
+  }
+
   log.info(
-    { count: proxies.length, names: proxies.map((t) => t.name) },
+    { count: accepted.length, names: accepted.map((t) => t.name) },
     "Registered skill proxy tools via IPC",
   );
-  return { registered: proxies.map((t) => t.name) };
+  return { registered: accepted.map((t) => t.name) };
 }
 
 async function handleRegisterSkillRoute(
-  params?: Record<string, unknown>,
+  params: Record<string, unknown> | undefined,
+  connection?: unknown,
 ): Promise<{ patternSource: string; methods: string[] }> {
-  const { patternSource, methods } = RegisterSkillRouteParams.parse(params);
+  const { patternSource, patternFlags, methods, skillId } =
+    RegisterSkillRouteParams.parse(params);
   let pattern: RegExp;
   try {
-    pattern = new RegExp(patternSource);
+    pattern = new RegExp(patternSource, patternFlags);
   } catch (err) {
     throw new Error(
-      `Invalid skill-route pattern "${patternSource}": ${String(err)}`,
+      `Invalid skill-route pattern "${patternSource}" (flags "${patternFlags}"): ${String(err)}`,
     );
   }
-  registerSkillRoute({
+  const handle = registerSkillRoute({
     pattern,
     methods,
     handler: async () => {
@@ -197,8 +217,13 @@ async function handleRegisterSkillRoute(
       );
     },
   });
+  // Retain the handle on the connection so disconnect revokes this route;
+  // without it, reconnects accumulate routes with no owner to unregister them.
+  const conn = connection as SkillIpcConnection | undefined;
+  conn?.addRouteHandle(skillId ?? conn.connectionId, handle);
+
   log.info(
-    { patternSource, methods },
+    { patternSource, patternFlags, methods, skillId },
     "Registered skill proxy HTTP route via IPC",
   );
   return { patternSource, methods };

--- a/assistant/src/ipc/skill-server.ts
+++ b/assistant/src/ipc/skill-server.ts
@@ -30,6 +30,11 @@ import { existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { dirname } from "node:path";
 
+import {
+  type SkillRouteHandle,
+  unregisterSkillRoute,
+} from "../runtime/skill-route-registry.js";
+import { unregisterSkillTools } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
 import type {
   IpcMethodHandler,
@@ -87,6 +92,86 @@ export type SkillIpcStreamingRoute = {
 };
 
 // ---------------------------------------------------------------------------
+// Per-connection context
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-connection state threaded into skill-IPC method handlers as their
+ * second argument. Lets `host.registries.*` handlers attach route handles
+ * and skill-tool owner IDs to the live connection so the server can tear
+ * them down when the connection closes — without this, a skill process
+ * that disconnects (crash or reconnect) would leak its contributions into
+ * the daemon's in-memory registries.
+ *
+ * Mirrors the plugin-bootstrap pattern (`external-plugins-bootstrap.ts`),
+ * which retains the opaque {@link SkillRouteHandle} returned from
+ * `registerSkillRoute` and unregisters by identity during teardown.
+ */
+export interface SkillIpcConnection {
+  readonly connectionId: string;
+  /**
+   * Store a route handle under the given skill id so disconnect can
+   * revoke exactly the routes this connection contributed. Pattern-text
+   * is not a stable key — two owners may legitimately register the same
+   * regex.
+   */
+  addRouteHandle(skillId: string, handle: SkillRouteHandle): void;
+  /**
+   * Mark a skill id as having registered tools on this connection. On
+   * disconnect the server calls `unregisterSkillTools(skillId)` once per
+   * tracked id so the ref-counted tool registry drops the contribution.
+   */
+  addSkillToolsOwner(skillId: string): void;
+}
+
+class SkillIpcConnectionState implements SkillIpcConnection {
+  readonly connectionId: string;
+  private routeHandlesBySkill = new Map<string, SkillRouteHandle[]>();
+  private skillToolOwners = new Set<string>();
+
+  constructor(connectionId: string) {
+    this.connectionId = connectionId;
+  }
+
+  addRouteHandle(skillId: string, handle: SkillRouteHandle): void {
+    const list = this.routeHandlesBySkill.get(skillId) ?? [];
+    list.push(handle);
+    this.routeHandlesBySkill.set(skillId, list);
+  }
+
+  addSkillToolsOwner(skillId: string): void {
+    this.skillToolOwners.add(skillId);
+  }
+
+  dispose(): void {
+    for (const handles of this.routeHandlesBySkill.values()) {
+      for (const handle of handles) {
+        try {
+          unregisterSkillRoute(handle);
+        } catch (err) {
+          log.warn(
+            { err, connectionId: this.connectionId },
+            "skill IPC disconnect: failed to unregister skill route",
+          );
+        }
+      }
+    }
+    this.routeHandlesBySkill.clear();
+    for (const skillId of this.skillToolOwners) {
+      try {
+        unregisterSkillTools(skillId);
+      } catch (err) {
+        log.warn(
+          { err, connectionId: this.connectionId, skillId },
+          "skill IPC disconnect: failed to unregister skill tools",
+        );
+      }
+    }
+    this.skillToolOwners.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Server
 // ---------------------------------------------------------------------------
 
@@ -106,6 +191,13 @@ export class SkillIpcServer {
    * locate the matching dispose callback.
    */
   private subscriptions = new WeakMap<Socket, Map<string, () => void>>();
+  /**
+   * Per-socket connection state threaded into `host.registries.*` handlers.
+   * Holds route handles + skill-tool owner ids the connection contributed
+   * so `teardownConnection` can revoke them on disconnect.
+   */
+  private connections = new WeakMap<Socket, SkillIpcConnectionState>();
+  private nextConnectionId = 1;
   private socketPath: string;
 
   constructor(options: SkillIpcServerOptions = {}) {
@@ -166,7 +258,14 @@ export class SkillIpcServer {
 
     this.server = createServer((socket) => {
       this.clients.add(socket);
-      log.debug("Skill IPC client connected");
+      const connection = new SkillIpcConnectionState(
+        `skill-ipc-${this.nextConnectionId++}`,
+      );
+      this.connections.set(socket, connection);
+      log.debug(
+        { connectionId: connection.connectionId },
+        "Skill IPC client connected",
+      );
 
       let buffer = "";
 
@@ -185,13 +284,21 @@ export class SkillIpcServer {
       socket.on("close", () => {
         this.clients.delete(socket);
         this.teardownSubscriptions(socket);
-        log.debug("Skill IPC client disconnected");
+        this.teardownConnection(socket);
+        log.debug(
+          { connectionId: connection.connectionId },
+          "Skill IPC client disconnected",
+        );
       });
 
       socket.on("error", (err) => {
-        log.warn({ err }, "Skill IPC client socket error");
+        log.warn(
+          { err, connectionId: connection.connectionId },
+          "Skill IPC client socket error",
+        );
         this.clients.delete(socket);
         this.teardownSubscriptions(socket);
+        this.teardownConnection(socket);
       });
     });
 
@@ -208,6 +315,7 @@ export class SkillIpcServer {
   stop(): void {
     for (const client of this.clients) {
       this.teardownSubscriptions(client);
+      this.teardownConnection(client);
       if (!client.destroyed) client.destroy();
     }
     this.clients.clear();
@@ -288,7 +396,8 @@ export class SkillIpcServer {
     }
 
     try {
-      const result = handler(req.params);
+      const connection = this.connections.get(socket);
+      const result = handler(req.params, connection);
       if (result instanceof Promise) {
         result
           .then((value) => {
@@ -406,6 +515,13 @@ export class SkillIpcServer {
       id: req.id,
       result: { closed: true },
     });
+  }
+
+  private teardownConnection(socket: Socket): void {
+    const connection = this.connections.get(socket);
+    if (!connection) return;
+    connection.dispose();
+    this.connections.delete(socket);
   }
 
   private teardownSubscriptions(socket: Socket): void {


### PR DESCRIPTION
Addresses Codex + Devin feedback on PR #27873: handleRegisterTools was using boot-time registerExternalTools (skill tools never reached live registry); route handles were discarded (leak on reconnect); RegExp lost i/m/g/s flags.

## Changes

- **Bug 1 (Devin HIGH):** `handleRegisterTools` now calls `registerSkillTools(proxies)` — the same path `conversation-skill-tools.ts` uses — so proxies land in the live tool registry the agent-loop reads from. The previous `registerExternalTools` path was only consumed inside `initializeTools()` at daemon boot, so IPC-child tools never reached the LLM.
- **Bug 2 (Codex P1 / Devin):** Route handles returned from `registerSkillRoute` are now retained on a per-connection `SkillIpcConnection` (keyed by skill id, mirroring the plugin-bootstrap pattern). On socket close/error, the server calls `unregisterSkillRoute` for each handle and `unregisterSkillTools(skillId)` for each tracked owner, so reconnects don't accumulate routes.
- **Bug 3 (Codex P2):** `RegisterSkillRouteParams` now includes `patternFlags` (default `""`); the handler passes them through as `new RegExp(patternSource, patternFlags)` so `i`/`m`/`g`/`s`/`u`/`y` flags survive the IPC round-trip.

## Test plan
- [x] `bun test src/ipc/skill-routes/__tests__/registries.test.ts src/ipc/__tests__/skill-server.test.ts` passes
- [x] `bunx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
