### PR TITLE
feat(ipc): bidirectional RPC — daemon can send requests to skill

### DIFF
--- a/assistant/src/ipc/__tests__/skill-server-bidirectional.test.ts
+++ b/assistant/src/ipc/__tests__/skill-server-bidirectional.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Bidirectional RPC smoke test for the skill IPC channel.
+ *
+ * Spins up `SkillIpcServer` on a temp socket and connects a real
+ * `SkillHostClient`. Verifies the daemon→skill direction end-to-end:
+ *   - Happy path: server `sendRequest` resolves with the handler's return.
+ *   - Handler-throw path: server `sendRequest` rejects with the thrown
+ *     error message.
+ *   - Missing-handler path: server `sendRequest` rejects with a "method
+ *     not found" error.
+ *   - Connection-close path: server `sendRequest` rejects with a clear
+ *     "connection closed" error when the peer disconnects mid-flight.
+ *
+ * Sits in the assistant package (not the contracts package) because it
+ * exercises both `SkillIpcServer` and `SkillHostClient` — the contracts
+ * package's own tests deliberately stand up a stub server to avoid a
+ * dependency on `assistant/`.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { connect, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { SkillHostClient } from "@vellumai/skill-host-contracts";
+
+import {
+  SKILL_IPC_DAEMON_ID_PREFIX,
+  type SkillIpcConnection,
+  SkillIpcServer,
+} from "../skill-server.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+let tempDir: string | null = null;
+let socketPath: string | null = null;
+let server: SkillIpcServer | null = null;
+let client: SkillHostClient | null = null;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "skill-ipc-bidir-"));
+  socketPath = join(tempDir, "assistant-skill.sock");
+});
+
+afterEach(async () => {
+  client?.close();
+  client = null;
+  server?.stop();
+  server = null;
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+    socketPath = null;
+  }
+});
+
+/**
+ * Stand up the server, connect a client, and return the
+ * server-side `SkillIpcConnection` handle once the connection is
+ * established. The handle is the target the daemon's `sendRequest`
+ * needs.
+ */
+async function startPair(): Promise<{
+  server: SkillIpcServer;
+  client: SkillHostClient;
+  connection: SkillIpcConnection;
+}> {
+  if (!socketPath) throw new Error("socketPath not initialized");
+  const srv = new SkillIpcServer({ socketPath });
+  await srv.start();
+  const c = new SkillHostClient({
+    socketPath,
+    skillId: "bidir-test",
+  });
+  // Stub the routes the contracts client prefetches at connect-time.
+  srv.registerMethod("host.identity.getInternalAssistantId", () => "self");
+  srv.registerMethod("host.identity.getAssistantName", () => null);
+  srv.registerMethod("host.platform.workspaceDir", () => "/tmp/workspace");
+  srv.registerMethod("host.platform.vellumRoot", () => "/tmp/vellum");
+  srv.registerMethod("host.platform.runtimeMode", () => "bare-metal");
+
+  await c.connect();
+  // The server does not expose its per-socket connection map publicly
+  // (it is a WeakMap keyed by the `Socket` object). Reach in via the
+  // private fields — acceptable for a same-package smoke test that
+  // needs the `SkillIpcConnection` handle to call `sendRequest`.
+  const internals = srv as unknown as {
+    clients: Set<object>;
+    connections: WeakMap<object, SkillIpcConnection>;
+  };
+  const connections: SkillIpcConnection[] = [];
+  for (const sock of internals.clients) {
+    const conn = internals.connections.get(sock);
+    if (conn) connections.push(conn);
+  }
+  if (connections.length !== 1) {
+    throw new Error(
+      `expected exactly one server-side connection, got ${connections.length}`,
+    );
+  }
+  const connection = connections[0]!;
+  server = srv;
+  client = c;
+  return { server: srv, client: c, connection };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SkillIpcServer.sendRequest", () => {
+  test("happy path — registered handler returns a value", async () => {
+    const pair = await startPair();
+    pair.client.registerHandler("echo", (params) => ({ got: params }));
+
+    const result = await pair.server.sendRequest(pair.connection, "echo", {
+      hi: "there",
+    });
+    expect(result).toEqual({ got: { hi: "there" } });
+  });
+
+  test("happy path — async handler is awaited", async () => {
+    const pair = await startPair();
+    pair.client.registerHandler("delayed", async (params) => {
+      await new Promise((r) => setTimeout(r, 10));
+      return { delayed: true, params };
+    });
+
+    const result = await pair.server.sendRequest(pair.connection, "delayed", {
+      tag: 7,
+    });
+    expect(result).toEqual({ delayed: true, params: { tag: 7 } });
+  });
+
+  test("handler error — rejected with the thrown message", async () => {
+    const pair = await startPair();
+    pair.client.registerHandler("boom", () => {
+      throw new Error("kaboom");
+    });
+
+    await expect(
+      pair.server.sendRequest(pair.connection, "boom"),
+    ).rejects.toThrow(/kaboom/);
+  });
+
+  test("missing handler — rejected with method-not-found", async () => {
+    const pair = await startPair();
+    // No handler registered for "missing".
+
+    await expect(
+      pair.server.sendRequest(pair.connection, "missing"),
+    ).rejects.toThrow(/method not found/);
+  });
+
+  test("connection close — rejects in-flight requests with a clear error", async () => {
+    const pair = await startPair();
+    // Handler that never returns so the request stays in-flight until the
+    // peer disconnects.
+    pair.client.registerHandler("hang", () => new Promise(() => {}));
+
+    const inFlight = pair.server.sendRequest(pair.connection, "hang");
+    // Force the client side to drop the socket. The server's "close"
+    // handler will then dispose the connection state and reject every
+    // pending daemon-initiated request.
+    pair.client.close();
+
+    await expect(inFlight).rejects.toThrow(/connection closed/);
+  });
+
+  test("daemon-initiated id prefix is `d:`", () => {
+    // Public-constant assertion: the `d:` prefix is part of the wire
+    // contract — peers (e.g. the contracts client) read it directly to
+    // route inbound frames. A future rename here without updating the
+    // peers would silently break bidirectional dispatch, so the
+    // constant is asserted.
+    expect(SKILL_IPC_DAEMON_ID_PREFIX).toBe("d:");
+  });
+
+  test("server rejects inbound skill-initiated requests whose ids start with `d:`", async () => {
+    if (!socketPath) throw new Error("socketPath not initialized");
+    const srv = new SkillIpcServer({ socketPath });
+    await srv.start();
+    server = srv;
+    srv.registerMethod("test.echo", (params) => ({ ok: true, params }));
+
+    // Send a request with a reserved-prefix id over a raw socket so we
+    // bypass the contracts client (which never mints `d:` ids).
+    const response = await new Promise<{
+      id: string;
+      error?: string;
+      result?: unknown;
+    }>((resolve, reject) => {
+      const sock: Socket = connect(socketPath!);
+      let buffer = "";
+      let settled = false;
+      const finish = (
+        v: { id: string; error?: string; result?: unknown } | Error,
+      ): void => {
+        if (settled) return;
+        settled = true;
+        sock.destroy();
+        if (v instanceof Error) reject(v);
+        else resolve(v);
+      };
+      sock.on("connect", () => {
+        sock.write(JSON.stringify({ id: "d:99", method: "test.echo" }) + "\n");
+      });
+      sock.on("data", (chunk) => {
+        buffer += chunk.toString();
+        const idx = buffer.indexOf("\n");
+        if (idx === -1) return;
+        const line = buffer.slice(0, idx).trim();
+        try {
+          finish(JSON.parse(line));
+        } catch (err) {
+          finish(err as Error);
+        }
+      });
+      sock.on("error", (err) => finish(err));
+    });
+
+    expect(response.id).toBe("d:99");
+    expect(response.result).toBeUndefined();
+    expect(response.error).toMatch(/Reserved id prefix/);
+  });
+
+  test("existing skill→daemon RPCs still succeed alongside daemon→skill ones", async () => {
+    const pair = await startPair();
+    pair.server.registerMethod("test.add", (params) => {
+      const p = params as { a: number; b: number };
+      return p.a + p.b;
+    });
+    pair.client.registerHandler("client-echo", (params) => params);
+
+    // Round-trip both directions concurrently.
+    const [skillResult, daemonResult] = await Promise.all([
+      pair.client.rawCall<number>("test.add", { a: 2, b: 3 }),
+      pair.server.sendRequest(pair.connection, "client-echo", { value: "ok" }),
+    ]);
+    expect(skillResult).toBe(5);
+    expect(daemonResult).toEqual({ value: "ok" });
+  });
+});

