### PR TITLE
feat: add scope parameter to TrustRuleV3Client.createRule

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -853,7 +853,8 @@ private struct ToolCallStepDetailRow: View {
                                 description: {
                                     let desc = tc.reasonDescription ?? ""
                                     return desc.isEmpty ? "\(rule.toolName) — \(rule.pattern)" : desc
-                                }()
+                                }(),
+                                scope: "everywhere"
                             )
                         }
                     },

--- a/clients/shared/Network/TrustRuleV3Client.swift
+++ b/clients/shared/Network/TrustRuleV3Client.swift
@@ -47,7 +47,7 @@ public enum TrustRuleV3ClientError: Error, LocalizedError {
 
 public protocol TrustRuleV3ClientProtocol {
     func listRules(origin: String?, tool: String?, includeDeleted: Bool?) async throws -> [TrustRuleV3]
-    func createRule(tool: String, pattern: String, risk: String, description: String) async throws -> TrustRuleV3
+    func createRule(tool: String, pattern: String, risk: String, description: String, scope: String) async throws -> TrustRuleV3
     func updateRule(id: String, risk: String?, description: String?) async throws -> TrustRuleV3
     func deleteRule(id: String) async throws
     func resetRule(id: String) async throws -> TrustRuleV3
@@ -75,12 +75,13 @@ public struct TrustRuleV3Client: TrustRuleV3ClientProtocol {
         return try JSONDecoder().decode(TrustRuleV3ListResponse.self, from: response.data).rules
     }
 
-    public func createRule(tool: String, pattern: String, risk: String, description: String) async throws -> TrustRuleV3 {
+    public func createRule(tool: String, pattern: String, risk: String, description: String, scope: String = "everywhere") async throws -> TrustRuleV3 {
         let body: [String: Any] = [
             "tool": tool,
             "pattern": pattern,
             "risk": risk,
             "description": description,
+            "scope": scope,
         ]
         let response = try await GatewayHTTPClient.post(
             path: "trust-rules-v3", json: body, timeout: 10


### PR DESCRIPTION
## Summary
- Add scope parameter to TrustRuleV3ClientProtocol.createRule
- Add scope to request body in TrustRuleV3Client implementation
- Default to "everywhere" for backward compatibility

Part of plan: dir-scope-swiftui.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
