### PR TITLE
Verify agentic recall rollout

### DIFF
--- a/assistant/src/__tests__/always-loaded-tools-guard.test.ts
+++ b/assistant/src/__tests__/always-loaded-tools-guard.test.ts
@@ -28,7 +28,7 @@ afterAll(() => {
 });
 
 describe("always-loaded tool count", () => {
-  test("should be exactly 11 (no-client baseline excludes host tools)", async () => {
+  test("should be exactly 11 with recall occupying the existing slot", async () => {
     await initializeTools();
     const allDefs = buildToolDefinitions();
 
@@ -65,6 +65,7 @@ describe("always-loaded tool count", () => {
     ].sort();
 
     expect(activeNames).toEqual(expectedNames);
+    expect(activeNames.filter((name) => name === "recall")).toHaveLength(1);
     expect(activeTools.length).toBe(11);
   });
 });

--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -100,6 +100,38 @@ describe("searchConversationSource", () => {
     ]);
   });
 
+  test("does not return private conversations", async () => {
+    const visible = await seedConversation({
+      title: "Visible conversation",
+      content: "privacytoken can be recalled from normal history.",
+    });
+    const privateConversation = createConversation({
+      title: "Private conversation",
+      conversationType: "private",
+    });
+    rawRun(
+      "UPDATE conversations SET memory_scope_id = 'default', conversation_type = 'private' WHERE id = ?",
+      privateConversation.id,
+    );
+    await addMessage(
+      privateConversation.id,
+      "user",
+      "privacytoken should not be recalled from private history.",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    const result = await searchConversationSource(
+      "privacytoken",
+      makeContext(),
+      10,
+    );
+
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${visible.conversation.id}#${visible.message.id}`,
+    ]);
+  });
+
   test("does not return derived subagent or auto-analysis conversations", async () => {
     const visible = await seedConversation({
       title: "User conversation",

--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -115,6 +115,7 @@ describe("tool manifest", () => {
   test("explicit tools list includes memory and credential tools", () => {
     const names = explicitTools.map((t) => t.name);
     expect(names).toContain("recall");
+    expect(names.filter((name) => name === "recall")).toHaveLength(1);
     expect(names).toContain("remember");
     expect(names).toContain("credential_store");
   });

--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -26,6 +26,8 @@ Subagents follow this status flow: `pending` -> `running` -> `completed` / `fail
 
 Each subagent is spawned with a role that determines its tool access. Choose the most restrictive role that can accomplish the task.
 
+`recall` is local information search across memory, the personal knowledge base, past conversations, and workspace files. Use it when a subagent needs prior context that is not already in the prompt.
+
 | Role | Tools | When to use |
 |---|---|---|
 | `general` | Full tool access | Task genuinely needs unrestricted capabilities (rare -- prefer a specialized role) |

--- a/assistant/src/memory/context-search/sources/conversations.ts
+++ b/assistant/src/memory/context-search/sources/conversations.ts
@@ -7,6 +7,7 @@ import { rawAll } from "../../db.js";
 import type { RecallSearchContext, RecallSearchResult } from "../types.js";
 
 const SUBAGENT_SOURCE = "subagent";
+const PRIVATE_CONVERSATION_TYPE = "private";
 
 interface ConversationEvidenceRow {
   message_id: string;
@@ -81,12 +82,14 @@ function searchWithFts(
     JOIN conversations c ON c.id = m.conversation_id
     WHERE messages_fts MATCH ?
       AND c.memory_scope_id = ?
+      AND c.conversation_type != ?
       AND (c.source IS NULL OR c.source NOT IN (?, ?))
     ORDER BY bm25(messages_fts), m.created_at DESC
     LIMIT ?
     `,
     ftsMatch,
     memoryScopeId,
+    PRIVATE_CONVERSATION_TYPE,
     SUBAGENT_SOURCE,
     AUTO_ANALYSIS_SOURCE,
     limit,
@@ -111,12 +114,14 @@ function searchWithLike(
     JOIN conversations c ON c.id = m.conversation_id
     WHERE m.content LIKE ? ESCAPE '\\'
       AND c.memory_scope_id = ?
+      AND c.conversation_type != ?
       AND (c.source IS NULL OR c.source NOT IN (?, ?))
     ORDER BY m.created_at DESC
     LIMIT ?
     `,
     buildLikePattern(query),
     memoryScopeId,
+    PRIVATE_CONVERSATION_TYPE,
     SUBAGENT_SOURCE,
     AUTO_ANALYSIS_SOURCE,
     limit,


### PR DESCRIPTION
## Summary
- Verifies the agentic recall rollout preserves tool counts and registry expectations.
- Updates bundled skill copy if needed.
- Keeps private conversation rows out of recall conversation-source results.
- Runs the targeted recall test set and assistant typecheck.

Part of plan: replace-recall-agentic-search.md (PR 14 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