--- a/assistant/src/ipc/skill-server.ts
+++ b/assistant/src/ipc/skill-server.ts
@@ -8,18 +8,29 @@
  *
  * Protocol: newline-delimited JSON over a Unix domain socket.
  *
- * One-shot RPC:
- * - Request:  { "id": string, "method": string, "params"?: Record<string, unknown> }
- * - Response: { "id": string, "result"?: unknown, "error"?: string }
+ * Bidirectional RPC: either side may initiate a request. Per-direction id
+ * namespacing prevents collisions:
+ * - Skill-initiated request ids start with `s:` (minted client-side).
+ * - Daemon-initiated request ids start with `d:` (minted server-side).
+ * Response frames echo the request id, so each side routes inbound responses
+ * to its own pending-request map by prefix.
  *
- * Streaming RPC (e.g. `host.events.subscribe`):
- * - Request:    { "id": string, "method": string, "params"?: Record<string, unknown> }
- * - Open ack:   { "id": string, "result": { "subscribed": true } }
- * - Deliveries: { "id": string, "event": "delivery", "payload": <data> } (0..N)
- * - Error:      { "id": string, "error": string } (terminal)
- * - Close req:  { "id": "<ctrl-id>", "method": "host.events.subscribe.close",
+ * Skill→daemon one-shot RPC:
+ * - Request:  { "id": "s:<n>", "method": string, "params"?: Record<string, unknown> }
+ * - Response: { "id": "s:<n>", "result"?: unknown, "error"?: string }
+ *
+ * Daemon→skill one-shot RPC:
+ * - Request:  { "id": "d:<n>", "method": string, "params"?: unknown }
+ * - Response: { "id": "d:<n>", "result"?: unknown, "error"?: string }
+ *
+ * Streaming RPC (e.g. `host.events.subscribe`, skill-initiated only):
+ * - Request:    { "id": "s:<n>", "method": string, "params"?: Record<string, unknown> }
+ * - Open ack:   { "id": "s:<n>", "result": { "subscribed": true } }
+ * - Deliveries: { "id": "s:<n>", "event": "delivery", "payload": <data> } (0..N)
+ * - Error:      { "id": "s:<n>", "error": string } (terminal)
+ * - Close req:  { "id": "s:<n>", "method": "host.events.subscribe.close",
  *                 "params": { "subscribeId": "<original-id>" } }
- * - Close ack:  { "id": "<ctrl-id>", "result": { "closed": true } }
+ * - Close ack:  { "id": "s:<n>", "result": { "closed": true } }
  *
  * The preferred socket path is `{workspaceDir}/assistant-skill.sock`. On
  * platforms with strict AF_UNIX path limits (notably macOS), the server falls
@@ -48,6 +59,16 @@ import {
 import { resolveSkillIpcSocketPath } from "./skill-socket-path.js";
 
 const log = getLogger("skill-ipc-server");
+
+// ---------------------------------------------------------------------------
+// Id namespacing
+// ---------------------------------------------------------------------------
+
+/** Prefix for ids minted by the daemon (server) side. */
+export const SKILL_IPC_DAEMON_ID_PREFIX = "d:" as const;
+
+/** Default per-call timeout for daemon-initiated requests. */
+const DEFAULT_SEND_REQUEST_TIMEOUT_MS = 30_000;
 
 // ---------------------------------------------------------------------------
 // Streaming
@@ -124,13 +145,33 @@ export interface SkillIpcConnection {
   addSkillToolsOwner(skillId: string): void;
 }
 
+/** Internal record for a daemon-initiated request awaiting a response. */
+interface PendingDaemonRequest {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
 class SkillIpcConnectionState implements SkillIpcConnection {
   readonly connectionId: string;
+  readonly socket: Socket;
   private routeHandlesBySkill = new Map<string, SkillRouteHandle[]>();
   private skillToolOwners = new Set<string>();
+  /**
+   * Pending daemon-initiated requests keyed by `d:<n>` id. Cleared on
+   * connection teardown so callers never see a hung promise.
+   */
+  readonly pendingDaemonRequests = new Map<string, PendingDaemonRequest>();
+  private nextRequestSeq = 1;
 
-  constructor(connectionId: string) {
+  constructor(connectionId: string, socket: Socket) {
     this.connectionId = connectionId;
+    this.socket = socket;
+  }
+
+  /** Allocate the next `d:<n>` id for a daemon-initiated request. */
+  nextDaemonRequestId(): string {
+    return `${SKILL_IPC_DAEMON_ID_PREFIX}${this.nextRequestSeq++}`;
   }
 
   addRouteHandle(skillId: string, handle: SkillRouteHandle): void {
@@ -168,6 +209,20 @@ class SkillIpcConnectionState implements SkillIpcConnection {
       }
     }
     this.skillToolOwners.clear();
+    // Reject every in-flight daemon-initiated request so callers don't
+    // hang on a dropped peer. The socket's "close" listener fires before
+    // dispose() in the normal path, but defending here keeps behavior
+    // identical when teardown is invoked from the explicit `stop()` path.
+    if (this.pendingDaemonRequests.size > 0) {
+      const closeErr = new Error(
+        `SkillIpcServer: connection closed before response (connectionId=${this.connectionId})`,
+      );
+      for (const pending of this.pendingDaemonRequests.values()) {
+        clearTimeout(pending.timer);
+        pending.reject(closeErr);
+      }
+      this.pendingDaemonRequests.clear();
+    }
   }
 }
 
@@ -239,6 +294,71 @@ export class SkillIpcServer {
     this.streamingMethods.set(method, handler);
   }
 
+  /**
+   * Send a request to the skill on the other side of `connection` and resolve
+   * with the matching response's `result` (or reject with its `error`).
+   *
+   * Daemon-initiated request ids are namespaced under the `d:` prefix so the
+   * skill can disambiguate them from its own `s:`-prefixed responses on the
+   * same socket. The pending entry is held on the per-connection state so a
+   * disconnect rejects every in-flight request without leaking timers.
+   *
+   * Throws synchronously if `connection` is unknown or its socket is already
+   * destroyed. Rejects asynchronously on:
+   *   - skill-side error response (`{ id, error }`),
+   *   - timeout (default 30s, override via `opts.timeoutMs`),
+   *   - peer disconnect before a response arrives.
+   */
+  sendRequest(
+    connection: SkillIpcConnection,
+    method: string,
+    params?: unknown,
+    opts?: { timeoutMs?: number },
+  ): Promise<unknown> {
+    const state = connection as SkillIpcConnectionState;
+    if (!(state instanceof SkillIpcConnectionState)) {
+      return Promise.reject(
+        new Error(
+          "SkillIpcServer.sendRequest: connection must be a SkillIpcConnection produced by this server",
+        ),
+      );
+    }
+    if (state.socket.destroyed) {
+      return Promise.reject(
+        new Error(
+          `SkillIpcServer.sendRequest: connection ${state.connectionId} socket is destroyed`,
+        ),
+      );
+    }
+
+    const id = state.nextDaemonRequestId();
+    const timeoutMs = opts?.timeoutMs ?? DEFAULT_SEND_REQUEST_TIMEOUT_MS;
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (state.pendingDaemonRequests.delete(id)) {
+          reject(
+            new Error(
+              `SkillIpcServer.sendRequest: '${method}' on ${state.connectionId} timed out after ${timeoutMs}ms`,
+            ),
+          );
+        }
+      }, timeoutMs);
+      state.pendingDaemonRequests.set(id, { resolve, reject, timer });
+      try {
+        const frame: { id: string; method: string; params?: unknown } = {
+          id,
+          method,
+        };
+        if (params !== undefined) frame.params = params;
+        state.socket.write(JSON.stringify(frame) + "\n");
+      } catch (err) {
+        state.pendingDaemonRequests.delete(id);
+        clearTimeout(timer);
+        reject(err as Error);
+      }
+    });
+  }
+
   /** Start listening on the Unix domain socket. */
   async start(): Promise<void> {
     // Ensure the parent directory exists before listening.
@@ -258,6 +378,7 @@ export class SkillIpcServer {
       this.clients.add(socket);
       const connection = new SkillIpcConnectionState(
         `skill-ipc-${this.nextConnectionId++}`,
+        socket,
       );
       this.connections.set(socket, connection);
       log.debug(
@@ -340,9 +461,12 @@ export class SkillIpcServer {
   // ── Internal ──────────────────────────────────────────────────────────
 
   private handleMessage(socket: Socket, line: string): void {
-    let req: IpcRequest;
+    let frame: IpcRequest & { result?: unknown; error?: string };
     try {
-      req = JSON.parse(line) as IpcRequest;
+      frame = JSON.parse(line) as IpcRequest & {
+        result?: unknown;
+        error?: string;
+      };
     } catch {
       this.sendResponse(socket, {
         id: "unknown",
@@ -352,22 +476,54 @@ export class SkillIpcServer {
     }
 
     if (
-      !req ||
-      typeof req !== "object" ||
-      Array.isArray(req) ||
-      !req.id ||
-      !req.method
+      !frame ||
+      typeof frame !== "object" ||
+      Array.isArray(frame) ||
+      !frame.id
     ) {
       const id =
-        req &&
-        typeof req === "object" &&
-        !Array.isArray(req) &&
-        typeof req.id === "string"
-          ? req.id
+        frame &&
+        typeof frame === "object" &&
+        !Array.isArray(frame) &&
+        typeof frame.id === "string"
+          ? frame.id
           : "unknown";
       this.sendResponse(socket, {
         id,
         error: "Missing 'id' or 'method' field",
+      });
+      return;
+    }
+
+    // Response frame for a daemon-initiated request — route to the
+    // pending-request map on the connection state instead of treating it
+    // as an inbound RPC. Identified by the `d:` id prefix and the
+    // absence of a `method` field.
+    if (
+      frame.method === undefined &&
+      frame.id.startsWith(SKILL_IPC_DAEMON_ID_PREFIX)
+    ) {
+      this.handleDaemonResponse(socket, frame);
+      return;
+    }
+
+    if (!frame.method) {
+      this.sendResponse(socket, {
+        id: frame.id,
+        error: "Missing 'id' or 'method' field",
+      });
+      return;
+    }
+
+    const req = frame as IpcRequest;
+
+    // Reserve the daemon prefix for server-minted ids. A skill that sends
+    // a request whose id starts with `d:` would collide with daemon-side
+    // pending entries; reject it loudly so the bug surfaces early.
+    if (req.id.startsWith(SKILL_IPC_DAEMON_ID_PREFIX)) {
+      this.sendResponse(socket, {
+        id: req.id,
+        error: `Reserved id prefix '${SKILL_IPC_DAEMON_ID_PREFIX}': skill-initiated request ids must not collide with daemon-initiated ids`,
       });
       return;
     }
@@ -513,6 +669,28 @@ export class SkillIpcServer {
       id: req.id,
       result: { closed: true },
     });
+  }
+
+  private handleDaemonResponse(
+    socket: Socket,
+    frame: { id: string; result?: unknown; error?: string },
+  ): void {
+    const connection = this.connections.get(socket);
+    if (!connection) return;
+    const pending = connection.pendingDaemonRequests.get(frame.id);
+    if (!pending) {
+      // Either a duplicate/late response or a frame for a request the
+      // server already timed out. Drop silently — it would have already
+      // settled the caller's promise.
+      return;
+    }
+    connection.pendingDaemonRequests.delete(frame.id);
+    clearTimeout(pending.timer);
+    if (frame.error !== undefined) {
+      pending.reject(new Error(String(frame.error)));
+    } else {
+      pending.resolve(frame.result);
+    }
   }
 
   private teardownConnection(socket: Socket): void {

--- a/packages/skill-host-contracts/src/client.ts
+++ b/packages/skill-host-contracts/src/client.ts
@@ -5,18 +5,25 @@
  *
  * Wire protocol (mirrors `assistant/src/ipc/skill-server.ts`):
  *
- *   one-shot RPC
- *     → { id, method, params? }
- *     ← { id, result } | { id, error }
+ *   skill-initiated RPC (one-shot)
+ *     → { id: "s:<n>", method, params? }
+ *     ← { id: "s:<n>", result } | { id: "s:<n>", error }
  *
- *   streaming RPC (e.g. `host.events.subscribe`)
- *     → { id, method, params? }
- *     ← { id, result: { subscribed: true } }            (open ack)
- *     ← { id, event: "delivery", payload: <data> }       (0..N)
- *     ← { id, error }                                    (terminal)
- *     → { id: ctrl-id, method: "host.events.subscribe.close",
+ *   daemon-initiated RPC (one-shot, requires registered handler)
+ *     ← { id: "d:<n>", method, params? }
+ *     → { id: "d:<n>", result } | { id: "d:<n>", error }
+ *
+ *   streaming RPC (e.g. `host.events.subscribe`, skill-initiated only)
+ *     → { id: "s:<n>", method, params? }
+ *     ← { id: "s:<n>", result: { subscribed: true } }     (open ack)
+ *     ← { id: "s:<n>", event: "delivery", payload: <data> } (0..N)
+ *     ← { id: "s:<n>", error }                            (terminal)
+ *     → { id: "s:<n>", method: "host.events.subscribe.close",
  *          params: { subscribeId: <original-id> } }
- *     ← { id: ctrl-id, result: { closed: true } }
+ *     ← { id: "s:<n>", result: { closed: true } }
+ *
+ * The `s:` / `d:` id prefixes namespace the two directions so each side can
+ * route inbound responses to its own pending-request map without collision.
  *
  * ### Sync-method bootstrap
  *
@@ -98,6 +105,11 @@ const DEFAULT_CONNECT_TIMEOUT_MS = 3_000;
 const DEFAULT_RECONNECT_BASE_DELAY_MS = 200;
 const DEFAULT_RECONNECT_MAX_DELAY_MS = 10_000;
 
+/** Prefix for ids minted by the daemon (server) side. */
+const DAEMON_ID_PREFIX = "d:" as const;
+/** Prefix for ids minted by the skill (client) side. */
+const SKILL_ID_PREFIX = "s:" as const;
+
 // ---------------------------------------------------------------------------
 // Wire-format types
 // ---------------------------------------------------------------------------
@@ -110,11 +122,22 @@ type IpcRequest = {
 
 type IpcResponseFrame = {
   id: string;
+  method?: string;
+  params?: unknown;
   result?: unknown;
   error?: string;
   event?: "delivery";
   payload?: unknown;
 };
+
+/**
+ * Handler for a daemon-initiated request. Returning a value (or a Promise)
+ * resolves the daemon's `sendRequest` call; throwing rejects it with the
+ * thrown error's message. Synchronous returns are wrapped automatically.
+ */
+export type SkillHostRequestHandler = (
+  params: unknown,
+) => unknown | Promise<unknown>;
 
 // ---------------------------------------------------------------------------
 // Public options
@@ -188,6 +211,16 @@ function swallow(err: unknown): void {
   }
 }
 
+/**
+ * Stringify an unknown error value for the wire — `Error.message` when
+ * available, otherwise `String(err)` so non-Error throws still surface
+ * something readable on the daemon side.
+ */
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
 // ---------------------------------------------------------------------------
 // Client implementation
 // ---------------------------------------------------------------------------
@@ -225,6 +258,21 @@ export class SkillHostClient implements SkillHost {
   private connectingPromise: Promise<void> | null = null;
   private closed = false;
   private reconnectAttempt = 0;
+  /**
+   * Monotonic counter for skill-initiated request ids, formatted as
+   * `s:<n>`. The daemon mints `d:<n>` ids independently, so the two
+   * sequences never collide on a shared socket.
+   */
+  private nextSkillRequestSeq = 1;
+  /**
+   * Handlers for daemon-initiated requests, keyed by method name. Populated
+   * via `registerHandler(method, handler)`. Daemon→skill request frames
+   * (id starts with `d:`) are dispatched through this table.
+   */
+  private readonly daemonRequestHandlers = new Map<
+    string,
+    SkillHostRequestHandler
+  >();
 
   // Prefetched sync state — populated by `connect()`.
   private cachedInternalAssistantId: string | null = null;
@@ -308,6 +356,17 @@ export class SkillHostClient implements SkillHost {
       this.socket.destroy();
     }
     this.socket = null;
+  }
+
+  /**
+   * Install a handler for daemon-initiated requests of the given method.
+   * The daemon's `SkillIpcServer.sendRequest(connection, method, ...)`
+   * resolves with whatever the handler returns (or rejects with the
+   * handler's thrown error). Re-registering a method replaces the prior
+   * handler — last writer wins.
+   */
+  registerHandler(method: string, handler: SkillHostRequestHandler): void {
+    this.daemonRequestHandlers.set(method, handler);
   }
 
   // ── Internal: socket lifecycle ──────────────────────────────────────────
@@ -453,6 +512,17 @@ export class SkillHostClient implements SkillHost {
       return;
     }
 
+    // Daemon-initiated request frame — dispatch to a registered handler
+    // and write back the response. Identified by the `d:` id prefix and
+    // the presence of a `method` field.
+    if (
+      typeof frame.method === "string" &&
+      frame.id.startsWith(DAEMON_ID_PREFIX)
+    ) {
+      this.dispatchDaemonRequest(frame.id, frame.method, frame.params);
+      return;
+    }
+
     // Response frame — resolve or reject the pending call.
     const pending = this.pending.get(frame.id);
     if (pending) {
@@ -478,11 +548,63 @@ export class SkillHostClient implements SkillHost {
     }
   }
 
+  private dispatchDaemonRequest(
+    id: string,
+    method: string,
+    params: unknown,
+  ): void {
+    const handler = this.daemonRequestHandlers.get(method);
+    if (!handler) {
+      this.writeResponseFrame({
+        id,
+        error: `method not found: ${method}`,
+      });
+      return;
+    }
+    let result: unknown;
+    try {
+      result = handler(params);
+    } catch (err) {
+      this.writeResponseFrame({ id, error: errorMessage(err) });
+      return;
+    }
+    if (result instanceof Promise) {
+      result.then(
+        (value) => {
+          this.writeResponseFrame({ id, result: value });
+        },
+        (err) => {
+          this.writeResponseFrame({ id, error: errorMessage(err) });
+        },
+      );
+    } else {
+      this.writeResponseFrame({ id, result });
+    }
+  }
+
+  private writeResponseFrame(response: {
+    id: string;
+    result?: unknown;
+    error?: string;
+  }): void {
+    if (!this.socket || this.socket.destroyed) {
+      // The peer is gone; silently drop. The daemon-side pending entry
+      // will already have been rejected by the connection-close path.
+      return;
+    }
+    this.socket.write(JSON.stringify(response) + "\n");
+  }
+
   private writeFrame(req: IpcRequest): void {
     if (!this.socket || this.socket.destroyed) {
       throw new Error("SkillHostClient: not connected");
     }
     this.socket.write(JSON.stringify(req) + "\n");
+  }
+
+  /** Allocate the next `s:<n>` id for a skill-initiated request. */
+  private nextSkillRequestId(): string {
+    return `${SKILL_ID_PREFIX}${this.nextSkillRequestSeq++}`;
   }
 
   private async call<T>(
@@ -497,7 +619,7 @@ export class SkillHostClient implements SkillHost {
         "SkillHostClient: not connected. Call `await client.connect()` first.",
       );
     }
-    const id = randomUUID();
+    const id = this.nextSkillRequestId();
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {
         if (this.pending.delete(id)) {
@@ -771,7 +893,7 @@ export class SkillHostClient implements SkillHost {
     filter: Filter,
     callback: AssistantEventCallback,
   ): Subscription {
-    const id = randomUUID();
+    const id = this.nextSkillRequestId();
     const active: ActiveSubscription = {
       id,
       filter,


### PR DESCRIPTION
## Summary
- SkillIpcServer.sendRequest(connection, method, params) — daemon can initiate RPCs to a connected skill.
- SkillHostClient.registerHandler(method, handler) — skill responds to daemon-initiated requests.
- Per-direction id namespacing (d: vs s:) prevents collisions.
- Round-trip test covers happy path, handler error, missing method, and connection close.
- Existing skill→daemon RPCs and the events-subscribe stream are unchanged.

Part of plan: skill-isolation.md (PR A — server-initiated dispatch follow-up)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
