### PR TITLE
chore: reuse mock logger in pkb tests

### DIFF
--- a/assistant/src/memory/pkb/pkb-index.test.ts
+++ b/assistant/src/memory/pkb/pkb-index.test.ts
@@ -3,11 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { makeMockLogger } from "../../__tests__/helpers/mock-logger.js";
+
 mock.module("../../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
+  getLogger: () => makeMockLogger(),
 }));
 
 // Capture calls to embedAndUpsert so we can assert on targetType + payload.
@@ -101,7 +100,7 @@ mock.module("../qdrant-client.js", () => ({
 
 // The circuit breaker is a thin wrapper; just call the function through.
 mock.module("../qdrant-circuit-breaker.js", () => ({
-  withQdrantBreaker: async <T,>(fn: () => Promise<T>) => fn(),
+  withQdrantBreaker: async <T>(fn: () => Promise<T>) => fn(),
 }));
 
 import {

--- a/assistant/src/memory/pkb/pkb-reconcile.test.ts
+++ b/assistant/src/memory/pkb/pkb-reconcile.test.ts
@@ -3,11 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { makeMockLogger } from "../../__tests__/helpers/mock-logger.js";
+
 mock.module("../../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
+  getLogger: () => makeMockLogger(),
 }));
 
 // Capture enqueued PKB re-index jobs.
@@ -51,7 +50,7 @@ mock.module("../qdrant-client.js", () => ({
 
 // Circuit breaker — pass-through.
 mock.module("../qdrant-circuit-breaker.js", () => ({
-  withQdrantBreaker: async <T,>(fn: () => Promise<T>) => fn(),
+  withQdrantBreaker: async <T>(fn: () => Promise<T>) => fn(),
 }));
 
 // indexPkbFile is not invoked from the reconcile path (we enqueue jobs


### PR DESCRIPTION
## Summary
- Replaces remaining PKB inline no-op logger proxies with the shared mock logger helper.

Fixes final slop audit item for replace-recall-agentic-search.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
