### PR TITLE
Update internal callers for the new recall contract

### DIFF
--- a/assistant/src/__tests__/memory-admin-recall.test.ts
+++ b/assistant/src/__tests__/memory-admin-recall.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AssistantConfig } from "../config/schema.js";
+import type { DeterministicRecallSearchResult } from "../memory/context-search/search.js";
+import type {
+  RecallEvidence,
+  RecallInput,
+  RecallSearchContext,
+} from "../memory/context-search/types.js";
+
+interface CapturedSearch {
+  input: RecallInput;
+  context: RecallSearchContext;
+}
+
+const capturedSearches: CapturedSearch[] = [];
+const getConfiguredProviderCalls: string[] = [];
+const scopeByConversation = new Map<string, string | undefined>();
+const testConfig = {} as AssistantConfig;
+
+mock.module("../config/loader.js", () => ({
+  API_KEY_PROVIDERS: [],
+  getConfig: () => testConfig,
+  getConfigReadOnly: () => testConfig,
+  loadConfig: () => testConfig,
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getProviderKeyAsync: async () => undefined,
+  getSecureKeyAsync: async () => undefined,
+  setSecureKeyAsync: async () => true,
+}));
+
+mock.module("../oauth/oauth-store.js", () => ({
+  getActiveConnection: () => undefined,
+  getConnectionByProvider: () => undefined,
+  getProvider: () => undefined,
+  isProviderConnected: () => false,
+  listConnections: () => [],
+  listProviders: () => [],
+}));
+
+mock.module("../memory/embedding-backend.js", () => ({
+  clearEmbeddingBackendCache: () => undefined,
+  embedWithBackend: async () => [],
+  generateSparseEmbedding: () => ({ indices: [], values: [] }),
+  getMemoryBackendStatus: async () => ({
+    enabled: false,
+    degraded: false,
+    reason: null,
+    provider: null,
+    model: null,
+  }),
+  selectedBackendSupportsMultimodal: async () => false,
+}));
+
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: () => ({ id: "msg-1" }),
+  createConversation: () => ({ id: "conv-1", memoryScopeId: "default" }),
+  deleteConversation: () => true,
+  getAssistantMessageIdsInTurn: () => [],
+  getConversation: () => null,
+  getConversationHostAccess: () => false,
+  getConversationMemoryScopeId: (conversationId: string) =>
+    scopeByConversation.get(conversationId),
+  getConversationOverrideProfile: () => undefined,
+  getConversationSource: () => null,
+  getConversationType: () => "standard",
+  getMessageById: () => null,
+  getMessages: () => [],
+  isPrivateScopeId: (scopeId: string) => scopeId.startsWith("private:"),
+  listPrivateMemoryScopeIds: () => [],
+  parseConversation: (row: unknown) => row,
+  privateScopeId: (conversationId: string) => `private:${conversationId}`,
+  updateConversationTitle: () => undefined,
+  updateConversationUsage: () => undefined,
+}));
+
+mock.module("../memory/graph/compaction.js", () => ({
+  compactLongMemories: async () => ({
+    scanned: 0,
+    candidates: 0,
+    compacted: 0,
+    skipped: 0,
+    failed: 0,
+  }),
+}));
+
+mock.module("../memory/indexer.js", () => ({
+  enqueueBackfillJob: () => "backfill-job",
+  enqueueRebuildIndexJob: () => "rebuild-job",
+  MIN_SEGMENT_CHARS: 50,
+}));
+
+mock.module("../memory/qdrant-circuit-breaker.js", () => ({
+  isQdrantBreakerOpen: () => false,
+  shouldAllowQdrantProbe: () => true,
+  withQdrantBreaker: async (fn: () => unknown) => fn(),
+}));
+
+mock.module("../memory/qdrant-client.js", () => ({
+  getQdrantClient: () => ({
+    deleteByTarget: async () => undefined,
+  }),
+  initQdrantClient: () => undefined,
+  resolveQdrantUrl: () => "http://127.0.0.1:6333",
+}));
+
+function makeEvidence(
+  id: string,
+  overrides: Partial<RecallEvidence> = {},
+): RecallEvidence {
+  return {
+    id,
+    source: "memory",
+    title: `${id} title`,
+    locator: `${id}:locator`,
+    excerpt: `${id} excerpt`,
+    score: 0.75,
+    timestampMs: 1234,
+    metadata: {
+      confidence: 0.8,
+      significance: 0.6,
+    },
+    ...overrides,
+  };
+}
+
+mock.module("../memory/context-search/search.js", () => ({
+  runDeterministicRecallSearch: async (
+    input: RecallInput,
+    context: RecallSearchContext,
+  ): Promise<DeterministicRecallSearchResult> => {
+    capturedSearches.push({ input, context });
+    return {
+      input: {
+        query: input.query,
+        sources: input.sources ?? [],
+        maxResults: input.max_results ?? 8,
+        depth: input.depth ?? "standard",
+        sourceRounds: 1,
+      },
+      evidence: [makeEvidence("memory:launch")],
+      searchedSources: (input.sources ?? []).map((source) => ({
+        source,
+        status: "searched" as const,
+        evidenceCount: source === "memory" ? 1 : 0,
+      })),
+    };
+  },
+}));
+
+mock.module("../providers/provider-send-message.js", () => ({
+  extractToolUse: () => null,
+  getConfiguredProvider: async (callSite: string) => {
+    getConfiguredProviderCalls.push(callSite);
+    return null;
+  },
+  userMessage: (text: string) => ({
+    role: "user",
+    content: [{ type: "text", text }],
+  }),
+}));
+
+const { queryMemory } = await import("../memory/admin.js");
+const { getWorkspaceDir } = await import("../util/platform.js");
+
+describe("memory admin recall", () => {
+  beforeEach(() => {
+    capturedSearches.length = 0;
+    getConfiguredProviderCalls.length = 0;
+    scopeByConversation.clear();
+  });
+
+  test("uses the conversation memory scope and safe admin sources", async () => {
+    scopeByConversation.set("conv-admin", "private:conv-admin");
+
+    const result = await queryMemory("launch notes", "conv-admin");
+
+    expect(capturedSearches).toHaveLength(1);
+    expect(capturedSearches[0].input).toEqual({
+      query: "launch notes",
+      sources: ["memory", "conversations", "pkb"],
+    });
+    expect(capturedSearches[0].context).toMatchObject({
+      workingDir: getWorkspaceDir(),
+      memoryScopeId: "private:conv-admin",
+      conversationId: "conv-admin",
+      config: testConfig,
+    });
+    expect(capturedSearches[0].input.sources).not.toContain("workspace");
+    expect(result).toEqual({
+      results: [
+        {
+          id: "memory:launch",
+          content: "memory:launch excerpt",
+          type: "memory",
+          confidence: 0.8,
+          significance: 0.6,
+          score: 0.75,
+          created: 1234,
+        },
+      ],
+      mode: "memory",
+      query: "launch notes",
+    });
+  });
+
+  test("falls back to default scope without invoking a provider", async () => {
+    await queryMemory("offline recall", "missing-conversation");
+
+    expect(capturedSearches).toHaveLength(1);
+    expect(capturedSearches[0].context).toMatchObject({
+      workingDir: getWorkspaceDir(),
+      memoryScopeId: "default",
+      conversationId: "missing-conversation",
+    });
+    expect(capturedSearches[0].input.sources).toEqual([
+      "memory",
+      "conversations",
+      "pkb",
+    ]);
+    expect(getConfiguredProviderCalls).toEqual([]);
+  });
+});

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -2,7 +2,10 @@ import { and, count, desc, eq, sql } from "drizzle-orm";
 
 import { getConfig } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir } from "../util/platform.js";
 import { deleteMemoryCheckpoint } from "./checkpoints.js";
