### PR TITLE
Refresh Gemini context normalization fixture

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -774,7 +774,7 @@ describe("normalizeLlmContextPayloads", () => {
     const normalized = normalizeLlmContextPayloads({
       createdAt: 1_742_400_000_002,
       requestPayload: {
-        model: "gemini-3-flash",
+        model: "gemini-3-flash-preview",
         contents: [
           {
             role: "user",
@@ -818,7 +818,7 @@ describe("normalizeLlmContextPayloads", () => {
         },
       },
       responsePayload: {
-        model: "gemini-3-flash-001",
+        model: "gemini-3-flash-preview",
         text: "Here is the summary.",
         functionCalls: [
           {
@@ -837,7 +837,7 @@ describe("normalizeLlmContextPayloads", () => {
 
     expect(normalized.summary).toEqual({
       provider: "gemini",
-      model: "gemini-3-flash-001",
+      model: "gemini-3-flash-preview",
       inputTokens: 200,
       outputTokens: 31,
       stopReason: "STOP",
@@ -902,7 +902,7 @@ describe("normalizeLlmContextPayloads", () => {
         kind: "settings",
         label: "Generation config",
         data: {
-          model: "gemini-3-flash",
+          model: "gemini-3-flash-preview",
           config: {
             temperature: 0.4,
             responseMimeType: "application/json",


### PR DESCRIPTION
## Summary
- Update the Gemini LLM context-normalization fixture from retired `gemini-3-flash` IDs to `gemini-3-flash-preview`
- Keeps stale exact Gemini IDs limited to append-only migrations and the repair migration coverage

## Validation
- `export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/llm-context-normalization.test.ts`
- commit hook: assistant lint + typecheck
- pre-push hook: assistant typecheck + lint
- `git diff --check`

Part of Gemini 3 model support plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
