### PR TITLE
fix: wake-driven turns honor conversation inferenceProfile

### DIFF
--- a/assistant/src/__tests__/agent-wake-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-wake-override-profile.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression test for the wake-driven override-profile gap.
+ *
+ * `wakeAgentForOpportunity` invokes `agentLoop.run(...)` directly, bypassing
+ * `runAgentLoopImpl`. Without an explicit row read, scheduled-task wakes and
+ * other opportunity wakes targeting a user conversation with a pinned profile
+ * would execute under workspace defaults — silently violating the user's
+ * pinned preference.
+ *
+ * This test pins `getConversationOverrideProfile` to return a fixed profile
+ * name and asserts that the wake forwards it to `agentLoop.run` as the
+ * `overrideProfile` positional argument. A second case verifies the absence
+ * path (no row override → `undefined` propagated).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let mockOverrideProfile: string | undefined = undefined;
+
+mock.module("../memory/conversation-crud.js", () => ({
+  getConversationOverrideProfile: (_id: string) => mockOverrideProfile,
+}));
+
+import type { AgentEvent } from "../agent/loop.js";
+import type { Message } from "../providers/types.js";
+import {
+  __resetWakeChainForTests,
+  wakeAgentForOpportunity,
+  type WakeTarget,
+} from "../runtime/agent-wake.js";
+
+interface RunArgs {
+  messages: Message[];
+  signal: AbortSignal | undefined;
+  requestId: string | undefined;
+  onCheckpoint: unknown;
+  callSite: unknown;
+  turnContext: unknown;
+  overrideProfile: string | undefined;
+}
+
+function makeTarget(): {
+  target: WakeTarget;
+  runArgs: RunArgs[];
+} {
+  const runArgs: RunArgs[] = [];
+  const history: Message[] = [
+    { role: "user", content: [{ type: "text", text: "hi" }] },
+  ];
+  let processing = false;
+
+  const target: WakeTarget = {
+    conversationId: "conv-wake-override",
+    agentLoop: {
+      run: (async (
+        messages: Message[],
+        _onEvent: (event: AgentEvent) => void | Promise<void>,
+        signal?: AbortSignal,
+        requestId?: string,
+        onCheckpoint?: unknown,
+        callSite?: unknown,
+        turnContext?: unknown,
+        overrideProfile?: string,
+      ) => {
+        runArgs.push({
+          messages: [...messages],
+          signal,
+          requestId,
+          onCheckpoint,
+          callSite,
+          turnContext,
+          overrideProfile,
+        });
+        // Return the input verbatim → silent no-op (no assistant tail).
+        return messages;
+      }) as WakeTarget["agentLoop"]["run"],
+    },
+    getMessages: () => history,
+    pushMessage: (msg) => {
+      history.push(msg);
+    },
+    emitAgentEvent: () => {},
+    isProcessing: () => processing,
+    markProcessing: (on) => {
+      processing = on;
+    },
+    persistTailMessage: async () => {},
+  };
+  return { target, runArgs };
+}
+
+beforeEach(() => {
+  __resetWakeChainForTests();
+});
+
+afterEach(() => {
+  mockOverrideProfile = undefined;
+});
+
+describe("wakeAgentForOpportunity — overrideProfile forwarding", () => {
+  test("forwards the conversation's pinned overrideProfile to agentLoop.run", async () => {
+    mockOverrideProfile = "frontier";
+    const { target, runArgs } = makeTarget();
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "test hint",
+        source: "scheduler",
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(result.invoked).toBe(true);
+    expect(runArgs).toHaveLength(1);
+    // The 8th positional argument (after messages, onEvent, signal,
+    // requestId, onCheckpoint, callSite, turnContext) is overrideProfile.
+    expect(runArgs[0]!.overrideProfile).toBe("frontier");
+    // Sanity: the wake-source tag still propagates as requestId.
+    expect(runArgs[0]!.requestId).toBe("wake:scheduler");
+  });
+
+  test("passes undefined when the conversation has no pinned profile", async () => {
+    mockOverrideProfile = undefined;
+    const { target, runArgs } = makeTarget();
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "test hint",
+        source: "unit-test",
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(runArgs).toHaveLength(1);
+    expect(runArgs[0]!.overrideProfile).toBeUndefined();
+  });
+});

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -15,7 +15,14 @@
  * `memory/conversation-crud.js`.
  */
 
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Stub the DB-backed override-profile read so unit tests don't need a
+// real SQLite database. The wake helper calls this on every invocation
+// to honor the conversation's pinned inference profile.
+mock.module("../../memory/conversation-crud.js", () => ({
+  getConversationOverrideProfile: () => undefined,
+}));
 
 import type { AgentEvent } from "../../agent/loop.js";
 import type { Message } from "../../providers/types.js";
@@ -199,7 +206,10 @@ describe("wakeAgentForOpportunity", () => {
     expect(input[2]).toEqual({
       role: "user",
       content: [
-        { type: "text", text: "[opportunity:unit-test] someone asked a question" },
+        {
+          type: "text",
+          text: "[opportunity:unit-test] someone asked a question",
+        },
       ],
     });
   });
@@ -723,9 +733,7 @@ describe("wakeAgentForOpportunity", () => {
     };
     const toolResultUserMsg: Message = {
       role: "user",
-      content: [
-        { type: "tool_result", tool_use_id: "tu-1", content: "ok" },
-      ],
+      content: [{ type: "tool_result", tool_use_id: "tu-1", content: "ok" }],
     };
     const followup: Message = {
       role: "assistant",
@@ -776,9 +784,7 @@ describe("wakeAgentForOpportunity", () => {
       };
       const toolResultUserMsg: Message = {
         role: "user",
-        content: [
-          { type: "tool_result", tool_use_id: "tu-1", content: "ok" },
-        ],
+        content: [{ type: "tool_result", tool_use_id: "tu-1", content: "ok" }],
       };
       const followup: Message = {
         role: "assistant",

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -37,6 +37,7 @@
  */
 
 import type { AgentEvent, AgentLoop } from "../agent/loop.js";
+import { getConversationOverrideProfile } from "../memory/conversation-crud.js";
 import type { Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 
@@ -352,6 +353,14 @@ export async function wakeAgentForOpportunity(
       buffered.push(event);
     };
 
+    // Honor the conversation's pinned inference-profile override (if any).
+    // Without this, scheduled-task wakes and other opportunity wakes bypass
+    // `runAgentLoopImpl` entirely and execute under workspace defaults,
+    // silently violating the user's pinned preference. Read before
+    // `markProcessing(true)` so a thrown DB read can't strand the
+    // processing flag.
+    const overrideProfile = getConversationOverrideProfile(conversationId);
+
     // Mark processing for the duration of the run so a concurrent user
     // send is queued by `enqueueMessage()` rather than spawning a second
     // concurrent agent loop on the same conversation (which would
@@ -371,6 +380,10 @@ export async function wakeAgentForOpportunity(
           onEvent,
           undefined, // no external abort signal
           `wake:${source}`,
+          undefined, // onCheckpoint
+          undefined, // callSite
+          undefined, // turnContext
+          overrideProfile,
         );
       } catch (err) {
         // Capture the error for post-finally logging, then short-circuit


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inference-profiles.md.

**Gap:** `wakeAgentForOpportunity` invoked `agentLoop.run` without forwarding the per-conversation overrideProfile, so scheduled wakes ignored the user's pinned profile.

**Fix:** Read `getConversationOverrideProfile(conversationId)` and forward it to `agentLoop.run`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
