### PR TITLE
fix(memory): make setConversationInferenceProfile synchronous

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1316,10 +1316,10 @@ export function unarchiveConversation(id: string): boolean {
  * Pass `null` to clear the override and fall back to the workspace
  * `llm.activeProfile` resolution.
  */
-export async function setConversationInferenceProfile(
+export function setConversationInferenceProfile(
   conversationId: string,
   profile: string | null,
-): Promise<void> {
+): void {
   const db = getDb();
   db.update(conversations)
     .set({ inferenceProfile: profile, updatedAt: Date.now() })

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -428,7 +428,7 @@ export function conversationManagementRouteDefinitions(
         }
 
         if (conversation.inferenceProfile !== profile) {
-          await setConversationInferenceProfile(resolvedId, profile);
+          setConversationInferenceProfile(resolvedId, profile);
           assistantEventHub
             .publish(
               buildAssistantEvent(


### PR DESCRIPTION
## Summary

Address review feedback on #28046.

`setConversationInferenceProfile` was marked \`async\` even though its body is a purely synchronous Drizzle \`db.update(...).run()\`. Every other conversation update helper in \`conversation-crud.ts\` (\`updateConversationTitle\`, \`updateConversationUsage\`, \`updateConversationContextWindow\`, \`updateConversationHostAccess\`, \`archiveConversation\`) is sync and returns \`void\`. The unnecessary \`async\` wrapped any synchronous SQLite exception in a rejected promise — a caller following the established \`try { fn(); } catch {}\` convention (without \`await\`) would silently miss errors as unhandled promise rejections.

Drops the \`async\` and \`Promise<void>\` return type, and drops the now-redundant \`await\` at the lone production caller in \`conversation-management-routes.ts\`. Test callers that wrap the call in \`Promise.all\` or \`await\` continue to work unchanged (await on non-Promise resolves to the value).

## Test plan

- [x] Type-check via .claude/ship preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
