### PR TITLE
feat: pass directoryScopeOptions to V3RuleEditorModal and scope to createRule

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -844,7 +844,7 @@ private struct ToolCallStepDetailRow: View {
                     commandDescription: tc.reasonDescription ?? "",
                     riskLevel: tc.riskLevel ?? "medium",
                     scopeOptions: Self.v3ScopeOptions(from: tc),
-                    directoryScopeOptions: [],
+                    directoryScopeOptions: tc.riskDirectoryScopeOptions ?? [],
                     onSave: { rule in
                         Task {
                             try? await Self.trustRuleV3Client.createRule(


### PR DESCRIPTION
## Summary
- Replace hardcoded empty array with tc.riskDirectoryScopeOptions ?? [] in V3RuleEditorModal instantiation

Part of plan: dir-scope-swiftui.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
