### PR TITLE
chore: reuse mock logger helper

### DIFF
--- a/assistant/src/__tests__/context-search-pkb-source.test.ts
+++ b/assistant/src/__tests__/context-search-pkb-source.test.ts
@@ -3,10 +3,10 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { AssistantConfig } from "../config/schema.js";
 import type { RecallSearchContext } from "../memory/context-search/types.js";
 import { PKB_WORKSPACE_SCOPE } from "../memory/pkb/types.js";
+import { makeMockLogger } from "./helpers/mock-logger.js";
 
 mock.module("../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  getLogger: () => makeMockLogger(),
 }));
 
 const embedCalls: Array<{
@@ -33,10 +33,34 @@ const sparseCalls: string[] = [];
 let sparseVector = { indices: [1], values: [1] };
 
 mock.module("../memory/embedding-backend.js", () => ({
+  clearEmbeddingBackendCache: () => {},
+  embedWithBackend: async () => ({
+    vectors: [],
+    provider: "test",
+    model: "test-model",
+  }),
   generateSparseEmbedding: (text: string) => {
     sparseCalls.push(text);
     return sparseVector;
   },
+  getMemoryBackendStatus: async () => ({
+    provider: "test",
+    model: "test-model",
+    available: true,
+  }),
+  logMemoryEmbeddingWarning: () => {},
+  resetLocalEmbeddingFailureState: () => {},
+  selectEmbeddingBackend: async () => ({
+    backend: {
+      provider: "test",
+      model: "test-model",
+      embed: async () => [],
+    },
+    provider: "test",
+    model: "test-model",
+  }),
+  selectedBackendSupportsMultimodal: async () => false,
+  SPARSE_EMBEDDING_VERSION: 2,
 }));
 
 type ScoredPoint = {
@@ -67,7 +91,10 @@ let hybridResults: ScoredPoint[] = [];
 let denseThrows: Error | null = null;
 
 mock.module("../memory/qdrant-circuit-breaker.js", () => ({
+  QdrantCircuitOpenError: class extends Error {},
+  _resetQdrantBreaker: () => {},
   isQdrantBreakerOpen: () => false,
+  shouldAllowQdrantProbe: () => true,
   withQdrantBreaker: async <T>(fn: () => Promise<T>): Promise<T> => fn(),
 }));
 
@@ -93,6 +120,9 @@ mock.module("../memory/qdrant-client.js", () => ({
       return hybridResults;
     },
   }),
+  initQdrantClient: () => {},
+  resolveQdrantUrl: () => "http://127.0.0.1:6333",
+  VellumQdrantClient: class {},
 }));
 
 let pkbContext: string | null = null;

--- a/assistant/src/memory/graph/graph-search.test.ts
+++ b/assistant/src/memory/graph/graph-search.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { makeMockLogger } from "../../__tests__/helpers/mock-logger.js";
+
 mock.module("../../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  getLogger: () => makeMockLogger(),
 }));
 
 let breakerOpen = false;

--- a/assistant/src/memory/pkb/pkb-search.test.ts
+++ b/assistant/src/memory/pkb/pkb-search.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { makeMockLogger } from "../../__tests__/helpers/mock-logger.js";
+
 mock.module("../../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  getLogger: () => makeMockLogger(),
 }));
 
 // Mutable breaker state + capture buffers for assertions.


### PR DESCRIPTION
## Summary
- Replaces inline no-op logger proxies with the shared mock logger helper in recall-adjacent tests.

Fixes round-two slop audit item for replace-recall-agentic-search.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
