### PR TITLE
Add cost-optimized LLM call-site defaults for recall

### DIFF
--- a/assistant/src/__tests__/workspace-migration-054-seed-recall-callsite.test.ts
+++ b/assistant/src/__tests__/workspace-migration-054-seed-recall-callsite.test.ts
@@ -1,0 +1,235 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import { LLMSchema } from "../config/schemas/llm.js";
+import { seedRecallCallsiteMigration } from "../workspace/migrations/054-seed-recall-callsite.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-054-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function configPath(): string {
+  return join(workspaceDir, "config.json");
+}
+
+beforeEach(() => {
+  freshWorkspace();
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+});
+
+afterEach(() => {
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("054-seed-recall-callsite migration", () => {
+  test("has correct migration id", () => {
+    expect(seedRecallCallsiteMigration.id).toBe("054-seed-recall-callsite");
+  });
+
+  test("LLMSchema accepts the recall call site", () => {
+    const parsed = LLMSchema.parse({
+      callSites: {
+        recall: {
+          profile: "cost-optimized",
+          maxTokens: 4096,
+          effort: "low",
+          thinking: { enabled: false, streamThinking: false },
+          temperature: 0,
+        },
+      },
+      profiles: {
+        "cost-optimized": {
+          provider: "anthropic",
+          model: "claude-haiku-4-5-20251001",
+        },
+      },
+    });
+
+    expect(parsed.callSites.recall).toEqual({
+      profile: "cost-optimized",
+      maxTokens: 4096,
+      effort: "low",
+      thinking: { enabled: false, streamThinking: false },
+      temperature: 0,
+    });
+  });
+
+  test("fresh config seeds Anthropic cheap defaults when cost profile is absent", () => {
+    expect(existsSync(configPath())).toBe(false);
+
+    seedRecallCallsiteMigration.run(workspaceDir);
+
+    expect(existsSync(configPath())).toBe(true);
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.recall).toEqual({
+      model: "claude-haiku-4-5-20251001",
+      maxTokens: 4096,
+      effort: "low",
+      thinking: { enabled: false, streamThinking: false },
+      temperature: 0,
+    });
+  });
+
+  test("existing config uses cost-optimized profile when it exists", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic", model: "claude-opus-4-7" },
+        profiles: {
+          "cost-optimized": {
+            provider: "anthropic",
+            model: "claude-haiku-4-5-20251001",
+            maxTokens: 8192,
+          },
+        },
+      },
+    });
+
+    seedRecallCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.recall).toEqual({
+      profile: "cost-optimized",
+      maxTokens: 4096,
+      effort: "low",
+      thinking: { enabled: false, streamThinking: false },
+      temperature: 0,
+    });
+  });
+
+  test("preserves user-defined recall call site unchanged", () => {
+    const userRecall = {
+      provider: "openai",
+      model: "gpt-5.4",
+      maxTokens: 2048,
+      effort: "medium",
+      thinking: { enabled: true, streamThinking: true },
+      temperature: 0.7,
+    };
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        profiles: {
+          "cost-optimized": {
+            provider: "anthropic",
+            model: "claude-haiku-4-5-20251001",
+          },
+        },
+        callSites: {
+          recall: userRecall,
+        },
+      },
+    });
+
+    seedRecallCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.recall).toEqual(userRecall);
+  });
+
+  test("missing cost profile falls back to provider-specific cheap defaults", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "openai", model: "gpt-5.4" },
+        profiles: {
+          balanced: {
+            provider: "openai",
+            model: "gpt-5.4",
+          },
+        },
+      },
+    });
+
+    seedRecallCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.recall).toEqual({
+      model: "gpt-5.4-nano",
+      maxTokens: 4096,
+      effort: "low",
+      thinking: { enabled: false, streamThinking: false },
+      temperature: 0,
+    });
+  });
+
+  test("skips when VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH is set", () => {
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = "/tmp/overlay.json";
+    writeConfig({
+      llm: { default: { provider: "anthropic" } },
+    });
+
+    seedRecallCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites?: Record<string, unknown> };
+    };
+    expect(config.llm.callSites).toBeUndefined();
+  });
+
+  test("resolved recall config uses cost profile model with low-cost leaves", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic", model: "claude-opus-4-7" },
+        profiles: {
+          "cost-optimized": {
+            provider: "anthropic",
+            model: "claude-haiku-4-5-20251001",
+            maxTokens: 8192,
+            effort: "low",
+            thinking: { enabled: false, streamThinking: false },
+          },
+        },
+      },
+    });
+
+    seedRecallCallsiteMigration.run(workspaceDir);
+
+    const onDisk = readConfig() as { llm: unknown };
+    const parsed = LLMSchema.parse(onDisk.llm);
+    const resolved = resolveCallSiteConfig("recall", parsed);
+    expect(resolved.model).toBe("claude-haiku-4-5-20251001");
+    expect(resolved.maxTokens).toBe(4096);
+    expect(resolved.effort).toBe("low");
+    expect(resolved.thinking).toEqual({
+      enabled: false,
+      streamThinking: false,
+    });
+    expect(resolved.temperature).toBe(0);
+  });
+});

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -44,6 +44,7 @@ export const LLMCallSiteEnum = z.enum([
   "memoryExtraction",
   "memoryConsolidation",
   "memoryRetrieval",
+  "recall",
   "narrativeRefinement",
   "patternScan",
   "conversationSummarization",

--- a/assistant/src/workspace/migrations/054-seed-recall-callsite.ts
+++ b/assistant/src/workspace/migrations/054-seed-recall-callsite.ts
@@ -1,0 +1,102 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Seed a cost-optimized default for the `recall` LLM call site.
+ *
+ * Agentic recall uses an LLM to evaluate and synthesize bounded search
+ * results. Without a call-site entry, it would inherit the workspace default,
+ * which may be an expensive high-effort model. Prefer the canonical
+ * `cost-optimized` profile when present, then fall back to the same cheap
+ * provider model map used by earlier latency/cost migrations.
+ *
+ * Existing `llm.callSites.recall` objects are preserved exactly.
+ */
+export const seedRecallCallsiteMigration: WorkspaceMigration = {
+  id: "054-seed-recall-callsite",
+  description: "Seed cost-optimized default for recall LLM call site",
+  run(workspaceDir: string): void {
+    if (process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH) return;
+
+    const configPath = join(workspaceDir, "config.json");
+    const configExisted = existsSync(configPath);
+
+    let config: Record<string, unknown> = {};
+    if (configExisted) {
+      try {
+        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+        config = raw as Record<string, unknown>;
+      } catch {
+        return;
+      }
+    }
+
+    const llm = readObject(config.llm) ?? {};
+    const callSites = readObject(llm.callSites) ?? {};
+    if (readObject(callSites.recall) !== null) return;
+
+    const profiles = readObject(llm.profiles) ?? {};
+    if (readObject(profiles["cost-optimized"]) !== null) {
+      callSites.recall = {
+        profile: "cost-optimized",
+        ...RECALL_LOW_COST_LEAVES,
+      };
+    } else {
+      const defaultBlock = readObject(llm.default);
+      const provider = readString(defaultBlock?.provider) ?? "anthropic";
+      const cheapModel = resolveLatencyModel(provider);
+      if (cheapModel === undefined) return;
+
+      callSites.recall = {
+        model: cheapModel,
+        ...RECALL_LOW_COST_LEAVES,
+      };
+    }
+
+    llm.callSites = callSites;
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: removing the seeded default would make recall inherit
+    // potentially expensive workspace defaults again.
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers — self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const RECALL_LOW_COST_LEAVES = {
+  maxTokens: 4096,
+  effort: "low",
+  thinking: { enabled: false, streamThinking: false },
+  temperature: 0,
+};
+
+const PROVIDER_LATENCY_MODELS: Record<string, string> = {
+  anthropic: "claude-haiku-4-5-20251001",
+  openai: "gpt-5.4-nano",
+  gemini: "gemini-3-flash",
+  ollama: "llama3.2",
+  fireworks: "accounts/fireworks/models/kimi-k2p5",
+  openrouter: "anthropic/claude-haiku-4.5",
+};
+
+function resolveLatencyModel(provider: string): string | undefined {
+  return PROVIDER_LATENCY_MODELS[provider];
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -51,6 +51,7 @@ import { seedMainAgentOpusCallsiteMigration } from "./050-seed-main-agent-opus-c
 import { seedConversationSummarizationCallsiteMigration } from "./051-seed-conversation-summarization-callsite.js";
 import { seedDefaultInferenceProfiles052 } from "./052-seed-default-inference-profiles.js";
 import { releaseNotesAcpCodexMigration } from "./053-release-notes-acp-codex.js";
+import { seedRecallCallsiteMigration } from "./054-seed-recall-callsite.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -113,4 +114,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   seedConversationSummarizationCallsiteMigration,
   seedDefaultInferenceProfiles052,
   releaseNotesAcpCodexMigration,
+  seedRecallCallsiteMigration,
 ];


### PR DESCRIPTION
## Summary
- Add a recall LLM call site.
- Seed cost-optimized recall defaults with a workspace migration.

Part of plan: replace-recall-agentic-search.md (PR 2 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
