### PR TITLE
fix(gateway): default to strict attachment validation when guardian lookup throws

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1703,10 +1703,24 @@ async function main() {
               // (e.g. .mkv, .dmg) for downstream processing. Resolved once
               // per message — the assistant re-checks gateway-service auth
               // before honoring the flag, so impersonation is not possible.
+              // Lookup failures (e.g. assistant.db unavailable) default to
+              // strict handling so non-guardian uploads still flow through
+              // the normal validation path instead of being dropped.
               const slackActorId = normalized.event.actor.actorExternalId;
-              const isGuardianActor = slackActorId
-                ? !!findGuardianForChannelActor("slack", slackActorId)
-                : false;
+              let isGuardianActor = false;
+              if (slackActorId) {
+                try {
+                  isGuardianActor = !!findGuardianForChannelActor(
+                    "slack",
+                    slackActorId,
+                  );
+                } catch (err) {
+                  log.warn(
+                    { err, slackActorId },
+                    "Guardian lookup failed; defaulting to strict attachment validation",
+                  );
+                }
+              }
 
               // Filter oversized attachments
               const eligible = eventAttachments.filter((att) => {


### PR DESCRIPTION
## Summary

Wraps the Slack guardian-actor lookup in `gateway/src/index.ts` in a try/catch so a `findGuardianForChannelActor` failure (e.g. `assistant.db` unavailable) no longer escapes the attachment block. Previously the throw bubbled up to the outer `forward()` handler and dropped *every* attachment on the message — including non-guardian uploads that should have continued through the normal strict validation path. On failure we now log a warning and fall back to \`isGuardianActor = false\`, preserving the strict behavior for that message.

Addresses Codex feedback on #28053.

## Test plan

- [ ] Trigger a Slack inbound with an attachment while \`assistant.db\` is unreachable; confirm message + attachments still flow through strict validation instead of being dropped wholesale.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
