### PR TITLE
build: fix worktree tsc errors via skills/* dep install + pre-push self-heal

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -250,6 +250,26 @@ if [ -n "$CHANGED_FILES" ]; then
     done <<< "$CHANGED_FILES"
 
     if [ $ASSISTANT_TS_CHANGED -eq 1 ]; then
+        # assistant/src/daemon/external-skills-bootstrap.ts statically imports
+        # skills/meet-join/register.ts, so `tsc --noEmit` in assistant/ follows
+        # the import and type-checks the skill. The skill's own imports
+        # (`@vellumai/skill-host-contracts`, `zod`) resolve via
+        # skills/meet-join/node_modules — which the shared worktree script does
+        # not symlink (its find runs at -maxdepth 2, but skills/meet-join lives
+        # at depth 3). Self-heal by installing on first run so worktrees don't
+        # produce false-positive type errors.
+        for skill_dir in "${REPO_ROOT}"/skills/*/; do
+            [ -f "${skill_dir}package.json" ] || continue
+            [ -d "${skill_dir}node_modules" ] && continue
+            skill_name="$(basename "$skill_dir")"
+            echo "  Installing skills/${skill_name}/ dependencies (missing node_modules)..."
+            _debug_log "skills/${skill_name}: bun install start"
+            (cd "$skill_dir" && "$BUN" install --frozen-lockfile >/dev/null 2>&1) || {
+                echo -e "  ${YELLOW}⚠️  bun install failed in skills/${skill_name}/ — tsc may produce false positives${NC}"
+            }
+            _debug_log "skills/${skill_name}: bun install done"
+        done
+
         echo ""
         echo "🔍 Type-checking assistant/..."
         _debug_log "tsc --noEmit start"

--- a/setup.sh
+++ b/setup.sh
@@ -88,6 +88,22 @@ for dir in "${REPO_ROOT}"/packages/*/; do
 done
 
 # ---------------------------------------------------------------------------
+# Install dependencies for skills that have their own package.json
+#
+# assistant/src/daemon/external-skills-bootstrap.ts statically imports
+# skills/meet-join/register.ts, so `tsc --noEmit` in assistant/ follows the
+# import into the skill and needs the skill's own node_modules to resolve
+# transitive imports. Missing deps surface as false-positive "Cannot find
+# module" errors.
+# ---------------------------------------------------------------------------
+for dir in "${REPO_ROOT}"/skills/*/; do
+  [ -f "${dir}/package.json" ] || continue
+  pkg="$(basename "${dir}")"
+  info "Installing dependencies in skills/${pkg}/"
+  (cd "${dir}" && bun install)
+done
+
+# ---------------------------------------------------------------------------
 # Link local packages into meta so it resolves to local source
 # ---------------------------------------------------------------------------
 info "Linking local packages into meta/"


### PR DESCRIPTION
## Summary
- Root cause: `tsc --noEmit` in `assistant/` follows a static import (`external-skills-bootstrap.ts` → `skills/meet-join/register.ts`) and needs that skill's `node_modules`. The shared `.claude/worktree` script only symlinks `node_modules` at `-maxdepth 2`, so the depth-3 `skills/meet-join/node_modules` isn't covered — fresh worktrees hit false-positive "Cannot find module" errors.
- `setup.sh` now installs each `skills/*/package.json` alongside the existing `packages/*/` loop (mirrors CI's explicit install in `pr-assistant.yaml`).
- `.githooks/pre-push` self-heals by running `bun install --frozen-lockfile` in any `skills/*/` missing `node_modules` right before the `assistant/` tsc check, so worktrees recover automatically without anyone having to remember the extra install step.

## Original prompt
prevent the typecheck errors from happening next time
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
