### PR TITLE
fix(skill-ipc): reject non-string frame ids before .startsWith() crashes

### DIFF
--- a/assistant/src/ipc/skill-server.ts
+++ b/assistant/src/ipc/skill-server.ts
@@ -516,6 +516,7 @@ export class SkillIpcServer {
       !frame ||
       typeof frame !== "object" ||
       Array.isArray(frame) ||
+      typeof frame.id !== "string" ||
       !frame.id
     ) {
       const id =

--- a/packages/skill-host-contracts/src/client.ts
+++ b/packages/skill-host-contracts/src/client.ts
@@ -615,6 +615,15 @@ export class SkillHostClient implements SkillHost {
       return;
     }
 
+    if (
+      !frame ||
+      typeof frame !== "object" ||
+      Array.isArray(frame) ||
+      typeof frame.id !== "string"
+    ) {
+      return;
+    }
+
     // Delivery frames route into the subscription callback.
     if (frame.event === "delivery") {
       const sub = this.subscriptions.get(frame.id);


### PR DESCRIPTION
## Summary
- Daemon-side `SkillIpcServer.handleMessage` and skill-side `SkillHostClient.handleFrame` both call `frame.id.startsWith(...)` without verifying the id is a string. The pre-existing `!frame.id` check only rejects falsy values; non-string truthy ids (`{"id": 123, ...}`) slip through and throw an uncaught `TypeError`, which can take down the daemon (or the skill process) on a single malformed frame.
- Added `typeof frame.id !== "string"` to the existing validation block in `skill-server.ts` so the daemon replies with a protocol error instead of crashing.
- Added a top-of-`handleFrame` guard in `packages/skill-host-contracts/src/client.ts` that drops malformed frames (non-object / array / non-string id) before any property dispatch.

Addresses review feedback from Codex and Devin on #28020.

## Test plan
- [ ] Existing skill-IPC tests still pass.
- [ ] Manual: send `{"id": 123, "method": "test.echo"}` to the skill socket; daemon replies with a validation error rather than crashing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
