### PR TITLE
fix(macos): drop InferenceProfile Codable conformance

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
@@ -15,7 +15,7 @@ import Foundation
 /// layer untouched — the JSON mapper preserves only the fields it knows
 /// about, but `SettingsStore.patchConfig` merges into the live config so
 /// unknown keys are not clobbered.
-public struct InferenceProfile: Codable, Hashable, Identifiable {
+public struct InferenceProfile: Equatable, Hashable, Identifiable {
     /// Profile name; doubles as the key under `llm.profiles` and the
     /// stable `id` for `Identifiable` conformance.
     public var name: String


### PR DESCRIPTION
## Summary
Auto-synthesized `Codable` on `InferenceProfile` produced a flat JSON shape (`thinkingEnabled`, `thinkingStreamThinking` as top-level keys), incompatible with the manual nested `toJSON()` / `init(name:json:)` mapper that mirrors the daemon's `LLMConfigFragment` schema (nested under `thinking.enabled` / `thinking.streamThinking`).

No code path uses `JSONEncoder`/`JSONDecoder` on `InferenceProfile`, so dropping `Codable` is safe and removes the silent-drop footgun if anyone reaches for it later. Now matches the established `CallSiteOverride` pattern (`Identifiable, Equatable, Hashable`).

Addresses Devin review comment on #28045.

## Test plan
- [x] `git diff` shows only the conformance change
- [ ] CI typecheck passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
