### PR TITLE
feat(daemon): register meet-join tools and routes from manifest with lazy IPC dispatch (flag gated)

### DIFF
--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -84,6 +84,57 @@ export const TwitterOAuthServiceSchema = BaseServiceSchema.extend({
 });
 export type TwitterOAuthService = z.infer<typeof TwitterOAuthServiceSchema>;
 
+/**
+ * `services.meet.host.*` — daemon-side knobs for the externalized meet-join
+ * skill process. Kept narrow: only the values the daemon reads before the
+ * meet-host child is spawned live here. Skill-internal configuration
+ * (avatar renderer, consent copy, proactive-chat keywords, etc.) lives in
+ * `skills/meet-join/config-schema.ts` and is sourced from the separate
+ * `<workspace>/config/meet.json` file the skill owns.
+ *
+ * `lazy_external` gates the manifest-driven lazy-spawn path. While the
+ * default is `false`, `external-skills-bootstrap.ts` keeps running the
+ * in-process `register(host)` path — identical to pre-isolation behavior.
+ * PR 32 flips the default to `true` after the remaining scaffolding lands.
+ */
+export const MeetHostConfigSchema = z
+  .object({
+    lazy_external: z
+      .boolean({
+        error: "services.meet.host.lazy_external must be a boolean",
+      })
+      .default(false)
+      .describe(
+        "When true, the daemon installs meet-join tools from the shipped manifest and spawns the meet-host child on first use instead of loading the skill in-process.",
+      ),
+    idle_timeout_ms: z
+      .number({
+        error: "services.meet.host.idle_timeout_ms must be a number",
+      })
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Idle window in milliseconds after the last active meet session closes before the meet-host child is shut down. Defaults to 5 minutes when unset.",
+      ),
+  })
+  .describe("Daemon-side configuration for the external meet-join skill host");
+export type MeetHostConfig = z.infer<typeof MeetHostConfigSchema>;
+
+/**
+ * Daemon-side `services.meet` block. Intentionally distinct from the
+ * skill-internal `MeetServiceSchema` in `skills/meet-join/config-schema.ts`,
+ * which validates the bot-facing `<workspace>/config/meet.json` file. This
+ * schema only describes the keys the assistant itself reads from its global
+ * `config.json` before the meet-host child process is spawned.
+ */
+export const MeetDaemonServiceSchema = z
+  .object({
+    host: MeetHostConfigSchema.default(MeetHostConfigSchema.parse({})),
+  })
+  .describe("meet-join skill daemon-side configuration");
+export type MeetDaemonService = z.infer<typeof MeetDaemonServiceSchema>;
+
 export const ServicesSchema = z.object({
   inference: InferenceServiceSchema.default(InferenceServiceSchema.parse({})),
   "image-generation": ImageGenerationServiceSchema.default(
@@ -116,6 +167,7 @@ export const ServicesSchema = z.object({
   "twitter-oauth": TwitterOAuthServiceSchema.default(
     TwitterOAuthServiceSchema.parse({}),
   ),
+  meet: MeetDaemonServiceSchema.default(MeetDaemonServiceSchema.parse({})),
 });
 export type Services = z.infer<typeof ServicesSchema>;
 

--- a/assistant/src/daemon/__tests__/meet-manifest-loader.test.ts
+++ b/assistant/src/daemon/__tests__/meet-manifest-loader.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Unit tests for `loadMeetManifestProxies`.
+ *
+ * Covers the shape of the proxy `Tool` and `SkillRoute` entries the
+ * loader installs, the "dispatch not implemented" stub behavior, and
+ * the shutdown-hook wiring. The real `MeetHostSupervisor` is replaced
+ * with a shallow stub so the test never touches `child_process.spawn`
+ * or Unix domain sockets. Manifest JSON is written to a tmp fixture
+ * path so the loader exercises its real `readFileSync` code path.
+ */
+
+import { writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SkillRoute } from "../../runtime/skill-route-registry.js";
+import { RiskLevel, type Tool } from "../../tools/types.js";
+import type { MeetHostSupervisor } from "../meet-host-supervisor.js";
+import {
+  loadMeetManifestFromDisk,
+  loadMeetManifestProxies,
+} from "../meet-manifest-loader.js";
+
+// ---------------------------------------------------------------------------
+// Fixture manifest + supervisor stub
+// ---------------------------------------------------------------------------
+
+const FIXTURE_MANIFEST = {
+  skill: "meet-join",
+  sourceHash: "a".repeat(64),
+  tools: [
+    {
+      name: "meet_demo",
+      description: "Fixture demo tool",
+      category: "meet",
+      risk: "medium",
+      input_schema: {
+        type: "object",
+        properties: { url: { type: "string" } },
+        required: ["url"],
+      },
+    },
+  ],
+  routes: [
+    {
+      pattern: "^/api/skills/meet/([^/]+)/events$",
+      methods: ["POST"],
+    },
+  ],
+  shutdownHooks: ["meet-host-shutdown"],
+};
+
+type SupervisorStub = {
+  supervisor: MeetHostSupervisor;
+  ensureRunning: ReturnType<typeof mock>;
+  shutdown: ReturnType<typeof mock>;
+  reportSessionStarted: ReturnType<typeof mock>;
+  reportSessionEnded: ReturnType<typeof mock>;
+};
+
+function makeSupervisorStub(
+  overrides: { ensureRunningError?: Error } = {},
+): SupervisorStub {
+  const ensureRunning = mock(async () => {
+    if (overrides.ensureRunningError) {
+      throw overrides.ensureRunningError;
+    }
+  });
+  const shutdown = mock(async () => {});
+  const reportSessionStarted = mock((_id: string) => {});
+  const reportSessionEnded = mock((_id: string) => {});
+  const supervisor = {
+    ensureRunning,
+    shutdown,
+    reportSessionStarted,
+    reportSessionEnded,
+    activeSessionCount: 0,
+    isRunning: false,
+    notifyHandshake: () => undefined,
+  } as unknown as MeetHostSupervisor;
+  return {
+    supervisor,
+    ensureRunning,
+    shutdown,
+    reportSessionStarted,
+    reportSessionEnded,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tmp-dir fixture
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let manifestPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "meet-manifest-loader-"));
+  manifestPath = join(tmpDir, "manifest.json");
+  writeFileSync(
+    manifestPath,
+    JSON.stringify(FIXTURE_MANIFEST, null, 2),
+    "utf8",
+  );
+});
+
+afterEach(() => {
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("loadMeetManifestProxies", () => {
+  test("registers a lazy tool provider that returns exactly the manifest tools", async () => {
+    const { supervisor } = makeSupervisorStub();
+    const capturedProviders: Array<() => Tool[]> = [];
+    const capturedRoutes: SkillRoute[] = [];
+    const capturedHooks: string[] = [];
+
+    await loadMeetManifestProxies(supervisor, {
+      manifestPath,
+      registerTools: (p) => capturedProviders.push(p),
+      registerRoute: (r) => capturedRoutes.push(r),
+      registerShutdown: (name) => capturedHooks.push(name),
+    });
+
+    expect(capturedProviders).toHaveLength(1);
+    const tools = capturedProviders[0]!();
+    expect(tools).toHaveLength(1);
+    const t = tools[0]!;
+    expect(t.name).toBe("meet_demo");
+    expect(t.description).toBe("Fixture demo tool");
+    expect(t.category).toBe("meet");
+    expect(t.defaultRiskLevel).toBe(RiskLevel.Medium);
+    expect(t.executionMode).toBe("proxy");
+    expect(t.origin).toBe("skill");
+    expect(t.ownerSkillId).toBe("meet-join");
+    expect(t.ownerSkillBundled).toBe(true);
+    expect(t.ownerSkillVersionHash).toBe(FIXTURE_MANIFEST.sourceHash);
+    expect(t.getDefinition().input_schema).toEqual(
+      FIXTURE_MANIFEST.tools[0]!.input_schema,
+    );
+  });
+
+  test("proxy tool execute calls ensureRunning and throws not-implemented", async () => {
+    const stub = makeSupervisorStub();
+    const captured: Array<() => Tool[]> = [];
+
+    await loadMeetManifestProxies(stub.supervisor, {
+      manifestPath,
+      registerTools: (p) => captured.push(p),
+      registerRoute: () => undefined,
+      registerShutdown: () => undefined,
+    });
+
+    const tool = captured[0]!()[0]!;
+    await expect(
+      tool.execute(
+        { url: "https://example.test/meet/x" },
+        {
+          workingDir: "/tmp",
+          conversationId: "c",
+          trustClass: "guardian",
+        },
+      ),
+    ).rejects.toThrow(/dispatch not implemented/i);
+    expect(stub.ensureRunning).toHaveBeenCalledTimes(1);
+  });
+
+  test("proxy route handler returns 501 with not-implemented body", async () => {
+    const stub = makeSupervisorStub();
+    const routes: SkillRoute[] = [];
+
+    await loadMeetManifestProxies(stub.supervisor, {
+      manifestPath,
+      registerTools: () => undefined,
+      registerRoute: (r) => routes.push(r),
+      registerShutdown: () => undefined,
+    });
+
+    expect(routes).toHaveLength(1);
+    const route = routes[0]!;
+    // The JS engine may escape forward slashes when normalizing the source
+    // string; compare via a fresh RegExp constructed from the manifest
+    // entry so the assertion is engine-insensitive.
+    expect(route.pattern.test("/api/skills/meet/test/events")).toBe(true);
+    expect(route.pattern.test("/something/else")).toBe(false);
+    expect(route.methods).toEqual(["POST"]);
+
+    const match = "/api/skills/meet/test-id/events".match(route.pattern);
+    if (!match) throw new Error("expected pattern match");
+    const response = await route.handler(
+      new Request("http://localhost/api/skills/meet/test-id/events", {
+        method: "POST",
+      }),
+      match,
+    );
+    expect(response.status).toBe(501);
+    expect(await response.text()).toMatch(/dispatch not implemented/i);
+    expect(stub.ensureRunning).toHaveBeenCalledTimes(1);
+  });
+
+  test("proxy route handler returns 503 when ensureRunning fails", async () => {
+    const err = new Error("spawn failed");
+    const stub = makeSupervisorStub({ ensureRunningError: err });
+    const routes: SkillRoute[] = [];
+
+    await loadMeetManifestProxies(stub.supervisor, {
+      manifestPath,
+      registerTools: () => undefined,
+      registerRoute: (r) => routes.push(r),
+      registerShutdown: () => undefined,
+    });
+
+    const route = routes[0]!;
+    const match = "/api/skills/meet/x/events".match(route.pattern);
+    if (!match) throw new Error("expected pattern match");
+    const response = await route.handler(
+      new Request("http://localhost/api/skills/meet/x/events", {
+        method: "POST",
+      }),
+      match,
+    );
+    expect(response.status).toBe(503);
+  });
+
+  test("registers shutdown hooks that call supervisor.shutdown()", async () => {
+    const stub = makeSupervisorStub();
+    const hooks: Array<{
+      name: string;
+      run: (reason: string) => Promise<void>;
+    }> = [];
+
+    await loadMeetManifestProxies(stub.supervisor, {
+      manifestPath,
+      registerTools: () => undefined,
+      registerRoute: () => undefined,
+      registerShutdown: (name, hook) => {
+        hooks.push({ name, run: hook });
+      },
+    });
+
+    expect(hooks.map((h) => h.name)).toEqual(["meet-host-shutdown"]);
+    await hooks[0]!.run("daemon-shutdown");
+    expect(stub.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws a clear error when the manifest file is missing", async () => {
+    const stub = makeSupervisorStub();
+    const missing = join(tmpDir, "does-not-exist.json");
+    await expect(
+      loadMeetManifestProxies(stub.supervisor, {
+        manifestPath: missing,
+        registerTools: () => undefined,
+        registerRoute: () => undefined,
+        registerShutdown: () => undefined,
+      }),
+    ).rejects.toThrow(/rebuild\/repackage/);
+  });
+
+  test("rejects a manifest whose skill field does not match meet-join", async () => {
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({ ...FIXTURE_MANIFEST, skill: "other-skill" }, null, 2),
+      "utf8",
+    );
+    const stub = makeSupervisorStub();
+    await expect(
+      loadMeetManifestProxies(stub.supervisor, {
+        manifestPath,
+        registerTools: () => undefined,
+        registerRoute: () => undefined,
+        registerShutdown: () => undefined,
+      }),
+    ).rejects.toThrow(/skill field/);
+  });
+});
+
+describe("loadMeetManifestFromDisk", () => {
+  test("parses a valid manifest and returns sourceHash", () => {
+    const result = loadMeetManifestFromDisk(manifestPath);
+    expect(result.skill).toBe("meet-join");
+    expect(result.sourceHash).toBe(FIXTURE_MANIFEST.sourceHash);
+    expect(result.tools).toHaveLength(1);
+    expect(result.routes).toHaveLength(1);
+    expect(result.shutdownHooks).toEqual(["meet-host-shutdown"]);
+  });
+
+  test("rejects malformed JSON", () => {
+    writeFileSync(manifestPath, "{not json", "utf8");
+    expect(() => loadMeetManifestFromDisk(manifestPath)).toThrow(
+      /not valid JSON/,
+    );
+  });
+});

--- a/assistant/src/daemon/external-skills-bootstrap.ts
+++ b/assistant/src/daemon/external-skills-bootstrap.ts
@@ -38,9 +38,94 @@
  * and extend the repo-root `.dockerignore` allowlist with the skill's
  * runtime files. Non-bundled skills (workspace-installed, third-party)
  * never belong in this file.
+ *
+ * ## Lazy-external meet-host path (behind `services.meet.host.lazy_external`)
+ *
+ * The flag defaults to `false`, so by default the bootstrap still runs
+ * the statically-imported `register(host)` path above — behavior is
+ * identical to pre-isolation main. When the flag flips to `true`
+ * (PR 32), the bootstrap instead constructs a {@link MeetHostSupervisor},
+ * wires it into the session-reporting IPC routes, and installs proxy
+ * tools/routes via the manifest loader so the meet-host child process
+ * spawns lazily on first meet use. The sanctioned-exception rationale
+ * above still holds for the static `register` import — the flag just
+ * switches between two load paths, it does not eliminate this file's
+ * role as the single in-process entry.
  */
 
 import { register as registerMeet } from "../../../skills/meet-join/register.js";
+import { getConfig, getNestedValue } from "../config/loader.js";
+import { setMeetHostSupervisorForSessionReports } from "../ipc/skill-routes/registries.js";
+import { getRepoSkillsDir } from "../skills/catalog-install.js";
+import { getLogger } from "../util/logger.js";
+import { getBundledBunPath, getSkillRuntimePath } from "../util/platform.js";
 import { createDaemonSkillHost } from "./daemon-skill-host.js";
+import { MeetHostSupervisor } from "./meet-host-supervisor.js";
+import {
+  loadMeetManifestFromDisk,
+  loadMeetManifestProxies,
+  resolveMeetManifestPath,
+} from "./meet-manifest-loader.js";
 
-registerMeet(createDaemonSkillHost("meet-join"));
+const log = getLogger("external-skills-bootstrap");
+
+const LAZY_EXTERNAL_CONFIG_KEY = "services.meet.host.lazy_external";
+
+function readLazyExternalFlag(): boolean {
+  try {
+    const raw = getNestedValue(
+      getConfig() as unknown as Record<string, unknown>,
+      LAZY_EXTERNAL_CONFIG_KEY,
+    );
+    return raw === true;
+  } catch (err) {
+    log.warn(
+      { err, configKey: LAZY_EXTERNAL_CONFIG_KEY },
+      "Failed to read lazy-external flag; defaulting to in-process path",
+    );
+    return false;
+  }
+}
+
+async function startLazyExternalMeetHost(): Promise<void> {
+  const skillsRoot = getRepoSkillsDir();
+  const skillRuntime = getSkillRuntimePath("meet-join", skillsRoot);
+  const manifestPath = resolveMeetManifestPath();
+  if (!skillRuntime || !manifestPath) {
+    throw new Error(
+      "Lazy-external meet-host path requires a shipped meet-join skill runtime. " +
+        "Rebuild/repackage so first-party skills ship with the daemon.",
+    );
+  }
+  const manifest = loadMeetManifestFromDisk(manifestPath);
+  const bunBinary = getBundledBunPath() ?? "bun";
+  const supervisor = new MeetHostSupervisor({
+    skillRuntimePath: skillRuntime,
+    bunBinaryPath: bunBinary,
+    manifest: { sourceHash: manifest.sourceHash },
+  });
+  setMeetHostSupervisorForSessionReports(supervisor);
+  await loadMeetManifestProxies(supervisor, { manifestPath });
+  log.info(
+    { skillRuntime, manifestPath },
+    "meet-join registered via lazy-external path",
+  );
+}
+
+if (readLazyExternalFlag()) {
+  // Lazy-external path. PR 32 flips the default; for now this branch is
+  // opt-in so `services.meet.host.lazy_external = true` in user config
+  // exercises the full manifest/supervisor flow end-to-end.
+  void startLazyExternalMeetHost().catch((err) => {
+    log.error(
+      { err },
+      "Failed to register meet-join via lazy-external path; daemon will continue without meet tools",
+    );
+  });
+} else {
+  // Default: in-process path, unchanged. The statically-imported named
+  // `register` above is how `bun --compile` pulls the skill source into
+  // the binary. See the module header for why this import is the single
+  // sanctioned exception to the skill-boundary rule.
+  registerMeet(createDaemonSkillHost("meet-join"));
+}

--- a/assistant/src/daemon/meet-manifest-loader.ts
+++ b/assistant/src/daemon/meet-manifest-loader.ts
@@ -1,0 +1,338 @@
+/**
+ * `meet-manifest-loader` — registers proxy tools, routes, and shutdown
+ * hooks for the meet-join skill from its shipped `manifest.json` without
+ * loading the skill's source in-process. Paired with
+ * {@link MeetHostSupervisor}, this is the lazy-external path that
+ * eventually replaces `external-skills-bootstrap.ts` (PR 33).
+ *
+ * ## Lifecycle today (flag off)
+ *
+ * The `services.meet.host.lazy_external` config key defaults to `false`
+ * (PR 32 flips it). When the flag is off, `external-skills-bootstrap.ts`
+ * runs the in-process path (`register(createDaemonSkillHost("meet-join"))`)
+ * and this loader is never invoked on main. Code lives here so PR 32
+ * becomes a one-line default flip rather than a large rebase-prone patch.
+ *
+ * ## Lifecycle when the flag is on
+ *
+ * 1. The bootstrap constructs a {@link MeetHostSupervisor} and calls
+ *    {@link setMeetHostSupervisorForSessionReports} so session-reporting
+ *    IPC frames flow into the supervisor's counter.
+ * 2. The bootstrap awaits `loadMeetManifestProxies(supervisor)` (this
+ *    function). It reads the shipped `manifest.json`, builds a proxy
+ *    `Tool` for every tool entry, a proxy `SkillRoute` for every route
+ *    entry, and a shutdown hook for every declared hook name.
+ * 3. Each proxy tool's `execute` and each proxy route handler call
+ *    `supervisor.ensureRunning()` before attempting to dispatch over the
+ *    skill IPC socket. Dispatch itself is **not yet implemented** because
+ *    the current JSON-lines protocol (see `assistant/src/ipc/skill-server.ts`)
+ *    models the daemon as the server and the skill as the client — the
+ *    daemon has no way to issue an RPC in the skill's direction without
+ *    the protocol extension slated for a later PR. Invocations therefore
+ *    throw a clear "dispatch not implemented" error.
+ *
+ * Since the flag defaults to `false`, this throw is unreachable on main.
+ * PR 32 extends the protocol (or picks a different direction model) and
+ * replaces the throw with a real round-trip before flipping the default.
+ *
+ * ## Manifest path
+ *
+ * The manifest is expected at `<skillRuntimePath>/manifest.json` where
+ * `skillRuntimePath` is resolved via
+ * `getSkillRuntimePath("meet-join", getRepoSkillsDir())`. The loader
+ * surfaces a clear error when the file is missing so packaging bugs
+ * (manifest not shipped in the Docker image or `.app` Resources) fail
+ * loudly at daemon startup rather than silently omitting the tools.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { SkillRoute } from "../runtime/skill-route-registry.js";
+import { registerSkillRoute } from "../runtime/skill-route-registry.js";
+import { getRepoSkillsDir } from "../skills/catalog-install.js";
+import { registerExternalTools } from "../tools/registry.js";
+import type { ExecutionTarget, Tool, ToolDefinition } from "../tools/types.js";
+import { RiskLevel } from "../tools/types.js";
+import { getLogger } from "../util/logger.js";
+import { getSkillRuntimePath } from "../util/platform.js";
+import type { MeetHostSupervisor } from "./meet-host-supervisor.js";
+import { registerShutdownHook } from "./shutdown-registry.js";
+
+const log = getLogger("meet-manifest-loader");
+
+const MEET_SKILL_ID = "meet-join";
+
+// ---------------------------------------------------------------------------
+// Manifest shape — mirrors skills/meet-join/scripts/emit-manifest.ts
+// ---------------------------------------------------------------------------
+
+interface ManifestToolEntry {
+  name: string;
+  description: string;
+  category: string;
+  risk: string;
+  input_schema: unknown;
+}
+
+interface ManifestRouteEntry {
+  pattern: string;
+  methods: string[];
+}
+
+interface Manifest {
+  skill: string;
+  tools: ManifestToolEntry[];
+  routes: ManifestRouteEntry[];
+  shutdownHooks: string[];
+  sourceHash: string;
+}
+
+function notImplementedError(context: string): Error {
+  return new Error(
+    `meet-host dispatch not implemented — requires server-initiated IPC (follow-up): ${context}`,
+  );
+}
+
+function coerceRiskLevel(value: string, toolName: string): RiskLevel {
+  // Manifest `risk` is a serialized RiskLevel ("low" | "medium" | "high").
+  const allowed: readonly string[] = ["low", "medium", "high"];
+  if (!allowed.includes(value)) {
+    throw new Error(
+      `meet-manifest-loader: unknown risk level "${value}" on tool "${toolName}"`,
+    );
+  }
+  return value as RiskLevel;
+}
+
+function buildProxyTool(
+  entry: ManifestToolEntry,
+  supervisor: MeetHostSupervisor,
+  manifestHash: string,
+): Tool {
+  const definition: ToolDefinition = {
+    name: entry.name,
+    description: entry.description,
+    input_schema: (entry.input_schema as object) ?? {},
+  };
+  const risk = coerceRiskLevel(entry.risk, entry.name);
+  return {
+    name: entry.name,
+    description: entry.description,
+    category: entry.category,
+    defaultRiskLevel: risk,
+    executionMode: "proxy",
+    executionTarget: "host" as ExecutionTarget,
+    origin: "skill",
+    ownerSkillId: MEET_SKILL_ID,
+    ownerSkillBundled: true,
+    ownerSkillVersionHash: manifestHash,
+    getDefinition: () => definition,
+    execute: async () => {
+      // Ensure the meet-host child is alive before attempting dispatch so
+      // handshake/hash-mismatch failures surface before we hit the
+      // not-implemented throw. This matters for diagnostic symmetry
+      // with PR 32's real dispatch path — when PR 32 replaces the throw
+      // with a `skill.dispatch_tool` round-trip, the ensureRunning call
+      // remains unchanged.
+      await supervisor.ensureRunning();
+      throw notImplementedError(`tool=${entry.name}`);
+    },
+  };
+}
+
+function buildProxyRoute(
+  entry: ManifestRouteEntry,
+  supervisor: MeetHostSupervisor,
+): SkillRoute {
+  let pattern: RegExp;
+  try {
+    pattern = new RegExp(entry.pattern);
+  } catch (err) {
+    throw new Error(
+      `meet-manifest-loader: invalid route pattern "${entry.pattern}": ${String(err)}`,
+    );
+  }
+  return {
+    pattern,
+    methods: [...entry.methods],
+    handler: async () => {
+      try {
+        await supervisor.ensureRunning();
+      } catch (err) {
+        log.warn(
+          { err, pattern: entry.pattern },
+          "meet-host supervisor ensureRunning failed while handling proxy route",
+        );
+        return new Response(
+          "meet-host unavailable — supervisor failed to start",
+          { status: 503 },
+        );
+      }
+      return new Response(
+        notImplementedError(`route=${entry.pattern}`).message,
+        { status: 501 },
+      );
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Manifest loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Locate the shipped manifest path. Visible for testing so callers can
+ * redirect to a fixture without stubbing `getRepoSkillsDir()` (which
+ * reads `import.meta.dir` and `process.env.VELLUM_DEV`).
+ */
+export function resolveMeetManifestPath(): string | undefined {
+  const skillsRoot = getRepoSkillsDir();
+  const skillRuntime = getSkillRuntimePath(MEET_SKILL_ID, skillsRoot);
+  if (!skillRuntime) return undefined;
+  return join(skillRuntime, "manifest.json");
+}
+
+/**
+ * Read and validate the shipped manifest from disk. Exposed so
+ * `external-skills-bootstrap.ts` can extract `sourceHash` for
+ * {@link MeetHostSupervisor} construction without duplicating the JSON
+ * validation shape.
+ */
+export function loadMeetManifestFromDisk(manifestPath: string): {
+  skill: string;
+  sourceHash: string;
+  tools: ManifestToolEntry[];
+  routes: ManifestRouteEntry[];
+  shutdownHooks: string[];
+} {
+  return loadManifestInternal(manifestPath);
+}
+
+function loadManifestInternal(manifestPath: string): Manifest {
+  if (!existsSync(manifestPath)) {
+    throw new Error(
+      `meet-join manifest not found at ${manifestPath} — ` +
+        "rebuild/repackage to include the meet-join manifest " +
+        "(skills/meet-join/scripts/emit-manifest.ts).",
+    );
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(manifestPath, "utf8");
+  } catch (err) {
+    throw new Error(
+      `meet-join manifest at ${manifestPath} could not be read: ${String(err)}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `meet-join manifest at ${manifestPath} is not valid JSON: ${String(err)}`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `meet-join manifest at ${manifestPath} must be a JSON object`,
+    );
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.skill !== MEET_SKILL_ID) {
+    throw new Error(
+      `meet-join manifest skill field was "${String(obj.skill)}" but expected "${MEET_SKILL_ID}"`,
+    );
+  }
+  if (
+    !Array.isArray(obj.tools) ||
+    !Array.isArray(obj.routes) ||
+    !Array.isArray(obj.shutdownHooks) ||
+    typeof obj.sourceHash !== "string"
+  ) {
+    throw new Error(
+      `meet-join manifest at ${manifestPath} is missing required fields`,
+    );
+  }
+  return obj as unknown as Manifest;
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Dependencies the loader reads to register manifest-derived proxies.
+ * All fields are optional — production callers rely on the module-level
+ * defaults and tests override one or two. Keeping them injectable lets
+ * the unit test inject a fixture manifest path without mocking
+ * `getRepoSkillsDir()` + `existsSync` + `readFileSync`.
+ */
+export interface MeetManifestLoaderDeps {
+  /** Override for the manifest path resolver. */
+  manifestPath?: string;
+  /** Override for {@link registerExternalTools}. */
+  registerTools?: (provider: () => Tool[]) => void;
+  /** Override for {@link registerSkillRoute}. */
+  registerRoute?: (route: SkillRoute) => unknown;
+  /** Override for {@link registerShutdownHook}. */
+  registerShutdown?: (
+    name: string,
+    hook: (reason: string) => Promise<void>,
+  ) => void;
+}
+
+/**
+ * Read the shipped manifest and install proxy tool/route/shutdown-hook
+ * registrations that front-run through {@link MeetHostSupervisor}.
+ * Throws when the manifest is missing or malformed so packaging errors
+ * surface at daemon startup.
+ */
+export async function loadMeetManifestProxies(
+  supervisor: MeetHostSupervisor,
+  deps: MeetManifestLoaderDeps = {},
+): Promise<void> {
+  const manifestPath = deps.manifestPath ?? resolveMeetManifestPath();
+  if (!manifestPath) {
+    throw new Error(
+      "meet-join manifest path is unresolved — " +
+        "the shipped skills directory was not found. " +
+        "Rebuild/repackage so first-party skills ship with the daemon.",
+    );
+  }
+  const manifest = loadManifestInternal(manifestPath);
+
+  const registerTools = deps.registerTools ?? registerExternalTools;
+  const registerRoute = deps.registerRoute ?? registerSkillRoute;
+  const registerShutdown = deps.registerShutdown ?? registerShutdownHook;
+
+  // Tool provider resolves the full proxy list lazily so the tool manifest
+  // reflects the manifest file at `initializeTools()` time — same timing
+  // contract as the in-process skill's provider closure.
+  registerTools(() =>
+    manifest.tools.map((entry) =>
+      buildProxyTool(entry, supervisor, manifest.sourceHash),
+    ),
+  );
+
+  for (const entry of manifest.routes) {
+    registerRoute(buildProxyRoute(entry, supervisor));
+  }
+
+  for (const hookName of manifest.shutdownHooks) {
+    registerShutdown(hookName, async () => {
+      await supervisor.shutdown();
+    });
+  }
+
+  log.info(
+    {
+      manifestPath,
+      tools: manifest.tools.length,
+      routes: manifest.routes.length,
+      shutdownHooks: manifest.shutdownHooks.length,
+      sourceHash: manifest.sourceHash,
+    },
+    "Loaded meet-join manifest and installed lazy proxies",
+  );
+}

--- a/assistant/src/ipc/skill-routes/registries.ts
+++ b/assistant/src/ipc/skill-routes/registries.ts
@@ -20,6 +20,7 @@
 
 import { z } from "zod";
 
+import type { MeetHostSupervisor } from "../../daemon/meet-host-supervisor.js";
 import { registerShutdownHook } from "../../daemon/shutdown-registry.js";
 import { registerSkillRoute } from "../../runtime/skill-route-registry.js";
 import { registerSkillTools } from "../../tools/registry.js";
@@ -80,34 +81,75 @@ const ReportSessionParams = z.object({
   meetingId: z.string().min(1),
 });
 
-// ── Session counter (replaced by PR 27 MeetHostSupervisor) ────────────
+// ── Session counter ───────────────────────────────────────────────────
 
 /**
- * Active-session set. Keyed by meetingId so duplicate `report_session_started`
- * calls for the same meeting are idempotent and `report_session_ended` with
- * no prior start is a no-op. PR 27's `MeetHostSupervisor` takes over this
- * responsibility and this module delegates to it when it lands; the IPC wire
- * format does not change.
+ * Fallback active-session set. Keyed by meetingId so duplicate
+ * `report_session_started` calls are idempotent and `report_session_ended`
+ * for an unknown id is a no-op. Used when no {@link MeetHostSupervisor}
+ * has been registered (e.g. when the lazy-external flag is off, in the
+ * narrow window before `external-skills-bootstrap.ts` runs, and in tests
+ * that exercise the IPC routes in isolation). Also backs the test-only
+ * peek helper since the supervisor owns its own counter.
  */
 const activeSessions = new Set<string>();
 
-// TODO(skill-isolation PR 27): replace this helper with a call into
-// MeetHostSupervisor so idle-timeout tracking shares state with the rest
-// of the daemon's session accounting.
+/**
+ * Optional supervisor injected by `external-skills-bootstrap.ts` when the
+ * lazy-external path is enabled. When set, IPC session-report frames are
+ * forwarded to it so its active-session counter and idle-shutdown timer
+ * stay in sync with the routes. When unset, the fallback set above is
+ * mutated directly.
+ */
+type SessionSupervisor = Pick<
+  MeetHostSupervisor,
+  "reportSessionStarted" | "reportSessionEnded" | "activeSessionCount"
+>;
+
+let sessionSupervisor: SessionSupervisor | null = null;
+
+/**
+ * Install a {@link MeetHostSupervisor} as the session-report sink. The IPC
+ * routes still maintain their fallback {@link Set} for diagnostics, but
+ * the supervisor's counter is the source of truth for the `activeCount`
+ * returned to the skill. Passing `null` detaches the supervisor — used
+ * by tests that want to exercise the fallback path cleanly.
+ */
+export function setMeetHostSupervisorForSessionReports(
+  supervisor: SessionSupervisor | null,
+): void {
+  sessionSupervisor = supervisor;
+}
+
 function reportSessionStarted(meetingId: string): number {
+  if (sessionSupervisor) {
+    sessionSupervisor.reportSessionStarted(meetingId);
+    const count = sessionSupervisor.activeSessionCount;
+    log.info(
+      { meetingId, activeCount: count },
+      "Skill reported session started",
+    );
+    return count;
+  }
   activeSessions.add(meetingId);
   log.info(
     { meetingId, activeCount: activeSessions.size },
-    "Skill reported session started (supervisor stub)",
+    "Skill reported session started",
   );
   return activeSessions.size;
 }
 
 function reportSessionEnded(meetingId: string): number {
+  if (sessionSupervisor) {
+    sessionSupervisor.reportSessionEnded(meetingId);
+    const count = sessionSupervisor.activeSessionCount;
+    log.info({ meetingId, activeCount: count }, "Skill reported session ended");
+    return count;
+  }
   activeSessions.delete(meetingId);
   log.info(
     { meetingId, activeCount: activeSessions.size },
-    "Skill reported session ended (supervisor stub)",
+    "Skill reported session ended",
   );
   return activeSessions.size;
 }
@@ -115,6 +157,7 @@ function reportSessionEnded(meetingId: string): number {
 /** Test-only: drop all active sessions between test cases. */
 export function __resetActiveSessionsForTesting(): void {
   activeSessions.clear();
+  sessionSupervisor = null;
 }
 
 /** Test-only: peek at the current active set size. */


### PR DESCRIPTION
## Summary
- Adds services.meet.host.lazy_external config flag (default false).
- Adds assistant/src/daemon/meet-manifest-loader.ts that reads manifest.json and installs proxy tools/routes whose execute/handler use MeetHostSupervisor.ensureRunning() and IPC dispatch.
- Wires host.registries.report_session_started/ended to the real supervisor.
- external-skills-bootstrap.ts branches on the flag; default path unchanged.
- Dispatch stubs throw not-implemented — the server-initiated IPC direction is a follow-up; flag is off on main so users never hit the stub.
- PR 32 flips the flag after remaining scaffolding lands.

Part of plan: skill-isolation.md (PR 28 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
