### PR TITLE
feat(meet-join): meet-host entrypoint

### DIFF
--- a/skills/meet-join/__tests__/entrypoint.test.ts
+++ b/skills/meet-join/__tests__/entrypoint.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Tests for `skills/meet-join/entrypoint.ts`.
+ *
+ * The entrypoint is the long-lived bin the daemon's `MeetHostSupervisor`
+ * spawns via `bun run skills/meet-join/entrypoint.ts`. It owns the
+ * `SkillHostClient` connection lifecycle, drives the skill's
+ * `register(host)` once connected, then keeps the socket alive until the
+ * daemon disconnects or sends `skill.shutdown` (or the OS signals us).
+ *
+ * What we test here:
+ *
+ *   1. `parseEntrypointArgs` — the CLI surface the supervisor depends on.
+ *      Missing `--ipc` must fail loudly; `--skill-id` must default to
+ *      `meet-join`.
+ *
+ *   2. `runEntrypoint` against a stand-in IPC server that mimics the
+ *      protocol shape `SkillIpcServer` exposes (newline-delimited JSON,
+ *      `host.identity.*` / `host.platform.*` bootstrap responses, and
+ *      observation of `host.registries.register_tools` calls).
+ *
+ *      We mock the skill-internal session-manager and route-handler
+ *      modules so `register()` doesn't drag the real Docker / HTTP
+ *      transitives into the test. Mocks live entirely under
+ *      `skills/meet-join/` so the PR 19 guard (forbidding `assistant/`
+ *      references from `skills/` test files) stays green.
+ *
+ *      The test exercises the full bootstrap-to-shutdown flow:
+ *        - open client connection
+ *        - observe `register_tools` reaching the server
+ *        - send a daemon-initiated `skill.shutdown` request
+ *        - assert `runEntrypoint` resolves with exit code 0
+ *
+ * Production parity: this is an integration test against the same
+ * `SkillHostClient` the deployed bin uses, so a regression in
+ * `register_tools` ordering, the sync-state prefetch, or the daemon→skill
+ * dispatch protocol would break this test before it broke the live
+ * supervisor.
+ */
+
+import { createServer, type Server, type Socket } from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Stub the meet-internal route handler so register() doesn't pull in the
+// HTTP transitives. The pattern regex is the only field register.ts
+// reads at registration time.
+mock.module("../routes/meet-internal.js", () => ({
+  MEET_INTERNAL_EVENTS_PATH_RE: /^\/v1\/internal\/meet\/([^/]+)\/events$/,
+  handleMeetInternalEvents: async () => new Response(null, { status: 204 }),
+}));
+
+// Stub the session manager so register() can construct it without
+// touching Docker / SQLite. The real factory pulls in heavy module
+// graphs; the stub is enough because register.ts only takes the return
+// value to pass into module-level singleton wiring elsewhere.
+mock.module("../daemon/session-manager.js", () => ({
+  createMeetSessionManager: () => ({
+    activeSessions: () => [],
+    getSession: () => null,
+  }),
+  MeetSessionManager: {
+    activeSessions: () => [],
+    getSession: () => null,
+  },
+}));
+
+// Stub each tool factory so we don't pay the schema-build cost in tests
+// that don't care about tool definitions. Each factory must return an
+// object that satisfies the `Tool` shape `register.ts` constructs.
+const fakeTool = (name: string) => ({
+  name,
+  description: "test fake",
+  category: "fake",
+  defaultRiskLevel: "low",
+  ownerSkillId: "meet-join",
+  ownerSkillBundled: true,
+  ownerSkillVersionHash: "test",
+  executionTarget: "host" as const,
+  executionMode: "proxy" as const,
+  getDefinition: () => ({ name, description: "test fake", input_schema: {} }),
+  execute: async () => ({ ok: true }),
+});
+
+mock.module("../tools/meet-avatar-tool.js", () => ({
+  createMeetEnableAvatarTool: () => fakeTool("meet_enable_avatar"),
+  createMeetDisableAvatarTool: () => fakeTool("meet_disable_avatar"),
+}));
+mock.module("../tools/meet-join-tool.js", () => ({
+  createMeetJoinTool: () => fakeTool("meet_join"),
+  MEET_FLAG_KEY: "meet",
+}));
+mock.module("../tools/meet-leave-tool.js", () => ({
+  createMeetLeaveTool: () => fakeTool("meet_leave"),
+}));
+mock.module("../tools/meet-send-chat-tool.js", () => ({
+  createMeetSendChatTool: () => fakeTool("meet_send_chat"),
+}));
+mock.module("../tools/meet-speak-tool.js", () => ({
+  createMeetSpeakTool: () => fakeTool("meet_speak"),
+  createMeetCancelSpeakTool: () => fakeTool("meet_cancel_speak"),
+}));
+
+// Pulled after mocks so the import resolves the stubbed module graph.
+const { parseEntrypointArgs, runEntrypoint } = await import(
+  "../entrypoint.js"
+);
+
+// ---------------------------------------------------------------------------
+// Stand-in IPC server
+// ---------------------------------------------------------------------------
+
+type IpcRequest = { id: string; method: string; params?: unknown };
+
+interface StubServer {
+  server: Server;
+  observed: IpcRequest[];
+  /** Push a daemon-initiated request frame to the connected skill. */
+  sendDaemonRequest: (method: string, params?: unknown) => Promise<unknown>;
+  stop: () => Promise<void>;
+}
+
+/**
+ * Spin up a Unix-domain server that speaks the same JSON-lines protocol
+ * as `SkillIpcServer`. Responds to the bootstrap RPCs the client issues
+ * during `connect()` and records every other request for assertions.
+ */
+async function startStubServer(socketPath: string): Promise<StubServer> {
+  const observed: IpcRequest[] = [];
+  let connectedSocket: Socket | null = null;
+  let nextDaemonId = 1;
+  const pendingDaemonResponses = new Map<
+    string,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+
+  const server = createServer((socket) => {
+    connectedSocket = socket;
+    let buffer = "";
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString();
+      let nl: number;
+      while ((nl = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, nl).trim();
+        buffer = buffer.slice(nl + 1);
+        if (!line) continue;
+        let frame: IpcRequest & { result?: unknown; error?: string };
+        try {
+          frame = JSON.parse(line) as IpcRequest & {
+            result?: unknown;
+            error?: string;
+          };
+        } catch {
+          continue;
+        }
+
+        // Response frame for a daemon-initiated request.
+        if (frame.id.startsWith("d:") && frame.method === undefined) {
+          const pending = pendingDaemonResponses.get(frame.id);
+          if (pending) {
+            pendingDaemonResponses.delete(frame.id);
+            if (frame.error !== undefined) {
+              pending.reject(new Error(String(frame.error)));
+            } else {
+              pending.resolve(frame.result);
+            }
+          }
+          continue;
+        }
+
+        observed.push(frame);
+
+        // Bootstrap responses the client awaits during `connect()`.
+        let result: unknown;
+        switch (frame.method) {
+          case "host.identity.getInternalAssistantId":
+            result = "self";
+            break;
+          case "host.identity.getAssistantName":
+            result = null;
+            break;
+          case "host.platform.workspaceDir":
+            result = "/tmp/test-workspace";
+            break;
+          case "host.platform.vellumRoot":
+            result = "/tmp/test-vellum";
+            break;
+          case "host.platform.runtimeMode":
+            result = "bare-metal";
+            break;
+          case "host.log":
+            result = { ok: true };
+            break;
+          case "host.registries.register_tools":
+          case "host.registries.register_skill_route":
+          case "host.registries.register_shutdown_hook":
+            result = { ok: true };
+            break;
+          default:
+            result = null;
+        }
+        socket.write(JSON.stringify({ id: frame.id, result }) + "\n");
+      }
+    });
+    socket.on("error", () => {
+      /* ignore */
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  return {
+    server,
+    observed,
+    sendDaemonRequest: (method, params) =>
+      new Promise<unknown>((resolve, reject) => {
+        if (!connectedSocket || connectedSocket.destroyed) {
+          reject(new Error("StubServer: no client connected"));
+          return;
+        }
+        const id = `d:${nextDaemonId++}`;
+        pendingDaemonResponses.set(id, { resolve, reject });
+        const frame: { id: string; method: string; params?: unknown } = {
+          id,
+          method,
+        };
+        if (params !== undefined) frame.params = params;
+        connectedSocket.write(JSON.stringify(frame) + "\n");
+      }),
+    stop: async () => {
+      if (connectedSocket && !connectedSocket.destroyed) {
+        connectedSocket.destroy();
+      }
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("parseEntrypointArgs", () => {
+  test("parses --ipc and defaults --skill-id to meet-join", () => {
+    expect(parseEntrypointArgs(["--ipc=/tmp/foo.sock"])).toEqual({
+      socketPath: "/tmp/foo.sock",
+      skillId: "meet-join",
+    });
+  });
+
+  test("respects an explicit --skill-id override", () => {
+    expect(
+      parseEntrypointArgs(["--ipc=/tmp/foo.sock", "--skill-id=other"]),
+    ).toEqual({
+      socketPath: "/tmp/foo.sock",
+      skillId: "other",
+    });
+  });
+
+  test("throws when --ipc is missing", () => {
+    expect(() => parseEntrypointArgs([])).toThrow(/--ipc=<socket-path>/);
+  });
+});
+
+describe("runEntrypoint", () => {
+  let tempDir = "";
+  let socketPath = "";
+  let stub: StubServer | null = null;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "meet-host-entrypoint-"));
+    socketPath = join(tempDir, "assistant-skill.sock");
+    stub = await startStubServer(socketPath);
+  });
+
+  afterEach(async () => {
+    await stub?.stop();
+    stub = null;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test(
+    "connects, drives register(), and exits 0 on skill.shutdown",
+    async () => {
+      const exitPromise = runEntrypoint({
+        socketPath,
+        skillId: "meet-join",
+      });
+
+      // Give register() a moment to run and emit IPC frames. The client's
+      // sync-state bootstrap fires five RPCs before we observe anything
+      // skill-side, so wait for register_tools to land.
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        if (
+          stub!.observed.some(
+            (f) => f.method === "host.registries.register_tools",
+          )
+        ) {
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 20));
+      }
+
+      // register_tools must have been called — that's the readiness
+      // signal the supervisor watches for. Tools may be empty here
+      // because the client's sync `host.config.isFeatureFlagEnabled`
+      // throws (the contract requires async feature-flag reads over
+      // IPC), and register.ts catches that and returns []. The frame
+      // arriving at all is what proves the entrypoint is alive.
+      const registerTools = stub!.observed.find(
+        (f) => f.method === "host.registries.register_tools",
+      );
+      expect(registerTools).toBeTruthy();
+
+      // The skill route registration is unconditional in register.ts.
+      expect(
+        stub!.observed.some(
+          (f) => f.method === "host.registries.register_skill_route",
+        ),
+      ).toBe(true);
+
+      // Send a daemon-initiated `skill.shutdown` request. The entrypoint's
+      // installed handler resolves the exit trigger; runEntrypoint should
+      // return 0 once teardown completes. The handler returns no value,
+      // which the client wraps as a successful response with `result: null`.
+      await stub!.sendDaemonRequest("skill.shutdown");
+
+      const code = await exitPromise;
+      expect(code).toBe(0);
+    },
+    10_000,
+  );
+
+  test(
+    "exits 1 when the socket path doesn't exist",
+    async () => {
+      const code = await runEntrypoint({
+        socketPath: join(tempDir, "does-not-exist.sock"),
+        skillId: "meet-join",
+      });
+      expect(code).toBe(1);
+    },
+    10_000,
+  );
+});

--- a/skills/meet-join/entrypoint.ts
+++ b/skills/meet-join/entrypoint.ts
@@ -1,0 +1,326 @@
+/**
+ * meet-host entrypoint — the long-lived bin spawned by
+ * `MeetHostSupervisor` via `bun run skills/meet-join/entrypoint.ts`.
+ *
+ * Lifecycle:
+ *
+ *   1. Parse CLI args:
+ *      - `--ipc=<path>`            (required) skill IPC socket path
+ *      - `--skill-id=<id>`         (optional) skill identifier; defaults
+ *                                   to `meet-join`. The id is used as the
+ *                                   default logger scope and as the owner
+ *                                   key for tool/route registrations on
+ *                                   the daemon side.
+ *
+ *   2. Construct `SkillHostClient({ socketPath, skillId })` and `await
+ *      client.connect()`. The client prefetches sync state
+ *      (`identity.internalAssistantId`, `platform.workspaceDir()`, etc.)
+ *      so subsequent in-skill code reads cache hits, not RPC round-trips.
+ *
+ *   3. Import the skill's `register(host)` from `./register.js` and
+ *      invoke it. `register(client)` walks the skill's tools, routes,
+ *      and shutdown hooks outward through `host.registries.*`. PR B
+ *      additionally installs inbound `skill.dispatch_*` handlers via
+ *      `client.registerHandler(...)` so the daemon can later proxy tool
+ *      and route invocations back to this process. PR B is in flight; if
+ *      it has not landed yet, the dispatch handlers simply are not
+ *      registered and the daemon's manifest loader will not yet send
+ *      such requests.
+ *
+ *   4. Stay alive. The skill registries return synchronously; once they
+ *      drain, the entrypoint has nothing further to do but keep the
+ *      socket open so the daemon can issue dispatch requests against
+ *      the long-lived connection.
+ *
+ *   5. Shut down on either of:
+ *      - **Socket disconnect** — the daemon dropped the socket
+ *        (graceful daemon shutdown or crash). Run any registered
+ *        shutdown hooks, log, and exit `0`.
+ *      - **`skill.shutdown` daemon-initiated request** — the daemon
+ *        explicitly asked us to wind down. Same teardown path.
+ *      - **OS signal** (SIGTERM/SIGINT) — an external lifecycle manager
+ *        signaled us. Same teardown path.
+ *
+ *  ## Readiness handshake
+ *
+ *  `MeetHostSupervisor` waits for `notifyHandshake({ sourceHash })`
+ *  to know the child has registered and is healthy. The supervisor's
+ *  IPC route handler that observes the first `host.registries.register_tools`
+ *  call forwards the source hash to the supervisor — so simply driving
+ *  `register(client)` to completion (which fires `register_tools` over
+ *  IPC) is what counts as readiness here. There is no separate
+ *  `host.registries.ready` ping at the entrypoint layer.
+ *
+ *  ## Failure modes
+ *
+ *  - Connect failure (socket missing, perm denied, …) → log, exit 1.
+ *  - register() throws (config schema invalid, sub-module wiring
+ *    failure, …) → log, attempt clean disconnect, exit 1.
+ *  - Unhandled rejection / exception inside steady-state operation →
+ *    log, exit 1. Letting the process die so the supervisor can
+ *    respawn is preferable to limping along in a half-broken state.
+ *
+ *  ## Why not use `register.ts` directly as the bin?
+ *
+ *  `register.ts` exports a pure `register(host)` function — it deliberately
+ *  has no side effects on import so the manifest emitter
+ *  (`scripts/emit-manifest.ts`) and the in-process daemon bootstrap
+ *  (`assistant/src/daemon/external-skills-bootstrap.ts`) can both load
+ *  it without spawning a network server. The entrypoint is the
+ *  out-of-process wrapper that turns `register(host)` into a runnable
+ *  bin: it owns the IPC connection, the readiness signaling, and the
+ *  teardown loop, none of which belong in the registration function.
+ */
+
+import { parseArgs } from "node:util";
+
+import { SkillHostClient } from "@vellumai/skill-host-contracts";
+
+import { register } from "./register.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SKILL_ID = "meet-join" as const;
+
+/**
+ * Daemon→skill request method the supervisor uses to ask the skill to
+ * shut itself down. Wired through `client.registerHandler(...)`. The
+ * supervisor's current implementation (PR 27) sends `skill.shutdown` on
+ * a fresh control socket; PR D replaces that path with a
+ * daemon-initiated request on the long-lived connection that resolves
+ * once registered shutdown hooks have run.
+ */
+const SKILL_SHUTDOWN_METHOD = "skill.shutdown" as const;
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+interface ParsedArgs {
+  socketPath: string;
+  skillId: string;
+}
+
+/**
+ * Parse the supervisor-supplied CLI args. Throws a descriptive error
+ * with usage info when `--ipc` is missing so the supervisor's stderr
+ * forwarder surfaces a clear message instead of an opaque crash.
+ */
+export function parseEntrypointArgs(argv: readonly string[]): ParsedArgs {
+  const { values } = parseArgs({
+    args: [...argv],
+    options: {
+      ipc: { type: "string" },
+      "skill-id": { type: "string" },
+    },
+    strict: true,
+  });
+
+  const socketPath = values.ipc;
+  if (!socketPath) {
+    throw new Error(
+      "meet-host entrypoint: missing required --ipc=<socket-path> argument. " +
+        "Usage: bun run skills/meet-join/entrypoint.ts --ipc=<socket> [--skill-id=<id>]",
+    );
+  }
+  const skillId = values["skill-id"] ?? DEFAULT_SKILL_ID;
+  return { socketPath, skillId };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the entrypoint to completion. Returns the exit code the caller
+ * should pass to `process.exit`. Split out so the unit test can
+ * exercise the connect/register/teardown flow without spawning a
+ * subprocess or letting the harness terminate via `process.exit`.
+ */
+export async function runEntrypoint(args: ParsedArgs): Promise<number> {
+  const client = new SkillHostClient({
+    socketPath: args.socketPath,
+    skillId: args.skillId,
+  });
+
+  // Promise that resolves once we should begin teardown — set by the
+  // socket-disconnect listener, the SIGTERM/SIGINT handler, or the
+  // `skill.shutdown` daemon-initiated request handler.
+  let resolveExit!: (reason: string) => void;
+  const exitTrigger = new Promise<string>((resolve) => {
+    resolveExit = resolve;
+  });
+
+  // Daemon-initiated `skill.shutdown` handler. Resolves immediately so
+  // the supervisor's `sendRequest` ack returns; the actual teardown is
+  // driven by `exitTrigger` and the registered shutdown hooks. The
+  // handler closure is harmless if PR D never wires the route — the
+  // dispatch table only fires on a matching `d:`-prefixed frame.
+  client.registerHandler(SKILL_SHUTDOWN_METHOD, () => {
+    resolveExit("skill.shutdown");
+  });
+
+  try {
+    await client.connect();
+  } catch (err) {
+    // Connect failures are fatal — there's no useful work the entrypoint
+    // can do without the daemon. Surface to stderr so the supervisor's
+    // stderr forwarder picks it up, then exit non-zero.
+    // eslint-disable-next-line no-console -- pre-logger fatal
+    console.error(
+      `meet-host entrypoint: failed to connect to ${args.socketPath}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return 1;
+  }
+
+  const log = client.logger.get("entrypoint");
+
+  // Watch the underlying socket for unexpected close so we can shut down
+  // when the daemon goes away. The client's `close()` is also our path
+  // for explicit teardown — both routes funnel through `exitTrigger`.
+  // The client doesn't expose its socket directly; instead we install a
+  // best-effort poller on the next tick that resolves when `rawCall`
+  // throws "not connected" or the socket is destroyed.
+  void watchSocketHealth(client, resolveExit);
+
+  // Drive the skill's registration. `register()` is synchronous — every
+  // host call is fire-and-forget over IPC — so any failure here is from
+  // a wiring exception (e.g. session-manager constructor throws), not a
+  // registration RPC error. Surface it and exit non-zero.
+  try {
+    register(client);
+  } catch (err) {
+    log.error("register() threw during bootstrap", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    client.close();
+    return 1;
+  }
+
+  log.info("meet-host registered; awaiting daemon requests", {
+    skillId: args.skillId,
+    socketPath: args.socketPath,
+  });
+
+  // Install OS signal handlers so an external SIGTERM (e.g. supervisor's
+  // signal escalation path, container teardown) walks the same teardown
+  // path as a `skill.shutdown` request. The returned uninstall removes
+  // the listeners on clean exit so repeated `runEntrypoint` invocations
+  // (notably under `bun test`) do not accumulate handlers and breach
+  // Node's default `maxListeners` ceiling.
+  const uninstallSignals = installSignalHandlers(resolveExit);
+
+  // Wait for any teardown trigger.
+  const reason = await exitTrigger;
+  uninstallSignals();
+  log.info("meet-host beginning teardown", { reason });
+
+  // Close the client — this rejects any in-flight calls and dispose()s
+  // every active subscription so registered shutdown hooks (PR D) see a
+  // clean shutdown sequence.
+  try {
+    client.close();
+  } catch (err) {
+    log.warn("client.close() failed during teardown", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return 0;
+}
+
+/**
+ * Best-effort socket-health watcher. Periodically pokes the client with
+ * a no-op ping; if the underlying socket has dropped, the call rejects
+ * with "not connected" and we resolve `exitTrigger`. The check interval
+ * is set high enough (one second) that it does not hot-loop the daemon
+ * while still triggering teardown promptly when the connection drops.
+ *
+ * The internal timer is `unref()`d so a hung loop does not pin the
+ * process alive past `process.exit` on the happy path.
+ *
+ * Future work (PR D): swap this poller for a `disconnect` event the
+ * `SkillHostClient` exposes directly so the entrypoint observes
+ * close-of-socket without the indirection.
+ */
+async function watchSocketHealth(
+  client: SkillHostClient,
+  resolveExit: (reason: string) => void,
+): Promise<void> {
+  const intervalMs = 1_000;
+  while (true) {
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(resolve, intervalMs);
+      t.unref();
+    });
+    try {
+      await client.rawCall<string>("host.identity.getInternalAssistantId");
+    } catch {
+      // Either the client has been closed (intentional teardown) or the
+      // socket has dropped (daemon went away). In both cases we want to
+      // resolve the exit trigger; subsequent calls in the steady-state
+      // path are no-ops.
+      resolveExit("socket-disconnect");
+      return;
+    }
+  }
+}
+
+/**
+ * Install SIGTERM/SIGINT handlers that drive the same teardown path as
+ * a daemon-issued `skill.shutdown`. Returns an uninstall fn the caller
+ * runs on clean exit so the handlers don't outlive the run. Repeated
+ * signals after the first are no-ops — Node's default SIGKILL
+ * escalation still applies if we hang during teardown.
+ */
+function installSignalHandlers(
+  resolveExit: (reason: string) => void,
+): () => void {
+  let triggered = false;
+  const signals: NodeJS.Signals[] = ["SIGTERM", "SIGINT"];
+  const handlers = signals.map((sig) => {
+    const handler = (): void => {
+      if (triggered) return;
+      triggered = true;
+      resolveExit(`signal:${sig}`);
+    };
+    process.on(sig, handler);
+    return { sig, handler };
+  });
+  return () => {
+    for (const { sig, handler } of handlers) {
+      process.off(sig, handler);
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Bin guard
+// ---------------------------------------------------------------------------
+
+// `import.meta.main` is true only when this file is the process entry
+// point (Bun + Node 22+). Tests import the file as a module so they
+// reach `runEntrypoint` directly without firing the bootstrap below.
+if (import.meta.main) {
+  const args = parseEntrypointArgs(process.argv.slice(2));
+  runEntrypoint(args)
+    .then((code) => {
+      process.exit(code);
+    })
+    .catch((err) => {
+      // Top-level catch for anything that escapes runEntrypoint's
+      // try/catch (should be impossible, but defends against future
+      // refactors that move work outside it).
+      // eslint-disable-next-line no-console -- top-level fatal
+      console.error(
+        `meet-host entrypoint: fatal error: ${
+          err instanceof Error ? err.stack ?? err.message : String(err)
+        }`,
+      );
+      process.exit(1);
+    });
+}

--- a/skills/meet-join/package.json
+++ b/skills/meet-join/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "emit-manifest": "bun run scripts/emit-manifest.ts"
+    "emit-manifest": "bun run scripts/emit-manifest.ts",
+    "meet-host": "bun run entrypoint.ts"
   },
   "dependencies": {
     "@vellumai/skill-host-contracts": "file:../../packages/skill-host-contracts",


### PR DESCRIPTION
## Summary
- Adds skills/meet-join/entrypoint.ts — the bin the supervisor spawns via bun run.
- Connects a SkillHostClient to the daemon's skill IPC socket, calls register(client), and stays alive until disconnect or skill.shutdown.
- Per PR B, register(client) wires both outbound host.* RPCs and inbound skill.dispatch_* handlers.

Part of plan: skill-isolation.md (PR C — server-initiated dispatch follow-up)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
