### PR TITLE
refactor(macos): extract shared composer pill-menu component

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
@@ -53,14 +53,6 @@ struct ChatProfilePicker: View {
     /// conversation falls back to `activeProfile`.
     let onSelect: (String?) -> Void
 
-    #if os(macOS)
-    @State private var isMenuOpen = false
-    @State private var activePanel: VMenuPanel?
-    @State private var triggerFrame: CGRect = .zero
-    #endif
-
-    private let composerActionButtonSize: CGFloat = 32
-
     /// Pill label: the override profile when set, otherwise
     /// "Default (`<activeProfile>`)". Internal so tests can assert on it
     /// without spinning up a SwiftUI host.
@@ -71,120 +63,52 @@ struct ChatProfilePicker: View {
 
     var body: some View {
         #if os(macOS)
-        Button {
-            if isMenuOpen {
-                activePanel?.close()
-                activePanel = nil
-                isMenuOpen = false
-            } else {
-                showMenu()
-            }
-        } label: {
-            HStack(spacing: 4) {
-                VIconView(.sparkles, size: 14)
-                    .foregroundStyle(VColor.contentSecondary)
-                Text(Self.label(current: current, activeProfile: activeProfile))
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-                    .lineLimit(1)
-                VIconView(.chevronDown, size: 10)
-                    .foregroundStyle(VColor.contentTertiary)
-            }
-            .frame(height: composerActionButtonSize)
-            .padding(.horizontal, VSpacing.xs)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .disabled(conversationId == nil)
-        .vTooltip("Inference profile for this conversation")
-        .accessibilityLabel("Inference profile")
-        .accessibilityValue(Self.label(current: current, activeProfile: activeProfile))
-        .overlay {
-            GeometryReader { geo in
-                Color.clear
-                    .onAppear { triggerFrame = geo.frame(in: .global) }
-                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
-                        triggerFrame = newFrame
-                    }
-            }
-        }
-        #endif
-    }
-
-    // MARK: - Menu
-
-    #if os(macOS)
-    private func showMenu() {
-        guard !isMenuOpen, conversationId != nil else { return }
-        isMenuOpen = true
-
-        NSApp.keyWindow?.makeFirstResponder(nil)
-
-        guard let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible }) else {
-            isMenuOpen = false
-            return
-        }
-
-        let triggerInWindow = CGPoint(x: triggerFrame.minX, y: triggerFrame.maxY)
-        let screenPoint = window.convertPoint(toScreen: NSPoint(
-            x: triggerInWindow.x,
-            y: window.frame.height - triggerInWindow.y
-        ))
-
-        let triggerScreenOrigin = window.convertPoint(toScreen: NSPoint(
-            x: triggerFrame.minX,
-            y: window.frame.height - triggerFrame.maxY
-        ))
-        let triggerScreenRect = CGRect(
-            origin: triggerScreenOrigin,
-            size: CGSize(width: triggerFrame.width, height: triggerFrame.height)
-        )
-
-        let appearance = window.effectiveAppearance
-        activePanel = VMenuPanel.show(
-            at: screenPoint,
-            sourceWindow: window,
-            sourceAppearance: appearance,
-            excludeRect: triggerScreenRect
+        ComposerPillMenu(
+            isEnabled: conversationId != nil,
+            accessibilityLabel: "Inference profile",
+            accessibilityValue: Self.label(current: current, activeProfile: activeProfile),
+            tooltip: "Inference profile for this conversation"
         ) {
-            VMenu(width: 240) {
-                ForEach(profiles) { profile in
-                    VMenuItem(
-                        icon: VIcon.sparkles.rawValue,
-                        label: profile.name,
-                        isActive: current == profile.name,
-                        size: .regular
-                    ) {
-                        onSelect(profile.name)
-                    } trailing: {
-                        VStack(alignment: .trailing, spacing: 2) {
-                            if current == profile.name {
-                                VIconView(.check, size: 12)
-                                    .foregroundStyle(VColor.primaryBase)
-                            }
-                        }
-                    }
-                }
+            VIconView(.sparkles, size: 14)
+                .foregroundStyle(VColor.contentSecondary)
+            Text(Self.label(current: current, activeProfile: activeProfile))
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .lineLimit(1)
+        } menu: {
+            ForEach(profiles) { profile in
                 VMenuItem(
-                    icon: VIcon.rotateCcw.rawValue,
-                    label: "Reset to default (\(activeProfile))",
-                    isActive: current == nil,
+                    icon: VIcon.sparkles.rawValue,
+                    label: profile.name,
+                    isActive: current == profile.name,
                     size: .regular
                 ) {
-                    onSelect(nil)
+                    onSelect(profile.name)
                 } trailing: {
                     VStack(alignment: .trailing, spacing: 2) {
-                        if current == nil {
+                        if current == profile.name {
                             VIconView(.check, size: 12)
                                 .foregroundStyle(VColor.primaryBase)
                         }
                     }
                 }
             }
-        } onDismiss: {
-            isMenuOpen = false
-            activePanel = nil
+            VMenuItem(
+                icon: VIcon.rotateCcw.rawValue,
+                label: "Reset to default (\(activeProfile))",
+                isActive: current == nil,
+                size: .regular
+            ) {
+                onSelect(nil)
+            } trailing: {
+                VStack(alignment: .trailing, spacing: 2) {
+                    if current == nil {
+                        VIconView(.check, size: 12)
+                            .foregroundStyle(VColor.primaryBase)
+                    }
+                }
+            }
         }
+        #endif
     }
-    #endif
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerPillMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerPillMenu.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A pill-shaped composer action-bar button that opens a ``VMenuPanel`` with
+/// custom contents. Centralizes the trigger-frame capture, screen-coordinate
+/// math, and panel lifecycle so individual pickers (e.g. ``ChatProfilePicker``,
+/// ``ComposerThresholdPicker``) only need to declare their own label content
+/// and menu items.
+///
+/// The chevron-down indicator, fixed height, and horizontal padding are owned
+/// by this view to keep all composer pills visually consistent. Callers supply
+/// only the leading icon + text via the ``label`` builder.
+@MainActor
+struct ComposerPillMenu<Label: View, Menu: View>: View {
+    /// When `false` the trigger is rendered as a disabled button and the menu
+    /// cannot be opened. Mirrors SwiftUI's `.disabled(_:)` semantics.
+    var isEnabled: Bool = true
+
+    /// VoiceOver label announced for the trigger.
+    let accessibilityLabel: String
+
+    /// VoiceOver value announced alongside the label (typically the current
+    /// selection's display string).
+    let accessibilityValue: String
+
+    /// Tooltip shown on hover.
+    let tooltip: String
+
+    /// Width of the popover menu surface.
+    var menuWidth: CGFloat = 240
+
+    /// Leading content of the pill — typically an icon followed by a label
+    /// `Text`. The chevron is appended by this view.
+    @ViewBuilder let label: () -> Label
+
+    /// Body of the popover menu — typically a ``VMenu`` with ``VMenuItem``
+    /// rows. Wrapped in a ``VMenu`` of width ``menuWidth`` by this view.
+    @ViewBuilder let menu: () -> Menu
+
+    #if os(macOS)
+    @State private var isMenuOpen = false
+    @State private var activePanel: VMenuPanel?
+    @State private var triggerFrame: CGRect = .zero
+    #endif
+
+    private let composerActionButtonSize: CGFloat = 32
+
+    var body: some View {
+        #if os(macOS)
+        Button {
+            if isMenuOpen {
+                activePanel?.close()
+                activePanel = nil
+                isMenuOpen = false
+            } else {
+                showMenu()
+            }
+        } label: {
+            HStack(spacing: 4) {
+                label()
+                VIconView(.chevronDown, size: 10)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .frame(height: composerActionButtonSize)
+            .padding(.horizontal, VSpacing.xs)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .vTooltip(tooltip)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityValue(accessibilityValue)
+        .overlay {
+            GeometryReader { geo in
+                Color.clear
+                    .onAppear { triggerFrame = geo.frame(in: .global) }
+                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
+                        triggerFrame = newFrame
+                    }
+            }
+        }
+        #endif
+    }
+
+    // MARK: - Menu
+
+    #if os(macOS)
+    private func showMenu() {
+        guard !isMenuOpen, isEnabled else { return }
+        isMenuOpen = true
+
+        NSApp.keyWindow?.makeFirstResponder(nil)
+
+        guard let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible }) else {
+            isMenuOpen = false
+            return
+        }
+
+        let triggerInWindow = CGPoint(x: triggerFrame.minX, y: triggerFrame.maxY)
+        let screenPoint = window.convertPoint(toScreen: NSPoint(
+            x: triggerInWindow.x,
+            y: window.frame.height - triggerInWindow.y
+        ))
+
+        let triggerScreenOrigin = window.convertPoint(toScreen: NSPoint(
+            x: triggerFrame.minX,
+            y: window.frame.height - triggerFrame.maxY
+        ))
+        let triggerScreenRect = CGRect(
+            origin: triggerScreenOrigin,
+            size: CGSize(width: triggerFrame.width, height: triggerFrame.height)
+        )
+
+        let appearance = window.effectiveAppearance
+        activePanel = VMenuPanel.show(
+            at: screenPoint,
+            sourceWindow: window,
+            sourceAppearance: appearance,
+            excludeRect: triggerScreenRect
+        ) {
+            VMenu(width: menuWidth) {
+                menu()
+            }
+        } onDismiss: {
+            isMenuOpen = false
+            activePanel = nil
+        }
+    }
+    #endif
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
@@ -129,14 +129,6 @@ struct ComposerThresholdPicker: View {
     /// GET responses don't overwrite an optimistic selection.
     @State private var hasUserInteracted: Bool = false
 
-    #if os(macOS)
-    @State private var isMenuOpen = false
-    @State private var activePanel: VMenuPanel?
-    @State private var triggerFrame: CGRect = .zero
-    #endif
-
-    private let composerActionButtonSize: CGFloat = 32
-
     private var pillLabelColor: Color {
         switch currentPreset {
         case .fullAccess: return VColor.systemNegativeStrong
@@ -147,39 +139,33 @@ struct ComposerThresholdPicker: View {
 
     var body: some View {
         #if os(macOS)
-        Button {
-            if isMenuOpen {
-                activePanel?.close()
-                activePanel = nil
-                isMenuOpen = false
-            } else {
-                showMenu()
-            }
-        } label: {
-            HStack(spacing: 4) {
-                VIconView(currentPreset.icon, size: 14)
-                    .foregroundStyle(currentPreset.iconColor)
-                Text(currentPreset.label)
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(pillLabelColor)
-                VIconView(.chevronDown, size: 10)
-                    .foregroundStyle(VColor.contentTertiary)
-            }
-            .frame(height: composerActionButtonSize)
-            .padding(.horizontal, VSpacing.xs)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .vTooltip(currentPreset.description)
-        .accessibilityLabel("Risk tolerance")
-        .accessibilityValue(currentPreset.label)
-        .overlay {
-            GeometryReader { geo in
-                Color.clear
-                    .onAppear { triggerFrame = geo.frame(in: .global) }
-                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
-                        triggerFrame = newFrame
+        ComposerPillMenu(
+            accessibilityLabel: "Risk tolerance",
+            accessibilityValue: currentPreset.label,
+            tooltip: currentPreset.description
+        ) {
+            VIconView(currentPreset.icon, size: 14)
+                .foregroundStyle(currentPreset.iconColor)
+            Text(currentPreset.label)
+                .font(VFont.labelDefault)
+                .foregroundStyle(pillLabelColor)
+        } menu: {
+            ForEach(ThresholdPreset.allCases) { preset in
+                VMenuItem(
+                    icon: preset.icon.rawValue,
+                    label: preset.label,
+                    isActive: currentPreset == preset,
+                    size: .regular
+                ) {
+                    selectPreset(preset)
+                } trailing: {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        if currentPreset == preset {
+                            VIconView(.check, size: 12)
+                                .foregroundStyle(VColor.primaryBase)
+                        }
                     }
+                }
             }
         }
         .task(id: conversationId) {
@@ -188,68 +174,6 @@ struct ComposerThresholdPicker: View {
         }
         #endif
     }
-
-    // MARK: - Menu
-
-    #if os(macOS)
-    private func showMenu() {
-        guard !isMenuOpen else { return }
-        isMenuOpen = true
-
-        NSApp.keyWindow?.makeFirstResponder(nil)
-
-        guard let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible }) else {
-            isMenuOpen = false
-            return
-        }
-
-        let triggerInWindow = CGPoint(x: triggerFrame.minX, y: triggerFrame.maxY)
-        let screenPoint = window.convertPoint(toScreen: NSPoint(
-            x: triggerInWindow.x,
-            y: window.frame.height - triggerInWindow.y
-        ))
-
-        let triggerScreenOrigin = window.convertPoint(toScreen: NSPoint(
-            x: triggerFrame.minX,
-            y: window.frame.height - triggerFrame.maxY
-        ))
-        let triggerScreenRect = CGRect(
-            origin: triggerScreenOrigin,
-            size: CGSize(width: triggerFrame.width, height: triggerFrame.height)
-        )
-
-        let appearance = window.effectiveAppearance
-        activePanel = VMenuPanel.show(
-            at: screenPoint,
-            sourceWindow: window,
-            sourceAppearance: appearance,
-            excludeRect: triggerScreenRect
-        ) {
-            VMenu(width: 240) {
-                ForEach(ThresholdPreset.allCases) { preset in
-                    VMenuItem(
-                        icon: preset.icon.rawValue,
-                        label: preset.label,
-                        isActive: currentPreset == preset,
-                        size: .regular
-                    ) {
-                        selectPreset(preset)
-                    } trailing: {
-                        VStack(alignment: .trailing, spacing: 2) {
-                            if currentPreset == preset {
-                                VIconView(.check, size: 12)
-                                    .foregroundStyle(VColor.primaryBase)
-                            }
-                        }
-                    }
-                }
-            }
-        } onDismiss: {
-            isMenuOpen = false
-            activePanel = nil
-        }
-    }
-    #endif
 
     // MARK: - Selection
 


### PR DESCRIPTION
## Summary
Extract the shared pill-button + popover-menu boilerplate (~60 duplicated lines) from `ChatProfilePicker` and `ComposerThresholdPicker` into a single `ComposerPillMenu` view. Each picker now passes only its label and menu items.

Behavioral parity preserved; existing tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
