### PR TITLE
Add right-click removal for conversation starters

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -2588,6 +2588,37 @@ paths:
           schema:
             type: string
           description: Scope ID (default "default")
+  /v1/conversation-starters/{id}:
+    delete:
+      operationId: conversationstarters_by_id_delete
+      summary: Delete conversation starter
+      description: Remove a generated conversation starter chip from the current starter set.
+      tags:
+        - conversation-starters
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+                  id:
+                    type: string
+                required:
+                  - deleted
+                  - id
+                additionalProperties: false
+        "404":
+          description: Conversation starter not found
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/conversations:
     delete:
       operationId: conversations_delete

--- a/assistant/src/__tests__/conversation-starter-routes.test.ts
+++ b/assistant/src/__tests__/conversation-starter-routes.test.ts
@@ -20,19 +20,26 @@ initializeDb();
 
 const routes = conversationStarterRouteDefinitions();
 
-function dispatch(path: string): Response | Promise<Response> {
+function dispatch(path: string, method = "GET"): Response | Promise<Response> {
   const url = new URL(`http://localhost/v1/${path}`);
-  const req = new Request(url.toString(), { method: "GET" });
+  const req = new Request(url.toString(), { method });
   const route = routes.find(
-    (r) => r.method === "GET" && r.endpoint === "conversation-starters",
+    (r) =>
+      r.method === method &&
+      (r.endpoint === "conversation-starters" ||
+        r.endpoint === "conversation-starters/:id"),
   );
   if (!route) throw new Error("No conversation-starters route found");
+  const params =
+    method === "DELETE"
+      ? { id: decodeURIComponent(path.split("/").at(-1) ?? "") }
+      : {};
   return route.handler({
     req,
     url,
     server: null as never,
     authContext: {} as never,
-    params: {},
+    params,
   });
 }
 
@@ -44,6 +51,7 @@ function clearTables() {
 }
 
 function insertStarter(overrides: {
+  id?: string;
   label: string;
   prompt: string;
   category: string;
@@ -52,11 +60,12 @@ function insertStarter(overrides: {
   createdAt?: number;
 }) {
   const now = Date.now();
+  const id = overrides.id ?? uuid();
   getSqlite().run(
     `INSERT INTO conversation_starters (id, label, prompt, category, generation_batch, scope_id, card_type, created_at)
      VALUES (?, ?, ?, ?, ?, ?, 'chip', ?)`,
     [
-      uuid(),
+      id,
       overrides.label,
       overrides.prompt,
       overrides.category,
@@ -65,6 +74,7 @@ function insertStarter(overrides: {
       overrides.createdAt ?? now,
     ],
   );
+  return id;
 }
 
 function insertMemoryItem(scopeId = "default") {
@@ -333,6 +343,48 @@ describe("GET /v1/conversation-starters", () => {
       .slice(0, 3)
       .map((starter) => starter.category);
     expect(new Set(firstThreeCategories).size).toBe(3);
+  });
+
+  test("deletes a starter and excludes it from subsequent list responses", async () => {
+    const deletedId = insertStarter({
+      label: "Draft a PR summary",
+      prompt: "Draft a summary for my latest PR",
+      category: "development",
+    });
+    const keptId = insertStarter({
+      label: "Check Slack threads",
+      prompt: "Check my unread Slack threads",
+      category: "communication",
+    });
+
+    const deleteRes = await dispatch(
+      `conversation-starters/${deletedId}`,
+      "DELETE",
+    );
+    const deleteBody = (await deleteRes.json()) as {
+      deleted: boolean;
+      id: string;
+    };
+    expect(deleteRes.status).toBe(200);
+    expect(deleteBody).toEqual({ deleted: true, id: deletedId });
+    expect(countStarterJobs()).toBe(0);
+
+    const listRes = await dispatch("conversation-starters");
+    const listBody = (await listRes.json()) as {
+      starters: Array<{ id: string }>;
+      total: number;
+    };
+    expect(listBody.total).toBe(1);
+    expect(listBody.starters.map((starter) => starter.id)).toEqual([keptId]);
+  });
+
+  test("returns 404 when deleting an unknown starter", async () => {
+    const res = await dispatch(`conversation-starters/${uuid()}`, "DELETE");
+    const body = (await res.json()) as { error: string };
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("NOT_FOUND");
+    expect(countStarterJobs()).toBe(0);
   });
 });
 

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -386,6 +386,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
 
   // Conversation starters
   { endpoint: "conversation-starters", scopes: ["chat.read"] },
+  { endpoint: "conversation-starters:DELETE", scopes: ["chat.write"] },
 
   // Message content
   { endpoint: "messages/content", scopes: ["chat.read"] },

--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -1,7 +1,8 @@
 /**
  * Route handlers for conversation starter endpoints.
  *
- * GET /v1/conversation-starters — list conversation starters (chips)
+ * GET    /v1/conversation-starters     — list conversation starters (chips)
+ * DELETE /v1/conversation-starters/:id — remove a conversation starter chip
  */
 
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
@@ -15,6 +16,7 @@ import {
   memoryCheckpoints,
   memoryJobs,
 } from "../../memory/schema.js";
+import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
 // ---------------------------------------------------------------------------
@@ -207,7 +209,9 @@ function handleListConversationStarters(url: URL): Response {
       db
         .select({ value: memoryCheckpoints.value })
         .from(memoryCheckpoints)
-        .where(eq(memoryCheckpoints.key, checkpointKey(CK_LAST_GEN_AT, scopeId)))
+        .where(
+          eq(memoryCheckpoints.key, checkpointKey(CK_LAST_GEN_AT, scopeId)),
+        )
         .get()?.value,
     );
     const staleByAge =
@@ -251,6 +255,39 @@ function handleListConversationStarters(url: URL): Response {
   return Response.json({ starters: [], total: 0, status: "generating" });
 }
 
+function handleDeleteConversationStarter(starterId: string): Response {
+  const db = getDb();
+  const existing = db
+    .select({ id: conversationStarters.id })
+    .from(conversationStarters)
+    .where(
+      and(
+        eq(conversationStarters.id, starterId),
+        eq(conversationStarters.cardType, "chip"),
+      ),
+    )
+    .get();
+
+  if (!existing) {
+    return httpError(
+      "NOT_FOUND",
+      `Conversation starter not found: ${starterId}`,
+      404,
+    );
+  }
+
+  db.delete(conversationStarters)
+    .where(
+      and(
+        eq(conversationStarters.id, starterId),
+        eq(conversationStarters.cardType, "chip"),
+      ),
+    )
+    .run();
+
+  return Response.json({ deleted: true, id: starterId });
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -291,6 +328,25 @@ export function conversationStarterRouteDefinitions(): RouteDefinition[] {
           .enum(["ready", "refreshing", "empty", "generating"])
           .describe("One of: ready, refreshing, empty, generating"),
       }),
+    },
+    {
+      endpoint: "conversation-starters/:id",
+      method: "DELETE",
+      policyKey: "conversation-starters",
+      summary: "Delete conversation starter",
+      description:
+        "Remove a generated conversation starter chip from the current starter set.",
+      tags: ["conversation-starters"],
+      handler: ({ params }) => handleDeleteConversationStarter(params.id),
+      responseBody: z.object({
+        deleted: z.boolean(),
+        id: z.string(),
+      }),
+      additionalResponses: {
+        "404": {
+          description: "Conversation starter not found",
+        },
+      },
     },
   ];
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -30,6 +30,7 @@ struct ChatEmptyStateView: View {
     var conversationStarters: [ConversationStarter] = []
     var conversationStartersLoading: Bool = false
     var onSelectStarter: ((ConversationStarter) -> Void)? = nil
+    var onRemoveStarter: ((ConversationStarter) -> Void)? = nil
     var onFetchConversationStarters: (() -> Void)? = nil
     var conversationHostAccessControl: ConversationHostAccessControlConfiguration? = nil
     var showThresholdPicker: Bool = false
@@ -194,7 +195,8 @@ struct ChatEmptyStateView: View {
         if !conversationStarters.isEmpty {
             ConversationStarterPillRow(
                 starters: conversationStarters,
-                onSelect: { starter in onSelectStarter?(starter) }
+                onSelect: { starter in onSelectStarter?(starter) },
+                onRemove: { starter in onRemoveStarter?(starter) }
             )
             .padding(.horizontal, VSpacing.lg)
             .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
@@ -237,13 +239,11 @@ struct ChatEmptyStateView: View {
 struct ConversationStarterPillRow: View {
     let starters: [ConversationStarter]
     let onSelect: (ConversationStarter) -> Void
+    let onRemove: (ConversationStarter) -> Void
 
-    /// Round down to the nearest even number, capped at 4.
+    /// Cap at 4, preserving the server's strongest-first order.
     private var visibleStarters: [ConversationStarter] {
-        let count = min(starters.count, 4)
-        let evenCount = count - (count % 2)
-        guard evenCount > 0 else { return [] }
-        return Array(starters.prefix(evenCount))
+        Array(starters.prefix(4))
     }
 
     private let columns = [
@@ -254,8 +254,10 @@ struct ConversationStarterPillRow: View {
     var body: some View {
         LazyVGrid(columns: columns, spacing: VSpacing.sm) {
             ForEach(visibleStarters) { starter in
-                ConversationStarterPill(label: starter.label) {
+                ConversationStarterPill(starter: starter) {
                     onSelect(starter)
+                } onRemove: {
+                    onRemove(starter)
                 }
                 .frame(maxWidth: .infinity)
             }
@@ -265,8 +267,9 @@ struct ConversationStarterPillRow: View {
 
 /// A single conversation starter pill with warm hover/press feedback.
 struct ConversationStarterPill: View {
-    let label: String
+    let starter: ConversationStarter
     let action: () -> Void
+    let onRemove: () -> Void
 
     @State private var isHovered = false
     @State private var isPressed = false
@@ -283,7 +286,7 @@ struct ConversationStarterPill: View {
 
     var body: some View {
         Button(action: action) {
-            Text(label)
+            Text(starter.label)
                 .font(VFont.bodyMediumLighter)
                 .foregroundStyle(isHovered ? VColor.contentDefault : VColor.contentSecondary)
                 .lineLimit(2)
@@ -306,7 +309,15 @@ struct ConversationStarterPill: View {
         .onHover { isHovered = $0 }
         .animation(VAnimation.fast, value: isHovered)
         .animation(VAnimation.snappy, value: isPressed)
-        .accessibilityLabel(label)
+        .accessibilityLabel(starter.label)
+        .vContextMenu(width: 180) {
+            VMenuItem(
+                icon: VIcon.trash.rawValue,
+                label: "Remove",
+                variant: .destructive,
+                action: onRemove
+            )
+        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -305,6 +305,7 @@ struct ChatView: View {
                     conversationStarters: conversationStartersEnabled ? viewModel.conversationStarters : [],
                     conversationStartersLoading: conversationStartersEnabled && viewModel.conversationStartersLoading,
                     onSelectStarter: { starter in viewModel.inputText = starter.prompt },
+                    onRemoveStarter: { starter in viewModel.removeConversationStarter(starter) },
                     onFetchConversationStarters: { viewModel.fetchConversationStarters() },
                     conversationHostAccessControl: conversationHostAccessControl,
                     showThresholdPicker: showThresholdPicker

--- a/clients/macos/vellum-assistantTests/ConversationStarterPillsTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationStarterPillsTests.swift
@@ -10,39 +10,36 @@ final class ConversationStarterPillsTests: XCTestCase {
         ConversationStarter(id: id, label: label, prompt: prompt, category: nil, batch: 0)
     }
 
-    /// Mirrors the even-count capping logic in ConversationStarterPillRow.
+    /// Mirrors the capping logic in ConversationStarterPillRow.
     private func visibleStarters(from starters: [ConversationStarter]) -> [ConversationStarter] {
-        let count = min(starters.count, 6)
-        let evenCount = count - (count % 2)
-        guard evenCount > 0 else { return [] }
-        return Array(starters.prefix(evenCount))
+        Array(starters.prefix(4))
     }
 
     // MARK: - Visible Count Cap
 
-    /// The pill row must never show more than six items, even when more are provided.
-    func testMaxVisibleCountIsSix() {
+    /// The pill row must never show more than four items, even when more are provided.
+    func testMaxVisibleCountIsFour() {
         let starters = (0..<10).map { i in
-            makeStarter(id: "\(i)", label: "Starter \(i)", prompt: "prompt \(i)")
-        }
-        XCTAssertEqual(visibleStarters(from: starters).count, 6)
-    }
-
-    /// Odd counts are rounded down to the nearest even number.
-    func testOddCountRoundsDown() {
-        let starters = (0..<5).map { i in
             makeStarter(id: "\(i)", label: "Starter \(i)", prompt: "prompt \(i)")
         }
         XCTAssertEqual(visibleStarters(from: starters).count, 4)
     }
 
-    /// A single starter produces no pills (rounds down to 0).
-    func testSingleStarterShowsNone() {
-        let starters = [makeStarter(id: "0", label: "Solo", prompt: "prompt")]
-        XCTAssertEqual(visibleStarters(from: starters).count, 0)
+    /// Odd counts stay visible so removing one chip does not hide another.
+    func testOddCountStaysVisible() {
+        let starters = (0..<3).map { i in
+            makeStarter(id: "\(i)", label: "Starter \(i)", prompt: "prompt \(i)")
+        }
+        XCTAssertEqual(visibleStarters(from: starters).count, 3)
     }
 
-    /// When given fewer than six even starters, all are shown.
+    /// A single remaining starter stays visible.
+    func testSingleStarterStaysVisible() {
+        let starters = [makeStarter(id: "0", label: "Solo", prompt: "prompt")]
+        XCTAssertEqual(visibleStarters(from: starters).count, 1)
+    }
+
+    /// When given fewer than four starters, all are shown.
     func testPillRowShowsAllWhenFewerThanCap() {
         let starters = (0..<2).map { i in
             makeStarter(id: "\(i)", label: "Starter \(i)", prompt: "prompt \(i)")

--- a/clients/shared/Features/Chat/ChatGreetingState.swift
+++ b/clients/shared/Features/Chat/ChatGreetingState.swift
@@ -27,6 +27,7 @@ public final class ChatGreetingState {
     public var conversationStartersLoading: Bool = false
 
     @ObservationIgnored nonisolated(unsafe) var conversationStarterPollTask: Task<Void, Never>?
+    @ObservationIgnored private var removedConversationStarterIds = Set<String>()
 
     // MARK: - Fallback Greetings
 
@@ -130,9 +131,26 @@ public final class ChatGreetingState {
         }
     }
 
+    public func removeConversationStarter(_ starter: ConversationStarter) {
+        removedConversationStarterIds.insert(starter.id)
+        conversationStarters.removeAll { $0.id == starter.id }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let deleted = await self.conversationStarterClient.deleteConversationStarter(id: starter.id)
+            guard !Task.isCancelled else { return }
+            if !deleted {
+                self.removedConversationStarterIds.remove(starter.id)
+                self.fetchConversationStarters()
+            }
+        }
+    }
+
     private func applyConversationStarterResponse(_ response: ConversationStartersResponse?) -> Bool {
         if let response, !response.starters.isEmpty {
-            conversationStarters = response.starters
+            conversationStarters = response.starters.filter {
+                !removedConversationStarterIds.contains($0.id)
+            }
         }
 
         let shouldPoll = response?.status == "generating" || response?.status == "refreshing"

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -43,6 +43,7 @@ struct ConversationStartersResponse: Codable {
 @MainActor
 protocol ConversationStarterClientProtocol {
     func fetchConversationStarters(limit: Int) async -> ConversationStartersResponse?
+    func deleteConversationStarter(id: String) async -> Bool
 }
 
 @MainActor
@@ -55,6 +56,17 @@ struct ConversationStarterClient: ConversationStarterClientProtocol {
             params: ["limit": String(limit)]
         ), response.isSuccess else { return nil }
         return try? JSONDecoder().decode(ConversationStartersResponse.self, from: response.data)
+    }
+
+    func deleteConversationStarter(id: String) async -> Bool {
+        guard let response = try? await GatewayHTTPClient.delete(
+            path: "assistants/{assistantId}/conversation-starters/\(Self.pathEscape(id))"
+        ) else { return false }
+        return response.isSuccess || response.statusCode == 404
+    }
+
+    private static func pathEscape(_ component: String) -> String {
+        component.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? component
     }
 }
 
@@ -1323,6 +1335,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
 
     public func fetchConversationStarters() {
         greetingState.fetchConversationStarters()
+    }
+
+    public func removeConversationStarter(_ starter: ConversationStarter) {
+        greetingState.removeConversationStarter(starter)
     }
 
     func bootstrapConversation(userMessage: String?, attachments: [UserMessageAttachment]?) {

--- a/clients/shared/Tests/ChatGreetingStateTests.swift
+++ b/clients/shared/Tests/ChatGreetingStateTests.swift
@@ -6,12 +6,20 @@ final class ChatGreetingStateTests: XCTestCase {
 
     private final class StubConversationStarterClient: ConversationStarterClientProtocol {
         var responses: [ConversationStartersResponse?] = []
+        var deleteResults: [Bool] = []
         var fetchCallCount = 0
+        var deletedIds: [String] = []
 
         func fetchConversationStarters(limit: Int) async -> ConversationStartersResponse? {
             fetchCallCount += 1
             guard !responses.isEmpty else { return nil }
             return responses.removeFirst()
+        }
+
+        func deleteConversationStarter(id: String) async -> Bool {
+            deletedIds.append(id)
+            guard !deleteResults.isEmpty else { return true }
+            return deleteResults.removeFirst()
         }
     }
 
@@ -69,5 +77,51 @@ final class ChatGreetingStateTests: XCTestCase {
         XCTAssertEqual(client.fetchCallCount, 2)
 
         state.cancelAll()
+    }
+
+    func testRemoveConversationStarterOptimisticallyDeletesAndCallsClient() async {
+        let starters = [
+            makeStarter(id: "starter-1", label: "Starter 1"),
+            makeStarter(id: "starter-2", label: "Starter 2"),
+        ]
+        let client = StubConversationStarterClient()
+        client.deleteResults = [true]
+        let state = ChatGreetingState(conversationStarterClient: client)
+        state.conversationStarters = starters
+
+        state.removeConversationStarter(starters[0])
+        await Task.yield()
+
+        XCTAssertEqual(state.conversationStarters.map(\.id), ["starter-2"])
+        XCTAssertEqual(client.deletedIds, ["starter-1"])
+        XCTAssertEqual(client.fetchCallCount, 0)
+    }
+
+    func testRemoveConversationStarterRefetchesOnDeleteFailure() async {
+        let staleStarters = [
+            makeStarter(id: "starter-1", label: "Starter 1"),
+            makeStarter(id: "starter-2", label: "Starter 2"),
+        ]
+        let refreshedStarters = [
+            makeStarter(id: "starter-3", label: "Starter 3"),
+        ]
+        let client = StubConversationStarterClient()
+        client.deleteResults = [false]
+        client.responses = [
+            ConversationStartersResponse(
+                starters: refreshedStarters,
+                total: refreshedStarters.count,
+                status: "ready"
+            ),
+        ]
+        let state = ChatGreetingState(conversationStarterClient: client)
+        state.conversationStarters = staleStarters
+
+        state.removeConversationStarter(staleStarters[0])
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(client.deletedIds, ["starter-1"])
+        XCTAssertEqual(state.conversationStarters.map(\.id), ["starter-3"])
     }
 }


### PR DESCRIPTION
## Summary
- Added a DELETE route for generated conversation starter chips and updated OpenAPI/policy metadata.
- Wired the macOS empty-chat starter pills to a right-click Remove menu backed by optimistic local deletion.
- Updated starter route/state/pill tests for deletion and remaining-chip visibility.

## Original prompt
[$do] --yolo --skip-ci the plan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
