### PR TITLE
refactor(acp): round-2 self-review fixes — session-manager resume hint, steer test pollution, helper migration, deduped install hints

### DIFF
--- a/assistant/src/acp/__tests__/helpers/acp-config-stub.ts
+++ b/assistant/src/acp/__tests__/helpers/acp-config-stub.ts
@@ -4,14 +4,14 @@
  * Bun's `mock.module` is process-global and only intercepts the literal keys
  * the factory returns. ACP test files have all been duplicating the same
  * mutable `mockAcpConfig` + `mock.module(..., () => ({ getConfig: ... }))`
- * boilerplate; this helper consolidates it. The `includeRealLoader` option
- * spreads the real loader's named exports into the mock so tests whose
- * code path transitively imports `loadConfig`, `invalidateConfigCache`,
- * etc. don't fail at parse time on "Export named 'loadConfig' not found".
+ * boilerplate; this helper consolidates it. The real loader's other named
+ * exports are spread into the mock so tests whose code path transitively
+ * imports `loadConfig`, `invalidateConfigCache`, etc. don't fail at parse
+ * time on "Export named 'X' not found".
  *
  * Like `which-stub.ts`, this is a process-global hook by design — Bun's
  * `mock.module` is process-global, so tests can't isolate it per-file.
- * Each test file should call `installAcpConfigStub()` once at the top
+ * Each test file should `await installAcpConfigStub()` once at the top
  * level and drive it via `setConfig(partial)` per test.
  */
 
@@ -37,27 +37,12 @@ export interface AcpConfigStubHandle {
 }
 
 /**
- * Installs a process-global mock of `getConfig`. Returns helpers that drive
- * the config the mock returns and read the current value back.
- *
- * Pass `includeRealLoader: true` when the test's code path transitively
- * imports other named exports from `loader.js` (e.g. `loadConfig`,
- * `invalidateConfigCache`) — without the spread, those imports fail at parse
- * time with "Export named 'X' not found". Resolution must happen *before*
- * the mock is registered: the helper returns a Promise in that case so the
- * caller `await`s it, ensuring downstream dynamic imports see the spread
- * version. The plain (sync) overload covers the common case where only
- * `getConfig` is needed.
+ * Installs a process-global mock of `getConfig`. The real loader's named
+ * exports are resolved *before* the mock registers so downstream dynamic
+ * imports see the spread version — that's why this returns a Promise the
+ * caller must `await`.
  */
