### PR TITLE
feat(daemon): wire real dispatch in meet-manifest-loader

### DIFF
--- a/assistant/src/daemon/__tests__/meet-host-supervisor.test.ts
+++ b/assistant/src/daemon/__tests__/meet-host-supervisor.test.ts
@@ -48,6 +48,8 @@ mock.module("../../ipc/skill-socket-path.js", () => ({
 }));
 
 const { MeetHostSupervisor } = await import("../meet-host-supervisor.js");
+const { __clearGlobalSkillIpcSenderForTesting } =
+  await import("../meet-host-supervisor.js");
 
 // ---------------------------------------------------------------------------
 // Fake child process + fake socket
@@ -102,6 +104,7 @@ interface Harness {
   supervisor: InstanceType<typeof MeetHostSupervisor>;
   spawnFn: ReturnType<typeof mock>;
   connectFn: ReturnType<typeof mock>;
+  sendRequest: ReturnType<typeof mock>;
 }
 
 function makeHarness(
@@ -110,6 +113,7 @@ function makeHarness(
     idleTimeoutMs?: number;
     gracefulExitGraceMs?: number;
     sigkillGraceMs?: number;
+    sendRequestImpl?: (...args: unknown[]) => Promise<unknown>;
   } = {},
 ): Harness {
   const child = new FakeChild();
@@ -119,18 +123,33 @@ function makeHarness(
     sock.triggerConnect();
     return sock as unknown as Socket;
   });
+  const sendRequest = mock(
+    overrides.sendRequestImpl ??
+      (async (..._args: unknown[]) => ({ ok: true })),
+  );
+  const ipcSender = {
+    sendRequest: sendRequest as unknown as (
+      connection: unknown,
+      method: string,
+      params?: unknown,
+      opts?: { timeoutMs?: number },
+    ) => Promise<unknown>,
+  };
   const supervisor = new MeetHostSupervisor({
     skillRuntimePath: "/fake/skills/meet-join",
     bunBinaryPath: "/fake/bin/bun",
     skillSocketPath: "/tmp/test-skill.sock",
     manifest: { sourceHash: overrides.manifestHash ?? "hash-abc" },
+    ipcSender: ipcSender as ConstructorParameters<
+      typeof MeetHostSupervisor
+    >[0]["ipcSender"],
     spawnFn,
     connectFn,
     idleTimeoutMsOverride: overrides.idleTimeoutMs ?? 60_000,
     gracefulExitGraceMs: overrides.gracefulExitGraceMs ?? 5,
     sigkillGraceMs: overrides.sigkillGraceMs ?? 5,
   });
-  return { child, supervisor, spawnFn, connectFn };
+  return { child, supervisor, spawnFn, connectFn, sendRequest };
 }
 
 /** Drain pending I/O callbacks so queued handshake promises settle. */
@@ -298,5 +317,205 @@ describe("MeetHostSupervisor", () => {
     await supervisor.shutdown();
     // ensureRunning after shutdown should reject — supervisor is done.
     await expect(supervisor.ensureRunning()).rejects.toThrow(/shutting down/);
+  });
+});
+
+describe("MeetHostSupervisor dispatch", () => {
+  let harness: Harness;
+
+  afterEach(async () => {
+    try {
+      await harness?.supervisor.shutdown();
+    } catch {
+      // Best-effort cleanup
+    }
+    __clearGlobalSkillIpcSenderForTesting();
+  });
+
+  beforeEach(() => {
+    harness = undefined as unknown as Harness;
+  });
+
+  /** Stub `SkillIpcConnection` shape — only `connectionId` is read by logs. */
+  function fakeConnection(id = "conn-1") {
+    return {
+      connectionId: id,
+      addRouteHandle: () => undefined,
+      addSkillToolsOwner: () => undefined,
+    } as unknown as Parameters<
+      InstanceType<typeof MeetHostSupervisor>["setActiveConnection"]
+    >[0];
+  }
+
+  test("dispatchTool sends skill.dispatch_tool on the active connection and unwraps result", async () => {
+    harness = makeHarness({
+      sendRequestImpl: async (..._args) => ({
+        result: { joinUrl: "https://example.test/m/abc" },
+      }),
+    });
+    const { supervisor, sendRequest } = harness;
+
+    // Bring the child up and register a connection so dispatch has a target.
+    const p = supervisor.ensureRunning();
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "hash-abc" });
+    await p;
+    const conn = fakeConnection();
+    supervisor.setActiveConnection(conn);
+
+    const out = await supervisor.dispatchTool(
+      "meet_demo",
+      { url: "x" },
+      { conversationId: "c" },
+    );
+    expect(out).toEqual({ joinUrl: "https://example.test/m/abc" });
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    const call = sendRequest.mock.calls[0] as [
+      unknown,
+      string,
+      Record<string, unknown>,
+    ];
+    expect(call[1]).toBe("skill.dispatch_tool");
+    expect(call[2]).toEqual({
+      name: "meet_demo",
+      input: { url: "x" },
+      context: { conversationId: "c" },
+    });
+  });
+
+  test("dispatchTool propagates remote errors from the sender", async () => {
+    harness = makeHarness({
+      sendRequestImpl: async () => {
+        throw new Error("remote: kaboom");
+      },
+    });
+    const { supervisor } = harness;
+
+    const p = supervisor.ensureRunning();
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "hash-abc" });
+    await p;
+    supervisor.setActiveConnection(fakeConnection());
+
+    await expect(supervisor.dispatchTool("meet_demo", {}, {})).rejects.toThrow(
+      /kaboom/,
+    );
+  });
+
+  test("dispatchTool throws when no IPC connection is registered", async () => {
+    harness = makeHarness();
+    const { supervisor } = harness;
+
+    const p = supervisor.ensureRunning();
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "hash-abc" });
+    await p;
+    // Intentionally do NOT call setActiveConnection.
+
+    await expect(supervisor.dispatchTool("meet_demo", {}, {})).rejects.toThrow(
+      /no IPC connection was registered/,
+    );
+  });
+
+  test("dispatchRoute sends skill.dispatch_route and returns the response envelope", async () => {
+    const envelope = {
+      status: 202,
+      headers: { "x-skill": "meet" },
+      body: '{"received":true}',
+    };
+    harness = makeHarness({ sendRequestImpl: async () => envelope });
+    const { supervisor, sendRequest } = harness;
+
+    const p = supervisor.ensureRunning();
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "hash-abc" });
+    await p;
+    supervisor.setActiveConnection(fakeConnection());
+
+    const result = await supervisor.dispatchRoute("^/api/skills/meet$", {
+      method: "POST",
+      url: "http://localhost/api/skills/meet",
+      body: '{"hi":1}',
+    });
+    expect(result).toEqual(envelope);
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    const call = sendRequest.mock.calls[0] as [
+      unknown,
+      string,
+      Record<string, unknown>,
+    ];
+    expect(call[1]).toBe("skill.dispatch_route");
+    expect(call[2].patternSource).toBe("^/api/skills/meet$");
+  });
+
+  test("dispatchShutdown is a no-op when no active connection is set", async () => {
+    harness = makeHarness();
+    const { supervisor, sendRequest } = harness;
+
+    // No spawn; dispatchShutdown should silently return.
+    await supervisor.dispatchShutdown("hook-x", "test");
+    expect(sendRequest).not.toHaveBeenCalled();
+  });
+
+  test("dispatchShutdown sends skill.shutdown when a connection is active", async () => {
+    harness = makeHarness();
+    const { supervisor, sendRequest } = harness;
+
+    const p = supervisor.ensureRunning();
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "hash-abc" });
+    await p;
+    supervisor.setActiveConnection(fakeConnection());
+
+    await supervisor.dispatchShutdown("hook-x", "daemon-shutdown");
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    const call = sendRequest.mock.calls[0] as [
+      unknown,
+      string,
+      Record<string, unknown>,
+    ];
+    expect(call[1]).toBe("skill.shutdown");
+    expect(call[2]).toEqual({ name: "hook-x", reason: "daemon-shutdown" });
+  });
+
+  test("setActiveConnection / clearActiveConnection are idempotent", async () => {
+    harness = makeHarness();
+    const { supervisor } = harness;
+
+    const p = supervisor.ensureRunning();
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "hash-abc" });
+    await p;
+
+    const conn = fakeConnection();
+    supervisor.setActiveConnection(conn);
+    // Re-set with the same connection: no-op (idempotency).
+    supervisor.setActiveConnection(conn);
+
+    supervisor.clearActiveConnection();
+    // Second clear: idempotent no-op.
+    supervisor.clearActiveConnection();
+
+    // dispatchShutdown after clear is silently a no-op (no connection,
+    // returns without sending).
+    await supervisor.dispatchShutdown("hook-x", "test");
+    expect(harness.sendRequest).not.toHaveBeenCalled();
+  });
+
+  test("shutdown clears the active connection", async () => {
+    harness = makeHarness();
+    const { supervisor } = harness;
+
+    const p = supervisor.ensureRunning();
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "hash-abc" });
+    await p;
+
+    supervisor.setActiveConnection(fakeConnection());
+    await supervisor.shutdown();
+
+    // dispatchShutdown after full shutdown: silent no-op (no connection).
+    await supervisor.dispatchShutdown("hook-x", "test");
+    expect(harness.sendRequest).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/daemon/__tests__/meet-manifest-loader.test.ts
+++ b/assistant/src/daemon/__tests__/meet-manifest-loader.test.ts
@@ -2,11 +2,13 @@
  * Unit tests for `loadMeetManifestProxies`.
  *
  * Covers the shape of the proxy `Tool` and `SkillRoute` entries the
