### PR TITLE
Price Gemini 3 models and update Gemini intents

### DIFF
--- a/assistant/src/__tests__/model-intents.test.ts
+++ b/assistant/src/__tests__/model-intents.test.ts
@@ -28,6 +28,15 @@ describe("model intents", () => {
     expect(resolveModelIntent("openai", "latency-optimized")).toBe(
       "gpt-5.4-nano",
     );
+    expect(resolveModelIntent("gemini", "latency-optimized")).toBe(
+      "gemini-3.1-flash-lite-preview",
+    );
+    expect(resolveModelIntent("gemini", "quality-optimized")).toBe(
+      "gemini-3.1-pro-preview",
+    );
+    expect(resolveModelIntent("gemini", "vision-optimized")).toBe(
+      "gemini-3-flash-preview",
+    );
   });
 
   test("uses GPT-5.5 as the OpenAI provider default", () => {

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -94,6 +94,50 @@ describe("resolvePricing", () => {
   });
 
   describe("Gemini models", () => {
+    test("returns priced for gemini-3.1-pro-preview", () => {
+      const result = resolvePricing(
+        "gemini",
+        "gemini-3.1-pro-preview",
+        1_000_000,
+        1_000_000,
+      );
+      expect(result.pricingStatus).toBe("priced");
+      expect(result.estimatedCostUsd).toBe(2 + 12);
+    });
+
+    test("returns priced for gemini-3.1-pro-preview-customtools", () => {
+      const result = resolvePricing(
+        "gemini",
+        "gemini-3.1-pro-preview-customtools",
+        1_000_000,
+        1_000_000,
+      );
+      expect(result.pricingStatus).toBe("priced");
+      expect(result.estimatedCostUsd).toBe(2 + 12);
+    });
+
+    test("returns priced for gemini-3-flash-preview", () => {
+      const result = resolvePricing(
+        "gemini",
+        "gemini-3-flash-preview",
+        1_000_000,
+        1_000_000,
+      );
+      expect(result.pricingStatus).toBe("priced");
+      expect(result.estimatedCostUsd).toBe(0.5 + 3);
+    });
+
+    test("returns priced for gemini-3.1-flash-lite-preview", () => {
+      const result = resolvePricing(
+        "gemini",
+        "gemini-3.1-flash-lite-preview",
+        1_000_000,
+        1_000_000,
+      );
+      expect(result.pricingStatus).toBe("priced");
+      expect(result.estimatedCostUsd).toBe(0.25 + 1.5);
+    });
+
     test("returns priced for gemini-2.5-pro", () => {
       const result = resolvePricing(
         "gemini",
@@ -113,7 +157,7 @@ describe("resolvePricing", () => {
         1_000_000,
       );
       expect(result.pricingStatus).toBe("priced");
-      expect(result.estimatedCostUsd).toBe(0.15 + 0.6);
+      expect(result.estimatedCostUsd).toBe(0.3 + 2.5);
     });
 
     test("returns priced for gemini-2.5-flash-lite", () => {
@@ -124,7 +168,7 @@ describe("resolvePricing", () => {
         1_000_000,
       );
       expect(result.pricingStatus).toBe("priced");
-      expect(result.estimatedCostUsd).toBe(0.02 + 0.1);
+      expect(result.estimatedCostUsd).toBe(0.1 + 0.4);
     });
   });
 

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -5,10 +5,9 @@ import type { ModelIntent } from "./types.js";
  * Derived from PROVIDER_CATALOG — single source of truth for default models.
  * Each provider's `defaultModel` in the catalog populates this map.
  */
-const PROVIDER_DEFAULT_MODELS: Record<string, string> =
-  Object.fromEntries(
-    PROVIDER_CATALOG.map((entry) => [entry.id, entry.defaultModel]),
-  );
+const PROVIDER_DEFAULT_MODELS: Record<string, string> = Object.fromEntries(
+  PROVIDER_CATALOG.map((entry) => [entry.id, entry.defaultModel]),
+);
 
 const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   anthropic: {
@@ -22,9 +21,9 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
     "vision-optimized": "gpt-5.4",
   },
   gemini: {
-    "latency-optimized": "gemini-2.5-flash-lite",
-    "quality-optimized": "gemini-2.5-flash",
-    "vision-optimized": "gemini-2.5-flash",
+    "latency-optimized": "gemini-3.1-flash-lite-preview",
+    "quality-optimized": "gemini-3.1-pro-preview",
+    "vision-optimized": "gemini-3-flash-preview",
   },
   ollama: {
     "latency-optimized": "llama3.2",

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -44,8 +44,18 @@ const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
     "o4-mini": { inputPer1M: 1.1, outputPer1M: 4.4 },
   },
   gemini: {
-    "gemini-2.5-flash": { inputPer1M: 0.15, outputPer1M: 0.6 },
-    "gemini-2.5-flash-lite": { inputPer1M: 0.02, outputPer1M: 0.1 },
+    "gemini-3.1-pro-preview": { inputPer1M: 2, outputPer1M: 12 },
+    "gemini-3.1-pro-preview-customtools": {
+      inputPer1M: 2,
+      outputPer1M: 12,
+    },
+    "gemini-3-flash-preview": { inputPer1M: 0.5, outputPer1M: 3 },
+    "gemini-3.1-flash-lite-preview": {
+      inputPer1M: 0.25,
+      outputPer1M: 1.5,
+    },
+    "gemini-2.5-flash": { inputPer1M: 0.3, outputPer1M: 2.5 },
+    "gemini-2.5-flash-lite": { inputPer1M: 0.1, outputPer1M: 0.4 },
     "gemini-2.5-pro": { inputPer1M: 1.25, outputPer1M: 10 },
     "gemini-2.0-flash": { inputPer1M: 0.1, outputPer1M: 0.4 },
   },


### PR DESCRIPTION
## Summary\n- Add pricing coverage for Gemini 3 text models and refresh Gemini 2.5 rates.\n- Route Gemini model intents to the new Gemini 3 choices.\n\nPart of plan: gemini-3-model-support.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
