### PR TITLE
chore(daemon): polish llm-resolver doc and dedupe conversation row read

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -123,10 +123,11 @@ mock.module("../memory/conversation-crud.js", () => ({
   clearStrippedInjectionMetadataForConversation: () => {},
   getMessages: () => [],
   getConversation: () => mockConversationRow,
-  getConversationOverrideProfile: () => {
-    if (mockConversationRow?.conversationType === "background")
-      return undefined;
-    const profile = mockConversationRow?.inferenceProfile;
+  getConversationOverrideProfileFromRow: (
+    row: { conversationType?: string; inferenceProfile?: string | null } | null,
+  ) => {
+    if (row?.conversationType === "background") return undefined;
+    const profile = row?.inferenceProfile;
     return typeof profile === "string" ? profile : undefined;
   },
   provenanceFromTrustContext: () => ({

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -12,12 +12,12 @@ import {
  * call-site overrides, optional per-call profile, an optional ad-hoc override
  * profile, the workspace's active profile, and the required `llm.default`.
  *
- * Resolution order (highest precedence wins):
- *   1. `llm.callSites[callSite]` fields (call-site override)
- *   2. `llm.profiles[site.profile]` fields (call-site's named profile)
+ * Merge layers (low → high precedence; later layers override earlier):
+ *   1. `llm.default` fields (required base)
+ *   2. `llm.profiles[llm.activeProfile]` (workspace-wide active profile)
  *   3. `llm.profiles[opts.overrideProfile]` (per-call ad-hoc override)
- *   4. `llm.profiles[llm.activeProfile]` (workspace-wide active profile)
- *   5. `llm.default` fields (required base)
+ *   4. `llm.profiles[site.profile]` fields (call-site's named profile)
+ *   5. `llm.callSites[callSite]` fields (call-site override)
  *
  * Nested objects (`thinking`, `contextWindow`, and
  * `contextWindow.overflowRecovery`) are deep-merged so partial overrides at

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -52,7 +52,7 @@ import {
   getConversation,
   getConversationOriginChannel,
   getConversationOriginInterface,
-  getConversationOverrideProfile,
+  getConversationOverrideProfileFromRow,
   getLastUserTimestampBefore,
   getMessageById,
   provenanceFromTrustContext,
@@ -624,6 +624,12 @@ export async function runAgentLoopImpl(
   // `llm.callSites.mainAgent` (falling back to `llm.default` when absent).
   const turnCallSite: LLMCallSite = options?.callSite ?? "mainAgent";
 
+  // Read the conversation row once for both the override-profile derivation
+  // below and the title-replaceability check at turn start. Later reads in
+  // this function (post-turn truncation, disk sync, home-feed emission)
+  // intentionally re-read because state can change during the turn.
+  const turnStartConversation = getConversation(ctx.conversationId);
+
   // Optional per-turn inference-profile override. Plumbed through to every
   // LLM call the loop emits and inherited by any subagents spawned during
   // this turn. Caller-supplied `options.overrideProfile` (e.g.
@@ -633,7 +639,7 @@ export async function runAgentLoopImpl(
   // explicitly inherited override.
   const turnOverrideProfile =
     options?.overrideProfile ??
-    getConversationOverrideProfile(ctx.conversationId);
+    getConversationOverrideProfileFromRow(turnStartConversation);
 
   // Snapshot for `createToolExecutor` to read into `ToolContext.overrideProfile`
   // — see field doc on `AgentLoopConversationContext` for why the tool needs
@@ -731,9 +737,7 @@ export async function runAgentLoopImpl(
     // cancels the response, since the user message is already persisted.
     // Deferred via setTimeout so the main agent loop LLM call enqueues
     // first, avoiding rate-limit slot contention on strict configs.
-    if (
-      isReplaceableTitle(getConversation(ctx.conversationId)?.title ?? null)
-    ) {
+    if (isReplaceableTitle(turnStartConversation?.title ?? null)) {
       // TurnContext routed through the canonical builder so the pipeline's
       // log record reports the same `conversationId`/`turnIndex` shape as
       // every other slot in this turn. Title generation does not depend on

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1328,18 +1328,32 @@ export function setConversationInferenceProfile(
 }
 
 /**
- * Resolve the per-turn inference-profile override for a conversation.
- * Returns the row's `inferenceProfile` for non-background conversations,
- * `undefined` otherwise — background turns (subagent fan-out, scheduled
- * tasks, update bulletins) run on the workspace defaults rather than
- * inheriting an interactive override.
+ * Resolve the per-turn inference-profile override from an already-loaded
+ * conversation row. Returns the row's `inferenceProfile` for non-background
+ * conversations, `undefined` otherwise — background turns (subagent fan-out,
+ * scheduled tasks, update bulletins) run on the workspace defaults rather
+ * than inheriting an interactive override.
+ *
+ * Prefer this row-based form when the caller already needs to read the
+ * conversation row for other reasons (e.g. the agent loop's title check).
+ */
+export function getConversationOverrideProfileFromRow(
+  conv: ConversationRow | null,
+): string | undefined {
+  if (conv?.conversationType === "background") return undefined;
+  return conv?.inferenceProfile ?? undefined;
+}
+
+/**
+ * Resolve the per-turn inference-profile override by conversation id.
+ * Convenience wrapper around `getConversationOverrideProfileFromRow` for
+ * standalone callers (e.g. subagent spawn, opportunity-wake) that don't
+ * already have the row in hand.
  */
 export function getConversationOverrideProfile(
   conversationId: string,
 ): string | undefined {
-  const conv = getConversation(conversationId);
-  if (conv?.conversationType === "background") return undefined;
-  return conv?.inferenceProfile ?? undefined;
+  return getConversationOverrideProfileFromRow(getConversation(conversationId));
 }
 
 /**


### PR DESCRIPTION
## Summary
Two backend polish fixes from inference-profiles plan re-review:
- Reorder `resolveCallSiteConfig`'s doc-comment precedence list so it matches the actual low→high merge layer order.
- Read the conversation row once in `runAgentLoopImpl` and derive `overrideProfile` from it, instead of double-reading via the helper.