### PR TITLE
fix(test): isolate inference-profile tests from cross-file mock pollution

### DIFF
--- a/assistant/src/__tests__/agent-loop-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-loop-override-profile.test.ts
@@ -15,9 +15,10 @@
 
 import { describe, expect, mock, test } from "bun:test";
 
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
 mock.module("../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  getLogger: () => makeMockLogger(),
 }));
 
 import { AgentLoop } from "../agent/loop.js";

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -11,7 +11,8 @@
  * exercised separately by their own tests.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createRequire } from "node:module";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type {
   AgentEvent,
@@ -21,12 +22,29 @@ import type {
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
+// Snapshot the real `conversation-crud` exports before `mock.module()` below
+// replaces them. We use a synchronous CJS-style require (via `createRequire`)
+// because static `import` is hoisted above `mock.module()` calls — but bun's
+// own `mock.module()` is NOT hoisted, so the only way to grab the real
+// exports at this exact line is the synchronous require. The spread freezes
+// each function reference — holding the module object directly would yield
+// the *mocked* values after `mock.module` runs, since the require'd object
+// is a live binding. `afterAll` re-mocks with this snapshot so downstream
+// files in the same `bun test` run get the real exports back (Bun's
+// `mock.module()` persists across files; `mock.restore()` does not restore
+// module mocks).
+const conversationCrudRealSnapshot = {
+  ...(createRequire(import.meta.url)(
+    "../memory/conversation-crud.js",
+  ) as Record<string, unknown>),
+};
 
 // ── Module mocks (must precede imports of the module under test) ─────
 
 mock.module("../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  getLogger: () => makeMockLogger(),
 }));
 
 mock.module("../config/loader.js", () => ({
@@ -487,6 +505,15 @@ beforeEach(() => {
     title: null,
   };
   resetPluginRegistryAndRegisterDefaults();
+});
+
+afterAll(() => {
+  // Restore real `conversation-crud` for downstream files; see the snapshot
+  // block near the top of this file for why this is necessary.
+  mock.module(
+    "../memory/conversation-crud.js",
+    () => conversationCrudRealSnapshot,
+  );
 });
 
 describe("runAgentLoopImpl — per-conversation inferenceProfile", () => {

--- a/assistant/src/__tests__/conversation-crud-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-crud-inference-profile.test.ts
@@ -1,10 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
 mock.module("../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
+  getLogger: () => makeMockLogger(),
 }));
 
 import {

--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -4,11 +4,10 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { eq, like } from "drizzle-orm";
 
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
 mock.module("../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
+  getLogger: () => makeMockLogger(),
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/conversation-inference-profile-list.test.ts
+++ b/assistant/src/__tests__/conversation-inference-profile-list.test.ts
@@ -9,11 +9,10 @@
  */
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
 mock.module("../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
+  getLogger: () => makeMockLogger(),
 }));
 
 mock.module("../config/env.js", () => ({

--- a/assistant/src/__tests__/conversation-inference-profile-route.test.ts
+++ b/assistant/src/__tests__/conversation-inference-profile-route.test.ts
@@ -1,10 +1,9 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
 mock.module("../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
+  getLogger: () => makeMockLogger(),
 }));
 
 const config = {

--- a/assistant/src/__tests__/db-conversation-inference-profile-migration.test.ts
+++ b/assistant/src/__tests__/db-conversation-inference-profile-migration.test.ts
@@ -3,15 +3,17 @@ import { Database } from "bun:sqlite";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
 const originalBunTest = process.env.BUN_TEST;
 
 mock.module("../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
+  getLogger: () => makeMockLogger(),
 }));
 
+import { _resetDisplayOrderMigrationForTests } from "../memory/conversation-display-order-migration.js";
+import { _resetGroupMigrationForTests } from "../memory/conversation-group-migration.js";
 import { initializeDb, resetDb } from "../memory/db.js";
 import { getSqliteFrom } from "../memory/db-connection.js";
 import { migrateAddConversationInferenceProfile } from "../memory/migrations/227-add-conversation-inference-profile.js";
@@ -64,6 +66,11 @@ function bootstrapPreInferenceProfileConversations(raw: Database): void {
 
 function removeTestDbFiles(): void {
   resetDb();
+  // Reset the in-process guards for the lazy `group_id` / `display_order` /
+  // `is_pinned` migrations so the freshly recreated DB gets those columns
+  // again. Otherwise downstream tests hit `no such column: group_id`.
+  _resetGroupMigrationForTests();
+  _resetDisplayOrderMigrationForTests();
   const dbPath = getDbPath();
   rmSync(dbPath, { force: true });
   rmSync(`${dbPath}-shm`, { force: true });

--- a/assistant/src/__tests__/db-rename-inference-profile-snake-case-migration.test.ts
+++ b/assistant/src/__tests__/db-rename-inference-profile-snake-case-migration.test.ts
@@ -3,11 +3,10 @@ import { describe, expect, mock, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
 mock.module("../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
+  getLogger: () => makeMockLogger(),
 }));
 
 import { getSqliteFrom } from "../memory/db-connection.js";

--- a/assistant/src/__tests__/helpers/mock-logger.ts
+++ b/assistant/src/__tests__/helpers/mock-logger.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared test helper: a recursive no-op logger mock.
+ *
+ * The naive pattern that several tests use — `getLogger: () => new Proxy({},
+ * { get: () => () => {} })` — silently breaks when any consumer calls
+ * `log.child({...}).<method>()`. The `.child()` thunk returns `undefined`,
+ * so `undefined.<method>` throws a TypeError. This usually doesn't surface in
+ * isolation, because the success path of most code under test doesn't call
+ * `.child()`. But Bun's `mock.module()` DOES NOT hoist above static imports
+ * in the same file: the test file's own `import { runAgentLoopImpl } from …`
+ * statement triggers a transitive import chain that calls `getLogger` AT
+ * MODULE-INIT TIME, BEFORE the test file's `mock.module(...)` runs. If a
+ * previous test file in the same `bun test` run installed a non-recursive
+ * proxy mock for `util/logger.js`, that mock is now active for every newly
+ * loaded module — and any path that touches `log.child(...)` blows up.
+ *
+ * This helper installs a recursive proxy whose `child` access returns another
+ * proxy of the same shape, so every `log.<method>(...)` and
+ * `log.child({...}).<method>(...)` call is a safe no-op regardless of how
+ * deep callers nest.
+ *
+ * Usage:
+ *
+ *   import { mock } from "bun:test";
+ *   import { makeMockLogger } from "./helpers/mock-logger.js";
+ *
+ *   mock.module("../util/logger.js", () => ({
+ *     getLogger: () => makeMockLogger(),
+ *   }));
+ */
+
+export function makeMockLogger(): unknown {
+  return new Proxy({} as Record<string, unknown>, {
+    get: (_target, prop) => (prop === "child" ? makeMockLogger : () => {}),
+  });
+}

--- a/assistant/src/__tests__/provider-send-message-override-profile.test.ts
+++ b/assistant/src/__tests__/provider-send-message-override-profile.test.ts
@@ -13,9 +13,10 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
 mock.module("../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  getLogger: () => makeMockLogger(),
 }));
 
 // Mutable LLM config consumed by the resolver via `getConfig()`.

--- a/assistant/src/memory/conversation-display-order-migration.ts
+++ b/assistant/src/memory/conversation-display-order-migration.ts
@@ -41,3 +41,13 @@ export function ensureDisplayOrderMigration(): void {
     displayOrderColumnsEnsured = true;
   }
 }
