### PR TITLE
Add safe workspace file source adapter for recall

### DIFF
--- a/assistant/src/__tests__/context-search-workspace-source.test.ts
+++ b/assistant/src/__tests__/context-search-workspace-source.test.ts
@@ -1,0 +1,229 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { AssistantConfig } from "../config/schema.js";
+import {
+  searchWorkspaceSource,
+  WORKSPACE_SOURCE_MAX_FILE_SIZE_BYTES,
+  WORKSPACE_SOURCE_MAX_SCANNED_FILES,
+} from "../memory/context-search/sources/workspace.js";
+import type { RecallSearchContext } from "../memory/context-search/types.js";
+
+const testDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(): string {
+  const dir = realpathSync(
+    mkdtempSync(join(tmpdir(), "context-search-workspace-source-")),
+  );
+  testDirs.push(dir);
+  return dir;
+}
+
+function makeContext(workingDir: string): RecallSearchContext {
+  return {
+    workingDir,
+    memoryScopeId: "scope-123",
+    conversationId: "conversation-123",
+    config: {} as AssistantConfig,
+  };
+}
+
+function writeWorkspaceFile(root: string, relativePath: string, text: string) {
+  const filePath = join(root, relativePath);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, text);
+}
+
+describe("searchWorkspaceSource", () => {
+  test("returns lexical excerpts scored by query term overlap", async () => {
+    const root = makeTempDir();
+    writeWorkspaceFile(
+      root,
+      "notes/project.md",
+      [
+        "intro line",
+        "alpha release planning",
+        "alpha beta launch checklist",
+        "closing line",
+      ].join("\n"),
+    );
+    writeWorkspaceFile(root, "notes/other.md", "alpha only");
+
+    const result = await searchWorkspaceSource(
+      "alpha beta",
+      makeContext(root),
+      10,
+    );
+
+    expect(result.evidence).toHaveLength(2);
+    expect(result.evidence[0]).toMatchObject({
+      source: "workspace",
+      title: "notes/project.md",
+      locator: "notes/project.md:3",
+    });
+    expect(result.evidence[0].excerpt).toBe(
+      "2: alpha release planning\n3: alpha beta launch checklist\n4: closing line",
+    );
+    expect(result.evidence[0].score).toBeGreaterThan(
+      result.evidence[1].score ?? 0,
+    );
+    expect(result.evidence[0].metadata).toMatchObject({
+      path: "notes/project.md",
+      lineNumber: 3,
+      matchedTerms: ["alpha", "beta"],
+    });
+  });
+
+  test("rejects symlink entries that resolve outside the workspace root", async () => {
+    const root = makeTempDir();
+    const outside = makeTempDir();
+    writeWorkspaceFile(outside, "outside.md", "needle outside secret");
+    symlinkSync(join(outside, "outside.md"), join(root, "linked.md"));
+    writeWorkspaceFile(root, "inside.md", "needle inside safe");
+
+    const result = await searchWorkspaceSource("needle", makeContext(root), 10);
+
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      "inside.md:1",
+    ]);
+  });
+
+  test("skips hidden, generated, dependency, and secret-shaped paths", async () => {
+    const root = makeTempDir();
+    writeWorkspaceFile(root, ".hidden.md", "needle hidden");
+    writeWorkspaceFile(root, ".git/config.md", "needle git");
+    writeWorkspaceFile(root, ".private/notes.md", "needle private");
+    writeWorkspaceFile(root, "node_modules/pkg/index.md", "needle dependency");
+    writeWorkspaceFile(root, "dist/output.md", "needle dist");
+    writeWorkspaceFile(root, "build/output.md", "needle build");
+    writeWorkspaceFile(root, ".cache/output.md", "needle cache");
+    writeWorkspaceFile(root, ".turbo/output.md", "needle turbo");
+    writeWorkspaceFile(root, ".next/output.md", "needle next");
+    writeWorkspaceFile(root, "coverage/output.md", "needle coverage");
+    writeWorkspaceFile(root, "target/output.md", "needle target");
+    writeWorkspaceFile(root, ".env.local", "needle env");
+    writeWorkspaceFile(root, "api-key.md", "needle key");
+    writeWorkspaceFile(root, "secret-plan.md", "needle secret");
+    writeWorkspaceFile(root, "token-cache.md", "needle token");
+    writeWorkspaceFile(root, "credentials.json", "needle credentials");
+    writeWorkspaceFile(root, "protected/readme.md", "needle protected");
+    writeWorkspaceFile(root, "gateway-security/readme.md", "needle gateway");
+    writeWorkspaceFile(root, "ces-security/readme.md", "needle ces");
+    writeWorkspaceFile(root, "src/readme.md", "needle safe");
+
+    const result = await searchWorkspaceSource("needle", makeContext(root), 10);
+
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      "src/readme.md:1",
+    ]);
+  });
+
+  test("reads only allowed text-like extensions", async () => {
+    const root = makeTempDir();
+    writeWorkspaceFile(root, "readme.md", "needle markdown");
+    writeWorkspaceFile(root, "notes.txt", "needle text");
+    writeWorkspaceFile(root, "config.json", "needle json");
+    writeWorkspaceFile(root, "config.yaml", "needle yaml");
+    writeWorkspaceFile(root, "config.yml", "needle yml");
+    writeWorkspaceFile(root, "src/index.ts", "needle ts");
+    writeWorkspaceFile(root, "src/view.tsx", "needle tsx");
+    writeWorkspaceFile(root, "src/index.js", "needle js");
+    writeWorkspaceFile(root, "src/view.jsx", "needle jsx");
+    writeWorkspaceFile(root, "scripts/tool.py", "needle py");
+    writeWorkspaceFile(root, "clients/App.swift", "needle swift");
+    writeWorkspaceFile(root, "scripts/run.sh", "needle sh");
+    writeWorkspaceFile(root, "settings.toml", "needle toml");
+    writeWorkspaceFile(root, "page.html", "needle html");
+    writeWorkspaceFile(root, "style.css", "needle css");
+    writeWorkspaceFile(root, "schema.sql", "needle sql");
+    writeWorkspaceFile(root, "image.png", "needle png");
+    writeWorkspaceFile(root, "README", "needle extensionless");
+
+    const result = await searchWorkspaceSource("needle", makeContext(root), 30);
+
+    expect(result.evidence.map((item) => item.title).sort()).toEqual([
+      "clients/App.swift",
+      "config.json",
+      "config.yaml",
+      "config.yml",
+      "notes.txt",
+      "page.html",
+      "readme.md",
+      "schema.sql",
+      "scripts/run.sh",
+      "scripts/tool.py",
+      "settings.toml",
+      "src/index.js",
+      "src/index.ts",
+      "src/view.jsx",
+      "src/view.tsx",
+      "style.css",
+    ]);
+  });
+
+  test("skips files larger than the workspace source size cap", async () => {
+    const root = makeTempDir();
+    writeWorkspaceFile(
+      root,
+      "large.md",
+      `${"x".repeat(WORKSPACE_SOURCE_MAX_FILE_SIZE_BYTES)}\nneedle`,
+    );
+    writeWorkspaceFile(root, "small.md", "needle small");
+
+    const result = await searchWorkspaceSource("needle", makeContext(root), 10);
+
+    expect(result.evidence.map((item) => item.locator)).toEqual(["small.md:1"]);
+  });
+
+  test("caps scanned files and returned results", async () => {
+    const root = makeTempDir();
+    for (
+      let index = 0;
+      index < WORKSPACE_SOURCE_MAX_SCANNED_FILES;
+      index += 1
+    ) {
+      writeWorkspaceFile(
+        root,
+        `docs/${String(index).padStart(3, "0")}.md`,
+        "needle scanned",
+      );
+    }
+    writeWorkspaceFile(root, "docs/999.md", "needle beyond cap");
+
+    const result = await searchWorkspaceSource("needle", makeContext(root), 7);
+
+    expect(result.evidence).toHaveLength(7);
+    expect(result.evidence.map((item) => item.title)).not.toContain(
+      "docs/999.md",
+    );
+  });
+
+  test("returns an empty result for a non-directory workspace root", async () => {
+    const root = makeTempDir();
+    const filePath = join(root, "not-a-directory.md");
+    writeFileSync(filePath, "needle");
+
+    const result = await searchWorkspaceSource(
+      "needle",
+      makeContext(filePath),
+      10,
+    );
+
+    expect(result.evidence).toEqual([]);
+  });
+});

