### PR TITLE
fix(gateway/ci): resolve trust-rules-v3 CI failures on main

### DIFF
--- a/gateway/src/__tests__/trust-rule-v3-store.test.ts
+++ b/gateway/src/__tests__/trust-rule-v3-store.test.ts
@@ -5,6 +5,11 @@ import "./test-preload.js";
 
 // ---------------------------------------------------------------------------
 // Setup / teardown
+//
+// resetGatewayDb() only closes the connection — the SQLite file persists
+// inside the per-file temp dir set by test-preload. That means tool+pattern
+// pairs must be unique across every test in this file or the UNIQUE index
+// on (tool, pattern) will trip on re-inserts.
 // ---------------------------------------------------------------------------
 
 let store: TrustRuleV3Store;
@@ -16,16 +21,23 @@ let store: TrustRuleV3Store;
 let seededDefaultCount: number;
 let seededBashCount: number;
 let seededTotalCount: number;
+let seededTotalWithDeleted: number;
 
 beforeEach(async () => {
   resetGatewayDb();
   await initGatewayDb();
   store = new TrustRuleV3Store();
 
-  // Capture baselines — initGatewayDb() seeds DEFAULT_COMMAND_REGISTRY
+  // Capture baselines — initGatewayDb() seeds DEFAULT_COMMAND_REGISTRY.
+  // The file accumulates user rules across tests, so these counts drift
+  // upward; tests should always compute deltas relative to the baseline.
+  // `seededTotalWithDeleted` is needed separately because prior tests may
+  // have soft-deleted rules that `list()` hides but `list({ includeDeleted })`
+  // surfaces.
   seededDefaultCount = store.list({ origin: "default" }).length;
   seededBashCount = store.list({ tool: "bash" }).length;
   seededTotalCount = store.list().length;
+  seededTotalWithDeleted = store.list({ includeDeleted: true }).length;
 });
 
 afterEach(() => {
@@ -40,7 +52,7 @@ describe("create()", () => {
   test("creates a user-defined rule with all fields", () => {
     const rule = store.create({
       tool: "bash",
-      pattern: "echo *",
+      pattern: "create-all-fields-echo",
       risk: "low",
       description: "Allow echo commands",
     });
@@ -51,7 +63,7 @@ describe("create()", () => {
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
     );
     expect(rule.tool).toBe("bash");
-    expect(rule.pattern).toBe("echo *");
+    expect(rule.pattern).toBe("create-all-fields-echo");
     expect(rule.risk).toBe("low");
     expect(rule.description).toBe("Allow echo commands");
     expect(rule.origin).toBe("user_defined");
@@ -65,7 +77,7 @@ describe("create()", () => {
     const before = new Date().toISOString();
     const rule = store.create({
       tool: "bash",
-      pattern: "my-custom-ls",
+      pattern: "create-iso-ls",
       risk: "low",
       description: "test",
     });
@@ -85,13 +97,13 @@ describe("list()", () => {
   test("returns all non-deleted rules by default", () => {
     store.create({
       tool: "bash",
-      pattern: "echo *",
+      pattern: "list-default-bash",
       risk: "low",
       description: "Rule 1",
     });
     store.create({
       tool: "file_read",
-      pattern: "/tmp/**",
+      pattern: "/list-default/tmp/**",
       risk: "medium",
       description: "Rule 2",
     });
@@ -103,19 +115,21 @@ describe("list()", () => {
   test("filters by origin", () => {
     store.create({
       tool: "bash",
-      pattern: "echo *",
+      pattern: "list-origin-user",
       risk: "low",
       description: "User rule",
     });
     store.upsertDefault({
-      id: "default:bash:rm-rf",
+      id: "default:bash:list-origin-rm-rf",
       tool: "bash",
-      pattern: "rm -rf *",
+      pattern: "list-origin-rm-rf",
       risk: "high",
       description: "Default rule",
     });
 
-    const userRules = store.list({ origin: "user_defined" });
+    const userRules = store
+      .list({ origin: "user_defined" })
+      .filter((r) => r.pattern === "list-origin-user");
     expect(userRules).toHaveLength(1);
     expect(userRules[0].origin).toBe("user_defined");
 
@@ -127,13 +141,13 @@ describe("list()", () => {
   test("filters by tool", () => {
     store.create({
       tool: "bash",
-      pattern: "echo *",
+      pattern: "list-tool-bash",
       risk: "low",
       description: "Bash rule",
     });
     store.create({
       tool: "file_read",
-      pattern: "/tmp/**",
+      pattern: "/list-tool/tmp/**",
       risk: "medium",
       description: "File rule",
     });
@@ -145,33 +159,36 @@ describe("list()", () => {
 
   test("excludes soft-deleted rules by default", () => {
     store.upsertDefault({
-      id: "default:bash:danger",
+      id: "default:bash:list-excl-danger",
       tool: "bash",
-      pattern: "danger",
+      pattern: "list-excl-danger",
       risk: "high",
       description: "Danger",
     });
-    store.remove("default:bash:danger");
+    store.remove("default:bash:list-excl-danger");
 
     const rules = store.list();
-    // Should have the seeded rules but not the soft-deleted one
+    // upsertDefault + remove is net-zero on the visible count, so we expect
+    // to be back at the pre-test baseline even though the row still exists.
     expect(rules).toHaveLength(seededTotalCount);
-    expect(rules.find((r) => r.id === "default:bash:danger")).toBeUndefined();
+    expect(
+      rules.find((r) => r.id === "default:bash:list-excl-danger"),
+    ).toBeUndefined();
   });
 
   test("includes soft-deleted rules when includeDeleted is true", () => {
     store.upsertDefault({
-      id: "default:bash:danger",
+      id: "default:bash:list-incl-danger",
       tool: "bash",
-      pattern: "danger",
+      pattern: "list-incl-danger",
       risk: "high",
       description: "Danger",
     });
-    store.remove("default:bash:danger");
+    store.remove("default:bash:list-incl-danger");
 
     const rules = store.list({ includeDeleted: true });
-    expect(rules).toHaveLength(seededTotalCount + 1);
-    const deleted = rules.find((r) => r.id === "default:bash:danger");
+    expect(rules).toHaveLength(seededTotalWithDeleted + 1);
+    const deleted = rules.find((r) => r.id === "default:bash:list-incl-danger");
     expect(deleted).toBeDefined();
     expect(deleted!.deleted).toBe(true);
   });
@@ -185,7 +202,7 @@ describe("getById()", () => {
   test("returns rule when found", () => {
     const created = store.create({
       tool: "bash",
-      pattern: "echo *",
+      pattern: "getbyid-found-echo",
       risk: "low",
       description: "Test",
     });
@@ -210,7 +227,7 @@ describe("update()", () => {
   test("updates risk and description", () => {
     const created = store.create({
       tool: "bash",
-      pattern: "echo *",
+      pattern: "update-risk-echo",
       risk: "low",
       description: "Original",
     });
@@ -222,29 +239,31 @@ describe("update()", () => {
 
     expect(updated.risk).toBe("high");
     expect(updated.description).toBe("Updated");
-    expect(updated.updatedAt > created.updatedAt).toBe(true);
+    expect(updated.updatedAt >= created.updatedAt).toBe(true);
   });
 
   test("sets userModified=true for default rules", () => {
     store.upsertDefault({
-      id: "default:bash:test-update",
+      id: "default:bash:update-set-usermod",
       tool: "bash",
-      pattern: "test-update",
+      pattern: "update-set-usermod",
       risk: "low",
       description: "Default rule",
     });
 
-    const rule = store.getById("default:bash:test-update")!;
+    const rule = store.getById("default:bash:update-set-usermod")!;
     expect(rule.userModified).toBe(false);
 
-    const updated = store.update("default:bash:test-update", { risk: "high" });
+    const updated = store.update("default:bash:update-set-usermod", {
+      risk: "high",
+    });
     expect(updated.userModified).toBe(true);
   });
 
   test("does not set userModified for user_defined rules", () => {
     const created = store.create({
       tool: "bash",
-      pattern: "echo *",
+      pattern: "update-no-usermod-echo",
       risk: "low",
       description: "User rule",
     });
@@ -268,7 +287,7 @@ describe("remove()", () => {
   test("hard-deletes user_defined rules", () => {
     const created = store.create({
       tool: "bash",
-      pattern: "echo *",
+      pattern: "remove-hard-echo",
       risk: "low",
       description: "User rule",
     });
@@ -286,24 +305,24 @@ describe("remove()", () => {
 
   test("soft-deletes default rules", () => {
     store.upsertDefault({
-      id: "default:bash:test-remove",
+      id: "default:bash:remove-soft",
       tool: "bash",
-      pattern: "test-remove",
+      pattern: "remove-soft",
       risk: "low",
       description: "Default rule",
     });
 
-    const result = store.remove("default:bash:test-remove");
+    const result = store.remove("default:bash:remove-soft");
     expect(result).toBe(true);
 
     // Should not appear in default list (without includeDeleted)
     const rules = store.list();
     expect(
-      rules.find((r) => r.id === "default:bash:test-remove"),
+      rules.find((r) => r.id === "default:bash:remove-soft"),
     ).toBeUndefined();
 
     // Should still exist as soft-deleted
-    const found = store.getById("default:bash:test-remove");
+    const found = store.getById("default:bash:remove-soft");
     expect(found).not.toBeNull();
     expect(found!.deleted).toBe(true);
   });
@@ -322,28 +341,30 @@ describe("remove()", () => {
 describe("reset()", () => {
   test("clears userModified and deleted, restores risk", () => {
     store.upsertDefault({
-      id: "default:bash:test-reset",
+      id: "default:bash:reset-clears",
       tool: "bash",
-      pattern: "test-reset",
+      pattern: "reset-clears",
       risk: "low",
       description: "Default rule",
     });
 
     // Modify and delete
-    store.update("default:bash:test-reset", { risk: "high" });
-    store.remove("default:bash:test-reset");
+    store.update("default:bash:reset-clears", { risk: "high" });
+    store.remove("default:bash:reset-clears");
 
-    const beforeReset = store.getById("default:bash:test-reset")!;
+    const beforeReset = store.getById("default:bash:reset-clears")!;
     expect(beforeReset.userModified).toBe(true);
     expect(beforeReset.deleted).toBe(true);
     expect(beforeReset.risk).toBe("high");
 
     // Reset
-    const resetRule = store.reset("default:bash:test-reset", "low");
+    const resetRule = store.reset("default:bash:reset-clears", "low");
     expect(resetRule.userModified).toBe(false);
     expect(resetRule.deleted).toBe(false);
     expect(resetRule.risk).toBe("low");
-    expect(resetRule.updatedAt > beforeReset.updatedAt).toBe(true);
+    // updatedAt is ISO millisecond precision; reset can land in the same ms
+    // as the preceding update/remove on fast machines, so allow equality.
+    expect(resetRule.updatedAt >= beforeReset.updatedAt).toBe(true);
   });
 
   test("throws if rule not found", () => {
@@ -355,7 +376,7 @@ describe("reset()", () => {
   test("throws if origin is not default", () => {
     const created = store.create({
       tool: "bash",
-      pattern: "echo *",
+      pattern: "reset-non-default-echo",
       risk: "low",
       description: "User rule",
     });
@@ -373,14 +394,14 @@ describe("reset()", () => {
 describe("upsertDefault()", () => {
   test("inserts a new default rule", () => {
     store.upsertDefault({
-      id: "default:bash:test-upsert",
+      id: "default:bash:upsert-insert",
       tool: "bash",
-      pattern: "test-upsert",
+      pattern: "upsert-insert",
       risk: "low",
       description: "Default rule",
     });
 
-    const rule = store.getById("default:bash:test-upsert");
+    const rule = store.getById("default:bash:upsert-insert");
     expect(rule).not.toBeNull();
     expect(rule!.origin).toBe("default");
     expect(rule!.userModified).toBe(false);
@@ -390,53 +411,53 @@ describe("upsertDefault()", () => {
 
   test("updates unmodified default rule on conflict", () => {
     store.upsertDefault({
-      id: "default:bash:test-upsert-conflict",
+      id: "default:bash:upsert-conflict",
       tool: "bash",
-      pattern: "test-upsert-conflict",
+      pattern: "upsert-conflict",
       risk: "low",
       description: "Original",
     });
 
     // Re-upsert with updated risk and description
     store.upsertDefault({
-      id: "default:bash:test-upsert-conflict",
+      id: "default:bash:upsert-conflict",
       tool: "bash",
-      pattern: "test-upsert-conflict",
+      pattern: "upsert-conflict",
       risk: "medium",
       description: "Updated",
     });
 
-    const rule = store.getById("default:bash:test-upsert-conflict")!;
+    const rule = store.getById("default:bash:upsert-conflict")!;
     expect(rule.risk).toBe("medium");
     expect(rule.description).toBe("Updated");
   });
 
   test("three-guard: does NOT overwrite user-modified rule", () => {
     store.upsertDefault({
-      id: "default:bash:test-3g-modified",
+      id: "default:bash:upsert-3g-modified",
       tool: "bash",
-      pattern: "test-3g-modified",
+      pattern: "upsert-3g-modified",
       risk: "low",
       description: "Original",
     });
 
     // User modifies the rule
-    store.update("default:bash:test-3g-modified", { risk: "high" });
+    store.update("default:bash:upsert-3g-modified", { risk: "high" });
 
-    const modified = store.getById("default:bash:test-3g-modified")!;
+    const modified = store.getById("default:bash:upsert-3g-modified")!;
     expect(modified.userModified).toBe(true);
     expect(modified.risk).toBe("high");
 
     // Re-upsert should NOT overwrite because userModified=true
     store.upsertDefault({
-      id: "default:bash:test-3g-modified",
+      id: "default:bash:upsert-3g-modified",
       tool: "bash",
-      pattern: "test-3g-modified",
+      pattern: "upsert-3g-modified",
       risk: "low",
       description: "Should not overwrite",
     });
 
-    const afterUpsert = store.getById("default:bash:test-3g-modified")!;
+    const afterUpsert = store.getById("default:bash:upsert-3g-modified")!;
     expect(afterUpsert.risk).toBe("high");
     expect(afterUpsert.description).toBe("Original");
     expect(afterUpsert.userModified).toBe(true);
@@ -444,29 +465,29 @@ describe("upsertDefault()", () => {
 
   test("three-guard: does NOT overwrite soft-deleted rule", () => {
     store.upsertDefault({
-      id: "default:bash:test-3g-deleted",
+      id: "default:bash:upsert-3g-deleted",
       tool: "bash",
-      pattern: "test-3g-deleted",
+      pattern: "upsert-3g-deleted",
       risk: "low",
       description: "Original",
     });
 
     // Soft-delete the rule
-    store.remove("default:bash:test-3g-deleted");
+    store.remove("default:bash:upsert-3g-deleted");
 
-    const deleted = store.getById("default:bash:test-3g-deleted")!;
+    const deleted = store.getById("default:bash:upsert-3g-deleted")!;
     expect(deleted.deleted).toBe(true);
 
     // Re-upsert should NOT overwrite because deleted=true
     store.upsertDefault({
-      id: "default:bash:test-3g-deleted",
+      id: "default:bash:upsert-3g-deleted",
       tool: "bash",
-      pattern: "test-3g-deleted",
+      pattern: "upsert-3g-deleted",
       risk: "medium",
       description: "Should not overwrite",
     });
 
-    const afterUpsert = store.getById("default:bash:test-3g-deleted")!;
+    const afterUpsert = store.getById("default:bash:upsert-3g-deleted")!;
     expect(afterUpsert.risk).toBe("low");
     expect(afterUpsert.description).toBe("Original");
     expect(afterUpsert.deleted).toBe(true);
@@ -476,7 +497,7 @@ describe("upsertDefault()", () => {
     // Create a user-defined rule first
     store.create({
       tool: "bash",
-      pattern: "custom-pattern",
+      pattern: "upsert-3g-user-defined",
       risk: "high",
       description: "User created",
     });
@@ -484,16 +505,18 @@ describe("upsertDefault()", () => {
     // Upsert a default with same tool+pattern should NOT overwrite
     // because origin != 'default'
     store.upsertDefault({
-      id: "default:bash:custom-pattern",
+      id: "default:bash:upsert-3g-user-defined",
       tool: "bash",
-      pattern: "custom-pattern",
+      pattern: "upsert-3g-user-defined",
       risk: "low",
       description: "Default version",
     });
 
     // The user-defined rule should remain unchanged
     const rules = store.list({ tool: "bash" });
-    const customRule = rules.find((r) => r.pattern === "custom-pattern");
+    const customRule = rules.find(
+      (r) => r.pattern === "upsert-3g-user-defined",
+    );
     expect(customRule).toBeDefined();
     expect(customRule!.origin).toBe("user_defined");
     expect(customRule!.risk).toBe("high");
@@ -509,36 +532,40 @@ describe("listActive()", () => {
   test("returns only non-deleted rules", () => {
     store.create({
       tool: "bash",
-      pattern: "echo *",
+      pattern: "listactive-only-user",
       risk: "low",
       description: "Active user rule",
     });
     store.upsertDefault({
-      id: "default:bash:danger",
+      id: "default:bash:listactive-only-danger",
       tool: "bash",
-      pattern: "danger",
+      pattern: "listactive-only-danger",
       risk: "high",
       description: "Deleted default",
     });
-    store.remove("default:bash:danger");
+    store.remove("default:bash:listactive-only-danger");
 
     const active = store.listActive();
-    // Seeded rules + 1 user rule, but NOT the soft-deleted danger rule
+    // Baseline + 1 active user rule, minus the soft-deleted upsert (net 0).
     expect(active).toHaveLength(seededTotalCount + 1);
-    expect(active.find((r) => r.pattern === "echo *")).toBeDefined();
-    expect(active.find((r) => r.pattern === "danger")).toBeUndefined();
+    expect(
+      active.find((r) => r.pattern === "listactive-only-user"),
+    ).toBeDefined();
+    expect(
+      active.find((r) => r.pattern === "listactive-only-danger"),
+    ).toBeUndefined();
   });
 
   test("filters by tool", () => {
     store.create({
       tool: "bash",
-      pattern: "echo *",
+      pattern: "listactive-tool-bash",
       risk: "low",
       description: "Bash rule",
     });
     store.create({
       tool: "file_read",
-      pattern: "/tmp/**",
+      pattern: "/listactive-tool/tmp/**",
       risk: "medium",
       description: "File rule",
     });
@@ -547,7 +574,9 @@ describe("listActive()", () => {
     expect(bashRules).toHaveLength(seededBashCount + 1);
     expect(bashRules.every((r) => r.tool === "bash")).toBe(true);
 
-    const fileRules = store.listActive("file_read");
+    const fileRules = store
+      .listActive("file_read")
+      .filter((r) => r.pattern === "/listactive-tool/tmp/**");
     expect(fileRules).toHaveLength(1);
     expect(fileRules[0].tool).toBe("file_read");
   });
@@ -555,13 +584,13 @@ describe("listActive()", () => {
   test("returns all active rules when no tool filter is provided", () => {
     store.create({
       tool: "bash",
-      pattern: "echo *",
+      pattern: "listactive-all-bash",
       risk: "low",
       description: "Bash rule",
     });
     store.create({
       tool: "file_read",
-      pattern: "/tmp/**",
+      pattern: "/listactive-all/tmp/**",
       risk: "medium",
       description: "File rule",
     });

--- a/gateway/src/__tests__/trust-rules-v3-routes.test.ts
+++ b/gateway/src/__tests__/trust-rules-v3-routes.test.ts
@@ -2,14 +2,9 @@
  * Tests for gateway trust-rule v3 route handlers.
  *
  * Tests exercise the route handlers directly (not via the full HTTP server),
- * using an in-memory SQLite database initialized by initGatewayDb().
- *
- * Note: Feature flag gating tests are skipped because mocking
- * getMergedFeatureFlags() across module boundaries is complex. The flag
- * gating is tested implicitly via integration tests. All mutation tests
- * here run with the flag assumed to be enabled (the handlers are called
- * directly, bypassing the flag check path by design — see individual
- * test comments).
+ * using the SQLite database initialized by initGatewayDb() against a temp dir.
+ * The `permission-controls-v3` feature flag is enabled in beforeEach so the
+ * mutation handlers don't short-circuit with 403.
  */
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
@@ -25,6 +20,10 @@ import {
   createTrustRuleV3sDeleteHandler,
   createTrustRuleV3sResetHandler,
 } from "../http/routes/trust-rules-v3.js";
+import {
+  clearFeatureFlagStoreCache,
+  writeFeatureFlag,
+} from "../feature-flag-store.js";
 import "./test-preload.js";
 
 // ---------------------------------------------------------------------------
@@ -36,13 +35,18 @@ let store: TrustRuleV3Store;
 beforeEach(async () => {
   resetGatewayDb();
   resetTrustRuleV3Cache();
+  clearFeatureFlagStoreCache();
   await initGatewayDb();
   initTrustRuleV3Cache();
   store = new TrustRuleV3Store();
+
+  // Mutation handlers are gated behind this flag (403 otherwise).
+  writeFeatureFlag("permission-controls-v3", true);
 });
 
 afterEach(() => {
   resetTrustRuleV3Cache();
+  clearFeatureFlagStoreCache();
   resetGatewayDb();
 });
 

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -3283,6 +3283,157 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/trust-rules-v3": {
+        get: {
+          summary: "List v3 trust rules",
+          description:
+            "Authenticated gateway endpoint that lists trust rules from the v3 SQLite-backed store. By default returns user-relevant rules (user_defined + user-modified defaults). Supports `origin`, `tool`, and `include_deleted` query filters.",
+          operationId: "trustRulesV3Get",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "origin",
+              in: "query",
+              required: false,
+              schema: { type: "string", enum: ["default", "user_defined"] },
+              description: "Filter by rule origin.",
+            },
+            {
+              name: "tool",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              description: "Filter by tool name.",
+            },
+            {
+              name: "include_deleted",
+              in: "query",
+              required: false,
+              schema: { type: "boolean" },
+              description: "Include soft-deleted rules in the response.",
+            },
+          ],
+          responses: {
+            "200": { description: "Trust rules returned" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "500": { description: "Internal server error" },
+          },
+        },
+        post: {
+          summary: "Create a v3 trust rule",
+          description:
+            "Authenticated gateway endpoint that creates a user-defined trust rule in the v3 SQLite-backed store. Gated behind the `permission-controls-v3` feature flag.",
+          operationId: "trustRulesV3Post",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "201": { description: "Trust rule created" },
+            "400": { description: "Invalid request payload" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "403": { description: "Feature not enabled" },
+          },
+        },
+      },
+      "/v1/trust-rules-v3/{ruleId}": {
+        patch: {
+          summary: "Update a v3 trust rule",
+          description:
+            "Authenticated gateway endpoint that updates a v3 trust rule's risk and/or description. Default rules are marked `userModified=true` on change. Gated behind the `permission-controls-v3` feature flag.",
+          operationId: "trustRulesV3Patch",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "ruleId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Trust rule updated" },
+            "400": { description: "Invalid request payload" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "403": { description: "Feature not enabled" },
+            "404": { description: "Trust rule not found" },
+          },
+        },
+        delete: {
+          summary: "Delete a v3 trust rule",
+          description:
+            "Authenticated gateway endpoint that deletes a v3 trust rule. User-defined rules are hard-deleted; default rules are soft-deleted. Gated behind the `permission-controls-v3` feature flag.",
+          operationId: "trustRulesV3Delete",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "ruleId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": { description: "Trust rule deleted" },
+            "400": { description: "Rule ID is required" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "403": { description: "Feature not enabled" },
+            "404": { description: "Trust rule not found" },
+            "500": { description: "Internal server error" },
+          },
+        },
+      },
+      "/v1/trust-rules-v3/{ruleId}/reset": {
+        post: {
+          summary: "Reset a v3 default trust rule",
+          description:
+            "Authenticated gateway endpoint that resets a modified default trust rule back to its original risk and description from the command registry. Only valid for rules with `origin=default`. Gated behind the `permission-controls-v3` feature flag.",
+          operationId: "trustRulesV3ResetPost",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "ruleId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": { description: "Trust rule reset to defaults" },
+            "400": {
+              description:
+                "Rule is not a default rule, or original values cannot be determined",
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "403": { description: "Feature not enabled" },
+            "404": { description: "Trust rule not found" },
+            "500": { description: "Internal server error" },
+          },
+        },
+      },
       "/v1/trust-rules": {
         get: {
           summary: "List trust rules",


### PR DESCRIPTION
## Summary
- Add OpenAPI schema entries for \`/v1/trust-rules-v3\` CRUD routes (\`route-schema-guard\` was flagging them as missing).
- Rewrite \`trust-rule-v3-store\` tests with unique patterns per test and a \`seededTotalWithDeleted\` baseline — the file-backed SQLite DB persists across \`beforeEach\`/\`afterEach\` resets, so shared \`(tool, pattern)\` pairs were tripping the UNIQUE index.
- Enable \`permission-controls-v3\` in the routes test \`beforeEach\` via \`writeFeatureFlag\` so the gated mutation handlers don't return 403.

Targets the three failing tests in https://github.com/vellum-ai/vellum-assistant/actions/runs/24882776492/job/72855129928 — \`route-schema-guard\`, \`trust-rule-v3-store\`, and \`trust-rules-v3-routes\`. Each one passes locally 5/5 runs after the fix.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24882776492/job/72855129928
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
