### PR TITLE
feat(skill-host-contracts): auto-register dispatch handlers in client

### DIFF
--- a/packages/skill-host-contracts/__tests__/client.test.ts
+++ b/packages/skill-host-contracts/__tests__/client.test.ts
@@ -64,6 +64,15 @@ class StubServer {
   methods = new Map<string, Handler>();
   streamMethods = new Map<string, StreamHandler>();
   observedRequests: Request[] = [];
+  /** Pending daemon-initiated requests, keyed by `d:<n>` id. */
+  daemonPending = new Map<
+    string,
+    {
+      resolve: (value: unknown) => void;
+      reject: (err: Error) => void;
+    }
+  >();
+  private nextDaemonSeq = 1;
 
   constructor(private socketPath: string) {
     this.server = createServer((socket) => {
@@ -95,6 +104,23 @@ class StubServer {
       socket.on("error", () => {
         /* ignore */
       });
+    });
+  }
+
+  /**
+   * Send a daemon-initiated request frame to the most recently connected
+   * client and resolve with the client's response. Mirrors what
+   * `SkillIpcServer.sendRequest` does on the daemon side.
+   */
+  sendRequest(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    const socket = [...this.clients][this.clients.size - 1];
+    if (!socket) {
+      return Promise.reject(new Error("StubServer: no connected client"));
+    }
+    const id = `d:${this.nextDaemonSeq++}`;
+    return new Promise<unknown>((resolve, reject) => {
+      this.daemonPending.set(id, { resolve, reject });
+      socket.write(JSON.stringify({ id, method, params }) + "\n");
     });
   }
 
@@ -134,6 +160,27 @@ class StubServer {
       req = JSON.parse(line) as Request;
     } catch {
       this.send(socket, { id: "unknown", error: "bad json" });
+      return;
+    }
+
+    // Frames whose id starts with `d:` are responses to daemon-initiated
+    // requests we sent via `sendRequest()`. They have either `result` or
+    // `error` set and no `method`. Route them into the pending-request map
+    // and bail out — they are not new requests for the server to handle.
+    if (
+      req.id?.startsWith("d:") &&
+      typeof (req as unknown as { method?: unknown }).method !== "string"
+    ) {
+      const pending = this.daemonPending.get(req.id);
+      if (pending) {
+        this.daemonPending.delete(req.id);
+        const frame = req as unknown as {
+          result?: unknown;
+          error?: string;
+        };
+        if (frame.error !== undefined) pending.reject(new Error(frame.error));
+        else pending.resolve(frame.result);
+      }
       return;
     }
     this.observedRequests.push(req);
@@ -488,6 +535,289 @@ describe("SkillHostClient: registries", () => {
     });
     await new Promise((r) => setTimeout(r, 30));
     expect(capturedName).toBe("demo-shutdown");
+  });
+});
+
+describe("SkillHostClient: daemon-initiated dispatch", () => {
+  test("skill.dispatch_tool routes to the registered tool's execute", async () => {
+    server!.register("host.registries.register_tools", () => ({
+      registered: ["demo.tool"],
+    }));
+    client = await openClient();
+    let observedInput: unknown;
+    let observedContext: unknown;
+    client.registries.registerTools(() => [
+      {
+        name: "demo.tool",
+        description: "demo",
+        category: "misc",
+        defaultRiskLevel: "low" as never,
+        getDefinition: () => ({
+          name: "demo.tool",
+          description: "demo",
+          input_schema: { type: "object" },
+        }),
+        execute: async (input, ctx) => {
+          observedInput = input;
+          observedContext = ctx;
+          return { ok: true } as never;
+        },
+      },
+    ]);
+    // Allow the register_tools fire-and-forget to flush so the client has
+    // installed the dispatch handler before we drive the daemon side.
+    await new Promise((r) => setTimeout(r, 30));
+
+    const result = await server!.sendRequest("skill.dispatch_tool", {
+      name: "demo.tool",
+      input: { foo: "bar" },
+      context: { workingDir: "/tmp", trustClass: "guardian" },
+    });
+    expect(result).toEqual({ result: { ok: true } });
+    expect(observedInput).toEqual({ foo: "bar" });
+    expect(observedContext).toMatchObject({
+      workingDir: "/tmp",
+      trustClass: "guardian",
+    });
+  });
+
+  test("skill.dispatch_tool surfaces unknown tool name as a remote error", async () => {
+    server!.register("host.registries.register_tools", () => ({
+      registered: ["demo.tool"],
+    }));
+    client = await openClient();
+    client.registries.registerTools(() => [
+      {
+        name: "demo.tool",
+        description: "demo",
+        category: "misc",
+        defaultRiskLevel: "low" as never,
+        getDefinition: () => ({
+          name: "demo.tool",
+          description: "demo",
+          input_schema: { type: "object" },
+        }),
+        execute: async () => ({ content: "", isError: false }),
+      },
+    ]);
+    await new Promise((r) => setTimeout(r, 30));
+
+    await expect(
+      server!.sendRequest("skill.dispatch_tool", {
+        name: "missing.tool",
+        input: {},
+      }),
+    ).rejects.toThrow(/unknown tool: missing\.tool/);
+  });
+
+  test("skill.dispatch_route invokes the matching route handler", async () => {
+    server!.register("host.registries.register_skill_route", () => ({
+      patternSource: "/api/echo/(\\w+)",
+      methods: ["GET"],
+    }));
+    client = await openClient();
+    let receivedReq: Request | null = null;
+    let receivedMatch: RegExpMatchArray | null = null;
+    const pattern = /\/api\/echo\/(\w+)/;
+    client.registries.registerSkillRoute({
+      pattern,
+      methods: ["GET"],
+      handler: async (req, match) => {
+        receivedReq = req;
+        receivedMatch = match;
+        return new Response("hello " + match[1], {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        });
+      },
+    });
+    await new Promise((r) => setTimeout(r, 30));
+
+    const response = await server!.sendRequest("skill.dispatch_route", {
+      patternSource: pattern.source,
+      request: {
+        method: "GET",
+        url: "http://localhost/api/echo/world",
+        headers: { "x-test": "1" },
+      },
+    });
+    expect(response).toMatchObject({
+      status: 200,
+      body: "hello world",
+    });
+    expect(
+      (response as { headers: Record<string, string> }).headers["content-type"],
+    ).toBe("text/plain");
+    expect(receivedReq).not.toBeNull();
+    expect(receivedReq!.method).toBe("GET");
+    expect(receivedMatch![1]).toBe("world");
+  });
+
+  test("skill.dispatch_route surfaces unknown route as a remote error", async () => {
+    server!.register("host.registries.register_skill_route", () => ({
+      patternSource: "/api/known",
+      methods: ["GET"],
+    }));
+    client = await openClient();
+    client.registries.registerSkillRoute({
+      pattern: /\/api\/known/,
+      methods: ["GET"],
+      handler: async () => new Response("ok"),
+    });
+    await new Promise((r) => setTimeout(r, 30));
+
+    await expect(
+      server!.sendRequest("skill.dispatch_route", {
+        patternSource: "/api/missing",
+        request: { method: "GET", url: "http://localhost/api/missing" },
+      }),
+    ).rejects.toThrow(/unknown route/);
+  });
+
+  test("skill.shutdown without name runs all hooks in reverse order", async () => {
+    server!.register("host.registries.register_shutdown_hook", (params) => ({
+      name: (params as { name: string }).name,
+    }));
+    client = await openClient();
+    const calls: string[] = [];
+    client.registries.registerShutdownHook("first", async () => {
+      calls.push("first");
+    });
+    client.registries.registerShutdownHook("second", async () => {
+      calls.push("second");
+    });
+    client.registries.registerShutdownHook("third", async () => {
+      calls.push("third");
+    });
+    await new Promise((r) => setTimeout(r, 30));
+
+    const result = await server!.sendRequest("skill.shutdown", {
+      reason: "test",
+    });
+    expect(result).toEqual({ ok: true });
+    expect(calls).toEqual(["third", "second", "first"]);
+  });
+
+  test("skill.shutdown with name runs only the targeted hook", async () => {
+    server!.register("host.registries.register_shutdown_hook", (params) => ({
+      name: (params as { name: string }).name,
+    }));
+    client = await openClient();
+    const calls: string[] = [];
+    client.registries.registerShutdownHook("alpha", async () => {
+      calls.push("alpha");
+    });
+    client.registries.registerShutdownHook("beta", async () => {
+      calls.push("beta");
+    });
+    await new Promise((r) => setTimeout(r, 30));
+
+    const result = await server!.sendRequest("skill.shutdown", {
+      name: "alpha",
+      reason: "test",
+    });
+    expect(result).toEqual({ ok: true });
+    expect(calls).toEqual(["alpha"]);
+  });
+
+  test("skill.shutdown swallows per-hook errors and runs remaining hooks", async () => {
+    // Stub host.log so the swallowed error doesn't surface as an
+    // unhandled rejection — the client logs hook failures via the host
+    // logger.
+    server!.register("host.log", () => ({ ok: true }));
+    server!.register("host.registries.register_shutdown_hook", (params) => ({
+      name: (params as { name: string }).name,
+    }));
+    client = await openClient();
+    const calls: string[] = [];
+    client.registries.registerShutdownHook("first", async () => {
+      calls.push("first");
+    });
+    client.registries.registerShutdownHook("boom", async () => {
+      throw new Error("hook failure");
+    });
+    client.registries.registerShutdownHook("third", async () => {
+      calls.push("third");
+    });
+    await new Promise((r) => setTimeout(r, 30));
+
+    const result = await server!.sendRequest("skill.shutdown", {});
+    expect(result).toEqual({ ok: true });
+    // 'boom' threw and was logged; 'first' and 'third' still ran in
+    // reverse order around it.
+    expect(calls).toEqual(["third", "first"]);
+  });
+
+  test("re-registering tools/routes/hooks does not duplicate dispatch handlers", async () => {
+    server!.register("host.registries.register_tools", () => ({
+      registered: [],
+    }));
+    server!.register("host.registries.register_skill_route", () => ({
+      patternSource: "^/x$",
+      methods: ["GET"],
+    }));
+    server!.register("host.registries.register_shutdown_hook", (params) => ({
+      name: (params as { name: string }).name,
+    }));
+    client = await openClient();
+
+    const provider1 = (): never[] => [];
+    const provider2 = () => [
+      {
+        name: "v2.tool",
+        description: "v2",
+        category: "misc",
+        defaultRiskLevel: "low" as never,
+        getDefinition: () => ({
+          name: "v2.tool",
+          description: "v2",
+          input_schema: { type: "object" },
+        }),
+        execute: async () => ({ ok: "v2" } as never),
+      },
+    ];
+    client.registries.registerTools(provider1);
+    client.registries.registerTools(provider2);
+
+    const routePattern = /\/route/;
+    client.registries.registerSkillRoute({
+      pattern: routePattern,
+      methods: ["GET"],
+      handler: async () => new Response("v1"),
+    });
+    client.registries.registerSkillRoute({
+      pattern: routePattern,
+      methods: ["GET"],
+      handler: async () => new Response("v2"),
+    });
+
+    const calls: string[] = [];
+    client.registries.registerShutdownHook("repeat", async () => {
+      calls.push("first");
+    });
+    client.registries.registerShutdownHook("repeat", async () => {
+      calls.push("second");
+    });
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Latest provider wins for tools.
+    const toolResult = await server!.sendRequest("skill.dispatch_tool", {
+      name: "v2.tool",
+      input: {},
+    });
+    expect(toolResult).toEqual({ result: { ok: "v2" } });
+
+    // Latest route handler wins for the same patternSource.
+    const routeResult = await server!.sendRequest("skill.dispatch_route", {
+      patternSource: routePattern.source,
+      request: { method: "GET", url: "http://localhost/route" },
+    });
+    expect((routeResult as { body: string }).body).toBe("v2");
+
+    // Re-registering the same hook name keeps a single entry — running
+    // shutdown should fire 'second' once, not both closures.
+    await server!.sendRequest("skill.shutdown", {});
+    expect(calls).toEqual(["second"]);
   });
 });
 

