### PR TITLE
feat(acp): add acp_steer tool to interrupt and redirect running sessions

### DIFF
--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -74,6 +74,32 @@
       },
       "executor": "tools/acp-abort.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "acp_steer",
+      "description": "**Interrupts** the in-flight prompt of a running ACP session and replaces it with `instruction`. Use to redirect the agent (e.g., 'stop, do X instead'). For follow-up work that should happen *after* the current task, do NOT use this — wait for `acp_session_completed` and `acp_spawn` again.",
+      "category": "orchestration",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "acp_session_id": {
+            "type": "string",
+            "description": "The ID of the ACP session to steer."
+          },
+          "instruction": {
+            "type": "string",
+            "description": "The new instruction that replaces the in-flight prompt."
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief explanation of why this tool is being called"
+          }
+        },
+        "required": ["acp_session_id", "instruction"]
+      },
+      "executor": "tools/acp-steer.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/acp/tools/acp-steer.ts
+++ b/assistant/src/config/bundled-skills/acp/tools/acp-steer.ts
@@ -1,0 +1,12 @@
+import { executeAcpSteer } from "../../../../tools/acp/steer.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAcpSteer(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -17,6 +17,7 @@ import type { SkillToolScript } from "../tools/skills/script-contract.js";
 import * as acpAbort from "./bundled-skills/acp/tools/acp-abort.js";
 import * as acpSpawn from "./bundled-skills/acp/tools/acp-spawn.js";
 import * as acpStatus from "./bundled-skills/acp/tools/acp-status.js";
+import * as acpSteer from "./bundled-skills/acp/tools/acp-steer.js";
 // ── app-builder ────────────────────────────────────────────────────────────────
 import * as appCreate from "./bundled-skills/app-builder/tools/app-create.js";
 import * as appDelete from "./bundled-skills/app-builder/tools/app-delete.js";
@@ -114,6 +115,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["acp:tools/acp-spawn.ts", acpSpawn],
   ["acp:tools/acp-status.ts", acpStatus],
   ["acp:tools/acp-abort.ts", acpAbort],
+  ["acp:tools/acp-steer.ts", acpSteer],
 
   // app-builder
   ["app-builder:tools/app-create.ts", appCreate],

--- a/assistant/src/tools/acp/steer.test.ts
+++ b/assistant/src/tools/acp/steer.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ToolContext } from "../types.js";
+
+interface SteerCall {
+  acpSessionId: string;
+  instruction: string;
+}
+
+const steerCalls: SteerCall[] = [];
+const defaultSteer = (acpSessionId: string, instruction: string) => {
+  steerCalls.push({ acpSessionId, instruction });
+  return Promise.resolve();
+};
+let steerImpl: (acpSessionId: string, instruction: string) => Promise<void> =
+  defaultSteer;
+
+mock.module("../../acp/index.js", () => ({
+  getAcpSessionManager: () => ({
+    steer: (acpSessionId: string, instruction: string) =>
+      steerImpl(acpSessionId, instruction),
+  }),
+}));
+
+const { executeAcpSteer } = await import("./steer.js");
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-test",
+    trustClass: "guardian",
+  };
+}
+
+beforeEach(() => {
+  steerCalls.length = 0;
+  steerImpl = defaultSteer;
+});
+
+describe("executeAcpSteer", () => {
+  test("happy path: returns steered status and forwards args to manager", async () => {
+    const result = await executeAcpSteer(
+      { acp_session_id: "acp-123", instruction: "stop, do X instead" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(steerCalls).toEqual([
+      { acpSessionId: "acp-123", instruction: "stop, do X instead" },
+    ]);
+
+    const parsed = JSON.parse(result.content as string);
+    expect(parsed).toEqual({
+      acpSessionId: "acp-123",
+      status: "steered",
+      message: "Interrupted in-flight prompt; new instruction is now running.",
+    });
+  });
+
+  test("missing instruction returns isError", async () => {
+    const result = await executeAcpSteer(
+      { acp_session_id: "acp-123" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('"instruction" is required');
+    expect(steerCalls).toEqual([]);
+  });
+
+  test("missing acp_session_id returns isError", async () => {
+    const result = await executeAcpSteer(
+      { instruction: "do something" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('"acp_session_id" is required');
+    expect(steerCalls).toEqual([]);
+  });
+
+  test("manager.steer throwing 'session not found' surfaces the error", async () => {
+    steerImpl = () => Promise.reject(new Error('ACP session "acp-x" not found'));
+
+    const result = await executeAcpSteer(
+      { acp_session_id: "acp-x", instruction: "redirect" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Could not steer ACP session "acp-x"');
+    expect(result.content).toContain("not found");
+  });
+});

--- a/assistant/src/tools/acp/steer.ts
+++ b/assistant/src/tools/acp/steer.ts
@@ -1,0 +1,38 @@
+import { getAcpSessionManager } from "../../acp/index.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+export async function executeAcpSteer(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const acpSessionId = input.acp_session_id as string;
+  if (!acpSessionId) {
+    return { content: '"acp_session_id" is required.', isError: true };
+  }
+
+  const instruction = input.instruction as string;
+  if (!instruction) {
+    return { content: '"instruction" is required.', isError: true };
+  }
+
+  try {
+    const manager = getAcpSessionManager();
+    await manager.steer(acpSessionId, instruction);
+
+    return {
+      content: JSON.stringify({
+        acpSessionId,
+        status: "steered",
+        message:
+          "Interrupted in-flight prompt; new instruction is now running.",
+      }),
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      content: `Could not steer ACP session "${acpSessionId}": ${msg}`,
+      isError: true,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Add `acp_steer` tool exposing the existing `AcpSessionManager.steer()` method to the LLM.
- Tool description leads with **Interrupts** to make the cancel-and-replace semantics unambiguous (the manager cancels any in-flight prompt before sending the new instruction; this is a redirect, not a queue).
- For queued follow-ups, callers should wait for `acp_session_completed` and `acp_spawn` again — flagged in the description.

Part of plan: acp-codex-claude.md (PR 3 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
