### PR TITLE
Add PKB source adapter for recall

### DIFF
--- a/assistant/src/__tests__/context-search-pkb-source.test.ts
+++ b/assistant/src/__tests__/context-search-pkb-source.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AssistantConfig } from "../config/schema.js";
+import type { RecallSearchContext } from "../memory/context-search/types.js";
+import { PKB_WORKSPACE_SCOPE } from "../memory/pkb/types.js";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+const embedCalls: Array<{
+  config: AssistantConfig;
+  texts: unknown[];
+  opts?: { signal?: AbortSignal };
+}> = [];
+let embedVectors: number[][] = [[0.1, 0.2, 0.3]];
+let embedThrows: Error | null = null;
+
+mock.module("../memory/embed.js", () => ({
+  embedWithRetry: async (
+    config: AssistantConfig,
+    texts: unknown[],
+    opts?: { signal?: AbortSignal },
+  ) => {
+    embedCalls.push({ config, texts, opts });
+    if (embedThrows) throw embedThrows;
+    return { vectors: embedVectors, provider: "test", model: "test-model" };
+  },
+}));
+
+const sparseCalls: string[] = [];
+let sparseVector = { indices: [1], values: [1] };
+
+mock.module("../memory/embedding-backend.js", () => ({
+  generateSparseEmbedding: (text: string) => {
+    sparseCalls.push(text);
+    return sparseVector;
+  },
+}));
+
+type ScoredPoint = {
+  id: string;
+  score: number;
+  payload: {
+    target_type: "pkb_file";
+    target_id: string;
+    path: string;
+    text?: string;
+  };
+};
+
+const qdrantSearchCalls: Array<{
+  vector: number[];
+  limit: number;
+  filter?: unknown;
+}> = [];
+const hybridSearchCalls: Array<{
+  denseVector: number[];
+  sparseVector: { indices: number[]; values: number[] };
+  filter?: unknown;
+  limit: number;
+  prefetchLimit?: number;
+}> = [];
+let denseResults: ScoredPoint[] = [];
+let hybridResults: ScoredPoint[] = [];
+let denseThrows: Error | null = null;
+
+mock.module("../memory/qdrant-circuit-breaker.js", () => ({
+  isQdrantBreakerOpen: () => false,
+  withQdrantBreaker: async <T>(fn: () => Promise<T>): Promise<T> => fn(),
+}));
+
+mock.module("../memory/qdrant-client.js", () => ({
+  getQdrantClient: () => ({
+    search: async (
+      vector: number[],
+      limit: number,
+      filter?: Record<string, unknown>,
+    ) => {
+      qdrantSearchCalls.push({ vector, limit, filter });
+      if (denseThrows) throw denseThrows;
+      return denseResults;
+    },
+    hybridSearch: async (params: {
+      denseVector: number[];
+      sparseVector: { indices: number[]; values: number[] };
+      filter?: unknown;
+      limit: number;
+      prefetchLimit?: number;
+    }) => {
+      hybridSearchCalls.push(params);
+      return hybridResults;
+    },
+  }),
+}));
+
+let pkbContext: string | null = null;
+let nowScratchpad: string | null = null;
+
+mock.module("../daemon/conversation-runtime-assembly.js", () => ({
+  readPkbContext: () => pkbContext,
+  readNowScratchpad: () => nowScratchpad,
+}));
+
+const { readPkbContextEvidence, searchPkbSource } =
+  await import("../memory/context-search/sources/pkb.js");
+
+function makeContext(signal?: AbortSignal): RecallSearchContext {
+  return {
+    workingDir: "/workspace",
+    memoryScopeId: "active-conversation-scope",
+    conversationId: "conv-xyz",
+    config: {} as AssistantConfig,
+    ...(signal ? { signal } : {}),
+  };
+}
+
+describe("PKB context-search source", () => {
+  beforeEach(() => {
+    embedCalls.length = 0;
+    embedVectors = [[0.1, 0.2, 0.3]];
+    embedThrows = null;
+    sparseCalls.length = 0;
+    sparseVector = { indices: [1], values: [1] };
+    qdrantSearchCalls.length = 0;
+    hybridSearchCalls.length = 0;
+    denseResults = [];
+    hybridResults = [];
+    denseThrows = null;
+    pkbContext = null;
+    nowScratchpad = null;
+  });
+
+  test("converts PKB hits to recall evidence with snippets and scores", async () => {
+    denseResults = [
+      {
+        id: "dense-a",
+        score: 0.82,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "a",
+          path: "notes/project.md",
+          text: "Dense project notes.",
+        },
+      },
+      {
+        id: "dense-b",
+        score: 0.71,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "b",
+          path: "notes/fallback.md",
+        },
+      },
+    ];
+    hybridResults = [
+      {
+        id: "hybrid-a",
+        score: 0.04,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "a",
+          path: "notes/project.md",
+          text: "Project notes mention the launch checklist.",
+        },
+      },
+    ];
+
+    const result = await searchPkbSource("launch checklist", makeContext(), 2);
+
+    expect(embedCalls[0]?.texts).toEqual(["launch checklist"]);
+    expect(sparseCalls).toEqual(["launch checklist"]);
+    expect(result.evidence).toEqual([
+      {
+        id: "pkb:notes/project.md:0",
+        source: "pkb",
+        title: "notes/project.md",
+        locator: "notes/project.md",
+        excerpt: "Project notes mention the launch checklist.",
+        score: 0.04,
+        metadata: {
+          path: "notes/project.md",
+          denseScore: 0.82,
+          hybridScore: 0.04,
+        },
+      },
+      {
+        id: "pkb:notes/fallback.md:1",
+        source: "pkb",
+        title: "notes/fallback.md",
+        locator: "notes/fallback.md",
+        excerpt: "notes/fallback.md",
+        score: 0.71,
+        metadata: {
+          path: "notes/fallback.md",
+          denseScore: 0.71,
+        },
+      },
+    ]);
+  });
+
+  test("uses the PKB workspace sentinel scope instead of the active context scope", async () => {
+    denseResults = [
+      {
+        id: "a",
+        score: 0.8,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "a",
+          path: "notes/a.md",
+        },
+      },
+    ];
+
+    await searchPkbSource("notes", makeContext(), 5);
+
+    expect(qdrantSearchCalls).toHaveLength(1);
+    const filter = qdrantSearchCalls[0]?.filter as {
+      must: Array<Record<string, unknown>>;
+    };
+    const scopeClause = filter.must.find(
+      (clause) => clause.key === "memory_scope_id",
+    ) as { match: { any: string[] } } | undefined;
+    expect(scopeClause?.match.any).toEqual([PKB_WORKSPACE_SCOPE]);
+    expect(scopeClause?.match.any).not.toContain("active-conversation-scope");
+  });
+
+  test("returns empty evidence when embedding has no vector", async () => {
+    embedVectors = [];
+
+    const result = await searchPkbSource("notes", makeContext(), 5);
+
+    expect(result).toEqual({ evidence: [] });
+    expect(qdrantSearchCalls).toHaveLength(0);
+  });
+
+  test("falls back to empty evidence when PKB search fails", async () => {
+    denseThrows = new Error("qdrant unavailable");
+
+    const result = await searchPkbSource("notes", makeContext(), 5);
+
+    expect(result).toEqual({ evidence: [] });
+  });
+
+  test("returns no static PKB evidence when injected context is missing", () => {
+    expect(readPkbContextEvidence(makeContext())).toEqual([]);
+  });
+
+  test("returns PKB auto-inject and NOW evidence when present", () => {
+    pkbContext = "Always include the product glossary.";
+    nowScratchpad = "Current priority: finish the launch checklist.";
+
+    const evidence = readPkbContextEvidence(makeContext());
+
+    expect(evidence).toEqual([
+      {
+        id: "pkb:auto-inject",
+        source: "pkb",
+        title: "PKB auto-injected context",
+        locator: "pkb:auto-inject",
+        excerpt: "Always include the product glossary.",
+        metadata: { kind: "auto-inject" },
+      },
+      {
+        id: "pkb:NOW.md",
+        source: "pkb",
+        title: "NOW.md",
+        locator: "NOW.md",
+        excerpt: "Current priority: finish the launch checklist.",
+        metadata: { kind: "now" },
+      },
+    ]);
+  });
+});

