### PR TITLE
feat(migrations): seed default inference profiles and activeProfile

### DIFF
--- a/assistant/src/__tests__/workspace-migration-052-seed-default-inference-profiles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-052-seed-default-inference-profiles.test.ts
@@ -1,0 +1,260 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { LLMSchema } from "../config/schemas/llm.js";
+import { seedDefaultInferenceProfiles052 } from "../workspace/migrations/052-seed-default-inference-profiles.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-052-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function configPath(): string {
+  return join(workspaceDir, "config.json");
+}
+
+beforeEach(() => {
+  freshWorkspace();
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+});
+
+afterEach(() => {
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+const ANTHROPIC_QUALITY = {
+  provider: "anthropic",
+  model: "claude-opus-4-7",
+  maxTokens: 32000,
+  effort: "max",
+  thinking: { enabled: true, streamThinking: true },
+};
+
+const ANTHROPIC_BALANCED = {
+  provider: "anthropic",
+  model: "claude-sonnet-4-6",
+  maxTokens: 16000,
+  effort: "high",
+  thinking: { enabled: true, streamThinking: true },
+};
+
+const ANTHROPIC_COST = {
+  provider: "anthropic",
+  model: "claude-haiku-4-5-20251001",
+  maxTokens: 8192,
+  effort: "low",
+  thinking: { enabled: false, streamThinking: false },
+};
+
+describe("052-seed-default-inference-profiles migration", () => {
+  test("has correct migration id", () => {
+    expect(seedDefaultInferenceProfiles052.id).toBe(
+      "052-seed-default-inference-profiles",
+    );
+  });
+
+  test("seeds all three profiles + activeProfile=balanced on Anthropic workspace", () => {
+    writeConfig({
+      llm: { default: { provider: "anthropic" } },
+    });
+
+    seedDefaultInferenceProfiles052.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: {
+        profiles: Record<string, Record<string, unknown>>;
+        activeProfile: string;
+      };
+    };
+    expect(config.llm.profiles["quality-optimized"]).toEqual(ANTHROPIC_QUALITY);
+    expect(config.llm.profiles.balanced).toEqual(ANTHROPIC_BALANCED);
+    expect(config.llm.profiles["cost-optimized"]).toEqual(ANTHROPIC_COST);
+    expect(config.llm.activeProfile).toBe("balanced");
+  });
+
+  test("defaults to Anthropic seeding when llm.default.provider is absent", () => {
+    writeConfig({});
+
+    seedDefaultInferenceProfiles052.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: {
+        profiles: Record<string, Record<string, unknown>>;
+        activeProfile: string;
+      };
+    };
+    expect(config.llm.profiles.balanced).toEqual(ANTHROPIC_BALANCED);
+    expect(config.llm.activeProfile).toBe("balanced");
+  });
+
+  test("is idempotent — second run produces identical bytes", () => {
+    writeConfig({
+      llm: { default: { provider: "anthropic" } },
+    });
+
+    seedDefaultInferenceProfiles052.run(workspaceDir);
+    const afterFirst = readFileSync(configPath(), "utf-8");
+    seedDefaultInferenceProfiles052.run(workspaceDir);
+    const afterSecond = readFileSync(configPath(), "utf-8");
+
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  test("preserves an existing user-defined quality-optimized profile", () => {
+    const userProfile = {
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      maxTokens: 8000,
+      effort: "low",
+    };
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        profiles: { "quality-optimized": userProfile },
+      },
+    });
+
+    seedDefaultInferenceProfiles052.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { profiles: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.profiles["quality-optimized"]).toEqual(userProfile);
+    // The other two slots still get seeded with the defaults.
+    expect(config.llm.profiles.balanced).toEqual(ANTHROPIC_BALANCED);
+    expect(config.llm.profiles["cost-optimized"]).toEqual(ANTHROPIC_COST);
+  });
+
+  test("preserves an existing activeProfile on Anthropic workspaces", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        activeProfile: "quality-optimized",
+      },
+    });
+
+    seedDefaultInferenceProfiles052.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { activeProfile: string };
+    };
+    expect(config.llm.activeProfile).toBe("quality-optimized");
+  });
+
+  test("non-Anthropic provider seeds empty shells but no activeProfile", () => {
+    writeConfig({
+      llm: { default: { provider: "openai", model: "gpt-5.4" } },
+    });
+
+    seedDefaultInferenceProfiles052.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: {
+        profiles: Record<string, Record<string, unknown>>;
+        activeProfile?: string;
+      };
+    };
+    expect(config.llm.profiles["quality-optimized"]).toEqual({});
+    expect(config.llm.profiles.balanced).toEqual({});
+    expect(config.llm.profiles["cost-optimized"]).toEqual({});
+    expect(config.llm.activeProfile).toBeUndefined();
+  });
+
+  test("does not touch existing llm.callSites entries", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        callSites: {
+          interactionClassifier: { model: "claude-haiku-4-5-20251001" },
+          mainAgent: { model: "claude-opus-4-7", maxTokens: 32000 },
+        },
+      },
+    });
+
+    seedDefaultInferenceProfiles052.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.interactionClassifier).toEqual({
+      model: "claude-haiku-4-5-20251001",
+    });
+    expect(config.llm.callSites.mainAgent).toEqual({
+      model: "claude-opus-4-7",
+      maxTokens: 32000,
+    });
+  });
+
+  test("skips entirely when VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH is set", () => {
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = "/tmp/overlay.json";
+    writeConfig({ llm: { default: { provider: "anthropic" } } });
+
+    seedDefaultInferenceProfiles052.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { profiles?: Record<string, unknown>; activeProfile?: string };
+    };
+    expect(config.llm.profiles).toBeUndefined();
+    expect(config.llm.activeProfile).toBeUndefined();
+  });
+
+  test("writes fresh starter config when config.json is absent (Anthropic default)", () => {
+    seedDefaultInferenceProfiles052.run(workspaceDir);
+
+    expect(existsSync(configPath())).toBe(true);
+    const config = readConfig() as {
+      llm: {
+        profiles: Record<string, Record<string, unknown>>;
+        activeProfile: string;
+      };
+    };
+    expect(config.llm.profiles.balanced).toEqual(ANTHROPIC_BALANCED);
+    expect(config.llm.activeProfile).toBe("balanced");
+  });
+
+  test("seeded config parses cleanly through LLMSchema", () => {
+    writeConfig({
+      llm: { default: { provider: "anthropic" } },
+    });
+
+    seedDefaultInferenceProfiles052.run(workspaceDir);
+
+    const onDisk = readConfig() as { llm: unknown };
+    const parsed = LLMSchema.parse(onDisk.llm);
+    expect(Object.keys(parsed.profiles ?? {})).toEqual(
+      expect.arrayContaining([
+        "quality-optimized",
+        "balanced",
+        "cost-optimized",
+      ]),
+    );
+    expect(parsed.activeProfile).toBe("balanced");
+  });
+});

