### PR TITLE
fix(ipc): backpressure and eviction handling for skill IPC streams

### DIFF
--- a/assistant/src/ipc/skill-routes/events.ts
+++ b/assistant/src/ipc/skill-routes/events.ts
@@ -111,9 +111,18 @@ export const eventsStreamingRoutes: SkillIpcStreamingRoute[] = [
     method: "host.events.subscribe",
     handler: (stream, params) => {
       const { filter } = SubscribeParams.parse(params);
-      const subscription = assistantEventHub.subscribe(filter, (event) => {
-        stream.send(event);
-      });
+      const subscription = assistantEventHub.subscribe(
+        filter,
+        (event) => {
+          stream.send(event);
+        },
+        // The hub evicts the oldest subscriber when its cap fills. Without
+        // this callback the IPC stream would silently stop receiving events
+        // while the client still believed it was subscribed. Mirror the SSE
+        // route's behavior by tearing the stream down with a terminal error
+        // frame so the client can resubscribe.
+        { onEvict: () => stream.close("subscription evicted by hub cap") },
+      );
       return () => {
         subscription.dispose();
       };

--- a/assistant/src/ipc/skill-server.ts
+++ b/assistant/src/ipc/skill-server.ts
@@ -91,9 +91,30 @@ export interface SkillIpcStream {
    * closed (client disconnect, explicit close, or server shutdown).
    */
   send(payload: unknown): void;
+  /**
+   * Terminate the stream from the server side. Sends a final error frame to
+   * the client (if `errorMessage` is provided and the socket is still
+   * writable), invokes the handler-returned dispose, and unregisters the
+   * stream from the per-socket subscription map. Idempotent — subsequent
+   * calls are no-ops. Use from `onEvict`-style callbacks where the upstream
+   * source has decided to terminate the subscription, or to surface
+   * unrecoverable conditions like backpressure.
+   */
+  close(errorMessage?: string): void;
   /** True until the stream has been disposed. */
   readonly active: boolean;
 }
+
+/**
+ * Maximum bytes Node may have queued in the socket's outbound buffer before
+ * the next streaming `send` will close the stream with a backpressure error.
+ * `socket.write()` returns `false` once the kernel buffer is full and Node
+ * starts queueing in user-space; without a cap, a slow or stalled subscriber
+ * would let that queue grow without bound and OOM the daemon. 1 MiB is large
+ * enough to absorb normal token-burst spikes but small enough to fail-fast
+ * on a genuinely stuck consumer.
+ */
+const STREAM_BACKPRESSURE_BYTES = 1024 * 1024;
 
 /**
  * Handler signature for long-lived streaming methods (e.g.
@@ -593,6 +614,36 @@ export class SkillIpcServer {
     }
 
     let active = true;
+    let userDispose: (() => void) | null = null;
+
+    const close = (errorMessage?: string): void => {
+      if (!active) return;
+      active = false;
+      if (errorMessage && !socket.destroyed) {
+        try {
+          socket.write(
+            JSON.stringify({ id: req.id, error: errorMessage }) + "\n",
+          );
+        } catch (err) {
+          log.warn(
+            { err, method: req.method },
+            "Skill IPC streaming close write error",
+          );
+        }
+      }
+      if (userDispose) {
+        try {
+          userDispose();
+        } catch (err) {
+          log.warn(
+            { err, method: req.method },
+            "Skill IPC streaming dispose error",
+          );
+        }
+      }
+      this.subscriptions.get(socket)?.delete(req.id);
+    };
+
     const stream: SkillIpcStream = {
       id: req.id,
       get active() {
@@ -600,6 +651,17 @@ export class SkillIpcServer {
       },
       send: (payload) => {
         if (!active || socket.destroyed) return;
+        // Fail-fast on slow/stalled consumers: when Node has more than
+        // STREAM_BACKPRESSURE_BYTES queued in user-space, terminate the
+        // stream rather than letting the buffer grow unbounded. The
+        // client sees a terminal error frame and the hub subscription
+        // is disposed in the same call.
+        if (socket.writableLength > STREAM_BACKPRESSURE_BYTES) {
+          close(
+            `Stream ${req.id} closed: client not draining (socket buffer exceeded ${STREAM_BACKPRESSURE_BYTES} bytes)`,
+          );
+          return;
+        }
         socket.write(
           JSON.stringify({
             id: req.id,
@@ -608,11 +670,11 @@ export class SkillIpcServer {
           }) + "\n",
         );
       },
+      close,
     };
 
-    let dispose: () => void;
     try {
-      dispose = handler(stream, req.params);
+      userDispose = handler(stream, req.params);
     } catch (err) {
       log.warn(
         { err, method: req.method },
@@ -624,18 +686,7 @@ export class SkillIpcServer {
 
     const map = existing ?? new Map<string, () => void>();
     if (!existing) this.subscriptions.set(socket, map);
-    map.set(req.id, () => {
-      if (!active) return;
-      active = false;
-      try {
-        dispose();
-      } catch (err) {
-        log.warn(
-          { err, method: req.method },
-          "Skill IPC streaming dispose error",
-        );
-      }
-    });
+    map.set(req.id, () => close());
 
     // Acknowledge the subscription open so the client can flip its
     // correlation entry from "pending" to "streaming" before deliveries


### PR DESCRIPTION
## Summary

Addresses two reviewer findings on #27880:

- **P1 (Codex) — backpressure on streaming socket writes.** \`SkillIpcStream.send\` previously wrote each delivery frame to the Unix socket without flow control. A slow or stalled subscriber (e.g. a skill not draining its end) caused unbounded growth in Node's user-space write queue. Fix: before each send, check \`socket.writableLength\`; if it exceeds 1 MiB the stream is terminated with a final error frame and the hub subscription is disposed.
- **P2 (Codex) + Devin — eviction handling for IPC subscribers.** \`host.events.subscribe\` did not pass an \`onEvict\` callback to \`assistantEventHub.subscribe\`, so when the hub hit its 100-subscriber cap and evicted an IPC subscriber the stream silently stopped delivering events while the client still believed it was subscribed (and the per-socket subscription map slot leaked until disconnect). Fix: pass \`onEvict\` that calls \`stream.close("subscription evicted by hub cap")\`, mirroring the SSE route.

To support both fixes, \`SkillIpcStream\` gains a \`close(errorMessage?)\` method that sends a terminal error frame, invokes the handler-returned dispose, and unregisters the stream from the per-socket subscription map. The existing socket-disconnect / explicit-close / server-shutdown teardown paths route through the same close, so behavior is unchanged on those paths.

## Test plan

- [ ] Existing \`events-ipc.test.ts\` still passes (subscribe ack, delivery filtering, explicit close, disconnect cleanup, duplicate id rejection, server-shutdown teardown).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
