### PR TITLE
feat(acp): persist terminal sessions to acp_session_history

### DIFF
--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Tests for AcpSessionManager's terminal-state persistence pipeline:
+ * the per-session ring buffer, the `acp_session_history` row written on
+ * terminal transition, and the buffer eviction policy.
+ *
+ * These tests inject a fake AcpAgentProcess directly into the session map
+ * to drive completion/failure without spawning a real child process —
+ * matching the `session cleanup after prompt` style in `acp-session.test.ts`.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { VellumAcpClientHandler } from "../../acp/client-handler.js";
+import { AcpSessionManager } from "../../acp/session-manager.js";
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { AcpSessionUpdate } from "../../daemon/message-types/acp.js";
+import { getSqlite, initializeDb } from "../../memory/db.js";
+
+initializeDb();
+
+function clearHistory() {
+  getSqlite().run("DELETE FROM acp_session_history");
+}
+
+interface HistoryRow {
+  id: string;
+  agent_id: string;
+  acp_session_id: string;
+  parent_conversation_id: string;
+  started_at: number;
+  completed_at: number | null;
+  status: string;
+  stop_reason: string | null;
+  error: string | null;
+  event_log_json: string;
+}
+
+function readHistoryRow(id: string): HistoryRow | null {
+  return getSqlite()
+    .query(
+      `SELECT id, agent_id, acp_session_id, parent_conversation_id,
+              started_at, completed_at, status, stop_reason, error, event_log_json
+       FROM acp_session_history WHERE id = ?`,
+    )
+    .get(id) as HistoryRow | null;
+}
+
+/**
+ * Builds a manager with a fake session pre-injected and returns the handles
+ * needed to drive terminal transitions in tests.
+ */
+function buildSessionWithFakeProcess(opts: {
+  id: string;
+  agentId: string;
+  protocolSessionId: string;
+  parentConversationId: string;
+}): {
+  manager: AcpSessionManager;
+  resolvePrompt: (v: { stopReason: string }) => void;
+  rejectPrompt: (e: Error) => void;
+  emitUpdate: (update: AcpSessionUpdate) => void;
+} {
+  const manager = new AcpSessionManager(1);
+  const sent: ServerMessage[] = [];
+  const sendToVellum = (msg: ServerMessage) => sent.push(msg);
+
+  let resolvePrompt!: (v: { stopReason: string }) => void;
+  let rejectPrompt!: (e: Error) => void;
+  const promptPromise = new Promise<{ stopReason: string }>((res, rej) => {
+    resolvePrompt = res;
+    rejectPrompt = rej;
+  });
+
+  const fakeProcess = {
+    prompt: () => promptPromise,
+    kill: () => {},
+    spawn: () => {},
+    initialize: () => Promise.resolve(),
+    createSession: () => Promise.resolve(opts.protocolSessionId),
+    cancel: () => Promise.resolve(),
+  };
+
+  // Match spawn()'s wiring: pre-create the buffer and route emitted updates
+  // through the wrapped sender so appendToBuffer fires for each event.
+  const sessions = (manager as unknown as { sessions: Map<string, unknown> })
+    .sessions;
+  const eventBuffers = (
+    manager as unknown as { eventBuffers: Map<string, unknown[]> }
+  ).eventBuffers;
+  eventBuffers.set(opts.id, []);
+
+  const wrappedSend = (msg: ServerMessage) => {
+    if (msg.type === "acp_session_update") {
+      (
+        manager as unknown as {
+          appendToBuffer: (id: string, u: AcpSessionUpdate) => void;
+        }
+      ).appendToBuffer(opts.id, msg);
+    }
+    sendToVellum(msg);
+  };
+
+  const clientHandler = new VellumAcpClientHandler(
+    opts.id,
+    wrappedSend,
+    opts.parentConversationId,
+  );
+
+  const entry = {
+    process: fakeProcess,
+    state: {
+      id: opts.id,
+      agentId: opts.agentId,
+      acpSessionId: opts.protocolSessionId,
+      status: "running",
+      startedAt: Date.now(),
+    },
+    clientHandler,
+    sendToVellum: wrappedSend,
+    currentPrompt: null as Promise<unknown> | null,
+    parentConversationId: opts.parentConversationId,
+    cwd: "/tmp",
+    command: "claude-agent-acp",
+  };
+  sessions.set(opts.id, entry);
+
+  // Fire the prompt via the private method, matching spawn()'s wiring.
+  const bgPromise = (
+    manager as unknown as {
+      firePromptInBackground: (
+        id: string,
+        e: typeof entry,
+        protoId: string,
+        msg: string,
+      ) => Promise<unknown>;
+    }
+  ).firePromptInBackground(opts.id, entry, opts.protocolSessionId, "do work");
+  entry.currentPrompt = bgPromise;
+
+  // Helper that pushes an update through the wrapped sender — exactly
+  // matching what VellumAcpClientHandler.sessionUpdate does.
+  const emitUpdate = (update: AcpSessionUpdate) => {
+    wrappedSend(update);
+  };
+
+  return {
+    manager,
+    resolvePrompt,
+    rejectPrompt,
+    emitUpdate,
+  };
+}
+
+describe("AcpSessionManager — terminal persistence", () => {
+  beforeEach(() => {
+    clearHistory();
+  });
+
+  test("persists a row with the buffered event log on completion and drops the buffer", async () => {
+    const id = "session-complete-1";
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-X",
+      protocolSessionId: "proto-X",
+      parentConversationId: "conv-1",
+    });
+
+    // Emit a few wire-shaped updates before the prompt resolves.
+    handles.emitUpdate({
+      type: "acp_session_update",
+      acpSessionId: id,
+      updateType: "agent_message_chunk",
+      content: "hello",
+    });
+    handles.emitUpdate({
+      type: "acp_session_update",
+      acpSessionId: id,
+      updateType: "tool_call",
+      toolCallId: "tc-1",
+      toolTitle: "Read file",
+      toolKind: "read",
+      toolStatus: "running",
+    });
+    handles.emitUpdate({
+      type: "acp_session_update",
+      acpSessionId: id,
+      updateType: "tool_call_update",
+      toolCallId: "tc-1",
+      toolStatus: "completed",
+    });
+
+    // Drive completion. Yield twice to flush the .then() and the
+    // subsequent persist call queued behind it.
+    handles.resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    expect(row!.status).toBe("completed");
+    expect(row!.stop_reason).toBe("end_turn");
+    expect(row!.agent_id).toBe("agent-X");
+    expect(row!.acp_session_id).toBe("proto-X");
+    expect(row!.parent_conversation_id).toBe("conv-1");
+    expect(row!.completed_at).not.toBeNull();
+    expect(row!.error).toBeNull();
+
+    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdate[];
+    expect(log).toHaveLength(3);
+    expect(log[0]).toMatchObject({
+      type: "acp_session_update",
+      acpSessionId: id,
+      updateType: "agent_message_chunk",
+      content: "hello",
+    });
+    expect(log[1]).toMatchObject({
+      updateType: "tool_call",
+      toolCallId: "tc-1",
+    });
+    expect(log[2]).toMatchObject({
+      updateType: "tool_call_update",
+      toolCallId: "tc-1",
+      toolStatus: "completed",
+    });
+
+    // Buffer entry is dropped after persistence.
+    const eventBuffers = (
+      handles.manager as unknown as { eventBuffers: Map<string, unknown[]> }
+    ).eventBuffers;
+    expect(eventBuffers.has(id)).toBe(false);
+  });
+
+  test("persists status='failed' with the error message on prompt rejection", async () => {
+    const id = "session-failed-1";
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-Y",
+      protocolSessionId: "proto-Y",
+      parentConversationId: "conv-2",
+    });
+
+    handles.emitUpdate({
+      type: "acp_session_update",
+      acpSessionId: id,
+      updateType: "agent_message_chunk",
+      content: "before crash",
+    });
+
+    handles.rejectPrompt(new Error("agent died"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    expect(row!.status).toBe("failed");
+    expect(row!.error).toBe("agent died");
+    expect(row!.stop_reason).toBeNull();
+
+    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdate[];
+    expect(log).toHaveLength(1);
+    expect(log[0]).toMatchObject({
+      updateType: "agent_message_chunk",
+      content: "before crash",
+    });
+  });
+
+  test("buffer caps event count at 200 — 300 emitted events => 200 persisted", async () => {
+    const id = "session-cap-1";
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-Z",
+      protocolSessionId: "proto-Z",
+      parentConversationId: "conv-3",
+    });
+
+    for (let i = 0; i < 300; i++) {
+      handles.emitUpdate({
+        type: "acp_session_update",
+        acpSessionId: id,
+        updateType: "agent_message_chunk",
+        content: `chunk-${i}`,
+      });
+    }
+
+    // Verify in-memory buffer is bounded before persistence.
+    const eventBuffers = (
+      handles.manager as unknown as {
+        eventBuffers: Map<string, { update: AcpSessionUpdate }[]>;
+      }
+    ).eventBuffers;
+    expect(eventBuffers.get(id)?.length).toBe(200);
+
+    handles.resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdate[];
+    expect(log).toHaveLength(200);
+    // Oldest events were evicted — the persisted log contains the last 200.
+    expect((log[0] as { content?: string }).content).toBe("chunk-100");
+    expect((log[199] as { content?: string }).content).toBe("chunk-299");
+  });
+
+  test("buffer caps aggregate JSON size at 256 KB", async () => {
+    const id = "session-bytes-1";
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-B",
+      protocolSessionId: "proto-B",
+      parentConversationId: "conv-bytes",
+    });
+
+    // Each event is ~5 KB of payload — 80 events => ~400 KB, well past the
+    // 256 KB byte cap. Persisted log should be smaller than 80.
+    const heavyPayload = "x".repeat(5000);
+    for (let i = 0; i < 80; i++) {
+      handles.emitUpdate({
+        type: "acp_session_update",
+        acpSessionId: id,
+        updateType: "agent_message_chunk",
+        content: heavyPayload,
+      });
+    }
+
+    handles.resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdate[];
+    expect(log.length).toBeLessThan(80);
+    expect(log.length).toBeGreaterThan(0);
+    // Persisted JSON must respect the 256 KB cap (allowing a small margin
+    // for the surrounding `[…]` and inter-element commas).
+    expect(row!.event_log_json.length).toBeLessThan(256 * 1024 + 1024);
+  });
+
+  test("persists empty event log when no updates were emitted", async () => {
+    const id = "session-empty-1";
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-empty",
+      protocolSessionId: "proto-empty",
+      parentConversationId: "conv-empty",
+    });
+
+    handles.resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    expect(row!.event_log_json).toBe("[]");
+    expect(row!.status).toBe("completed");
+  });
+});

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -6,6 +6,9 @@
 import { randomUUID } from "node:crypto";
 
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AcpSessionUpdate } from "../daemon/message-types/acp.js";
+import { getDb } from "../memory/db.js";
+import { acpSessionHistory } from "../memory/schema.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { getLogger } from "../util/logger.js";
 import { AcpAgentProcess } from "./agent-process.js";
