### PR TITLE
Guard Gemini 3 model catalogs

### DIFF
--- a/assistant/src/daemon/handlers/config-model.test.ts
+++ b/assistant/src/daemon/handlers/config-model.test.ts
@@ -59,6 +59,23 @@ describe("projectProviderForWire", () => {
     expect(wire.models.length).toBe(anthropic!.models.length);
   });
 
+  test("projects Gemini 3 text models onto the wire catalog", () => {
+    const gemini = PROVIDER_CATALOG.find((p) => p.id === "gemini");
+    expect(gemini).toBeDefined();
+    const wire = projectProviderForWire(gemini!);
+    const modelIds = wire.models.map((model) => model.id);
+
+    for (const modelId of [
+      "gemini-3.1-pro-preview",
+      "gemini-3.1-pro-preview-customtools",
+      "gemini-3-flash-preview",
+      "gemini-3.1-flash-lite-preview",
+    ]) {
+      expect(modelIds).toContain(modelId);
+    }
+    expect(modelIds).not.toContain("gemini-3-pro-preview");
+  });
+
   test("omits apiKeyUrl/apiKeyPlaceholder when source entry has none (keyless providers)", () => {
     const ollama = PROVIDER_CATALOG.find((p) => p.id === "ollama");
     expect(ollama).toBeDefined();

--- a/clients/shared/Tests/LLMProviderRegistryTests.swift
+++ b/clients/shared/Tests/LLMProviderRegistryTests.swift
@@ -35,6 +35,7 @@ final class LLMProviderRegistryTests: XCTestCase {
         }
 
         XCTAssertEqual(gemini.defaultModel, "gemini-2.5-flash")
+        XCTAssertFalse(gemini.models.map(\.id).contains("gemini-3-pro-preview"))
         XCTAssertEqual(
             Array(gemini.models.prefix(7).map(\.id)),
             [


### PR DESCRIPTION
## Summary
- Add a daemon wire-catalog regression for the currently shipped Gemini 3 text model IDs.
- Guard both daemon and Swift fallback catalogs against the deprecated `gemini-3-pro-preview` ID.

## Validation
- `export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/daemon/handlers/config-model.test.ts`
- `cd clients && swift package clean && swift test --filter LLMProviderRegistryTests`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