--- a/assistant/src/memory/context-search/sources/workspace.ts
+++ b/assistant/src/memory/context-search/sources/workspace.ts
@@ -1,0 +1,394 @@
+import { readdir, readFile, realpath, stat } from "node:fs/promises";
+import { extname, isAbsolute, join, relative, sep } from "node:path";
+
+import type {
+  RecallEvidence,
+  RecallSearchContext,
+  RecallSearchResult,
+  RecallSourceAdapter,
+} from "../types.js";
+
+export const WORKSPACE_SOURCE_MAX_FILE_SIZE_BYTES = 256 * 1024;
+export const WORKSPACE_SOURCE_MAX_SCANNED_FILES = 500;
+
+const EXCERPT_LINE_RADIUS = 1;
+const EXCERPT_MAX_CHARS = 600;
+
+const GENERATED_OR_DEPENDENCY_DIR_NAMES = new Set([
+  ".git",
+  ".private",
+  "node_modules",
+  "dist",
+  "build",
+  ".cache",
+  ".turbo",
+  ".next",
+  "coverage",
+  "target",
+]);
+
+const SECRET_SEGMENT_NAMES = new Set([
+  "protected",
+  "gateway-security",
+  "ces-security",
+]);
+
+const TEXT_LIKE_EXTENSIONS = new Set([
+  ".md",
+  ".txt",
+  ".json",
+  ".yaml",
+  ".yml",
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".py",
+  ".swift",
+  ".sh",
+  ".toml",
+  ".html",
+  ".css",
+  ".sql",
+]);
+
+interface WorkspaceMatch {
+  relativePath: string;
+  excerpt: string;
+  lineNumber: number;
+  score: number;
+  fileSizeBytes: number;
+  matchedTerms: string[];
+}
+
+interface WalkState {
+  scannedFiles: number;
+  visitedDirs: Set<string>;
+}
+
+export const workspaceSourceAdapter: RecallSourceAdapter = {
+  source: "workspace",
+  search: searchWorkspaceSource,
+};
+
+export async function searchWorkspaceSource(
+  query: string,
+  context: RecallSearchContext,
+  limit: number,
+): Promise<RecallSearchResult> {
+  const queryTerms = tokenize(query);
+  if (queryTerms.size === 0 || limit <= 0) {
+    return { evidence: [] };
+  }
+
+  const rootRealPath = await resolveRoot(context.workingDir);
+  if (!rootRealPath) {
+    return { evidence: [] };
+  }
+
+  const matches: WorkspaceMatch[] = [];
+  const state: WalkState = {
+    scannedFiles: 0,
+    visitedDirs: new Set([rootRealPath]),
+  };
+
+  await walkDirectory(rootRealPath, rootRealPath, queryTerms, matches, state, {
+    signal: context.signal,
+  });
+
+  const evidence = matches
+    .sort(compareWorkspaceMatches)
+    .slice(0, limit)
+    .map(toEvidence);
+
+  return { evidence };
+}
+
+async function resolveRoot(workingDir: string): Promise<string | null> {
+  try {
+    const rootRealPath = await realpath(workingDir);
+    const rootStats = await stat(rootRealPath);
+    return rootStats.isDirectory() ? rootRealPath : null;
+  } catch {
+    return null;
+  }
+}
+
+async function walkDirectory(
+  directoryPath: string,
+  rootRealPath: string,
+  queryTerms: ReadonlySet<string>,
+  matches: WorkspaceMatch[],
+  state: WalkState,
+  options: { signal: AbortSignal | undefined },
+): Promise<boolean> {
+  throwIfAborted(options.signal);
+
+  let entries;
+  try {
+    entries = await readdir(directoryPath, { withFileTypes: true });
+  } catch {
+    return true;
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const entry of entries) {
+    throwIfAborted(options.signal);
+    if (state.scannedFiles >= WORKSPACE_SOURCE_MAX_SCANNED_FILES) {
+      return false;
+    }
+
+    if (shouldSkipSegmentName(entry.name)) {
+      continue;
+    }
+
+    const entryPath = join(directoryPath, entry.name);
+    const entryRealPath = await resolveContainedPath(entryPath, rootRealPath);
+    if (!entryRealPath) {
+      continue;
+    }
+
+    const realRelativePath = toWorkspaceRelativePath(
+      rootRealPath,
+      entryRealPath,
+    );
+    if (
+      realRelativePath !== "" &&
+      shouldSkipRelativePath(realRelativePath.split("/"))
+    ) {
+      continue;
+    }
+
+    let entryStats;
+    try {
+      entryStats = await stat(entryRealPath);
+    } catch {
+      continue;
+    }
+
+    if (entryStats.isDirectory()) {
+      if (state.visitedDirs.has(entryRealPath)) {
+        continue;
+      }
+      state.visitedDirs.add(entryRealPath);
+      const shouldContinue = await walkDirectory(
+        entryRealPath,
+        rootRealPath,
+        queryTerms,
+        matches,
+        state,
+        options,
+      );
+      if (!shouldContinue) {
+        return false;
+      }
+      continue;
+    }
+
+    if (!entryStats.isFile()) {
+      continue;
+    }
+
+    const lexicalRelativePath = toWorkspaceRelativePath(
+      rootRealPath,
+      entryPath,
+    );
+    if (
+      shouldSkipFilePath(lexicalRelativePath) ||
+      shouldSkipFilePath(realRelativePath) ||
+      entryStats.size > WORKSPACE_SOURCE_MAX_FILE_SIZE_BYTES
+    ) {
+      continue;
+    }
+
+    state.scannedFiles += 1;
+    const match = await searchFile(
+      entryRealPath,
+      lexicalRelativePath,
+      entryStats.size,
+      queryTerms,
+    );
+    if (match) {
+      matches.push(match);
+    }
+  }
+
+  return true;
+}
+
+async function resolveContainedPath(
+  entryPath: string,
+  rootRealPath: string,
+): Promise<string | null> {
+  try {
+    const entryRealPath = await realpath(entryPath);
+    return isPathInsideRoot(entryRealPath, rootRealPath) ? entryRealPath : null;
+  } catch {
+    return null;
+  }
+}
+
+async function searchFile(
+  filePath: string,
+  relativePath: string,
+  fileSizeBytes: number,
+  queryTerms: ReadonlySet<string>,
+): Promise<WorkspaceMatch | null> {
+  let contents;
+  try {
+    contents = await readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+
+  const lines = contents.split(/\r?\n/);
+  const bestLine = findBestLine(lines, queryTerms);
+  if (!bestLine) {
+    return null;
+  }
+
+  const pathTerms = termOverlap(tokenize(relativePath), queryTerms);
+  const score =
+    bestLine.matchedTerms.size / queryTerms.size + pathTerms.size * 0.05;
+
+  return {
+    relativePath,
+    excerpt: buildExcerpt(lines, bestLine.lineIndex),
+    lineNumber: bestLine.lineIndex + 1,
+    score,
+    fileSizeBytes,
+    matchedTerms: [...bestLine.matchedTerms].sort(),
+  };
+}
+
+function findBestLine(
+  lines: readonly string[],
+  queryTerms: ReadonlySet<string>,
+): { lineIndex: number; matchedTerms: Set<string> } | null {
+  let best: { lineIndex: number; matchedTerms: Set<string> } | null = null;
+
+  lines.forEach((line, lineIndex) => {
+    const lineTerms = tokenize(line);
+    const matchedTerms = termOverlap(lineTerms, queryTerms);
+    if (matchedTerms.size === 0) {
+      return;
+    }
+
+    if (!best || matchedTerms.size > best.matchedTerms.size) {
+      best = { lineIndex, matchedTerms };
+    }
+  });
+
+  return best;
+}
+
+function buildExcerpt(lines: readonly string[], lineIndex: number): string {
+  const start = Math.max(0, lineIndex - EXCERPT_LINE_RADIUS);
+  const end = Math.min(lines.length, lineIndex + EXCERPT_LINE_RADIUS + 1);
+  const excerpt = lines
+    .slice(start, end)
+    .map((line, offset) => `${start + offset + 1}: ${line.trimEnd()}`)
+    .join("\n")
+    .trim();
+
+  if (excerpt.length <= EXCERPT_MAX_CHARS) {
+    return excerpt;
+  }
+
+  return `${excerpt.slice(0, EXCERPT_MAX_CHARS - 3).trimEnd()}...`;
+}
+
+function toEvidence(match: WorkspaceMatch): RecallEvidence {
+  return {
+    id: `workspace:${match.relativePath}:${match.lineNumber}`,
+    source: "workspace",
+    title: match.relativePath,
+    locator: `${match.relativePath}:${match.lineNumber}`,
+    excerpt: match.excerpt,
+    score: match.score,
+    metadata: {
+      path: match.relativePath,
+      lineNumber: match.lineNumber,
+      fileSizeBytes: match.fileSizeBytes,
+      matchedTerms: match.matchedTerms,
+    },
+  };
+}
+
+function compareWorkspaceMatches(a: WorkspaceMatch, b: WorkspaceMatch): number {
+  if (b.score !== a.score) {
+    return b.score - a.score;
+  }
+  const pathCompare = a.relativePath.localeCompare(b.relativePath);
+  if (pathCompare !== 0) {
+    return pathCompare;
+  }
+  return a.lineNumber - b.lineNumber;
+}
+
+function shouldSkipFilePath(relativePath: string): boolean {
+  const pathSegments = relativePath.split("/");
+  if (shouldSkipRelativePath(pathSegments)) {
+    return true;
+  }
+
+  return !TEXT_LIKE_EXTENSIONS.has(extname(relativePath).toLowerCase());
+}
+
+function shouldSkipRelativePath(pathSegments: readonly string[]): boolean {
+  return pathSegments.some(shouldSkipSegmentName);
+}
+
+function shouldSkipSegmentName(name: string): boolean {
+  const lowerName = name.toLowerCase();
+  return (
+    lowerName.startsWith(".") ||
+    GENERATED_OR_DEPENDENCY_DIR_NAMES.has(lowerName) ||
+    lowerName.startsWith(".env") ||
+    lowerName.includes("key") ||
+    lowerName.includes("secret") ||
+    lowerName.includes("token") ||
+    lowerName.startsWith("credentials") ||
+    SECRET_SEGMENT_NAMES.has(lowerName)
+  );
+}
+
+function isPathInsideRoot(pathToCheck: string, rootRealPath: string): boolean {
+  const pathRelativeToRoot = relative(rootRealPath, pathToCheck);
+  return (
+    pathRelativeToRoot === "" ||
+    (!pathRelativeToRoot.startsWith("..") && !isAbsolute(pathRelativeToRoot))
+  );
+}
+
+function toWorkspaceRelativePath(
+  rootRealPath: string,
+  filePath: string,
+): string {
+  const relativePath = relative(rootRealPath, filePath);
+  return relativePath.split(sep).join("/");
+}
+
+function tokenize(text: string): Set<string> {
+  return new Set(text.toLowerCase().match(/[a-z0-9_]+/g) ?? []);
+}
+
+function termOverlap(
+  haystackTerms: ReadonlySet<string>,
+  queryTerms: ReadonlySet<string>,
+): Set<string> {
+  const matchedTerms = new Set<string>();
+  for (const term of queryTerms) {
+    if (haystackTerms.has(term)) {
+      matchedTerms.add(term);
+    }
+  }
+  return matchedTerms;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw signal.reason ?? new Error("Workspace recall search aborted");
+  }
+}


### PR DESCRIPTION
## Summary
- Add a safe read-only workspace file source adapter for agentic recall.
- Add focused tests for containment, exclusions, caps, and excerpts.

Part of plan: replace-recall-agentic-search.md (PR 6 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
