### PR TITLE
feat: wire directoryScopeOptions into V3RuleEditorModal

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -853,7 +853,8 @@ private struct ToolCallStepDetailRow: View {
                                 description: {
                                     let desc = tc.reasonDescription ?? ""
                                     return desc.isEmpty ? "\(rule.toolName) — \(rule.pattern)" : desc
-                                }()
+                                }(),
+                                scope: "everywhere"
                             )
                         }
                     },

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -844,6 +844,7 @@ private struct ToolCallStepDetailRow: View {
                     commandDescription: tc.reasonDescription ?? "",
                     riskLevel: tc.riskLevel ?? "medium",
                     scopeOptions: Self.v3ScopeOptions(from: tc),
+                    directoryScopeOptions: [],
                     onSave: { rule in
                         Task {
                             try? await Self.trustRuleV3Client.createRule(
@@ -854,7 +855,7 @@ private struct ToolCallStepDetailRow: View {
                                     let desc = tc.reasonDescription ?? ""
                                     return desc.isEmpty ? "\(rule.toolName) — \(rule.pattern)" : desc
                                 }(),
-                                scope: "everywhere"
+                                scope: rule.scope
                             )
                         }
                     },

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -844,7 +844,7 @@ private struct ToolCallStepDetailRow: View {
                     commandDescription: tc.reasonDescription ?? "",
                     riskLevel: tc.riskLevel ?? "medium",
                     scopeOptions: Self.v3ScopeOptions(from: tc),
-                    directoryScopeOptions: [],
+                    directoryScopeOptions: tc.riskDirectoryScopeOptions ?? [],
                     onSave: { rule in
                         Task {
                             try? await Self.trustRuleV3Client.createRule(

--- a/clients/macos/vellum-assistant/Features/Chat/V3RuleEditorModal.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/V3RuleEditorModal.swift
@@ -27,12 +27,14 @@ struct V3RuleEditorModal: View {
     let commandDescription: String
     let riskLevel: String
     let scopeOptions: [V3ScopeOptionItem]
+    let directoryScopeOptions: [ConfirmationRequestDirectoryScopeOption]
     let onSave: (V3SavedRule) -> Void
     let onDismiss: () -> Void
 
     @State private var selectedPatternIndex: Int = 1 // Start from first generalization (skip exact match at index 0)
     @State private var selectedRiskLevel: String = "medium"
     @State private var isSaving: Bool = false
+    @State private var selectedDirectoryScopeIndex: Int = -1  // -1 = "Everywhere" (default)
 
     /// Generalized pattern options.
     /// If scopeOptions has multiple elements, skip the exact match at index 0.
@@ -91,6 +93,7 @@ struct V3RuleEditorModal: View {
             VStack(alignment: .leading, spacing: VSpacing.xl) {
                 contextHeader
                 applyToSection
+                whereSection
                 treatAsSection
                 saveSection
             }
@@ -201,6 +204,50 @@ struct V3RuleEditorModal: View {
         .accessibilityValue(selectedPatternIndex == targetIndex ? "Selected" : "Not selected")
     }
 
+    // MARK: - Where Section
+
+    @ViewBuilder
+    private var whereSection: some View {
+        if !directoryScopeOptions.isEmpty {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("Where")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .accessibilityAddTraits(.isHeader)
+
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    ForEach(Array(directoryScopeOptions.filter { $0.scope != "everywhere" }.enumerated()), id: \.offset) { index, option in
+                        directoryScopeRow(label: option.label, index: index)
+                    }
+                    directoryScopeRow(label: "Everywhere", index: -1)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func directoryScopeRow(label: String, index: Int) -> some View {
+        Button {
+            selectedDirectoryScopeIndex = index
+        } label: {
+            HStack(spacing: VSpacing.sm) {
+                VIconView(selectedDirectoryScopeIndex == index ? .circleDot : .circle, size: 14)
+                    .foregroundStyle(selectedDirectoryScopeIndex == index ? VColor.primaryBase : VColor.contentTertiary)
+                    .accessibilityHidden(true)
+                Text(label)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                Spacer(minLength: 0)
+            }
+            .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.sm, bottom: VSpacing.sm, trailing: VSpacing.sm))
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(selectedDirectoryScopeIndex == index ? [.isSelected] : [])
+        .accessibilityValue(selectedDirectoryScopeIndex == index ? "Selected" : "Not selected")
+    }
+
     // MARK: - Section 2: Treat as
 
     @ViewBuilder
@@ -273,12 +320,18 @@ struct V3RuleEditorModal: View {
                 guard !isSaving, !scopeOptions.isEmpty, selectedPatternIndex < scopeOptions.count else { return }
                 isSaving = true
                 let selectedOption = scopeOptions[selectedPatternIndex]
-                // Always use "everywhere" scope (directory scoping removed in v1)
+                let scope: String = {
+                    let filtered = directoryScopeOptions.filter { $0.scope != "everywhere" }
+                    if selectedDirectoryScopeIndex >= 0, selectedDirectoryScopeIndex < filtered.count {
+                        return filtered[selectedDirectoryScopeIndex].scope
+                    }
+                    return "everywhere"
+                }()
                 let rule = V3SavedRule(
                     toolName: toolName,
                     pattern: selectedOption.pattern,
                     riskLevel: selectedRiskLevel,
-                    scope: "everywhere"
+                    scope: scope
                 )
                 onSave(rule)
                 onDismiss()

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -1180,6 +1180,7 @@ final class ChatActionHandler {
             diff: msg.diff,
             allowlistOptions: msg.allowlistOptions,
             scopeOptions: msg.scopeOptions,
+            directoryScopeOptions: msg.directoryScopeOptions ?? [],
             executionTarget: msg.executionTarget,
             persistentDecisionsAllowed: msg.persistentDecisionsAllowed ?? true,
             temporaryOptionsAvailable: msg.temporaryOptionsAvailable ?? [],
@@ -1198,6 +1199,10 @@ final class ChatActionHandler {
                     .first(where: { $0.scope != "everywhere" })?.scope
             }
             vm.messages[msgIdx].toolCalls[tcIdx].isContainerized = msg.isContainerized ?? false
+            let dirOpts = confirmation.directoryScopeOptions
+            if !dirOpts.isEmpty {
+                vm.messages[msgIdx].toolCalls[tcIdx].riskDirectoryScopeOptions = dirOpts
+            }
         }
         let confirmMsg = ChatMessage(
             role: .assistant,

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -42,6 +42,7 @@ public struct ToolConfirmationData: Equatable {
     public let diff: ConfirmationRequestDiff?
     public let allowlistOptions: [ConfirmationRequestAllowlistOption]
     public let scopeOptions: [ConfirmationRequestScopeOption]
+    public let directoryScopeOptions: [ConfirmationRequestDirectoryScopeOption]
     public let executionTarget: String?
     /// When false, hide "Always Allow" and trust-rule persistence controls.
     public let persistentDecisionsAllowed: Bool
@@ -578,7 +579,7 @@ public struct ToolConfirmationData: Equatable {
         )
     }
 
-    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, riskReason: String? = nil, diff: ConfirmationRequestDiff? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption] = [], scopeOptions: [ConfirmationRequestScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, temporaryOptionsAvailable: [String] = [], toolUseId: String? = nil, state: ToolConfirmationState = .pending) {
+    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, riskReason: String? = nil, diff: ConfirmationRequestDiff? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption] = [], scopeOptions: [ConfirmationRequestScopeOption] = [], directoryScopeOptions: [ConfirmationRequestDirectoryScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, temporaryOptionsAvailable: [String] = [], toolUseId: String? = nil, state: ToolConfirmationState = .pending) {
         self.requestId = requestId
         self.toolName = toolName
         self.input = input
@@ -587,6 +588,7 @@ public struct ToolConfirmationData: Equatable {
         self.diff = diff
         self.allowlistOptions = allowlistOptions
         self.scopeOptions = scopeOptions
+        self.directoryScopeOptions = directoryScopeOptions
         self.executionTarget = executionTarget
         self.persistentDecisionsAllowed = persistentDecisionsAllowed
         self.temporaryOptionsAvailable = temporaryOptionsAvailable
@@ -884,6 +886,8 @@ public struct ToolCallData: Identifiable, Equatable {
     public var riskReason: String?
     /// Scope options ladder for the rule editor (pattern + label pairs, narrowest to broadest).
     public var riskScopeOptions: [ToolResultRiskScopeOption]?
+    /// Directory scope options ladder for the rule editor (scope + label pairs, narrowest to broadest).
+    public var riskDirectoryScopeOptions: [ConfirmationRequestDirectoryScopeOption]?
     /// Working directory for this tool call (extracted from confirmation scope options).
     /// Persists after pendingConfirmation is cleared so the rule editor modal can use it.
     public var workingDir: String?

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -443,6 +443,7 @@ extension ChatViewModel {
             messages[msgIndex].toolCalls[tcIndex].riskReason = msg.riskReason
             if let containerized = msg.isContainerized { messages[msgIndex].toolCalls[tcIndex].isContainerized = containerized }
             messages[msgIndex].toolCalls[tcIndex].riskScopeOptions = msg.riskScopeOptions
+            messages[msgIndex].toolCalls[tcIndex].riskDirectoryScopeOptions = msg.riskDirectoryScopeOptions
             if let status = msg.status, !status.isEmpty {
                 messages[msgIndex].toolCalls[tcIndex].buildingStatus = status
             }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -777,6 +777,7 @@ public struct ConfirmationRequest: Codable, Sendable {
     public let executionTarget: String?
     public let allowlistOptions: [ConfirmationRequestAllowlistOption]
     public let scopeOptions: [ConfirmationRequestScopeOption]
+    public let directoryScopeOptions: [ConfirmationRequestDirectoryScopeOption]?
     public let diff: ConfirmationRequestDiff?
     public let sandboxed: Bool?
     public let conversationId: String?
@@ -787,7 +788,7 @@ public struct ConfirmationRequest: Codable, Sendable {
     /// The tool_use block ID for client-side correlation with specific tool calls.
     public let toolUseId: String?
 
-    public init(type: String, requestId: String, toolName: String, input: [String: AnyCodable], riskLevel: String, riskReason: String? = nil, isContainerized: Bool? = nil, executionTarget: String? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption], scopeOptions: [ConfirmationRequestScopeOption], diff: ConfirmationRequestDiff? = nil, sandboxed: Bool? = nil, conversationId: String? = nil, persistentDecisionsAllowed: Bool? = nil, temporaryOptionsAvailable: [String]? = nil, toolUseId: String? = nil) {
+    public init(type: String, requestId: String, toolName: String, input: [String: AnyCodable], riskLevel: String, riskReason: String? = nil, isContainerized: Bool? = nil, executionTarget: String? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption], scopeOptions: [ConfirmationRequestScopeOption], directoryScopeOptions: [ConfirmationRequestDirectoryScopeOption]? = nil, diff: ConfirmationRequestDiff? = nil, sandboxed: Bool? = nil, conversationId: String? = nil, persistentDecisionsAllowed: Bool? = nil, temporaryOptionsAvailable: [String]? = nil, toolUseId: String? = nil) {
         self.type = type
         self.requestId = requestId
         self.toolName = toolName
@@ -798,6 +799,7 @@ public struct ConfirmationRequest: Codable, Sendable {
         self.executionTarget = executionTarget
         self.allowlistOptions = allowlistOptions
         self.scopeOptions = scopeOptions
+        self.directoryScopeOptions = directoryScopeOptions
         self.diff = diff
         self.sandboxed = sandboxed
         self.conversationId = conversationId
@@ -840,6 +842,15 @@ public struct ConfirmationRequestScopeOption: Codable, Sendable {
     public init(label: String, scope: String) {
         self.label = label
         self.scope = scope
+    }
+}
+
+public struct ConfirmationRequestDirectoryScopeOption: Codable, Sendable, Equatable {
+    public let scope: String
+    public let label: String
+    public init(scope: String, label: String) {
+        self.scope = scope
+        self.label = label
     }
 }
 
@@ -4839,8 +4850,9 @@ public struct ToolResult: Codable, Sendable {
     public let isContainerized: Bool?
     /// Scope options ladder for the rule editor modal (narrowest to broadest).
     public let riskScopeOptions: [ToolResultRiskScopeOption]?
+    public let riskDirectoryScopeOptions: [ConfirmationRequestDirectoryScopeOption]?
 
-    public init(type: String, toolName: String, result: String, isError: Bool? = nil, diff: ToolResultDiff? = nil, status: String? = nil, conversationId: String? = nil, imageDataList: [String]? = nil, toolUseId: String? = nil, riskLevel: String? = nil, riskReason: String? = nil, isContainerized: Bool? = nil, riskScopeOptions: [ToolResultRiskScopeOption]? = nil) {
+    public init(type: String, toolName: String, result: String, isError: Bool? = nil, diff: ToolResultDiff? = nil, status: String? = nil, conversationId: String? = nil, imageDataList: [String]? = nil, toolUseId: String? = nil, riskLevel: String? = nil, riskReason: String? = nil, isContainerized: Bool? = nil, riskScopeOptions: [ToolResultRiskScopeOption]? = nil, riskDirectoryScopeOptions: [ConfirmationRequestDirectoryScopeOption]? = nil) {
         self.type = type
         self.toolName = toolName
         self.result = result
@@ -4854,6 +4866,7 @@ public struct ToolResult: Codable, Sendable {
         self.riskReason = riskReason
         self.isContainerized = isContainerized
         self.riskScopeOptions = riskScopeOptions
+        self.riskDirectoryScopeOptions = riskDirectoryScopeOptions
     }
 }
 

--- a/clients/shared/Network/TrustRuleV3Client.swift
+++ b/clients/shared/Network/TrustRuleV3Client.swift
@@ -47,7 +47,7 @@ public enum TrustRuleV3ClientError: Error, LocalizedError {
 
 public protocol TrustRuleV3ClientProtocol {
     func listRules(origin: String?, tool: String?, includeDeleted: Bool?) async throws -> [TrustRuleV3]
-    func createRule(tool: String, pattern: String, risk: String, description: String) async throws -> TrustRuleV3
+    func createRule(tool: String, pattern: String, risk: String, description: String, scope: String) async throws -> TrustRuleV3
     func updateRule(id: String, risk: String?, description: String?) async throws -> TrustRuleV3
     func deleteRule(id: String) async throws
     func resetRule(id: String) async throws -> TrustRuleV3
@@ -75,12 +75,13 @@ public struct TrustRuleV3Client: TrustRuleV3ClientProtocol {
         return try JSONDecoder().decode(TrustRuleV3ListResponse.self, from: response.data).rules
     }
 
-    public func createRule(tool: String, pattern: String, risk: String, description: String) async throws -> TrustRuleV3 {
+    public func createRule(tool: String, pattern: String, risk: String, description: String, scope: String = "everywhere") async throws -> TrustRuleV3 {
         let body: [String: Any] = [
             "tool": tool,
             "pattern": pattern,
             "risk": risk,
             "description": description,
+            "scope": scope,
         ]
         let response = try await GatewayHTTPClient.post(
             path: "trust-rules-v3", json: body, timeout: 10


### PR DESCRIPTION
## Summary
Add directory scope selection UI to the V3 Rule Editor Modal so users can scope trust rules to specific directories (e.g. "In scratch/", "In vellum-assistant/") instead of always defaulting to "Everywhere". The daemon already sends `directoryScopeOptions` on confirmation_request and `riskDirectoryScopeOptions` on tool_result — this PR threads the data through the Swift client and renders it.

## PRs merged into feature branch
- #27971: feat: add ConfirmationRequestDirectoryScopeOption type and wire fields
- #27972: feat: add scope parameter to TrustRuleV3Client.createRule
- #27974: feat: add directoryScopeOptions to ToolConfirmationData and ToolCallData
- #27975: feat: add "Where" directory scope section to V3RuleEditorModal
- #27976: feat: persist directoryScopeOptions in ChatActionHandler and streaming helpers
- #27978: feat: wire riskDirectoryScopeOptions from ToolCallData to V3RuleEditorModal

Part of plan: dir-scope-swiftui.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
