### PR TITLE
feat(workspace): release notes migration for ACP Codex + steer

### DIFF
--- a/assistant/src/__tests__/workspace-migration-053-release-notes-acp-codex.test.ts
+++ b/assistant/src/__tests__/workspace-migration-053-release-notes-acp-codex.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for workspace migration `053-release-notes-acp-codex`.
+ *
+ * Pins the four idempotency paths covered by the in-file HTML marker logic
+ * the migration uses to guard against duplicate appends (crash between
+ * `appendFileSync` and the runner's checkpoint promotion, or hand-edits to
+ * UPDATES.md after a partial prior run):
+ *
+ *   (a) Empty workspace — UPDATES.md is created with the marker + body.
+ *   (b) Existing UPDATES.md without the marker — append with one blank line
+ *       between prior content and the new note.
+ *   (c) Existing UPDATES.md with the marker already present — byte-identical
+ *       re-run (asserted twice).
+ *   (d) Existing UPDATES.md ending with `\n` vs `\n\n` — both produce exactly
+ *       one blank line between old and new content (no triple-newline, no
+ *       missing separator).
+ */
+
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { releaseNotesAcpCodexMigration } from "../workspace/migrations/053-release-notes-acp-codex.js";
+
+const MIGRATION_ID = "053-release-notes-acp-codex";
+const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
+
+let testRoot: string;
+let workspaceDir: string;
+
+beforeAll(() => {
+  testRoot = mkdtempSync(join(tmpdir(), "migration-053-test-"));
+});
+
+afterAll(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(testRoot, "ws-"));
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+function updatesPath(): string {
+  return join(workspaceDir, "UPDATES.md");
+}
+
+describe("workspace migration 053-release-notes-acp-codex", () => {
+  test("has the correct id and description", () => {
+    expect(releaseNotesAcpCodexMigration.id).toBe(MIGRATION_ID);
+    expect(releaseNotesAcpCodexMigration.description).toContain("ACP");
+  });
+
+  // ─── (a) Empty workspace ──────────────────────────────────────────
+
+  test("creates UPDATES.md with marker and key copy when file is absent", () => {
+    expect(existsSync(updatesPath())).toBe(false);
+
+    releaseNotesAcpCodexMigration.run(workspaceDir);
+
+    expect(existsSync(updatesPath())).toBe(true);
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content).toContain(MARKER);
+    expect(content).toContain("ACP");
+    expect(content).toContain("`claude`");
+    expect(content).toContain("`codex`");
+    expect(content).toContain("acp_steer");
+    expect(content).toContain("acp.enabled");
+    expect(content).toContain("@zed-industries/codex-acp");
+    expect(content).toContain("@agentclientprotocol/claude-agent-acp");
+    // First-time write has no leading separator — starts directly with the marker.
+    expect(content.startsWith(MARKER)).toBe(true);
+  });
+
+  // ─── (b) Existing UPDATES.md without the marker ───────────────────
+
+  test("appends to existing UPDATES.md when marker is absent, preserving prior content with one blank line between blocks", () => {
+    const priorContent =
+      "## Earlier note\n\nSomething the assistant wrote before.\n";
+    writeFileSync(updatesPath(), priorContent, "utf-8");
+
+    releaseNotesAcpCodexMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    // Prior content preserved.
+    expect(content.startsWith(priorContent)).toBe(true);
+    // Marker present once.
+    expect(content.split(MARKER).length - 1).toBe(1);
+    // Exactly one blank line between old and new content: prior ends with
+    // `\n`, so we expect a single `\n` separator added, producing `\n\n`
+    // (one blank line) immediately before the marker.
+    expect(content).toBe(
+      `${priorContent}\n${content.slice(priorContent.length + 1)}`,
+    );
+    // The appended block starts at the marker.
+    expect(content.slice(priorContent.length)).toMatch(
+      /^\n<!-- release-note-id:/,
+    );
+    // No triple-newline (would indicate a stray blank line).
+    expect(content).not.toContain("\n\n\n");
+  });
+
+  // ─── (c) Existing UPDATES.md with marker — byte-identical re-run ──
+
+  test("is a no-op when marker is already present, byte-identical across two runs", () => {
+    // Seed with a file that already contains the marker (prior successful run).
+    const seeded = `## Something pre-existing\n\n${MARKER}\n## ACP defaults\n\nBody.\n`;
+    writeFileSync(updatesPath(), seeded, "utf-8");
+
+    const before = readFileSync(updatesPath(), "utf-8");
+
+    releaseNotesAcpCodexMigration.run(workspaceDir);
+    const afterFirst = readFileSync(updatesPath(), "utf-8");
+    expect(afterFirst).toBe(before);
+
+    releaseNotesAcpCodexMigration.run(workspaceDir);
+    const afterSecond = readFileSync(updatesPath(), "utf-8");
+    expect(afterSecond).toBe(before);
+
+    // Marker still appears exactly once.
+    expect(afterSecond.split(MARKER).length - 1).toBe(1);
+  });
+
+  // ─── Re-append after marker is missing (user deleted UPDATES.md) ─
+
+  test("re-appends when UPDATES.md was deleted between runs", () => {
+    releaseNotesAcpCodexMigration.run(workspaceDir);
+    expect(existsSync(updatesPath())).toBe(true);
+
+    // User (or the agent) processed and deleted UPDATES.md.
+    rmSync(updatesPath());
+    expect(existsSync(updatesPath())).toBe(false);
+
+    // Re-running should re-create the file with the note.
+    releaseNotesAcpCodexMigration.run(workspaceDir);
+    expect(existsSync(updatesPath())).toBe(true);
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content).toContain(MARKER);
+    expect(content.startsWith(MARKER)).toBe(true);
+  });
+
+  // ─── (d) Trailing-newline variations ──────────────────────────────
+
+  test("existing UPDATES.md ending with a single trailing newline produces exactly one blank line separator", () => {
+    const prior = "## Prior\n\nBody line.\n"; // ends with exactly one `\n`
+    expect(prior.endsWith("\n")).toBe(true);
+    expect(prior.endsWith("\n\n")).toBe(false);
+    writeFileSync(updatesPath(), prior, "utf-8");
+
+    releaseNotesAcpCodexMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    // Prior preserved verbatim at the start.
+    expect(content.startsWith(prior)).toBe(true);
+    // Exactly one blank line (i.e. `\n\n`) between prior content's final
+    // character (which is `\n`) and the marker. So the bytes immediately
+    // after `prior` must begin with `\n<!-- release-note-id:` — the extra
+    // `\n` combined with prior's trailing `\n` yields a single blank line.
+    expect(content.slice(prior.length)).toMatch(/^\n<!-- release-note-id:/);
+    // No triple-newline anywhere.
+    expect(content).not.toContain("\n\n\n");
+  });
+
+  test("existing UPDATES.md ending with two trailing newlines produces exactly one blank line separator (no extra padding)", () => {
+    const prior = "## Prior\n\nBody line.\n\n"; // ends with `\n\n`
+    expect(prior.endsWith("\n\n")).toBe(true);
+    writeFileSync(updatesPath(), prior, "utf-8");
+
+    releaseNotesAcpCodexMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    // Prior preserved verbatim.
+    expect(content.startsWith(prior)).toBe(true);
+    // Prior already ends with a blank line; the migration should append the
+    // marker directly with no additional separator. The bytes immediately
+    // after `prior` must begin with the marker itself.
+    expect(content.slice(prior.length).startsWith(MARKER)).toBe(true);
+    // No triple-newline anywhere.
+    expect(content).not.toContain("\n\n\n");
+  });
+
+  test("existing UPDATES.md with no trailing newline produces exactly one blank line separator", () => {
+    const prior = "## Prior\n\nBody line."; // no trailing newline
+    expect(prior.endsWith("\n")).toBe(false);
+    writeFileSync(updatesPath(), prior, "utf-8");
+
+    releaseNotesAcpCodexMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content.startsWith(prior)).toBe(true);
+    // Separator must be `\n\n` (blank line) before the marker since there
+    // was no trailing newline at all.
+    expect(content.slice(prior.length)).toMatch(/^\n\n<!-- release-note-id:/);
+    expect(content).not.toContain("\n\n\n");
+  });
+
+  // ─── down() is a no-op ────────────────────────────────────────────
+
+  test("down() is a no-op and does not throw", () => {
+    writeFileSync(updatesPath(), `${MARKER}\nBody.\n`, "utf-8");
+    const before = readFileSync(updatesPath(), "utf-8");
+
+    releaseNotesAcpCodexMigration.down(workspaceDir);
+
+    expect(readFileSync(updatesPath(), "utf-8")).toBe(before);
+  });
+});

