### PR TITLE
feat(daemon): drop "private" from conversationType union and remove fork-block

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -36,7 +36,6 @@ import {
   forkConversation,
   getConversationHostAccess,
   getMessages,
-  PRIVATE_CONVERSATION_FORK_ERROR,
 } from "../memory/conversation-crud.js";
 import { getConversationDirPath } from "../memory/conversation-disk-view.js";
 import { getDb, initializeDb } from "../memory/db.js";
@@ -350,45 +349,6 @@ describe("forkConversation", () => {
     expect(forkJsonl[1]?.attachments).toEqual(["wireframe.png"]);
     expect(getAttachmentsForMessage(sourceAssistant.id)[0]?.id).toBe(
       sourceAttachments[0]?.id,
-    );
-  });
-
-  test("rejects private source forks", async () => {
-    const source = createConversation({
-      title: "Private notes",
-      conversationType: "private",
-    });
-    await addMessage(
-      source.id,
-      "assistant",
-      "This started as private context.",
-      undefined,
-      { skipIndexing: true },
-    );
-
-    const db = getDb();
-    const now = Date.now();
-    db.update(conversations)
-      .set({ originChannel: "telegram", originInterface: "cli" })
-      .where(eq(conversations.id, source.id))
-      .run();
-    db.insert(externalConversationBindings)
-      .values({
-        conversationId: source.id,
-        sourceChannel: "telegram",
-        externalChatId: "chat-1",
-        externalUserId: "user-1",
-        displayName: "Alex",
-        username: "alex",
-        createdAt: now,
-        updatedAt: now,
-        lastInboundAt: now,
-        lastOutboundAt: now,
-      })
-      .run();
-
-    expect(() => forkConversation({ conversationId: source.id })).toThrow(
-      PRIVATE_CONVERSATION_FORK_ERROR,
     );
   });
 

--- a/assistant/src/__tests__/conversation-fork-route.test.ts
+++ b/assistant/src/__tests__/conversation-fork-route.test.ts
@@ -44,11 +44,7 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
-import {
-  addMessage,
-  createConversation,
-  PRIVATE_CONVERSATION_FORK_ERROR,
-} from "../memory/conversation-crud.js";
+import { addMessage, createConversation } from "../memory/conversation-crud.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { getPolicy } from "../runtime/auth/route-policy.js";
 import { mintToken } from "../runtime/auth/token-service.js";
