### PR TITLE
feat(acp): add default agent profiles for claude and codex

### DIFF
--- a/assistant/src/config/acp-defaults.test.ts
+++ b/assistant/src/config/acp-defaults.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_ACP_AGENT_PROFILES,
+  DEFAULT_AGENT_INSTALL_HINTS,
+} from "./acp-defaults.js";
+
+describe("DEFAULT_ACP_AGENT_PROFILES", () => {
+  test("ships exactly the expected agent ids", () => {
+    expect(Object.keys(DEFAULT_ACP_AGENT_PROFILES).sort()).toEqual([
+      "claude",
+      "codex",
+    ]);
+  });
+
+  test("claude profile uses the @agentclientprotocol adapter binary", () => {
+    expect(DEFAULT_ACP_AGENT_PROFILES.claude).toEqual({
+      command: "claude-agent-acp",
+      args: [],
+      description: "Claude Code (via @agentclientprotocol/claude-agent-acp)",
+    });
+  });
+
+  test("codex profile uses the @zed-industries adapter binary", () => {
+    expect(DEFAULT_ACP_AGENT_PROFILES.codex).toEqual({
+      command: "codex-acp",
+      args: [],
+      description: "OpenAI Codex CLI (via @zed-industries/codex-acp)",
+    });
+  });
+
+  test("is frozen at runtime so mutation throws in strict mode", () => {
+    expect(Object.isFrozen(DEFAULT_ACP_AGENT_PROFILES)).toBe(true);
+    for (const profile of Object.values(DEFAULT_ACP_AGENT_PROFILES)) {
+      expect(Object.isFrozen(profile)).toBe(true);
+    }
+  });
+});
+
+describe("DEFAULT_AGENT_INSTALL_HINTS", () => {
+  test("is keyed by command name, not agent id", () => {
+    expect(Object.keys(DEFAULT_AGENT_INSTALL_HINTS).sort()).toEqual([
+      "claude-agent-acp",
+      "codex-acp",
+    ]);
+  });
+
+  test("hints reference the new @agentclientprotocol package for claude", () => {
+    expect(DEFAULT_AGENT_INSTALL_HINTS["claude-agent-acp"]).toBe(
+      "npm i -g @agentclientprotocol/claude-agent-acp",
+    );
+  });
+
+  test("hints reference the @zed-industries package for codex", () => {
+    expect(DEFAULT_AGENT_INSTALL_HINTS["codex-acp"]).toBe(
+      "npm i -g @zed-industries/codex-acp",
+    );
+  });
+
+  test("every default profile's command has a matching install hint", () => {
+    for (const profile of Object.values(DEFAULT_ACP_AGENT_PROFILES)) {
+      expect(DEFAULT_AGENT_INSTALL_HINTS[profile.command]).toBeDefined();
+    }
+  });
+
+  test("is frozen at runtime so mutation throws in strict mode", () => {
+    expect(Object.isFrozen(DEFAULT_AGENT_INSTALL_HINTS)).toBe(true);
+  });
+
+  test("readonly type rejects mutation at compile time", () => {
+    const _assignNewKey: () => void = () => {
+      // @ts-expect-error — DEFAULT_AGENT_INSTALL_HINTS has a Readonly index signature
+      DEFAULT_AGENT_INSTALL_HINTS["new-binary"] = "npm i -g foo";
+    };
+    const _assignNewProfile: () => void = () => {
+      // @ts-expect-error — DEFAULT_ACP_AGENT_PROFILES has a Readonly index signature
+      DEFAULT_ACP_AGENT_PROFILES.newAgent = { command: "x", args: [] };
+    };
+    // The assertions live in the @ts-expect-error comments above; this test
+    // exists to surface a type-check failure if the readonly contract regresses.
+    expect(_assignNewKey).toBeFunction();
+    expect(_assignNewProfile).toBeFunction();
+  });
+});

--- a/assistant/src/config/acp-defaults.ts
+++ b/assistant/src/config/acp-defaults.ts
@@ -1,0 +1,39 @@
+import type { AcpAgentConfig } from "./acp-schema.js";
+
+/**
+ * Default ACP agent profiles that ship with the assistant.
+ *
+ * When `acp.enabled: true` and the user has not provided a config entry for an
+ * agent id, the resolver falls back to this map so common agents like `claude`
+ * and `codex` Just Work without requiring per-user config.
+ *
+ * Keyed by agent id. Frozen so accidental runtime mutation throws in strict
+ * mode and the readonly type matches actual runtime behavior.
+ */
+export const DEFAULT_ACP_AGENT_PROFILES: Readonly<
+  Record<string, AcpAgentConfig>
+> = Object.freeze({
+  claude: Object.freeze({
+    command: "claude-agent-acp",
+    args: [],
+    description: "Claude Code (via @agentclientprotocol/claude-agent-acp)",
+  }),
+  codex: Object.freeze({
+    command: "codex-acp",
+    args: [],
+    description: "OpenAI Codex CLI (via @zed-industries/codex-acp)",
+  }),
+});
+
+/**
+ * Install hints for ACP adapter binaries, keyed by command name (not agent id).
+ *
+ * Keying by command name lets the resolver and `acp_list_agents` reuse this
+ * map regardless of how a user's config aliases an agent — the install hint
+ * follows the binary, not the alias.
+ */
+export const DEFAULT_AGENT_INSTALL_HINTS: Readonly<Record<string, string>> =
+  Object.freeze({
+    "claude-agent-acp": "npm i -g @agentclientprotocol/claude-agent-acp",
+    "codex-acp": "npm i -g @zed-industries/codex-acp",
+  });


### PR DESCRIPTION
## Summary
- Add `DEFAULT_ACP_AGENT_PROFILES` for `claude` (claude-agent-acp) and `codex` (codex-acp) so enabling ACP yields useful defaults.
- Add `DEFAULT_AGENT_INSTALL_HINTS` keyed by command for reuse by the resolver and `acp_list_agents`.
- No consumers yet — wired in later PRs.

Part of plan: acp-codex-claude.md (PR 1 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