@@ -14,10 +17,23 @@ import type { AcpAgentConfig, AcpSessionState } from "./types.js";
 
 const log = getLogger("acp:session-manager");
 
+/** Maximum number of update events kept in a session's ring buffer. */
+const MAX_BUFFER_EVENTS = 200;
+/** Maximum aggregate JSON size of a session's ring buffer, in bytes. */
+const MAX_BUFFER_BYTES = 256 * 1024;
+
+interface BufferedAcpUpdate {
+  /** The wire-shaped update — exactly what was forwarded to clients. */
+  update: AcpSessionUpdate;
+  /** Cached UTF-8 byte length of `JSON.stringify(update)` for cap math. */
+  byteSize: number;
+}
+
 interface SessionEntry {
   process: AcpAgentProcess;
   state: AcpSessionState;
   clientHandler: VellumAcpClientHandler;
+  /** Wrapped sender that also appends to the ring buffer. */
   sendToVellum: (msg: ServerMessage) => void;
   currentPrompt: Promise<unknown> | null;
   parentConversationId: string;
@@ -29,6 +45,13 @@ interface SessionEntry {
 
 export class AcpSessionManager {
   private sessions = new Map<string, SessionEntry>();
+  /**
+   * Per-session ring buffer of wire-shaped update events forwarded to
+   * clients. Bounded by event count and aggregate JSON byte size; oldest
+   * events are dropped first when caps are exceeded. Persisted to
+   * `acp_session_history` on terminal transition, then cleared.
+   */
+  private eventBuffers = new Map<string, BufferedAcpUpdate[]>();
 
   /**
    * Optional callback to inject a completion/failure message into the parent
@@ -78,9 +101,22 @@ export class AcpSessionManager {
       "ACP spawn requested",
     );
 
+    // Initialize the per-session ring buffer before any update can fire.
+    this.eventBuffers.set(acpSessionId, []);
+
+    // Wrap the sender so every emitted message is mirrored into the buffer
+    // when it's an `acp_session_update`. The wrapper preserves the original
+    // call semantics — it forwards every message unchanged.
+    const wrappedSend = (msg: ServerMessage) => {
+      if (msg.type === "acp_session_update") {
+        this.appendToBuffer(acpSessionId, msg);
+      }
+      sendToVellum(msg);
+    };
+
     const clientHandler = new VellumAcpClientHandler(
       acpSessionId,
-      sendToVellum,
+      wrappedSend,
       parentConversationId,
     );
 
@@ -104,7 +140,7 @@ export class AcpSessionManager {
       process: agentProcess,
       state,
       clientHandler,
-      sendToVellum,
+      sendToVellum: wrappedSend,
       currentPrompt: null,
       parentConversationId,
       cwd,
@@ -134,10 +170,11 @@ export class AcpSessionManager {
       // Kill the orphaned child process and remove the reserved slot.
       agentProcess.kill();
       this.sessions.delete(acpSessionId);
+      this.eventBuffers.delete(acpSessionId);
       throw err;
     }
 
-    sendToVellum({
+    wrappedSend({
       type: "acp_session_spawned",
       acpSessionId,
       agent: agentId,
@@ -199,6 +236,11 @@ export class AcpSessionManager {
 
   /**
    * Cancels an ongoing prompt in the specified session.
+   *
+   * The session's in-flight `prompt()` will reject in response, and the
+   * catch handler in `firePromptInBackground` performs the terminal
+   * persistence + teardown. We just flip the status here so that handler
+   * preserves "cancelled" instead of overwriting with "failed".
    */
   async cancel(acpSessionId: string): Promise<void> {
     const entry = this.sessions.get(acpSessionId);
@@ -233,6 +275,9 @@ export class AcpSessionManager {
     }
     entry.process.kill();
     this.sessions.delete(acpSessionId);
+    // Free the buffer in case persistTerminal hasn't already (e.g. close()
+    // before terminal transition).
+    this.eventBuffers.delete(acpSessionId);
   }
 
   /**
@@ -257,6 +302,68 @@ export class AcpSessionManager {
       return entry.state;
     }
     return Array.from(this.sessions.values()).map((e) => e.state);
+  }
+
+  /**
+   * Appends a wire-shaped update to the ring buffer, evicting oldest events
+   * when either the count or aggregate-byte cap is exceeded. Byte
+   * accounting tracks the sum of element JSON sizes; the cap is a soft
+   * target (off by at most `buffer.length` for delimiters in the eventual
+   * `JSON.stringify(buffer)` output).
+   */
+  private appendToBuffer(acpSessionId: string, update: AcpSessionUpdate): void {
+    const buffer = this.eventBuffers.get(acpSessionId);
+    if (!buffer) return; // Session already torn down.
+    const byteSize = Buffer.byteLength(JSON.stringify(update), "utf8");
+    buffer.push({ update, byteSize });
+    let totalBytes = 0;
+    for (const entry of buffer) totalBytes += entry.byteSize;
+
+    while (
+      buffer.length > 0 &&
+      (buffer.length > MAX_BUFFER_EVENTS || totalBytes > MAX_BUFFER_BYTES)
+    ) {
+      const dropped = buffer.shift();
+      if (dropped !== undefined) totalBytes -= dropped.byteSize;
+    }
+  }
+
+  /**
+   * Persists the session's final state + buffered event log to
+   * `acp_session_history`, then frees the buffer entry. Best-effort: a DB
+   * failure is logged but does not propagate, since the session has already
+   * reached a terminal state and clients have been notified.
+   */
+  private persistTerminal(acpSessionId: string, entry: SessionEntry): void {
+    const buffer = this.eventBuffers.get(acpSessionId) ?? [];
+    // Serialize only the wire-shaped updates — drop the byte-size accounting
+    // metadata so persisted rows match the protocol shape clients receive.
+    const wireUpdates = buffer.map((buffered) => buffered.update);
+    try {
+      getDb()
+        .insert(acpSessionHistory)
+        .values({
+          id: acpSessionId,
+          agentId: entry.state.agentId,
+          acpSessionId: entry.state.acpSessionId,
+          parentConversationId: entry.parentConversationId,
+          startedAt: entry.state.startedAt,
+          completedAt: entry.state.completedAt ?? null,
+          status: entry.state.status,
+          stopReason: entry.state.stopReason ?? null,
+          error: entry.state.error ?? null,
+          eventLogJson: JSON.stringify(wireUpdates),
+        })
+        .onConflictDoNothing()
+        .run();
+    } catch (err) {
+      log.error(
+        { acpSessionId, err },
+        "Failed to persist ACP session history row",
+      );
+    }
+    // Drop the buffer entry to free memory regardless of write outcome.
+    this.eventBuffers.delete(acpSessionId);
   }
 
   /**
@@ -293,6 +400,10 @@ export class AcpSessionManager {
             acpSessionId,
             stopReason: response.stopReason,
           });
+
+          // Persist the terminal row + buffered event log before tearing
+          // down (teardown deletes the buffer entry).
+          this.persistTerminal(acpSessionId, current);
 
           // Free the session slot, deny any pending permissions, and
           // kill the agent process.
@@ -341,6 +452,9 @@ export class AcpSessionManager {
             acpSessionId,
             error: err.message,
           });
+
+          // Persist the terminal row before teardown clears the buffer.
+          this.persistTerminal(acpSessionId, current);
 
           // Free the session slot and deny any pending permissions.
           this.teardownSession(acpSessionId, current);

--- a/assistant/src/memory/schema/acp.ts
+++ b/assistant/src/memory/schema/acp.ts
@@ -1,0 +1,30 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/**
+ * ACP (Agent Client Protocol) session history. Persists completed ACP
+ * sessions so the sessions UI has data across daemon restarts.
+ *
+ * Created by migration 230. Rows are written when a session reaches a
+ * terminal state (completed, failed, cancelled).
+ */
+export const acpSessionHistory = sqliteTable(
+  "acp_session_history",
+  {
+    id: text("id").primaryKey(),
+    agentId: text("agent_id").notNull(),
+    acpSessionId: text("acp_session_id").notNull(),
+    parentConversationId: text("parent_conversation_id").notNull(),
+    startedAt: integer("started_at").notNull(),
+    completedAt: integer("completed_at"),
+    status: text("status").notNull(),
+    stopReason: text("stop_reason"),
+    error: text("error"),
+    eventLogJson: text("event_log_json").notNull().default("[]"),
+  },
+  (table) => [
+    index("idx_acp_session_history_started_at").on(table.startedAt),
+    index("idx_acp_session_history_parent_conversation_id").on(
+      table.parentConversationId,
+    ),
+  ],
+);

--- a/assistant/src/memory/schema/index.ts
+++ b/assistant/src/memory/schema/index.ts
@@ -1,3 +1,4 @@
+export * from "./acp.js";
 export * from "./calls.js";
 export * from "./contacts.js";
 export * from "./conversations.js";


### PR DESCRIPTION
## Summary
- Adds per-session ring buffer (capped at 200 events / 256 KB) tracking wire-shaped updates.
- Persists session row + serialized event log to `acp_session_history` on terminal transition.
- Drops buffer entry after write to free memory.

Part of plan: acp-sessions-ui.md (PR 6 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
