### PR TITLE
Run agentic recall on the cost-optimized call site

### DIFF
--- a/assistant/src/__tests__/context-search-agent-runner.test.ts
+++ b/assistant/src/__tests__/context-search-agent-runner.test.ts
@@ -1,0 +1,379 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AssistantConfig } from "../config/schema.js";
+import type { Provider, ProviderResponse } from "../providers/types.js";
+
+let configuredProvider: Provider | null = null;
+const getConfiguredProviderCallSites: string[] = [];
+
+mock.module("../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async (callSite: string) => {
+    getConfiguredProviderCallSites.push(callSite);
+    return configuredProvider;
+  },
+}));
+
+import { runAgenticRecall } from "../memory/context-search/agent-runner.js";
+import type {
+  RecallEvidence,
+  RecallSearchContext,
+  RecallSource,
+  RecallSourceAdapter,
+} from "../memory/context-search/types.js";
+
+interface SearchCall {
+  source: RecallSource;
+  query: string;
+  limit: number;
+  signal?: AbortSignal;
+}
+
+function makeContext(signal?: AbortSignal): RecallSearchContext {
+  return {
+    workingDir: "/workspace",
+    memoryScopeId: "scope-123",
+    conversationId: "conv-xyz",
+    config: {} as AssistantConfig,
+    ...(signal ? { signal } : {}),
+  };
+}
+
+function makeEvidence(
+  id: string,
+  overrides: Partial<RecallEvidence> = {},
+): RecallEvidence {
+  return {
+    id,
+    source: "workspace",
+    title: `${id} title`,
+    locator: `${id}.md`,
+    excerpt: `${id} excerpt`,
+    score: 0.9,
+    ...overrides,
+  };
+}
+
+function makeAdapter(
+  evidenceByQuery: Record<string, RecallEvidence[]>,
+  calls: SearchCall[] = [],
+  source: RecallSource = "workspace",
+): RecallSourceAdapter {
+  return {
+    source,
+    async search(query, context, limit) {
+      calls.push({ source, query, limit, signal: context.signal });
+      return { evidence: evidenceByQuery[query] ?? [] };
+    },
+  };
+}
+
+function makeProvider(
+  responses: Array<ProviderResponse | Error>,
+  calls: unknown[][] = [],
+): Provider {
+  return {
+    name: "mock-provider",
+    async sendMessage(...args) {
+      calls.push(args);
+      const next = responses.shift();
+      if (!next) {
+        throw new Error("unexpected provider call");
+      }
+      if (next instanceof Error) {
+        throw next;
+      }
+      return next;
+    },
+  };
+}
+
+function toolResponse(
+  name: string,
+  input: Record<string, unknown>,
+): ProviderResponse {
+  return {
+    content: [{ type: "tool_use", id: `${name}-1`, name, input }],
+    model: "mock-model",
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "tool_use",
+  };
+}
+
+function textResponse(text: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text }],
+    model: "mock-model",
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "end_turn",
+  };
+}
+
+describe("runAgenticRecall", () => {
+  beforeEach(() => {
+    configuredProvider = null;
+    getConfiguredProviderCallSites.length = 0;
+  });
+
+  test("falls back to deterministic recall when no provider is configured", async () => {
+    const searchCalls: SearchCall[] = [];
+    const result = await runAgenticRecall(
+      { query: "launch notes", sources: ["workspace"], max_results: 3 },
+      makeContext(),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter(
+              { "launch notes": [makeEvidence("workspace:launch")] },
+              searchCalls,
+            ),
+          ],
+        },
+      },
+    );
+
+    expect(getConfiguredProviderCallSites).toEqual(["recall"]);
+    expect(searchCalls.map((call) => call.query)).toEqual(["launch notes"]);
+    expect(result.debug).toMatchObject({
+      mode: "deterministic_fallback",
+      fallbackReason: "no_provider",
+      roundsUsed: 0,
+    });
+    expect(result.content).toContain("Found evidence:");
+    expect(result.evidence.map((item) => item.id)).toEqual([
+      "workspace:launch",
+    ]);
+  });
+
+  test("returns a valid finish_recall answer with cited evidence", async () => {
+    configuredProvider = makeProvider([
+      toolResponse("finish_recall", {
+        answer: "Alice chose Friday.",
+        confidence: "high",
+        citation_ids: ["workspace:launch"],
+      }),
+    ]);
+
+    const result = await runAgenticRecall(
+      { query: "launch notes", sources: ["workspace"] },
+      makeContext(),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter({
+              "launch notes": [makeEvidence("workspace:launch")],
+            }),
+          ],
+        },
+      },
+    );
+
+    expect(result.content).toBe("Alice chose Friday.");
+    expect(result.debug.mode).toBe("agentic");
+    expect(result.debug.roundsUsed).toBe(1);
+    expect(result.debug.finish).toEqual({
+      confidence: "high",
+      citationIds: ["workspace:launch"],
+    });
+    expect(result.evidence.map((item) => item.id)).toEqual([
+      "workspace:launch",
+    ]);
+  });
+
+  test("executes follow-up search_sources through narrowed local searches", async () => {
+    const providerCalls: unknown[][] = [];
+    configuredProvider = makeProvider(
+      [
+        toolResponse("search_sources", {
+          query: "decision notes",
+          sources: ["workspace", "memory"],
+          limit: 2,
+          reason: "Need the explicit decision.",
+        }),
+        toolResponse("finish_recall", {
+          answer: "The decision note says Friday.",
+          confidence: "medium",
+          citation_ids: ["workspace:decision"],
+        }),
+      ],
+      providerCalls,
+    );
+    const controller = new AbortController();
+    const searchCalls: SearchCall[] = [];
+
+    const result = await runAgenticRecall(
+      {
+        query: "launch notes",
+        sources: ["workspace"],
+        max_results: 3,
+        depth: "standard",
+      },
+      makeContext(controller.signal),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter(
+              {
+                "launch notes": [makeEvidence("workspace:seed")],
+                "decision notes": [makeEvidence("workspace:decision")],
+              },
+              searchCalls,
+            ),
+          ],
+        },
+      },
+    );
+
+    expect(providerCalls).toHaveLength(2);
+    expect(searchCalls).toEqual([
+      {
+        source: "workspace",
+        query: "launch notes",
+        limit: 6,
+        signal: controller.signal,
+      },
+      {
+        source: "workspace",
+        query: "decision notes",
+        limit: 2,
+        signal: controller.signal,
+      },
+    ]);
+    expect(result.content).toBe("The decision note says Friday.");
+    expect(result.debug.searchCalls).toEqual([
+      {
+        round: 1,
+        query: "decision notes",
+        sources: ["workspace"],
+        limit: 2,
+        reason: "Need the explicit decision.",
+        evidenceCount: 1,
+      },
+    ]);
+  });
+
+  test("falls back when the provider exhausts the round budget", async () => {
+    const providerCalls: unknown[][] = [];
+    configuredProvider = makeProvider(
+      [
+        toolResponse("search_sources", {
+          query: "more notes",
+          sources: ["workspace"],
+          reason: "Need more.",
+        }),
+      ],
+      providerCalls,
+    );
+
+    const result = await runAgenticRecall(
+      { query: "launch notes", sources: ["workspace"], depth: "fast" },
+      makeContext(),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter({
+              "launch notes": [makeEvidence("workspace:seed")],
+              "more notes": [makeEvidence("workspace:more")],
+            }),
+          ],
+        },
+      },
+    );
+
+    expect(providerCalls).toHaveLength(1);
+    expect(result.debug.roundLimit).toBe(1);
+    expect(result.debug.roundsUsed).toBe(1);
+    expect(result.debug).toMatchObject({
+      mode: "deterministic_fallback",
+      fallbackReason: "round_limit",
+    });
+    expect(result.evidence.map((item) => item.id)).toEqual(["workspace:seed"]);
+  });
+
+  test("falls back when finish_recall cites unknown evidence", async () => {
+    configuredProvider = makeProvider([
+      toolResponse("finish_recall", {
+        answer: "Unsupported answer.",
+        confidence: "high",
+        citation_ids: ["workspace:missing"],
+      }),
+    ]);
+
+    const result = await runAgenticRecall(
+      { query: "launch notes", sources: ["workspace"] },
+      makeContext(),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter({
+              "launch notes": [makeEvidence("workspace:seed")],
+            }),
+          ],
+        },
+      },
+    );
+
+    expect(result.debug).toMatchObject({
+      mode: "deterministic_fallback",
+      fallbackReason: "citation_validation_failed",
+      fallbackDetail: "unknown_citation_ids",
+    });
+    expect(result.content).toContain("Found evidence:");
+  });
+
+  test("falls back on provider errors", async () => {
+    configuredProvider = makeProvider([new Error("provider unavailable")]);
+
+    const result = await runAgenticRecall(
+      { query: "launch notes", sources: ["workspace"] },
+      makeContext(),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter({
+              "launch notes": [makeEvidence("workspace:seed")],
+            }),
+          ],
+        },
+      },
+    );
+
+    expect(result.debug).toMatchObject({
+      mode: "deterministic_fallback",
+      fallbackReason: "provider_error",
+      fallbackDetail: "provider unavailable",
+    });
+  });
+
+  test("routes provider calls through the recall call site with temperature zero", async () => {
+    const providerCalls: unknown[][] = [];
+    configuredProvider = makeProvider(
+      [textResponse("not a tool call")],
+      providerCalls,
+    );
+
+    await runAgenticRecall(
+      { query: "launch notes", sources: ["workspace"] },
+      makeContext(),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter({
+              "launch notes": [makeEvidence("workspace:seed")],
+            }),
+          ],
+        },
+      },
+    );
+
+    expect(getConfiguredProviderCallSites).toEqual(["recall"]);
+    expect(providerCalls).toHaveLength(1);
+    const options = providerCalls[0]?.[3] as {
+      config?: Record<string, unknown>;
+    };
+    expect(options.config).toEqual({
+      callSite: "recall",
+      temperature: 0,
+    });
+    expect(options.config).not.toHaveProperty("thinking");
+  });
+});

