### PR TITLE
fix(clients/shared): add missing HostProxyClientProtocol stubs to MockHostProxyClient

### DIFF
--- a/clients/shared/Tests/HostBrowserExecutorTests.swift
+++ b/clients/shared/Tests/HostBrowserExecutorTests.swift
@@ -13,6 +13,9 @@ private final class MockHostProxyClient: HostProxyClientProtocol {
     func postBashResult(_ result: HostBashResultPayload) async -> Bool { true }
     func postFileResult(_ result: HostFileResultPayload) async -> Bool { true }
     func postCuResult(_ result: HostCuResultPayload) async -> Bool { true }
+    func postTransferResult(_ result: HostTransferResultPayload) async -> Bool { true }
+    func pullTransferContent(transferId: String) async throws -> Data { Data() }
+    func pushTransferContent(transferId: String, data: Data, sha256: String, sourcePath: String) async throws -> Bool { true }
 
     func postBrowserResult(_ result: HostBrowserResultPayload) async -> Bool {
         postedBrowserResults.append(result)


### PR DESCRIPTION
## Summary
- Add stubs for `postTransferResult`, `pullTransferContent`, and `pushTransferContent` to `MockHostProxyClient` so the test suite builds again.
- These three methods were added to `HostProxyClientProtocol` but the test-only mock wasn't updated, breaking the macOS Tests CI job.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24868580650/job/72810007569
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
