### PR TITLE
Add Gemini provider metadata to tool-use content

### DIFF
--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -34,6 +34,11 @@ export interface ToolUseContent {
   id: string;
   name: string;
   input: Record<string, unknown>;
+  providerMetadata?: {
+    gemini?: {
+      thoughtSignature?: string;
+    };
+  };
 }
 
 export interface ThinkingContent {


### PR DESCRIPTION
## Summary\n- Add optional Gemini provider metadata to tool-use content blocks.\n- Preserve existing tool-use construction compatibility.\n\nPart of plan: gemini-3-model-support.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
