### PR TITLE
Tighten Gemini pricing and test fixtures

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -96,7 +96,7 @@ function finishChunk(
   return {
     candidates: [{ finishReason: reason }],
     usageMetadata: { promptTokenCount: prompt, candidatesTokenCount: output },
-    modelVersion: "gemini-3-flash-001",
+    modelVersion: "gemini-3-flash-preview-001",
   };
 }
 
@@ -156,7 +156,7 @@ describe("GeminiProvider", () => {
   let provider: GeminiProvider;
 
   beforeEach(() => {
-    provider = new GeminiProvider("test-api-key", "gemini-3-flash");
+    provider = new GeminiProvider("test-api-key", "gemini-3-flash-preview");
     fakeChunks = [];
     lastStreamParams = null;
     lastConstructorOpts = null;
@@ -179,7 +179,7 @@ describe("GeminiProvider", () => {
 
     expect(result.content).toHaveLength(1);
     expect(result.content[0]).toEqual({ type: "text", text: "Hello, world!" });
-    expect(result.model).toBe("gemini-3-flash-001");
+    expect(result.model).toBe("gemini-3-flash-preview-001");
     expect(result.usage).toEqual({ inputTokens: 10, outputTokens: 5 });
     expect(result.stopReason).toBe("STOP");
   });
@@ -638,7 +638,7 @@ describe("GeminiProvider", () => {
       ],
       undefined,
       undefined,
-      { config: { model: "models/gemini-3-pro-preview" } },
+      { config: { model: "models/gemini-3.1-pro-preview" } },
     );
 
     const contents = lastStreamParams!.contents as Array<{
@@ -1002,7 +1002,7 @@ describe("GeminiProvider", () => {
       { role: "user", content: [{ type: "text", text: "Hi" }] },
     ]);
 
-    expect(lastStreamParams!.model).toBe("gemini-3-flash");
+    expect(lastStreamParams!.model).toBe("gemini-3-flash-preview");
     const contents = lastStreamParams!.contents as Array<{
       role: string;
       parts: unknown[];
@@ -1062,12 +1062,12 @@ describe("GeminiProvider", () => {
   // Managed transport — constructor configuration
   // -----------------------------------------------------------------------
   test("does not set httpOptions when managedBaseUrl is not provided", () => {
-    new GeminiProvider("test-key", "gemini-3-flash");
+    new GeminiProvider("test-key", "gemini-3-flash-preview");
     expect(lastConstructorOpts).toEqual({ apiKey: "test-key" });
   });
 
   test("sets httpOptions.baseUrl when managedBaseUrl is provided", () => {
-    new GeminiProvider("managed-key", "gemini-3-flash", {
+    new GeminiProvider("managed-key", "gemini-3-flash-preview", {
       managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
     });
     expect(lastConstructorOpts).toEqual({
@@ -1081,7 +1081,7 @@ describe("GeminiProvider", () => {
   test("managed transport produces same ProviderResponse shape", async () => {
     const managedProvider = new GeminiProvider(
       "managed-key",
-      "gemini-3-flash",
+      "gemini-3-flash-preview",
       {
         managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
       },
@@ -1098,7 +1098,7 @@ describe("GeminiProvider", () => {
       type: "text",
       text: "Hello from managed",
     });
-    expect(result.model).toBe("gemini-3-flash-001");
+    expect(result.model).toBe("gemini-3-flash-preview-001");
     expect(result.usage).toEqual({ inputTokens: 15, outputTokens: 8 });
     expect(result.stopReason).toBe("STOP");
   });
@@ -1106,7 +1106,7 @@ describe("GeminiProvider", () => {
   test("managed transport handles tool calls correctly", async () => {
     const managedProvider = new GeminiProvider(
       "managed-key",
-      "gemini-3-flash",
+      "gemini-3-flash-preview",
       {
         managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
       },

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -420,6 +420,32 @@ describe("resolvePricingForUsage", () => {
       10,
     );
   });
+
+  test("uses Gemini 2.5 Flash Standard cache-read rates", () => {
+    const flash = resolvePricingForUsage("gemini", "gemini-2.5-flash", {
+      directInputTokens: 0,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 1_000_000,
+      anthropicCacheCreation: null,
+    });
+    const flashLite = resolvePricingForUsage(
+      "gemini",
+      "gemini-2.5-flash-lite",
+      {
+        directInputTokens: 0,
+        outputTokens: 0,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 1_000_000,
+        anthropicCacheCreation: null,
+      },
+    );
+
+    expect(flash.pricingStatus).toBe("priced");
+    expect(flash.estimatedCostUsd).toBe(0.03);
+    expect(flashLite.pricingStatus).toBe("priced");
+    expect(flashLite.estimatedCostUsd).toBe(0.01);
+  });
 });
 
 describe("fast mode pricing", () => {

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -84,8 +84,16 @@ const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
       inputPer1M: 0.25,
       outputPer1M: 1.5,
     },
-    "gemini-2.5-flash": { inputPer1M: 0.3, outputPer1M: 2.5 },
-    "gemini-2.5-flash-lite": { inputPer1M: 0.1, outputPer1M: 0.4 },
+    "gemini-2.5-flash": {
+      inputPer1M: 0.3,
+      outputPer1M: 2.5,
+      cacheReadPer1M: 0.03,
+    },
+    "gemini-2.5-flash-lite": {
+      inputPer1M: 0.1,
+      outputPer1M: 0.4,
+      cacheReadPer1M: 0.01,
+    },
     "gemini-2.5-pro": { inputPer1M: 1.25, outputPer1M: 10 },
     "gemini-2.0-flash": { inputPer1M: 0.1, outputPer1M: 0.4 },
   },


### PR DESCRIPTION
## Summary
- Price Gemini 2.5 Flash/Flash-Lite cache reads at their Standard cache-read rates instead of falling back to input rates.
- Update Gemini provider tests to use current Gemini 3 model IDs, including the Gemini 3.1 Pro fallback fixture.

## Validation
- `cd assistant && bun test src/__tests__/pricing.test.ts src/__tests__/gemini-provider.test.ts`
- `cd assistant && bunx tsc --noEmit`

Part of Gemini 3 model support run-plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
