### PR TITLE
fix(meet-join/session-manager): suppress orphan-reaper in build, honor getWorkspaceDir

### DIFF
--- a/skills/meet-join/daemon/docker-runner.ts
+++ b/skills/meet-join/daemon/docker-runner.ts
@@ -1252,11 +1252,21 @@ export const DOCKER_RUNNER_MODULE = "docker-runner";
  * `host.platform.*` / `host.logger.get(...)` so the runner stays free of
  * any `assistant/` imports. Tests that want to override the socket path
  * or inject fakes continue to construct {@link DockerRunner} directly.
+ *
+ * `resolveWorkspaceDir`, when supplied, overrides the default
+ * `host.platform.workspaceDir()` lookup — the session manager passes its
+ * own resolver so test callers that override `deps.getWorkspaceDir` have
+ * one consistent path for both session-manager state and Docker mounts.
  */
-export function createDockerRunner(host: SkillHost): DockerRunner {
+export function createDockerRunner(
+  host: SkillHost,
+  resolveWorkspaceDir?: () => string,
+): DockerRunner {
   return new DockerRunner({
     resolveMode: () => host.platform.runtimeMode(),
-    workspaceDir: host.platform.workspaceDir(),
+    workspaceDir: resolveWorkspaceDir
+      ? resolveWorkspaceDir()
+      : host.platform.workspaceDir(),
     logger: host.logger.get("meet-docker-runner"),
   });
 }

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -847,7 +847,7 @@ class MeetSessionManagerImpl {
     const resolveWorkspaceDir =
       deps.getWorkspaceDir ?? (() => host.platform.workspaceDir());
     const dockerRunnerSubModule = resolveSubModuleFactory<
-      (host: SkillHost) => DockerRunner
+      (host: SkillHost, resolveWorkspaceDir?: () => string) => DockerRunner
     >(DOCKER_RUNNER_MODULE);
     const audioIngestSubModule = resolveSubModuleFactory<
       (host: SkillHost) => () => MeetAudioIngest
@@ -867,7 +867,10 @@ class MeetSessionManagerImpl {
       ) => MeetConversationBridge
     >("conversation-bridge");
     const storageWriterSubModule = resolveSubModuleFactory<
-      (host: SkillHost) => (meetingId: string) => MeetStorageWriter
+      (
+        host: SkillHost,
+        resolveWorkspaceDir?: () => string,
+      ) => (meetingId: string) => MeetStorageWriter
     >("storage-writer");
     const chatOpportunityDetectorSubModule = resolveSubModuleFactory<
       (
@@ -885,11 +888,11 @@ class MeetSessionManagerImpl {
     >("barge-in-watcher");
 
     const dockerRunnerBuilder = (): DockerRunner =>
-      dockerRunnerSubModule(host);
+      dockerRunnerSubModule(host, resolveWorkspaceDir);
     const audioIngestBuilder = audioIngestSubModule(host);
     const consentMonitorBuilder = consentMonitorSubModule(host);
     const conversationBridgeBuilder = conversationBridgeSubModule(host);
-    const storageWriterBuilder = storageWriterSubModule(host);
+    const storageWriterBuilder = storageWriterSubModule(host, resolveWorkspaceDir);
     const chatOpportunityDetectorBuilder = chatOpportunityDetectorSubModule(host);
     const ttsBridgeBuilder = ttsBridgeSubModule(host);
     const ttsLipsyncBuilder = ttsLipsyncSubModule(host);

--- a/skills/meet-join/daemon/storage-writer.ts
+++ b/skills/meet-join/daemon/storage-writer.ts
@@ -629,11 +629,14 @@ export class MeetStorageWriter {
  */
 export function createStorageWriter(
   host: SkillHost,
+  resolveWorkspaceDir?: () => string,
 ): (meetingId: string, overrides?: MeetStorageWriterDeps) => MeetStorageWriter {
   const logger = host.logger.get("meet-storage-writer");
+  const getWorkspaceDir =
+    resolveWorkspaceDir ?? (() => host.platform.workspaceDir());
   return (meetingId, overrides = {}) =>
     new MeetStorageWriter(meetingId, {
-      getWorkspaceDir: () => host.platform.workspaceDir(),
+      getWorkspaceDir,
       logger,
       ...overrides,
     });

--- a/skills/meet-join/register.ts
+++ b/skills/meet-join/register.ts
@@ -58,14 +58,31 @@ import {
   createMeetSpeakTool,
 } from "./tools/meet-speak-tool.js";
 
-export function register(host: SkillHost): void {
+/**
+ * Options accepted by {@link register}. Build-tooling callers (notably
+ * `scripts/emit-manifest.ts`) pass `disableStartupOrphanReaper: true` so
+ * the session-manager constructor's one-shot Docker sweep does not fire
+ * against the developer's real Docker socket and SIGTERM live meet-bot
+ * containers. The daemon bootstrap leaves the flag unset so the reaper
+ * runs as intended on daemon startup.
+ */
+export interface MeetJoinRegisterOptions {
+  disableStartupOrphanReaper?: boolean;
+}
+
+export function register(
+  host: SkillHost,
+  options: MeetJoinRegisterOptions = {},
+): void {
   // Construct the session manager eagerly so the tool modules that import
   // the module-level `MeetSessionManager` singleton resolve against a live
   // instance. Sub-module factories are resolved from the in-skill
   // registry inside the constructor — the session-manager module's
   // side-effect imports trigger the required `registerSubModule(...)`
   // registrations at import time.
-  createMeetSessionManager(host);
+  createMeetSessionManager(host, {
+    disableStartupOrphanReaper: options.disableStartupOrphanReaper,
+  });
 
   host.registries.registerSkillRoute({
     pattern: MEET_INTERNAL_EVENTS_PATH_RE,

--- a/skills/meet-join/scripts/emit-manifest.ts
+++ b/skills/meet-join/scripts/emit-manifest.ts
@@ -310,7 +310,11 @@ async function main(): Promise<void> {
   const host = buildCollectorHost(captured);
 
   const registerMod = await import("../register.js");
-  registerMod.register(host);
+  // Suppress the session manager's one-shot startup orphan-reaper sweep:
+  // the emitter's collector host would otherwise wire a real DockerRunner
+  // against `/var/run/docker.sock` and, with zero active sessions, SIGTERM
+  // every same-instance meet-bot container on the developer's machine.
+  registerMod.register(host, { disableStartupOrphanReaper: true });
 
   // Sort by name / pattern so the manifest is independent of
   // registration order — reshuffling entries inside register.ts must


### PR DESCRIPTION
Addresses Codex + Devin feedback on PR #27814. register() unconditionally fired the orphan-reaper — running emit-manifest on a dev machine could SIGKILL live meet-bot containers. Also threads getWorkspaceDir override into dockerRunnerBuilder and storageWriterBuilder so tests can isolate workspace paths cleanly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
