### PR TITLE
Repair stale Gemini workspace model IDs

### DIFF
--- a/assistant/src/__tests__/workspace-migration-057-repair-stale-gemini-model-ids.test.ts
+++ b/assistant/src/__tests__/workspace-migration-057-repair-stale-gemini-model-ids.test.ts
@@ -1,0 +1,232 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { repairStaleGeminiModelIdsMigration } from "../workspace/migrations/057-repair-stale-gemini-model-ids.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-057-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function configPath(): string {
+  return join(workspaceDir, "config.json");
+}
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("057-repair-stale-gemini-model-ids migration", () => {
+  test("has correct migration id and is registered", () => {
+    expect(repairStaleGeminiModelIdsMigration.id).toBe(
+      "057-repair-stale-gemini-model-ids",
+    );
+    expect(WORKSPACE_MIGRATIONS.at(-1)?.id).toBe(
+      "057-repair-stale-gemini-model-ids",
+    );
+  });
+
+  test("repairs stale call-site model IDs with site-aware replacements", () => {
+    writeConfig({
+      llm: {
+        callSites: {
+          analyzeConversation: {
+            model: "gemini-3-flash",
+            temperature: 0,
+          },
+          conversationSummarization: { model: "gemini-3-flash" },
+          memoryRetrieval: { model: "gemini-3-flash" },
+          recall: {
+            model: "gemini-3-flash",
+            maxTokens: 4096,
+          },
+          commitMessage: {
+            model: "prefix-gemini-3-flash",
+          },
+          malformed: "gemini-3-flash",
+        },
+      },
+    });
+
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown> | string> };
+    };
+    expect(config.llm.callSites.analyzeConversation).toEqual({
+      model: "gemini-3.1-flash-lite-preview",
+      temperature: 0,
+    });
+    expect(config.llm.callSites.conversationSummarization).toEqual({
+      model: "gemini-3.1-flash-lite-preview",
+    });
+    expect(config.llm.callSites.memoryRetrieval).toEqual({
+      model: "gemini-3.1-flash-lite-preview",
+    });
+    expect(config.llm.callSites.recall).toEqual({
+      model: "gemini-3-flash-preview",
+      maxTokens: 4096,
+    });
+    expect(config.llm.callSites.commitMessage).toEqual({
+      model: "prefix-gemini-3-flash",
+    });
+    expect(config.llm.callSites.malformed).toBe("gemini-3-flash");
+  });
+
+  test("repairs default and profile model IDs with generic Gemini Flash replacement", () => {
+    writeConfig({
+      llm: {
+        default: {
+          provider: "gemini",
+          model: "gemini-3-flash",
+          maxTokens: 8192,
+        },
+        profiles: {
+          balanced: {
+            provider: "gemini",
+            model: "gemini-3-flash",
+          },
+          "cost-optimized": {
+            provider: "gemini",
+            model: "gemini-3.1-flash-lite-preview",
+          },
+          malformed: "gemini-3-flash",
+        },
+      },
+    });
+
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: {
+        default: Record<string, unknown>;
+        profiles: Record<string, Record<string, unknown> | string>;
+      };
+    };
+    expect(config.llm.default).toEqual({
+      provider: "gemini",
+      model: "gemini-3-flash-preview",
+      maxTokens: 8192,
+    });
+    expect(config.llm.profiles.balanced).toEqual({
+      provider: "gemini",
+      model: "gemini-3-flash-preview",
+    });
+    expect(config.llm.profiles["cost-optimized"]).toEqual({
+      provider: "gemini",
+      model: "gemini-3.1-flash-lite-preview",
+    });
+    expect(config.llm.profiles.malformed).toBe("gemini-3-flash");
+  });
+
+  test("preserves unrelated values and does not rewrite substring matches", () => {
+    writeConfig({
+      model: "gemini-3-flash",
+      imageGeneration: {
+        model: "gemini-3-flash",
+      },
+      llm: {
+        default: {
+          model: "gemini-3-flash-001",
+        },
+        callSites: {
+          analyzeConversation: {
+            model: "gemini-3-flash-preview",
+          },
+        },
+        profiles: {
+          custom: {
+            model: "my-gemini-3-flash",
+          },
+        },
+      },
+    });
+    const before = readFileSync(configPath(), "utf-8");
+
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+
+    expect(readFileSync(configPath(), "utf-8")).toBe(before);
+  });
+
+  test("is idempotent after repairing stale model IDs", () => {
+    writeConfig({
+      llm: {
+        default: { model: "gemini-3-flash" },
+        callSites: {
+          memoryRetrieval: { model: "gemini-3-flash" },
+          interactionClassifier: { model: "gemini-3-flash" },
+        },
+        profiles: {
+          balanced: { model: "gemini-3-flash" },
+        },
+      },
+    });
+
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+    const afterFirst = readFileSync(configPath(), "utf-8");
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+    const afterSecond = readFileSync(configPath(), "utf-8");
+
+    expect(afterSecond).toBe(afterFirst);
+
+    const config = readConfig() as {
+      llm: {
+        default: { model: string };
+        callSites: Record<string, { model: string }>;
+        profiles: Record<string, { model: string }>;
+      };
+    };
+    expect(config.llm.default.model).toBe("gemini-3-flash-preview");
+    expect(config.llm.callSites.memoryRetrieval.model).toBe(
+      "gemini-3.1-flash-lite-preview",
+    );
+    expect(config.llm.callSites.interactionClassifier.model).toBe(
+      "gemini-3-flash-preview",
+    );
+    expect(config.llm.profiles.balanced.model).toBe("gemini-3-flash-preview");
+  });
+
+  test("no-ops when config.json is missing or invalid", () => {
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+    expect(existsSync(configPath())).toBe(false);
+
+    writeFileSync(configPath(), "not-valid-json");
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+    expect(readFileSync(configPath(), "utf-8")).toBe("not-valid-json");
+
+    writeFileSync(configPath(), JSON.stringify([1, 2, 3]));
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+    expect(readFileSync(configPath(), "utf-8")).toBe("[1,2,3]");
+  });
+});