--- a/packages/skill-host-contracts/src/client.ts
+++ b/packages/skill-host-contracts/src/client.ts
@@ -25,6 +25,42 @@
  * The `s:` / `d:` id prefixes namespace the two directions so each side can
  * route inbound responses to its own pending-request map without collision.
  *
+ * ### Daemon-initiated dispatch handlers
+ *
+ * After the skill registers tools / routes / shutdown hooks via
+ * `registries.registerTools`, `registries.registerSkillRoute`, and
+ * `registries.registerShutdownHook`, the client also installs local
+ * handlers for the matching `skill.dispatch_*` methods so the daemon can
+ * invoke skill-side closures over the bidirectional RPC. The wire shapes
+ * are:
+ *
+ *   skill.dispatch_tool
+ *     daemon → skill: { name: string, input: Record<string, unknown>,
+ *                        context?: unknown }
+ *     skill → daemon: { result: unknown }
+ *     errors: throws "unknown tool: <name>" when the tool name is not in
+ *             the most recently registered provider's output.
+ *
+ *   skill.dispatch_route
+ *     daemon → skill: { patternSource: string,
+ *                        request: { method: string, url: string,
+ *                                   headers?: Record<string, string>,
+ *                                   body?: string } }
+ *     skill → daemon: { status: number,
+ *                        headers: Record<string, string>,
+ *                        body: string }
+ *     errors: throws "unknown route: <patternSource>" when no registered
+ *             route matches the patternSource, or "url did not match
+ *             pattern: <patternSource>" when the regex fails to match.
+ *
+ *   skill.shutdown
+ *     daemon → skill: { name?: string, reason?: string }
+ *     skill → daemon: { ok: true }
+ *     semantics: when `name` is set, runs only that hook; otherwise runs
+ *                all registered hooks in reverse-registration order. Per-
+ *                hook errors are swallowed (logged via the host logger if
+ *                `connect()` has populated one).
+ *
  * ### Sync-method bootstrap
  *
  * The `SkillHost` contract exposes a number of synchronous accessors
