### PR TITLE
fix(ipc/skill): refcount tool owners, thread patternFlags, require ownerSkillId

### DIFF
--- a/assistant/src/ipc/skill-routes/__tests__/registries.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/registries.test.ts
@@ -86,6 +86,7 @@ describe("host.registries.register_tools", () => {
           input_schema: { type: "object" },
           defaultRiskLevel: "medium",
           category: "skill",
+          ownerSkillId: "stub-skill",
         },
       ],
     });
@@ -308,6 +309,7 @@ describe("lazy-external short-circuit", () => {
             input_schema: {},
             defaultRiskLevel: "low",
             category: "skill",
+            ownerSkillId: "demo-skill",
           },
         ],
       },

--- a/assistant/src/ipc/skill-routes/registries.ts
+++ b/assistant/src/ipc/skill-routes/registries.ts
@@ -53,7 +53,10 @@ const ToolManifestSchema = z.object({
   category: z.string().min(1),
   executionTarget: z.enum(["sandbox", "host"]).optional(),
   executionMode: z.enum(["local", "proxy"]).optional(),
-  ownerSkillId: z.string().optional(),
+  // Required so disconnect can decrement the tool-registry refcount: a
+  // tool registered without an owner has no ref-counted entry to drop and
+  // would leak into the global registry on socket close.
+  ownerSkillId: z.string().min(1),
   ownerSkillBundled: z.boolean().optional(),
   ownerSkillVersionHash: z.string().optional(),
 });
@@ -237,6 +240,9 @@ async function handleRegisterTools(
   // `registerSkillTools` into the live registry the agent-loop reads from.
   const accepted = registerSkillTools(proxies);
 
+  // `registerSkillTools` increments the registry refcount once per unique
+  // ownerSkillId in the batch; mirror that on the connection so disconnect
+  // issues exactly the matching number of decrements.
   if (conn) {
     const ownerIds = new Set<string>();
     for (const tool of accepted) {

--- a/assistant/src/ipc/skill-server.ts
+++ b/assistant/src/ipc/skill-server.ts
@@ -159,9 +159,13 @@ export interface SkillIpcConnection {
    */
   addRouteHandle(skillId: string, handle: SkillRouteHandle): void;
   /**
-   * Mark a skill id as having registered tools on this connection. On
-   * disconnect the server calls `unregisterSkillTools(skillId)` once per
-   * tracked id so the ref-counted tool registry drops the contribution.
+   * Record that this connection registered tools for `skillId`. The tool
+   * registry's `registerSkillTools` increments its internal refcount on
+   * every call, so each register_tools frame must be paired with exactly
+   * one `unregisterSkillTools` on disconnect — a deduplicated Set would
+   * leak the extra increments and pin stale proxies in the registry. On
+   * teardown the server calls `unregisterSkillTools(skillId)` once per
+   * recorded registration.
    */
   addSkillToolsOwner(skillId: string): void;
 }
@@ -177,7 +181,14 @@ class SkillIpcConnectionState implements SkillIpcConnection {
   readonly connectionId: string;
   readonly socket: Socket;
   private routeHandlesBySkill = new Map<string, SkillRouteHandle[]>();
-  private skillToolOwners = new Set<string>();
+  /**
+   * Per-skill registration counts. `registerSkillTools` increments the
+   * tool-registry refcount on every call; storing a count (rather than a
+   * deduplicated Set) lets `dispose()` issue the matching number of
+   * `unregisterSkillTools` calls so a connection that registered tools in
+   * multiple batches doesn't leak refcount on disconnect.
+   */
+  private skillToolOwnerCounts = new Map<string, number>();
   /**
    * Pending daemon-initiated requests keyed by `d:<n>` id. Cleared on
    * connection teardown so callers never see a hung promise.
@@ -202,7 +213,10 @@ class SkillIpcConnectionState implements SkillIpcConnection {
   }
 
   addSkillToolsOwner(skillId: string): void {
-    this.skillToolOwners.add(skillId);
+    this.skillToolOwnerCounts.set(
+      skillId,
+      (this.skillToolOwnerCounts.get(skillId) ?? 0) + 1,
+    );
   }
 
   dispose(): void {
@@ -219,17 +233,19 @@ class SkillIpcConnectionState implements SkillIpcConnection {
       }
     }
     this.routeHandlesBySkill.clear();
-    for (const skillId of this.skillToolOwners) {
-      try {
-        unregisterSkillTools(skillId);
-      } catch (err) {
-        log.warn(
-          { err, connectionId: this.connectionId, skillId },
-          "skill IPC disconnect: failed to unregister skill tools",
-        );
+    for (const [skillId, count] of this.skillToolOwnerCounts) {
+      for (let i = 0; i < count; i++) {
+        try {
+          unregisterSkillTools(skillId);
+        } catch (err) {
+          log.warn(
+            { err, connectionId: this.connectionId, skillId },
+            "skill IPC disconnect: failed to unregister skill tools",
+          );
+        }
       }
     }
-    this.skillToolOwners.clear();
+    this.skillToolOwnerCounts.clear();
     // Reject every in-flight daemon-initiated request so callers don't
     // hang on a dropped peer. The socket's "close" listener fires before
     // dispose() in the normal path, but defending here keeps behavior

--- a/packages/skill-host-contracts/src/client.ts
+++ b/packages/skill-host-contracts/src/client.ts
@@ -1098,8 +1098,11 @@ export class SkillHostClient implements SkillHost {
         );
         // The `handler` closure cannot cross IPC; the daemon side installs
         // a proxy that dispatches back over `skill.dispatch_route` (PR D).
+        // `patternFlags` ships separately so `i/m/g/s/u/y` survive the
+        // RegExp → string round-trip — `new RegExp(source)` alone drops them.
         this.call("host.registries.register_skill_route", {
           patternSource: route.pattern.source,
+          patternFlags: route.pattern.flags,
           methods: route.methods,
         }).catch(swallow);
         // The contract models the handle as a branded opaque object — we


### PR DESCRIPTION
Addresses Codex + Devin feedback on #27931.

## Changes

- **Codex P1 / Devin (refcount leak):** `SkillIpcConnectionState` tracks per-skill registration counts in a `Map<string, number>` instead of a deduplicated `Set`. `registerSkillTools` increments the tool-registry refcount once per unique \`ownerSkillId\` per batch, so a connection that calls \`register_tools\` in multiple batches needs \`unregisterSkillTools(skillId)\` invoked the matching number of times on disconnect. With a Set, only the first call's increment was decremented and the rest leaked, pinning stale proxies in the registry forever.
- **Codex P2 (patternFlags):** \`SkillHostClient.registries.registerSkillRoute\` now sends \`patternFlags: route.pattern.flags\` alongside \`patternSource\` on the IPC frame. The daemon-side handler already accepted \`patternFlags\`; without the client side, real traffic still constructed \`new RegExp(source, "")\` and dropped i/m/g/s/u/y.
- **Devin (orphan cleanup):** \`ToolManifestSchema\` requires \`ownerSkillId\` (\`z.string().min(1)\`). Tools registered without an owner had no ref-counted entry to drop and would leak into the global registry on socket close. The skill IPC client already defaults \`ownerSkillId\` to its \`skillId\`, so this is enforcement of the existing contract.

## Test plan
- [x] \`bun test src/ipc/skill-routes/__tests__/registries.test.ts\` (existing tests still pass; the \"missing required fields\" assertion continues to hold under the stricter schema)
- [x] \`bunx tsc --noEmit\` clean

Addressed in PR #27931 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
