### PR TITLE
chore(macos): four small inference-profile polish nits

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
@@ -33,9 +33,12 @@ struct ChatProfilePickerConfiguration {
 /// updates the local conversation model and persists to the daemon.
 @MainActor
 struct ChatProfilePicker: View {
-    /// The conversation whose override is being edited. `nil` disables the
-    /// pill (e.g. for not-yet-persisted draft conversations).
-    let conversationId: UUID?
+    /// Whether the picker can be opened. `false` disables the pill — used
+    /// for not-yet-persisted draft conversations where there's no
+    /// conversation id to attach the override to. The actual conversation
+    /// id needed for persistence is captured into ``onSelect`` by the
+    /// parent.
+    let isEnabled: Bool
 
     /// The current per-conversation inference-profile override. `nil` means
     /// the conversation inherits `activeProfile`.
@@ -64,7 +67,7 @@ struct ChatProfilePicker: View {
     var body: some View {
         #if os(macOS)
         ComposerPillMenu(
-            isEnabled: conversationId != nil,
+            isEnabled: isEnabled,
             accessibilityLabel: "Inference profile",
             accessibilityValue: Self.label(current: current, activeProfile: activeProfile),
             tooltip: "Inference profile for this conversation"

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerPillMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerPillMenu.swift
@@ -26,15 +26,12 @@ struct ComposerPillMenu<Label: View, Menu: View>: View {
     /// Tooltip shown on hover.
     let tooltip: String
 
-    /// Width of the popover menu surface.
-    var menuWidth: CGFloat = 240
-
     /// Leading content of the pill — typically an icon followed by a label
     /// `Text`. The chevron is appended by this view.
     @ViewBuilder let label: () -> Label
 
     /// Body of the popover menu — typically a ``VMenu`` with ``VMenuItem``
-    /// rows. Wrapped in a ``VMenu`` of width ``menuWidth`` by this view.
+    /// rows. Wrapped in a fixed-width ``VMenu`` by this view.
     @ViewBuilder let menu: () -> Menu
 
     #if os(macOS)
@@ -118,7 +115,7 @@ struct ComposerPillMenu<Label: View, Menu: View>: View {
             sourceAppearance: appearance,
             excludeRect: triggerScreenRect
         ) {
-            VMenu(width: menuWidth) {
+            VMenu(width: 240) {
                 menu()
             }
         } onDismiss: {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -483,7 +483,7 @@ struct ComposerView: View, Equatable {
 
             if let inferenceProfilePicker, !inferenceProfilePicker.profiles.isEmpty {
                 ChatProfilePicker(
-                    conversationId: conversationId,
+                    isEnabled: conversationId != nil,
                     current: inferenceProfilePicker.current,
                     profiles: inferenceProfilePicker.profiles,
                     activeProfile: inferenceProfilePicker.activeProfile,

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -39,6 +39,11 @@ struct InferenceProfileEditor: View {
     /// Verbosity mirrors the daemon's `VerbositySetting` schema.
     static let verbosityOptions: [String] = ["low", "medium", "high"]
 
+    /// Temperature seeded when the user toggles the Set switch on. Also used
+    /// as the slider's display fallback when the binding's value is nil so
+    /// the slider position matches what the toggle-on path will write.
+    private static let defaultTemperatureWhenSet: Double = 0.7
+
     /// Live-edited maxTokens text. Kept as a string so partial input
     /// (empty field, mid-typing) doesn't immediately clobber the binding
     /// with `0`. Synced into `profile.maxTokens` on every change.
@@ -294,7 +299,7 @@ struct InferenceProfileEditor: View {
             HStack(spacing: VSpacing.md) {
                 VSlider(
                     value: Binding(
-                        get: { profile.temperature.doubleValue ?? 0.7 },
+                        get: { profile.temperature.doubleValue ?? Self.defaultTemperatureWhenSet },
                         set: { profile.temperature = .value($0) }
                     ),
                     range: 0...2,
@@ -306,13 +311,15 @@ struct InferenceProfileEditor: View {
                         get: { profile.temperature.doubleValue != nil },
                         set: { newValue in
                             // OFF: clear so the resolver falls back to the
-                            // model-default temperature instead of pinning 0.7.
-                            // Maps to `.unset` rather than `.explicitNull` —
-                            // the editor doesn't surface the explicit-null
-                            // distinction; daemon-emitted explicit-null
-                            // values still round-trip through the JSON
-                            // mapper untouched.
-                            profile.temperature = newValue ? .value(0.7) : .unset
+                            // model-default temperature instead of pinning the
+                            // seeded default. Maps to `.unset` rather than
+                            // `.explicitNull` — the editor doesn't surface the
+                            // explicit-null distinction; daemon-emitted
+                            // explicit-null values still round-trip through
+                            // the JSON mapper untouched.
+                            profile.temperature = newValue
+                                ? .value(Self.defaultTemperatureWhenSet)
+                                : .unset
                         }
                     ),
                     label: "Set"

--- a/clients/macos/vellum-assistantTests/CallSiteOverridesSheetTests.swift
+++ b/clients/macos/vellum-assistantTests/CallSiteOverridesSheetTests.swift
@@ -17,9 +17,9 @@ final class CallSiteOverridesSheetTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockSettingsClient = MockSettingsClient()
-        mockSettingsClient.patchConfigResponse = true
-        store = SettingsStore(settingsClient: mockSettingsClient)
+        let fixture = SettingsTestFixture.make()
+        store = fixture.store
+        mockSettingsClient = fixture.mockClient
     }
 
     override func tearDown() {

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
@@ -142,7 +142,7 @@ final class ChatProfilePickerTests: XCTestCase {
         manager: ConversationManager
     ) -> ChatProfilePicker {
         ChatProfilePicker(
-            conversationId: conversationId,
+            isEnabled: true,
             current: current,
             profiles: profiles,
             activeProfile: activeProfile,

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsTestFixture.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsTestFixture.swift
@@ -2,8 +2,9 @@ import Foundation
 @testable import VellumAssistantLib
 @testable import VellumAssistantShared
 
-/// Shared scaffolding for the inference-profile test suites. The four
-/// `InferenceProfile*Tests` and `SettingsStoreInferenceProfilesTests`
+/// Shared scaffolding for the inference-profile and call-site-override
+/// test suites. The four `InferenceProfile*Tests` and
+/// `SettingsStoreInferenceProfilesTests` plus `CallSiteOverridesSheetTests`
 /// each rebuilt the same `MockSettingsClient` + `SettingsStore` +
 /// provider-catalog literal in their `setUp`. This factory bundles those
 /// pieces so individual tests only override what they care about.


### PR DESCRIPTION
## Summary
Bundles four small polish fixes flagged in inference-profiles plan re-review:
- Migrate `CallSiteOverridesSheetTests` to the shared `SettingsTestFixture` extracted in PR #28111.
- Drop unused `menuWidth` parameter from `ComposerPillMenu` (no caller overrode it).
- Tighten `ChatProfilePicker` API: replace UUID? with Bool isEnabled — picker doesn't actually use the UUID.
- Extract duplicated `0.7` literal in `InferenceProfileEditor` into a named constant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
