### PR TITLE
chore(macos/settings): remove "In Temporary Chat" toggle from tool tester

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -58,7 +58,6 @@ final class ToolPermissionTesterModel: ObservableObject {
     @Published var toolName: String = ""
     @Published var workingDir: String = ""
     @Published var isInteractive: Bool = true
-    @Published var forcePromptSideEffects: Bool = false
 
     // MARK: - Dynamic Input Fields
 
@@ -341,8 +340,7 @@ final class ToolPermissionTesterModel: ObservableObject {
                     toolName: toolName,
                     input: parsed,
                     workingDir: workingDir.isEmpty ? nil : workingDir,
-                    isInteractive: isInteractive,
-                    forcePromptSideEffects: forcePromptSideEffects
+                    isInteractive: isInteractive
                 )
                 handleSimulateResponse(response)
             } catch {

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -42,16 +42,10 @@ struct ToolPermissionTesterView: View {
                 )
             }
 
-            // Toggles
-            HStack(spacing: VSpacing.xl) {
-                VToggle(isOn: $model.isInteractive, label: "Interactive")
-                    .font(VFont.bodyMediumLighter)
-                    .foregroundStyle(VColor.contentSecondary)
-
-                VToggle(isOn: $model.forcePromptSideEffects, label: "In Temporary Chat")
-                    .font(VFont.bodyMediumLighter)
-                    .foregroundStyle(VColor.contentSecondary)
-            }
+            // Interactive mode
+            VToggle(isOn: $model.isInteractive, label: "Interactive")
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentSecondary)
         }
     }
 

--- a/clients/macos/vellum-assistantTests/MockToolClient.swift
+++ b/clients/macos/vellum-assistantTests/MockToolClient.swift
@@ -7,7 +7,7 @@ final class MockToolClient: ToolClientProtocol {
     // MARK: - Spy State
 
     var fetchToolNamesListCallCount = 0
-    var simulateToolPermissionCalls: [(toolName: String, input: [String: AnyCodable], workingDir: String?, isInteractive: Bool?, forcePromptSideEffects: Bool?)] = []
+    var simulateToolPermissionCalls: [(toolName: String, input: [String: AnyCodable], workingDir: String?, isInteractive: Bool?)] = []
 
     // MARK: - Configurable Responses
 
@@ -31,10 +31,9 @@ final class MockToolClient: ToolClientProtocol {
         toolName: String,
         input: [String: AnyCodable],
         workingDir: String?,
-        isInteractive: Bool?,
-        forcePromptSideEffects: Bool?
+        isInteractive: Bool?
     ) async throws -> ToolPermissionSimulateResponseMessage {
-        simulateToolPermissionCalls.append((toolName, input, workingDir, isInteractive, forcePromptSideEffects))
+        simulateToolPermissionCalls.append((toolName, input, workingDir, isInteractive))
         if let error = simulateError { throw error }
         guard let response = simulateResponse else {
             throw NSError(domain: "MockToolClient", code: 0, userInfo: [NSLocalizedDescriptionKey: "No mock response configured"])

--- a/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
@@ -96,7 +96,6 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.fieldEnabled = ["command": true]
         model.workingDir = "/tmp"
         model.isInteractive = false
-        model.forcePromptSideEffects = true
         model.simulate()
 
         let predicate = NSPredicate { _, _ in !self.model.isSimulating }
@@ -108,7 +107,6 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         XCTAssertEqual(call.toolName, "host_bash")
         XCTAssertEqual(call.workingDir, "/tmp")
         XCTAssertEqual(call.isInteractive, false)
-        XCTAssertEqual(call.forcePromptSideEffects, true)
     }
 
     func testSimulate_emptyOptionalFieldsSendNil() {
@@ -326,7 +324,6 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         XCTAssertEqual(model.toolName, "")
         XCTAssertEqual(model.workingDir, "")
         XCTAssertTrue(model.isInteractive)
-        XCTAssertFalse(model.forcePromptSideEffects)
         XCTAssertFalse(model.isSimulating)
         XCTAssertNil(model.lastResult)
         XCTAssertNil(model.lastError)

--- a/clients/shared/Network/ToolClient.swift
+++ b/clients/shared/Network/ToolClient.swift
@@ -10,8 +10,7 @@ public protocol ToolClientProtocol {
         toolName: String,
         input: [String: AnyCodable],
         workingDir: String?,
-        isInteractive: Bool?,
-        forcePromptSideEffects: Bool?
+        isInteractive: Bool?
     ) async throws -> ToolPermissionSimulateResponseMessage
 }
 
@@ -46,8 +45,7 @@ public struct ToolClient: ToolClientProtocol {
         toolName: String,
         input: [String: AnyCodable],
         workingDir: String? = nil,
-        isInteractive: Bool? = nil,
-        forcePromptSideEffects: Bool? = nil
+        isInteractive: Bool? = nil
     ) async throws -> ToolPermissionSimulateResponseMessage {
         var body: [String: Any] = [
             "toolName": toolName,
@@ -62,7 +60,6 @@ public struct ToolClient: ToolClientProtocol {
 
         if let workingDir { body["workingDir"] = workingDir }
         if let isInteractive { body["isInteractive"] = isInteractive }
-        if let forcePromptSideEffects { body["forcePromptSideEffects"] = forcePromptSideEffects }
 
         let response = try await GatewayHTTPClient.post(
             path: "assistants/{assistantId}/tools/simulate-permission", json: body, timeout: 10


### PR DESCRIPTION
## Summary
- Removes the Temporary Chat force-prompt toggle from the Tool Permission Tester.
- Drops macOS-side tester wiring for forcePromptSideEffects while preserving real assistant-side force-prompt callers.

Part of plan: remove-private-conversations.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
