### PR TITLE
feat(attachments): trusted-source bypass for guardian channel uploads

### DIFF
--- a/assistant/src/__tests__/attachment-upload-trusted-source.test.ts
+++ b/assistant/src/__tests__/attachment-upload-trusted-source.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests the trustedSource flag plumbing through handleUploadAttachment.
+ * The flag is forwarded by the gateway when a channel actor resolves to
+ * a guardian binding; the assistant only honors it when the request is
+ * authenticated as a gateway service token.
+ */
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  loadConfig: () => ({}),
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  getAssistantDomain: () => "vellum.me",
+}));
+
+import { initializeDb } from "../memory/db.js";
+import type { AuthContext } from "../runtime/auth/types.js";
+import { handleUploadAttachment } from "../runtime/routes/attachment-routes.js";
+
+const SMALL_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+function makeJsonRequest(body: unknown): Request {
+  return new Request("http://localhost/v1/attachments", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeServiceAuthContext(): AuthContext {
+  return {
+    subject: "svc:gateway:self",
+    principalType: "svc_gateway",
+    assistantId: "self",
+    actorPrincipalId: undefined,
+    scopeProfile: "gateway_service_v1",
+    scopes: new Set(),
+    policyEpoch: 0,
+  } as AuthContext;
+}
+
+function makeActorAuthContext(): AuthContext {
+  return {
+    subject: "actor:self:principal-abc",
+    principalType: "actor",
+    assistantId: "self",
+    actorPrincipalId: "principal-abc",
+    scopeProfile: "actor_client_v1",
+    scopes: new Set(),
+    policyEpoch: 0,
+  } as AuthContext;
+}
+
+describe("handleUploadAttachment — trustedSource flag", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    // Each test uploads a fresh attachment with unique filename; no per-test
+    // cleanup needed since the staging directory is recreated lazily.
+  });
+
+  test("svc_gateway + trustedSource:true accepts a non-allowlisted MIME type", async () => {
+    const res = await handleUploadAttachment(
+      makeJsonRequest({
+        filename: "clip.mkv",
+        mimeType: "video/x-matroska",
+        data: SMALL_PNG_BASE64, // bytes don't have to match the claimed MIME for this path
+        trustedSource: true,
+      }),
+      makeServiceAuthContext(),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string; mime_type: string };
+    expect(body.id).toBeDefined();
+    expect(body.mime_type).toBe("video/x-matroska");
+  });
+
+  test("svc_gateway + trustedSource:true accepts a dangerous extension", async () => {
+    const res = await handleUploadAttachment(
+      makeJsonRequest({
+        filename: "installer.dmg",
+        mimeType: "application/octet-stream",
+        data: SMALL_PNG_BASE64,
+        trustedSource: true,
+      }),
+      makeServiceAuthContext(),
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  test("actor caller with trustedSource:true is still rejected (gating works)", async () => {
+    const res = await handleUploadAttachment(
+      makeJsonRequest({
+        filename: "clip.mkv",
+        mimeType: "video/x-matroska",
+        data: SMALL_PNG_BASE64,
+        trustedSource: true,
+      }),
+      makeActorAuthContext(),
+    );
+
+    expect(res.status).toBe(415);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("Unsupported MIME type");
+  });
+
+  test("svc_gateway without trustedSource keeps existing rejection", async () => {
+    const res = await handleUploadAttachment(
+      makeJsonRequest({
+        filename: "payload.exe",
+        mimeType: "application/octet-stream",
+        data: SMALL_PNG_BASE64,
+      }),
+      makeServiceAuthContext(),
+    );
+
+    expect(res.status).toBe(415);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("Dangerous file type");
+  });
+});

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -649,4 +649,47 @@ describe("validateAttachmentUpload", () => {
       expect(result.ok).toBe(false);
     }
   });
+
+  test("trustedSource bypasses MIME allowlist", () => {
+    // video/x-matroska is not on the allowlist
+    expect(validateAttachmentUpload("clip.mkv", "video/x-matroska").ok).toBe(
+      false,
+    );
+    expect(
+      validateAttachmentUpload("clip.mkv", "video/x-matroska", {
+        trustedSource: true,
+      }).ok,
+    ).toBe(true);
+  });
+
+  test("trustedSource bypasses dangerous-extensions blocklist", () => {
+    expect(
+      validateAttachmentUpload("installer.dmg", "application/octet-stream", {
+        trustedSource: true,
+      }).ok,
+    ).toBe(true);
+    expect(
+      validateAttachmentUpload("payload.exe", "application/octet-stream", {
+        trustedSource: true,
+      }).ok,
+    ).toBe(true);
+    expect(
+      validateAttachmentUpload("build.sh", "text/plain", {
+        trustedSource: true,
+      }).ok,
+    ).toBe(true);
+  });
+
+  test("trustedSource: false keeps strict validation", () => {
+    expect(
+      validateAttachmentUpload("clip.mkv", "video/x-matroska", {
+        trustedSource: false,
+      }).ok,
+    ).toBe(false);
+    expect(
+      validateAttachmentUpload("payload.exe", "application/octet-stream", {
+        trustedSource: false,
+      }).ok,
+    ).toBe(false);
+  });
 });

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -460,14 +460,26 @@ export type AttachmentValidationResult =
  *
  * Rejects files whose extension is in the dangerous blocklist or whose
  * MIME type is not on the allowlist.
