### PR TITLE
feat(macos): conversation inference-profile field and setter

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
@@ -461,6 +461,7 @@ final class ConversationListStore {
             source: item.source,
             conversationType: item.conversationType,
             hostAccess: item.hostAccess ?? false,
+            inferenceProfile: item.inferenceProfile,
             scheduleJobId: item.scheduleJobId,
             hasUnseenLatestAssistantMessage: (item.assistantAttention?.hasUnseenLatestAssistantMessage ?? false),
             latestAssistantMessageAt: item.assistantAttention?.latestAssistantMessageAt.map {
@@ -492,6 +493,11 @@ final class ConversationListStore {
     func updateConversationHostAccess(id: UUID, hostAccess: Bool) {
         guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
         conversations[index].hostAccess = hostAccess
+    }
+
+    func updateConversationInferenceProfile(id: UUID, profile: String?) {
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
+        conversations[index].inferenceProfile = profile
     }
 
     /// Rename a conversation and send the rename to the daemon.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -77,6 +77,7 @@ final class ConversationManager: ConversationRestorerDelegate {
     private let conversationForkClient: any ConversationForkClientProtocol
     private let conversationDetailClient: any ConversationDetailClientProtocol
     private let conversationHostAccessClient: any ConversationHostAccessClientProtocol
+    private let conversationInferenceProfileClient: any ConversationInferenceProfileClientProtocol
     private let conversationAnalysisClient: ConversationAnalysisClientProtocol
     private let conversationRestorer: ConversationRestorer
 
@@ -202,6 +203,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         conversationForkClient: any ConversationForkClientProtocol = ConversationForkClient(),
         conversationDetailClient: any ConversationDetailClientProtocol = ConversationDetailClient(),
         conversationHostAccessClient: any ConversationHostAccessClientProtocol = ConversationHostAccessClient(),
+        conversationInferenceProfileClient: any ConversationInferenceProfileClientProtocol = ConversationInferenceProfileClient(),
         conversationAnalysisClient: ConversationAnalysisClientProtocol = ConversationAnalysisClient(),
         isFirstLaunch: Bool = false,
         preChatContext: PreChatOnboardingContext? = nil
@@ -213,6 +215,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         self.conversationForkClient = conversationForkClient
         self.conversationDetailClient = conversationDetailClient
         self.conversationHostAccessClient = conversationHostAccessClient
+        self.conversationInferenceProfileClient = conversationInferenceProfileClient
         self.conversationAnalysisClient = conversationAnalysisClient
         self.conversationRestorer = ConversationRestorer(connectionManager: connectionManager, eventStreamClient: eventStreamClient)
         self.selectionStore = ConversationSelectionStore(listStore: listStore)
@@ -251,6 +254,11 @@ final class ConversationManager: ConversationRestorerDelegate {
                     self.applyConversationHostAccessUpdate(
                         serverConversationId: message.conversationId,
                         hostAccess: message.hostAccess
+                    )
+                case .conversationInferenceProfileUpdated(let message):
+                    self.applyConversationInferenceProfileUpdate(
+                        serverConversationId: message.conversationId,
+                        profile: message.profile
                     )
                 default:
                     break
@@ -1169,6 +1177,38 @@ final class ConversationManager: ConversationRestorerDelegate {
         return true
     }
 
+    /// Set the per-conversation inference-profile override. Pass `nil` to
+    /// clear the override and fall back to the workspace `llm.activeProfile`.
+    /// Returns `true` when the daemon accepted the change and the local
+    /// model has been updated; `false` otherwise (in which case the local
+    /// model is rolled back).
+    @discardableResult
+    func setConversationInferenceProfile(id localId: UUID, profile: String?) async -> Bool {
+        guard let index = listStore.conversations.firstIndex(where: { $0.id == localId }),
+              let conversationId = listStore.conversations[index].conversationId else {
+            return false
+        }
+
+        let previousProfile = listStore.conversations[index].inferenceProfile
+        guard previousProfile != profile else { return true }
+
+        listStore.updateConversationInferenceProfile(id: localId, profile: profile)
+        let response = await conversationInferenceProfileClient.setConversationInferenceProfile(
+            conversationId: conversationId,
+            profile: profile
+        )
+        guard let response else {
+            listStore.updateConversationInferenceProfile(id: localId, profile: previousProfile)
+            return false
+        }
+
+        applyConversationInferenceProfileUpdate(
+            serverConversationId: response.conversationId,
+            profile: response.profile
+        )
+        return true
+    }
+
     func renameConversation(id: UUID, title: String) {
         listStore.renameConversation(id: id, title: title)
     }
@@ -1472,6 +1512,13 @@ final class ConversationManager: ConversationRestorerDelegate {
             return
         }
         listStore.updateConversationHostAccess(id: localId, hostAccess: hostAccess)
+    }
+
+    private func applyConversationInferenceProfileUpdate(serverConversationId: String, profile: String?) {
+        guard let localId = listStore.conversations.first(where: { $0.conversationId == serverConversationId })?.id else {
+            return
+        }
+        listStore.updateConversationInferenceProfile(id: localId, profile: profile)
     }
 
     // MARK: - Assistant Activity Handling

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
@@ -47,6 +47,9 @@ struct ConversationModel: Identifiable, Hashable {
     /// by older daemons that predate the field; callers should treat `nil` as non-suppressed.
     var conversationType: String?
     var hostAccess: Bool
+    /// Per-conversation override for the LLM inference profile. `nil` means
+    /// the conversation inherits the workspace `llm.activeProfile`.
+    var inferenceProfile: String?
     /// The schedule job ID that created this conversation, if any.
     /// Conversations sharing the same scheduleJobId belong to the same schedule group.
     var scheduleJobId: String?
@@ -56,7 +59,7 @@ struct ConversationModel: Identifiable, Hashable {
     var forkParent: ConversationForkParent?
     var originChannel: String?
 
-    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), conversationId: String? = nil, isArchived: Bool = false, groupId: String? = nil, displayOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ConversationKind = .standard, source: String? = nil, conversationType: String? = nil, hostAccess: Bool = false, scheduleJobId: String? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil, forkParent: ConversationForkParent? = nil, originChannel: String? = nil) {
+    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), conversationId: String? = nil, isArchived: Bool = false, groupId: String? = nil, displayOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ConversationKind = .standard, source: String? = nil, conversationType: String? = nil, hostAccess: Bool = false, inferenceProfile: String? = nil, scheduleJobId: String? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil, forkParent: ConversationForkParent? = nil, originChannel: String? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -69,6 +72,7 @@ struct ConversationModel: Identifiable, Hashable {
         self.source = source
         self.conversationType = conversationType
         self.hostAccess = hostAccess
+        self.inferenceProfile = inferenceProfile
         self.scheduleJobId = scheduleJobId
         self.hasUnseenLatestAssistantMessage = hasUnseenLatestAssistantMessage
         self.latestAssistantMessageAt = latestAssistantMessageAt
@@ -165,6 +169,7 @@ struct ConversationModel: Identifiable, Hashable {
             lhs.source == rhs.source &&
             lhs.conversationType == rhs.conversationType &&
             lhs.hostAccess == rhs.hostAccess &&
+            lhs.inferenceProfile == rhs.inferenceProfile &&
             lhs.scheduleJobId == rhs.scheduleJobId &&
             lhs.hasUnseenLatestAssistantMessage == rhs.hasUnseenLatestAssistantMessage &&
             lhs.latestAssistantMessageAt == rhs.latestAssistantMessageAt &&
@@ -188,6 +193,7 @@ struct ConversationModel: Identifiable, Hashable {
         hasher.combine(source)
         hasher.combine(conversationType)
         hasher.combine(hostAccess)
+        hasher.combine(inferenceProfile)
         hasher.combine(scheduleJobId)
         hasher.combine(hasUnseenLatestAssistantMessage)
         hasher.combine(latestAssistantMessageAt)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -385,6 +385,7 @@ final class ConversationRestorer {
                 source: session.source,
                 conversationType: session.conversationType,
                 hostAccess: session.hostAccess ?? false,
+                inferenceProfile: session.inferenceProfile,
                 scheduleJobId: session.scheduleJobId,
                 hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false,
                 latestAssistantMessageAt: session.assistantAttention?.latestAssistantMessageAt.map {

--- a/clients/macos/vellum-assistantTests/Features/Chat/ConversationManagerInferenceProfileTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ConversationManagerInferenceProfileTests.swift
@@ -1,0 +1,254 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ConversationManagerInferenceProfileTests: XCTestCase {
+    private var connectionManager: GatewayConnectionManager!
+    private var mockProfileClient: MockConversationInferenceProfileClient!
+    private var conversationManager: ConversationManager!
+
+    override func setUp() {
+        super.setUp()
+        connectionManager = GatewayConnectionManager()
+        connectionManager.isConnected = true
+        mockProfileClient = MockConversationInferenceProfileClient()
+        conversationManager = ConversationManager(
+            connectionManager: connectionManager,
+            eventStreamClient: connectionManager.eventStreamClient,
+            conversationInferenceProfileClient: mockProfileClient
+        )
+    }
+
+    override func tearDown() {
+        conversationManager = nil
+        mockProfileClient = nil
+        connectionManager = nil
+        super.tearDown()
+    }
+
+    // MARK: - Setter
+
+    func testSetConversationInferenceProfileUpdatesConversationOnSuccess() async {
+        let localId = UUID()
+        conversationManager.conversations = [
+            ConversationModel(
+                id: localId,
+                title: "Profile target",
+                conversationId: "conv-1",
+                inferenceProfile: nil
+            )
+        ]
+        mockProfileClient.setResponse = ConversationInferenceProfileResponse(
+            conversationId: "conv-1",
+            profile: "balanced"
+        )
+
+        let success = await conversationManager.setConversationInferenceProfile(
+            id: localId,
+            profile: "balanced"
+        )
+
+        XCTAssertTrue(success)
+        XCTAssertEqual(
+            mockProfileClient.setCalls,
+            [MockConversationInferenceProfileClient.SetCall(conversationId: "conv-1", profile: "balanced")]
+        )
+        XCTAssertEqual(conversationManager.conversations[0].inferenceProfile, "balanced")
+    }
+
+    func testSetConversationInferenceProfileClearsOverrideWithNil() async {
+        let localId = UUID()
+        conversationManager.conversations = [
+            ConversationModel(
+                id: localId,
+                title: "Profile target",
+                conversationId: "conv-1",
+                inferenceProfile: "balanced"
+            )
+        ]
+        mockProfileClient.setResponse = ConversationInferenceProfileResponse(
+            conversationId: "conv-1",
+            profile: nil
+        )
+
+        let success = await conversationManager.setConversationInferenceProfile(
+            id: localId,
+            profile: nil
+        )
+
+        XCTAssertTrue(success)
+        XCTAssertEqual(
+            mockProfileClient.setCalls,
+            [MockConversationInferenceProfileClient.SetCall(conversationId: "conv-1", profile: nil)]
+        )
+        XCTAssertNil(conversationManager.conversations[0].inferenceProfile)
+    }
+
+    func testSetConversationInferenceProfileRevertsOnFailure() async {
+        let localId = UUID()
+        conversationManager.conversations = [
+            ConversationModel(
+                id: localId,
+                title: "Profile target",
+                conversationId: "conv-1",
+                inferenceProfile: "balanced"
+            )
+        ]
+        mockProfileClient.setResponse = nil
+
+        let success = await conversationManager.setConversationInferenceProfile(
+            id: localId,
+            profile: "quality-optimized"
+        )
+
+        XCTAssertFalse(success)
+        XCTAssertEqual(
+            mockProfileClient.setCalls,
+            [MockConversationInferenceProfileClient.SetCall(conversationId: "conv-1", profile: "quality-optimized")]
+        )
+        // Local model rolls back to the previous value when the daemon rejects the change.
+        XCTAssertEqual(conversationManager.conversations[0].inferenceProfile, "balanced")
+    }
+
+    func testSetConversationInferenceProfileNoOpsWhenAlreadyMatching() async {
+        let localId = UUID()
+        conversationManager.conversations = [
+            ConversationModel(
+                id: localId,
+                title: "Profile target",
+                conversationId: "conv-1",
+                inferenceProfile: "balanced"
+            )
+        ]
+
+        let success = await conversationManager.setConversationInferenceProfile(
+            id: localId,
+            profile: "balanced"
+        )
+
+        XCTAssertTrue(success)
+        XCTAssertTrue(mockProfileClient.setCalls.isEmpty)
+        XCTAssertEqual(conversationManager.conversations[0].inferenceProfile, "balanced")
+    }
+
+    func testSetConversationInferenceProfileRequiresConversationId() async {
+        // A conversation that has not yet been backfilled with a daemon-side
+        // conversationId can't be persisted server-side, so the call fails fast
+        // and leaves the local model alone.
+        let localId = UUID()
+        conversationManager.conversations = [
+            ConversationModel(
+                id: localId,
+                title: "No daemon id yet",
+                conversationId: nil,
+                inferenceProfile: nil
+            )
+        ]
+
+        let success = await conversationManager.setConversationInferenceProfile(
+            id: localId,
+            profile: "balanced"
+        )
+
+        XCTAssertFalse(success)
+        XCTAssertTrue(mockProfileClient.setCalls.isEmpty)
+        XCTAssertNil(conversationManager.conversations[0].inferenceProfile)
+    }
+
+    // MARK: - Event-hub convergence
+
+    func testConversationInferenceProfileUpdatedEventMergesIntoConversation() async throws {
+        let localId = UUID()
+        conversationManager.conversations = [
+            ConversationModel(
+                id: localId,
+                title: "External update target",
+                conversationId: "conv-2",
+                inferenceProfile: nil
+            )
+        ]
+
+        connectionManager.eventStreamClient.broadcastMessage(
+            .conversationInferenceProfileUpdated(
+                ConversationInferenceProfileUpdatedMessage(
+                    conversationId: "conv-2",
+                    profile: "quality-optimized"
+                )
+            )
+        )
+
+        try await waitForCondition {
+            self.conversationManager.conversations.first?.inferenceProfile == "quality-optimized"
+        }
+
+        XCTAssertEqual(conversationManager.conversations[0].inferenceProfile, "quality-optimized")
+    }
+
+    func testConversationInferenceProfileUpdatedEventClearsLocalOverride() async throws {
+        let localId = UUID()
+        conversationManager.conversations = [
+            ConversationModel(
+                id: localId,
+                title: "External clear target",
+                conversationId: "conv-3",
+                inferenceProfile: "balanced"
+            )
+        ]
+
+        connectionManager.eventStreamClient.broadcastMessage(
+            .conversationInferenceProfileUpdated(
+                ConversationInferenceProfileUpdatedMessage(
+                    conversationId: "conv-3",
+                    profile: nil
+                )
+            )
+        )
+
+        try await waitForCondition {
+            self.conversationManager.conversations.first?.inferenceProfile == nil
+        }
+
+        XCTAssertNil(conversationManager.conversations[0].inferenceProfile)
+    }
+
+    /// Polls `condition` on the MainActor until it returns true or the
+    /// timeout elapses. ConversationManager wires its event-stream
+    /// subscription in a `Task { ... for await ... }` during init; the
+    /// loop only begins iterating after the runtime schedules that Task,
+    /// so a `broadcastMessage` issued immediately after `init` needs a
+    /// few main-queue turns before it lands. `XCTNSPredicateExpectation`
+    /// is unreliable for this race in `@MainActor` test classes — polling
+    /// drains the queue deterministically.
+    private func waitForCondition(
+        timeout: TimeInterval = 1.0,
+        _ condition: () -> Bool,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTFail("waitForCondition timed out after \(timeout)s", file: file, line: line)
+    }
+}
+
+private final class MockConversationInferenceProfileClient: ConversationInferenceProfileClientProtocol {
+    struct SetCall: Equatable {
+        let conversationId: String
+        let profile: String?
+    }
+
+    var setResponse: ConversationInferenceProfileResponse?
+    private(set) var setCalls: [SetCall] = []
+
+    func setConversationInferenceProfile(
+        conversationId: String,
+        profile: String?
+    ) async -> ConversationInferenceProfileResponse? {
+        setCalls.append(SetCall(conversationId: conversationId, profile: profile))
+        return setResponse
+    }
+}

--- a/clients/shared/Network/ConversationAnalysisClient.swift
+++ b/clients/shared/Network/ConversationAnalysisClient.swift
@@ -51,7 +51,8 @@ public struct ConversationAnalysisClient: ConversationAnalysisClientProtocol {
             displayOrder: conversation.displayOrder,
             isPinned: conversation.isPinned,
             groupId: groupId,
-            forkParent: conversation.forkParent
+            forkParent: conversation.forkParent,
+            inferenceProfile: conversation.inferenceProfile
         )
     }
 }

--- a/clients/shared/Network/ConversationDetailClient.swift
+++ b/clients/shared/Network/ConversationDetailClient.swift
@@ -51,7 +51,8 @@ public struct ConversationDetailClient: ConversationDetailClientProtocol {
             displayOrder: conversation.displayOrder,
             isPinned: conversation.isPinned,
             groupId: groupId,
-            forkParent: conversation.forkParent
+            forkParent: conversation.forkParent,
+            inferenceProfile: conversation.inferenceProfile
         )
     }
 }

--- a/clients/shared/Network/ConversationForkClient.swift
+++ b/clients/shared/Network/ConversationForkClient.swift
@@ -56,7 +56,8 @@ public struct ConversationForkClient: ConversationForkClientProtocol {
             displayOrder: conversation.displayOrder,
             isPinned: conversation.isPinned,
             groupId: groupId,
-            forkParent: conversation.forkParent
+            forkParent: conversation.forkParent,
+            inferenceProfile: conversation.inferenceProfile
         )
     }
 }

--- a/clients/shared/Network/ConversationInferenceProfileClient.swift
+++ b/clients/shared/Network/ConversationInferenceProfileClient.swift
@@ -1,0 +1,54 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ConversationInferenceProfileClient")
+
+/// Response shape for `PUT /v1/conversations/:id/inference-profile`. The
+/// server emits `{ conversationId, profile }` where `profile` is `null`
+/// when the conversation override was cleared.
+public struct ConversationInferenceProfileResponse: Decodable, Sendable {
+    public let conversationId: String
+    public let profile: String?
+
+    public init(conversationId: String, profile: String?) {
+        self.conversationId = conversationId
+        self.profile = profile
+    }
+}
+
+public protocol ConversationInferenceProfileClientProtocol {
+    /// Update the conversation's inference profile override. Pass `nil` to
+    /// clear the override and fall back to the workspace `llm.activeProfile`.
+    func setConversationInferenceProfile(
+        conversationId: String,
+        profile: String?
+    ) async -> ConversationInferenceProfileResponse?
+}
+
+public struct ConversationInferenceProfileClient: ConversationInferenceProfileClientProtocol {
+    nonisolated public init() {}
+
+    public func setConversationInferenceProfile(
+        conversationId: String,
+        profile: String?
+    ) async -> ConversationInferenceProfileResponse? {
+        // The daemon route accepts `{ profile: <string|null> }` — Foundation's
+        // JSON serializer renders `NSNull()` as `null`, which is the wire shape
+        // the daemon's Zod schema (`z.string().nullable()`) expects.
+        let body: [String: Any] = ["profile": profile ?? NSNull()]
+        do {
+            let response = try await GatewayHTTPClient.put(
+                path: "assistants/{assistantId}/conversations/\(conversationId)/inference-profile",
+                json: body
+            )
+            guard response.isSuccess else {
+                log.warning("PUT /conversations/\(conversationId, privacy: .public)/inference-profile failed with status \(response.statusCode)")
+                return nil
+            }
+            return try JSONDecoder().decode(ConversationInferenceProfileResponse.self, from: response.data)
+        } catch {
+            log.error("Failed to update conversation inference profile: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/clients/shared/Network/ConversationListClient.swift
+++ b/clients/shared/Network/ConversationListClient.swift
@@ -54,7 +54,8 @@ public struct ConversationListClient: ConversationListClientProtocol {
                     displayOrder: $0.displayOrder,
                     isPinned: $0.isPinned,
                     groupId: $0.groupId,
-                    forkParent: $0.forkParent
+                    forkParent: $0.forkParent,
+                    inferenceProfile: $0.inferenceProfile
                 )
             }
             return ConversationListResponse(
@@ -385,6 +386,7 @@ private struct HTTPConversationsListResponse: Decodable {
         let isPinned: Bool?
         let groupId: String?
         let forkParent: ConversationForkParent?
+        let inferenceProfile: String?
     }
     let conversations: [Conversation]
     let hasMore: Bool?

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3527,14 +3527,16 @@ public struct ConversationInfo: Codable, Sendable {
     public let correlationId: String?
     public let conversationType: String?
     public let hostAccess: Bool?
+    public let inferenceProfile: String?
 
-    public init(type: String, conversationId: String, title: String, correlationId: String? = nil, conversationType: String? = nil, hostAccess: Bool? = nil) {
+    public init(type: String, conversationId: String, title: String, correlationId: String? = nil, conversationType: String? = nil, hostAccess: Bool? = nil, inferenceProfile: String? = nil) {
         self.type = type
         self.conversationId = conversationId
         self.title = title
         self.correlationId = correlationId
         self.conversationType = conversationType
         self.hostAccess = hostAccess
+        self.inferenceProfile = inferenceProfile
     }
 }
 
@@ -3605,8 +3607,11 @@ public struct ConversationListResponseItem: Codable, Sendable {
     public let groupId: String?
     public let forkParent: ConversationForkParent?
     public let archivedAt: Int?
+    /// Per-conversation override for the LLM inference profile. `nil` means
+    /// the conversation inherits the workspace `llm.activeProfile`.
+    public let inferenceProfile: String?
 
-    public init(id: String, title: String, createdAt: Int? = nil, updatedAt: Int, lastMessageAt: Int? = nil, conversationType: String? = nil, source: String? = nil, hostAccess: Bool? = nil, scheduleJobId: String? = nil, channelBinding: ChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: AssistantAttention? = nil, displayOrder: Double? = nil, isPinned: Bool? = nil, groupId: String? = nil, forkParent: ConversationForkParent? = nil, archivedAt: Int? = nil) {
+    public init(id: String, title: String, createdAt: Int? = nil, updatedAt: Int, lastMessageAt: Int? = nil, conversationType: String? = nil, source: String? = nil, hostAccess: Bool? = nil, scheduleJobId: String? = nil, channelBinding: ChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: AssistantAttention? = nil, displayOrder: Double? = nil, isPinned: Bool? = nil, groupId: String? = nil, forkParent: ConversationForkParent? = nil, archivedAt: Int? = nil, inferenceProfile: String? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -3625,6 +3630,7 @@ public struct ConversationListResponseItem: Codable, Sendable {
         self.groupId = groupId
         self.forkParent = forkParent
         self.archivedAt = archivedAt
+        self.inferenceProfile = inferenceProfile
     }
 }
 

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -736,6 +736,19 @@ public struct ConversationHostAccessUpdatedMessage: Decodable, Sendable {
     public let hostAccess: Bool
 }
 
+/// Server push: the per-conversation inference-profile override changed.
+/// `profile` is `nil` when the override was cleared (the conversation now
+/// inherits the workspace `llm.activeProfile`).
+public struct ConversationInferenceProfileUpdatedMessage: Decodable, Sendable {
+    public let conversationId: String
+    public let profile: String?
+
+    public init(conversationId: String, profile: String?) {
+        self.conversationId = conversationId
+        self.profile = profile
+    }
+}
+
 /// Server push — tells clients their sidebar conversation list is stale.
 public struct ConversationListInvalidatedMessage: Decodable, Sendable {
     public let reason: String
@@ -2530,6 +2543,7 @@ public enum ServerMessage: Decodable, Sendable {
     case messageComplete(MessageCompleteMessage)
     case conversationInfo(ConversationInfoMessage)
     case conversationHostAccessUpdated(ConversationHostAccessUpdatedMessage)
+    case conversationInferenceProfileUpdated(ConversationInferenceProfileUpdatedMessage)
     case conversationTitleUpdated(ConversationTitleUpdatedMessage)
     case conversationListResponse(ConversationListResponseMessage)
     case conversationListInvalidated(ConversationListInvalidatedMessage)
@@ -2742,6 +2756,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "conversation_host_access_updated":
             let message = try ConversationHostAccessUpdatedMessage(from: decoder)
             self = .conversationHostAccessUpdated(message)
+        case "conversation_inference_profile_updated":
+            let message = try ConversationInferenceProfileUpdatedMessage(from: decoder)
+            self = .conversationInferenceProfileUpdated(message)
         case "conversation_title_updated":
             let message = try ConversationTitleUpdatedMessage(from: decoder)
             self = .conversationTitleUpdated(message)

--- a/clients/shared/Network/NetworkResponseTypes.swift
+++ b/clients/shared/Network/NetworkResponseTypes.swift
@@ -32,6 +32,9 @@ public struct ConversationsListResponse: Decodable {
         public let isPinned: Bool?
         public let groupId: String?
         public let forkParent: ConversationForkParent?
+        /// Per-conversation override for the LLM inference profile. `nil` means
+        /// the conversation inherits the workspace `llm.activeProfile`.
+        public let inferenceProfile: String?
     }
     public let conversations: [Conversation]
     public let hasMore: Bool?

--- a/clients/shared/Tests/HTTPDaemonClientInferenceProfileDecodingTests.swift
+++ b/clients/shared/Tests/HTTPDaemonClientInferenceProfileDecodingTests.swift
@@ -1,0 +1,204 @@
+import XCTest
+
+@testable import VellumAssistantShared
+
+/// Decoding contract for the per-conversation `inferenceProfile` field across
+/// the conversation transport DTOs surfaced to the macOS client.
+///
+/// The HTTP route `PUT /v1/conversations/:id/inference-profile` returns
+/// `{ conversationId, profile }`, and conversation list/detail/fork endpoints
+/// surface the field as an optional `inferenceProfile` so older daemons
+/// (which omit the field entirely) continue to decode cleanly.
+final class HTTPDaemonClientInferenceProfileDecodingTests: XCTestCase {
+    private let decoder = JSONDecoder()
+
+    // MARK: - Setter response
+
+    func testSetInferenceProfileResponseDecodesProfile() throws {
+        let data = Data(
+            """
+            {
+              "conversationId": "conv-1",
+              "profile": "balanced"
+            }
+            """.utf8
+        )
+
+        let response = try decoder.decode(ConversationInferenceProfileResponse.self, from: data)
+
+        XCTAssertEqual(response.conversationId, "conv-1")
+        XCTAssertEqual(response.profile, "balanced")
+    }
+
+    func testSetInferenceProfileResponseDecodesNullProfile() throws {
+        let data = Data(
+            """
+            {
+              "conversationId": "conv-1",
+              "profile": null
+            }
+            """.utf8
+        )
+
+        let response = try decoder.decode(ConversationInferenceProfileResponse.self, from: data)
+
+        XCTAssertEqual(response.conversationId, "conv-1")
+        XCTAssertNil(response.profile)
+    }
+
+    func testSetInferenceProfileResponseDecodesMissingProfileAsNil() throws {
+        // The field is optional on the wire — an older daemon (or a future
+        // route that uses a different shape) might omit it; we expect nil.
+        let data = Data(
+            """
+            {
+              "conversationId": "conv-1"
+            }
+            """.utf8
+        )
+
+        let response = try decoder.decode(ConversationInferenceProfileResponse.self, from: data)
+
+        XCTAssertEqual(response.conversationId, "conv-1")
+        XCTAssertNil(response.profile)
+    }
+
+    // MARK: - Conversation list payload
+
+    func testConversationsListResponseDecodesInferenceProfile() throws {
+        let data = Data(
+            """
+            {
+              "conversations": [
+                {
+                  "id": "conv-1",
+                  "title": "With profile",
+                  "createdAt": 1700000000,
+                  "updatedAt": 1700000100,
+                  "inferenceProfile": "quality-optimized"
+                }
+              ],
+              "hasMore": false
+            }
+            """.utf8
+        )
+
+        let response = try decoder.decode(ConversationsListResponse.self, from: data)
+        let conversation = try XCTUnwrap(response.conversations.first)
+
+        XCTAssertEqual(conversation.inferenceProfile, "quality-optimized")
+    }
+
+    func testConversationsListResponseDecodesWithoutInferenceProfile() throws {
+        // Backwards-compatibility: pre-PR-16 daemons omit the field entirely.
+        let data = Data(
+            """
+            {
+              "conversations": [
+                {
+                  "id": "conv-2",
+                  "title": "Without profile",
+                  "createdAt": 1700000000,
+                  "updatedAt": 1700000100
+                }
+              ],
+              "hasMore": false
+            }
+            """.utf8
+        )
+
+        let response = try decoder.decode(ConversationsListResponse.self, from: data)
+        let conversation = try XCTUnwrap(response.conversations.first)
+
+        XCTAssertNil(conversation.inferenceProfile)
+    }
+
+    // MARK: - Single conversation payload (used by ConversationDetailClient)
+
+    func testSingleConversationResponseDecodesInferenceProfile() throws {
+        let data = Data(
+            """
+            {
+              "conversation": {
+                "id": "conv-3",
+                "title": "Detail",
+                "createdAt": 1700000000,
+                "updatedAt": 1700000100,
+                "inferenceProfile": "cost-optimized"
+              }
+            }
+            """.utf8
+        )
+
+        let response = try decoder.decode(SingleConversationResponse.self, from: data)
+
+        XCTAssertEqual(response.conversation.inferenceProfile, "cost-optimized")
+    }
+
+    // MARK: - Server-pushed event
+
+    func testConversationListResponseTransportDecodesInferenceProfile() throws {
+        let data = Data(
+            """
+            {
+              "type": "conversation_list_response",
+              "conversations": [
+                {
+                  "id": "conv-4",
+                  "title": "Transport",
+                  "createdAt": 1700000000,
+                  "updatedAt": 1700000100,
+                  "inferenceProfile": "balanced"
+                }
+              ],
+              "hasMore": false
+            }
+            """.utf8
+        )
+
+        let response = try decoder.decode(ConversationListResponse.self, from: data)
+        let conversation = try XCTUnwrap(response.conversations.first)
+
+        XCTAssertEqual(conversation.inferenceProfile, "balanced")
+    }
+
+    func testServerMessageDecodesConversationInferenceProfileUpdated() throws {
+        let data = Data(
+            """
+            {
+              "type": "conversation_inference_profile_updated",
+              "conversationId": "conv-5",
+              "profile": "quality-optimized"
+            }
+            """.utf8
+        )
+
+        let message = try decoder.decode(ServerMessage.self, from: data)
+        guard case .conversationInferenceProfileUpdated(let payload) = message else {
+            return XCTFail("Expected .conversationInferenceProfileUpdated, got \(message)")
+        }
+
+        XCTAssertEqual(payload.conversationId, "conv-5")
+        XCTAssertEqual(payload.profile, "quality-optimized")
+    }
+
+    func testServerMessageDecodesConversationInferenceProfileUpdatedWithNullProfile() throws {
+        let data = Data(
+            """
+            {
+              "type": "conversation_inference_profile_updated",
+              "conversationId": "conv-5",
+              "profile": null
+            }
+            """.utf8
+        )
+
+        let message = try decoder.decode(ServerMessage.self, from: data)
+        guard case .conversationInferenceProfileUpdated(let payload) = message else {
+            return XCTFail("Expected .conversationInferenceProfileUpdated, got \(message)")
+        }
+
+        XCTAssertEqual(payload.conversationId, "conv-5")
+        XCTAssertNil(payload.profile)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `inferenceProfile: String?` to conversation DTOs and the published `ConversationModel`.
- `ConversationManager.setInferenceProfile` calls `PUT /v1/conversations/:id/inference-profile`.
- Subscribe to `conversation_inference_profile_updated` events to converge on remote updates.

Part of plan: inference-profiles.md (PR 16 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
