### PR TITLE
feat(agent): accept and propagate overrideProfile

### DIFF
--- a/assistant/src/__tests__/agent-loop-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-loop-override-profile.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Verifies that the per-turn `overrideProfile` plumbed into `AgentLoop.run()`
+ * surfaces on every `SendMessageOptions.config` the loop emits, and that
+ * `SubagentManager.spawn()` propagates an inherited `overrideProfile` from
+ * its `SubagentConfig` into the subagent's `runAgentLoop()` call.
+ *
+ * Together these two assertions establish the PR 6 contract: a parent
+ * conversation that pins an inference profile sees that profile applied to
+ * every LLM call within its agent-loop turn, and any subagent spawned during
+ * that turn inherits the same profile automatically.
+ *
+ * Default behavior (no `overrideProfile` set) must remain unchanged — the
+ * field is omitted from `providerConfig` rather than carrying `undefined`.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+import { AgentLoop } from "../agent/loop.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+} from "../providers/types.js";
+
+const userMessage: Message = {
+  role: "user",
+  content: [{ type: "text", text: "hi" }],
+};
+
+function textResponse(text: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text }],
+    model: "mock-model",
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "end_turn",
+  };
+}
+
+function toolUseResponse(
+  id: string,
+  name: string,
+  input: Record<string, unknown>,
+): ProviderResponse {
+  return {
+    content: [{ type: "tool_use", id, name, input }],
+    model: "mock-model",
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "tool_use",
+  };
+}
+
+/**
+ * Build a provider that records every `SendMessageOptions.config` it sees so
+ * the test can assert how the agent loop populated `overrideProfile` on each
+ * iteration of the multi-turn tool loop.
+ */
+function makeRecordingProvider(responses: ProviderResponse[]): {
+  provider: Provider;
+  configs: () => Array<Record<string, unknown> | undefined>;
+} {
+  const configs: Array<Record<string, unknown> | undefined> = [];
+  let i = 0;
+  const provider: Provider = {
+    name: "mock",
+    async sendMessage(
+      _messages: Message[],
+      _tools?: ToolDefinition[],
+      _systemPrompt?: string,
+      options?: SendMessageOptions,
+    ): Promise<ProviderResponse> {
+      configs.push(options?.config as Record<string, unknown> | undefined);
+      const response = responses[i] ?? responses[responses.length - 1];
+      i++;
+      return response;
+    },
+  };
+  return { provider, configs: () => configs };
+}
+
+describe("AgentLoop.run — overrideProfile plumbing", () => {
+  test("forwards overrideProfile to providerConfig on every LLM call (multi-turn)", async () => {
+    // Two tool-use turns followed by a final text response so the loop
+    // performs three provider sends. Every send must carry the same
+    // overrideProfile that was passed into `run()`.
+    const { provider, configs } = makeRecordingProvider([
+      toolUseResponse("t1", "echo", { value: "first" }),
+      toolUseResponse("t2", "echo", { value: "second" }),
+      textResponse("done"),
+    ]);
+
+    const dummyTools: ToolDefinition[] = [
+      {
+        name: "echo",
+        description: "Echo back the input",
+        input_schema: {
+          type: "object",
+          properties: { value: { type: "string" } },
+        },
+      },
+    ];
+
+    const toolExecutor = async (
+      _name: string,
+      _input: Record<string, unknown>,
+    ) => ({ content: "ok", isError: false });
+
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      { maxTokens: 1024 },
+      dummyTools,
+      toolExecutor,
+    );
+
+    await loop.run(
+      [userMessage],
+      () => {},
+      undefined, // signal
+      undefined, // requestId
+      undefined, // onCheckpoint
+      "mainAgent", // callSite
+      undefined, // turnContext
+      "fast", // overrideProfile
+    );
+
+    // Three sends — initial + two tool round-trips.
+    expect(configs()).toHaveLength(3);
+    for (const cfg of configs()) {
+      expect(cfg?.overrideProfile).toBe("fast");
+    }
+  });
+
+  test("omits overrideProfile from providerConfig when unset (default behavior unchanged)", async () => {
+    const { provider, configs } = makeRecordingProvider([textResponse("hi")]);
+    const loop = new AgentLoop(provider, "system", { maxTokens: 1024 });
+
+    await loop.run([userMessage], () => {});
+
+    // Single send, no overrideProfile field at all.
+    expect(configs()).toHaveLength(1);
+    expect(configs()[0]).toBeDefined();
+    expect("overrideProfile" in (configs()[0] ?? {})).toBe(false);
+  });
+
+  test("missing overrideProfile name still flows through (silent fall-through is the resolver's job)", async () => {
+    // The agent loop must NOT validate the profile name — that's the
+    // resolver's responsibility. The loop forwards whatever string it
+    // receives so a non-existent profile silently falls back at the
+    // provider layer (covered by provider-send-message-override-profile.test.ts).
+    const { provider, configs } = makeRecordingProvider([textResponse("hi")]);
+    const loop = new AgentLoop(provider, "system", { maxTokens: 1024 });
+
+    await loop.run(
+      [userMessage],
+      () => {},
+      undefined,
+      undefined,
+      undefined,
+      "mainAgent",
+      undefined,
+      "does-not-exist",
+    );
+
+    expect(configs()[0]?.overrideProfile).toBe("does-not-exist");
+  });
+});
+
+// ── Subagent inheritance ─────────────────────────────────────────────────
+
+// Capture the SubagentManager → Conversation handshake so we can verify the
+// `overrideProfile` from `SubagentConfig` is forwarded into the spawned
+// subagent's `runAgentLoop()` invocation. Same pattern as
+// `subagent-call-site-routing.test.ts`.
+interface CapturedRunAgentLoopOptions {
+  isInteractive?: boolean;
+  isUserMessage?: boolean;
+  titleText?: string;
+  callSite?: string;
+  overrideProfile?: string;
+}
+
+const capturedRunAgentLoopOptions: CapturedRunAgentLoopOptions[] = [];
+
+class FakeConversation {
+  constructor() {}
+  updateClient() {}
+  setIsSubagent() {}
+  setTrustContext() {}
+  setAuthContext() {}
+  getAuthContext() {
+    return undefined;
+  }
+  setAssistantId() {}
+  hasSystemPromptOverride = false;
+  setSubagentAllowedTools() {}
+  setPreactivatedSkillIds() {}
+  preactivateSkills() {}
+  preactivateSkillsAsync() {}
+  setSpawnHints() {}
+  injectInheritedContext() {}
+  setActiveBranchId() {}
+  setBranchTag() {}
+  setForkPolicy() {}
+  setForkParentMessageCount() {}
+  setForkParentSystemPrompt() {}
+  enqueueMessage() {
+    return { rejected: false, queued: false };
+  }
+  abort() {}
+  dispose() {}
+  messages = [];
+  usageStats = { inputTokens: 0, outputTokens: 0, estimatedCost: 0 };
+  sendToClient() {}
+  loadFromDb() {
+    return Promise.resolve();
+  }
+  persistUserMessage() {
+    return Promise.resolve("msg-id");
+  }
+  runAgentLoop(
+    _content: string,
+    _userMessageId: string,
+    _onEvent: unknown,
+    options?: CapturedRunAgentLoopOptions,
+  ) {
+    capturedRunAgentLoopOptions.push({ ...(options ?? {}) });
+    return Promise.resolve();
+  }
+  getCurrentSystemPrompt() {
+    return "system";
+  }
+}
+
+mock.module("../daemon/conversation.js", () => ({
+  Conversation: FakeConversation,
+}));
+
+mock.module("../memory/conversation-bootstrap.js", () => ({
+  bootstrapConversation: () => ({ id: "conv-id" }),
+}));
+
+mock.module("../prompts/system-prompt.js", () => ({
+  buildSystemPrompt: () => "system prompt",
+  buildSubagentSystemPrompt: () => "subagent system",
+}));
+
+const anthropicStub = { name: "anthropic" };
+
+mock.module("../providers/registry.js", () => ({
+  getProvider: () => anthropicStub,
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    llm: { default: { provider: "anthropic", model: "claude-opus-4-7" } },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+import { SubagentManager } from "../subagent/manager.js";
+
+describe("SubagentManager.spawn — overrideProfile inheritance", () => {
+  test("forwards overrideProfile from SubagentConfig into runAgentLoop", async () => {
+    capturedRunAgentLoopOptions.length = 0;
+
+    const manager = new SubagentManager();
+    await manager.spawn(
+      {
+        parentConversationId: "parent-1",
+        label: "child",
+        objective: "do the thing",
+        overrideProfile: "fast",
+      },
+      () => {},
+    );
+
+    // The spawned subagent's runAgentLoop must receive both the
+    // `subagentSpawn` callSite (existing behavior) and the inherited
+    // `overrideProfile` (new behavior).
+    expect(capturedRunAgentLoopOptions).toHaveLength(1);
+    const captured = capturedRunAgentLoopOptions[0];
+    expect(captured.callSite).toBe("subagentSpawn");
+    expect(captured.overrideProfile).toBe("fast");
+  });
+
+  test("omits overrideProfile when SubagentConfig does not set it", async () => {
+    capturedRunAgentLoopOptions.length = 0;
+
+    const manager = new SubagentManager();
+    await manager.spawn(
+      {
+        parentConversationId: "parent-2",
+        label: "child",
+        objective: "do the thing",
+      },
+      () => {},
+    );
+
+    expect(capturedRunAgentLoopOptions).toHaveLength(1);
+    const captured = capturedRunAgentLoopOptions[0];
+    expect(captured.callSite).toBe("subagentSpawn");
+    // Field must be absent rather than carrying `undefined`, mirroring the
+    // agent loop's "field omitted when unset" contract.
+    expect("overrideProfile" in captured).toBe(false);
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -353,6 +353,16 @@ export class AgentLoop {
      * in unit tests.
      */
     turnContext?: TurnContext,
+    /**
+     * Optional ad-hoc inference-profile override applied to every LLM call
+     * the loop issues. When set, each `SendMessageOptions.config` carries
+     * `overrideProfile = <name>` so the provider's resolver layers
+     * `llm.profiles[<name>]` between the workspace `activeProfile` and any
+     * call-site named profile. Missing profile names silently fall through.
+     * Used by per-conversation pinned profiles to override the workspace
+     * default for the lifetime of an agent loop run.
+     */
+    overrideProfile?: string,
   ): Promise<Message[]> {
     const history = [...messages];
     const initialHistoryLength = messages.length;
@@ -450,6 +460,16 @@ export class AgentLoop {
         // analyze, etc.) pass their own `callSite`.
         if (callSite) {
           providerConfig.callSite = callSite;
+        }
+
+        // Per-call inference-profile override. The resolver layers
+        // `llm.profiles[overrideProfile]` between the workspace's
+        // `activeProfile` and any call-site named profile. Threading it on
+        // every send (rather than once at construction) keeps subagents that
+        // share an `AgentLoop` instance but ought to inherit a different
+        // profile correct — and matches how `callSite` is plumbed.
+        if (overrideProfile) {
+          providerConfig.overrideProfile = overrideProfile;
         }
 
         // Rate-limit consecutive LLM calls to prevent spin when tools return instantly

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -574,6 +574,16 @@ export async function runAgentLoopImpl(
      * the agent loop defaults to `'mainAgent'` for user-initiated turns.
      */
     callSite?: LLMCallSite;
+    /**
+     * Optional ad-hoc inference-profile override applied to every LLM call
+     * the loop issues. When set, the agent loop sets
+     * `SendMessageOptions.config.overrideProfile` on each provider call so
+     * the resolver layers `llm.profiles[<name>]` between the workspace's
+     * `activeProfile` and the call-site's named profile. Used by
+     * per-conversation pinned profiles (and inherited by subagents the loop
+     * spawns).
+     */
+    overrideProfile?: string;
   },
 ): Promise<void> {
   if (!ctx.abortController) {
@@ -603,6 +613,11 @@ export async function runAgentLoopImpl(
   // `resolveCallSiteConfig`, picking up any user overrides under
   // `llm.callSites.mainAgent` (falling back to `llm.default` when absent).
   const turnCallSite: LLMCallSite = options?.callSite ?? "mainAgent";
+
+  // Optional per-turn inference-profile override. Plumbed through to every
+  // LLM call the loop emits and inherited by any subagents spawned during
+  // this turn.
+  const turnOverrideProfile = options?.overrideProfile;
 
   // Capture the turn channel context *before* any awaits so a second
   // message from a different channel can't overwrite it mid-flight.
@@ -1687,6 +1702,7 @@ export async function runAgentLoopImpl(
       onCheckpoint,
       turnCallSite,
       loopTurnCtx,
+      turnOverrideProfile,
     );
 
     rlog.info(
@@ -1836,6 +1852,7 @@ export async function runAgentLoopImpl(
         onCheckpoint,
         turnCallSite,
         loopTurnCtx,
+        turnOverrideProfile,
       );
     }
 
@@ -1891,6 +1908,7 @@ export async function runAgentLoopImpl(
         onCheckpoint,
         turnCallSite,
         loopTurnCtx,
+        turnOverrideProfile,
       );
 
       if (state.orderingErrorDetected) {
@@ -2077,6 +2095,7 @@ export async function runAgentLoopImpl(
           onCheckpoint,
           turnCallSite,
           loopTurnCtx,
+          turnOverrideProfile,
         );
 
         // If the rerun still yields at checkpoint, the turn is still
@@ -2234,6 +2253,7 @@ export async function runAgentLoopImpl(
             onCheckpoint,
             turnCallSite,
             loopTurnCtx,
+            turnOverrideProfile,
           );
         }
         // action === "fail_gracefully" falls through to the final error below

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1492,6 +1492,15 @@ export class Conversation {
       isUserMessage?: boolean;
       titleText?: string;
       callSite?: LLMCallSite;
+      /**
+       * Optional ad-hoc inference-profile override applied to every LLM call
+       * the loop issues for this turn. Forwarded into
+       * {@link runAgentLoopImpl} and threaded through to
+       * {@link AgentLoop.run} so each provider call carries
+       * `config.overrideProfile`. Subagents spawned during the turn inherit
+       * this value via {@link SubagentManager.spawn}.
+       */
+      overrideProfile?: string;
     },
   ): Promise<void> {
     return runAgentLoopImpl(this, content, userMessageId, onEvent, options);

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -482,6 +482,9 @@ export class SubagentManager {
       const messageId = await conversation.persistUserMessage(message, []);
       await conversation.runAgentLoop(message, messageId, onEvent, {
         callSite: "subagentSpawn",
+        ...(managed.state.config.overrideProfile
+          ? { overrideProfile: managed.state.config.overrideProfile }
+          : {}),
       });
 
       // Agent loop completed successfully.
@@ -679,6 +682,9 @@ export class SubagentManager {
       conversation
         .runAgentLoop(trimmed, messageId, onEvent, {
           callSite: "subagentSpawn",
+          ...(managed.state.config.overrideProfile
+            ? { overrideProfile: managed.state.config.overrideProfile }
+            : {}),
         })
         .catch((err) => {
           log.error({ subagentId, err }, "Subagent message processing failed");

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -60,6 +60,15 @@ export interface SubagentConfig {
    * for forks, this IS the system prompt (no subagent preamble is built).
    */
   parentSystemPrompt?: string;
+  /**
+   * Optional ad-hoc inference-profile override the parent inherits down to this
+   * subagent. When set, every LLM call the subagent issues carries
+   * `SendMessageOptions.config.overrideProfile = <name>` so the resolver layers
+   * `llm.profiles[<name>]` between the workspace's `activeProfile` and the
+   * call-site's named profile. If a parent conversation is pinned to a
+   * profile, every spawned subagent inherits it automatically.
+   */
+  overrideProfile?: string;
 }
 
 // ── State (runtime) ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `runAgentLoop` accepts `overrideProfile?: string` and forwards it to every LLM call's SendMessageOptions.
- Subagent spawn inherits the parent's `overrideProfile`.
- Default behavior (no override set) is unchanged.

Part of plan: inference-profiles.md (PR 6 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
