### PR TITLE
feat(daemon): default meet-host to lazy external process

### DIFF
--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -92,10 +92,12 @@ export type TwitterOAuthService = z.infer<typeof TwitterOAuthServiceSchema>;
  * `skills/meet-join/config-schema.ts` and is sourced from the separate
  * `<workspace>/config/meet.json` file the skill owns.
  *
- * `lazy_external` gates the manifest-driven lazy-spawn path. While the
- * default is `false`, `external-skills-bootstrap.ts` keeps running the
- * in-process `register(host)` path — identical to pre-isolation behavior.
- * PR 32 flips the default to `true` after the remaining scaffolding lands.
+ * `lazy_external` gates the manifest-driven lazy-spawn path. The default
+ * is `true`: the daemon reads the shipped meet-join manifest at startup
+ * and spawns the meet-host child via `bun run` on first tool/route use.
+ * Setting `false` keeps the in-process `register(host)` path that
+ * `external-skills-bootstrap.ts` runs as an opt-out — useful for local
+ * iteration when the manifest or shipped skill source is stale.
  */
 export const MeetHostConfigSchema = z
   .object({
@@ -103,7 +105,7 @@ export const MeetHostConfigSchema = z
       .boolean({
         error: "services.meet.host.lazy_external must be a boolean",
       })
-      .default(false)
+      .default(true)
       .describe(
         "When true, the daemon installs meet-join tools from the shipped manifest and spawns the meet-host child on first use instead of loading the skill in-process.",
       ),


### PR DESCRIPTION
## Summary
- Flips services.meet.host.lazy_external default from false to true.
- Daemon startup now reads the shipped manifest.json and spawns meet-host lazily on first tool/route invocation. The in-process path remains as an opt-out via user config.
- All scaffolding for the external path landed in PRs 20-28 + A-D; this PR just flips the default. The supervisor/manifest contract was already covered by unit tests; a fuller subprocess integration test is deferred.

Part of plan: skill-isolation.md (PR 32 of 34)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
