### PR TITLE
Define bounded agentic recall protocol

### DIFF
--- a/assistant/src/__tests__/context-search-agent-protocol.test.ts
+++ b/assistant/src/__tests__/context-search-agent-protocol.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildRecallAgentPrompt,
+  FINISH_RECALL_TOOL_DEFINITION,
+  RECALL_AGENT_TOOL_DEFINITIONS,
+  SEARCH_SOURCES_TOOL_DEFINITION,
+  truncateRecallEvidenceToBudget,
+  validateFinishRecallPayload,
+  validateRecallCitationIds,
+} from "../memory/context-search/agent-protocol.js";
+import type { RecallEvidence } from "../memory/context-search/types.js";
+
+function makeEvidence(
+  id: string,
+  overrides: Partial<RecallEvidence> = {},
+): RecallEvidence {
+  return {
+    id,
+    source: "workspace",
+    title: `${id} title`,
+    locator: `${id}.md`,
+    excerpt: `${id} excerpt`,
+    ...overrides,
+  };
+}
+
+function schemaProperties(tool: {
+  input_schema: Record<string, unknown>;
+}): Record<string, Record<string, unknown>> {
+  return tool.input_schema.properties as Record<
+    string,
+    Record<string, unknown>
+  >;
+}
+
+describe("recall agent protocol tool definitions", () => {
+  test("defines bounded search_sources and finish_recall provider tools", () => {
+    expect(RECALL_AGENT_TOOL_DEFINITIONS.map((tool) => tool.name)).toEqual([
+      "search_sources",
+      "finish_recall",
+    ]);
+
+    expect(SEARCH_SOURCES_TOOL_DEFINITION.input_schema.required).toEqual([
+      "query",
+      "reason",
+    ]);
+    expect(
+      schemaProperties(SEARCH_SOURCES_TOOL_DEFINITION).sources.items,
+    ).toEqual({
+      type: "string",
+      enum: ["memory", "pkb", "conversations", "workspace"],
+    });
+    expect(
+      schemaProperties(SEARCH_SOURCES_TOOL_DEFINITION).limit,
+    ).toMatchObject({
+      type: "integer",
+      minimum: 1,
+      maximum: 20,
+    });
+
+    expect(FINISH_RECALL_TOOL_DEFINITION.input_schema.required).toEqual([
+      "answer",
+      "confidence",
+      "citation_ids",
+    ]);
+    expect(
+      schemaProperties(FINISH_RECALL_TOOL_DEFINITION).confidence.enum,
+    ).toEqual(["high", "medium", "low"]);
+  });
+});
+
+describe("buildRecallAgentPrompt", () => {
+  test("explains source boundaries, citation rules, conflicts, and finish tool use", () => {
+    const prompt = buildRecallAgentPrompt({
+      query: "What did Alice decide about launch timing?",
+      availableSources: ["memory", "workspace"],
+      evidence: [
+        makeEvidence("ev-1", {
+          source: "memory",
+          excerpt: "Alice said launch should wait until Friday.",
+        }),
+        makeEvidence("ev-2", {
+          source: "workspace",
+          excerpt: "Launch notes say Tuesday is still possible.",
+        }),
+      ],
+      maxSearchCalls: 2,
+    });
+
+    expect(prompt).toContain("memory: durable memory graph facts");
+    expect(prompt).toContain("workspace: files and text");
+    expect(prompt).not.toContain("pkb: personal knowledge base");
+    expect(prompt).toContain("Do not use external web");
+    expect(prompt).toContain("Do not guess");
+    expect(prompt).toContain("Report conflicts");
+    expect(prompt).toContain("finish_recall tool call");
+    expect(prompt).toContain("Allowed citation_ids: ev-1, ev-2");
+    expect(prompt).toContain("id: ev-1");
+    expect(prompt).not.toContain("ev-404");
+  });
+});
+
+describe("recall agent validation helpers", () => {
+  test("rejects citations that are not present in the evidence table", () => {
+    const result = validateRecallCitationIds(
+      ["ev-1", "ev-404", "ev-1"],
+      [makeEvidence("ev-1"), makeEvidence("ev-2")],
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      validCitationIds: ["ev-1"],
+      missingCitationIds: ["ev-404"],
+    });
+  });
+
+  test("truncates evidence text to the active budget", () => {
+    const result = truncateRecallEvidenceToBudget(
+      [
+        makeEvidence("ev-1", { excerpt: "abcdefghijklmnopqrstuvwxyz" }),
+        makeEvidence("ev-2", { excerpt: "second excerpt" }),
+      ],
+      10,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.excerpt).toBe("abcdefg...");
+    expect(
+      result.reduce((sum, item) => sum + item.excerpt.length, 0),
+    ).toBeLessThanOrEqual(10);
+  });
+
+  test("accepts well-formed finish payloads with supplied citations", () => {
+    const result = validateFinishRecallPayload(
+      {
+        answer: "Alice chose Friday.",
+        confidence: "high",
+        citation_ids: ["ev-1", "ev-1"],
+        unresolved: ["Tuesday note conflicts with Friday decision."],
+      },
+      [makeEvidence("ev-1")],
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      finish: {
+        answer: "Alice chose Friday.",
+        confidence: "high",
+        citationIds: ["ev-1"],
+        unresolved: ["Tuesday note conflicts with Friday decision."],
+      },
+    });
+  });
+
+  test("converts malformed finish payloads into deterministic fallback signals", () => {
+    expect(validateFinishRecallPayload("not an object", [])).toEqual({
+      ok: false,
+      reason: "malformed_finish_payload",
+      finish: {
+        answer: "No reliable answer could be produced by the recall agent.",
+        confidence: "low",
+        citationIds: [],
+        unresolved: ["Recall agent returned malformed_finish_payload."],
+      },
+    });
+
+    expect(
+      validateFinishRecallPayload(
+        { answer: "Unsupported", confidence: "certain", citation_ids: [] },
+        [],
+      ),
+    ).toMatchObject({
+      ok: false,
+      reason: "invalid_confidence",
+    });
+
+    expect(
+      validateFinishRecallPayload(
+        {
+          answer: "Uses missing citation.",
+          confidence: "low",
+          citation_ids: ["ev-404"],
+        },
+        [makeEvidence("ev-1")],
+      ),
+    ).toMatchObject({
+      ok: false,
+      reason: "unknown_citation_ids",
+      missingCitationIds: ["ev-404"],
+      finish: {
+        answer: "No reliable answer could be produced by the recall agent.",
+        confidence: "low",
+        citationIds: [],
+      },
+    });
+  });
+
+  test("defaults to all source descriptions when available sources are omitted", () => {
+    const prompt = buildRecallAgentPrompt({
+      query: "deployment notes",
+      evidence: [],
+    });
+
+    expect(prompt).toContain("memory: durable memory graph facts");
+    expect(prompt).toContain("pkb: personal knowledge base");
+    expect(prompt).toContain("conversations: past assistant conversations");
+    expect(prompt).toContain("workspace: files and text");
+  });
+});

