### PR TITLE
feat(acp): add acp_list_agents tool with availability hints

### DIFF
--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -100,6 +100,24 @@
       },
       "executor": "tools/acp-steer.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "acp_list_agents",
+      "description": "Lists ACP coding agents available to spawn. Each entry includes whether ACP is enabled, whether the agent's binary is on PATH, and an install command if not. Use this to decide between 'claude' and 'codex' or to surface setup steps to the user.",
+      "category": "orchestration",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "activity": {
+            "type": "string",
+            "description": "Brief explanation of why this tool is being called"
+          }
+        },
+        "required": []
+      },
+      "executor": "tools/acp-list-agents.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/acp/tools/acp-list-agents.ts
+++ b/assistant/src/config/bundled-skills/acp/tools/acp-list-agents.ts
@@ -1,0 +1,12 @@
+import { executeAcpListAgents } from "../../../../tools/acp/list-agents.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAcpListAgents(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -15,6 +15,7 @@
 import type { SkillToolScript } from "../tools/skills/script-contract.js";
 // ── acp ────────────────────────────────────────────────────────────────────────
 import * as acpAbort from "./bundled-skills/acp/tools/acp-abort.js";
+import * as acpListAgents from "./bundled-skills/acp/tools/acp-list-agents.js";
 import * as acpSpawn from "./bundled-skills/acp/tools/acp-spawn.js";
 import * as acpStatus from "./bundled-skills/acp/tools/acp-status.js";
 import * as acpSteer from "./bundled-skills/acp/tools/acp-steer.js";
@@ -116,6 +117,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["acp:tools/acp-status.ts", acpStatus],
   ["acp:tools/acp-abort.ts", acpAbort],
   ["acp:tools/acp-steer.ts", acpSteer],
+  ["acp:tools/acp-list-agents.ts", acpListAgents],
 
   // app-builder
   ["app-builder:tools/app-create.ts", appCreate],

