### PR TITLE
fix: conversation-starter-routes test type error and 404 assertion

### DIFF
--- a/assistant/src/__tests__/conversation-starter-routes.test.ts
+++ b/assistant/src/__tests__/conversation-starter-routes.test.ts
@@ -10,6 +10,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 import { getSqlite, initializeDb } from "../memory/db.js";
+import type { RouteParams } from "../runtime/http-router.js";
 import {
   CONVERSATION_STARTERS_STALE_TTL_MS,
   conversationStarterRouteDefinitions,
@@ -30,7 +31,7 @@ function dispatch(path: string, method = "GET"): Response | Promise<Response> {
         r.endpoint === "conversation-starters/:id"),
   );
   if (!route) throw new Error("No conversation-starters route found");
-  const params =
+  const params: RouteParams =
     method === "DELETE"
       ? { id: decodeURIComponent(path.split("/").at(-1) ?? "") }
       : {};
@@ -380,10 +381,10 @@ describe("GET /v1/conversation-starters", () => {
 
   test("returns 404 when deleting an unknown starter", async () => {
     const res = await dispatch(`conversation-starters/${uuid()}`, "DELETE");
-    const body = (await res.json()) as { error: string };
+    const body = (await res.json()) as { error: { code: string } };
 
     expect(res.status).toBe(404);
-    expect(body.error).toBe("NOT_FOUND");
+    expect(body.error.code).toBe("NOT_FOUND");
     expect(countStarterJobs()).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Annotate the `dispatch()` test helper's `params` variable as `RouteParams` so the conditional literal narrows correctly (was failing TS2322 on the optional `id`).
- Update the \"returns 404 when deleting an unknown starter\" test to read `body.error.code` instead of `body.error`, matching the standard `httpError()` envelope shape.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24940672612/job/73033758953
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
