### PR TITLE
Improve agentic recall local truth retrieval

### DIFF
--- a/assistant/src/__tests__/context-search-agent-protocol.test.ts
+++ b/assistant/src/__tests__/context-search-agent-protocol.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildRecallAgentPrompt,
   FINISH_RECALL_TOOL_DEFINITION,
+  INSPECT_WORKSPACE_PATHS_TOOL_DEFINITION,
   RECALL_AGENT_TOOL_DEFINITIONS,
   SEARCH_SOURCES_TOOL_DEFINITION,
   truncateRecallEvidenceToBudget,
@@ -35,9 +36,10 @@ function schemaProperties(tool: {
 }
 
 describe("recall agent protocol tool definitions", () => {
-  test("defines bounded search_sources and finish_recall provider tools", () => {
+  test("defines bounded recall provider tools", () => {
     expect(RECALL_AGENT_TOOL_DEFINITIONS.map((tool) => tool.name)).toEqual([
       "search_sources",
+      "inspect_workspace_paths",
       "finish_recall",
     ]);
 
@@ -57,6 +59,18 @@ describe("recall agent protocol tool definitions", () => {
       type: "integer",
       minimum: 1,
       maximum: 20,
+    });
+
+    expect(
+      INSPECT_WORKSPACE_PATHS_TOOL_DEFINITION.input_schema.required,
+    ).toEqual(["paths", "reason"]);
+    expect(
+      schemaProperties(INSPECT_WORKSPACE_PATHS_TOOL_DEFINITION).paths,
+    ).toMatchObject({
+      type: "array",
+      minItems: 1,
+      maxItems: 5,
+      uniqueItems: true,
     });
 
     expect(FINISH_RECALL_TOOL_DEFINITION.input_schema.required).toEqual([
@@ -93,6 +107,8 @@ describe("buildRecallAgentPrompt", () => {
     expect(prompt).not.toContain("pkb: personal knowledge base");
     expect(prompt).toContain("Do not use external web");
     expect(prompt).toContain("Do not guess");
+    expect(prompt).toContain("inspect_workspace_paths");
+    expect(prompt).toContain("concrete workspace file");
     expect(prompt).toContain("For indirect references");
     expect(prompt).toContain("search those candidates");
     expect(prompt).toContain("not mandatory search terms");

--- a/assistant/src/__tests__/context-search-agent-runner.test.ts
+++ b/assistant/src/__tests__/context-search-agent-runner.test.ts
@@ -1,4 +1,13 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { AssistantConfig } from "../config/schema.js";
 import type { Provider, ProviderResponse } from "../providers/types.js";
@@ -28,9 +37,34 @@ interface SearchCall {
   signal?: AbortSignal;
 }
 
-function makeContext(signal?: AbortSignal): RecallSearchContext {
+const testDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(): string {
+  const dir = realpathSync(
+    mkdtempSync(join(tmpdir(), "context-search-agent-runner-")),
+  );
+  testDirs.push(dir);
+  return dir;
+}
+
+function writeWorkspaceFile(root: string, relativePath: string, text: string) {
+  const filePath = join(root, relativePath);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, text);
+}
+
+function makeContext(
+  signal?: AbortSignal,
+  workingDir = "/workspace",
+): RecallSearchContext {
   return {
-    workingDir: "/workspace",
+    workingDir,
     memoryScopeId: "scope-123",
     conversationId: "conv-xyz",
     config: {} as AssistantConfig,
@@ -248,6 +282,157 @@ describe("runAgenticRecall", () => {
         reason: "Need the explicit decision.",
         evidenceCount: 1,
       },
+    ]);
+  });
+
+  test("executes inspect_workspace_paths for surfaced workspace paths", async () => {
+    const root = makeTempDir();
+    writeWorkspaceFile(
+      root,
+      "scratch/handoff.md",
+      ["# Handoff", "Use the crimson folder for the next review."].join("\n"),
+    );
+    const providerCalls: unknown[][] = [];
+    configuredProvider = makeProvider(
+      [
+        toolResponse("inspect_workspace_paths", {
+          paths: ["scratch/handoff.md"],
+          reason: "Need the exact handoff file.",
+        }),
+        toolResponse("finish_recall", {
+          answer: "The handoff says to use the crimson folder.",
+          confidence: "high",
+          citation_ids: ["workspace:scratch/handoff.md:1:path"],
+        }),
+      ],
+      providerCalls,
+    );
+
+    const result = await runAgenticRecall(
+      { query: "handoff", sources: ["workspace"], max_results: 5 },
+      makeContext(undefined, root),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter({
+              handoff: [
+                makeEvidence("workspace:pointer", {
+                  excerpt: "The current handoff file is scratch/handoff.md.",
+                }),
+              ],
+            }),
+          ],
+        },
+      },
+    );
+
+    expect(providerCalls).toHaveLength(2);
+    expect(result.content).toContain("crimson folder");
+    expect(result.debug.inspectCalls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          round: 1,
+          paths: ["scratch/handoff.md"],
+          evidenceCount: 1,
+        }),
+      ]),
+    );
+    expect(result.evidence).toEqual([
+      expect.objectContaining({
+        id: "workspace:scratch/handoff.md:1:path",
+        title: "scratch/handoff.md",
+      }),
+    ]);
+  });
+
+  test("auto-inspects exact workspace paths before deterministic fallback", async () => {
+    const root = makeTempDir();
+    writeWorkspaceFile(root, "scratch/handoff.md", "handoff exact truth");
+
+    const result = await runAgenticRecall(
+      { query: "handoff", sources: ["workspace"], max_results: 5 },
+      makeContext(undefined, root),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter({
+              handoff: [
+                makeEvidence("workspace:pointer", {
+                  excerpt: "The exact note is at scratch/handoff.md.",
+                }),
+              ],
+            }),
+          ],
+        },
+      },
+    );
+
+    expect(result.debug).toMatchObject({
+      mode: "deterministic_fallback",
+      fallbackReason: "no_provider",
+      inspectCalls: [
+        {
+          round: 0,
+          paths: ["scratch/handoff.md"],
+          evidenceCount: 1,
+        },
+      ],
+    });
+    expect(result.evidence.map((item) => item.id)).toEqual([
+      "workspace:pointer",
+      "workspace:scratch/handoff.md:1:path",
+    ]);
+  });
+
+  test("rejects unsafe inspect_workspace_paths requests as unresolved evidence", async () => {
+    configuredProvider = makeProvider([
+      toolResponse("inspect_workspace_paths", {
+        paths: ["../secret.md"],
+        reason: "Try an unsafe path.",
+      }),
+      toolResponse("finish_recall", {
+        answer: "The requested file could not be inspected safely.",
+        confidence: "low",
+        citation_ids: ["workspace:inspect-error:1:0"],
+        unresolved: ["The path was not surfaced as a safe workspace file."],
+      }),
+    ]);
+
+    const result = await runAgenticRecall(
+      { query: "unsafe handoff", sources: ["workspace"], max_results: 5 },
+      makeContext(),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter({
+              "unsafe handoff": [makeEvidence("workspace:seed")],
+            }),
+          ],
+        },
+      },
+    );
+
+    expect(result.content).toContain("could not be inspected safely");
+    expect(result.debug.inspectCalls).toEqual([
+      {
+        round: 1,
+        paths: ["../secret.md"],
+        reason: "Try an unsafe path.",
+        evidenceCount: 1,
+        errors: [
+          {
+            path: "../secret.md",
+            reason:
+              "path was not a safe relative workspace file surfaced by the query or prior evidence",
+          },
+        ],
+      },
+    ]);
+    expect(result.evidence).toEqual([
+      expect.objectContaining({
+        id: "workspace:inspect-error:1:0",
+        locator: "../secret.md",
+      }),
     ]);
   });
 

