### PR TITLE
fix: enqueue private vector cleanup jobs

### DIFF
--- a/assistant/src/memory/migrations/229-delete-private-conversations.test.ts
+++ b/assistant/src/memory/migrations/229-delete-private-conversations.test.ts
@@ -766,6 +766,19 @@ function countWhere(raw: Database, table: string, where: string): number {
   ).count;
 }
 
+function getVectorCleanupJobs(raw: Database): Array<{
+  id: string;
+  payload: string;
+}> {
+  return raw
+    .query(
+      `SELECT id, payload FROM memory_jobs
+       WHERE type = 'delete_qdrant_vectors'
+       ORDER BY id`,
+    )
+    .all() as Array<{ id: string; payload: string }>;
+}
+
 describe("migrateDeletePrivateConversations", () => {
   test("deletes private conversations and dependents while preserving other conversation types", () => {
     const db = createTestDb();
@@ -810,7 +823,12 @@ describe("migrateDeletePrivateConversations", () => {
     `);
 
     migrateDeletePrivateConversations(db);
+    const vectorCleanupJobsAfterFirstRun = getVectorCleanupJobs(raw);
     migrateDeletePrivateConversations(db);
+    const vectorCleanupJobsAfterSecondRun = getVectorCleanupJobs(raw);
+    expect(vectorCleanupJobsAfterSecondRun).toEqual(
+      vectorCleanupJobsAfterFirstRun,
+    );
 
     const remainingConversations = raw
       .query(`SELECT id FROM conversations ORDER BY id`)
@@ -913,14 +931,7 @@ describe("migrateDeletePrivateConversations", () => {
       countWhere(raw, "memory_embeddings", `id = 'graph-background-embedding'`),
     ).toBe(1);
 
-    const vectorCleanupJobs = raw
-      .query(
-        `SELECT id, payload FROM memory_jobs
-         WHERE type = 'delete_qdrant_vectors'
-         ORDER BY id`,
-      )
-      .all() as Array<{ id: string; payload: string }>;
-    expect(vectorCleanupJobs).toEqual([
+    expect(vectorCleanupJobsAfterSecondRun).toEqual([
       {
         id: "migration-229-delete-private-graph-node-vector:graph-private-a",
         payload: '{"targetType":"graph_node","targetId":"graph-private-a"}',
@@ -928,6 +939,14 @@ describe("migrateDeletePrivateConversations", () => {
       {
         id: "migration-229-delete-private-graph-node-vector:graph-private-b",
         payload: '{"targetType":"graph_node","targetId":"graph-private-b"}',
+      },
+      {
+        id: "migration-229-delete-private-segment-vector:conv-private-segment",
+        payload: '{"targetType":"segment","targetId":"conv-private-segment"}',
+      },
+      {
+        id: "migration-229-delete-private-summary-vector:summary-private",
+        payload: '{"targetType":"summary","targetId":"summary-private"}',
       },
     ]);
     expect(

--- a/assistant/src/memory/migrations/229-delete-private-conversations.ts
+++ b/assistant/src/memory/migrations/229-delete-private-conversations.ts
@@ -65,12 +65,58 @@ export function migrateDeletePrivateConversations(database: DrizzleDb): void {
     WHERE conversation_id IN (${PRIVATE_CONVERSATION_IDS})
   `);
   database.run(/*sql*/ `
+    INSERT OR IGNORE INTO memory_jobs (
+      id,
+      type,
+      payload,
+      status,
+      attempts,
+      run_after,
+      created_at,
+      updated_at
+    )
+    SELECT
+      'migration-229-delete-private-segment-vector:' || id,
+      'delete_qdrant_vectors',
+      json_object('targetType', 'segment', 'targetId', id),
+      'pending',
+      0,
+      0,
+      0,
+      0
+    FROM memory_segments
+    WHERE conversation_id IN (${PRIVATE_CONVERSATION_IDS})
+  `);
+  database.run(/*sql*/ `
     DELETE FROM memory_embeddings
     WHERE target_type = 'segment'
       AND target_id IN (
         SELECT id FROM memory_segments
         WHERE conversation_id IN (${PRIVATE_CONVERSATION_IDS})
       )
+  `);
+  database.run(/*sql*/ `
+    INSERT OR IGNORE INTO memory_jobs (
+      id,
+      type,
+      payload,
+      status,
+      attempts,
+      run_after,
+      created_at,
+      updated_at
+    )
+    SELECT
+      'migration-229-delete-private-summary-vector:' || id,
+      'delete_qdrant_vectors',
+      json_object('targetType', 'summary', 'targetId', id),
+      'pending',
+      0,
+      0,
+      0,
+      0
+    FROM memory_summaries
+    WHERE scope_id LIKE 'private:%'
   `);
   database.run(/*sql*/ `
     DELETE FROM memory_embeddings


### PR DESCRIPTION
## Summary
- Enqueues deterministic vector cleanup jobs for private segment and summary embeddings.
- Extends migration coverage for segment, summary, and graph-node cleanup jobs.

Fixes round-two integration gap for replace-recall-agentic-search.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
