### PR TITLE
feat(macos): add InferenceProfile Swift model

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// User-editable inference profile that mirrors the daemon's
+/// `LLMConfigFragment` schema (`assistant/src/config/schemas/llm.ts`).
+///
+/// Each profile is a partial `llm.default` override stored under
+/// `llm.profiles.<name>`. Call sites can reference a profile by name, and
+/// the resolver layers the profile's fields on top of `llm.default` before
+/// applying any per-call-site overrides.
+///
+/// Only the leaves the macOS UI exposes are modeled here: `provider`,
+/// `model`, `maxTokens`, `effort`, `speed`, `verbosity`, `temperature`,
+/// and the two `thinking` sub-fields. Other `LLMConfigFragment` leaves
+/// (e.g. `contextWindow`, `openrouter`) flow through the daemon's config
+/// layer untouched — the JSON mapper preserves only the fields it knows
+/// about, but `SettingsStore.patchConfig` merges into the live config so
+/// unknown keys are not clobbered.
+public struct InferenceProfile: Codable, Hashable, Identifiable {
+    /// Profile name; doubles as the key under `llm.profiles` and the
+    /// stable `id` for `Identifiable` conformance.
+    public var name: String
+
+    public var provider: String?
+    public var model: String?
+    public var maxTokens: Int?
+    public var effort: String?
+    public var speed: String?
+    public var verbosity: String?
+    public var temperature: Double?
+
+    /// Maps to `thinking.enabled` in the fragment JSON.
+    public var thinkingEnabled: Bool?
+
+    /// Maps to `thinking.streamThinking` in the fragment JSON.
+    public var thinkingStreamThinking: Bool?
+
+    public var id: String { name }
+
+    public init(
+        name: String,
+        provider: String? = nil,
+        model: String? = nil,
+        maxTokens: Int? = nil,
+        effort: String? = nil,
+        speed: String? = nil,
+        verbosity: String? = nil,
+        temperature: Double? = nil,
+        thinkingEnabled: Bool? = nil,
+        thinkingStreamThinking: Bool? = nil
+    ) {
+        self.name = name
+        self.provider = provider
+        self.model = model
+        self.maxTokens = maxTokens
+        self.effort = effort
+        self.speed = speed
+        self.verbosity = verbosity
+        self.temperature = temperature
+        self.thinkingEnabled = thinkingEnabled
+        self.thinkingStreamThinking = thinkingStreamThinking
+    }
+
+    /// Decodes a fragment JSON dictionary as produced by the daemon's
+    /// config sync. Unknown keys are ignored. Empty strings are treated
+    /// as nil so the round-trip stays symmetric with `toJSON()`, which
+    /// omits nil keys entirely.
+    public init(name: String, json: [String: Any]) {
+        self.name = name
+        self.provider = (json["provider"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        self.model = (json["model"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        self.maxTokens = json["maxTokens"] as? Int
+        self.effort = (json["effort"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        self.speed = (json["speed"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        self.verbosity = (json["verbosity"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        self.temperature = json["temperature"] as? Double
+        let thinking = json["thinking"] as? [String: Any]
+        self.thinkingEnabled = thinking?["enabled"] as? Bool
+        self.thinkingStreamThinking = thinking?["streamThinking"] as? Bool
+    }
+
+    /// Encodes the profile as a fragment JSON dictionary suitable for
+    /// `settingsClient.patchConfig`. Nil keys are omitted; the nested
+    /// `thinking` dict is emitted only when at least one of its
+    /// sub-fields is set.
+    public func toJSON() -> [String: Any] {
+        var result: [String: Any] = [:]
+        if let provider { result["provider"] = provider }
+        if let model { result["model"] = model }
+        if let maxTokens { result["maxTokens"] = maxTokens }
+        if let effort { result["effort"] = effort }
+        if let speed { result["speed"] = speed }
+        if let verbosity { result["verbosity"] = verbosity }
+        if let temperature { result["temperature"] = temperature }
+        var thinking: [String: Any] = [:]
+        if let thinkingEnabled { thinking["enabled"] = thinkingEnabled }
+        if let thinkingStreamThinking { thinking["streamThinking"] = thinkingStreamThinking }
+        if !thinking.isEmpty {
+            result["thinking"] = thinking
+        }
+        return result
+    }
+}
+
+/// The three first-class profiles the daemon seeds into every workspace
+/// (see migration 040 in `assistant/src/workspace/migrations/`). The
+/// macOS UI uses this enum only to render a "Built-in" badge — deletion
+/// and editing remain allowed for these profiles.
+public enum BuiltInInferenceProfile: String, CaseIterable {
+    case qualityOptimized = "quality-optimized"
+    case balanced = "balanced"
+    case costOptimized = "cost-optimized"
+
+    /// Set of built-in profile names, derived from `allCases`. Used by
+    /// the profile editor to decide whether to render the badge.
+    public static var allNames: Set<String> {
+        Set(allCases.map(\.rawValue))
+    }
+}

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+@testable import VellumAssistantLib
+
+/// Verifies the `InferenceProfile` JSON ↔ struct round-trip used by
+/// `SettingsStore` to patch `llm.profiles.<name>`. The fragment shape
+/// must stay aligned with the daemon's `LLMConfigFragment` schema in
+/// `assistant/src/config/schemas/llm.ts`.
+final class InferenceProfileTests: XCTestCase {
+
+    // MARK: - Empty fragment
+
+    func testEmptyFragmentRoundTrips() {
+        let profile = InferenceProfile(name: "empty")
+        let json = profile.toJSON()
+        XCTAssertTrue(json.isEmpty, "Empty profile must produce an empty JSON dict")
+
+        let decoded = InferenceProfile(name: "empty", json: json)
+        XCTAssertEqual(decoded, profile)
+    }
+
+    func testEmptyJSONDecodesToAllNilFields() {
+        let profile = InferenceProfile(name: "empty", json: [:])
+        XCTAssertNil(profile.provider)
+        XCTAssertNil(profile.model)
+        XCTAssertNil(profile.maxTokens)
+        XCTAssertNil(profile.effort)
+        XCTAssertNil(profile.speed)
+        XCTAssertNil(profile.verbosity)
+        XCTAssertNil(profile.temperature)
+        XCTAssertNil(profile.thinkingEnabled)
+        XCTAssertNil(profile.thinkingStreamThinking)
+    }
+
+    // MARK: - Fully-populated fragment
+
+    func testFullyPopulatedFragmentRoundTrips() {
+        let original = InferenceProfile(
+            name: "balanced",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            maxTokens: 64000,
+            effort: "medium",
+            speed: "standard",
+            verbosity: "high",
+            temperature: 0.7,
+            thinkingEnabled: true,
+            thinkingStreamThinking: false
+        )
+
+        let json = original.toJSON()
+        XCTAssertEqual(json["provider"] as? String, "anthropic")
+        XCTAssertEqual(json["model"] as? String, "claude-sonnet-4-6")
+        XCTAssertEqual(json["maxTokens"] as? Int, 64000)
+        XCTAssertEqual(json["effort"] as? String, "medium")
+        XCTAssertEqual(json["speed"] as? String, "standard")
+        XCTAssertEqual(json["verbosity"] as? String, "high")
+        XCTAssertEqual(json["temperature"] as? Double, 0.7)
+        let thinking = json["thinking"] as? [String: Any]
+        XCTAssertNotNil(thinking)
+        XCTAssertEqual(thinking?["enabled"] as? Bool, true)
+        XCTAssertEqual(thinking?["streamThinking"] as? Bool, false)
+
+        let decoded = InferenceProfile(name: "balanced", json: json)
+        XCTAssertEqual(decoded, original)
+    }
+
+    // MARK: - Thinking-only fragment
+
+    func testThinkingOnlyFragmentRoundTrips() {
+        let original = InferenceProfile(
+            name: "thinking-only",
+            thinkingEnabled: false,
+            thinkingStreamThinking: true
+        )
+
+        let json = original.toJSON()
+        XCTAssertNil(json["provider"])
+        XCTAssertNil(json["model"])
+        XCTAssertNil(json["maxTokens"])
+        XCTAssertNil(json["effort"])
+        XCTAssertNil(json["speed"])
+        XCTAssertNil(json["verbosity"])
+        XCTAssertNil(json["temperature"])
+        let thinking = json["thinking"] as? [String: Any]
+        XCTAssertNotNil(thinking, "Thinking dict must be present when any sub-field is set")
+        XCTAssertEqual(thinking?["enabled"] as? Bool, false)
+        XCTAssertEqual(thinking?["streamThinking"] as? Bool, true)
+
+        let decoded = InferenceProfile(name: "thinking-only", json: json)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testThinkingDictOmittedWhenBothSubFieldsAreNil() {
+        let profile = InferenceProfile(
+            name: "no-thinking",
+            provider: "openai"
+        )
+        let json = profile.toJSON()
+        XCTAssertNil(json["thinking"], "Thinking dict must be omitted when both sub-fields are nil")
+    }
+
+    func testThinkingDictKeptWhenOnlyOneSubFieldIsSet() {
+        let onlyEnabled = InferenceProfile(name: "only-enabled", thinkingEnabled: true)
+        let onlyEnabledThinking = onlyEnabled.toJSON()["thinking"] as? [String: Any]
+        XCTAssertNotNil(onlyEnabledThinking)
+        XCTAssertEqual(onlyEnabledThinking?["enabled"] as? Bool, true)
+        XCTAssertNil(onlyEnabledThinking?["streamThinking"])
+
+        let onlyStream = InferenceProfile(name: "only-stream", thinkingStreamThinking: true)
+        let onlyStreamThinking = onlyStream.toJSON()["thinking"] as? [String: Any]
+        XCTAssertNotNil(onlyStreamThinking)
+        XCTAssertNil(onlyStreamThinking?["enabled"])
+        XCTAssertEqual(onlyStreamThinking?["streamThinking"] as? Bool, true)
+    }
+
+    // MARK: - Decoder edge cases
+
+    func testEmptyStringFieldsDecodeAsNil() {
+        let json: [String: Any] = [
+            "provider": "",
+            "model": "",
+            "effort": "",
+            "speed": "",
+            "verbosity": "",
+        ]
+        let profile = InferenceProfile(name: "empties", json: json)
+        XCTAssertNil(profile.provider)
+        XCTAssertNil(profile.model)
+        XCTAssertNil(profile.effort)
+        XCTAssertNil(profile.speed)
+        XCTAssertNil(profile.verbosity)
+    }
+
+    func testUnknownKeysAreIgnored() {
+        let json: [String: Any] = [
+            "provider": "anthropic",
+            "totallyUnknown": "ignored",
+            "thinking": [
+                "enabled": true,
+                "alsoUnknown": 123,
+            ],
+        ]
+        let profile = InferenceProfile(name: "extra", json: json)
+        XCTAssertEqual(profile.provider, "anthropic")
+        XCTAssertEqual(profile.thinkingEnabled, true)
+        XCTAssertNil(profile.thinkingStreamThinking)
+    }
+
+    // MARK: - Identifiable
+
+    func testIdReturnsName() {
+        let profile = InferenceProfile(name: "balanced")
+        XCTAssertEqual(profile.id, "balanced")
+    }
+
+    // MARK: - BuiltInInferenceProfile
+
+    func testBuiltInProfileNames() {
+        XCTAssertEqual(BuiltInInferenceProfile.qualityOptimized.rawValue, "quality-optimized")
+        XCTAssertEqual(BuiltInInferenceProfile.balanced.rawValue, "balanced")
+        XCTAssertEqual(BuiltInInferenceProfile.costOptimized.rawValue, "cost-optimized")
+    }
+
+    func testBuiltInAllNamesContainsEveryCase() {
+        XCTAssertEqual(
+            BuiltInInferenceProfile.allNames,
+            ["quality-optimized", "balanced", "cost-optimized"]
+        )
+        XCTAssertEqual(BuiltInInferenceProfile.allNames.count, BuiltInInferenceProfile.allCases.count)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `InferenceProfile` struct mirroring the daemon's `LLMConfigFragment` shape.
- Add `BuiltInInferenceProfile` enum naming the three default profiles.
- JSON round-trip mapper preserves nested `thinking` keys.

Part of plan: inference-profiles.md (PR 10 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
