### PR TITLE
feat(providers): thread overrideProfile through send-message options

### DIFF
--- a/assistant/src/__tests__/provider-send-message-override-profile.test.ts
+++ b/assistant/src/__tests__/provider-send-message-override-profile.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Verifies that `config.overrideProfile` on `SendMessageOptions` plumbs an
+ * ad-hoc profile through both the `RetryProvider` normalization step (which
+ * resolves model/maxTokens/effort/etc.) and the `CallSiteRoutingProvider`
+ * provider-selection step.
+ *
+ * The end-to-end contract: a caller setting
+ * `config.overrideProfile = "fast"` on a single send must see the request
+ * land on the profile's provider with the profile's model — without
+ * modifying the workspace's `activeProfile` or any call-site entry. This
+ * makes per-conversation pinned profiles (PR 6+) work.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+// Mutable LLM config consumed by the resolver via `getConfig()`.
+let mockLlmConfig: Record<string, unknown> = {};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ llm: mockLlmConfig }),
+}));
+
+import { LLMSchema } from "../config/schemas/llm.js";
+import { CallSiteRoutingProvider } from "../providers/call-site-routing.js";
+import { RetryProvider } from "../providers/retry.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+} from "../providers/types.js";
+
+const DUMMY_MESSAGES: Message[] = [
+  { role: "user", content: [{ type: "text", text: "hi" }] },
+];
+
+function makeResponse(model: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text: "ok" }],
+    model,
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "end_turn",
+  };
+}
+
+function setLlmConfig(raw: unknown): void {
+  mockLlmConfig = LLMSchema.parse(raw) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  mockLlmConfig = LLMSchema.parse({}) as Record<string, unknown>;
+});
+
+describe("SendMessageOptions.config.overrideProfile", () => {
+  test("RetryProvider resolves model from named profile when overrideProfile is set", async () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      profiles: {
+        fast: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+      },
+    });
+
+    let captured: Record<string, unknown> | undefined;
+    const inner: Provider = {
+      name: "anthropic",
+      async sendMessage(
+        _messages: Message[],
+        _tools?: ToolDefinition[],
+        _systemPrompt?: string,
+        options?: SendMessageOptions,
+      ): Promise<ProviderResponse> {
+        captured = options?.config as Record<string, unknown> | undefined;
+        return makeResponse("anthropic");
+      },
+    };
+
+    const provider = new RetryProvider(inner);
+    await provider.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "mainAgent", overrideProfile: "fast" },
+    });
+
+    // The override profile's model should win over `llm.default.model`.
+    expect(captured?.model).toBe("claude-haiku-4-5-20251001");
+    // `overrideProfile` is a routing key — it must not leak to the provider.
+    expect(captured?.overrideProfile).toBeUndefined();
+    // `callSite` is also stripped post-resolve.
+    expect(captured?.callSite).toBeUndefined();
+  });
+
+  test("CallSiteRoutingProvider switches transport when overrideProfile changes the provider", async () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      profiles: {
+        fast: { provider: "openai", model: "gpt-5.4" },
+      },
+    });
+
+    const calls = { default: 0, alt: 0 };
+    const defaultProvider: Provider = {
+      name: "anthropic",
+      async sendMessage() {
+        calls.default++;
+        return makeResponse("anthropic");
+      },
+    };
+    const altProvider: Provider = {
+      name: "openai",
+      async sendMessage() {
+        calls.alt++;
+        return makeResponse("openai");
+      },
+    };
+
+    const wrapped = new CallSiteRoutingProvider(defaultProvider, (name) =>
+      name === "openai" ? altProvider : undefined,
+    );
+
+    const response = await wrapped.sendMessage(
+      DUMMY_MESSAGES,
+      undefined,
+      undefined,
+      { config: { callSite: "mainAgent", overrideProfile: "fast" } },
+    );
+
+    expect(calls.default).toBe(0);
+    expect(calls.alt).toBe(1);
+    expect(response.model).toBe("openai");
+  });
+
+  test("missing overrideProfile name silently falls through to base resolution", async () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      profiles: {
+        fast: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+      },
+    });
+
+    let captured: Record<string, unknown> | undefined;
+    const inner: Provider = {
+      name: "anthropic",
+      async sendMessage(
+        _messages: Message[],
+        _tools?: ToolDefinition[],
+        _systemPrompt?: string,
+        options?: SendMessageOptions,
+      ): Promise<ProviderResponse> {
+        captured = options?.config as Record<string, unknown> | undefined;
+        return makeResponse("anthropic");
+      },
+    };
+
+    const provider = new RetryProvider(inner);
+    await provider.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "mainAgent", overrideProfile: "does-not-exist" },
+    });
+
+    // Falls through to `llm.default.model` since the named profile isn't found.
+    expect(captured?.model).toBe("claude-opus-4-7");
+  });
+
+  test("absent overrideProfile leaves prior resolution behavior intact", async () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      profiles: {
+        fast: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+      },
+    });
+
+    let captured: Record<string, unknown> | undefined;
+    const inner: Provider = {
+      name: "anthropic",
+      async sendMessage(
+        _messages: Message[],
+        _tools?: ToolDefinition[],
+        _systemPrompt?: string,
+        options?: SendMessageOptions,
+      ): Promise<ProviderResponse> {
+        captured = options?.config as Record<string, unknown> | undefined;
+        return makeResponse("anthropic");
+      },
+    };
+
+    const provider = new RetryProvider(inner);
+    await provider.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(captured?.model).toBe("claude-opus-4-7");
+  });
+
+  test("overrideProfile is stripped even when callSite is absent", async () => {
+    let captured: Record<string, unknown> | undefined;
+    const inner: Provider = {
+      name: "anthropic",
+      async sendMessage(
+        _messages: Message[],
+        _tools?: ToolDefinition[],
+        _systemPrompt?: string,
+        options?: SendMessageOptions,
+      ): Promise<ProviderResponse> {
+        captured = options?.config as Record<string, unknown> | undefined;
+        return makeResponse("anthropic");
+      },
+    };
+
+    const provider = new RetryProvider(inner);
+    await provider.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { overrideProfile: "fast" },
+    });
+
+    // `overrideProfile` must never leak as a wire-format field, even when no
+    // callSite is set (the resolver never runs, but the leak guard still
+    // applies).
+    expect(captured?.overrideProfile).toBeUndefined();
+  });
+});