@@ -197,10 +193,7 @@ describe("POST /v1/conversations/fork", () => {
   });
 
   test("does not expose private parents in detail reads", async () => {
-    const parent = createConversation({
-      title: "Private parent",
-      conversationType: "private",
-    });
+    const parent = createConversation("Private parent");
     const parentMessage = await addMessage(
       parent.id,
       "assistant",
@@ -209,6 +202,11 @@ describe("POST /v1/conversations/fork", () => {
       { skipIndexing: true },
     );
     const child = createConversation("Child conversation");
+    getDb().run(
+      `UPDATE conversations
+       SET conversation_type = 'private'
+       WHERE id = '${parent.id}'`,
+    );
     getDb().run(
       `UPDATE conversations
        SET fork_parent_conversation_id = '${parent.id}',
@@ -226,29 +224,6 @@ describe("POST /v1/conversations/fork", () => {
       conversation: ConversationSummary;
     };
     expect(body.conversation).not.toHaveProperty("forkParent");
-  });
-
-  test("rejects private source conversations", async () => {
-    const source = createConversation({
-      title: "Private source",
-      conversationType: "private",
-    });
-
-    await startServer();
-
-    const response = await fetch(url("/conversations/fork"), {
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
-      body: JSON.stringify({ conversationId: source.id }),
-    });
-
-    expect(response.status).toBe(403);
-    expect(await response.json()).toEqual({
-      error: {
-        code: "FORBIDDEN",
-        message: PRIVATE_CONVERSATION_FORK_ERROR,
-      },
-    });
   });
 
   test("rejects nonexistent and cross-conversation branch point message IDs", async () => {

--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -200,7 +200,6 @@ mock.module("../memory/conversation-crud.js", () => ({
   parseMessage: () => null,
   getAssistantMessageIdsInTurn: () => [],
   getTurnTimeBounds: () => null,
-  PRIVATE_CONVERSATION_FORK_ERROR: "Cannot fork a private conversation",
   countConversationsByScheduleJobId: () => 0,
   selectSlackMetaCandidateMetadata: () => [],
   forkConversation: () => null,

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -64,7 +64,8 @@ import { cancelPendingJobsForConversation } from "./task-memory-cleanup.js";
 const log = getLogger("conversation-store");
 
 /** Prefix for private-conversation memory scope IDs (`private:<convId>`). */
-export const PRIVATE_SCOPE_PREFIX = "private:";
+const PRIVATE_SCOPE_KIND = "private";
+export const PRIVATE_SCOPE_PREFIX = `${PRIVATE_SCOPE_KIND}:`;
 
 /** Build the memory scope ID for a private conversation. */
 export function privateScopeId(conversationId: string): string {
@@ -90,9 +91,6 @@ const subagentNotificationSchema = z.object({
   error: z.string().optional(),
   conversationId: z.string().optional(),
 });
-
-export const PRIVATE_CONVERSATION_FORK_ERROR =
-  "Private conversations cannot be forked";
 
 export const messageMetadataSchema = z
   .object({
@@ -269,7 +267,11 @@ export function createConversation(
     | string
     | {
         title?: string;
-        conversationType?: "standard" | "private" | "background" | "scheduled";
+        conversationType?:
+          | "standard"
+          | "background"
+          | "scheduled"
+          | (string & {});
         source?: string;
         scheduleJobId?: string;
         groupId?: string;
@@ -283,12 +285,16 @@ export function createConversation(
     typeof titleOrOpts === "string"
       ? { title: titleOrOpts }
       : (titleOrOpts ?? {});
-  const conversationType = opts.conversationType ?? "standard";
+  const requestedConversationType = opts.conversationType;
+  const conversationType: string =
+    requestedConversationType === "background" ||
+    requestedConversationType === "scheduled"
+      ? requestedConversationType
+      : "standard";
   const source = opts.source ?? "user";
   const groupId = opts.groupId;
   const id = uuid();
-  const memoryScopeId =
-    conversationType === "private" ? privateScopeId(id) : "default";
+  const memoryScopeId = "default";
 
   // Ensure group_id column exists for deterministic schema readiness,
   // even when this conversation has no groupId (a subsequent query or
@@ -511,10 +517,6 @@ export function forkConversation(params: {
   if (!sourceConversation) {
     throw new UserError(`Conversation ${conversationId} not found`);
   }
-  if (sourceConversation.conversationType === "private") {
-    throw new UserError(PRIVATE_CONVERSATION_FORK_ERROR);
-  }
-
   const sourceMessages = getMessages(conversationId);
 
   if (sourceMessages.length === 0) {

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -29,7 +29,6 @@ import {
   deleteConversation,
   getConversation,
   getConversationHostAccess,
-  PRIVATE_CONVERSATION_FORK_ERROR,
   setConversationInferenceProfile,
   unarchiveConversation,
   updateConversationHostAccess,
@@ -102,9 +101,7 @@ export function conversationManagementRouteDefinitions(
         conversationKey: z
           .string()
           .describe("Idempotency key for the conversation"),
-        conversationType: z
-          .string()
-          .describe("'standard' (default) or 'private'"),
+        conversationType: z.string().describe("'standard' (default)"),
       }),
       responseBody: z.object({
         id: z.string(),
@@ -119,10 +116,8 @@ export function conversationManagementRouteDefinitions(
           // Empty or malformed body — fall through with defaults.
         }
         const conversationKey = body.conversationKey ?? crypto.randomUUID();
-        const requestedType =
-          body.conversationType === "private" ? "private" : "standard";
         const result = getOrCreateConversation(conversationKey, {
-          conversationType: requestedType,
+          conversationType: "standard",
         });
         if (result.created) {
           updateConversationTitle(result.conversationId, "New Conversation");
@@ -208,9 +203,6 @@ export function conversationManagementRouteDefinitions(
           return Response.json({ conversation });
         } catch (err) {
           if (err instanceof UserError) {
-            if (err.message === PRIVATE_CONVERSATION_FORK_ERROR) {
-              return httpError("FORBIDDEN", err.message, 403);
-            }
             return httpError("NOT_FOUND", err.message, 404);
           }
           throw err;


### PR DESCRIPTION
## Summary
- Drops private from new conversation creation and always uses the default memory scope.
- Removes the private-conversation fork error and related tests.

Part of plan: remove-private-conversations.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