--- a/assistant/src/memory/context-search/agent-protocol.ts
+++ b/assistant/src/memory/context-search/agent-protocol.ts
@@ -1,0 +1,366 @@
+import { truncate } from "../../util/truncate.js";
+import { ALL_RECALL_SOURCES, normalizeRecallSources } from "./limits.js";
+import type { RecallEvidence, RecallSource } from "./types.js";
+
+export type RecallAgentConfidence = "high" | "medium" | "low";
+
+export interface RecallAgentToolDefinition {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+export interface RecallAgentPromptOptions {
+  query: string;
+  availableSources?: readonly RecallSource[];
+  evidence: readonly RecallEvidence[];
+  evidenceBudgetChars?: number;
+  maxSearchCalls?: number;
+}
+
+export interface RecallAgentFinish {
+  answer: string;
+  confidence: RecallAgentConfidence;
+  citationIds: string[];
+  unresolved?: string[];
+}
+
+export type RecallFinishFallbackReason =
+  | "malformed_finish_payload"
+  | "invalid_confidence"
+  | "invalid_citation_ids"
+  | "unknown_citation_ids"
+  | "empty_answer";
+
+export type RecallFinishValidationResult =
+  | { ok: true; finish: RecallAgentFinish }
+  | {
+      ok: false;
+      reason: RecallFinishFallbackReason;
+      finish: RecallAgentFinish;
+      missingCitationIds?: string[];
+    };
+
+export interface RecallCitationValidationResult {
+  ok: boolean;
+  validCitationIds: string[];
+  missingCitationIds: string[];
+}
+
+const DEFAULT_RECALL_AGENT_EVIDENCE_BUDGET_CHARS = 12_000;
+const DEFAULT_MAX_SEARCH_CALLS = 4;
+
+const RECALL_SOURCE_DESCRIPTIONS: Record<RecallSource, string> = {
+  memory: "durable memory graph facts and relationship/context memories",
+  pkb: "personal knowledge base notes, NOW context, and pinned context",
+  conversations: "past assistant conversations and conversation summaries",
+  workspace: "files and text available in the current workspace",
+};
+
+export const SEARCH_SOURCES_TOOL_DEFINITION: RecallAgentToolDefinition = {
+  name: "search_sources",
+  description:
+    "Search bounded internal recall sources for evidence relevant to the user's query.",
+  input_schema: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "Focused search query for the evidence to retrieve.",
+      },
+      sources: {
+        type: "array",
+        description: "Optional subset of internal sources to search.",
+        items: { type: "string", enum: [...ALL_RECALL_SOURCES] },
+        uniqueItems: true,
+      },
+      limit: {
+        type: "integer",
+        description: "Optional maximum number of evidence items to return.",
+        minimum: 1,
+        maximum: 20,
+      },
+      reason: {
+        type: "string",
+        description:
+          "Brief reason this search is needed and what uncertainty it should resolve.",
+      },
+    },
+    required: ["query", "reason"],
+    additionalProperties: false,
+  },
+};
+
+export const FINISH_RECALL_TOOL_DEFINITION: RecallAgentToolDefinition = {
+  name: "finish_recall",
+  description:
+    "Return the final recall answer with confidence and exact evidence citations.",
+  input_schema: {
+    type: "object",
+    properties: {
+      answer: {
+        type: "string",
+        description:
+          "Final answer. Report uncertainty or conflicts instead of guessing.",
+      },
+      confidence: {
+        type: "string",
+        enum: ["high", "medium", "low"],
+      },
+      citation_ids: {
+        type: "array",
+        description:
+          "Evidence ids that directly support the answer. Use only ids supplied by the engine.",
+        items: { type: "string" },
+      },
+      unresolved: {
+        type: "array",
+        description:
+          "Optional unresolved questions, missing evidence, or conflicts.",
+        items: { type: "string" },
+      },
+    },
+    required: ["answer", "confidence", "citation_ids"],
+    additionalProperties: false,
+  },
+};
+
+export const RECALL_AGENT_TOOL_DEFINITIONS: readonly RecallAgentToolDefinition[] =
+  [SEARCH_SOURCES_TOOL_DEFINITION, FINISH_RECALL_TOOL_DEFINITION] as const;
+
+export function buildRecallAgentPrompt(
+  options: RecallAgentPromptOptions,
+): string {
+  const availableSources = normalizeRecallSources(options.availableSources);
+  const maxSearchCalls = options.maxSearchCalls ?? DEFAULT_MAX_SEARCH_CALLS;
+  const evidence = truncateRecallEvidenceToBudget(
+    options.evidence,
+    options.evidenceBudgetChars ?? DEFAULT_RECALL_AGENT_EVIDENCE_BUDGET_CHARS,
+  );
+  const citationIds = evidence.map((item) => item.id);
+
+  return [
+    "You are the bounded internal recall agent. Find reliable information for the user's recall request using only the internal sources and evidence supplied by the engine.",
+    "",
+    `User query: ${options.query}`,
+    "",
+    "Available internal sources:",
+    ...availableSources.map(
+      (source) => `- ${source}: ${RECALL_SOURCE_DESCRIPTIONS[source]}`,
+    ),
+    "",
+    "Rules:",
+    "- Use search_sources when more evidence is needed. Keep searches focused and explain the reason.",
+    `- Do not make more than ${maxSearchCalls} search_sources calls unless the engine gives you a new budget.`,
+    "- Do not use external web, internet, browser, or network sources.",
+    "- Do not guess. If the evidence is missing, weak, or contradictory, say so.",
+    "- Report conflicts in the answer or unresolved field instead of silently choosing one side.",
+    "- Cite supporting evidence with exact citation_ids from the evidence table only.",
+    "- The final output must be a finish_recall tool call.",
+    "",
+    formatAllowedCitationIds(citationIds),
+    "",
+    "Evidence table:",
+    formatRecallEvidenceTable(evidence),
+  ].join("\n");
+}
+
+export function truncateRecallEvidenceToBudget(
+  evidence: readonly RecallEvidence[],
+  maxTextChars: number,
+): RecallEvidence[] {
+  if (!Number.isFinite(maxTextChars) || maxTextChars <= 0) {
+    return [];
+  }
+
+  const truncated: RecallEvidence[] = [];
+  let remaining = Math.floor(maxTextChars);
+
+  for (const item of evidence) {
+    if (remaining <= 0) break;
+
+    const excerpt = truncate(item.excerpt, remaining);
+    if (excerpt.length === 0) {
+      continue;
+    }
+
+    truncated.push(excerpt === item.excerpt ? item : { ...item, excerpt });
+    remaining -= excerpt.length;
+  }
+
+  return truncated;
+}
+
+export function validateRecallCitationIds(
+  citationIds: readonly string[],
+  evidence: readonly RecallEvidence[],
+): RecallCitationValidationResult {
+  const allowedIds = new Set(evidence.map((item) => item.id));
+  const validCitationIds: string[] = [];
+  const missingCitationIds: string[] = [];
+
+  for (const citationId of dedupeStrings(citationIds)) {
+    if (allowedIds.has(citationId)) {
+      validCitationIds.push(citationId);
+    } else {
+      missingCitationIds.push(citationId);
+    }
+  }
+
+  return {
+    ok: missingCitationIds.length === 0,
+    validCitationIds,
+    missingCitationIds,
+  };
+}
+
+export function validateFinishRecallPayload(
+  payload: unknown,
+  evidence: readonly RecallEvidence[],
+): RecallFinishValidationResult {
+  if (!isRecord(payload)) {
+    return fallbackFinish("malformed_finish_payload");
+  }
+
+  const answer = readNonEmptyString(payload.answer);
+  if (!answer) {
+    return fallbackFinish("empty_answer");
+  }
+
+  if (!isRecallAgentConfidence(payload.confidence)) {
+    return fallbackFinish("invalid_confidence");
+  }
+
+  if (!isStringArray(payload.citation_ids)) {
+    return fallbackFinish("invalid_citation_ids");
+  }
+
+  const citationValidation = validateRecallCitationIds(
+    payload.citation_ids,
+    evidence,
+  );
+  if (!citationValidation.ok) {
+    return {
+      ...fallbackFinish("unknown_citation_ids", [
+        `Unknown citation ids: ${citationValidation.missingCitationIds.join(
+          ", ",
+        )}`,
+      ]),
+      missingCitationIds: citationValidation.missingCitationIds,
+    };
+  }
+
+  const unresolved = readOptionalStringArray(payload.unresolved);
+  if (unresolved === null) {
+    return fallbackFinish("malformed_finish_payload");
+  }
+
+  return {
+    ok: true,
+    finish: {
+      answer,
+      confidence: payload.confidence,
+      citationIds: citationValidation.validCitationIds,
+      ...(unresolved.length > 0 ? { unresolved } : {}),
+    },
+  };
+}
+
+function formatAllowedCitationIds(citationIds: readonly string[]): string {
+  if (citationIds.length === 0) {
+    return "Allowed citation_ids: none yet. Search for evidence before citing.";
+  }
+
+  return `Allowed citation_ids: ${citationIds.join(", ")}`;
+}
+
+function formatRecallEvidenceTable(
+  evidence: readonly RecallEvidence[],
+): string {
+  if (evidence.length === 0) {
+    return "No evidence supplied yet.";
+  }
+
+  return evidence.map(formatEvidenceRow).join("\n");
+}
+
+function formatEvidenceRow(item: RecallEvidence): string {
+  return [
+    `- id: ${item.id}`,
+    `  source: ${item.source}`,
+    `  title: ${item.title}`,
+    `  locator: ${item.locator}`,
+    `  text: ${compactWhitespace(item.excerpt)}`,
+  ].join("\n");
+}
+
+function fallbackFinish(
+  reason: RecallFinishFallbackReason,
+  unresolved: string[] = [`Recall agent returned ${reason}.`],
+): RecallFinishValidationResult & { ok: false } {
+  return {
+    ok: false,
+    reason,
+    finish: {
+      answer: "No reliable answer could be produced by the recall agent.",
+      confidence: "low",
+      citationIds: [],
+      unresolved,
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isRecallAgentConfidence(
+  value: unknown,
+): value is RecallAgentConfidence {
+  return value === "high" || value === "medium" || value === "low";
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+function readOptionalStringArray(value: unknown): string[] | null {
+  if (value === undefined) {
+    return [];
+  }
+  if (!isStringArray(value)) {
+    return null;
+  }
+
+  return dedupeStrings(value.map((item) => item.trim()).filter(Boolean));
+}
+
+function dedupeStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+
+  for (const value of values) {
+    if (seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    deduped.push(value);
+  }
+
+  return deduped;
+}
+
+function compactWhitespace(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}


### PR DESCRIPTION
## Summary
- Adds provider-agnostic recall tool schemas and prompt construction.
- Adds citation/evidence validation and malformed-finish fallback helpers.
- Covers protocol behavior with focused tests.

Part of plan: replace-recall-agentic-search.md (PR 8 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
