### PR TITLE
fix(memory): broaden recall to cross-scope, bump RRF prefetch floor

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -63,6 +63,19 @@ import { cancelPendingJobsForConversation } from "./task-memory-cleanup.js";
 
 const log = getLogger("conversation-store");
 
+/** Prefix for private-conversation memory scope IDs (`private:<convId>`). */
+export const PRIVATE_SCOPE_PREFIX = "private:";
+
+/** Build the memory scope ID for a private conversation. */
+export function privateScopeId(conversationId: string): string {
+  return `${PRIVATE_SCOPE_PREFIX}${conversationId}`;
+}
+
+/** True if the scope ID belongs to a private conversation. */
+export function isPrivateScopeId(scopeId: string): boolean {
+  return scopeId.startsWith(PRIVATE_SCOPE_PREFIX);
+}
+
 // ── Message metadata Zod schema ──────────────────────────────────────
 // Validates the JSON stored in messages.metadata. Known fields are typed;
 // extra keys are allowed via passthrough so callers can attach ad-hoc data.
@@ -275,7 +288,7 @@ export function createConversation(
   const groupId = opts.groupId;
   const id = uuid();
   const memoryScopeId =
-    conversationType === "private" ? `private:${id}` : "default";
+    conversationType === "private" ? privateScopeId(id) : "default";
 
   // Ensure group_id column exists for deterministic schema readiness,
   // even when this conversation has no groupId (a subsequent query or
@@ -451,6 +464,21 @@ export function getConversationType(
 export function getConversationMemoryScopeId(conversationId: string): string {
   const conv = getConversation(conversationId);
   return conv?.memoryScopeId ?? "default";
+}
+
+/**
+ * Return the list of memory scope IDs that belong to private conversations.
+ * Used by recall to exclude private-conversation memories when called from
+ * a non-private scope, so private conversations stay isolated.
+ */
+export function listPrivateMemoryScopeIds(): string[] {
+  const db = getDb();
+  const rows = db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(eq(conversations.conversationType, "private"))
+    .all();
+  return rows.map((r) => privateScopeId(r.id));
 }
 
 export function getConversationHostAccess(conversationId: string): boolean {
@@ -711,7 +739,9 @@ export function deleteConversation(id: string): DeletedMemoryIds {
   const convBeforeDelete = getConversation(id);
   const createdAtForDiskCleanup = convBeforeDelete?.createdAt;
   const memoryScopeId = convBeforeDelete?.memoryScopeId;
-  const isPrivateScope = memoryScopeId?.startsWith("private:") ?? false;
+  const isPrivateScope = memoryScopeId
+    ? isPrivateScopeId(memoryScopeId)
+    : false;
 
   db.transaction((tx) => {
     // Collect all message IDs for this conversation.

--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -14,6 +14,7 @@ import { v4 as uuid } from "uuid";
 
 import { getLogger } from "../util/logger.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
+import { privateScopeId } from "./conversation-crud.js";
 import { initConversationDir } from "./conversation-disk-view.js";
 import { GENERATING_TITLE } from "./conversation-title-service.js";
 import { getDb } from "./db.js";
@@ -220,7 +221,9 @@ export function getOrCreateConversation(
     const conversationId = uuid();
     const title = GENERATING_TITLE;
     const memoryScopeId =
-      conversationType === "private" ? `private:${conversationId}` : "default";
+      conversationType === "private"
+        ? privateScopeId(conversationId)
+        : "default";
 
     tx.insert(conversations)
       .values({

--- a/assistant/src/memory/graph/graph-search.test.ts
+++ b/assistant/src/memory/graph/graph-search.test.ts
@@ -91,3 +91,94 @@ describe("searchGraphNodes — _meta filter parity", () => {
     expect(metaClause?.match.value).toBe(true);
   });
 });
+
+describe("searchGraphNodes — excludeScopeIds", () => {
+  beforeEach(() => {
+    breakerOpen = false;
+    hybridSearchCalls.length = 0;
+    searchCalls.length = 0;
+  });
+
+  test("hybrid path adds memory_scope_id must_not when excludeScopeIds provided", async () => {
+    await searchGraphNodes(
+      [0.1],
+      5,
+      undefined,
+      { indices: [1], values: [1] },
+      undefined,
+      ["private:abc", "private:xyz"],
+    );
+
+    expect(hybridSearchCalls).toHaveLength(1);
+    const filter = hybridSearchCalls[0]?.filter as {
+      must_not: Array<Record<string, unknown>>;
+    };
+    const scopeExclude = filter.must_not.find(
+      (c) => c.key === "memory_scope_id",
+    ) as { match: { any: string[] } } | undefined;
+    expect(scopeExclude?.match.any).toEqual(["private:abc", "private:xyz"]);
+  });
+
+  test("dense-only path adds memory_scope_id must_not when excludeScopeIds provided", async () => {
+    await searchGraphNodes([0.1], 5, undefined, undefined, undefined, [
+      "private:abc",
+    ]);
+
+    expect(searchCalls).toHaveLength(1);
+    const filter = searchCalls[0]?.filter as {
+      must_not: Array<Record<string, unknown>>;
+    };
+    const scopeExclude = filter.must_not.find(
+      (c) => c.key === "memory_scope_id",
+    ) as { match: { any: string[] } } | undefined;
+    expect(scopeExclude?.match.any).toEqual(["private:abc"]);
+  });
+
+  test("hybrid path omits memory_scope_id must_not when excludeScopeIds is empty", async () => {
+    await searchGraphNodes(
+      [0.1],
+      5,
+      undefined,
+      { indices: [1], values: [1] },
+      undefined,
+      [],
+    );
+
+    expect(hybridSearchCalls).toHaveLength(1);
+    const filter = hybridSearchCalls[0]?.filter as {
+      must_not: Array<Record<string, unknown>>;
+    };
+    const scopeExclude = filter.must_not.find(
+      (c) => c.key === "memory_scope_id",
+    );
+    expect(scopeExclude).toBeUndefined();
+  });
+});
+
+describe("searchGraphNodes — prefetch floor", () => {
+  beforeEach(() => {
+    breakerOpen = false;
+    hybridSearchCalls.length = 0;
+    searchCalls.length = 0;
+  });
+
+  test("hybrid prefetchLimit floors at 200 for small limits", async () => {
+    await searchGraphNodes([0.1], 10, ["default"], {
+      indices: [1],
+      values: [1],
+    });
+
+    expect(hybridSearchCalls).toHaveLength(1);
+    expect(hybridSearchCalls[0]?.prefetchLimit).toBe(200);
+  });
+
+  test("hybrid prefetchLimit scales with limit when limit*10 exceeds floor", async () => {
+    await searchGraphNodes([0.1], 50, ["default"], {
+      indices: [1],
+      values: [1],
+    });
+
+    expect(hybridSearchCalls).toHaveLength(1);
+    expect(hybridSearchCalls[0]?.prefetchLimit).toBe(500);
+  });
+});

--- a/assistant/src/memory/graph/graph-search.ts
+++ b/assistant/src/memory/graph/graph-search.ts
@@ -37,6 +37,9 @@ export interface GraphSearchResult {
  * that the caller can hydrate from the graph store.
  *
  * Filters to `target_type: "graph_node"` and optionally by scope.
+ * `excludeScopeIds` adds a `must_not` against `memory_scope_id`, used by
+ * recall to keep private-conversation memories from leaking into public
+ * scopes.
  */
 export async function searchGraphNodes(
   queryVector: number[],
@@ -44,6 +47,7 @@ export async function searchGraphNodes(
   scopeIds?: string[],
   sparseVector?: QdrantSparseVector,
   dateRange?: { afterMs?: number; beforeMs?: number },
+  excludeScopeIds?: string[],
 ): Promise<GraphSearchResult[]> {
   if (isQdrantBreakerOpen()) {
     log.warn("Qdrant circuit breaker open, skipping graph search");
@@ -51,6 +55,16 @@ export async function searchGraphNodes(
   }
 
   const client = getQdrantClient();
+
+  const mustNot: Record<string, unknown>[] = [
+    { key: "_meta", match: { value: true } },
+  ];
+  if (excludeScopeIds && excludeScopeIds.length > 0) {
+    mustNot.push({
+      key: "memory_scope_id",
+      match: { any: excludeScopeIds },
+    });
+  }
 
   // Use hybrid search (dense + sparse with RRF fusion) when a non-empty
   // sparse vector is available; otherwise fall back to dense-only search.
@@ -67,10 +81,12 @@ export async function searchGraphNodes(
     if (dateRange?.beforeMs != null) {
       must.push({ key: "created_at", range: { lte: dateRange.beforeMs } });
     }
-    const filter = {
-      must,
-      must_not: [{ key: "_meta", match: { value: true } }],
-    };
+    const filter = { must, must_not: mustNot };
+
+    // RRF fuses per-modality top-N. A small prefetch (e.g. limit*3) silently
+    // truncates good matches when the query is wordy or low-similarity, so
+    // give RRF a meaningful candidate window with a generous floor.
+    const prefetchLimit = Math.max(limit * 10, 200);
 
     const results: QdrantSearchResult[] = await withQdrantBreaker(() =>
       client.hybridSearch({
@@ -78,7 +94,7 @@ export async function searchGraphNodes(
         sparseVector,
         filter,
         limit,
-        prefetchLimit: limit * 3,
+        prefetchLimit,
       }),
     );
 
@@ -112,7 +128,7 @@ export async function searchGraphNodes(
 
   const filter: Record<string, unknown> = {
     must: denseMusts,
-    must_not: [{ key: "_meta", match: { value: true } }],
+    must_not: mustNot,
   };
 
   const results: QdrantSearchResult[] = await withQdrantBreaker(async () => {

--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -11,6 +11,10 @@ import { join } from "node:path";
 import type { AssistantConfig } from "../../config/types.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
+import {
+  isPrivateScopeId,
+  listPrivateMemoryScopeIds,
+} from "../conversation-crud.js";
 import { buildExcerpt, buildFtsMatchQuery } from "../conversation-queries.js";
 import { embedWithRetry } from "../embed.js";
 import { generateSparseEmbedding } from "../embedding-backend.js";
@@ -97,16 +101,28 @@ async function handleMemoryRecall(
     if (!isNaN(beforeMs)) dateRange.beforeMs = beforeMs;
   }
 
+  // Recall searches across the assistant's whole memory by default. When
+  // invoked from inside a private conversation, pin to that scope so the
+  // private conversation stays isolated from itself outward AND can't
+  // see other memories. From any non-private scope, search every scope
+  // EXCEPT the set of private conversation scopes.
+  const isPrivateScope = isPrivateScopeId(scopeId);
+  const callScopeIds = isPrivateScope ? [scopeId] : undefined;
+  const excludeScopeIds = isPrivateScope
+    ? undefined
+    : listPrivateMemoryScopeIds();
+
   // Search graph nodes
   const limit = Math.max(1, Math.min(input.num_results ?? 20, 50));
   const searchResults = await searchGraphNodes(
     queryVector,
     limit,
-    [scopeId],
+    callScopeIds,
     sparseVector,
     dateRange.afterMs != null || dateRange.beforeMs != null
       ? dateRange
       : undefined,
+    excludeScopeIds,
   );
   if (searchResults.length === 0) {
     return { results: [], mode: "memory", query: input.query };

--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -25,6 +25,10 @@ import {
 import { z } from "zod";
 
 import { getConfig } from "../../config/loader.js";
+import {
+  isPrivateScopeId,
+  PRIVATE_SCOPE_PREFIX,
+} from "../../memory/conversation-crud.js";
 import { getDb } from "../../memory/db.js";
 import {
   embedWithBackend,
@@ -161,8 +165,8 @@ function resolveScopeLabel(
   titleMap: Map<string, string | null>,
 ): string | null {
   if (scopeId === "default") return null;
-  if (scopeId.startsWith("private:")) {
-    const conversationId = scopeId.slice("private:".length);
+  if (isPrivateScopeId(scopeId)) {
+    const conversationId = scopeId.slice(PRIVATE_SCOPE_PREFIX.length);
     const title = titleMap.get(conversationId);
     return title ? `Private · ${title}` : "Private";
   }
@@ -177,8 +181,8 @@ function buildConversationTitleMap(
   scopeIds: string[],
 ): Map<string, string | null> {
   const conversationIds = scopeIds
-    .filter((s) => s.startsWith("private:"))
-    .map((s) => s.slice("private:".length));
+    .filter(isPrivateScopeId)
+    .map((s) => s.slice(PRIVATE_SCOPE_PREFIX.length));
 
   const uniqueIds = [...new Set(conversationIds)];
   if (uniqueIds.length === 0) return new Map();


### PR DESCRIPTION
## Summary
- The `recall` tool was scope-filtering to the calling conversation's `memoryScopeId`, silently hiding cross-scope memories. It also passed a tiny `prefetchLimit = limit*3` to Qdrant's RRF fusion, which starved the fuser of candidates. With `num_results: 10` and a wordy query, recall would return 2 hits while the UI memory browser surfaced 8+ obvious matches against the same store.
- Recall now searches every scope by default and excludes private-conversation scopes (so private convs stay isolated). When called from a `private:<id>` scope, it pins to that scope only. Hybrid prefetch floor bumped to `max(limit*10, 200)` for better RRF accuracy.
- Extracts `PRIVATE_SCOPE_PREFIX`, `privateScopeId()`, and `isPrivateScopeId()` helpers to dedupe the four hand-rolled `'private:'` call sites.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
