### PR TITLE
feat(acp): add shared resolveAcpAgent helper with defaults and binary preflight

### DIFF
--- a/assistant/src/acp/resolve-agent.test.ts
+++ b/assistant/src/acp/resolve-agent.test.ts
@@ -1,0 +1,339 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AcpAgentConfig } from "../config/acp-schema.js";
+
+// ---------------------------------------------------------------------------
+// Mock infrastructure
+// ---------------------------------------------------------------------------
+
+interface MockAcpConfig {
+  enabled: boolean;
+  maxConcurrentSessions: number;
+  agents: Record<string, AcpAgentConfig>;
+}
+
+let mockAcpConfig: MockAcpConfig = {
+  enabled: true,
+  maxConcurrentSessions: 4,
+  agents: {},
+};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ acp: mockAcpConfig }),
+}));
+
+// Swap Bun.which with a stub so tests can deterministically simulate "binary
+// on PATH" / "binary missing" without depending on the host environment.
+// `mock.module` does not work for globals, so we capture the original and
+// restore in afterAll to keep this test file from leaking into others.
+const originalWhich = Bun.which;
+let whichStub: (command: string) => string | null = () => null;
+(Bun as unknown as { which: (cmd: string) => string | null }).which = (cmd) =>
+  whichStub(cmd);
+
+afterAll(() => {
+  (Bun as unknown as { which: typeof originalWhich }).which = originalWhich;
+});
+
+const { resolveAcpAgent, listAcpAgents } = await import("./resolve-agent.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setConfig(partial: Partial<MockAcpConfig>): void {
+  mockAcpConfig = {
+    enabled: true,
+    maxConcurrentSessions: 4,
+    agents: {},
+    ...partial,
+  };
+}
+
+function setWhich(map: Record<string, string | null>): void {
+  whichStub = (cmd) => map[cmd] ?? null;
+}
+
+beforeEach(() => {
+  setConfig({});
+  // Default: every command on PATH so binary preflight passes unless a test
+  // explicitly says otherwise.
+  whichStub = (cmd) => `/usr/local/bin/${cmd}`;
+});
+
+// ---------------------------------------------------------------------------
+// resolveAcpAgent
+// ---------------------------------------------------------------------------
+
+describe("resolveAcpAgent", () => {
+  test("returns acp_disabled when config.acp.enabled is false", () => {
+    setConfig({ enabled: false });
+
+    const result = resolveAcpAgent("claude");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("acp_disabled");
+    if (result.reason !== "acp_disabled") return;
+    expect(result.hint).toContain("acp.enabled");
+    expect(result.hint).toContain("config.json");
+  });
+
+  test("user config wins over default profile", () => {
+    setConfig({
+      agents: {
+        claude: {
+          command: "my-custom-claude",
+          args: ["--my-flag"],
+          description: "user override",
+        },
+      },
+    });
+
+    const result = resolveAcpAgent("claude");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.source).toBe("config");
+    expect(result.agent.command).toBe("my-custom-claude");
+    expect(result.agent.args).toEqual(["--my-flag"]);
+    expect(result.agent.description).toBe("user override");
+  });
+
+  test("falls back to default profile when no user entry", () => {
+    setConfig({ agents: {} });
+
+    const result = resolveAcpAgent("codex");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.source).toBe("default");
+    expect(result.agent.command).toBe("codex-acp");
+    expect(result.agent.description).toContain("@zed-industries/codex-acp");
+  });
+
+  test("falls back to default profile for claude when no user entry", () => {
+    setConfig({ agents: {} });
+
+    const result = resolveAcpAgent("claude");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.source).toBe("default");
+    expect(result.agent.command).toBe("claude-agent-acp");
+  });
+
+  test("returns unknown_agent with merged available list when id not found", () => {
+    setConfig({
+      agents: {
+        "user-only": { command: "some-binary", args: [] },
+      },
+    });
+
+    const result = resolveAcpAgent("nonexistent");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("unknown_agent");
+    if (result.reason !== "unknown_agent") return;
+    // Defaults plus user-only ids, deduped, in stable order (defaults first).
+    expect(result.available).toEqual(["claude", "codex", "user-only"]);
+    expect(result.hint).toContain("nonexistent");
+  });
+
+  test("unknown_agent available list contains both defaults when user config is empty", () => {
+    setConfig({ agents: {} });
+
+    const result = resolveAcpAgent("nonexistent");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("unknown_agent");
+    if (result.reason !== "unknown_agent") return;
+    expect(result.available).toContain("claude");
+    expect(result.available).toContain("codex");
+  });
+
+  test("returns binary_not_found with the registered install hint", () => {
+    setConfig({ agents: {} });
+    setWhich({}); // no commands on PATH
+
+    const result = resolveAcpAgent("claude");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("binary_not_found");
+    if (result.reason !== "binary_not_found") return;
+    expect(result.hint).toBe("npm i -g @agentclientprotocol/claude-agent-acp");
+    expect(result.agent.command).toBe("claude-agent-acp");
+    expect(result.source).toBe("default");
+  });
+
+  test("binary_not_found uses generic hint for user-only commands without a registered hint", () => {
+    setConfig({
+      agents: {
+        custom: { command: "unknown-binary", args: [] },
+      },
+    });
+    setWhich({});
+
+    const result = resolveAcpAgent("custom");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("binary_not_found");
+    if (result.reason !== "binary_not_found") return;
+    expect(result.hint).toBe(
+      "Install 'unknown-binary' and ensure it is on PATH.",
+    );
+    expect(result.source).toBe("config");
+  });
+
+  test("binary_not_found uses the install hint based on the resolved command, not the agent id", () => {
+    // User aliases id "claude" to the codex binary — the install hint should
+    // follow the binary, not the id.
+    setConfig({
+      agents: {
+        claude: { command: "codex-acp", args: [] },
+      },
+    });
+    setWhich({});
+
+    const result = resolveAcpAgent("claude");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("binary_not_found");
+    if (result.reason !== "binary_not_found") return;
+    expect(result.hint).toBe("npm i -g @zed-industries/codex-acp");
+  });
+
+  test("ok result when user config provides agent and binary is on PATH", () => {
+    setConfig({
+      agents: {
+        codex: { command: "codex-acp", args: ["--verbose"] },
+      },
+    });
+    setWhich({ "codex-acp": "/opt/bin/codex-acp" });
+
+    const result = resolveAcpAgent("codex");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.source).toBe("config");
+    expect(result.agent.args).toEqual(["--verbose"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listAcpAgents
+// ---------------------------------------------------------------------------
+
+describe("listAcpAgents", () => {
+  test("returns enabled: false with empty agents when ACP is disabled", () => {
+    setConfig({ enabled: false });
+
+    const result = listAcpAgents();
+
+    expect(result.enabled).toBe(false);
+    expect(result.agents).toEqual([]);
+  });
+
+  test("includes both bundled defaults when user config is empty", () => {
+    setConfig({ agents: {} });
+
+    const result = listAcpAgents();
+
+    expect(result.enabled).toBe(true);
+    const ids = result.agents.map((a) => a.id);
+    expect(ids).toEqual(["claude", "codex"]);
+    for (const entry of result.agents) {
+      expect(entry.source).toBe("default");
+      expect(entry.available).toBe(true);
+      expect(entry.unavailableReason).toBeUndefined();
+      expect(entry.setupHint).toBeUndefined();
+    }
+  });
+
+  test("user override flips source to 'config' for the overridden id", () => {
+    setConfig({
+      agents: {
+        claude: {
+          command: "my-claude",
+          args: [],
+          description: "custom",
+        },
+      },
+    });
+    setWhich({
+      "my-claude": "/usr/bin/my-claude",
+      "codex-acp": "/usr/bin/codex-acp",
+    });
+
+    const result = listAcpAgents();
+
+    const claude = result.agents.find((a) => a.id === "claude");
+    const codex = result.agents.find((a) => a.id === "codex");
+    expect(claude?.source).toBe("config");
+    expect(claude?.command).toBe("my-claude");
+    expect(claude?.description).toBe("custom");
+    expect(codex?.source).toBe("default");
+  });
+
+  test("unavailable agent surfaces install hint from DEFAULT_AGENT_INSTALL_HINTS", () => {
+    setConfig({ agents: {} });
+    setWhich({ "claude-agent-acp": "/usr/bin/claude-agent-acp" });
+
+    const result = listAcpAgents();
+
+    const codex = result.agents.find((a) => a.id === "codex");
+    expect(codex?.available).toBe(false);
+    expect(codex?.unavailableReason).toBe("'codex-acp' is not on PATH");
+    expect(codex?.setupHint).toBe("npm i -g @zed-industries/codex-acp");
+  });
+
+  test("user-only agent appended after defaults in stable order", () => {
+    setConfig({
+      agents: {
+        "my-agent": {
+          command: "my-binary",
+          args: [],
+          description: "user-only",
+        },
+      },
+    });
+    setWhich({
+      "claude-agent-acp": "/x",
+      "codex-acp": "/x",
+      "my-binary": "/x",
+    });
+
+    const result = listAcpAgents();
+
+    expect(result.agents.map((a) => a.id)).toEqual([
+      "claude",
+      "codex",
+      "my-agent",
+    ]);
+    const userOnly = result.agents[2];
+    expect(userOnly.source).toBe("config");
+    expect(userOnly.description).toBe("user-only");
+  });
+
+  test("unavailable user-only agent without registered hint falls back to generic install hint", () => {
+    setConfig({
+      agents: {
+        custom: { command: "unknown-binary", args: [] },
+      },
+    });
+    setWhich({ "claude-agent-acp": "/x", "codex-acp": "/x" });
+
+    const result = listAcpAgents();
+
+    const custom = result.agents.find((a) => a.id === "custom");
+    expect(custom?.available).toBe(false);
+    expect(custom?.setupHint).toBe(
+      "Install 'unknown-binary' and ensure it is on PATH.",
+    );
+  });
+});

--- a/assistant/src/acp/resolve-agent.ts
+++ b/assistant/src/acp/resolve-agent.ts
@@ -1,0 +1,174 @@
+/**
+ * Shared resolver for ACP agent ids → agent config + binary preflight.
+ *
+ * `resolveAcpAgent(id)` merges user-provided `config.acp.agents[id]` (wins on
+ * overlap) with the bundled `DEFAULT_ACP_AGENT_PROFILES` so common agents like
+ * `claude` and `codex` Just Work whenever `acp.enabled: true` — no per-user
+ * config required. The result is a discriminated union covering every reason
+ * a spawn might fail before we even start the agent process: ACP disabled,
+ * unknown agent id, or binary missing from PATH. Callers (acp_spawn,
+ * acp_list_agents, acp_steer) get a single source of truth and matching
+ * actionable hints.
+ *
+ * `listAcpAgents()` exposes the merged catalog with availability info for
+ * the `acp_list_agents` tool — same merge semantics, plus per-entry
+ * `available` / `setupHint` derived from `Bun.which` + `DEFAULT_AGENT_INSTALL_HINTS`.
+ */
+
+import {
+  DEFAULT_ACP_AGENT_PROFILES,
+  DEFAULT_AGENT_INSTALL_HINTS,
+} from "../config/acp-defaults.js";
+import type { AcpAgentConfig } from "../config/acp-schema.js";
+import { getConfig } from "../config/loader.js";
+
+/**
+ * Whether this agent's entry came from user config (wins over default) or
+ * fell back to the bundled default profile. Surfaced in tool output so users
+ * can see at a glance which agents they've customized.
+ */
+export type AcpAgentSource = "config" | "default";
+
+export type ResolveAcpAgentResult =
+  | { ok: true; agent: AcpAgentConfig; source: AcpAgentSource }
+  | { ok: false; reason: "acp_disabled"; hint: string }
+  | { ok: false; reason: "unknown_agent"; hint: string; available: string[] }
+  | {
+      ok: false;
+      reason: "binary_not_found";
+      hint: string;
+      agent: AcpAgentConfig;
+      source: AcpAgentSource;
+    };
+
+export interface AcpAgentEntry {
+  id: string;
+  command: string;
+  description?: string;
+  source: AcpAgentSource;
+  available: boolean;
+  unavailableReason?: string;
+  setupHint?: string;
+}
+
+const ACP_DISABLED_HINT =
+  "Set 'acp.enabled': true in ~/.vellum/workspace/config.json (or via the runtime config endpoint).";
+
+function installHintFor(command: string): string {
+  return (
+    DEFAULT_AGENT_INSTALL_HINTS[command] ??
+    `Install '${command}' and ensure it is on PATH.`
+  );
+}
+
+/**
+ * Resolve an id against user config first, then bundled defaults. Returns the
+ * resolved entry plus a `source` label so callers can surface "user override
+ * vs bundled default" without re-deriving it.
+ */
+function lookupAgent(
+  userAgents: Record<string, AcpAgentConfig>,
+  id: string,
+): { agent: AcpAgentConfig; source: AcpAgentSource } | undefined {
+  const userAgent = userAgents[id];
+  if (userAgent) return { agent: userAgent, source: "config" };
+  const defaultAgent = DEFAULT_ACP_AGENT_PROFILES[id];
+  if (defaultAgent) return { agent: defaultAgent, source: "default" };
+  return undefined;
+}
+
+/**
+ * Defaults first (declaration order), then user-only ids. Deduplicated so a
+ * user config that overrides a default doesn't list the id twice.
+ */
+function mergedAgentIds(userAgents: Record<string, AcpAgentConfig>): string[] {
+  return Array.from(
+    new Set([
+      ...Object.keys(DEFAULT_ACP_AGENT_PROFILES),
+      ...Object.keys(userAgents),
+    ]),
+  );
+}
+
+/**
+ * Resolve an ACP agent id to its config + binary preflight result.
+ *
+ * Order of checks:
+ * 1. ACP must be enabled in config.
+ * 2. The id must resolve to an agent (user config wins; falls back to defaults).
+ * 3. The agent's `command` must be discoverable via `Bun.which` (PATH lookup).
+ *
+ * Each failure mode carries an actionable hint so callers can surface a
+ * single user-facing message without re-deriving the remediation.
+ */
+export function resolveAcpAgent(id: string): ResolveAcpAgentResult {
+  const config = getConfig();
+  if (!config.acp.enabled) {
+    return { ok: false, reason: "acp_disabled", hint: ACP_DISABLED_HINT };
+  }
+
+  const userAgents = config.acp.agents;
+  const found = lookupAgent(userAgents, id);
+  if (!found) {
+    return {
+      ok: false,
+      reason: "unknown_agent",
+      hint: `Unknown agent "${id}". Set 'acp.agents.${id}' in config or use one of the bundled defaults.`,
+      available: mergedAgentIds(userAgents),
+    };
+  }
+
+  const { agent, source } = found;
+  if (!Bun.which(agent.command)) {
+    return {
+      ok: false,
+      reason: "binary_not_found",
+      hint: installHintFor(agent.command),
+      agent,
+      source,
+    };
+  }
+
+  return { ok: true, agent, source };
+}
+
+/**
+ * Catalog of every ACP agent the assistant knows about — bundled defaults
+ * plus any user-only entries — with per-entry availability info. Used by the
+ * `acp_list_agents` tool to render setup steps when an agent's binary isn't
+ * installed yet.
+ *
+ * `enabled: false` short-circuits and returns an empty catalog so the tool
+ * can render a single "ACP is disabled" hint instead of advertising agents
+ * the user can't actually run.
+ */
+export function listAcpAgents(): {
+  enabled: boolean;
+  agents: AcpAgentEntry[];
+} {
+  const config = getConfig();
+  if (!config.acp.enabled) {
+    return { enabled: false, agents: [] };
+  }
+
+  const userAgents = config.acp.agents;
+  const agents: AcpAgentEntry[] = mergedAgentIds(userAgents).map((id) => {
+    // Non-null: ids come from `mergedAgentIds` so the lookup always resolves.
+    const { agent, source } = lookupAgent(userAgents, id)!;
+    const available = Bun.which(agent.command) !== null;
+    const entry: AcpAgentEntry = {
+      id,
+      command: agent.command,
+      description: agent.description,
+      source,
+      available,
+    };
+    if (!available) {
+      entry.unavailableReason = `'${agent.command}' is not on PATH`;
+      entry.setupHint = installHintFor(agent.command);
+    }
+    return entry;
+  });
+
+  return { enabled: true, agents };
+}


### PR DESCRIPTION
## Summary
- Add `resolveAcpAgent(id)` returning a discriminated union: `ok: true` with the merged agent + source, or `ok: false` with reason (`acp_disabled` / `unknown_agent` / `binary_not_found`) and an actionable hint.
- Merge logic: user `config.acp.agents[id]` wins over `DEFAULT_ACP_AGENT_PROFILES[id]`. Binary preflight via `Bun.which`.
- Also export `listAcpAgents()` for the upcoming `acp_list_agents` tool (PR 5).
- No consumers yet; wired in PRs 5/6/7.

Part of plan: acp-codex-claude.md (PR 4 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
