### PR TITLE
feat(routes): PUT /v1/conversations/:id/inference-profile

### DIFF
--- a/assistant/src/__tests__/conversation-inference-profile-route.test.ts
+++ b/assistant/src/__tests__/conversation-inference-profile-route.test.ts
@@ -1,0 +1,254 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const config = {
+  llm: {
+    profiles: {
+      "quality-optimized": {},
+      balanced: {},
+      "cost-optimized": {},
+    },
+  },
+};
+
+mock.module("../config/loader.js", () => ({
+  loadConfig: () => config,
+  getConfig: () => config,
+}));
+
+import {
+  createConversation,
+  getConversation,
+} from "../memory/conversation-crud.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { conversationManagementRouteDefinitions } from "../runtime/routes/conversation-management-routes.js";
+
+initializeDb();
+
+const routes = conversationManagementRouteDefinitions({
+  switchConversation: async (conversationId) => ({
+    conversationId,
+    title: "Switched",
+    conversationType: "standard",
+    hostAccess: false,
+  }),
+  renameConversation: () => true,
+  clearAllConversations: () => 0,
+  cancelGeneration: () => true,
+  destroyConversation: () => {},
+  undoLastMessage: async () => null,
+  regenerateResponse: async () => null,
+});
+
+function findRoute(method: string, endpoint: string) {
+  const route = routes.find(
+    (routeDef) => routeDef.method === method && routeDef.endpoint === endpoint,
+  );
+  if (!route) {
+    throw new Error(`Route not found: ${method} ${endpoint}`);
+  }
+  return route;
+}
+
+function clearTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM conversation_assistant_attention_state");
+  db.run("DELETE FROM external_conversation_bindings");
+  db.run("DELETE FROM conversation_keys");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+describe("PUT /v1/conversations/:id/inference-profile", () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  afterAll(() => {
+    resetDb();
+    mock.restore();
+  });
+
+  test("sets the override and emits a hub event for a known profile", async () => {
+    const conversation = createConversation("inference-profile-route");
+
+    const received: Array<{
+      assistantId: string;
+      type: string;
+      conversationId?: string;
+      profile?: string | null;
+    }> = [];
+    const subscription = assistantEventHub.subscribe(
+      { assistantId: DAEMON_INTERNAL_ASSISTANT_ID },
+      (event) => {
+        received.push({
+          assistantId: event.assistantId,
+          type: event.message.type,
+          conversationId: event.conversationId,
+          profile:
+            event.message.type === "conversation_inference_profile_updated"
+              ? event.message.profile
+              : undefined,
+        });
+      },
+    );
+
+    const route = findRoute("PUT", "conversations/:id/inference-profile");
+    const response = await route.handler({
+      req: new Request(
+        `http://localhost/v1/conversations/${conversation.id}/inference-profile`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ profile: "quality-optimized" }),
+        },
+      ),
+      url: new URL(
+        `http://localhost/v1/conversations/${conversation.id}/inference-profile`,
+      ),
+      server: null as never,
+      authContext: {} as never,
+      params: { id: conversation.id },
+    });
+
+    await Promise.resolve();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      conversationId: conversation.id,
+      profile: "quality-optimized",
+    });
+    expect(getConversation(conversation.id)?.inferenceProfile).toBe(
+      "quality-optimized",
+    );
+    expect(received).toEqual([
+      {
+        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+        type: "conversation_inference_profile_updated",
+        conversationId: conversation.id,
+        profile: "quality-optimized",
+      },
+    ]);
+
+    subscription.dispose();
+  });
+
+  test("rejects unknown profile names with 400", async () => {
+    const conversation = createConversation("inference-profile-unknown");
+
+    const route = findRoute("PUT", "conversations/:id/inference-profile");
+    const response = await route.handler({
+      req: new Request(
+        `http://localhost/v1/conversations/${conversation.id}/inference-profile`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ profile: "does-not-exist" }),
+        },
+      ),
+      url: new URL(
+        `http://localhost/v1/conversations/${conversation.id}/inference-profile`,
+      ),
+      server: null as never,
+      authContext: {} as never,
+      params: { id: conversation.id },
+    });
+
+    expect(response.status).toBe(400);
+    expect(getConversation(conversation.id)?.inferenceProfile).toBeNull();
+  });
+
+  test("clears the override when profile is null", async () => {
+    const conversation = createConversation("inference-profile-clear");
+
+    // Seed an override first via the route.
+    const setRoute = findRoute("PUT", "conversations/:id/inference-profile");
+    const setResponse = await setRoute.handler({
+      req: new Request(
+        `http://localhost/v1/conversations/${conversation.id}/inference-profile`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ profile: "balanced" }),
+        },
+      ),
+      url: new URL(
+        `http://localhost/v1/conversations/${conversation.id}/inference-profile`,
+      ),
+      server: null as never,
+      authContext: {} as never,
+      params: { id: conversation.id },
+    });
+    expect(setResponse.status).toBe(200);
+    expect(getConversation(conversation.id)?.inferenceProfile).toBe("balanced");
+
+    const received: Array<{ profile?: string | null }> = [];
+    const subscription = assistantEventHub.subscribe(
+      { assistantId: DAEMON_INTERNAL_ASSISTANT_ID },
+      (event) => {
+        if (event.message.type === "conversation_inference_profile_updated") {
+          received.push({ profile: event.message.profile });
+        }
+      },
+    );
+
+    const clearResponse = await setRoute.handler({
+      req: new Request(
+        `http://localhost/v1/conversations/${conversation.id}/inference-profile`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ profile: null }),
+        },
+      ),
+      url: new URL(
+        `http://localhost/v1/conversations/${conversation.id}/inference-profile`,
+      ),
+      server: null as never,
+      authContext: {} as never,
+      params: { id: conversation.id },
+    });
+
+    await Promise.resolve();
+
+    expect(clearResponse.status).toBe(200);
+    expect(await clearResponse.json()).toEqual({
+      conversationId: conversation.id,
+      profile: null,
+    });
+    expect(getConversation(conversation.id)?.inferenceProfile).toBeNull();
+    expect(received).toEqual([{ profile: null }]);
+
+    subscription.dispose();
+  });
+
+  test("returns 404 when the conversation does not exist", async () => {
+    const route = findRoute("PUT", "conversations/:id/inference-profile");
+    const response = await route.handler({
+      req: new Request(
+        "http://localhost/v1/conversations/missing/inference-profile",
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ profile: "balanced" }),
+        },
+      ),
+      url: new URL(
+        "http://localhost/v1/conversations/missing/inference-profile",
+      ),
+      server: null as never,
+      authContext: {} as never,
+      params: { id: "missing" },
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -351,6 +351,18 @@ export interface ConversationHostAccessUpdated {
   hostAccess: boolean;
 }
 
+/**
+ * Broadcast to clients when a conversation's inference-profile override
+ * changes. `profile` is the profile name (a key in `llm.profiles`) or
+ * `null` when the override is cleared and the conversation falls back to
+ * the workspace `llm.activeProfile` resolution.
+ */
+export interface ConversationInferenceProfileUpdated {
+  type: "conversation_inference_profile_updated";
+  conversationId: string;
+  profile: string | null;
+}
+
 export type TraceEventKind =
   | "request_received"
   | "request_queued"
@@ -413,4 +425,5 @@ export type _MessagesServerMessages =
   | TraceEvent
   | ConfirmationStateChanged
   | AssistantActivityState
-  | ConversationHostAccessUpdated;
+  | ConversationHostAccessUpdated
+  | ConversationInferenceProfileUpdated;

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -135,6 +135,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "conversations/name", scopes: ["chat.write"] },
   { endpoint: "conversations/host-access:GET", scopes: ["chat.read"] },
   { endpoint: "conversations/host-access", scopes: ["approval.write"] },
