### PR TITLE
fix(meet-host): forward path+query to skill route, unblock readiness handshake

### DIFF
--- a/assistant/src/daemon/__tests__/meet-host-supervisor.test.ts
+++ b/assistant/src/daemon/__tests__/meet-host-supervisor.test.ts
@@ -224,6 +224,25 @@ describe("MeetHostSupervisor", () => {
     expect(args).toContain("--skill-id=meet-join");
   });
 
+  test("setActiveConnection resolves a pending handshake (lazy-external readiness)", async () => {
+    harness = makeHarness();
+    const { supervisor } = harness;
+
+    const p = supervisor.ensureRunning();
+    await tick();
+    // Production path: the first `host.registries.register_*` frame
+    // funnels through `setActiveConnection`. That should also be the
+    // readiness signal — no separate `notifyHandshake` is wired today.
+    supervisor.setActiveConnection({
+      connectionId: "conn-ready",
+      addRouteHandle: () => undefined,
+      addSkillToolsOwner: () => undefined,
+    } as unknown as Parameters<typeof supervisor.setActiveConnection>[0]);
+
+    await p;
+    expect(supervisor.isRunning).toBe(true);
+  });
+
   test("hash mismatch rejects ensureRunning with a clear error and allows re-spawn", async () => {
     harness = makeHarness({ manifestHash: "expected-hash" });
     const { supervisor, spawnFn, child: firstChild } = harness;

--- a/assistant/src/daemon/__tests__/meet-manifest-loader.test.ts
+++ b/assistant/src/daemon/__tests__/meet-manifest-loader.test.ts
@@ -280,7 +280,7 @@ describe("loadMeetManifestProxies", () => {
     const match = "/api/skills/meet/test-id/events".match(route.pattern);
     if (!match) throw new Error("expected pattern match");
     const response = await route.handler(
-      new Request("http://localhost/api/skills/meet/test-id/events", {
+      new Request("http://localhost/api/skills/meet/test-id/events?ts=1", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: '{"hello":"world"}',
@@ -304,7 +304,9 @@ describe("loadMeetManifestProxies", () => {
     ];
     expect(call[0]).toBe("^/api/skills/meet/([^/]+)/events$");
     expect(call[1].method).toBe("POST");
-    expect(call[1].url).toBe("http://localhost/api/skills/meet/test-id/events");
+    // Skill-side `dispatchRoute` re-runs path-anchored regexes against the
+    // forwarded URL — must be pathname (+ querystring), not absolute URL.
+    expect(call[1].url).toBe("/api/skills/meet/test-id/events?ts=1");
     expect(call[1].body).toBe('{"hello":"world"}');
     expect(call[1].headers?.["content-type"]).toBe("application/json");
   });

--- a/assistant/src/daemon/meet-host-supervisor.ts
+++ b/assistant/src/daemon/meet-host-supervisor.ts
@@ -123,8 +123,8 @@ export interface MeetHostSupervisorDeps {
   /**
    * Sender used to dispatch `skill.dispatch_*` and `skill.shutdown` frames
    * back to the meet-host child over the active IPC connection. Optional
-   * because PR D wires this in only on the lazy-external path; tests that
-   * exercise lifecycle without dispatch can omit it.
+   * because the bootstrap wires this at runtime via the daemon-wide
+   * sender; tests that exercise lifecycle without dispatch can omit it.
    */
   ipcSender?: SkillRequestSender;
   /** Child-process spawn function (override for tests). */
@@ -371,6 +371,12 @@ export class MeetHostSupervisor {
       { connectionId: connection.connectionId },
       "Active meet-host IPC connection registered",
     );
+    // The first `host.registries.register_*` frame doubles as the
+    // readiness signal: it means `register(client)` ran to completion and
+    // the IPC socket is healthy. Resolve any in-flight handshake so
+    // `ensureRunning()` unblocks. `notifyHandshake` remains the path for
+    // callers that send a dedicated hash-bearing handshake frame.
+    this.handshakeResolve?.();
   }
 
   /**

--- a/assistant/src/daemon/meet-manifest-loader.ts
+++ b/assistant/src/daemon/meet-manifest-loader.ts
@@ -204,9 +204,14 @@ function buildProxyRoute(
           method === "GET" || method === "HEAD"
             ? undefined
             : await request.text();
+        // Skill-side `dispatchRoute` re-runs the registered regex against
+        // the forwarded URL; meet-join's patterns are path-anchored
+        // (e.g. `^/v1/internal/meet/...$`), so the absolute `request.url`
+        // would never match. Send pathname + search instead.
+        const { pathname, search } = new URL(request.url);
         response = await supervisor.dispatchRoute(entry.pattern, {
           method,
-          url: request.url,
+          url: `${pathname}${search}`,
           headers,
           ...(body !== undefined ? { body } : {}),
         });

--- a/assistant/src/ipc/skill-routes/registries.ts
+++ b/assistant/src/ipc/skill-routes/registries.ts
@@ -2,20 +2,19 @@
  * Skill IPC routes — `host.registries.*` surface.
  *
  * Lets an out-of-process skill install tools, HTTP routes, shutdown hooks
- * and session-tracking signals into the daemon's in-memory registries. The
- * register_* routes install proxy entries whose behavior ultimately dispatches
- * back over the same IPC socket via `skill.dispatch_*` calls; those
- * reverse-direction dispatch paths are PR 28's concern, so the proxies here
- * install `execute` / handler / hook stubs that throw a "not implemented —
- * dispatch added in PR 28" error. The shape of the registration (name,
- * description, risk level, execution target, regex, methods) is what matters
- * for this PR — downstream PRs only need to swap the stub body for a real
- * `skill.dispatch_*` round-trip.
+ * and session-tracking signals into the daemon's in-memory registries. When
+ * a {@link MeetHostSupervisor} is attached (production lazy-external path),
+ * the register_* handlers short-circuit because the manifest loader has
+ * already installed proxy entries that round-trip via `skill.dispatch_*`;
+ * the handler simply pins the incoming connection on the supervisor so
+ * dispatches have a target. When no supervisor is attached (tests, boot
+ * race), the handler installs in-memory proxies whose stubs surface a
+ * 501/501-equivalent error — those paths are not exercised end-to-end.
  *
  * `report_session_started` / `report_session_ended` keep an internal counter
- * the PR 27 `MeetHostSupervisor` reads. Until that supervisor lands the
- * counter lives in this module — PR 27 replaces the helper without changing
- * the IPC wire contract.
+ * mirrored to the supervisor's own counter (which is the source of truth
+ * once attached); the local set backs tests that exercise the IPC routes
+ * without a supervisor.
  */
 
 import { z } from "zod";
@@ -200,8 +199,11 @@ function buildProxyTool(manifest: ToolManifest): Tool {
     ownerSkillVersionHash: manifest.ownerSkillVersionHash,
     getDefinition: () => definition,
     execute: async () => {
+      // Only reached when no supervisor is attached (tests/boot race);
+      // the supervisor short-circuit above replaces this with the
+      // manifest's dispatching execute closure on the production path.
       throw new Error(
-        `Skill tool "${manifest.name}" invocation not implemented — dispatch added in PR 28`,
+        `Skill tool "${manifest.name}" invocation requires an attached MeetHostSupervisor`,
       );
     },
   };
@@ -286,11 +288,11 @@ async function handleRegisterSkillRoute(
     pattern,
     methods,
     handler: async () => {
-      // PR 28 replaces this stub with a `skill.dispatch_route` round-trip
-      // that marshals the Request across the IPC socket and materializes
-      // the Response back on the daemon side.
+      // Only reached when no supervisor is attached (tests/boot race);
+      // the supervisor short-circuit above keeps the manifest's
+      // dispatching handler in place on the production path.
       return new Response(
-        "Skill route dispatch not implemented — added in PR 28",
+        "Skill route dispatch requires an attached MeetHostSupervisor",
         { status: 501 },
       );
     },
@@ -325,12 +327,11 @@ async function handleRegisterShutdownHook(
   }
 
   registerShutdownHook(name, async (reason) => {
-    // PR 28 replaces this stub with a `skill.shutdown` dispatch that
-    // delivers the reason string to the out-of-process skill and awaits
-    // its teardown before returning.
+    // Only reached when no supervisor is attached; production attaches a
+    // dispatching hook via the manifest loader.
     log.info(
       { name, reason },
-      "Skill shutdown hook fired (dispatch stub — added in PR 28)",
+      "Skill shutdown hook fired (no-op without attached MeetHostSupervisor)",
     );
   });
   return { name };


### PR DESCRIPTION
## Summary

Address review feedback on #28027:

- **Codex P1**: `meet-manifest-loader`'s route proxy was forwarding the absolute `request.url` to the skill side. Skill-side `dispatchRoute` re-runs the registered regex against that string, but meet-join's patterns are path-anchored (e.g. `^/v1/internal/meet/...$`), so internal callbacks would consistently fail and return 503. Forward `pathname + search` instead.
- **Devin (notifyHandshake hang)**: `MeetHostSupervisor.notifyHandshake` had no production caller, so `ensureRunning()` would hang forever on the lazy-external path (now the sole entry path after #28029). Make `setActiveConnection` resolve any in-flight handshake — the first `host.registries.register_*` frame doubles as the readiness signal. `notifyHandshake` remains for callers that want the hash-bearing handshake frame.
- **Devin (stale comments)**: Drop "PR D" / "PR 28" / "PR 27" forward references in `meet-host-supervisor.ts` and `registries.ts` and rewrite the stub error strings/log lines to describe current state.

## Test plan

- [x] `bun test src/daemon/__tests__/meet-manifest-loader.test.ts src/daemon/__tests__/meet-host-supervisor.test.ts` (27 pass)
- [x] Existing route-proxy test updated to assert pathname+search rather than absolute URL
- [x] New supervisor test covers `setActiveConnection` resolving a pending handshake
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
