### PR TITLE
feat(providers): map OpenAI reasoning to new xhigh tier

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1338,18 +1338,18 @@ describe("OpenAIProvider reasoning_effort", () => {
     expect(lastCreateParams!.reasoning_effort).toBe("high");
   });
 
-  test('effort: "max" maps to reasoning_effort: "high"', async () => {
+  test('effort: "max" maps to reasoning_effort: "xhigh"', async () => {
     await provider.sendMessage([userMsg("hi")], undefined, "system", {
       config: { effort: "max" },
     });
-    expect(lastCreateParams!.reasoning_effort).toBe("high");
+    expect(lastCreateParams!.reasoning_effort).toBe("xhigh");
   });
 
-  test('effort: "xhigh" maps to reasoning_effort: "high"', async () => {
+  test('effort: "xhigh" maps to reasoning_effort: "xhigh"', async () => {
     await provider.sendMessage([userMsg("hi")], undefined, "system", {
       config: { effort: "xhigh" },
     });
-    expect(lastCreateParams!.reasoning_effort).toBe("high");
+    expect(lastCreateParams!.reasoning_effort).toBe("xhigh");
   });
 
   test("no effort config means no reasoning_effort in params", async () => {

--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -496,7 +496,7 @@ describe("OpenAIResponsesProvider", () => {
     expect(lastStreamParams!.reasoning).toEqual({ effort: "high" });
   });
 
-  test('effort: "max" maps to reasoning: { effort: "high" }', async () => {
+  test('effort: "max" maps to reasoning: { effort: "xhigh" }', async () => {
     fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
 
     await provider.sendMessage(
@@ -506,10 +506,10 @@ describe("OpenAIResponsesProvider", () => {
       { config: { effort: "max" } },
     );
 
-    expect(lastStreamParams!.reasoning).toEqual({ effort: "high" });
+    expect(lastStreamParams!.reasoning).toEqual({ effort: "xhigh" });
   });
 
-  test('effort: "xhigh" maps to reasoning: { effort: "high" }', async () => {
+  test('effort: "xhigh" maps to reasoning: { effort: "xhigh" }', async () => {
     fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
 
     await provider.sendMessage(
@@ -519,7 +519,7 @@ describe("OpenAIResponsesProvider", () => {
       { config: { effort: "xhigh" } },
     );
 
-    expect(lastStreamParams!.reasoning).toEqual({ effort: "high" });
+    expect(lastStreamParams!.reasoning).toEqual({ effort: "xhigh" });
   });
 
   test("no effort config means no reasoning in params", async () => {

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -65,8 +65,7 @@ export interface OpenAIChatCompletionsProviderOptions {
 }
 
 /** Map our internal effort values to OpenAI's reasoning_effort parameter.
- *  OpenAI's reasoning_effort caps at "high", so "xhigh" and "max" both
- *  collapse to "high" on this transport. */
+ *  OpenAI caps at "xhigh", so our "max" tier collapses to "xhigh". */
 const EFFORT_TO_REASONING_EFFORT: Record<
   string,
   NonNullable<
@@ -76,8 +75,8 @@ const EFFORT_TO_REASONING_EFFORT: Record<
   low: "low",
   medium: "medium",
   high: "high",
-  xhigh: "high",
-  max: "high",
+  xhigh: "xhigh",
+  max: "xhigh",
 };
 
 const OPENAI_SUPPORTED_IMAGE_TYPES = new Set([

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -26,13 +26,16 @@ export interface OpenAIResponsesProviderOptions {
 }
 
 /** Map our internal effort values to the Responses API reasoning.effort parameter.
- *  The Responses API caps at "high", so "xhigh" and "max" both collapse to "high". */
-const EFFORT_TO_REASONING_EFFORT: Record<string, "low" | "medium" | "high"> = {
+ *  OpenAI caps at "xhigh", so our "max" tier collapses to "xhigh". */
+const EFFORT_TO_REASONING_EFFORT: Record<
+  string,
+  "low" | "medium" | "high" | "xhigh"
+> = {
   low: "low",
   medium: "medium",
   high: "high",
-  xhigh: "high",
-  max: "high",
+  xhigh: "xhigh",
+  max: "xhigh",
 };
 
 /** Values accepted by the Responses API `text.verbosity` parameter. */


### PR DESCRIPTION
## Summary
- OpenAI SDK v6.29 added `xhigh` to the `ReasoningEffort` union. Vellum's old mapping collapsed both `xhigh` and `max` to OpenAI's `high`, which meant users could not reach the top reasoning tier on GPT-5 series models.
- Updated `EFFORT_TO_REASONING_EFFORT` in both Responses and Chat Completions providers so Vellum `xhigh` passes through as `xhigh` and Vellum `max` caps at `xhigh`. Updated tests to match.

## Original prompt
max should map to xhigh for OpenAI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
