### PR TITLE
test(skill-routes): align proxy-execute test with current error message

### DIFF
--- a/assistant/src/ipc/skill-routes/__tests__/registries.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/registries.test.ts
@@ -77,7 +77,7 @@ describe("host.registries.register_tools", () => {
     expect(installed!.executionMode).toBe("proxy");
   });
 
-  test("proxy execute throws not-implemented until PR 28 dispatch lands", async () => {
+  test("proxy execute throws when no supervisor is attached", async () => {
     await registerToolsRoute.handler({
       tools: [
         {
@@ -102,7 +102,7 @@ describe("host.registries.register_tools", () => {
           trustClass: "guardian",
         },
       ),
-    ).rejects.toThrow(/not implemented.*PR 28/i);
+    ).rejects.toThrow(/requires an attached MeetHostSupervisor/i);
   });
 
   test("rejects empty tool list", async () => {


### PR DESCRIPTION
## Summary
- Updates the assertion in `registries.test.ts` for the no-supervisor fallback path: the error message changed from "not implemented — dispatch added in PR 28" to "requires an attached MeetHostSupervisor" in #28027, but the test regex still expected the old string.
- Renames the test to reflect what it actually exercises now (the no-supervisor fallback throw), since "PR 28 dispatch lands" is stale.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24926935149/job/72998345592
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
