### PR TITLE
fix(macos): optimistic active-profile selection with in-flight cancellation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -54,6 +54,10 @@ struct InferenceServiceCard: View {
     /// Captured at confirmation time so the message stays accurate even if
     /// `initialProvider` is mutated during the deferred save.
     @State private var pendingOverrideOldProviderName: String = ""
+    /// The most recent in-flight `setActiveProfile` task, retained so a
+    /// subsequent dropdown pick can cancel it and avoid an out-of-order
+    /// PATCH landing the older selection last.
+    @State private var activeProfileTask: Task<Void, Never>?
 
     // MARK: - Provider Helpers
 
@@ -449,12 +453,19 @@ struct InferenceServiceCard: View {
     /// `set` for those, so no sync-suppression flag is needed. The
     /// equality guard short-circuits the rare echo where SwiftUI reflects
     /// the latest `get` back through the dropdown's `set`.
+    ///
+    /// `setActiveProfile` updates `store.activeProfile` synchronously
+    /// (optimistic update) so the dropdown reflects the new selection
+    /// immediately; the await only carries the network PATCH. Each pick
+    /// cancels any prior in-flight task to prevent a slower earlier
+    /// PATCH from landing the older selection last.
     private var activeProfileBinding: Binding<String> {
         Binding(
             get: { store.activeProfile },
             set: { newValue in
                 guard newValue != store.activeProfile else { return }
-                Task { _ = await store.setActiveProfile(newValue) }
+                activeProfileTask?.cancel()
+                activeProfileTask = Task { _ = await store.setActiveProfile(newValue) }
             }
         )
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3209,14 +3209,26 @@ public final class SettingsStore: ObservableObject {
     /// Persists `llm.activeProfile` so the daemon's resolver layers the
     /// named profile into every callsite resolution. The mock client
     /// captures the patch payload for assertion in tests.
+    ///
+    /// Optimistically updates `self.activeProfile` synchronously before
+    /// the await so SwiftUI bindings reading the published value (e.g.
+    /// the dropdown selection in `InferenceServiceCard`) see the new
+    /// value on the next render cycle without waiting for the network
+    /// round-trip. Reverts on failure, but only when the current state
+    /// still matches the optimistic write — a newer call that has
+    /// already overwritten the value owns the published state and must
+    /// not be stomped by a stale revert.
     @discardableResult
     func setActiveProfile(_ name: String) async -> Bool {
+        let previous = self.activeProfile
+        self.activeProfile = name
         let success = await settingsClient.patchConfig([
             "llm": ["activeProfile": name]
         ])
-        if success {
-            self.activeProfile = name
-        } else {
+        if !success {
+            if self.activeProfile == name {
+                self.activeProfile = previous
+            }
             log.error("Failed to patch config for llm.activeProfile")
         }
         return success


### PR DESCRIPTION
## Summary

Two complementary fixes for the Active Profile picker introduced in #28061:

- **Optimistic UI update** (Devin): `SettingsStore.setActiveProfile` now writes `self.activeProfile` synchronously before the async PATCH, then reverts on failure (only when the current value still matches the optimistic write, so a newer call's value is not stomped by a stale revert). The dropdown's `get` reads the published value, so selections now reflect immediately instead of waiting for the network round-trip.
- **In-flight task cancellation** (Codex): `InferenceServiceCard` retains the most-recent `Task` from the active-profile binding's `set` closure and cancels it before spawning the next one, so rapid consecutive picks cannot land an older selection last.

## Not addressing

Codex's recommendation to restore the `llm.default.model` write to Save is intentionally **not** addressed. Removing that write was the central architectural shift of #28061 — Active Profile owns model selection now. The partial-profile staleness edge case (active profile fragment omits model, provider PATCH leaves a stale model from the previous provider) is a real concern but should be solved at the resolver layer or in profile-creation UI validation, not by reverting the architectural change.

## Test plan

- [ ] Manually pick a different active profile in the inference card; verify the dropdown label updates immediately (no flicker/revert).
- [ ] Rapidly click through three different profiles in quick succession; verify the final daemon-persisted `llm.activeProfile` matches the last pick.
- [ ] Existing `SettingsStoreInferenceProfilesTests.testSetActiveProfileFailureLeavesLocalStateUntouched` still passes — the optimistic write reverts on PATCH failure, restoring the prior value.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