--- a/assistant/src/providers/call-site-routing.ts
+++ b/assistant/src/providers/call-site-routing.ts
@@ -53,14 +53,18 @@ export class CallSiteRoutingProvider implements Provider {
 
   /**
    * Pick the provider to route this call through. The default provider wins
-   * unless the per-call `callSite` resolves to a different provider name and
-   * the registry can produce a Provider for it.
+   * unless the per-call `callSite` (layered with any `overrideProfile`)
+   * resolves to a different provider name and the registry can produce a
+   * Provider for it.
    */
   private selectProvider(options?: SendMessageOptions): Provider {
     const callSite = options?.config?.callSite;
     if (!callSite) return this.defaultProvider;
 
-    const resolved = resolveCallSiteConfig(callSite, getConfig().llm);
+    const overrideProfile = options?.config?.overrideProfile;
+    const resolved = resolveCallSiteConfig(callSite, getConfig().llm, {
+      overrideProfile,
+    });
     if (resolved.provider === this.defaultProvider.name) {
       return this.defaultProvider;
     }

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -7,11 +7,7 @@
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
-import {
-  getProvider,
-  initializeProviders,
-  listProviders,
-} from "./registry.js";
+import { getProvider, initializeProviders, listProviders } from "./registry.js";
 import type {
   ContentBlock,
   Message,
@@ -43,15 +39,19 @@ let lazyInitPromise: Promise<void> | null = null;
  * performs a one-shot `initializeProviders(getConfig())`.
  *
  * The provider name is sourced from
- * `resolveCallSiteConfig(callSite, config.llm).provider` — i.e. the unified
- * `llm` block drives selection. The `callSite` argument is required so the
- * resolver can layer per-call-site overrides; pass the closest matching
- * call-site identifier from `LLMCallSiteEnum` when adding a new caller.
+ * `resolveCallSiteConfig(callSite, config.llm, opts).provider` — i.e. the
+ * unified `llm` block drives selection. The `callSite` argument is required
+ * so the resolver can layer per-call-site overrides; pass the closest
+ * matching call-site identifier from `LLMCallSiteEnum` when adding a new
+ * caller. Pass `opts.overrideProfile` to apply a per-call ad-hoc profile
+ * override (e.g. a per-conversation pinned profile) on top of any workspace
+ * `activeProfile`.
  *
  * Returns `null` when no providers are available at all.
  */
 export async function resolveConfiguredProvider(
   callSite: LLMCallSite,
+  opts: { overrideProfile?: string } = {},
 ): Promise<ConfiguredProviderResult | null> {
   const config = getConfig();
 
@@ -68,7 +68,11 @@ export async function resolveConfiguredProvider(
     }
   }
 
-  const inferenceProvider = resolveCallSiteConfig(callSite, config.llm).provider;
+  const inferenceProvider = resolveCallSiteConfig(
+    callSite,
+    config.llm,
+    opts,
+  ).provider;
 
   try {
     const provider = getProvider(inferenceProvider);
@@ -91,8 +95,9 @@ export async function resolveConfiguredProvider(
  */
 export async function getConfiguredProvider(
   callSite: LLMCallSite,
+  opts: { overrideProfile?: string } = {},
 ): Promise<Provider | null> {
-  const result = await resolveConfiguredProvider(callSite);
+  const result = await resolveConfiguredProvider(callSite, opts);
   return result?.provider ?? null;
 }
 

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -120,16 +120,24 @@ function normalizeSendMessageOptions(
 
   const nextConfig: Record<string, unknown> = { ...config };
 
+  // `overrideProfile` is a routing/resolution-time concern (consumed by the
+  // resolver below and `CallSiteRoutingProvider`'s provider selection); it is
+  // not a wire-format field. Strip unconditionally so it never leaks into
+  // provider request bodies even when callers set it without a `callSite`.
+  delete nextConfig.overrideProfile;
+
   if (config.callSite !== undefined) {
-    const resolved = resolveCallSiteConfig(config.callSite, getConfig().llm);
+    const resolved = resolveCallSiteConfig(config.callSite, getConfig().llm, {
+      overrideProfile: config.overrideProfile,
+    });
 
     const explicitModel =
       typeof config.model === "string" && config.model.trim().length > 0
         ? config.model.trim()
         : undefined;
 
-    // Routing key is consumed by the RetryProvider layer and must not leak
-    // downstream.
+    // Routing key is consumed by the resolver above and must not leak
+    // downstream as a wire-format field.
     delete nextConfig.callSite;
 
     // Apply resolved values, letting per-call explicit fields win where set.

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -142,6 +142,15 @@ export interface SendMessageConfig {
    * `llm.default` when no callSite-specific entry is present.
    */
   callSite?: LLMCallSite;
+  /**
+   * Optional ad-hoc profile override applied per request. When set, the
+   * resolver layers `llm.profiles[overrideProfile]` between the workspace's
+   * `activeProfile` and the call-site's named profile (see
+   * `resolveCallSiteConfig`). Used by per-conversation pinned profiles to
+   * override the workspace default for a single send. Missing profile names
+   * silently fall through.
+   */
+  overrideProfile?: string;
   effort?: "none" | "low" | "medium" | "high" | "xhigh" | "max";
   speed?: "standard" | "fast";
   [key: string]: unknown;


### PR DESCRIPTION
## Summary
- Add `overrideProfile?: string` to SendMessageOptions.config and propagate through the resolver, call-site routing, and retry layers.
- New test verifies a send-message call with `config.overrideProfile = "fast"` resolves to the named profile's model.

Part of plan: inference-profiles.md (PR 5 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
