### PR TITLE
feat(macos): chat composer profile picker pill

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Bundle of the per-conversation inference-profile state and the persistence
+/// callback the composer threads through to ``ChatProfilePicker``. Mirrors the
+/// `ConversationHostAccessControlConfiguration` pattern so a single optional
+/// parameter on ``ComposerView`` / ``ComposerSection`` toggles the pill.
+struct ChatProfilePickerConfiguration {
+    /// The current per-conversation inference-profile override. `nil` means
+    /// the conversation inherits `activeProfile`.
+    let current: String?
+
+    /// Profiles available to pick from — typically `SettingsStore.profiles`.
+    let profiles: [InferenceProfile]
+
+    /// The workspace `llm.activeProfile`. Rendered in the pill label when
+    /// `current` is `nil`.
+    let activeProfile: String
+
+    /// Persists a selection. Passing `nil` clears the override so the
+    /// conversation falls back to `activeProfile`.
+    let onSelect: (String?) -> Void
+}
+
+/// A compact pill button in the composer action bar that lets the user pick a
+/// per-conversation inference profile override. Opens a dropdown with every
+/// profile defined in `SettingsStore.profiles`, plus a "Reset to default"
+/// item that clears the override and falls back to `llm.activeProfile`.
+///
+/// State ownership: the pill is stateless. The label is derived from the
+/// `current` override plus `activeProfile`; selection is forwarded straight to
+/// `ConversationManager.setConversationInferenceProfile(id:profile:)` which
+/// updates the local conversation model and persists to the daemon.
+@MainActor
+struct ChatProfilePicker: View {
+    /// The conversation whose override is being edited. `nil` disables the
+    /// pill (e.g. for not-yet-persisted draft conversations).
+    let conversationId: UUID?
+
+    /// The current per-conversation inference-profile override. `nil` means
+    /// the conversation inherits `activeProfile`.
+    let current: String?
+
+    /// Profiles available to pick from — typically `SettingsStore.profiles`.
+    let profiles: [InferenceProfile]
+
+    /// The workspace `llm.activeProfile`. Surfaced in the pill label when
+    /// `current` is `nil` so the user can see which profile the conversation
+    /// will inherit.
+    let activeProfile: String
+
+    /// Persists a selection. Passing `nil` clears the override so the
+    /// conversation falls back to `activeProfile`.
+    let onSelect: (String?) -> Void
+
+    #if os(macOS)
+    @State private var isMenuOpen = false
+    @State private var activePanel: VMenuPanel?
+    @State private var triggerFrame: CGRect = .zero
+    #endif
+
+    private let composerActionButtonSize: CGFloat = 32
+
+    /// Pill label: the override profile when set, otherwise
+    /// "Default (`<activeProfile>`)". Internal so tests can assert on it
+    /// without spinning up a SwiftUI host.
+    static func label(current: String?, activeProfile: String) -> String {
+        if let current { return current }
+        return "Default (\(activeProfile))"
+    }
+
+    var body: some View {
+        #if os(macOS)
+        Button {
+            if isMenuOpen {
+                activePanel?.close()
+                activePanel = nil
+                isMenuOpen = false
+            } else {
+                showMenu()
+            }
+        } label: {
+            HStack(spacing: 4) {
+                VIconView(.sparkles, size: 14)
+                    .foregroundStyle(VColor.contentSecondary)
+                Text(Self.label(current: current, activeProfile: activeProfile))
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .lineLimit(1)
+                VIconView(.chevronDown, size: 10)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .frame(height: composerActionButtonSize)
+            .padding(.horizontal, VSpacing.xs)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(conversationId == nil)
+        .vTooltip("Inference profile for this conversation")
+        .accessibilityLabel("Inference profile")
+        .accessibilityValue(Self.label(current: current, activeProfile: activeProfile))
+        .overlay {
+            GeometryReader { geo in
+                Color.clear
+                    .onAppear { triggerFrame = geo.frame(in: .global) }
+                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
+                        triggerFrame = newFrame
+                    }
+            }
+        }
+        #endif
+    }
+
+    // MARK: - Menu
+
+    #if os(macOS)
+    private func showMenu() {
+        guard !isMenuOpen, conversationId != nil else { return }
+        isMenuOpen = true
+
+        NSApp.keyWindow?.makeFirstResponder(nil)
+
+        guard let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible }) else {
+            isMenuOpen = false
+            return
+        }
+
+        let triggerInWindow = CGPoint(x: triggerFrame.minX, y: triggerFrame.maxY)
+        let screenPoint = window.convertPoint(toScreen: NSPoint(
+            x: triggerInWindow.x,
+            y: window.frame.height - triggerInWindow.y
+        ))
+
+        let triggerScreenOrigin = window.convertPoint(toScreen: NSPoint(
+            x: triggerFrame.minX,
+            y: window.frame.height - triggerFrame.maxY
+        ))
+        let triggerScreenRect = CGRect(
+            origin: triggerScreenOrigin,
+            size: CGSize(width: triggerFrame.width, height: triggerFrame.height)
+        )
+
+        let appearance = window.effectiveAppearance
+        activePanel = VMenuPanel.show(
+            at: screenPoint,
+            sourceWindow: window,
+            sourceAppearance: appearance,
+            excludeRect: triggerScreenRect
+        ) {
+            VMenu(width: 240) {
+                ForEach(profiles) { profile in
+                    VMenuItem(
+                        icon: VIcon.sparkles.rawValue,
+                        label: profile.name,
+                        isActive: current == profile.name,
+                        size: .regular
+                    ) {
+                        onSelect(profile.name)
+                    } trailing: {
+                        VStack(alignment: .trailing, spacing: 2) {
+                            if current == profile.name {
+                                VIconView(.check, size: 12)
+                                    .foregroundStyle(VColor.primaryBase)
+                            }
+                        }
+                    }
+                }
+                VMenuItem(
+                    icon: VIcon.rotateCcw.rawValue,
+                    label: "Reset to default (\(activeProfile))",
+                    isActive: current == nil,
+                    size: .regular
+                ) {
+                    onSelect(nil)
+                } trailing: {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        if current == nil {
+                            VIconView(.check, size: 12)
+                                .foregroundStyle(VColor.primaryBase)
+                        }
+                    }
+                }
+            }
+        } onDismiss: {
+            isMenuOpen = false
+            activePanel = nil
+        }
+    }
+    #endif
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -32,6 +32,8 @@ struct ChatView: View {
     var configuredProviders: Set<String> = []
     var providerCatalog: [ProviderCatalogEntry] = []
     var mediaEmbedSettings: MediaEmbedResolverSettings?
+    var inferenceProfiles: [InferenceProfile] = []
+    var activeInferenceProfile: String = "balanced"
 
     // MARK: - Parent Callbacks (capture parent state)
 
@@ -536,10 +538,32 @@ struct ChatView: View {
                 contextWindowTokens: viewModel.contextWindowTokens,
                 contextWindowMaxTokens: viewModel.contextWindowMaxTokens,
                 conversationHostAccessControl: conversationHostAccessControl,
-                showThresholdPicker: showThresholdPicker
+                showThresholdPicker: showThresholdPicker,
+                inferenceProfilePicker: inferenceProfilePicker
             )
             .equatable()
         }
