### PR TITLE
fix(tests): align conversation tests with removed private conversation creation

### DIFF
--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -465,23 +465,6 @@ describe("createConversation with conversation type option", () => {
     expect(conv.memoryScopeId).toBe("default");
   });
 
-  test("private create sets conversationType and derives memoryScopeId", () => {
-    const conv = createConversation({
-      title: "secret",
-      conversationType: "private",
-    });
-    expect(conv.conversationType).toBe("private");
-    expect(conv.memoryScopeId).toBe(`private:${conv.id}`);
-  });
-
-  test("private create memoryScopeId is persisted", () => {
-    const conv = createConversation({ conversationType: "private" });
-    const loaded = getConversation(conv.id);
-    expect(loaded).not.toBeNull();
-    expect(loaded!.conversationType).toBe("private");
-    expect(loaded!.memoryScopeId).toBe(`private:${conv.id}`);
-  });
-
   test("no-arg create uses defaults", () => {
     const conv = createConversation();
     expect(conv.conversationType).toBe("standard");
@@ -501,11 +484,6 @@ describe("conversation metadata read helpers", () => {
     expect(getConversationType(conv.id)).toBe("standard");
   });
 
-  test("getConversationType returns private for private conversation", () => {
-    const conv = createConversation({ conversationType: "private" });
-    expect(getConversationType(conv.id)).toBe("private");
-  });
-
   test("getConversationType returns standard for missing conversation", () => {
     expect(getConversationType("nonexistent-id")).toBe("standard");
   });
@@ -513,11 +491,6 @@ describe("conversation metadata read helpers", () => {
   test("getConversationMemoryScopeId returns default for standard conversation", () => {
     const conv = createConversation("test");
     expect(getConversationMemoryScopeId(conv.id)).toBe("default");
-  });
-
-  test("getConversationMemoryScopeId returns private scope for private conversation", () => {
-    const conv = createConversation({ conversationType: "private" });
-    expect(getConversationMemoryScopeId(conv.id)).toBe(`private:${conv.id}`);
   });
 
   test("getConversationMemoryScopeId returns default for missing conversation", () => {
@@ -801,146 +774,5 @@ describe("attachment reuse across conversation lifecycles", () => {
     const second = uploadAttachment("photo.png", "image/png", "DEDUPCROSS");
 
     expect(second.id).not.toBe(first.id);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Baseline: no private-conversation visibility boundary for attachments
-// ---------------------------------------------------------------------------
-
-describe("no private-conversation attachment visibility boundary", () => {
-  beforeEach(() => {
-    const db = getDb();
-    db.run("DELETE FROM message_attachments");
-    db.run("DELETE FROM attachments");
-    db.run("DELETE FROM messages");
-    db.run("DELETE FROM conversations");
-  });
-
-  test("attachment from a private conversation is visible via getAttachmentById (no conversation scoping)", async () => {
-    const privateConv = createConversation({
-      title: "Secret",
-      conversationType: "private",
-    });
-    expect(privateConv.conversationType).toBe("private");
-
-    const msg = await addMessage(
-      privateConv.id,
-      "assistant",
-      "Private content",
-    );
-    const stored = uploadAttachment("secret.pdf", "application/pdf", "JVBER");
-    linkAttachmentToMessage(msg.id, stored.id, 0);
-
-    // Attachment is globally visible by ID — no conversation-type filter exists
-    const fetched = getAttachmentById(stored.id);
-    expect(fetched).not.toBeNull();
-    expect(fetched!.originalFilename).toBe("secret.pdf");
-  });
-
-  test("attachment from a private conversation is copied when linked into a standard conversation", async () => {
-    const privateConv = createConversation({
-      title: "Private",
-      conversationType: "private",
-    });
-    const standardConv = createConversation({
-      title: "Standard",
-      conversationType: "standard",
-    });
-
-    const privateMsg = await addMessage(
-      privateConv.id,
-      "assistant",
-      "Private file",
-    );
-    const standardMsg = await addMessage(
-      standardConv.id,
-      "assistant",
-      "Reusing private file",
-    );
-
-    const stored = uploadAttachment("private-doc.png", "image/png", "PRIVDATA");
-    linkAttachmentToMessage(privateMsg.id, stored.id, 0);
-    linkAttachmentToMessage(standardMsg.id, stored.id, 0);
-
-    // Both conversations can see the attachment
-    const linkedPrivate = getAttachmentsForMessage(privateMsg.id);
-    expect(linkedPrivate).toHaveLength(1);
-
-    const linkedStandard = getAttachmentsForMessage(standardMsg.id);
-    expect(linkedStandard).toHaveLength(1);
-    expect(linkedStandard[0].id).not.toBe(stored.id);
-  });
-
-  test("getAttachmentsForMessage returns private conversation attachments", async () => {
-    const privateConv = createConversation({
-      title: "Private",
-      conversationType: "private",
-    });
-    const msg = await addMessage(privateConv.id, "assistant", "Private media");
-    const stored = uploadAttachment("photo.jpg", "image/jpeg", "AAAA");
-    linkAttachmentToMessage(msg.id, stored.id, 0);
-
-    const linked = getAttachmentsForMessage(msg.id);
-    expect(linked).toHaveLength(1);
-    expect(linked[0].id).toBe(stored.id);
-  });
-
-  test("identical uploads remain distinct across private and standard conversations", () => {
-    createConversation({ title: "Private", conversationType: "private" });
-    createConversation({ title: "Standard", conversationType: "standard" });
-
-    // Same content uploaded in private and standard contexts
-    const fromPrivate = uploadAttachment(
-      "file.png",
-      "image/png",
-      "CROSSCONVERSATION",
-    );
-    const fromStandard = uploadAttachment(
-      "file.png",
-      "image/png",
-      "CROSSCONVERSATION",
-    );
-
-    expect(fromStandard.id).not.toBe(fromPrivate.id);
-  });
-
-  test("clearAll removes attachments from both private and standard conversations", async () => {
-    const privateConv = createConversation({
-      title: "Private",
-      conversationType: "private",
-    });
-    const standardConv = createConversation({
-      title: "Standard",
-      conversationType: "standard",
-    });
-
-    const privateMsg = await addMessage(
-      privateConv.id,
-      "assistant",
-      "Private file",
-    );
-    const standardMsg = await addMessage(
-      standardConv.id,
-      "assistant",
-      "Standard file",
-    );
-
-    const att1 = uploadAttachment("private.png", "image/png", "PRIV");
-    const att2 = uploadAttachment("standard.png", "image/png", "STD");
-    linkAttachmentToMessage(privateMsg.id, att1.id, 0);
-    linkAttachmentToMessage(standardMsg.id, att2.id, 0);
-
-    clearAll();
-
-    const raw = (
-      getDb() as unknown as {
-        $client: import("bun:sqlite").Database;
-      }
-    ).$client;
-    const attachmentCount = raw
-      .query("SELECT COUNT(*) AS c FROM attachments")
-      .get() as { c: number };
-    expect(attachmentCount.c).toBe(0);
   });
 });

--- a/assistant/src/__tests__/conversation-wipe.test.ts
+++ b/assistant/src/__tests__/conversation-wipe.test.ts
@@ -155,9 +155,30 @@ describe("deleteConversation — private scope cleanup", () => {
     db.run(`DELETE FROM conversations`);
   });
 
+  // createConversation no longer accepts conversationType "private", but the
+  // deleteConversation cleanup path still handles legacy private rows. Stamp
+  // the memory_scope_id directly to simulate one.
+  function makeLegacyPrivateConversation(): {
+    id: string;
+    scopeId: string;
+  } {
+    const conv = createConversation("legacy private");
+    const scopeId = `private:${conv.id}`;
+    const raw = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client;
+    raw
+      .query(
+        `UPDATE conversations SET memory_scope_id = ?, conversation_type = 'private' WHERE id = ?`,
+      )
+      .run(scopeId, conv.id);
+    return { id: conv.id, scopeId };
+  }
+
   test("summaries cleaned up", () => {
-    const conv = createConversation({ conversationType: "private" });
-    const scopeId = conv.memoryScopeId;
+    const conv = makeLegacyPrivateConversation();
     const now = Date.now();
 
     const raw = (
@@ -172,7 +193,7 @@ describe("deleteConversation — private scope cleanup", () => {
         `INSERT INTO memory_summaries (id, scope, scope_key, summary, token_estimate, version, scope_id, start_at, end_at, created_at, updated_at)
          VALUES ('priv-sum-1', 'global', 'all', 'private summary', 100, 1, ?, ?, ?, ?, ?)`,
       )
-      .run(scopeId, now, now, now, now);
+      .run(conv.scopeId, now, now, now, now);
 
     const result = deleteConversation(conv.id);
 
@@ -187,20 +208,16 @@ describe("deleteConversation — private scope cleanup", () => {
   });
 
   test("standard conversations unaffected", async () => {
-    // Create a standard conversation and a private one
     const standardConv = createConversation("standard test");
-    const privateConv = createConversation({ conversationType: "private" });
+    const privateConv = makeLegacyPrivateConversation();
 
-    // Delete the private conversation
     deleteConversation(privateConv.id);
 
-    // Standard conversation should still exist
     expect(getConversation(standardConv.id)).not.toBeNull();
   });
 
   test("conversationStarters cleaned up", () => {
-    const conv = createConversation({ conversationType: "private" });
-    const scopeId = conv.memoryScopeId;
+    const conv = makeLegacyPrivateConversation();
     const now = Date.now();
 
     const raw = (
@@ -215,7 +232,7 @@ describe("deleteConversation — private scope cleanup", () => {
         `INSERT INTO conversation_starters (id, label, prompt, generation_batch, scope_id, card_type, created_at)
          VALUES ('starter-1', 'Test starter', 'Tell me about tests', 1, ?, 'chip', ?)`,
       )
-      .run(scopeId, now);
+      .run(conv.scopeId, now);
 
     // Also insert a default-scope starter that should NOT be deleted
     raw


### PR DESCRIPTION
## Summary
- Drop conversation-store tests that asserted on the removed `createConversation({ conversationType: "private" })` path
- Drop the entire "no private-conversation attachment visibility boundary" describe block — its baseline assumption no longer holds
- Update conversation-wipe private-scope cleanup tests to stamp `memory_scope_id` directly via raw SQL, simulating a legacy private row (the cleanup logic is still alive for legacy data)

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24927942074/job/73000962755
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
