### PR TITLE
feat(memory): add inferenceProfile read/write helpers on conversations

### DIFF
--- a/assistant/src/__tests__/conversation-crud-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-crud-inference-profile.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  createConversation,
+  getConversation,
+  setConversationInferenceProfile,
+} from "../memory/conversation-crud.js";
+import { getDb, initializeDb } from "../memory/db.js";
+
+initializeDb();
+
+describe("setConversationInferenceProfile", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test("round-trips null → name → null on the inferenceProfile column", async () => {
+    const conv = createConversation("inference-profile-roundtrip");
+    expect(getConversation(conv.id)?.inferenceProfile).toBeNull();
+
+    await setConversationInferenceProfile(conv.id, "quality-optimized");
+    expect(getConversation(conv.id)?.inferenceProfile).toBe(
+      "quality-optimized",
+    );
+
+    await setConversationInferenceProfile(conv.id, null);
+    expect(getConversation(conv.id)?.inferenceProfile).toBeNull();
+  });
+
+  test("does not throw when called with a valid conversation id", async () => {
+    const conv = createConversation("inference-profile-no-throw");
+    await expect(
+      setConversationInferenceProfile(conv.id, "balanced"),
+    ).resolves.toBeUndefined();
+    await expect(
+      setConversationInferenceProfile(conv.id, null),
+    ).resolves.toBeUndefined();
+  });
+
+  test("getConversation surfaces the column on every fetch", async () => {
+    const conv = createConversation("inference-profile-getter");
+    const fresh = getConversation(conv.id);
+    expect(fresh).not.toBeNull();
+    expect(fresh).toHaveProperty("inferenceProfile", null);
+
+    await setConversationInferenceProfile(conv.id, "cost-optimized");
+    const updated = getConversation(conv.id);
+    expect(updated).toHaveProperty("inferenceProfile", "cost-optimized");
+  });
+});

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1311,6 +1311,22 @@ export function unarchiveConversation(id: string): boolean {
 }
 
 /**
+ * Set or clear the inference profile override for a conversation.
+ * Pass `null` to clear the override and fall back to the workspace
+ * `llm.activeProfile` resolution.
+ */
+export async function setConversationInferenceProfile(
+  conversationId: string,
+  profile: string | null,
+): Promise<void> {
+  const db = getDb();
+  db.update(conversations)
+    .set({ inferenceProfile: profile, updatedAt: Date.now() })
+    .where(eq(conversations.id, conversationId))
+    .run();
+}
+
+/**
  * Delete all conversations, messages, and related data (tool invocations,
  * memory segments, etc.) from the daemon database.
  * Returns { conversations, messages } counts.


### PR DESCRIPTION
## Summary
- Add `setConversationInferenceProfile(conversationId, profile)` Drizzle update helper (pass null to clear).
- Verify `getConversation` returns the new column on `ConversationRow`.
- Test: round-trip null → name → null on the inferenceProfile column.

Part of plan: inference-profiles.md (PR 7 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