--- a/assistant/src/memory/context-search/sources/pkb.ts
+++ b/assistant/src/memory/context-search/sources/pkb.ts
@@ -1,0 +1,91 @@
+import {
+  readNowScratchpad,
+  readPkbContext,
+} from "../../../daemon/conversation-runtime-assembly.js";
+import { getLogger } from "../../../util/logger.js";
+import { embedWithRetry } from "../../embed.js";
+import { generateSparseEmbedding } from "../../embedding-backend.js";
+import { searchPkbFiles } from "../../pkb/pkb-search.js";
+import { PKB_WORKSPACE_SCOPE } from "../../pkb/types.js";
+import type {
+  RecallEvidence,
+  RecallSearchContext,
+  RecallSearchResult,
+} from "../types.js";
+
+const log = getLogger("context-search-pkb-source");
+
+export async function searchPkbSource(
+  query: string,
+  context: RecallSearchContext,
+  limit: number,
+): Promise<RecallSearchResult> {
+  try {
+    const result = await embedWithRetry(context.config, [query], {
+      signal: context.signal,
+    });
+    const queryVector = result.vectors[0];
+    if (!queryVector) return { evidence: [] };
+
+    const sparseVector = generateSparseEmbedding(query);
+    const hits = await searchPkbFiles(queryVector, sparseVector, limit, [
+      PKB_WORKSPACE_SCOPE,
+    ]);
+
+    return {
+      evidence: hits.map((hit, index): RecallEvidence => {
+        const score = hit.hybridScore ?? hit.denseScore;
+        return {
+          id: `pkb:${hit.path}:${index}`,
+          source: "pkb",
+          title: hit.path,
+          locator: hit.path,
+          excerpt: hit.snippet ?? hit.path,
+          score,
+          metadata: {
+            path: hit.path,
+            denseScore: hit.denseScore,
+            ...(hit.hybridScore !== undefined
+              ? { hybridScore: hit.hybridScore }
+              : {}),
+          },
+        };
+      }),
+    };
+  } catch (err) {
+    log.warn({ err }, "PKB recall source failed; returning empty results");
+    return { evidence: [] };
+  }
+}
+
+export function readPkbContextEvidence(
+  _context: RecallSearchContext,
+): RecallEvidence[] {
+  const evidence: RecallEvidence[] = [];
+
+  const pkbContext = readPkbContext();
+  if (pkbContext) {
+    evidence.push({
+      id: "pkb:auto-inject",
+      source: "pkb",
+      title: "PKB auto-injected context",
+      locator: "pkb:auto-inject",
+      excerpt: pkbContext,
+      metadata: { kind: "auto-inject" },
+    });
+  }
+
+  const nowScratchpad = readNowScratchpad();
+  if (nowScratchpad) {
+    evidence.push({
+      id: "pkb:NOW.md",
+      source: "pkb",
+      title: "NOW.md",
+      locator: "NOW.md",
+      excerpt: nowScratchpad,
+      metadata: { kind: "now" },
+    });
+  }
+
+  return evidence;
+}

