### PR TITLE
docs(llm): align EffortEnum docstring with OpenAI explicit-none behavior

### DIFF
--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -75,11 +75,16 @@ export type LLMCallSite = z.infer<typeof LLMCallSiteEnum>;
 
 /**
  * Reasoning/thinking effort tier. `"none"` is a Vellum-specific value meaning
- * "omit the provider's effort/reasoning parameter entirely" — providers
- * translate it to skipping the relevant field on the wire (no `reasoning` on
- * OpenAI Responses, no `reasoning_effort` on Chat Completions, no
- * `output_config.effort` on Anthropic). All other values map to
- * provider-specific tiers via each provider's own mapping table.
+ * "the user has opted out of provider-side reasoning". Each provider
+ * translates it however actually disables reasoning on that wire format:
+ * OpenAI Responses sends `reasoning.effort: "none"` and Chat Completions
+ * sends `reasoning_effort: "none"` explicitly, because omitting the field
+ * causes OpenAI to default to `"medium"`; Anthropic omits
+ * `output_config.effort` entirely, which is the documented opt-out there.
+ * When adding a new provider, pick whichever encoding actually disables
+ * reasoning on that wire format — do not assume omission is universally safe.
+ * All other values map to provider-specific tiers via each provider's own
+ * mapping table.
  */
 export const EffortEnum = z.enum([
   "none",


### PR DESCRIPTION
## Summary
Follow-up to #28024. The previous `EffortEnum` docstring claimed `"none"` always meant "omit the provider's effort/reasoning parameter entirely" — but #28024 changed both OpenAI providers to send `"none"` explicitly on the wire (because OpenAI defaults to `"medium"` when the field is omitted, silently overriding the user's opt-out).

Updated the docstring so it describes the per-provider encoding actually in use: OpenAI sends explicit `"none"`, Anthropic omits `output_config.effort`. Also added a note for future provider authors not to assume omission is universally safe.

Addresses Devin Review feedback on #28024.

## Test plan
- [x] Comment-only change; no behavior change

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