+
+/**
+ * Reset the in-memory `displayOrderColumnsEnsured` guard so the next
+ * `ensureDisplayOrderMigration()` call re-runs. Intended ONLY for tests that
+ * recreate the SQLite database mid-process (e.g. `removeTestDbFiles()` in
+ * `db-conversation-inference-profile-migration.test.ts`).
+ */
+export function _resetDisplayOrderMigrationForTests(): void {
+  displayOrderColumnsEnsured = false;
+}

--- a/assistant/src/memory/conversation-group-migration.ts
+++ b/assistant/src/memory/conversation-group-migration.ts
@@ -21,6 +21,18 @@ function isDuplicateColumnError(err: unknown): boolean {
 let migrated = false;
 
 /**
+ * Reset the in-memory `migrated` guard so the next `ensureGroupMigration()`
+ * call re-runs the full migration. Intended ONLY for tests that recreate
+ * the SQLite database mid-process (e.g. `removeTestDbFiles()` in
+ * `db-conversation-inference-profile-migration.test.ts`) — without this,
+ * subsequent tests in the same `bun test` run hit
+ * `no such column: group_id` because the guard short-circuits the recreate.
+ */
+export function _resetGroupMigrationForTests(): void {
+  migrated = false;
+}
+
+/**
  * Uses raw BEGIN/COMMIT for the one-time backfill. Must NOT be called
  * for the first time inside a Drizzle db.transaction() block — SQLite
  * does not support nested transactions. In practice this is safe because
@@ -235,7 +247,10 @@ export function ensureGroupMigration(): void {
       rawExec("COMMIT");
     } catch (err) {
       rawExec("ROLLBACK");
-      log.error({ err }, "reflections-to-background migration failed, rolled back");
+      log.error(
+        { err },
+        "reflections-to-background migration failed, rolled back",
+      );
       throw err;
     }
   }
@@ -262,7 +277,9 @@ export function ensureGroupMigration(): void {
         WHERE group_id = 'system:reflections'
       `);
 
-      rawExec(`DELETE FROM conversation_groups WHERE id = 'system:reflections'`);
+      rawExec(
+        `DELETE FROM conversation_groups WHERE id = 'system:reflections'`,
+      );
 
       rawExec(`
         INSERT OR IGNORE INTO conversation_groups (id, name, sort_position, is_system_group)


### PR DESCRIPTION
## Summary

Fixes test isolation issues from the inference-profiles plan execution. Running the seven new inference-profile test files together produced 9-10 failures that disappeared when each file was run alone.

## Root causes

**1. Non-recursive logger proxy (affected 9 files).** The duplicated pattern `getLogger: () => new Proxy({}, { get: () => () => {} })` returns `undefined` for `log.child(...)` (the proxy's `child` thunk returns undefined). Bun's `mock.module()` does NOT hoist above static imports — when test file A's static-import chain transitively pulls in modules that call `getLogger()`, those modules capture the *previous* test file's mock at their module-init time. If that mock is non-recursive, any code path that touches `log.child(...).<method>()` blows up later.

Fixed by extracting a shared `makeMockLogger()` helper (`assistant/src/__tests__/helpers/mock-logger.ts`) that returns a recursive proxy where `child` access yields another proxy of the same shape. Replaced the inline pattern in 9 inference-profile test files.

**2. `conversation-crud` mock leaking from `conversation-agent-loop-inference-profile.test.ts`.** That file mocks `getConversation` to return a stub conversation row. Bun's `mock.module()` mocks persist across files in a single `bun test` run, and `mock.restore()` does not restore module mocks. Subsequent files that import the real `getConversation` got the stub.

Fixed by snapshotting the real exports via `createRequire` *before* the mock (the spread freezes the references — holding the live module would yield the mocked values), then re-mocking with the snapshot in `afterAll`.

**3. Lazy-migration guard pollution.** `db-conversation-inference-profile-migration.test.ts` calls `removeTestDbFiles()` which deletes the SQLite file mid-process, but the in-memory `migrated` guards in `conversation-group-migration.ts` and `conversation-display-order-migration.ts` were never reset, so subsequent tests hit `SQLiteError: no such column: group_id` (the lazy migration short-circuits the recreate).

Fixed by adding test-only `_resetGroupMigrationForTests()` / `_resetDisplayOrderMigrationForTests()` escape hatches (matching the existing `_setStorePath` test-only pattern in `encrypted-store.ts`) and calling them from `removeTestDbFiles()`.

## Issue 2 (pre-existing failure in `conversation-crud-inference-profile.test.ts`)

Already fixed in commit `1083f7d69d` ("test(memory): drop flaky .resolves matcher"). The R3.1 agent saw it as failing because they were running the file inside a polluted batch — running it alone passes 3/3.

## Verification

- All 13 inference-profile test files pass when run together (`bun test ... 13 files` → 92 pass / 0 fail).
- The original 8-file failing batch passes (45/45).
- Each file passes in isolation.
- `bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
