### PR TITLE
fix: nested subagent inherits overrideProfile via ToolContext

### DIFF
--- a/assistant/src/__tests__/agent-loop-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-loop-override-profile.test.ts
@@ -311,3 +311,93 @@ describe("SubagentManager.spawn — overrideProfile inheritance", () => {
     expect("overrideProfile" in captured).toBe(false);
   });
 });
+
+// ── Nested subagent spawn — context.overrideProfile preferred ────────────
+
+// Verify the third-level inheritance contract: when a subagent's agent loop
+// is running with `currentTurnOverrideProfile`, the executor closure plumbs
+// that value into `ToolContext.overrideProfile`. `executeSubagentSpawn` must
+// then prefer `context.overrideProfile` over a row read against the in-flight
+// subagent's own conversationId — that row never has `inferenceProfile` set,
+// and `getConversationOverrideProfile` short-circuits for background
+// conversations regardless. Without preferring the in-memory context, the
+// inheritance chain breaks at the second nesting level.
+
+mock.module("../memory/conversation-crud.js", () => ({
+  // Always return undefined for the row read so the test fails fast unless
+  // executeSubagentSpawn reads from context.overrideProfile first.
+  getConversationOverrideProfile: () => undefined,
+}));
+
+import { getSubagentManager } from "../subagent/index.js";
+import { executeSubagentSpawn } from "../tools/subagent/spawn.js";
+
+describe("executeSubagentSpawn — nested inheritance via context.overrideProfile", () => {
+  test("forwards context.overrideProfile to SubagentConfig (third-level inheritance)", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "nested-subagent-id";
+    };
+
+    try {
+      // Simulate the second-level spawn: tool invocation occurs inside the
+      // first subagent's tool context, where `overrideProfile` was populated
+      // by `runAgentLoopImpl` from its `currentTurnOverrideProfile` snapshot.
+      // The first subagent's own conversation row has no `inferenceProfile`,
+      // so the row-read fallback would otherwise return undefined.
+      const result = await executeSubagentSpawn(
+        { label: "nested", objective: "do nested work" },
+        {
+          workingDir: "/tmp",
+          conversationId: "subagent-conv-id",
+          trustClass: "guardian",
+          sendToClient: () => {},
+          overrideProfile: "fast",
+        } as import("../tools/types.js").ToolContext,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(capturedConfig).toBeDefined();
+      // The forwarded SubagentConfig must carry the in-memory override so
+      // SubagentManager.spawn forwards it into the nested subagent's
+      // runAgentLoop options — preserving inheritance across the chain.
+      expect(capturedConfig!.overrideProfile).toBe("fast");
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("omits overrideProfile when neither context nor row carries it", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "nested-subagent-id-2";
+    };
+
+    try {
+      await executeSubagentSpawn(
+        { label: "nested", objective: "do nested work" },
+        {
+          workingDir: "/tmp",
+          conversationId: "subagent-conv-id-2",
+          trustClass: "guardian",
+          sendToClient: () => {},
+          // no overrideProfile
+        } as import("../tools/types.js").ToolContext,
+      );
+
+      expect(capturedConfig).toBeDefined();
+      // Field must be absent rather than carrying `undefined` so the
+      // SubagentConfig respects the same "field omitted when unset"
+      // contract the agent loop uses.
+      expect("overrideProfile" in capturedConfig!).toBe(false);
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -466,6 +466,15 @@ export interface AgentLoopConversationContext {
   currentTurnTrustContext?: TrustContext;
   /** Per-turn snapshot of channelCapabilities, frozen at message-processing start. */
   currentTurnChannelCapabilities?: ChannelCapabilities;
+  /**
+   * Per-turn snapshot of the resolved inference-profile override. Read by
+   * `createToolExecutor` so `ToolContext.overrideProfile` carries the same
+   * profile the agent loop is sending to the provider. Without this, a tool
+   * that spawns nested subagents (e.g. `subagent_spawn`) cannot recover the
+   * override from a row read because the in-flight subagent's own row never
+   * had `inferenceProfile` set.
+   */
+  currentTurnOverrideProfile?: string;
   commandIntent?: { type: string; payload?: string; languageCode?: string };
   trustContext?: TrustContext;
   /** Task-run scope for the current turn. Cleared at turn end so queued/drained turns don't inherit it. */
@@ -625,6 +634,11 @@ export async function runAgentLoopImpl(
   const turnOverrideProfile =
     options?.overrideProfile ??
     getConversationOverrideProfile(ctx.conversationId);
+
+  // Snapshot for `createToolExecutor` to read into `ToolContext.overrideProfile`
+  // — see field doc on `AgentLoopConversationContext` for why the tool needs
+  // it (nested subagent spawns can't recover the override from a row read).
+  ctx.currentTurnOverrideProfile = turnOverrideProfile;
 
   // Capture the turn channel context *before* any awaits so a second
   // message from a different channel can't overwrite it mid-flight.
@@ -2753,6 +2767,7 @@ export async function runAgentLoopImpl(
     ctx.currentActiveSurfaceId = undefined;
     ctx.allowedToolNames = undefined;
     ctx.preactivatedSkillIds = undefined;
+    ctx.currentTurnOverrideProfile = undefined;
     // Channel command intents (e.g. Telegram /start) are single-turn metadata.
     // Clear at turn end so they never leak into subsequent unrelated messages.
     ctx.commandIntent = undefined;

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -136,6 +136,14 @@ export interface ToolSetupContext extends SurfaceConversationContext {
   ) => void;
   /** Turn-scoped flag: true when any tool call in the current turn received explicit user approval via interactive prompt. Cleared at turn end. */
   approvedViaPromptThisTurn?: boolean;
+  /**
+   * Per-turn snapshot of the resolved inference-profile override, set by
+   * `runAgentLoopImpl`. Propagated into `ToolContext.overrideProfile` so
+   * tools that spawn nested invocations (e.g. `subagent_spawn`) can forward
+   * the override without round-tripping through a row read that would
+   * return `undefined` for the in-flight (background) subagent.
+   */
+  currentTurnOverrideProfile?: string;
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -246,6 +254,7 @@ export function createToolExecutor(
       cesClient: ctx.cesClient,
       transportInterface: ctx.transportInterface,
       hostBrowserRegistryRouted: !!ctx.hostBrowserSenderOverride,
+      overrideProfile: ctx.currentTurnOverrideProfile,
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => {
         // Tool context's sendToClient uses a loose { type: string; [key: string]: unknown }

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -244,6 +244,7 @@ export class Conversation {
    */
   /** @internal */ currentTurnTrustContext?: TrustContext;
   /** @internal */ currentTurnChannelCapabilities?: ChannelCapabilities;
+  /** @internal */ currentTurnOverrideProfile?: string;
   /** @internal */ authContext?: AuthContext;
   /** @internal */ loadedHistoryTrustClass?: TrustClass;
   /** @internal */ voiceCallControlPrompt?: string;

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -73,9 +73,19 @@ export async function executeSubagentSpawn(
   // Pass the parent's profile explicitly via `SubagentConfig` so the
   // PR 6 plumbing in `SubagentManager.spawn` forwards it back into the
   // subagent's `runAgentLoop` call as `options.overrideProfile`.
-  const inheritedOverrideProfile = getConversationOverrideProfile(
-    context.conversationId,
-  );
+  //
+  // Prefer the per-turn `context.overrideProfile` (populated by
+  // `runAgentLoopImpl` from its resolved `turnOverrideProfile`) over a
+  // row read so nested spawns inherit correctly. The current subagent's
+  // own conversation row never has `inferenceProfile` set — its override
+  // arrived via in-memory `SubagentConfig.overrideProfile` — and even if it
+  // were set, `getConversationOverrideProfile` short-circuits for
+  // background conversations and returns `undefined`. Falling back to the
+  // row read preserves behavior for tool calls that originate outside an
+  // agent-loop turn.
+  const inheritedOverrideProfile =
+    context.overrideProfile ??
+    getConversationOverrideProfile(context.conversationId);
 
   try {
     const subagentId = await manager.spawn(

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -267,6 +267,16 @@ export interface ToolContext {
    * cdp-inspect — the proxy was never expected to service browser requests.
    */
   hostBrowserRegistryRouted?: boolean;
+  /**
+   * The per-turn inference-profile override the agent loop is currently
+   * running under, propagated through tool context so subagent-spawn tools
+   * can forward it when spawning nested subagents. Without this, sub-subagent
+   * spawns silently lose inheritance because their own conversation row never
+   * has `inferenceProfile` set — the override only flows through the
+   * in-memory `SubagentConfig.overrideProfile` chain. See
+   * `executeSubagentSpawn` in tools/subagent/spawn.ts.
+   */
+  overrideProfile?: string;
 }
 
 export interface Tool {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inference-profiles.md.

**Gap:** Sub-subagents (spawn → spawn) silently lost the parent's pinned inference profile because `executeSubagentSpawn` read the in-flight subagent's row, which never has `inferenceProfile` set.

**Fix:** Add `overrideProfile` to `ToolContext`, populate from the agent loop's per-turn value, and have `executeSubagentSpawn` prefer it over the row read.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
