### PR TITLE
Add recall nudge to PKB reminder

### DIFF
--- a/assistant/src/daemon/pkb-reminder-builder.test.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.test.ts
@@ -2,18 +2,17 @@ import { describe, expect, test } from "bun:test";
 
 import { buildPkbReminder } from "./pkb-reminder-builder.js";
 
-// Byte-for-byte fixture of the original PKB_SYSTEM_REMINDER from
-// conversation-runtime-assembly.ts. If this ever needs to change, the
-// matching string in conversation-runtime-assembly.ts must change too.
-const ORIGINAL_REMINDER =
+// Byte-for-byte fixture of the base PKB reminder.
+const BASE_REMINDER =
   "<system_reminder>" +
   "\nRead any unread Personal Knowledge Base files that might be even partially relevant to this conversation" +
   "\nUse `remember` for anything you learn immediately" +
+  "\nIf you're unsure about something that may have an answer in your workspace, use `recall` to try to find it before asking or making assumptions" +
   "\n</system_reminder>";
 
 describe("buildPkbReminder", () => {
-  test("empty hints returns exact original reminder byte-for-byte", () => {
-    expect(buildPkbReminder([])).toBe(ORIGINAL_REMINDER);
+  test("empty hints returns exact base reminder byte-for-byte", () => {
+    expect(buildPkbReminder([])).toBe(BASE_REMINDER);
   });
 
   test("single hint renders one bullet with no duplicates or trailing blank line", () => {
@@ -24,6 +23,7 @@ describe("buildPkbReminder", () => {
       "\nBased on the current context, these files look especially relevant:" +
       "\n- projects/alpha.md" +
       "\nUse `remember` for anything you learn immediately" +
+      "\nIf you're unsure about something that may have an answer in your workspace, use `recall` to try to find it before asking or making assumptions" +
       "\n</system_reminder>";
     expect(out).toBe(expected);
 
@@ -46,6 +46,7 @@ describe("buildPkbReminder", () => {
       "\n- sub/b.md" +
       "\n- c/d/e.md" +
       "\nUse `remember` for anything you learn immediately" +
+      "\nIf you're unsure about something that may have an answer in your workspace, use `recall` to try to find it before asking or making assumptions" +
       "\n</system_reminder>";
     expect(out).toBe(expected);
 

--- a/assistant/src/daemon/pkb-reminder-builder.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.ts
@@ -2,7 +2,7 @@
  * Render the PKB system_reminder text, optionally with a bulleted list of
  * hint paths that look especially relevant to the current conversation.
  *
- * When `hints` is empty, returns the legacy two-line reminder byte-for-byte.
+ * When `hints` is empty, returns the base reminder byte-for-byte.
  * When `hints` is non-empty, renders an extended reminder with a bullet per
  * hint. Hints are emitted verbatim — they are trusted internal paths, not
  * user input, so no escaping is performed.
@@ -15,6 +15,7 @@ export function buildPkbReminder(hints: ReadonlyArray<string>): string {
       "<system_reminder>" +
       "\nRead any unread Personal Knowledge Base files that might be even partially relevant to this conversation" +
       "\nUse `remember` for anything you learn immediately" +
+      "\nIf you're unsure about something that may have an answer in your workspace, use `recall` to try to find it before asking or making assumptions" +
       "\n</system_reminder>"
     );
   }
@@ -26,6 +27,7 @@ export function buildPkbReminder(hints: ReadonlyArray<string>): string {
     "\nBased on the current context, these files look especially relevant:" +
     `\n${bullets}` +
     "\nUse `remember` for anything you learn immediately" +
+    "\nIf you're unsure about something that may have an answer in your workspace, use `recall` to try to find it before asking or making assumptions" +
     "\n</system_reminder>"
   );
 }


### PR DESCRIPTION
## Summary
- Add a `recall` nudge immediately after the `remember` instruction in the PKB system reminder.
- Update byte-for-byte reminder fixtures for base and hinted reminder variants.

## Original prompt
[$do](/Users/sidd/vocify/claude-skills/skills/do/SKILL.md) --yolo --skip-ci can you update the system_reminder injection so that after this line:
Use `remember` for anything you learn immediately
there's another line that says something like:
If you're unsure about something that may have an answer in your workspace, use `recall` to try to find it before asking or making assumptions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
