### PR TITLE
fix(tests): remove stale private conversation mock slop

### DIFF
--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -130,7 +130,6 @@ mock.module("../security/secret-allowlist.js", () => ({
 }));
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},

--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -80,7 +80,6 @@ mock.module("../runtime/gateway-client.js", () => ({
 }));
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},
@@ -745,9 +744,8 @@ describe("channel-reply-delivery", () => {
       const merged = updateMessageMetadataCalls[0].updates.slackMeta as string;
       // Imported here so the production read path (the same one the renderer
       // uses) is what actually validates the merged envelope.
-      const { readSlackMetadata } = await import(
-        "../messaging/providers/slack/message-metadata.js"
-      );
+      const { readSlackMetadata } =
+        await import("../messaging/providers/slack/message-metadata.js");
       const parsed = readSlackMetadata(merged);
       expect(parsed).not.toBeNull();
       expect(parsed?.channelTs).toBe("1700000700.000333");

--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -125,7 +125,6 @@ mock.module("../security/secret-allowlist.js", () => ({
 }));
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},

--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -107,7 +107,6 @@ mock.module("../workspace/git-service.js", () => ({
 let persistedMessages: Array<{ role: string; content: string }> = [];
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},

--- a/assistant/src/__tests__/conversation-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/conversation-confirmation-signals.test.ts
@@ -120,7 +120,6 @@ mock.module("../security/secret-allowlist.js", () => ({
 }));
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},

--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -72,7 +72,6 @@ let mockConversation: Record<string, unknown> | null = null;
 let nextMockMessageId = 1;
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},
   updateConversationTitle: () => {},

--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -74,7 +74,6 @@ let mockConversation: Record<string, unknown> | null = null;
 let nextMockMessageId = 1;
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},
   updateConversationTitle: () => {},

--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -52,7 +52,6 @@ const getConversationMock = mock((id: string) => {
 });
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},

--- a/assistant/src/__tests__/conversation-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/conversation-pre-run-repair.test.ts
@@ -96,7 +96,6 @@ let mockDbMessages: Array<{ id: string; role: string; content: string }> = [];
 let mockConversation: Record<string, unknown> | null = null;
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},

--- a/assistant/src/__tests__/conversation-process-callsite.test.ts
+++ b/assistant/src/__tests__/conversation-process-callsite.test.ts
@@ -125,7 +125,6 @@ let mockDbMessages: Array<{ id: string; role: string; content: string }> = [];
 let mockConversation: Record<string, unknown> | null = null;
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   setConversationOriginInterfaceIfUnset: () => {},
   updateConversationContextWindow: () => {},

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -158,7 +158,6 @@ mock.module("../security/secret-allowlist.js", () => ({
 }));
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   deleteMessageById: () => {},
   getMessages: () => [],

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -156,7 +156,6 @@ mock.module("../security/secret-allowlist.js", () => ({
 }));
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   setConversationOriginInterfaceIfUnset: () => {},
   updateConversationContextWindow: () => {},

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -99,7 +99,6 @@ mock.module("../security/secret-allowlist.js", () => ({
 }));
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   setConversationOriginInterfaceIfUnset: () => {},
   updateConversationContextWindow: () => {},

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -105,7 +105,6 @@ const addMessageCalls: Array<{
 }> = [];
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},

--- a/assistant/src/__tests__/conversation-speed-override.test.ts
+++ b/assistant/src/__tests__/conversation-speed-override.test.ts
@@ -128,7 +128,6 @@ mock.module("../security/secret-allowlist.js", () => ({
 }));
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},

