### PR TITLE
Fix Gemini signature fallback and tiered pricing

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -654,7 +654,7 @@ describe("GeminiProvider", () => {
           name: "file_read",
           args: { path: "/a" },
         },
-        thoughtSignature: "context_engineering_is_the_way to_go",
+        thoughtSignature: "context_engineering_is_the_way_to_go",
       },
       {
         functionCall: {

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -94,26 +94,54 @@ describe("resolvePricing", () => {
   });
 
   describe("Gemini models", () => {
-    test("returns priced for gemini-3.1-pro-preview", () => {
+    test("prices gemini-3.1-pro-preview at the low-context tier through 200k input tokens", () => {
       const result = resolvePricing(
         "gemini",
         "gemini-3.1-pro-preview",
-        1_000_000,
+        200_000,
         1_000_000,
       );
       expect(result.pricingStatus).toBe("priced");
-      expect(result.estimatedCostUsd).toBe(2 + 12);
+      expect(result.estimatedCostUsd).toBe(0.4 + 12);
     });
 
-    test("returns priced for gemini-3.1-pro-preview-customtools", () => {
+    test("prices gemini-3.1-pro-preview at the high-context tier above 200k input tokens", () => {
+      const result = resolvePricing(
+        "gemini",
+        "gemini-3.1-pro-preview",
+        200_001,
+        1_000_000,
+      );
+      expect(result.pricingStatus).toBe("priced");
+      expect(result.estimatedCostUsd).toBeCloseTo(
+        (200_001 / 1_000_000) * 4 + 18,
+        10,
+      );
+    });
+
+    test("prices gemini-3.1-pro-preview-customtools at the low-context tier through 200k input tokens", () => {
       const result = resolvePricing(
         "gemini",
         "gemini-3.1-pro-preview-customtools",
-        1_000_000,
+        200_000,
         1_000_000,
       );
       expect(result.pricingStatus).toBe("priced");
-      expect(result.estimatedCostUsd).toBe(2 + 12);
+      expect(result.estimatedCostUsd).toBe(0.4 + 12);
+    });
+
+    test("prices gemini-3.1-pro-preview-customtools at the high-context tier above 200k input tokens", () => {
+      const result = resolvePricing(
+        "gemini",
+        "gemini-3.1-pro-preview-customtools",
+        200_001,
+        1_000_000,
+      );
+      expect(result.pricingStatus).toBe("priced");
+      expect(result.estimatedCostUsd).toBeCloseTo(
+        (200_001 / 1_000_000) * 4 + 18,
+        10,
+      );
     });
 
     test("returns priced for gemini-3-flash-preview", () => {
@@ -337,6 +365,60 @@ describe("resolvePricingForUsage", () => {
 
     expect(result.pricingStatus).toBe("unpriced");
     expect(result.estimatedCostUsd).toBeNull();
+  });
+
+  test("uses total prompt tokens to select the Gemini 3.1 Pro pricing tier", () => {
+    const usage: PricingUsage = {
+      directInputTokens: 199_000,
+      outputTokens: 1_000_000,
+      cacheCreationInputTokens: 1_000,
+      cacheReadInputTokens: 1,
+      anthropicCacheCreation: null,
+    };
+
+    const result = resolvePricingForUsage(
+      "gemini",
+      "gemini-3.1-pro-preview",
+      usage,
+    );
+
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBeCloseTo(
+      (200_000 / 1_000_000) * 4 + (1 / 1_000_000) * 0.4 + 18,
+      10,
+    );
+  });
+
+  test("uses Gemini 3.1 Pro tier-specific cache-read rates", () => {
+    const lowTier = resolvePricingForUsage("gemini", "gemini-3.1-pro-preview", {
+      directInputTokens: 0,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 200_000,
+      anthropicCacheCreation: null,
+    });
+    const highTier = resolvePricingForUsage(
+      "gemini",
+      "gemini-3.1-pro-preview",
+      {
+        directInputTokens: 0,
+        outputTokens: 0,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 200_001,
+        anthropicCacheCreation: null,
+      },
+    );
+
+    expect(lowTier.pricingStatus).toBe("priced");
+    expect(lowTier.estimatedCostUsd).toBeCloseTo(
+      (200_000 / 1_000_000) * 0.2,
+      10,
+    );
+    expect(highTier.pricingStatus).toBe("priced");
+    expect(highTier.estimatedCostUsd).toBeCloseTo(
+      (200_001 / 1_000_000) * 0.4,
+      10,
+    );
   });
 });
 

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -28,7 +28,7 @@ const GEMINI_CONTEXT_OVERFLOW_TOKEN_PATTERNS =
   /token.?count.*exceeds|exceeds.*maximum.*tokens|prompt.?is.?too.?long|too.?many.?(?:input.?)?tokens|input.?too.?long|context.?length.?exceeded/i;
 
 const GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE =
-  "context_engineering_is_the_way to_go";
+  "context_engineering_is_the_way_to_go";
 
 export function isGemini3Model(model: string): boolean {
   return model.startsWith("gemini-3") || model.startsWith("models/gemini-3");

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -4,6 +4,15 @@ import type { PricingResult, PricingUsage } from "../usage/types.js";
 interface ModelPricing {
   inputPer1M: number; // USD per 1M input tokens
   outputPer1M: number; // USD per 1M output tokens
+  cacheReadPer1M?: number; // USD per 1M cache-read input tokens
+  tiers?: ModelPricingTier[];
+}
+
+interface ModelPricingTier {
+  inputTokenThreshold: number;
+  inputPer1M: number;
+  outputPer1M: number;
+  cacheReadPer1M?: number;
 }
 
 const ANTHROPIC_PROMPT_CACHE_MULTIPLIERS = {
@@ -44,10 +53,31 @@ const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
     "o4-mini": { inputPer1M: 1.1, outputPer1M: 4.4 },
   },
   gemini: {
-    "gemini-3.1-pro-preview": { inputPer1M: 2, outputPer1M: 12 },
+    "gemini-3.1-pro-preview": {
+      inputPer1M: 2,
+      outputPer1M: 12,
+      cacheReadPer1M: 0.2,
+      tiers: [
+        {
+          inputTokenThreshold: 200_000,
+          inputPer1M: 4,
+          outputPer1M: 18,
+          cacheReadPer1M: 0.4,
+        },
+      ],
+    },
     "gemini-3.1-pro-preview-customtools": {
       inputPer1M: 2,
       outputPer1M: 12,
+      cacheReadPer1M: 0.2,
+      tiers: [
+        {
+          inputTokenThreshold: 200_000,
+          inputPer1M: 4,
+          outputPer1M: 18,
+          cacheReadPer1M: 0.4,
+        },
+      ],
     },
     "gemini-3-flash-preview": { inputPer1M: 0.5, outputPer1M: 3 },
     "gemini-3.1-flash-lite-preview": {
@@ -193,6 +223,42 @@ function calculateTokenCost(ratePer1M: number, tokens: number): number {
   return (Math.max(tokens, 0) / 1_000_000) * ratePer1M;
 }
 
+function getTotalPromptInputTokens(usage: PricingUsage): number {
+  return (
+    Math.max(usage.directInputTokens, 0) +
+    Math.max(usage.cacheCreationInputTokens, 0) +
+    Math.max(usage.cacheReadInputTokens, 0)
+  );
+}
+
+function selectPricingTier(
+  pricing: ModelPricing,
+  usage: PricingUsage,
+): ModelPricing {
+  if (!pricing.tiers || pricing.tiers.length === 0) return pricing;
+
+  const totalPromptInputTokens = getTotalPromptInputTokens(usage);
+  let selectedTier: ModelPricingTier | undefined;
+  for (const tier of pricing.tiers) {
+    if (
+      totalPromptInputTokens > tier.inputTokenThreshold &&
+      (!selectedTier ||
+        tier.inputTokenThreshold > selectedTier.inputTokenThreshold)
+    ) {
+      selectedTier = tier;
+    }
+  }
+
+  if (!selectedTier) return pricing;
+
+  return {
+    ...pricing,
+    inputPer1M: selectedTier.inputPer1M,
+    outputPer1M: selectedTier.outputPer1M,
+    cacheReadPer1M: selectedTier.cacheReadPer1M ?? pricing.cacheReadPer1M,
+  };
+}
+
 function getAnthropicCacheWriteTokens(usage: PricingUsage): {
   ephemeral5mInputTokens: number;
   ephemeral1hInputTokens: number;
@@ -235,14 +301,19 @@ function calculateUsageCost(
   usage: PricingUsage,
 ): number {
   const useAnthropicRules = usesAnthropicPricingRules(provider, model);
+  const tieredPricing = selectPricingTier(pricing, usage);
   // Anthropic fast mode: 6x multiplier on base rates (cache multipliers stack on top)
   const speedMultiplier =
     useAnthropicRules && usage.speed === "fast"
       ? ANTHROPIC_FAST_MODE_MULTIPLIER
       : 1;
   const effectivePricing: ModelPricing = {
-    inputPer1M: pricing.inputPer1M * speedMultiplier,
-    outputPer1M: pricing.outputPer1M * speedMultiplier,
+    inputPer1M: tieredPricing.inputPer1M * speedMultiplier,
+    outputPer1M: tieredPricing.outputPer1M * speedMultiplier,
+    cacheReadPer1M:
+      tieredPricing.cacheReadPer1M == null
+        ? undefined
+        : tieredPricing.cacheReadPer1M * speedMultiplier,
   };
 
   const directInputCost = calculateTokenCost(
@@ -260,7 +331,11 @@ function calculateUsageCost(
       outputCost +
       calculateTokenCost(
         effectivePricing.inputPer1M,
-        usage.cacheCreationInputTokens + usage.cacheReadInputTokens,
+        usage.cacheCreationInputTokens,
+      ) +
+      calculateTokenCost(
+        effectivePricing.cacheReadPer1M ?? effectivePricing.inputPer1M,
+        usage.cacheReadInputTokens,
       )
     );
   }


### PR DESCRIPTION
## Summary
- Correct Gemini 3 unsigned tool-call fallback thought signature to the documented dummy value.
- Add Gemini 3.1 Pro pricing tiers for >200k prompt tokens, including tier-specific cache-read pricing.
- Cover low/high context pricing and cache-read tier selection in targeted tests.

## Validation
- `export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/pricing.test.ts src/__tests__/gemini-provider.test.ts`
- `export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
