### PR TITLE
fix: tighten recall evidence accounting

### DIFF
--- a/assistant/src/__tests__/context-search-agent-runner.test.ts
+++ b/assistant/src/__tests__/context-search-agent-runner.test.ts
@@ -286,7 +286,96 @@ describe("runAgenticRecall", () => {
       mode: "deterministic_fallback",
       fallbackReason: "round_limit",
     });
-    expect(result.evidence.map((item) => item.id)).toEqual(["workspace:seed"]);
+    expect(result.evidence.map((item) => item.id)).toEqual([
+      "workspace:seed",
+      "workspace:more",
+    ]);
+    expect(result.content).toContain("workspace:more excerpt");
+  });
+
+  test("rejects finish citations omitted from the prompted evidence table", async () => {
+    const providerCalls: unknown[][] = [];
+    configuredProvider = makeProvider(
+      [
+        toolResponse("finish_recall", {
+          answer: "Unsupported by prompted evidence.",
+          confidence: "high",
+          citation_ids: ["workspace:omitted"],
+        }),
+      ],
+      providerCalls,
+    );
+
+    const longExcerpt = "a".repeat(6_000);
+    const result = await runAgenticRecall(
+      {
+        query: "launch notes",
+        sources: ["memory", "pkb", "workspace"],
+        max_results: 3,
+      },
+      makeContext(),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter(
+              {
+                "launch notes": [
+                  makeEvidence("memory:included", {
+                    source: "memory",
+                    excerpt: longExcerpt,
+                    score: 0.9,
+                  }),
+                ],
+              },
+              [],
+              "memory",
+            ),
+            makeAdapter(
+              {
+                "launch notes": [
+                  makeEvidence("pkb:included", {
+                    source: "pkb",
+                    excerpt: longExcerpt,
+                    score: 0.8,
+                  }),
+                ],
+              },
+              [],
+              "pkb",
+            ),
+            makeAdapter(
+              {
+                "launch notes": [
+                  makeEvidence("workspace:omitted", {
+                    source: "workspace",
+                    excerpt: longExcerpt,
+                    score: 0.7,
+                  }),
+                ],
+              },
+              [],
+              "workspace",
+            ),
+          ],
+          readPkbContextEvidence: () => [],
+        },
+      },
+    );
+
+    expect(providerCalls).toHaveLength(1);
+    const messages = providerCalls[0]?.[0] as Array<{
+      content: Array<{ type: string; text?: string }>;
+    }>;
+    const prompt = messages[0]?.content[0]?.text ?? "";
+    expect(prompt).toContain(
+      "Allowed citation_ids: memory:included, pkb:included",
+    );
+    expect(prompt).not.toContain("workspace:omitted");
+    expect(result.debug).toMatchObject({
+      mode: "deterministic_fallback",
+      fallbackReason: "citation_validation_failed",
+      fallbackDetail: "unknown_citation_ids",
+    });
   });
 
   test("falls back when finish_recall cites unknown evidence", async () => {

--- a/assistant/src/__tests__/context-search-fanout.test.ts
+++ b/assistant/src/__tests__/context-search-fanout.test.ts
@@ -93,6 +93,54 @@ describe("runDeterministicRecallSearch", () => {
     ]);
   });
 
