### PR TITLE
chore(db): delete existing private conversation rows via migration

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -70,6 +70,7 @@ import {
   migrateCreateMemoryRecallLogs,
   migrateCreateThreadStartersTable,
   migrateCreateTraceEventsTable,
+  migrateDeletePrivateConversations,
   migrateDropAccountsTable,
   migrateDropAssistantIdColumns,
   migrateDropCallbackTransportColumn,
@@ -386,6 +387,7 @@ export function initializeDb(): void {
     migrateScheduleWakeConversationId,
     migrateAddConversationInferenceProfile,
     migrateRenameInferenceProfileSnakeCase,
+    migrateDeletePrivateConversations,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/229-delete-private-conversations.test.ts
+++ b/assistant/src/memory/migrations/229-delete-private-conversations.test.ts
@@ -1,0 +1,336 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../db-connection.js";
+import * as schema from "../schema.js";
+import { migrateDeletePrivateConversations } from "./229-delete-private-conversations.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function bootstrapTables(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      conversation_type TEXT NOT NULL DEFAULT 'standard',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE tool_invocations (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id),
+      tool_name TEXT NOT NULL,
+      input TEXT NOT NULL,
+      result TEXT NOT NULL,
+      decision TEXT NOT NULL,
+      risk_level TEXT NOT NULL,
+      duration_ms INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE llm_request_logs (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      request_payload TEXT NOT NULL,
+      response_payload TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE memory_segments (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      role TEXT NOT NULL,
+      segment_index INTEGER NOT NULL,
+      text TEXT NOT NULL,
+      token_estimate INTEGER NOT NULL,
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE memory_embeddings (
+      id TEXT PRIMARY KEY,
+      target_type TEXT NOT NULL,
+      target_id TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      model TEXT NOT NULL,
+      dimensions INTEGER NOT NULL,
+      vector_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE attachments (
+      id TEXT PRIMARY KEY,
+      original_filename TEXT NOT NULL,
+      mime_type TEXT NOT NULL,
+      size_bytes INTEGER NOT NULL,
+      kind TEXT NOT NULL,
+      data_base64 TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE message_attachments (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+      attachment_id TEXT NOT NULL REFERENCES attachments(id) ON DELETE CASCADE,
+      position INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE conversation_graph_memory_state (
+      conversation_id TEXT PRIMARY KEY REFERENCES conversations(id) ON DELETE CASCADE,
+      state_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE memory_summaries (
+      id TEXT PRIMARY KEY,
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      summary TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE conversation_starters (
+      id TEXT PRIMARY KEY,
+      label TEXT NOT NULL,
+      prompt TEXT NOT NULL,
+      generation_batch INTEGER NOT NULL,
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      card_type TEXT NOT NULL DEFAULT 'chip',
+      created_at INTEGER NOT NULL
+    );
+  `);
+}
+
+function seedConversation(raw: Database, id: string, conversationType: string) {
+  const now = Date.now();
+  raw
+    .query(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .run(id, conversationType, now, now);
+  raw
+    .query(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at)
+       VALUES (?, ?, 'user', '[]', ?)`,
+    )
+    .run(`${id}-message`, id, now);
+  raw
+    .query(
+      `INSERT INTO tool_invocations (
+        id,
+        conversation_id,
+        tool_name,
+        input,
+        result,
+        decision,
+        risk_level,
+        duration_ms,
+        created_at
+      ) VALUES (?, ?, 'test_tool', '{}', '{}', 'allow', 'low', 1, ?)`,
+    )
+    .run(`${id}-tool`, id, now);
+  raw
+    .query(
+      `INSERT INTO llm_request_logs (
+        id,
+        conversation_id,
+        request_payload,
+        response_payload,
+        created_at
+      ) VALUES (?, ?, '{}', '{}', ?)`,
+    )
+    .run(`${id}-llm`, id, now);
+  raw
+    .query(
+      `INSERT INTO memory_segments (
+        id,
+        message_id,
+        conversation_id,
+        role,
+        segment_index,
+        text,
+        token_estimate,
+        scope_id,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, 'user', 0, 'hello', 1, ?, ?, ?)`,
+    )
+    .run(
+      `${id}-segment`,
+      `${id}-message`,
+      id,
+      `${conversationType}:${id}`,
+      now,
+      now,
+    );
+  raw
+    .query(
+      `INSERT INTO memory_embeddings (
+        id,
+        target_type,
+        target_id,
+        provider,
+        model,
+        dimensions,
+        vector_json,
+        created_at,
+        updated_at
+      ) VALUES (?, 'segment', ?, 'test-provider', 'test-model', 3, '[0,0,0]', ?, ?)`,
+    )
+    .run(`${id}-segment-embedding`, `${id}-segment`, now, now);
+  raw
+    .query(
+      `INSERT INTO attachments (
+        id,
+        original_filename,
+        mime_type,
+        size_bytes,
+        kind,
+        data_base64,
+        created_at
+      ) VALUES (?, 'example.txt', 'text/plain', 1, 'text', 'eA==', ?)`,
+    )
+    .run(`${id}-attachment`, now);
+  raw
+    .query(
+      `INSERT INTO message_attachments (id, message_id, attachment_id, position, created_at)
+       VALUES (?, ?, ?, 0, ?)`,
+    )
+    .run(`${id}-message-attachment`, `${id}-message`, `${id}-attachment`, now);
+  raw
+    .query(
+      `INSERT INTO conversation_graph_memory_state (conversation_id, state_json, created_at, updated_at)
+       VALUES (?, '{}', ?, ?)`,
+    )
+    .run(id, now, now);
+}
+
+function countWhere(raw: Database, table: string, where: string): number {
+  return (
+    raw
+      .query(`SELECT COUNT(*) AS count FROM ${table} WHERE ${where}`)
+      .get() as {
+      count: number;
+    }
+  ).count;
+}
+
+describe("migrateDeletePrivateConversations", () => {
+  test("deletes private conversations and dependents while preserving other conversation types", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapTables(raw);
+    seedConversation(raw, "conv-private", "private");
+    seedConversation(raw, "conv-standard", "standard");
+    seedConversation(raw, "conv-background", "background");
+
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_summaries (id, scope_id, summary, created_at, updated_at)
+      VALUES
+        ('summary-private', 'private:conv-private', 'private', ${now}, ${now}),
+        ('summary-standard', 'default', 'standard', ${now}, ${now}),
+        ('summary-background', 'background:conv-background', 'background', ${now}, ${now});
+
+      INSERT INTO memory_embeddings (
+        id,
+        target_type,
+        target_id,
+        provider,
+        model,
+        dimensions,
+        vector_json,
+        created_at,
+        updated_at
+      ) VALUES
+        ('summary-private-embedding', 'summary', 'summary-private', 'test-provider', 'test-model', 3, '[0,0,0]', ${now}, ${now}),
+        ('summary-standard-embedding', 'summary', 'summary-standard', 'test-provider', 'test-model', 3, '[0,0,0]', ${now}, ${now}),
+        ('summary-background-embedding', 'summary', 'summary-background', 'test-provider', 'test-model', 3, '[0,0,0]', ${now}, ${now});
+
+      INSERT INTO conversation_starters (id, label, prompt, generation_batch, scope_id, card_type, created_at)
+      VALUES
+        ('starter-private', 'Private', 'Private', 1, 'private:conv-private', 'chip', ${now}),
+        ('starter-standard', 'Standard', 'Standard', 1, 'default', 'chip', ${now}),
+        ('starter-background', 'Background', 'Background', 1, 'background:conv-background', 'chip', ${now});
+    `);
+
+    migrateDeletePrivateConversations(db);
+    migrateDeletePrivateConversations(db);
+
+    const remainingConversations = raw
+      .query(`SELECT id FROM conversations ORDER BY id`)
+      .all() as Array<{ id: string }>;
+    expect(remainingConversations.map((row) => row.id)).toEqual([
+      "conv-background",
+      "conv-standard",
+    ]);
+
+    for (const { table, column } of [
+      { table: "messages", column: "id" },
+      { table: "tool_invocations", column: "id" },
+      { table: "llm_request_logs", column: "id" },
+      { table: "memory_segments", column: "id" },
+      { table: "memory_embeddings", column: "id" },
+      { table: "message_attachments", column: "id" },
+      { table: "conversation_graph_memory_state", column: "conversation_id" },
+    ]) {
+      expect(countWhere(raw, table, `${column} LIKE 'conv-private%'`)).toBe(0);
+      expect(countWhere(raw, table, `${column} LIKE 'conv-standard%'`)).toBe(1);
+      expect(countWhere(raw, table, `${column} LIKE 'conv-background%'`)).toBe(
+        1,
+      );
+    }
+
+    expect(
+      countWhere(raw, "memory_summaries", `scope_id LIKE 'private:%'`),
+    ).toBe(0);
+    expect(
+      countWhere(raw, "conversation_starters", `scope_id LIKE 'private:%'`),
+    ).toBe(0);
+    expect(countWhere(raw, "memory_summaries", `scope_id = 'default'`)).toBe(1);
+    expect(
+      countWhere(raw, "memory_summaries", `scope_id LIKE 'background:%'`),
+    ).toBe(1);
+    expect(
+      countWhere(raw, "memory_embeddings", `id = 'summary-private-embedding'`),
+    ).toBe(0);
+    expect(
+      countWhere(raw, "memory_embeddings", `id = 'summary-standard-embedding'`),
+    ).toBe(1);
+    expect(
+      countWhere(
+        raw,
+        "memory_embeddings",
+        `id = 'summary-background-embedding'`,
+      ),
+    ).toBe(1);
+    expect(
+      countWhere(raw, "conversation_starters", `scope_id = 'default'`),
+    ).toBe(1);
+    expect(
+      countWhere(raw, "conversation_starters", `scope_id LIKE 'background:%'`),
+    ).toBe(1);
+  });
+});

--- a/assistant/src/memory/migrations/229-delete-private-conversations.ts
+++ b/assistant/src/memory/migrations/229-delete-private-conversations.ts
@@ -1,0 +1,50 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+const PRIVATE_CONVERSATION_IDS = /*sql*/ `
+  SELECT id FROM conversations WHERE conversation_type = 'private'
+`;
+
+export function migrateDeletePrivateConversations(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    DELETE FROM tool_invocations
+    WHERE conversation_id IN (${PRIVATE_CONVERSATION_IDS})
+  `);
+  database.run(/*sql*/ `
+    DELETE FROM llm_request_logs
+    WHERE conversation_id IN (${PRIVATE_CONVERSATION_IDS})
+  `);
+  database.run(/*sql*/ `
+    DELETE FROM memory_embeddings
+    WHERE target_type = 'segment'
+      AND target_id IN (
+        SELECT id FROM memory_segments
+        WHERE conversation_id IN (${PRIVATE_CONVERSATION_IDS})
+      )
+  `);
+  database.run(/*sql*/ `
+    DELETE FROM memory_embeddings
+    WHERE target_type = 'summary'
+      AND target_id IN (
+        SELECT id FROM memory_summaries
+        WHERE scope_id LIKE 'private:%'
+      )
+  `);
+  database.run(/*sql*/ `
+    DELETE FROM messages
+    WHERE conversation_id IN (${PRIVATE_CONVERSATION_IDS})
+  `);
+  database.run(/*sql*/ `
+    DELETE FROM memory_summaries
+    WHERE scope_id LIKE 'private:%'
+  `);
+  database.run(/*sql*/ `
+    DELETE FROM conversation_starters
+    WHERE scope_id LIKE 'private:%'
+  `);
+
+  // Qdrant vectors for deleted embedding rows are cleaned up by background sweeps.
+  database.run(/*sql*/ `
+    DELETE FROM conversations
+    WHERE conversation_type = 'private'
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -174,6 +174,7 @@ export { migrateOAuthProvidersAvailableScopes } from "./225-oauth-providers-avai
 export { migrateScheduleWakeConversationId } from "./226-schedule-wake-conversation-id.js";
 export { migrateAddConversationInferenceProfile } from "./227-add-conversation-inference-profile.js";
 export { migrateRenameInferenceProfileSnakeCase } from "./228-rename-inference-profile-snake-case.js";
+export { migrateDeletePrivateConversations } from "./229-delete-private-conversations.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,


### PR DESCRIPTION
## Summary
- Adds an idempotent DB migration that removes existing private conversations and dependent rows.
- Registers the migration in the assistant DB migration list.

Part of plan: remove-private-conversations.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
