### PR TITLE
Replace recall tool implementation with agentic search

### DIFF
--- a/assistant/src/memory/graph/tools.ts
+++ b/assistant/src/memory/graph/tools.ts
@@ -5,68 +5,50 @@
 // ---------------------------------------------------------------------------
 
 import type { ToolDefinition } from "../../providers/types.js";
+import {
+  ALL_RECALL_SOURCES,
+  MAX_RECALL_MAX_RESULTS,
+  MIN_RECALL_MAX_RESULTS,
+} from "../context-search/limits.js";
+
+const RECALL_DEPTHS = ["fast", "standard", "deep"] as const;
 
 /**
- * Explicit memory search across the living graph or raw archive.
- *
- * Auto-injection is incomplete by design — the assistant should recall
- * aggressively whenever uncertain, before guessing or asking.
+ * Explicit local information search across memory, PKB, conversations, and
+ * workspace files.
  */
 export const graphRecallDefinition: ToolDefinition = {
   name: "recall",
   description:
-    'Search your memory the moment you feel uncertain. Call this AGGRESSIVELY — before you guess, before you ask, before you hedge. Auto-injection is incomplete by design; it surfaces patterns, not the specifics you need to answer well. If you catch yourself reaching for "I think", "I believe", "if I remember", "didn\'t we", "last time" — that\'s the signal. Recall. If the user references someone, a place, or a decision you should already know — recall. If you\'re about to ask a clarifying question memory might answer — recall first. Searching costs nothing; guessing costs trust. Call it multiple times per conversation if the turn warrants it. Be specific in your query — a topic, feeling, time period, or person — for best results.',
+    'Search local information the moment you feel uncertain. Use recall for memory, the personal knowledge base, past conversations, and workspace files — before you guess, before you ask, before you hedge. Auto-injection is incomplete by design; it surfaces patterns, not the specifics you need to answer well. If you catch yourself reaching for "I think", "I believe", "if I remember", "didn\'t we", "last time" — that\'s the signal. Recall. If the user references someone, a place, a decision, a document, or prior work you should be able to find locally — recall. Call it multiple times per conversation if the turn warrants it. Be specific in your query for best results.',
   input_schema: {
     type: "object",
     properties: {
       query: {
         type: "string",
         description:
-          "What you're looking for — be specific and descriptive. Can be a topic, feeling, time period, or person.",
+          "What you're looking for. Be specific and descriptive: include the topic, person, project, decision, time period, or file clues when known.",
       },
-      num_results: {
-        type: "integer",
-        description:
-          "Maximum number of results to return (default 20, max 50).",
-      },
-      mode: {
-        type: "string",
-        enum: ["memory", "archive"],
-        description:
-          '"memory" searches the living memory graph using semantic similarity (default). "archive" searches raw conversation transcripts using keyword matching. Supports FTS5 syntax: use "quoted phrases" for exact matching, AND/OR for boolean logic, NEAR(word1 word2, N) for proximity. Without operators, all keywords must appear (implicit AND). Short words like "I" and "a" are ignored. Prefer "memory" for conceptual/emotional queries, "archive" for finding specific wording.',
-      },
-      filters: {
-        type: "object",
-        description: "Optional filters to narrow results",
-        properties: {
-          types: {
-            type: "array",
-            items: {
-              type: "string",
-              enum: [
-                "episodic",
-                "semantic",
-                "procedural",
-                "emotional",
-                "prospective",
-                "behavioral",
-                "narrative",
-                "shared",
-              ],
-            },
-            description: "Only return memories of these types",
-          },
-          after: {
-            type: "string",
-            description:
-              "Only return memories created after this date (ISO 8601)",
-          },
-          before: {
-            type: "string",
-            description:
-              "Only return memories created before this date (ISO 8601)",
-          },
+      sources: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: [...ALL_RECALL_SOURCES],
         },
+        description:
+          "Optional local sources to search. Omit to search memory, PKB, conversations, and workspace files.",
+      },
+      max_results: {
+        type: "integer",
+        minimum: MIN_RECALL_MAX_RESULTS,
+        maximum: MAX_RECALL_MAX_RESULTS,
+        description: "Maximum number of evidence items to return.",
+      },
+      depth: {
+        type: "string",
+        enum: [...RECALL_DEPTHS],
+        description:
+          "Search effort. Use fast for quick lookups, standard by default, and deep when the answer may require multiple local searches.",
       },
     },
     required: ["query"],

--- a/assistant/src/tools/memory/register.test.ts
+++ b/assistant/src/tools/memory/register.test.ts
@@ -27,6 +27,12 @@ const enqueueCalls: Array<{
 }> = [];
 let enqueueShouldThrow = false;
 
+const recallCalls: Array<{
+  input: Record<string, unknown>;
+  context: Record<string, unknown>;
+}> = [];
+let recallContent = "agentic recall answer";
+
 mock.module("../../memory/jobs/embed-pkb-file.js", () => ({
   enqueuePkbIndexJob: (input: {
     pkbRoot: string;
@@ -38,6 +44,21 @@ mock.module("../../memory/jobs/embed-pkb-file.js", () => ({
       throw new Error("simulated enqueue failure");
     }
     return "job-mock-id";
+  },
+}));
+
+mock.module("../../memory/context-search/agent-runner.js", () => ({
+  runAgenticRecall: async (
+    input: Record<string, unknown>,
+    context: Record<string, unknown>,
+  ) => {
+    recallCalls.push({ input, context });
+    return {
+      content: recallContent,
+      answer: recallContent,
+      evidence: [],
+      debug: { mode: "agentic" },
+    };
   },
 }));
 
@@ -57,7 +78,8 @@ afterAll(() => {
 });
 
 // Import after the env var is set so getWorkspaceDir() resolves to the tmpdir.
-const { rememberTool } = await import("./register.js");
+const { recallTool, rememberTool } = await import("./register.js");
+const { getConfig } = await import("../../config/loader.js");
 
 function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
   return {
@@ -67,6 +89,116 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
     ...overrides,
   };
 }
+
+describe("recallTool definition", () => {
+  test("exposes the agentic local search schema", () => {
+    const definition = recallTool.getDefinition();
+
+    expect(definition.name).toBe("recall");
+    expect(definition.description).toContain("Search local information");
+    expect(definition.description).toContain("workspace files");
+
+    const inputSchema = definition.input_schema as {
+      required?: string[];
+      properties: Record<string, unknown>;
+    };
+    expect(inputSchema.required).toEqual(["query"]);
+
+    const properties = inputSchema.properties;
+    expect(Object.keys(properties).sort()).toEqual([
+      "depth",
+      "max_results",
+      "query",
+      "sources",
+    ]);
+    expect(properties).not.toHaveProperty("mode");
+    expect(properties).not.toHaveProperty("num_results");
+    expect(properties).not.toHaveProperty("filters");
+    expect(properties.sources).toMatchObject({
+      type: "array",
+      items: {
+        type: "string",
+        enum: ["memory", "pkb", "conversations", "workspace"],
+      },
+    });
+    expect(properties.max_results).toMatchObject({
+      type: "integer",
+      minimum: 1,
+      maximum: 20,
+    });
+    expect(properties.depth).toMatchObject({
+      type: "string",
+      enum: ["fast", "standard", "deep"],
+    });
+  });
+});
+
+describe("recallTool.execute", () => {
+  beforeEach(() => {
+    recallCalls.length = 0;
+    recallContent = "agentic recall answer";
+  });
+
+  test("passes source filtering input through to agentic recall", async () => {
+    const result = await recallTool.execute(
+      {
+        query: "release notes",
+        sources: ["pkb", "workspace"],
+        max_results: 4,
+        depth: "deep",
+      },
+      makeContext({ memoryScopeId: "scope-filter" }),
+    );
+
+    expect(result).toEqual({
+      content: "agentic recall answer",
+      isError: false,
+    });
+    expect(recallCalls).toHaveLength(1);
+    expect(recallCalls[0]?.input).toEqual({
+      query: "release notes",
+      sources: ["pkb", "workspace"],
+      max_results: 4,
+      depth: "deep",
+    });
+  });
+
+  test("returns deterministic fallback content directly", async () => {
+    recallContent = "Found evidence:\n\n- [workspace] fallback note";
+
+    const result = await recallTool.execute(
+      { query: "fallback search", sources: ["workspace"], depth: "fast" },
+      makeContext({ memoryScopeId: "scope-fallback" }),
+    );
+
+    expect(result).toEqual({
+      content: "Found evidence:\n\n- [workspace] fallback note",
+      isError: false,
+    });
+  });
+
+  test("propagates tool context and defaults missing memory scope", async () => {
+    const controller = new AbortController();
+
+    await recallTool.execute(
+      { query: "context propagation" },
+      makeContext({
+        workingDir: "/workspace/project",
+        conversationId: "conv-context",
+        signal: controller.signal,
+      }),
+    );
+
+    expect(recallCalls).toHaveLength(1);
+    expect(recallCalls[0]?.context).toEqual({
+      workingDir: "/workspace/project",
+      conversationId: "conv-context",
+      memoryScopeId: "default",
+      config: getConfig(),
+      signal: controller.signal,
+    });
+  });
+});
 
 describe("rememberTool.execute — finish_turn", () => {
   test("omits yieldToUser when finish_turn is not provided", async () => {

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -1,8 +1,8 @@
 import { getConfig } from "../../config/loader.js";
+import { runAgenticRecall } from "../../memory/context-search/agent-runner.js";
+import type { RecallInput } from "../../memory/context-search/types.js";
 import {
-  handleRecall,
   handleRemember,
-  type RecallInput,
   type RememberInput,
 } from "../../memory/graph/tool-handlers.js";
 import {
@@ -60,41 +60,16 @@ class RecallTool implements Tool {
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
     const config = getConfig();
-    const result = await handleRecall(
-      input as unknown as RecallInput,
+    const result = await runAgenticRecall(input as unknown as RecallInput, {
+      workingDir: context.workingDir,
+      conversationId: context.conversationId,
+      memoryScopeId: context.memoryScopeId ?? "default",
       config,
-      context.memoryScopeId ?? "default",
-    );
+      signal: context.signal,
+    });
 
-    if (result.results.length === 0) {
-      return { content: "No results found.", isError: false };
-    }
-
-    const formatted = result.results
-      .map((r) => {
-        const ts = formatTimestamp(r.created);
-        const meta =
-          result.mode === "memory"
-            ? `[${r.type}] ${ts} (confidence: ${r.confidence.toFixed(2)}, score: ${r.score.toFixed(3)})`
-            : `[archive] ${ts}`;
-        return `${meta}\n${r.content}`;
-      })
-      .join("\n\n---\n\n");
-
-    return { content: formatted, isError: false };
+    return { content: result.content, isError: false };
   }
-}
-
-// ── Helpers ─────────────────────────────────────────────────────────
-
-function formatTimestamp(epochMs: number): string {
-  const d = new Date(epochMs);
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  const yy = String(d.getFullYear()).slice(-2);
-  const hh = String(d.getHours()).padStart(2, "0");
-  const min = String(d.getMinutes()).padStart(2, "0");
-  return `${mm}/${dd}/${yy} ${hh}:${min}`;
 }
 
 // ── Exported tool instances ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Updates the existing recall tool schema to the new local information search contract.
- Wires recall execution through the agentic recall runner with tool context propagation.
- Updates memory tool registration tests for schema and fallback behavior.

Part of plan: replace-recall-agentic-search.md (PR 10 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
