### PR TITLE
fix(providers): surface cached input tokens for OpenAI

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -37,6 +37,9 @@ interface FakeChunk {
     completion_tokens_details?: {
       reasoning_tokens?: number;
     };
+    prompt_tokens_details?: {
+      cached_tokens?: number;
+    };
   } | null;
   model: string;
 }
@@ -177,6 +180,25 @@ function reasoningUsageChunk(
       total_tokens: prompt + completion,
       completion_tokens_details: {
         reasoning_tokens: reasoning,
+      },
+    },
+    model: "gpt-5.2",
+  };
+}
+
+function cachedUsageChunk(
+  prompt: number,
+  completion: number,
+  cached: number,
+): FakeChunk {
+  return {
+    choices: [{ delta: {}, finish_reason: "stop" }],
+    usage: {
+      prompt_tokens: prompt,
+      completion_tokens: completion,
+      total_tokens: prompt + completion,
+      prompt_tokens_details: {
+        cached_tokens: cached,
       },
     },
     model: "gpt-5.2",
@@ -963,6 +985,45 @@ describe("OpenAIProvider", () => {
     // rawResponse should not include completion_tokens_details
     const rawUsage = (result.rawResponse as any).usage;
     expect(rawUsage).not.toHaveProperty("completion_tokens_details");
+  });
+
+  // -----------------------------------------------------------------------
+  // Cached input tokens (prompt caching)
+  // -----------------------------------------------------------------------
+  test("maps cached prompt tokens to cacheReadInputTokens", async () => {
+    // OpenAI's prompt_tokens already includes the cached portion, so the
+    // normalized inputTokens stays at the API value and the cached subset
+    // surfaces separately as cacheReadInputTokens.
+    fakeChunks = [
+      textChunk("Cached reply"),
+      cachedUsageChunk(50_648, 114, 49_536),
+    ];
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+    ]);
+
+    expect(result.usage).toEqual({
+      inputTokens: 50_648,
+      outputTokens: 114,
+      cacheReadInputTokens: 49_536,
+    });
+
+    const rawUsage = (result.rawResponse as any).usage;
+    expect(rawUsage.prompt_tokens_details).toEqual({ cached_tokens: 49_536 });
+  });
+
+  test("omits cacheReadInputTokens when no cached tokens", async () => {
+    fakeChunks = [textChunk("Fresh reply"), usageChunk(10, 5)];
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+    ]);
+
+    expect(result.usage).not.toHaveProperty("cacheReadInputTokens");
+
+    const rawUsage = (result.rawResponse as any).usage;
+    expect(rawUsage).not.toHaveProperty("prompt_tokens_details");
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -133,6 +133,7 @@ function completedEvent(
   outputTokens: number,
   opts?: {
     reasoningTokens?: number;
+    cachedTokens?: number;
     model?: string;
     status?: string;
     output?: unknown[];
@@ -155,6 +156,9 @@ function completedEvent(
         output_tokens_details: {
           reasoning_tokens: opts?.reasoningTokens ?? 0,
         },
+        ...(opts?.cachedTokens
+          ? { input_tokens_details: { cached_tokens: opts.cachedTokens } }
+          : {}),
       },
     },
   };
@@ -462,6 +466,40 @@ describe("OpenAIResponsesProvider", () => {
 
     expect(result.usage).toEqual({ inputTokens: 10, outputTokens: 5 });
     expect(result.usage).not.toHaveProperty("reasoningTokens");
+  });
+
+  // -----------------------------------------------------------------------
+  // Cached input tokens (prompt caching)
+  // -----------------------------------------------------------------------
+  test("maps cached input tokens to cacheReadInputTokens", async () => {
+    // OpenAI's input_tokens already includes the cached portion, so the
+    // normalized inputTokens stays at the API value and the cached subset
+    // surfaces separately as cacheReadInputTokens. Downstream code derives
+    // directInputTokens by subtracting cache read/creation from inputTokens.
+    fakeStreamEvents = [
+      textDeltaEvent("Cached reply"),
+      completedEvent(50_648, 114, { cachedTokens: 49_536 }),
+    ];
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+    ]);
+
+    expect(result.usage).toEqual({
+      inputTokens: 50_648,
+      outputTokens: 114,
+      cacheReadInputTokens: 49_536,
+    });
+  });
+
+  test("omits cacheReadInputTokens when no cached tokens", async () => {
+    fakeStreamEvents = [textDeltaEvent("Fresh reply"), completedEvent(10, 5)];
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+    ]);
+
+    expect(result.usage).not.toHaveProperty("cacheReadInputTokens");
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -181,6 +181,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
       let promptTokens = 0;
       let completionTokens = 0;
       let reasoningTokens = 0;