@@ -93,7 +129,7 @@ import type {
   TtsProvidersFacet,
   UserMessage,
 } from "./skill-host.js";
-import type { Tool } from "./tool-types.js";
+import type { Tool, ToolContext } from "./tool-types.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -280,6 +316,30 @@ export class SkillHostClient implements SkillHost {
   private cachedWorkspaceDir: string | null = null;
   private cachedVellumRoot: string | null = null;
   private cachedRuntimeMode: DaemonRuntimeMode | null = null;
+
+  // ── Local dispatch state ────────────────────────────────────────────────
+  // Caches populated by `registries.register*` so the daemon can dispatch
+  // skill-owned closures back over the bidirectional RPC. Mirrors what the
+  // out-of-process skill installed in-process before the IPC split.
+
+  /** Most recently registered tool provider (last writer wins, matching the in-process semantics where a single skill module owns one provider). */
+  private cachedToolsProvider: (() => Tool[]) | null = null;
+  /**
+   * Routes keyed by `pattern.source`. Last writer wins on collision so
+   * re-registering the same regex source replaces the prior handler — mirrors
+   * how an in-process skill would re-`registerSkillRoute` on hot reload.
+   */
+  private readonly cachedRoutes = new Map<string, SkillRoute>();
+  /**
+   * Shutdown hooks ordered by registration time. We use an array (not a Map
+   * keyed by name) because the spec requires running hooks in reverse-
+   * registration order when no name is provided. Re-registering an existing
+   * name replaces the prior entry in place to keep the cache idempotent.
+   */
+  private readonly cachedShutdownHooks: Array<{
+    name: string;
+    hook: (reason: string) => Promise<void>;
+  }> = [];
 
   constructor(options: SkillHostClientOptions) {
     this.options = {
@@ -979,14 +1039,29 @@ export class SkillHostClient implements SkillHost {
             ownerSkillVersionHash: t.ownerSkillVersionHash,
           };
         });
