### PR TITLE
fix(providers): send reasoning.effort="none" explicitly to OpenAI

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1360,11 +1360,14 @@ describe("OpenAIProvider reasoning_effort", () => {
     expect(lastCreateParams!.reasoning_effort).toBeUndefined();
   });
 
-  test('effort: "none" omits the reasoning_effort param', async () => {
+  test('effort: "none" is sent explicitly as reasoning_effort: "none"', async () => {
+    // OpenAI defaults `reasoning_effort` to "medium" when the field is
+    // omitted, so the user's opt-out is only honored when we send the
+    // explicit "none" value on the wire.
     await provider.sendMessage([userMsg("hi")], undefined, "system", {
       config: { effort: "none" },
     });
-    expect(lastCreateParams!.reasoning_effort).toBeUndefined();
+    expect(lastCreateParams!.reasoning_effort).toBe("none");
   });
 
   test("extraCreateParams reasoning_effort is not clobbered when no effort is set", async () => {

--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -535,7 +535,10 @@ describe("OpenAIResponsesProvider", () => {
     expect(lastStreamParams!.reasoning).toBeUndefined();
   });
 
-  test('effort: "none" omits the reasoning param entirely', async () => {
+  test('effort: "none" is sent explicitly as reasoning: { effort: "none" }', async () => {
+    // The OpenAI Responses API defaults `reasoning.effort` to "medium" when
+    // the field is omitted, so the user's opt-out is only honored when we
+    // send the explicit "none" value on the wire.
     fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
 
     await provider.sendMessage(
@@ -545,7 +548,7 @@ describe("OpenAIResponsesProvider", () => {
       { config: { effort: "none" } },
     );
 
-    expect(lastStreamParams!.reasoning).toBeUndefined();
+    expect(lastStreamParams!.reasoning).toEqual({ effort: "none" });
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -65,13 +65,17 @@ export interface OpenAIChatCompletionsProviderOptions {
 }
 
 /** Map our internal effort values to OpenAI's reasoning_effort parameter.
- *  OpenAI caps at "xhigh", so our "max" tier collapses to "xhigh". */
+ *  OpenAI caps at "xhigh", so our "max" tier collapses to "xhigh". `"none"` is
+ *  passed through explicitly because OpenAI defaults `reasoning_effort` to
+ *  "medium" when the field is omitted — the user's opt-out is only honored
+ *  when we send it on the wire. */
 const EFFORT_TO_REASONING_EFFORT: Record<
   string,
   NonNullable<
     OpenAI.Chat.Completions.ChatCompletionCreateParams["reasoning_effort"]
   >
 > = {
+  none: "none",
   low: "low",
   medium: "medium",
   high: "high",

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -26,11 +26,15 @@ export interface OpenAIResponsesProviderOptions {
 }
 
 /** Map our internal effort values to the Responses API reasoning.effort parameter.
- *  OpenAI caps at "xhigh", so our "max" tier collapses to "xhigh". */
+ *  OpenAI caps at "xhigh", so our "max" tier collapses to "xhigh". `"none"` is
+ *  passed through explicitly because OpenAI defaults `reasoning.effort` to
+ *  "medium" when the field is omitted — the user's opt-out is only honored
+ *  when we send it on the wire. */
 const EFFORT_TO_REASONING_EFFORT: Record<
   string,
-  "low" | "medium" | "high" | "xhigh"
+  "none" | "low" | "medium" | "high" | "xhigh"
 > = {
+  none: "none",
   low: "low",
   medium: "medium",
   high: "high",


### PR DESCRIPTION
## Summary
- Bug: setting `effort: "none"` in config caused OpenAI to apply its own default `reasoning.effort: "medium"` because we were omitting the field entirely. The user's opt-out was silently overridden server-side.
- Fix: map Vellum `"none"` to OpenAI `"none"` on the wire (a real value in `Shared.ReasoningEffort` since SDK v6.29). Both Responses and Chat Completions providers now emit the explicit opt-out instead of relying on field absence.
- Updated the two `effort: "none"` tests to assert the explicit wire value instead of `undefined`.

## Original prompt
"none" is defaulting to "medium" not explicitly being treated as "none". can you fix this?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
