### PR TITLE
feat(acp): add optional parentConversationId to AcpSessionState

### DIFF
--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -21,6 +21,8 @@ export interface AcpSessionState {
   id: string;
   agentId: string;
   acpSessionId: string;
+  /** Conversation that spawned this session. */
+  parentConversationId?: string;
   status: "initializing" | "running" | "completed" | "failed" | "cancelled";
   startedAt: number;
   completedAt?: number;


### PR DESCRIPTION
## Summary
- Adds optional `parentConversationId?: string` field to `AcpSessionState`.
- Producer wiring follows in PR 2 of this plan.

Part of plan: acp-sessions-ui.md (PR 1 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
