### PR TITLE
fix(llm): reject empty string for llm.activeProfile

### DIFF
--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -329,7 +329,7 @@ export const LLMSchema = z
     // are seeded into the user's on-disk config by migration 040, not at
     // schema level, so `LLMSchema.parse({})` yields an empty map.
     callSites: z.partialRecord(LLMCallSiteEnum, LLMCallSiteConfig).default({}),
-    activeProfile: z.string().optional(),
+    activeProfile: z.string().min(1).optional(),
     pricingOverrides: z.array(PricingOverrideSchema).default([]),
   })
   .superRefine((config, ctx) => {


### PR DESCRIPTION
Aligns `llm.activeProfile` validation with the call-site `profile` field by adding `.min(1)`. Without this, `activeProfile: ""` falls through to the cross-reference check and produces a confusing `Profile "" referenced by llm.activeProfile is not defined` message.

Addresses review feedback on #28043.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
