### PR TITLE
chore(macos): polish InferenceProfile type and rename UX

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
@@ -15,7 +15,14 @@ import Foundation
 /// layer untouched — the JSON mapper preserves only the fields it knows
 /// about, but `SettingsStore.patchConfig` merges into the live config so
 /// unknown keys are not clobbered.
-public struct InferenceProfile: Equatable, Hashable, Identifiable {
+///
+/// Conformance is intentionally limited to `Hashable` and `Identifiable`.
+/// `Codable` is *not* on the list because the wire shape is bespoke (the
+/// daemon emits a nested `thinking` sub-object) and synthesized Codable
+/// would emit the two `thinking*` properties as flat keys, which the
+/// daemon would reject. JSON round-trips go through the manual
+/// `init(name:json:)` / `toJSON()` pair below.
+public struct InferenceProfile: Hashable, Identifiable {
     /// Profile name; doubles as the key under `llm.profiles` and the
     /// stable `id` for `Identifiable` conformance.
     public var name: String
@@ -26,7 +33,17 @@ public struct InferenceProfile: Equatable, Hashable, Identifiable {
     public var effort: String?
     public var speed: String?
     public var verbosity: String?
-    public var temperature: Double?
+
+    /// Three-state temperature so JSON round-trips preserve the daemon's
+    /// `null` vs absent distinction. The resolver's `deepMerge` skips
+    /// `undefined` (absent) but treats `null` as a value that overrides
+    /// the previous layer — see `assistant/src/config/llm-resolver.ts`,
+    /// which has `if (value === undefined) continue;` and no analogous
+    /// short-circuit for `null`. `LLMConfigBase.temperature` is
+    /// `z.number().min(0).max(2).nullable()` and defaults to `null`, so
+    /// an explicit `null` in a fragment carries semantic weight: it
+    /// erases any non-null value layered below.
+    public var temperature: TemperatureValue
 
     /// Maps to `thinking.enabled` in the fragment JSON.
     public var thinkingEnabled: Bool?
@@ -44,7 +61,7 @@ public struct InferenceProfile: Equatable, Hashable, Identifiable {
         effort: String? = nil,
         speed: String? = nil,
         verbosity: String? = nil,
-        temperature: Double? = nil,
+        temperature: TemperatureValue = .unset,
         thinkingEnabled: Bool? = nil,
         thinkingStreamThinking: Bool? = nil
     ) {
@@ -60,10 +77,41 @@ public struct InferenceProfile: Equatable, Hashable, Identifiable {
         self.thinkingStreamThinking = thinkingStreamThinking
     }
 
+    /// Convenience overload that accepts an `Optional<Double>`. `nil`
+    /// maps to `.unset` (the field is absent from the fragment). To
+    /// produce an explicit `null`, pass `.explicitNull` directly.
+    public init(
+        name: String,
+        provider: String? = nil,
+        model: String? = nil,
+        maxTokens: Int? = nil,
+        effort: String? = nil,
+        speed: String? = nil,
+        verbosity: String? = nil,
+        temperature: Double?,
+        thinkingEnabled: Bool? = nil,
+        thinkingStreamThinking: Bool? = nil
+    ) {
+        self.init(
+            name: name,
+            provider: provider,
+            model: model,
+            maxTokens: maxTokens,
+            effort: effort,
+            speed: speed,
+            verbosity: verbosity,
+            temperature: TemperatureValue(value: temperature),
+            thinkingEnabled: thinkingEnabled,
+            thinkingStreamThinking: thinkingStreamThinking
+        )
+    }
+
     /// Decodes a fragment JSON dictionary as produced by the daemon's
     /// config sync. Unknown keys are ignored. Empty strings are treated
     /// as nil so the round-trip stays symmetric with `toJSON()`, which
-    /// omits nil keys entirely.
+    /// omits nil keys entirely. `temperature: null` round-trips as
+    /// `.explicitNull` so the daemon's "clear back to default" semantics
+    /// survive a save.
     public init(name: String, json: [String: Any]) {
         self.name = name
         self.provider = (json["provider"] as? String).flatMap { $0.isEmpty ? nil : $0 }
@@ -72,7 +120,7 @@ public struct InferenceProfile: Equatable, Hashable, Identifiable {
         self.effort = (json["effort"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         self.speed = (json["speed"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         self.verbosity = (json["verbosity"] as? String).flatMap { $0.isEmpty ? nil : $0 }
-        self.temperature = json["temperature"] as? Double
+        self.temperature = TemperatureValue(jsonValue: json["temperature"], present: json.keys.contains("temperature"))
         let thinking = json["thinking"] as? [String: Any]
         self.thinkingEnabled = thinking?["enabled"] as? Bool
         self.thinkingStreamThinking = thinking?["streamThinking"] as? Bool
@@ -90,7 +138,8 @@ public struct InferenceProfile: Equatable, Hashable, Identifiable {
         if let v = fragment.effort { merged.effort = v }
         if let v = fragment.speed { merged.speed = v }
         if let v = fragment.verbosity { merged.verbosity = v }
-        if let v = fragment.temperature { merged.temperature = v }
+        // `.unset` means "no opinion" — any other state overrides.
+        if fragment.temperature != .unset { merged.temperature = fragment.temperature }
         if let v = fragment.thinkingEnabled { merged.thinkingEnabled = v }
         if let v = fragment.thinkingStreamThinking { merged.thinkingStreamThinking = v }
         return merged
@@ -99,7 +148,9 @@ public struct InferenceProfile: Equatable, Hashable, Identifiable {
     /// Encodes the profile as a fragment JSON dictionary suitable for
     /// `settingsClient.patchConfig`. Nil keys are omitted; the nested
     /// `thinking` dict is emitted only when at least one of its
-    /// sub-fields is set.
+    /// sub-fields is set. `temperature` emits `NSNull()` for
+    /// `.explicitNull` so the daemon receives the original wire-shape
+    /// distinction between "absent" and "null".
     public func toJSON() -> [String: Any] {
         var result: [String: Any] = [:]
         if let provider { result["provider"] = provider }
@@ -108,7 +159,14 @@ public struct InferenceProfile: Equatable, Hashable, Identifiable {
         if let effort { result["effort"] = effort }
         if let speed { result["speed"] = speed }
         if let verbosity { result["verbosity"] = verbosity }
-        if let temperature { result["temperature"] = temperature }
+        switch temperature {
+        case .unset:
+            break
+        case .explicitNull:
+            result["temperature"] = NSNull()
+        case .value(let v):
+            result["temperature"] = v
+        }
         var thinking: [String: Any] = [:]
         if let thinkingEnabled { thinking["enabled"] = thinkingEnabled }
         if let thinkingStreamThinking { thinking["streamThinking"] = thinkingStreamThinking }
@@ -119,18 +177,69 @@ public struct InferenceProfile: Equatable, Hashable, Identifiable {
     }
 }
 
-/// The three first-class profiles the daemon seeds into every workspace
-/// (see migration 052 in `assistant/src/workspace/migrations/`). The
-/// macOS UI uses this enum only to render a "Built-in" badge — deletion
-/// and editing remain allowed for these profiles.
-public enum BuiltInInferenceProfile: String, CaseIterable {
-    case qualityOptimized = "quality-optimized"
-    case balanced = "balanced"
-    case costOptimized = "cost-optimized"
+/// Three-state representation of `LLMConfigFragment.temperature`. The
+/// daemon's resolver distinguishes "absent" (let the previous layer's
+/// value pass through) from "explicit null" (override to null and clear
+/// any value layered below); see `assistant/src/config/llm-resolver.ts`
+/// and the `nullable` schema in `assistant/src/config/schemas/llm.ts`.
+public enum TemperatureValue: Hashable {
+    /// Field absent from the fragment — no opinion.
+    case unset
 
-    /// Set of built-in profile names, derived from `allCases`. Used by
-    /// the profile editor to decide whether to render the badge.
-    public static var allNames: Set<String> {
-        Set(allCases.map(\.rawValue))
+    /// Field present in the fragment with JSON `null`. Overrides any
+    /// non-null temperature layered below.
+    case explicitNull
+
+    /// Field present with a numeric value in `[0, 2]`.
+    case value(Double)
+
+    /// Convenience: map an `Optional<Double>` (the legacy shape) into
+    /// the three-state enum. `nil` maps to `.unset`. To produce
+    /// `.explicitNull`, construct the case directly.
+    public init(value: Double?) {
+        if let value {
+            self = .value(value)
+        } else {
+            self = .unset
+        }
+    }
+
+    /// Decodes the temperature leaf from a JSON dictionary entry.
+    /// `present` indicates whether the dictionary contained the
+    /// `temperature` key at all — JSON `null` decodes to `NSNull` in
+    /// `[String: Any]`, which fails the `Double` cast, so we need the
+    /// presence flag to distinguish "key absent" from "key set to null".
+    public init(jsonValue: Any?, present: Bool) {
+        if !present {
+            self = .unset
+        } else if let number = jsonValue as? Double {
+            self = .value(number)
+        } else if let int = jsonValue as? Int {
+            self = .value(Double(int))
+        } else {
+            // Present but not a number — either explicit `NSNull` or an
+            // unexpected shape. Treat both as `.explicitNull`; the
+            // daemon's schema accepts only `null` or a number, so a
+            // non-number is the only other valid daemon-emitted shape.
+            self = .explicitNull
+        }
+    }
+
+    /// The numeric value, if any. Returns `nil` for both `.unset` and
+    /// `.explicitNull` — callers that need to distinguish them should
+    /// switch on the enum directly.
+    public var doubleValue: Double? {
+        if case .value(let v) = self { return v }
+        return nil
     }
 }
+
+/// The three first-class profile names the daemon seeds into every
+/// workspace (see migration 052 in `assistant/src/workspace/migrations/`).
+/// The macOS UI uses this set only to render a "Built-in" badge —
+/// deletion and editing remain allowed for these profiles.
+public let builtInInferenceProfileNames: Set<String> = [
+    "quality-optimized",
+    "balanced",
+    "cost-optimized",
+]

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -108,7 +108,7 @@ struct InferenceProfileEditor: View {
                 Text("Edit Inference Profile")
                     .font(VFont.titleSmall)
                     .foregroundStyle(VColor.contentDefault)
-                if BuiltInInferenceProfile.allNames.contains(profile.name) {
+                if builtInInferenceProfileNames.contains(profile.name) {
                     Text("Built-in profile")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(.secondary)
@@ -280,12 +280,13 @@ struct InferenceProfileEditor: View {
     }
 
     private var temperatureField: some View {
-        labeled(
+        let currentValue = profile.temperature.doubleValue
+        return labeled(
             "Temperature",
             spacing: VSpacing.sm,
             accessory: {
                 Spacer(minLength: 0)
-                Text(profile.temperature.map { String(format: "%.2f", $0) } ?? "—")
+                Text(currentValue.map { String(format: "%.2f", $0) } ?? "—")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }
@@ -293,20 +294,25 @@ struct InferenceProfileEditor: View {
             HStack(spacing: VSpacing.md) {
                 VSlider(
                     value: Binding(
-                        get: { profile.temperature ?? 0.7 },
-                        set: { profile.temperature = $0 }
+                        get: { profile.temperature.doubleValue ?? 0.7 },
+                        set: { profile.temperature = .value($0) }
                     ),
                     range: 0...2,
                     step: 0.05
                 )
-                .disabled(profile.temperature == nil)
+                .disabled(currentValue == nil)
                 VToggle(
                     isOn: Binding(
-                        get: { profile.temperature != nil },
+                        get: { profile.temperature.doubleValue != nil },
                         set: { newValue in
                             // OFF: clear so the resolver falls back to the
                             // model-default temperature instead of pinning 0.7.
-                            profile.temperature = newValue ? 0.7 : nil
+                            // Maps to `.unset` rather than `.explicitNull` —
+                            // the editor doesn't surface the explicit-null
+                            // distinction; daemon-emitted explicit-null
+                            // values still round-trip through the JSON
+                            // mapper untouched.
+                            profile.temperature = newValue ? .value(0.7) : .unset
                         }
                     ),
                     label: "Set"

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
@@ -194,7 +194,7 @@ struct InferenceProfilesSheet: View {
                     Text(profile.name)
                         .font(VFont.bodyMediumEmphasised)
                         .foregroundStyle(VColor.contentDefault)
-                    if BuiltInInferenceProfile.allNames.contains(profile.name) {
+                    if builtInInferenceProfileNames.contains(profile.name) {
                         VBadge(label: "Built-in", tone: .neutral, emphasis: .subtle)
                     }
                 }

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileTests.swift
@@ -26,7 +26,7 @@ final class InferenceProfileTests: XCTestCase {
         XCTAssertNil(profile.effort)
         XCTAssertNil(profile.speed)
         XCTAssertNil(profile.verbosity)
-        XCTAssertNil(profile.temperature)
+        XCTAssertEqual(profile.temperature, .unset)
         XCTAssertNil(profile.thinkingEnabled)
         XCTAssertNil(profile.thinkingStreamThinking)
     }
@@ -153,19 +153,74 @@ final class InferenceProfileTests: XCTestCase {
         XCTAssertEqual(profile.id, "balanced")
     }
 
-    // MARK: - BuiltInInferenceProfile
+    // MARK: - Built-in profile names
 
-    func testBuiltInProfileNames() {
-        XCTAssertEqual(BuiltInInferenceProfile.qualityOptimized.rawValue, "quality-optimized")
-        XCTAssertEqual(BuiltInInferenceProfile.balanced.rawValue, "balanced")
-        XCTAssertEqual(BuiltInInferenceProfile.costOptimized.rawValue, "cost-optimized")
-    }
-
-    func testBuiltInAllNamesContainsEveryCase() {
+    func testBuiltInProfileNamesIsExactlyTheMigrationSeededTrio() {
         XCTAssertEqual(
-            BuiltInInferenceProfile.allNames,
+            builtInInferenceProfileNames,
             ["quality-optimized", "balanced", "cost-optimized"]
         )
-        XCTAssertEqual(BuiltInInferenceProfile.allNames.count, BuiltInInferenceProfile.allCases.count)
+    }
+
+    // MARK: - Temperature: explicit null vs unset
+
+    /// `null` and "absent" are NOT semantically equivalent in the daemon's
+    /// resolver. `assistant/src/config/llm-resolver.ts` deepMerge does
+    /// `if (value === undefined) continue;` — `null` is *not* skipped, so
+    /// a profile fragment with `temperature: null` overrides any non-null
+    /// value layered below. The Swift mapper must preserve the distinction.
+    func testExplicitNullTemperatureSurvivesRoundTrip() {
+        let json: [String: Any] = ["temperature": NSNull()]
+        let decoded = InferenceProfile(name: "explicit-null", json: json)
+        XCTAssertEqual(decoded.temperature, .explicitNull)
+
+        let reEncoded = decoded.toJSON()
+        XCTAssertTrue(
+            reEncoded["temperature"] is NSNull,
+            "Explicit null must round-trip as NSNull, not be omitted"
+        )
+    }
+
+    func testAbsentTemperatureRoundTripsAsUnset() {
+        let json: [String: Any] = [:]
+        let decoded = InferenceProfile(name: "absent", json: json)
+        XCTAssertEqual(decoded.temperature, .unset)
+
+        let reEncoded = decoded.toJSON()
+        XCTAssertNil(
+            reEncoded["temperature"],
+            "Unset temperature must remain absent on re-encode"
+        )
+    }
+
+    func testTemperatureValueRoundTripsAsValue() {
+        let json: [String: Any] = ["temperature": 0.42]
+        let decoded = InferenceProfile(name: "warm", json: json)
+        XCTAssertEqual(decoded.temperature, .value(0.42))
+
+        let reEncoded = decoded.toJSON()
+        XCTAssertEqual(reEncoded["temperature"] as? Double, 0.42)
+    }
+
+    /// The convenience `Optional<Double>` initializer maps `nil` to
+    /// `.unset` so existing call sites that constructed profiles with
+    /// `temperature: nil` keep producing fragments where the field is
+    /// absent (the previous behavior).
+    func testOptionalDoubleInitializerMapsNilToUnset() {
+        let profile = InferenceProfile(
+            name: "legacy",
+            temperature: Double?.none
+        )
+        XCTAssertEqual(profile.temperature, .unset)
+        XCTAssertNil(profile.toJSON()["temperature"])
+    }
+
+    func testOptionalDoubleInitializerMapsValueToValue() {
+        let profile = InferenceProfile(
+            name: "legacy-set",
+            temperature: 0.7
+        )
+        XCTAssertEqual(profile.temperature, .value(0.7))
+        XCTAssertEqual(profile.toJSON()["temperature"] as? Double, 0.7)
     }
 }

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfilesSheetTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfilesSheetTests.swift
@@ -75,8 +75,8 @@ final class InferenceProfilesSheetTests: XCTestCase {
 
     // MARK: - Built-in detection
 
-    /// The badge wiring uses `BuiltInInferenceProfile.allNames.contains`,
-    /// so the row's badge presence should match the enum exactly.
+    /// The badge wiring uses `builtInInferenceProfileNames.contains`, so
+    /// the row's badge presence should match the constant exactly.
     func testBuiltInProfilesShowBadgeAndCustomDoesNot() {
         seedBuiltInsAndCustom(includeCustom: true)
         XCTAssertEqual(store.profiles.count, 4)
@@ -87,17 +87,17 @@ final class InferenceProfilesSheetTests: XCTestCase {
         XCTAssertTrue(names.contains("cost-optimized"))
         XCTAssertTrue(names.contains("experimental"))
 
-        // The badge predicate is defined on the static enum so the row
-        // can stay declarative. Verify it directly here so the contract
-        // doesn't drift.
+        // The badge predicate is defined as a top-level constant so the
+        // row can stay declarative. Verify it directly here so the
+        // contract doesn't drift.
         for name in ["quality-optimized", "balanced", "cost-optimized"] {
             XCTAssertTrue(
-                BuiltInInferenceProfile.allNames.contains(name),
+                builtInInferenceProfileNames.contains(name),
                 "\(name) must render with a Built-in badge"
             )
         }
         XCTAssertFalse(
-            BuiltInInferenceProfile.allNames.contains("experimental"),
+            builtInInferenceProfileNames.contains("experimental"),
             "Custom profiles must not render the Built-in badge"
         )
     }
@@ -294,6 +294,95 @@ final class InferenceProfilesSheetTests: XCTestCase {
         // `cost-optimized` and before `quality-optimized`.
         let names = store.profiles.map(\.name)
         XCTAssertEqual(names, names.sorted(), "Profiles list must remain alphabetically sorted")
+    }
+
+    // MARK: - Rename flow
+
+    /// Renaming the active profile must atomically migrate the
+    /// `activeProfile` pointer and any callsite overrides onto the new
+    /// name BEFORE deleting the old key, so the rename never leaves a
+    /// stale dangling reference. Mirrors the orchestration in
+    /// `commitEditor` — exercised here at the store level.
+    func testRenameActiveProfileMigratesActivePointerAndDropsOldKey() async {
+        seedBuiltInsAndCustom()
+        XCTAssertEqual(store.activeProfile, "balanced")
+
+        // Step 1: write the new key with the migrated draft.
+        let renamed = InferenceProfile(
+            name: "balanced-renamed",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            maxTokens: 16000,
+            effort: "high"
+        )
+        let setSuccess = await store.setProfile(name: "balanced-renamed", fragment: renamed)
+        XCTAssertTrue(setSuccess)
+
+        // Step 2: re-target the active pointer.
+        let activeSuccess = await store.setActiveProfile("balanced-renamed")
+        XCTAssertTrue(activeSuccess)
+
+        // Step 3: drop the old key. After re-targeting, this must
+        // succeed (no `.blockedByActive`).
+        let result = await store.deleteProfile(name: "balanced")
+        XCTAssertEqual(result, .deleted)
+
+        XCTAssertEqual(store.activeProfile, "balanced-renamed")
+        XCTAssertFalse(store.profiles.contains(where: { $0.name == "balanced" }))
+        XCTAssertTrue(store.profiles.contains(where: { $0.name == "balanced-renamed" }))
+    }
+
+    /// Renaming a profile referenced by call sites must re-target every
+    /// override to the new name BEFORE deleting the source.
+    func testRenameProfileReferencedByCallSitesMigratesOverridesAndDropsOldKey() async {
+        seedBuiltInsAndCustom(includeCustom: true)
+        store.loadCallSiteOverrides(config: [
+            "llm": [
+                "callSites": [
+                    "mainAgent": ["profile": "experimental"],
+                    "memoryRetrieval": ["profile": "experimental"],
+                ]
+            ]
+        ])
+        // Sanity: the source profile is referenced by two call sites.
+        let referencedIds = store.callSiteOverrides
+            .filter { $0.profile == "experimental" }
+            .map(\.id)
+        XCTAssertEqual(Set(referencedIds), ["mainAgent", "memoryRetrieval"])
+
+        // Step 1: write the new key.
+        let renamed = InferenceProfile(
+            name: "experimental-renamed",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6"
+        )
+        let setSuccess = await store.setProfile(name: "experimental-renamed", fragment: renamed)
+        XCTAssertTrue(setSuccess)
+
+        // Step 2: re-target every conflicting override onto the new name.
+        for override in store.callSiteOverrides where override.profile == "experimental" {
+            let task = store.replaceCallSiteOverride(
+                override.id,
+                provider: override.provider,
+                model: override.model,
+                profile: "experimental-renamed"
+            )
+            let replaceSuccess = await task.value
+            XCTAssertTrue(replaceSuccess)
+        }
+
+        // Step 3: delete the old key. Must succeed (no `.blockedByCallSites`).
+        let result = await store.deleteProfile(name: "experimental")
+        XCTAssertEqual(result, .deleted)
+
+        // Every override now points at the new name; none reference the
+        // dropped one.
+        let stillReferencingOld = store.callSiteOverrides.filter { $0.profile == "experimental" }
+        XCTAssertTrue(stillReferencingOld.isEmpty)
+        let referencingNew = store.callSiteOverrides
+            .filter { $0.profile == "experimental-renamed" }
+            .map(\.id)
+        XCTAssertEqual(Set(referencingNew), ["mainAgent", "memoryRetrieval"])
     }
 
     /// The "+ New profile" toolbar action seeds a draft with the default


### PR DESCRIPTION
## Summary
Bundles three Swift polish fixes from inference-profiles plan re-review (Gap 4 already shipped in #28100, retained as additional store-level test coverage):
- Replace `BuiltInInferenceProfile` enum with a `Set<String>` constant.
- Drop unused `Codable`/`Equatable` conformance from `InferenceProfile` (`Hashable` already implies `Equatable`).
- Preserve daemon-side `temperature: null` vs absent distinction with a 3-state `TemperatureValue` enum (`unset`/`explicitNull`/`value`); the resolver's `deepMerge` skips `undefined` but treats `null` as an override, so the round-trip must preserve which one the daemon sent.
- Adds two `InferenceProfilesSheetTests` cases covering the rename re-target invariants the rename UX depends on (orthogonal to #28100's sheet-level error surface).