- * loader installs, the "dispatch not implemented" stub behavior, and
- * the shutdown-hook wiring. The real `MeetHostSupervisor` is replaced
- * with a shallow stub so the test never touches `child_process.spawn`
- * or Unix domain sockets. Manifest JSON is written to a tmp fixture
- * path so the loader exercises its real `readFileSync` code path.
+ * loader installs, the live dispatch behaviour (calls
+ * `supervisor.dispatchTool/Route/Shutdown` and surfaces the result),
+ * and the shutdown-hook wiring. The real `MeetHostSupervisor` is
+ * replaced with a shallow stub so the test never touches
+ * `child_process.spawn` or Unix domain sockets. Manifest JSON is
+ * written to a tmp fixture path so the loader exercises its real
+ * `readFileSync` code path.
  */
 
 import { writeFileSync } from "node:fs";
@@ -56,34 +58,70 @@ type SupervisorStub = {
   supervisor: MeetHostSupervisor;
   ensureRunning: ReturnType<typeof mock>;
   shutdown: ReturnType<typeof mock>;
+  dispatchTool: ReturnType<typeof mock>;
+  dispatchRoute: ReturnType<typeof mock>;
+  dispatchShutdown: ReturnType<typeof mock>;
   reportSessionStarted: ReturnType<typeof mock>;
   reportSessionEnded: ReturnType<typeof mock>;
 };
 
+interface SupervisorOverrides {
+  dispatchToolResult?: unknown;
+  dispatchToolError?: Error;
+  dispatchRouteResult?: {
+    status: number;
+    headers: Record<string, string>;
+    body: string;
+  };
+  dispatchRouteError?: Error;
+  dispatchShutdownError?: Error;
+}
+
 function makeSupervisorStub(
-  overrides: { ensureRunningError?: Error } = {},
+  overrides: SupervisorOverrides = {},
 ): SupervisorStub {
-  const ensureRunning = mock(async () => {
-    if (overrides.ensureRunningError) {
-      throw overrides.ensureRunningError;
-    }
-  });
+  const ensureRunning = mock(async () => {});
   const shutdown = mock(async () => {});
+  const dispatchTool = mock(async () => {
+    if (overrides.dispatchToolError) throw overrides.dispatchToolError;
+    return overrides.dispatchToolResult ?? { ok: true };
+  });
+  const dispatchRoute = mock(async () => {
+    if (overrides.dispatchRouteError) throw overrides.dispatchRouteError;
+    return (
+      overrides.dispatchRouteResult ?? {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+        body: "skill-handled",
+      }
+    );
+  });
+  const dispatchShutdown = mock(async () => {
+    if (overrides.dispatchShutdownError) throw overrides.dispatchShutdownError;
+  });
   const reportSessionStarted = mock((_id: string) => {});
   const reportSessionEnded = mock((_id: string) => {});
   const supervisor = {
     ensureRunning,
     shutdown,
+    dispatchTool,
+    dispatchRoute,
+    dispatchShutdown,
     reportSessionStarted,
     reportSessionEnded,
     activeSessionCount: 0,
     isRunning: false,
     notifyHandshake: () => undefined,
+    setActiveConnection: () => undefined,
+    clearActiveConnection: () => undefined,
   } as unknown as MeetHostSupervisor;
   return {
     supervisor,
     ensureRunning,
     shutdown,
+    dispatchTool,
+    dispatchRoute,
+    dispatchShutdown,
     reportSessionStarted,
     reportSessionEnded,
   };
@@ -150,8 +188,52 @@ describe("loadMeetManifestProxies", () => {
     );
   });
 