--- a/assistant/src/memory/context-search/agent-runner.ts
+++ b/assistant/src/memory/context-search/agent-runner.ts
@@ -1,0 +1,408 @@
+import { getConfiguredProvider } from "../../providers/provider-send-message.js";
+import type {
+  Message,
+  ProviderResponse,
+  ToolUseContent,
+} from "../../providers/types.js";
+import {
+  buildRecallAgentPrompt,
+  RECALL_AGENT_TOOL_DEFINITIONS,
+  validateFinishRecallPayload,
+} from "./agent-protocol.js";
+import { formatDeterministicRecallAnswer } from "./format.js";
+import {
+  type NormalizedRecallInput,
+  normalizeRecallInput,
+  normalizeRecallMaxResults,
+} from "./limits.js";
+import {
+  type DeterministicRecallSearchOptions,
+  type DeterministicRecallSearchResult,
+  runDeterministicRecallSearch,
+} from "./search.js";
+import type {
+  RecallAnswer,
+  RecallEvidence,
+  RecallInput,
+  RecallSearchContext,
+  RecallSource,
+} from "./types.js";
+
+export type AgenticRecallFallbackReason =
+  | "no_provider"
+  | "provider_error"
+  | "timeout"
+  | "no_valid_finish"
+  | "round_limit"
+  | "citation_validation_failed";
+
+export interface AgenticRecallSearchDebug {
+  round: number;
+  query: string;
+  sources: RecallSource[];
+  limit: number;
+  reason: string;
+  evidenceCount: number;
+  error?: string;
+}
+
+export interface AgenticRecallDebug {
+  mode: "agentic" | "deterministic_fallback";
+  normalizedInput: NormalizedRecallInput;
+  roundLimit: number;
+  roundsUsed: number;
+  seedEvidenceCount: number;
+  searchCalls: AgenticRecallSearchDebug[];
+  finish?: {
+    confidence: string;
+    citationIds: string[];
+    unresolved?: string[];
+  };
+  fallbackReason?: AgenticRecallFallbackReason;
+  fallbackDetail?: string;
+}
+
+export interface AgenticRecallResult extends RecallAnswer {
+  content: string;
+  debug: AgenticRecallDebug;
+}
+
+export interface RunAgenticRecallOptions {
+  searchOptions?: DeterministicRecallSearchOptions;
+}
+
+export async function runAgenticRecall(
+  input: RecallInput,
+  context: RecallSearchContext,
+  options: RunAgenticRecallOptions = {},
+): Promise<AgenticRecallResult> {
+  const normalizedInput = normalizeRecallInput(input);
+  const roundLimit = normalizedInput.sourceRounds;
+  const debug: AgenticRecallDebug = {
+    mode: "agentic",
+    normalizedInput,
+    roundLimit,
+    roundsUsed: 0,
+    seedEvidenceCount: 0,
+    searchCalls: [],
+  };
+
+  const provider = await getConfiguredProvider("recall");
+  if (!provider) {
+    const fallbackResult = await runDeterministicRecallSearch(
+      toRecallInput(normalizedInput),
+      context,
+      options.searchOptions,
+    );
+    debug.seedEvidenceCount = fallbackResult.evidence.length;
+    return deterministicFallback(
+      fallbackResult,
+      debug,
+      "no_provider",
+      "No recall provider is configured.",
+    );
+  }
+
+  const seedResult = await runDeterministicRecallSearch(
+    toRecallInput(normalizedInput),
+    context,
+    options.searchOptions,
+  );
+  debug.seedEvidenceCount = seedResult.evidence.length;
+  let evidence = [...seedResult.evidence];
+  let fallbackReason: AgenticRecallFallbackReason = "no_valid_finish";
+  let fallbackDetail = "Recall provider did not return a valid finish_recall.";
+
+  for (let round = 1; round <= roundLimit; round++) {
+    debug.roundsUsed = round;
+
+    let response: ProviderResponse;
+    try {
+      response = await provider.sendMessage(
+        [userTextMessage(buildPrompt(normalizedInput, evidence, roundLimit))],
+        [...RECALL_AGENT_TOOL_DEFINITIONS],
+        undefined,
+        {
+          config: { callSite: "recall", temperature: 0 },
+          signal: context.signal,
+        },
+      );
+    } catch (err) {
+      fallbackReason = isAbortError(err) ? "timeout" : "provider_error";
+      fallbackDetail = errorToMessage(err);
+      break;
+    }
+
+    const toolUses = extractToolUses(response);
+    const finishTool = toolUses.find((tool) => tool.name === "finish_recall");
+    if (finishTool) {
+      const validation = validateFinishRecallPayload(
+        finishTool.input,
+        evidence,
+      );
+      if (!validation.ok) {
+        fallbackReason = "citation_validation_failed";
+        fallbackDetail = validation.reason;
+        break;
+      }
+
+      const finish = validation.finish;
+      const citedEvidence = selectCitedEvidence(evidence, finish.citationIds);
+      debug.finish = {
+        confidence: finish.confidence,
+        citationIds: finish.citationIds,
+        ...(finish.unresolved ? { unresolved: finish.unresolved } : {}),
+      };
+
+      return {
+        content: finish.answer,
+        answer: finish.answer,
+        evidence: citedEvidence,
+        debug,
+      };
+    }
+
+    const searchTools = toolUses.filter(
+      (tool) => tool.name === "search_sources",
+    );
+    if (searchTools.length === 0) {
+      fallbackReason = "no_valid_finish";
+      fallbackDetail =
+        "Recall provider returned no search_sources or finish_recall tool call.";
+      break;
+    }
+
+    const remainingSearchBudget = roundLimit - debug.searchCalls.length;
+    if (remainingSearchBudget <= 0) {
+      fallbackReason = "round_limit";
+      fallbackDetail =
+        "Recall provider exhausted the configured search budget.";
+      break;
+    }
+
+    for (const searchTool of searchTools.slice(0, remainingSearchBudget)) {
+      const searchResult = await executeSearchSources(
+        searchTool.input,
+        normalizedInput,
+        context,
+        round,
+        options.searchOptions,
+      );
+      debug.searchCalls.push(searchResult.debug);
+      evidence = mergeEvidence(evidence, searchResult.evidence);
+    }
+
+    if (round === roundLimit) {
+      fallbackReason = "round_limit";
+      fallbackDetail = "Recall provider exhausted the configured round budget.";
+    }
+  }
+
+  return deterministicFallback(
+    seedResult,
+    debug,
+    fallbackReason,
+    fallbackDetail,
+  );
+}
+
+function buildPrompt(
+  input: NormalizedRecallInput,
+  evidence: readonly RecallEvidence[],
+  roundLimit: number,
+): string {
+  return buildRecallAgentPrompt({
+    query: input.query,
+    availableSources: input.sources,
+    evidence,
+    maxSearchCalls: roundLimit,
+  });
+}
+
+function userTextMessage(text: string): Message {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+function extractToolUses(response: ProviderResponse): ToolUseContent[] {
+  return response.content.filter(
+    (block): block is ToolUseContent => block.type === "tool_use",
+  );
+}
+
+async function executeSearchSources(
+  payload: Record<string, unknown>,
+  input: NormalizedRecallInput,
+  context: RecallSearchContext,
+  round: number,
+  searchOptions: DeterministicRecallSearchOptions | undefined,
+): Promise<{
+  evidence: RecallEvidence[];
+  debug: AgenticRecallSearchDebug;
+}> {
+  const query = readSearchQuery(payload.query);
+  const reason = readSearchReason(payload.reason);
+  const rawLimit = readSearchLimit(payload.limit);
+  const limit =
+    rawLimit === undefined
+      ? input.maxResults
+      : normalizeRecallMaxResults(rawLimit);
+  const sources = narrowSearchSources(payload.sources, input.sources);
+
+  const debug: AgenticRecallSearchDebug = {
+    round,
+    query,
+    sources,
+    limit,
+    reason,
+    evidenceCount: 0,
+  };
+
+  if (!query || sources.length === 0) {
+    return {
+      evidence: [],
+      debug: {
+        ...debug,
+        error: !query
+          ? "search_sources query must be a non-empty string"
+          : "search_sources requested no allowed local sources",
+      },
+    };
+  }
+
+  try {
+    const result = await runDeterministicRecallSearch(
+      {
+        query,
+        sources,
+        max_results: limit,
+        depth: "fast",
+      },
+      context,
+      searchOptions,
+    );
+    return {
+      evidence: result.evidence,
+      debug: { ...debug, evidenceCount: result.evidence.length },
+    };
+  } catch (err) {
+    return {
+      evidence: [],
+      debug: { ...debug, error: errorToMessage(err) },
+    };
+  }
+}
+
+function readSearchQuery(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function readSearchReason(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function readSearchLimit(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+function narrowSearchSources(
+  value: unknown,
+  allowedSources: readonly RecallSource[],
+): RecallSource[] {
+  const allowed = new Set(allowedSources);
+  const requested = Array.isArray(value)
+    ? dedupeSources(value.filter(isRecallSourceLike))
+    : [...allowedSources];
+
+  return requested.filter((source) => allowed.has(source));
+}
+
+function isRecallSourceLike(value: unknown): value is RecallSource {
+  return (
+    value === "memory" ||
+    value === "pkb" ||
+    value === "conversations" ||
+    value === "workspace"
+  );
+}
+
+function mergeEvidence(
+  existing: readonly RecallEvidence[],
+  next: readonly RecallEvidence[],
+): RecallEvidence[] {
+  const seen = new Set(existing.map((item) => item.id));
+  const merged = [...existing];
+
+  for (const item of next) {
+    if (seen.has(item.id)) {
+      continue;
+    }
+    seen.add(item.id);
+    merged.push(item);
+  }
+
+  return merged;
+}
+
+function toRecallInput(input: NormalizedRecallInput): RecallInput {
+  return {
+    query: input.query,
+    sources: input.sources,
+    max_results: input.maxResults,
+    depth: input.depth,
+  };
+}
+
+function dedupeSources(sources: readonly RecallSource[]): RecallSource[] {
+  const deduped: RecallSource[] = [];
+  for (const source of sources) {
+    if (!deduped.includes(source)) {
+      deduped.push(source);
+    }
+  }
+  return deduped;
+}
+
+function selectCitedEvidence(
+  evidence: readonly RecallEvidence[],
+  citationIds: readonly string[],
+): RecallEvidence[] {
+  const byId = new Map(evidence.map((item) => [item.id, item]));
+  return citationIds.flatMap((id) => {
+    const item = byId.get(id);
+    return item ? [item] : [];
+  });
+}
+
+function deterministicFallback(
+  result: DeterministicRecallSearchResult,
+  debug: AgenticRecallDebug,
+  reason: AgenticRecallFallbackReason,
+  detail: string,
+): AgenticRecallResult {
+  const fallback = formatDeterministicRecallAnswer(result);
+  return {
+    content: fallback.answer,
+    answer: fallback.answer,
+    evidence: fallback.evidence,
+    debug: {
+      ...debug,
+      mode: "deterministic_fallback",
+      fallbackReason: reason,
+      fallbackDetail: detail,
+    },
+  };
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+function errorToMessage(err: unknown): string {
+  if (err instanceof Error && err.message) {
+    return err.message;
+  }
+  return String(err);
+}


### PR DESCRIPTION
## Summary
- Adds a bounded provider-backed recall runner using the recall call site.
- Routes model follow-up searches through local deterministic source search only.
- Falls back to deterministic answers on provider or validation failures.

Part of plan: replace-recall-agentic-search.md (PR 9 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
