### PR TITLE
fix(vbundle-tar-stream): fail fast instead of hanging when source destroyed before parse

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-tar-stream.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-tar-stream.test.ts
@@ -219,4 +219,20 @@ describe("parseVBundleStream — cleanup", () => {
     // Source should now be destroyed (no dangling listeners keeping it alive).
     expect(source.destroyed).toBe(true);
   });
+
+  test("throws (does not hang) when source is already destroyed before parse", async () => {
+    const source = readableFromBuffer(new Uint8Array(0));
+    source.destroy(new Error("upstream torn down"));
+
+    let threw = false;
+    try {
+      for await (const _entry of parseVBundleStream(source)) {
+        // unreachable
+      }
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+  }, 1000);
 });

--- a/assistant/src/runtime/migrations/vbundle-tar-stream.ts
+++ b/assistant/src/runtime/migrations/vbundle-tar-stream.ts
@@ -155,9 +155,17 @@ export async function* parseVBundleStream(
     extractor.destroy(err);
   });
 
-  // Kick off the pipeline. We wire stages with `.pipe(..., { end: true })`
-  // so that clean EOF from the source triggers `finish` on the extractor.
-  source.pipe(gunzip).pipe(extractor);
+  // `pipe()` is a no-op on an already-destroyed Readable, so gunzip and
+  // extractor would never see `end` and `nextEntry()` would await forever.
+  // Synthesize a terminal error instead.
+  if (source.destroyed) {
+    const err = new Error("vbundle source stream was destroyed before parse");
+    pushError(err);
+    gunzip.destroy(err);
+    extractor.destroy(err);
+  } else {
+    source.pipe(gunzip).pipe(extractor);
+  }
 
   function nextEntry(): Promise<PendingEntry | null> {
     if (pipelineError) return Promise.reject(pipelineError);


### PR DESCRIPTION
## Summary

Follow-up to #27936. Both review bots flagged that the no-op `taggedSource.on('error', () => {})` absorbs the error if the upstream socket dies during the async window inside `streamCommitImport` (workspace recovery / temp-dir mkdir) — *before* `parseVBundleStream` attaches its own `source.on('error')` listener. By the time the parser runs, the source is destroyed and `source.pipe(...)` is a no-op on a destroyed Readable, so gunzip and extractor never see `end` and the for-await loop in the importer hangs indefinitely. The post-import `wasFetchBodyTornDown` branch is never reached, so the request returns nothing instead of `fetch_failed`.

## Fix

In `parseVBundleStream`, after attaching the source error listener, synchronously check `source.destroyed`. If it is, push a terminal error so the for-await throws and bubbles out of `streamCommitImport`. `kFetchBodyTornDown` was latched on the wrapper before the destroy, so the existing post-import branch still maps the failure to `fetch_failed`.

Also added a regression test that destroys the source before calling `parseVBundleStream` and asserts the loop throws within a 1s test timeout (it would hang without the fix).

## Test plan

- [x] New unit test covers the destroyed-before-parse case.
- [x] Existing tests in vbundle-tar-stream.test.ts unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
