### PR TITLE
Make recall synthesis trust local evidence

### DIFF
--- a/assistant/src/__tests__/context-search-agent-protocol.test.ts
+++ b/assistant/src/__tests__/context-search-agent-protocol.test.ts
@@ -113,6 +113,7 @@ describe("buildRecallAgentPrompt", () => {
     expect(prompt).toContain("search those candidates");
     expect(prompt).toContain("not mandatory search terms");
     expect(prompt).toContain("Report conflicts");
+    expect(prompt).toContain("Do not say the information is absent");
     expect(prompt).toContain("finish_recall tool call");
     expect(prompt).toContain("Allowed citation_ids: ev-1, ev-2");
     expect(prompt).toContain("id: ev-1");

--- a/assistant/src/__tests__/context-search-agent-runner.test.ts
+++ b/assistant/src/__tests__/context-search-agent-runner.test.ts
@@ -201,7 +201,9 @@ describe("runAgenticRecall", () => {
       },
     );
 
-    expect(result.content).toBe("Alice chose Friday.");
+    expect(result.content).toBe(
+      "Alice chose Friday.\n\nSearched sources: workspace.",
+    );
     expect(result.debug.mode).toBe("agentic");
     expect(result.debug.roundsUsed).toBe(1);
     expect(result.debug.finish).toEqual({
@@ -211,6 +213,119 @@ describe("runAgenticRecall", () => {
     expect(result.evidence.map((item) => item.id)).toEqual([
       "workspace:launch",
     ]);
+  });
+
+  test("rejects negative synthesized answers when relevant evidence exists", async () => {
+    configuredProvider = makeProvider([
+      toolResponse("finish_recall", {
+        answer:
+          "The available evidence does not contain information about where Alice lives.",
+        confidence: "low",
+        citation_ids: [],
+      }),
+    ]);
+    const searchCalls: SearchCall[] = [];
+
+    const result = await runAgenticRecall(
+      { query: "Where does Alice live?", sources: ["pkb"], max_results: 5 },
+      makeContext(),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter(
+              {
+                "alice lives residence": [
+                  makeEvidence("pkb:alice-home", {
+                    source: "pkb",
+                    title: "people/alice.md",
+                    locator: "people/alice.md:6",
+                    excerpt:
+                      "6: Lives at Bob's parents' house in Katy and has her own room there.",
+                    metadata: {
+                      retrieval: "lexical",
+                      path: "people/alice.md",
+                    },
+                  }),
+                ],
+              },
+              searchCalls,
+              "pkb",
+            ),
+          ],
+          readPkbContextEvidence: () => [],
+        },
+      },
+    );
+
+    expect(searchCalls.map((call) => call.query)).toEqual([
+      "Where does Alice live?",
+      "alice home address location",
+      "alice lives residence",
+    ]);
+    expect(result.debug).toMatchObject({
+      mode: "deterministic_fallback",
+      fallbackReason: "finish_answer_validation_failed",
+      fallbackDetail: "negative_or_incomplete_finish_with_relevant_evidence",
+    });
+    expect(result.content).toContain("Found evidence:");
+    expect(result.content).toContain("Lives at Bob's parents' house in Katy");
+    expect(result.content).toContain("Searched sources: pkb.");
+  });
+
+  test("seeds lead-in questions with declarative chain searches", async () => {
+    const searchCalls: SearchCall[] = [];
+    configuredProvider = makeProvider([
+      toolResponse("finish_recall", {
+        answer:
+          "Bob's April 24 letter followed the proud moment, the 1-in-99 hypothetical, and the direct evening disclosure.",
+        confidence: "high",
+        citation_ids: ["pkb:bob-letter-chain"],
+      }),
+    ]);
+
+    const result = await runAgenticRecall(
+      {
+        query: "What led to Bob's April 24 letter?",
+        sources: ["pkb"],
+        max_results: 5,
+      },
+      makeContext(),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter(
+              {
+                "bob april 24 letter": [
+                  makeEvidence("pkb:bob-letter-chain", {
+                    source: "pkb",
+                    title: "archive/2026-04-24.md",
+                    locator: "archive/2026-04-24.md:42",
+                    excerpt:
+                      "42: The day moved from the PROUD beat to the 1/99 hypothetical, then into Bob's letter and the direct disclosure.",
+                    metadata: {
+                      retrieval: "lexical",
+                      path: "archive/2026-04-24.md",
+                    },
+                  }),
+                ],
+              },
+              searchCalls,
+              "pkb",
+            ),
+          ],
+          readPkbContextEvidence: () => [],
+        },
+      },
+    );
+
+    expect(searchCalls.map((call) => call.query)).toEqual([
+      "What led to Bob's April 24 letter?",
+      "led bob april 24 letter",
+      "bob april 24 letter",
+      "bob april 24 letter context reason before chain",
+    ]);
+    expect(result.content).toContain("1-in-99 hypothetical");
+    expect(result.content).toContain("Searched sources: pkb.");
   });
 
   test("executes follow-up search_sources through narrowed local searches", async () => {
@@ -272,7 +387,9 @@ describe("runAgenticRecall", () => {
         signal: controller.signal,
       },
     ]);
-    expect(result.content).toBe("The decision note says Friday.");
+    expect(result.content).toBe(
+      "The decision note says Friday.\n\nSearched sources: workspace.",
+    );
     expect(result.debug.searchCalls).toEqual([
       {
         round: 1,
@@ -381,6 +498,66 @@ describe("runAgenticRecall", () => {
     expect(result.evidence.map((item) => item.id)).toEqual([
       "workspace:pointer",
       "workspace:scratch/handoff.md:1:path",
+    ]);
+  });
+
+  test("auto-inspects PKB-relative paths as workspace paths", async () => {
+    const root = makeTempDir();
+    writeWorkspaceFile(
+      root,
+      "pkb/archive/2026-04-24.md",
+      "The archive has the exact letter chain.",
+    );
+
+    const result = await runAgenticRecall(
+      {
+        query: "letter chain",
+        sources: ["pkb"],
+        max_results: 5,
+      },
+      makeContext(undefined, root),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter(
+              {
+                "letter chain": [
+                  makeEvidence("pkb:pointer", {
+                    source: "pkb",
+                    title: "archive/2026-04-24.md",
+                    locator: "archive/2026-04-24.md:42",
+                    excerpt: "The exact note is archive/2026-04-24.md.",
+                    metadata: {
+                      retrieval: "lexical",
+                      path: "archive/2026-04-24.md",
+                    },
+                  }),
+                ],
+              },
+              [],
+              "pkb",
+            ),
+          ],
+          readPkbContextEvidence: () => [],
+        },
+      },
+    );
+
+    expect(result.debug.inspectCalls).toEqual([
+      {
+        round: 0,
+        paths: ["pkb/archive/2026-04-24.md"],
+        reason:
+          "Automatically inspect exact workspace paths surfaced by seed evidence.",
+        evidenceCount: 1,
+      },
+    ]);
+    expect(result.content).toContain(
+      "Inspected workspace paths: pkb/archive/2026-04-24.md.",
+    );
+    expect(result.evidence.map((item) => item.id)).toEqual([
+      "pkb:pointer",
+      "workspace:pkb/archive/2026-04-24.md:1:path",
     ]);
   });
 
@@ -584,7 +761,9 @@ describe("runAgenticRecall", () => {
     const finalTools = providerCalls[1]?.[1] as Array<{ name: string }>;
     expect(finalTools.map((tool) => tool.name)).toEqual(["finish_recall"]);
     expect(result.evidence.map((item) => item.id)).toEqual(["workspace:more"]);
-    expect(result.content).toBe("The follow-up note resolves it.");
+    expect(result.content).toBe(
+      "The follow-up note resolves it.\n\nAvailable evidence:\n1. [workspace] workspace:more title (workspace:more.md): workspace:more excerpt\n2. [workspace] workspace:seed title (workspace:seed.md): workspace:seed excerpt\n\nSearched sources: workspace.",
+    );
   });
 
   test("rejects finish citations omitted from the prompted evidence table", async () => {

--- a/assistant/src/__tests__/context-search-fanout.test.ts
+++ b/assistant/src/__tests__/context-search-fanout.test.ts
@@ -184,6 +184,49 @@ describe("runDeterministicRecallSearch", () => {
     }
   });
 
+  test("pinned PKB context leaves excerpt budget for exact PKB hits", async () => {
+    const result = await runDeterministicRecallSearch(
+      { query: "where does alice live", sources: ["pkb"], max_results: 3 },
+      makeContext(),
+      {
+        adapters: [
+          makeAdapter("pkb", [
+            makeEvidence("pkb", {
+              id: "pkb:lexical:people/alice.md:5",
+              score: 0.2,
+              excerpt:
+                "5: - Lives at Bob's parents' house in Katy and has her own room.",
+              metadata: { retrieval: "lexical" },
+            }),
+          ]),
+        ],
+        readPkbContextEvidence: () => [
+          makeEvidence("pkb", {
+            id: "pkb:auto-inject",
+            title: "PKB auto-injected context",
+            locator: "pkb:auto-inject",
+            excerpt: "A".repeat(RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE * 2),
+          }),
+          makeEvidence("pkb", {
+            id: "pkb:NOW.md",
+            title: "NOW.md",
+            locator: "NOW.md",
+            excerpt: "B".repeat(RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE * 2),
+          }),
+        ],
+      },
+    );
+
+    expect(result.evidence.map((item) => item.id)).toContain(
+      "pkb:lexical:people/alice.md:5",
+    );
+    expect(
+      result.evidence.find(
+        (item) => item.id === "pkb:lexical:people/alice.md:5",
+      )?.excerpt,
+    ).toContain("Lives at Bob's parents' house in Katy");
+  });
+
   test("searches every source by default", async () => {
     const calls: RecallSource[] = [];
     await runDeterministicRecallSearch({ query: "deployment" }, makeContext(), {

--- a/assistant/src/__tests__/context-search-pkb-source.test.ts
+++ b/assistant/src/__tests__/context-search-pkb-source.test.ts
@@ -338,6 +338,42 @@ describe("PKB context-search source", () => {
     expect(result.evidence[0]?.excerpt).toContain("vanilla with raspberry");
   });
 
+  test("lexical PKB fallback finds declarative residence facts", async () => {
+    const root = makeTempDir();
+    embedVectors = [];
+    writeWorkspaceFile(
+      root,
+      "pkb/people/alice.md",
+      [
+        "# Alice",
+        "",
+        "Notes about family geography.",
+        "",
+        "- Lives at Bob's parents' house in Katy and has her own room.",
+      ].join("\n"),
+    );
+
+    const result = await searchPkbSource(
+      "alice lives residence home location address",
+      makeContext({ workingDir: root }),
+      5,
+    );
+
+    expect(result.evidence[0]).toMatchObject({
+      id: "pkb:lexical:people/alice.md:5",
+      source: "pkb",
+      title: "people/alice.md",
+      locator: "people/alice.md:5",
+      metadata: {
+        retrieval: "lexical",
+        matchedTerms: ["lives"],
+      },
+    });
+    expect(result.evidence[0]?.excerpt).toContain(
+      "Lives at Bob's parents' house in Katy",
+    );
+  });
+
   test("lexical PKB fallback preserves the matched line when context is long", async () => {
     const root = makeTempDir();
     embedVectors = [];

--- a/assistant/src/memory/context-search/agent-protocol.ts
+++ b/assistant/src/memory/context-search/agent-protocol.ts
@@ -202,6 +202,7 @@ export function buildRecallAgentPromptBundle(
     "- Treat requested output fields like flavor, decoration, message, recipient, timing, or plan details as things to answer, not mandatory search terms.",
     "- Do not use external web, internet, browser, or network sources.",
     "- Do not guess. If the evidence is missing, weak, or contradictory, say so.",
+    "- Do not say the information is absent while any supplied evidence contains relevant facts; cite and summarize the partial evidence instead.",
     "- Report conflicts in the answer or unresolved field instead of silently choosing one side.",
     "- Cite supporting evidence with exact citation_ids from the evidence table only.",
     "- The final output must be a finish_recall tool call.",

--- a/assistant/src/memory/context-search/agent-runner.ts
+++ b/assistant/src/memory/context-search/agent-runner.ts
@@ -9,9 +9,13 @@ import {
   buildRecallAgentPromptBundle,
   FINISH_RECALL_TOOL_DEFINITION,
   RECALL_AGENT_TOOL_DEFINITIONS,
+  type RecallAgentFinish,
   validateFinishRecallPayload,
 } from "./agent-protocol.js";
-import { formatDeterministicRecallAnswer } from "./format.js";
+import {
+  formatDeterministicRecallAnswer,
+  formatRecallFooter,
+} from "./format.js";
 import {
   isRecallSource,
   type NormalizedRecallInput,
@@ -43,7 +47,8 @@ export type AgenticRecallFallbackReason =
   | "timeout"
   | "no_valid_finish"
   | "round_limit"
-  | "citation_validation_failed";
+  | "citation_validation_failed"
+  | "finish_answer_validation_failed";
 
 export interface AgenticRecallSearchDebug {
   round: number;
@@ -93,6 +98,14 @@ const REFERENT_QUERY_PATTERN =
   /\b(asked about|referred to|talking about|mentioned|meant by|referent)\b/i;
 const DETAIL_QUERY_PATTERN =
   /\b(details?|specifics?|flavor|decoration|design|message|inscription|recipient|timing|plan)\b/i;
+const QUESTION_QUERY_PATTERN = /\b(where|what|why|how)\b/i;
+const LOCATION_QUERY_PATTERN =
+  /\b(where|live|lives|lived|living|residence|home|address|location|located)\b/i;
+const LEAD_IN_QUERY_PATTERN =
+  /\b(led to|lead to|leads to|what led|why|how did|chain|context|cause|reason)\b/i;
+
+const LOW_CONFIDENCE_AVAILABLE_EVIDENCE_MAX_ITEMS = 5;
+const AVAILABLE_EVIDENCE_EXCERPT_MAX_CHARS = 220;
 
 const DETAIL_EXPANSION_TERMS = [
   "paid",
@@ -115,6 +128,34 @@ const DETAIL_FIELD_TERMS = new Set([
   "specifics",
   "timing",
   "plan",
+]);
+
+const LOCATION_FIELD_TERMS = new Set([
+  "address",
+  "home",
+  "live",
+  "lived",
+  "lives",
+  "living",
+  "located",
+  "location",
+  "residence",
+  "where",
+]);
+
+const LEAD_IN_FIELD_TERMS = new Set([
+  "cause",
+  "chain",
+  "context",
+  "did",
+  "how",
+  "lead",
+  "leads",
+  "led",
+  "reason",
+  "to",
+  "what",
+  "why",
 ]);
 
 const NON_SALIENT_REFERENT_TERMS = new Set([
@@ -153,6 +194,36 @@ const NON_SALIENT_REFERENT_TERMS = new Set([
   "who",
   "with",
 ]);
+
+const FINISH_NEGATIVE_PATTERNS = [
+  /\bavailable evidence does not contain\b/i,
+  /\bavailable evidence doesn't contain\b/i,
+  /\bevidence does not contain\b/i,
+  /\bevidence doesn't contain\b/i,
+  /\bdoes not contain information\b/i,
+  /\bdoesn't contain information\b/i,
+  /\bno (?:reliable |available |relevant )?(?:evidence|information|results|answer)\b/i,
+  /\bnot enough evidence\b/i,
+  /\binsufficient evidence\b/i,
+  /\bunable to (?:answer|determine|find|provide)\b/i,
+  /\bcannot (?:answer|determine|find|provide)\b/i,
+  /\bcan't (?:answer|determine|find|provide)\b/i,
+  /\bonly the locator path\b/i,
+  /\bno text\b/i,
+];
+
+const PKB_RELATIVE_PATH_PREFIXES = [
+  "archive/",
+  "dpo/",
+  "essentials.md",
+  "INDEX.md",
+  "intimate/",
+  "people/",
+  "preferences/",
+  "procedures/",
+  "schedule/",
+  "us-arcs/",
+];
 
 export async function runAgenticRecall(
   input: RecallInput,
@@ -249,14 +320,17 @@ export async function runAgenticRecall(
       const finishResult = finishRecallFromToolUse(
         finishTool,
         promptBundle.evidence,
+        evidence,
         debug,
+        normalizedInput,
+        withFallbackEvidence(seedResult, evidence),
       );
       if (finishResult.ok) {
         return finishResult.answer;
       }
 
       if (!finishResult.ok) {
-        fallbackReason = "citation_validation_failed";
+        fallbackReason = finishResult.reason;
         fallbackDetail = finishResult.detail;
         break;
       }
@@ -322,6 +396,7 @@ export async function runAgenticRecall(
       evidence,
       debug,
       context,
+      searchResult: withFallbackEvidence(seedResult, evidence),
     });
     if (finalFinish.ok) {
       return finalFinish.answer;
@@ -397,8 +472,14 @@ async function runSeedRecallSearch(
 function buildReferentExpansionQueries(query: string): string[] {
   const shouldExpandReferent = REFERENT_QUERY_PATTERN.test(query);
   const shouldExpandDetails = DETAIL_QUERY_PATTERN.test(query);
+  const shouldExpandQuestion = QUESTION_QUERY_PATTERN.test(query);
+  const shouldExpandLocation = LOCATION_QUERY_PATTERN.test(query);
+  const shouldExpandLeadIn = LEAD_IN_QUERY_PATTERN.test(query);
   const terms = tokenizeReferentTerms(query);
-  if (terms.length === 0 || (!shouldExpandReferent && !shouldExpandDetails)) {
+  if (
+    terms.length === 0 ||
+    (!shouldExpandReferent && !shouldExpandDetails && !shouldExpandQuestion)
+  ) {
     return [];
   }
 
@@ -429,6 +510,26 @@ function buildReferentExpansionQueries(query: string): string[] {
     queries.push(`${lastTerm} ${DETAIL_EXPANSION_TERMS.join(" ")}`);
   }
 
+  if (shouldExpandQuestion && !shouldExpandLocation && terms.length > 1) {
+    queries.push(terms.join(" "));
+  }
+
+  if (shouldExpandLocation && firstTerm) {
+    const entityTerms = terms.filter((term) => !LOCATION_FIELD_TERMS.has(term));
+    const entity = entityTerms[0] ?? firstTerm;
+    queries.push(`${entity} home address location`);
+    queries.push(`${entity} lives residence`);
+  }
+
+  if (shouldExpandLeadIn && terms.length > 1) {
+    const leadTerms = terms.filter((term) => !LEAD_IN_FIELD_TERMS.has(term));
+    const focusedTerms = leadTerms.length > 0 ? leadTerms : terms;
+    queries.push(focusedTerms.join(" "));
+    if (focusedTerms.length > 1) {
+      queries.push(`${focusedTerms.join(" ")} context reason before chain`);
+    }
+  }
+
   return [...new Set(queries)].filter((candidate) => candidate !== query);
 }
 
@@ -448,6 +549,7 @@ async function tryFinalFinishRecall(options: {
   evidence: readonly RecallEvidence[];
   debug: AgenticRecallDebug;
   context: RecallSearchContext;
+  searchResult: DeterministicRecallSearchResult;
 }): Promise<
   | { ok: true; answer: AgenticRecallAnswer }
   | {
@@ -496,7 +598,10 @@ async function tryFinalFinishRecall(options: {
   const finishResult = finishRecallFromToolUse(
     finishTool,
     promptBundle.evidence,
+    options.evidence,
     options.debug,
+    options.normalizedInput,
+    options.searchResult,
   );
   if (finishResult.ok) {
     return finishResult;
@@ -504,38 +609,237 @@ async function tryFinalFinishRecall(options: {
 
   return {
     ok: false,
-    reason: "citation_validation_failed",
+    reason: finishResult.reason,
     detail: finishResult.detail,
   };
 }
 
 function finishRecallFromToolUse(
   finishTool: ToolUseContent,
-  evidence: readonly RecallEvidence[],
+  promptEvidence: readonly RecallEvidence[],
+  allEvidence: readonly RecallEvidence[],
   debug: AgenticRecallDebug,
-): { ok: true; answer: AgenticRecallAnswer } | { ok: false; detail: string } {
-  const validation = validateFinishRecallPayload(finishTool.input, evidence);
+  input: NormalizedRecallInput,
+  searchResult: DeterministicRecallSearchResult,
+):
+  | { ok: true; answer: AgenticRecallAnswer }
+  | { ok: false; reason: AgenticRecallFallbackReason; detail: string } {
+  const validation = validateFinishRecallPayload(
+    finishTool.input,
+    promptEvidence,
+  );
   if (!validation.ok) {
-    return { ok: false, detail: validation.reason };
+    return {
+      ok: false,
+      reason: "citation_validation_failed",
+      detail: validation.reason,
+    };
   }
 
   const finish = validation.finish;
-  const citedEvidence = selectCitedEvidence(evidence, finish.citationIds);
+  const answerValidation = validateFinishAnswerAgainstEvidence(
+    input.query,
+    finish,
+    allEvidence,
+  );
+  if (!answerValidation.ok) {
+    return {
+      ok: false,
+      reason: "finish_answer_validation_failed",
+      detail: answerValidation.reason,
+    };
+  }
+
+  const citedEvidence = selectCitedEvidence(promptEvidence, finish.citationIds);
   debug.finish = {
     confidence: finish.confidence,
     citationIds: finish.citationIds,
     ...(finish.unresolved ? { unresolved: finish.unresolved } : {}),
   };
+  const content = formatAgenticRecallContent({
+    answer: finish.answer,
+    availableEvidence: shouldAppendAvailableEvidence(finish)
+      ? selectAvailableEvidence(input.query, allEvidence, citedEvidence)
+      : [],
+    footer: formatRecallFooter({
+      searchedSources: searchResult.searchedSources,
+      inspectCalls: debug.inspectCalls,
+    }),
+  });
 
   return {
     ok: true,
     answer: {
-      content: finish.answer,
-      answer: finish.answer,
+      content,
+      answer: content,
       evidence: citedEvidence,
       debug,
     },
   };
+}
+
+function validateFinishAnswerAgainstEvidence(
+  query: string,
+  finish: RecallAgentFinish,
+  evidence: readonly RecallEvidence[],
+): { ok: true } | { ok: false; reason: string } {
+  if (!isNegativeOrIncompleteFinish(finish)) {
+    return { ok: true };
+  }
+
+  const relevantEvidence = selectRelevantEvidence(query, evidence);
+  if (relevantEvidence.length === 0) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    reason: "negative_or_incomplete_finish_with_relevant_evidence",
+  };
+}
+
+function isNegativeOrIncompleteFinish(finish: RecallAgentFinish): boolean {
+  const finishText = [finish.answer, ...(finish.unresolved ?? [])].join("\n");
+  return FINISH_NEGATIVE_PATTERNS.some((pattern) => pattern.test(finishText));
+}
+
+function shouldAppendAvailableEvidence(finish: RecallAgentFinish): boolean {
+  return finish.confidence === "low" || (finish.unresolved?.length ?? 0) > 0;
+}
+
+function selectAvailableEvidence(
+  query: string,
+  evidence: readonly RecallEvidence[],
+  citedEvidence: readonly RecallEvidence[],
+): RecallEvidence[] {
+  return dedupeEvidenceById([
+    ...citedEvidence,
+    ...selectRelevantEvidence(query, evidence),
+    ...evidence.filter(isUsableEvidence),
+  ]).slice(0, LOW_CONFIDENCE_AVAILABLE_EVIDENCE_MAX_ITEMS);
+}
+
+function selectRelevantEvidence(
+  query: string,
+  evidence: readonly RecallEvidence[],
+): RecallEvidence[] {
+  const queryTerms = tokenizeValidationTerms(query);
+  if (queryTerms.size === 0) {
+    return [];
+  }
+
+  return evidence.filter(
+    (item) =>
+      isUsableEvidence(item) &&
+      hasTermOverlap(queryTerms, tokenizeValidationTerms(evidenceText(item))),
+  );
+}
+
+function isUsableEvidence(item: RecallEvidence): boolean {
+  return item.excerpt.trim().length > 0 && item.metadata?.inspectError !== true;
+}
+
+function evidenceText(item: RecallEvidence): string {
+  const metadataPath = item.metadata?.path;
+  return [
+    item.title,
+    item.locator,
+    item.excerpt,
+    typeof metadataPath === "string" ? metadataPath : "",
+  ].join("\n");
+}
+
+function hasTermOverlap(
+  queryTerms: ReadonlySet<string>,
+  evidenceTerms: ReadonlySet<string>,
+): boolean {
+  for (const term of queryTerms) {
+    if (evidenceTerms.has(term)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function tokenizeValidationTerms(text: string): Set<string> {
+  const terms = new Set<string>();
+  for (const token of text.toLowerCase().match(/[a-z0-9_]+/g) ?? []) {
+    if (token.length < 2 || NON_SALIENT_REFERENT_TERMS.has(token)) {
+      continue;
+    }
+    terms.add(token);
+    terms.add(stemValidationTerm(token));
+  }
+  return terms;
+}
+
+function stemValidationTerm(term: string): string {
+  if (term.length > 4 && term.endsWith("ies")) {
+    return `${term.slice(0, -3)}y`;
+  }
+  if (term.length > 3 && term.endsWith("s") && !term.endsWith("ss")) {
+    return term.slice(0, -1);
+  }
+  return term;
+}
+
+function formatAgenticRecallContent(options: {
+  answer: string;
+  availableEvidence: readonly RecallEvidence[];
+  footer: string;
+}): string {
+  return [
+    options.answer.trim(),
+    formatAvailableEvidence(options.availableEvidence),
+    options.footer,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function formatAvailableEvidence(evidence: readonly RecallEvidence[]): string {
+  if (evidence.length === 0) {
+    return "";
+  }
+
+  return [
+    "Available evidence:",
+    ...evidence.map((item, index) => {
+      const excerpt = compactText(
+        item.excerpt,
+        AVAILABLE_EVIDENCE_EXCERPT_MAX_CHARS,
+      );
+      return `${index + 1}. [${item.source}] ${item.title} (${item.locator}): ${excerpt}`;
+    }),
+  ].join("\n");
+}
+
+function compactText(text: string, maxChars: number): string {
+  const compacted = text.trim().replace(/\s+/g, " ");
+  if (compacted.length <= maxChars) {
+    return compacted;
+  }
+  if (maxChars <= 3) {
+    return compacted.slice(0, maxChars);
+  }
+  return `${compacted.slice(0, maxChars - 3).trimEnd()}...`;
+}
+
+function dedupeEvidenceById(
+  evidence: readonly RecallEvidence[],
+): RecallEvidence[] {
+  const seen = new Set<string>();
+  const deduped: RecallEvidence[] = [];
+
+  for (const item of evidence) {
+    if (seen.has(item.id)) {
+      continue;
+    }
+    seen.add(item.id);
+    deduped.push(item);
+  }
+
+  return deduped;
 }
 
 async function executeSearchSources(
@@ -614,10 +918,19 @@ async function executeInspectWorkspacePaths(
   const reason = readSearchReason(payload.reason);
   const requestedPaths = readInspectPaths(payload.paths);
   const allowedPaths = collectInspectableWorkspacePaths(input.query, evidence);
-  const acceptedPaths = requestedPaths.filter((path) => allowedPaths.has(path));
-  const rejectedPaths = requestedPaths.filter(
-    (path) => !allowedPaths.has(path),
-  );
+  const acceptedPaths: string[] = [];
+  const rejectedPaths: string[] = [];
+  for (const requestedPath of requestedPaths) {
+    const acceptedPath = normalizeRequestedWorkspaceInspectionPath(
+      requestedPath,
+      allowedPaths,
+    );
+    if (acceptedPath) {
+      acceptedPaths.push(acceptedPath);
+    } else {
+      rejectedPaths.push(requestedPath);
+    }
+  }
 
   const debug: AgenticRecallInspectDebug = {
     round,
@@ -693,7 +1006,7 @@ async function runAutomaticWorkspaceInspection(
   evidence: RecallEvidence[];
   debug?: AgenticRecallInspectDebug;
 }> {
-  if (!input.sources.includes("workspace")) {
+  if (!input.sources.includes("workspace") && !input.sources.includes("pkb")) {
     return { evidence: [] };
   }
 
@@ -755,12 +1068,7 @@ function collectAutomaticWorkspaceInspectionPaths(
 ): string[] {
   const paths = new Set(extractWorkspacePathLiterals(query));
   for (const item of evidence) {
-    if (item.source !== "workspace") {
-      continue;
-    }
-    for (const path of extractWorkspacePathLiterals(item.excerpt)) {
-      paths.add(path);
-    }
+    collectEvidenceWorkspacePaths(item).forEach((path) => paths.add(path));
   }
   return [...paths].filter(isSafeWorkspaceRelativePath).slice(0, 3);
 }
@@ -771,25 +1079,72 @@ function collectInspectableWorkspacePaths(
 ): Set<string> {
   const paths = new Set(extractWorkspacePathLiterals(query));
   for (const item of evidence) {
-    const metadataPath = item.metadata?.path;
-    if (
-      typeof metadataPath === "string" &&
-      isSafeWorkspaceRelativePath(metadataPath)
-    ) {
-      paths.add(metadataPath);
-    }
-
-    for (const path of extractWorkspacePathLiterals(item.locator)) {
-      paths.add(path);
-    }
-    for (const path of extractWorkspacePathLiterals(item.title)) {
-      paths.add(path);
-    }
-    for (const path of extractWorkspacePathLiterals(item.excerpt)) {
-      paths.add(path);
-    }
+    collectEvidenceWorkspacePaths(item).forEach((path) => paths.add(path));
   }
   return paths;
+}
+
+function collectEvidenceWorkspacePaths(item: RecallEvidence): string[] {
+  if (isPinnedPkbContextEvidence(item)) {
+    return [];
+  }
+
+  const rawPaths = new Set<string>();
+  const metadataPath = item.metadata?.path;
+  if (typeof metadataPath === "string") {
+    rawPaths.add(metadataPath);
+  }
+  for (const text of [item.locator, item.title, item.excerpt]) {
+    for (const path of extractWorkspacePathLiterals(text)) {
+      rawPaths.add(path);
+    }
+  }
+
+  const paths: string[] = [];
+  for (const rawPath of rawPaths) {
+    for (const path of normalizeEvidenceWorkspacePath(rawPath, item.source)) {
+      if (isSafeWorkspaceRelativePath(path)) {
+        paths.push(path);
+      }
+    }
+  }
+  return [...new Set(paths)];
+}
+
+function isPinnedPkbContextEvidence(item: RecallEvidence): boolean {
+  return item.id === "pkb:auto-inject" || item.id === "pkb:NOW.md";
+}
+
+function normalizeRequestedWorkspaceInspectionPath(
+  requestedPath: string,
+  allowedPaths: ReadonlySet<string>,
+): string | null {
+  const pkbPrefixedPath = `pkb/${requestedPath}`;
+  if (!requestedPath.startsWith("pkb/") && allowedPaths.has(pkbPrefixedPath)) {
+    return pkbPrefixedPath;
+  }
+
+  if (allowedPaths.has(requestedPath)) {
+    return requestedPath;
+  }
+
+  return null;
+}
+
+function normalizeEvidenceWorkspacePath(
+  path: string,
+  source: RecallSource,
+): string[] {
+  if (path.startsWith("pkb/")) {
+    return [path];
+  }
+  if (
+    source === "pkb" ||
+    PKB_RELATIVE_PATH_PREFIXES.some((prefix) => path.startsWith(prefix))
+  ) {
+    return [`pkb/${path}`];
+  }
+  return [path];
 }
 
 function makeWorkspaceInspectionErrorEvidence(options: {
@@ -897,7 +1252,9 @@ function deterministicFallback(
   reason: AgenticRecallFallbackReason,
   detail: string,
 ): AgenticRecallAnswer {
-  const fallback = formatDeterministicRecallAnswer(result);
+  const fallback = formatDeterministicRecallAnswer(result, {
+    inspectCalls: debug.inspectCalls,
+  });
   return {
     content: fallback.answer,
     answer: fallback.answer,

--- a/assistant/src/memory/context-search/format.ts
+++ b/assistant/src/memory/context-search/format.ts
@@ -1,17 +1,37 @@
-import type { DeterministicRecallSearchResult } from "./search.js";
+import type {
+  DeterministicRecallSearchResult,
+  DeterministicRecallSourceNote,
+} from "./search.js";
 import type { RecallAnswer, RecallEvidence } from "./types.js";
 
 const CITATION_EXCERPT_MAX_CHARS = 280;
 
+export interface RecallFooterInspectCall {
+  paths: readonly string[];
+  errors?: readonly { path: string; reason: string }[];
+}
+
+export interface RecallFooterOptions {
+  searchedSources: readonly DeterministicRecallSourceNote[];
+  inspectCalls?: readonly RecallFooterInspectCall[];
+}
+
+export interface FormatDeterministicRecallAnswerOptions {
+  inspectCalls?: readonly RecallFooterInspectCall[];
+}
+
 export function formatDeterministicRecallAnswer(
   result: DeterministicRecallSearchResult,
+  options: FormatDeterministicRecallAnswerOptions = {},
 ): RecallAnswer {
   if (result.evidence.length === 0) {
     return {
       answer: [
         "No reliable results found.",
-        formatSearchedSources(result),
-        formatDegradedSources(result),
+        formatRecallFooter({
+          searchedSources: result.searchedSources,
+          inspectCalls: options.inspectCalls,
+        }),
       ]
         .filter(Boolean)
         .join("\n"),
@@ -23,13 +43,26 @@ export function formatDeterministicRecallAnswer(
     answer: [
       "Found evidence:",
       ...result.evidence.map(formatCitation),
-      formatSearchedSources(result),
-      formatDegradedSources(result),
+      formatRecallFooter({
+        searchedSources: result.searchedSources,
+        inspectCalls: options.inspectCalls,
+      }),
     ]
       .filter(Boolean)
       .join("\n"),
     evidence: result.evidence,
   };
+}
+
+export function formatRecallFooter(options: RecallFooterOptions): string {
+  return [
+    formatSearchedSources(options.searchedSources),
+    formatDegradedSources(options.searchedSources),
+    formatInspectedWorkspacePaths(options.inspectCalls ?? []),
+    formatWorkspaceInspectionIssues(options.inspectCalls ?? []),
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 function formatCitation(evidence: RecallEvidence, index: number): string {
@@ -38,22 +71,20 @@ function formatCitation(evidence: RecallEvidence, index: number): string {
 }
 
 function formatSearchedSources(
-  result: DeterministicRecallSearchResult,
+  searchedSources: readonly DeterministicRecallSourceNote[],
 ): string {
-  if (result.searchedSources.length === 0) {
+  if (searchedSources.length === 0) {
     return "";
   }
-  return `Searched sources: ${result.searchedSources
+  return `Searched sources: ${searchedSources
     .map((note) => note.source)
     .join(", ")}.`;
 }
 
 function formatDegradedSources(
-  result: DeterministicRecallSearchResult,
+  searchedSources: readonly DeterministicRecallSourceNote[],
 ): string {
-  const degraded = result.searchedSources.filter(
-    (note) => note.status === "degraded",
-  );
+  const degraded = searchedSources.filter((note) => note.status === "degraded");
   if (degraded.length === 0) {
     return "";
   }
@@ -67,6 +98,41 @@ function formatDegradedSources(
     .join(", ")}.`;
 }
 
+function formatInspectedWorkspacePaths(
+  inspectCalls: readonly RecallFooterInspectCall[],
+): string {
+  const inspectedPaths = dedupeStrings(
+    inspectCalls.flatMap((call) => {
+      const errorPaths = new Set(
+        (call.errors ?? []).map((error) => error.path),
+      );
+      return call.paths.filter((path) => !errorPaths.has(path));
+    }),
+  );
+  if (inspectedPaths.length === 0) {
+    return "";
+  }
+
+  return `Inspected workspace paths: ${inspectedPaths.join(", ")}.`;
+}
+
+function formatWorkspaceInspectionIssues(
+  inspectCalls: readonly RecallFooterInspectCall[],
+): string {
+  const errors = dedupeStrings(
+    inspectCalls.flatMap((call) =>
+      (call.errors ?? []).map(
+        (error) => `${error.path} (${compactText(error.reason, 120)})`,
+      ),
+    ),
+  );
+  if (errors.length === 0) {
+    return "";
+  }
+
+  return `Workspace inspection issues: ${errors.join(", ")}.`;
+}
+
 function compactText(text: string, maxChars: number): string {
   const compacted = text.trim().replace(/\s+/g, " ");
   if (compacted.length <= maxChars) {
@@ -76,4 +142,19 @@ function compactText(text: string, maxChars: number): string {
     return compacted.slice(0, maxChars);
   }
   return `${compacted.slice(0, maxChars - 3).trimEnd()}...`;
+}
+
+function dedupeStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+
+  for (const value of values) {
+    if (seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    deduped.push(value);
+  }
+
+  return deduped;
 }

--- a/assistant/src/memory/context-search/search.ts
+++ b/assistant/src/memory/context-search/search.ts
@@ -43,6 +43,9 @@ const PINNED_PKB_CONTEXT_EVIDENCE_IDS = new Set([
   "pkb:auto-inject",
   "pkb:NOW.md",
 ]);
+const PINNED_PKB_CONTEXT_TEXT_CAP = Math.floor(
+  RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE / 2,
+);
 
 export async function runDeterministicRecallSearch(
   input: RecallInput,
@@ -188,7 +191,7 @@ function sortEvidence(evidence: RecallEvidence[]): RecallEvidence[] {
 }
 
 function compareEvidence(a: RecallEvidence, b: RecallEvidence): number {
-  const scoreCompare = (b.score ?? 0) - (a.score ?? 0);
+  const scoreCompare = rankScore(b) - rankScore(a);
   if (scoreCompare !== 0) return scoreCompare;
 
   const timestampCompare = (b.timestampMs ?? 0) - (a.timestampMs ?? 0);
@@ -207,6 +210,19 @@ function compareEvidence(a: RecallEvidence, b: RecallEvidence): number {
       a.excerpt.localeCompare(b.excerpt),
     ].find((comparison) => comparison !== 0) ?? 0
   );
+}
+
+function rankScore(item: RecallEvidence): number {
+  return (item.score ?? 0) + retrievalRankBoost(item);
+}
+
+function retrievalRankBoost(item: RecallEvidence): number {
+  const retrieval = item.metadata?.retrieval;
+  if (retrieval === "path") return 0.45;
+  if (retrieval === "structured-json") return 0.4;
+  if (retrieval === "section") return 0.35;
+  if (retrieval === "lexical") return item.source === "pkb" ? 1.5 : 0.25;
+  return 0;
 }
 
 function dedupeEvidence(evidence: readonly RecallEvidence[]): RecallEvidence[] {
@@ -298,7 +314,11 @@ function getReservedPinnedTextBudget(
   },
 ): number {
   const sourceTextSize = state.textSizeBySource.get(item.source) ?? 0;
-  const sourceRemaining = RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE - sourceTextSize;
+  const pinnedSourceCap =
+    item.source === "pkb"
+      ? PINNED_PKB_CONTEXT_TEXT_CAP
+      : RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE;
+  const sourceRemaining = pinnedSourceCap - sourceTextSize;
   const totalRemaining = RECALL_TOTAL_EVIDENCE_TEXT_CAP - state.totalTextSize;
   const remaining = Math.min(sourceRemaining, totalRemaining);
   return Math.max(1, Math.floor(remaining / state.pinnedRemaining));

--- a/assistant/src/memory/context-search/sources/pkb.ts
+++ b/assistant/src/memory/context-search/sources/pkb.ts
@@ -302,7 +302,7 @@ async function searchPkbFile(
     queryTerms,
   );
   const score =
-    bestLine.matchedTerms.size / queryTerms.size + pathTerms.size * 0.05;
+    bestLine.matchedTerms.size / queryTerms.size + pathTerms.size * 0.35;
 
   return {
     relativePath,
@@ -317,7 +317,11 @@ function findBestPkbLine(
   lines: readonly string[],
   queryTerms: ReadonlySet<string>,
 ): { lineIndex: number; matchedTerms: Set<string> } | null {
-  let best: { lineIndex: number; matchedTerms: Set<string> } | null = null;
+  let best: {
+    lineIndex: number;
+    matchedTerms: Set<string>;
+    score: number;
+  } | null = null;
 
   lines.forEach((line, lineIndex) => {
     const lineTerms = tokenizeSalientRecallTerms(line);
@@ -326,8 +330,9 @@ function findBestPkbLine(
       return;
     }
 
-    if (!best || matchedTerms.size > best.matchedTerms.size) {
-      best = { lineIndex, matchedTerms };
+    const score = matchedTerms.size * 10 + Math.min(lineTerms.size, 12) / 100;
+    if (!best || score > best.score) {
+      best = { lineIndex, matchedTerms, score };
     }
   });
 


### PR DESCRIPTION
## Summary
- Add searched-source and inspection footers to agentic recall responses so synthesis remains observable.
- Reject unsupported negative recall finishes when relevant evidence exists and fall back to local evidence.
- Improve question-shaped recall retrieval/ranking for location and lead-in queries, with regressions for PKB lexical hits.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
