### PR TITLE
fix(prompts): preserve third-party names in starter voice examples

### DIFF
--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -280,11 +280,11 @@ Bad → Good (ticket-speak → natural):
 Bad → Good (assistant voice → user voice):
 - "You've got a busy week ahead" → "Plan my week ahead"
 - "Let me check your calendar" → "Check my Thursday schedule"
-- "Catch up with Alice today" → "Catch up with you today"
+- "Catch up with <user's own name> today" → "Catch up with you today" (only the user's own name becomes "you" — third-party names like a colleague or friend stay as written)
 
 Bad → Good (prompt in assistant's voice → prompt in user's voice):
-- "It's Saturday morning and I haven't connected with him yet. Let me see what he's been up to." → "What have you been up to today? Let's catch up."
-- "She's had a busy week — I should check in on how she's feeling." → "I've had a busy week — can we talk through how it went?"
+- "It's Saturday morning and I haven't connected with <user's own name> yet. Let me see what they've been up to." → "What have you been up to today? Let's catch up." (assistant narrating about the user → user speaking to assistant; only the user's own name becomes "you/I", names of other people are preserved)
+- "<User's own name> has had a busy week — I should check in on how they're feeling." → "I've had a busy week — can we talk through how it went?"
 
 Bad → Good (incomplete phrase → complete):
 - "Prep for Friday's quarterly" → "Prep for Friday's quarterly review"


### PR DESCRIPTION
## Summary

Codex review on #28042 flagged that the example `"Catch up with Alice today" → "Catch up with you today"` teaches the model to replace any name (not just the user's) with "you". When memory says to follow up with a colleague or friend, that rewrite would corrupt the chip.

Tighten the bad→good examples in `conversation-starters.ts` so the user-name→"you" rule is explicit and third-party names are preserved:
- `"Catch up with <user's own name> today" → "Catch up with you today"` with a parenthetical that third-party names stay as written.
- Same clarification on the prompt-voice examples.

Addresses review feedback on #28042.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
