### PR TITLE
fix(wake): pass mainAgent callSite so resolver applies overrideProfile

### DIFF
--- a/assistant/src/__tests__/agent-wake-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-wake-override-profile.test.ts
@@ -7,10 +7,22 @@
  * would execute under workspace defaults — silently violating the user's
  * pinned preference.
  *
- * This test pins `getConversationOverrideProfile` to return a fixed profile
- * name and asserts that the wake forwards it to `agentLoop.run` as the
- * `overrideProfile` positional argument. A second case verifies the absence
- * path (no row override → `undefined` propagated).
+ * The wake also has to pass `callSite: "mainAgent"` explicitly. The agent loop
+ * threads `callSite` and `overrideProfile` onto the per-call provider config,
+ * but `RetryProvider.normalizeSendMessageOptions` only invokes
+ * `resolveCallSiteConfig` when `config.callSite !== undefined` and
+ * `CallSiteRoutingProvider.selectProvider` short-circuits to the default
+ * provider when `callSite` is absent. So a wake that only set
+ * `overrideProfile` (with `callSite: undefined`) would still execute under
+ * workspace defaults — the pinned profile would be silently dropped.
+ *
+ * This file pins `getConversationOverrideProfile` to a fixed profile name and
+ * asserts that:
+ *   1. The wake forwards `overrideProfile` to `agentLoop.run`.
+ *   2. The wake forwards `callSite: "mainAgent"` to `agentLoop.run`.
+ *   3. With both set, `RetryProvider.normalizeSendMessageOptions` actually
+ *      invokes the resolver and replaces workspace defaults with the
+ *      pinned-profile values.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -21,8 +33,28 @@ mock.module("../memory/conversation-crud.js", () => ({
   getConversationOverrideProfile: (_id: string) => mockOverrideProfile,
 }));
 
+// Mutable stub for `getConfig().llm` consumed by `RetryProvider`'s
+// resolver path in the integration-style assertion below. Defined ahead of
+// import so the module-level `getConfig()` reference inside `retry.ts`
+// closes over our mutable holder.
+let mockLlmConfig: Record<string, unknown> = {};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    llm: mockLlmConfig,
+    services: { inference: { mode: "your-own" } },
+  }),
+}));
+
 import type { AgentEvent } from "../agent/loop.js";