--- a/assistant/src/__tests__/context-search-workspace-source.test.ts
+++ b/assistant/src/__tests__/context-search-workspace-source.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import type { AssistantConfig } from "../config/schema.js";
 import {
+  inspectWorkspacePaths,
   searchWorkspaceSource,
   WORKSPACE_SOURCE_MAX_FILE_SIZE_BYTES,
   WORKSPACE_SOURCE_MAX_SCANNED_FILES,
@@ -106,6 +107,11 @@ describe("searchWorkspaceSource", () => {
   test("allows safe hidden paths while skipping generated, dependency, and secret-shaped paths", async () => {
     const root = makeTempDir();
     writeWorkspaceFile(root, ".hidden.md", "needle hidden");
+    writeWorkspaceFile(
+      root,
+      ".birthday-builds/.format-rec.md",
+      "needle safe hidden file",
+    );
     writeWorkspaceFile(root, ".birthday-builds/cake.md", "needle safe hidden");
     writeWorkspaceFile(root, ".git/config.md", "needle git");
     writeWorkspaceFile(root, ".private/notes.md", "needle private");
@@ -130,6 +136,7 @@ describe("searchWorkspaceSource", () => {
     const result = await searchWorkspaceSource("needle", makeContext(root), 10);
 
     expect(result.evidence.map((item) => item.locator)).toEqual([
+      ".birthday-builds/.format-rec.md:1",
       ".birthday-builds/cake.md:1",
       ".hidden.md:1",
       "src/readme.md:1",
@@ -160,6 +167,228 @@ describe("searchWorkspaceSource", () => {
     expect(result.evidence.map((item) => item.locator)).toEqual([
       "journal/today.md:1",
     ]);
+  });
+
+  test("gives each traversal bucket enough budget for later authored truth", async () => {
+    const root = makeTempDir();
+    for (
+      let index = 0;
+      index < WORKSPACE_SOURCE_MAX_SCANNED_FILES;
+      index += 1
+    ) {
+      writeWorkspaceFile(
+        root,
+        `scratch/${String(index).padStart(3, "0")}.md`,
+        "sharedneedle scratch filler",
+      );
+    }
+    writeWorkspaceFile(
+      root,
+      ".birthday-builds/format.md",
+      "formatneedle hidden authored decision",
+    );
+    writeWorkspaceFile(root, "work/source.md", "workneedle live authored doc");
+    writeWorkspaceFile(
+      root,
+      "data/apps/example-app.json",
+      JSON.stringify({
+        name: "Example App",
+        description: "appneedle current app metadata",
+        dirName: "example-app",
+      }),
+    );
+
+    const result = await searchWorkspaceSource(
+      "sharedneedle formatneedle workneedle appneedle",
+      makeContext(root),
+      10,
+    );
+
+    expect(result.evidence.map((item) => item.title)).toEqual(
+      expect.arrayContaining([
+        ".birthday-builds/format.md",
+        "work/source.md",
+        "data/apps/example-app.json",
+      ]),
+    );
+  });
+
+  test("skips nested repo checkouts under scratch", async () => {
+    const root = makeTempDir();
+    writeWorkspaceFile(
+      root,
+      "scratch/vellum-assistant/notes.md",
+      "deepneedle generated checkout",
+    );
+    writeWorkspaceFile(root, "work/notes.md", "deepneedle live authored note");
+
+    const result = await searchWorkspaceSource(
+      "deepneedle",
+      makeContext(root),
+      10,
+    );
+
+    expect(result.evidence.map((item) => item.title)).toEqual([
+      "work/notes.md",
+    ]);
+  });
+
+  test("ranks live work documents above archive references", async () => {
+    const root = makeTempDir();
+    writeWorkspaceFile(
+      root,
+      "backups/archive.md",
+      "launch architecture decision exists in a separate work document",
+    );
+    writeWorkspaceFile(
+      root,
+      "work/decision.md",
+      "launch architecture decision: keep the local-first design",
+    );
+
+    const result = await searchWorkspaceSource(
+      "launch architecture decision local-first",
+      makeContext(root),
+      10,
+    );
+
+    expect(result.evidence[0]?.title).toBe("work/decision.md");
+    expect(result.evidence[0]?.excerpt).toContain("local-first design");
+  });
+
+  test("ranks current location tracker JSON above older PKB summaries", async () => {
+    const root = makeTempDir();
+    writeWorkspaceFile(
+      root,
+      "pkb/archive/location.md",
+      "home current place metadata was summarized previously",
+    );
+    writeWorkspaceFile(
+      root,
+      "scratch/location-tracker/named_places.json",
+      JSON.stringify({
+        places: [
+          {
+            name: "Home",
+            description: "current place metadata",
+            lat: 12.34,
+            lon: 56.78,
+            radius_m: 90,
+          },
+        ],
+      }),
+    );
+
+    const result = await searchWorkspaceSource(
+      "home current place metadata",
+      makeContext(root),
+      10,
+    );
+
+    expect(result.evidence[0]).toMatchObject({
+      title: "scratch/location-tracker/named_places.json",
+      metadata: { retrieval: "structured-json" },
+    });
+    expect(result.evidence[0]?.excerpt).toContain('"radius_m": 90');
+  });
+
+  test("returns the matching markdown section with heading metadata", async () => {
+    const root = makeTempDir();
+    writeWorkspaceFile(
+      root,
+      "scratch/cases.md",
+      [
+        "# Case Notes",
+        "A general index with voluntary mentions.",
+        "",
+        "## Voluntary Silence Case",
+        "The remedy is to wait for an explicit opt-in before sending updates.",
+        "The boundary applies to quiet periods and follow-up prompts.",
+        "",
+        "## Other Case",
+        "This section should not be returned for the remedy query.",
+      ].join("\n"),
+    );
+
+    const result = await searchWorkspaceSource(
+      "voluntary silence case remedy boundary",
+      makeContext(root),
+      10,
+    );
+
+    expect(result.evidence[0]).toMatchObject({
+      title: "scratch/cases.md",
+      locator: "scratch/cases.md:4",
+      metadata: {
+        retrieval: "section",
+        heading: "Voluntary Silence Case",
+      },
+    });
+    expect(result.evidence[0]?.excerpt).toContain(
+      "4: ## Voluntary Silence Case",
+    );
+    expect(result.evidence[0]?.excerpt).toContain(
+      "wait for an explicit opt-in",
+    );
+  });
+
+  test("returns compact structured JSON excerpts for app metadata", async () => {
+    const root = makeTempDir();
+    writeWorkspaceFile(
+      root,
+      "data/apps/example-app.json",
+      JSON.stringify({
+        name: "Example Apartment",
+        description: "A small apartment inventory app with current metadata.",
+        dirName: "example-apartment",
+        nested: {
+          name: "Nested Tool",
+          description: "Nested fields should be compact.",
+          veryLargeField: "x".repeat(2_000),
+        },
+      }),
+    );
+
+    const result = await searchWorkspaceSource(
+      "apartment app current metadata",
+      makeContext(root),
+      10,
+    );
+
+    expect(result.evidence[0]).toMatchObject({
+      title: "data/apps/example-app.json",
+      locator: "data/apps/example-app.json:1",
+      metadata: { retrieval: "structured-json" },
+    });
+    expect(result.evidence[0]?.excerpt).toContain(
+      '"name": "Example Apartment"',
+    );
+    expect(result.evidence[0]?.excerpt).toContain(
+      '"dirName": "example-apartment"',
+    );
+    expect(result.evidence[0]?.excerpt.length).toBeLessThanOrEqual(1_400);
+  });
+
+  test("returns exact safe path literals even when file text does not match", async () => {
+    const root = makeTempDir();
+    writeWorkspaceFile(
+      root,
+      "scratch/handoff.md",
+      ["# Handoff", "Use the crimson folder for the next review."].join("\n"),
+    );
+
+    const result = await searchWorkspaceSource(
+      "inspect scratch/handoff.md",
+      makeContext(root),
+      10,
+    );
+
+    expect(result.evidence[0]).toMatchObject({
+      title: "scratch/handoff.md",
+      locator: "scratch/handoff.md:1",
+      metadata: { retrieval: "path", path: "scratch/handoff.md" },
+    });
+    expect(result.evidence[0]?.excerpt).toContain("crimson folder");
   });
 
   test("skips conversation metadata files in workspace search", async () => {
@@ -283,5 +512,34 @@ describe("searchWorkspaceSource", () => {
     );
 
     expect(result.evidence).toEqual([]);
+  });
+});
+
+describe("inspectWorkspacePaths", () => {
+  test("inspects up to five safe surfaced files and reports unsafe paths", async () => {
+    const root = makeTempDir();
+    writeWorkspaceFile(root, "scratch/handoff.md", "handoff exact truth");
+    writeWorkspaceFile(
+      root,
+      ".birthday-builds/format.md",
+      "hidden exact truth",
+    );
+
+    const result = await inspectWorkspacePaths(
+      ["scratch/handoff.md", ".birthday-builds/format.md", "../secret.md"],
+      "unrelated query terms",
+      makeContext(root),
+    );
+
+    expect(result.evidence.map((item) => item.title)).toEqual([
+      "scratch/handoff.md",
+      ".birthday-builds/format.md",
+    ]);
+    expect(result.errors).toEqual([
+      {
+        path: "../secret.md",
+        reason: "path is not a safe relative workspace path",
+      },
+    ]);
   });
 });

--- a/assistant/src/memory/context-search/agent-protocol.ts
+++ b/assistant/src/memory/context-search/agent-protocol.ts
@@ -96,6 +96,34 @@ export const SEARCH_SOURCES_TOOL_DEFINITION: RecallAgentToolDefinition = {
   },
 };
 
+export const INSPECT_WORKSPACE_PATHS_TOOL_DEFINITION: RecallAgentToolDefinition =
+  {
+    name: "inspect_workspace_paths",
+    description:
+      "Inspect exact safe workspace-relative files that were surfaced by the query or prior evidence.",
+    input_schema: {
+      type: "object",
+      properties: {
+        paths: {
+          type: "array",
+          description:
+            "Safe relative workspace file paths to inspect, such as scratch/handoff.md.",
+          items: { type: "string" },
+          minItems: 1,
+          maxItems: 5,
+          uniqueItems: true,
+        },
+        reason: {
+          type: "string",
+          description:
+            "Brief reason these exact paths need inspection before answering.",
+        },
+      },
+      required: ["paths", "reason"],
+      additionalProperties: false,
+    },
+  };
+
 export const FINISH_RECALL_TOOL_DEFINITION: RecallAgentToolDefinition = {
   name: "finish_recall",
   description:
@@ -131,7 +159,11 @@ export const FINISH_RECALL_TOOL_DEFINITION: RecallAgentToolDefinition = {
 };
 
 export const RECALL_AGENT_TOOL_DEFINITIONS: readonly RecallAgentToolDefinition[] =
-  [SEARCH_SOURCES_TOOL_DEFINITION, FINISH_RECALL_TOOL_DEFINITION] as const;
+  [
+    SEARCH_SOURCES_TOOL_DEFINITION,
+    INSPECT_WORKSPACE_PATHS_TOOL_DEFINITION,
+    FINISH_RECALL_TOOL_DEFINITION,
+  ] as const;
 
 export function buildRecallAgentPrompt(
   options: RecallAgentPromptOptions,
@@ -163,6 +195,8 @@ export function buildRecallAgentPromptBundle(
     "Rules:",
     "- Use search_sources when more evidence is needed. Keep searches focused and explain the reason.",
     `- Do not make more than ${maxSearchCalls} search_sources calls unless the engine gives you a new budget.`,
+    "- Use inspect_workspace_paths when the user query or evidence points at a concrete workspace file. Inspect the file before saying the answer is missing.",
+    "- inspect_workspace_paths only accepts safe relative paths that appeared in the query or evidence; if inspection fails, report that uncertainty instead of guessing.",
     "- For indirect references (for example, 'the cake Bob asked about'), first find the referring exchange, then search likely candidate referents named or implied by that evidence before finishing.",
     "- If evidence says a referent is unresolved but gives candidate events, objects, or adjacent facts, search those candidates and report the caveat instead of stopping at 'unresolved'.",
     "- Treat requested output fields like flavor, decoration, message, recipient, timing, or plan details as things to answer, not mandatory search terms.",

--- a/assistant/src/memory/context-search/agent-runner.ts
+++ b/assistant/src/memory/context-search/agent-runner.ts
@@ -24,6 +24,11 @@ import {
   type DeterministicRecallSearchResult,
   runDeterministicRecallSearch,
 } from "./search.js";
+import {
+  extractWorkspacePathLiterals,
+  inspectWorkspacePaths,
+  isSafeWorkspaceRelativePath,
+} from "./sources/workspace.js";
 import type {
   RecallAnswer,
   RecallEvidence,
@@ -50,6 +55,14 @@ export interface AgenticRecallSearchDebug {
   error?: string;
 }
 
+export interface AgenticRecallInspectDebug {
+  round: number;
+  paths: string[];
+  reason: string;
+  evidenceCount: number;
+  errors?: Array<{ path: string; reason: string }>;
+}
+
 export interface AgenticRecallDebug {
   mode: "agentic" | "deterministic_fallback";
   normalizedInput: NormalizedRecallInput;
@@ -57,6 +70,7 @@ export interface AgenticRecallDebug {
   roundsUsed: number;
   seedEvidenceCount: number;
   searchCalls: AgenticRecallSearchDebug[];
+  inspectCalls: AgenticRecallInspectDebug[];
   finish?: {
     confidence: string;
     citationIds: string[];
@@ -154,6 +168,7 @@ export async function runAgenticRecall(
     roundsUsed: 0,
     seedEvidenceCount: 0,
     searchCalls: [],
+    inspectCalls: [],
   };
 
   const provider = await getConfiguredProvider("recall");
@@ -163,9 +178,21 @@ export async function runAgenticRecall(
       context,
       options.searchOptions,
     );
-    debug.seedEvidenceCount = fallbackResult.evidence.length;
+    const autoInspect = await runAutomaticWorkspaceInspection(
+      normalizedInput,
+      context,
+      fallbackResult.evidence,
+    );
+    if (autoInspect.debug) {
+      debug.inspectCalls.push(autoInspect.debug);
+    }
+    const fallbackEvidence = mergeEvidence(
+      fallbackResult.evidence,
+      autoInspect.evidence,
+    );
+    debug.seedEvidenceCount = fallbackEvidence.length;
     return deterministicFallback(
-      fallbackResult,
+      withFallbackEvidence(fallbackResult, fallbackEvidence),
       debug,
       "no_provider",
       "No recall provider is configured.",
@@ -177,8 +204,17 @@ export async function runAgenticRecall(
     context,
     options.searchOptions,
   );
-  debug.seedEvidenceCount = seedResult.evidence.length;
   let evidence = [...seedResult.evidence];
+  const autoInspect = await runAutomaticWorkspaceInspection(
+    normalizedInput,
+    context,
+    evidence,
+  );
+  if (autoInspect.debug) {
+    debug.inspectCalls.push(autoInspect.debug);
+    evidence = mergeEvidence(evidence, autoInspect.evidence);
+  }
+  debug.seedEvidenceCount = evidence.length;
   let fallbackReason: AgenticRecallFallbackReason = "no_valid_finish";
   let fallbackDetail = "Recall provider did not return a valid finish_recall.";
 
@@ -226,34 +262,51 @@ export async function runAgenticRecall(
       }
     }
 
+    const inspectTools = toolUses.filter(
+      (tool) => tool.name === "inspect_workspace_paths",
+    );
     const searchTools = toolUses.filter(
       (tool) => tool.name === "search_sources",
     );
-    if (searchTools.length === 0) {
+    if (inspectTools.length === 0 && searchTools.length === 0) {
       fallbackReason = "no_valid_finish";
       fallbackDetail =
-        "Recall provider returned no search_sources or finish_recall tool call.";
+        "Recall provider returned no search_sources, inspect_workspace_paths, or finish_recall tool call.";
       break;
     }
 
-    const remainingSearchBudget = roundLimit - debug.searchCalls.length;
-    if (remainingSearchBudget <= 0) {
-      fallbackReason = "round_limit";
-      fallbackDetail =
-        "Recall provider exhausted the configured search budget.";
-      break;
-    }
-
-    for (const searchTool of searchTools.slice(0, remainingSearchBudget)) {
-      const searchResult = await executeSearchSources(
-        searchTool.input,
+    for (const inspectTool of inspectTools) {
+      const inspectResult = await executeInspectWorkspacePaths(
+        inspectTool.input,
         normalizedInput,
         context,
+        evidence,
         round,
-        options.searchOptions,
       );
-      debug.searchCalls.push(searchResult.debug);
-      evidence = mergeEvidence(evidence, searchResult.evidence);
+      debug.inspectCalls.push(inspectResult.debug);
+      evidence = mergeEvidence(evidence, inspectResult.evidence);
+    }
+
+    if (searchTools.length > 0) {
+      const remainingSearchBudget = roundLimit - debug.searchCalls.length;
+      if (remainingSearchBudget <= 0) {
+        fallbackReason = "round_limit";
+        fallbackDetail =
+          "Recall provider exhausted the configured search budget.";
+        break;
+      }
+
+      for (const searchTool of searchTools.slice(0, remainingSearchBudget)) {
+        const searchResult = await executeSearchSources(
+          searchTool.input,
+          normalizedInput,
+          context,
+          round,
+          options.searchOptions,
+        );
+        debug.searchCalls.push(searchResult.debug);
+        evidence = mergeEvidence(evidence, searchResult.evidence);
+      }
     }
 
     if (round === roundLimit) {
@@ -548,6 +601,125 @@ async function executeSearchSources(
   }
 }
 
+async function executeInspectWorkspacePaths(
+  payload: Record<string, unknown>,
+  input: NormalizedRecallInput,
+  context: RecallSearchContext,
+  evidence: readonly RecallEvidence[],
+  round: number,
+): Promise<{
+  evidence: RecallEvidence[];
+  debug: AgenticRecallInspectDebug;
+}> {
+  const reason = readSearchReason(payload.reason);
+  const requestedPaths = readInspectPaths(payload.paths);
+  const allowedPaths = collectInspectableWorkspacePaths(input.query, evidence);
+  const acceptedPaths = requestedPaths.filter((path) => allowedPaths.has(path));
+  const rejectedPaths = requestedPaths.filter(
+    (path) => !allowedPaths.has(path),
+  );
+
+  const debug: AgenticRecallInspectDebug = {
+    round,
+    paths: requestedPaths,
+    reason,
+    evidenceCount: 0,
+  };
+
+  if (requestedPaths.length === 0) {
+    return {
+      evidence: [
+        makeWorkspaceInspectionErrorEvidence({
+          round,
+          index: 0,
+          path: "inspect_workspace_paths",
+          reason: "inspect_workspace_paths paths must be non-empty strings",
+        }),
+      ],
+      debug: {
+        ...debug,
+        errors: [
+          {
+            path: "inspect_workspace_paths",
+            reason: "paths must be non-empty strings",
+          },
+        ],
+      },
+    };
+  }
+
+  const errors = rejectedPaths.map((path) => ({
+    path,
+    reason:
+      "path was not a safe relative workspace file surfaced by the query or prior evidence",
+  }));
+
+  let inspectionEvidence: RecallEvidence[] = [];
+  if (acceptedPaths.length > 0) {
+    const inspectionResult = await inspectWorkspacePaths(
+      acceptedPaths,
+      input.query,
+      context,
+    );
+    inspectionEvidence = inspectionResult.evidence;
+    errors.push(...inspectionResult.errors);
+  }
+
+  const errorEvidence = errors.map((error, index) =>
+    makeWorkspaceInspectionErrorEvidence({
+      round,
+      index,
+      path: error.path,
+      reason: error.reason,
+    }),
+  );
+  const allEvidence = [...inspectionEvidence, ...errorEvidence];
+
+  return {
+    evidence: allEvidence,
+    debug: {
+      ...debug,
+      evidenceCount: allEvidence.length,
+      ...(errors.length > 0 ? { errors } : {}),
+    },
+  };
+}
+
+async function runAutomaticWorkspaceInspection(
+  input: NormalizedRecallInput,
+  context: RecallSearchContext,
+  evidence: readonly RecallEvidence[],
+): Promise<{
+  evidence: RecallEvidence[];
+  debug?: AgenticRecallInspectDebug;
+}> {
+  if (!input.sources.includes("workspace")) {
+    return { evidence: [] };
+  }
+
+  const paths = collectAutomaticWorkspaceInspectionPaths(input.query, evidence);
+  if (paths.length === 0) {
+    return { evidence: [] };
+  }
+
+  const inspectionResult = await inspectWorkspacePaths(
+    paths,
+    input.query,
+    context,
+  );
+  const debug: AgenticRecallInspectDebug = {
+    round: 0,
+    paths,
+    reason:
+      "Automatically inspect exact workspace paths surfaced by seed evidence.",
+    evidenceCount: inspectionResult.evidence.length,
+    ...(inspectionResult.errors.length > 0
+      ? { errors: inspectionResult.errors }
+      : {}),
+  };
+  return { evidence: inspectionResult.evidence, debug };
+}
+
 function readSearchQuery(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
@@ -561,6 +733,85 @@ function readSearchLimit(value: unknown): number | undefined {
     return undefined;
   }
   return value;
+}
+
+function readInspectPaths(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return [
+    ...new Set(
+      value
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0),
+    ),
+  ].slice(0, 5);
+}
+
+function collectAutomaticWorkspaceInspectionPaths(
+  query: string,
+  evidence: readonly RecallEvidence[],
+): string[] {
+  const paths = new Set(extractWorkspacePathLiterals(query));
+  for (const item of evidence) {
+    if (item.source !== "workspace") {
+      continue;
+    }
+    for (const path of extractWorkspacePathLiterals(item.excerpt)) {
+      paths.add(path);
+    }
+  }
+  return [...paths].filter(isSafeWorkspaceRelativePath).slice(0, 3);
+}
+
+function collectInspectableWorkspacePaths(
+  query: string,
+  evidence: readonly RecallEvidence[],
+): Set<string> {
+  const paths = new Set(extractWorkspacePathLiterals(query));
+  for (const item of evidence) {
+    const metadataPath = item.metadata?.path;
+    if (
+      typeof metadataPath === "string" &&
+      isSafeWorkspaceRelativePath(metadataPath)
+    ) {
+      paths.add(metadataPath);
+    }
+
+    for (const path of extractWorkspacePathLiterals(item.locator)) {
+      paths.add(path);
+    }
+    for (const path of extractWorkspacePathLiterals(item.title)) {
+      paths.add(path);
+    }
+    for (const path of extractWorkspacePathLiterals(item.excerpt)) {
+      paths.add(path);
+    }
+  }
+  return paths;
+}
+
+function makeWorkspaceInspectionErrorEvidence(options: {
+  round: number;
+  index: number;
+  path: string;
+  reason: string;
+}): RecallEvidence {
+  return {
+    id: `workspace:inspect-error:${options.round}:${options.index}`,
+    source: "workspace",
+    title: "Workspace path inspection",
+    locator: options.path,
+    excerpt: `Could not inspect workspace path: ${options.reason}.`,
+    score: 0,
+    metadata: {
+      retrieval: "path",
+      inspectError: true,
+      path: options.path,
+      reason: options.reason,
+    },
+  };
 }
 
 function narrowSearchSources(

--- a/assistant/src/memory/context-search/sources/workspace.ts
+++ b/assistant/src/memory/context-search/sources/workspace.ts
@@ -9,24 +9,40 @@ import type {
 
 export const WORKSPACE_SOURCE_MAX_FILE_SIZE_BYTES = 256 * 1024;
 export const WORKSPACE_SOURCE_MAX_SCANNED_FILES = 500;
+export const WORKSPACE_INSPECT_MAX_PATHS = 5;
 
 const EXCERPT_LINE_RADIUS = 1;
 const EXCERPT_MAX_CHARS = 600;
+const SECTION_EXCERPT_MAX_CHARS = 1_200;
+const STRUCTURED_JSON_EXCERPT_MAX_CHARS = 1_400;
+const MAX_SECTION_MATCHES_PER_FILE = 2;
+const MAX_LINE_MATCHES_PER_FILE = 1;
 
-const HIGH_PRIORITY_DIR_NAMES = new Map<string, number>([
-  ["pkb", 10],
-  ["journal", 20],
-  ["scratch", 30],
-  ["users", 40],
-  ["work", 45],
-]);
+const PATH_LITERAL_PATTERN =
+  /(?:^|[\s"'`([{<])((?:\.?[A-Za-z0-9_@~.-]+\/)*\.?[A-Za-z0-9_@~.-]+\.(?:md|txt|json|yaml|yml|toml|html|css|ts|tsx|js|jsx|py|swift|sh|sql))(?:[:#]\d+)?/g;
 
-const LOW_PRIORITY_DIR_NAMES = new Map<string, number>([
-  ["conversations", 50],
-  ["data", 60],
-  ["backups", 70],
-  ["logs", 80],
-]);
+const WORKSPACE_BUCKETS: readonly WorkspaceBucket[] = [
+  { name: "root", relativePath: "", budget: 100, rootFilesOnly: true },
+  { name: "pkb", relativePath: "pkb", budget: 500 },
+  { name: "journal", relativePath: "journal", budget: 250 },
+  { name: "birthday-builds", relativePath: ".birthday-builds", budget: 250 },
+  { name: "scratch", relativePath: "scratch", budget: 500 },
+  { name: "users", relativePath: "users", budget: 250 },
+  { name: "work", relativePath: "work", budget: 250 },
+  { name: "data-apps", relativePath: "data/apps", budget: 250 },
+  { name: "conversations", relativePath: "conversations", budget: 150 },
+  { name: "data", relativePath: "data", budget: 150 },
+  { name: "backups", relativePath: "backups", budget: 100 },
+  { name: "logs", relativePath: "logs", budget: 50 },
+  { name: "other", relativePath: null, budget: 150 },
+];
+
+const KNOWN_BUCKET_TOP_LEVEL_DIRS = new Set(
+  WORKSPACE_BUCKETS.flatMap((bucket) => {
+    if (!bucket.relativePath) return [];
+    return [bucket.relativePath.split("/")[0] ?? ""];
+  }),
+);
 
 const GENERATED_OR_DEPENDENCY_DIR_NAMES = new Set([
   ".git",
@@ -39,12 +55,59 @@ const GENERATED_OR_DEPENDENCY_DIR_NAMES = new Set([
   ".next",
   "coverage",
   "target",
+  "browser-profile",
+  "embedding-models",
+  "vellum-assistant",
 ]);
 
 const SECRET_SEGMENT_NAMES = new Set([
   "protected",
   "gateway-security",
   "ces-security",
+]);
+
+const QUERY_STOP_WORDS = new Set([
+  "a",
+  "about",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "been",
+  "being",
+  "by",
+  "can",
+  "did",
+  "do",
+  "does",
+  "for",
+  "from",
+  "had",
+  "has",
+  "have",
+  "how",
+  "in",
+  "into",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "should",
+  "that",
+  "the",
+  "this",
+  "to",
+  "was",
+  "were",
+  "what",
+  "when",
+  "where",
+  "which",
+  "who",
+  "why",
+  "with",
 ]);
 
 const TEXT_LIKE_EXTENSIONS = new Set([
@@ -66,6 +129,19 @@ const TEXT_LIKE_EXTENSIONS = new Set([
   ".sql",
 ]);
 
+type WorkspaceRetrievalKind =
+  | "lexical"
+  | "path"
+  | "section"
+  | "structured-json";
+
+interface WorkspaceBucket {
+  name: string;
+  relativePath: string | null;
+  budget: number;
+  rootFilesOnly?: boolean;
+}
+
 interface WorkspaceMatch {
   relativePath: string;
   excerpt: string;
@@ -73,11 +149,24 @@ interface WorkspaceMatch {
   score: number;
   fileSizeBytes: number;
   matchedTerms: string[];
+  retrieval: WorkspaceRetrievalKind;
+  heading?: string;
+}
+
+interface WorkspacePathInspectionError {
+  path: string;
+  reason: string;
+}
+
+interface WorkspacePathInspectionResult {
+  evidence: RecallEvidence[];
+  errors: WorkspacePathInspectionError[];
 }
 
 interface WalkState {
   scannedFiles: number;
   visitedDirs: Set<string>;
+  scannedRelativePaths: Set<string>;
 }
 
 export async function searchWorkspaceSource(
@@ -85,8 +174,9 @@ export async function searchWorkspaceSource(
   context: RecallSearchContext,
   limit: number,
 ): Promise<RecallSearchResult> {
-  const queryTerms = tokenize(query);
-  if (queryTerms.size === 0 || limit <= 0) {
+  const queryTerms = tokenizeQuery(query);
+  const pathLiterals = extractWorkspacePathLiterals(query);
+  if ((queryTerms.size === 0 && pathLiterals.length === 0) || limit <= 0) {
     return { evidence: [] };
   }
 
@@ -96,21 +186,159 @@ export async function searchWorkspaceSource(
   }
 
   const matches: WorkspaceMatch[] = [];
-  const state: WalkState = {
-    scannedFiles: 0,
-    visitedDirs: new Set([rootRealPath]),
-  };
+  const scannedRelativePaths = new Set<string>();
 
-  await walkDirectory(rootRealPath, rootRealPath, queryTerms, matches, state, {
-    signal: context.signal,
-  });
+  for (const pathLiteral of pathLiterals) {
+    const directMatches = await readWorkspaceFileMatches({
+      relativePath: pathLiteral,
+      rootRealPath,
+      queryTerms,
+      retrieval: "path",
+      scoreBoost: 4,
+    });
+    matches.push(...directMatches);
+    for (const match of directMatches) {
+      scannedRelativePaths.add(match.relativePath);
+    }
+  }
 
-  const evidence = matches
+  for (const bucket of WORKSPACE_BUCKETS) {
+    const state: WalkState = {
+      scannedFiles: 0,
+      visitedDirs: new Set([rootRealPath]),
+      scannedRelativePaths,
+    };
+
+    if (bucket.relativePath === null) {
+      await scanOtherTopLevelEntries(rootRealPath, queryTerms, matches, state, {
+        budget: bucket.budget,
+        signal: context.signal,
+      });
+      continue;
+    }
+
+    const bucketPath = join(rootRealPath, bucket.relativePath);
+    if (bucket.rootFilesOnly) {
+      await scanRootFiles(rootRealPath, queryTerms, matches, state, {
+        budget: bucket.budget,
+        signal: context.signal,
+      });
+      continue;
+    }
+
+    const bucketRealPath = await resolveContainedPath(bucketPath, rootRealPath);
+    if (!bucketRealPath) {
+      continue;
+    }
+
+    await walkDirectory(
+      bucketRealPath,
+      rootRealPath,
+      queryTerms,
+      matches,
+      state,
+      {
+        budget: bucket.budget,
+        signal: context.signal,
+      },
+    );
+  }
+
+  const evidence = dedupeWorkspaceMatches(matches)
     .sort(compareWorkspaceMatches)
     .slice(0, limit)
     .map(toEvidence);
 
   return { evidence };
+}
+
+export async function inspectWorkspacePaths(
+  paths: readonly string[],
+  query: string,
+  context: RecallSearchContext,
+): Promise<WorkspacePathInspectionResult> {
+  const rootRealPath = await resolveRoot(context.workingDir);
+  if (!rootRealPath) {
+    return {
+      evidence: [],
+      errors: paths.slice(0, WORKSPACE_INSPECT_MAX_PATHS).map((path) => ({
+        path,
+        reason: "workspace root is not a readable directory",
+      })),
+    };
+  }
+
+  const queryTerms = tokenizeQuery(query);
+  const evidence: RecallEvidence[] = [];
+  const errors: WorkspacePathInspectionError[] = [];
+
+  for (const requestedPath of dedupeStrings(paths).slice(
+    0,
+    WORKSPACE_INSPECT_MAX_PATHS,
+  )) {
+    const relativePath = normalizeWorkspacePathLiteral(requestedPath);
+    if (!relativePath || !isSafeWorkspaceRelativePath(relativePath)) {
+      errors.push({
+        path: requestedPath,
+        reason: "path is not a safe relative workspace path",
+      });
+      continue;
+    }
+
+    const matches = await readWorkspaceFileMatches({
+      relativePath,
+      rootRealPath,
+      queryTerms,
+      retrieval: "path",
+      scoreBoost: 4,
+    });
+
+    if (matches.length === 0) {
+      errors.push({
+        path: relativePath,
+        reason: "path was missing, unreadable, too large, or had no text match",
+      });
+      continue;
+    }
+
+    evidence.push(...matches.slice(0, 1).map(toEvidence));
+  }
+
+  return { evidence, errors };
+}
+
+export function extractWorkspacePathLiterals(text: string): string[] {
+  const paths: string[] = [];
+  for (const match of text.matchAll(PATH_LITERAL_PATTERN)) {
+    const rawPath = match[1];
+    const normalizedPath = rawPath
+      ? normalizeWorkspacePathLiteral(rawPath)
+      : null;
+    if (normalizedPath && isSafeWorkspaceRelativePath(normalizedPath)) {
+      paths.push(normalizedPath);
+    }
+  }
+  return dedupeStrings(paths);
+}
+
+export function isSafeWorkspaceRelativePath(relativePath: string): boolean {
+  const normalizedPath = normalizeWorkspacePathLiteral(relativePath);
+  if (
+    !normalizedPath ||
+    isAbsolute(normalizedPath) ||
+    normalizedPath === "." ||
+    normalizedPath.startsWith("../") ||
+    normalizedPath.includes("/../")
+  ) {
+    return false;
+  }
+
+  const pathSegments = normalizedPath.split("/");
+  return (
+    !shouldSkipWorkspaceFile(normalizedPath) &&
+    !shouldSkipFilePath(normalizedPath) &&
+    !shouldSkipRelativePath(pathSegments)
+  );
 }
 
 async function resolveRoot(workingDir: string): Promise<string | null> {
@@ -123,21 +351,125 @@ async function resolveRoot(workingDir: string): Promise<string | null> {
   }
 }
 
+async function scanRootFiles(
+  rootRealPath: string,
+  queryTerms: ReadonlySet<string>,
+  matches: WorkspaceMatch[],
+  state: WalkState,
+  options: { budget: number; signal: AbortSignal | undefined },
+): Promise<void> {
+  throwIfAborted(options.signal);
+
+  let entries;
+  try {
+    entries = await readdir(rootRealPath, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const entry of entries) {
+    throwIfAborted(options.signal);
+    if (state.scannedFiles >= options.budget) {
+      return;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    await maybeSearchFileEntry(
+      rootRealPath,
+      rootRealPath,
+      entry.name,
+      queryTerms,
+      matches,
+      state,
+    );
+  }
+}
+
+async function scanOtherTopLevelEntries(
+  rootRealPath: string,
+  queryTerms: ReadonlySet<string>,
+  matches: WorkspaceMatch[],
+  state: WalkState,
+  options: { budget: number; signal: AbortSignal | undefined },
+): Promise<void> {
+  throwIfAborted(options.signal);
+
+  let entries;
+  try {
+    entries = await readdir(rootRealPath, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const entry of entries) {
+    throwIfAborted(options.signal);
+    if (state.scannedFiles >= options.budget) {
+      return;
+    }
+    if (
+      shouldSkipSegmentName(entry.name) ||
+      KNOWN_BUCKET_TOP_LEVEL_DIRS.has(entry.name)
+    ) {
+      continue;
+    }
+
+    if (entry.isFile()) {
+      await maybeSearchFileEntry(
+        rootRealPath,
+        rootRealPath,
+        entry.name,
+        queryTerms,
+        matches,
+        state,
+      );
+      continue;
+    }
+
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const entryPath = join(rootRealPath, entry.name);
+    const entryRealPath = await resolveContainedPath(entryPath, rootRealPath);
+    if (!entryRealPath || state.visitedDirs.has(entryRealPath)) {
+      continue;
+    }
+    state.visitedDirs.add(entryRealPath);
+    await walkDirectory(
+      entryRealPath,
+      rootRealPath,
+      queryTerms,
+      matches,
+      state,
+      {
+        budget: options.budget,
+        signal: options.signal,
+      },
+    );
+  }
+}
+
 async function walkDirectory(
   directoryPath: string,
   rootRealPath: string,
   queryTerms: ReadonlySet<string>,
   matches: WorkspaceMatch[],
   state: WalkState,
-  options: { signal: AbortSignal | undefined },
-): Promise<boolean> {
+  options: { budget: number; signal: AbortSignal | undefined },
+): Promise<void> {
   throwIfAborted(options.signal);
 
   let entries;
   try {
     entries = await readdir(directoryPath, { withFileTypes: true });
   } catch {
-    return true;
+    return;
   }
 
   entries.sort((a, b) =>
@@ -146,8 +478,8 @@ async function walkDirectory(
 
   for (const entry of entries) {
     throwIfAborted(options.signal);
-    if (state.scannedFiles >= WORKSPACE_SOURCE_MAX_SCANNED_FILES) {
-      return false;
+    if (state.scannedFiles >= options.budget) {
+      return;
     }
 
     if (shouldSkipSegmentName(entry.name)) {
@@ -183,17 +515,17 @@ async function walkDirectory(
         continue;
       }
       state.visitedDirs.add(entryRealPath);
-      const shouldContinue = await walkDirectory(
+      await walkDirectory(
         entryRealPath,
         rootRealPath,
         queryTerms,
         matches,
         state,
-        options,
+        {
+          budget: options.budget,
+          signal: options.signal,
+        },
       );
-      if (!shouldContinue) {
-        return false;
-      }
       continue;
     }
 
@@ -205,28 +537,137 @@ async function walkDirectory(
       rootRealPath,
       entryPath,
     );
-    if (
-      shouldSkipWorkspaceFile(lexicalRelativePath) ||
-      shouldSkipFilePath(lexicalRelativePath) ||
-      shouldSkipFilePath(realRelativePath) ||
-      entryStats.size > WORKSPACE_SOURCE_MAX_FILE_SIZE_BYTES
-    ) {
-      continue;
-    }
-
-    state.scannedFiles += 1;
-    const match = await searchFile(
+    await maybeSearchResolvedFile(
       entryRealPath,
       lexicalRelativePath,
       entryStats.size,
       queryTerms,
+      matches,
+      state,
     );
-    if (match) {
-      matches.push(match);
-    }
+  }
+}
+
+async function maybeSearchFileEntry(
+  rootRealPath: string,
+  directoryPath: string,
+  entryName: string,
+  queryTerms: ReadonlySet<string>,
+  matches: WorkspaceMatch[],
+  state: WalkState,
+): Promise<void> {
+  const entryPath = join(directoryPath, entryName);
+  const entryRealPath = await resolveContainedPath(entryPath, rootRealPath);
+  if (!entryRealPath) {
+    return;
   }
 
-  return true;
+  let entryStats;
+  try {
+    entryStats = await stat(entryRealPath);
+  } catch {
+    return;
+  }
+
+  if (!entryStats.isFile()) {
+    return;
+  }
+
+  await maybeSearchResolvedFile(
+    entryRealPath,
+    toWorkspaceRelativePath(rootRealPath, entryPath),
+    entryStats.size,
+    queryTerms,
+    matches,
+    state,
+  );
+}
+
+async function maybeSearchResolvedFile(
+  realPath: string,
+  relativePath: string,
+  fileSizeBytes: number,
+  queryTerms: ReadonlySet<string>,
+  matches: WorkspaceMatch[],
+  state: WalkState,
+): Promise<void> {
+  if (
+    state.scannedRelativePaths.has(relativePath) ||
+    shouldSkipWorkspaceFile(relativePath) ||
+    shouldSkipFilePath(relativePath) ||
+    fileSizeBytes > WORKSPACE_SOURCE_MAX_FILE_SIZE_BYTES
+  ) {
+    return;
+  }
+
+  state.scannedRelativePaths.add(relativePath);
+  state.scannedFiles += 1;
+  matches.push(
+    ...(await searchFile(realPath, relativePath, fileSizeBytes, queryTerms)),
+  );
+}
+
+async function readWorkspaceFileMatches(options: {
+  relativePath: string;
+  rootRealPath: string;
+  queryTerms: ReadonlySet<string>;
+  retrieval: WorkspaceRetrievalKind;
+  scoreBoost: number;
+}): Promise<WorkspaceMatch[]> {
+  const normalizedPath = normalizeWorkspacePathLiteral(options.relativePath);
+  if (!normalizedPath || !isSafeWorkspaceRelativePath(normalizedPath)) {
+    return [];
+  }
+
+  const filePath = join(options.rootRealPath, normalizedPath);
+  const fileRealPath = await resolveContainedPath(
+    filePath,
+    options.rootRealPath,
+  );
+  if (!fileRealPath) {
+    return [];
+  }
+
+  let fileStats;
+  try {
+    fileStats = await stat(fileRealPath);
+  } catch {
+    return [];
+  }
+
+  if (
+    !fileStats.isFile() ||
+    fileStats.size > WORKSPACE_SOURCE_MAX_FILE_SIZE_BYTES
+  ) {
+    return [];
+  }
+
+  const matches = await searchFile(
+    fileRealPath,
+    normalizedPath,
+    fileStats.size,
+    options.queryTerms.size > 0
+      ? options.queryTerms
+      : tokenizeQuery(options.relativePath),
+  );
+  const fallbackMatches =
+    matches.length === 0 && options.retrieval === "path"
+      ? await readPathPreviewMatch(
+          fileRealPath,
+          normalizedPath,
+          fileStats.size,
+          options.queryTerms,
+        )
+      : [];
+
+  return [...matches, ...fallbackMatches].slice(0, 1).map((match) => ({
+    ...match,
+    retrieval:
+      match.retrieval === "structured-json"
+        ? "structured-json"
+        : options.retrieval,
+    score: match.score + options.scoreBoost,
+  }));
 }
 
 async function resolveContainedPath(
@@ -246,53 +687,212 @@ async function searchFile(
   relativePath: string,
   fileSizeBytes: number,
   queryTerms: ReadonlySet<string>,
-): Promise<WorkspaceMatch | null> {
+): Promise<WorkspaceMatch[]> {
   let contents;
   try {
     contents = await readFile(filePath, "utf8");
   } catch {
-    return null;
+    return [];
   }
 
+  const extension = extname(relativePath).toLowerCase();
+  if (extension === ".json") {
+    return searchJsonFile(contents, relativePath, fileSizeBytes, queryTerms);
+  }
+  if (extension === ".md") {
+    const sectionMatches = searchMarkdownSections(
+      contents,
+      relativePath,
+      fileSizeBytes,
+      queryTerms,
+    );
+    if (sectionMatches.length > 0) {
+      return sectionMatches;
+    }
+  }
+
+  return searchLineMatches(contents, relativePath, fileSizeBytes, queryTerms);
+}
+
+async function readPathPreviewMatch(
+  filePath: string,
+  relativePath: string,
+  fileSizeBytes: number,
+  queryTerms: ReadonlySet<string>,
+): Promise<WorkspaceMatch[]> {
+  let contents;
+  try {
+    contents = await readFile(filePath, "utf8");
+  } catch {
+    return [];
+  }
+
+  const extension = extname(relativePath).toLowerCase();
+  const retrieval: WorkspaceRetrievalKind =
+    extension === ".json" ? "structured-json" : "path";
+  const excerpt =
+    extension === ".json"
+      ? buildStructuredJsonExcerpt(contents)
+      : buildFilePreviewExcerpt(contents);
+  if (!excerpt) {
+    return [];
+  }
+
+  const matchedTerms = termOverlap(
+    tokenize(`${relativePath}\n${excerpt}`),
+    queryTerms,
+  );
+
+  return [
+    {
+      relativePath,
+      excerpt,
+      lineNumber: 1,
+      score: scoreMatch({
+        relativePath,
+        queryTerms,
+        matchedTerms,
+        retrieval,
+        heading: undefined,
+      }),
+      fileSizeBytes,
+      matchedTerms: [...matchedTerms].sort(),
+      retrieval,
+    },
+  ];
+}
+
+function searchJsonFile(
+  contents: string,
+  relativePath: string,
+  fileSizeBytes: number,
+  queryTerms: ReadonlySet<string>,
+): WorkspaceMatch[] {
+  const textTerms = tokenize(contents);
+  const matchedTerms = termOverlap(textTerms, queryTerms);
+  if (matchedTerms.size === 0) {
+    return [];
+  }
+
+  const excerpt = buildStructuredJsonExcerpt(contents);
+  const score = scoreMatch({
+    relativePath,
+    queryTerms,
+    matchedTerms,
+    retrieval: "structured-json",
+    heading: undefined,
+  });
+
+  return [
+    {
+      relativePath,
+      excerpt,
+      lineNumber: 1,
+      score,
+      fileSizeBytes,
+      matchedTerms: [...matchedTerms].sort(),
+      retrieval: "structured-json",
+    },
+  ];
+}
+
+function searchMarkdownSections(
+  contents: string,
+  relativePath: string,
+  fileSizeBytes: number,
+  queryTerms: ReadonlySet<string>,
+): WorkspaceMatch[] {
   const lines = contents.split(/\r?\n/);
-  const bestLine = findBestLine(lines, queryTerms);
-  if (!bestLine) {
-    return null;
-  }
+  const sections = parseMarkdownSections(lines);
 
-  const pathTerms = termOverlap(tokenize(relativePath), queryTerms);
-  const score =
-    bestLine.matchedTerms.size / queryTerms.size + pathTerms.size * 0.05;
+  return sections
+    .flatMap((section): WorkspaceMatch[] => {
+      const sectionText = lines.slice(section.start, section.end).join("\n");
+      const sectionTerms = tokenize(`${section.heading}\n${sectionText}`);
+      const matchedTerms = termOverlap(sectionTerms, queryTerms);
+      if (matchedTerms.size === 0) {
+        return [];
+      }
 
-  return {
+      return [
+        {
+          relativePath,
+          excerpt: buildSectionExcerpt(lines, section.start, section.end),
+          lineNumber: section.start + 1,
+          score: scoreMatch({
+            relativePath,
+            queryTerms,
+            matchedTerms,
+            retrieval: "section",
+            heading: section.heading,
+          }),
+          fileSizeBytes,
+          matchedTerms: [...matchedTerms].sort(),
+          retrieval: "section",
+          heading: section.heading,
+        },
+      ];
+    })
+    .sort(compareWorkspaceMatches)
+    .slice(0, MAX_SECTION_MATCHES_PER_FILE);
+}
+
+function searchLineMatches(
+  contents: string,
+  relativePath: string,
+  fileSizeBytes: number,
+  queryTerms: ReadonlySet<string>,
+): WorkspaceMatch[] {
+  const lines = contents.split(/\r?\n/);
+  const bestLines = findBestLines(lines, queryTerms);
+  return bestLines.map((bestLine) => ({
     relativePath,
     excerpt: buildExcerpt(lines, bestLine.lineIndex),
     lineNumber: bestLine.lineIndex + 1,
-    score,
+    score: scoreMatch({
+      relativePath,
+      queryTerms,
+      matchedTerms: bestLine.matchedTerms,
+      retrieval: "lexical",
+      heading: undefined,
+    }),
     fileSizeBytes,
     matchedTerms: [...bestLine.matchedTerms].sort(),
-  };
+    retrieval: "lexical",
+  }));
 }
 
-function findBestLine(
+function findBestLines(
   lines: readonly string[],
   queryTerms: ReadonlySet<string>,
-): { lineIndex: number; matchedTerms: Set<string> } | null {
-  let best: { lineIndex: number; matchedTerms: Set<string> } | null = null;
+): Array<{ lineIndex: number; matchedTerms: Set<string> }> {
+  return lines
+    .flatMap((line, lineIndex) => {
+      const lineTerms = tokenize(line);
+      const matchedTerms = termOverlap(lineTerms, queryTerms);
+      return matchedTerms.size > 0 ? [{ lineIndex, matchedTerms }] : [];
+    })
+    .sort((a, b) => b.matchedTerms.size - a.matchedTerms.size)
+    .slice(0, MAX_LINE_MATCHES_PER_FILE);
+}
 
-  lines.forEach((line, lineIndex) => {
-    const lineTerms = tokenize(line);
-    const matchedTerms = termOverlap(lineTerms, queryTerms);
-    if (matchedTerms.size === 0) {
-      return;
-    }
-
-    if (!best || matchedTerms.size > best.matchedTerms.size) {
-      best = { lineIndex, matchedTerms };
-    }
+function parseMarkdownSections(
+  lines: readonly string[],
+): Array<{ heading: string; start: number; end: number }> {
+  const headingIndexes = lines.flatMap((line, index) => {
+    const heading = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
+    return heading ? [{ index, heading: heading[2] ?? "" }] : [];
   });
 
-  return best;
+  if (headingIndexes.length === 0) {
+    return [];
+  }
+
+  return headingIndexes.map((heading, index) => ({
+    heading: heading.heading,
+    start: heading.index,
+    end: headingIndexes[index + 1]?.index ?? lines.length,
+  }));
 }
 
 function buildExcerpt(lines: readonly string[], lineIndex: number): string {
@@ -316,9 +916,155 @@ function buildExcerpt(lines: readonly string[], lineIndex: number): string {
   return `${focusedLine.slice(0, EXCERPT_MAX_CHARS - 3).trimEnd()}...`;
 }
 
+function buildSectionExcerpt(
+  lines: readonly string[],
+  start: number,
+  end: number,
+): string {
+  const excerpt = lines
+    .slice(start, end)
+    .map((line, offset) => `${start + offset + 1}: ${line.trimEnd()}`)
+    .join("\n")
+    .trim();
+
+  if (excerpt.length <= SECTION_EXCERPT_MAX_CHARS) {
+    return excerpt;
+  }
+
+  return `${excerpt.slice(0, SECTION_EXCERPT_MAX_CHARS - 3).trimEnd()}...`;
+}
+
+function buildStructuredJsonExcerpt(contents: string): string {
+  try {
+    const parsed = JSON.parse(contents) as unknown;
+    const compact = summarizeJsonValue(parsed);
+    return truncateExcerpt(
+      JSON.stringify(compact, null, 2),
+      STRUCTURED_JSON_EXCERPT_MAX_CHARS,
+    );
+  } catch {
+    return truncateExcerpt(contents.trim(), STRUCTURED_JSON_EXCERPT_MAX_CHARS);
+  }
+}
+
+function buildFilePreviewExcerpt(contents: string): string {
+  const lines = contents.split(/\r?\n/).slice(0, 40);
+  const excerpt = lines
+    .map((line, offset) => `${offset + 1}: ${line.trimEnd()}`)
+    .join("\n")
+    .trim();
+  return truncateExcerpt(excerpt, SECTION_EXCERPT_MAX_CHARS);
+}
+
+function summarizeJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.slice(0, 20).map(summarizeJsonValue);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>).slice(0, 30);
+  return Object.fromEntries(
+    entries.map(([key, entryValue]) => {
+      if (
+        entryValue &&
+        typeof entryValue === "object" &&
+        !Array.isArray(entryValue)
+      ) {
+        const record = entryValue as Record<string, unknown>;
+        const preferredKeys = [
+          "name",
+          "description",
+          "dirName",
+          "notes",
+          "lat",
+          "lon",
+          "radius_m",
+          "emoji",
+          "id",
+          "createdAt",
+          "updatedAt",
+        ];
+        const summary = Object.fromEntries(
+          preferredKeys
+            .filter((preferredKey) => preferredKey in record)
+            .map((preferredKey) => [preferredKey, record[preferredKey]]),
+        );
+        return [
+          key,
+          Object.keys(summary).length > 0
+            ? summary
+            : summarizeJsonValue(record),
+        ];
+      }
+      return [key, summarizeJsonValue(entryValue)];
+    }),
+  );
+}
+
+function truncateExcerpt(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${text.slice(0, maxChars - 3).trimEnd()}...`;
+}
+
+function scoreMatch(options: {
+  relativePath: string;
+  queryTerms: ReadonlySet<string>;
+  matchedTerms: ReadonlySet<string>;
+  retrieval: WorkspaceRetrievalKind;
+  heading: string | undefined;
+}): number {
+  const pathTerms = termOverlap(
+    tokenize(options.relativePath),
+    options.queryTerms,
+  );
+  const headingTerms = termOverlap(
+    tokenize(options.heading ?? ""),
+    options.queryTerms,
+  );
+  const retrievalBoost =
+    options.retrieval === "path"
+      ? 4
+      : options.retrieval === "structured-json"
+        ? 0.4
+        : options.retrieval === "section"
+          ? 1.1
+          : 0;
+  return (
+    retrievalBoost +
+    getPathPriorityBoost(options.relativePath) +
+    options.matchedTerms.size / Math.max(options.queryTerms.size, 1) +
+    pathTerms.size * 0.08 +
+    headingTerms.size * 0.12
+  );
+}
+
+function getPathPriorityBoost(relativePath: string): number {
+  if (relativePath.startsWith("data/apps/")) return 0.65;
+  if (relativePath.startsWith("scratch/location-tracker/")) return 0.65;
+  if (relativePath.startsWith(".birthday-builds/")) return 0.6;
+  if (relativePath.startsWith("work/")) return 0.45;
+  if (relativePath.startsWith("scratch/")) return 0.35;
+  if (relativePath.startsWith("users/")) return 0.3;
+  if (relativePath.startsWith("journal/")) return 0.25;
+  if (relativePath.startsWith("pkb/archive/")) return -0.15;
+  if (relativePath.startsWith("pkb/")) return 0.2;
+  if (
+    relativePath.startsWith("conversations/") ||
+    relativePath.startsWith("backups/") ||
+    relativePath.startsWith("logs/")
+  ) {
+    return -0.3;
+  }
+  return 0;
+}
+
 function toEvidence(match: WorkspaceMatch): RecallEvidence {
   return {
-    id: `workspace:${match.relativePath}:${match.lineNumber}`,
+    id: `workspace:${match.relativePath}:${match.lineNumber}:${match.retrieval}`,
     source: "workspace",
     title: match.relativePath,
     locator: `${match.relativePath}:${match.lineNumber}`,
@@ -329,8 +1075,31 @@ function toEvidence(match: WorkspaceMatch): RecallEvidence {
       lineNumber: match.lineNumber,
       fileSizeBytes: match.fileSizeBytes,
       matchedTerms: match.matchedTerms,
+      retrieval: match.retrieval,
+      ...(match.heading ? { heading: match.heading } : {}),
     },
   };
+}
+
+function dedupeWorkspaceMatches(
+  matches: readonly WorkspaceMatch[],
+): WorkspaceMatch[] {
+  const seen = new Set<string>();
+  const deduped: WorkspaceMatch[] = [];
+  for (const match of matches) {
+    const key = [
+      match.relativePath,
+      match.lineNumber,
+      match.retrieval,
+      normalizeExcerptForDedupe(match.excerpt),
+    ].join("\0");
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(match);
+  }
+  return deduped;
 }
 
 function compareWorkspaceMatches(a: WorkspaceMatch, b: WorkspaceMatch): number {
@@ -375,11 +1144,13 @@ function getTraversalPriority(
 
   const [firstSegment = ""] = relativePath.split("/");
   const lowerFirstSegment = firstSegment.toLowerCase();
-  return (
-    HIGH_PRIORITY_DIR_NAMES.get(lowerFirstSegment) ??
-    LOW_PRIORITY_DIR_NAMES.get(lowerFirstSegment) ??
-    46
-  );
+  const bucketIndex = WORKSPACE_BUCKETS.findIndex((bucket) => {
+    if (!bucket.relativePath) return false;
+    return (
+      bucket.relativePath.split("/")[0]?.toLowerCase() === lowerFirstSegment
+    );
+  });
+  return bucketIndex >= 0 ? bucketIndex + 1 : 99;
 }
 
 function shouldSkipFilePath(relativePath: string): boolean {
@@ -417,6 +1188,18 @@ function shouldSkipSegmentName(name: string): boolean {
   );
 }
 
+function normalizeWorkspacePathLiteral(pathLiteral: string): string | null {
+  const trimmed = pathLiteral
+    .trim()
+    .replace(/^["'`]+|["'`.,;:)>\]}]+$/g, "")
+    .replace(/^\.\//, "");
+  const withoutLineSuffix = trimmed.replace(/(\.[A-Za-z0-9]+):\d+$/, "$1");
+  if (!withoutLineSuffix || withoutLineSuffix.startsWith("~")) {
+    return null;
+  }
+  return withoutLineSuffix.split(sep).join("/");
+}
+
 function isPathInsideRoot(pathToCheck: string, rootRealPath: string): boolean {
   const pathRelativeToRoot = relative(rootRealPath, pathToCheck);
   return (
@@ -431,6 +1214,13 @@ function toWorkspaceRelativePath(
 ): string {
   const relativePath = relative(rootRealPath, filePath);
   return relativePath.split(sep).join("/");
+}
+
+function tokenizeQuery(text: string): Set<string> {
+  const terms = [...tokenize(text)].filter(
+    (term) => term.length >= 2 && !QUERY_STOP_WORDS.has(term),
+  );
+  return new Set(terms);
 }
 
 function tokenize(text: string): Set<string> {
@@ -448,6 +1238,14 @@ function termOverlap(
     }
   }
   return matchedTerms;
+}
+
+function dedupeStrings(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+function normalizeExcerptForDedupe(excerpt: string): string {
+  return excerpt.trim().replace(/\s+/g, " ").toLowerCase();
 }
 
 function throwIfAborted(signal: AbortSignal | undefined): void {


### PR DESCRIPTION
## Summary
- Add bucketed workspace traversal with safe hidden authored paths, exact path detection, markdown section extraction, and compact JSON excerpts.
- Teach the recall agent to inspect surfaced workspace paths and synthesize after budget exhaustion.
- Add regression coverage for local truth retrieval, path inspection, and referent/search behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