+    }
+
+    /// Bundles the inference-profile pill state for ``ComposerView``. Returns
+    /// `nil` when no manager is wired (preview/testing) so the pill stays
+    /// hidden until a real persistence path exists.
+    private var inferenceProfilePicker: ChatProfilePickerConfiguration? {
+        guard let conversationManager else { return nil }
+        return ChatProfilePickerConfiguration(
+            current: currentConversation?.inferenceProfile,
+            profiles: inferenceProfiles,
+            activeProfile: activeInferenceProfile,
+            onSelect: { profile in
+                guard let conversationId else { return }
+                Task { @MainActor in
+                    await conversationManager.setConversationInferenceProfile(
+                        id: conversationId,
+                        profile: profile
+                    )
+                }
+            }
+        )
     }
 
     private func toggleConversationHostAccess() {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -49,6 +49,12 @@ struct ComposerSection: View, Equatable {
             && lhs.conversationHostAccessControl?.subtitle == rhs.conversationHostAccessControl?.subtitle
             && lhs.conversationHostAccessControl?.errorMessage == rhs.conversationHostAccessControl?.errorMessage
             && lhs.showThresholdPicker == rhs.showThresholdPicker
+            // Closure prevents Equatable conformance on the configuration; compare
+            // the value-type fields that drive rendering plus nil/non-nil parity.
+            && lhs.inferenceProfilePicker?.current == rhs.inferenceProfilePicker?.current
+            && lhs.inferenceProfilePicker?.profiles == rhs.inferenceProfilePicker?.profiles
+            && lhs.inferenceProfilePicker?.activeProfile == rhs.inferenceProfilePicker?.activeProfile
+            && (lhs.inferenceProfilePicker == nil) == (rhs.inferenceProfilePicker == nil)
     }
 
     @Binding var inputText: String
@@ -83,6 +89,7 @@ struct ComposerSection: View, Equatable {
     var contextWindowMaxTokens: Int? = nil
     var conversationHostAccessControl: ConversationHostAccessControlConfiguration? = nil
     var showThresholdPicker: Bool = false
+    var inferenceProfilePicker: ChatProfilePickerConfiguration? = nil
 
     var body: some View {
         VStack(spacing: 0) {
@@ -125,7 +132,8 @@ struct ComposerSection: View, Equatable {
                 contextWindowTokens: contextWindowTokens,
                 contextWindowMaxTokens: contextWindowMaxTokens,
                 conversationHostAccessControl: conversationHostAccessControl,
-                showThresholdPicker: showThresholdPicker
+                showThresholdPicker: showThresholdPicker,
+                inferenceProfilePicker: inferenceProfilePicker
             )
             .equatable()
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -51,6 +51,12 @@ struct ComposerView: View, Equatable {
             && lhs.conversationHostAccessControl?.subtitle == rhs.conversationHostAccessControl?.subtitle
             && lhs.conversationHostAccessControl?.errorMessage == rhs.conversationHostAccessControl?.errorMessage
             && lhs.showThresholdPicker == rhs.showThresholdPicker
+            // Closure prevents Equatable conformance on the configuration; compare
+            // the value-type fields that drive rendering plus nil/non-nil parity.
+            && lhs.inferenceProfilePicker?.current == rhs.inferenceProfilePicker?.current
+            && lhs.inferenceProfilePicker?.profiles == rhs.inferenceProfilePicker?.profiles
+            && lhs.inferenceProfilePicker?.activeProfile == rhs.inferenceProfilePicker?.activeProfile
+            && (lhs.inferenceProfilePicker == nil) == (rhs.inferenceProfilePicker == nil)
     }
     private let composerMaxHeight: CGFloat = 300
     private let composerActionButtonSize: CGFloat = 32
@@ -106,6 +112,7 @@ struct ComposerView: View, Equatable {
     var contextWindowMaxTokens: Int? = nil
     var conversationHostAccessControl: ConversationHostAccessControlConfiguration? = nil
     var showThresholdPicker: Bool = false
+    var inferenceProfilePicker: ChatProfilePickerConfiguration? = nil
 
     @Environment(\.cmdEnterToSend) private var cmdEnterToSend
     #if os(macOS)
@@ -472,6 +479,16 @@ struct ComposerView: View, Equatable {
 
             if showThresholdPicker {
                 ComposerThresholdPicker(conversationId: conversationId)
+            }
+
+            if let inferenceProfilePicker, !inferenceProfilePicker.profiles.isEmpty {
+                ChatProfilePicker(
+                    conversationId: conversationId,
+                    current: inferenceProfilePicker.current,
+                    profiles: inferenceProfilePicker.profiles,
+                    activeProfile: inferenceProfilePicker.activeProfile,
+                    onSelect: inferenceProfilePicker.onSelect
+                )
             }
 
             VContextWindowIndicator(

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -945,6 +945,8 @@ struct ActiveChatViewWrapper: View {
                     enabledSince: settingsStore.mediaEmbedsEnabledSince,
                     allowedDomains: settingsStore.mediaEmbedVideoAllowlistDomains
                 ),
+                inferenceProfiles: settingsStore.profiles,
+                activeInferenceProfile: settingsStore.activeProfile,
                 onMicrophoneToggle: onMicrophoneToggle,
                 onForkFromMessage: isReadonly ? nil : { [conversationManager] daemonMessageId in
                     Task { @MainActor in

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ChatProfilePickerTests: XCTestCase {
+
+    // MARK: - Label
+
+    func testLabelShowsDefaultWhenOverrideIsNil() {
+        XCTAssertEqual(
+            ChatProfilePicker.label(current: nil, activeProfile: "balanced"),
+            "Default (balanced)"
+        )
+    }
+
+    func testLabelShowsProfileNameWhenOverrideIsSet() {
+        XCTAssertEqual(
+            ChatProfilePicker.label(current: "quality-optimized", activeProfile: "balanced"),
+            "quality-optimized"
+        )
+    }
+
+    func testLabelReflectsActiveProfileChange() {
+        XCTAssertEqual(
+            ChatProfilePicker.label(current: nil, activeProfile: "cost-optimized"),
+            "Default (cost-optimized)"
+        )
+    }
+
+    // MARK: - Selection callback wiring (covers ComposerView → ChatProfilePicker → ConversationManager)
+
+    func testConversationManagerSetsOverrideOnSelection() async {
+        let env = makeManagerEnvironment(initialProfile: nil)
+        env.mockClient.setResponse = ConversationInferenceProfileResponse(
+            conversationId: "conv-1",
+            profile: "quality-optimized"
+        )
+
+        let picker = makePicker(
+            conversationId: env.localId,
+            current: nil,
+            profiles: env.profiles,
+            activeProfile: "balanced",
+            manager: env.manager
+        )
+
+        picker.onSelect("quality-optimized")
+        await env.drainPendingTasks()
+
+        XCTAssertEqual(
+            env.mockClient.setCalls,
+            [MockChatProfilePickerClient.SetCall(conversationId: "conv-1", profile: "quality-optimized")]
+        )
+        XCTAssertEqual(env.manager.conversations[0].inferenceProfile, "quality-optimized")
+    }
+
+    func testResetToDefaultClearsOverride() async {
+        let env = makeManagerEnvironment(initialProfile: "balanced")
+        env.mockClient.setResponse = ConversationInferenceProfileResponse(
+            conversationId: "conv-1",
+            profile: nil
+        )
+
+        let picker = makePicker(
+            conversationId: env.localId,
+            current: "balanced",
+            profiles: env.profiles,
+            activeProfile: "balanced",
+            manager: env.manager
+        )
+
+        picker.onSelect(nil)
+        await env.drainPendingTasks()
+
+        XCTAssertEqual(
+            env.mockClient.setCalls,
+            [MockChatProfilePickerClient.SetCall(conversationId: "conv-1", profile: nil)]
+        )
+        XCTAssertNil(env.manager.conversations[0].inferenceProfile)
+    }
+
+    // MARK: - Helpers
+
+    private struct ManagerEnvironment {
+        let localId: UUID
+        let manager: ConversationManager
+        let mockClient: MockChatProfilePickerClient
+        let profiles: [InferenceProfile]
+        let drainPendingTasks: () async -> Void
+    }
+
+    private func makeManagerEnvironment(initialProfile: String?) -> ManagerEnvironment {
+        let connectionManager = GatewayConnectionManager()
+        connectionManager.isConnected = true
+        let mock = MockChatProfilePickerClient()
+        let manager = ConversationManager(
+            connectionManager: connectionManager,
+            eventStreamClient: connectionManager.eventStreamClient,
+            conversationInferenceProfileClient: mock
+        )
+        let localId = UUID()
+        manager.conversations = [
+            ConversationModel(
+                id: localId,
+                title: "Picker target",
+                conversationId: "conv-1",
+                inferenceProfile: initialProfile
+            )
+        ]
+        let profiles: [InferenceProfile] = [
+            InferenceProfile(name: "balanced"),
+            InferenceProfile(name: "quality-optimized"),
+            InferenceProfile(name: "cost-optimized"),
+        ]
+        return ManagerEnvironment(
+            localId: localId,
+            manager: manager,
+            mockClient: mock,
+            profiles: profiles,
+            drainPendingTasks: {
+                // The picker hands selection to a Task; drain a few main-queue
+                // turns so the manager's async setter completes before we
+                // assert against its observed state.
+                for _ in 0..<10 {
+                    try? await Task.sleep(nanoseconds: 5_000_000)
+                    if !mock.setCalls.isEmpty { return }
+                }
+            }
+        )
+    }
+
+    /// Mirrors the `onSelect` closure the composer wires up: dispatches into
+    /// `ConversationManager.setConversationInferenceProfile`. Using the same
+    /// closure shape under test pins the integration contract end-to-end.
+    private func makePicker(
+        conversationId: UUID,
+        current: String?,
+        profiles: [InferenceProfile],
+        activeProfile: String,
+        manager: ConversationManager
+    ) -> ChatProfilePicker {
+        ChatProfilePicker(
+            conversationId: conversationId,
+            current: current,
+            profiles: profiles,
+            activeProfile: activeProfile,
+            onSelect: { selection in
+                Task { @MainActor in
+                    await manager.setConversationInferenceProfile(
+                        id: conversationId,
+                        profile: selection
+                    )
+                }
+            }
+        )
+    }
+}
+
+private final class MockChatProfilePickerClient: ConversationInferenceProfileClientProtocol {
+    struct SetCall: Equatable {
+        let conversationId: String
+        let profile: String?
+    }
+
+    var setResponse: ConversationInferenceProfileResponse?
+    private(set) var setCalls: [SetCall] = []
+
+    func setConversationInferenceProfile(
+        conversationId: String,
+        profile: String?
+    ) async -> ConversationInferenceProfileResponse? {
+        setCalls.append(SetCall(conversationId: conversationId, profile: profile))
+        return setResponse
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ChatProfilePicker` pill in the composer action bar (between host-access toggle and context window indicator).
- Mirrors `ComposerThresholdPicker` structure; selecting a profile persists via `ConversationManager` and the daemon endpoint.
- "Reset to default" clears the per-conversation override.

Part of plan: inference-profiles.md (PR 17 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
