### PR TITLE
fix(skill-host-contracts): match dispatchRoute regex against pathname

### DIFF
--- a/packages/skill-host-contracts/__tests__/client.test.ts
+++ b/packages/skill-host-contracts/__tests__/client.test.ts
@@ -653,6 +653,40 @@ describe("SkillHostClient: daemon-initiated dispatch", () => {
     expect(receivedMatch![1]).toBe("world");
   });
 
+  test("skill.dispatch_route matches path-anchored patterns against relative pathname", async () => {
+    server!.register("host.registries.register_skill_route", () => ({
+      patternSource: "^/v1/echo/([^/]+)$",
+      methods: ["POST"],
+    }));
+    client = await openClient();
+    let receivedReq: Request | null = null;
+    let receivedMatch: RegExpMatchArray | null = null;
+    const pattern = /^\/v1\/echo\/([^/]+)$/;
+    client.registries.registerSkillRoute({
+      pattern,
+      methods: ["POST"],
+      handler: async (req, match) => {
+        receivedReq = req;
+        receivedMatch = match;
+        return new Response("ok " + match[1]);
+      },
+    });
+    await new Promise((r) => setTimeout(r, 30));
+
+    const response = await server!.sendRequest("skill.dispatch_route", {
+      patternSource: pattern.source,
+      request: {
+        method: "POST",
+        url: "/v1/echo/abc?ts=1",
+        headers: {},
+        body: "{}",
+      },
+    });
+    expect((response as { body: string }).body).toBe("ok abc");
+    expect(receivedReq).not.toBeNull();
+    expect(receivedMatch![1]).toBe("abc");
+  });
+
   test("skill.dispatch_route surfaces unknown route as a remote error", async () => {
     server!.register("host.registries.register_skill_route", () => ({
       patternSource: "/api/known",

--- a/packages/skill-host-contracts/src/client.ts
+++ b/packages/skill-host-contracts/src/client.ts
@@ -1237,13 +1237,18 @@ export class SkillHostClient implements SkillHost {
         "skill.dispatch_route: missing or invalid 'request.url' parameter",
       );
     }
+    // Resolve against a synthetic base so `new Request` accepts the URL
+    // (it rejects bare paths, but the daemon forwards `pathname + search`)
+    // and so the regex can run against `pathname` alone — keeps query
+    // strings out of anchored patterns like `^/v1/...$`.
+    const parsedUrl = new URL(req.url, "http://skill.local");
     // Reset lastIndex so a global/sticky regex doesn't carry state across
     // dispatches — `exec()` mutates lastIndex on g/y flags and the route's
     // RegExp may be reused across requests.
     if (route.pattern.global || route.pattern.sticky) {
       route.pattern.lastIndex = 0;
     }
-    const match = route.pattern.exec(req.url);
+    const match = route.pattern.exec(parsedUrl.pathname);
     if (!match) {
       throw new Error(`url did not match pattern: ${patternSource}`);
     }
@@ -1260,7 +1265,10 @@ export class SkillHostClient implements SkillHost {
     ) {
       init.body = req.body;
     }
-    const response = await route.handler(new Request(req.url, init), match);
+    const response = await route.handler(
+      new Request(parsedUrl.toString(), init),
+      match,
+    );
     const headers: Record<string, string> = {};
     response.headers.forEach((value, key) => {
       headers[key] = value;


### PR DESCRIPTION
## Summary
- Address codex P1 review feedback on #28022.
- After #28102 the daemon forwards `pathname + search` (relative) to the skill so path-anchored route patterns like `^/v1/...$` match. `dispatchRoute` still ran the regex against `req.url` and passed it straight to `new Request`, which (a) breaks anchored matches when a query string is present and (b) throws because `new Request` rejects bare paths.
- Resolve `req.url` against a synthetic base (`http://skill.local`), run the regex against `parsedUrl.pathname`, and hand the absolute serialized URL to `new Request`. Absolute URLs from older callers round-trip unchanged.
- Devin's note about `patternFlags` not being forwarded was already addressed by #28099 (it now ships `patternFlags: route.pattern.flags` alongside `patternSource`).

## Test plan
- [x] Added `packages/skill-host-contracts/__tests__/client.test.ts` regression: path-anchored regex + relative URL with querystring round-trips through `skill.dispatch_route`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
