### PR TITLE
fix(migration-routes): stop unhandled error when upstream socket dies early in URL import

### DIFF
--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -1152,6 +1152,19 @@ export async function runGcsImport(
     taggedSource.destroy(err);
   });
   upstreamNodeStream.pipe(taggedSource);
+  // Absorb stream errors on `taggedSource`. `streamCommitImport` does
+  // several `await`s (workspace recovery, temp-dir mkdir) before
+  // `parseVBundleStream(source)` attaches its own `source.on('error')`
+  // listener. If the upstream socket is destroyed during that window,
+  // the `upstreamNodeStream.on('close')` handler above calls
+  // `taggedSource.destroy(err)` with no listener attached yet and the
+  // error surfaces as unhandled. We don't need to act on it here — the
+  // `kFetchBodyTornDown` flag has already been latched on the stream,
+  // and the post-import branch below (`wasFetchBodyTornDown(taggedSource)`)
+  // maps the failure to `fetch_failed`. Register this absorber
+  // unconditionally so there is always at least one `'error'` listener
+  // on the wrapper for the lifetime of the stream.
+  taggedSource.on("error", () => {});
   // Propagate wrapper teardown back to the upstream fetch body. When the
   // streaming importer hits a validation/extraction error, it destroys
   // `source` (which is `taggedSource`). Without this listener the


### PR DESCRIPTION
## Summary
- The 'upstream body dropped mid-stream' test was failing on CI because when the upstream socket was destroyed during an await in `streamCommitImport` (before `parseVBundleStream` attached its source-error listener), the synthesized error on `taggedSource` surfaced as unhandled.
- Attach a no-op `error` listener on `taggedSource` up front so there is always an error listener; the existing `kFetchBodyTornDown` flag continues to drive the `fetch_failed` mapping after `streamCommitImport` returns.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24882314676
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
