### PR TITLE
Add conversation history source adapter for recall

### DIFF
--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -1,0 +1,261 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { searchConversationSource } from "../memory/context-search/sources/conversations.js";
+import type { RecallSearchContext } from "../memory/context-search/types.js";
+import { addMessage, createConversation } from "../memory/conversation-crud.js";
+import { getDb, initializeDb, rawRun } from "../memory/db.js";
+
+initializeDb();
+
+describe("searchConversationSource", () => {
+  beforeEach(() => {
+    getDb().run("DELETE FROM messages");
+    getDb().run("DELETE FROM conversations");
+  });
+
+  test("returns matching message evidence through the FTS path", async () => {
+    const conversation = createConversation("Launch notes");
+    const message = await addMessage(
+      conversation.id,
+      "assistant",
+      "The alpha launch checklist includes database backups.",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    const result = await searchConversationSource(
+      "alpha launch",
+      makeContext(),
+      5,
+    );
+
+    expect(result.evidence).toHaveLength(1);
+    expect(result.evidence[0]).toMatchObject({
+      id: `conversations:${conversation.id}:${message.id}`,
+      source: "conversations",
+      title: "Launch notes",
+      locator: `${conversation.id}#${message.id}`,
+      excerpt: "The alpha launch checklist includes database backups.",
+      timestampMs: message.createdAt,
+      metadata: {
+        role: "assistant",
+        conversationId: conversation.id,
+      },
+    });
+  });
+
+  test("uses LIKE fallback for short and non-ASCII queries", async () => {
+    const shortConversation = createConversation("C++ notes");
+    await addMessage(
+      shortConversation.id,
+      "user",
+      "Use C++ when the example needs deterministic lifetime notes.",
+      undefined,
+      { skipIndexing: true },
+    );
+    const unicodeConversation = createConversation("Unicode notes");
+    await addMessage(
+      unicodeConversation.id,
+      "assistant",
+      "The keyword 東京 appears in this conversation.",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    const shortResult = await searchConversationSource("C++", makeContext(), 5);
+    const unicodeResult = await searchConversationSource(
+      "東京",
+      makeContext(),
+      5,
+    );
+
+    expect(shortResult.evidence.map((item) => item.title)).toEqual([
+      "C++ notes",
+    ]);
+    expect(unicodeResult.evidence.map((item) => item.title)).toEqual([
+      "Unicode notes",
+    ]);
+  });
+
+  test("filters results to the requested memory scope", async () => {
+    const inScope = await seedConversation({
+      title: "In-scope conversation",
+      memoryScopeId: "scope-a",
+      content: "sharedtoken belongs to scope A.",
+    });
+    await seedConversation({
+      title: "Out-of-scope conversation",
+      memoryScopeId: "scope-b",
+      content: "sharedtoken belongs to scope B.",
+    });
+
+    const result = await searchConversationSource(
+      "sharedtoken",
+      makeContext({ memoryScopeId: "scope-a" }),
+      10,
+    );
+
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${inScope.conversation.id}#${inScope.message.id}`,
+    ]);
+  });
+
+  test("does not return private conversations", async () => {
+    const visible = await seedConversation({
+      title: "Visible conversation",
+      content: "privacytoken can be recalled from normal history.",
+    });
+    const privateConversation = createConversation({
+      title: "Private conversation",
+      conversationType: "private",
+    });
+    rawRun(
+      "UPDATE conversations SET memory_scope_id = 'default' WHERE id = ?",
+      privateConversation.id,
+    );
+    await addMessage(
+      privateConversation.id,
+      "user",
+      "privacytoken should not be recalled from private history.",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    const result = await searchConversationSource(
+      "privacytoken",
+      makeContext(),
+      10,
+    );
+
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${visible.conversation.id}#${visible.message.id}`,
+    ]);
+  });
+
+  test("does not return derived subagent or auto-analysis conversations", async () => {
+    const visible = await seedConversation({
+      title: "User conversation",
+      content: "derivedtoken belongs to a user-authored conversation.",
+    });
+    await seedConversation({
+      title: "Subagent conversation",
+      source: "subagent",
+      content: "derivedtoken should not include subagent output.",
+    });
+    await seedConversation({
+      title: "Auto-analysis conversation",
+      source: "auto-analysis",
+      content: "derivedtoken should not include auto-analysis output.",
+    });
+
+    const result = await searchConversationSource(
+      "derivedtoken",
+      makeContext(),
+      10,
+    );
+
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${visible.conversation.id}#${visible.message.id}`,
+    ]);
+  });
+
+  test("includes archived, scheduled, and background conversations", async () => {
+    const archived = await seedConversation({
+      title: "Archived conversation",
+      content: "includetoken appears in archived history.",
+    });
+    rawRun(
+      "UPDATE conversations SET archived_at = ? WHERE id = ?",
+      Date.now(),
+      archived.conversation.id,
+    );
+    const scheduled = await seedConversation({
+      title: "Scheduled conversation",
+      conversationType: "scheduled",
+      content: "includetoken appears in scheduled history.",
+    });
+    const background = await seedConversation({
+      title: "Background conversation",
+      conversationType: "background",
+      content: "includetoken appears in background history.",
+    });
+
+    const result = await searchConversationSource(
+      "includetoken",
+      makeContext(),
+      10,
+    );
+
+    expect(new Set(result.evidence.map((item) => item.locator))).toEqual(
+      new Set([
+        `${archived.conversation.id}#${archived.message.id}`,
+        `${scheduled.conversation.id}#${scheduled.message.id}`,
+        `${background.conversation.id}#${background.message.id}`,
+      ]),
+    );
+  });
+
+  test("formats fallback title and excerpts from message content blocks", async () => {
+    const content = JSON.stringify([
+      {
+        type: "text",
+        text: "Before the needle marker, the useful text is inside a content block.",
+      },
+    ]);
+    const { conversation, message } = await seedConversation({
+      title: undefined,
+      content,
+    });
+
+    const result = await searchConversationSource("needle", makeContext(), 1);
+
+    expect(result.evidence).toHaveLength(1);
+    expect(result.evidence[0].title).toBe("Untitled conversation");
+    expect(result.evidence[0].locator).toBe(`${conversation.id}#${message.id}`);
+    expect(result.evidence[0].excerpt).toBe(
+      "Before the needle marker, the useful text is inside a content block.",
+    );
+  });
+});
+
+async function seedConversation(opts: {
+  title?: string;
+  conversationType?: "standard" | "background" | "scheduled";
+  source?: string;
+  memoryScopeId?: string;
+  content: string;
+}) {
+  const conversation = createConversation({
+    title: opts.title,
+    conversationType: opts.conversationType,
+    source: opts.source,
+  });
+  if (opts.memoryScopeId) {
+    rawRun(
+      "UPDATE conversations SET memory_scope_id = ? WHERE id = ?",
+      opts.memoryScopeId,
+      conversation.id,
+    );
+  }
+  const message = await addMessage(
+    conversation.id,
+    "assistant",
+    opts.content,
+    undefined,
+    { skipIndexing: true },
+  );
+
+  return { conversation, message };
+}
+
+function makeContext(
+  overrides: Partial<RecallSearchContext> = {},
+): RecallSearchContext {
+  return {
+    workingDir: "/tmp/example-workspace",
+    memoryScopeId: "default",
+    conversationId: "current-conversation",
+    config: {} as RecallSearchContext["config"],
+    ...overrides,
+  };
+}

