### PR TITLE
fix(ios): add missing return in IOSConversationStore.load closure

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -1696,7 +1696,7 @@ class IOSConversationStore: ObservableObject {
         return zip(persisted, legacyEphemeralFlags).compactMap { persistedConversation, isLegacyEphemeral in
             let p = persistedConversation
             guard !isLegacyEphemeral else { return nil }
-            IOSConversation(
+            return IOSConversation(
                 id: p.id,
                 title: p.title,
                 createdAt: p.createdAt,


### PR DESCRIPTION
## Summary
- The closure passed to `compactMap` in `IOSConversationStore.load` constructed an `IOSConversation` but never returned it, breaking the iOS build with `error: missing return in closure expected to return 'IOSConversation?'`.
- Added the missing `return` keyword.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24940585313/job/73033535991
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
