### PR TITLE
chore(openapi): regenerate stale openapi.yaml

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -2640,7 +2640,7 @@ paths:
                   description: Idempotency key for the conversation
                 conversationType:
                   type: string
-                  description: "'standard' (default) or 'private'"
+                  description: "'standard' (default)"
               required:
                 - conversationKey
                 - conversationType


### PR DESCRIPTION
## Summary
- Regenerates `assistant/openapi.yaml` to fix the failing `OpenAPI Spec Check` job in CI.
- Drops the stale `'private'` mention from the `conversationType` field description on `POST /conversations`; the generator now reflects the current source of truth.

## Original prompt
```
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24927942074/job/73000962760
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
