### PR TITLE
Show profile picker for new conversations

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5632,6 +5632,9 @@ paths:
                   type: string
                 slashCommand:
                   type: string
+                inferenceProfile:
+                  type: string
+                  nullable: true
               required:
                 - content
               additionalProperties: false

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -62,7 +62,11 @@ import {
   writeRelationshipState,
 } from "../../home/relationship-state-writer.js";
 import { rewriteCommandPreview } from "../../home/rewrite-command-preview.js";
-import { getAttachmentById, getAttachmentMetadataForMessage, getAttachmentsByIds } from "../../memory/attachments-store.js";
+import {
+  getAttachmentById,
+  getAttachmentMetadataForMessage,
+  getAttachmentsByIds,
+} from "../../memory/attachments-store.js";
 import {
   createCanonicalGuardianRequest,
   generateCanonicalRequestCode,
@@ -78,6 +82,7 @@ import {
   hasMessages,
   type MessageRow,
   provenanceFromTrustContext,
+  setConversationInferenceProfile,
   setConversationOriginChannelIfUnset,
   setConversationOriginInterfaceIfUnset,
 } from "../../memory/conversation-crud.js";
@@ -1432,6 +1437,7 @@ export async function handleSendMessage(
     hostUsername?: string;
     clientId?: string;
     clientMessageId?: string;
+    inferenceProfile?: string | null;
     onboarding?: {
       tools: string[];
       tasks: string[];
@@ -1444,6 +1450,39 @@ export async function handleSendMessage(
   const { conversationKey, content, attachmentIds } = body;
   const clientMessageId =
     typeof body.clientMessageId === "string" ? body.clientMessageId : undefined;
+  const requestedInferenceProfile =
+    typeof body.inferenceProfile === "string"
+      ? body.inferenceProfile
+      : undefined;
+  if (
+    body.inferenceProfile != null &&
+    typeof body.inferenceProfile !== "string"
+  ) {
+    return httpError(
+      "BAD_REQUEST",
+      "inferenceProfile must be a non-empty string or null",
+      400,
+    );
+  }
+  if (requestedInferenceProfile === "") {
+    return httpError(
+      "BAD_REQUEST",
+      "inferenceProfile must be a non-empty string or null",
+      400,
+    );
+  }
+  if (requestedInferenceProfile !== undefined) {
+    const profiles = getConfig().llm.profiles ?? {};
+    if (
+      !Object.prototype.hasOwnProperty.call(profiles, requestedInferenceProfile)
+    ) {
+      return httpError(
+        "BAD_REQUEST",
+        `Profile "${requestedInferenceProfile}" is not defined in llm.profiles`,
+        400,
+      );
+    }
+  }
   if (!body.sourceChannel || typeof body.sourceChannel !== "string") {
     return httpError("BAD_REQUEST", "sourceChannel is required", 400);
   }
@@ -1589,6 +1628,13 @@ export async function handleSendMessage(
     mapping.conversationId,
     { transport },
   );
+
+  if (requestedInferenceProfile !== undefined) {
+    setConversationInferenceProfile(
+      mapping.conversationId,
+      requestedInferenceProfile,
+    );
+  }
 
   // Store pre-chat onboarding context on the conversation when this is the
   // very first message (no prior messages loaded). Artifact persistence
@@ -2664,6 +2710,7 @@ export function conversationRouteDefinitions(deps: {
           .optional(),
         conversationType: z.string().optional(),
         slashCommand: z.string().optional(),
+        inferenceProfile: z.string().nullable().optional(),
       }),
       handler: async ({ req, authContext }) =>
         handleSendMessage(

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -34,6 +34,7 @@ struct ChatEmptyStateView: View {
     var onFetchConversationStarters: (() -> Void)? = nil
     var conversationHostAccessControl: ConversationHostAccessControlConfiguration? = nil
     var showThresholdPicker: Bool = false
+    var inferenceProfilePicker: ChatProfilePickerConfiguration? = nil
 
     @State private var visible = false
     @State private var fallbackPlaceholder: String = placeholderTexts.randomElement()!
@@ -181,7 +182,8 @@ struct ChatEmptyStateView: View {
                 placeholderText: fallbackPlaceholder,
                 conversationId: conversationId,
                 conversationHostAccessControl: conversationHostAccessControl,
-                showThresholdPicker: showThresholdPicker
+                showThresholdPicker: showThresholdPicker,
+                inferenceProfilePicker: inferenceProfilePicker
             )
             .equatable()
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
@@ -23,9 +23,11 @@ struct ChatProfilePickerConfiguration {
 }
 
 /// A compact pill button in the composer action bar that lets the user pick a
-/// per-conversation inference profile override. Opens a dropdown with every
-/// profile defined in `SettingsStore.profiles`, plus a "Reset to default"
-/// item that clears the override and falls back to `llm.activeProfile`.
+/// per-conversation inference profile override. Draft conversations stage the
+/// selected profile locally until the first message creates the conversation.
+/// Opens a dropdown with every profile defined in `SettingsStore.profiles`,
+/// plus a "Reset to default" item that clears the override and falls back to
+/// `llm.activeProfile`.
 ///
 /// State ownership: the pill is stateless. The label is derived from the
 /// `current` override plus `activeProfile`; selection is forwarded straight to
@@ -33,11 +35,8 @@ struct ChatProfilePickerConfiguration {
 /// updates the local conversation model and persists to the daemon.
 @MainActor
 struct ChatProfilePicker: View {
-    /// Whether the picker can be opened. `false` disables the pill — used
-    /// for not-yet-persisted draft conversations where there's no
-    /// conversation id to attach the override to. The actual conversation
-    /// id needed for persistence is captured into ``onSelect`` by the
-    /// parent.
+    /// Whether the picker can be opened. The actual persistence or staging
+    /// destination is captured into ``onSelect`` by the parent.
     let isEnabled: Bool
 
     /// The current per-conversation inference-profile override. `nil` means

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -308,7 +308,8 @@ struct ChatView: View {
                     onRemoveStarter: { starter in viewModel.removeConversationStarter(starter) },
                     onFetchConversationStarters: { viewModel.fetchConversationStarters() },
                     conversationHostAccessControl: conversationHostAccessControl,
-                    showThresholdPicker: showThresholdPicker
+                    showThresholdPicker: showThresholdPicker,
+                    inferenceProfilePicker: inferenceProfilePicker
                 )
                 .id(conversationId)
             } else {
@@ -526,10 +527,14 @@ struct ChatView: View {
     private var inferenceProfilePicker: ChatProfilePickerConfiguration? {
         guard let conversationManager else { return nil }
         return ChatProfilePickerConfiguration(
-            current: currentConversation?.inferenceProfile,
+            current: currentConversation?.inferenceProfile ?? viewModel.pendingInferenceProfile,
             profiles: inferenceProfiles,
             activeProfile: activeInferenceProfile,
             onSelect: { profile in
+                if conversationId == nil {
+                    viewModel.pendingInferenceProfile = profile
+                    return
+                }
                 guard let conversationId else { return }
                 Task { @MainActor in
                     await conversationManager.setConversationInferenceProfile(

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -483,7 +483,7 @@ struct ComposerView: View, Equatable {
 
             if let inferenceProfilePicker, !inferenceProfilePicker.profiles.isEmpty {
                 ChatProfilePicker(
-                    isEnabled: conversationId != nil,
+                    isEnabled: true,
                     current: inferenceProfilePicker.current,
                     profiles: inferenceProfilePicker.profiles,
                     activeProfile: inferenceProfilePicker.activeProfile,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -565,7 +565,12 @@ final class ConversationManager: ConversationRestorerDelegate {
         // references it (e.g. `.appEditing(_, draftLocalId)`) stays valid
         // without an extra state transition after promotion.
         let localId = selectionStore.draftLocalId ?? UUID()
-        let conversation = ConversationModel(id: localId, title: "Untitled", groupId: ConversationGroup.all.id)
+        let conversation = ConversationModel(
+            id: localId,
+            title: "Untitled",
+            groupId: ConversationGroup.all.id,
+            inferenceProfile: viewModel.pendingInferenceProfile
+        )
         listStore.conversations.insert(conversation, at: 0)
         selectionStore.chatViewModels[conversation.id] = viewModel
         activityStore.observeBusyState(for: conversation.id, messageManager: viewModel.messageManager)
@@ -1128,6 +1133,12 @@ final class ConversationManager: ConversationRestorerDelegate {
     /// model is rolled back).
     @discardableResult
     func setConversationInferenceProfile(id localId: UUID, profile: String?) async -> Bool {
+        if localId == selectionStore.draftLocalId,
+           let draftViewModel = selectionStore.draftViewModel {
+            draftViewModel.pendingInferenceProfile = profile
+            return true
+        }
+
         guard let index = listStore.conversations.firstIndex(where: { $0.id == localId }),
               let conversationId = listStore.conversations[index].conversationId else {
             return false

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -712,7 +712,7 @@ extension MainWindowView {
                 onVoiceModeToggle: isVoiceModeEnabled ? {
                     toggleVoiceMode()
                 } : nil,
-                conversationId: conversationManager.activeConversationId,
+                conversationId: conversationManager.activeConversationId ?? conversationManager.draftLocalId,
                 anchorMessageId: $conversationManager.pendingAnchorMessageId,
                 highlightedMessageId: $conversationManager.highlightedMessageId
             )

--- a/clients/macos/vellum-assistantTests/Features/Chat/ConversationManagerInferenceProfileTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ConversationManagerInferenceProfileTests.swift
@@ -156,6 +156,32 @@ final class ConversationManagerInferenceProfileTests: XCTestCase {
         XCTAssertNil(conversationManager.conversations[0].inferenceProfile)
     }
 
+    func testSetConversationInferenceProfileStagesDraftSelection() async throws {
+        let draftLocalId = try XCTUnwrap(conversationManager.draftLocalId)
+        let draftViewModel = try XCTUnwrap(conversationManager.draftViewModel)
+
+        let success = await conversationManager.setConversationInferenceProfile(
+            id: draftLocalId,
+            profile: "quality-optimized"
+        )
+
+        XCTAssertTrue(success)
+        XCTAssertTrue(mockProfileClient.setCalls.isEmpty)
+        XCTAssertEqual(draftViewModel.pendingInferenceProfile, "quality-optimized")
+        XCTAssertTrue(conversationManager.conversations.isEmpty)
+    }
+
+    func testDraftSelectionCarriesIntoPromotedConversation() throws {
+        let draftLocalId = try XCTUnwrap(conversationManager.draftLocalId)
+        let draftViewModel = try XCTUnwrap(conversationManager.draftViewModel)
+        draftViewModel.pendingInferenceProfile = "cost-optimized"
+
+        draftViewModel.onUserMessageSent?()
+
+        XCTAssertEqual(conversationManager.conversations.first?.id, draftLocalId)
+        XCTAssertEqual(conversationManager.conversations.first?.inferenceProfile, "cost-optimized")
+    }
+
     // MARK: - Event-hub convergence
 
     func testConversationInferenceProfileUpdatedEventMergesIntoConversation() async throws {

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -410,11 +410,13 @@ final class ChatActionHandler {
                 let attachments = vm.pendingUserAttachments
                 let automated = vm.pendingUserMessageAutomated
                 let pendingClientMessageId = vm.pendingUserMessageClientMessageId
+                let pendingInferenceProfile = vm.pendingUserInferenceProfile
                 vm.pendingUserMessage = nil
                 vm.pendingUserMessageDisplayText = nil
                 vm.pendingUserAttachments = nil
                 vm.pendingUserMessageAutomated = false
                 vm.pendingUserMessageClientMessageId = nil
+                vm.pendingUserInferenceProfile = nil
                 vm.eventStreamClient.sendUserMessage(
                     content: pending,
                     conversationId: info.conversationId,
@@ -422,7 +424,8 @@ final class ChatActionHandler {
                     conversationType: nil,
                     automated: automated ? true : nil,
                     bypassSecretCheck: nil,
-                    clientMessageId: pendingClientMessageId
+                    clientMessageId: pendingClientMessageId,
+                    inferenceProfile: pendingInferenceProfile
                 )
             } else {
                 // Message-less conversation create — conversation is claimed,

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -322,6 +322,8 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                     self.pendingUserMessageDisplayText = nil
                     self.pendingUserAttachments = nil
                     self.pendingUserMessageAutomated = false
+                    self.pendingUserMessageClientMessageId = nil
+                    self.pendingUserInferenceProfile = nil
                     // Queue tracking state
                     self.pendingQueuedCount = 0
                     self.pendingMessageIds.removeAll()
@@ -703,6 +705,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// actual POST, so the echo dedup in ChatActionHandler can match even when
     /// the conversation was not yet created at send-intent time.
     @ObservationIgnored var pendingUserMessageClientMessageId: String?
+    /// Inference profile selected while this chat is still a draft. Included
+    /// in the first POST so the first assistant turn uses the staged profile.
+    public var pendingInferenceProfile: String?
+    @ObservationIgnored var pendingUserInferenceProfile: String?
     /// Optional callback for sending notifications when tool-use messages complete
     @ObservationIgnored public var onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)?
     /// Whether the current assistant response was triggered by a voice message.

--- a/clients/shared/Features/Chat/MessageSendCoordinator.swift
+++ b/clients/shared/Features/Chat/MessageSendCoordinator.swift
@@ -29,6 +29,8 @@ protocol MessageSendCoordinatorDelegate: AnyObject {
     var pendingUserMessageDisplayText: String? { get set }
     var pendingUserMessageAutomated: Bool { get set }
     var pendingUserMessageClientMessageId: String? { get set }
+    var pendingInferenceProfile: String? { get set }
+    var pendingUserInferenceProfile: String? { get set }
     var pendingUserAttachments: [UserMessageAttachment]? { get set }
     var pendingVoiceMessage: Bool { get set }
     var lastFailedMessageText: String? { get set }
@@ -215,6 +217,7 @@ final class MessageSendCoordinator {
                 delegate.pendingUserMessageDisplayText = rawText
                 delegate.pendingUserMessageAutomated = hidden
                 delegate.pendingUserMessageClientMessageId = clientMessageId
+                delegate.pendingUserInferenceProfile = delegate.pendingInferenceProfile
                 delegate.pendingUserAttachments = attachments.isEmpty ? nil : attachments.map {
                     UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil, filePath: $0.filePath, rawData: $0.rawData)
                 }
@@ -340,6 +343,7 @@ final class MessageSendCoordinator {
         }
         delegate.pendingUserMessage = userMessage
         delegate.pendingUserAttachments = attachments
+        delegate.pendingUserInferenceProfile = userMessage == nil ? nil : delegate.pendingInferenceProfile
 
         // Generate a unique correlation ID so this ChatViewModel only claims
         // the conversation_info response that belongs to its own conversation_create request.
@@ -370,6 +374,7 @@ final class MessageSendCoordinator {
                     delegate.pendingUserAttachments = nil
                     delegate.pendingUserMessageAutomated = false
                     delegate.pendingUserMessageClientMessageId = nil
+                    delegate.pendingUserInferenceProfile = nil
                     self.errorManager.errorText = delegate.lastFailedSendError
                     return
                 }
@@ -398,12 +403,20 @@ final class MessageSendCoordinator {
                 let pendingAttachments = delegate.pendingUserAttachments
                 let automated = delegate.pendingUserMessageAutomated
                 let pendingClientMessageId = delegate.pendingUserMessageClientMessageId
+                let pendingInferenceProfile = delegate.pendingUserInferenceProfile
                 delegate.pendingUserMessage = nil
                 delegate.pendingUserMessageDisplayText = nil
                 delegate.pendingUserAttachments = nil
                 delegate.pendingUserMessageAutomated = false
                 delegate.pendingUserMessageClientMessageId = nil
-                self.sendUserMessage(pending, attachments: pendingAttachments, automated: automated, clientMessageId: pendingClientMessageId)
+                delegate.pendingUserInferenceProfile = nil
+                self.sendUserMessage(
+                    pending,
+                    attachments: pendingAttachments,
+                    automated: automated,
+                    clientMessageId: pendingClientMessageId,
+                    inferenceProfile: pendingInferenceProfile
+                )
             } else {
                 self.messageManager.isSending = false
                 self.messageManager.isThinking = false
@@ -413,7 +426,16 @@ final class MessageSendCoordinator {
 
     // MARK: - Send User Message
 
-    func sendUserMessage(_ text: String, displayText: String? = nil, attachments: [UserMessageAttachment]? = nil, queuedMessageId: UUID? = nil, automated: Bool = false, bypassSecretCheck: Bool = false, clientMessageId: String? = nil) {
+    func sendUserMessage(
+        _ text: String,
+        displayText: String? = nil,
+        attachments: [UserMessageAttachment]? = nil,
+        queuedMessageId: UUID? = nil,
+        automated: Bool = false,
+        bypassSecretCheck: Bool = false,
+        clientMessageId: String? = nil,
+        inferenceProfile: String? = nil
+    ) {
         guard let delegate else { return }
         guard let conversationId = delegate.conversationId else { return }
 
@@ -503,7 +525,8 @@ final class MessageSendCoordinator {
             automated: automated ? true : nil,
             bypassSecretCheck: bypassSecretCheck ? true : nil,
             onboarding: onboarding,
-            clientMessageId: clientMessageId
+            clientMessageId: clientMessageId,
+            inferenceProfile: inferenceProfile
         )
     }
 
@@ -518,6 +541,7 @@ final class MessageSendCoordinator {
         delegate.pendingUserAttachments = nil
         delegate.pendingUserMessageAutomated = false
         delegate.pendingUserMessageClientMessageId = nil
+        delegate.pendingUserInferenceProfile = nil
         messageManager.isWorkspaceRefinementInFlight = false
         messageManager.refinementMessagePreview = nil
         messageManager.refinementStreamingText = nil
@@ -560,6 +584,7 @@ final class MessageSendCoordinator {
             delegate.pendingUserAttachments = nil
             delegate.pendingUserMessageAutomated = false
             delegate.pendingUserMessageClientMessageId = nil
+            delegate.pendingUserInferenceProfile = nil
             delegate.bootstrapCorrelationId = nil
             messageManager.isWorkspaceRefinementInFlight = false
             messageManager.refinementMessagePreview = nil

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -219,7 +219,8 @@ public final class EventStreamClient {
         automated: Bool? = nil,
         bypassSecretCheck: Bool? = nil,
         onboarding: PreChatOnboardingContext? = nil,
-        clientMessageId: String? = nil
+        clientMessageId: String? = nil,
+        inferenceProfile: String? = nil
     ) {
         locallyOwnedConversationIds.insert(conversationId)
         pendingMappingLocalIds.insert(conversationId)
@@ -293,7 +294,8 @@ public final class EventStreamClient {
                 automated: automated,
                 bypassSecretCheck: bypassSecretCheck,
                 onboarding: onboarding,
-                clientMessageId: clientMessageId
+                clientMessageId: clientMessageId,
+                inferenceProfile: inferenceProfile
             )
 
             switch sendResult {

--- a/clients/shared/Network/MessageClient.swift
+++ b/clients/shared/Network/MessageClient.swift
@@ -31,7 +31,17 @@ public enum MessageSendResult: Sendable {
 public protocol MessageClientProtocol {
     func uploadAttachment(filename: String, mimeType: String, data: String, filePath: String?) async -> AttachmentUploadResult
     func uploadAttachmentMultipart(filename: String, mimeType: String, data: Data) async -> AttachmentUploadResult
-    func sendMessage(content: String?, conversationKey: String, attachmentIds: [String], conversationType: String?, automated: Bool?, bypassSecretCheck: Bool?, onboarding: PreChatOnboardingContext?, clientMessageId: String?) async -> MessageSendResult
+    func sendMessage(
+        content: String?,
+        conversationKey: String,
+        attachmentIds: [String],
+        conversationType: String?,
+        automated: Bool?,
+        bypassSecretCheck: Bool?,
+        onboarding: PreChatOnboardingContext?,
+        clientMessageId: String?,
+        inferenceProfile: String?
+    ) async -> MessageSendResult
 }
 
 /// Gateway-backed implementation of ``MessageClientProtocol``.
@@ -156,7 +166,17 @@ public struct MessageClient: MessageClientProtocol {
         }
     }
 
-    public func sendMessage(content: String?, conversationKey: String, attachmentIds: [String] = [], conversationType: String? = nil, automated: Bool? = nil, bypassSecretCheck: Bool? = nil, onboarding: PreChatOnboardingContext? = nil, clientMessageId: String? = nil) async -> MessageSendResult {
+    public func sendMessage(
+        content: String?,
+        conversationKey: String,
+        attachmentIds: [String] = [],
+        conversationType: String? = nil,
+        automated: Bool? = nil,
+        bypassSecretCheck: Bool? = nil,
+        onboarding: PreChatOnboardingContext? = nil,
+        clientMessageId: String? = nil,
+        inferenceProfile: String? = nil
+    ) async -> MessageSendResult {
         log.info("[send-pipeline] message request start — uploadedAttachmentIds=\(attachmentIds.count)")
 
         var body: [String: Any] = [
@@ -181,6 +201,9 @@ public struct MessageClient: MessageClientProtocol {
         }
         if let clientMessageId {
             body["clientMessageId"] = clientMessageId
+        }
+        if let inferenceProfile {
+            body["inferenceProfile"] = inferenceProfile
         }
         if let hostHomeDir = Self.hostHomeDir {
             body["hostHomeDir"] = hostHomeDir


### PR DESCRIPTION
## Summary
- Show the inference profile picker in the new-conversation composer.
- Stage draft profile selection locally and promote it when the conversation is created.
- Send the selected profile with the first message and persist it before the assistant run starts.

## Verification
- git diff --check
- assistant prettier on openapi.yaml and conversation-routes.ts
- pre-commit hook: secrets, generic examples, prettier, eslint
- pre-push Swift build was blocked by SwiftPM dependency resolution: no SwiftMath 1.7.3 version resolved
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