--- a/assistant/src/workspace/migrations/057-repair-stale-gemini-model-ids.ts
+++ b/assistant/src/workspace/migrations/057-repair-stale-gemini-model-ids.ts
@@ -1,0 +1,98 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Repair stale Gemini model IDs that earlier workspace migrations could seed.
+ *
+ * `gemini-3-flash` is no longer a catalog model ID. Repair only known LLM
+ * config leaves where migrations write model IDs, and only when the value is
+ * an exact stale match so unrelated user config and substring values are left
+ * untouched.
+ */
+export const repairStaleGeminiModelIdsMigration: WorkspaceMigration = {
+  id: "057-repair-stale-gemini-model-ids",
+  description: "Repair stale gemini-3-flash model IDs in workspace LLM config",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) return;
+
+    let changed = false;
+
+    const defaultBlock = readObject(llm.default);
+    if (defaultBlock !== null) {
+      changed = repairModel(defaultBlock, DEFAULT_REPLACEMENT_MODEL) || changed;
+    }
+
+    const callSites = readObject(llm.callSites);
+    if (callSites !== null) {
+      for (const [site, rawConfig] of Object.entries(callSites)) {
+        const callSiteConfig = readObject(rawConfig);
+        if (callSiteConfig === null) continue;
+        const replacement = LATENCY_CALL_SITES.has(site)
+          ? LATENCY_REPLACEMENT_MODEL
+          : DEFAULT_REPLACEMENT_MODEL;
+        changed = repairModel(callSiteConfig, replacement) || changed;
+      }
+    }
+
+    const profiles = readObject(llm.profiles);
+    if (profiles !== null) {
+      for (const rawProfile of Object.values(profiles)) {
+        const profile = readObject(rawProfile);
+        if (profile === null) continue;
+        changed = repairModel(profile, DEFAULT_REPLACEMENT_MODEL) || changed;
+      }
+    }
+
+    if (!changed) return;
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: reintroducing the stale model ID would break Gemini calls.
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers — self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const STALE_MODEL = "gemini-3-flash";
+const DEFAULT_REPLACEMENT_MODEL = "gemini-3-flash-preview";
+const LATENCY_REPLACEMENT_MODEL = "gemini-3.1-flash-lite-preview";
+
+const LATENCY_CALL_SITES = new Set([
+  "analyzeConversation",
+  "conversationSummarization",
+  "memoryRetrieval",
+]);
+
+function repairModel(
+  config: Record<string, unknown>,
+  replacement: string,
+): boolean {
+  if (config.model !== STALE_MODEL) return false;
+  config.model = replacement;
+  return true;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -54,6 +54,7 @@ import { releaseNotesAcpCodexMigration } from "./053-release-notes-acp-codex.js"
 import { seedRecallCallsiteMigration } from "./054-seed-recall-callsite.js";
 import { releaseNotesAgenticRecallMigration } from "./055-release-notes-agentic-recall.js";
 import { releaseNotesInferenceProfileReorderingMigration } from "./056-release-notes-inference-profile-reordering.js";
+import { repairStaleGeminiModelIdsMigration } from "./057-repair-stale-gemini-model-ids.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -119,4 +120,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   seedRecallCallsiteMigration,
   releaseNotesAgenticRecallMigration,
   releaseNotesInferenceProfileReorderingMigration,
+  repairStaleGeminiModelIdsMigration,
 ];


### PR DESCRIPTION
Summary:
- Add workspace migration 057 to repair exact stale gemini-3-flash model IDs in config.json.
- Map analyzeConversation, conversationSummarization, and memoryRetrieval call-site models to gemini-3.1-flash-lite-preview; map default, profiles, and other call-site models to gemini-3-flash-preview.
- Register the migration and cover repair, preservation, and idempotence behavior.

Validation:
- export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/workspace-migration-057-repair-stale-gemini-model-ids.test.ts
- export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bunx tsc --noEmit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
