### PR TITLE
fix(skill-host-contracts): make getConfigured + resolveStreamingTranscriber async/nullable, add createTimeout cleanup

### DIFF
--- a/assistant/src/daemon/__tests__/daemon-skill-host.test.ts
+++ b/assistant/src/daemon/__tests__/daemon-skill-host.test.ts
@@ -226,10 +226,10 @@ describe("createDaemonSkillHost", () => {
     expect(typeof host.providers.llm.getConfigured).toBe("function");
     expect(typeof host.providers.llm.userMessage).toBe("function");
     expect(typeof host.providers.llm.extractToolUse).toBe("function");
-    const controller = host.providers.llm.createTimeout(1000);
-    expect(controller).toBeInstanceOf(AbortController);
-    controller.abort();
-    expect(controller.signal.aborted).toBe(true);
+    const { signal, cleanup } = host.providers.llm.createTimeout(1000);
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(typeof cleanup).toBe("function");
+    cleanup();
   });
 
   test("memory.addMessage and wakeAgentForOpportunity are callable", async () => {

--- a/assistant/src/daemon/daemon-skill-host.ts
+++ b/assistant/src/daemon/daemon-skill-host.ts
@@ -40,6 +40,7 @@ import type {
   SkillRoute,
   SkillRouteHandle,
   SpeakersFacet,
+  StreamingTranscriber,
   SttProvidersFacet,
   Subscription,
   ToolUse,
@@ -55,6 +56,7 @@ import { getConfig, getNestedValue } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { addMessage } from "../memory/conversation-crud.js";
 import {
+  createTimeout,
   extractToolUse,
   getConfiguredProvider,
   userMessage,
@@ -130,24 +132,13 @@ function buildPlatformFacet(): PlatformFacet {
 
 function buildLlmProvidersFacet(): LlmProvidersFacet {
   return {
-    // `getConfiguredProvider` is async in the daemon. The contract types the
-    // return as `Provider = unknown`, so the awaited value is threaded back
-    // through other host methods by the skill; we return the promise here.
-    getConfigured: (callSite) =>
-      getConfiguredProvider(callSite as LLMCallSite) as unknown as Provider,
+    getConfigured: async (callSite) =>
+      (await getConfiguredProvider(callSite as LLMCallSite)) as Provider | null,
     userMessage: (text) => userMessage(text) as unknown as UserMessage,
     extractToolUse: (response) =>
-      (extractToolUse(response as never) ?? null) as ToolUse | null,
-    // Contract returns an `AbortController`; daemon's helper returns
-    // `{ signal, cleanup }`. The controller's `abort()` already fires the
-    // signal, and an already-aborted controller lets its timer be GC'd, so
-    // a minimal controller-driven timer matches the contract exactly.
-    createTimeout: (ms) => {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), ms);
-      controller.signal.addEventListener("abort", () => clearTimeout(timer));
-      return controller;
-    },
+      (extractToolUse(response as Parameters<typeof extractToolUse>[0]) ??
+        null) as ToolUse | null,
+    createTimeout,
   };
 }
 
@@ -158,9 +149,14 @@ function buildSttProvidersFacet(): SttProvidersFacet {
     // daemon-streaming boundary which is the only boundary skills currently
     // care about. Passes the id through to the daemon helper.
     supportsBoundary: (id) =>
-      sttSupportsBoundary(id as never, "daemon-streaming"),
-    resolveStreamingTranscriber: (spec) =>
-      sttResolveStreamingTranscriber(spec as never) as never,
+      sttSupportsBoundary(
+        id as Parameters<typeof sttSupportsBoundary>[0],
+        "daemon-streaming",
+      ),
+    resolveStreamingTranscriber: async (spec) =>
+      (await sttResolveStreamingTranscriber(
+        spec as Parameters<typeof sttResolveStreamingTranscriber>[0],
+      )) as StreamingTranscriber | null,
   };
 }
 

--- a/packages/skill-host-contracts/src/client.ts
+++ b/packages/skill-host-contracts/src/client.ts
@@ -626,10 +626,9 @@ export class SkillHostClient implements SkillHost {
   private buildLlmProvidersFacet(): LlmProvidersFacet {
     // The provider, user-message, and tool-use values are opaque tokens on
     // the contract; the client synthesizes structurally inert descriptors
-    // that round-trip through future dispatch routes. Synthesis is sync
-    // to match the contract shape.
+    // that round-trip through future dispatch routes.
     return {
-      getConfigured: (callSite: string): Provider =>
+      getConfigured: async (callSite: string): Promise<Provider | null> =>
         ({
           __vellumSkillHostClientHandle: "llm-provider",
           callSite,
@@ -650,8 +649,10 @@ export class SkillHostClient implements SkillHost {
       createTimeout: (ms: number) => {
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), ms);
-        controller.signal.addEventListener("abort", () => clearTimeout(timer));
-        return controller;
+        return {
+          signal: controller.signal,
+          cleanup: () => clearTimeout(timer),
+        };
       },
     };
   }
@@ -672,7 +673,7 @@ export class SkillHostClient implements SkillHost {
           "SkillHostClient.providers.stt.supportsBoundary: use `client.rawCall('host.providers.stt.supportsBoundary', { id, boundary: 'daemon-streaming' })` and await the result.",
         );
       },
-      resolveStreamingTranscriber: (spec: unknown) =>
+      resolveStreamingTranscriber: async (spec: unknown) =>
         ({
           __vellumSkillHostClientHandle: "streaming-transcriber",
           spec,

--- a/packages/skill-host-contracts/src/skill-host.ts
+++ b/packages/skill-host-contracts/src/skill-host.ts
@@ -134,18 +134,24 @@ export type UserMessage = unknown;
 export type ToolUse = unknown;
 
 export interface LlmProvidersFacet {
-  /** Resolve the provider configured for the given LLM call site. */
-  getConfigured(callSite: string): Provider;
+  /**
+   * Resolve the provider configured for the given LLM call site, or `null`
+   * when no provider is available (missing credentials, unsupported
+   * call-site, misconfigured profile). Async because the daemon's resolver
+   * reads the credential store asynchronously.
+   */
+  getConfigured(callSite: string): Promise<Provider | null>;
   /** Wrap plain text into the provider's user-message envelope shape. */
   userMessage(text: string): UserMessage;
   /** Pull the first `tool_use` block out of a completion response, if any. */
   extractToolUse(response: unknown): ToolUse | null;
   /**
-   * Produce an `AbortController` that aborts after `ms` milliseconds.
-   * Callers pass `controller.signal` into the LLM request to enforce a
-   * per-call deadline.
+   * Produce an `AbortSignal` that fires after `ms` milliseconds, alongside a
+   * `cleanup()` callback that cancels the underlying timer. Callers pass
+   * `signal` into the LLM request and must invoke `cleanup()` in a `finally`
+   * block so the timer does not leak when the request finishes first.
    */
-  createTimeout(ms: number): AbortController;
+  createTimeout(ms: number): { signal: AbortSignal; cleanup: () => void };
 }
 
 /** Opaque STT spec (skill passes an instance obtained from config through). */
@@ -157,7 +163,14 @@ export type StreamingTranscriber = unknown;
 export interface SttProvidersFacet {
   listProviderIds(): string[];
   supportsBoundary(id: string): boolean;
-  resolveStreamingTranscriber(spec: SttSpec): StreamingTranscriber;
+  /**
+   * Resolve a streaming transcriber for `spec`, or `null` when no configured
+   * STT provider supports the requested boundary/diarization. Async because
+   * the daemon's resolver reads credentials and pings the provider catalog.
+   */
+  resolveStreamingTranscriber(
+    spec: SttSpec,
+  ): Promise<StreamingTranscriber | null>;
 }
 
 /** Opaque TTS provider handle. */

--- a/skills/meet-join/__tests__/build-test-host.ts
+++ b/skills/meet-join/__tests__/build-test-host.ts
@@ -148,15 +148,17 @@ function defaultPlatformFacet(): PlatformFacet {
 
 function defaultLlmFacet(): LlmProvidersFacet {
   return {
-    getConfigured: () => undefined as unknown as Provider,
+    getConfigured: async () => null as unknown as Provider | null,
     userMessage: (text: string) =>
       ({ role: "user", content: text }) as unknown as UserMessage,
     extractToolUse: () => null,
     createTimeout: (ms: number) => {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), ms);
-      controller.signal.addEventListener("abort", () => clearTimeout(timer));
-      return controller;
+      return {
+        signal: controller.signal,
+        cleanup: () => clearTimeout(timer),
+      };
     },
   };
 }
@@ -165,8 +167,8 @@ function defaultSttFacet(): SttProvidersFacet {
   return {
     listProviderIds: () => [],
     supportsBoundary: () => false,
-    resolveStreamingTranscriber: () =>
-      undefined as unknown as StreamingTranscriber,
+    resolveStreamingTranscriber: async () =>
+      null as unknown as StreamingTranscriber | null,
   };
 }
 

--- a/skills/meet-join/daemon/__tests__/audio-ingest.test.ts
+++ b/skills/meet-join/daemon/__tests__/audio-ingest.test.ts
@@ -953,15 +953,18 @@ describe("createAudioIngest — default transcriber factory", () => {
       },
       providers: {
         llm: {
-          getConfigured: () => undefined,
+          getConfigured: async () => undefined,
           userMessage: () => undefined,
           extractToolUse: () => null,
-          createTimeout: () => new AbortController(),
+          createTimeout: () => ({
+            signal: new AbortController().signal,
+            cleanup: () => {},
+          }),
         },
         stt: {
           listProviderIds: () => options.providerIds ?? ["deepgram"],
           supportsBoundary: () => true,
-          resolveStreamingTranscriber: ((spec?: Record<string, unknown>) =>
+          resolveStreamingTranscriber: (async (spec?: Record<string, unknown>) =>
             options.resolver(spec)) as never,
         },
         tts: {

--- a/skills/meet-join/daemon/__tests__/event-publisher.test.ts
+++ b/skills/meet-join/daemon/__tests__/event-publisher.test.ts
@@ -101,15 +101,18 @@ function makeTestHost(): {
     },
     providers: {
       llm: {
-        getConfigured: () => ({}),
+        getConfigured: async () => ({}),
         userMessage: () => ({}),
         extractToolUse: () => null,
-        createTimeout: () => new AbortController(),
+        createTimeout: () => ({
+          signal: new AbortController().signal,
+          cleanup: () => {},
+        }),
       },
       stt: {
         listProviderIds: () => [],
         supportsBoundary: () => false,
-        resolveStreamingTranscriber: () => ({}),
+        resolveStreamingTranscriber: async () => ({}),
       },
       tts: {
         get: () => ({}),

--- a/skills/meet-join/daemon/consent-monitor.ts
+++ b/skills/meet-join/daemon/consent-monitor.ts
@@ -774,29 +774,35 @@ function createDefaultLlmAsk(host: SkillHost): ObjectionLLMAsk {
       return { objected: false, reason: "" };
     }
 
-    const controller = host.providers.llm.createTimeout(CONSENT_LLM_TIMEOUT_MS);
-    const response = await provider.sendMessage(
-      [host.providers.llm.userMessage(prompt)],
-      [OBJECTION_TOOL],
-      "You are a strict JSON classifier. Only respond via the report_objection tool.",
-      {
-        config: {
-          callSite: "meetConsentMonitor",
-          max_tokens: CONSENT_LLM_MAX_TOKENS,
-          tool_choice: { type: "tool" as const, name: OBJECTION_TOOL.name },
-        },
-        signal: controller.signal,
-      },
+    const { signal, cleanup } = host.providers.llm.createTimeout(
+      CONSENT_LLM_TIMEOUT_MS,
     );
-    const tool = host.providers.llm.extractToolUse(response) as {
-      input?: { objected?: unknown; reason?: unknown };
-    } | null;
-    if (!tool) return { objected: false, reason: "" };
-    const input = tool.input ?? {};
-    return {
-      objected: input.objected === true,
-      reason: typeof input.reason === "string" ? input.reason : "",
-    };
+    try {
+      const response = await provider.sendMessage(
+        [host.providers.llm.userMessage(prompt)],
+        [OBJECTION_TOOL],
+        "You are a strict JSON classifier. Only respond via the report_objection tool.",
+        {
+          config: {
+            callSite: "meetConsentMonitor",
+            max_tokens: CONSENT_LLM_MAX_TOKENS,
+            tool_choice: { type: "tool" as const, name: OBJECTION_TOOL.name },
+          },
+          signal,
+        },
+      );
+      const tool = host.providers.llm.extractToolUse(response) as {
+        input?: { objected?: unknown; reason?: unknown };
+      } | null;
+      if (!tool) return { objected: false, reason: "" };
+      const input = tool.input ?? {};
+      return {
+        objected: input.objected === true,
+        reason: typeof input.reason === "string" ? input.reason : "",
+      };
+    } finally {
+      cleanup();
+    }
   };
 }
 

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -2463,32 +2463,38 @@ class MeetSessionManagerImpl {
       return { shouldRespond: false, reason: "" };
     }
 
-    const controller = llm.createTimeout(CHAT_OPPORTUNITY_LLM_TIMEOUT_MS);
-    const response = await provider.sendMessage(
-      [llm.userMessage(prompt)],
-      [CHAT_OPPORTUNITY_TOOL],
-      "You are a strict JSON classifier. Only respond via the report_chat_opportunity tool.",
-      {
-        config: {
-          callSite: "meetChatOpportunity",
-          max_tokens: CHAT_OPPORTUNITY_LLM_MAX_TOKENS,
-          tool_choice: {
-            type: "tool" as const,
-            name: CHAT_OPPORTUNITY_TOOL.name,
-          },
-        },
-        signal: controller.signal,
-      },
+    const { signal, cleanup } = llm.createTimeout(
+      CHAT_OPPORTUNITY_LLM_TIMEOUT_MS,
     );
-    const tool = llm.extractToolUse(response) as {
-      input?: { shouldRespond?: unknown; reason?: unknown };
-    } | null;
-    if (!tool) return { shouldRespond: false, reason: "" };
-    const input = tool.input ?? {};
-    return {
-      shouldRespond: input.shouldRespond === true,
-      reason: typeof input.reason === "string" ? input.reason : "",
-    };
+    try {
+      const response = await provider.sendMessage(
+        [llm.userMessage(prompt)],
+        [CHAT_OPPORTUNITY_TOOL],
+        "You are a strict JSON classifier. Only respond via the report_chat_opportunity tool.",
+        {
+          config: {
+            callSite: "meetChatOpportunity",
+            max_tokens: CHAT_OPPORTUNITY_LLM_MAX_TOKENS,
+            tool_choice: {
+              type: "tool" as const,
+              name: CHAT_OPPORTUNITY_TOOL.name,
+            },
+          },
+          signal,
+        },
+      );
+      const tool = llm.extractToolUse(response) as {
+        input?: { shouldRespond?: unknown; reason?: unknown };
+      } | null;
+      if (!tool) return { shouldRespond: false, reason: "" };
+      const input = tool.input ?? {};
+      return {
+        shouldRespond: input.shouldRespond === true,
+        reason: typeof input.reason === "string" ? input.reason : "",
+      };
+    } finally {
+      cleanup();
+    }
   }
 }
 
@@ -2638,10 +2644,10 @@ function buildSessionManagerTestHost(): SkillHost {
         createTimeout: (ms: number) => {
           const controller = new AbortController();
           const timer = setTimeout(() => controller.abort(), ms);
-          controller.signal.addEventListener("abort", () =>
-            clearTimeout(timer),
-          );
-          return controller;
+          return {
+            signal: controller.signal,
+            cleanup: () => clearTimeout(timer),
+          };
         },
       },
       stt: {

--- a/skills/meet-join/scripts/emit-manifest.ts
+++ b/skills/meet-join/scripts/emit-manifest.ts
@@ -121,15 +121,18 @@ function buildCollectorHost(captured: Captured): SkillHost {
     },
     providers: {
       llm: {
-        getConfigured: () => undefined,
+        getConfigured: async () => null,
         userMessage: () => undefined,
         extractToolUse: () => null,
-        createTimeout: () => new AbortController(),
+        createTimeout: () => ({
+          signal: new AbortController().signal,
+          cleanup: () => {},
+        }),
       },
       stt: {
         listProviderIds: () => [],
         supportsBoundary: () => false,
-        resolveStreamingTranscriber: () => undefined,
+        resolveStreamingTranscriber: async () => null,
       },
       tts: {
         get: () => undefined,


### PR DESCRIPTION
Addresses Codex feedback on PR #27753. The SkillHost interface declared LLM and STT resolvers as sync/non-null but the daemon adapter hid a Promise behind 'as never'; skill consumers following the interface would get a Promise at runtime. createTimeout also dropped the cleanup handle, so timers could leak. This PR aligns the interface with the real daemon behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
