### PR TITLE
feat(acp): add agent_thought_chunk variant to update type union

### DIFF
--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -14,6 +14,7 @@ export interface AcpSessionUpdate {
   acpSessionId: string;
   updateType:
     | "agent_message_chunk"
+    | "agent_thought_chunk"
     | "user_message_chunk"
     | "tool_call"
     | "tool_call_update"


### PR DESCRIPTION
## Summary
- Extends `AcpSessionUpdate.updateType` to include `agent_thought_chunk`.
- Forwarding wiring lands in PR 4 of this plan; UI rendering in PR 23.

Part of plan: acp-sessions-ui.md (PR 3 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
