### PR TITLE
Add typed scaffolding for agentic recall search

### DIFF
--- a/assistant/src/__tests__/context-search-types.test.ts
+++ b/assistant/src/__tests__/context-search-types.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ALL_RECALL_SOURCES,
+  DEFAULT_RECALL_MAX_RESULTS,
+  normalizeRecallInput,
+  normalizeRecallMaxResults,
+  normalizeRecallSources,
+  RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE,
+  RECALL_SOURCE_ROUNDS_BY_DEPTH,
+  RECALL_TOTAL_EVIDENCE_TEXT_CAP,
+} from "../memory/context-search/limits.js";
+import type {
+  RecallInput,
+  RecallSource,
+  RecallSourceAdapter,
+} from "../memory/context-search/types.js";
+
+describe("normalizeRecallInput", () => {
+  test("defaults omitted sources, max results, and depth", () => {
+    const normalized = normalizeRecallInput({ query: "project notes" });
+
+    expect(normalized).toEqual({
+      query: "project notes",
+      sources: [...ALL_RECALL_SOURCES],
+      maxResults: DEFAULT_RECALL_MAX_RESULTS,
+      depth: "standard",
+      sourceRounds: 2,
+    });
+  });
+
+  test("clamps max results to the supported range", () => {
+    expect(normalizeRecallMaxResults(0)).toBe(1);
+    expect(normalizeRecallMaxResults(-10)).toBe(1);
+    expect(normalizeRecallMaxResults(21)).toBe(20);
+    expect(normalizeRecallMaxResults(2.9)).toBe(2);
+    expect(normalizeRecallMaxResults(Number.NaN)).toBe(
+      DEFAULT_RECALL_MAX_RESULTS,
+    );
+  });
+
+  test("de-duplicates sources while preserving first-seen order", () => {
+    expect(
+      normalizeRecallSources(["workspace", "memory", "workspace", "pkb"]),
+    ).toEqual(["workspace", "memory", "pkb"]);
+  });
+
+  test("rejects unknown sources before adapters are run", async () => {
+    let adapterRan = false;
+    const adapter: RecallSourceAdapter = {
+      source: "memory",
+      async search() {
+        adapterRan = true;
+        return { evidence: [] };
+      },
+    };
+
+    expect(() =>
+      normalizeRecallInput({
+        query: "deployment",
+        sources: ["memory", "calendar"] as unknown as RecallSource[],
+      }),
+    ).toThrow("Unknown recall source: calendar");
+
+    expect(adapterRan).toBe(false);
+    expect(adapter.source).toBe("memory");
+  });
+
+  test("maps depth to source-round budgets", () => {
+    expect(RECALL_SOURCE_ROUNDS_BY_DEPTH).toEqual({
+      fast: 1,
+      standard: 2,
+      deep: 3,
+    });
+
+    const cases: Array<[NonNullable<RecallInput["depth"]>, number]> = [
+      ["fast", 1],
+      ["standard", 2],
+      ["deep", 3],
+    ];
+
+    for (const [depth, sourceRounds] of cases) {
+      expect(normalizeRecallInput({ query: "notes", depth }).sourceRounds).toBe(
+        sourceRounds,
+      );
+    }
+  });
+
+  test("exports evidence text caps", () => {
+    expect(RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE).toBeGreaterThan(0);
+    expect(RECALL_TOTAL_EVIDENCE_TEXT_CAP).toBeGreaterThan(
+      RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE,
+    );
+  });
+});

