### PR TITLE
Capture Gemini function-call thought signatures

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -22,6 +22,16 @@ interface FakeChunk {
   }>;
   candidates?: Array<{
     finishReason?: string;
+    content?: {
+      parts?: Array<{
+        functionCall?: {
+          id?: string;
+          name?: string;
+          args?: Record<string, unknown>;
+        };
+        thoughtSignature?: string;
+      }>;
+    };
   }>;
   usageMetadata?: {
     promptTokenCount?: number;
@@ -95,6 +105,42 @@ function functionCallChunk(
 ): FakeChunk {
   return {
     functionCalls: calls.map((c) => ({
+      id: c.id,
+      name: c.name,
+      args: c.args,
+    })),
+  };
+}
+
+function candidateFunctionCallChunk(
+  calls: Array<{
+    id?: string;
+    name: string;
+    args: Record<string, unknown>;
+    thoughtSignature?: string;
+  }>,
+  fallbackCalls?: Array<{
+    id?: string;
+    name: string;
+    args: Record<string, unknown>;
+  }>,
+): FakeChunk {
+  return {
+    candidates: [
+      {
+        content: {
+          parts: calls.map((c) => ({
+            functionCall: {
+              id: c.id,
+              name: c.name,
+              args: c.args,
+            },
+            thoughtSignature: c.thoughtSignature,
+          })),
+        },
+      },
+    ],
+    functionCalls: fallbackCalls?.map((c) => ({
       id: c.id,
       name: c.name,
       args: c.args,
@@ -241,6 +287,44 @@ describe("GeminiProvider", () => {
     });
   });
 
+  test("captures thought signature from streamed candidate function call parts", async () => {
+    fakeChunks = [
+      candidateFunctionCallChunk(
+        [
+          {
+            id: "call_signed",
+            name: "file_read",
+            args: { path: "/tmp/test" },
+            thoughtSignature: "signed-thought-1",
+          },
+        ],
+        [
+          {
+            id: "call_duplicate",
+            name: "file_read",
+            args: { path: "/tmp/dup" },
+          },
+        ],
+      ),
+      finishChunk("STOP", 10, 15),
+    ];
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Read /tmp/test" }] },
+    ]);
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toEqual({
+      type: "tool_use",
+      id: "call_signed",
+      name: "file_read",
+      input: { path: "/tmp/test" },
+      providerMetadata: {
+        gemini: { thoughtSignature: "signed-thought-1" },
+      },
+    });
+  });
+
   // -----------------------------------------------------------------------
   // Function call without id — fallback to call_N
   // -----------------------------------------------------------------------
@@ -314,6 +398,42 @@ describe("GeminiProvider", () => {
       id: "call_1",
       name: "file_read",
       input: { path: "/a" },
+    });
+    expect(result.content[1]).toEqual({
+      type: "tool_use",
+      id: "call_2",
+      name: "file_read",
+      input: { path: "/b" },
+    });
+  });
+
+  test("preserves parallel candidate function call order and only captured signatures", async () => {
+    fakeChunks = [
+      candidateFunctionCallChunk([
+        {
+          id: "call_1",
+          name: "file_read",
+          args: { path: "/a" },
+          thoughtSignature: "signed-thought-1",
+        },
+        { id: "call_2", name: "file_read", args: { path: "/b" } },
+      ]),
+      finishChunk("STOP", 10, 30),
+    ];
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Read /a and /b" }] },
+    ]);
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0]).toEqual({
+      type: "tool_use",
+      id: "call_1",
+      name: "file_read",
+      input: { path: "/a" },
+      providerMetadata: {
+        gemini: { thoughtSignature: "signed-thought-1" },
+      },
     });
     expect(result.content[1]).toEqual({
       type: "tool_use",

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -192,7 +192,19 @@ export class GeminiProvider implements Provider {
         id: string;
         name: string;
         args: Record<string, unknown>;
+        thoughtSignature?: string;
       }> = [];
+      const appendFunctionCall = (
+        fc: genai.FunctionCall,
+        thoughtSignature?: string,
+      ) => {
+        functionCalls.push({
+          id: fc.id ?? `call_${crypto.randomUUID()}`,
+          name: fc.name ?? "",
+          args: fc.args ?? {},
+          thoughtSignature,
+        });
+      };
       let finishReason = "unknown";
       let promptTokens = 0;
       let outputTokens = 0;
@@ -213,15 +225,24 @@ export class GeminiProvider implements Provider {
             onEvent?.({ type: "text_delta", text: chunkText });
           }
 
-          // Extract function calls
-          const calls = chunk.functionCalls;
-          if (calls) {
-            for (const fc of calls) {
-              functionCalls.push({
-                id: fc.id ?? `call_${crypto.randomUUID()}`,
-                name: fc.name ?? "",
-                args: fc.args ?? {},
-              });
+          // Extract function calls. Candidate parts carry provider metadata
+          // that the SDK's convenience getter omits, so prefer them when present.
+          const functionCallParts =
+            chunk.candidates?.[0]?.content?.parts?.filter(
+              (part) => part.functionCall,
+            ) ?? [];
+          if (functionCallParts.length > 0) {
+            for (const part of functionCallParts) {
+              const fc = part.functionCall;
+              if (!fc) continue;
+              appendFunctionCall(fc, part.thoughtSignature);
+            }
+          } else {
+            const calls = chunk.functionCalls;
+            if (calls) {
+              for (const fc of calls) {
+                appendFunctionCall(fc);
+              }
             }
           }
 
@@ -250,12 +271,18 @@ export class GeminiProvider implements Provider {
         content.push({ type: "text", text: fullText });
       }
       for (const fc of functionCalls) {
-        content.push({
+        const block: ContentBlock = {
           type: "tool_use",
           id: fc.id,
           name: fc.name,
           input: fc.args,
-        });
+        };
+        if (fc.thoughtSignature) {
+          block.providerMetadata = {
+            gemini: { thoughtSignature: fc.thoughtSignature },
+          };
+        }
+        content.push(block);
       }
 
       const rawRequest = {


### PR DESCRIPTION
## Summary\n- Capture Gemini thought signatures from streamed function-call parts.\n- Preserve existing function-call fallback behavior and add provider tests.\n\nPart of plan: gemini-3-model-support.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
