### PR TITLE
fix(daemon): remove private conversation protocol type

### DIFF
--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -138,8 +138,6 @@ export interface ConversationCreateOptions {
   /** Whether this turn can block on interactive approval prompts. */
   isInteractive?: boolean;
   memoryScopeId?: string;
-  isPrivateConversation?: boolean;
-  strictPrivateSideEffects?: boolean;
   /** Channel command intent metadata (e.g. Telegram /start). */
   commandIntent?: { type: string; payload?: string; languageCode?: string };
   /** Optional callback to receive real-time agent loop events (text deltas, tool starts, etc.). */

--- a/assistant/src/daemon/message-types/shared.ts
+++ b/assistant/src/daemon/message-types/shared.ts
@@ -1,12 +1,15 @@
 // Shared types used across multiple message domains.
 
-export type ConversationType = "standard" | "private";
+export type ConversationType = "standard" | "background" | "scheduled";
 
 /** Runtime normalizer — collapses unknown/legacy DB values to 'standard'. */
 export function normalizeConversationType(
   raw: string | null | undefined,
 ): ConversationType {
-  return raw === "private" ? "private" : "standard";
+  if (raw === "background" || raw === "scheduled") {
+    return raw;
+  }
+  return "standard";
 }
 
 export interface UsageStats {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -233,6 +233,8 @@ export const parseMessage = createRowMapper<
   metadata: "metadata",
 });
 
+export type ConversationCreateType = "standard" | "background" | "scheduled";
+
 /**
  * Monotonic timestamp source for message ordering. Two messages saved within
  * the same millisecond (e.g., tool_results user message + assistant message in
@@ -252,11 +254,7 @@ export function createConversation(
     | string
     | {
         title?: string;
-        conversationType?:
-          | "standard"
-          | "background"
-          | "scheduled"
-          | (string & {});
+        conversationType?: ConversationCreateType;
         source?: string;
         scheduleJobId?: string;
         groupId?: string;
@@ -271,11 +269,8 @@ export function createConversation(
       ? { title: titleOrOpts }
       : (titleOrOpts ?? {});
   const requestedConversationType = opts.conversationType;
-  const conversationType: string =
-    requestedConversationType === "background" ||
-    requestedConversationType === "scheduled"
-      ? requestedConversationType
-      : "standard";
+  const conversationType: ConversationCreateType =
+    requestedConversationType ?? "standard";
   const source = opts.source ?? "user";
   const groupId = opts.groupId;
   const id = uuid();

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -44,6 +44,7 @@ import {
 } from "../config/env.js";
 import { getConfig } from "../config/loader.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import { normalizeConversationType } from "../daemon/message-types/shared.js";
 import { PairingStore } from "../daemon/pairing-store.js";
 import {
   type AttentionState,
@@ -1587,7 +1588,9 @@ export class RuntimeHttpServer {
       createdAt: conversation.createdAt,
       updatedAt: conversation.updatedAt,
       lastMessageAt: conversation.lastMessageAt,
-      conversationType: conversation.conversationType ?? "standard",
+      conversationType: normalizeConversationType(
+        conversation.conversationType,
+      ),
       source: conversation.source ?? "user",
       hostAccess: conversation.hostAccess === 1,
       ...(conversation.scheduleJobId

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -22,6 +22,7 @@
 import { z } from "zod";
 
 import { loadConfig } from "../../config/loader.js";
+import { normalizeConversationType } from "../../daemon/message-types/shared.js";
 import {
   archiveConversation,
   batchSetDisplayOrders,
@@ -52,6 +53,13 @@ import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("conversation-management-routes");
+
+function normalizeManagedConversationCreateType(raw: unknown): "standard" {
+  const normalized = normalizeConversationType(
+    typeof raw === "string" ? raw : undefined,
+  );
+  return normalized === "standard" ? normalized : "standard";
+}
 
 // ---------------------------------------------------------------------------
 // Dependency types — injected by the daemon at wiring time
@@ -116,8 +124,11 @@ export function conversationManagementRouteDefinitions(
           // Empty or malformed body — fall through with defaults.
         }
         const conversationKey = body.conversationKey ?? crypto.randomUUID();
+        const conversationType = normalizeManagedConversationCreateType(
+          body.conversationType,
+        );
         const result = getOrCreateConversation(conversationKey, {
-          conversationType: "standard",
+          conversationType,
         });
         if (result.created) {
           updateConversationTitle(result.conversationId, "New Conversation");
@@ -134,7 +145,9 @@ export function conversationManagementRouteDefinitions(
           {
             id: result.conversationId,
             conversationKey,
-            conversationType: result.conversationType,
+            conversationType: normalizeConversationType(
+              result.conversationType,
+            ),
           },
           { status: result.created ? 201 : 200 },
         );
@@ -255,7 +268,7 @@ export function conversationManagementRouteDefinitions(
         return Response.json({
           conversationId: result.conversationId,
           title: result.title,
-          conversationType: result.conversationType,
+          conversationType: normalizeConversationType(result.conversationType),
           hostAccess: result.hostAccess,
           ...(result.inferenceProfile != null
             ? { inferenceProfile: result.inferenceProfile }


### PR DESCRIPTION
## Summary
Fixes self-review gap for remove-private-conversations.md.

**Gap:** daemon message protocol and createConversation typing still exposed private conversation type.
**Fix:** remove private from protocol/internal creation types and normalize legacy external values at boundaries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
