### PR TITLE
test(memory): drop flaky .resolves matcher in inference-profile test

### DIFF
--- a/assistant/src/__tests__/conversation-crud-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-crud-inference-profile.test.ts
@@ -38,12 +38,8 @@ describe("setConversationInferenceProfile", () => {
 
   test("does not throw when called with a valid conversation id", async () => {
     const conv = createConversation("inference-profile-no-throw");
-    await expect(
-      setConversationInferenceProfile(conv.id, "balanced"),
-    ).resolves.toBeUndefined();
-    await expect(
-      setConversationInferenceProfile(conv.id, null),
-    ).resolves.toBeUndefined();
+    await setConversationInferenceProfile(conv.id, "balanced");
+    await setConversationInferenceProfile(conv.id, null);
   });
 
   test("getConversation surfaces the column on every fetch", async () => {


### PR DESCRIPTION
## Summary

- Replace `expect(...).resolves.toBeUndefined()` with plain `await` in `does not throw when called with a valid conversation id`. The function being tested is async but does only synchronous work (`db.update().run()`), so the returned Promise resolves on the same microtask. Bun's `.resolves` matcher intermittently fails to recognize the already-settled value as a Promise, producing a flaky CI failure ([example](https://github.com/vellum-ai/vellum-assistant/actions/runs/24926715151/job/72997778499)).
- The test's intent is "does not throw" — `await` enforces that contract directly, no matcher needed.

## Original prompt

--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24926715151/job/72997778499
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
