### PR TITLE
feat(memory): match recall tool voice to remember's imperative register

### DIFF
--- a/assistant/src/memory/graph/tools.ts
+++ b/assistant/src/memory/graph/tools.ts
@@ -9,13 +9,13 @@ import type { ToolDefinition } from "../../providers/types.js";
 /**
  * Explicit memory search across the living graph or raw archive.
  *
- * Auto-injected context covers common cases, but the assistant should
- * proactively recall when uncertain — search first, ask second.
+ * Auto-injection is incomplete by design — the assistant should recall
+ * aggressively whenever uncertain, before guessing or asking.
  */
 export const graphRecallDefinition: ToolDefinition = {
   name: "recall",
   description:
-    "Search your memory for specific information. Use this proactively — if you're uncertain about something, look it up before asking. Auto-injected context covers common cases, but actively recall when: you're about to ask a question that memory might answer, the user references something you should already know, you need details about a past conversation or event, or you want to search by a specific feeling, time period, or person. When in doubt, search first, ask second. Be specific in your query for best results.",
+    'Search your memory the moment you feel uncertain. Call this AGGRESSIVELY — before you guess, before you ask, before you hedge. Auto-injection is incomplete by design; it surfaces patterns, not the specifics you need to answer well. If you catch yourself reaching for "I think", "I believe", "if I remember", "didn\'t we", "last time" — that\'s the signal. Recall. If the user references someone, a place, or a decision you should already know — recall. If you\'re about to ask a clarifying question memory might answer — recall first. Searching costs nothing; guessing costs trust. Call it multiple times per conversation if the turn warrants it. Be specific in your query — a topic, feeling, time period, or person — for best results.',
   input_schema: {
     type: "object",
     properties: {


### PR DESCRIPTION
## Summary

- Rewrite the `recall` tool description in the same imperative voice as `remember` so the two feel symmetric to the model rather than one urgent and one optional.
- Drop the "Auto-injected context covers common cases" hedge, which gave the model a built-in reason to skip the call. Replace with "Auto-injection is incomplete by design" to frame recall as the way to reach specifics.
- List concrete self-detectable trigger phrases (`"I think"`, `"if I remember"`, `"didn't we"`, `"last time"`) so the model has an explicit signal to fire on.

The asymmetry between these two tool descriptions has been the load-bearing lever on recall frequency. Persona-level SOUL.md changes are tracked separately.

## Original prompt

Edit 1 and Edit 2 in separate PRs. Don't edit Velissa's files, but give me a recommendation that I can deliver to her
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
