### PR TITLE
fix(providers): cap Fireworks reasoning_effort at high

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1440,4 +1440,22 @@ describe("OpenAIProvider reasoning_effort", () => {
     });
     expect(lastCreateParams!.reasoning_effort).toBe("medium");
   });
+
+  test('maxReasoningEffort: "high" caps "xhigh"/"max" at "high"', async () => {
+    const capped = new OpenAIProvider("test-key", "gpt-5", {
+      maxReasoningEffort: "high",
+    });
+    await capped.sendMessage([userMsg("hi")], undefined, "system", {
+      config: { effort: "xhigh" },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBe("high");
+    await capped.sendMessage([userMsg("hi")], undefined, "system", {
+      config: { effort: "max" },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBe("high");
+    await capped.sendMessage([userMsg("hi")], undefined, "system", {
+      config: { effort: "medium" },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBe("medium");
+  });
 });

--- a/assistant/src/providers/fireworks/client.ts
+++ b/assistant/src/providers/fireworks/client.ts
@@ -19,6 +19,9 @@ export class FireworksProvider extends OpenAIChatCompletionsProvider {
       providerName: "fireworks",
       providerLabel: "Fireworks",
       streamTimeoutMs: options.streamTimeoutMs,
+      // Fireworks' OpenAI-compatible chat-completions API documents only
+      // low|medium|high for reasoning_effort; sending "xhigh" 4xxs upstream.
+      maxReasoningEffort: "high",
     });
   }
 }

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -62,6 +62,11 @@ export interface OpenAIChatCompletionsProviderOptions {
   streamTimeoutMs?: number;
   /** Extra params spread into every chat.completions.create call (e.g. reasoning). */
   extraCreateParams?: Record<string, unknown>;
+  /** Upper bound for `reasoning_effort` sent on the wire. Defaults to "xhigh"
+   *  (OpenAI's current ceiling). Compatibility providers whose APIs only
+   *  document `low|medium|high` (e.g. Fireworks) should set this to "high" so
+   *  Vellum's `xhigh`/`max` tiers don't 4xx upstream. */
+  maxReasoningEffort?: "high" | "xhigh";
 }
 
 /** Map our internal effort values to OpenAI's reasoning_effort parameter.
@@ -104,6 +109,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
   private model: string;
   private streamTimeoutMs: number;
   private extraCreateParams: Record<string, unknown>;
+  private maxReasoningEffort: "high" | "xhigh";
 
   constructor(
     apiKey: string,
@@ -119,6 +125,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     this.model = model;
     this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;
     this.extraCreateParams = options.extraCreateParams ?? {};
+    this.maxReasoningEffort = options.maxReasoningEffort ?? "xhigh";
   }
 
   async sendMessage(
@@ -153,7 +160,10 @@ export class OpenAIChatCompletionsProvider implements Provider {
         ? EFFORT_TO_REASONING_EFFORT[effort]
         : undefined;
       if (reasoningEffort) {
-        params.reasoning_effort = reasoningEffort;
+        params.reasoning_effort =
+          reasoningEffort === "xhigh" && this.maxReasoningEffort === "high"
+            ? "high"
+            : reasoningEffort;
       }
 
       if (tools && tools.length > 0) {


### PR DESCRIPTION
## Summary
- PR #28023 changed the shared `OpenAIChatCompletionsProvider` to map Vellum's `xhigh`/`max` effort tiers to OpenAI's `xhigh`. `FireworksProvider` extends that class, so Fireworks requests started emitting `reasoning_effort: "xhigh"` too — but Fireworks' OpenAI-compatible chat-completions API only documents `low|medium|high`, so those requests can 4xx. The default LLM effort is `max`, making this a regression for every Fireworks call.
- Adds a `maxReasoningEffort` cap option to `OpenAIChatCompletionsProviderOptions` (default `"xhigh"`, matching OpenAI's ceiling). Fireworks sets it to `"high"` so `xhigh`/`max` downgrade on the wire. OpenAI/OpenRouter/Ollama keep current behavior.

## Test plan
- [x] New test verifies `maxReasoningEffort: "high"` downgrades both `xhigh` and `max`, and leaves lower tiers untouched.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
