### PR TITLE
fix(routes): skip no-op inference-profile updates

### DIFF
--- a/assistant/src/__tests__/conversation-inference-profile-route.test.ts
+++ b/assistant/src/__tests__/conversation-inference-profile-route.test.ts
@@ -230,6 +230,69 @@ describe("PUT /v1/conversations/:id/inference-profile", () => {
     subscription.dispose();
   });
 
+  test("skips write and event when the profile is unchanged", async () => {
+    const conversation = createConversation("inference-profile-noop");
+
+    const route = findRoute("PUT", "conversations/:id/inference-profile");
+    const setResponse = await route.handler({
+      req: new Request(
+        `http://localhost/v1/conversations/${conversation.id}/inference-profile`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ profile: "balanced" }),
+        },
+      ),
+      url: new URL(
+        `http://localhost/v1/conversations/${conversation.id}/inference-profile`,
+      ),
+      server: null as never,
+      authContext: {} as never,
+      params: { id: conversation.id },
+    });
+    expect(setResponse.status).toBe(200);
+    const updatedAtAfterSet = getConversation(conversation.id)?.updatedAt;
+
+    const received: Array<{ profile?: string | null }> = [];
+    const subscription = assistantEventHub.subscribe(
+      { assistantId: DAEMON_INTERNAL_ASSISTANT_ID },
+      (event) => {
+        if (event.message.type === "conversation_inference_profile_updated") {
+          received.push({ profile: event.message.profile });
+        }
+      },
+    );
+
+    const repeatResponse = await route.handler({
+      req: new Request(
+        `http://localhost/v1/conversations/${conversation.id}/inference-profile`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ profile: "balanced" }),
+        },
+      ),
+      url: new URL(
+        `http://localhost/v1/conversations/${conversation.id}/inference-profile`,
+      ),
+      server: null as never,
+      authContext: {} as never,
+      params: { id: conversation.id },
+    });
+
+    await Promise.resolve();
+
+    expect(repeatResponse.status).toBe(200);
+    expect(await repeatResponse.json()).toEqual({
+      conversationId: conversation.id,
+      profile: "balanced",
+    });
+    expect(getConversation(conversation.id)?.updatedAt).toBe(updatedAtAfterSet);
+    expect(received).toEqual([]);
+
+    subscription.dispose();
+  });
+
   test("returns 404 when the conversation does not exist", async () => {
     const route = findRoute("PUT", "conversations/:id/inference-profile");
     const response = await route.handler({

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -427,25 +427,27 @@ export function conversationManagementRouteDefinitions(
           }
         }
 
-        await setConversationInferenceProfile(resolvedId, profile);
-        assistantEventHub
-          .publish(
-            buildAssistantEvent(
-              DAEMON_INTERNAL_ASSISTANT_ID,
-              {
-                type: "conversation_inference_profile_updated",
-                conversationId: resolvedId,
-                profile,
-              },
-              resolvedId,
-            ),
-          )
-          .catch((err) => {
-            log.warn(
-              { err, conversationId: resolvedId },
-              "Failed to publish conversation_inference_profile_updated event",
-            );
-          });
+        if (conversation.inferenceProfile !== profile) {
+          await setConversationInferenceProfile(resolvedId, profile);
+          assistantEventHub
+            .publish(
+              buildAssistantEvent(
+                DAEMON_INTERNAL_ASSISTANT_ID,
+                {
+                  type: "conversation_inference_profile_updated",
+                  conversationId: resolvedId,
+                  profile,
+                },
+                resolvedId,
+              ),
+            )
+            .catch((err) => {
+              log.warn(
+                { err, conversationId: resolvedId },
+                "Failed to publish conversation_inference_profile_updated event",
+              );
+            });
+        }
 
         return Response.json({ conversationId: resolvedId, profile });
       },


### PR DESCRIPTION
## Summary
- `PUT /v1/conversations/:id/inference-profile` now short-circuits when the requested profile matches the conversation's current value.
- Avoids bumping `updatedAt` (which feeds conversation ordering via `COALESCE(lastMessageAt, updatedAt)`) and avoids emitting a duplicate `conversation_inference_profile_updated` event for retries / idempotent submits.

## Test plan
- [x] Added route test asserting `updatedAt` is unchanged and no event fires when the same profile is PUT twice.

Addresses Codex review feedback on #28051.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