--- a/assistant/src/workspace/migrations/052-seed-default-inference-profiles.ts
+++ b/assistant/src/workspace/migrations/052-seed-default-inference-profiles.ts
@@ -1,0 +1,150 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Seed default inference profiles (`quality-optimized`, `balanced`,
+ * `cost-optimized`) and the workspace-level `llm.activeProfile` selector.
+ *
+ * Inference profiles are named LLM-config fragments that the resolver
+ * applies between `llm.default` and per-call-site overrides. PR 1 of the
+ * inference-profiles plan added the `llm.profiles` record and
+ * `llm.activeProfile` to the schema; this migration backfills the three
+ * canonical profiles so existing workspaces have something to point at
+ * out of the box.
+ *
+ * Behavior:
+ *
+ *   - **Anthropic providers** (default for new installs): seed all three
+ *     profiles with full Anthropic model fragments and set
+ *     `llm.activeProfile = "balanced"` when absent.
+ *   - **Non-Anthropic providers**: seed empty `{}` shells for each profile
+ *     name so the named slots exist (giving users somewhere to attach
+ *     their own provider-specific configs), but do **not** set
+ *     `activeProfile` — leaving it unset means the resolver continues to
+ *     use `llm.default` and per-call-site entries unchanged.
+ *
+ * Existing values are never overwritten:
+ *   - A pre-existing profile by any of the three names is left intact.
+ *   - A pre-existing `activeProfile` is preserved on Anthropic workspaces.
+ *   - `llm.callSites` entries are not touched — they continue to win at
+ *     resolver layer 5 over both `activeProfile` and per-site `profile`
+ *     references.
+ *
+ * **Skip when `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` is set.** Like
+ * migration 040, a platform-provided default-config overlay (applied
+ * after migrations) is the authoritative source for both provider and
+ * profile seeds. Skipping here avoids mismatched provider/model pairs.
+ */
+export const seedDefaultInferenceProfiles052: WorkspaceMigration = {
+  id: "052-seed-default-inference-profiles",
+  description:
+    "Seed default inference profiles (quality-optimized, balanced, cost-optimized) and activeProfile",
+  run(workspaceDir: string): void {
+    if (process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH) return;
+
+    const configPath = join(workspaceDir, "config.json");
+
+    let config: Record<string, unknown> = {};
+    if (existsSync(configPath)) {
+      try {
+        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+        config = raw as Record<string, unknown>;
+      } catch {
+        return;
+      }
+    }
+
+    const llm = readObject(config.llm) ?? {};
+    const defaultBlock = readObject(llm.default);
+    const provider = readString(defaultBlock?.provider) ?? "anthropic";
+    const isAnthropic = provider === "anthropic";
+
+    const profiles = readObject(llm.profiles) ?? {};
+
+    let changed = false;
+
+    for (const name of PROFILE_NAMES) {
+      if (readObject(profiles[name]) !== null) continue;
+      profiles[name] = isAnthropic
+        ? cloneFragment(ANTHROPIC_PROFILES[name])
+        : {};
+      changed = true;
+    }
+
+    if (changed) {
+      llm.profiles = profiles;
+    }
+
+    if (isAnthropic && llm.activeProfile === undefined) {
+      llm.activeProfile = "balanced";
+      changed = true;
+    }
+
+    if (!changed) return;
+
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: removing the seeded profiles would break any user
+    // configs that reference them via `activeProfile` or per-call-site
+    // `profile`.
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers — self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const PROFILE_NAMES = [
+  "quality-optimized",
+  "balanced",
+  "cost-optimized",
+] as const;
+
+const ANTHROPIC_PROFILES: Record<
+  (typeof PROFILE_NAMES)[number],
+  Record<string, unknown>
+> = {
+  "quality-optimized": {
+    provider: "anthropic",
+    model: "claude-opus-4-7",
+    maxTokens: 32000,
+    effort: "max",
+    thinking: { enabled: true, streamThinking: true },
+  },
+  balanced: {
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    maxTokens: 16000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+  },
+  "cost-optimized": {
+    provider: "anthropic",
+    model: "claude-haiku-4-5-20251001",
+    maxTokens: 8192,
+    effort: "low",
+    thinking: { enabled: false, streamThinking: false },
+  },
+};
+
+function cloneFragment(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -49,6 +49,7 @@ import { removeWorkspaceHooksMigration } from "./048-remove-workspace-hooks.js";
 import { releaseNotesDefaultSonnetMigration } from "./049-release-notes-default-sonnet.js";
 import { seedMainAgentOpusCallsiteMigration } from "./050-seed-main-agent-opus-callsite.js";
 import { seedConversationSummarizationCallsiteMigration } from "./051-seed-conversation-summarization-callsite.js";
+import { seedDefaultInferenceProfiles052 } from "./052-seed-default-inference-profiles.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -109,4 +110,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   releaseNotesDefaultSonnetMigration,
   seedMainAgentOpusCallsiteMigration,
   seedConversationSummarizationCallsiteMigration,
+  seedDefaultInferenceProfiles052,
 ];


### PR DESCRIPTION
## Summary
- Seed `quality-optimized`, `balanced`, `cost-optimized` profiles in `llm.profiles` for Anthropic providers (empty shells for others).
- Set `llm.activeProfile = balanced` when absent.
- Idempotent; preserves any existing user-defined values; does not touch `llm.callSites`.

Part of plan: inference-profiles.md (PR 3 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
