### PR TITLE
fix: gate recall for untrusted actors

### DIFF
--- a/assistant/src/tools/memory/register.test.ts
+++ b/assistant/src/tools/memory/register.test.ts
@@ -139,6 +139,34 @@ describe("recallTool.execute", () => {
     recallContent = "agentic recall answer";
   });
 
+  test("allows guardian recall to invoke the agentic runner", async () => {
+    const result = await recallTool.execute(
+      { query: "guardian recall" },
+      makeContext({ trustClass: "guardian" }),
+    );
+
+    expect(result).toEqual({
+      content: "agentic recall answer",
+      isError: false,
+    });
+    expect(recallCalls).toHaveLength(1);
+    expect(recallCalls[0]?.input).toEqual({ query: "guardian recall" });
+  });
+
+  test.each(["trusted_contact", "unknown"] as const)(
+    "blocks %s recall before invoking the agentic runner",
+    async (trustClass) => {
+      const result = await recallTool.execute(
+        { query: "sensitive local search", sources: ["workspace"] },
+        makeContext({ trustClass }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("only available to the guardian");
+      expect(recallCalls).toHaveLength(0);
+    },
+  );
+
   test("passes source filtering input through to agentic recall", async () => {
     const result = await recallTool.execute(
       {

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -11,6 +11,7 @@ import {
 } from "../../memory/graph/tools.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
+import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
 // ── remember ────────────────────────────────────────────────────────
@@ -59,6 +60,14 @@ class RecallTool implements Tool {
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
+    if (isUntrustedTrustClass(context.trustClass)) {
+      return {
+        content:
+          "Recall is only available to the guardian because it can read sensitive local context.",
+        isError: true,
+      };
+    }
+
     const config = getConfig();
     const result = await runAgenticRecall(input as unknown as RecallInput, {
       workingDir: context.workingDir,


### PR DESCRIPTION
## Summary
- Blocks expanded recall searches for untrusted actors before local sources are read.
- Keeps guardian recall behavior unchanged.
- Adds focused registration tests for the trust boundary.

Fixes self-review gap for replace-recall-agentic-search.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