--- a/assistant/src/memory/pkb/pkb-search.test.ts
+++ b/assistant/src/memory/pkb/pkb-search.test.ts
@@ -20,7 +20,12 @@ const searchCalls: Array<{
   filter?: unknown;
 }> = [];
 
-type Payload = { target_type: string; target_id: string; path?: string };
+type Payload = {
+  target_type: string;
+  target_id: string;
+  path?: string;
+  text?: string;
+};
 type ScoredPoint = { id: string; score: number; payload: Payload };
 
 let hybridResults: ScoredPoint[] = [];
@@ -241,6 +246,80 @@ describe("searchPkbFiles", () => {
     expect(same?.hybridScore).toBe(0.03);
     expect(other?.denseScore).toBe(0.7);
     expect(other?.hybridScore).toBeUndefined();
+  });
+
+  test("propagates snippet from the best matching chunk without changing ranking", async () => {
+    denseResults = [
+      {
+        id: "chunk-1",
+        score: 0.9,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-1",
+          path: "/notes/same.md",
+          text: "Dense best chunk.",
+        },
+      },
+      {
+        id: "chunk-2",
+        score: 0.5,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-2",
+          path: "/notes/same.md",
+          text: "Dense weaker chunk.",
+        },
+      },
+      {
+        id: "chunk-3",
+        score: 0.7,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-3",
+          path: "/notes/other.md",
+          text: "Other dense chunk.",
+        },
+      },
+    ];
+    hybridResults = [
+      {
+        id: "chunk-2",
+        score: 0.04,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-2",
+          path: "/notes/same.md",
+          text: "Hybrid best chunk.",
+        },
+      },
+      {
+        id: "chunk-1",
+        score: 0.02,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "t-1",
+          path: "/notes/same.md",
+          text: "Hybrid weaker chunk.",
+        },
+      },
+    ];
+
+    const results = await searchPkbFiles(
+      [0.1],
+      { indices: [1], values: [1] },
+      10,
+    );
+
+    expect(results.map((r) => r.path)).toEqual([
+      "/notes/same.md",
+      "/notes/other.md",
+    ]);
+    const same = results.find((r) => r.path === "/notes/same.md");
+    const other = results.find((r) => r.path === "/notes/other.md");
+    expect(same?.denseScore).toBe(0.9);
+    expect(same?.hybridScore).toBe(0.04);
+    expect(same?.snippet).toBe("Hybrid best chunk.");
+    expect(other?.snippet).toBe("Other dense chunk.");
   });
 
   test("hybrid-only hits (no dense match) are dropped so they can't evict dense-qualified paths before the slice", async () => {

--- a/assistant/src/memory/pkb/pkb-search.ts
+++ b/assistant/src/memory/pkb/pkb-search.ts
@@ -7,12 +7,13 @@ import {
   isQdrantBreakerOpen,
   withQdrantBreaker,
 } from "../qdrant-circuit-breaker.js";
-import {
-  getQdrantClient,
-  type QdrantSearchResult,
-  type QdrantSparseVector,
+import type {
+  QdrantSearchResult,
+  QdrantSparseVector,
 } from "../qdrant-client.js";
-import { PKB_TARGET_TYPE, type PkbSearchResult } from "./types.js";
+import { getQdrantClient } from "../qdrant-client.js";
+import type { PkbSearchResult } from "./types.js";
+import { PKB_TARGET_TYPE } from "./types.js";
 
 const log = getLogger("pkb-search");
 
@@ -117,12 +118,16 @@ export async function searchPkbFiles(
   // the top-`limit` window before callers ever get a chance to gate on
   // denseScore. Dropping them keeps gating meaningful with the pre-slice.
   const merged: PkbSearchResult[] = [];
-  for (const [path, denseScore] of denseByPath) {
-    const hybridScore = hybridByPath.get(path);
+  for (const [path, denseMatch] of denseByPath) {
+    const hybridMatch = hybridByPath.get(path);
+    const snippet = hybridMatch?.snippet ?? denseMatch.snippet;
     merged.push({
       path,
-      denseScore,
-      ...(useHybrid && hybridScore !== undefined ? { hybridScore } : {}),
+      denseScore: denseMatch.score,
+      ...(useHybrid && hybridMatch !== undefined
+        ? { hybridScore: hybridMatch.score }
+        : {}),
+      ...(snippet !== undefined ? { snippet } : {}),
     });
   }
 
@@ -143,16 +148,24 @@ export async function searchPkbFiles(
   return merged.slice(0, limit);
 }
 
+interface CollapsedPkbMatch {
+  score: number;
+  snippet?: string;
+}
+
 /** Collapse chunk-level Qdrant hits to one score per payload.path (max). */
-function collapseByPath(results: QdrantSearchResult[]): Map<string, number> {
-  const best = new Map<string, number>();
+function collapseByPath(
+  results: QdrantSearchResult[],
+): Map<string, CollapsedPkbMatch> {
+  const best = new Map<string, CollapsedPkbMatch>();
   for (const r of results) {
-    const payload = r.payload as unknown as { path?: unknown };
+    const payload = r.payload as unknown as { path?: unknown; text?: unknown };
     const path = typeof payload.path === "string" ? payload.path : undefined;
     if (!path) continue;
+    const snippet = typeof payload.text === "string" ? payload.text : undefined;
     const existing = best.get(path);
-    if (existing === undefined || r.score > existing) {
-      best.set(path, r.score);
+    if (existing === undefined || r.score > existing.score) {
+      best.set(path, { score: r.score, ...(snippet ? { snippet } : {}) });
     }
   }
   return best;


### PR DESCRIPTION
## Summary
- Add PKB/NOW source evidence for agentic recall.
- Preserve PKB ranking while adding snippets and focused tests.

Part of plan: replace-recall-agentic-search.md (PR 5 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
