### PR TITLE
fix(skill-ipc): bounded probe-connect timeout, EADDRINUSE error code, CliIpcServer parity

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -909,7 +909,7 @@ export class DaemonServer {
     // Start the CLI IPC server. Built-in methods (wake_conversation) are
     // registered by the constructor; CLI commands connect to this socket to
     // invoke daemon-side operations that require in-process state.
-    this.cliIpc.start();
+    await this.cliIpc.start();
 
     // Start the skill IPC server. First-party skill processes connect to this
     // socket to access host capabilities (host.log, host.config.*,

--- a/assistant/src/ipc/__tests__/attachment-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/attachment-ipc.test.ts
@@ -51,7 +51,7 @@ function createOutsideFile(content: string, filename?: string): string {
 
 beforeEach(async () => {
   server = new CliIpcServer();
-  server.start();
+  await server.start();
   // Allow the server socket to bind.
   await new Promise((resolve) => setTimeout(resolve, 50));
 });

--- a/assistant/src/ipc/__tests__/cache-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/cache-ipc.test.ts
@@ -21,7 +21,7 @@ let server: CliIpcServer | null = null;
 beforeEach(async () => {
   clearCacheForTests();
   server = new CliIpcServer();
-  server.start();
+  await server.start();
   // Allow the server socket to bind.
   await new Promise((resolve) => setTimeout(resolve, 50));
 });

--- a/assistant/src/ipc/__tests__/cli-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/cli-ipc.test.ts
@@ -49,7 +49,7 @@ afterEach(() => {
 
 async function startServer(): Promise<void> {
   server = new CliIpcServer();
-  server.start();
+  await server.start();
   await new Promise((resolve) => setTimeout(resolve, 50));
 }
 

--- a/assistant/src/ipc/__tests__/ui-request-route.test.ts
+++ b/assistant/src/ipc/__tests__/ui-request-route.test.ts
@@ -42,7 +42,7 @@ beforeEach(async () => {
   resetInteractiveUiResolverForTests();
   resetSurfaceIdCounterForTests();
   server = new CliIpcServer();
-  server.start();
+  await server.start();
   // Allow the server socket to bind.
   await new Promise((resolve) => setTimeout(resolve, 50));
 });

--- a/assistant/src/ipc/__tests__/watcher-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/watcher-ipc.test.ts
@@ -47,7 +47,7 @@ const createdWatcherIds: string[] = [];
 
 beforeEach(async () => {
   server = new CliIpcServer();
-  server.start();
+  await server.start();
   // Allow the server socket to bind.
   await new Promise((resolve) => setTimeout(resolve, 50));
 });

--- a/assistant/src/ipc/cli-server.ts
+++ b/assistant/src/ipc/cli-server.ts
@@ -21,6 +21,7 @@ import { dirname } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import { cliIpcRoutes } from "./routes/index.js";
+import { ensureSocketPathFree } from "./socket-cleanup.js";
 import { resolveIpcSocketPath } from "./socket-path.js";
 
 const log = getLogger("cli-ipc-server");
@@ -87,21 +88,17 @@ export class CliIpcServer {
   }
 
   /** Start listening on the Unix domain socket. */
-  start(): void {
+  async start(): Promise<void> {
     // Ensure the parent directory exists before listening.
     const socketDir = dirname(this.socketPath);
     if (!existsSync(socketDir)) {
       mkdirSync(socketDir, { recursive: true, mode: 0o700 });
     }
 
-    // Clean up stale socket file from a previous run
-    if (existsSync(this.socketPath)) {
-      try {
-        unlinkSync(this.socketPath);
-      } catch {
-        // Ignore — may already be gone
-      }
-    }
+    // Probe before unlink so a second daemon can't silently orphan an active
+    // listener (Unix lets you unlink a still-bound socket file). See
+    // `ensureSocketPathFree` for the behavior matrix.
+    await ensureSocketPathFree(this.socketPath);
 
     this.server = createServer((socket) => {
       this.clients.add(socket);

--- a/assistant/src/ipc/skill-server.ts
+++ b/assistant/src/ipc/skill-server.ts
@@ -38,7 +38,7 @@
  */
 
 import { existsSync, mkdirSync, unlinkSync } from "node:fs";
-import { connect, createServer, type Server, type Socket } from "node:net";
+import { createServer, type Server, type Socket } from "node:net";
 import { dirname } from "node:path";
 
 import {
@@ -57,6 +57,7 @@ import {
   skillIpcStreamingRoutes,
 } from "./skill-routes/index.js";
 import { resolveSkillIpcSocketPath } from "./skill-socket-path.js";
+import { ensureSocketPathFree } from "./socket-cleanup.js";
 
 const log = getLogger("skill-ipc-server");
 
@@ -404,11 +405,9 @@ export class SkillIpcServer {
       mkdirSync(socketDir, { recursive: true, mode: 0o700 });
     }
 
-    // Probe-connect before unlinking: Unix sockets can be unlinked while still
-    // bound, so a blind `unlinkSync` on a live path would silently orphan
-    // another daemon's listener. Only unlink when the connect fails with
-    // ECONNREFUSED (stale file from a previous crash) / ENOENT (race with
-    // removal) — fail fast on a successful connect.
+    // Probe before unlink so a second daemon can't silently orphan an active
+    // listener (Unix lets you unlink a still-bound socket file). See
+    // `ensureSocketPathFree` for the behavior matrix.
     await ensureSocketPathFree(this.socketPath);
 
     this.server = createServer((socket) => {
@@ -787,35 +786,4 @@ export class SkillIpcServer {
       socket.write(JSON.stringify(response) + "\n");
     }
   }
-}
-
-/**
- * Probe-connect to `socketPath`. If a live listener answers, reject so the
- * caller can surface `EADDRINUSE`-style errors instead of silently hijacking
- * the path. If the connect fails with `ECONNREFUSED`/`ENOENT`, the file is a
- * stale leftover and we unlink it. Any other error propagates.
- */
-async function ensureSocketPathFree(socketPath: string): Promise<void> {
-  if (!existsSync(socketPath)) return;
-  await new Promise<void>((resolve, reject) => {
-    const client = connect(socketPath);
-    client.once("connect", () => {
-      client.end();
-      reject(
-        new Error(`EADDRINUSE: another daemon is listening at ${socketPath}`),
-      );
-    });
-    client.once("error", (err: NodeJS.ErrnoException) => {
-      if (err.code === "ECONNREFUSED" || err.code === "ENOENT") {
-        try {
-          unlinkSync(socketPath);
-        } catch {
-          // Ignore — may already be gone
-        }
-        resolve();
-      } else {
-        reject(err);
-      }
-    });
-  });
 }

--- a/assistant/src/ipc/socket-cleanup.ts
+++ b/assistant/src/ipc/socket-cleanup.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared helpers for IPC server socket lifecycle. Both `CliIpcServer` and
+ * `SkillIpcServer` need the same probe-before-unlink dance to avoid silently
+ * stealing another daemon's listener: a blind `unlinkSync` on a live Unix
+ * socket file would orphan the bound listener (Linux/macOS allow unlink while
+ * still bound) and the new server would happily `listen()` on the now-renamed
+ * inode, leaving two daemons in conflict with no error.
+ */
+
+import { existsSync, unlinkSync } from "node:fs";
+import { connect } from "node:net";
+
+/**
+ * Maximum time to wait for the probe `connect()` to settle before declaring
+ * the path occupied. Without a bound, a hung process holding the socket would
+ * make the daemon hang during startup — violating the AGENTS.md rule that
+ * startup must never block. Two seconds is large enough to absorb a slow
+ * peer's accept-loop latency but short enough to fail fast in the wedged
+ * case.
+ */
+const PROBE_CONNECT_TIMEOUT_MS = 2000;
+
+/**
+ * Build an `EADDRINUSE`-coded error so callers (and `categorizeDaemonError`)
+ * can branch on `err.code` and surface the structured "already running"
+ * guidance instead of a generic UNKNOWN.
+ */
+function makeAddrInUseError(message: string): NodeJS.ErrnoException {
+  const err = new Error(message) as NodeJS.ErrnoException;
+  err.code = "EADDRINUSE";
+  return err;
+}
+
+/**
+ * Probe-connect to `socketPath`. Behavior:
+ *   - Path doesn't exist → return.
+ *   - Connect succeeds (live listener) → throw `EADDRINUSE` so the caller can
+ *     surface the structured "already running" error.
+ *   - Connect fails with `ECONNREFUSED`/`ENOENT` (stale leftover) → unlink
+ *     the file and return.
+ *   - Connect doesn't settle within {@link PROBE_CONNECT_TIMEOUT_MS} → throw
+ *     `EADDRINUSE` (no fallback to blind unlink — the whole point of this
+ *     helper is to keep the silent-orphan defense).
+ *   - Any other socket error → propagate.
+ */
+export async function ensureSocketPathFree(socketPath: string): Promise<void> {
+  if (!existsSync(socketPath)) return;
+  await new Promise<void>((resolve, reject) => {
+    const client = connect(socketPath);
+    let settled = false;
+    const settle = (action: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      client.removeAllListeners();
+      client.destroy();
+      action();
+    };
+    const timer = setTimeout(() => {
+      settle(() =>
+        reject(
+          makeAddrInUseError(
+            `EADDRINUSE: probe-connect to ${socketPath} did not settle within ${PROBE_CONNECT_TIMEOUT_MS}ms`,
+          ),
+        ),
+      );
+    }, PROBE_CONNECT_TIMEOUT_MS);
+    client.once("connect", () => {
+      settle(() =>
+        reject(
+          makeAddrInUseError(
+            `EADDRINUSE: another daemon is listening at ${socketPath}`,
+          ),
+        ),
+      );
+    });
+    client.once("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "ECONNREFUSED" || err.code === "ENOENT") {
+        settle(() => {
+          try {
+            unlinkSync(socketPath);
+          } catch {
+            // Ignore — may already be gone
+          }
+          resolve();
+        });
+      } else {
+        settle(() => reject(err));
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Partial follow-up to #27929. Three review-comment fixes around the probe-connect-before-unlink dance for the Unix domain sockets backing the daemon's IPC servers.

- **EADDRINUSE error code (Codex finding).** When the probe sees a live listener, the rejection now sets `err.code = "EADDRINUSE"` so `categorizeDaemonError` in `daemon/startup-error.ts` reports `PORT_IN_USE` and surfaces the structured "already running" guidance instead of falling through to `UNKNOWN`.
- **Bounded probe timeout (Devin finding, kernel of valid concern).** The probe `connect()` had no timeout — a hung peer holding the path would hang daemon startup, violating the "never block startup" rule. The probe now bounds itself with a 2s timeout and throws an `EADDRINUSE`-coded error on timeout. We deliberately do **not** fall back to the old blind `unlinkSync` on failure: the whole point of #27929 was to remove that fallback, so the right safety net here is the bounded timeout, not catch-and-unlink.
- **CliIpcServer parity (Devin finding).** The CLI IPC server's `start()` was still using the synchronous blind-unlink pattern. It now uses the same shared probe-connect helper (`assistant/src/ipc/socket-cleanup.ts`), making `start()` async and updating callers accordingly.

The probe logic was extracted to `assistant/src/ipc/socket-cleanup.ts` so both servers share one implementation.

## Test plan

- [x] `bunx tsc --noEmit` (assistant package)
- [x] `bun test src/ipc/__tests__/skill-server.test.ts src/ipc/__tests__/cli-ipc.test.ts src/ipc/__tests__/cache-ipc.test.ts` — all 30 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
