### PR TITLE
fix(macos): merge inferenceProfile when restoring existing conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -354,6 +354,7 @@ final class ConversationRestorer {
                 existing.source = session.source
                 existing.conversationType = session.conversationType
                 existing.originChannel = session.channelBinding?.sourceChannel ?? session.conversationOriginChannel
+                existing.inferenceProfile = session.inferenceProfile
                 delegate.conversations[existingIdx] = existing
                 // Attention merge must go through mergeAssistantAttention so that
                 // pendingAttentionOverrides are reconciled (e.g. a notification


### PR DESCRIPTION
The existing-conversation merge path in `ConversationRestorer.handleConversationListResponse` updates several mutable fields from the server response (`hostAccess`, `source`, `conversationType`, `originChannel`, etc.) but was missing `inferenceProfile`. The new-conversation creation path already passes it correctly.

Without this, a conversation created locally before the list arrived (e.g. via `createNotificationConversation`), or one whose profile changed on the server between reconnects, would keep a stale local `inferenceProfile`. The dedicated `conversationInferenceProfileUpdated` event only fires on active changes and won't retroactively fix it.

Addresses review feedback on #28059.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
