### PR TITLE
refactor(macos test): extract shared settings-store fixture

### DIFF
--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
@@ -18,34 +18,13 @@ final class InferenceProfileEditorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockSettingsClient = MockSettingsClient()
-        mockSettingsClient.patchConfigResponse = true
-        store = SettingsStore(settingsClient: mockSettingsClient)
-        // Override the catalog with a tiny deterministic fixture so tests
-        // don't depend on the live `LLMProviderRegistry` shape.
-        store.providerCatalog = [
-            ProviderCatalogEntry(
-                id: "anthropic",
-                displayName: "Anthropic",
-                models: [
-                    CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
-                    CatalogModel(id: "claude-opus-4-7", displayName: "Claude Opus 4.7"),
-                ],
-                defaultModel: "claude-sonnet-4-6",
-                apiKeyUrl: nil,
-                apiKeyPlaceholder: nil
-            ),
-            ProviderCatalogEntry(
-                id: "openai",
-                displayName: "OpenAI",
-                models: [
-                    CatalogModel(id: "gpt-5", displayName: "GPT-5"),
-                ],
-                defaultModel: "gpt-5",
-                apiKeyUrl: nil,
-                apiKeyPlaceholder: nil
-            ),
-        ]
+        // Tiny deterministic catalog so tests don't depend on the live
+        // `LLMProviderRegistry` shape.
+        let fixture = SettingsTestFixture.make(
+            providerCatalog: SettingsTestFixture.anthropicAndOpenAICatalog()
+        )
+        store = fixture.store
+        mockSettingsClient = fixture.mockClient
     }
 
     override func tearDown() {

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfilesSheetTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfilesSheetTests.swift
@@ -19,25 +19,13 @@ final class InferenceProfilesSheetTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockSettingsClient = MockSettingsClient()
-        mockSettingsClient.patchConfigResponse = true
-        store = SettingsStore(settingsClient: mockSettingsClient)
         // Tiny deterministic catalog so summary lookups produce stable
         // human-readable strings without depending on the live registry.
-        store.providerCatalog = [
-            ProviderCatalogEntry(
-                id: "anthropic",
-                displayName: "Anthropic",
-                models: [
-                    CatalogModel(id: "claude-opus-4-7", displayName: "Claude Opus 4.7"),
-                    CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
-                    CatalogModel(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),
-                ],
-                defaultModel: "claude-sonnet-4-6",
-                apiKeyUrl: nil,
-                apiKeyPlaceholder: nil
-            ),
-        ]
+        let fixture = SettingsTestFixture.make(
+            providerCatalog: SettingsTestFixture.anthropicWithHaikuCatalog
+        )
+        store = fixture.store
+        mockSettingsClient = fixture.mockClient
     }
 
     override func tearDown() {
@@ -51,29 +39,7 @@ final class InferenceProfilesSheetTests: XCTestCase {
     /// Seeds the store with the three canonical built-in profiles plus an
     /// optional custom one. Mirrors the daemon's migration-052 seed shape.
     private func seedBuiltInsAndCustom(includeCustom: Bool = false) {
-        var profiles: [String: Any] = [
-            "quality-optimized": [
-                "provider": "anthropic",
-                "model": "claude-opus-4-7",
-                "maxTokens": 32000,
-                "effort": "max",
-                "thinking": ["enabled": true, "streamThinking": true],
-            ],
-            "balanced": [
-                "provider": "anthropic",
-                "model": "claude-sonnet-4-6",
-                "maxTokens": 16000,
-                "effort": "high",
-                "thinking": ["enabled": true, "streamThinking": true],
-            ],
-            "cost-optimized": [
-                "provider": "anthropic",
-                "model": "claude-haiku-4-5-20251001",
-                "maxTokens": 8192,
-                "effort": "low",
-                "thinking": ["enabled": false, "streamThinking": false],
-            ],
-        ]
+        var profiles = SettingsTestFixture.builtInProfilesPayload
         if includeCustom {
             profiles["experimental"] = [
                 "provider": "anthropic",

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceServiceCardTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceServiceCardTests.swift
@@ -20,37 +20,22 @@ final class InferenceServiceCardTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockSettingsClient = MockSettingsClient()
-        mockSettingsClient.patchConfigResponse = true
-        store = SettingsStore(settingsClient: mockSettingsClient)
+        // Tiny deterministic catalog so provider/model lookups are stable.
+        let fixture = SettingsTestFixture.make(
+            providerCatalog: SettingsTestFixture.anthropicAndOpenAICatalog(
+                anthropicApiKeyPlaceholder: "sk-ant-...",
+                openaiApiKeyPlaceholder: "sk-..."
+            )
+        )
+        store = fixture.store
+        mockSettingsClient = fixture.mockClient
         authManager = AuthManager()
         apiKeyTextBox = ApiKeyTextBox()
-        // Tiny deterministic catalog so provider/model lookups are stable.
-        store.providerCatalog = [
-            ProviderCatalogEntry(
-                id: "anthropic",
-                displayName: "Anthropic",
-                models: [
-                    CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
-                    CatalogModel(id: "claude-opus-4-7", displayName: "Claude Opus 4.7"),
-                ],
-                defaultModel: "claude-sonnet-4-6",
-                apiKeyUrl: nil,
-                apiKeyPlaceholder: "sk-ant-..."
-            ),
-            ProviderCatalogEntry(
-                id: "openai",
-                displayName: "OpenAI",
-                models: [
-                    CatalogModel(id: "gpt-5", displayName: "GPT-5"),
-                ],
-                defaultModel: "gpt-5",
-                apiKeyUrl: nil,
-                apiKeyPlaceholder: "sk-..."
-            ),
-        ]
         // Seed three built-in profiles so the Active Profile dropdown has
-        // real options in tests.
+        // real options in tests. Inlined rather than reusing
+        // `SettingsTestFixture.builtInProfilesPayload` because the card's
+        // dropdown only reads provider+model — the detailed fragment
+        // (maxTokens/effort/thinking) doesn't affect this surface.
         store.loadInferenceProfiles(config: [
             "llm": [
                 "activeProfile": "balanced",

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -16,9 +16,9 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockSettingsClient = MockSettingsClient()
-        mockSettingsClient.patchConfigResponse = true
-        store = SettingsStore(settingsClient: mockSettingsClient)
+        let fixture = SettingsTestFixture.make()
+        store = fixture.store
+        mockSettingsClient = fixture.mockClient
     }
 
     override func tearDown() {

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsTestFixture.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsTestFixture.swift
@@ -1,0 +1,106 @@
+import Foundation
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Shared scaffolding for the inference-profile test suites. The four
+/// `InferenceProfile*Tests` and `SettingsStoreInferenceProfilesTests`
+/// each rebuilt the same `MockSettingsClient` + `SettingsStore` +
+/// provider-catalog literal in their `setUp`. This factory bundles those
+/// pieces so individual tests only override what they care about.
+@MainActor
+enum SettingsTestFixture {
+
+    /// Builds a `(store, mockClient)` pair with `patchConfigResponse = true`.
+    /// Optionally installs a provider catalog.
+    static func make(
+        providerCatalog: [ProviderCatalogEntry]? = nil
+    ) -> (store: SettingsStore, mockClient: MockSettingsClient) {
+        let mockClient = MockSettingsClient()
+        mockClient.patchConfigResponse = true
+        let store = SettingsStore(settingsClient: mockClient)
+        if let providerCatalog {
+            store.providerCatalog = providerCatalog
+        }
+        return (store, mockClient)
+    }
+
+    // MARK: - Provider catalog fixtures
+
+    /// Anthropic + OpenAI with `claude-sonnet-4-6`, `claude-opus-4-7`, and
+    /// `gpt-5`. Used by the editor and inference-card tests.
+    static func anthropicAndOpenAICatalog(
+        anthropicApiKeyPlaceholder: String? = nil,
+        openaiApiKeyPlaceholder: String? = nil
+    ) -> [ProviderCatalogEntry] {
+        [
+            ProviderCatalogEntry(
+                id: "anthropic",
+                displayName: "Anthropic",
+                models: [
+                    CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
+                    CatalogModel(id: "claude-opus-4-7", displayName: "Claude Opus 4.7"),
+                ],
+                defaultModel: "claude-sonnet-4-6",
+                apiKeyUrl: nil,
+                apiKeyPlaceholder: anthropicApiKeyPlaceholder
+            ),
+            ProviderCatalogEntry(
+                id: "openai",
+                displayName: "OpenAI",
+                models: [
+                    CatalogModel(id: "gpt-5", displayName: "GPT-5"),
+                ],
+                defaultModel: "gpt-5",
+                apiKeyUrl: nil,
+                apiKeyPlaceholder: openaiApiKeyPlaceholder
+            ),
+        ]
+    }
+
+    /// Anthropic-only catalog with sonnet 4.6, opus 4.7, and haiku 4.5.
+    /// Used by the sheet tests, which need a haiku entry for the
+    /// cost-optimized built-in profile's display name lookup.
+    static let anthropicWithHaikuCatalog: [ProviderCatalogEntry] = [
+        ProviderCatalogEntry(
+            id: "anthropic",
+            displayName: "Anthropic",
+            models: [
+                CatalogModel(id: "claude-opus-4-7", displayName: "Claude Opus 4.7"),
+                CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
+                CatalogModel(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),
+            ],
+            defaultModel: "claude-sonnet-4-6",
+            apiKeyUrl: nil,
+            apiKeyPlaceholder: nil
+        ),
+    ]
+
+    // MARK: - Built-in profile payloads
+
+    /// Mirrors the daemon's migration-052 seed: the three canonical
+    /// built-in inference profiles (quality-optimized, balanced,
+    /// cost-optimized).
+    static let builtInProfilesPayload: [String: Any] = [
+        "quality-optimized": [
+            "provider": "anthropic",
+            "model": "claude-opus-4-7",
+            "maxTokens": 32000,
+            "effort": "max",
+            "thinking": ["enabled": true, "streamThinking": true],
+        ],
+        "balanced": [
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "maxTokens": 16000,
+            "effort": "high",
+            "thinking": ["enabled": true, "streamThinking": true],
+        ],
+        "cost-optimized": [
+            "provider": "anthropic",
+            "model": "claude-haiku-4-5-20251001",
+            "maxTokens": 8192,
+            "effort": "low",
+            "thinking": ["enabled": false, "streamThinking": false],
+        ],
+    ]
+}


### PR DESCRIPTION
## Summary
Extract a shared `SettingsTestFixture` for the four inference-profile test suites that each rebuilt the same `MockSettingsClient` + `SettingsStore` + provider-catalog scaffolding (~100 lines of duplication). Tests parameterize what they need; the fixture provides defaults.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
