### PR TITLE
fix: reserve recall budget for pinned PKB context

### DIFF
--- a/assistant/src/__tests__/context-search-fanout.test.ts
+++ b/assistant/src/__tests__/context-search-fanout.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { AssistantConfig } from "../config/schema.js";
 import { formatDeterministicRecallAnswer } from "../memory/context-search/format.js";
+import { RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE } from "../memory/context-search/limits.js";
 import { runDeterministicRecallSearch } from "../memory/context-search/search.js";
 import type {
   RecallEvidence,
@@ -139,6 +140,48 @@ describe("runDeterministicRecallSearch", () => {
       { source: "pkb", status: "searched", evidenceCount: 2 },
       { source: "workspace", status: "searched", evidenceCount: 0 },
     ]);
+  });
+
+  test("reserves text budget for each pinned PKB context row", async () => {
+    const result = await runDeterministicRecallSearch(
+      { query: "launch notes", sources: ["pkb"], max_results: 1 },
+      makeContext(),
+      {
+        adapters: [
+          makeAdapter("pkb", [
+            makeEvidence("pkb", {
+              id: "pkb:search",
+              score: 0.5,
+              excerpt: "Normal PKB search result.",
+            }),
+          ]),
+        ],
+        readPkbContextEvidence: () => [
+          makeEvidence("pkb", {
+            id: "pkb:auto-inject",
+            title: "PKB auto-injected context",
+            locator: "pkb:auto-inject",
+            score: 1,
+            excerpt: "A".repeat(RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE * 2),
+          }),
+          makeEvidence("pkb", {
+            id: "pkb:NOW.md",
+            title: "NOW.md",
+            locator: "NOW.md",
+            score: 0.9,
+            excerpt: "Current launch focus.",
+          }),
+        ],
+      },
+    );
+
+    expect(result.evidence.map((item) => item.id)).toEqual([
+      "pkb:auto-inject",
+      "pkb:NOW.md",
+    ]);
+    for (const item of result.evidence) {
+      expect(item.excerpt.length).toBeGreaterThan(0);
+    }
   });
 
   test("searches every source by default", async () => {

--- a/assistant/src/memory/context-search/search.ts
+++ b/assistant/src/memory/context-search/search.ts
@@ -245,11 +245,21 @@ function capEvidence(
   const textSizeBySource = new Map<RecallSource, number>();
   let totalTextSize = 0;
 
-  for (const item of pinnedEvidence) {
+  for (let index = 0; index < pinnedEvidence.length; index += 1) {
+    const item = pinnedEvidence[index];
+    if (!item) continue;
+
+    const pinnedRemaining = pinnedEvidence.length - index;
+    const reservedTextBudget = getReservedPinnedTextBudget(item, {
+      textSizeBySource,
+      totalTextSize,
+      pinnedRemaining,
+    });
     const appended = appendCappedEvidence(item, {
       capped,
       textSizeBySource,
       totalTextSize,
+      textBudget: reservedTextBudget,
     });
     totalTextSize = appended.totalTextSize;
     if (appended.totalRemaining <= 0) {
@@ -279,18 +289,38 @@ function isPinnedPkbContextEvidence(item: RecallEvidence): boolean {
   return item.source === "pkb" && PINNED_PKB_CONTEXT_EVIDENCE_IDS.has(item.id);
 }
 
+function getReservedPinnedTextBudget(
+  item: RecallEvidence,
+  state: {
+    textSizeBySource: Map<RecallSource, number>;
+    totalTextSize: number;
+    pinnedRemaining: number;
+  },
+): number {
+  const sourceTextSize = state.textSizeBySource.get(item.source) ?? 0;
+  const sourceRemaining = RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE - sourceTextSize;
+  const totalRemaining = RECALL_TOTAL_EVIDENCE_TEXT_CAP - state.totalTextSize;
+  const remaining = Math.min(sourceRemaining, totalRemaining);
+  return Math.max(1, Math.floor(remaining / state.pinnedRemaining));
+}
+
 function appendCappedEvidence(
   item: RecallEvidence,
   state: {
     capped: RecallEvidence[];
     textSizeBySource: Map<RecallSource, number>;
     totalTextSize: number;
+    textBudget?: number;
   },
 ): { totalTextSize: number; totalRemaining: number } {
   const sourceTextSize = state.textSizeBySource.get(item.source) ?? 0;
   const sourceRemaining = RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE - sourceTextSize;
   const totalRemaining = RECALL_TOTAL_EVIDENCE_TEXT_CAP - state.totalTextSize;
-  const remaining = Math.min(sourceRemaining, totalRemaining);
+  const remaining = Math.min(
+    sourceRemaining,
+    totalRemaining,
+    state.textBudget ?? Number.MAX_SAFE_INTEGER,
+  );
   if (remaining <= 0) {
     return { totalTextSize: state.totalTextSize, totalRemaining };
   }


### PR DESCRIPTION
## Summary
- Ensures both pinned PKB context rows survive deterministic text caps.
- Adds regression coverage for long PKB context plus NOW evidence.

Fixes round-two self-review gap for replace-recall-agentic-search.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
