### PR TITLE
fix: exclude private conversation rows from recall

### DIFF
--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -117,6 +117,38 @@ describe("searchConversationSource", () => {
     ]);
   });
 
+  test("does not return legacy private conversations", async () => {
+    const visibleFts = await seedConversation({
+      title: "Visible FTS conversation",
+      content: "privatetoken belongs to a normal conversation.",
+    });
+    const privateFts = await seedConversation({
+      title: "Private FTS conversation",
+      content: "privatetoken belongs to private history.",
+    });
+    const privateLike = await seedConversation({
+      title: "Private LIKE conversation",
+      content: "C++ private history should stay hidden.",
+    });
+    rawRun(
+      "UPDATE conversations SET conversation_type = 'private' WHERE id IN (?, ?)",
+      privateFts.conversation.id,
+      privateLike.conversation.id,
+    );
+
+    const ftsResult = await searchConversationSource(
+      "privatetoken",
+      makeContext(),
+      10,
+    );
+    const likeResult = await searchConversationSource("C++", makeContext(), 10);
+
+    expect(ftsResult.evidence.map((item) => item.locator)).toEqual([
+      `${visibleFts.conversation.id}#${visibleFts.message.id}`,
+    ]);
+    expect(likeResult.evidence).toHaveLength(0);
+  });
+
   test("includes archived, scheduled, and background conversations", async () => {
     const archived = await seedConversation({
       title: "Archived conversation",

--- a/assistant/src/memory/context-search/sources/conversations.ts
+++ b/assistant/src/memory/context-search/sources/conversations.ts
@@ -81,6 +81,7 @@ function searchWithFts(
     JOIN conversations c ON c.id = m.conversation_id
     WHERE messages_fts MATCH ?
       AND c.memory_scope_id = ?
+      AND c.conversation_type != 'private'
       AND (c.source IS NULL OR c.source NOT IN (?, ?))
     ORDER BY bm25(messages_fts), m.created_at DESC
     LIMIT ?
@@ -111,6 +112,7 @@ function searchWithLike(
     JOIN conversations c ON c.id = m.conversation_id
     WHERE m.content LIKE ? ESCAPE '\\'
       AND c.memory_scope_id = ?
+      AND c.conversation_type != 'private'
       AND (c.source IS NULL OR c.source NOT IN (?, ?))
     ORDER BY m.created_at DESC
     LIMIT ?


### PR DESCRIPTION
## Summary
- Defensively excludes legacy private conversations from recall source SQL.
- Adds regression coverage for legacy private rows without using removed typed APIs.

Fixes round-two self-review gap for replace-recall-agentic-search.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
