### PR TITLE
feat: persist directoryScopeOptions in ChatActionHandler and streaming helpers

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -1180,6 +1180,7 @@ final class ChatActionHandler {
             diff: msg.diff,
             allowlistOptions: msg.allowlistOptions,
             scopeOptions: msg.scopeOptions,
+            directoryScopeOptions: msg.directoryScopeOptions ?? [],
             executionTarget: msg.executionTarget,
             persistentDecisionsAllowed: msg.persistentDecisionsAllowed ?? true,
             temporaryOptionsAvailable: msg.temporaryOptionsAvailable ?? [],
@@ -1198,6 +1199,10 @@ final class ChatActionHandler {
                     .first(where: { $0.scope != "everywhere" })?.scope
             }
             vm.messages[msgIdx].toolCalls[tcIdx].isContainerized = msg.isContainerized ?? false
+            let dirOpts = confirmation.directoryScopeOptions
+            if !dirOpts.isEmpty {
+                vm.messages[msgIdx].toolCalls[tcIdx].riskDirectoryScopeOptions = dirOpts
+            }
         }
         let confirmMsg = ChatMessage(
             role: .assistant,

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -443,6 +443,7 @@ extension ChatViewModel {
             messages[msgIndex].toolCalls[tcIndex].riskReason = msg.riskReason
             if let containerized = msg.isContainerized { messages[msgIndex].toolCalls[tcIndex].isContainerized = containerized }
             messages[msgIndex].toolCalls[tcIndex].riskScopeOptions = msg.riskScopeOptions
+            messages[msgIndex].toolCalls[tcIndex].riskDirectoryScopeOptions = msg.riskDirectoryScopeOptions
             if let status = msg.status, !status.isEmpty {
                 messages[msgIndex].toolCalls[tcIndex].buildingStatus = status
             }


### PR DESCRIPTION
## Summary
- Map directoryScopeOptions from confirmation_request to ToolConfirmationData
- Persist directory scope options on ToolCallData from confirmation
- Decode riskDirectoryScopeOptions from tool_result messages

Part of plan: dir-scope-swiftui.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