+  test("keeps PKB pinned context evidence through very low result caps", async () => {
+    const result = await runDeterministicRecallSearch(
+      { query: "launch notes", sources: ["pkb", "workspace"], max_results: 1 },
+      makeContext(),
+      {
+        adapters: [
+          makeAdapter("pkb", [
+            makeEvidence("pkb", {
+              id: "pkb:search",
+              score: 0.99,
+              excerpt: "High scoring indexed PKB result.",
+            }),
+          ]),
+          makeAdapter("workspace", [
+            makeEvidence("workspace", {
+              id: "workspace:search",
+              score: 1,
+              excerpt: "High scoring workspace result.",
+            }),
+          ]),
+        ],
+        readPkbContextEvidence: () => [
+          makeEvidence("pkb", {
+            id: "pkb:auto-inject",
+            title: "PKB auto-injected context",
+            locator: "pkb:auto-inject",
+            excerpt: "Pinned launch plan from context.",
+          }),
+          makeEvidence("pkb", {
+            id: "pkb:NOW.md",
+            title: "NOW.md",
+            locator: "NOW.md",
+            excerpt: "Current launch focus.",
+          }),
+        ],
+      },
+    );
+
+    expect(result.evidence.map((item) => item.id)).toEqual([
+      "pkb:NOW.md",
+      "pkb:auto-inject",
+    ]);
+    expect(result.searchedSources).toEqual([
+      { source: "pkb", status: "searched", evidenceCount: 2 },
+      { source: "workspace", status: "searched", evidenceCount: 0 },
+    ]);
+  });
+
   test("searches every source by default", async () => {
     const calls: RecallSource[] = [];
     await runDeterministicRecallSearch({ query: "deployment" }, makeContext(), {

--- a/assistant/src/memory/context-search/agent-protocol.ts
+++ b/assistant/src/memory/context-search/agent-protocol.ts
@@ -18,6 +18,11 @@ export interface RecallAgentPromptOptions {
   maxSearchCalls?: number;
 }
 
+export interface RecallAgentPromptBundle {
+  prompt: string;
+  evidence: RecallEvidence[];
+}
+
 export interface RecallAgentFinish {
   answer: string;
   confidence: RecallAgentConfidence;
@@ -131,15 +136,21 @@ export const RECALL_AGENT_TOOL_DEFINITIONS: readonly RecallAgentToolDefinition[]
 export function buildRecallAgentPrompt(
   options: RecallAgentPromptOptions,
 ): string {
+  return buildRecallAgentPromptBundle(options).prompt;
+}
+
+export function buildRecallAgentPromptBundle(
+  options: RecallAgentPromptOptions,
+): RecallAgentPromptBundle {
   const availableSources = normalizeRecallSources(options.availableSources);
   const maxSearchCalls = options.maxSearchCalls ?? DEFAULT_MAX_SEARCH_CALLS;
-  const evidence = truncateRecallEvidenceToBudget(
+  const evidence = prepareRecallAgentPromptEvidence(
     options.evidence,
-    options.evidenceBudgetChars ?? DEFAULT_RECALL_AGENT_EVIDENCE_BUDGET_CHARS,
+    options.evidenceBudgetChars,
   );
   const citationIds = evidence.map((item) => item.id);
 
-  return [
+  const prompt = [
     "You are the bounded internal recall agent. Find reliable information for the user's recall request using only the internal sources and evidence supplied by the engine.",
     "",
     `User query: ${options.query}`,
@@ -163,6 +174,15 @@ export function buildRecallAgentPrompt(
     "Evidence table:",
     formatRecallEvidenceTable(evidence),
   ].join("\n");
+
+  return { prompt, evidence };
+}
+
+export function prepareRecallAgentPromptEvidence(
+  evidence: readonly RecallEvidence[],
+  evidenceBudgetChars = DEFAULT_RECALL_AGENT_EVIDENCE_BUDGET_CHARS,
+): RecallEvidence[] {
+  return truncateRecallEvidenceToBudget(evidence, evidenceBudgetChars);
 }
 
 export function truncateRecallEvidenceToBudget(

--- a/assistant/src/memory/context-search/agent-runner.ts
+++ b/assistant/src/memory/context-search/agent-runner.ts
@@ -5,15 +5,17 @@ import type {
   ToolUseContent,
 } from "../../providers/types.js";
 import {
-  buildRecallAgentPrompt,
+  buildRecallAgentPromptBundle,
   RECALL_AGENT_TOOL_DEFINITIONS,
   validateFinishRecallPayload,
 } from "./agent-protocol.js";
 import { formatDeterministicRecallAnswer } from "./format.js";
 import {
+  isRecallSource,
   type NormalizedRecallInput,
   normalizeRecallInput,
   normalizeRecallMaxResults,
+  normalizeRecallSources,
 } from "./limits.js";
 import {
   type DeterministicRecallSearchOptions,
@@ -115,11 +117,16 @@ export async function runAgenticRecall(
 
   for (let round = 1; round <= roundLimit; round++) {
     debug.roundsUsed = round;
+    const promptBundle = buildPromptBundle(
+      normalizedInput,
+      evidence,
+      roundLimit,
+    );
 
     let response: ProviderResponse;
     try {
       response = await provider.sendMessage(
-        [userTextMessage(buildPrompt(normalizedInput, evidence, roundLimit))],
+        [userTextMessage(promptBundle.prompt)],
         [...RECALL_AGENT_TOOL_DEFINITIONS],
         undefined,
         {
@@ -138,7 +145,7 @@ export async function runAgenticRecall(
     if (finishTool) {
       const validation = validateFinishRecallPayload(
         finishTool.input,
-        evidence,
+        promptBundle.evidence,
       );
       if (!validation.ok) {
         fallbackReason = "citation_validation_failed";
@@ -147,7 +154,10 @@ export async function runAgenticRecall(
       }
 
       const finish = validation.finish;
-      const citedEvidence = selectCitedEvidence(evidence, finish.citationIds);
+      const citedEvidence = selectCitedEvidence(
+        promptBundle.evidence,
+        finish.citationIds,
+      );
       debug.finish = {
         confidence: finish.confidence,
         citationIds: finish.citationIds,
@@ -199,19 +209,19 @@ export async function runAgenticRecall(
   }
 
   return deterministicFallback(
-    seedResult,
+    withFallbackEvidence(seedResult, evidence),
     debug,
     fallbackReason,
     fallbackDetail,
   );
 }
 
-function buildPrompt(
+function buildPromptBundle(
   input: NormalizedRecallInput,
   evidence: readonly RecallEvidence[],
   roundLimit: number,
-): string {
-  return buildRecallAgentPrompt({
+): ReturnType<typeof buildRecallAgentPromptBundle> {
+  return buildRecallAgentPromptBundle({
     query: input.query,
     availableSources: input.sources,
     evidence,
@@ -313,19 +323,15 @@ function narrowSearchSources(
 ): RecallSource[] {
   const allowed = new Set(allowedSources);
   const requested = Array.isArray(value)
-    ? dedupeSources(value.filter(isRecallSourceLike))
+    ? normalizeRequestedSources(value)
     : [...allowedSources];
 
   return requested.filter((source) => allowed.has(source));
 }
 
-function isRecallSourceLike(value: unknown): value is RecallSource {
-  return (
-    value === "memory" ||
-    value === "pkb" ||
-    value === "conversations" ||
-    value === "workspace"
-  );
+function normalizeRequestedSources(value: readonly unknown[]): RecallSource[] {
+  const sources = value.filter(isRecallSource);
+  return sources.length > 0 ? normalizeRecallSources(sources) : [];
 }
 
 function mergeEvidence(
@@ -355,16 +361,6 @@ function toRecallInput(input: NormalizedRecallInput): RecallInput {
   };
 }
 
-function dedupeSources(sources: readonly RecallSource[]): RecallSource[] {
-  const deduped: RecallSource[] = [];
-  for (const source of sources) {
-    if (!deduped.includes(source)) {
-      deduped.push(source);
-    }
-  }
-  return deduped;
-}
-
 function selectCitedEvidence(
   evidence: readonly RecallEvidence[],
   citationIds: readonly string[],
@@ -374,6 +370,28 @@ function selectCitedEvidence(
     const item = byId.get(id);
     return item ? [item] : [];
   });
+}
+
+function withFallbackEvidence(
+  result: DeterministicRecallSearchResult,
+  evidence: readonly RecallEvidence[],
+): DeterministicRecallSearchResult {
+  const evidenceCountBySource = new Map<RecallSource, number>();
+  for (const item of evidence) {
+    evidenceCountBySource.set(
+      item.source,
+      (evidenceCountBySource.get(item.source) ?? 0) + 1,
+    );
+  }
+
+  return {
+    ...result,
+    evidence: [...evidence],
+    searchedSources: result.searchedSources.map((note) => ({
+      ...note,
+      evidenceCount: evidenceCountBySource.get(note.source) ?? 0,
+    })),
+  };
 }
 
 function deterministicFallback(

--- a/assistant/src/memory/context-search/search.ts
+++ b/assistant/src/memory/context-search/search.ts
@@ -39,6 +39,11 @@ const SOURCE_PRIORITY = new Map<RecallSource, number>(
   ALL_RECALL_SOURCES.map((source, index) => [source, index]),
 );
 
+const PINNED_PKB_CONTEXT_EVIDENCE_IDS = new Set([
+  "pkb:auto-inject",
+  "pkb:NOW.md",
+]);
+
 export async function runDeterministicRecallSearch(
   input: RecallInput,
   context: RecallSearchContext,
@@ -232,36 +237,77 @@ function capEvidence(
   evidence: readonly RecallEvidence[],
   maxResults: number,
 ): RecallEvidence[] {
+  const pinnedEvidence = evidence.filter(isPinnedPkbContextEvidence);
+  const regularEvidence = evidence.filter(
+    (item) => !isPinnedPkbContextEvidence(item),
+  );
   const capped: RecallEvidence[] = [];
   const textSizeBySource = new Map<RecallSource, number>();
   let totalTextSize = 0;
 
-  for (const item of evidence) {
-    if (capped.length >= maxResults) {
+  for (const item of pinnedEvidence) {
+    const appended = appendCappedEvidence(item, {
+      capped,
+      textSizeBySource,
+      totalTextSize,
+    });
+    totalTextSize = appended.totalTextSize;
+    if (appended.totalRemaining <= 0) {
+      return capped;
+    }
+  }
+
+  const resultLimit = Math.max(maxResults, capped.length);
+  for (const item of regularEvidence) {
+    if (capped.length >= resultLimit) {
       break;
     }
 
-    const sourceTextSize = textSizeBySource.get(item.source) ?? 0;
-    const sourceRemaining =
-      RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE - sourceTextSize;
-    const totalRemaining = RECALL_TOTAL_EVIDENCE_TEXT_CAP - totalTextSize;
-    const remaining = Math.min(sourceRemaining, totalRemaining);
-    if (remaining <= 0) {
-      if (totalRemaining <= 0) break;
-      continue;
-    }
-
-    const excerpt = truncateText(item.excerpt, remaining);
-    if (excerpt.length === 0) {
-      continue;
-    }
-
-    capped.push(excerpt === item.excerpt ? item : { ...item, excerpt });
-    textSizeBySource.set(item.source, sourceTextSize + excerpt.length);
-    totalTextSize += excerpt.length;
+    const appended = appendCappedEvidence(item, {
+      capped,
+      textSizeBySource,
+      totalTextSize,
+    });
+    totalTextSize = appended.totalTextSize;
+    if (appended.totalRemaining <= 0) break;
   }
 
   return capped;
+}
+
+function isPinnedPkbContextEvidence(item: RecallEvidence): boolean {
+  return item.source === "pkb" && PINNED_PKB_CONTEXT_EVIDENCE_IDS.has(item.id);
+}
+
+function appendCappedEvidence(
+  item: RecallEvidence,
+  state: {
+    capped: RecallEvidence[];
+    textSizeBySource: Map<RecallSource, number>;
+    totalTextSize: number;
+  },
+): { totalTextSize: number; totalRemaining: number } {
+  const sourceTextSize = state.textSizeBySource.get(item.source) ?? 0;
+  const sourceRemaining = RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE - sourceTextSize;
+  const totalRemaining = RECALL_TOTAL_EVIDENCE_TEXT_CAP - state.totalTextSize;
+  const remaining = Math.min(sourceRemaining, totalRemaining);
+  if (remaining <= 0) {
+    return { totalTextSize: state.totalTextSize, totalRemaining };
+  }
+
+  const excerpt = truncateText(item.excerpt, remaining);
+  if (excerpt.length === 0) {
+    return { totalTextSize: state.totalTextSize, totalRemaining };
+  }
+
+  state.capped.push(excerpt === item.excerpt ? item : { ...item, excerpt });
+  state.textSizeBySource.set(item.source, sourceTextSize + excerpt.length);
+  const totalTextSize = state.totalTextSize + excerpt.length;
+
+  return {
+    totalTextSize,
+    totalRemaining: RECALL_TOTAL_EVIDENCE_TEXT_CAP - totalTextSize,
+  };
 }
 
 function truncateText(text: string, maxChars: number): string {

--- a/assistant/src/memory/context-search/sources/memory.ts
+++ b/assistant/src/memory/context-search/sources/memory.ts
@@ -8,15 +8,9 @@ import type {
   RecallEvidence,
   RecallSearchContext,
   RecallSearchResult,
-  RecallSourceAdapter,
 } from "../types.js";
 
 const log = getLogger("context-search-memory-source");
-
-export const memorySourceAdapter: RecallSourceAdapter = {
-  source: "memory",
-  search: searchMemorySource,
-};
 
 export async function searchMemorySource(
   query: string,

--- a/assistant/src/memory/context-search/sources/workspace.ts
+++ b/assistant/src/memory/context-search/sources/workspace.ts
@@ -5,7 +5,6 @@ import type {
   RecallEvidence,
   RecallSearchContext,
   RecallSearchResult,
-  RecallSourceAdapter,
 } from "../types.js";
 
 export const WORKSPACE_SOURCE_MAX_FILE_SIZE_BYTES = 256 * 1024;
@@ -65,11 +64,6 @@ interface WalkState {
   scannedFiles: number;
   visitedDirs: Set<string>;
 }
-
-export const workspaceSourceAdapter: RecallSourceAdapter = {
-  source: "workspace",
-  search: searchWorkspaceSource,
-};
 
 export async function searchWorkspaceSource(
   query: string,


### PR DESCRIPTION
## Summary
- Pins PKB context evidence through deterministic caps.
- Uses accumulated follow-up evidence for agentic fallback.
- Validates finish citations against the exact prompted evidence table.

Fixes self-review gaps for replace-recall-agentic-search.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
