### PR TITLE
Set OpenAI default model to GPT-5.5

### DIFF
--- a/assistant/src/__tests__/model-intents.test.ts
+++ b/assistant/src/__tests__/model-intents.test.ts
@@ -30,6 +30,10 @@ describe("model intents", () => {
     );
   });
 
+  test("uses GPT-5.5 as the OpenAI provider default", () => {
+    expect(getProviderDefaultModel("openai")).toBe("gpt-5.5");
+  });
+
   test("falls back to provider default for unknown providers", () => {
     expect(getProviderDefaultModel("unknown-provider")).toBe(
       "claude-sonnet-4-6",

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -208,7 +208,7 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         },
       },
     ],
-    defaultModel: "gpt-5.4",
+    defaultModel: "gpt-5.5",
     apiKeyUrl: "https://platform.openai.com/api-keys",
     apiKeyPlaceholder: "sk-proj-...",
   },

--- a/clients/shared/Tests/LLMProviderRegistryTests.swift
+++ b/clients/shared/Tests/LLMProviderRegistryTests.swift
@@ -35,6 +35,7 @@ final class LLMProviderRegistryTests: XCTestCase {
         XCTAssertEqual(openai?.displayName, "OpenAI")
         XCTAssertEqual(openai?.setupMode, .apiKey)
         XCTAssertEqual(openai?.envVar, "OPENAI_API_KEY")
+        XCTAssertEqual(openai?.defaultModel, "gpt-5.5")
 
         let ollama = LLMProviderRegistry.provider(id: "ollama")
         XCTAssertNotNil(ollama)

--- a/clients/shared/Utilities/LLMProviderRegistry.swift
+++ b/clients/shared/Utilities/LLMProviderRegistry.swift
@@ -258,7 +258,7 @@ private let fallbackCatalog = LLMProviderCatalog(
                 url: "https://platform.openai.com/api-keys",
                 linkLabel: "Open OpenAI Platform"
             ),
-            defaultModel: "gpt-5.4",
+            defaultModel: "gpt-5.5",
             models: [
                 LLMModelEntry(id: "gpt-5.5", displayName: "GPT-5.5"),
                 LLMModelEntry(id: "gpt-5.4", displayName: "GPT-5.4"),

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -95,7 +95,7 @@
         "url": "https://platform.openai.com/api-keys",
         "linkLabel": "Open OpenAI Platform"
       },
-      "defaultModel": "gpt-5.4",
+      "defaultModel": "gpt-5.5",
       "models": [
         {
           "id": "gpt-5.5",


### PR DESCRIPTION
## Summary
- Set OpenAI provider defaults to GPT-5.5 in the daemon catalog, client JSON catalog, and Swift fallback registry.
- Add targeted regression assertions for the daemon default helper and Swift fallback registry.

## Original prompt
/do --yolo --skip-ci this plan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
