### PR TITLE
fix: forkConversation inherits inferenceProfile from source

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -393,6 +393,33 @@ describe("forkConversation", () => {
     );
   });
 
+  test("inherits the source conversation's inference profile", async () => {
+    const source = createConversation("Pinned profile thread");
+    await addMessage(source.id, "user", "Use the balanced profile", undefined, {
+      skipIndexing: true,
+    });
+    getDb()
+      .update(conversations)
+      .set({ inferenceProfile: "balanced" })
+      .where(eq(conversations.id, source.id))
+      .run();
+
+    const fork = forkConversation({ conversationId: source.id });
+
+    expect(fork.inferenceProfile).toBe("balanced");
+  });
+
+  test("leaves inference profile null when source has no override", async () => {
+    const source = createConversation("Default profile thread");
+    await addMessage(source.id, "user", "No pinned profile", undefined, {
+      skipIndexing: true,
+    });
+
+    const fork = forkConversation({ conversationId: source.id });
+
+    expect(fork.inferenceProfile).toBeNull();
+  });
+
   test("marks copied assistant history as seen and excludes request logs, queued work, and inbound events", async () => {
     const source = createConversation("Support thread");
     const sourceUser = await addMessage(

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -558,6 +558,7 @@ export function forkConversation(params: {
         contextCompactedAt: preserveSourceCompactionState
           ? sourceConversation.contextCompactedAt
           : null,
+        inferenceProfile: sourceConversation.inferenceProfile,
       })
       .where(eq(conversations.id, fc.id))
       .run();


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inference-profiles.md.

**Gap:** Forking a conversation with a pinned inference profile silently dropped the profile, snapping the fork back to the workspace default.

**Fix:** Propagate the source row's `inferenceProfile` into the forked conversation, matching the existing fork-parent / context-summary inheritance pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
