### PR TITLE
chore(macos): polish inference-profile review nits

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
@@ -102,7 +102,7 @@ public struct InferenceProfile: Codable, Hashable, Identifiable {
 }
 
 /// The three first-class profiles the daemon seeds into every workspace
-/// (see migration 040 in `assistant/src/workspace/migrations/`). The
+/// (see migration 052 in `assistant/src/workspace/migrations/`). The
 /// macOS UI uses this enum only to render a "Built-in" badge — deletion
 /// and editing remain allowed for these profiles.
 public enum BuiltInInferenceProfile: String, CaseIterable {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3431,27 +3431,6 @@ public final class SettingsStore: ObservableObject {
             if let model { entry["model"] = model }
             if let profile { entry["profile"] = profile }
             guard !entry.isEmpty else { return true }
-            // When the caller is assigning a profile-only override (no raw
-            // provider/model), explicitly null out the fragment leaves
-            // (`provider`, `model`, `maxTokens`, `effort`, `speed`,
-            // `verbosity`, `temperature`, `thinking`, `contextWindow`) so
-            // any pre-existing fragment fields don't shadow the profile's
-            // resolved values. The daemon's type-aware deep-merge treats
-            // `null` on object/scalar leaves as deletion. Without this,
-            // switching a row from "Custom" (raw fragment) to a profile
-            // would leave stale leaves in `llm.callSites.<id>` that win
-            // over the profile in the resolver.
-            if profile != nil && provider == nil && model == nil {
-                entry["provider"] = NSNull()
-                entry["model"] = NSNull()
-                entry["maxTokens"] = NSNull()
-                entry["effort"] = NSNull()
-                entry["speed"] = NSNull()
-                entry["verbosity"] = NSNull()
-                entry["temperature"] = NSNull()
-                entry["thinking"] = NSNull()
-                entry["contextWindow"] = NSNull()
-            }
             let setSuccess = await settingsClient.patchConfig([
                 "llm": ["callSites": [id: entry]]
             ])

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -5,9 +5,9 @@ import XCTest
 /// Verifies the inference-profile state and CRUD APIs on `SettingsStore`:
 /// daemon-push parsing into `profiles` / `activeProfile`, profile create/
 /// update via `setProfile`, active selection via `setActiveProfile`,
-/// reference-aware deletion via `deleteProfile`, and the
-/// `replaceCallSiteOverride` adjustment that clears stale fragment
-/// fields when assigning a profile.
+/// reference-aware deletion via `deleteProfile`, and the two-step
+/// clear-then-write semantics of `replaceCallSiteOverride` when
+/// assigning a profile.
 @MainActor
 final class SettingsStoreInferenceProfilesTests: XCTestCase {
 
@@ -314,17 +314,14 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
         XCTAssertTrue(store.profiles.contains(where: { $0.name == "experimental" }))
     }
 
-    // MARK: - replaceCallSiteOverride profile-only stale-clear
+    // MARK: - replaceCallSiteOverride profile-only path
 
     /// When `replaceCallSiteOverride` is invoked with `profile` set and
-    /// no raw `provider`/`model`, the second PATCH must explicitly null
-    /// out the fragment leaves so any stale `provider`/`model`/
-    /// `maxTokens`/`effort`/etc. don't shadow the profile in the
-    /// resolver. The first (entry-level) clear PATCH already handles
-    /// the same job, but emitting both shores up the contract under
-    /// flaky network conditions where the clear could be retried out
-    /// of order.
-    func testReplaceCallSiteOverrideClearsFragmentLeavesWhenAssigningProfile() async {
+    /// no raw `provider`/`model`, the entry-level clear PATCH (first
+    /// step) already removes any stale fragment leaves, so the second
+    /// PATCH writes only the `profile` field — no leaf-level NSNull
+    /// blanket is needed.
+    func testReplaceCallSiteOverrideWritesProfileOnlyAfterEntryClear() async {
         _ = store.replaceCallSiteOverride("memoryRetrieval", profile: "fast")
         // Wait for both the clear and set PATCHes to flush.
         let predicate = NSPredicate { _, _ in
@@ -353,17 +350,17 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
         XCTAssertTrue(sawClear, "replaceCallSiteOverride must first NSNull-clear the entry")
         XCTAssertNotNil(setPayloadEntry, "replaceCallSiteOverride must follow the clear with a set PATCH")
         XCTAssertEqual(setPayloadEntry?["profile"] as? String, "fast")
-        // Fragment leaves must be NSNull-cleared in the same SET PATCH so
-        // any concurrent persisted state is overwritten with deletes.
-        XCTAssertTrue(setPayloadEntry?["provider"] is NSNull)
-        XCTAssertTrue(setPayloadEntry?["model"] is NSNull)
-        XCTAssertTrue(setPayloadEntry?["maxTokens"] is NSNull)
-        XCTAssertTrue(setPayloadEntry?["effort"] is NSNull)
-        XCTAssertTrue(setPayloadEntry?["speed"] is NSNull)
-        XCTAssertTrue(setPayloadEntry?["verbosity"] is NSNull)
-        XCTAssertTrue(setPayloadEntry?["temperature"] is NSNull)
-        XCTAssertTrue(setPayloadEntry?["thinking"] is NSNull)
-        XCTAssertTrue(setPayloadEntry?["contextWindow"] is NSNull)
+        // The entry-level clear handles stale leaves; the SET payload
+        // should contain only `profile` and no fragment fields.
+        XCTAssertNil(setPayloadEntry?["provider"])
+        XCTAssertNil(setPayloadEntry?["model"])
+        XCTAssertNil(setPayloadEntry?["maxTokens"])
+        XCTAssertNil(setPayloadEntry?["effort"])
+        XCTAssertNil(setPayloadEntry?["speed"])
+        XCTAssertNil(setPayloadEntry?["verbosity"])
+        XCTAssertNil(setPayloadEntry?["temperature"])
+        XCTAssertNil(setPayloadEntry?["thinking"])
+        XCTAssertNil(setPayloadEntry?["contextWindow"])
     }
 
     /// Sanity-check that the stale-clear behavior does NOT trigger when


### PR DESCRIPTION
## Summary
Bundles two small polish fixes from inference-profiles plan review:

- Update stale `BuiltInInferenceProfile` doc comment to reference migration 052 (was 040).
- Remove redundant NSNull-blanket from `replaceCallSiteOverride`'s profile-only branch — the prior PATCH already clears the entire `llm.callSites.<id>` entry, so the leaf-null trick was dead code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
