### PR TITLE
feat(macos): callsite overrides — profile picker with Custom escape hatch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/CallSiteOverrideRow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CallSiteOverrideRow.swift
@@ -3,8 +3,9 @@ import VellumAssistantShared
 
 /// Single editable row in `CallSiteOverridesSheet`. Renders a call site's
 /// display name plus a compact summary, an "Override default" toggle, and
-/// — when the toggle is ON — provider/model pickers with Save/Reset
-/// actions.
+/// — when the toggle is ON — a profile picker. Most rows pick a named
+/// inference profile; the `"Custom"` sentinel reveals the legacy
+/// provider+model form for one-off overrides that don't fit any profile.
 ///
 /// State ownership:
 /// - The `draft` binding is the row's working copy. The parent sheet owns
@@ -26,13 +27,27 @@ struct CallSiteOverrideRow: View {
     let providerDisplayName: (String) -> String
     let availableModels: [String: [String]]
     let modelDisplayName: (String, String) -> String
+    /// Named inference profiles available for selection. Sourced from
+    /// `store.profiles` by the parent sheet.
+    let profiles: [InferenceProfile]
     let onSave: () -> Void
     let onClear: () -> Void
+    /// Invoked when the user picks a named profile from the picker. The
+    /// parent sheet routes this through
+    /// `store.replaceCallSiteOverride(id:profile:)` which clears any
+    /// stale fragment fields server-side, and refreshes the draft so the
+    /// row converges immediately.
+    let onSelectProfile: (String) -> Void
 
     /// Local expansion state. Defaults to "expanded when the row already has
     /// an override or when the user toggles it on" so a freshly-opened sheet
     /// shows configured rows expanded but leaves untouched rows collapsed.
     @State private var isExpanded: Bool = false
+
+    /// Sentinel value used in the profile picker to surface the legacy
+    /// provider+model form. Selecting it keeps the row in raw-fragment
+    /// mode; the existing Save button persists the fragment.
+    static let customSentinel = "Custom"
 
     // MARK: - Computed State
 
@@ -63,9 +78,31 @@ struct CallSiteOverrideRow: View {
         return nil
     }
 
+    /// True when the user is editing a raw fragment (Custom) rather than
+    /// picking a profile. Drives the visibility of the provider+model form
+    /// and the per-row Save button (profile selection persists immediately
+    /// via `onSelectProfile` so no Save click is needed).
+    private var isCustomMode: Bool {
+        Self.profilePickerValue(for: draft) == Self.customSentinel
+    }
+
     private var canSave: Bool {
         guard hasUnsavedChanges else { return false }
         return validationError == nil
+    }
+
+    /// Computes the profile picker's current value from the draft's state.
+    /// Returns the profile name when set, `"Custom"` when raw
+    /// provider/model fields are populated without a profile, or `""`
+    /// when no override is active.
+    static func profilePickerValue(for draft: CallSiteOverride) -> String {
+        if let profile = draft.profile, !profile.isEmpty {
+            return profile
+        }
+        if draft.provider != nil || draft.model != nil {
+            return Self.customSentinel
+        }
+        return ""
     }
 
     var body: some View {
@@ -126,22 +163,17 @@ struct CallSiteOverrideRow: View {
                     get: { isOverrideOn },
                     set: { newValue in
                         if newValue {
-                            // Switching ON: seed with the user's actual
-                            // default provider so the picker starts where
-                            // the user already operates. Falling back to
-                            // catalog order would silently pin a different
-                            // provider on Save when the catalog's first
-                            // entry isn't the user's default.
+                            // Switching ON: default new rows to the first
+                            // profile when one is available so the common
+                            // case is one click. Fall back to a Custom
+                            // fragment seeded with the user's default
+                            // provider when no profiles exist.
                             if !draft.hasOverride {
-                                let seedProvider: String
-                                if providerIds.contains(defaultProvider) {
-                                    seedProvider = defaultProvider
+                                if let firstProfile = profiles.first {
+                                    draft.profile = firstProfile.name
                                 } else {
-                                    seedProvider = providerIds.first ?? "anthropic"
+                                    seedCustomFragment()
                                 }
-                                draft.provider = seedProvider
-                                let firstModel = availableModels[seedProvider]?.first ?? ""
-                                draft.model = firstModel.isEmpty ? nil : firstModel
                             }
                             withAnimation(VAnimation.fast) { isExpanded = true }
                         } else {
@@ -162,17 +194,21 @@ struct CallSiteOverrideRow: View {
         }
     }
 
-    // MARK: - Editor (provider/model pickers + actions)
+    // MARK: - Editor (profile picker + optional provider/model form)
 
     private var editor: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            providerPicker
-            modelPicker
+            profilePicker
 
-            if let error = validationError {
-                Text(error)
-                    .font(VFont.bodySmallDefault)
-                    .foregroundStyle(VColor.systemNegativeStrong)
+            if isCustomMode {
+                providerPicker
+                modelPicker
+
+                if let error = validationError {
+                    Text(error)
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.systemNegativeStrong)
+                }
             }
 
             HStack(spacing: VSpacing.sm) {
@@ -183,16 +219,70 @@ struct CallSiteOverrideRow: View {
                     onClear()
                 }
                 Spacer(minLength: 0)
-                VButton(
-                    label: "Save",
-                    style: .primary,
-                    isDisabled: !canSave
-                ) {
-                    onSave()
+                if isCustomMode {
+                    VButton(
+                        label: "Save",
+                        style: .primary,
+                        isDisabled: !canSave
+                    ) {
+                        onSave()
+                    }
                 }
             }
         }
         .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.md, bottom: 0, trailing: 0))
+    }
+
+    private var profilePicker: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Profile")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+            VDropdown(
+                placeholder: "Select a profile\u{2026}",
+                selection: Binding(
+                    get: { Self.profilePickerValue(for: draft) },
+                    set: { newValue in
+                        let current = Self.profilePickerValue(for: draft)
+                        guard newValue != current else { return }
+                        if newValue == Self.customSentinel {
+                            // Switch to Custom: drop the profile reference
+                            // and seed provider/model from the default so
+                            // the form renders valid values.
+                            draft.profile = nil
+                            if draft.provider == nil && draft.model == nil {
+                                seedCustomFragment()
+                            }
+                        } else {
+                            // Switch to a named profile: clear fragment
+                            // fields locally and persist via the parent's
+                            // `onSelectProfile` callback, which routes
+                            // through `replaceCallSiteOverride` to clear
+                            // stale fragment leaves server-side.
+                            draft.provider = nil
+                            draft.model = nil
+                            draft.profile = newValue
+                            onSelectProfile(newValue)
+                        }
+                    }
+                ),
+                options: profiles.map { (label: $0.name, value: $0.name) }
+                    + [(label: Self.customSentinel, value: Self.customSentinel)]
+            )
+        }
+    }
+
+    /// Populates `draft.provider` and `draft.model` with the user's default
+    /// provider and that provider's first model so a fresh Custom row
+    /// renders with valid values rather than empty pickers (which would
+    /// also fail Save validation).
+    private func seedCustomFragment() {
+        let seedProvider = providerIds.contains(defaultProvider)
+            ? defaultProvider
+            : (providerIds.first ?? "anthropic")
+        draft.provider = seedProvider
+        let firstModel = availableModels[seedProvider]?.first ?? ""
+        draft.model = firstModel.isEmpty ? nil : firstModel
     }
 
     private var providerPicker: some View {
@@ -260,15 +350,14 @@ struct CallSiteOverrideRow: View {
             return "Follows default"
         }
         var parts: [String] = []
-        if let provider = draft.provider, let model = draft.model {
+        if let profile = draft.profile {
+            parts.append("Profile: \(profile)")
+        } else if let provider = draft.provider, let model = draft.model {
             parts.append("\(providerDisplayName(provider)) \u{00B7} \(modelDisplayName(provider, model))")
         } else if let model = draft.model {
             parts.append(model)
         } else if let provider = draft.provider {
             parts.append("Provider: \(providerDisplayName(provider))")
-        }
-        if let profile = draft.profile {
-            parts.append("Profile: \(profile)")
         }
         if hasUnsavedChanges {
             parts.append("Unsaved")

--- a/clients/macos/vellum-assistant/Features/Settings/CallSiteOverridesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CallSiteOverridesSheet.swift
@@ -177,8 +177,10 @@ struct CallSiteOverridesSheet: View {
                                 let models = store.dynamicProviderModels(provider)
                                 return models.first { $0.id == modelId }?.displayName ?? modelId
                             },
+                            profiles: store.profiles,
                             onSave: { save(id: entry.id) },
-                            onClear: { clear(id: entry.id) }
+                            onClear: { clear(id: entry.id) },
+                            onSelectProfile: { name in selectProfile(id: entry.id, name: name) }
                         )
                     }
                 } header: {
@@ -280,6 +282,21 @@ struct CallSiteOverridesSheet: View {
         drafts[id]?.profile = nil
         store.clearCallSiteOverride(id)
         // Baseline now matches the cleared draft (no override).
+        lastSyncedFromStore[id] = drafts[id]
+    }
+
+    private func selectProfile(id: String, name: String) {
+        // Picking a profile name persists immediately — no Save click
+        // required. Update the local draft to match (provider/model
+        // cleared, profile set) so the row converges before the next
+        // config push, and route the write through `replaceCallSiteOverride`
+        // which also clears stale fragment leaves server-side per PR 11.
+        drafts[id]?.provider = nil
+        drafts[id]?.model = nil
+        drafts[id]?.profile = name
+        store.replaceCallSiteOverride(id, provider: nil, model: nil, profile: name)
+        // The draft now matches the new persisted state — bump the baseline
+        // so the next external `onChange` doesn't re-flag the row as touched.
         lastSyncedFromStore[id] = drafts[id]
     }
 

--- a/clients/macos/vellum-assistantTests/CallSiteOverridesSheetTests.swift
+++ b/clients/macos/vellum-assistantTests/CallSiteOverridesSheetTests.swift
@@ -1,0 +1,208 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Verifies the per-row profile picker logic in
+/// `CallSiteOverrideRow` and the parent sheet's `selectProfile` flow:
+/// - Rows with `{ profile: name }` render the named profile in the picker.
+/// - Legacy rows with `{ provider, model }` render `"Custom"` and surface
+///   the inline form so the user can keep editing the raw fragment.
+/// - Switching from `Custom` to a named profile clears the fragment fields
+///   in the patch payload (verified end-to-end against `SettingsStore`).
+@MainActor
+final class CallSiteOverridesSheetTests: XCTestCase {
+
+    private var mockSettingsClient: MockSettingsClient!
+    private var store: SettingsStore!
+
+    override func setUp() {
+        super.setUp()
+        mockSettingsClient = MockSettingsClient()
+        mockSettingsClient.patchConfigResponse = true
+        store = SettingsStore(settingsClient: mockSettingsClient)
+    }
+
+    override func tearDown() {
+        store = nil
+        mockSettingsClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func waitForPatchCount(_ expected: Int, timeout: TimeInterval = 2.0) {
+        let predicate = NSPredicate { _, _ in
+            self.mockSettingsClient.patchConfigCalls.count >= expected
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    /// Returns the most recent `llm.callSites.<id>` entry written to the
+    /// mock client. Walks the patch history newest-first so test cases can
+    /// assert against the final state.
+    private func lastEntryPatch(for id: String) -> [String: Any]? {
+        for payload in mockSettingsClient.patchConfigCalls.reversed() {
+            guard let llm = payload["llm"] as? [String: Any],
+                  let sites = llm["callSites"] as? [String: Any],
+                  let entry = sites[id] as? [String: Any] else { continue }
+            return entry
+        }
+        return nil
+    }
+
+    // MARK: - Profile picker value derivation
+
+    func testProfilePickerRendersProfileNameWhenSet() {
+        let row = CallSiteOverride(
+            id: "memoryRetrieval",
+            displayName: "Memory · Retrieval",
+            domain: .memory,
+            profile: "balanced"
+        )
+        XCTAssertEqual(
+            CallSiteOverrideRow.profilePickerValue(for: row),
+            "balanced",
+            "A row with profile set must render the profile name in the picker"
+        )
+    }
+
+    func testProfilePickerRendersCustomForLegacyProviderModelRow() {
+        let row = CallSiteOverride(
+            id: "memoryRetrieval",
+            displayName: "Memory · Retrieval",
+            domain: .memory,
+            provider: "openai",
+            model: "gpt-4.1"
+        )
+        XCTAssertEqual(
+            CallSiteOverrideRow.profilePickerValue(for: row),
+            CallSiteOverrideRow.customSentinel,
+            "Legacy rows with provider+model and no profile must render as Custom"
+        )
+    }
+
+    func testProfilePickerRendersCustomForProviderOnlyRow() {
+        let row = CallSiteOverride(
+            id: "memoryRetrieval",
+            displayName: "Memory · Retrieval",
+            domain: .memory,
+            provider: "anthropic"
+        )
+        XCTAssertEqual(
+            CallSiteOverrideRow.profilePickerValue(for: row),
+            CallSiteOverrideRow.customSentinel,
+            "A row with only a provider override is still Custom — partial fragments use the legacy form"
+        )
+    }
+
+    func testProfilePickerRendersEmptyForUntouchedRow() {
+        let row = CallSiteOverride(
+            id: "memoryRetrieval",
+            displayName: "Memory · Retrieval",
+            domain: .memory
+        )
+        XCTAssertEqual(
+            CallSiteOverrideRow.profilePickerValue(for: row),
+            "",
+            "An untouched row inherits the default and must render empty in the picker"
+        )
+    }
+
+    func testProfilePickerEmptyStringProfileTreatedAsUnset() {
+        // Defense against config payloads that round-trip an empty string
+        // through `loadCallSiteOverrides` — the loader normalizes empty
+        // strings to nil but the picker logic should be robust to either
+        // shape.
+        let row = CallSiteOverride(
+            id: "memoryRetrieval",
+            displayName: "Memory · Retrieval",
+            domain: .memory,
+            profile: ""
+        )
+        XCTAssertEqual(
+            CallSiteOverrideRow.profilePickerValue(for: row),
+            "",
+            "An empty-string profile must not be treated as a real selection"
+        )
+    }
+
+    // MARK: - Profile selection clears stale fragment fields
+
+    /// End-to-end: a row that was previously a `{provider, model}` Custom
+    /// override switches to the `"balanced"` profile. The persisted patch
+    /// must scrub the legacy fragment fields so the resolver layers the
+    /// profile cleanly without stale `provider`/`model` overrides shadowing
+    /// it. See `replaceCallSiteOverride` in `SettingsStore.swift` for the
+    /// server-side null-write that PR 11 introduced.
+    func testSelectingProfileClearsLegacyFragmentFieldsInPatch() {
+        // Arrange: pre-populate a Custom-style override.
+        store.loadCallSiteOverrides(config: [
+            "llm": [
+                "callSites": [
+                    "memoryRetrieval": [
+                        "provider": "openai",
+                        "model": "gpt-4.1"
+                    ]
+                ]
+            ]
+        ])
+
+        // Act: select the `balanced` profile, mirroring what the row does
+        // when the user picks a profile name from the picker.
+        _ = store.replaceCallSiteOverride(
+            "memoryRetrieval",
+            provider: nil,
+            model: nil,
+            profile: "balanced"
+        )
+        // replaceCallSiteOverride emits two patches: the initial null-clear
+        // and then the final entry write.
+        waitForPatchCount(2)
+
+        // Assert: the final patch sets `profile` and explicitly nulls every
+        // fragment leaf so the daemon's deep-merge deletes them. This is the
+        // critical invariant — without the null leaves the resolver would
+        // continue to layer the stale `{ provider, model }` fragment on top
+        // of the profile, defeating the point of the picker.
+        let entry = lastEntryPatch(for: "memoryRetrieval")
+        XCTAssertEqual(entry?["profile"] as? String, "balanced")
+        XCTAssertTrue(entry?["provider"] is NSNull, "provider must be nulled when switching to a profile")
+        XCTAssertTrue(entry?["model"] is NSNull, "model must be nulled when switching to a profile")
+        XCTAssertTrue(entry?["maxTokens"] is NSNull, "maxTokens must be nulled when switching to a profile")
+        XCTAssertTrue(entry?["effort"] is NSNull, "effort must be nulled when switching to a profile")
+        XCTAssertTrue(entry?["thinking"] is NSNull, "thinking must be nulled when switching to a profile")
+
+        // Local cache reflects the new profile-only override.
+        let cached = store.callSiteOverrides.first(where: { $0.id == "memoryRetrieval" })
+        XCTAssertEqual(cached?.profile, "balanced")
+        XCTAssertNil(cached?.provider)
+        XCTAssertNil(cached?.model)
+    }
+
+    /// Selecting a profile when the row was already on a profile is a
+    /// no-stale-fields case but should still produce a clean
+    /// `profile: <name>` entry without surprise leaves.
+    func testSelectingProfileFromAnotherProfileEmitsCleanEntry() {
+        store.loadCallSiteOverrides(config: [
+            "llm": [
+                "callSites": [
+                    "mainAgent": ["profile": "fast"]
+                ]
+            ]
+        ])
+
+        _ = store.replaceCallSiteOverride(
+            "mainAgent",
+            provider: nil,
+            model: nil,
+            profile: "balanced"
+        )
+        waitForPatchCount(2)
+
+        let entry = lastEntryPatch(for: "mainAgent")
+        XCTAssertEqual(entry?["profile"] as? String, "balanced")
+        XCTAssertTrue(entry?["provider"] is NSNull)
+        XCTAssertTrue(entry?["model"] is NSNull)
+    }
+}


### PR DESCRIPTION
## Summary
- Per-row picker now defaults to choosing a profile; `Custom` reveals the legacy provider+model+effort form.
- Existing legacy rows render as `Custom` without losing data; selecting a profile clears stale fragment fields.

Part of plan: inference-profiles.md (PR 15 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
