### PR TITLE
fix(macos): nil-map default speed/verbosity and seed provider default model

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -173,8 +173,11 @@ struct InferenceProfileEditor: View {
                         // with the new provider's catalog default keeps
                         // Save immediately reachable.
                         if let provider = normalized {
-                            let firstModel = store.dynamicProviderModels(provider).first?.id ?? ""
-                            profile.model = firstModel.isEmpty ? nil : firstModel
+                            let defaultModel = store.dynamicProviderDefaultModel(provider)
+                            let seeded = defaultModel.isEmpty
+                                ? (store.dynamicProviderModels(provider).first?.id ?? "")
+                                : defaultModel
+                            profile.model = seeded.isEmpty ? nil : seeded
                         } else {
                             profile.model = nil
                         }
@@ -258,7 +261,7 @@ struct InferenceProfileEditor: View {
                 items: Self.speedOptions.map { (label: $0, tag: $0) },
                 selection: Binding(
                     get: { profile.speed ?? "standard" },
-                    set: { profile.speed = $0 }
+                    set: { profile.speed = $0 == "standard" ? nil : $0 }
                 )
             )
         }
@@ -270,7 +273,7 @@ struct InferenceProfileEditor: View {
                 items: Self.verbosityOptions.map { (label: $0, tag: $0) },
                 selection: Binding(
                     get: { profile.verbosity ?? "medium" },
-                    set: { profile.verbosity = $0 }
+                    set: { profile.verbosity = $0 == "medium" ? nil : $0 }
                 )
             )
         }


### PR DESCRIPTION
## Summary
Addresses post-merge review feedback on #28052 (`InferenceProfileEditor`):

- **speed/verbosity**: setters now map the default option (`standard` / `medium`) back to `nil` so the saved fragment stays minimal, matching the existing pattern in `effortField`. Previously, interacting with either segment control persisted an explicit value into the JSON fragment, overriding the resolver's layered default.
- **provider seed model**: switching providers now seeds `profile.model` from `store.dynamicProviderDefaultModel(provider)` (with first-catalog-entry fallback) rather than always picking the first catalog entry — catalog order isn't guaranteed to lead with the default.

## Test plan
- [ ] Build the macOS app and edit an inference profile: change provider, confirm seeded model matches the provider's declared default.
- [ ] Toggle speed and verbosity to their default values; confirm the saved fragment omits those keys instead of persisting them.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
