### PR TITLE
fix(meet-host): guard child exit/error handlers against stale firings

### DIFF
--- a/assistant/src/daemon/__tests__/meet-host-supervisor.test.ts
+++ b/assistant/src/daemon/__tests__/meet-host-supervisor.test.ts
@@ -61,17 +61,33 @@ class FakeChild extends EventEmitter {
   pid = 12345;
   stdout = new PassThrough();
   stderr = new PassThrough();
+  /** When true, `kill()` queues the exit until `flushDeferredExit()`. */
+  deferExit = false;
+  private pendingExit: {
+    code: number;
+    signal: NodeJS.Signals | number;
+  } | null = null;
   kill = mock((_signal?: NodeJS.Signals | number) => {
-    // Simulate the process exiting almost immediately on signal.
+    if (this.exitCode != null) return true;
+    this.exitCode = 143;
+    this.killed = true;
+    if (this.deferExit) {
+      this.pendingExit = { code: 143, signal: _signal ?? "SIGTERM" };
+      return true;
+    }
     queueMicrotask(() => {
-      if (this.exitCode == null) {
-        this.exitCode = 143;
-        this.killed = true;
-        this.emit("exit", 143, _signal ?? "SIGTERM");
-      }
+      this.emit("exit", 143, _signal ?? "SIGTERM");
     });
     return true;
   });
+
+  /** Emit a deferred exit queued by `kill()` while `deferExit` was true. */
+  flushDeferredExit() {
+    const pending = this.pendingExit;
+    if (!pending) return;
+    this.pendingExit = null;
+    this.emit("exit", pending.code, pending.signal);
+  }
 
   /** Force-exit the child with a given code (simulated crash). */
   simulateExit(code: number | null, signal: NodeJS.Signals | null = null) {
@@ -232,6 +248,37 @@ describe("MeetHostSupervisor", () => {
     await tick();
     supervisor.notifyHandshake({ sourceHash: "expected-hash" });
     await p2;
+    expect(supervisor.isRunning).toBe(true);
+  });
+
+  test("stale exit handler from a replaced child does not kill the successor", async () => {
+    harness = makeHarness({ manifestHash: "expected-hash" });
+    const { supervisor, spawnFn, child: firstChild } = harness;
+    // Defer the first child's exit so it fires AFTER the respawn —
+    // mirrors real Node.js, where SIGCHLD arrives on a later tick.
+    firstChild.deferExit = true;
+
+    const p = supervisor.ensureRunning();
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "wrong-hash" });
+    await expect(p).rejects.toThrow(/source hash mismatch/);
+    expect(firstChild.kill).toHaveBeenCalledWith("SIGKILL");
+
+    // Respawn before the old child's exit event fires.
+    const secondChild = new FakeChild();
+    spawnFn.mockImplementation(() => secondChild as unknown as ChildProcess);
+    const p2 = supervisor.ensureRunning();
+    await tick();
+    supervisor.notifyHandshake({ sourceHash: "expected-hash" });
+    await p2;
+    expect(supervisor.isRunning).toBe(true);
+
+    // Now deliver the stale exit. Without the guard this rejects the
+    // (already-resolved) handshake and SIGKILL's secondChild.
+    firstChild.flushDeferredExit();
+    await tick();
+
+    expect(secondChild.kill).not.toHaveBeenCalled();
     expect(supervisor.isRunning).toBe(true);
   });
 

--- a/assistant/src/daemon/meet-host-supervisor.ts
+++ b/assistant/src/daemon/meet-host-supervisor.ts
@@ -550,6 +550,12 @@ export class MeetHostSupervisor {
 
     child.on("exit", (code, signal) => {
       log.info({ code, signal }, "meet-host child exited");
+      // Stale exit from a child we already replaced: SIGKILL delivers
+      // SIGCHLD on a later event-loop tick, so an old child's exit can
+      // fire after teardownChild has nulled the field and ensureRunning
+      // has spawned a successor. Mutating supervisor state here would
+      // reject the new child's handshake and SIGKILL it.
+      if (this.child !== child) return;
       // Reject any in-flight handshake so callers fail fast instead of
       // hanging waiting for a frame that will never arrive.
       if (this.handshakeReject) {
@@ -564,6 +570,7 @@ export class MeetHostSupervisor {
     });
     child.on("error", (err) => {
       log.error({ err }, "meet-host spawn error");
+      if (this.child !== child) return;
       if (this.handshakeReject) this.handshakeReject(err);
     });
 


### PR DESCRIPTION
Addresses review feedback on #27928 (Codex P1 / Devin BUG-0001).

When `teardownChild()` SIGKILLs a child (e.g. on hash-mismatch), Node.js delivers `SIGCHLD` on a later event-loop tick. If `ensureRunning()` respawns before the old child's exit event fires, the stale handler — which closes over supervisor-level state `this.child` / `this.handshakeReject` — would reject the *new* child's handshake and SIGKILL the new child via `teardownChild()`.

Fix: guard both the `exit` and `error` handlers with `if (this.child !== child) return;` so only the handler bound to the current child can mutate supervisor state.

## Test

Adds a regression test (`stale exit handler from a replaced child does not kill the successor`) that:
1. Spawns child A with a deferred-exit `FakeChild`
2. Triggers a hash mismatch → SIGKILL on A (exit deferred)
3. Respawns child B and completes handshake
4. Flushes A's stale exit
5. Asserts B was not killed and supervisor remains running

Without the guard the test fails because A's stale handler tears down B.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
