### PR TITLE
test(events-ipc): replace brittle 30ms tick with deterministic subscriber-count poll

### DIFF
--- a/assistant/src/ipc/skill-routes/__tests__/events-ipc.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/events-ipc.test.ts
@@ -118,8 +118,15 @@ async function openClient(): Promise<TestClient> {
   };
 }
 
-function tick(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 30));
+async function waitForSubscriberCount(
+  expected: number,
+  timeoutMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (assistantEventHub.subscriberCount() !== expected) {
+    if (Date.now() > deadline) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -275,7 +282,7 @@ describe("host.events.subscribe", () => {
     ).toBe("e4");
 
     client.close();
-    await tick();
+    await waitForSubscriberCount(baseSubscribers);
     expect(assistantEventHub.subscriberCount()).toBe(baseSubscribers);
   });
 
@@ -315,7 +322,7 @@ describe("host.events.subscribe", () => {
     expect(assistantEventHub.subscriberCount()).toBe(baseSubscribers + 1);
 
     client.close();
-    await tick();
+    await waitForSubscriberCount(baseSubscribers);
     expect(assistantEventHub.subscriberCount()).toBe(baseSubscribers);
 
     // Further publishes do not reach the disposed subscription. If the
@@ -344,7 +351,7 @@ describe("host.events.subscribe", () => {
 
     server?.stop();
     server = null;
-    await tick();
+    await waitForSubscriberCount(baseSubscribers);
     expect(assistantEventHub.subscriberCount()).toBe(baseSubscribers);
 
     // Clean up the client socket; the server already destroyed it.


### PR DESCRIPTION
## Summary

- The \`opens ack, delivers matching events, filters non-matching\` test in \`events-ipc.test.ts\` flaked on CI: it asserts \`assistantEventHub.subscriberCount() === baseSubscribers\` after \`client.close()\` + a 30ms \`tick()\`, but the cleanup path runs in the server's async \`socket.on(\"close\")\` handler. On a 16-worker CI runner, that handler can fire after the 30ms window.
- Replaced \`tick()\` with \`waitForSubscriberCount(expected)\` — polls every 5ms up to 2s and returns immediately once the count matches. Applied to all three subscribe tests with the same race (client-disconnect cleanup, server-shutdown cleanup, and the failing filter test).
- No production code change; this is a test-stability fix only.

Failing CI job: https://github.com/vellum-ai/vellum-assistant/actions/runs/24925369836/job/72994332222

## Original prompt

--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24925369836/job/72994332222
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