--- a/assistant/src/tools/acp/list-agents.test.ts
+++ b/assistant/src/tools/acp/list-agents.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AcpAgentConfig } from "../../config/acp-schema.js";
+import type { ToolContext } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Mock infrastructure
+// ---------------------------------------------------------------------------
+
+interface MockAcpConfig {
+  enabled: boolean;
+  maxConcurrentSessions: number;
+  agents: Record<string, AcpAgentConfig>;
+}
+
+let mockAcpConfig: MockAcpConfig = {
+  enabled: true,
+  maxConcurrentSessions: 4,
+  agents: {},
+};
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({ acp: mockAcpConfig }),
+}));
+
+// Swap Bun.which with a stub so tests can deterministically simulate "binary
+// on PATH" / "binary missing" without depending on the host environment.
+const originalWhich = Bun.which;
+let whichStub: (command: string) => string | null = () => null;
+(Bun as unknown as { which: (cmd: string) => string | null }).which = (cmd) =>
+  whichStub(cmd);
+
+afterAll(() => {
+  (Bun as unknown as { which: typeof originalWhich }).which = originalWhich;
+});
+
+const { executeAcpListAgents } = await import("./list-agents.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setConfig(partial: Partial<MockAcpConfig>): void {
+  mockAcpConfig = {
+    enabled: true,
+    maxConcurrentSessions: 4,
+    agents: {},
+    ...partial,
+  };
+}
+
+function setWhich(map: Record<string, string | null>): void {
+  whichStub = (cmd) => map[cmd] ?? null;
+}
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-test",
+    trustClass: "guardian",
+  };
+}
+
+beforeEach(() => {
+  setConfig({});
+  // Default: every command on PATH so binary preflight passes unless a test
+  // explicitly says otherwise.
+  whichStub = (cmd) => `/usr/local/bin/${cmd}`;
+});
+
+// ---------------------------------------------------------------------------
+// executeAcpListAgents
+// ---------------------------------------------------------------------------
+
+describe("executeAcpListAgents", () => {
+  test("returns disabled hint when ACP is disabled", async () => {
+    setConfig({ enabled: false });
+
+    const result = await executeAcpListAgents({}, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content as string);
+    expect(parsed).toEqual({
+      enabled: false,
+      hint: "Set 'acp.enabled': true to use ACP agents.",
+    });
+  });
+
+  test("enabled, no user config: both defaults present with source 'default' and available based on Bun.which", async () => {
+    setConfig({ agents: {} });
+
+    const result = await executeAcpListAgents({}, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content as string);
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.agents.map((a: { id: string }) => a.id)).toEqual([
+      "claude",
+      "codex",
+    ]);
+    for (const entry of parsed.agents) {
+      expect(entry.source).toBe("default");
+      expect(entry.available).toBe(true);
+      expect(entry.unavailableReason).toBeUndefined();
+      expect(entry.setupHint).toBeUndefined();
+    }
+  });
+
+  test("enabled, user overrides claude: claude has source 'config' and the user's command", async () => {
+    setConfig({
+      agents: {
+        claude: {
+          command: "my-claude-bin",
+          args: [],
+          description: "user override",
+        },
+      },
+    });
+
+    const result = await executeAcpListAgents({}, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content as string);
+    expect(parsed.enabled).toBe(true);
+
+    const claude = parsed.agents.find((a: { id: string }) => a.id === "claude");
+    expect(claude.source).toBe("config");
+    expect(claude.command).toBe("my-claude-bin");
+    expect(claude.description).toBe("user override");
+    expect(claude.available).toBe(true);
+
+    const codex = parsed.agents.find((a: { id: string }) => a.id === "codex");
+    expect(codex.source).toBe("default");
+  });
+
+  test("unavailable agent surfaces setupHint from DEFAULT_AGENT_INSTALL_HINTS", async () => {
+    setConfig({ agents: {} });
+    setWhich({ "claude-agent-acp": "/usr/local/bin/claude-agent-acp" });
+
+    const result = await executeAcpListAgents({}, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content as string);
+
+    const codex = parsed.agents.find((a: { id: string }) => a.id === "codex");
+    expect(codex.available).toBe(false);
+    expect(codex.unavailableReason).toBe("'codex-acp' is not on PATH");
+    expect(codex.setupHint).toBe("npm i -g @zed-industries/codex-acp");
+
+    const claude = parsed.agents.find((a: { id: string }) => a.id === "claude");
+    expect(claude.available).toBe(true);
+    expect(claude.setupHint).toBeUndefined();
+  });
+});

--- a/assistant/src/tools/acp/list-agents.ts
+++ b/assistant/src/tools/acp/list-agents.ts
@@ -1,0 +1,31 @@
+import { listAcpAgents } from "../../acp/resolve-agent.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Lists ACP coding agents available to spawn (configured + bundled defaults),
+ * marking each with its source (`config` vs `default`), whether the agent's
+ * binary is on PATH, and an install hint when missing.
+ *
+ * When `acp.enabled: false`, returns a single hint instructing the user to
+ * enable ACP — no agent list is surfaced because none can run.
+ */
+export async function executeAcpListAgents(
+  _input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const { enabled, agents } = listAcpAgents();
+  if (!enabled) {
+    return {
+      content: JSON.stringify({
+        enabled: false,
+        hint: "Set 'acp.enabled': true to use ACP agents.",
+      }),
+      isError: false,
+    };
+  }
+
+  return {
+    content: JSON.stringify({ enabled, agents }),
+    isError: false,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `acp_list_agents` tool: lists configured ACP agents (config + defaults), reports whether each binary is on PATH, surfaces install hints when missing.
- When `acp.enabled: false`, returns a single disabled hint so the LLM can guide the user to enable it.
- Wired through `listAcpAgents()` from PR 4's resolver.

Part of plan: acp-codex-claude.md (PR 5 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
