### PR TITLE
Show Gemini 3 models in macOS settings fallback catalog

### DIFF
--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
@@ -21,7 +21,7 @@ final class InferenceProfileEditorTests: XCTestCase {
         // Tiny deterministic catalog so tests don't depend on the live
         // `LLMProviderRegistry` shape.
         let fixture = SettingsTestFixture.make(
-            providerCatalog: SettingsTestFixture.anthropicAndOpenAICatalog()
+            providerCatalog: Self.editorProviderCatalog()
         )
         store = fixture.store
         mockSettingsClient = fixture.mockClient
@@ -77,6 +77,37 @@ final class InferenceProfileEditorTests: XCTestCase {
             maxOutputTokens: maxOutputTokens,
             supportsThinking: supportsThinking
         )
+    }
+
+    private static func editorProviderCatalog() -> [ProviderCatalogEntry] {
+        SettingsTestFixture.anthropicAndOpenAICatalog() + [
+            ProviderCatalogEntry(
+                id: "gemini",
+                displayName: "Google Gemini",
+                models: [
+                    CatalogModel(
+                        id: "gemini-3.1-pro-preview",
+                        displayName: "Gemini 3.1 Pro Preview"
+                    ),
+                    CatalogModel(
+                        id: "gemini-3.1-pro-preview-customtools",
+                        displayName: "Gemini 3.1 Pro Preview (Custom Tools)"
+                    ),
+                    CatalogModel(
+                        id: "gemini-3-flash-preview",
+                        displayName: "Gemini 3 Flash Preview"
+                    ),
+                    CatalogModel(
+                        id: "gemini-3.1-flash-lite-preview",
+                        displayName: "Gemini 3.1 Flash-Lite Preview"
+                    ),
+                    CatalogModel(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash"),
+                    CatalogModel(id: "gemini-2.5-flash-lite", displayName: "Gemini 2.5 Flash Lite"),
+                    CatalogModel(id: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro"),
+                ],
+                defaultModel: "gemini-2.5-flash"
+            ),
+        ]
     }
 
     // MARK: - Form structure
@@ -213,6 +244,32 @@ final class InferenceProfileEditorTests: XCTestCase {
         )
     }
 
+    func testGemini3ShowsOnlyMaxTokensWithCurrentProviderSupport() {
+        let visibility = InferenceProfileParameterVisibility.resolve(
+            provider: "gemini",
+            model: "gemini-3.1-pro-preview",
+            isKnownModel: true,
+            modelEntry: modelEntry(
+                id: "gemini-3.1-pro-preview",
+                displayName: "Gemini 3.1 Pro Preview",
+                maxOutputTokens: 65536,
+                supportsThinking: true
+            )
+        )
+
+        XCTAssertEqual(
+            visibility,
+            InferenceProfileParameterVisibility(
+                maxTokens: true,
+                effort: false,
+                speed: false,
+                verbosity: false,
+                temperature: false,
+                thinking: false
+            )
+        )
+    }
+
     func testOpenRouterReasoningModelsShowEffortAndThinking() {
         let visibility = InferenceProfileParameterVisibility.resolve(
             provider: "openrouter",
@@ -316,6 +373,34 @@ final class InferenceProfileEditorTests: XCTestCase {
             provider: "anthropic",
             model: "claude-sonnet-4-6"
         ))
+        XCTAssertTrue(editor.canSave)
+    }
+
+    func testCanSelectGemini3ModelFromDynamicCatalog() {
+        let geminiModels = store.dynamicProviderModels("gemini")
+        XCTAssertEqual(
+            geminiModels.prefix(4).map(\.id),
+            [
+                "gemini-3.1-pro-preview",
+                "gemini-3.1-pro-preview-customtools",
+                "gemini-3-flash-preview",
+                "gemini-3.1-flash-lite-preview",
+            ]
+        )
+        XCTAssertEqual(
+            geminiModels.first { $0.id == "gemini-3.1-pro-preview" }?.displayName,
+            "Gemini 3.1 Pro Preview"
+        )
+
+        let (editor, box) = makeEditor(profile: InferenceProfile(
+            name: "gemini-3",
+            provider: "gemini",
+            model: "gemini-3.1-pro-preview"
+        ))
+
+        XCTAssertEqual(box.profile.model, "gemini-3.1-pro-preview")
+        XCTAssertFalse(editor.isModelMissing)
+        XCTAssertFalse(editor.isModelInvalid)
         XCTAssertTrue(editor.canSave)
     }
 

--- a/clients/shared/Tests/LLMProviderRegistryTests.swift
+++ b/clients/shared/Tests/LLMProviderRegistryTests.swift
@@ -29,6 +29,26 @@ final class LLMProviderRegistryTests: XCTestCase {
         }
     }
 
+    func testGeminiFallbackModelsIncludeGemini3BeforeGemini25() {
+        guard let gemini = LLMProviderRegistry.provider(id: "gemini") else {
+            return XCTFail("Expected Gemini provider in fallback catalog")
+        }
+
+        XCTAssertEqual(gemini.defaultModel, "gemini-2.5-flash")
+        XCTAssertEqual(
+            Array(gemini.models.prefix(7).map(\.id)),
+            [
+                "gemini-3.1-pro-preview",
+                "gemini-3.1-pro-preview-customtools",
+                "gemini-3-flash-preview",
+                "gemini-3.1-flash-lite-preview",
+                "gemini-2.5-flash",
+                "gemini-2.5-flash-lite",
+                "gemini-2.5-pro",
+            ]
+        )
+    }
+
     func testProviderLookupReturnsExpectedEntry() {
         let openai = LLMProviderRegistry.provider(id: "openai")
         XCTAssertNotNil(openai)

--- a/clients/shared/Utilities/LLMProviderRegistry.swift
+++ b/clients/shared/Utilities/LLMProviderRegistry.swift
@@ -282,6 +282,16 @@ private let fallbackCatalog = LLMProviderCatalog(
             ),
             defaultModel: "gemini-2.5-flash",
             models: [
+                LLMModelEntry(id: "gemini-3.1-pro-preview", displayName: "Gemini 3.1 Pro Preview"),
+                LLMModelEntry(
+                    id: "gemini-3.1-pro-preview-customtools",
+                    displayName: "Gemini 3.1 Pro Preview (Custom Tools)"
+                ),
+                LLMModelEntry(id: "gemini-3-flash-preview", displayName: "Gemini 3 Flash Preview"),
+                LLMModelEntry(
+                    id: "gemini-3.1-flash-lite-preview",
+                    displayName: "Gemini 3.1 Flash-Lite Preview"
+                ),
                 LLMModelEntry(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash"),
                 LLMModelEntry(id: "gemini-2.5-flash-lite", displayName: "Gemini 2.5 Flash Lite"),
                 LLMModelEntry(id: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro"),


### PR DESCRIPTION
## Summary\n- Add Gemini 3 text models to the Swift fallback provider catalog.\n- Cover Gemini 3 fallback ordering and settings validation behavior.\n\nPart of plan: gemini-3-model-support.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
