### PR TITLE
Add deterministic multi-source recall search

### DIFF
--- a/assistant/src/__tests__/context-search-fanout.test.ts
+++ b/assistant/src/__tests__/context-search-fanout.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AssistantConfig } from "../config/schema.js";
+import { formatDeterministicRecallAnswer } from "../memory/context-search/format.js";
+import { runDeterministicRecallSearch } from "../memory/context-search/search.js";
+import type {
+  RecallEvidence,
+  RecallSearchContext,
+  RecallSource,
+  RecallSourceAdapter,
+} from "../memory/context-search/types.js";
+
+function makeContext(): RecallSearchContext {
+  return {
+    workingDir: "/workspace",
+    memoryScopeId: "scope-123",
+    conversationId: "conv-xyz",
+    config: {} as AssistantConfig,
+  };
+}
+
+function makeEvidence(
+  source: RecallSource,
+  overrides: Partial<RecallEvidence> = {},
+): RecallEvidence {
+  return {
+    id: `${source}:evidence`,
+    source,
+    title: `${source} title`,
+    locator: `${source}:locator`,
+    excerpt: `${source} excerpt`,
+    ...overrides,
+  };
+}
+
+function makeAdapter(
+  source: RecallSource,
+  evidence: RecallEvidence[],
+  calls: RecallSource[] = [],
+): RecallSourceAdapter {
+  return {
+    source,
+    async search() {
+      calls.push(source);
+      return { evidence };
+    },
+  };
+}
+
+describe("runDeterministicRecallSearch", () => {
+  test("runs only selected source adapters and includes PKB context evidence", async () => {
+    const calls: RecallSource[] = [];
+    const result = await runDeterministicRecallSearch(
+      { query: "launch notes", sources: ["pkb", "workspace"], max_results: 5 },
+      makeContext(),
+      {
+        adapters: [
+          makeAdapter("memory", [makeEvidence("memory")], calls),
+          makeAdapter(
+            "pkb",
+            [makeEvidence("pkb", { id: "pkb:search" })],
+            calls,
+          ),
+          makeAdapter("workspace", [makeEvidence("workspace")], calls),
+        ],
+        readPkbContextEvidence: () => [
+          makeEvidence("pkb", {
+            id: "pkb:auto-inject",
+            title: "PKB auto-injected context",
+            locator: "pkb:auto-inject",
+            excerpt: "Pinned launch plan from context.",
+          }),
+          makeEvidence("pkb", {
+            id: "pkb:NOW.md",
+            title: "NOW.md",
+            locator: "NOW.md",
+            excerpt: "Current launch focus.",
+          }),
+        ],
+      },
+    );
+
+    expect(calls).toEqual(["pkb", "workspace"]);
+    expect(result.searchedSources.map((note) => note.source)).toEqual([
+      "pkb",
+      "workspace",
+    ]);
+    expect(result.evidence.map((item) => item.id)).toEqual([
+      "pkb:NOW.md",
+      "pkb:auto-inject",
+      "pkb:search",
+      "workspace:evidence",
+    ]);
+  });
+
+  test("searches every source by default", async () => {
+    const calls: RecallSource[] = [];
+    await runDeterministicRecallSearch({ query: "deployment" }, makeContext(), {
+      adapters: [
+        makeAdapter("memory", [], calls),
+        makeAdapter("pkb", [], calls),
+        makeAdapter("conversations", [], calls),
+        makeAdapter("workspace", [], calls),
+      ],
+      readPkbContextEvidence: () => [],
+    });
+
+    expect(calls).toEqual(["memory", "pkb", "conversations", "workspace"]);
+  });
+
+  test("isolates adapter failures and reports degraded source notes", async () => {
+    const result = await runDeterministicRecallSearch(
+      { query: "status", sources: ["memory", "workspace"] },
+      makeContext(),
+      {
+        adapters: [
+          {
+            source: "memory",
+            async search() {
+              throw new Error("memory unavailable");
+            },
+          },
+          makeAdapter("workspace", [
+            makeEvidence("workspace", { excerpt: "Workspace status note." }),
+          ]),
+        ],
+      },
+    );
+
+    expect(result.evidence.map((item) => item.source)).toEqual(["workspace"]);
+    expect(result.searchedSources).toEqual([
+      {
+        source: "memory",
+        status: "degraded",
+        evidenceCount: 0,
+        error: "memory unavailable",
+      },
+      { source: "workspace", status: "searched", evidenceCount: 1 },
+    ]);
+
+    const answer = formatDeterministicRecallAnswer(result).answer;
+    expect(answer).toContain("Found evidence:");
+    expect(answer).toContain("Degraded sources: memory (memory unavailable).");
+  });
+
+  test("de-duplicates evidence by source, locator, and normalized excerpt", async () => {
+    const result = await runDeterministicRecallSearch(
+      { query: "same", sources: ["workspace"], max_results: 5 },
+      makeContext(),
+      {
+        adapters: [
+          makeAdapter("workspace", [
+            makeEvidence("workspace", {
+              id: "workspace:best",
+              locator: "notes.md:1",
+              excerpt: "Repeated fact",
+              score: 0.9,
+            }),
+            makeEvidence("workspace", {
+              id: "workspace:duplicate",
+              locator: "notes.md:1",
+              excerpt: " repeated   FACT ",
+              score: 0.2,
+            }),
+            makeEvidence("workspace", {
+              id: "workspace:distinct",
+              locator: "notes.md:2",
+              excerpt: "Repeated fact",
+              score: 0.1,
+            }),
+          ]),
+        ],
+      },
+    );
+
+    expect(result.evidence.map((item) => item.id)).toEqual([
+      "workspace:best",
+      "workspace:distinct",
+    ]);
+  });
+
+  test("sorts by score, recency, and source priority before enforcing total cap", async () => {
+    const result = await runDeterministicRecallSearch(
+      {
+        query: "priority",
+        sources: ["workspace", "memory", "pkb"],
+        max_results: 3,
+      },
+      makeContext(),
+      {
+        adapters: [
+          makeAdapter("workspace", [
+            makeEvidence("workspace", {
+              id: "workspace:older-high",
+              score: 0.8,
+              timestampMs: 100,
+            }),
+          ]),
+          makeAdapter("memory", [
+            makeEvidence("memory", {
+              id: "memory:older-low",
+              score: 0.4,
+              timestampMs: 100,
+            }),
+            makeEvidence("memory", {
+              id: "memory:same-score",
+              score: 0.7,
+              timestampMs: 50,
+            }),
+          ]),
+          makeAdapter("pkb", [
+            makeEvidence("pkb", {
+              id: "pkb:newer-same-score",
+              score: 0.7,
+              timestampMs: 200,
+            }),
+            makeEvidence("pkb", {
+              id: "pkb:source-priority",
+              score: 0.4,
+              timestampMs: 100,
+            }),
+          ]),
+        ],
+        readPkbContextEvidence: () => [],
+      },
+    );
+
+    expect(result.evidence.map((item) => item.id)).toEqual([
+      "workspace:older-high",
+      "pkb:newer-same-score",
+      "memory:same-score",
+    ]);
+  });
+
+  test("formats no-result responses with searched and degraded sources", async () => {
+    const result = await runDeterministicRecallSearch(
+      { query: "nothing", sources: ["memory", "workspace"] },
+      makeContext(),
+      {
+        adapters: [
+          makeAdapter("memory", []),
+          {
+            source: "workspace",
+            async search() {
+              throw new Error("workspace timed out");
+            },
+          },
+        ],
+      },
+    );
+
+    expect(formatDeterministicRecallAnswer(result)).toEqual({
+      answer:
+        "No reliable results found.\nSearched sources: memory, workspace.\nDegraded sources: workspace (workspace timed out).",
+      evidence: [],
+    });
+  });
+});

