### PR TITLE
chore(openapi): regenerate spec for inferenceProfile in switch response

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3204,6 +3204,8 @@ paths:
                     type: string
                   hostAccess:
                     type: boolean
+                  inferenceProfile:
+                    type: string
                 required:
                   - conversationId
                   - title


### PR DESCRIPTION
## Summary
Fixes a stale-spec gap from inference-profiles plan re-review. PR #28067 added `inferenceProfile` to the `conversations/switch` Zod response without regenerating `assistant/openapi.yaml`, so the openapi-check CI job would fail on the next PR.

Regenerated via `bun run generate:openapi`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
