### PR TITLE
feat(config): add llm.activeProfile pointer to LLMSchema

### DIFF
--- a/assistant/src/__tests__/llm-schema.test.ts
+++ b/assistant/src/__tests__/llm-schema.test.ts
@@ -202,6 +202,49 @@ describe("LLMSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  test("activeProfile undefined parses fine", () => {
+    const result = LLMSchema.safeParse({
+      default: fullDefault,
+      profiles: { fast: { speed: "fast" } },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.activeProfile).toBeUndefined();
+    }
+  });
+
+  test("activeProfile referencing existing profile parses fine", () => {
+    const result = LLMSchema.safeParse({
+      default: fullDefault,
+      profiles: { fast: { speed: "fast" } },
+      activeProfile: "fast",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.activeProfile).toBe("fast");
+    }
+  });
+
+  test("activeProfile referencing missing profile fails superRefine", () => {
+    const result = LLMSchema.safeParse({
+      default: fullDefault,
+      profiles: { fast: { speed: "fast" } },
+      activeProfile: "ghost",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages.join("\n")).toContain(
+        'Profile "ghost" referenced by llm.activeProfile is not defined in llm.profiles',
+      );
+      const issue = result.error.issues.find(
+        (i) =>
+          i.message.includes("ghost") && i.message.includes("activeProfile"),
+      );
+      expect(issue?.path).toEqual(["activeProfile"]);
+    }
+  });
+
   test("contextWindow deep-partial override accepted (nested overflowRecovery only)", () => {
     const result = LLMSchema.safeParse({
       default: fullDefault,

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -324,6 +324,7 @@ export const LLMSchema = z
     // are seeded into the user's on-disk config by migration 040, not at
     // schema level, so `LLMSchema.parse({})` yields an empty map.
     callSites: z.partialRecord(LLMCallSiteEnum, LLMCallSiteConfig).default({}),
+    activeProfile: z.string().optional(),
     pricingOverrides: z.array(PricingOverrideSchema).default([]),
   })
   .superRefine((config, ctx) => {
@@ -337,6 +338,16 @@ export const LLMSchema = z
           message: `Profile "${siteConfig.profile}" referenced by call site "${siteId}" is not defined in llm.profiles`,
         });
       }
+    }
+    if (
+      config.activeProfile != null &&
+      !profileNames.has(config.activeProfile)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["activeProfile"],
+        message: `Profile "${config.activeProfile}" referenced by llm.activeProfile is not defined in llm.profiles`,
+      });
     }
   });
 


### PR DESCRIPTION
## Summary
- Add optional `llm.activeProfile` field to `LLMSchema` with superRefine validation that the named profile exists.
- Extend schema tests to cover the three reference cases.

Part of plan: inference-profiles.md (PR 1 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
