### PR TITLE
fix(db): rename conversations.inferenceProfile to inference_profile

### DIFF
--- a/assistant/src/__tests__/db-conversation-inference-profile-migration.test.ts
+++ b/assistant/src/__tests__/db-conversation-inference-profile-migration.test.ts
@@ -81,19 +81,22 @@ describe("conversation inference profile migration", () => {
     removeTestDbFiles();
   });
 
-  test("fresh DB initialization includes nullable inferenceProfile column", () => {
+  test("fresh DB initialization includes nullable inference_profile column", () => {
     initializeDb();
 
     const raw = new Database(getDbPath());
     const columns = getColumnNames(raw);
-    expect(columns).toContain("inferenceProfile");
+    // Migration 228 renames the camelCase column added by 227 to snake_case to
+    // match the rest of the table.
+    expect(columns).toContain("inference_profile");
+    expect(columns).not.toContain("inferenceProfile");
 
     const inferenceProfileColumn = (
       raw.query(`PRAGMA table_info(conversations)`).all() as Array<{
         name: string;
         notnull: number;
       }>
-    ).find((column) => column.name === "inferenceProfile");
+    ).find((column) => column.name === "inference_profile");
 
     expect(inferenceProfileColumn).toBeDefined();
     expect(inferenceProfileColumn?.notnull).toBe(0);

--- a/assistant/src/__tests__/db-rename-inference-profile-snake-case-migration.test.ts
+++ b/assistant/src/__tests__/db-rename-inference-profile-snake-case-migration.test.ts
@@ -1,0 +1,133 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getSqliteFrom } from "../memory/db-connection.js";
+import { migrateRenameInferenceProfileSnakeCase } from "../memory/migrations/228-rename-inference-profile-snake-case.js";
+import * as schema from "../memory/schema.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function getColumnNames(raw: Database): string[] {
+  return (
+    raw.query(`PRAGMA table_info(conversations)`).all() as Array<{
+      name: string;
+    }>
+  ).map((column) => column.name);
+}
+
+function bootstrapMinimalConversations(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+}
+
+describe("migrate rename inferenceProfile → inference_profile", () => {
+  test("renames the camelCase column to snake_case and preserves existing values", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapMinimalConversations(raw);
+    raw.exec(
+      /*sql*/ `ALTER TABLE conversations ADD COLUMN inferenceProfile TEXT`,
+    );
+    raw.exec(/*sql*/ `
+      INSERT INTO conversations (id, title, created_at, updated_at, inferenceProfile)
+      VALUES ('conv-1', 'with profile', ${now}, ${now}, 'quality-optimized')
+    `);
+
+    migrateRenameInferenceProfileSnakeCase(db);
+
+    const columns = getColumnNames(raw);
+    expect(columns).toContain("inference_profile");
+    expect(columns).not.toContain("inferenceProfile");
+
+    const row = raw
+      .query(
+        `SELECT id, inference_profile FROM conversations WHERE id = 'conv-1'`,
+      )
+      .get() as { id: string; inference_profile: string | null } | null;
+    expect(row).toEqual({
+      id: "conv-1",
+      inference_profile: "quality-optimized",
+    });
+  });
+
+  test("is a no-op when the column is already snake_case", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapMinimalConversations(raw);
+    raw.exec(
+      /*sql*/ `ALTER TABLE conversations ADD COLUMN inference_profile TEXT`,
+    );
+    raw.exec(/*sql*/ `
+      INSERT INTO conversations (id, title, created_at, updated_at, inference_profile)
+      VALUES ('conv-2', 'already snake', ${now}, ${now}, 'balanced')
+    `);
+
+    expect(() => migrateRenameInferenceProfileSnakeCase(db)).not.toThrow();
+
+    const columns = getColumnNames(raw);
+    expect(columns).toContain("inference_profile");
+    expect(columns).not.toContain("inferenceProfile");
+
+    const row = raw
+      .query(`SELECT inference_profile FROM conversations WHERE id = 'conv-2'`)
+      .get() as { inference_profile: string | null } | null;
+    expect(row).toEqual({ inference_profile: "balanced" });
+  });
+
+  test("is a no-op when neither column exists", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    bootstrapMinimalConversations(raw);
+    const before = getColumnNames(raw);
+    expect(before).not.toContain("inferenceProfile");
+    expect(before).not.toContain("inference_profile");
+
+    expect(() => migrateRenameInferenceProfileSnakeCase(db)).not.toThrow();
+
+    const after = getColumnNames(raw);
+    expect(after).not.toContain("inferenceProfile");
+    expect(after).not.toContain("inference_profile");
+  });
+
+  test("re-running the migration is idempotent", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    bootstrapMinimalConversations(raw);
+    raw.exec(
+      /*sql*/ `ALTER TABLE conversations ADD COLUMN inferenceProfile TEXT`,
+    );
+
+    migrateRenameInferenceProfileSnakeCase(db);
+    expect(() => migrateRenameInferenceProfileSnakeCase(db)).not.toThrow();
+
+    const columns = getColumnNames(raw);
+    expect(columns).toContain("inference_profile");
+    expect(columns).not.toContain("inferenceProfile");
+  });
+});

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -134,6 +134,7 @@ import {
   migrateRenameGmailProviderKeyToGoogle,
   migrateRenameGuardianVerificationValues,
   migrateRenameInboxThreadStateTable,
+  migrateRenameInferenceProfileSnakeCase,
   migrateRenameMemoryGraphTypeValues,
   migrateRenameNotificationThreadColumns,
   migrateRenameSequenceEnrollmentsThreadIdColumn,
@@ -384,6 +385,7 @@ export function initializeDb(): void {
     migrateOAuthProvidersAvailableScopes,
     migrateScheduleWakeConversationId,
     migrateAddConversationInferenceProfile,
+    migrateRenameInferenceProfileSnakeCase,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/228-rename-inference-profile-snake-case.ts
+++ b/assistant/src/memory/migrations/228-rename-inference-profile-snake-case.ts
@@ -1,0 +1,27 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+
+/**
+ * Rename `conversations.inferenceProfile` (camelCase, accidentally introduced
+ * by migration 227) to `inference_profile` so it matches the snake_case
+ * convention used by every other column on the table.
+ *
+ * Idempotent:
+ * - camelCase column present, snake_case absent → renames it.
+ * - snake_case column already present → no-op.
+ * - neither column present → no-op (shouldn't happen since 227 ran first,
+ *   but we guard for completeness).
+ */
+export function migrateRenameInferenceProfileSnakeCase(
+  database: DrizzleDb,
+): void {
+  if (tableHasColumn(database, "conversations", "inference_profile")) {
+    return;
+  }
+  if (!tableHasColumn(database, "conversations", "inferenceProfile")) {
+    return;
+  }
+  database.run(
+    `ALTER TABLE conversations RENAME COLUMN inferenceProfile TO inference_profile`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -173,6 +173,7 @@ export { migrateOAuthProvidersManagedServiceIsPaid } from "./224-oauth-providers
 export { migrateOAuthProvidersAvailableScopes } from "./225-oauth-providers-available-scopes.js";
 export { migrateScheduleWakeConversationId } from "./226-schedule-wake-conversation-id.js";
 export { migrateAddConversationInferenceProfile } from "./227-add-conversation-inference-profile.js";
+export { migrateRenameInferenceProfileSnakeCase } from "./228-rename-inference-profile-snake-case.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -33,7 +33,7 @@ export const conversations = sqliteTable(
     scheduleJobId: text("schedule_job_id"),
     lastMessageAt: integer("last_message_at"),
     archivedAt: integer("archived_at"),
-    inferenceProfile: text("inferenceProfile"),
+    inferenceProfile: text("inference_profile"),
   },
   (table) => [
     index("idx_conversations_updated_at").on(table.updatedAt),


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inference-profiles.md.

**Gap:** The new `inferenceProfile` SQL column was added in camelCase, breaking the conversations table's snake_case convention.

**Fix:** New idempotent rename migration that converts `inferenceProfile` → `inference_profile`; Drizzle schema updated to match. The TS field name stays `inferenceProfile` (Drizzle handles the SQL/TS mapping).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
