### PR TITLE
fix(daemon-skill-host): thread skillId into logger and shutdown-hook keys

### DIFF
--- a/assistant/src/daemon/daemon-skill-host.ts
+++ b/assistant/src/daemon/daemon-skill-host.ts
@@ -96,9 +96,9 @@ function adaptLogger(name: string): Logger {
   };
 }
 
-function buildLoggerFacet(): LoggerFacet {
+function buildLoggerFacet(skillId: string): LoggerFacet {
   return {
-    get: (name) => adaptLogger(name),
+    get: (name) => adaptLogger(`${skillId}:${name}`),
   };
 }
 
@@ -216,7 +216,7 @@ function buildEventsFacet(): EventsFacet {
   };
 }
 
-function buildRegistriesFacet(): RegistriesFacet {
+function buildRegistriesFacet(skillId: string): RegistriesFacet {
   return {
     // Contract's `Tool` is structurally independent of the daemon's
     // overlay (`assistant/src/tools/types.ts`); the assistant-side
@@ -226,7 +226,11 @@ function buildRegistriesFacet(): RegistriesFacet {
     registerTools: (provider) => registerExternalTools(provider as never),
     registerSkillRoute: (route: SkillRoute): SkillRouteHandle =>
       registerSkillRoute(route) as unknown as SkillRouteHandle,
-    registerShutdownHook: (name, hook) => registerShutdownHook(name, hook),
+    // Namespace hook names by skillId so two skills using the same label
+    // (e.g. "cleanup") cannot silently overwrite each other's entries in
+    // the shared shutdown-hook map.
+    registerShutdownHook: (name, hook) =>
+      registerShutdownHook(`${skillId}:${name}`, hook),
   };
 }
 
@@ -238,24 +242,21 @@ function buildSpeakersFacet(): SpeakersFacet {
 
 /**
  * Build a `SkillHost` for the in-process first-party skill identified by
- * `skillId`. The `skillId` is currently threaded through only for log
- * scoping and future per-skill config gating; the returned host surface is
- * the same for every caller.
+ * `skillId`. The id prefixes logger names (so cross-cutting diagnostics
+ * carry the owning skill) and namespaces shutdown-hook registrations (so
+ * two skills using the same hook label cannot silently overwrite each
+ * other in the shared shutdown-hook map).
  */
 export function createDaemonSkillHost(skillId: string): SkillHost {
-  // `skillId` is intentionally read once for its side-effect name — keep it
-  // visible in the logger default scope so cross-cutting diagnostics (slow
-  // publishes, shutdown-hook failures) carry the owning skill's name.
-  void skillId;
   return {
-    logger: buildLoggerFacet(),
+    logger: buildLoggerFacet(skillId),
     config: buildConfigFacet(),
     identity: buildIdentityFacet(),
     platform: buildPlatformFacet(),
     providers: buildProvidersFacet(),
     memory: buildMemoryFacet(),
     events: buildEventsFacet(),
-    registries: buildRegistriesFacet(),
+    registries: buildRegistriesFacet(skillId),
     speakers: buildSpeakersFacet(),
   };
 }


### PR DESCRIPTION
## Summary

Addresses review feedback on #27758:

- **skillId silently discarded.** `createDaemonSkillHost(skillId)` previously did `void skillId` while the comment claimed it provided logger scoping. Now `skillId` is threaded into `buildLoggerFacet` and prefixed onto every logger name (`<skillId>:<name>`) so cross-cutting diagnostics actually carry the owning skill.
- **Shutdown-hook collisions.** `registerShutdownHook` was forwarded with the raw hook name into a shared `Map<string, ShutdownHook>` that silently replaces existing entries. Two skills using the same label (e.g. `"cleanup"`) would drop one of the hooks. Hook names are now namespaced as `<skillId>:<name>`.

The async-mismatch finding from review was already resolved in a follow-up commit on main (`getConfigured` and `resolveStreamingTranscriber` are async in the contract today).

## Test plan
- [x] `bun test src/daemon/__tests__/daemon-skill-host.test.ts` — 14 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
