### PR TITLE
feat(providers): add effort:"none" to disable reasoning

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -1417,9 +1417,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(isPlaceholderSentinelText("")).toBe(false);
     expect(isPlaceholderSentinelText("__PLACEHOLDER__")).toBe(false);
     expect(
-      isPlaceholderSentinelText(
-        "prefix __PLACEHOLDER__[empty assistant turn]",
-      ),
+      isPlaceholderSentinelText("prefix __PLACEHOLDER__[empty assistant turn]"),
     ).toBe(false);
   });
 
@@ -2032,6 +2030,24 @@ describe("AnthropicProvider — Haiku Model Gating", () => {
 
     expect(lastStreamParams!.output_config).toBeUndefined();
   });
+
+  test('effort: "none" omits output_config.effort on non-Haiku models', async () => {
+    const sonnetProvider = new AnthropicProvider(
+      "sk-ant-test",
+      "claude-sonnet-4-6",
+    );
+    await sonnetProvider.sendMessage(
+      [userMsg("Hi")],
+      undefined,
+      "You are helpful.",
+      { config: { effort: "none" } },
+    );
+
+    // mergedOutputConfig is empty when effort is "none" and no other
+    // output_config fields were supplied, so output_config is not attached
+    // to the request at all.
+    expect(lastStreamParams!.output_config).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -2046,9 +2062,8 @@ describe("OpenRouterProvider — Anthropic dispatch", () => {
   });
 
   test("anthropic/ models are routed to Anthropic Messages API with Bearer auth", async () => {
-    const { OpenRouterProvider } = await import(
-      "../providers/openrouter/client.js"
-    );
+    const { OpenRouterProvider } =
+      await import("../providers/openrouter/client.js");
     const provider = new OpenRouterProvider(
       "or-key",
       "anthropic/claude-sonnet-4.6",
@@ -2065,9 +2080,8 @@ describe("OpenRouterProvider — Anthropic dispatch", () => {
   });
 
   test("custom baseURL has trailing /v1 stripped for Messages API", async () => {
-    const { OpenRouterProvider } = await import(
-      "../providers/openrouter/client.js"
-    );
+    const { OpenRouterProvider } =
+      await import("../providers/openrouter/client.js");
     const provider = new OpenRouterProvider(
       "ast-key",
       "anthropic/claude-opus-4.6",
@@ -2083,9 +2097,8 @@ describe("OpenRouterProvider — Anthropic dispatch", () => {
   });
 
   test("thinking config flows through to Anthropic Messages API natively", async () => {
-    const { OpenRouterProvider } = await import(
-      "../providers/openrouter/client.js"
-    );
+    const { OpenRouterProvider } =
+      await import("../providers/openrouter/client.js");
     const provider = new OpenRouterProvider(
       "or-key",
       "anthropic/claude-sonnet-4.6",
@@ -2101,9 +2114,8 @@ describe("OpenRouterProvider — Anthropic dispatch", () => {
   });
 
   test("per-request model override routes based on the overridden model", async () => {
-    const { OpenRouterProvider } = await import(
-      "../providers/openrouter/client.js"
-    );
+    const { OpenRouterProvider } =
+      await import("../providers/openrouter/client.js");
     // Default model is non-Anthropic, but the request overrides with an
     // Anthropic model — dispatch must honour the request-level model.
     const provider = new OpenRouterProvider("or-key", "x-ai/grok-4");

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1360,6 +1360,13 @@ describe("OpenAIProvider reasoning_effort", () => {
     expect(lastCreateParams!.reasoning_effort).toBeUndefined();
   });
 
+  test('effort: "none" omits the reasoning_effort param', async () => {
+    await provider.sendMessage([userMsg("hi")], undefined, "system", {
+      config: { effort: "none" },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBeUndefined();
+  });
+
   test("extraCreateParams reasoning_effort is not clobbered when no effort is set", async () => {
     const providerWithExtra = new OpenAIProvider("test-key", "gpt-5", {
       extraCreateParams: { reasoning_effort: "medium" },

--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -535,6 +535,19 @@ describe("OpenAIResponsesProvider", () => {
     expect(lastStreamParams!.reasoning).toBeUndefined();
   });
 
+  test('effort: "none" omits the reasoning param entirely', async () => {
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      { config: { effort: "none" } },
+    );
+
+    expect(lastStreamParams!.reasoning).toBeUndefined();
+  });
+
   // -----------------------------------------------------------------------
   // Verbosity → text param
   // -----------------------------------------------------------------------

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -45,7 +45,7 @@ export interface AgentLoopConfig {
   maxTokens: number;
   maxInputTokens?: number; // context window size for tool result truncation
   thinking?: { enabled: boolean };
-  effort: "low" | "medium" | "high" | "xhigh" | "max";
+  effort: "none" | "low" | "medium" | "high" | "xhigh" | "max";
   speed?: "standard" | "fast";
   toolChoice?:
     | { type: "auto" }

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -73,7 +73,22 @@ export type LLMCallSite = z.infer<typeof LLMCallSiteEnum>;
 // Effort, Speed & Verbosity
 // ---------------------------------------------------------------------------
 
-export const EffortEnum = z.enum(["low", "medium", "high", "xhigh", "max"]);
+/**
+ * Reasoning/thinking effort tier. `"none"` is a Vellum-specific value meaning
+ * "omit the provider's effort/reasoning parameter entirely" — providers
+ * translate it to skipping the relevant field on the wire (no `reasoning` on
+ * OpenAI Responses, no `reasoning_effort` on Chat Completions, no
+ * `output_config.effort` on Anthropic). All other values map to
+ * provider-specific tiers via each provider's own mapping table.
+ */
+export const EffortEnum = z.enum([
+  "none",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
 export type Effort = z.infer<typeof EffortEnum>;
 
 export const SpeedEnum = z.enum(["standard", "fast"]);

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -821,8 +821,10 @@ export class AnthropicProvider implements Provider {
         // "xhigh" is an intermediate tier between "high" and "max" supported
         // by newer Anthropic models (e.g. Opus 4.7). The SDK's OutputConfig
         // type doesn't yet include it, so we widen to the internal effort
-        // union and cast when building mergedOutputConfig.
-        effort?: "low" | "medium" | "high" | "xhigh" | "max";
+        // union and cast when building mergedOutputConfig. "none" is a
+        // Vellum-wide value meaning "omit the effort param entirely" — we
+        // skip the output_config.effort field in that case.
+        effort?: "none" | "low" | "medium" | "high" | "xhigh" | "max";
         speed?: "standard" | "fast";
         output_config?: Record<string, unknown>;
       };
@@ -836,7 +838,7 @@ export class AnthropicProvider implements Provider {
       const supportsEffort = !isHaiku;
       const mergedOutputConfig = {
         ...(output_config ?? {}),
-        ...(effort && supportsEffort
+        ...(effort && effort !== "none" && supportsEffort
           ? { effort: effort as Anthropic.OutputConfig["effort"] }
           : {}),
       };

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -142,7 +142,7 @@ export interface SendMessageConfig {
    * `llm.default` when no callSite-specific entry is present.
    */
   callSite?: LLMCallSite;
-  effort?: "low" | "medium" | "high" | "xhigh" | "max";
+  effort?: "none" | "low" | "medium" | "high" | "xhigh" | "max";
   speed?: "standard" | "fast";
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary
- Add `"none"` to `EffortEnum` and every `effort` type union so user config can opt out of reasoning. Previously setting `effort: "none"` was silently rejected and fell back to the schema default `"max"`, which mapped to `reasoning.effort: "high"` on OpenAI.
- On Anthropic, skip attaching `output_config.effort` when effort is `"none"`. On OpenAI Responses/Chat, the existing mapping already returns `undefined` for unknown keys, so the `reasoning`/`reasoning_effort` params are omitted automatically — only the type union needed widening.
- Adds provider-level tests that verify `effort: "none"` produces no `reasoning`, `reasoning_effort`, or `output_config.effort` on the wire.

## Original prompt
I have "effort" set to "none" in Velissa's config but we're still sending reasoning.effort = "high" to OpenAI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