--- a/assistant/src/memory/context-search/sources/conversations.ts
+++ b/assistant/src/memory/context-search/sources/conversations.ts
@@ -1,0 +1,133 @@
+import { AUTO_ANALYSIS_SOURCE } from "../../auto-analysis-guard.js";
+import {
+  buildExcerpt,
+  buildFtsMatchQuery,
+} from "../../conversation-queries.js";
+import { rawAll } from "../../db.js";
+import type { RecallSearchContext, RecallSearchResult } from "../types.js";
+
+const SUBAGENT_SOURCE = "subagent";
+
+interface ConversationEvidenceRow {
+  message_id: string;
+  conversation_id: string;
+  role: string;
+  content: string;
+  created_at: number;
+  title: string | null;
+}
+
+export async function searchConversationSource(
+  query: string,
+  context: RecallSearchContext,
+  limit: number,
+): Promise<RecallSearchResult> {
+  const trimmedQuery = query.trim();
+  const normalizedLimit = Number.isFinite(limit)
+    ? Math.max(0, Math.floor(limit))
+    : 0;
+
+  if (!trimmedQuery || normalizedLimit === 0) {
+    return { evidence: [] };
+  }
+
+  const ftsMatch = buildFtsMatchQuery(trimmedQuery);
+  let rows: ConversationEvidenceRow[] = [];
+
+  if (ftsMatch) {
+    try {
+      rows = searchWithFts(ftsMatch, context.memoryScopeId, normalizedLimit);
+    } catch {
+      rows = [];
+    }
+  }
+
+  if (rows.length === 0) {
+    rows = searchWithLike(trimmedQuery, context.memoryScopeId, normalizedLimit);
+  }
+
+  return {
+    evidence: rows.map((row) => ({
+      id: `conversations:${row.conversation_id}:${row.message_id}`,
+      source: "conversations",
+      title: row.title?.trim() || "Untitled conversation",
+      locator: `${row.conversation_id}#${row.message_id}`,
+      excerpt: buildExcerpt(row.content, trimmedQuery),
+      timestampMs: row.created_at,
+      metadata: {
+        role: row.role,
+        conversationId: row.conversation_id,
+      },
+    })),
+  };
+}
+
+function searchWithFts(
+  ftsMatch: string,
+  memoryScopeId: string,
+  limit: number,
+): ConversationEvidenceRow[] {
+  return rawAll<ConversationEvidenceRow>(
+    `
+    SELECT
+      m.id AS message_id,
+      m.conversation_id,
+      m.role,
+      m.content,
+      m.created_at,
+      c.title
+    FROM messages_fts
+    JOIN messages m ON m.id = messages_fts.message_id
+    JOIN conversations c ON c.id = m.conversation_id
+    WHERE messages_fts MATCH ?
+      AND c.memory_scope_id = ?
+      AND c.conversation_type != 'private'
+      AND (c.source IS NULL OR c.source NOT IN (?, ?))
+    ORDER BY bm25(messages_fts), m.created_at DESC
+    LIMIT ?
+    `,
+    ftsMatch,
+    memoryScopeId,
+    SUBAGENT_SOURCE,
+    AUTO_ANALYSIS_SOURCE,
+    limit,
+  );
+}
+
+function searchWithLike(
+  query: string,
+  memoryScopeId: string,
+  limit: number,
+): ConversationEvidenceRow[] {
+  return rawAll<ConversationEvidenceRow>(
+    `
+    SELECT
+      m.id AS message_id,
+      m.conversation_id,
+      m.role,
+      m.content,
+      m.created_at,
+      c.title
+    FROM messages m
+    JOIN conversations c ON c.id = m.conversation_id
+    WHERE m.content LIKE ? ESCAPE '\\'
+      AND c.memory_scope_id = ?
+      AND c.conversation_type != 'private'
+      AND (c.source IS NULL OR c.source NOT IN (?, ?))
+    ORDER BY m.created_at DESC
+    LIMIT ?
+    `,
+    buildLikePattern(query),
+    memoryScopeId,
+    SUBAGENT_SOURCE,
+    AUTO_ANALYSIS_SOURCE,
+    limit,
+  );
+}
+
+function buildLikePattern(query: string): string {
+  return `%${query
+    .replace(/\\/g, "\\\\")
+    .replace(/%/g, "\\%")
+    .replace(/_/g, "\\_")}%`;
+}


### PR DESCRIPTION
## Summary
- Add a conversation-history source adapter for agentic recall.
- Add focused tests for scope/exclusion/fallback behavior.

Part of plan: replace-recall-agentic-search.md (PR 4 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
