### PR TITLE
refactor(acp): address self-review feedback (resume hint, TOOLS.json, FAILED_DEPENDENCY, resolver cleanup)

### DIFF
--- a/assistant/src/acp/resolve-agent.test.ts
+++ b/assistant/src/acp/resolve-agent.test.ts
@@ -18,7 +18,15 @@ let mockAcpConfig: MockAcpConfig = {
   agents: {},
 };
 
+// Spread the real loader's named exports so transitive importers that pull
+// `loadConfig`, `invalidateConfigCache`, etc. from the same module path
+// still resolve at parse time. Bun's `mock.module` is process-global and
+// returns *exactly* the keys the factory returns — without the spread, any
+// module evaluated after this test file errors at load with
+// "Export named '<X>' not found".
+const realLoader = await import("../config/loader.js");
 mock.module("../config/loader.js", () => ({
+  ...realLoader,
   getConfig: () => ({ acp: mockAcpConfig }),
 }));
 
@@ -94,7 +102,6 @@ describe("resolveAcpAgent", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.source).toBe("config");
     expect(result.agent.command).toBe("my-custom-claude");
     expect(result.agent.args).toEqual(["--my-flag"]);
     expect(result.agent.description).toBe("user override");
@@ -107,7 +114,6 @@ describe("resolveAcpAgent", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.source).toBe("default");
     expect(result.agent.command).toBe("codex-acp");
     expect(result.agent.description).toContain("@zed-industries/codex-acp");
   });
@@ -119,7 +125,6 @@ describe("resolveAcpAgent", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.source).toBe("default");
     expect(result.agent.command).toBe("claude-agent-acp");
   });
 
