### PR TITLE
docs(injectors): rewrite remaining G2.1 references in present tense

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1715,7 +1715,7 @@ export async function composeInjectorChain(ctx: TurnContext): Promise<string> {
 /**
  * Default block placement. Kept in sync with {@link InjectionBlock} so
  * blocks produced without an explicit `placement` (e.g. third-party
- * injectors written against the pre-G2.1 API) behave predictably.
+ * injectors that omit the field) behave predictably.
  */
 const DEFAULT_PLACEMENT: InjectionPlacement = "append-user-tail";
 
@@ -2128,8 +2128,8 @@ export async function applyRuntimeInjections(
   }
 
   // ── Step 3: hardcoded branches that stayed outside the injector chain ──
-  // These run in the same historical order as before G2.1 so their
-  // interleaving with any prior tail content stays stable.
+  // Their order here is load-bearing: each branch may mutate the tail
+  // user message, so reordering changes how they interleave.
 
   // For non-interactive conversations (scheduled jobs, work items), instruct the
   // model to never ask for clarification — there is no human present to answer.


### PR DESCRIPTION
## Summary

Follow-up to PR #27653 review feedback (Devin flagged remaining stale migration references outside the original diff hunks). PR #27777 cleaned up the \"pre-migration\" references; this PR finishes the cleanup by rewriting the two remaining \"G2.1\" / \"pre-G2.1\" comments in \`conversation-runtime-assembly.ts\` so they describe current behavior rather than referencing a now-removed migration.

- \`DEFAULT_PLACEMENT\` docstring: drop the \"injectors written against the pre-G2.1 API\" framing and just describe what the default covers (third-party injectors that omit the \`placement\` field).
- Step-3 hardcoded-branch comment: drop \"the same historical order as before G2.1\" and explain why the order is load-bearing (each branch may mutate the tail user message).

## Test plan

- [x] \`rg 'pre-migration|PR 21|PR 3|G2\\.1|pre-G2' assistant/src/daemon/conversation-runtime-assembly.ts assistant/src/plugins/defaults/injectors.ts\` returns no matches
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
