### PR TITLE
fix(test): align cost-tracker test with current Gemini 2.5 Flash pricing

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/__tests__/cost-tracker.test.ts
+++ b/assistant/src/config/bundled-skills/media-processing/__tests__/cost-tracker.test.ts
@@ -24,8 +24,8 @@ describe("CostTracker", () => {
     expect(summary.segmentCount).toBe(2);
     expect(summary.totalInputTokens).toBe(1_000_000);
     expect(summary.totalOutputTokens).toBe(1_000_000);
-    // $0.15 for 1M input + $0.60 for 1M output = $0.75
-    expect(summary.totalEstimatedUSD).toBeCloseTo(0.75, 6);
+    // $0.30 for 1M input + $2.50 for 1M output = $2.80
+    expect(summary.totalEstimatedUSD).toBeCloseTo(2.8, 6);
   });
 
   it("computes per-entry costs using Gemini 2.5 Flash pricing", () => {
@@ -38,10 +38,10 @@ describe("CostTracker", () => {
       outputTokens: 50_000,
     });
 
-    // Input: 200k * ($0.15 / 1M) = $0.03
-    // Output: 50k * ($0.60 / 1M) = $0.03
-    // Total: $0.06
-    expect(entry.estimatedUSD).toBeCloseTo(0.06, 6);
+    // Input: 200k * ($0.30 / 1M) = $0.06
+    // Output: 50k * ($2.50 / 1M) = $0.125
+    // Total: $0.185
+    expect(entry.estimatedUSD).toBeCloseTo(0.185, 6);
     expect(entry.segmentId).toBe("seg-010");
     expect(entry.model).toBe("gemini-2.5-flash");
   });


### PR DESCRIPTION
## Summary
- Update `cost-tracker.test.ts` expected USD values to match the current `gemini-2.5-flash` pricing in `assistant/src/util/pricing.ts` ($0.30/1M input, $2.50/1M output).
- Fixes the two failing assertions in CI: `accumulates costs across multiple segments` and `computes per-entry costs using Gemini 2.5 Flash pricing`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24945439616/job/73046000308
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
