### PR TITLE
Clarify forced compaction no-op message

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -72,6 +72,31 @@ describe("ContextWindowManager", () => {
     expect(result.reason).toBe("below compaction threshold");
   });
 
+  test("explains forced compaction skip when conversation already fits target", async () => {
+    const provider = createProvider(() => {
+      throw new Error("summarizer should not be called");
+    });
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({
+        maxInputTokens: 10_000,
+        targetBudgetRatio: 0.5,
+      }),
+    });
+    const history = [message("user", "hello"), message("assistant", "hi")];
+
+    const result = await manager.maybeCompact(history, undefined, {
+      force: true,
+    });
+
+    expect(result.compacted).toBe(false);
+    expect(result.messages).toEqual(history);
+    expect(result.reason).toBe(
+      "conversation already fits within the compaction target",
+    );
+  });
+
   test("compacts old turns and keeps recent user turns", async () => {
     let summaryCalls = 0;
     const provider = createProvider(() => {

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -513,7 +513,7 @@ export class ContextWindowManager {
         summaryText: existingSummary ?? "",
         reason: didTruncate
           ? "truncated tool results without summarization"
-          : "unable to compact while keeping recent turns",
+          : "conversation already fits within the compaction target",
       };
     }
 


### PR DESCRIPTION
## Summary
- Replace the vague forced-compaction skip reason with a clearer message when the conversation already fits the compaction target.
- Add a regression test for the `/compact` force path that should not call the summarizer when there is nothing to summarize.

## Original prompt
Improve the error message in this case
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