+import { runDeterministicRecallSearch } from "./context-search/search.js";
+import type { RecallEvidence } from "./context-search/types.js";
 import { getConversationMemoryScopeId } from "./conversation-crud.js";
 import { getDb, rawGet } from "./db.js";
 import { getMemoryBackendStatus } from "./embedding-backend.js";
@@ -11,7 +14,6 @@ import {
   type CompactionResult,
   compactLongMemories,
 } from "./graph/compaction.js";
-import { handleRecall, type RecallResult } from "./graph/tool-handlers.js";
 import {
   enqueueBackfillJob,
   enqueueRebuildIndexJob,
@@ -42,6 +44,20 @@ export interface MemorySystemStatus {
     embeddings: number;
   };
   jobs: Record<string, number>;
+}
+
+export interface AdminMemoryQueryResult {
+  results: Array<{
+    id: string;
+    content: string;
+    type: string;
+    confidence: number;
+    significance: number;
+    score: number;
+    created: number;
+  }>;
+  mode: "memory";
+  query: string;
 }
 
 export async function getMemorySystemStatus(): Promise<MemorySystemStatus> {
@@ -82,10 +98,51 @@ export function requestMemoryRebuildIndex(): string {
 
 export async function queryMemory(
   query: string,
-  _conversationId: string,
-): Promise<RecallResult> {
+  conversationId: string,
+): Promise<AdminMemoryQueryResult> {
   const config = getConfig();
-  return handleRecall({ query }, config, "default");
+  const result = await runDeterministicRecallSearch(
+    { query, sources: ["memory", "conversations", "pkb"] },
+    {
+      workingDir: getWorkspaceDir(),
+      memoryScopeId: getConversationMemoryScopeId(conversationId) ?? "default",
+      conversationId,
+      config,
+    },
+  );
+
+  return {
+    results: result.evidence.map(evidenceToAdminResult),
+    mode: "memory",
+    query,
+  };
+}
+
+function evidenceToAdminResult(
+  evidence: RecallEvidence,
+): AdminMemoryQueryResult["results"][number] {
+  const confidence = readNumericMetadata(evidence, "confidence");
+  const significance = readNumericMetadata(evidence, "significance");
+
+  return {
+    id: evidence.id,
+    content: evidence.excerpt,
+    type: evidence.source,
+    confidence: confidence ?? evidence.score ?? 0,
+    significance: significance ?? 0,
+    score: evidence.score ?? 0,
+    created: evidence.timestampMs ?? 0,
+  };
+}
+
+function readNumericMetadata(
+  evidence: RecallEvidence,
+  key: string,
+): number | undefined {
+  const value = evidence.metadata?.[key];
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
 }
 
 // ── Short segment cleanup ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Updates internal memory admin recall to use deterministic context search.
- Preserves safe source selection for admin queries.
- Adds focused tests for scope and no-provider behavior.

Part of plan: replace-recall-agentic-search.md (PR 11 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
