### PR TITLE
feat: add Allow & Create Rule button with LLM trust rule suggestions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -36,6 +36,10 @@ struct AssistantProgressView: View {
     @State private var processingStartDate: Date?
     @State private var isOverflowPopoverShown: Bool = false
     @State private var suppressNextExpand: Bool = false
+    /// Tool call that triggered the suggestion-driven rule editor (from "Allow & Create Rule").
+    @State private var suggestRuleToolCall: ToolCallData?
+    /// LLM-generated suggestion returned from the suggest API.
+    @State private var suggestRuleSuggestion: TrustRuleSuggestion?
     /// When the post-tool-completion thinking phase started (typically the last
     /// tool's `completedAt`). Nil until all tools complete and the card remains active.
     @State private var thinkingAfterToolsStartDate: Date?
@@ -296,6 +300,35 @@ struct AssistantProgressView: View {
         .onAppear {
             handleOnAppear()
         }
+        .sheet(item: $suggestRuleToolCall) { tc in
+            V3RuleEditorModal(
+                toolName: tc.toolName,
+                commandText: tc.inputSummary,
+                commandDescription: tc.reasonDescription ?? "",
+                riskLevel: tc.riskLevel ?? "medium",
+                scopeOptions: ToolCallStepDetailRow.v3ScopeOptions(from: tc),
+                directoryScopeOptions: tc.riskDirectoryScopeOptions ?? [],
+                suggestion: suggestRuleSuggestion,
+                onSave: { rule in
+                    Task {
+                        try? await TrustRuleV3Client().createRule(
+                            tool: rule.toolName,
+                            pattern: rule.pattern,
+                            risk: rule.riskLevel,
+                            description: {
+                                let desc = tc.reasonDescription ?? ""
+                                return desc.isEmpty ? "\(rule.toolName) — \(rule.pattern)" : desc
+                            }(),
+                            scope: rule.scope
+                        )
+                    }
+                },
+                onDismiss: {
+                    suggestRuleToolCall = nil
+                    suggestRuleSuggestion = nil
+                }
+            )
+        }
     }
 
     // MARK: - Change Handlers (extracted to reduce body type-check complexity)
@@ -476,6 +509,44 @@ struct AssistantProgressView: View {
         }
     }
 
+    /// Calls the suggest API for a tool call and opens the rule editor with the result.
+    @MainActor
+    private func fetchSuggestionAndOpenEditor(for toolCall: ToolCallData) async {
+        let client = TrustRuleV3Client()
+        let scopeOpts: [(pattern: String, label: String)] = (toolCall.riskScopeOptions ?? []).map {
+            (pattern: $0.pattern, label: $0.label)
+        }
+        let dirScopeOpts: [(scope: String, label: String)] = (toolCall.riskDirectoryScopeOptions ?? []).map {
+            (scope: $0.scope, label: $0.label)
+        }
+        // Use the full command text for the LLM — inputSummary is truncated to ~80 chars.
+        let fullCommand: String = {
+            if !toolCall.inputFull.isEmpty { return toolCall.inputFull }
+            if let dict = toolCall.inputRawDict { return ToolCallData.formatAllToolInput(dict) }
+            return toolCall.inputSummary
+        }()
+        do {
+            let suggestion = try await client.suggestRule(
+                tool: toolCall.toolName,
+                command: fullCommand,
+                riskAssessment: (
+                    risk: toolCall.riskLevel ?? "medium",
+                    reasoning: toolCall.riskReason ?? "",
+                    reasonDescription: toolCall.reasonDescription ?? ""
+                ),
+                scopeOptions: scopeOpts,
+                directoryScopeOptions: dirScopeOpts,
+                intent: "auto_approve"
+            )
+            suggestRuleSuggestion = suggestion
+            suggestRuleToolCall = toolCall
+        } catch {
+            // Suggestion failed — fall back to opening the rule editor without a suggestion.
+            suggestRuleSuggestion = nil
+            suggestRuleToolCall = toolCall
+        }
+    }
+
     @MainActor
     private func syncStartDateFromModelIfNeeded() {
         if let earliest = model.earliestStartedAt, startDate != earliest {
@@ -647,7 +718,20 @@ struct AssistantProgressView: View {
                         onAllow: { onConfirmationAllow?(confirmation.requestId) },
                         onDeny: { onConfirmationDeny?(confirmation.requestId) },
                         onAlwaysAllow: onAlwaysAllow ?? { _, _, _, _ in },
-                        onTemporaryAllow: onTemporaryAllow
+                        onTemporaryAllow: onTemporaryAllow,
+                        onAllowAndSuggestRule: {
+                            // Allow the tool first
+                            if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
+                                let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
+                                onAlwaysAllow?(confirmation.requestId, option.pattern, scope, "allow")
+                            } else {
+                                onConfirmationAllow?(confirmation.requestId)
+                            }
+                            // Fire the suggest API and open the rule editor with the result
+                            Task {
+                                await fetchSuggestionAndOpenEditor(for: toolCall)
+                            }
+                        }
                     )
                     .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
                 }
