### PR TITLE
feat(db): add conversations.inferenceProfile column

### DIFF
--- a/assistant/src/__tests__/db-conversation-inference-profile-migration.test.ts
+++ b/assistant/src/__tests__/db-conversation-inference-profile-migration.test.ts
@@ -1,0 +1,237 @@
+import { rmSync } from "node:fs";
+import { Database } from "bun:sqlite";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+const originalBunTest = process.env.BUN_TEST;
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { initializeDb, resetDb } from "../memory/db.js";
+import { getSqliteFrom } from "../memory/db-connection.js";
+import { migrateAddConversationInferenceProfile } from "../memory/migrations/227-add-conversation-inference-profile.js";
+import * as schema from "../memory/schema.js";
+import { getDbPath } from "../util/platform.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function getColumnNames(raw: Database): string[] {
+  return (
+    raw.query(`PRAGMA table_info(conversations)`).all() as Array<{
+      name: string;
+    }>
+  ).map((column) => column.name);
+}
+
+function bootstrapPreInferenceProfileConversations(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      total_input_tokens INTEGER NOT NULL DEFAULT 0,
+      total_output_tokens INTEGER NOT NULL DEFAULT 0,
+      total_estimated_cost REAL NOT NULL DEFAULT 0,
+      context_summary TEXT,
+      context_compacted_message_count INTEGER NOT NULL DEFAULT 0,
+      context_compacted_at INTEGER,
+      conversation_type TEXT NOT NULL DEFAULT 'standard',
+      source TEXT NOT NULL DEFAULT 'user',
+      memory_scope_id TEXT NOT NULL DEFAULT 'default',
+      origin_channel TEXT,
+      origin_interface TEXT,
+      fork_parent_conversation_id TEXT,
+      fork_parent_message_id TEXT,
+      host_access INTEGER NOT NULL DEFAULT 0,
+      is_auto_title INTEGER NOT NULL DEFAULT 1,
+      schedule_job_id TEXT,
+      last_message_at INTEGER,
+      archived_at INTEGER
+    )
+  `);
+}
+
+function removeTestDbFiles(): void {
+  resetDb();
+  const dbPath = getDbPath();
+  rmSync(dbPath, { force: true });
+  rmSync(`${dbPath}-shm`, { force: true });
+  rmSync(`${dbPath}-wal`, { force: true });
+}
+
+describe("conversation inference profile migration", () => {
+  beforeEach(() => {
+    process.env.BUN_TEST = "0";
+    removeTestDbFiles();
+  });
+
+  afterAll(() => {
+    process.env.BUN_TEST = originalBunTest;
+    removeTestDbFiles();
+  });
+
+  test("fresh DB initialization includes nullable inferenceProfile column", () => {
+    initializeDb();
+
+    const raw = new Database(getDbPath());
+    const columns = getColumnNames(raw);
+    expect(columns).toContain("inferenceProfile");
+
+    const inferenceProfileColumn = (
+      raw.query(`PRAGMA table_info(conversations)`).all() as Array<{
+        name: string;
+        notnull: number;
+      }>
+    ).find((column) => column.name === "inferenceProfile");
+
+    expect(inferenceProfileColumn).toBeDefined();
+    expect(inferenceProfileColumn?.notnull).toBe(0);
+    raw.close();
+  });
+
+  test("migration upgrades the previous schema without disturbing existing rows", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapPreInferenceProfileConversations(raw);
+    raw.exec(/*sql*/ `
+      INSERT INTO conversations (
+        id,
+        title,
+        created_at,
+        updated_at,
+        conversation_type,
+        source,
+        memory_scope_id,
+        is_auto_title
+      ) VALUES (
+        'conv-existing',
+        'Existing conversation',
+        ${now},
+        ${now},
+        'standard',
+        'user',
+        'default',
+        1
+      )
+    `);
+
+    migrateAddConversationInferenceProfile(db);
+
+    expect(getColumnNames(raw)).toContain("inferenceProfile");
+
+    const row = raw
+      .query(
+        `SELECT id, title, inferenceProfile FROM conversations WHERE id = 'conv-existing'`,
+      )
+      .get() as {
+      id: string;
+      title: string | null;
+      inferenceProfile: string | null;
+    } | null;
+
+    expect(row).toEqual({
+      id: "conv-existing",
+      title: "Existing conversation",
+      inferenceProfile: null,
+    });
+  });
+
+  test("re-running the migration is a no-op and preserves stored values", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapPreInferenceProfileConversations(raw);
+    raw.exec(/*sql*/ `
+      INSERT INTO conversations (
+        id,
+        title,
+        created_at,
+        updated_at,
+        conversation_type,
+        source,
+        memory_scope_id,
+        is_auto_title
+      ) VALUES (
+        'conv-rerun',
+        'Conversation with override',
+        ${now},
+        ${now},
+        'standard',
+        'user',
+        'default',
+        1
+      )
+    `);
+
+    migrateAddConversationInferenceProfile(db);
+    raw.exec(/*sql*/ `
+      UPDATE conversations
+      SET inferenceProfile = 'quality-optimized'
+      WHERE id = 'conv-rerun'
+    `);
+
+    expect(() => migrateAddConversationInferenceProfile(db)).not.toThrow();
+
+    const row = raw
+      .query(
+        `SELECT inferenceProfile FROM conversations WHERE id = 'conv-rerun'`,
+      )
+      .get() as {
+      inferenceProfile: string | null;
+    } | null;
+
+    expect(row).toEqual({ inferenceProfile: "quality-optimized" });
+  });
+
+  test("new rows default to NULL inferenceProfile after migration", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapPreInferenceProfileConversations(raw);
+    migrateAddConversationInferenceProfile(db);
+    raw.exec(/*sql*/ `
+      INSERT INTO conversations (
+        id,
+        title,
+        created_at,
+        updated_at,
+        conversation_type,
+        source,
+        memory_scope_id,
+        is_auto_title
+      ) VALUES (
+        'conv-new',
+        'New conversation',
+        ${now},
+        ${now},
+        'standard',
+        'user',
+        'default',
+        1
+      )
+    `);
+
+    const row = raw
+      .query(`SELECT inferenceProfile FROM conversations WHERE id = 'conv-new'`)
+      .get() as {
+      inferenceProfile: string | null;
+    } | null;
+
+    expect(row).toEqual({ inferenceProfile: null });
+  });
+});

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -184,6 +184,7 @@ export interface ConversationRow {
   scheduleJobId: string | null;
   lastMessageAt: number | null;
   archivedAt: number | null;
+  inferenceProfile: string | null;
 }
 
 export const parseConversation = createRowMapper<
@@ -212,6 +213,7 @@ export const parseConversation = createRowMapper<
   scheduleJobId: "scheduleJobId",
   lastMessageAt: "lastMessageAt",
   archivedAt: "archivedAt",
+  inferenceProfile: "inferenceProfile",
 });
 
 export interface MessageRow {

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -37,6 +37,7 @@ import {
   createSequenceTables,
   createTasksAndWorkItemsTables,
   createWatchersAndLogsTables,
+  migrateAddConversationInferenceProfile,
   migrateAddSourceTypeColumns,
   migrateAssistantContactMetadata,
   migrateBackfillAudioAttachmentMimeTypes,
@@ -382,6 +383,7 @@ export function initializeDb(): void {
     migrateOAuthProvidersManagedServiceIsPaid,
     migrateOAuthProvidersAvailableScopes,
     migrateScheduleWakeConversationId,
+    migrateAddConversationInferenceProfile,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/227-add-conversation-inference-profile.ts
+++ b/assistant/src/memory/migrations/227-add-conversation-inference-profile.ts
@@ -1,0 +1,18 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateAddConversationInferenceProfile(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+  const columns = raw.query(`PRAGMA table_info(conversations)`).all() as Array<{
+    name: string;
+  }>;
+  const hasColumn = columns.some(
+    (column) => column.name === "inferenceProfile",
+  );
+  if (hasColumn) {
+    return;
+  }
+  raw.exec(`ALTER TABLE conversations ADD COLUMN inferenceProfile TEXT`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -172,6 +172,7 @@ export { migrateScheduleScriptColumn } from "./223-schedule-script-column.js";
 export { migrateOAuthProvidersManagedServiceIsPaid } from "./224-oauth-providers-managed-service-is-paid.js";
 export { migrateOAuthProvidersAvailableScopes } from "./225-oauth-providers-available-scopes.js";
 export { migrateScheduleWakeConversationId } from "./226-schedule-wake-conversation-id.js";
+export { migrateAddConversationInferenceProfile } from "./227-add-conversation-inference-profile.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -33,6 +33,7 @@ export const conversations = sqliteTable(
     scheduleJobId: text("schedule_job_id"),
     lastMessageAt: integer("last_message_at"),
     archivedAt: integer("archived_at"),
+    inferenceProfile: text("inferenceProfile"),
   },
   (table) => [
     index("idx_conversations_updated_at").on(table.updatedAt),


### PR DESCRIPTION
## Summary
- Add nullable `inferenceProfile` column to the assistant conversations table for per-conversation inference profile overrides.
- Idempotent migration #227 mirroring the existing 226-style pattern.
- Test covers fresh init, re-run no-op, and existing-row preservation.

Part of plan: inference-profiles.md (PR 4 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
