### PR TITLE
feat(acp): forward agent_thought_chunk to clients instead of dropping

### DIFF
--- a/assistant/src/acp/__tests__/client-handler.test.ts
+++ b/assistant/src/acp/__tests__/client-handler.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+import { VellumAcpClientHandler } from "../client-handler.js";
+
+const ACP_SESSION_ID = "acp-session-abc";
+const PARENT_CONVERSATION_ID = "conv-xyz";
+
+function makeHandler(): {
+  handler: VellumAcpClientHandler;
+  sent: ServerMessage[];
+} {
+  const sent: ServerMessage[] = [];
+  const handler = new VellumAcpClientHandler(
+    ACP_SESSION_ID,
+    (msg) => {
+      sent.push(msg);
+    },
+    PARENT_CONVERSATION_ID,
+  );
+  return { handler, sent };
+}
+
+describe("VellumAcpClientHandler.sessionUpdate", () => {
+  test("forwards agent_thought_chunk as an acp_session_update", async () => {
+    const { handler, sent } = makeHandler();
+
+    const notification: SessionNotification = {
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "internal reasoning here" },
+      },
+    };
+
+    await handler.sessionUpdate(notification);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({
+      type: "acp_session_update",
+      acpSessionId: ACP_SESSION_ID,
+      updateType: "agent_thought_chunk",
+      content: "internal reasoning here",
+    });
+  });
+
+  test("agent_thought_chunk does not contribute to accumulated response text", async () => {
+    const { handler } = makeHandler();
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "thinking..." },
+      },
+    });
+
+    // Thoughts are forwarded for UI display but should not be treated as the
+    // agent's final response text.
+    expect(handler.responseText).toBe("");
+  });
+});

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -88,6 +88,17 @@ export class VellumAcpClientHandler implements Client {
         break;
       }
 
+      case "agent_thought_chunk": {
+        const text = extractText(update.content);
+        this.sendToVellum({
+          type: "acp_session_update",
+          acpSessionId: this.acpSessionId,
+          updateType: "agent_thought_chunk",
+          content: text,
+        });
+        break;
+      }
+
       case "user_message_chunk": {
         const text = extractText(update.content);
         this.sendToVellum({
@@ -135,9 +146,9 @@ export class VellumAcpClientHandler implements Client {
       }
 
       default: {
-        // Other update types (agent_thought_chunk, available_commands_update,
-        // current_mode_update, config_option_update, session_info_update,
-        // usage_update) are not forwarded to Vellum.
+        // Other update types (available_commands_update, current_mode_update,
+        // config_option_update, session_info_update, usage_update) are not
+        // forwarded to Vellum.
         log.debug(
           {
             acpSessionId: this.acpSessionId,


### PR DESCRIPTION
## Summary
- Adds `agent_thought_chunk` case in the client-handler's session-update switch.
- Removes the default-case comment about dropping thoughts.
- Adds a regression test.

Part of plan: acp-sessions-ui.md (PR 4 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