+  { endpoint: "conversations/inference-profile", scopes: ["chat.write"] },
   { endpoint: "conversations/cancel", scopes: ["chat.write"] },
   { endpoint: "conversations/undo", scopes: ["chat.write"] },
   { endpoint: "conversations/regenerate", scopes: ["chat.write"] },

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -6,6 +6,7 @@
  * POST   /v1/conversations/fork           — fork an existing conversation
  * GET    /v1/conversations/:id/host-access — read host access for one conversation
  * PATCH  /v1/conversations/:id/host-access — update host access for one conversation
+ * PUT    /v1/conversations/:id/inference-profile — set per-conversation inference profile
  * PATCH  /v1/conversations/:id/name       — rename a conversation
  * DELETE /v1/conversations                 — clear all conversations
  * POST   /v1/conversations/:id/wipe       — wipe conversation and revert memory
@@ -20,6 +21,7 @@
 
 import { z } from "zod";
 
+import { loadConfig } from "../../config/loader.js";
 import {
   archiveConversation,
   batchSetDisplayOrders,
@@ -28,6 +30,7 @@ import {
   getConversation,
   getConversationHostAccess,
   PRIVATE_CONVERSATION_FORK_ERROR,
+  setConversationInferenceProfile,
   unarchiveConversation,
   updateConversationHostAccess,
   wipeConversation,
@@ -359,6 +362,87 @@ export function conversationManagementRouteDefinitions(
           conversationId: resolvedId,
           hostAccess: nextHostAccess,
         });
+      },
+    },
+    {
+      endpoint: "conversations/:id/inference-profile",
+      method: "PUT",
+      policyKey: "conversations/inference-profile",
+      summary: "Set conversation inference profile",
+      description:
+        "Override the LLM inference profile for a single conversation. Pass `null` to clear the override and fall back to the workspace `llm.activeProfile`.",
+      tags: ["conversations"],
+      requestBody: z.object({
+        profile: z.string().nullable(),
+      }),
+      responseBody: z.object({
+        conversationId: z.string(),
+        profile: z.string().nullable(),
+      }),
+      handler: async ({ req, params }) => {
+        const resolvedId = resolveConversationId(params.id) ?? params.id;
+        const conversation = getConversation(resolvedId);
+        if (!conversation) {
+          return httpError(
+            "NOT_FOUND",
+            `Conversation ${params.id} not found`,
+            404,
+          );
+        }
+
+        let body: { profile?: unknown };
+        try {
+          body = (await req.json()) as { profile?: unknown };
+        } catch {
+          return httpError("BAD_REQUEST", "Invalid request body", 400);
+        }
+        if (body == null || typeof body !== "object" || Array.isArray(body)) {
+          return httpError("BAD_REQUEST", "Invalid request body", 400);
+        }
+        if (
+          body.profile !== null &&
+          (typeof body.profile !== "string" || body.profile.length === 0)
+        ) {
+          return httpError(
+            "BAD_REQUEST",
+            "profile must be a non-empty string or null",
+            400,
+          );
+        }
+
+        const profile = body.profile as string | null;
+        if (profile !== null) {
+          const profiles = loadConfig().llm?.profiles ?? {};
+          if (!Object.prototype.hasOwnProperty.call(profiles, profile)) {
+            return httpError(
+              "BAD_REQUEST",
+              `Profile "${profile}" is not defined in llm.profiles`,
+              400,
+            );
+          }
+        }
+
+        await setConversationInferenceProfile(resolvedId, profile);
+        assistantEventHub
+          .publish(
+            buildAssistantEvent(
+              DAEMON_INTERNAL_ASSISTANT_ID,
+              {
+                type: "conversation_inference_profile_updated",
+                conversationId: resolvedId,
+                profile,
+              },
+              resolvedId,
+            ),
+          )
+          .catch((err) => {
+            log.warn(
+              { err, conversationId: resolvedId },
+              "Failed to publish conversation_inference_profile_updated event",
+            );
+          });
+
+        return Response.json({ conversationId: resolvedId, profile });
       },
     },
     {


### PR DESCRIPTION
## Summary
- Add `PUT /v1/conversations/:id/inference-profile` accepting `{ profile: string | null }`.
- Validates against `llm.profiles` keys; emits `conversation_inference_profile_updated` event on success.

Part of plan: inference-profiles.md (PR 8 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