+        // Cache the provider so `skill.dispatch_tool` can resolve a tool
+        // name back to its `execute` closure. Last writer wins.
+        this.cachedToolsProvider = provider;
+        this.ensureDaemonHandler(
+          "skill.dispatch_tool",
+          this.dispatchTool.bind(this),
+        );
         // Fire-and-forget; registration failures surface in the daemon log.
         this.call("host.registries.register_tools", { tools: manifests }).catch(
           swallow,
         );
       },
       registerSkillRoute: (route: SkillRoute): SkillRouteHandle => {
+        // Cache the route by its regex source — `skill.dispatch_route` uses
+        // the same key to find the handler closure. Re-registering the same
+        // source replaces the prior route, matching in-process hot-reload.
+        this.cachedRoutes.set(route.pattern.source, route);
+        this.ensureDaemonHandler(
+          "skill.dispatch_route",
+          this.dispatchRoute.bind(this),
+        );
         // The `handler` closure cannot cross IPC; the daemon side installs
-        // a proxy that dispatches back over `skill.dispatch_route` (PR 28).
+        // a proxy that dispatches back over `skill.dispatch_route` (PR D).
         this.call("host.registries.register_skill_route", {
           patternSource: route.pattern.source,
           methods: route.methods,
@@ -995,16 +1070,199 @@ export class SkillHostClient implements SkillHost {
         // return a structurally inert placeholder.
         return {} as SkillRouteHandle;
       },
-      registerShutdownHook: (name: string, _hook) => {
-        // The `hook` closure cannot cross IPC; PR 28 wires the
-        // reverse-direction dispatch so the daemon can invoke it at
-        // shutdown. For now, just register the hook name so the daemon
-        // logs its firing during teardown.
+      registerShutdownHook: (name: string, hook) => {
+        // Cache the hook so `skill.shutdown` can invoke it. If the same
+        // name is re-registered, replace in place to keep the array tidy
+        // without disturbing relative order of unrelated entries.
+        const existingIdx = this.cachedShutdownHooks.findIndex(
+          (h) => h.name === name,
+        );
+        const entry = { name, hook };
+        if (existingIdx >= 0) {
+          this.cachedShutdownHooks[existingIdx] = entry;
+        } else {
+          this.cachedShutdownHooks.push(entry);
+        }
+        this.ensureDaemonHandler(
+          "skill.shutdown",
+          this.dispatchShutdown.bind(this),
+        );
+        // Fire-and-forget; the daemon registers a proxy that fires the
+        // skill.shutdown dispatch at teardown (PR D).
         this.call("host.registries.register_shutdown_hook", { name }).catch(
           swallow,
         );
       },
     };
+  }
+
+  // ── Local dispatch helpers ──────────────────────────────────────────────
+
+  /**
+   * Install a daemon-initiated request handler exactly once per method.
+   * Idempotent so repeated `register*` calls don't churn the handler table
+   * — every dispatch is routed through the same bound method anyway.
+   */
+  private ensureDaemonHandler(
+    method: string,
+    handler: SkillHostRequestHandler,
+  ): void {
+    if (!this.daemonRequestHandlers.has(method)) {
+      this.daemonRequestHandlers.set(method, handler);
+    }
+  }
+
+  /**
+   * `skill.dispatch_tool` handler — resolves the tool by name from the
+   * cached provider and invokes its `execute(input, context)`. Returns
+   * `{ result }` so the daemon can distinguish the wrapper from the
+   * tool's own (potentially undefined) return value.
+   */
+  private async dispatchTool(params: unknown): Promise<{ result: unknown }> {
+    const { name, input, context } = (params ?? {}) as {
+      name?: unknown;
+      input?: unknown;
+      context?: unknown;
+    };
+    if (typeof name !== "string" || !name) {
+      throw new Error(
+        "skill.dispatch_tool: missing or invalid 'name' parameter",
+      );
+    }
+    const provider = this.cachedToolsProvider;
+    if (!provider) {
+      throw new Error(`unknown tool: ${name}`);
+    }
+    // Re-invoke the provider on each dispatch so feature-flag-gated tool
+    // lists stay live — matches the daemon's lazy-manifest semantics in
+    // `assistant/src/tools/registry.ts`.
+    const tools = provider();
+    const tool = tools.find((t) => t.name === name);
+    if (!tool) {
+      throw new Error(`unknown tool: ${name}`);
+    }
+    // The daemon-side `ToolContext` is opaque on the wire; the skill's
+    // `Tool.execute` runtime-validates any field it actually reads, so a
+    // structural cast is sufficient here. Missing required-on-paper fields
+    // are tolerated in practice — meet-host's tools only consult a small
+    // subset that the daemon serializes through.
+    const ctx = (context ?? {}) as ToolContext;
+    const result = await tool.execute(
+      (input ?? {}) as Record<string, unknown>,
+      ctx,
+    );
+    return { result };
+  }
+
+  /**
+   * `skill.dispatch_route` handler — looks up the route by patternSource,
+   * re-runs the regex against the inbound URL to recover match groups,
+   * invokes the handler, and serializes the `Response` to a
+   * JSON-friendly `{ status, headers, body }`.
+   */
+  private async dispatchRoute(params: unknown): Promise<{
+    status: number;
+    headers: Record<string, string>;
+    body: string;
+  }> {
+    const { patternSource, request } = (params ?? {}) as {
+      patternSource?: unknown;
+      request?: unknown;
+    };
+    if (typeof patternSource !== "string" || !patternSource) {
+      throw new Error(
+        "skill.dispatch_route: missing or invalid 'patternSource' parameter",
+      );
+    }
+    const route = this.cachedRoutes.get(patternSource);
+    if (!route) {
+      throw new Error(`unknown route: ${patternSource}`);
+    }
+    const req = (request ?? {}) as {
+      method?: string;
+      url?: string;
+      headers?: Record<string, string>;
+      body?: string;
+    };
+    if (typeof req.url !== "string" || !req.url) {
+      throw new Error(
+        "skill.dispatch_route: missing or invalid 'request.url' parameter",
+      );
+    }
+    // Reset lastIndex so a global/sticky regex doesn't carry state across
+    // dispatches — `exec()` mutates lastIndex on g/y flags and the route's
+    // RegExp may be reused across requests.
+    if (route.pattern.global || route.pattern.sticky) {
+      route.pattern.lastIndex = 0;
+    }
+    const match = route.pattern.exec(req.url);
+    if (!match) {
+      throw new Error(`url did not match pattern: ${patternSource}`);
+    }
+    const init: RequestInit = {
+      method: req.method ?? "GET",
+      headers: req.headers ?? {},
+    };
+    // GET/HEAD requests cannot carry a body in the standard fetch `Request`
+    // constructor; only attach when the verb permits.
+    if (
+      req.body !== undefined &&
+      init.method !== "GET" &&
+      init.method !== "HEAD"
+    ) {
+      init.body = req.body;
+    }
+    const response = await route.handler(new Request(req.url, init), match);
+    const headers: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+    const body = await response.text();
+    return { status: response.status, headers, body };
+  }
+
+  /**
+   * `skill.shutdown` handler — runs cached shutdown hooks. With `name`
+   * set, runs only that hook; otherwise runs all hooks in reverse-
+   * registration order. Per-hook errors are logged via the host logger
+   * and otherwise swallowed so one misbehaving hook can't block the
+   * daemon's overall teardown.
+   */
+  private async dispatchShutdown(params: unknown): Promise<{ ok: true }> {
+    const { name, reason } = (params ?? {}) as {
+      name?: unknown;
+      reason?: unknown;
+    };
+    const reasonStr = typeof reason === "string" ? reason : "shutdown";
+    const log = this.buildLogger(this.options.skillId);
+    const runOne = async (entry: {
+      name: string;
+      hook: (reason: string) => Promise<void>;
+    }): Promise<void> => {
+      try {
+        await entry.hook(reasonStr);
+      } catch (err) {
+        log.warn(`shutdown hook '${entry.name}' threw`, {
+          error: errorMessage(err),
+        });
+      }
+    };
+    if (typeof name === "string" && name) {
+      const entry = this.cachedShutdownHooks.find((h) => h.name === name);
+      if (entry) await runOne(entry);
+      // Silently no-op for unknown names — the daemon may call shutdown
+      // for a hook that was never registered (e.g. a stale registration
+      // leftover from a previous skill load), which shouldn't fail the
+      // overall teardown.
+      return { ok: true };
+    }
+    // Reverse-registration order so later-registered hooks (which often
+    // depend on earlier ones) tear down first.
+    for (let i = this.cachedShutdownHooks.length - 1; i >= 0; i--) {
+      const entry = this.cachedShutdownHooks[i];
+      if (entry) await runOne(entry);
+    }
+    return { ok: true };
   }
 
   private buildSpeakersFacet(): SpeakersFacet {


### PR DESCRIPTION
## Summary
- registerTools / registerSkillRoute / registerShutdownHook on SkillHostClient now also install local handlers for skill.dispatch_tool / skill.dispatch_route / skill.shutdown via the bidirectional RPC added in PR A.
- The skill side can now respond to daemon-initiated tool invocations, route dispatches, and shutdown requests.
- PR D wires the daemon side to actually send those requests.

Part of plan: skill-isolation.md (PR B — server-initiated dispatch follow-up)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
