### PR TITLE
fix: restore private conversation recall filter

### DIFF
--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -117,6 +117,52 @@ describe("searchConversationSource", () => {
     ]);
   });
 
+  test("does not return legacy private conversations through the FTS path", async () => {
+    const visible = await seedConversation({
+      title: "Visible conversation",
+      content: "privatesecret belongs to a normal conversation.",
+    });
+    const hidden = await seedConversation({
+      title: "Private conversation",
+      content: "privatesecret belongs to a private conversation.",
+    });
+    rawRun(
+      "UPDATE conversations SET conversation_type = 'private' WHERE id = ?",
+      hidden.conversation.id,
+    );
+
+    const result = await searchConversationSource(
+      "privatesecret",
+      makeContext(),
+      10,
+    );
+
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${visible.conversation.id}#${visible.message.id}`,
+    ]);
+  });
+
+  test("does not return legacy private conversations through the LIKE path", async () => {
+    const visible = await seedConversation({
+      title: "Visible short query conversation",
+      content: "zz appears in a normal conversation.",
+    });
+    const hidden = await seedConversation({
+      title: "Private short query conversation",
+      content: "zz appears in a private conversation.",
+    });
+    rawRun(
+      "UPDATE conversations SET conversation_type = 'private' WHERE id = ?",
+      hidden.conversation.id,
+    );
+
+    const result = await searchConversationSource("zz", makeContext(), 10);
+
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${visible.conversation.id}#${visible.message.id}`,
+    ]);
+  });
+
   test("includes archived, scheduled, and background conversations", async () => {
     const archived = await seedConversation({
       title: "Archived conversation",

--- a/assistant/src/memory/context-search/sources/conversations.ts
+++ b/assistant/src/memory/context-search/sources/conversations.ts
@@ -81,6 +81,7 @@ function searchWithFts(
     JOIN conversations c ON c.id = m.conversation_id
     WHERE messages_fts MATCH ?
       AND c.memory_scope_id = ?
+      AND (c.conversation_type IS NULL OR c.conversation_type != 'private')
       AND (c.source IS NULL OR c.source NOT IN (?, ?))
     ORDER BY bm25(messages_fts), m.created_at DESC
     LIMIT ?
@@ -111,6 +112,7 @@ function searchWithLike(
     JOIN conversations c ON c.id = m.conversation_id
     WHERE m.content LIKE ? ESCAPE '\\'
       AND c.memory_scope_id = ?
+      AND (c.conversation_type IS NULL OR c.conversation_type != 'private')
       AND (c.source IS NULL OR c.source NOT IN (?, ?))
     ORDER BY m.created_at DESC
     LIMIT ?


### PR DESCRIPTION
## Summary
- Restores defensive private-conversation filtering in recall SQL.
- Adds regression coverage for legacy private rows.

Fixes final self-review gap for replace-recall-agentic-search.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