--- a/assistant/src/memory/context-search/format.ts
+++ b/assistant/src/memory/context-search/format.ts
@@ -1,0 +1,79 @@
+import type { DeterministicRecallSearchResult } from "./search.js";
+import type { RecallAnswer, RecallEvidence } from "./types.js";
+
+const CITATION_EXCERPT_MAX_CHARS = 280;
+
+export function formatDeterministicRecallAnswer(
+  result: DeterministicRecallSearchResult,
+): RecallAnswer {
+  if (result.evidence.length === 0) {
+    return {
+      answer: [
+        "No reliable results found.",
+        formatSearchedSources(result),
+        formatDegradedSources(result),
+      ]
+        .filter(Boolean)
+        .join("\n"),
+      evidence: [],
+    };
+  }
+
+  return {
+    answer: [
+      "Found evidence:",
+      ...result.evidence.map(formatCitation),
+      formatSearchedSources(result),
+      formatDegradedSources(result),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+    evidence: result.evidence,
+  };
+}
+
+function formatCitation(evidence: RecallEvidence, index: number): string {
+  const excerpt = compactText(evidence.excerpt, CITATION_EXCERPT_MAX_CHARS);
+  return `${index + 1}. [${evidence.source}] ${evidence.title} (${evidence.locator}): ${excerpt}`;
+}
+
+function formatSearchedSources(
+  result: DeterministicRecallSearchResult,
+): string {
+  if (result.searchedSources.length === 0) {
+    return "";
+  }
+  return `Searched sources: ${result.searchedSources
+    .map((note) => note.source)
+    .join(", ")}.`;
+}
+
+function formatDegradedSources(
+  result: DeterministicRecallSearchResult,
+): string {
+  const degraded = result.searchedSources.filter(
+    (note) => note.status === "degraded",
+  );
+  if (degraded.length === 0) {
+    return "";
+  }
+
+  return `Degraded sources: ${degraded
+    .map((note) =>
+      note.error
+        ? `${note.source} (${compactText(note.error, 120)})`
+        : note.source,
+    )
+    .join(", ")}.`;
+}
+
+function compactText(text: string, maxChars: number): string {
+  const compacted = text.trim().replace(/\s+/g, " ");
+  if (compacted.length <= maxChars) {
+    return compacted;
+  }
+  if (maxChars <= 3) {
+    return compacted.slice(0, maxChars);
+  }
+  return `${compacted.slice(0, maxChars - 3).trimEnd()}...`;
+}

--- a/assistant/src/memory/context-search/search.ts
+++ b/assistant/src/memory/context-search/search.ts
@@ -1,0 +1,282 @@
+import {
+  ALL_RECALL_SOURCES,
+  type NormalizedRecallInput,
+  normalizeRecallInput,
+  RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE,
+  RECALL_TOTAL_EVIDENCE_TEXT_CAP,
+} from "./limits.js";
+import type {
+  RecallEvidence,
+  RecallInput,
+  RecallSearchContext,
+  RecallSearchResult,
+  RecallSource,
+  RecallSourceAdapter,
+} from "./types.js";
+
+export type DeterministicRecallSourceStatus = "searched" | "degraded";
+
+export interface DeterministicRecallSourceNote {
+  source: RecallSource;
+  status: DeterministicRecallSourceStatus;
+  evidenceCount: number;
+  error?: string;
+}
+
+export interface DeterministicRecallSearchResult extends RecallSearchResult {
+  input: NormalizedRecallInput;
+  searchedSources: DeterministicRecallSourceNote[];
+}
+
+export interface DeterministicRecallSearchOptions {
+  adapters?: readonly RecallSourceAdapter[];
+  readPkbContextEvidence?: (
+    context: RecallSearchContext,
+  ) => Promise<readonly RecallEvidence[]> | readonly RecallEvidence[];
+}
+
+const SOURCE_PRIORITY = new Map<RecallSource, number>(
+  ALL_RECALL_SOURCES.map((source, index) => [source, index]),
+);
+
+export async function runDeterministicRecallSearch(
+  input: RecallInput,
+  context: RecallSearchContext,
+  options: DeterministicRecallSearchOptions = {},
+): Promise<DeterministicRecallSearchResult> {
+  const normalizedInput = normalizeRecallInput(input);
+  const adapters =
+    options.adapters ??
+    (await loadDefaultRecallSourceAdapters(normalizedInput.sources));
+  const adapterBySource = new Map<RecallSource, RecallSourceAdapter>(
+    adapters.map((adapter) => [adapter.source, adapter]),
+  );
+  const evidenceBySource = new Map<RecallSource, RecallEvidence[]>(
+    normalizedInput.sources.map((source) => [source, []]),
+  );
+  const errorsBySource = new Map<RecallSource, string>();
+
+  if (normalizedInput.sources.includes("pkb")) {
+    try {
+      const contextEvidence = await readPkbContextEvidenceForSearch(
+        context,
+        options,
+      );
+      appendEvidence(evidenceBySource, "pkb", contextEvidence);
+    } catch (err) {
+      errorsBySource.set("pkb", errorToMessage(err));
+    }
+  }
+
+  const selectedAdapters = normalizedInput.sources.flatMap((source) => {
+    const adapter = adapterBySource.get(source);
+    return adapter ? [adapter] : [];
+  });
+  const perAdapterLimit =
+    normalizedInput.maxResults * normalizedInput.sourceRounds;
+  const adapterResults = await Promise.allSettled(
+    selectedAdapters.map((adapter) =>
+      adapter.search(normalizedInput.query, context, perAdapterLimit),
+    ),
+  );
+
+  adapterResults.forEach((settledResult, index) => {
+    const source = selectedAdapters[index]?.source;
+    if (!source) return;
+
+    if (settledResult.status === "fulfilled") {
+      appendEvidence(evidenceBySource, source, settledResult.value.evidence);
+      return;
+    }
+
+    errorsBySource.set(source, errorToMessage(settledResult.reason));
+  });
+
+  const evidence = capEvidence(
+    dedupeEvidence(sortEvidence([...evidenceBySource.values()].flat())),
+    normalizedInput.maxResults,
+  );
+
+  const finalCountBySource = new Map<RecallSource, number>();
+  for (const item of evidence) {
+    finalCountBySource.set(
+      item.source,
+      (finalCountBySource.get(item.source) ?? 0) + 1,
+    );
+  }
+
+  return {
+    input: normalizedInput,
+    evidence,
+    searchedSources: normalizedInput.sources.map((source) => {
+      const error = errorsBySource.get(source);
+      return {
+        source,
+        status: error ? "degraded" : "searched",
+        evidenceCount: finalCountBySource.get(source) ?? 0,
+        ...(error ? { error } : {}),
+      };
+    }),
+  };
+}
+
+async function loadDefaultRecallSourceAdapters(
+  sources: readonly RecallSource[],
+): Promise<readonly RecallSourceAdapter[]> {
+  return Promise.all(sources.map(loadDefaultRecallSourceAdapter));
+}
+
+async function loadDefaultRecallSourceAdapter(
+  source: RecallSource,
+): Promise<RecallSourceAdapter> {
+  switch (source) {
+    case "memory": {
+      const { searchMemorySource } = await import("./sources/memory.js");
+      return { source, search: searchMemorySource };
+    }
+    case "pkb": {
+      const { searchPkbSource } = await import("./sources/pkb.js");
+      return { source, search: searchPkbSource };
+    }
+    case "conversations": {
+      const { searchConversationSource } =
+        await import("./sources/conversations.js");
+      return { source, search: searchConversationSource };
+    }
+    case "workspace": {
+      const { searchWorkspaceSource } = await import("./sources/workspace.js");
+      return { source, search: searchWorkspaceSource };
+    }
+  }
+
+  const exhaustiveSource: never = source;
+  throw new Error(`Unknown recall source: ${String(exhaustiveSource)}`);
+}
+
+async function readPkbContextEvidenceForSearch(
+  context: RecallSearchContext,
+  options: DeterministicRecallSearchOptions,
+): Promise<readonly RecallEvidence[]> {
+  if (options.readPkbContextEvidence) {
+    return options.readPkbContextEvidence(context);
+  }
+
+  const { readPkbContextEvidence } = await import("./sources/pkb.js");
+  return readPkbContextEvidence(context);
+}
+
+function appendEvidence(
+  evidenceBySource: Map<RecallSource, RecallEvidence[]>,
+  source: RecallSource,
+  evidence: readonly RecallEvidence[],
+): void {
+  const existing = evidenceBySource.get(source);
+  if (existing) {
+    existing.push(...evidence);
+  } else {
+    evidenceBySource.set(source, [...evidence]);
+  }
+}
+
+function sortEvidence(evidence: RecallEvidence[]): RecallEvidence[] {
+  return [...evidence].sort(compareEvidence);
+}
+
+function compareEvidence(a: RecallEvidence, b: RecallEvidence): number {
+  const scoreCompare = (b.score ?? 0) - (a.score ?? 0);
+  if (scoreCompare !== 0) return scoreCompare;
+
+  const timestampCompare = (b.timestampMs ?? 0) - (a.timestampMs ?? 0);
+  if (timestampCompare !== 0) return timestampCompare;
+
+  const priorityCompare =
+    (SOURCE_PRIORITY.get(a.source) ?? Number.MAX_SAFE_INTEGER) -
+    (SOURCE_PRIORITY.get(b.source) ?? Number.MAX_SAFE_INTEGER);
+  if (priorityCompare !== 0) return priorityCompare;
+
+  return (
+    [
+      a.locator.localeCompare(b.locator),
+      a.title.localeCompare(b.title),
+      a.id.localeCompare(b.id),
+      a.excerpt.localeCompare(b.excerpt),
+    ].find((comparison) => comparison !== 0) ?? 0
+  );
+}
+
+function dedupeEvidence(evidence: readonly RecallEvidence[]): RecallEvidence[] {
+  const seen = new Set<string>();
+  const deduped: RecallEvidence[] = [];
+
+  for (const item of evidence) {
+    const key = [
+      item.source,
+      item.locator,
+      normalizeExcerptForDedupe(item.excerpt),
+    ].join("\0");
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(item);
+  }
+
+  return deduped;
+}
+
+function normalizeExcerptForDedupe(excerpt: string): string {
+  return excerpt.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function capEvidence(
+  evidence: readonly RecallEvidence[],
+  maxResults: number,
+): RecallEvidence[] {
+  const capped: RecallEvidence[] = [];
+  const textSizeBySource = new Map<RecallSource, number>();
+  let totalTextSize = 0;
+
+  for (const item of evidence) {
+    if (capped.length >= maxResults) {
+      break;
+    }
+
+    const sourceTextSize = textSizeBySource.get(item.source) ?? 0;
+    const sourceRemaining =
+      RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE - sourceTextSize;
+    const totalRemaining = RECALL_TOTAL_EVIDENCE_TEXT_CAP - totalTextSize;
+    const remaining = Math.min(sourceRemaining, totalRemaining);
+    if (remaining <= 0) {
+      if (totalRemaining <= 0) break;
+      continue;
+    }
+
+    const excerpt = truncateText(item.excerpt, remaining);
+    if (excerpt.length === 0) {
+      continue;
+    }
+
+    capped.push(excerpt === item.excerpt ? item : { ...item, excerpt });
+    textSizeBySource.set(item.source, sourceTextSize + excerpt.length);
+    totalTextSize += excerpt.length;
+  }
+
+  return capped;
+}
+
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  if (maxChars <= 3) {
+    return text.slice(0, maxChars);
+  }
+  return `${text.slice(0, maxChars - 3).trimEnd()}...`;
+}
+
+function errorToMessage(err: unknown): string {
+  if (err instanceof Error && err.message) {
+    return err.message;
+  }
+  return String(err);
+}


### PR DESCRIPTION
## Summary
- Adds deterministic recall fanout across selected local sources.
- Adds compact deterministic answer formatting with degraded-source notes.
- Covers source filtering, isolation, de-duping, caps, and no-result formatting.

Part of plan: replace-recall-agentic-search.md (PR 7 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
