### PR TITLE
feat(macos): SettingsStore inference-profile state and CRUD

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -71,6 +71,20 @@ public final class SettingsStore: ObservableObject {
     /// authoritative config.
     @Published var callSiteOverrides: [CallSiteOverride] = CallSiteCatalog.all
 
+    // MARK: - Inference Profiles
+
+    /// User-editable inference profiles mirrored from `llm.profiles` in
+    /// the workspace config. Each profile bundles a partial
+    /// `LLMConfigFragment` (provider, model, effort, etc.) that call sites
+    /// reference by name. Sync'd from the daemon's pushed config payload
+    /// via `loadInferenceProfiles(config:)`.
+    @Published var profiles: [InferenceProfile] = []
+
+    /// Name of the active inference profile (`llm.activeProfile` in the
+    /// workspace config). Seeded with the canonical default `"balanced"`
+    /// so the UI renders predictable state before the first config push.
+    @Published var activeProfile: String = "balanced"
+
     static let availableImageGenModels: [String] = [
         "gemini-3.1-flash-image-preview",
         "gemini-3-pro-image-preview",
@@ -3167,6 +3181,128 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
+    // MARK: - Inference Profiles
+
+    /// Reads `llm.profiles` and `llm.activeProfile` from the workspace
+    /// config dictionary and replaces the published `profiles` /
+    /// `activeProfile` state. Profiles are emitted in alphabetical order
+    /// by name so the UI renders a stable list across config refreshes.
+    ///
+    /// `activeProfile` is preserved at its current value when the config
+    /// payload omits the key — the seeded `"balanced"` default keeps the
+    /// dropdown predictable until the daemon ships an authoritative value.
+    func loadInferenceProfiles(config: [String: Any]) {
+        let llm = config["llm"] as? [String: Any]
+        let profilesRaw = (llm?["profiles"] as? [String: Any]) ?? [:]
+        var decoded: [InferenceProfile] = []
+        for (name, raw) in profilesRaw {
+            guard let entry = raw as? [String: Any] else { continue }
+            decoded.append(InferenceProfile(name: name, json: entry))
+        }
+        decoded.sort { $0.name < $1.name }
+        self.profiles = decoded
+        if let active = (llm?["activeProfile"] as? String).flatMap({ $0.isEmpty ? nil : $0 }) {
+            self.activeProfile = active
+        }
+    }
+
+    /// Persists `llm.activeProfile` so the daemon's resolver layers the
+    /// named profile into every callsite resolution. The mock client
+    /// captures the patch payload for assertion in tests.
+    @discardableResult
+    func setActiveProfile(_ name: String) async -> Bool {
+        let success = await settingsClient.patchConfig([
+            "llm": ["activeProfile": name]
+        ])
+        if success {
+            self.activeProfile = name
+        } else {
+            log.error("Failed to patch config for llm.activeProfile")
+        }
+        return success
+    }
+
+    /// Persists a profile fragment under `llm.profiles.<name>`. The
+    /// fragment merges into any existing entry — callers that want
+    /// "replace" semantics should issue a delete first.
+    @discardableResult
+    func setProfile(name: String, fragment: InferenceProfile) async -> Bool {
+        let success = await settingsClient.patchConfig([
+            "llm": ["profiles": [name: fragment.toJSON()]]
+        ])
+        if success {
+            var copy = fragment
+            copy.name = name
+            if let index = profiles.firstIndex(where: { $0.name == name }) {
+                profiles[index] = copy
+            } else {
+                profiles.append(copy)
+                profiles.sort { $0.name < $1.name }
+            }
+        } else {
+            log.error("Failed to patch config for llm.profiles.\(name, privacy: .public)")
+        }
+        return success
+    }
+
+    /// Result of a `deleteProfile` call. References to the profile must
+    /// be cleared before deletion can succeed; the blocked variants name
+    /// the conflicting locations so the caller can guide the user
+    /// through resolving them.
+    enum DeleteProfileResult: Equatable {
+        /// Profile was deleted successfully.
+        case deleted
+
+        /// Deletion blocked because the profile is the current
+        /// `llm.activeProfile`. Associated value is the active profile
+        /// name (matches the requested delete in this case but kept for
+        /// symmetry with the call-sites variant).
+        case blockedByActive(String)
+
+        /// Deletion blocked because one or more call-site overrides
+        /// reference the profile by name. Associated value lists each
+        /// conflicting call-site ID so the UI can render a remediation
+        /// affordance.
+        case blockedByCallSites([String])
+
+        /// Reference checks passed but the daemon PATCH failed — typically
+        /// a transient connectivity issue. The caller should surface a
+        /// retry affordance; the next config sync will reconcile the
+        /// authoritative state.
+        case failed
+    }
+
+    /// Deletes a profile under `llm.profiles.<name>` after verifying no
+    /// references remain. References checked: the global
+    /// `llm.activeProfile` pointer and every per-row entry in
+    /// `callSiteOverrides`. When references exist, returns the
+    /// corresponding `.blockedBy*` variant so the caller can guide the
+    /// user through clearing them. Otherwise issues a PATCH with
+    /// `NSNull()` at the profile key, which the daemon's deep-merge
+    /// treats as deletion.
+    @discardableResult
+    func deleteProfile(name: String) async -> DeleteProfileResult {
+        if activeProfile == name {
+            return .blockedByActive(activeProfile)
+        }
+        let conflictingCallSites = callSiteOverrides
+            .filter { $0.profile == name }
+            .map(\.id)
+        if !conflictingCallSites.isEmpty {
+            return .blockedByCallSites(conflictingCallSites)
+        }
+        let success = await settingsClient.patchConfig([
+            "llm": ["profiles": [name: NSNull()]]
+        ])
+        if success {
+            profiles.removeAll(where: { $0.name == name })
+            return .deleted
+        } else {
+            log.error("Failed to patch config to delete llm.profiles.\(name, privacy: .public)")
+            return .failed
+        }
+    }
+
     /// Persists an override for a single call site at
     /// `llm.callSites.<id>.{provider,model,profile}`. Nil arguments are
     /// omitted from the patch payload — passing `provider: nil` does
@@ -3295,6 +3431,27 @@ public final class SettingsStore: ObservableObject {
             if let model { entry["model"] = model }
             if let profile { entry["profile"] = profile }
             guard !entry.isEmpty else { return true }
+            // When the caller is assigning a profile-only override (no raw
+            // provider/model), explicitly null out the fragment leaves
+            // (`provider`, `model`, `maxTokens`, `effort`, `speed`,
+            // `verbosity`, `temperature`, `thinking`, `contextWindow`) so
+            // any pre-existing fragment fields don't shadow the profile's
+            // resolved values. The daemon's type-aware deep-merge treats
+            // `null` on object/scalar leaves as deletion. Without this,
+            // switching a row from "Custom" (raw fragment) to a profile
+            // would leave stale leaves in `llm.callSites.<id>` that win
+            // over the profile in the resolver.
+            if profile != nil && provider == nil && model == nil {
+                entry["provider"] = NSNull()
+                entry["model"] = NSNull()
+                entry["maxTokens"] = NSNull()
+                entry["effort"] = NSNull()
+                entry["speed"] = NSNull()
+                entry["verbosity"] = NSNull()
+                entry["temperature"] = NSNull()
+                entry["thinking"] = NSNull()
+                entry["contextWindow"] = NSNull()
+            }
             let setSuccess = await settingsClient.patchConfig([
                 "llm": ["callSites": [id: entry]]
             ])
@@ -4161,6 +4318,7 @@ public final class SettingsStore: ObservableObject {
 
         loadServiceModes(config: config)
         loadCallSiteOverrides(config: config)
+        loadInferenceProfiles(config: config)
 
         // Persist enabledSince when it was defaulted so subsequent loads
         // produce a deterministic timestamp.

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -1,0 +1,401 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Verifies the inference-profile state and CRUD APIs on `SettingsStore`:
+/// daemon-push parsing into `profiles` / `activeProfile`, profile create/
+/// update via `setProfile`, active selection via `setActiveProfile`,
+/// reference-aware deletion via `deleteProfile`, and the
+/// `replaceCallSiteOverride` adjustment that clears stale fragment
+/// fields when assigning a profile.
+@MainActor
+final class SettingsStoreInferenceProfilesTests: XCTestCase {
+
+    private var mockSettingsClient: MockSettingsClient!
+    private var store: SettingsStore!
+
+    override func setUp() {
+        super.setUp()
+        mockSettingsClient = MockSettingsClient()
+        mockSettingsClient.patchConfigResponse = true
+        store = SettingsStore(settingsClient: mockSettingsClient)
+    }
+
+    override func tearDown() {
+        store = nil
+        mockSettingsClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Returns the most recent `llm.profiles` patch payload captured by
+    /// the mock client, or `nil` if no such patch has been emitted.
+    private func lastProfilesPatch() -> [String: Any]? {
+        for payload in mockSettingsClient.patchConfigCalls.reversed() {
+            if let llm = payload["llm"] as? [String: Any],
+               let profiles = llm["profiles"] as? [String: Any] {
+                return profiles
+            }
+        }
+        return nil
+    }
+
+    /// Returns the most recent `llm.activeProfile` value captured by the
+    /// mock client, or `nil` if no such patch has been emitted.
+    private func lastActiveProfilePatch() -> String? {
+        for payload in mockSettingsClient.patchConfigCalls.reversed() {
+            if let llm = payload["llm"] as? [String: Any],
+               let active = llm["activeProfile"] as? String {
+                return active
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Initial state
+
+    func testInitialStateSeedsBalancedActiveProfile() {
+        XCTAssertEqual(store.activeProfile, "balanced")
+        XCTAssertTrue(store.profiles.isEmpty)
+    }
+
+    // MARK: - Daemon push parsing
+
+    func testLoadInferenceProfilesPopulatesPublishedState() {
+        let config: [String: Any] = [
+            "llm": [
+                "activeProfile": "quality-optimized",
+                "profiles": [
+                    "balanced": [
+                        "provider": "anthropic",
+                        "model": "claude-sonnet-4-6",
+                        "maxTokens": 16000,
+                        "effort": "high",
+                        "thinking": ["enabled": true, "streamThinking": true],
+                    ],
+                    "quality-optimized": [
+                        "provider": "anthropic",
+                        "model": "claude-opus-4-7",
+                        "maxTokens": 32000,
+                        "effort": "max",
+                        "thinking": ["enabled": true, "streamThinking": true],
+                    ],
+                    "cost-optimized": [
+                        "provider": "anthropic",
+                        "model": "claude-haiku-4-5-20251001",
+                        "maxTokens": 8192,
+                        "effort": "low",
+                        "thinking": ["enabled": false, "streamThinking": false],
+                    ],
+                ],
+            ]
+        ]
+
+        store.loadInferenceProfiles(config: config)
+
+        XCTAssertEqual(store.activeProfile, "quality-optimized")
+        XCTAssertEqual(store.profiles.count, 3)
+
+        // Profiles render in alphabetical order so the UI list is stable
+        // across config refreshes.
+        XCTAssertEqual(store.profiles.map(\.name), ["balanced", "cost-optimized", "quality-optimized"])
+
+        let balanced = store.profiles.first(where: { $0.name == "balanced" })
+        XCTAssertEqual(balanced?.provider, "anthropic")
+        XCTAssertEqual(balanced?.model, "claude-sonnet-4-6")
+        XCTAssertEqual(balanced?.maxTokens, 16000)
+        XCTAssertEqual(balanced?.effort, "high")
+        XCTAssertEqual(balanced?.thinkingEnabled, true)
+        XCTAssertEqual(balanced?.thinkingStreamThinking, true)
+    }
+
+    func testLoadInferenceProfilesEmptyConfigKeepsDefaultActiveProfile() {
+        store.loadInferenceProfiles(config: [:])
+        XCTAssertEqual(store.activeProfile, "balanced", "Empty config must not clobber the seeded default")
+        XCTAssertTrue(store.profiles.isEmpty)
+    }
+
+    func testLoadInferenceProfilesReplacesPriorState() {
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "fast",
+                "profiles": ["fast": ["model": "claude-haiku-4-5"]],
+            ]
+        ])
+        XCTAssertEqual(store.activeProfile, "fast")
+        XCTAssertEqual(store.profiles.map(\.name), ["fast"])
+
+        // Reload against a config with different profiles — old entries
+        // must be evicted, not merged.
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "balanced",
+                "profiles": ["balanced": ["model": "claude-sonnet-4-6"]],
+            ]
+        ])
+        XCTAssertEqual(store.activeProfile, "balanced")
+        XCTAssertEqual(store.profiles.map(\.name), ["balanced"])
+    }
+
+    // MARK: - setActiveProfile
+
+    func testSetActiveProfileRoundTrips() async {
+        let success = await store.setActiveProfile("quality-optimized")
+        XCTAssertTrue(success)
+        XCTAssertEqual(store.activeProfile, "quality-optimized")
+        XCTAssertEqual(lastActiveProfilePatch(), "quality-optimized")
+    }
+
+    func testSetActiveProfileFailureLeavesLocalStateUntouched() async {
+        mockSettingsClient.patchConfigResponse = false
+        let success = await store.setActiveProfile("quality-optimized")
+        XCTAssertFalse(success)
+        XCTAssertEqual(
+            store.activeProfile,
+            "balanced",
+            "Local state must not advance when the daemon PATCH fails"
+        )
+    }
+
+    // MARK: - setProfile
+
+    func testSetProfileRoundTripsAndUpdatesPublishedState() async {
+        let fragment = InferenceProfile(
+            name: "fast",
+            provider: "anthropic",
+            model: "claude-haiku-4-5",
+            maxTokens: 4096,
+            effort: "low",
+            thinkingEnabled: false,
+            thinkingStreamThinking: false
+        )
+        let success = await store.setProfile(name: "fast", fragment: fragment)
+        XCTAssertTrue(success)
+
+        let profiles = lastProfilesPatch()
+        XCTAssertNotNil(profiles)
+        let fast = profiles?["fast"] as? [String: Any]
+        XCTAssertEqual(fast?["provider"] as? String, "anthropic")
+        XCTAssertEqual(fast?["model"] as? String, "claude-haiku-4-5")
+        XCTAssertEqual(fast?["maxTokens"] as? Int, 4096)
+        XCTAssertEqual(fast?["effort"] as? String, "low")
+        let thinking = fast?["thinking"] as? [String: Any]
+        XCTAssertEqual(thinking?["enabled"] as? Bool, false)
+        XCTAssertEqual(thinking?["streamThinking"] as? Bool, false)
+
+        // Local cache reflects the new profile.
+        XCTAssertEqual(store.profiles.map(\.name), ["fast"])
+        let stored = store.profiles.first(where: { $0.name == "fast" })
+        XCTAssertEqual(stored?.model, "claude-haiku-4-5")
+    }
+
+    func testSetProfileUpdatesExistingEntry() async {
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "profiles": [
+                    "balanced": [
+                        "provider": "anthropic",
+                        "model": "claude-sonnet-4-6",
+                    ]
+                ]
+            ]
+        ])
+        XCTAssertEqual(store.profiles.count, 1)
+
+        let updated = InferenceProfile(
+            name: "balanced",
+            provider: "openai",
+            model: "gpt-5"
+        )
+        let success = await store.setProfile(name: "balanced", fragment: updated)
+        XCTAssertTrue(success)
+
+        XCTAssertEqual(store.profiles.count, 1, "Updating an existing profile must not duplicate the entry")
+        let stored = store.profiles.first(where: { $0.name == "balanced" })
+        XCTAssertEqual(stored?.provider, "openai")
+        XCTAssertEqual(stored?.model, "gpt-5")
+    }
+
+    // MARK: - deleteProfile blocked-by-active
+
+    func testDeleteProfileBlockedByActive() async {
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "balanced",
+                "profiles": [
+                    "balanced": ["model": "claude-sonnet-4-6"],
+                    "fast": ["model": "claude-haiku-4-5"],
+                ],
+            ]
+        ])
+        XCTAssertEqual(store.activeProfile, "balanced")
+
+        let result = await store.deleteProfile(name: "balanced")
+        XCTAssertEqual(result, .blockedByActive("balanced"))
+        // Must not emit a PATCH when blocked.
+        XCTAssertNil(lastProfilesPatch())
+        // Profile must still be present locally.
+        XCTAssertTrue(store.profiles.contains(where: { $0.name == "balanced" }))
+    }
+
+    // MARK: - deleteProfile blocked-by-call-sites
+
+    func testDeleteProfileBlockedByCallSites() async {
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "balanced",
+                "profiles": [
+                    "balanced": ["model": "claude-sonnet-4-6"],
+                    "fast": ["model": "claude-haiku-4-5"],
+                ],
+            ]
+        ])
+        store.loadCallSiteOverrides(config: [
+            "llm": [
+                "callSites": [
+                    "memoryRetrieval": ["profile": "fast"],
+                    "mainAgent": ["profile": "fast"],
+                    "watchSummary": ["provider": "openai"],
+                ]
+            ]
+        ])
+
+        let result = await store.deleteProfile(name: "fast")
+        if case .blockedByCallSites(let ids) = result {
+            XCTAssertEqual(Set(ids), ["memoryRetrieval", "mainAgent"])
+        } else {
+            XCTFail("Expected .blockedByCallSites, got \(result)")
+        }
+        XCTAssertNil(lastProfilesPatch())
+        XCTAssertTrue(store.profiles.contains(where: { $0.name == "fast" }))
+    }
+
+    // MARK: - deleteProfile success
+
+    func testDeleteProfileSucceedsWhenUnreferenced() async {
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "balanced",
+                "profiles": [
+                    "balanced": ["model": "claude-sonnet-4-6"],
+                    "experimental": ["model": "experimental-model"],
+                ],
+            ]
+        ])
+
+        let result = await store.deleteProfile(name: "experimental")
+        XCTAssertEqual(result, .deleted)
+
+        let profiles = lastProfilesPatch()
+        XCTAssertNotNil(profiles?["experimental"])
+        XCTAssertTrue(profiles?["experimental"] is NSNull, "Delete must PATCH NSNull at the profile key")
+
+        // Local cache reflects the deletion.
+        XCTAssertFalse(store.profiles.contains(where: { $0.name == "experimental" }))
+        XCTAssertTrue(store.profiles.contains(where: { $0.name == "balanced" }))
+    }
+
+    func testDeleteProfileFailureSurfacedAsFailed() async {
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "balanced",
+                "profiles": [
+                    "balanced": ["model": "claude-sonnet-4-6"],
+                    "experimental": ["model": "x"],
+                ],
+            ]
+        ])
+        mockSettingsClient.patchConfigResponse = false
+
+        let result = await store.deleteProfile(name: "experimental")
+        XCTAssertEqual(result, .failed)
+        // Local cache must remain intact when the daemon PATCH fails.
+        XCTAssertTrue(store.profiles.contains(where: { $0.name == "experimental" }))
+    }
+
+    // MARK: - replaceCallSiteOverride profile-only stale-clear
+
+    /// When `replaceCallSiteOverride` is invoked with `profile` set and
+    /// no raw `provider`/`model`, the second PATCH must explicitly null
+    /// out the fragment leaves so any stale `provider`/`model`/
+    /// `maxTokens`/`effort`/etc. don't shadow the profile in the
+    /// resolver. The first (entry-level) clear PATCH already handles
+    /// the same job, but emitting both shores up the contract under
+    /// flaky network conditions where the clear could be retried out
+    /// of order.
+    func testReplaceCallSiteOverrideClearsFragmentLeavesWhenAssigningProfile() async {
+        _ = store.replaceCallSiteOverride("memoryRetrieval", profile: "fast")
+        // Wait for both the clear and set PATCHes to flush.
+        let predicate = NSPredicate { _, _ in
+            self.mockSettingsClient.patchConfigCalls.count >= 2
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        await fulfillment(of: [expectation], timeout: 2.0)
+
+        // Locate the SET payload — second of the two callSites PATCHes
+        // emitted by replaceCallSiteOverride. The first clears the
+        // entry; the second writes the new fragment.
+        var setPayloadEntry: [String: Any]?
+        var sawClear = false
+        for payload in mockSettingsClient.patchConfigCalls {
+            guard let llm = payload["llm"] as? [String: Any],
+                  let sites = llm["callSites"] as? [String: Any],
+                  let entry = sites["memoryRetrieval"] else { continue }
+            if entry is NSNull {
+                sawClear = true
+                continue
+            }
+            if let dict = entry as? [String: Any] {
+                setPayloadEntry = dict
+            }
+        }
+        XCTAssertTrue(sawClear, "replaceCallSiteOverride must first NSNull-clear the entry")
+        XCTAssertNotNil(setPayloadEntry, "replaceCallSiteOverride must follow the clear with a set PATCH")
+        XCTAssertEqual(setPayloadEntry?["profile"] as? String, "fast")
+        // Fragment leaves must be NSNull-cleared in the same SET PATCH so
+        // any concurrent persisted state is overwritten with deletes.
+        XCTAssertTrue(setPayloadEntry?["provider"] is NSNull)
+        XCTAssertTrue(setPayloadEntry?["model"] is NSNull)
+        XCTAssertTrue(setPayloadEntry?["maxTokens"] is NSNull)
+        XCTAssertTrue(setPayloadEntry?["effort"] is NSNull)
+        XCTAssertTrue(setPayloadEntry?["speed"] is NSNull)
+        XCTAssertTrue(setPayloadEntry?["verbosity"] is NSNull)
+        XCTAssertTrue(setPayloadEntry?["temperature"] is NSNull)
+        XCTAssertTrue(setPayloadEntry?["thinking"] is NSNull)
+        XCTAssertTrue(setPayloadEntry?["contextWindow"] is NSNull)
+    }
+
+    /// Sanity-check that the stale-clear behavior does NOT trigger when
+    /// the caller passes a raw provider/model fragment ("Custom" path):
+    /// the SET payload must contain the raw fields verbatim, no NSNull
+    /// clears.
+    func testReplaceCallSiteOverrideDoesNotInjectNullsForRawFragmentWrite() async {
+        _ = store.replaceCallSiteOverride(
+            "memoryRetrieval",
+            provider: "openai",
+            model: "gpt-4.1"
+        )
+        let predicate = NSPredicate { _, _ in
+            self.mockSettingsClient.patchConfigCalls.count >= 2
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        await fulfillment(of: [expectation], timeout: 2.0)
+
+        var setPayloadEntry: [String: Any]?
+        for payload in mockSettingsClient.patchConfigCalls {
+            guard let llm = payload["llm"] as? [String: Any],
+                  let sites = llm["callSites"] as? [String: Any],
+                  let entry = sites["memoryRetrieval"] as? [String: Any] else { continue }
+            setPayloadEntry = entry
+        }
+        XCTAssertNotNil(setPayloadEntry)
+        XCTAssertEqual(setPayloadEntry?["provider"] as? String, "openai")
+        XCTAssertEqual(setPayloadEntry?["model"] as? String, "gpt-4.1")
+        XCTAssertNil(setPayloadEntry?["profile"])
+        // No NSNull-clear should leak into the raw-fragment path.
+        XCTAssertNil(setPayloadEntry?["maxTokens"])
+        XCTAssertNil(setPayloadEntry?["effort"])
+        XCTAssertNil(setPayloadEntry?["thinking"])
+    }
+}


### PR DESCRIPTION
## Summary
- Add @Published profiles/activeProfile synced from daemon config push.
- Add setActiveProfile, setProfile, deleteProfile (blocked-by-references).
- Update replaceCallSiteOverride to clear stale fragment fields when assigning a profile.

Part of plan: inference-profiles.md (PR 11 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
