### PR TITLE
chore: regenerate openapi.yaml

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -2639,11 +2639,11 @@ paths:
                   type: string
                   description: Idempotency key for the conversation
                 conversationType:
+                  description: Only standard conversations are created by this endpoint
                   type: string
-                  description: "'standard' (default)"
+                  const: standard
               required:
                 - conversationKey
-                - conversationType
               additionalProperties: false
   /v1/conversations/{id}:
     delete:


### PR DESCRIPTION
## Summary
- Regenerate `assistant/openapi.yaml` to match the current route schemas — the OpenAPI Spec Check CI job was failing because the committed spec was stale.
- Reflects an updated `conversationType` schema on `POST /v1/conversations`: now `const: "standard"` with a clearer description, and no longer in the `required` list.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24929287421/job/73004341084
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
