### PR TITLE
Replay Gemini thought signatures in tool history

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -540,7 +540,7 @@ describe("GeminiProvider", () => {
     // assistant → model with functionCall, user → user with functionResponse
     expect(contents).toHaveLength(3);
     expect(contents[1].role).toBe("model");
-    expect(contents[1].parts[0]).toEqual({
+    expect(contents[1].parts[0]).toMatchObject({
       functionCall: {
         name: "file_read",
         args: { path: "/tmp/test" },
@@ -553,6 +553,152 @@ describe("GeminiProvider", () => {
         response: { output: "file content here" },
       },
     });
+  });
+
+  test("replays Gemini thought signatures on serialized tool_use history", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Read /tmp/test" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "call_signed",
+            name: "file_read",
+            input: { path: "/tmp/test" },
+            providerMetadata: {
+              gemini: { thoughtSignature: "signed-thought-1" },
+            },
+          },
+          {
+            type: "tool_use",
+            id: "call_unsigned",
+            name: "file_read",
+            input: { path: "/tmp/other" },
+          },
+        ],
+      },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const contents = lastStreamParams!.contents as Array<{
+      role: string;
+      parts: Array<{
+        functionCall?: unknown;
+        thoughtSignature?: string;
+      }>;
+    }>;
+    expect(contents[1].parts).toEqual([
+      {
+        functionCall: {
+          name: "file_read",
+          args: { path: "/tmp/test" },
+        },
+        thoughtSignature: "signed-thought-1",
+      },
+      {
+        functionCall: {
+          name: "file_read",
+          args: { path: "/tmp/other" },
+        },
+      },
+    ]);
+  });
+
+  test("adds Gemini 3 fallback thought signature to old unsigned tool_use history", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    const overrideProvider = new GeminiProvider(
+      "test-api-key",
+      "gemini-2.5-flash",
+    );
+    await overrideProvider.sendMessage(
+      [
+        { role: "user", content: [{ type: "text", text: "Read files" }] },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "call_1",
+              name: "file_read",
+              input: { path: "/a" },
+            },
+            {
+              type: "tool_use",
+              id: "call_2",
+              name: "file_read",
+              input: { path: "/b" },
+            },
+          ],
+        },
+      ],
+      undefined,
+      undefined,
+      { config: { model: "models/gemini-3-pro-preview" } },
+    );
+
+    const contents = lastStreamParams!.contents as Array<{
+      role: string;
+      parts: Array<{
+        functionCall?: unknown;
+        thoughtSignature?: string;
+      }>;
+    }>;
+    expect(contents[1].parts).toEqual([
+      {
+        functionCall: {
+          name: "file_read",
+          args: { path: "/a" },
+        },
+        thoughtSignature: "context_engineering_is_the_way to_go",
+      },
+      {
+        functionCall: {
+          name: "file_read",
+          args: { path: "/b" },
+        },
+      },
+    ]);
+  });
+
+  test("does not add fallback thought signature for Gemini 2.5 tool_use history", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    const gemini25Provider = new GeminiProvider(
+      "test-api-key",
+      "gemini-2.5-flash",
+    );
+    await gemini25Provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Read /tmp/test" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "call_unsigned",
+            name: "file_read",
+            input: { path: "/tmp/test" },
+          },
+        ],
+      },
+    ]);
+
+    const contents = lastStreamParams!.contents as Array<{
+      role: string;
+      parts: unknown[];
+    }>;
+    expect(contents[1].parts).toEqual([
+      {
+        functionCall: {
+          name: "file_read",
+          args: { path: "/tmp/test" },
+        },
+      },
+    ]);
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -27,6 +27,13 @@ import {
 const GEMINI_CONTEXT_OVERFLOW_TOKEN_PATTERNS =
   /token.?count.*exceeds|exceeds.*maximum.*tokens|prompt.?is.?too.?long|too.?many.?(?:input.?)?tokens|input.?too.?long|context.?length.?exceeded/i;
 
+const GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE =
+  "context_engineering_is_the_way to_go";
+
+export function isGemini3Model(model: string): boolean {
+  return model.startsWith("gemini-3") || model.startsWith("models/gemini-3");
+}
+
 /**
  * Detect Gemini's context-overflow signals on an `ApiError`. Gemini surfaces
  * this condition via its "RESOURCE_EXHAUSTED" category. The Gemini SDK's
@@ -155,9 +162,10 @@ export class GeminiProvider implements Provider {
     const configObj = config as Record<string, unknown> | undefined;
     const maxTokens = configObj?.max_tokens as number | undefined;
     const modelOverride = configObj?.model as string | undefined;
+    const activeModel = modelOverride ?? this.model;
 
     try {
-      const geminiContents = this.toGeminiContents(messages);
+      const geminiContents = this.toGeminiContents(messages, activeModel);
 
       const geminiConfig: genai.GenerateContentConfig = {};
 
@@ -208,11 +216,11 @@ export class GeminiProvider implements Provider {
       let finishReason = "unknown";
       let promptTokens = 0;
       let outputTokens = 0;
-      let responseModel = modelOverride ?? this.model;
+      let responseModel = activeModel;
 
       try {
         const stream = await this.client.models.generateContentStream({
-          model: modelOverride ?? this.model,
+          model: activeModel,
           contents: geminiContents,
           config: geminiConfig,
         });
@@ -286,7 +294,7 @@ export class GeminiProvider implements Provider {
       }
 
       const rawRequest = {
-        model: modelOverride ?? this.model,
+        model: activeModel,
         contents: geminiContents,
         config: geminiConfig,
       };
@@ -349,7 +357,10 @@ export class GeminiProvider implements Provider {
   }
 
   /** Convert neutral messages to Gemini Content[] format. */
-  private toGeminiContents(messages: Message[]): genai.Content[] {
+  private toGeminiContents(
+    messages: Message[],
+    model: string,
+  ): genai.Content[] {
     const result: genai.Content[] = [];
 
     // Build a map from tool_use id → function name so tool_result blocks
@@ -368,6 +379,8 @@ export class GeminiProvider implements Provider {
       const { parts, toolResultImageParts } = this.toGeminiParts(
         msg.content,
         toolCallNames,
+        model,
+        role,
       );
       if (parts.length > 0) {
         result.push({ role, parts });
@@ -387,6 +400,8 @@ export class GeminiProvider implements Provider {
   private toGeminiParts(
     blocks: ContentBlock[],
     toolCallNames: Map<string, string>,
+    model: string,
+    role: "model" | "user",
   ): { parts: genai.Part[]; toolResultImageParts: genai.Part[] } {
     const parts: genai.Part[] = [];
     const toolResultImageParts: genai.Part[] = [];
@@ -420,12 +435,20 @@ export class GeminiProvider implements Provider {
           }
           break;
         case "tool_use":
-          parts.push({
-            functionCall: {
-              name: block.name,
-              args: block.input,
-            },
-          });
+          {
+            const functionCallPart: genai.Part = {
+              functionCall: {
+                name: block.name,
+                args: block.input,
+              },
+            };
+            const thoughtSignature =
+              block.providerMetadata?.gemini?.thoughtSignature;
+            if (thoughtSignature) {
+              functionCallPart.thoughtSignature = thoughtSignature;
+            }
+            parts.push(functionCallPart);
+          }
           break;
         case "tool_result": {
           let outputText = block.content;
@@ -470,7 +493,31 @@ export class GeminiProvider implements Provider {
       }
     }
 
+    if (role === "model") {
+      this.addGemini3UnsignedToolCallFallback(parts, model);
+    }
+
     return { parts, toolResultImageParts };
+  }
+
+  private addGemini3UnsignedToolCallFallback(
+    parts: genai.Part[],
+    model: string,
+  ): void {
+    if (!isGemini3Model(model)) return;
+
+    const functionCallParts = parts.filter((part) => part.functionCall);
+    if (functionCallParts.length === 0) return;
+
+    const hasRealThoughtSignature = functionCallParts.some((part) =>
+      Boolean(part.thoughtSignature),
+    );
+    if (hasRealThoughtSignature) return;
+
+    const firstFunctionCallPart = functionCallParts[0];
+    if (!firstFunctionCallPart) return;
+    firstFunctionCallPart.thoughtSignature =
+      GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE;
   }
 
   private supportsGeminiInlineFile(mimeType: string): boolean {


### PR DESCRIPTION
## Summary
- Replay stored Gemini thought signatures when serializing assistant tool_use history back into functionCall parts.
- Add Gemini 3-only fallback thought signature for old unsigned tool-use history, scoped to the first functionCall in a model content entry.
- Cover real signature replay, Gemini 3 fallback, and Gemini 2.5 no-fallback behavior.

## Validation
- `export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/gemini-provider.test.ts`
- `export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