--- a/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
@@ -86,7 +86,6 @@ mock.module("../security/secret-allowlist.js", () => ({
 }));
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   provenanceFromTrustContext: () => ({
     source: "user",

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -111,7 +111,6 @@ mock.module("../security/secret-allowlist.js", () => ({
 }));
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   provenanceFromTrustContext: () => ({
     source: "user",

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -109,7 +109,6 @@ mock.module("../security/secret-allowlist.js", () => ({
 }));
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   provenanceFromTrustContext: () => ({
     source: "user",

--- a/assistant/src/__tests__/file-write-tool.test.ts
+++ b/assistant/src/__tests__/file-write-tool.test.ts
@@ -204,7 +204,7 @@ describe("file_write tool PKB re-index hook", () => {
 
     const ctx: ToolContext = {
       ...makeContext(workingDir),
-      memoryScopeId: "private:abc123",
+      memoryScopeId: "subagent:abc123",
     };
 
     const result = await fileWriteTool.execute(
@@ -263,8 +263,6 @@ describe("file_write tool PKB re-index hook", () => {
     // The mock throws, so nothing gets pushed to enqueueCalls. The critical
     // behavior is that the thrown error never surfaces through execute().
     expect(enqueueCalls).toHaveLength(0);
-    expect(
-      existsSync(join(workingDir, "pkb", "oops.md")),
-    ).toBe(true);
+    expect(existsSync(join(workingDir, "pkb", "oops.md"))).toBe(true);
   });
 });

--- a/assistant/src/__tests__/filing-service.test.ts
+++ b/assistant/src/__tests__/filing-service.test.ts
@@ -35,7 +35,6 @@ const createdConversations: Array<{ title: string; conversationType: string }> =
 let conversationIdCounter = 0;
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -61,7 +61,6 @@ const createdConversations: Array<{ title: string; conversationType: string }> =
 let conversationIdCounter = 0;
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},

--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -49,7 +49,6 @@ const mockMessages: Array<{ id: string; role: string; content: string }> = [];
 let mockMessageIdCounter = 0;
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},

--- a/assistant/src/__tests__/secret-ingress-http.test.ts
+++ b/assistant/src/__tests__/secret-ingress-http.test.ts
@@ -106,7 +106,6 @@ mock.module("../memory/conversation-crud.js", () => ({
   provenanceFromTrustContext: () => undefined,
   setConversationOriginChannelIfUnset: () => {},
   setConversationOriginInterfaceIfUnset: () => {},
-  getConversationType: () => undefined,
   getConversationMemoryScopeId: () => undefined,
 }));
 

--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, mock, test } from "bun:test";
 
 // Mock conversation-crud before importing tool executors that depend on it.
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},
@@ -120,11 +119,7 @@ describe("notify_parent tool definition", () => {
     expect(
       (schema.properties as Record<string, Record<string, unknown>>).urgency
         .enum,
-    ).toEqual([
-      "info",
-      "important",
-      "blocked",
-    ]);
+    ).toEqual(["info", "important", "blocked"]);
     expect(notifyParentTool.category).toBe("orchestration");
   });
 
@@ -185,10 +180,7 @@ describe("executeSubagentNotifyParent", () => {
 
     // Wire up the onSubagentFinished callback.
     let capturedMessage = "";
-    manager.onSubagentFinished = (
-      _parentId: string,
-      message: string,
-    ) => {
+    manager.onSubagentFinished = (_parentId: string, message: string) => {
       capturedMessage = message;
     };
 
@@ -221,10 +213,7 @@ describe("executeSubagentNotifyParent", () => {
     });
 
     let capturedMessage = "";
-    manager.onSubagentFinished = (
-      _parentId: string,
-      message: string,
-    ) => {
+    manager.onSubagentFinished = (_parentId: string, message: string) => {
       capturedMessage = message;
     };
 
@@ -287,10 +276,7 @@ describe("executeSubagentNotifyParent", () => {
     injectSubagent(manager, subagentId, parentConversationId, "running");
 
     let capturedMessage = "";
-    manager.onSubagentFinished = (
-      _parentId: string,
-      message: string,
-    ) => {
+    manager.onSubagentFinished = (_parentId: string, message: string) => {
       capturedMessage = message;
     };
 
@@ -315,19 +301,10 @@ describe("SubagentManager.notifyParent", () => {
   test("returns false for terminal subagents", () => {
     const manager = getSubagentManager();
 
-    for (const terminalStatus of [
-      "completed",
-      "failed",
-      "aborted",
-    ] as const) {
+    for (const terminalStatus of ["completed", "failed", "aborted"] as const) {
       const subagentId = `notify-terminal-${terminalStatus}`;
       const parentConversationId = `notify-terminal-parent-${terminalStatus}`;
-      injectSubagent(
-        manager,
-        subagentId,
-        parentConversationId,
-        terminalStatus,
-      );
+      injectSubagent(manager, subagentId, parentConversationId, terminalStatus);
 
       manager.onSubagentFinished = () => {};
 

--- a/assistant/src/__tests__/subagent-spawn-tool-fork.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-tool-fork.test.ts
@@ -3,7 +3,6 @@ import { mock } from "bun:test";
 
 // Mock conversation-crud before importing tool executors that depend on it.
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},
@@ -334,7 +333,9 @@ describe("subagent_spawn fork parameter", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toContain("Cannot fork");
-      expect(result.content).toContain("parent conversation could not be resolved");
+      expect(result.content).toContain(
+        "parent conversation could not be resolved",
+      );
     } finally {
       manager.resolveParentConversation = originalResolve;
     }
@@ -359,7 +360,9 @@ describe("subagent_spawn fork parameter", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toContain("Cannot fork");
-      expect(result.content).toContain("parent conversation could not be resolved");
+      expect(result.content).toContain(
+        "parent conversation could not be resolved",
+      );
     } finally {
       manager.resolveParentConversation = originalResolve;
     }

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -7,7 +7,6 @@ let mockGetMessages: (
   conversationId: string,
 ) => Array<{ role: string; content: string }> | null = () => null;
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -8,7 +8,7 @@
  * for voice facts; IDENTITY.md for assistant / hatched metadata) plus
  * the DB-authoritative conversation count (via
  * `conversation-queries.countConversations`, matching the UI's
- * `listConversations` filter — no `background` / `private` / `scheduled`)
+ * `listConversations` filter — no `background` / `scheduled`)
  * and the OAuth connection store (for capability tiers), and writes it
  * to `<workspace>/data/relationship-state.json`.
  *

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -332,7 +332,7 @@ The `/deliver/telegram` endpoint requires bearer auth unconditionally (fail-clos
 
 ### Channel Approval Flow
 
-When the assistant requires tool-use confirmation during a channel session (e.g., Telegram), the approval flow intercepts the run and surfaces an interactive prompt to the user. This approval-aware path is always active when orchestrator + callback context are available. Guardian enforcement (fail-closed denial for unknown actors, `forceStrictSideEffects`, guardian-routed approval prompts) applies consistently to non-guardian/unverified actors.
+When the assistant requires tool-use confirmation during a channel session (e.g., Telegram), the approval flow intercepts the run and surfaces an interactive prompt to the user. This approval-aware path is always active when orchestrator + callback context are available. Guardian enforcement (fail-closed denial for unknown actors, explicit approval prompts for side effects, guardian-routed approval prompts) applies consistently to non-guardian/unverified actors.
 
 **State machine:**
 
@@ -367,7 +367,7 @@ Runtime detects needs_confirmation
 
 **Conversational approval turn:** When a text message arrives while an approval is pending (e.g., non-Telegram channels or user typing a reply instead of clicking a button), a **conversational approval turn** is run via `runApprovalConversationTurn()` from `approval-conversation-turn.ts`. The conversational engine uses LLM structured output (native `tool_use`) to classify user intent as: `keep_pending` (reply without deciding), `approve_once`, `approve_always`, or `reject`. Non-decision messages receive a natural assistant reply and the run stays pending — no reminder spam. The engine fails closed: any model failure returns `keep_pending` with a deterministic fallback asking the user to try again. Callback/button handling remains deterministic and unchanged. The `channelSupportsRichApprovalUI()` function determines whether to send the structured `promptText` (for rich channels like Telegram) or the `plainTextFallback` string (for all other channels). Currently only `telegram` is classified as a rich channel.
 
-**Guardian-aware routing:** When a guardian binding exists for the channel, the approval flow resolves the sender's actor role (`guardian` vs `non-guardian`). Non-guardian actors have `forceStrictSideEffects` set on the session so all side-effect tools trigger approval prompts regardless of existing allow rules. Approval prompts for non-guardian actions are routed to the guardian's delivery chat (not the requester's chat), and a `channelGuardianApprovalRequest` record is created. When the guardian approves or denies, the decision is applied to the underlying run and the requester's chat is notified of the outcome. Guardian actors follow the standard approval flow. Guardian approval follow-ups also use the conversational engine with role-specific context; `approve_always` is downgraded to `approve_once` for guardian approvals since permanent allow-rules require guardian authority. All guardian state (bindings, challenges, approval requests) is scoped to the `(assistantId, channel)` pair -- the `assistantId` parameter flows through `handleChannelInbound`, `validateAndConsumeVerification`, `isGuardian`, `getGuardianBinding`, and `createApprovalRequest`.
+**Guardian-aware routing:** When a guardian binding exists for the channel, the approval flow resolves the sender's actor role (`guardian` vs `non-guardian`). Non-guardian actors have `forcePromptSideEffects` set on the session so all side-effect tools trigger approval prompts regardless of existing allow rules. Approval prompts for non-guardian actions are routed to the guardian's delivery chat (not the requester's chat), and a `channelGuardianApprovalRequest` record is created. When the guardian approves or denies, the decision is applied to the underlying run and the requester's chat is notified of the outcome. Guardian actors follow the standard approval flow. Guardian approval follow-ups also use the conversational engine with role-specific context; `approve_always` is downgraded to `approve_once` for guardian approvals since permanent allow-rules require guardian authority. All guardian state (bindings, challenges, approval requests) is scoped to the `(assistantId, channel)` pair -- the `assistantId` parameter flows through `handleChannelInbound`, `validateAndConsumeVerification`, `isGuardian`, `getGuardianBinding`, and `createApprovalRequest`.
 
 **Proactive expiry sweep:** The runtime runs a periodic sweep every 60 seconds (`sweepExpiredGuardianApprovals`) that finds guardian approval requests past the 30-minute TTL, auto-denies the underlying runs, and notifies both the requester and guardian via the gateway's per-channel `/deliver/<channel>` endpoint. This ensures expired approvals are closed without waiting for follow-up traffic from either party. The sweep is started automatically whenever a run orchestrator is available.
 
@@ -489,10 +489,10 @@ This ordering ensures that ingress ACL decisions are finalized before any agent 
 
 #### Actor Role Resolution
 
-When a message arrives on a channel, the runtime resolves the sender's role. Role _classification_ runs unconditionally. Guardian enforcement (`forceStrictSideEffects`, fail-closed denial, guardian approval routing) applies to non-guardian/unverified actors whenever orchestrator + callback context are available:
+When a message arrives on a channel, the runtime resolves the sender's role. Role _classification_ runs unconditionally. Guardian enforcement (`forcePromptSideEffects`, fail-closed denial, guardian approval routing) applies to non-guardian/unverified actors whenever orchestrator + callback context are available:
 
 - **Guardian**: `actorExternalId` matches the binding's `guardianExternalUserId` (DB column) for the `(assistantId, channel)` pair. Self-approval is handled through the same approval-aware channel flow.
-- **Non-guardian**: A known sender who is not the guardian. Side-effect tools are forced through the confirmation flow (`forceStrictSideEffects`), and approval prompts are routed to the guardian's chat instead of the requester's chat.
+- **Non-guardian**: A known sender who is not the guardian. Side-effect tools are forced through the confirmation flow (`forcePromptSideEffects`), and approval prompts are routed to the guardian's chat instead of the requester's chat.
 - **Unverified channel**: No guardian binding exists for the channel, or `actorExternalId` is absent. Sensitive actions are auto-denied immediately (fail-closed). This prevents unverified senders from self-approving actions or bypassing guardian enforcement by omitting identity data.
 
 #### Sensitive Action Gating (Non-Guardian Approval)
@@ -510,7 +510,7 @@ sequenceDiagram
     NG->>TG: Message triggers tool use
     TG->>GW: POST /webhooks/telegram
     GW->>Daemon: POST /v1/channels/inbound (JWT auth)
-    Daemon->>Daemon: Detect non-guardian, set forceStrictSideEffects
+    Daemon->>Daemon: Detect non-guardian, set forcePromptSideEffects
     Daemon->>Daemon: Tool needs confirmation → create GuardianApprovalRequest
     Daemon->>GW: POST /deliver/telegram (approval prompt + inline keyboard)
     GW->>Guardian: sendMessage (approval prompt)


### PR DESCRIPTION
## Summary
Fixes final self-review slop for remove-private-conversations.md.

**Gap:** stale getConversationType mocks, private-scope fixtures, and comments/docs remained.
**Fix:** remove dead mock exports and update stale test/comment/doc wording.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
