### PR TITLE
feat(macos): add acpSessions case to NativePanelId enum

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -5,6 +5,8 @@ import VellumAssistantShared
 
 public enum NativePanelId: String, Equatable, Sendable {
     case chat, conversationList, settings, logsAndUsage, generated, avatarCustomization, apps, intelligence, home
+    /// Coding agents (ACP sessions) panel.
+    case acpSessions
 }
 
 extension NativePanelId: Codable {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -150,6 +150,9 @@ extension MainWindowView {
             )
         case .home:
             homePanelView(onDismiss: { windowState.selection = nil })
+        case .acpSessions:
+            // Routing is added in a follow-up PR; render nothing for now.
+            EmptyView()
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `acpSessions` case to `NativePanelId` (no behavior change).
- PR 19 wires the routing; PR 20 adds the toolbar button.

Part of plan: acp-sessions-ui.md (PR 17 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