-export function installAcpConfigStub(opts: {
-  includeRealLoader: true;
-}): Promise<AcpConfigStubHandle>;
-export function installAcpConfigStub(opts?: {
-  includeRealLoader?: false;
-}): AcpConfigStubHandle;
-export function installAcpConfigStub(opts?: {
-  includeRealLoader?: boolean;
-}): AcpConfigStubHandle | Promise<AcpConfigStubHandle> {
+export async function installAcpConfigStub(): Promise<AcpConfigStubHandle> {
   let mockAcpConfig: MockAcpConfig = { ...DEFAULT_CONFIG };
   const handle: AcpConfigStubHandle = {
     setConfig(partial) {
@@ -68,18 +53,9 @@ export function installAcpConfigStub(opts?: {
     },
   };
 
-  if (opts?.includeRealLoader) {
-    return (async () => {
-      const realLoader = await import("../../../config/loader.js");
-      mock.module("../../../config/loader.js", () => ({
-        ...realLoader,
-        getConfig: () => ({ acp: mockAcpConfig }),
-      }));
-      return handle;
-    })();
-  }
-
+  const realLoader = await import("../../../config/loader.js");
   mock.module("../../../config/loader.js", () => ({
+    ...realLoader,
     getConfig: () => ({ acp: mockAcpConfig }),
   }));
   return handle;

--- a/assistant/src/acp/resolve-agent.test.ts
+++ b/assistant/src/acp/resolve-agent.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { installAcpConfigStub } from "./__tests__/helpers/acp-config-stub.js";
 import { installWhichStub } from "./__tests__/helpers/which-stub.js";
 
-const config = await installAcpConfigStub({ includeRealLoader: true });
+const config = await installAcpConfigStub();
 const which = installWhichStub();
 
 afterAll(() => {
@@ -232,7 +232,7 @@ describe("listAcpAgents", () => {
     expect(codex?.source).toBe("default");
   });
 
-  test("unavailable agent surfaces install hint from DEFAULT_AGENT_INSTALL_HINTS", () => {
+  test("unavailable agent surfaces install hint derived from DEFAULT_AGENT_NPM_PACKAGES", () => {
     config.setConfig({ agents: {} });
     which.setWhich({ "claude-agent-acp": "/usr/bin/claude-agent-acp" });
 

--- a/assistant/src/acp/resolve-agent.ts
+++ b/assistant/src/acp/resolve-agent.ts
@@ -12,12 +12,12 @@
  *
  * `listAcpAgents()` exposes the merged catalog with availability info for
  * the `acp_list_agents` tool — same merge semantics, plus per-entry
- * `available` / `setupHint` derived from `Bun.which` + `DEFAULT_AGENT_INSTALL_HINTS`.
+ * `available` / `setupHint` derived from `Bun.which` + `DEFAULT_AGENT_NPM_PACKAGES`.
  */
 
 import {
   DEFAULT_ACP_AGENT_PROFILES,
-  DEFAULT_AGENT_INSTALL_HINTS,
+  DEFAULT_AGENT_NPM_PACKAGES,
 } from "../config/acp-defaults.js";
 import type { AcpAgentConfig } from "../config/acp-schema.js";
 import { getConfig } from "../config/loader.js";
@@ -59,10 +59,10 @@ export const ACP_DISABLED_HINT =
   "Set 'acp.enabled': true in ~/.vellum/workspace/config.json (or via the runtime config endpoint).";
 
 function installHintFor(command: string): string {
-  return (
-    DEFAULT_AGENT_INSTALL_HINTS[command] ??
-    `Install '${command}' and ensure it is on PATH.`
-  );
+  const pkg = DEFAULT_AGENT_NPM_PACKAGES[command];
+  return pkg
+    ? `npm i -g ${pkg}`
+    : `Install '${command}' and ensure it is on PATH.`;
 }
 
 /**

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -22,6 +22,9 @@ interface SessionEntry {
   currentPrompt: Promise<unknown> | null;
   parentConversationId: string;
   cwd: string;
+  /** The adapter binary that was spawned. Used to gate resume hints to
+   *  the only adapter (claude-agent-acp) whose CLI accepts `--resume`. */
+  command: string;
 }
 
 export class AcpSessionManager {
@@ -105,6 +108,7 @@ export class AcpSessionManager {
       currentPrompt: null,
       parentConversationId,
       cwd,
+      command: agentConfig.command,
     };
 
     this.sessions.set(acpSessionId, entry);
@@ -299,9 +303,14 @@ export class AcpSessionManager {
             const agentLabel = current.state.agentId;
             const responseText = current.clientHandler.responseText;
             const sessionId = current.state.acpSessionId;
-            const notifyMessage =
-              `[ACP agent "${agentLabel}" completed]\n\n${responseText}\n\n` +
-              `To resume: cd ${current.cwd} && claude --resume ${sessionId}`;
+            // `claude --resume <id>` is Claude Code-specific (the
+            // claude-agent-acp adapter binary). Other adapters resume
+            // differently or not at all, so the hint is gated.
+            const resumeHint =
+              current.command === "claude-agent-acp"
+                ? `\n\nTo resume: cd ${current.cwd} && claude --resume ${sessionId}`
+                : "";
+            const notifyMessage = `[ACP agent "${agentLabel}" completed]\n\n${responseText}${resumeHint}`;
             this.onAcpSessionFinished(
               current.parentConversationId,
               notifyMessage,

--- a/assistant/src/config/acp-defaults.test.ts
+++ b/assistant/src/config/acp-defaults.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 
 import {
   DEFAULT_ACP_AGENT_PROFILES,
-  DEFAULT_AGENT_INSTALL_HINTS,
   DEFAULT_AGENT_NPM_PACKAGES,
 } from "./acp-defaults.js";
 
@@ -38,52 +37,6 @@ describe("DEFAULT_ACP_AGENT_PROFILES", () => {
   });
 });
 
-describe("DEFAULT_AGENT_INSTALL_HINTS", () => {
-  test("is keyed by command name, not agent id", () => {
-    expect(Object.keys(DEFAULT_AGENT_INSTALL_HINTS).sort()).toEqual([
-      "claude-agent-acp",
-      "codex-acp",
-    ]);
-  });
-
-  test("hints reference the new @agentclientprotocol package for claude", () => {
-    expect(DEFAULT_AGENT_INSTALL_HINTS["claude-agent-acp"]).toBe(
-      "npm i -g @agentclientprotocol/claude-agent-acp",
-    );
-  });
-
-  test("hints reference the @zed-industries package for codex", () => {
-    expect(DEFAULT_AGENT_INSTALL_HINTS["codex-acp"]).toBe(
-      "npm i -g @zed-industries/codex-acp",
-    );
-  });
-
-  test("every default profile's command has a matching install hint", () => {
-    for (const profile of Object.values(DEFAULT_ACP_AGENT_PROFILES)) {
-      expect(DEFAULT_AGENT_INSTALL_HINTS[profile.command]).toBeDefined();
-    }
-  });
-
-  test("is frozen at runtime so mutation throws in strict mode", () => {
-    expect(Object.isFrozen(DEFAULT_AGENT_INSTALL_HINTS)).toBe(true);
-  });
-
-  test("readonly type rejects mutation at compile time", () => {
-    const _assignNewKey: () => void = () => {
-      // @ts-expect-error — DEFAULT_AGENT_INSTALL_HINTS has a Readonly index signature
-      DEFAULT_AGENT_INSTALL_HINTS["new-binary"] = "npm i -g foo";
-    };
-    const _assignNewProfile: () => void = () => {
-      // @ts-expect-error — DEFAULT_ACP_AGENT_PROFILES has a Readonly index signature
-      DEFAULT_ACP_AGENT_PROFILES.newAgent = { command: "x", args: [] };
-    };
-    // The assertions live in the @ts-expect-error comments above; this test
-    // exists to surface a type-check failure if the readonly contract regresses.
-    expect(_assignNewKey).toBeFunction();
-    expect(_assignNewProfile).toBeFunction();
-  });
-});
-
 describe("DEFAULT_AGENT_NPM_PACKAGES", () => {
   test("is keyed by command name with the canonical npm package", () => {
     expect(DEFAULT_AGENT_NPM_PACKAGES).toEqual({
@@ -92,17 +45,13 @@ describe("DEFAULT_AGENT_NPM_PACKAGES", () => {
     });
   });
 
-  test("is frozen at runtime so mutation throws in strict mode", () => {
-    expect(Object.isFrozen(DEFAULT_AGENT_NPM_PACKAGES)).toBe(true);
+  test("every default profile's command has a matching npm package", () => {
+    for (const profile of Object.values(DEFAULT_ACP_AGENT_PROFILES)) {
+      expect(DEFAULT_AGENT_NPM_PACKAGES[profile.command]).toBeDefined();
+    }
   });
 
-  test("DEFAULT_AGENT_INSTALL_HINTS is derived from DEFAULT_AGENT_NPM_PACKAGES", () => {
-    for (const [command, pkg] of Object.entries(DEFAULT_AGENT_NPM_PACKAGES)) {
-      expect(DEFAULT_AGENT_INSTALL_HINTS[command]).toBe(`npm i -g ${pkg}`);
-    }
-    // No extra keys in install hints that aren't in the npm map.
-    expect(Object.keys(DEFAULT_AGENT_INSTALL_HINTS).sort()).toEqual(
-      Object.keys(DEFAULT_AGENT_NPM_PACKAGES).sort(),
-    );
+  test("is frozen at runtime so mutation throws in strict mode", () => {
+    expect(Object.isFrozen(DEFAULT_AGENT_NPM_PACKAGES)).toBe(true);
   });
 });

--- a/assistant/src/config/acp-defaults.ts
+++ b/assistant/src/config/acp-defaults.ts
@@ -27,7 +27,7 @@ export const DEFAULT_ACP_AGENT_PROFILES: Readonly<
 
 /**
  * Single source of truth for adapter binary → npm package name. Both the
- * version-check probe in `acp_spawn` and the install-hint generator below
+ * version-check probe in `acp_spawn` and the resolver's install-hint format
  * key off this map, so a new adapter only needs one entry here.
  *
  * Keyed by command name (not agent id) so the mapping follows the binary
@@ -38,19 +38,3 @@ export const DEFAULT_AGENT_NPM_PACKAGES: Readonly<Record<string, string>> =
     "claude-agent-acp": "@agentclientprotocol/claude-agent-acp",
     "codex-acp": "@zed-industries/codex-acp",
   });
-
-/**
- * Install hints for ACP adapter binaries, keyed by command name (not agent id).
- *
- * Derived from `DEFAULT_AGENT_NPM_PACKAGES` so adapter→package and
- * adapter→install-hint can never drift.
- */
-export const DEFAULT_AGENT_INSTALL_HINTS: Readonly<Record<string, string>> =
-  Object.freeze(
-    Object.fromEntries(
-      Object.entries(DEFAULT_AGENT_NPM_PACKAGES).map(([command, pkg]) => [
-        command,
-        `npm i -g ${pkg}`,
-      ]),
-    ),
-  );

--- a/assistant/src/runtime/routes/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-routes.test.ts
@@ -1,75 +1,24 @@
 /**
  * Tests for the POST /v1/acp/spawn route handler — focused on the three
  * failure paths produced by `resolveAcpAgent` (acp_disabled, unknown_agent,
- * binary_not_found). Mirrors the resolver's test setup: stubs `getConfig`
- * via `mock.module` and swaps `Bun.which` to deterministically simulate
- * binary presence/absence without touching the host environment.
+ * binary_not_found). Mirrors the resolver's test setup using the shared
+ * `installAcpConfigStub` and `installWhichStub` helpers so the host
+ * environment doesn't influence the resolver's PATH preflight.
  */
 
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
-import type { AcpAgentConfig } from "../../config/acp-schema.js";
+import { installAcpConfigStub } from "../../acp/__tests__/helpers/acp-config-stub.js";
+import { installWhichStub } from "../../acp/__tests__/helpers/which-stub.js";
 
-// ---------------------------------------------------------------------------
-// Mock infrastructure
-// ---------------------------------------------------------------------------
-
-interface MockAcpConfig {
-  enabled: boolean;
-  maxConcurrentSessions: number;
-  agents: Record<string, AcpAgentConfig>;
-}
-
-let mockAcpConfig: MockAcpConfig = {
-  enabled: true,
-  maxConcurrentSessions: 4,
-  agents: {},
-};
-
-// Spread the real loader's named exports so transitive importers that pull
-// `loadConfig`, `invalidateConfigCache`, etc. from the same module path
-// still resolve at parse time. Bun's `mock.module` is process-global and
-// returns *exactly* the keys the factory returns — without the spread,
-// any module the test pulls in transitively that does
-// `import { loadConfig } from "../config/loader.js"` errors at evaluation
-// time on "Export named 'loadConfig' not found".
-const realLoader = await import("../../config/loader.js");
-mock.module("../../config/loader.js", () => ({
-  ...realLoader,
-  getConfig: () => ({ acp: mockAcpConfig }),
-}));
-
-// `Bun.which` is a global, not an ESM module export — `mock.module` cannot
-// touch it. Capture the original and restore in afterAll so the swap doesn't
-// leak into other test files.
-const originalWhich = Bun.which;
-let whichStub: (command: string) => string | null = (cmd) =>
-  `/usr/local/bin/${cmd}`;
-(Bun as unknown as { which: (cmd: string) => string | null }).which = (cmd) =>
-  whichStub(cmd);
+const config = await installAcpConfigStub();
+const which = installWhichStub();
 
 afterAll(() => {
-  (Bun as unknown as { which: typeof originalWhich }).which = originalWhich;
+  which.restore();
 });
 
 const { acpRouteDefinitions } = await import("./acp-routes.js");
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function setConfig(partial: Partial<MockAcpConfig>): void {
-  mockAcpConfig = {
-    enabled: true,
-    maxConcurrentSessions: 4,
-    agents: {},
-    ...partial,
-  };
-}
-
-function setWhich(map: Record<string, string | null>): void {
-  whichStub = (cmd) => map[cmd] ?? null;
-}
 
 function getSpawnHandler() {
   const route = acpRouteDefinitions().find(
@@ -95,8 +44,8 @@ function makeSpawnCtx(body: unknown) {
 }
 
 beforeEach(() => {
-  setConfig({});
-  whichStub = (cmd) => `/usr/local/bin/${cmd}`;
+  config.setConfig({});
+  which.setWhich((cmd) => `/usr/local/bin/${cmd}`);
 });
 
 // ---------------------------------------------------------------------------
@@ -105,7 +54,7 @@ beforeEach(() => {
 
 describe("POST /v1/acp/spawn", () => {
   test("returns 400 with the resolver hint when ACP is disabled", async () => {
-    setConfig({ enabled: false });
+    config.setConfig({ enabled: false });
 
     const handler = getSpawnHandler();
     const res = await handler(
@@ -126,7 +75,7 @@ describe("POST /v1/acp/spawn", () => {
   });
 
   test("returns 400 with merged available list when agent id is unknown", async () => {
-    setConfig({
+    config.setConfig({
       agents: {
         "user-only": { command: "some-binary", args: [] },
       },
@@ -153,8 +102,8 @@ describe("POST /v1/acp/spawn", () => {
   });
 
   test("returns 424 FAILED_DEPENDENCY with command + install hint when the agent binary is missing", async () => {
-    setConfig({ agents: {} });
-    setWhich({}); // no commands on PATH
+    config.setConfig({ agents: {} });
+    which.setWhich({}); // no commands on PATH
 
     const handler = getSpawnHandler();
     const res = await handler(
@@ -178,7 +127,7 @@ describe("POST /v1/acp/spawn", () => {
   test("body-shape guard short-circuits before the resolver runs", async () => {
     // Disable ACP so a resolver-reached path would surface the disabled
     // hint — the body-shape error message must win, proving we short-circuit.
-    setConfig({ enabled: false });
+    config.setConfig({ enabled: false });
 
     const handler = getSpawnHandler();
     const res = await handler(makeSpawnCtx({ agent: "claude" }));

--- a/assistant/src/tools/acp/list-agents.test.ts
+++ b/assistant/src/tools/acp/list-agents.test.ts
@@ -1,65 +1,17 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
-import type { AcpAgentConfig } from "../../config/acp-schema.js";
+import { installAcpConfigStub } from "../../acp/__tests__/helpers/acp-config-stub.js";
+import { installWhichStub } from "../../acp/__tests__/helpers/which-stub.js";
 import type { ToolContext } from "../types.js";
 
-// ---------------------------------------------------------------------------
-// Mock infrastructure
-// ---------------------------------------------------------------------------
-
-interface MockAcpConfig {
-  enabled: boolean;
-  maxConcurrentSessions: number;
-  agents: Record<string, AcpAgentConfig>;
-}
-
-let mockAcpConfig: MockAcpConfig = {
-  enabled: true,
-  maxConcurrentSessions: 4,
-  agents: {},
-};
-
-// Spread the real loader's named exports so transitive importers that pull
-// `loadConfig`, `invalidateConfigCache`, etc. from the same module path
-// still resolve at parse time. Bun's `mock.module` is process-global and
-// returns *exactly* the keys the factory returns — without the spread, any
-// module evaluated after this test file errors at load with
-// "Export named '<X>' not found".
-const realLoader = await import("../../config/loader.js");
-mock.module("../../config/loader.js", () => ({
-  ...realLoader,
-  getConfig: () => ({ acp: mockAcpConfig }),
-}));
-
-// Swap Bun.which with a stub so tests can deterministically simulate "binary
-// on PATH" / "binary missing" without depending on the host environment.
-const originalWhich = Bun.which;
-let whichStub: (command: string) => string | null = () => null;
-(Bun as unknown as { which: (cmd: string) => string | null }).which = (cmd) =>
-  whichStub(cmd);
+const config = await installAcpConfigStub();
+const which = installWhichStub();
 
 afterAll(() => {
-  (Bun as unknown as { which: typeof originalWhich }).which = originalWhich;
+  which.restore();
 });
 
 const { executeAcpListAgents } = await import("./list-agents.js");
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function setConfig(partial: Partial<MockAcpConfig>): void {
-  mockAcpConfig = {
-    enabled: true,
-    maxConcurrentSessions: 4,
-    agents: {},
-    ...partial,
-  };
-}
-
-function setWhich(map: Record<string, string | null>): void {
-  whichStub = (cmd) => map[cmd] ?? null;
-}
 
 function makeContext(): ToolContext {
   return {
@@ -70,10 +22,10 @@ function makeContext(): ToolContext {
 }
 
 beforeEach(() => {
-  setConfig({});
+  config.setConfig({});
   // Default: every command on PATH so binary preflight passes unless a test
   // explicitly says otherwise.
-  whichStub = (cmd) => `/usr/local/bin/${cmd}`;
+  which.setWhich((cmd) => `/usr/local/bin/${cmd}`);
 });
 
 // ---------------------------------------------------------------------------
@@ -82,7 +34,7 @@ beforeEach(() => {
 
 describe("executeAcpListAgents", () => {
   test("returns disabled hint when ACP is disabled", async () => {
-    setConfig({ enabled: false });
+    config.setConfig({ enabled: false });
 
     const result = await executeAcpListAgents({}, makeContext());
 
@@ -96,7 +48,7 @@ describe("executeAcpListAgents", () => {
   });
 
   test("enabled, no user config: both defaults present with source 'default' and available based on Bun.which", async () => {
-    setConfig({ agents: {} });
+    config.setConfig({ agents: {} });
 
     const result = await executeAcpListAgents({}, makeContext());
 
@@ -116,7 +68,7 @@ describe("executeAcpListAgents", () => {
   });
 
   test("enabled, user overrides claude: claude has source 'config' and the user's command", async () => {
-    setConfig({
+    config.setConfig({
       agents: {
         claude: {
           command: "my-claude-bin",
@@ -142,9 +94,9 @@ describe("executeAcpListAgents", () => {
     expect(codex.source).toBe("default");
   });
 
-  test("unavailable agent surfaces setupHint from DEFAULT_AGENT_INSTALL_HINTS", async () => {
-    setConfig({ agents: {} });
-    setWhich({ "claude-agent-acp": "/usr/local/bin/claude-agent-acp" });
+  test("unavailable agent surfaces setupHint derived from DEFAULT_AGENT_NPM_PACKAGES", async () => {
+    config.setConfig({ agents: {} });
+    which.setWhich({ "claude-agent-acp": "/usr/local/bin/claude-agent-acp" });
 
     const result = await executeAcpListAgents({}, makeContext());
 

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -1,6 +1,8 @@
 import * as realChildProcess from "node:child_process";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { installAcpConfigStub } from "../../acp/__tests__/helpers/acp-config-stub.js";
+import { installWhichStub } from "../../acp/__tests__/helpers/which-stub.js";
 import type { ToolContext } from "../types.js";
 
 // ---------------------------------------------------------------------------
@@ -57,53 +59,20 @@ mock.module("node:child_process", () => ({
   execFile: execFileMock,
 }));
 
-// Mock config so getConfig() returns enabled ACP with our test agents. The
-// resolver consumes this same loader, so updates here are visible to it.
-interface MockConfig {
-  acp: {
-    enabled: boolean;
-    maxConcurrentSessions: number;
-    agents: Record<string, { command: string; args: string[] }>;
-  };
-}
-
-const defaultMockConfig: MockConfig = {
-  acp: {
-    enabled: true,
-    maxConcurrentSessions: 5,
-    agents: {
-      claude: { command: "claude-agent-acp", args: [] },
-      codex: { command: "codex-acp", args: [] },
-      "unknown-agent": { command: "some-other-binary", args: [] },
-    },
-  },
+// Default ACP config used by these tests: the `unknown-agent` entry is here
+// to give the "no version check" test a configured agent whose binary isn't
+// in DEFAULT_AGENT_NPM_PACKAGES.
+const DEFAULT_TEST_AGENTS = {
+  claude: { command: "claude-agent-acp", args: [] },
+  codex: { command: "codex-acp", args: [] },
+  "unknown-agent": { command: "some-other-binary", args: [] },
 };
 
-let mockConfig: MockConfig = structuredClone(defaultMockConfig);
-
-// Spread the real loader's named exports so transitive importers that pull
-// `loadConfig`, `invalidateConfigCache`, etc. from the same module path still
-// resolve at parse time. Bun's `mock.module` is process-global and returns
-// *exactly* the keys the factory returns — without the spread, any module
-// evaluated after this test file errors at load with
-// "Export named '<X>' not found".
-const realLoader = await import("../../config/loader.js");
-mock.module("../../config/loader.js", () => ({
-  ...realLoader,
-  getConfig: () => mockConfig,
-}));
-
-// Swap Bun.which with a stub so the resolver's PATH preflight is deterministic
-// regardless of the host environment. By default every command resolves; tests
-// override `whichStub` to simulate a missing binary.
-const originalWhich = Bun.which;
-let whichStub: (command: string) => string | null = (cmd) =>
-  `/usr/local/bin/${cmd}`;
-(Bun as unknown as { which: (cmd: string) => string | null }).which = (cmd) =>
-  whichStub(cmd);
+const config = await installAcpConfigStub();
+const which = installWhichStub();
 
 afterAll(() => {
-  (Bun as unknown as { which: typeof originalWhich }).which = originalWhich;
+  which.restore();
 });
 
 mock.module("../../util/logger.js", () => ({
@@ -161,8 +130,8 @@ beforeEach(() => {
   execFileMock.mockClear();
   spawnMock.mockClear();
   _resetAdapterVersionCacheForTests();
-  mockConfig = structuredClone(defaultMockConfig);
-  whichStub = (cmd) => `/usr/local/bin/${cmd}`;
+  config.setConfig({ agents: DEFAULT_TEST_AGENTS });
+  which.setWhich((cmd) => `/usr/local/bin/${cmd}`);
 });
 
 // ---------------------------------------------------------------------------
@@ -329,7 +298,7 @@ describe("executeAcpSpawn — input validation", () => {
   });
 
   test("acp disabled returns error with config hint", async () => {
-    mockConfig.acp.enabled = false;
+    config.setConfig({ enabled: false, agents: DEFAULT_TEST_AGENTS });
     const result = await executeAcpSpawn(
       { agent: "claude", task: "do something" },
       makeContext(),
@@ -339,7 +308,7 @@ describe("executeAcpSpawn — input validation", () => {
   });
 
   test("missing binary returns install hint", async () => {
-    whichStub = () => null;
+    which.setWhich({});
     const result = await executeAcpSpawn(
       { agent: "claude", task: "do something" },
       makeContext(),
@@ -356,7 +325,7 @@ describe("executeAcpSpawn — input validation", () => {
     // No user `agents.codex` entry, but `agent: "codex"` works via the bundled
     // default profile (command: "codex-acp"). The resolver merges defaults
     // automatically.
-    mockConfig.acp.agents = {};
+    config.setConfig({ agents: {} });
     execScripts.set("npm ls", { error: new Error("npm not installed") });
     execScripts.set("npm view", { error: new Error("npm not installed") });
 

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -187,10 +187,12 @@ export async function executeAcpSpawn(
       sendToClient as (msg: unknown) => void,
     );
 
-    // `claude --resume <id>` is Claude Code-specific; codex and other
-    // adapters resume differently or not at all, so the hint is gated.
+    // `claude --resume <id>` is Claude Code-specific (the claude-agent-acp
+    // adapter binary). Other adapters resume differently or not at all,
+    // so the hint is gated by the resolved binary, not the agent id —
+    // this stays correct when a user aliases an id to a different binary.
     const resumeHint =
-      agent === "claude"
+      agentConfig.command === "claude-agent-acp"
         ? ` To resume this session later, run: cd ${cwd} && claude --resume ${protocolSessionId}`
         : "";
     const payload = JSON.stringify({

--- a/assistant/src/tools/acp/steer.test.ts
+++ b/assistant/src/tools/acp/steer.test.ts
@@ -15,7 +15,13 @@ const defaultSteer = (acpSessionId: string, instruction: string) => {
 let steerImpl: (acpSessionId: string, instruction: string) => Promise<void> =
   defaultSteer;
 
+// Spread the real module's exports so transitive importers that pull other
+// names from `../../acp/index.js` (e.g. `broadcastToAllClients` from the
+// HTTP route layer) still resolve at parse time. Bun's `mock.module` is
+// process-global and returns *exactly* the keys the factory returns.
+const realAcpModule = await import("../../acp/index.js");
 mock.module("../../acp/index.js", () => ({
+  ...realAcpModule,
   getAcpSessionManager: () => ({
     steer: (acpSessionId: string, instruction: string) =>
       steerImpl(acpSessionId, instruction),
@@ -80,7 +86,8 @@ describe("executeAcpSteer", () => {
   });
 
   test("manager.steer throwing 'session not found' surfaces the error", async () => {
-    steerImpl = () => Promise.reject(new Error('ACP session "acp-x" not found'));
+    steerImpl = () =>
+      Promise.reject(new Error('ACP session "acp-x" not found'));
 
     const result = await executeAcpSteer(
       { acp_session_id: "acp-x", instruction: "redirect" },


### PR DESCRIPTION
## Summary
Round-2 self-review remediation for plan acp-codex-claude.md:
- **Bug fix**: `session-manager.ts` hardcoded `claude --resume` in the parent-conversation completion message regardless of agent — wrong for codex sessions. Now gated on `agentConfig.command === "claude-agent-acp"`.
- **Bug fix**: `steer.test.ts` was missed by the round-1 test-pollution fix; running it alongside `acp-routes.test.ts` in one Bun process failed at parse with 'Export named broadcastToAllClients not found'. Added the `realAcpModule` spread.
- **Brittleness fix**: `spawn.ts` resume-hint gate now keys on the resolved binary (`agentConfig.command`) instead of the alias (`agent === "claude"`).
- **Slop**: removed `DEFAULT_AGENT_INSTALL_HINTS` derived map; inlined the format into `installHintFor()`. Removed unused sync overload of `installAcpConfigStub`. Migrated the remaining 3 ACP test files to use the shared helpers (round 1 only migrated one). Net -203 lines across 11 files.

Self-review remediation for plan acp-codex-claude.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