--- a/assistant/src/workspace/migrations/053-release-notes-acp-codex.ts
+++ b/assistant/src/workspace/migrations/053-release-notes-acp-codex.ts
@@ -1,0 +1,107 @@
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migration-053-release-notes-acp-codex");
+
+const MIGRATION_ID = "053-release-notes-acp-codex";
+const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
+
+const RELEASE_NOTE = `${MARKER}
+## ACP: Codex and Claude profiles + \`acp_steer\`
+
+The assistant now ships with default ACP profiles for \`claude\` and
+\`codex\`. They become available **after enabling ACP and installing the
+corresponding adapter** — the profiles are wired in by default but the
+underlying agent binaries are not bundled.
+
+A new \`acp_steer\` tool lets the assistant interrupt and redirect a
+running ACP session without ending it, so I can course-correct an agent
+mid-task.
+
+### Setup
+
+1. Enable ACP in your config:
+
+   \`\`\`bash
+   assistant config set acp.enabled true
+   \`\`\`
+
+2. Install the adapter for whichever agent(s) you want to use:
+
+   \`\`\`bash
+   npm i -g @zed-industries/codex-acp
+   npm i -g @agentclientprotocol/claude-agent-acp
+   \`\`\`
+
+If a required binary is missing when I try to spawn an ACP session, I'll
+surface an install hint so you know which package to add.
+
+### Known limitation (v1)
+
+Live step-by-step progress for ACP sessions is not yet rendered in the
+macOS app. The agent's final response lands in chat when it completes —
+intermediate tool calls and partial output are still being plumbed
+through. Live progress UI is a follow-up.
+`;
+
+/**
+ * Release-notes migration for the ACP Codex/Claude defaults + \`acp_steer\`.
+ *
+ * Per AGENTS.md § Release Update Hygiene, user-facing changes ship notes via a
+ * workspace migration that appends to `<workspace>/UPDATES.md`. The in-file
+ * HTML marker guards against duplicate appends if the runner re-executes this
+ * migration after a mid-run crash (between `appendFileSync` and the runner's
+ * checkpoint promotion to `applied`), which the runner's own checkpoint state
+ * does not cover on its own.
+ */
+export const releaseNotesAcpCodexMigration: WorkspaceMigration = {
+  id: MIGRATION_ID,
+  description:
+    "Append release notes for ACP Codex/Claude defaults and acp_steer to UPDATES.md",
+
+  run(workspaceDir: string): void {
+    const updatesPath = join(workspaceDir, "UPDATES.md");
+
+    try {
+      if (existsSync(updatesPath)) {
+        const existing = readFileSync(updatesPath, "utf-8");
+        if (existing.includes(MARKER)) {
+          // Marker already present — a prior run of this migration appended
+          // the note. Short-circuit to keep the migration idempotent across
+          // the narrow crash window between append and runner checkpoint.
+          return;
+        }
+        // Ensure separation from prior content.
+        const needsLeadingNewline = !existing.endsWith("\n\n");
+        const prefix = existing.endsWith("\n") ? "\n" : "\n\n";
+        appendFileSync(
+          updatesPath,
+          needsLeadingNewline ? `${prefix}${RELEASE_NOTE}` : RELEASE_NOTE,
+          "utf-8",
+        );
+      } else {
+        writeFileSync(updatesPath, RELEASE_NOTE, "utf-8");
+      }
+      log.info({ path: updatesPath }, "Appended ACP Codex/Claude release note");
+    } catch (err) {
+      log.warn(
+        { err, path: updatesPath },
+        "Failed to append ACP Codex/Claude release note to UPDATES.md",
+      );
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: UPDATES.md is a user-facing bulletin the assistant
+    // processes and deletes on its own. Attempting to reverse a note that may
+    // have already been read/deleted would risk surprising user-visible state.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -50,6 +50,7 @@ import { releaseNotesDefaultSonnetMigration } from "./049-release-notes-default-
 import { seedMainAgentOpusCallsiteMigration } from "./050-seed-main-agent-opus-callsite.js";
 import { seedConversationSummarizationCallsiteMigration } from "./051-seed-conversation-summarization-callsite.js";
 import { seedDefaultInferenceProfiles052 } from "./052-seed-default-inference-profiles.js";
+import { releaseNotesAcpCodexMigration } from "./053-release-notes-acp-codex.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -111,4 +112,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   seedMainAgentOpusCallsiteMigration,
   seedConversationSummarizationCallsiteMigration,
   seedDefaultInferenceProfiles052,
+  releaseNotesAcpCodexMigration,
 ];


### PR DESCRIPTION
## Summary
- Migration 053 appends a release note about ACP defaults for `claude`/`codex`, the new `acp_steer` redirect tool, setup commands, and the v1 deferral of live UI progress.
- Idempotent: short-circuits if the in-file marker is already present.
- Tests cover fresh-append, idempotent re-run, and re-append after marker is missing.

Part of plan: acp-codex-claude.md (PR 9 of 9 — final)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
