### PR TITLE
fix(llm-inspector): surface cached input tokens for OpenAI in normalization

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -1521,6 +1521,71 @@ describe("normalizeLlmContextPayloads", () => {
     expect(normalized.summary?.stopReason).toBe("incomplete");
   });
 
+  test("extracts cached input tokens from Responses API input_tokens_details", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_027,
+      requestPayload: {
+        model: "gpt-5.4",
+        instructions: "Be brief.",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "Hi" }],
+            type: "message",
+          },
+        ],
+      },
+      responsePayload: {
+        model: "gpt-5.4",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Hey!" }],
+          },
+        ],
+        usage: {
+          input_tokens: 100,
+          output_tokens: 5,
+          input_tokens_details: { cached_tokens: 60 },
+        },
+        status: "completed",
+      },
+    });
+
+    expect(normalized.summary?.cacheReadInputTokens).toBe(60);
+    expect(normalized.summary?.cacheCreationInputTokens).toBeUndefined();
+    expect(normalized.summary?.inputTokens).toBe(100);
+  });
+
+  test("extracts cached input tokens from Chat Completions prompt_tokens_details", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_028,
+      requestPayload: {
+        model: "gpt-4.1",
+        messages: [{ role: "user", content: "Hi" }],
+      },
+      responsePayload: {
+        model: "gpt-4.1",
+        choices: [
+          {
+            finish_reason: "stop",
+            message: { role: "assistant", content: "Hey!" },
+          },
+        ],
+        usage: {
+          prompt_tokens: 80,
+          completion_tokens: 4,
+          prompt_tokens_details: { cached_tokens: 40 },
+        },
+      },
+    });
+
+    expect(normalized.summary?.cacheReadInputTokens).toBe(40);
+    expect(normalized.summary?.cacheCreationInputTokens).toBeUndefined();
+    expect(normalized.summary?.inputTokens).toBe(80);
+  });
+
   test("legacy chat-completions payloads are still normalized correctly alongside Responses tests", () => {
     // This test verifies backward compatibility: existing chat-completions
     // logs stored in the database must continue to normalize correctly even

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -466,6 +466,7 @@ function normalizeOpenAiResponsesResponsePayload(
   }
 
   const usage = asRecord(response.usage);
+  const inputTokensDetails = asRecord(usage?.input_tokens_details);
   const toolCallNames = toolCallSections
     .map((section) => section.toolName)
     .filter((name): name is string => typeof name === "string");
@@ -482,7 +483,7 @@ function normalizeOpenAiResponsesResponsePayload(
       inputTokens: asNumber(usage?.input_tokens),
       outputTokens: asNumber(usage?.output_tokens),
       cacheCreationInputTokens: undefined,
-      cacheReadInputTokens: undefined,
+      cacheReadInputTokens: asNumber(inputTokensDetails?.cached_tokens),
       stopReason,
       requestMessageCount: undefined,
       requestToolCount: undefined,
@@ -536,6 +537,7 @@ function normalizeOpenAiChatCompletionsResponsePayload(
   responseSections.push(...responseToolSections);
 
   const usage = asRecord(response.usage);
+  const promptTokensDetails = asRecord(usage?.prompt_tokens_details);
   const toolCallNames = responseToolSections
     .map((section) => section.toolName)
     .filter((name): name is string => typeof name === "string");
@@ -548,7 +550,7 @@ function normalizeOpenAiChatCompletionsResponsePayload(
       inputTokens: asNumber(usage?.prompt_tokens),
       outputTokens: asNumber(usage?.completion_tokens),
       cacheCreationInputTokens: undefined,
-      cacheReadInputTokens: undefined,
+      cacheReadInputTokens: asNumber(promptTokensDetails?.cached_tokens),
       stopReason: asString(firstChoice?.finish_reason),
       requestMessageCount: undefined,
       requestToolCount: undefined,


### PR DESCRIPTION
## Summary
Follow-up to #28035 addressing Devin review feedback.

- The provider layer was fixed in #28035 to populate `cacheReadInputTokens` on `ProviderResponse.usage`, but the LLM context inspector pulls its summary through `normalizeLlmContextPayloads` in `assistant/src/runtime/routes/llm-context-normalization.ts`, which hardcoded `cacheReadInputTokens: undefined` for both OpenAI Responses and Chat Completions payloads.
- Now extracts `input_tokens_details.cached_tokens` (Responses API) and `prompt_tokens_details.cached_tokens` (Chat Completions) from the raw response `usage` block.
- Tests added for both paths.

This only affects the inspector UI's cached-token display; runtime usage accounting was already correct after #28035.

Original PR feedback: https://github.com/vellum-ai/vellum-assistant/pull/28035#discussion_r3141155237
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
