### PR TITLE
ci(macos): retry transient app artifact upload on macOS Build job

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -289,6 +289,23 @@ jobs:
           done
 
       - name: Upload app artifact
+        id: upload-app
+        continue-on-error: true
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: macos-app-dist
+          path: clients/macos/dist/${{ env.APP_DISPLAY_NAME }}.app
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Wait before app artifact upload retry
+        if: steps.upload-app.outcome == 'failure'
+        run: |
+          echo "::warning::Initial app artifact upload failed (likely transient GitHub Actions artifact service timeout). Retrying after 30s."
+          sleep 30
+
+      - name: Upload app artifact (retry)
+        if: steps.upload-app.outcome == 'failure'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: macos-app-dist


### PR DESCRIPTION
## Summary
- Run 24925268362 failed on the macOS Build job's \"Upload app artifact\" step after five consecutive \`CreateArtifact\` API timeouts against GitHub's artifact service. \`actions/upload-artifact@v4\` retries hardcoded, so a single transient service hiccup fails the whole job and skips the downstream DMG upload.
- Mirror the existing retry pattern from the \"Generate GitHub App token\" step in the same workflow (#26819): mark the first attempt \`continue-on-error\`, sleep 30s, and rerun \`actions/upload-artifact\` only when the first outcome is \`failure\`.
- Scoped to the failing step only — DMG upload is a single-file upload that didn't fail and is left alone.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24925268362/job/72994074578
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
