### PR TITLE
fix(memory): remove private recall filters and stale mocks

### DIFF
--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -2,10 +2,11 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import { searchConversationSource } from "../memory/context-search/sources/conversations.js";
 import type { RecallSearchContext } from "../memory/context-search/types.js";
-import { addMessage, createConversation } from "../memory/conversation-crud.js";
 import { getDb, initializeDb, rawRun } from "../memory/db.js";
 
 initializeDb();
+
+let seedId = 0;
 
 describe("searchConversationSource", () => {
   beforeEach(() => {
@@ -14,14 +15,10 @@ describe("searchConversationSource", () => {
   });
 
   test("returns matching message evidence through the FTS path", async () => {
-    const conversation = createConversation("Launch notes");
-    const message = await addMessage(
-      conversation.id,
-      "assistant",
-      "The alpha launch checklist includes database backups.",
-      undefined,
-      { skipIndexing: true },
-    );
+    const { conversation, message } = await seedConversation({
+      title: "Launch notes",
+      content: "The alpha launch checklist includes database backups.",
+    });
 
     const result = await searchConversationSource(
       "alpha launch",
@@ -45,22 +42,15 @@ describe("searchConversationSource", () => {
   });
 
   test("uses LIKE fallback for short and non-ASCII queries", async () => {
-    const shortConversation = createConversation("C++ notes");
-    await addMessage(
-      shortConversation.id,
-      "user",
-      "Use C++ when the example needs deterministic lifetime notes.",
-      undefined,
-      { skipIndexing: true },
-    );
-    const unicodeConversation = createConversation("Unicode notes");
-    await addMessage(
-      unicodeConversation.id,
-      "assistant",
-      "The keyword 東京 appears in this conversation.",
-      undefined,
-      { skipIndexing: true },
-    );
+    await seedConversation({
+      title: "C++ notes",
+      role: "user",
+      content: "Use C++ when the example needs deterministic lifetime notes.",
+    });
+    await seedConversation({
+      title: "Unicode notes",
+      content: "The keyword 東京 appears in this conversation.",
+    });
 
     const shortResult = await searchConversationSource("C++", makeContext(), 5);
     const unicodeResult = await searchConversationSource(
@@ -97,38 +87,6 @@ describe("searchConversationSource", () => {
 
     expect(result.evidence.map((item) => item.locator)).toEqual([
       `${inScope.conversation.id}#${inScope.message.id}`,
-    ]);
-  });
-
-  test("does not return private conversations", async () => {
-    const visible = await seedConversation({
-      title: "Visible conversation",
-      content: "privacytoken can be recalled from normal history.",
-    });
-    const privateConversation = createConversation({
-      title: "Private conversation",
-      conversationType: "private",
-    });
-    rawRun(
-      "UPDATE conversations SET memory_scope_id = 'default', conversation_type = 'private' WHERE id = ?",
-      privateConversation.id,
-    );
-    await addMessage(
-      privateConversation.id,
-      "user",
-      "privacytoken should not be recalled from private history.",
-      undefined,
-      { skipIndexing: true },
-    );
-
-    const result = await searchConversationSource(
-      "privacytoken",
-      makeContext(),
-      10,
-    );
-
-    expect(result.evidence.map((item) => item.locator)).toEqual([
-      `${visible.conversation.id}#${visible.message.id}`,
     ]);
   });
 
@@ -218,31 +176,60 @@ describe("searchConversationSource", () => {
   });
 });
 
-async function seedConversation(opts: {
+function seedConversation(opts: {
   title?: string;
   conversationType?: "standard" | "background" | "scheduled";
   source?: string;
   memoryScopeId?: string;
+  role?: string;
   content: string;
 }) {
-  const conversation = createConversation({
-    title: opts.title,
-    conversationType: opts.conversationType,
-    source: opts.source,
-  });
-  if (opts.memoryScopeId) {
-    rawRun(
-      "UPDATE conversations SET memory_scope_id = ? WHERE id = ?",
-      opts.memoryScopeId,
-      conversation.id,
-    );
-  }
-  const message = await addMessage(
+  const id = ++seedId;
+  const now = Date.now() + id;
+  const conversation = {
+    id: `test-conversation-${id}`,
+    title: opts.title ?? null,
+  };
+  const message = {
+    id: `test-message-${id}`,
+    createdAt: now,
+  };
+
+  rawRun(
+    `
+    INSERT INTO conversations (
+      id,
+      title,
+      created_at,
+      updated_at,
+      conversation_type,
+      source,
+      memory_scope_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    `,
     conversation.id,
-    "assistant",
+    conversation.title,
+    now,
+    now,
+    opts.conversationType ?? "standard",
+    opts.source ?? "user",
+    opts.memoryScopeId ?? "default",
+  );
+  rawRun(
+    `
+    INSERT INTO messages (
+      id,
+      conversation_id,
+      role,
+      content,
+      created_at
+    ) VALUES (?, ?, ?, ?, ?)
+    `,
+    message.id,
+    conversation.id,
+    opts.role ?? "assistant",
     opts.content,
-    undefined,
-    { skipIndexing: true },
+    now,
   );
 
   return { conversation, message };

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -139,7 +139,6 @@ let mockConversationRow: {
 };
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationUsage: () => {},
   updateMessageMetadata: () => {},

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -146,7 +146,6 @@ mock.module("../daemon/context-overflow-policy.js", () => ({
 }));
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationUsage: () => {},
   getMessages: () => [],

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -132,7 +132,6 @@ const clearStrippedInjectionMetadataForConversationMock = mock(
   (_conversationId: string) => {},
 );
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationUsage: () => {},
   updateMessageMetadata: updateMessageMetadataMock,

--- a/assistant/src/__tests__/memory-admin-recall.test.ts
+++ b/assistant/src/__tests__/memory-admin-recall.test.ts
@@ -65,13 +65,9 @@ mock.module("../memory/conversation-crud.js", () => ({
     scopeByConversation.get(conversationId),
   getConversationOverrideProfile: () => undefined,
   getConversationSource: () => null,
-  getConversationType: () => "standard",
   getMessageById: () => null,
   getMessages: () => [],
-  isPrivateScopeId: (scopeId: string) => scopeId.startsWith("private:"),
-  listPrivateMemoryScopeIds: () => [],
   parseConversation: (row: unknown) => row,
-  privateScopeId: (conversationId: string) => `private:${conversationId}`,
   updateConversationTitle: () => undefined,
   updateConversationUsage: () => undefined,
 }));
@@ -173,7 +169,7 @@ describe("memory admin recall", () => {
   });
 
   test("uses the conversation memory scope and safe admin sources", async () => {
-    scopeByConversation.set("conv-admin", "private:conv-admin");
+    scopeByConversation.set("conv-admin", "scope-admin");
 
     const result = await queryMemory("launch notes", "conv-admin");
 
@@ -184,7 +180,7 @@ describe("memory admin recall", () => {
     });
     expect(capturedSearches[0].context).toMatchObject({
       workingDir: getWorkspaceDir(),
-      memoryScopeId: "private:conv-admin",
+      memoryScopeId: "scope-admin",
       conversationId: "conv-admin",
       config: testConfig,
     });

--- a/assistant/src/memory/context-search/sources/conversations.ts
+++ b/assistant/src/memory/context-search/sources/conversations.ts
@@ -7,7 +7,6 @@ import { rawAll } from "../../db.js";
 import type { RecallSearchContext, RecallSearchResult } from "../types.js";
 
 const SUBAGENT_SOURCE = "subagent";
-const PRIVATE_CONVERSATION_TYPE = "private";
 
 interface ConversationEvidenceRow {
   message_id: string;
@@ -82,14 +81,12 @@ function searchWithFts(
     JOIN conversations c ON c.id = m.conversation_id
     WHERE messages_fts MATCH ?
       AND c.memory_scope_id = ?
-      AND c.conversation_type != ?
       AND (c.source IS NULL OR c.source NOT IN (?, ?))
     ORDER BY bm25(messages_fts), m.created_at DESC
     LIMIT ?
     `,
     ftsMatch,
     memoryScopeId,
-    PRIVATE_CONVERSATION_TYPE,
     SUBAGENT_SOURCE,
     AUTO_ANALYSIS_SOURCE,
     limit,
@@ -114,14 +111,12 @@ function searchWithLike(
     JOIN conversations c ON c.id = m.conversation_id
     WHERE m.content LIKE ? ESCAPE '\\'
       AND c.memory_scope_id = ?
-      AND c.conversation_type != ?
       AND (c.source IS NULL OR c.source NOT IN (?, ?))
     ORDER BY m.created_at DESC
     LIMIT ?
     `,
     buildLikePattern(query),
     memoryScopeId,
-    PRIVATE_CONVERSATION_TYPE,
     SUBAGENT_SOURCE,
     AUTO_ANALYSIS_SOURCE,
     limit,


### PR DESCRIPTION
## Summary
Fixes round-2 self-review gaps for remove-private-conversations.md.

**Gap:** agentic recall and test mocks still preserved removed private-conversation helpers.
**Fix:** remove private recall filtering/test coverage and stale mocks for deleted private helpers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