+      let cachedPromptTokens = 0;
 
       try {
         const stream = await this.client.chat.completions.create(params, {
@@ -215,12 +216,18 @@ export class OpenAIChatCompletionsProvider implements Provider {
           if (chunk.usage) {
             promptTokens = chunk.usage.prompt_tokens;
             completionTokens = chunk.usage.completion_tokens;
-            const details = (
+            const completionDetails = (
               chunk.usage as {
                 completion_tokens_details?: { reasoning_tokens?: number };
               }
             ).completion_tokens_details;
-            reasoningTokens = details?.reasoning_tokens ?? 0;
+            reasoningTokens = completionDetails?.reasoning_tokens ?? 0;
+            const promptDetails = (
+              chunk.usage as {
+                prompt_tokens_details?: { cached_tokens?: number };
+              }
+            ).prompt_tokens_details;
+            cachedPromptTokens = promptDetails?.cached_tokens ?? 0;
           }
 
           responseModel = chunk.model;
@@ -279,6 +286,13 @@ export class OpenAIChatCompletionsProvider implements Provider {
                 },
               }
             : {}),
+          ...(cachedPromptTokens > 0
+            ? {
+                prompt_tokens_details: {
+                  cached_tokens: cachedPromptTokens,
+                },
+              }
+            : {}),
         },
       };
 
@@ -289,6 +303,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
           inputTokens: promptTokens,
           outputTokens: completionTokens,
           ...(reasoningTokens > 0 ? { reasoningTokens } : {}),
+          ...(cachedPromptTokens > 0
+            ? { cacheReadInputTokens: cachedPromptTokens }
+            : {}),
         },
         stopReason: finishReason,
         rawRequest: params,

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -66,6 +66,7 @@ interface ResponsesStreamEvent {
       input_tokens?: number;
       output_tokens?: number;
       output_tokens_details?: { reasoning_tokens?: number };
+      input_tokens_details?: { cached_tokens?: number };
     };
   };
 }
@@ -199,6 +200,7 @@ export class OpenAIResponsesProvider implements Provider {
       let inputTokens = 0;
       let outputTokens = 0;
       let reasoningTokens = 0;
+      let cachedInputTokens = 0;
       let rawFinalResponse: unknown = undefined;
 
       try {
@@ -296,6 +298,8 @@ export class OpenAIResponsesProvider implements Provider {
                   outputTokens = response.usage.output_tokens ?? 0;
                   reasoningTokens =
                     response.usage.output_tokens_details?.reasoning_tokens ?? 0;
+                  cachedInputTokens =
+                    response.usage.input_tokens_details?.cached_tokens ?? 0;
                 }
                 finishReason = response.status ?? "completed";
               }
@@ -365,6 +369,9 @@ export class OpenAIResponsesProvider implements Provider {
           inputTokens,
           outputTokens,
           ...(reasoningTokens > 0 ? { reasoningTokens } : {}),
+          ...(cachedInputTokens > 0
+            ? { cacheReadInputTokens: cachedInputTokens }
+            : {}),
         },
         stopReason,
         rawRequest: params,


### PR DESCRIPTION
## Summary
- OpenAI's \`input_tokens\`/\`prompt_tokens\` already include the cached portion; the cached subset lives under \`input_tokens_details.cached_tokens\` (Responses API) or \`prompt_tokens_details.cached_tokens\` (Chat Completions). Neither provider read those fields, so \`cacheReadInputTokens\` stayed undefined and the message inspector showed "Unavailable".
- Extract the cached subset in both providers and populate \`cacheReadInputTokens\`. \`inputTokens\` stays unchanged because downstream (\`conversation-usage.ts:141\`) derives \`directInputTokens = inputTokens - cacheRead - cacheCreation\`. OpenAI has no separate "cache creation" concept, so \`cacheCreationInputTokens\` remains undefined.
- Added regression tests covering populated + empty cases in both provider test files.

Note: \`pricing.ts\` currently charges cache-read tokens at the full input rate for non-Anthropic providers. OpenAI actually discounts cached input (typically 50%), so cost estimates will be high. Worth a follow-up but out of scope here.

## Original prompt
we're not detecting cached input token properly for OpenAI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
