### PR TITLE
fix(macos): mirror daemon deep-merge in setProfile local cache

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
@@ -78,6 +78,24 @@ public struct InferenceProfile: Codable, Hashable, Identifiable {
         self.thinkingStreamThinking = thinking?["streamThinking"] as? Bool
     }
 
+    /// Returns a copy of `self` with every non-nil field on `fragment`
+    /// applied on top — mirrors the daemon's deep-merge semantics for
+    /// `llm.profiles.<name>` patches so the local cache stays in sync
+    /// with what the daemon will store after a partial-update PATCH.
+    public func merging(_ fragment: InferenceProfile) -> InferenceProfile {
+        var merged = self
+        if let v = fragment.provider { merged.provider = v }
+        if let v = fragment.model { merged.model = v }
+        if let v = fragment.maxTokens { merged.maxTokens = v }
+        if let v = fragment.effort { merged.effort = v }
+        if let v = fragment.speed { merged.speed = v }
+        if let v = fragment.verbosity { merged.verbosity = v }
+        if let v = fragment.temperature { merged.temperature = v }
+        if let v = fragment.thinkingEnabled { merged.thinkingEnabled = v }
+        if let v = fragment.thinkingStreamThinking { merged.thinkingStreamThinking = v }
+        return merged
+    }
+
     /// Encodes the profile as a fragment JSON dictionary suitable for
     /// `settingsClient.patchConfig`. Nil keys are omitted; the nested
     /// `thinking` dict is emitted only when at least one of its

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3231,11 +3231,14 @@ public final class SettingsStore: ObservableObject {
             "llm": ["profiles": [name: fragment.toJSON()]]
         ])
         if success {
-            var copy = fragment
-            copy.name = name
             if let index = profiles.firstIndex(where: { $0.name == name }) {
-                profiles[index] = copy
+                // Daemon deep-merges the patch (toJSON omits nil fields).
+                // Mirror that locally so fields the fragment leaves nil
+                // retain whatever the daemon already had.
+                profiles[index] = profiles[index].merging(fragment)
             } else {
+                var copy = fragment
+                copy.name = name
                 profiles.append(copy)
                 profiles.sort { $0.name < $1.name }
             }

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -197,15 +197,17 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
                     "balanced": [
                         "provider": "anthropic",
                         "model": "claude-sonnet-4-6",
+                        "maxTokens": 16000,
                     ]
                 ]
             ]
         ])
         XCTAssertEqual(store.profiles.count, 1)
 
+        // Partial fragment — only the model changes. The daemon deep-merges,
+        // so `provider` and `maxTokens` must remain set locally as well.
         let updated = InferenceProfile(
             name: "balanced",
-            provider: "openai",
             model: "gpt-5"
         )
         let success = await store.setProfile(name: "balanced", fragment: updated)
@@ -213,8 +215,9 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
 
         XCTAssertEqual(store.profiles.count, 1, "Updating an existing profile must not duplicate the entry")
         let stored = store.profiles.first(where: { $0.name == "balanced" })
-        XCTAssertEqual(stored?.provider, "openai")
         XCTAssertEqual(stored?.model, "gpt-5")
+        XCTAssertEqual(stored?.provider, "anthropic", "Local cache must mirror the daemon's deep-merge — fields absent from the fragment must persist")
+        XCTAssertEqual(stored?.maxTokens, 16000, "Local cache must mirror the daemon's deep-merge — fields absent from the fragment must persist")
     }
 
     // MARK: - deleteProfile blocked-by-active


### PR DESCRIPTION
## Summary

Address review feedback on #28049.

`SettingsStore.setProfile` was replacing the local profile entry wholesale (`profiles[index] = copy`), but the daemon PATCH does a deep-merge — `fragment.toJSON()` omits nil fields and `deepMergeOverwrite` preserves daemon-side fields the fragment doesn't touch. Result: any field set on the daemon profile but absent from the fragment was preserved server-side and silently lost in the UI until the next config push reconciled.

Fix: when an entry already exists locally, mirror the daemon's merge semantics by overlaying only the fragment's non-nil fields onto the existing entry. Encapsulated as `InferenceProfile.merging(_:)` so the field list stays in one place when new leaves are added.

## What I skipped

- **P1 (deleteProfile authoritative reference check)**: Would require a daemon-side validation endpoint or server-side conflict response; out of scope for a client-only patch. The local cache is sourced from the daemon's last config push, so the silent-corruption window is short and reconciles on the next sync.
- **P2 (setProfile cannot clear removed fields)**: This is by design — the doc comment explicitly states "fragment merges into any existing entry; callers that want replace semantics should issue a delete first." Making nil mean "clear" would break the partial-update path that is the documented use case.

## Test plan

- [x] Updated `testSetProfileUpdatesExistingEntry` to verify a partial fragment preserves daemon-side fields locally (provider + maxTokens) while applying the fragment's model change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
