### PR TITLE
fix(providers): gate OpenAI text.verbosity on GPT-5 models

### DIFF
--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -638,10 +638,43 @@ describe("OpenAIResponsesProvider", () => {
       [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
       undefined,
       undefined,
-      { config: { verbosity: "bogus" } },
+      // Cast through unknown — the test deliberately exercises the runtime
+      // guard against malformed values that would bypass the type system
+      // (e.g. arriving via the index signature on `SendMessageConfig`).
+      { config: { verbosity: "bogus" as unknown as "low" } },
     );
 
     expect(lastStreamParams!.text).toBeUndefined();
+  });
+
+  test("verbosity is suppressed for non-GPT-5 models", async () => {
+    // `text.verbosity` is a GPT-5-series-only parameter; forwarding it to
+    // older Responses-API models (o-series, etc.) risks HTTP 400 rejections.
+    const oSeriesProvider = new OpenAIResponsesProvider("sk-test", "o3");
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await oSeriesProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      { config: { verbosity: "high" } },
+    );
+
+    expect(lastStreamParams!.text).toBeUndefined();
+  });
+
+  test("verbosity is forwarded when model override is GPT-5", async () => {
+    const oSeriesProvider = new OpenAIResponsesProvider("sk-test", "o3");
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await oSeriesProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      { config: { verbosity: "high", model: "gpt-5.2" } },
+    );
+
+    expect(lastStreamParams!.text).toEqual({ verbosity: "high" });
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -45,6 +45,15 @@ const EFFORT_TO_REASONING_EFFORT: Record<
 /** Values accepted by the Responses API `text.verbosity` parameter. */
 const VALID_VERBOSITIES = new Set<string>(["low", "medium", "high"]);
 
+/** `text.verbosity` is a GPT-5-series-only parameter. Older models on the
+ *  Responses API (o-series, etc.) reject unknown wire fields with HTTP 400, so
+ *  gate forwarding by model name here. The retry layer can't make this call
+ *  because verbosity defaults to "medium" in the LLM schema, so every
+ *  callSite-resolved request would otherwise carry it regardless of model. */
+function modelSupportsVerbosity(model: string): boolean {
+  return /^gpt-5(\b|[-.])/i.test(model);
+}
+
 /** Loosely-typed Responses stream event to avoid `any` while the SDK types settle. */
 interface ResponsesStreamEvent {
   type: string;
@@ -149,7 +158,11 @@ export class OpenAIResponsesProvider implements Provider {
         params.reasoning = { effort: reasoningEffort };
       }
 
-      if (verbosity && VALID_VERBOSITIES.has(verbosity)) {
+      if (
+        verbosity &&
+        VALID_VERBOSITIES.has(verbosity) &&
+        modelSupportsVerbosity(modelOverride ?? this.model)
+      ) {
         params.text = { verbosity };
       }
 

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -137,9 +137,9 @@ export interface SendMessageConfig {
   model?: string;
   /**
    * LLM call-site identifier. `RetryProvider` resolves
-   * provider/model/maxTokens/effort/speed/temperature/thinking/contextWindow
-   * via `resolveCallSiteConfig(callSite, config.llm)`, falling back to
-   * `llm.default` when no callSite-specific entry is present.
+   * provider/model/maxTokens/effort/speed/verbosity/temperature/thinking/
+   * contextWindow via `resolveCallSiteConfig(callSite, config.llm)`, falling
+   * back to `llm.default` when no callSite-specific entry is present.
    */
   callSite?: LLMCallSite;
   /**
@@ -153,6 +153,7 @@ export interface SendMessageConfig {
   overrideProfile?: string;
   effort?: "none" | "low" | "medium" | "high" | "xhigh" | "max";
   speed?: "standard" | "fast";
+  verbosity?: "low" | "medium" | "high";
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #28018 addressing review feedback.

- **Codex P1 / Devin**: `LLMConfigBase` defaults \`verbosity\` to \`\"medium\"\`, so after #28018 every callSite-resolved OpenAI Responses request was carrying \`text.verbosity\` regardless of model. \`text.verbosity\` is a GPT-5-series-only parameter and older Responses-API models (o-series, etc.) can reject unknown wire fields with HTTP 400. Gate forwarding by model name in \`OpenAIResponsesProvider\` so non-GPT-5 models never see the field.
- **Devin**: Add typed \`verbosity\` property to \`SendMessageConfig\` and mention it in the \`callSite\` JSDoc, matching the existing pattern for \`effort\` and \`speed\`.

## Test plan

- [x] Added \`verbosity is suppressed for non-GPT-5 models\` test (instantiates an o3 provider, asserts \`text\` is omitted even when verbosity is set).
- [x] Added \`verbosity is forwarded when model override is GPT-5\` test (o3 provider with a per-call \`model: \"gpt-5.2\"\` override).
- [x] Existing verbosity tests continue to pass against the default \`gpt-5.2\` provider.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