-import type { Message } from "../providers/types.js";
+import { LLMSchema } from "../config/schemas/llm.js";
+import { RetryProvider } from "../providers/retry.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../providers/types.js";
 import {
   __resetWakeChainForTests,
   wakeAgentForOpportunity,
@@ -91,6 +123,7 @@ function makeTarget(): {
 
 beforeEach(() => {
   __resetWakeChainForTests();
+  mockLlmConfig = LLMSchema.parse({}) as Record<string, unknown>;
 });
 
 afterEach(() => {
@@ -98,7 +131,7 @@ afterEach(() => {
 });
 
 describe("wakeAgentForOpportunity — overrideProfile forwarding", () => {
-  test("forwards the conversation's pinned overrideProfile to agentLoop.run", async () => {
+  test("forwards the conversation's pinned overrideProfile + mainAgent callSite to agentLoop.run", async () => {
     mockOverrideProfile = "frontier";
     const { target, runArgs } = makeTarget();
 
@@ -116,11 +149,17 @@ describe("wakeAgentForOpportunity — overrideProfile forwarding", () => {
     // The 8th positional argument (after messages, onEvent, signal,
     // requestId, onCheckpoint, callSite, turnContext) is overrideProfile.
     expect(runArgs[0]!.overrideProfile).toBe("frontier");
+    // The 6th positional argument is callSite. Wakes resume a user-facing
+    // conversation, so route through the same `mainAgent` call site as a
+    // normal user turn — without it the resolver and routing layers would
+    // short-circuit and silently drop both the call-site config and the
+    // pinned override profile.
+    expect(runArgs[0]!.callSite).toBe("mainAgent");
     // Sanity: the wake-source tag still propagates as requestId.
     expect(runArgs[0]!.requestId).toBe("wake:scheduler");
   });
 
-  test("passes undefined when the conversation has no pinned profile", async () => {
+  test("passes undefined overrideProfile when the conversation has no pinned profile, but still forwards mainAgent callSite", async () => {
     mockOverrideProfile = undefined;
     const { target, runArgs } = makeTarget();
 
@@ -135,5 +174,88 @@ describe("wakeAgentForOpportunity — overrideProfile forwarding", () => {
 
     expect(runArgs).toHaveLength(1);
     expect(runArgs[0]!.overrideProfile).toBeUndefined();
+    // Even without an override profile, we still need callSite="mainAgent"
+    // so the resolver picks up `llm.callSites.mainAgent` config (model,
+    // maxTokens, effort, etc.). Otherwise the wake silently runs under
+    // workspace defaults regardless of any per-call-site configuration.
+    expect(runArgs[0]!.callSite).toBe("mainAgent");
+  });
+});
+
+describe("wakeAgentForOpportunity — resolver actually engages", () => {
+  // The unit tests above only assert positional argument forwarding. They
+  // do not exercise the real provider chain, which is exactly the gap that
+  // let the original bug ship: the wake forwarded `overrideProfile` but
+  // passed `callSite: undefined`, and `RetryProvider.normalizeSendMessageOptions`
+  // only invokes `resolveCallSiteConfig` when `config.callSite !== undefined`.
+  // This test wires the same `(callSite, overrideProfile)` pair the wake now
+  // produces into a real `RetryProvider.sendMessage` call to confirm the
+  // resolver fires and the pinned-profile values replace workspace defaults.
+
+  function makeProvider(
+    name: string,
+    onCall: (options: SendMessageOptions | undefined) => void,
+  ): Provider {
+    return {
+      name,
+      async sendMessage(_messages, _tools, _systemPrompt, options) {
+        onCall(options);
+        const response: ProviderResponse = {
+          content: [{ type: "text", text: "ok" }],
+          model: "stub",
+          usage: { inputTokens: 1, outputTokens: 1 },
+          stopReason: "end_turn",
+        };
+        return response;
+      },
+    };
+  }
+
+  test("with callSite='mainAgent' + overrideProfile, RetryProvider resolves the pinned-profile model/maxTokens", async () => {
+    // Workspace defaults intentionally differ from the pinned-profile values
+    // so we can detect whether the resolver engaged. If `callSite` were
+    // undefined (the original bug), the retry layer would skip the resolver
+    // entirely and the downstream provider would see only the wire defaults.
+    mockLlmConfig = LLMSchema.parse({
+      default: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        maxTokens: 64000,
+      },
+      profiles: {
+        frontier: {
+          model: "claude-opus-4-7",
+          maxTokens: 32000,
+        },
+      },
+      callSites: {
+        mainAgent: {},
+      },
+    }) as Record<string, unknown>;
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+    );
+
+    // Mirror exactly what `agentLoop.run` puts on `providerConfig` when
+    // `callSite` and `overrideProfile` are both set (see `agent/loop.ts`).
+    await wrapped.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      undefined,
+      undefined,
+      { config: { callSite: "mainAgent", overrideProfile: "frontier" } },
+    );
+
+    const config = seen?.config as Record<string, unknown>;
+    // Resolver engaged → pinned-profile values applied.
+    expect(config.model).toBe("claude-opus-4-7");
+    expect(config.max_tokens).toBe(32000);
+    // Both routing keys are stripped before delegating downstream so they
+    // never leak into provider request bodies.
+    expect(config.callSite).toBeUndefined();
+    expect(config.overrideProfile).toBeUndefined();
   });
 });

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -381,7 +381,12 @@ export async function wakeAgentForOpportunity(
           undefined, // no external abort signal
           `wake:${source}`,
           undefined, // onCheckpoint
-          undefined, // callSite
+          // Route through `mainAgent` — same as a normal user turn on this
+          // conversation. Without an explicit callSite, the resolver in
+          // `RetryProvider` and the routing in `CallSiteRoutingProvider`
+          // short-circuit and silently drop both `llm.callSites.mainAgent`
+          // config and the pinned `overrideProfile` below.
+          "mainAgent",
           undefined, // turnContext
           overrideProfile,
         );


### PR DESCRIPTION
## Summary
Fixes a real functional bug from inference-profiles plan re-review. PR #28065 forwarded `overrideProfile` to `agentLoop.run` from `wakeAgentForOpportunity` but passed `callSite: undefined`, so the resolver/routing layers short-circuited and the override was silently dropped.

Pass `callSite: "mainAgent"` so the resolver fires and the pinned profile actually applies. Strengthen the regression test to assert callSite is forwarded and that the resolver layer engages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
