### PR TITLE
chore(openapi): regenerate spec for inference-profile and trustedSource

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -996,6 +996,11 @@ paths:
                 filePath:
                   type: string
                   description: On-disk file path (file-backed upload)
+                trustedSource:
+                  type: boolean
+                  description:
+                    Set by the gateway when the file came from a guardian-bound channel actor. Honored only when the request is
+                    authenticated as a gateway service token; ignored otherwise.
               required:
                 - filename
                 - mimeType
@@ -2785,6 +2790,53 @@ paths:
                   type: boolean
               required:
                 - hostAccess
+              additionalProperties: false
+  /v1/conversations/{id}/inference-profile:
+    put:
+      operationId: conversations_by_id_inferenceprofile_put
+      summary: Set conversation inference profile
+      description:
+        Override the LLM inference profile for a single conversation. Pass `null` to clear the override and fall
+        back to the workspace `llm.activeProfile`.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  profile:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                required:
+                  - conversationId
+                  - profile
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                profile:
+                  anyOf:
+                    - type: string
+                    - type: "null"
+              required:
+                - profile
               additionalProperties: false
   /v1/conversations/{id}/name:
     patch:


### PR DESCRIPTION
## Summary
- Regenerates `assistant/openapi.yaml` to capture two recently merged endpoints/fields whose code landed without the spec update:
  - `PUT /v1/conversations/{id}/inference-profile` (from #28051)
  - `trustedSource` field on the attachments upload schema (from #28053)
- Fixes the failing `OpenAPI Spec Check` job on main.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24925369836/job/72994332223
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