+ *
+ * When `opts.trustedSource` is true, both the dangerous-extensions
+ * blocklist and the MIME allowlist are bypassed. This is intended for
+ * gateway-mediated channel ingress where the actor has already been
+ * resolved to a guardian binding — the threat model behind those filters
+ * (untrusted senders staging executables) does not apply when the
+ * guardian themselves is the sender. Filename normalization still runs.
  */
 export function validateAttachmentUpload(
   filename: string,
   mimeType: string,
+  opts?: { trustedSource?: boolean },
 ): AttachmentValidationResult {
   // Normalize filename: trim whitespace and strip trailing dots to prevent
   // bypasses like "payload.exe " or "payload.exe."
   const normalizedFilename = filename.trim().replace(/\.+$/, "");
+
+  if (opts?.trustedSource) {
+    return { ok: true };
+  }
 
   const dot = normalizedFilename.lastIndexOf(".");
   if (dot !== -1) {

--- a/assistant/src/runtime/auth/context.ts
+++ b/assistant/src/runtime/auth/context.ts
@@ -61,3 +61,12 @@ export function buildAuthContext(claims: TokenClaims): BuildAuthContextResult {
 
   return { ok: true, context };
 }
+
+/**
+ * True when the request was authenticated as the gateway service.
+ * Used at endpoints that gate platform-only or trust-mediated behavior
+ * on the caller being the gateway rather than an end-user actor.
+ */
+export function isServiceGatewayPrincipal(authContext: AuthContext): boolean {
+  return authContext.principalType === "svc_gateway";
+}

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -19,6 +19,8 @@ import {
   validateAttachmentUpload,
 } from "../../memory/attachments-store.js";
 import { getWorkspaceDir } from "../../util/platform.js";
+import { isServiceGatewayPrincipal } from "../auth/context.js";
+import type { AuthContext } from "../auth/types.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
@@ -122,8 +124,14 @@ function attachmentResponse(
 /**
  * Handle multipart/form-data upload.
  * Expects: "file" (Blob), "filename" (string), "mimeType" (string).
+ *
+ * `gatewayTrustedSource` is true only when the caller is the gateway
+ * service AND requested the bypass — see `handleUploadAttachment`.
  */
-async function handleMultipartUpload(req: Request): Promise<Response> {
+async function handleMultipartUpload(
+  req: Request,
+  gatewayTrustedSource: boolean,
+): Promise<Response> {
   // Pre-check Content-Length before parsing to reject oversized requests
   // without buffering the full multipart body into memory. Binary uploads
   // have no base64 overhead, so use the raw file size limit directly.
@@ -172,7 +180,12 @@ async function handleMultipartUpload(req: Request): Promise<Response> {
     );
   }
 
-  const validation = validateAttachmentUpload(filename, mimeType);
+  const trustedSource =
+    gatewayTrustedSource && formData.get("trustedSource") === "true";
+
+  const validation = validateAttachmentUpload(filename, mimeType, {
+    trustedSource,
+  });
   if (!validation.ok) {
     return httpError("UNPROCESSABLE_ENTITY", validation.error, 415);
   }
@@ -190,8 +203,13 @@ async function handleMultipartUpload(req: Request): Promise<Response> {
 /**
  * Handle application/octet-stream upload.
  * filename and mimeType come from URL query params.
+ *
+ * See `handleMultipartUpload` for `gatewayTrustedSource` semantics.
  */
-async function handleOctetStreamUpload(req: Request): Promise<Response> {
+async function handleOctetStreamUpload(
+  req: Request,
+  gatewayTrustedSource: boolean,
+): Promise<Response> {
   // Pre-check Content-Length before buffering to reject oversized requests
   // without reading the full body into memory.
   const contentLength = req.headers.get("content-length");
@@ -232,7 +250,12 @@ async function handleOctetStreamUpload(req: Request): Promise<Response> {
     );
   }
 
-  const validation = validateAttachmentUpload(filename, mimeType);
+  const trustedSource =
+    gatewayTrustedSource && url.searchParams.get("trustedSource") === "true";
+
+  const validation = validateAttachmentUpload(filename, mimeType, {
+    trustedSource,
+  });
   if (!validation.ok) {
     return httpError("UNPROCESSABLE_ENTITY", validation.error, 415);
   }
@@ -249,8 +272,13 @@ async function handleOctetStreamUpload(req: Request): Promise<Response> {
 
 /**
  * Handle application/json upload (existing behaviour — base64 or file-path).
+ *
+ * See `handleMultipartUpload` for `gatewayTrustedSource` semantics.
  */
-async function handleJsonUpload(req: Request): Promise<Response> {
+async function handleJsonUpload(
+  req: Request,
+  gatewayTrustedSource: boolean,
+): Promise<Response> {
   const rawBody = await req.arrayBuffer();
   if (rawBody.byteLength > MAX_UPLOAD_BODY_BYTES) {
     return httpError(
@@ -265,6 +293,7 @@ async function handleJsonUpload(req: Request): Promise<Response> {
     mimeType?: string;
     data?: string;
     filePath?: string;
+    trustedSource?: boolean;
   };
 
   const { filename, mimeType, data, filePath } = body;
@@ -277,7 +306,11 @@ async function handleJsonUpload(req: Request): Promise<Response> {
     return httpError("BAD_REQUEST", "mimeType is required", 400);
   }
 
-  const validation = validateAttachmentUpload(filename, mimeType);
+  const trustedSource = gatewayTrustedSource && body.trustedSource === true;
+
+  const validation = validateAttachmentUpload(filename, mimeType, {
+    trustedSource,
+  });
   if (!validation.ok) {
     return httpError("UNPROCESSABLE_ENTITY", validation.error, 415);
   }
@@ -361,19 +394,29 @@ async function handleJsonUpload(req: Request): Promise<Response> {
   return attachmentResponse(attachment);
 }
 
-export async function handleUploadAttachment(req: Request): Promise<Response> {
+export async function handleUploadAttachment(
+  req: Request,
+  authContext: AuthContext,
+): Promise<Response> {
   const contentType = req.headers.get("content-type") ?? "";
 
+  // Decide once whether the caller is allowed to opt into the validation
+  // bypass; each handler combines this with its own per-request flag
+  // (form field, query param, or JSON body) to produce the final
+  // trustedSource boolean. End-user actor tokens never get the bypass —
+  // the assistant ignores any trustedSource flag on such requests.
+  const gatewayTrustedSource = isServiceGatewayPrincipal(authContext);
+
   if (contentType.includes("multipart/form-data")) {
-    return handleMultipartUpload(req);
+    return handleMultipartUpload(req, gatewayTrustedSource);
   }
 
   if (contentType.includes("application/octet-stream")) {
-    return handleOctetStreamUpload(req);
+    return handleOctetStreamUpload(req, gatewayTrustedSource);
   }
 
   // Default: JSON+base64 (existing behaviour)
-  return handleJsonUpload(req);
+  return handleJsonUpload(req, gatewayTrustedSource);
 }
 
 export async function handleDeleteAttachment(req: Request): Promise<Response> {
@@ -564,6 +607,12 @@ export function attachmentRouteDefinitions(): RouteDefinition[] {
           .string()
           .describe("On-disk file path (file-backed upload)")
           .optional(),
+        trustedSource: z
+          .boolean()
+          .describe(
+            "Set by the gateway when the file came from a guardian-bound channel actor. Honored only when the request is authenticated as a gateway service token; ignored otherwise.",
+          )
+          .optional(),
       }),
       responseBody: z.object({
         id: z.string(),
@@ -572,7 +621,8 @@ export function attachmentRouteDefinitions(): RouteDefinition[] {
         size_bytes: z.number(),
         kind: z.string(),
       }),
-      handler: async ({ req }) => handleUploadAttachment(req),
+      handler: async ({ req, authContext }) =>
+        handleUploadAttachment(req, authContext),
     },
     {
       endpoint: "attachments",

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -34,6 +34,7 @@ import type {
   ContactType,
 } from "../../contacts/types.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
+import { isServiceGatewayPrincipal } from "../auth/context.js";
 import type { AuthContext } from "../auth/types.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
@@ -431,7 +432,7 @@ export async function handleAddGuardianChannel(
   // email as a guardian channel. Direct actor/local calls are not permitted
   // because the endpoint bypasses normal channel verification (no code sent,
   // no confirmation) and would allow guardian channel takeover (ATL-102).
-  if (authContext.principalType !== "svc_gateway") {
+  if (!isServiceGatewayPrincipal(authContext)) {
     return httpError(
       "FORBIDDEN",
       "This endpoint is restricted to platform service calls",

--- a/gateway/src/__tests__/guardian-channel-actor-lookup.test.ts
+++ b/gateway/src/__tests__/guardian-channel-actor-lookup.test.ts
@@ -1,0 +1,152 @@
+import { describe, test, expect, afterEach, beforeEach } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import {
+  closeAssistantDb,
+  findGuardianForChannelActor,
+} from "../auth/guardian-bootstrap.js";
+
+let testRoot: string;
+
+function setupTestDb(): void {
+  testRoot = mkdtempSync(join(tmpdir(), "guardian-channel-actor-"));
+  const dbDir = join(testRoot, "data", "db");
+  mkdirSync(dbDir, { recursive: true });
+
+  const db = new Database(join(dbDir, "assistant.db"));
+  db.exec("PRAGMA journal_mode=WAL");
+  db.exec("PRAGMA foreign_keys=ON");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS contacts (
+      id TEXT PRIMARY KEY,
+      display_name TEXT NOT NULL,
+      notes TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      role TEXT NOT NULL DEFAULT 'contact',
+      principal_id TEXT,
+      user_file TEXT,
+      contact_type TEXT NOT NULL DEFAULT 'human'
+    )
+  `);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS contact_channels (
+      id TEXT PRIMARY KEY,
+      contact_id TEXT NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+      type TEXT NOT NULL,
+      address TEXT NOT NULL,
+      is_primary INTEGER NOT NULL DEFAULT 0,
+      external_user_id TEXT,
+      external_chat_id TEXT,
+      status TEXT NOT NULL DEFAULT 'unverified',
+      policy TEXT NOT NULL DEFAULT 'allow',
+      verified_at INTEGER,
+      verified_via TEXT,
+      invite_id TEXT,
+      revoked_reason TEXT,
+      blocked_reason TEXT,
+      last_seen_at INTEGER,
+      interaction_count INTEGER NOT NULL DEFAULT 0,
+      last_interaction INTEGER,
+      updated_at INTEGER,
+      created_at INTEGER NOT NULL
+    )
+  `);
+  db.close();
+
+  process.env.VELLUM_WORKSPACE_DIR = testRoot;
+}
+
+function seedGuardianChannel(args: {
+  channelType: string;
+  externalUserId: string;
+  status?: string;
+  principalId?: string;
+}): void {
+  const dbPath = join(testRoot, "data", "db", "assistant.db");
+  const db = new Database(dbPath);
+  const now = Date.now();
+  const principalId = args.principalId ?? "guardian-principal-001";
+
+  db.run(
+    `INSERT INTO contacts
+       (id, display_name, role, principal_id, created_at, updated_at)
+     VALUES (?, ?, 'guardian', ?, ?, ?)`,
+    ["guardian-001", "Test Guardian", principalId, now, now],
+  );
+
+  db.run(
+    `INSERT INTO contact_channels
+       (id, contact_id, type, address, external_user_id, status, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [
+      `ch-${args.channelType}-001`,
+      "guardian-001",
+      args.channelType,
+      `${args.channelType}-address`,
+      args.externalUserId,
+      args.status ?? "active",
+      now,
+    ],
+  );
+  db.close();
+}
+
+beforeEach(() => {
+  setupTestDb();
+});
+
+afterEach(() => {
+  closeAssistantDb();
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("findGuardianForChannelActor", () => {
+  test("returns null when no binding exists", () => {
+    expect(findGuardianForChannelActor("slack", "U_UNKNOWN")).toBeNull();
+  });
+
+  test("returns principalId for an active slack guardian binding", () => {
+    seedGuardianChannel({
+      channelType: "slack",
+      externalUserId: "U_OWNER",
+      principalId: "principal-owner",
+    });
+
+    const result = findGuardianForChannelActor("slack", "U_OWNER");
+    expect(result).not.toBeNull();
+    expect(result?.principalId).toBe("principal-owner");
+  });
+
+  test("returns null when the binding is not active", () => {
+    seedGuardianChannel({
+      channelType: "slack",
+      externalUserId: "U_REVOKED",
+      status: "revoked",
+    });
+
+    expect(findGuardianForChannelActor("slack", "U_REVOKED")).toBeNull();
+  });
+
+  test("does not match a different channel type", () => {
+    seedGuardianChannel({
+      channelType: "telegram",
+      externalUserId: "1234",
+    });
+
+    // Same external ID but different channel type — should miss
+    expect(findGuardianForChannelActor("slack", "1234")).toBeNull();
+  });
+
+  test("returns null for empty inputs", () => {
+    expect(findGuardianForChannelActor("", "U_OWNER")).toBeNull();
+    expect(findGuardianForChannelActor("slack", "")).toBeNull();
+  });
+});

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -163,6 +163,39 @@ function findVellumGuardian(db: Database): { principalId: string } | null {
 }
 
 /**
+ * Look up the guardian binding for a given external user on a specific
+ * channel type (e.g. `"slack"`, `"telegram"`, `"whatsapp"`). Returns the
+ * guardian's principal ID when the actor is bound as a guardian on an
+ * active channel of that type, or `null` otherwise.
+ *
+ * Used by channel ingress paths to decide whether an inbound message
+ * came from the assistant's owner — see `index.ts` Slack upload flow.
+ */
+export function findGuardianForChannelActor(
+  channelType: string,
+  externalUserId: string,
+): { principalId: string } | null {
+  if (!channelType || !externalUserId) return null;
+
+  const db = getAssistantDb();
+  const row = db
+    .query<GuardianLookupRow, [string, string]>(
+      `SELECT c.id AS contact_id, c.principal_id
+       FROM contacts c
+       INNER JOIN contact_channels cc ON cc.contact_id = c.id
+       WHERE c.role = 'guardian'
+         AND cc.type = ?
+         AND cc.external_user_id = ?
+         AND cc.status = 'active'
+       LIMIT 1`,
+    )
+    .get(channelType, externalUserId);
+
+  if (!row?.principal_id) return null;
+  return { principalId: row.principal_id };
+}
+
+/**
  * Create a guardian contact + vellum channel binding.
  *
  * Persona-file seeding (`users/<slug>.md`) and trust-rule cache

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -7,7 +7,10 @@ import {
   initSigningKey,
 } from "./auth/token-service.js";
 import { validateEdgeToken, mintServiceToken } from "./auth/token-exchange.js";
-import { ensureVellumGuardianBinding } from "./auth/guardian-bootstrap.js";
+import {
+  ensureVellumGuardianBinding,
+  findGuardianForChannelActor,
+} from "./auth/guardian-bootstrap.js";
 import { ConfigFileCache } from "./config-file-cache.js";
 import { ConfigFileWatcher } from "./config-file-watcher.js";
 import { FeatureFlagWatcher } from "./feature-flag-watcher.js";
@@ -1694,6 +1697,17 @@ async function main() {
                 config.maxAttachmentBytes.slack ??
                 config.maxAttachmentBytes.default;
 
+              // Guardian-actor bypass: when the Slack sender is the
+              // assistant's owner, the upload is marked trustedSource so the
+              // assistant accepts arbitrary MIME types and extensions
+              // (e.g. .mkv, .dmg) for downstream processing. Resolved once
+              // per message — the assistant re-checks gateway-service auth
+              // before honoring the flag, so impersonation is not possible.
+              const slackActorId = normalized.event.actor.actorExternalId;
+              const isGuardianActor = slackActorId
+                ? !!findGuardianForChannelActor("slack", slackActorId)
+                : false;
+
               // Filter oversized attachments
               const eligible = eventAttachments.filter((att) => {
                 if (att.fileSize !== undefined && att.fileSize > maxBytes) {
@@ -1735,9 +1749,11 @@ async function main() {
                       slackFile,
                       botToken,
                     );
-                    return uploadAttachment(config, downloaded, {
-                      skipCircuitBreaker: true,
-                    });
+                    return uploadAttachment(
+                      config,
+                      { ...downloaded, trustedSource: isGuardianActor },
+                      { skipCircuitBreaker: true },
+                    );
                   }),
                 );
                 for (let j = 0; j < results.length; j++) {

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -351,6 +351,12 @@ export type UploadAttachmentInput = {
   filename: string;
   mimeType: string;
   data: string; // base64-encoded
+  /**
+   * Set to true when the upload comes from a channel ingress where the
+   * actor has been resolved to a guardian binding. Forwarded to the
+   * assistant; the assistant only honors it for service-token callers.
+   */
+  trustedSource?: boolean;
 };
 
 export type UploadAttachmentResponse = {


### PR DESCRIPTION
## Summary

- Add an opt-in trustedSource flag to validateAttachmentUpload that bypasses the MIME allowlist and dangerous-extensions blocklist. Filename normalization and the 100 MB size limit still apply.
- Gate the bypass on the upload route by service-token auth: only requests from svc:gateway:* may set the flag; other callers (desktop client, IPC) keep the strict policy.
- Gateway: when a Slack inbound message has attachments, resolve the actor against the guardian binding and pass trustedSource on each upload. Other channels (Telegram, WhatsApp, email) are unchanged for now.
- Extract a shared isServiceGatewayPrincipal helper and reuse it from contact-routes.ts.

## Original prompt

I want to support sending all file types in Slack messages when I'm talking to Velissa. For example I want to be able to send her a video in a Slack DM, and then she can take the file and run ffmpeg or whatever she wants in order to process it.

## Test plan

- [ ] DM Velissa an .mkv from Slack — the file lands in the conversation attachments dir; ffprobe via bash works.
- [ ] DM the bot the same .mkv from a non-guardian Slack account — legacy "[file(s) could not be retrieved]" path triggers.
- [ ] Existing desktop file-picker upload of a non-allowlisted MIME still returns 415.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