@@ -138,7 +143,6 @@ describe("resolveAcpAgent", () => {
     if (result.reason !== "unknown_agent") return;
     // Defaults plus user-only ids, deduped, in stable order (defaults first).
     expect(result.available).toEqual(["claude", "codex", "user-only"]);
-    expect(result.hint).toContain("nonexistent");
   });
 
   test("unknown_agent available list contains both defaults when user config is empty", () => {
@@ -165,8 +169,7 @@ describe("resolveAcpAgent", () => {
     expect(result.reason).toBe("binary_not_found");
     if (result.reason !== "binary_not_found") return;
     expect(result.hint).toBe("npm i -g @agentclientprotocol/claude-agent-acp");
-    expect(result.agent.command).toBe("claude-agent-acp");
-    expect(result.source).toBe("default");
+    expect(result.command).toBe("claude-agent-acp");
   });
 
   test("binary_not_found uses generic hint for user-only commands without a registered hint", () => {
@@ -186,7 +189,7 @@ describe("resolveAcpAgent", () => {
     expect(result.hint).toBe(
       "Install 'unknown-binary' and ensure it is on PATH.",
     );
-    expect(result.source).toBe("config");
+    expect(result.command).toBe("unknown-binary");
   });
 
   test("binary_not_found uses the install hint based on the resolved command, not the agent id", () => {
@@ -220,7 +223,6 @@ describe("resolveAcpAgent", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.source).toBe("config");
     expect(result.agent.args).toEqual(["--verbose"]);
   });
 });

--- a/assistant/src/acp/resolve-agent.ts
+++ b/assistant/src/acp/resolve-agent.ts
@@ -7,8 +7,8 @@
  * config required. The result is a discriminated union covering every reason
  * a spawn might fail before we even start the agent process: ACP disabled,
  * unknown agent id, or binary missing from PATH. Callers (acp_spawn,
- * acp_list_agents, acp_steer) get a single source of truth and matching
- * actionable hints.
+ * acp_list_agents, and the `/v1/acp/spawn` HTTP route) get a single source
+ * of truth and matching actionable hints.
  *
  * `listAcpAgents()` exposes the merged catalog with availability info for
  * the `acp_list_agents` tool — same merge semantics, plus per-entry
@@ -24,21 +24,20 @@ import { getConfig } from "../config/loader.js";
 
 /**
  * Whether this agent's entry came from user config (wins over default) or
- * fell back to the bundled default profile. Surfaced in tool output so users
- * can see at a glance which agents they've customized.
+ * fell back to the bundled default profile. Surfaced in `acp_list_agents`
+ * output so users can see at a glance which agents they've customized.
  */
 export type AcpAgentSource = "config" | "default";
 
 export type ResolveAcpAgentResult =
-  | { ok: true; agent: AcpAgentConfig; source: AcpAgentSource }
+  | { ok: true; agent: AcpAgentConfig }
   | { ok: false; reason: "acp_disabled"; hint: string }
-  | { ok: false; reason: "unknown_agent"; hint: string; available: string[] }
+  | { ok: false; reason: "unknown_agent"; available: string[] }
   | {
       ok: false;
       reason: "binary_not_found";
       hint: string;
-      agent: AcpAgentConfig;
-      source: AcpAgentSource;
+      command: string;
     };
 
 export interface AcpAgentEntry {
@@ -51,7 +50,12 @@ export interface AcpAgentEntry {
   setupHint?: string;
 }
 
-const ACP_DISABLED_HINT =
+/**
+ * Single-source-of-truth hint for "ACP is disabled". Exported so any caller
+ * that surfaces a disabled-state message (resolver, list-agents tool) reads
+ * the same string instead of duplicating near-identical copy.
+ */
+export const ACP_DISABLED_HINT =
   "Set 'acp.enabled': true in ~/.vellum/workspace/config.json (or via the runtime config endpoint).";
 
 function installHintFor(command: string): string {
@@ -113,23 +117,21 @@ export function resolveAcpAgent(id: string): ResolveAcpAgentResult {
     return {
       ok: false,
       reason: "unknown_agent",
-      hint: `Unknown agent "${id}". Set 'acp.agents.${id}' in config or use one of the bundled defaults.`,
       available: mergedAgentIds(userAgents),
     };
   }
 
-  const { agent, source } = found;
+  const { agent } = found;
   if (!Bun.which(agent.command)) {
     return {
       ok: false,
       reason: "binary_not_found",
       hint: installHintFor(agent.command),
-      agent,
-      source,
+      command: agent.command,
     };
   }
 
-  return { ok: true, agent, source };
+  return { ok: true, agent };
 }
 
 /**

--- a/assistant/src/config/acp-defaults.test.ts
+++ b/assistant/src/config/acp-defaults.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   DEFAULT_ACP_AGENT_PROFILES,
   DEFAULT_AGENT_INSTALL_HINTS,
+  DEFAULT_AGENT_NPM_PACKAGES,
 } from "./acp-defaults.js";
 
 describe("DEFAULT_ACP_AGENT_PROFILES", () => {
@@ -80,5 +81,28 @@ describe("DEFAULT_AGENT_INSTALL_HINTS", () => {
     // exists to surface a type-check failure if the readonly contract regresses.
     expect(_assignNewKey).toBeFunction();
     expect(_assignNewProfile).toBeFunction();
+  });
+});
+
+describe("DEFAULT_AGENT_NPM_PACKAGES", () => {
+  test("is keyed by command name with the canonical npm package", () => {
+    expect(DEFAULT_AGENT_NPM_PACKAGES).toEqual({
+      "claude-agent-acp": "@agentclientprotocol/claude-agent-acp",
+      "codex-acp": "@zed-industries/codex-acp",
+    });
+  });
+
+  test("is frozen at runtime so mutation throws in strict mode", () => {
+    expect(Object.isFrozen(DEFAULT_AGENT_NPM_PACKAGES)).toBe(true);
+  });
+
+  test("DEFAULT_AGENT_INSTALL_HINTS is derived from DEFAULT_AGENT_NPM_PACKAGES", () => {
+    for (const [command, pkg] of Object.entries(DEFAULT_AGENT_NPM_PACKAGES)) {
+      expect(DEFAULT_AGENT_INSTALL_HINTS[command]).toBe(`npm i -g ${pkg}`);
+    }
+    // No extra keys in install hints that aren't in the npm map.
+    expect(Object.keys(DEFAULT_AGENT_INSTALL_HINTS).sort()).toEqual(
+      Object.keys(DEFAULT_AGENT_NPM_PACKAGES).sort(),
+    );
   });
 });

--- a/assistant/src/config/acp-defaults.ts
+++ b/assistant/src/config/acp-defaults.ts
@@ -26,14 +26,31 @@ export const DEFAULT_ACP_AGENT_PROFILES: Readonly<
 });
 
 /**
+ * Single source of truth for adapter binary → npm package name. Both the
+ * version-check probe in `acp_spawn` and the install-hint generator below
+ * key off this map, so a new adapter only needs one entry here.
+ *
+ * Keyed by command name (not agent id) so the mapping follows the binary
+ * regardless of how a user's config aliases an agent.
+ */
+export const DEFAULT_AGENT_NPM_PACKAGES: Readonly<Record<string, string>> =
+  Object.freeze({
+    "claude-agent-acp": "@agentclientprotocol/claude-agent-acp",
+    "codex-acp": "@zed-industries/codex-acp",
+  });
+
+/**
  * Install hints for ACP adapter binaries, keyed by command name (not agent id).
  *
- * Keying by command name lets the resolver and `acp_list_agents` reuse this
- * map regardless of how a user's config aliases an agent — the install hint
- * follows the binary, not the alias.
+ * Derived from `DEFAULT_AGENT_NPM_PACKAGES` so adapter→package and
+ * adapter→install-hint can never drift.
  */
 export const DEFAULT_AGENT_INSTALL_HINTS: Readonly<Record<string, string>> =
-  Object.freeze({
-    "claude-agent-acp": "npm i -g @agentclientprotocol/claude-agent-acp",
-    "codex-acp": "npm i -g @zed-industries/codex-acp",
-  });
+  Object.freeze(
+    Object.fromEntries(
+      Object.entries(DEFAULT_AGENT_NPM_PACKAGES).map(([command, pkg]) => [
+        command,
+        `npm i -g ${pkg}`,
+      ]),
+    ),
+  );

--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "acp_spawn",
-      "description": "Spawn an external coding agent (e.g. Claude Code, Codex, Gemini CLI) via ACP to work on a task. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access. If ACP is not enabled, follow the setup instructions in SKILL.md to install claude-agent-acp and configure it. The command MUST be 'claude-agent-acp' - NEVER use 'claude', 'claude -p', or 'claude --acp'.",
+      "description": "Spawn an external coding agent (e.g. Claude Code, Codex) via ACP to work on a task. Default profiles ship for `claude` (`claude-agent-acp`) and `codex` (`codex-acp`); the assistant resolves the agent id to the right adapter binary. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access. If a binary is missing, the call returns an actionable install hint — do NOT alter `agents.<id>.command` to swap binaries. If ACP is disabled, follow the setup instructions in SKILL.md.",
       "category": "orchestration",
       "risk": "high",
       "input_schema": {

--- a/assistant/src/runtime/http-errors.ts
+++ b/assistant/src/runtime/http-errors.ts
@@ -24,6 +24,7 @@ export type HttpErrorCode =
   | "GONE"
   | "RATE_LIMITED"
   | "UNPROCESSABLE_ENTITY"
+  | "FAILED_DEPENDENCY"
   | "INTERNAL_ERROR"
   | "NOT_IMPLEMENTED"
   | "SERVICE_UNAVAILABLE";
@@ -94,6 +95,8 @@ export function httpErrorCodeFromStatus(status: number): HttpErrorCode {
       return "GONE";
     case 422:
       return "UNPROCESSABLE_ENTITY";
+    case 424:
+      return "FAILED_DEPENDENCY";
     case 429:
       return "RATE_LIMITED";
     case 501:

--- a/assistant/src/runtime/routes/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-routes.test.ts
@@ -152,7 +152,7 @@ describe("POST /v1/acp/spawn", () => {
     );
   });
 
-  test("returns 400 with command + install hint when the agent binary is missing", async () => {
+  test("returns 424 FAILED_DEPENDENCY with command + install hint when the agent binary is missing", async () => {
     setConfig({ agents: {} });
     setWhich({}); // no commands on PATH
 
@@ -165,11 +165,11 @@ describe("POST /v1/acp/spawn", () => {
       }),
     );
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(424);
     const body = (await res.json()) as {
       error: { code: string; message: string };
     };
-    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.code).toBe("FAILED_DEPENDENCY");
     expect(body.error.message).toContain("codex-acp is not on PATH");
     // Same install hint the LLM tool surfaces.
     expect(body.error.message).toContain("npm i -g @zed-industries/codex-acp");

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -53,26 +53,32 @@ export function acpRouteDefinitions(): RouteDefinition[] {
         }
         const resolved = resolveAcpAgent(body.agent);
         if (!resolved.ok) {
-          if (resolved.reason === "acp_disabled") {
-            return httpError("BAD_REQUEST", resolved.hint, 400);
+          switch (resolved.reason) {
+            case "acp_disabled":
+              return httpError("BAD_REQUEST", resolved.hint, 400);
+            case "unknown_agent":
+              return httpError(
+                "BAD_REQUEST",
+                `Unknown agent "${body.agent}". Available: ${resolved.available.join(", ")}.`,
+                400,
+              );
+            case "binary_not_found":
+              // 424 FAILED_DEPENDENCY: input is well-formed, but the host
+              // environment is missing the adapter binary — clients render
+              // the install hint as a setup step, not a "fix your input"
+              // error.
+              return httpError(
+                "FAILED_DEPENDENCY",
+                `${resolved.command} is not on PATH. ${resolved.hint}`,
+                424,
+              );
+            default: {
+              const _exhaustive: never = resolved;
+              throw new Error(
+                `Unexpected acp resolver reason: ${(_exhaustive as { reason: string }).reason}`,
+              );
+            }
           }
-          if (resolved.reason === "unknown_agent") {
-            return httpError(
-              "BAD_REQUEST",
-              `Unknown agent "${body.agent}". Available: ${resolved.available.join(", ")}.`,
-              400,
-            );
-          }
-          // binary_not_found — `httpError` does not currently expose a
-          // FAILED_DEPENDENCY (424) code, so surface as 400 with the
-          // command + install hint inline so other clients of
-          // POST /v1/acp/spawn see the same actionable text the LLM
-          // tool surfaces.
-          return httpError(
-            "BAD_REQUEST",
-            `${resolved.agent.command} is not on PATH. ${resolved.hint}`,
-            400,
-          );
         }
         log.info(
           {

--- a/assistant/src/tools/acp/list-agents.test.ts
+++ b/assistant/src/tools/acp/list-agents.test.ts
@@ -19,7 +19,15 @@ let mockAcpConfig: MockAcpConfig = {
   agents: {},
 };
 
+// Spread the real loader's named exports so transitive importers that pull
+// `loadConfig`, `invalidateConfigCache`, etc. from the same module path
+// still resolve at parse time. Bun's `mock.module` is process-global and
+// returns *exactly* the keys the factory returns — without the spread, any
+// module evaluated after this test file errors at load with
+// "Export named '<X>' not found".
+const realLoader = await import("../../config/loader.js");
 mock.module("../../config/loader.js", () => ({
+  ...realLoader,
   getConfig: () => ({ acp: mockAcpConfig }),
 }));
 
@@ -80,10 +88,11 @@ describe("executeAcpListAgents", () => {
 
     expect(result.isError).toBe(false);
     const parsed = JSON.parse(result.content as string);
-    expect(parsed).toEqual({
-      enabled: false,
-      hint: "Set 'acp.enabled': true to use ACP agents.",
-    });
+    expect(parsed.enabled).toBe(false);
+    // Pulls from the shared ACP_DISABLED_HINT constant exported by
+    // resolve-agent.ts. The exact wording is checked in resolve-agent.test.ts.
+    expect(parsed.hint).toContain("acp.enabled");
+    expect(parsed.hint).toContain("config.json");
   });
 
   test("enabled, no user config: both defaults present with source 'default' and available based on Bun.which", async () => {

--- a/assistant/src/tools/acp/list-agents.ts
+++ b/assistant/src/tools/acp/list-agents.ts
@@ -1,4 +1,4 @@
-import { listAcpAgents } from "../../acp/resolve-agent.js";
+import { ACP_DISABLED_HINT, listAcpAgents } from "../../acp/resolve-agent.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 /**
@@ -18,7 +18,7 @@ export async function executeAcpListAgents(
     return {
       content: JSON.stringify({
         enabled: false,
-        hint: "Set 'acp.enabled': true to use ACP agents.",
+        hint: ACP_DISABLED_HINT,
       }),
       isError: false,
     };

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -81,7 +81,15 @@ const defaultMockConfig: MockConfig = {
 
 let mockConfig: MockConfig = structuredClone(defaultMockConfig);
 
+// Spread the real loader's named exports so transitive importers that pull
+// `loadConfig`, `invalidateConfigCache`, etc. from the same module path still
+// resolve at parse time. Bun's `mock.module` is process-global and returns
+// *exactly* the keys the factory returns — without the spread, any module
+// evaluated after this test file errors at load with
+// "Export named '<X>' not found".
+const realLoader = await import("../../config/loader.js");
 mock.module("../../config/loader.js", () => ({
+  ...realLoader,
   getConfig: () => mockConfig,
 }));
 
@@ -120,7 +128,15 @@ const spawnMock = mock(
   }),
 );
 
+// Spread the real module's exports so transitive importers that pull other
+// names from `../../acp/index.js` (e.g. `broadcastToAllClients` from the
+// HTTP route layer) still resolve at parse time. Bun's `mock.module` is
+// process-global and returns *exactly* the keys the factory returns —
+// without the spread, any module evaluated after this test file errors at
+// load with "Export named '<X>' not found".
+const realAcpModule = await import("../../acp/index.js");
 mock.module("../../acp/index.js", () => ({
+  ...realAcpModule,
   getAcpSessionManager: () => ({ spawn: spawnMock }),
 }));
 
@@ -354,5 +370,41 @@ describe("executeAcpSpawn — input validation", () => {
     // The agentConfig handed to spawn() should be the bundled default.
     const agentConfigArg = spawnMock.mock.calls[0][1] as { command: string };
     expect(agentConfigArg.command).toBe("codex-acp");
+  });
+});
+
+describe("executeAcpSpawn — per-agent resume hint", () => {
+  test("claude payload includes the `claude --resume` hint", async () => {
+    execScripts.set("npm ls", { error: new Error("npm not installed") });
+    execScripts.set("npm view", { error: new Error("npm not installed") });
+
+    const result = await executeAcpSpawn(
+      { agent: "claude", task: "do something" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const [payloadJson] = result.content.split("\n\n");
+    const payload = JSON.parse(payloadJson);
+    expect(payload.message).toContain("claude --resume");
+    expect(payload.message).toContain("To resume this session later");
+  });
+
+  test("non-claude payload omits the `claude --resume` hint", async () => {
+    // `claude --resume <id>` is Claude Code-specific. Codex (and any other
+    // adapter) should not have that command suggested back to the user.
+    execScripts.set("npm ls", { error: new Error("npm not installed") });
+    execScripts.set("npm view", { error: new Error("npm not installed") });
+
+    const result = await executeAcpSpawn(
+      { agent: "codex", task: "do something" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const [payloadJson] = result.content.split("\n\n");
+    const payload = JSON.parse(payloadJson);
+    expect(payload.message).not.toContain("claude --resume");
+    expect(payload.message).not.toContain("To resume this session later");
   });
 });

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -2,20 +2,11 @@ import { execFile } from "node:child_process";
 
 import { getAcpSessionManager } from "../../acp/index.js";
 import { resolveAcpAgent } from "../../acp/resolve-agent.js";
+import { DEFAULT_AGENT_NPM_PACKAGES } from "../../config/acp-defaults.js";
 import { getLogger } from "../../util/logger.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 const log = getLogger("acp:spawn");
-
-/**
- * Maps adapter binary commands to their npm package names. The version
- * check is best-effort and only runs for known adapters; unknown commands
- * skip the check entirely.
- */
-const ADAPTER_NPM_PACKAGES: Record<string, string> = {
-  "claude-agent-acp": "@agentclientprotocol/claude-agent-acp",
-  "codex-acp": "@zed-industries/codex-acp",
-};
 
 /** Per-call timeout for `npm` probes. Best-effort: timeouts are non-fatal. */
 const NPM_PROBE_TIMEOUT_MS = 5_000;
@@ -79,7 +70,7 @@ async function checkAdapterVersion(
     return adapterVersionCache.get(command) ?? null;
   }
 
-  const packageName = ADAPTER_NPM_PACKAGES[command];
+  const packageName = DEFAULT_AGENT_NPM_PACKAGES[command];
   if (!packageName) {
     adapterVersionCache.set(command, null);
     return null;
@@ -157,9 +148,15 @@ export async function executeAcpSpawn(
         };
       case "binary_not_found":
         return {
-          content: `${resolved.agent.command} is not on PATH. ${resolved.hint}`,
+          content: `${resolved.command} is not on PATH. ${resolved.hint}`,
           isError: true,
         };
+      default: {
+        const _exhaustive: never = resolved;
+        throw new Error(
+          `Unexpected acp resolver reason: ${(_exhaustive as { reason: string }).reason}`,
+        );
+      }
     }
   }
   const agentConfig = resolved.agent;
@@ -190,6 +187,12 @@ export async function executeAcpSpawn(
       sendToClient as (msg: unknown) => void,
     );
 
+    // `claude --resume <id>` is Claude Code-specific; codex and other
+    // adapters resume differently or not at all, so the hint is gated.
+    const resumeHint =
+      agent === "claude"
+        ? ` To resume this session later, run: cd ${cwd} && claude --resume ${protocolSessionId}`
+        : "";
     const payload = JSON.stringify({
       acpSessionId,
       protocolSessionId,
@@ -198,8 +201,7 @@ export async function executeAcpSpawn(
       status: "running",
       message:
         `ACP agent "${agent}" spawned (session: ${protocolSessionId}). ` +
-        `Results stream back via SSE. You will be notified when it completes. ` +
-        `To resume this session later, run: cd ${cwd} && claude --resume ${protocolSessionId}`,
+        `Results stream back via SSE. You will be notified when it completes.${resumeHint}`,
     });
 
     let content = payload;


### PR DESCRIPTION
## Summary
Addresses 9 gaps from self-review of plan acp-codex-claude.md:
- `acp_spawn` resume hint is now per-agent (drops `claude --resume` for non-claude agents).
- `acp_spawn` TOOLS.json description rewritten to reflect Codex+Claude defaults; no longer instructs the LLM that the command MUST be `claude-agent-acp`.
- `/v1/acp/spawn` returns 424 `FAILED_DEPENDENCY` for missing-binary failures (added to `HttpErrorCode`); 4xx semantics now distinguish input errors from environmental misconfiguration.
- Resolver doc comment fixed (`acp_steer` is not a caller — it operates on session IDs).
- Added exhaustiveness checks in `acp_spawn` and `/v1/acp/spawn` switch statements.
- Dropped dead `unknown_agent.hint` field; callers rebuild the message inline anyway.
- Dropped unused `source` field from `ok: true` and `binary_not_found` resolver variants (kept on `AcpAgentEntry` where it's actually consumed by `acp_list_agents`).
- Single source of truth for adapter → npm package via `DEFAULT_AGENT_NPM_PACKAGES`.
- Extracted `ACP_DISABLED_HINT` constant; `list-agents.ts` reuses it.

Self-review remediation for plan acp-codex-claude.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