--- a/assistant/src/memory/context-search/limits.ts
+++ b/assistant/src/memory/context-search/limits.ts
@@ -1,0 +1,106 @@
+import type { RecallDepth, RecallInput, RecallSource } from "./types.js";
+
+export const ALL_RECALL_SOURCES: readonly RecallSource[] = [
+  "memory",
+  "pkb",
+  "conversations",
+  "workspace",
+] as const;
+
+const RECALL_SOURCE_SET: ReadonlySet<unknown> = new Set(ALL_RECALL_SOURCES);
+
+export const DEFAULT_RECALL_MAX_RESULTS = 8;
+export const MIN_RECALL_MAX_RESULTS = 1;
+export const MAX_RECALL_MAX_RESULTS = 20;
+
+export const DEFAULT_RECALL_DEPTH: RecallDepth = "standard";
+
+export const RECALL_SOURCE_ROUNDS_BY_DEPTH: Record<RecallDepth, number> = {
+  fast: 1,
+  standard: 2,
+  deep: 3,
+};
+
+export const RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE = 6_000;
+export const RECALL_TOTAL_EVIDENCE_TEXT_CAP = 18_000;
+
+export interface NormalizedRecallInput {
+  query: string;
+  sources: RecallSource[];
+  maxResults: number;
+  depth: RecallDepth;
+  sourceRounds: number;
+}
+
+export function normalizeRecallInput(
+  input: RecallInput,
+): NormalizedRecallInput {
+  const depth = normalizeRecallDepth(input.depth);
+
+  return {
+    query: input.query,
+    sources: normalizeRecallSources(input.sources),
+    maxResults: normalizeRecallMaxResults(input.max_results),
+    depth,
+    sourceRounds: RECALL_SOURCE_ROUNDS_BY_DEPTH[depth],
+  };
+}
+
+export function normalizeRecallSources(
+  sources: readonly RecallSource[] | undefined,
+): RecallSource[] {
+  if (!sources || sources.length === 0) {
+    return [...ALL_RECALL_SOURCES];
+  }
+
+  const normalized: RecallSource[] = [];
+  for (const source of sources) {
+    if (!isRecallSource(source)) {
+      throw new Error(`Unknown recall source: ${String(source)}`);
+    }
+    if (!normalized.includes(source)) {
+      normalized.push(source);
+    }
+  }
+
+  return normalized;
+}
+
+export function normalizeRecallMaxResults(
+  maxResults: number | undefined,
+): number {
+  if (typeof maxResults !== "number" || !Number.isFinite(maxResults)) {
+    return DEFAULT_RECALL_MAX_RESULTS;
+  }
+
+  const integerMaxResults = Math.floor(maxResults);
+  return clamp(
+    integerMaxResults,
+    MIN_RECALL_MAX_RESULTS,
+    MAX_RECALL_MAX_RESULTS,
+  );
+}
+
+export function normalizeRecallDepth(
+  depth: RecallDepth | undefined,
+): RecallDepth {
+  if (depth === undefined) {
+    return DEFAULT_RECALL_DEPTH;
+  }
+
+  if (depth !== "fast" && depth !== "standard" && depth !== "deep") {
+    throw new Error(`Unknown recall depth: ${String(depth)}`);
+  }
+
+  return depth;
+}
+
+export function isRecallSource(source: unknown): source is RecallSource {
+  return RECALL_SOURCE_SET.has(source);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}

--- a/assistant/src/memory/context-search/types.ts
+++ b/assistant/src/memory/context-search/types.ts
@@ -1,0 +1,49 @@
+import type { AssistantConfig } from "../../config/schema.js";
+
+export type RecallSource = "memory" | "pkb" | "conversations" | "workspace";
+
+export type RecallDepth = "fast" | "standard" | "deep";
+
+export interface RecallInput {
+  query: string;
+  sources?: RecallSource[];
+  max_results?: number;
+  depth?: RecallDepth;
+}
+
+export interface RecallEvidence {
+  id: string;
+  source: RecallSource;
+  title: string;
+  locator: string;
+  excerpt: string;
+  timestampMs?: number;
+  score?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RecallSearchContext {
+  workingDir: string;
+  memoryScopeId: string;
+  conversationId: string;
+  config: AssistantConfig;
+  signal?: AbortSignal;
+}
+
+export interface RecallSearchResult {
+  evidence: RecallEvidence[];
+}
+
+export interface RecallAnswer {
+  answer: string;
+  evidence: RecallEvidence[];
+}
+
+export interface RecallSourceAdapter {
+  source: RecallSource;
+  search(
+    query: string,
+    context: RecallSearchContext,
+    limit: number,
+  ): Promise<RecallSearchResult>;
+}


### PR DESCRIPTION
## Summary
- Add typed scaffolding and normalization helpers for agentic recall search.
- Add focused tests for source/depth/default normalization.

Part of plan: replace-recall-agentic-search.md (PR 1 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
