### PR TITLE
feat(providers): add GPT-5.5 model to catalog

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -133,6 +133,21 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     },
     models: [
       {
+        id: "gpt-5.5",
+        displayName: "GPT-5.5",
+        contextWindowTokens: 1050000,
+        maxOutputTokens: 128000,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 5.0,
+          outputPer1mTokens: 30.0,
+          cacheReadPer1mTokens: 0.5,
+        },
+      },
+      {
         id: "gpt-5.4",
         displayName: "GPT-5.4",
         contextWindowTokens: 400000,

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -28,6 +28,7 @@ const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
     "claude-haiku-4": { inputPer1M: 1, outputPer1M: 5 },
   },
   openai: {
+    "gpt-5.5": { inputPer1M: 5, outputPer1M: 30 },
     "gpt-5.4": { inputPer1M: 2.5, outputPer1M: 15 },
     "gpt-5.4-mini": { inputPer1M: 0.5, outputPer1M: 3 },
     "gpt-5.4-nano": { inputPer1M: 0.2, outputPer1M: 1.25 },

--- a/clients/shared/Utilities/LLMProviderRegistry.swift
+++ b/clients/shared/Utilities/LLMProviderRegistry.swift
@@ -260,6 +260,7 @@ private let fallbackCatalog = LLMProviderCatalog(
             ),
             defaultModel: "gpt-5.4",
             models: [
+                LLMModelEntry(id: "gpt-5.5", displayName: "GPT-5.5"),
                 LLMModelEntry(id: "gpt-5.4", displayName: "GPT-5.4"),
                 LLMModelEntry(id: "gpt-5.2", displayName: "GPT-5.2"),
                 LLMModelEntry(id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini"),

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -98,6 +98,21 @@
       "defaultModel": "gpt-5.4",
       "models": [
         {
+          "id": "gpt-5.5",
+          "displayName": "GPT-5.5",
+          "contextWindowTokens": 1050000,
+          "maxOutputTokens": 128000,
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 5.0,
+            "outputPer1mTokens": 30.0,
+            "cacheReadPer1mTokens": 0.5
+          }
+        },
+        {
           "id": "gpt-5.4",
           "displayName": "GPT-5.4",
           "contextWindowTokens": 400000,

--- a/skills/vellum-self-knowledge/references/inference.md
+++ b/skills/vellum-self-knowledge/references/inference.md
@@ -16,6 +16,7 @@ All known models by provider, so you can interpret model IDs from config:
 | Anthropic     | `claude-opus-4-6`                     | Claude Opus 4.6   |
 | Anthropic     | `claude-sonnet-4-6`                   | Claude Sonnet 4.6 |
 | Anthropic     | `claude-haiku-4-5-20251001`           | Claude Haiku 4.5  |
+| OpenAI        | `gpt-5.5`                             | GPT-5.5           |
 | OpenAI        | `gpt-5.2`                             | GPT-5.2           |
 | OpenAI        | `gpt-5.4`                             | GPT-5.4           |
 | OpenAI        | `gpt-5.4-nano`                        | GPT-5.4 Nano      |

--- a/skills/vellum-self-knowledge/scripts/self-info.ts
+++ b/skills/vellum-self-knowledge/scripts/self-info.ts
@@ -20,6 +20,7 @@ const MODEL_DISPLAY_NAMES: Record<string, string> = {
   "claude-opus-4-6": "Claude Opus 4.6",
   "claude-sonnet-4-6": "Claude Sonnet 4.6",
   "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
+  "gpt-5.5": "GPT-5.5",
   "gpt-5.2": "GPT-5.2",
   "gpt-5.4": "GPT-5.4",
   "gpt-5.4-nano": "GPT-5.4 Nano",


### PR DESCRIPTION
## Summary
- Add `gpt-5.5` (1.05M context window, 128K max output) to the OpenAI catalog across `model-catalog.ts`, `meta/llm-provider-catalog.json`, and the Swift fallback registry.
- Register pricing ($5/1M input, $30/1M output, $0.5/1M cache read) in `assistant/src/util/pricing.ts`.
- Add display-name mapping + reference-table entry in `skills/vellum-self-knowledge/`.

## Original prompt
Add support for GPT 5.5: https://developers.openai.com/api/docs/models/gpt-5.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
