### PR TITLE
Refresh Gemini LLM context client fixture

### DIFF
--- a/clients/shared/Tests/LLMContextClientDecodingTests.swift
+++ b/clients/shared/Tests/LLMContextClientDecodingTests.swift
@@ -189,7 +189,7 @@ final class LLMContextClientDecodingTests: XCTestCase {
                   "createdAt": 99887767,
                   "summary": {
                     "provider": "gemini",
-                    "model": "gemini-3-flash-001",
+                    "model": "gemini-3-flash-preview",
                     "stopReason": "STOP"
                   },
                   "requestSections": [


### PR DESCRIPTION
## Summary
- Update the Swift LLM context client decoding fixture from retired `gemini-3-flash-001` to `gemini-3-flash-preview`
- Clears the final stale Gemini 3 fixture ID found during internal review

## Validation
- `rg -n 'gemini-3-flash-001|gemini-3-flash"|gemini-3-pro-preview' clients/shared/Tests/LLMContextClientDecodingTests.swift clients || true` produced no hits
- `git diff --check`
- `cd clients && swift test --filter LLMContextClientDecodingTests` did not reach tests because SwiftPM stopped on a stale module-cache path from a prior worktree build

Part of Gemini 3 model support plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
