### PR TITLE
feat(macos): inference profiles management sheet

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
@@ -1,0 +1,533 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Management sheet for the user's inference profiles. Lists every entry in
+/// `store.profiles`, surfaces a "Built-in" badge for the canonical profiles
+/// seeded by workspace migration 052, and exposes Edit / Duplicate / Delete
+/// per row plus a `+ New profile` toolbar action.
+///
+/// State ownership:
+/// - The list mirrors `store.profiles` directly. Edits route through
+///   `store.setProfile(name:fragment:)` which updates the published state
+///   optimistically, so the sheet does not maintain a separate draft cache
+///   for the list rows.
+/// - The editor is presented modally over the sheet via the
+///   `editorState` @State. The editor has its own draft binding —
+///   committing pushes the fragment to the store and dismisses the editor.
+/// - Delete blocked-by-references confirmation surfaces via `blockedState`.
+///   The user can re-target every conflicting reference to a replacement
+///   profile, which retries the delete after the patches land.
+///
+/// Built-in profiles are *not* protected — the badge is informational only.
+/// Users can edit, duplicate, or delete a built-in profile. Re-running the
+/// seed migration is idempotent and skips entries the user has touched, so
+/// deleted built-ins stay deleted across daemon restarts.
+@MainActor
+struct InferenceProfilesSheet: View {
+    @ObservedObject var store: SettingsStore
+    @Binding var isPresented: Bool
+
+    @State private var editorState: EditorState?
+
+    /// Local working copy for the active editor session. Bound into
+    /// `InferenceProfileEditor` so the user's edits flow through without
+    /// requiring the store to allocate intermediate state.
+    @State private var editorDraft: InferenceProfile = InferenceProfile(name: "")
+
+    /// Original profile name when an edit session begins. Drives the rename
+    /// detection in `commitEditor` — when the user changes the name we
+    /// delete the old key after the new one writes successfully.
+    @State private var editorOriginalName: String?
+
+    @State private var blockedState: BlockedDeleteState?
+
+    /// Picked replacement profile name in the blocked-delete dialog. Drives
+    /// the "Pick replacement" affordance.
+    @State private var replacementSelection: String = ""
+
+    /// Inline error surfaced when a save or delete fails. Cleared at the
+    /// start of every action.
+    @State private var actionError: String?
+
+    enum EditorState: Equatable {
+        case create
+        case edit(name: String)
+        case duplicate(name: String)
+    }
+
+    /// Conflict surface for a blocked delete. Mirrors
+    /// `SettingsStore.DeleteProfileResult.blockedBy*` so the UI can render a
+    /// per-shape message + remediation affordance.
+    enum BlockedDeleteState: Equatable {
+        case active(profileName: String, activeProfile: String)
+        case callSites(profileName: String, callSiteIds: [String])
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            SettingsDivider()
+            profilesList
+            SettingsDivider()
+            footer
+        }
+        .frame(width: 560, height: 540)
+        .background(VColor.surfaceLift)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .sheet(item: $editorState) { _ in
+            editorSheet
+        }
+        .sheet(item: $blockedState) { _ in
+            blockedDeleteSheet
+        }
+        .onChange(of: editorState) { _, newValue in
+            // Clear the draft when the editor dismisses so the next
+            // session starts from a clean slate. Re-seeding happens in
+            // `beginCreate` / `beginEdit` / `beginDuplicate`.
+            if newValue == nil {
+                editorDraft = InferenceProfile(name: "")
+                editorOriginalName = nil
+            }
+        }
+        .onChange(of: blockedState) { _, newValue in
+            if newValue == nil {
+                replacementSelection = ""
+            }
+        }
+    }
+
+    // MARK: - Header / Footer
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Inference Profiles")
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+                Text("Bundle a provider, model, and tuning into a named profile. Assign profiles to call sites or pick one for a single chat.")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+            HStack(spacing: VSpacing.sm) {
+                VButton(label: "+ New Profile", style: .primary) {
+                    beginCreate()
+                }
+                VButton(
+                    label: "Close",
+                    iconOnly: VIcon.x.rawValue,
+                    style: .ghost,
+                    tintColor: VColor.contentTertiary
+                ) {
+                    isPresented = false
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+    }
+
+    private var footer: some View {
+        HStack {
+            if let actionError {
+                Text(actionError)
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+            }
+            Spacer()
+            VButton(label: "Done", style: .outlined) {
+                isPresented = false
+            }
+        }
+        .padding(VSpacing.lg)
+    }
+
+    // MARK: - Profiles List
+
+    private var profilesList: some View {
+        List {
+            if store.profiles.isEmpty {
+                emptyState
+                    .listRowSeparator(.hidden)
+            } else {
+                ForEach(store.profiles) { profile in
+                    profileRow(profile)
+                        .contextMenu {
+                            Button("Edit") { beginEdit(profile.name) }
+                            Button("Duplicate") { beginDuplicate(profile.name) }
+                            Divider()
+                            Button("Delete", role: .destructive) {
+                                Task { await attemptDelete(profile.name) }
+                            }
+                        }
+                }
+            }
+        }
+        .listStyle(.inset)
+        .frame(maxHeight: .infinity)
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .center, spacing: VSpacing.sm) {
+            Text("No inference profiles configured")
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(VColor.contentDefault)
+            Text("Add a profile to bundle a provider, model, and tuning under a name you can reuse across call sites and chats.")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(VSpacing.xl)
+    }
+
+    /// Single row: name + optional badge on the leading column, summary on
+    /// the trailing column. Tapping opens the editor; the context menu
+    /// surfaces Duplicate and Delete in addition.
+    private func profileRow(_ profile: InferenceProfile) -> some View {
+        HStack(alignment: .center, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                HStack(spacing: VSpacing.xs) {
+                    Text(profile.name)
+                        .font(VFont.bodyMediumEmphasised)
+                        .foregroundStyle(VColor.contentDefault)
+                    if BuiltInInferenceProfile.allNames.contains(profile.name) {
+                        VBadge(label: "Built-in", tone: .neutral, emphasis: .subtle)
+                    }
+                }
+                Text(InferenceProfilesSheet.summary(for: profile, store: store))
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+            Spacer(minLength: 0)
+            VButton(label: "Edit", style: .ghost) {
+                beginEdit(profile.name)
+            }
+        }
+        .padding(.vertical, VSpacing.xs)
+        .contentShape(Rectangle())
+    }
+
+    // MARK: - Editor Sheet
+
+    private var editorSheet: some View {
+        InferenceProfileEditor(
+            store: store,
+            profile: $editorDraft,
+            onSave: {
+                Task { await commitEditor() }
+            },
+            onCancel: {
+                editorState = nil
+            }
+        )
+    }
+
+    // MARK: - Blocked Delete Sheet
+
+    private var blockedDeleteSheet: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            blockedDeleteHeader
+            blockedDeleteBody
+            blockedDeleteActions
+        }
+        .padding(VSpacing.xl)
+        .frame(width: 460)
+        .background(VColor.surfaceOverlay)
+    }
+
+    private var blockedDeleteHeader: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Can't Delete Profile")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+            Text(blockedSummary)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    @ViewBuilder
+    private var blockedDeleteBody: some View {
+        switch blockedState {
+        case .active:
+            EmptyView()
+        case .callSites(_, let ids):
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Call sites using this profile:")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                ForEach(ids, id: \.self) { id in
+                    Text("• \(callSiteDisplayName(id))")
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentDefault)
+                }
+            }
+        case .none:
+            EmptyView()
+        }
+    }
+
+    private var blockedDeleteActions: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            if !replacementOptions.isEmpty {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Pick replacement")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                    VDropdown(
+                        placeholder: "Select a replacement profile\u{2026}",
+                        selection: $replacementSelection,
+                        options: replacementOptions.map { (label: $0, value: $0) }
+                    )
+                }
+            }
+            HStack(spacing: VSpacing.sm) {
+                Spacer(minLength: 0)
+                VButton(label: "Cancel", style: .ghost) {
+                    blockedState = nil
+                }
+                VButton(
+                    label: "Reassign and Delete",
+                    style: .danger,
+                    isDisabled: replacementSelection.isEmpty
+                ) {
+                    Task { await retargetAndDelete() }
+                }
+            }
+        }
+    }
+
+    private var blockedSummary: String {
+        switch blockedState {
+        case .active(let profileName, let active):
+            return "\"\(profileName)\" is the active profile (\"\(active)\"). Pick a different active profile or a replacement below to delete it."
+        case .callSites(let profileName, let ids):
+            let count = ids.count
+            let suffix = count == 1 ? "call site" : "call sites"
+            return "\"\(profileName)\" is in use by \(count) \(suffix). Pick a replacement to re-target the references, or cancel and clear them manually."
+        case .none:
+            return ""
+        }
+    }
+
+    /// Replacement candidates are every profile except the one we're trying
+    /// to delete. Sorted alphabetically to match the list ordering.
+    private var replacementOptions: [String] {
+        let blockedName: String?
+        switch blockedState {
+        case .active(let name, _):
+            blockedName = name
+        case .callSites(let name, _):
+            blockedName = name
+        case .none:
+            blockedName = nil
+        }
+        return store.profiles
+            .map(\.name)
+            .filter { $0 != blockedName }
+            .sorted()
+    }
+
+    // MARK: - Actions
+
+    private func beginCreate() {
+        actionError = nil
+        let baseName = "new-profile"
+        let uniqueName = uniqueProfileName(prefix: baseName)
+        editorDraft = InferenceProfile(name: uniqueName)
+        editorOriginalName = nil
+        editorState = .create
+    }
+
+    private func beginEdit(_ name: String) {
+        actionError = nil
+        guard let existing = store.profiles.first(where: { $0.name == name }) else { return }
+        editorDraft = existing
+        editorOriginalName = name
+        editorState = .edit(name: name)
+    }
+
+    private func beginDuplicate(_ name: String) {
+        actionError = nil
+        guard let source = store.profiles.first(where: { $0.name == name }) else { return }
+        var copy = source
+        copy.name = uniqueProfileName(prefix: "\(name)-copy")
+        editorDraft = copy
+        editorOriginalName = nil
+        editorState = .duplicate(name: name)
+    }
+
+    private func commitEditor() async {
+        let draft = editorDraft
+        let originalName = editorOriginalName
+        let name = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Refuse to commit empty or whitespace-only names — the daemon
+        // would accept them but the row would render unusably.
+        guard !name.isEmpty else { return }
+
+        let success = await store.setProfile(name: name, fragment: draft)
+        guard success else {
+            actionError = "Couldn't save profile. Please try again."
+            return
+        }
+
+        // Renaming an existing profile: drop the old key. We do this only
+        // when the rename succeeded so a failed rename leaves the source
+        // intact.
+        if let originalName, originalName != name {
+            // Best-effort delete — the editor doesn't surface
+            // blocked-by errors here because the user just renamed; the
+            // worst case is a stale entry the user can clean up manually.
+            _ = await store.deleteProfile(name: originalName)
+        }
+
+        editorState = nil
+    }
+
+    private func attemptDelete(_ name: String) async {
+        actionError = nil
+        let result = await store.deleteProfile(name: name)
+        switch result {
+        case .deleted:
+            break
+        case .blockedByActive(let active):
+            blockedState = .active(profileName: name, activeProfile: active)
+        case .blockedByCallSites(let ids):
+            blockedState = .callSites(profileName: name, callSiteIds: ids)
+        case .failed:
+            actionError = "Couldn't delete \"\(name)\". Please try again."
+        }
+    }
+
+    /// Re-targets every conflicting reference to `replacementSelection`,
+    /// then retries the delete. Used by the "Pick replacement" affordance
+    /// in the blocked-delete sheet.
+    private func retargetAndDelete() async {
+        guard !replacementSelection.isEmpty,
+              let blocked = blockedState else { return }
+        let replacement = replacementSelection
+        let blockedName: String
+        switch blocked {
+        case .active(let name, _):
+            blockedName = name
+            // Re-target the active profile pointer.
+            _ = await store.setActiveProfile(replacement)
+        case .callSites(let name, let ids):
+            blockedName = name
+            for id in ids {
+                _ = store.replaceCallSiteOverride(
+                    id,
+                    provider: nil,
+                    model: nil,
+                    profile: replacement
+                )
+            }
+            // Wait for the optimistic local cache to reflect the
+            // replacement so the next deleteProfile reference scan
+            // doesn't re-trip on stale state. The store updates the
+            // cache synchronously in `replaceCallSiteOverride` before
+            // dispatching the daemon PATCH, so the published list is
+            // already correct here — but the daemon-side patches are in
+            // flight. We optimistically retry; the deleteProfile
+            // reference scan reads the local cache, not the daemon.
+        }
+        // Dismiss the blocked sheet first so the retry can re-present it
+        // if needed (otherwise SwiftUI would suppress a second sheet
+        // presentation).
+        blockedState = nil
+        // Retry the delete now that references are pointing at the
+        // replacement.
+        await attemptDelete(blockedName)
+    }
+
+    /// Generates a name that doesn't collide with any existing profile.
+    /// `"new-profile"` becomes `"new-profile-2"`, `"new-profile-3"`, etc.
+    static func nextAvailableProfileName(prefix: String, existing: Set<String>) -> String {
+        if !existing.contains(prefix) {
+            return prefix
+        }
+        var suffix = 2
+        while existing.contains("\(prefix)-\(suffix)") {
+            suffix += 1
+        }
+        return "\(prefix)-\(suffix)"
+    }
+
+    private func uniqueProfileName(prefix: String) -> String {
+        Self.nextAvailableProfileName(
+            prefix: prefix,
+            existing: Set(store.profiles.map(\.name))
+        )
+    }
+
+    /// Resolves a callsite ID to its catalog display name when known,
+    /// falling back to the raw ID if the catalog has no entry.
+    private func callSiteDisplayName(_ id: String) -> String {
+        CallSiteCatalog.byId[id]?.displayName ?? id
+    }
+
+    // MARK: - Static Helpers
+
+    /// Composes the row's summary line. Resolves provider+model display
+    /// names against the store's catalog when present so the user sees the
+    /// human-readable label rather than the wire ID, then appends effort
+    /// and thinking summaries when they're set on the fragment.
+    static func summary(for profile: InferenceProfile, store: SettingsStore) -> String {
+        var pieces: [String] = []
+        if let provider = profile.provider, !provider.isEmpty {
+            if let model = profile.model, !model.isEmpty {
+                let models = store.dynamicProviderModels(provider)
+                let label = models.first(where: { $0.id == model })?.displayName ?? model
+                pieces.append(label)
+            } else {
+                pieces.append(store.dynamicProviderDisplayName(provider))
+            }
+        } else if let model = profile.model, !model.isEmpty {
+            pieces.append(model)
+        }
+        if let effort = profile.effort, !effort.isEmpty {
+            pieces.append("\(effort) effort")
+        }
+        if let thinkingEnabled = profile.thinkingEnabled {
+            pieces.append("thinking \(thinkingEnabled ? "on" : "off")")
+        }
+        if pieces.isEmpty {
+            return "Inherits defaults"
+        }
+        return pieces.joined(separator: " \u{00B7} ")
+    }
+}
+
+// MARK: - Identifiable Conformance
+
+/// `EditorState` is used as an `Identifiable` value via `.sheet(item:)`.
+/// Each variant maps to a stable string id so SwiftUI can drive the sheet's
+/// presentation lifecycle.
+extension InferenceProfilesSheet.EditorState: Identifiable {
+    var id: String {
+        switch self {
+        case .create:
+            return "create"
+        case .edit(let name):
+            return "edit:\(name)"
+        case .duplicate(let name):
+            return "duplicate:\(name)"
+        }
+    }
+}
+
+extension InferenceProfilesSheet.BlockedDeleteState: Identifiable {
+    var id: String {
+        switch self {
+        case .active(let name, _):
+            return "active:\(name)"
+        case .callSites(let name, _):
+            return "callSites:\(name)"
+        }
+    }
+}

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfilesSheetTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfilesSheetTests.swift
@@ -1,0 +1,364 @@
+import SwiftUI
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Structural tests for `InferenceProfilesSheet`. We exercise the view's
+/// pure helpers (summary string, identifiable IDs) plus the store-backed
+/// invariants that drive the list, badge, and delete-flow behavior. The
+/// SwiftUI tree itself is constructed without rendering (mirrors the
+/// `InferenceProfileEditorTests` pattern) so we don't take a snapshot
+/// dependency; combined with the SettingsStore-level coverage in
+/// `SettingsStoreInferenceProfilesTests`, this validates the full
+/// management UX.
+@MainActor
+final class InferenceProfilesSheetTests: XCTestCase {
+
+    private var mockSettingsClient: MockSettingsClient!
+    private var store: SettingsStore!
+
+    override func setUp() {
+        super.setUp()
+        mockSettingsClient = MockSettingsClient()
+        mockSettingsClient.patchConfigResponse = true
+        store = SettingsStore(settingsClient: mockSettingsClient)
+        // Tiny deterministic catalog so summary lookups produce stable
+        // human-readable strings without depending on the live registry.
+        store.providerCatalog = [
+            ProviderCatalogEntry(
+                id: "anthropic",
+                displayName: "Anthropic",
+                models: [
+                    CatalogModel(id: "claude-opus-4-7", displayName: "Claude Opus 4.7"),
+                    CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
+                    CatalogModel(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),
+                ],
+                defaultModel: "claude-sonnet-4-6",
+                apiKeyUrl: nil,
+                apiKeyPlaceholder: nil
+            ),
+        ]
+    }
+
+    override func tearDown() {
+        store = nil
+        mockSettingsClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Seeds the store with the three canonical built-in profiles plus an
+    /// optional custom one. Mirrors the daemon's migration-052 seed shape.
+    private func seedBuiltInsAndCustom(includeCustom: Bool = false) {
+        var profiles: [String: Any] = [
+            "quality-optimized": [
+                "provider": "anthropic",
+                "model": "claude-opus-4-7",
+                "maxTokens": 32000,
+                "effort": "max",
+                "thinking": ["enabled": true, "streamThinking": true],
+            ],
+            "balanced": [
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-6",
+                "maxTokens": 16000,
+                "effort": "high",
+                "thinking": ["enabled": true, "streamThinking": true],
+            ],
+            "cost-optimized": [
+                "provider": "anthropic",
+                "model": "claude-haiku-4-5-20251001",
+                "maxTokens": 8192,
+                "effort": "low",
+                "thinking": ["enabled": false, "streamThinking": false],
+            ],
+        ]
+        if includeCustom {
+            profiles["experimental"] = [
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-6",
+                "effort": "medium",
+            ]
+        }
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "balanced",
+                "profiles": profiles,
+            ]
+        ])
+    }
+
+    private func makeSheet() -> InferenceProfilesSheet {
+        let isPresented = Binding<Bool>(get: { true }, set: { _ in })
+        return InferenceProfilesSheet(store: store, isPresented: isPresented)
+    }
+
+    // MARK: - Body construction
+
+    func testSheetBuildsForEmptyProfileList() {
+        let sheet = makeSheet()
+        XCTAssertNotNil(sheet.body, "Body must be constructible when no profiles are loaded")
+    }
+
+    func testSheetBuildsWithBuiltInProfiles() {
+        seedBuiltInsAndCustom()
+        let sheet = makeSheet()
+        XCTAssertNotNil(sheet.body)
+    }
+
+    // MARK: - Built-in detection
+
+    /// The badge wiring uses `BuiltInInferenceProfile.allNames.contains`,
+    /// so the row's badge presence should match the enum exactly.
+    func testBuiltInProfilesShowBadgeAndCustomDoesNot() {
+        seedBuiltInsAndCustom(includeCustom: true)
+        XCTAssertEqual(store.profiles.count, 4)
+
+        let names = Set(store.profiles.map(\.name))
+        XCTAssertTrue(names.contains("quality-optimized"))
+        XCTAssertTrue(names.contains("balanced"))
+        XCTAssertTrue(names.contains("cost-optimized"))
+        XCTAssertTrue(names.contains("experimental"))
+
+        // The badge predicate is defined on the static enum so the row
+        // can stay declarative. Verify it directly here so the contract
+        // doesn't drift.
+        for name in ["quality-optimized", "balanced", "cost-optimized"] {
+            XCTAssertTrue(
+                BuiltInInferenceProfile.allNames.contains(name),
+                "\(name) must render with a Built-in badge"
+            )
+        }
+        XCTAssertFalse(
+            BuiltInInferenceProfile.allNames.contains("experimental"),
+            "Custom profiles must not render the Built-in badge"
+        )
+    }
+
+    // MARK: - Summary line
+
+    func testSummaryComposesProviderModelEffortThinkingForFullFragment() {
+        let profile = InferenceProfile(
+            name: "quality-optimized",
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+            effort: "max",
+            thinkingEnabled: true
+        )
+        let summary = InferenceProfilesSheet.summary(for: profile, store: store)
+        XCTAssertEqual(summary, "Claude Opus 4.7 \u{00B7} max effort \u{00B7} thinking on")
+    }
+
+    func testSummaryReportsThinkingOff() {
+        let profile = InferenceProfile(
+            name: "cost-optimized",
+            provider: "anthropic",
+            model: "claude-haiku-4-5-20251001",
+            effort: "low",
+            thinkingEnabled: false
+        )
+        let summary = InferenceProfilesSheet.summary(for: profile, store: store)
+        XCTAssertEqual(summary, "Claude Haiku 4.5 \u{00B7} low effort \u{00B7} thinking off")
+    }
+
+    func testSummaryFallsBackToInheritsDefaultsForEmptyFragment() {
+        let profile = InferenceProfile(name: "empty")
+        let summary = InferenceProfilesSheet.summary(for: profile, store: store)
+        XCTAssertEqual(summary, "Inherits defaults")
+    }
+
+    func testSummaryFallsBackToProviderWhenModelIsNil() {
+        let profile = InferenceProfile(name: "p", provider: "anthropic")
+        let summary = InferenceProfilesSheet.summary(for: profile, store: store)
+        XCTAssertEqual(summary, "Anthropic")
+    }
+
+    func testSummaryUsesRawModelWhenCatalogMissesIt() {
+        let profile = InferenceProfile(
+            name: "x",
+            provider: "anthropic",
+            model: "experimental-vintage-1"
+        )
+        let summary = InferenceProfilesSheet.summary(for: profile, store: store)
+        // The catalog has no display name for this model, so we fall back
+        // to the raw model id.
+        XCTAssertEqual(summary, "experimental-vintage-1")
+    }
+
+    // MARK: - EditorState identifiable
+
+    func testEditorStateIDsAreStable() {
+        XCTAssertEqual(InferenceProfilesSheet.EditorState.create.id, "create")
+        XCTAssertEqual(
+            InferenceProfilesSheet.EditorState.edit(name: "balanced").id,
+            "edit:balanced"
+        )
+        XCTAssertEqual(
+            InferenceProfilesSheet.EditorState.duplicate(name: "balanced").id,
+            "duplicate:balanced"
+        )
+    }
+
+    func testEditorStateEquatableDistinguishesNames() {
+        XCTAssertEqual(
+            InferenceProfilesSheet.EditorState.edit(name: "a"),
+            InferenceProfilesSheet.EditorState.edit(name: "a")
+        )
+        XCTAssertNotEqual(
+            InferenceProfilesSheet.EditorState.edit(name: "a"),
+            InferenceProfilesSheet.EditorState.edit(name: "b")
+        )
+        XCTAssertNotEqual(
+            InferenceProfilesSheet.EditorState.edit(name: "a"),
+            InferenceProfilesSheet.EditorState.duplicate(name: "a")
+        )
+    }
+
+    // MARK: - BlockedDeleteState identifiable
+
+    func testBlockedDeleteStateIDsAreStable() {
+        let active = InferenceProfilesSheet.BlockedDeleteState.active(
+            profileName: "balanced",
+            activeProfile: "balanced"
+        )
+        XCTAssertEqual(active.id, "active:balanced")
+
+        let callSites = InferenceProfilesSheet.BlockedDeleteState.callSites(
+            profileName: "fast",
+            callSiteIds: ["mainAgent", "memoryRetrieval"]
+        )
+        XCTAssertEqual(callSites.id, "callSites:fast")
+    }
+
+    // MARK: - Delete flow integration with store
+
+    /// Deleting the active profile produces `.blockedByActive`. The sheet
+    /// uses this to drive its `BlockedDeleteState.active` presentation.
+    func testDeletingActiveProfileReturnsBlockedByActiveResult() async {
+        seedBuiltInsAndCustom()
+        XCTAssertEqual(store.activeProfile, "balanced")
+
+        let result = await store.deleteProfile(name: "balanced")
+        XCTAssertEqual(result, .blockedByActive("balanced"))
+    }
+
+    /// Deleting a profile that's referenced by call sites returns
+    /// `.blockedByCallSites`. The sheet maps this to its callSites
+    /// confirmation surface.
+    func testDeletingCallSiteReferencedProfileReturnsBlockedByCallSitesResult() async {
+        seedBuiltInsAndCustom(includeCustom: true)
+        store.loadCallSiteOverrides(config: [
+            "llm": [
+                "callSites": [
+                    "mainAgent": ["profile": "experimental"],
+                    "memoryRetrieval": ["profile": "experimental"],
+                ]
+            ]
+        ])
+
+        let result = await store.deleteProfile(name: "experimental")
+        if case .blockedByCallSites(let ids) = result {
+            XCTAssertEqual(Set(ids), ["mainAgent", "memoryRetrieval"])
+        } else {
+            XCTFail("Expected .blockedByCallSites, got \(result)")
+        }
+    }
+
+    /// Deleting a custom profile that nothing references succeeds and
+    /// removes it from the store. The sheet's row count drops by one as
+    /// a result.
+    func testDeletingUnreferencedCustomProfileSucceedsAndShrinksList() async {
+        seedBuiltInsAndCustom(includeCustom: true)
+        XCTAssertEqual(store.profiles.count, 4)
+        XCTAssertTrue(store.profiles.contains(where: { $0.name == "experimental" }))
+
+        let result = await store.deleteProfile(name: "experimental")
+        XCTAssertEqual(result, .deleted)
+        XCTAssertEqual(store.profiles.count, 3)
+        XCTAssertFalse(store.profiles.contains(where: { $0.name == "experimental" }))
+    }
+
+    /// Built-in profiles remain deletable when nothing references them —
+    /// the badge is informational, not a guard. This protects the
+    /// invariant called out in the plan: "Built-ins render with the badge
+    /// but remain editable and deletable when not referenced."
+    func testBuiltInProfileIsDeletableWhenNotReferenced() async {
+        seedBuiltInsAndCustom()
+        // Make a non-built-in the active profile so the built-in target
+        // isn't blocked by the active-profile check. Use a fresh custom
+        // entry to avoid colliding with the seeded set.
+        let custom = InferenceProfile(
+            name: "alt",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6"
+        )
+        let saved = await store.setProfile(name: "alt", fragment: custom)
+        XCTAssertTrue(saved)
+        let switched = await store.setActiveProfile("alt")
+        XCTAssertTrue(switched)
+
+        // Now delete a built-in. No call-site override references it, so
+        // the result must be .deleted.
+        let result = await store.deleteProfile(name: "quality-optimized")
+        XCTAssertEqual(result, .deleted)
+        XCTAssertFalse(store.profiles.contains(where: { $0.name == "quality-optimized" }))
+    }
+
+    // MARK: - "+ New profile" flow
+
+    /// Adding a new profile via the store path the sheet uses extends the
+    /// list. The sheet's beginCreate/commitEditor flow ultimately routes
+    /// through `setProfile`, so verifying that path covers the row append.
+    func testAddingNewProfileViaStoreAppendsToList() async {
+        seedBuiltInsAndCustom()
+        let countBefore = store.profiles.count
+
+        let new = InferenceProfile(
+            name: "new-profile",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6"
+        )
+        let success = await store.setProfile(name: "new-profile", fragment: new)
+        XCTAssertTrue(success)
+
+        XCTAssertEqual(store.profiles.count, countBefore + 1)
+        XCTAssertTrue(store.profiles.contains(where: { $0.name == "new-profile" }))
+        // List is sorted alphabetically — `new-profile` should land after
+        // `cost-optimized` and before `quality-optimized`.
+        let names = store.profiles.map(\.name)
+        XCTAssertEqual(names, names.sorted(), "Profiles list must remain alphabetically sorted")
+    }
+
+    /// The "+ New profile" toolbar action seeds a draft with the default
+    /// name `"new-profile"`. The static helper avoids collisions by
+    /// appending `-2`, `-3`, etc. when the default is already in use.
+    func testNextAvailableProfileNameAvoidsCollisions() {
+        let unused = InferenceProfilesSheet.nextAvailableProfileName(
+            prefix: "new-profile",
+            existing: []
+        )
+        XCTAssertEqual(unused, "new-profile")
+
+        let onePresent = InferenceProfilesSheet.nextAvailableProfileName(
+            prefix: "new-profile",
+            existing: ["new-profile"]
+        )
+        XCTAssertEqual(onePresent, "new-profile-2")
+
+        let twoPresent = InferenceProfilesSheet.nextAvailableProfileName(
+            prefix: "new-profile",
+            existing: ["new-profile", "new-profile-2"]
+        )
+        XCTAssertEqual(twoPresent, "new-profile-3")
+
+        // Holes in the suffix sequence are not back-filled; the helper
+        // monotonically advances. This keeps the algorithm O(n) and the
+        // user never sees the same candidate name twice in one session.
+        let hole = InferenceProfilesSheet.nextAvailableProfileName(
+            prefix: "balanced-copy",
+            existing: ["balanced-copy", "balanced-copy-3"]
+        )
+        XCTAssertEqual(hole, "balanced-copy-2")
+    }
+}


### PR DESCRIPTION
## Summary
- Add SwiftUI `InferenceProfilesSheet` listing all profiles with Edit/Duplicate/Delete actions and a + New profile toolbar item.
- Built-in profiles show a badge but remain editable; delete shows a blocked-by-references sheet when conflicts exist.

Part of plan: inference-profiles.md (PR 13 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
