### PR TITLE
fix(daemon/meet-manifest-loader): eager-validate tool risk levels at load time

### DIFF
--- a/assistant/src/daemon/__tests__/meet-manifest-loader.test.ts
+++ b/assistant/src/daemon/__tests__/meet-manifest-loader.test.ts
@@ -395,6 +395,35 @@ describe("loadMeetManifestProxies", () => {
     ).rejects.toThrow(/rebuild\/repackage/);
   });
 
+  test("rejects an unknown tool risk level eagerly, before the provider is invoked", async () => {
+    writeFileSync(
+      manifestPath,
+      JSON.stringify(
+        {
+          ...FIXTURE_MANIFEST,
+          tools: [{ ...FIXTURE_MANIFEST.tools[0]!, risk: "extreme" }],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    const stub = makeSupervisorStub();
+    let providerInvoked = false;
+    await expect(
+      loadMeetManifestProxies(stub.supervisor, {
+        manifestPath,
+        registerTools: (p) => {
+          providerInvoked = true;
+          p();
+        },
+        registerRoute: () => undefined,
+        registerShutdown: () => undefined,
+      }),
+    ).rejects.toThrow(/unknown risk level "extreme"/);
+    expect(providerInvoked).toBe(false);
+  });
+
   test("rejects a manifest whose skill field does not match meet-join", async () => {
     writeFileSync(
       manifestPath,

--- a/assistant/src/daemon/meet-manifest-loader.ts
+++ b/assistant/src/daemon/meet-manifest-loader.ts
@@ -354,6 +354,13 @@ export async function loadMeetManifestProxies(
   const registerRoute = deps.registerRoute ?? registerSkillRoute;
   const registerShutdown = deps.registerShutdown ?? registerShutdownHook;
 
+  // Eagerly validate every tool entry so a malformed manifest (e.g. an
+  // unknown `risk` value) surfaces here, where startup catches it, rather
+  // than later inside the lazy tool provider during `initializeTools()`.
+  for (const entry of manifest.tools) {
+    coerceRiskLevel(entry.risk, entry.name);
+  }
+
   // Tool provider resolves the full proxy list lazily so the tool manifest
   // reflects the manifest file at `initializeTools()` time — same timing
   // contract as the in-process skill's provider closure.


### PR DESCRIPTION
## Summary
- Hoist per-tool \`coerceRiskLevel\` from inside the lazy \`registerTools\` provider into an eager pass in \`loadMeetManifestProxies\`. A malformed shipped manifest (e.g. an unrecognized \`risk\` value) now throws at startup where the caller can guard it, rather than later during \`initializeTools()\` where it surfaces as a startup failure outside that guard.
- Add a regression test that asserts (a) the eager throw and (b) that the lazy provider is never invoked on a bad manifest.

Addresses P2 review feedback on #27933. The P1 finding (defer flag check until startup) is moot — #28029 deleted \`external-skills-bootstrap.ts\` and made the lazy-external path the sole entry, so the module-level flag read no longer exists.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