@@ -746,6 +830,8 @@ private struct ToolCallStepDetailRow: View {
     /// Drives the Rule Editor Modal sheet presentation. Set to a tool call
     /// when the user taps a risk badge in the expanded view.
     @State private var ruleEditorToolCall: ToolCallData?
+    /// LLM-generated suggestion to pre-populate the rule editor.
+    @State private var ruleEditorSuggestion: TrustRuleSuggestion?
 
     /// Shared across all rows — `TrustRuleClient` is a stateless HTTP client,
     /// so a single static instance avoids re-creation on every view rebuild.
@@ -845,6 +931,7 @@ private struct ToolCallStepDetailRow: View {
                     riskLevel: tc.riskLevel ?? "medium",
                     scopeOptions: Self.v3ScopeOptions(from: tc),
                     directoryScopeOptions: tc.riskDirectoryScopeOptions ?? [],
+                    suggestion: ruleEditorSuggestion,
                     onSave: { rule in
                         Task {
                             try? await Self.trustRuleV3Client.createRule(
@@ -859,7 +946,10 @@ private struct ToolCallStepDetailRow: View {
                             )
                         }
                     },
-                    onDismiss: { ruleEditorToolCall = nil }
+                    onDismiss: {
+                        ruleEditorToolCall = nil
+                        ruleEditorSuggestion = nil
+                    }
                 )
             } else {
                 RuleEditorModal(
@@ -942,7 +1032,7 @@ private struct ToolCallStepDetailRow: View {
 
     /// Constructs the V3 scope option items from the tool call's risk scope options.
     /// Falls back to a single exact command option when none are provided.
-    private static func v3ScopeOptions(from toolCall: ToolCallData) -> [V3ScopeOptionItem] {
+    static func v3ScopeOptions(from toolCall: ToolCallData) -> [V3ScopeOptionItem] {
         guard let options = toolCall.riskScopeOptions, !options.isEmpty else {
             return [
                 V3ScopeOptionItem(

--- a/clients/macos/vellum-assistant/Features/Chat/V3RuleEditorModal.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/V3RuleEditorModal.swift
@@ -28,6 +28,8 @@ struct V3RuleEditorModal: View {
     let riskLevel: String
     let scopeOptions: [V3ScopeOptionItem]
     let directoryScopeOptions: [ConfirmationRequestDirectoryScopeOption]
+    /// Optional LLM-generated suggestion used to pre-populate selections.
+    let suggestion: TrustRuleSuggestion?
     let onSave: (V3SavedRule) -> Void
     let onDismiss: () -> Void
 
@@ -102,8 +104,36 @@ struct V3RuleEditorModal: View {
         .frame(width: 480)
         .background(VColor.surfaceLift)
         .onAppear {
+            applySuggestionOrDefaults()
+        }
+    }
+
+    // MARK: - Suggestion / Default Application
+
+    private func applySuggestionOrDefaults() {
+        if let suggestion {
+            // Risk level from suggestion
+            selectedRiskLevel = suggestion.risk.isEmpty ? (riskLevel.isEmpty ? "medium" : riskLevel) : suggestion.risk
+
+            // Pattern: find the matching scope option index.
+            // In multi-option mode the UI hides index 0 (exact match), so skip
+            // it to avoid an invisible selection that silently persists.
+            if let matchIndex = scopeOptions.firstIndex(where: { $0.pattern == suggestion.pattern }),
+               (matchIndex > 0 || isSingleOption) {
+                selectedPatternIndex = matchIndex
+            } else if isSingleOption {
+                selectedPatternIndex = 0
+            }
+
+            // Directory scope: match suggestion scope to options
+            if let suggestedScope = suggestion.scope, suggestedScope != "everywhere" {
+                let filtered = directoryScopeOptions.filter { $0.scope != "everywhere" }
+                if let matchIndex = filtered.firstIndex(where: { $0.scope == suggestedScope }) {
+                    selectedDirectoryScopeIndex = matchIndex
+                }
+            }
+        } else {
             selectedRiskLevel = riskLevel.isEmpty ? "medium" : riskLevel
-            // If single option, use index 0. Otherwise, start at index 1 (skip exact match)
             if isSingleOption {
                 selectedPatternIndex = 0
             }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -21,6 +21,9 @@ public struct ToolConfirmationBubble: View {
     /// Called when the user taps the post-decision "Create a rule" nudge.
     /// The caller is responsible for presenting the rule editor.
     public let onCreateRule: (() -> Void)?
+    /// Called when the user taps "Allow & Create Rule" in the v3 prompt.
+    /// The parent should allow the tool, call the suggest API, and open the rule editor.
+    public let onAllowAndSuggestRule: (() -> Void)?
 
     @State private var showDiff = false
     @State private var showTechnicalDetails = false
@@ -40,7 +43,8 @@ public struct ToolConfirmationBubble: View {
         onDeny: @escaping () -> Void,
         onAlwaysAllow: @escaping (String, String, String, String) -> Void,
         onTemporaryAllow: ((String, String) -> Void)? = nil,
-        onCreateRule: (() -> Void)? = nil
+        onCreateRule: (() -> Void)? = nil,
+        onAllowAndSuggestRule: (() -> Void)? = nil
     ) {
         self.confirmation = confirmation
         self.isKeyboardActive = isKeyboardActive
@@ -50,6 +54,7 @@ public struct ToolConfirmationBubble: View {
         self.onAlwaysAllow = onAlwaysAllow
         self.onTemporaryAllow = onTemporaryAllow
         self.onCreateRule = onCreateRule
+        self.onAllowAndSuggestRule = onAllowAndSuggestRule
     }
 
     private var hasRuleOptions: Bool {
@@ -142,7 +147,8 @@ public struct ToolConfirmationBubble: View {
                     isKeyboardActive: isKeyboardActive,
                     onAllow: onAllow,
                     onDeny: onDeny,
-                    onAlwaysAllow: onAlwaysAllow
+                    onAlwaysAllow: onAlwaysAllow,
+                    onAllowAndSuggestRule: onAllowAndSuggestRule
                 )
             }
         } else {

--- a/clients/shared/Features/Chat/V3PermissionPromptView.swift
+++ b/clients/shared/Features/Chat/V3PermissionPromptView.swift
@@ -12,6 +12,9 @@ public struct V3PermissionPromptView: View {
     public let onAllow: () -> Void
     public let onDeny: () -> Void
     public let onAlwaysAllow: (String, String, String, String) -> Void
+    /// Called when the user taps "Allow & Create Rule". The parent is responsible
+    /// for calling the suggest API and presenting the rule editor modal.
+    public let onAllowAndSuggestRule: (() -> Void)?
 
     @State private var showTechnicalDetails = false
     @State private var keyboardModel: ToolConfirmationKeyboardModel?
@@ -24,13 +27,15 @@ public struct V3PermissionPromptView: View {
         isKeyboardActive: Bool,
         onAllow: @escaping () -> Void,
         onDeny: @escaping () -> Void,
-        onAlwaysAllow: @escaping (String, String, String, String) -> Void
+        onAlwaysAllow: @escaping (String, String, String, String) -> Void,
+        onAllowAndSuggestRule: (() -> Void)? = nil
     ) {
         self.confirmation = confirmation
         self.isKeyboardActive = isKeyboardActive
         self.onAllow = onAllow
         self.onDeny = onDeny
         self.onAlwaysAllow = onAlwaysAllow
+        self.onAllowAndSuggestRule = onAllowAndSuggestRule
     }
 
     private var v3TopLevelActions: [ToolConfirmationKeyboardModel.Action] {
@@ -200,25 +205,42 @@ public struct V3PermissionPromptView: View {
         }
     }
 
-    /// v3 simplified actions: flat Allow + Deny buttons, no split button or duration.
+    /// v3 simplified actions: Allow (with optional split for suggest) + Deny.
     private var v3ConfirmationActions: some View {
         HStack(spacing: VSpacing.sm) {
-            VButton(label: "Allow", style: .primary, size: .compact) {
-                // In v3, "Allow" sends the selected allowlist pattern + scope
-                // through the always-allow path when patterns are available,
-                // otherwise falls back to a simple allow.
-                if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
-                    let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
-                    onAlwaysAllow(confirmation.requestId, option.pattern, scope, "allow")
-                } else {
-                    onAllow()
+            if onAllowAndSuggestRule != nil {
+                VSplitButton(label: "Allow", style: .primary, size: .compact, action: {
+                    if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
+                        let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
+                        onAlwaysAllow(confirmation.requestId, option.pattern, scope, "allow")
+                    } else {
+                        onAllow()
+                    }
+                }) {
+                    Button("Allow & Create Rule") {
+                        onAllowAndSuggestRule?()
+                    }
                 }
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .strokeBorder(VColor.primaryBase, lineWidth: keyboardModel?.selectedAction == .allowOnce ? 2 : 0)
+                        .allowsHitTesting(false)
+                )
+            } else {
+                VButton(label: "Allow", style: .primary, size: .compact) {
+                    if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
+                        let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
+                        onAlwaysAllow(confirmation.requestId, option.pattern, scope, "allow")
+                    } else {
+                        onAllow()
+                    }
+                }
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .strokeBorder(VColor.primaryBase, lineWidth: keyboardModel?.selectedAction == .allowOnce ? 2 : 0)
+                        .allowsHitTesting(false)
+                )
             }
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .strokeBorder(VColor.primaryBase, lineWidth: keyboardModel?.selectedAction == .allowOnce ? 2 : 0)
-                    .allowsHitTesting(false)
-            )
 
             VButton(label: "Deny", style: .danger, size: .compact) {
                 onDeny()

--- a/clients/shared/Network/TrustRuleV3Client.swift
+++ b/clients/shared/Network/TrustRuleV3Client.swift
@@ -27,6 +27,30 @@ private struct TrustRuleV3SingleResponse: Decodable {
     let rule: TrustRuleV3
 }
 
+/// LLM-generated trust rule suggestion from `POST /v1/trust-rules-v3/suggest`.
+public struct TrustRuleSuggestion: Decodable, Sendable {
+    public let pattern: String
+    public let risk: String
+    public let scope: String?
+    public let description: String
+    public let scopeOptions: [TrustRuleSuggestionScopeOption]
+    public let directoryScopeOptions: [TrustRuleSuggestionDirectoryScopeOption]?
+}
+
+public struct TrustRuleSuggestionScopeOption: Decodable, Sendable {
+    public let pattern: String
+    public let label: String
+}
+
+public struct TrustRuleSuggestionDirectoryScopeOption: Decodable, Sendable {
+    public let scope: String
+    public let label: String
+}
+
+private struct TrustRuleSuggestionResponse: Decodable {
+    let suggestion: TrustRuleSuggestion
+}
+
 // MARK: - Errors
 
 public enum TrustRuleV3ClientError: Error, LocalizedError {
@@ -51,6 +75,14 @@ public protocol TrustRuleV3ClientProtocol {
     func updateRule(id: String, risk: String?, description: String?) async throws -> TrustRuleV3
     func deleteRule(id: String) async throws
     func resetRule(id: String) async throws -> TrustRuleV3
+    func suggestRule(
+        tool: String,
+        command: String,
+        riskAssessment: (risk: String, reasoning: String, reasonDescription: String),
+        scopeOptions: [(pattern: String, label: String)],
+        directoryScopeOptions: [(scope: String, label: String)],
+        intent: String
+    ) async throws -> TrustRuleSuggestion
 }
 
 // MARK: - Gateway-Backed Implementation
@@ -151,5 +183,39 @@ public struct TrustRuleV3Client: TrustRuleV3ClientProtocol {
             throw TrustRuleV3ClientError.requestFailed(response.statusCode)
         }
         return try JSONDecoder().decode(TrustRuleV3SingleResponse.self, from: response.data).rule
+    }
+
+    public func suggestRule(
+        tool: String,
+        command: String,
+        riskAssessment: (risk: String, reasoning: String, reasonDescription: String),
+        scopeOptions: [(pattern: String, label: String)],
+        directoryScopeOptions: [(scope: String, label: String)],
+        intent: String = "auto_approve"
+    ) async throws -> TrustRuleSuggestion {
+        let body: [String: Any] = [
+            "tool": tool,
+            "command": command,
+            "riskAssessment": [
+                "risk": riskAssessment.risk,
+                "reasoning": riskAssessment.reasoning,
+                "reasonDescription": riskAssessment.reasonDescription,
+            ],
+            "scopeOptions": scopeOptions.map { ["pattern": $0.pattern, "label": $0.label] },
+            "directoryScopeOptions": directoryScopeOptions.map { ["scope": $0.scope, "label": $0.label] },
+            "currentThreshold": "",
+            "intent": intent,
+        ]
+        let response = try await GatewayHTTPClient.post(
+            path: "trust-rules-v3/suggest", json: body, timeout: 30
+        )
+        if response.statusCode == 403 {
+            throw TrustRuleV3ClientError.featureDisabled
+        }
+        guard response.isSuccess else {
+            log.error("suggestRule failed (HTTP \(response.statusCode))")
+            throw TrustRuleV3ClientError.requestFailed(response.statusCode)
+        }
+        return try JSONDecoder().decode(TrustRuleSuggestionResponse.self, from: response.data).suggestion
     }
 }


### PR DESCRIPTION
## Summary
- Adds `suggestRule()` method to `TrustRuleV3Client` that calls the gateway's `POST /v1/trust-rules-v3/suggest` endpoint
- Adds "Allow & Create Rule" option to the v3 permission prompt as a split button dropdown — allows the tool immediately, then calls the suggest API and opens the rule editor pre-populated with the LLM suggestion
- Adds optional `TrustRuleSuggestion` parameter to `V3RuleEditorModal` that pre-selects the suggested pattern, risk level, and directory scope

## Test plan
- [ ] Open a v3 permission prompt (permission-controls-v3 flag enabled)
- [ ] Verify the Allow button now has a dropdown arrow with "Allow & Create Rule" option
- [ ] Click "Allow & Create Rule" — confirm the tool is allowed immediately
- [ ] Verify the rule editor modal opens after a short delay (LLM suggestion latency)
- [ ] Check that the rule editor has the suggested pattern, risk level, and directory scope pre-selected
- [ ] Modify selections and save — verify the trust rule is created correctly
- [ ] Test the regular "Allow" button still works as before (no regression)
- [ ] Test the risk badge → rule editor flow still works without a suggestion (no regression)
- [ ] Test when the suggest API fails — verify the rule editor opens without pre-populated values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/27999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