-  test("proxy tool execute calls ensureRunning and throws not-implemented", async () => {
-    const stub = makeSupervisorStub();
+  test("proxy tool execute dispatches through supervisor.dispatchTool and returns the result", async () => {
+    const stub = makeSupervisorStub({
+      dispatchToolResult: { joinUrl: "https://example.test/m/abc" },
+    });
+    const captured: Array<() => Tool[]> = [];
+
+    await loadMeetManifestProxies(stub.supervisor, {
+      manifestPath,
+      registerTools: (p) => captured.push(p),
+      registerRoute: () => undefined,
+      registerShutdown: () => undefined,
+    });
+
+    const tool = captured[0]!()[0]!;
+    const result = await tool.execute(
+      { url: "https://example.test/meet/x" },
+      {
+        workingDir: "/tmp",
+        conversationId: "conv-xyz",
+        trustClass: "guardian",
+        assistantId: "self",
+      },
+    );
+
+    expect(result as unknown).toEqual({
+      joinUrl: "https://example.test/m/abc",
+    });
+    expect(stub.dispatchTool).toHaveBeenCalledTimes(1);
+    const call = stub.dispatchTool.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+      Record<string, unknown>,
+    ];
+    expect(call[0]).toBe("meet_demo");
+    expect(call[1]).toEqual({ url: "https://example.test/meet/x" });
+    // The serialized context should carry conversationId and trustClass at
+    // minimum so meet-join's tools can read them on the skill side.
+    expect(call[2].conversationId).toBe("conv-xyz");
+    expect(call[2].trustClass).toBe("guardian");
+    expect(call[2].assistantId).toBe("self");
+  });
+
+  test("proxy tool execute propagates supervisor.dispatchTool errors", async () => {
+    const stub = makeSupervisorStub({
+      dispatchToolError: new Error("remote tool exploded"),
+    });
     const captured: Array<() => Tool[]> = [];
 
     await loadMeetManifestProxies(stub.supervisor, {
@@ -171,12 +253,17 @@ describe("loadMeetManifestProxies", () => {
           trustClass: "guardian",
         },
       ),
-    ).rejects.toThrow(/dispatch not implemented/i);
-    expect(stub.ensureRunning).toHaveBeenCalledTimes(1);
+    ).rejects.toThrow(/remote tool exploded/);
   });
 
-  test("proxy route handler returns 501 with not-implemented body", async () => {
-    const stub = makeSupervisorStub();
+  test("proxy route handler dispatches through supervisor.dispatchRoute and materializes the response", async () => {
+    const stub = makeSupervisorStub({
+      dispatchRouteResult: {
+        status: 202,
+        headers: { "content-type": "application/json", "x-skill": "meet" },
+        body: '{"received":true}',
+      },
+    });
     const routes: SkillRoute[] = [];
 
     await loadMeetManifestProxies(stub.supervisor, {
@@ -188,11 +275,6 @@ describe("loadMeetManifestProxies", () => {
 
     expect(routes).toHaveLength(1);
     const route = routes[0]!;
-    // The JS engine may escape forward slashes when normalizing the source
-    // string; compare via a fresh RegExp constructed from the manifest
-    // entry so the assertion is engine-insensitive.
-    expect(route.pattern.test("/api/skills/meet/test/events")).toBe(true);
-    expect(route.pattern.test("/something/else")).toBe(false);
     expect(route.methods).toEqual(["POST"]);
 
     const match = "/api/skills/meet/test-id/events".match(route.pattern);
@@ -200,17 +282,37 @@ describe("loadMeetManifestProxies", () => {
     const response = await route.handler(
       new Request("http://localhost/api/skills/meet/test-id/events", {
         method: "POST",
+        headers: { "content-type": "application/json" },
+        body: '{"hello":"world"}',
       }),
       match,
     );
-    expect(response.status).toBe(501);
-    expect(await response.text()).toMatch(/dispatch not implemented/i);
-    expect(stub.ensureRunning).toHaveBeenCalledTimes(1);
+
+    expect(response.status).toBe(202);
+    expect(await response.text()).toBe('{"received":true}');
+    expect(response.headers.get("x-skill")).toBe("meet");
+
+    expect(stub.dispatchRoute).toHaveBeenCalledTimes(1);
+    const call = stub.dispatchRoute.mock.calls[0] as [
+      string,
+      {
+        method: string;
+        url: string;
+        headers?: Record<string, string>;
+        body?: string;
+      },
+    ];
+    expect(call[0]).toBe("^/api/skills/meet/([^/]+)/events$");
+    expect(call[1].method).toBe("POST");
+    expect(call[1].url).toBe("http://localhost/api/skills/meet/test-id/events");
+    expect(call[1].body).toBe('{"hello":"world"}');
+    expect(call[1].headers?.["content-type"]).toBe("application/json");
   });
 
-  test("proxy route handler returns 503 when ensureRunning fails", async () => {
-    const err = new Error("spawn failed");
-    const stub = makeSupervisorStub({ ensureRunningError: err });
+  test("proxy route handler returns 503 when supervisor.dispatchRoute throws", async () => {
+    const stub = makeSupervisorStub({
+      dispatchRouteError: new Error("connection lost"),
+    });
     const routes: SkillRoute[] = [];
 
     await loadMeetManifestProxies(stub.supervisor, {
@@ -232,7 +334,7 @@ describe("loadMeetManifestProxies", () => {
     expect(response.status).toBe(503);
   });
 
-  test("registers shutdown hooks that call supervisor.shutdown()", async () => {
+  test("registers shutdown hooks that dispatch the named hook and tear down the supervisor", async () => {
     const stub = makeSupervisorStub();
     const hooks: Array<{
       name: string;
@@ -250,6 +352,33 @@ describe("loadMeetManifestProxies", () => {
 
     expect(hooks.map((h) => h.name)).toEqual(["meet-host-shutdown"]);
     await hooks[0]!.run("daemon-shutdown");
+    expect(stub.dispatchShutdown).toHaveBeenCalledTimes(1);
+    const call = stub.dispatchShutdown.mock.calls[0] as [string, string];
+    expect(call[0]).toBe("meet-host-shutdown");
+    expect(call[1]).toBe("daemon-shutdown");
+    expect(stub.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  test("shutdown hook still tears down the supervisor when dispatchShutdown fails", async () => {
+    const stub = makeSupervisorStub({
+      dispatchShutdownError: new Error("connection gone"),
+    });
+    const hooks: Array<{
+      name: string;
+      run: (reason: string) => Promise<void>;
+    }> = [];
+
+    await loadMeetManifestProxies(stub.supervisor, {
+      manifestPath,
+      registerTools: () => undefined,
+      registerRoute: () => undefined,
+      registerShutdown: (name, hook) => {
+        hooks.push({ name, run: hook });
+      },
+    });
+
+    await hooks[0]!.run("daemon-shutdown");
+    expect(stub.dispatchShutdown).toHaveBeenCalledTimes(1);
     expect(stub.shutdown).toHaveBeenCalledTimes(1);
   });
 

--- a/assistant/src/daemon/meet-host-supervisor.ts
+++ b/assistant/src/daemon/meet-host-supervisor.ts
@@ -6,8 +6,8 @@
  * is the one place that knows how to find the bun binary, resolve the
  * installed skill path, spawn the child, wait for its handshake, count
  * active sessions, and idle-shut it down. The IPC surface between the
- * two processes lives in `assistant/src/ipc/skill-server.ts` (PR 20)
- * and the `host.registries.*` routes that back it (PR 24).
+ * two processes lives in `assistant/src/ipc/skill-server.ts` and the
+ * `host.registries.*` routes that back it.
  *
  * ## Lifecycle
  *
@@ -20,10 +20,21 @@
  *     a clear error pointing the user at regenerating the manifest.
  *
  *   - `reportSessionStarted(id)` / `reportSessionEnded(id)` — mutate
- *     the active-session counter. Called by PR 24's
+ *     the active-session counter, called by the
  *     `host.registries.report_session_*` IPC routes. The counter is
  *     tracked by session id (Set of live ids) so duplicate or
  *     out-of-order `ended` frames can't drop the count below zero.
+ *
+ *   - `setActiveConnection(connection)` / `clearActiveConnection()` —
+ *     called by the `host.registries.register_*` route handlers when
+ *     the child sends its first registration frame. Pinning the live
+ *     `SkillIpcConnection` lets `dispatchTool/Route/Shutdown` route
+ *     daemon→skill RPC traffic to the right peer.
+ *
+ *   - `dispatchTool` / `dispatchRoute` / `dispatchShutdown` — send
+ *     `skill.dispatch_*` / `skill.shutdown` frames to the meet-host
+ *     child over the active connection and resolve with its response.
+ *     Used by the manifest proxies installed in `meet-manifest-loader`.
  *
  *   - Idle timer — when the counter reaches zero the supervisor arms
  *     a 5-minute timer (configurable via
@@ -39,11 +50,6 @@
  *     next `ensureRunning()` call respawns.
  *
  *   - `shutdown()` — graceful termination on daemon shutdown.
- *
- * PR 27 adds the supervisor only — it does NOT register any IPC
- * routes or auto-start on daemon boot. PR 28 wires this class into
- * `meet-manifest-loader.ts` so proxy tool invocations call
- * `ensureRunning()` before dispatching.
  */
 
 import {
@@ -54,6 +60,7 @@ import {
 import { connect as defaultConnect, type Socket } from "node:net";
 
 import { getConfig, getNestedValue } from "../config/loader.js";
+import type { SkillIpcConnection } from "../ipc/skill-server.js";
 import { getSkillSocketPath } from "../ipc/skill-socket-path.js";
 import { getLogger } from "../util/logger.js";
 
@@ -82,6 +89,24 @@ export interface MeetHostHandshakePayload {
 }
 
 /**
+ * Minimal sender surface the supervisor needs to dispatch frames over
+ * the bidirectional skill IPC channel. {@link SkillIpcServer.sendRequest}
+ * satisfies this shape; tests can pass a stub that records calls instead.
+ *
+ * Pulling the dependency through a one-method interface keeps the
+ * supervisor unaware of the rest of the IPC server's surface and avoids a
+ * circular import in tests that already stub `skill-server.js`.
+ */
+export interface SkillRequestSender {
+  sendRequest(
+    connection: SkillIpcConnection,
+    method: string,
+    params?: unknown,
+    opts?: { timeoutMs?: number },
+  ): Promise<unknown>;
+}
+
+/**
  * Dependencies the supervisor needs to spawn and supervise the
  * child. All are optional on construction — production callers
  * rely on the defaults and tests override one or two at a time.
@@ -95,6 +120,13 @@ export interface MeetHostSupervisorDeps {
   skillSocketPath?: string;
   /** Shipped manifest (source of the hash we check handshake against). */
   manifest: MeetHostManifest;
+  /**
+   * Sender used to dispatch `skill.dispatch_*` and `skill.shutdown` frames
+   * back to the meet-host child over the active IPC connection. Optional
+   * because PR D wires this in only on the lazy-external path; tests that
+   * exercise lifecycle without dispatch can omit it.
+   */
+  ipcSender?: SkillRequestSender;
   /** Child-process spawn function (override for tests). */
   spawnFn?: (
     command: string,
@@ -124,6 +156,32 @@ const DEFAULT_GRACEFUL_EXIT_GRACE_MS = 2_000;
 const DEFAULT_SIGKILL_GRACE_MS = 1_000;
 
 const log = getLogger("meet-host-supervisor");
+
+/**
+ * Module-level reference to the daemon's `SkillIpcServer.sendRequest`
+ * capability. The bootstrap constructs the supervisor before the
+ * `DaemonServer` instance exists, so the supervisor cannot receive the
+ * sender via constructor injection on the production path. The daemon
+ * sets this once during construction (see `daemon/server.ts`) and the
+ * supervisor consults it lazily at dispatch time. Tests still inject
+ * `ipcSender` directly via constructor deps and bypass this global.
+ */
+let globalIpcSender: SkillRequestSender | null = null;
+
+/**
+ * Install the daemon-wide skill IPC sender used by every supervisor that
+ * doesn't carry an explicit `ipcSender` dep. Idempotent: re-installing
+ * the same sender is a no-op so the daemon can call this from any setup
+ * path without double-wiring.
+ */
+export function setGlobalSkillIpcSender(sender: SkillRequestSender): void {
+  globalIpcSender = sender;
+}
+
+/** Test-only: drop the global sender between tests. */
+export function __clearGlobalSkillIpcSenderForTesting(): void {
+  globalIpcSender = null;
+}
 
 /**
  * Read the idle timeout from config, falling back to the default. The
@@ -162,6 +220,7 @@ export class MeetHostSupervisor {
   private readonly idleTimeoutMs: number;
   private readonly gracefulExitGraceMs: number;
   private readonly sigkillGraceMs: number;
+  private readonly ipcSender: SkillRequestSender | null;
 
   private child: ChildProcess | null = null;
   private spawnPromise: Promise<void> | null = null;
@@ -170,12 +229,20 @@ export class MeetHostSupervisor {
   private readonly activeSessions = new Set<string>();
   private idleTimer: ReturnType<typeof setTimeout> | null = null;
   private shuttingDown = false;
+  /**
+   * Live IPC connection to the meet-host child. Captured by the
+   * `host.registries.register_*` route handlers when the child sends its
+   * first registration frame, cleared on disconnect/shutdown. Dispatch
+   * methods reject when this is `null`.
+   */
+  private activeConnection: SkillIpcConnection | null = null;
 
   constructor(deps: MeetHostSupervisorDeps) {
     this.skillRuntimePath = deps.skillRuntimePath;
     this.bunBinaryPath = deps.bunBinaryPath;
     this.skillSocketPath = deps.skillSocketPath ?? getSkillSocketPath();
     this.manifest = deps.manifest;
+    this.ipcSender = deps.ipcSender ?? null;
     this.spawnFn = deps.spawnFn ?? defaultSpawn;
     this.connectFn = deps.connectFn ?? defaultConnect;
     this.idleTimeoutMs =
@@ -284,9 +351,150 @@ export class MeetHostSupervisor {
   }
 
   /**
+   * Register the live IPC connection to the meet-host child. The
+   * `host.registries.register_*` route handlers call this once the child
+   * has dialed the skill socket and started installing tools/routes —
+   * that handshake doubles as the signal that the child is ready to
+   * receive `skill.dispatch_*` frames.
+   *
+   * Re-registering with the same connection is a no-op so duplicate
+   * `register_tools` / `register_skill_route` / `register_shutdown_hook`
+   * frames from the same child do not churn the field. A different
+   * connection replaces the old one — the prior child is presumed dead
+   * (its socket close path has already cleared its handles via
+   * {@link clearActiveConnection} or `dispose()`).
+   */
+  setActiveConnection(connection: SkillIpcConnection): void {
+    if (this.activeConnection === connection) return;
+    this.activeConnection = connection;
+    log.debug(
+      { connectionId: connection.connectionId },
+      "Active meet-host IPC connection registered",
+    );
+  }
+
+  /**
+   * Drop the active IPC connection. Called by route handlers (or future
+   * connection-disconnect plumbing) when the meet-host child goes away;
+   * subsequent dispatches will trigger a fresh `ensureRunning()` and a
+   * new handshake before any frame is sent.
+   */
+  clearActiveConnection(): void {
+    if (!this.activeConnection) return;
+    log.debug(
+      { connectionId: this.activeConnection.connectionId },
+      "Active meet-host IPC connection cleared",
+    );
+    this.activeConnection = null;
+  }
+
+  /**
+   * Dispatch a tool invocation to the meet-host child over the
+   * bidirectional IPC channel. Spawns the child first if it isn't
+   * running, fails fast if no IPC sender was injected, and propagates
+   * any remote error back to the caller (the LLM-facing tool execute).
+   */
+  async dispatchTool(
+    name: string,
+    input: unknown,
+    context?: unknown,
+  ): Promise<unknown> {
+    const connection = await this.ensureConnection(`dispatch_tool:${name}`);
+    const sender = this.requireSender(`dispatch_tool:${name}`);
+    const response = await sender.sendRequest(
+      connection,
+      "skill.dispatch_tool",
+      {
+        name,
+        input,
+        context,
+      },
+    );
+    // The skill-side handler wraps the tool's return value in
+    // `{ result }` so the daemon can distinguish the wrapper from a
+    // potentially-undefined tool return; unwrap before handing back.
+    if (
+      response &&
+      typeof response === "object" &&
+      "result" in (response as Record<string, unknown>)
+    ) {
+      return (response as { result: unknown }).result;
+    }
+    return response;
+  }
+
+  /**
+   * Dispatch an HTTP route invocation to the meet-host child. The skill
+   * looks up the route by `patternSource`, invokes its handler with a
+   * synthesized `Request`, and returns a `{ status, headers, body }`
+   * envelope the daemon-side proxy materializes back into a `Response`.
+   */
+  async dispatchRoute(
+    patternSource: string,
+    request: {
+      method: string;
+      url: string;
+      headers?: Record<string, string>;
+      body?: string;
+    },
+  ): Promise<{
+    status: number;
+    headers: Record<string, string>;
+    body: string;
+  }> {
+    const connection = await this.ensureConnection(
+      `dispatch_route:${patternSource}`,
+    );
+    const sender = this.requireSender(`dispatch_route:${patternSource}`);
+    const response = await sender.sendRequest(
+      connection,
+      "skill.dispatch_route",
+      { patternSource, request },
+    );
+    return response as {
+      status: number;
+      headers: Record<string, string>;
+      body: string;
+    };
+  }
+
+  /**
+   * Dispatch a shutdown hook invocation. With `name` set, runs only that
+   * hook on the skill side; otherwise the skill runs every registered
+   * hook in reverse-registration order. Returns once the skill has
+   * acknowledged completion. Safe to call when no connection is active
+   * (or no sender is wired) — the call is a best-effort notification and
+   * silently no-ops in those cases since the supervisor's process-level
+   * `shutdown()` will tear the child down regardless.
+   */
+  async dispatchShutdown(name?: string, reason?: string): Promise<void> {
+    if (!this.activeConnection) {
+      log.debug(
+        { name, reason },
+        "dispatchShutdown skipped: no active meet-host connection",
+      );
+      return;
+    }
+    const sender = this.ipcSender ?? globalIpcSender;
+    if (!sender) {
+      log.debug(
+        { name, reason },
+        "dispatchShutdown skipped: no IPC sender available",
+      );
+      return;
+    }
+    const params: Record<string, unknown> = {};
+    if (name !== undefined) params.name = name;
+    if (reason !== undefined) params.reason = reason;
+    await sender.sendRequest(this.activeConnection, "skill.shutdown", params);
+  }
+
+  /**
    * Graceful termination. Cancels the idle timer, sends
    * `skill.shutdown` to the child, then SIGTERM → SIGKILL on
-   * escalation. Safe to call multiple times.
+   * escalation. Safe to call multiple times. `stopChild` calls
+   * `teardownChild` which already nulls `activeConnection`, so no
+   * separate clear is needed here.
    */
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
@@ -394,6 +602,42 @@ export class MeetHostSupervisor {
     this.handshakeResolve = null;
     this.handshakeReject = null;
     this.activeSessions.clear();
+    // The connection belonged to the dying child. Drop it so the next
+    // ensureRunning re-handshake captures a fresh handle, even if the
+    // server's socket-close path hasn't run yet (event ordering varies).
+    this.activeConnection = null;
+  }
+
+  /**
+   * Resolve the active IPC connection, spawning the child if necessary.
+   * Throws a clear error when no connection is registered after
+   * `ensureRunning` resolves — that means the child handshook against the
+   * supervisor but never reached the registries route handlers, which is
+   * a packaging or wiring bug rather than a transient state.
+   */
+  private async ensureConnection(
+    callContext: string,
+  ): Promise<SkillIpcConnection> {
+    if (!this.activeConnection) {
+      await this.ensureRunning();
+    }
+    if (!this.activeConnection) {
+      throw new Error(
+        `meet-host dispatch (${callContext}): handshake completed but no IPC connection was registered. ` +
+          "This indicates the meet-host child finished spawning without invoking host.registries.register_*; check the bootstrap wiring.",
+      );
+    }
+    return this.activeConnection;
+  }
+
+  private requireSender(callContext: string): SkillRequestSender {
+    const sender = this.ipcSender ?? globalIpcSender;
+    if (!sender) {
+      throw new Error(
+        `meet-host dispatch (${callContext}): no IPC sender configured on the supervisor.`,
+      );
+    }
+    return sender;
   }
 
   private armIdleTimer(): void {

--- a/assistant/src/daemon/meet-manifest-loader.ts
+++ b/assistant/src/daemon/meet-manifest-loader.ts
@@ -24,16 +24,12 @@
  *    entry, and a shutdown hook for every declared hook name.
  * 3. Each proxy tool's `execute` and each proxy route handler call
  *    `supervisor.ensureRunning()` before attempting to dispatch over the
- *    skill IPC socket. Dispatch itself is **not yet implemented** because
- *    the current JSON-lines protocol (see `assistant/src/ipc/skill-server.ts`)
- *    models the daemon as the server and the skill as the client — the
- *    daemon has no way to issue an RPC in the skill's direction without
- *    the protocol extension slated for a later PR. Invocations therefore
- *    throw a clear "dispatch not implemented" error.
- *
- * Since the flag defaults to `false`, this throw is unreachable on main.
- * PR 32 extends the protocol (or picks a different direction model) and
- * replaces the throw with a real round-trip before flipping the default.
+ *    skill IPC socket. Dispatch itself is implemented via the
+ *    bidirectional skill IPC RPC: the proxy invokes
+ *    `supervisor.dispatchTool` / `dispatchRoute` / `dispatchShutdown`,
+ *    which sends a `skill.dispatch_*` frame to the meet-host child and
+ *    awaits its response. Remote errors propagate to the LLM (for tools)
+ *    or to the HTTP caller (for routes) as normal.
  *
  * ## Manifest path
  *
@@ -52,7 +48,12 @@ import type { SkillRoute } from "../runtime/skill-route-registry.js";
 import { registerSkillRoute } from "../runtime/skill-route-registry.js";
 import { getRepoSkillsDir } from "../skills/catalog-install.js";
 import { registerExternalTools } from "../tools/registry.js";
-import type { ExecutionTarget, Tool, ToolDefinition } from "../tools/types.js";
+import type {
+  ExecutionTarget,
+  Tool,
+  ToolContext,
+  ToolDefinition,
+} from "../tools/types.js";
 import { RiskLevel } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
 import { getSkillRuntimePath } from "../util/platform.js";
@@ -88,12 +89,6 @@ interface Manifest {
   sourceHash: string;
 }
 
-function notImplementedError(context: string): Error {
-  return new Error(
-    `meet-host dispatch not implemented — requires server-initiated IPC (follow-up): ${context}`,
-  );
-}
-
 function coerceRiskLevel(value: string, toolName: string): RiskLevel {
   // Manifest `risk` is a serialized RiskLevel ("low" | "medium" | "high").
   const allowed: readonly string[] = ["low", "medium", "high"];
@@ -103,6 +98,42 @@ function coerceRiskLevel(value: string, toolName: string): RiskLevel {
     );
   }
   return value as RiskLevel;
+}
+
+/**
+ * Allowlist of {@link ToolContext} fields that survive JSON serialization
+ * cleanly and that a remote skill might reasonably consult. Function /
+ * AbortSignal / CesClient / proxy fields are intentionally excluded —
+ * they cannot cross the IPC boundary.
+ */
+const SERIALIZABLE_TOOL_CONTEXT_KEYS = [
+  "workingDir",
+  "conversationId",
+  "trustClass",
+  "assistantId",
+  "taskRunId",
+  "requestId",
+  "executionChannel",
+  "callSessionId",
+  "principal",
+  "toolUseId",
+  "memoryScopeId",
+  "requesterExternalUserId",
+  "requesterChatId",
+  "requesterIdentifier",
+  "requesterDisplayName",
+  "transportInterface",
+  "isInteractive",
+  "isPlatformHosted",
+] as const satisfies ReadonlyArray<keyof ToolContext>;
+
+function serializeToolContext(context: ToolContext): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of SERIALIZABLE_TOOL_CONTEXT_KEYS) {
+    const value = context[key];
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
 }
 
 function buildProxyTool(
@@ -128,15 +159,20 @@ function buildProxyTool(
     ownerSkillBundled: true,
     ownerSkillVersionHash: manifestHash,
     getDefinition: () => definition,
-    execute: async () => {
-      // Ensure the meet-host child is alive before attempting dispatch so
-      // handshake/hash-mismatch failures surface before we hit the
-      // not-implemented throw. This matters for diagnostic symmetry
-      // with PR 32's real dispatch path — when PR 32 replaces the throw
-      // with a `skill.dispatch_tool` round-trip, the ensureRunning call
-      // remains unchanged.
-      await supervisor.ensureRunning();
-      throw notImplementedError(`tool=${entry.name}`);
+    execute: async (input, context) => {
+      // `dispatchTool` ensures the meet-host child is up + connected
+      // before sending the frame, so callers don't need a separate
+      // `ensureRunning()` call. Remote errors propagate as normal.
+      const result = await supervisor.dispatchTool(
+        entry.name,
+        input,
+        serializeToolContext(context),
+      );
+      // The skill returns whatever its `Tool.execute` produced — the
+      // daemon-side ToolExecutor expects `ToolExecutionResult` shape but
+      // proxies forward verbatim; the LLM-facing executor reconciles the
+      // shape downstream.
+      return result as Awaited<ReturnType<Tool["execute"]>>;
     },
   };
 }
@@ -156,23 +192,43 @@ function buildProxyRoute(
   return {
     pattern,
     methods: [...entry.methods],
-    handler: async () => {
+    handler: async (request) => {
+      let response: {
+        status: number;
+        headers: Record<string, string>;
+        body: string;
+      };
       try {
-        await supervisor.ensureRunning();
+        // Materialize the inbound Request into a JSON-serializable
+        // envelope: skill-side `dispatchRoute` reconstructs a fresh
+        // `Request(url, init)` from this shape and runs the skill's
+        // handler against it.
+        const headers: Record<string, string> = {};
+        request.headers.forEach((value, key) => {
+          headers[key] = value;
+        });
+        const method = request.method;
+        const body =
+          method === "GET" || method === "HEAD"
+            ? undefined
+            : await request.text();
+        response = await supervisor.dispatchRoute(entry.pattern, {
+          method,
+          url: request.url,
+          headers,
+          ...(body !== undefined ? { body } : {}),
+        });
       } catch (err) {
         log.warn(
           { err, pattern: entry.pattern },
-          "meet-host supervisor ensureRunning failed while handling proxy route",
+          "meet-host route dispatch failed",
         );
-        return new Response(
-          "meet-host unavailable — supervisor failed to start",
-          { status: 503 },
-        );
+        return new Response("meet-host route dispatch failed", { status: 503 });
       }
-      return new Response(
-        notImplementedError(`route=${entry.pattern}`).message,
-        { status: 501 },
-      );
+      return new Response(response.body, {
+        status: response.status,
+        headers: response.headers,
+      });
     },
   };
 }
@@ -320,7 +376,19 @@ export async function loadMeetManifestProxies(
   }
 
   for (const hookName of manifest.shutdownHooks) {
-    registerShutdown(hookName, async () => {
+    registerShutdown(hookName, async (reason) => {
+      // Fire the named shutdown hook on the skill side so it runs any
+      // teardown the in-process registration would have run. Best-effort:
+      // if the connection is gone or the dispatch throws, the supervisor
+      // still tears down the child below.
+      try {
+        await supervisor.dispatchShutdown(hookName, reason);
+      } catch (err) {
+        log.warn(
+          { err, hookName, reason },
+          "meet-host shutdown hook dispatch failed; continuing with supervisor teardown",
+        );
+      }
       await supervisor.shutdown();
     });
   }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -114,6 +114,7 @@ import { HostBrowserProxy } from "./host-browser-proxy.js";
 import { HostCuProxy } from "./host-cu-proxy.js";
 import { HostFileProxy } from "./host-file-proxy.js";
 import { HostTransferProxy } from "./host-transfer-proxy.js";
+import { setGlobalSkillIpcSender } from "./meet-host-supervisor.js";
 import type {
   ServerMessage,
   UserMessageAttachment,
@@ -445,6 +446,12 @@ export class DaemonServer {
       this.conversations.get(id);
     setBroadcastToAllClients((msg) => this.broadcast(msg));
     setEnsureAppSourceWatcher(() => this.appSourceWatcher.ensureStarted());
+    // Wire the skill IPC server into the meet-host supervisor's lazy
+    // dispatch path. The supervisor is constructed in
+    // `external-skills-bootstrap.ts` at module-load time — earlier than
+    // this DaemonServer instance exists — so the sender flows through a
+    // module-level global rather than constructor injection.
+    setGlobalSkillIpcSender(this.skillIpc);
     this.evictor.onEvict = (conversationId: string) => {
       getSubagentManager().abortAllForParent(conversationId);
     };

--- a/assistant/src/ipc/skill-routes/__tests__/registries.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/registries.test.ts
@@ -28,6 +28,7 @@ import {
   registerToolsRoute,
   reportSessionEndedRoute,
   reportSessionStartedRoute,
+  setMeetHostSupervisorForSessionReports,
 } from "../registries.js";
 
 // ---------------------------------------------------------------------------
@@ -247,5 +248,112 @@ describe("host.registries.report_session_{started,ended}", () => {
     await expect(
       reportSessionEndedRoute.handler({ meetingId: "" }),
     ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lazy-external short-circuit (PR D)
+//
+// When a `MeetHostSupervisor` is registered via
+// `setMeetHostSupervisorForSessionReports`, the manifest loader has
+// already installed proxy tools/routes/shutdown hooks. The IPC handlers
+// must NOT re-install duplicates — they should just pin the incoming
+// connection on the supervisor and return a sensible ack frame.
+// ---------------------------------------------------------------------------
+
+describe("lazy-external short-circuit", () => {
+  type CapturedConnection = {
+    connectionId: string;
+    addRouteHandle: () => void;
+    addSkillToolsOwner: () => void;
+  };
+
+  function makeFakeConnection(id = "conn-test"): CapturedConnection {
+    return {
+      connectionId: id,
+      addRouteHandle: () => undefined,
+      addSkillToolsOwner: () => undefined,
+    };
+  }
+
+  function makeStubSupervisor(): {
+    supervisor: Parameters<typeof setMeetHostSupervisorForSessionReports>[0];
+    setActiveCalls: CapturedConnection[];
+  } {
+    const setActiveCalls: CapturedConnection[] = [];
+    const supervisor = {
+      reportSessionStarted: () => undefined,
+      reportSessionEnded: () => undefined,
+      activeSessionCount: 0,
+      setActiveConnection: (conn: CapturedConnection) => {
+        setActiveCalls.push(conn);
+      },
+    } as unknown as Parameters<
+      typeof setMeetHostSupervisorForSessionReports
+    >[0];
+    return { supervisor, setActiveCalls };
+  }
+
+  test("register_tools skips in-memory registration and pins connection", async () => {
+    const { supervisor, setActiveCalls } = makeStubSupervisor();
+    setMeetHostSupervisorForSessionReports(supervisor);
+    const conn = makeFakeConnection();
+
+    const result = (await registerToolsRoute.handler(
+      {
+        tools: [
+          {
+            name: "skill_demo_tool",
+            description: "demo",
+            input_schema: {},
+            defaultRiskLevel: "low",
+            category: "skill",
+          },
+        ],
+      },
+      conn,
+    )) as { registered: string[] };
+
+    expect(result.registered).toEqual(["skill_demo_tool"]);
+    expect(setActiveCalls).toHaveLength(1);
+    expect(setActiveCalls[0]?.connectionId).toBe(conn.connectionId);
+    // Tool should NOT have been installed into the in-memory registry —
+    // the manifest loader already owns that side.
+    expect(getTool("skill_demo_tool")).toBeUndefined();
+  });
+
+  test("register_skill_route skips in-memory registration and pins connection", async () => {
+    const { supervisor, setActiveCalls } = makeStubSupervisor();
+    setMeetHostSupervisorForSessionReports(supervisor);
+    const conn = makeFakeConnection("route-conn");
+
+    const result = (await registerSkillRouteRoute.handler(
+      {
+        patternSource: "^/skill/lazy$",
+        methods: ["GET"],
+      },
+      conn,
+    )) as { patternSource: string; methods: string[] };
+
+    expect(result.patternSource).toBe("^/skill/lazy$");
+    expect(setActiveCalls).toHaveLength(1);
+    expect(setActiveCalls[0]?.connectionId).toBe("route-conn");
+    // Route should NOT have been installed in the route registry.
+    expect(matchSkillRoute("/skill/lazy", "GET")).toBeNull();
+  });
+
+  test("register_shutdown_hook skips registration and pins connection", async () => {
+    const { supervisor, setActiveCalls } = makeStubSupervisor();
+    setMeetHostSupervisorForSessionReports(supervisor);
+    const conn = makeFakeConnection("hook-conn");
+
+    const result = (await registerShutdownHookRoute.handler(
+      { name: "lazy-hook" },
+      conn,
+    )) as { name: string };
+
+    expect(result.name).toBe("lazy-hook");
+    expect(setActiveCalls).toHaveLength(1);
+    expect(setActiveCalls[0]?.connectionId).toBe("hook-conn");
   });
 });

--- a/assistant/src/ipc/skill-routes/registries.ts
+++ b/assistant/src/ipc/skill-routes/registries.ts
@@ -98,20 +98,26 @@ const activeSessions = new Set<string>();
  * Optional supervisor injected by `external-skills-bootstrap.ts` when the
  * lazy-external path is enabled. When set, IPC session-report frames are
  * forwarded to it so its active-session counter and idle-shutdown timer
- * stay in sync with the routes. When unset, the fallback set above is
- * mutated directly.
+ * stay in sync with the routes; the `register_*` handlers also pin the
+ * incoming connection on the supervisor so daemon→skill dispatches have a
+ * target. When unset, the fallback set above is mutated directly and the
+ * register_* handlers fall back to in-memory proxy installation.
  */
 type SessionSupervisor = Pick<
   MeetHostSupervisor,
-  "reportSessionStarted" | "reportSessionEnded" | "activeSessionCount"
+  | "reportSessionStarted"
+  | "reportSessionEnded"
+  | "activeSessionCount"
+  | "setActiveConnection"
 >;
 
 let sessionSupervisor: SessionSupervisor | null = null;
 
 /**
- * Install a {@link MeetHostSupervisor} as the session-report sink. The IPC
- * routes still maintain their fallback {@link Set} for diagnostics, but
- * the supervisor's counter is the source of truth for the `activeCount`
+ * Install a {@link MeetHostSupervisor} as the session-report sink and
+ * connection holder for daemon→skill dispatch. The IPC routes still
+ * maintain their fallback {@link Set} for diagnostics, but the
+ * supervisor's counter is the source of truth for the `activeCount`
  * returned to the skill. Passing `null` detaches the supervisor — used
  * by tests that want to exercise the fallback path cleanly.
  */
@@ -209,13 +215,29 @@ async function handleRegisterTools(
   connection?: unknown,
 ): Promise<{ registered: string[] }> {
   const { tools } = RegisterToolsParams.parse(params);
+  const conn = connection as SkillIpcConnection | undefined;
+
+  // Lazy-external short-circuit: when a supervisor is registered, the
+  // manifest loader has already installed proxy tools at daemon boot.
+  // Re-installing here would double-register and clobber the manifest's
+  // execute closures with these placeholder ones. Pin the incoming
+  // connection on the supervisor so daemon→skill dispatches have a
+  // target, then return the manifest-declared tool names.
+  if (sessionSupervisor) {
+    if (conn) sessionSupervisor.setActiveConnection(conn);
+    log.info(
+      { count: tools.length, names: tools.map((t) => t.name) },
+      "Lazy-external mode: skipping in-memory tool re-registration; manifest proxies serve dispatches",
+    );
+    return { registered: tools.map((t) => t.name) };
+  }
+
   const proxies = tools.map(buildProxyTool);
   // `registerExternalTools` is only consumed inside `initializeTools()` at
   // daemon boot; IPC children connect after boot, so route through
   // `registerSkillTools` into the live registry the agent-loop reads from.
   const accepted = registerSkillTools(proxies);
 
-  const conn = connection as SkillIpcConnection | undefined;
   if (conn) {
     const ownerIds = new Set<string>();
     for (const tool of accepted) {
@@ -239,6 +261,20 @@ async function handleRegisterSkillRoute(
 ): Promise<{ patternSource: string; methods: string[] }> {
   const { patternSource, patternFlags, methods, skillId } =
     RegisterSkillRouteParams.parse(params);
+  const conn = connection as SkillIpcConnection | undefined;
+
+  // Lazy-external short-circuit: route already installed by the manifest
+  // loader; pin the connection and let the manifest's proxy handler call
+  // supervisor.dispatchRoute over IPC.
+  if (sessionSupervisor) {
+    if (conn) sessionSupervisor.setActiveConnection(conn);
+    log.info(
+      { patternSource, patternFlags, methods, skillId },
+      "Lazy-external mode: skipping in-memory route re-registration; manifest proxy serves dispatches",
+    );
+    return { patternSource, methods };
+  }
+
   let pattern: RegExp;
   try {
     pattern = new RegExp(patternSource, patternFlags);
@@ -262,7 +298,6 @@ async function handleRegisterSkillRoute(
   });
   // Retain the handle on the connection so disconnect revokes this route;
   // without it, reconnects accumulate routes with no owner to unregister them.
-  const conn = connection as SkillIpcConnection | undefined;
   conn?.addRouteHandle(skillId ?? conn.connectionId, handle);
 
   log.info(
@@ -273,9 +308,23 @@ async function handleRegisterSkillRoute(
 }
 
 async function handleRegisterShutdownHook(
-  params?: Record<string, unknown>,
+  params: Record<string, unknown> | undefined,
+  connection?: unknown,
 ): Promise<{ name: string }> {
   const { name } = RegisterShutdownHookParams.parse(params);
+  const conn = connection as SkillIpcConnection | undefined;
+
+  // Lazy-external short-circuit: shutdown hook already registered by the
+  // manifest loader; just pin the connection so dispatches can flow.
+  if (sessionSupervisor) {
+    if (conn) sessionSupervisor.setActiveConnection(conn);
+    log.info(
+      { name },
+      "Lazy-external mode: skipping shutdown-hook re-registration; manifest hook serves dispatches",
+    );
+    return { name };
+  }
+
   registerShutdownHook(name, async (reason) => {
     // PR 28 replaces this stub with a `skill.shutdown` dispatch that
     // delivers the reason string to the out-of-process skill and awaits


### PR DESCRIPTION
## Summary
- MeetHostSupervisor now tracks the active skill connection and exposes dispatchTool/dispatchRoute/dispatchShutdown that send via SkillIpcServer.sendRequest (PR A).
- meet-manifest-loader proxies replace the throw-not-implemented stubs with calls to those dispatch methods. Lazy-external flag-on path is now functional end-to-end.
- registries.ts captures the connection from incoming register_tools / register_skill_route / register_shutdown_hook requests and short-circuits double-registration when the supervisor is active.
- Route handlers updated to accept a context parameter that carries the originating connection.

Part of plan: skill-isolation.md (PR D - server-initiated dispatch follow-up)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
