### PR TITLE
Add release notes for improved recall

### DIFF
--- a/assistant/src/__tests__/workspace-migration-055-release-notes-agentic-recall.test.ts
+++ b/assistant/src/__tests__/workspace-migration-055-release-notes-agentic-recall.test.ts
@@ -1,0 +1,128 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { releaseNotesAgenticRecallMigration } from "../workspace/migrations/055-release-notes-agentic-recall.js";
+
+const MIGRATION_ID = "055-release-notes-agentic-recall";
+const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
+
+let testRoot: string;
+let workspaceDir: string;
+
+beforeAll(() => {
+  testRoot = mkdtempSync(join(tmpdir(), "migration-055-test-"));
+});
+
+afterAll(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(testRoot, "ws-"));
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+function updatesPath(): string {
+  return join(workspaceDir, "UPDATES.md");
+}
+
+describe("workspace migration 055-release-notes-agentic-recall", () => {
+  test("has the correct id and description", () => {
+    expect(releaseNotesAgenticRecallMigration.id).toBe(MIGRATION_ID);
+    expect(releaseNotesAgenticRecallMigration.description).toContain("recall");
+  });
+
+  test("creates UPDATES.md with marker and key copy when file is absent", () => {
+    expect(existsSync(updatesPath())).toBe(false);
+
+    releaseNotesAgenticRecallMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content.startsWith(MARKER)).toBe(true);
+    expect(content).toContain("Recall can search more places now");
+    expect(content).toContain("memory");
+    expect(content).toContain("knowledge base notes");
+    expect(content).toContain("past conversations");
+    expect(content).toContain("workspace files");
+  });
+
+  test("appends to existing UPDATES.md when marker is absent and preserves existing content", () => {
+    const prior = "## Earlier note\n\nSomething already queued.\n";
+    writeFileSync(updatesPath(), prior, "utf-8");
+
+    releaseNotesAgenticRecallMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content.startsWith(prior)).toBe(true);
+    expect(content.slice(prior.length).startsWith(`\n${MARKER}`)).toBe(true);
+    expect(content.split(MARKER).length - 1).toBe(1);
+    expect(content).not.toContain("\n\n\n");
+  });
+
+  test("is a no-op when marker is already present", () => {
+    const seeded = `## Prior\n\n${MARKER}\n## Recall\n\nAlready appended.\n`;
+    writeFileSync(updatesPath(), seeded, "utf-8");
+
+    releaseNotesAgenticRecallMigration.run(workspaceDir);
+    const afterFirst = readFileSync(updatesPath(), "utf-8");
+    expect(afterFirst).toBe(seeded);
+
+    releaseNotesAgenticRecallMigration.run(workspaceDir);
+    const afterSecond = readFileSync(updatesPath(), "utf-8");
+    expect(afterSecond).toBe(seeded);
+    expect(afterSecond.split(MARKER).length - 1).toBe(1);
+  });
+
+  test("re-creates UPDATES.md when it was deleted between runs", () => {
+    releaseNotesAgenticRecallMigration.run(workspaceDir);
+    expect(existsSync(updatesPath())).toBe(true);
+
+    rmSync(updatesPath());
+
+    releaseNotesAgenticRecallMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content.startsWith(MARKER)).toBe(true);
+    expect(content).toContain("workspace files");
+  });
+
+  test("existing UPDATES.md with no trailing newline gets one blank line separator", () => {
+    const prior = "## Prior\n\nBody.";
+    writeFileSync(updatesPath(), prior, "utf-8");
+
+    releaseNotesAgenticRecallMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content.startsWith(prior)).toBe(true);
+    expect(content.slice(prior.length).startsWith(`\n\n${MARKER}`)).toBe(true);
+    expect(content).not.toContain("\n\n\n");
+  });
+
+  test("down() is a no-op", () => {
+    writeFileSync(updatesPath(), `${MARKER}\nBody.\n`, "utf-8");
+    const before = readFileSync(updatesPath(), "utf-8");
+
+    releaseNotesAgenticRecallMigration.down(workspaceDir);
+
+    expect(readFileSync(updatesPath(), "utf-8")).toBe(before);
+  });
+});

--- a/assistant/src/workspace/migrations/055-release-notes-agentic-recall.ts
+++ b/assistant/src/workspace/migrations/055-release-notes-agentic-recall.ts
@@ -1,0 +1,63 @@
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migration-055-release-notes-agentic-recall");
+
+const MIGRATION_ID = "055-release-notes-agentic-recall";
+const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
+
+const RELEASE_NOTE = `${MARKER}
+## Recall can search more places now
+
+When you ask me to recall something, I can now search across memory,
+knowledge base notes, past conversations, and workspace files. That means
+I can find relevant context from more of your assistant workspace without
+you needing to remember where it was saved.
+`;
+
+export const releaseNotesAgenticRecallMigration: WorkspaceMigration = {
+  id: MIGRATION_ID,
+  description:
+    "Append release notes for improved recall search coverage to UPDATES.md",
+
+  run(workspaceDir: string): void {
+    const updatesPath = join(workspaceDir, "UPDATES.md");
+
+    try {
+      if (existsSync(updatesPath)) {
+        const existing = readFileSync(updatesPath, "utf-8");
+        if (existing.includes(MARKER)) {
+          return;
+        }
+        const needsLeadingNewline = !existing.endsWith("\n\n");
+        const prefix = existing.endsWith("\n") ? "\n" : "\n\n";
+        appendFileSync(
+          updatesPath,
+          needsLeadingNewline ? `${prefix}${RELEASE_NOTE}` : RELEASE_NOTE,
+          "utf-8",
+        );
+      } else {
+        writeFileSync(updatesPath, RELEASE_NOTE, "utf-8");
+      }
+      log.info({ path: updatesPath }, "Appended agentic recall release note");
+    } catch (err) {
+      log.warn(
+        { err, path: updatesPath },
+        "Failed to append agentic recall release note to UPDATES.md",
+      );
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: UPDATES.md is a user-facing bulletin the assistant
+    // processes and deletes on its own.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -52,6 +52,7 @@ import { seedConversationSummarizationCallsiteMigration } from "./051-seed-conve
 import { seedDefaultInferenceProfiles052 } from "./052-seed-default-inference-profiles.js";
 import { releaseNotesAcpCodexMigration } from "./053-release-notes-acp-codex.js";
 import { seedRecallCallsiteMigration } from "./054-seed-recall-callsite.js";
+import { releaseNotesAgenticRecallMigration } from "./055-release-notes-agentic-recall.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -115,4 +116,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   seedDefaultInferenceProfiles052,
   releaseNotesAcpCodexMigration,
   seedRecallCallsiteMigration,
+  releaseNotesAgenticRecallMigration,
 ];


### PR DESCRIPTION
## Summary
- Adds a release-note workspace migration for improved recall.
- Uses the required in-file marker for idempotent appends.
- Covers append and marker skip behavior with tests.

Part of plan: replace-recall-agentic-search.md (PR 12 of 14)