### PR TITLE
ci(macos): add overwrite:true to artifact upload retry

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -312,6 +312,7 @@ jobs:
           path: clients/macos/dist/${{ env.APP_DISPLAY_NAME }}.app
           retention-days: 30
           if-no-files-found: error
+          overwrite: true
 
       - name: Create DMG
         working-directory: clients/macos


### PR DESCRIPTION
## Summary
- Addresses review feedback on #28057.
- \`actions/upload-artifact@v4\` registers the artifact name before file transfer; if the initial upload fails mid-transfer, the retry would fail with a duplicate-name error. Adding \`overwrite: true\` to the retry step matches the pattern in \`ci-benchmarks.yaml:70\`.

## Test plan
- [ ] Workflow parses; behavior verified on next transient artifact upload failure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
