### PR TITLE
Demote auto-injected recall context

### DIFF
--- a/assistant/src/__tests__/context-search-agent-runner.test.ts
+++ b/assistant/src/__tests__/context-search-agent-runner.test.ts
@@ -906,6 +906,63 @@ describe("runAgenticRecall", () => {
     });
   });
 
+  test("keeps auto-injected context behind concrete evidence after agent searches", async () => {
+    configuredProvider = makeProvider([
+      toolResponse("search_sources", {
+        query: "follow up",
+        sources: ["workspace"],
+        reason: "Need concrete follow-up evidence.",
+      }),
+      textResponse("not a finish"),
+    ]);
+
+    const result = await runAgenticRecall(
+      {
+        query: "launch notes",
+        sources: ["pkb", "workspace"],
+        max_results: 3,
+      },
+      makeContext(),
+      {
+        searchOptions: {
+          adapters: [
+            makeAdapter({}, [], "pkb"),
+            makeAdapter(
+              {
+                "launch notes": [makeEvidence("workspace:seed")],
+                "follow up": [makeEvidence("workspace:searched")],
+              },
+              [],
+              "workspace",
+            ),
+          ],
+          readPkbContextEvidence: () => [
+            makeEvidence("pkb:auto-inject", {
+              source: "pkb",
+              title: "PKB auto-injected context",
+              locator: "pkb:auto-inject",
+              excerpt: "Always-present background context.",
+            }),
+            makeEvidence("pkb:NOW.md", {
+              source: "pkb",
+              title: "NOW.md",
+              locator: "NOW.md",
+              excerpt: "Always-present NOW context.",
+            }),
+          ],
+        },
+      },
+    );
+
+    expect(result.debug.mode).toBe("deterministic_fallback");
+    expect(result.evidence.map((item) => item.id)).toEqual([
+      "workspace:seed",
+      "workspace:searched",
+      "pkb:NOW.md",
+      "pkb:auto-inject",
+    ]);
+  });
+
   test("routes provider calls through the recall call site with temperature zero", async () => {
     const providerCalls: unknown[][] = [];
     configuredProvider = makeProvider(

--- a/assistant/src/__tests__/context-search-fanout.test.ts
+++ b/assistant/src/__tests__/context-search-fanout.test.ts
@@ -87,14 +87,14 @@ describe("runDeterministicRecallSearch", () => {
       "workspace",
     ]);
     expect(result.evidence.map((item) => item.id)).toEqual([
-      "pkb:NOW.md",
-      "pkb:auto-inject",
       "pkb:search",
       "workspace:evidence",
+      "pkb:NOW.md",
+      "pkb:auto-inject",
     ]);
   });
 
-  test("keeps PKB pinned context evidence through very low result caps", async () => {
+  test("does not let PKB auto-injected context displace concrete evidence", async () => {
     const result = await runDeterministicRecallSearch(
       { query: "launch notes", sources: ["pkb", "workspace"], max_results: 1 },
       makeContext(),
@@ -133,29 +133,20 @@ describe("runDeterministicRecallSearch", () => {
     );
 
     expect(result.evidence.map((item) => item.id)).toEqual([
-      "pkb:NOW.md",
-      "pkb:auto-inject",
+      "workspace:search",
     ]);
     expect(result.searchedSources).toEqual([
-      { source: "pkb", status: "searched", evidenceCount: 2 },
-      { source: "workspace", status: "searched", evidenceCount: 0 },
+      { source: "pkb", status: "searched", evidenceCount: 0 },
+      { source: "workspace", status: "searched", evidenceCount: 1 },
     ]);
   });
 
-  test("reserves text budget for each pinned PKB context row", async () => {
+  test("uses PKB auto-injected context when no concrete evidence is available", async () => {
     const result = await runDeterministicRecallSearch(
       { query: "launch notes", sources: ["pkb"], max_results: 1 },
       makeContext(),
       {
-        adapters: [
-          makeAdapter("pkb", [
-            makeEvidence("pkb", {
-              id: "pkb:search",
-              score: 0.5,
-              excerpt: "Normal PKB search result.",
-            }),
-          ]),
-        ],
+        adapters: [makeAdapter("pkb", [])],
         readPkbContextEvidence: () => [
           makeEvidence("pkb", {
             id: "pkb:auto-inject",
@@ -175,16 +166,13 @@ describe("runDeterministicRecallSearch", () => {
       },
     );
 
-    expect(result.evidence.map((item) => item.id)).toEqual([
-      "pkb:auto-inject",
-      "pkb:NOW.md",
-    ]);
+    expect(result.evidence.map((item) => item.id)).toEqual(["pkb:auto-inject"]);
     for (const item of result.evidence) {
       expect(item.excerpt.length).toBeGreaterThan(0);
     }
   });
 
-  test("pinned PKB context leaves excerpt budget for exact PKB hits", async () => {
+  test("auto-injected PKB context leaves excerpt budget for exact PKB hits", async () => {
     const result = await runDeterministicRecallSearch(
       { query: "where does alice live", sources: ["pkb"], max_results: 3 },
       makeContext(),

--- a/assistant/src/memory/context-search/agent-runner.ts
+++ b/assistant/src/memory/context-search/agent-runner.ts
@@ -26,6 +26,7 @@ import {
 import {
   type DeterministicRecallSearchOptions,
   type DeterministicRecallSearchResult,
+  isAutoInjectedPkbContextEvidence,
   runDeterministicRecallSearch,
 } from "./search.js";
 import {
@@ -1085,7 +1086,7 @@ function collectInspectableWorkspacePaths(
 }
 
 function collectEvidenceWorkspacePaths(item: RecallEvidence): string[] {
-  if (isPinnedPkbContextEvidence(item)) {
+  if (isAutoInjectedPkbContextEvidence(item)) {
     return [];
   }
 
@@ -1109,10 +1110,6 @@ function collectEvidenceWorkspacePaths(item: RecallEvidence): string[] {
     }
   }
   return [...new Set(paths)];
-}
-
-function isPinnedPkbContextEvidence(item: RecallEvidence): boolean {
-  return item.id === "pkb:auto-inject" || item.id === "pkb:NOW.md";
 }
 
 function normalizeRequestedWorkspaceInspectionPath(
@@ -1201,7 +1198,24 @@ function mergeEvidence(
     merged.push(item);
   }
 
-  return merged;
+  return demoteAutoInjectedContextEvidence(merged);
+}
+
+function demoteAutoInjectedContextEvidence(
+  evidence: readonly RecallEvidence[],
+): RecallEvidence[] {
+  const regularEvidence: RecallEvidence[] = [];
+  const autoInjectedContextEvidence: RecallEvidence[] = [];
+
+  for (const item of evidence) {
+    if (isAutoInjectedPkbContextEvidence(item)) {
+      autoInjectedContextEvidence.push(item);
+    } else {
+      regularEvidence.push(item);
+    }
+  }
+
+  return [...regularEvidence, ...autoInjectedContextEvidence];
 }
 
 function toRecallInput(input: NormalizedRecallInput): RecallInput {
@@ -1228,8 +1242,9 @@ function withFallbackEvidence(
   result: DeterministicRecallSearchResult,
   evidence: readonly RecallEvidence[],
 ): DeterministicRecallSearchResult {
+  const orderedEvidence = demoteAutoInjectedContextEvidence(evidence);
   const evidenceCountBySource = new Map<RecallSource, number>();
-  for (const item of evidence) {
+  for (const item of orderedEvidence) {
     evidenceCountBySource.set(
       item.source,
       (evidenceCountBySource.get(item.source) ?? 0) + 1,
@@ -1238,7 +1253,7 @@ function withFallbackEvidence(
 
   return {
     ...result,
-    evidence: [...evidence],
+    evidence: orderedEvidence,
     searchedSources: result.searchedSources.map((note) => ({
       ...note,
       evidenceCount: evidenceCountBySource.get(note.source) ?? 0,

--- a/assistant/src/memory/context-search/search.ts
+++ b/assistant/src/memory/context-search/search.ts
@@ -39,11 +39,11 @@ const SOURCE_PRIORITY = new Map<RecallSource, number>(
   ALL_RECALL_SOURCES.map((source, index) => [source, index]),
 );
 
-const PINNED_PKB_CONTEXT_EVIDENCE_IDS = new Set([
+const AUTO_INJECTED_PKB_CONTEXT_EVIDENCE_IDS = new Set([
   "pkb:auto-inject",
   "pkb:NOW.md",
 ]);
-const PINNED_PKB_CONTEXT_TEXT_CAP = Math.floor(
+const AUTO_INJECTED_PKB_CONTEXT_TEXT_CAP = Math.floor(
   RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE / 2,
 );
 
@@ -253,39 +253,18 @@ function capEvidence(
   evidence: readonly RecallEvidence[],
   maxResults: number,
 ): RecallEvidence[] {
-  const pinnedEvidence = evidence.filter(isPinnedPkbContextEvidence);
+  const autoInjectedContextEvidence = evidence.filter(
+    isAutoInjectedPkbContextEvidence,
+  );
   const regularEvidence = evidence.filter(
-    (item) => !isPinnedPkbContextEvidence(item),
+    (item) => !isAutoInjectedPkbContextEvidence(item),
   );
   const capped: RecallEvidence[] = [];
   const textSizeBySource = new Map<RecallSource, number>();
   let totalTextSize = 0;
 
-  for (let index = 0; index < pinnedEvidence.length; index += 1) {
-    const item = pinnedEvidence[index];
-    if (!item) continue;
-
-    const pinnedRemaining = pinnedEvidence.length - index;
-    const reservedTextBudget = getReservedPinnedTextBudget(item, {
-      textSizeBySource,
-      totalTextSize,
-      pinnedRemaining,
-    });
-    const appended = appendCappedEvidence(item, {
-      capped,
-      textSizeBySource,
-      totalTextSize,
-      textBudget: reservedTextBudget,
-    });
-    totalTextSize = appended.totalTextSize;
-    if (appended.totalRemaining <= 0) {
-      return capped;
-    }
-  }
-
-  const resultLimit = Math.max(maxResults, capped.length);
   for (const item of regularEvidence) {
-    if (capped.length >= resultLimit) {
+    if (capped.length >= maxResults) {
       break;
     }
 
@@ -298,30 +277,60 @@ function capEvidence(
     if (appended.totalRemaining <= 0) break;
   }
 
+  for (let index = 0; index < autoInjectedContextEvidence.length; index += 1) {
+    if (capped.length >= maxResults) {
+      break;
+    }
+
+    const item = autoInjectedContextEvidence[index];
+    if (!item) continue;
+
+    const autoInjectedRemaining = autoInjectedContextEvidence.length - index;
+    const reservedTextBudget = getReservedAutoInjectedTextBudget(item, {
+      textSizeBySource,
+      totalTextSize,
+      autoInjectedRemaining,
+    });
+    const appended = appendCappedEvidence(item, {
+      capped,
+      textSizeBySource,
+      totalTextSize,
+      textBudget: reservedTextBudget,
+    });
+    totalTextSize = appended.totalTextSize;
+    if (appended.totalRemaining <= 0) {
+      break;
+    }
+  }
+
   return capped;
 }
 
-function isPinnedPkbContextEvidence(item: RecallEvidence): boolean {
-  return item.source === "pkb" && PINNED_PKB_CONTEXT_EVIDENCE_IDS.has(item.id);
+export function isAutoInjectedPkbContextEvidence(
+  item: RecallEvidence,
+): boolean {
+  return (
+    item.source === "pkb" && AUTO_INJECTED_PKB_CONTEXT_EVIDENCE_IDS.has(item.id)
+  );
 }
 
-function getReservedPinnedTextBudget(
+function getReservedAutoInjectedTextBudget(
   item: RecallEvidence,
   state: {
     textSizeBySource: Map<RecallSource, number>;
     totalTextSize: number;
-    pinnedRemaining: number;
+    autoInjectedRemaining: number;
   },
 ): number {
   const sourceTextSize = state.textSizeBySource.get(item.source) ?? 0;
-  const pinnedSourceCap =
+  const autoInjectedSourceCap =
     item.source === "pkb"
-      ? PINNED_PKB_CONTEXT_TEXT_CAP
+      ? AUTO_INJECTED_PKB_CONTEXT_TEXT_CAP
       : RECALL_EVIDENCE_TEXT_CAP_PER_SOURCE;
-  const sourceRemaining = pinnedSourceCap - sourceTextSize;
+  const sourceRemaining = autoInjectedSourceCap - sourceTextSize;
   const totalRemaining = RECALL_TOTAL_EVIDENCE_TEXT_CAP - state.totalTextSize;
   const remaining = Math.min(sourceRemaining, totalRemaining);
-  return Math.max(1, Math.floor(remaining / state.pinnedRemaining));
+  return Math.max(1, Math.floor(remaining / state.autoInjectedRemaining));
 }
 
 function appendCappedEvidence(


### PR DESCRIPTION
## Summary
- Demote NOW.md and PKB auto-injected context so concrete recall evidence fills top result slots first.
- Preserve auto-injected context as background evidence when there is spare room or no concrete evidence.
- Add regression coverage for deterministic and agent fallback ordering.

## Original prompt
--yolo --skip-ci the remaining fix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
