### PR TITLE
fix: serialize inferenceProfile in conversation HTTP responses

### DIFF
--- a/assistant/src/__tests__/conversation-inference-profile-list.test.ts
+++ b/assistant/src/__tests__/conversation-inference-profile-list.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests that the conversation list/detail HTTP responses serialize the
+ * per-conversation `inferenceProfile` override.
+ *
+ * The macOS chat picker pill reads `inferenceProfile` from
+ * `GET /v1/conversations` and `GET /v1/conversations/:id`. Without it the
+ * pill renders "Default" for every conversation after an app restart, even
+ * when the DB has a pinned profile.
+ */
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  getGatewayPort: () => 7830,
+  getRuntimeHttpPort: () => 7821,
+  getRuntimeHttpHost: () => "127.0.0.1",
+  getRuntimeGatewayOriginSecret: () => undefined,
+  getIngressPublicBaseUrl: () => undefined,
+  setIngressPublicBaseUrl: () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+}));
+
+import {
+  createConversation,
+  setConversationInferenceProfile,
+} from "../memory/conversation-crud.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { RuntimeHttpServer } from "../runtime/http-server.js";
+
+initializeDb();
+
+type ConversationSummary = {
+  id: string;
+  title: string;
+  inferenceProfile?: string;
+};
+
+describe("conversation HTTP responses include inferenceProfile", () => {
+  let server: RuntimeHttpServer | null = null;
+
+  beforeEach(async () => {
+    await server?.stop();
+    server = null;
+    clearTables();
+  });
+
+  afterAll(async () => {
+    await server?.stop();
+    resetDb();
+  });
+
+  test("GET /v1/conversations includes inferenceProfile for pinned conversations and omits it when unset", async () => {
+    const pinned = createConversation("Pinned-profile conversation");
+    const unset = createConversation("Default-profile conversation");
+    await setConversationInferenceProfile(pinned.id, "quality-optimized");
+
+    await startServer();
+
+    const response = await fetch(url("/conversations"));
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      conversations: ConversationSummary[];
+    };
+    const pinnedListed = body.conversations.find((c) => c.id === pinned.id);
+    const unsetListed = body.conversations.find((c) => c.id === unset.id);
+    expect(pinnedListed).toBeDefined();
+    expect(unsetListed).toBeDefined();
+    expect(pinnedListed?.inferenceProfile).toBe("quality-optimized");
+    expect(unsetListed?.inferenceProfile).toBeUndefined();
+  });
+
+  test("GET /v1/conversations/:id includes inferenceProfile in the detail response", async () => {
+    const conv = createConversation("Detail-profile conversation");
+    await setConversationInferenceProfile(conv.id, "balanced");
+
+    await startServer();
+
+    const response = await fetch(url(`/conversations/${conv.id}`));
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      conversation: ConversationSummary;
+    };
+    expect(body.conversation.id).toBe(conv.id);
+    expect(body.conversation.inferenceProfile).toBe("balanced");
+  });
+
+  function clearTables(): void {
+    const db = getDb();
+    db.run("DELETE FROM conversation_assistant_attention_state");
+    db.run("DELETE FROM external_conversation_bindings");
+    db.run("DELETE FROM conversation_keys");
+    db.run("DELETE FROM messages");
+    db.run("DELETE FROM conversations");
+  }
+
+  async function startServer(): Promise<void> {
+    server = new RuntimeHttpServer({
+      port: 0,
+      bearerToken: "test-bearer-token",
+    });
+    await server.start();
+  }
+
+  function url(pathname: string): string {
+    if (!server) throw new Error("server not started");
+    return `http://127.0.0.1:${server.actualPort}/v1${pathname}`;
+  }
+});

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -237,6 +237,7 @@ export async function switchConversation(
   title: string;
   conversationType: ReturnType<typeof normalizeConversationType>;
   hostAccess: boolean;
+  inferenceProfile?: string;
 } | null> {
   const conversation = getConversation(conversationId);
   if (!conversation) {
@@ -260,6 +261,7 @@ export async function switchConversation(
     title: conversation.title ?? "Untitled",
     conversationType: normalizeConversationType(conversation.conversationType),
     hostAccess: conversation.hostAccess === 1,
+    inferenceProfile: conversation.inferenceProfile ?? undefined,
   };
 }
 
@@ -282,6 +284,7 @@ export async function handleConversationSwitch(
     title: result.title,
     conversationType: result.conversationType,
     hostAccess: result.hostAccess,
+    inferenceProfile: result.inferenceProfile,
   });
 }
 

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -212,6 +212,11 @@ export interface ConversationInfo {
   correlationId?: string;
   conversationType?: ConversationType;
   hostAccess: boolean;
+  /**
+   * Per-conversation override for the LLM inference profile. `undefined`
+   * means the conversation inherits the workspace `llm.activeProfile`.
+   */
+  inferenceProfile?: string;
 }
 
 export interface ConversationTitleUpdated {
@@ -262,6 +267,11 @@ export interface ConversationListResponse {
     displayOrder?: number;
     isPinned?: boolean;
     forkParent?: ConversationForkParent;
+    /**
+     * Per-conversation override for the LLM inference profile. Omitted when
+     * the conversation inherits the workspace `llm.activeProfile`.
+     */
+    inferenceProfile?: string;
   }>;
   /** Whether more conversations exist beyond the returned page. */
   hasMore?: boolean;

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -1624,6 +1624,9 @@ export class RuntimeHttpServer {
       ...(conversation.archivedAt != null
         ? { archivedAt: conversation.archivedAt }
         : {}),
+      ...(conversation.inferenceProfile != null
+        ? { inferenceProfile: conversation.inferenceProfile }
+        : {}),
     };
   }
 

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -68,6 +68,7 @@ export interface ConversationManagementDeps {
     title: string;
     conversationType: string;
     hostAccess: boolean;
+    inferenceProfile?: string;
   } | null>;
   renameConversation: (conversationId: string, name: string) => boolean;
   clearAllConversations: () => number;
@@ -235,6 +236,7 @@ export function conversationManagementRouteDefinitions(
         title: z.string(),
         conversationType: z.string(),
         hostAccess: z.boolean(),
+        inferenceProfile: z.string().optional(),
       }),
       handler: async ({ req }) => {
         const body = (await req.json()) as {
@@ -264,6 +266,9 @@ export function conversationManagementRouteDefinitions(
           conversationType:
             result.conversationType === "private" ? "private" : "standard",
           hostAccess: result.hostAccess,
+          ...(result.inferenceProfile != null
+            ? { inferenceProfile: result.inferenceProfile }
+            : {}),
         });
       },
     },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inference-profiles.md.

**Gap:** Daemon conversation list/detail/info responses omitted `inferenceProfile`, so the macOS chat pill always rendered "Default" after app restart even when the DB had a pinned profile.

**Fix:** Add `inferenceProfile` to `serializeConversationSummary()`, `conversation_info` push payload, and the `ConversationListResponse` TS type.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
