### PR TITLE
fix(macos-ci): clean stale SPM binary artifact on retry

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -47,6 +47,7 @@ swift_with_retry() {
     local attempt=1
     local _pch_cleaned=0
     local _build_cleaned=0
+    local _artifact_cleaned=0
     local _stderr_log
     _stderr_log=$(mktemp)
     # FIFO for stderr streaming. Process substitutions (2> >(tee ...)) are
@@ -88,6 +89,22 @@ swift_with_retry() {
             echo "warning: stale SPM build cache detected (XCFramework path points to missing worktree), cleaning .build and retrying..."
             rm -rf "$SCRIPT_DIR/../.build"
             _build_cleaned=1
+            continue
+        fi
+        # Auto-clean stale SPM binary artifacts when a previous download was
+        # interrupted, leaving a partial entry that blocks the re-download.
+        # SPM surfaces this as:
+        #   error: failed downloading '<url>' which is required by binary
+        #   target '<name>': <path> already exists in file system
+        # Common on hosted CI runners with rotated/partial caches.
+        if [ "$_artifact_cleaned" -eq 0 ] && grep -q "already exists in file system" "$_stderr_log" 2>/dev/null; then
+            echo "warning: stale SPM binary artifact detected, cleaning and retrying..."
+            sed -nE 's/.*: (\/[^[:space:]]+) already exists in file system.*/\1/p' "$_stderr_log" 2>/dev/null \
+                | sort -u \
+                | while IFS= read -r _stale_path; do
+                    [ -n "$_stale_path" ] && rm -rf "$_stale_path"
+                done
+            _artifact_cleaned=1
             continue
         fi
         # Signal 5 (SIGTRAP) is a non-transient crash (e.g. WebKit


### PR DESCRIPTION
## Summary
- The macOS Tests job has been failing with \`error: failed downloading 'Sparkle...zip' ... already exists in file system\` — a stale SPM artifact from a partial/interrupted previous download blocks every retry.
- \`swift_with_retry\` in \`clients/macos/build.sh\` already handles two analogous cases (stale module caches, missing XCFramework paths). Add a third one-shot cleanup that extracts the offending path from the error and removes it before retrying.
- Failing run: https://github.com/vellum-ai/vellum-assistant/actions/runs/24943246003/job/73040286673

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24943246003/job/73040286673
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
