### PR TITLE
fix(skill-host-contracts): SkillHostClient connect/close/reopen review fixes

### DIFF
--- a/packages/skill-host-contracts/__tests__/client.test.ts
+++ b/packages/skill-host-contracts/__tests__/client.test.ts
@@ -833,3 +833,25 @@ describe("SkillHostClient: close() drains pending calls", () => {
     await expect(call).rejects.toThrow(/closed/);
   });
 });
+
+describe("SkillHostClient: connect() retry semantics", () => {
+  test("re-runs prefetch over an existing socket after a failed bootstrap", async () => {
+    // Force the assistant-name prefetch to throw on first attempt only.
+    let nameCalls = 0;
+    server!.register("host.identity.getAssistantName", () => {
+      nameCalls += 1;
+      if (nameCalls === 1) throw new Error("boom");
+      return "Recovered Assistant";
+    });
+    client = new SkillHostClient({ socketPath, skillId: "test-skill" });
+    await expect(client.connect()).rejects.toThrow(/boom/);
+    // Sync accessors should still throw — the cache wasn't populated.
+    expect(() => client!.identity.internalAssistantId).toThrow(/not connected/);
+    // Second connect() must retry prefetch instead of short-circuiting on
+    // the still-alive socket.
+    await client.connect();
+    expect(client.identity.internalAssistantId).toBe("self");
+    expect(client.identity.getAssistantName()).toBe("Recovered Assistant");
+    expect(nameCalls).toBe(2);
+  });
+});

--- a/packages/skill-host-contracts/src/client.ts
+++ b/packages/skill-host-contracts/src/client.ts
@@ -378,9 +378,16 @@ export class SkillHostClient implements SkillHost {
       throw new Error("SkillHostClient: cannot connect after close()");
     }
     if (this.connectingPromise) return this.connectingPromise;
-    if (this.socket && !this.socket.destroyed) return;
+    // Fully connected: live socket *and* prefetch already populated.
+    // If the socket survived but a prior `prefetchSyncState()` rejected,
+    // the caches are still null and sync accessors would throw — fall
+    // through and re-run prefetch over the existing socket.
+    const socketAlive = !!this.socket && !this.socket.destroyed;
+    const prefetchDone = this.cachedInternalAssistantId !== null;
+    if (socketAlive && prefetchDone) return;
 
-    this.connectingPromise = this.doConnect()
+    const ensureSocket = socketAlive ? Promise.resolve() : this.doConnect();
+    this.connectingPromise = ensureSocket
       .then(async () => {
         await this.prefetchSyncState();
       })
@@ -452,6 +459,15 @@ export class SkillHostClient implements SkillHost {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
+        // The client may have been `close()`d while `connect()` was
+        // still pending. If we attach now we'd reintroduce a live
+        // socket on a closed client and leak the server-side connection
+        // until process teardown.
+        if (this.closed) {
+          socket.destroy();
+          reject(new Error("SkillHostClient: closed during connect"));
+          return;
+        }
         this.attachSocket(socket);
         resolve();
       });
@@ -540,11 +556,52 @@ export class SkillHostClient implements SkillHost {
       disposed: false,
     };
     this.subscriptions.set(fresh.id, fresh);
-    this.writeFrame({
-      id: fresh.id,
-      method: "host.events.subscribe",
-      params: { filter: fresh.filter },
+    // Mirror `openSubscription`: pre-register a pending entry so the
+    // server's `{ id, result: { subscribed: true } }` ack frame is
+    // matched (otherwise `handleFrame` silently drops it) and so we
+    // tear the subscription down on ack timeout instead of leaking it.
+    this.registerSubscribeAck(fresh);
+    try {
+      this.writeFrame({
+        id: fresh.id,
+        method: "host.events.subscribe",
+        params: { filter: fresh.filter },
+      });
+    } catch (err) {
+      this.cancelSubscribeAck(fresh);
+      swallow(err);
+    }
+  }
+
+  private registerSubscribeAck(active: ActiveSubscription): void {
+    const ackTimer = setTimeout(() => {
+      if (this.pending.delete(active.id)) {
+        active.disposed = true;
+        this.subscriptions.delete(active.id);
+      }
+    }, this.options.callTimeoutMs);
+    this.pending.set(active.id, {
+      resolve: () => {
+        clearTimeout(ackTimer);
+      },
+      reject: (err) => {
+        clearTimeout(ackTimer);
+        active.disposed = true;
+        this.subscriptions.delete(active.id);
+        swallow(err);
+      },
+      timer: ackTimer,
     });
+  }
+
+  private cancelSubscribeAck(active: ActiveSubscription): void {
+    const entry = this.pending.get(active.id);
+    if (entry) {
+      clearTimeout(entry.timer);
+      this.pending.delete(active.id);
+    }
+    active.disposed = true;
+    this.subscriptions.delete(active.id);
   }
 
   // ── Internal: frame I/O ─────────────────────────────────────────────────
@@ -964,25 +1021,7 @@ export class SkillHostClient implements SkillHost {
     // Pre-register a pending call for the open ack. The server writes a
     // `{ id, result: { subscribed: true } }` frame back; subsequent
     // `delivery` frames share the same id.
-    const ackTimer = setTimeout(() => {
-      if (this.pending.delete(id)) {
-        // Ack timeout — dispose the subscription silently.
-        active.disposed = true;
-        this.subscriptions.delete(id);
-      }
-    }, this.options.callTimeoutMs);
-    this.pending.set(id, {
-      resolve: () => {
-        clearTimeout(ackTimer);
-      },
-      reject: (err) => {
-        clearTimeout(ackTimer);
-        active.disposed = true;
-        this.subscriptions.delete(id);
-        swallow(err);
-      },
-      timer: ackTimer,
-    });
+    this.registerSubscribeAck(active);
     try {
       this.writeFrame({
         id,
@@ -990,10 +1029,7 @@ export class SkillHostClient implements SkillHost {
         params: { filter },
       });
     } catch (err) {
-      this.pending.delete(id);
-      clearTimeout(ackTimer);
-      active.disposed = true;
-      this.subscriptions.delete(id);
+      this.cancelSubscribeAck(active);
       throw err;
     }
 


### PR DESCRIPTION
## Summary

Addresses review feedback on #27884.

- **`connect()` retries `prefetchSyncState()` over a live socket.** Prior code short-circuited on `this.socket && !this.socket.destroyed`, which left the client permanently broken if any of the five bootstrap RPCs threw — caches stayed null, sync accessors kept throwing \`not connected\`, and a retry never re-ran the prefetch. Now it short-circuits only when the socket *and* the cache are populated.
- **\`doConnect()\` honors a \`close()\` race in its connect handler.** If the client was \`close()\`d while the connect was still pending, we used to attach the socket and resolve, reintroducing a live socket on a closed client and leaking the server-side connection until process teardown.
- **\`reopenSubscription()\` now registers a pending entry for the open ack.** Refactored \`openSubscription\`/\`reopenSubscription\` over shared \`registerSubscribeAck\`/\`cancelSubscribeAck\` helpers so reconnect-driven re-subscribes match the server's \`{ subscribed: true }\` ack frame and tear down on ack timeout instead of leaking.

Skipped Devin's \`extractToolUse\` finding — returning \`null\` is by design per the inline comment (the client cannot pull in Anthropic SDK types).

## Test plan
- [x] \`bun test __tests__/client.test.ts\` passes (23/23)
- [x] New regression test covers the bootstrap-retry path
- [x] \`bunx tsc --noEmit\` in \`packages/skill-host-contracts/\` is clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
