### PR TITLE
feat(providers): support OpenAI text.verbosity

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -174,6 +174,7 @@ describe("AssistantConfigSchema", () => {
       maxTokens: 64000,
       effort: "max",
       speed: "standard",
+      verbosity: "medium",
       temperature: null,
       thinking: { enabled: true, streamThinking: true },
       contextWindow: {

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -11,6 +11,7 @@ const fullDefault = {
   maxTokens: 64000,
   effort: "max" as const,
   speed: "standard" as const,
+  verbosity: "medium" as const,
   temperature: null,
   thinking: { enabled: true, streamThinking: true },
   contextWindow: {

--- a/assistant/src/__tests__/llm-schema.test.ts
+++ b/assistant/src/__tests__/llm-schema.test.ts
@@ -74,6 +74,7 @@ describe("LLMSchema", () => {
       maxTokens: 64000,
       effort: "max",
       speed: "standard",
+      verbosity: "medium",
       temperature: null,
       thinking: { enabled: true, streamThinking: true },
       contextWindow: {

--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -536,6 +536,61 @@ describe("OpenAIResponsesProvider", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Verbosity → text param
+  // -----------------------------------------------------------------------
+  test('verbosity: "low" maps to text: { verbosity: "low" }', async () => {
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      { config: { verbosity: "low" } },
+    );
+
+    expect(lastStreamParams!.text).toEqual({ verbosity: "low" });
+  });
+
+  test('verbosity: "high" maps to text: { verbosity: "high" }', async () => {
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      { config: { verbosity: "high" } },
+    );
+
+    expect(lastStreamParams!.text).toEqual({ verbosity: "high" });
+  });
+
+  test("no verbosity config means no text param", async () => {
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      { config: {} },
+    );
+
+    expect(lastStreamParams!.text).toBeUndefined();
+  });
+
+  test("unrecognized verbosity value is ignored", async () => {
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      { config: { verbosity: "bogus" } },
+    );
+
+    expect(lastStreamParams!.text).toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
   // Model override
   // -----------------------------------------------------------------------
   test("uses model from config when provided", async () => {

--- a/assistant/src/__tests__/retry-verbosity-normalization.test.ts
+++ b/assistant/src/__tests__/retry-verbosity-normalization.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Verifies that `RetryProvider.normalizeSendMessageOptions` plumbs
+ * `verbosity` only to providers that consume it (OpenAI) and strips it for
+ * every other provider — so strict-schema clients (Anthropic, …) never see
+ * the unknown field on the wire.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+let mockLlmConfig: Record<string, unknown> = {};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ llm: mockLlmConfig }),
+}));
+
+import { LLMSchema } from "../config/schemas/llm.js";
+import { RetryProvider } from "../providers/retry.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+} from "../providers/types.js";
+
+function setLlmConfig(raw: unknown): void {
+  mockLlmConfig = LLMSchema.parse(raw) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  mockLlmConfig = LLMSchema.parse({}) as Record<string, unknown>;
+});
+
+function makePipeline(providerName: string): {
+  provider: Provider;
+  lastConfig: () => Record<string, unknown> | undefined;
+} {
+  let captured: Record<string, unknown> | undefined;
+  const inner: Provider = {
+    name: providerName,
+    async sendMessage(
+      _messages: Message[],
+      _tools?: ToolDefinition[],
+      _systemPrompt?: string,
+      options?: SendMessageOptions,
+    ): Promise<ProviderResponse> {
+      captured = options?.config as Record<string, unknown> | undefined;
+      return {
+        content: [],
+        model: "test",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: "stop",
+      };
+    },
+  };
+  return {
+    provider: new RetryProvider(inner),
+    lastConfig: () => captured,
+  };
+}
+
+const userMessage: Message = {
+  role: "user",
+  content: [{ type: "text", text: "hi" }],
+};
+
+describe("retry normalization for verbosity", () => {
+  test("forwards verbosity on the outbound config for openai", async () => {
+    setLlmConfig({
+      default: {
+        provider: "openai",
+        model: "gpt-5.5",
+        verbosity: "high",
+      },
+    });
+    const { provider, lastConfig } = makePipeline("openai");
+    await provider.sendMessage([userMessage], undefined, undefined, {
+      config: { callSite: "mainAgent" },
+    });
+    expect(lastConfig()?.verbosity).toBe("high");
+  });
+
+  test("strips verbosity from config for anthropic provider", async () => {
+    const { provider, lastConfig } = makePipeline("anthropic");
+    await provider.sendMessage([userMessage], undefined, undefined, {
+      config: { verbosity: "low" },
+    });
+    expect(lastConfig()?.verbosity).toBe(undefined);
+  });
+
+  test("strips verbosity from config for openrouter provider", async () => {
+    const { provider, lastConfig } = makePipeline("openrouter");
+    await provider.sendMessage([userMessage], undefined, undefined, {
+      config: { verbosity: "low" },
+    });
+    expect(lastConfig()?.verbosity).toBe(undefined);
+  });
+
+  test("call-site override replaces default verbosity", async () => {
+    setLlmConfig({
+      default: {
+        provider: "openai",
+        model: "gpt-5.5",
+        verbosity: "low",
+      },
+      callSites: {
+        mainAgent: { verbosity: "high" },
+      },
+    });
+    const { provider, lastConfig } = makePipeline("openai");
+    await provider.sendMessage([userMessage], undefined, undefined, {
+      config: { callSite: "mainAgent" },
+    });
+    expect(lastConfig()?.verbosity).toBe("high");
+  });
+
+  test("per-call explicit verbosity overrides resolved call-site value", async () => {
+    setLlmConfig({
+      default: {
+        provider: "openai",
+        model: "gpt-5.5",
+        verbosity: "low",
+      },
+      callSites: {
+        mainAgent: { verbosity: "medium" },
+      },
+    });
+    const { provider, lastConfig } = makePipeline("openai");
+    await provider.sendMessage([userMessage], undefined, undefined, {
+      config: { callSite: "mainAgent", verbosity: "high" },
+    });
+    expect(lastConfig()?.verbosity).toBe("high");
+  });
+});

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -70,7 +70,7 @@ export const LLMCallSiteEnum = z.enum([
 export type LLMCallSite = z.infer<typeof LLMCallSiteEnum>;
 
 // ---------------------------------------------------------------------------
-// Effort & Speed
+// Effort, Speed & Verbosity
 // ---------------------------------------------------------------------------
 
 export const EffortEnum = z.enum(["low", "medium", "high", "xhigh", "max"]);
@@ -78,6 +78,14 @@ export type Effort = z.infer<typeof EffortEnum>;
 
 export const SpeedEnum = z.enum(["standard", "fast"]);
 export type Speed = z.infer<typeof SpeedEnum>;
+
+/**
+ * Response verbosity. Currently consumed by OpenAI's Responses API as
+ * `text.verbosity` (low|medium|high). Providers that don't support this knob
+ * are stripped in `retry.ts` normalization.
+ */
+export const VerbosityEnum = z.enum(["low", "medium", "high"]);
+export type Verbosity = z.infer<typeof VerbosityEnum>;
 
 // ---------------------------------------------------------------------------
 // Leaf primitives (shared between LLMConfigBase and LLMConfigFragment)
@@ -248,6 +256,7 @@ export const LLMConfigBase = z.object({
   maxTokens: MaxTokensSchema.default(64000),
   effort: EffortEnum.default("max"),
   speed: SpeedEnum.default("standard"),
+  verbosity: VerbosityEnum.default("medium"),
   temperature: TemperatureSchema.default(null),
   thinking: ThinkingSchema.default(ThinkingSchema.parse({})),
   contextWindow: ContextWindowSchema.default(ContextWindowSchema.parse({})),
@@ -267,6 +276,7 @@ export const LLMConfigFragment = z.object({
   maxTokens: MaxTokensSchema.optional(),
   effort: EffortEnum.optional(),
   speed: SpeedEnum.optional(),
+  verbosity: VerbosityEnum.optional(),
   temperature: TemperatureSchema.optional(),
   thinking: ThinkingFragmentSchema.optional(),
   contextWindow: ContextWindowDeepPartialSchema.optional(),

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -35,6 +35,9 @@ const EFFORT_TO_REASONING_EFFORT: Record<string, "low" | "medium" | "high"> = {
   max: "high",
 };
 
+/** Values accepted by the Responses API `text.verbosity` parameter. */
+const VALID_VERBOSITIES = new Set<string>(["low", "medium", "high"]);
+
 /** Loosely-typed Responses stream event to avoid `any` while the SDK types settle. */
 interface ResponsesStreamEvent {
   type: string;
@@ -109,6 +112,7 @@ export class OpenAIResponsesProvider implements Provider {
     const maxTokens = configObj?.max_tokens as number | undefined;
     const modelOverride = configObj?.model as string | undefined;
     const effort = configObj?.effort as string | undefined;
+    const verbosity = configObj?.verbosity as string | undefined;
 
     try {
       const input = this.toResponsesInput(messages);
@@ -135,6 +139,10 @@ export class OpenAIResponsesProvider implements Provider {
         : undefined;
       if (reasoningEffort) {
         params.reasoning = { effort: reasoningEffort };
+      }
+
+      if (verbosity && VALID_VERBOSITIES.has(verbosity)) {
+        params.text = { verbosity };
       }
 
       if (tools && tools.length > 0) {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -35,6 +35,12 @@ const EFFORT_SUPPORTED_PROVIDERS = new Set([
  */
 const THINKING_AWARE_PROVIDERS = new Set(["anthropic", "openrouter"]);
 
+/**
+ * Providers that consume the `verbosity` config. Currently OpenAI (mapped to
+ * `text.verbosity` on the Responses API — a GPT-5-series parameter).
+ */
+const VERBOSITY_SUPPORTED_PROVIDERS = new Set(["openai"]);
+
 /** Patterns that indicate a transient streaming corruption from the SDK. */
 const RETRYABLE_STREAM_PATTERNS = [
   "Unexpected event order",
@@ -88,22 +94,22 @@ function isRetryableError(error: unknown): boolean {
  * Normalize per-call options before handing them to the wrapped provider.
  *
  * When `config.callSite` is set, resolves model/maxTokens/effort/speed/
- * temperature/thinking via `resolveCallSiteConfig` and writes them into
- * `nextConfig` using the wire-format names that downstream provider clients
- * consume (`max_tokens` snake-case for the token cap; camelCase for the rest,
- * which matches the resolver's shape). Per-call explicit overrides on the
- * original `config` object win over the resolved values, so callers can pin
- * a model or other parameter for a single request. `contextWindow` and
+ * verbosity/temperature/thinking via `resolveCallSiteConfig` and writes them
+ * into `nextConfig` using the wire-format names that downstream provider
+ * clients consume (`max_tokens` snake-case for the token cap; camelCase for
+ * the rest, which matches the resolver's shape). Per-call explicit overrides
+ * on the original `config` object win over the resolved values, so callers can
+ * pin a model or other parameter for a single request. `contextWindow` and
  * `provider` are intentionally excluded from the written fields — they are
  * server-side routing/overflow concerns, not provider request parameters,
  * and forwarding them would leak unknown fields into provider request bodies
  * (strict-schema clients like Anthropic reject the request).
  *
  * Whether or not `callSite` is set, this function applies per-provider
- * stripping (`thinking`/`effort`/`speed`) based on the wrapped provider's
- * name — agent-loop callers that pre-resolve provider/model still need this
- * stripping so they don't accidentally send Anthropic-only knobs to OpenAI
- * etc.
+ * stripping (`thinking`/`effort`/`speed`/`verbosity`) based on the wrapped
+ * provider's name — agent-loop callers that pre-resolve provider/model still
+ * need this stripping so they don't accidentally send Anthropic-only knobs to
+ * OpenAI etc.
  */
 function normalizeSendMessageOptions(
   providerName: string,
@@ -136,6 +142,9 @@ function normalizeSendMessageOptions(
     }
     if (nextConfig.speed === undefined) {
       nextConfig.speed = resolved.speed;
+    }
+    if (nextConfig.verbosity === undefined) {
+      nextConfig.verbosity = resolved.verbosity;
     }
     // `temperature` defaults to `null` in the LLM schema (meaning "no opinion
     // — let the provider pick its own default"). Only forward when the
@@ -231,6 +240,15 @@ function normalizeSendMessageOptions(
   // speed (fast mode) is Anthropic-specific; strip for other providers
   if (providerName !== "anthropic" && nextConfig.speed !== undefined) {
     delete nextConfig.speed;
+  }
+
+  // verbosity maps to OpenAI's `text.verbosity` (Responses API); strip for
+  // providers that don't accept it to avoid leaking unknown fields on the wire.
+  if (
+    !VERBOSITY_SUPPORTED_PROVIDERS.has(providerName) &&
+    nextConfig.verbosity !== undefined
+  ) {
+    delete nextConfig.verbosity;
   }
 
   // `openrouter.only` is OpenRouter-specific routing; strip for other


### PR DESCRIPTION
## Summary
- Add `verbosity` to the LLM config schema (low|medium|high, default medium) and expose it as a per-call-site override alongside `effort` and `speed`.
- Resolve `verbosity` in `retry.ts` normalization and strip it for providers that don't consume it (Anthropic, OpenRouter, Gemini, Fireworks, Ollama) so strict-schema clients never see an unknown field.
- Apply the resolved value on OpenAI's Responses API as `text.verbosity`, completing GPT-5-series parameter coverage (`reasoning.effort` was already wired).

## Original prompt
add support for reasoning.effort and text.verbosity for the gpt series of models from openai https://developers.openai.com/api/reference/resources/responses/methods/create

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
