### PR TITLE
feat(clients): add Swift structs for ACP session messages

### DIFF
--- a/clients/macos/vellum-assistantTests/Network/ACPMessagesTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/ACPMessagesTests.swift
@@ -1,0 +1,362 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class ACPMessagesTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func decode<T: Decodable>(_ type: T.Type, _ json: String) throws -> T {
+        try JSONDecoder().decode(type, from: Data(json.utf8))
+    }
+
+    private func encodeToDict<T: Encodable>(_ value: T) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(value)
+        guard let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            XCTFail("Encoded value is not a JSON object")
+            return [:]
+        }
+        return dict
+    }
+
+    // MARK: - ACPSessionState
+
+    func test_acpSessionState_decodesAllFields() throws {
+        let json = #"""
+        {
+          "id": "sess-1",
+          "agentId": "claude-code",
+          "acpSessionId": "acp-abc",
+          "parentConversationId": "conv-xyz",
+          "status": "running",
+          "startedAt": 1700000000000,
+          "completedAt": 1700000005000,
+          "error": null,
+          "stopReason": "end_turn"
+        }
+        """#
+
+        let state = try decode(ACPSessionState.self, json)
+
+        XCTAssertEqual(state.id, "sess-1")
+        XCTAssertEqual(state.agentId, "claude-code")
+        XCTAssertEqual(state.acpSessionId, "acp-abc")
+        XCTAssertEqual(state.parentConversationId, "conv-xyz")
+        XCTAssertEqual(state.status, .running)
+        XCTAssertEqual(state.startedAt, 1_700_000_000_000)
+        XCTAssertEqual(state.completedAt, 1_700_000_005_000)
+        XCTAssertNil(state.error)
+        XCTAssertEqual(state.stopReason, .endTurn)
+    }
+
+    func test_acpSessionState_decodesMinimalFields() throws {
+        let json = #"""
+        {
+          "id": "sess-2",
+          "agentId": "agent-x",
+          "acpSessionId": "acp-2",
+          "status": "initializing",
+          "startedAt": 1700000000000
+        }
+        """#
+
+        let state = try decode(ACPSessionState.self, json)
+
+        XCTAssertEqual(state.status, .initializing)
+        XCTAssertNil(state.parentConversationId)
+        XCTAssertNil(state.completedAt)
+        XCTAssertNil(state.error)
+        XCTAssertNil(state.stopReason)
+    }
+
+    func test_acpSessionState_unknownStatus_fallsBackToUnknown() throws {
+        let json = #"""
+        {
+          "id": "sess-3",
+          "agentId": "a",
+          "acpSessionId": "acp-3",
+          "status": "future_status_value",
+          "startedAt": 0
+        }
+        """#
+
+        let state = try decode(ACPSessionState.self, json)
+        XCTAssertEqual(state.status, .unknown)
+    }
+
+    func test_acpSessionState_unknownStopReason_fallsBackToUnknown() throws {
+        let json = #"""
+        {
+          "id": "sess-4",
+          "agentId": "a",
+          "acpSessionId": "acp-4",
+          "status": "completed",
+          "startedAt": 0,
+          "stopReason": "future_reason"
+        }
+        """#
+
+        let state = try decode(ACPSessionState.self, json)
+        XCTAssertEqual(state.stopReason, .unknown)
+    }
+
+    func test_acpSessionState_roundTrip_preservesEquality() throws {
+        let original = ACPSessionState(
+            id: "sess-rt",
+            agentId: "a",
+            acpSessionId: "acp-rt",
+            parentConversationId: "conv-rt",
+            status: .completed,
+            startedAt: 1,
+            completedAt: 2,
+            error: "boom",
+            stopReason: .maxTokens
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ACPSessionState.self, from: data)
+
+        XCTAssertEqual(decoded, original)
+    }
+
+    func test_acpSessionState_encode_writesSnakeCaseStopReason() throws {
+        let state = ACPSessionState(
+            id: "x",
+            agentId: "a",
+            acpSessionId: "acp-x",
+            status: .completed,
+            startedAt: 0,
+            stopReason: .maxTurnRequests
+        )
+
+        let dict = try encodeToDict(state)
+        XCTAssertEqual(dict["stopReason"] as? String, "max_turn_requests")
+        XCTAssertEqual(dict["status"] as? String, "completed")
+    }
+
+    // MARK: - ACPSessionSpawnedMessage
+
+    func test_acpSessionSpawned_decodes() throws {
+        let json = #"""
+        {
+          "acpSessionId": "acp-spawn",
+          "agent": "claude-code",
+          "parentConversationId": "conv-1"
+        }
+        """#
+
+        let msg = try decode(ACPSessionSpawnedMessage.self, json)
+
+        XCTAssertEqual(msg.acpSessionId, "acp-spawn")
+        XCTAssertEqual(msg.agent, "claude-code")
+        XCTAssertEqual(msg.parentConversationId, "conv-1")
+    }
+
+    func test_acpSessionSpawned_roundTrip() throws {
+        let original = ACPSessionSpawnedMessage(
+            acpSessionId: "acp-spawn",
+            agent: "claude-code",
+            parentConversationId: "conv-1"
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ACPSessionSpawnedMessage.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+
+    // MARK: - ACPSessionUpdateMessage
+
+    func test_acpSessionUpdate_decodes_agentMessageChunk() throws {
+        let json = #"""
+        {
+          "acpSessionId": "acp-1",
+          "updateType": "agent_message_chunk",
+          "content": "Hello, world"
+        }
+        """#
+
+        let msg = try decode(ACPSessionUpdateMessage.self, json)
+
+        XCTAssertEqual(msg.acpSessionId, "acp-1")
+        XCTAssertEqual(msg.updateType, .agentMessageChunk)
+        XCTAssertEqual(msg.content, "Hello, world")
+        XCTAssertNil(msg.toolCallId)
+    }
+
+    func test_acpSessionUpdate_decodes_agentThoughtChunk() throws {
+        let json = #"""
+        {
+          "acpSessionId": "acp-1",
+          "updateType": "agent_thought_chunk",
+          "content": "Reasoning..."
+        }
+        """#
+
+        let msg = try decode(ACPSessionUpdateMessage.self, json)
+        XCTAssertEqual(msg.updateType, .agentThoughtChunk)
+        XCTAssertEqual(msg.content, "Reasoning...")
+    }
+
+    func test_acpSessionUpdate_decodes_toolCall() throws {
+        let json = #"""
+        {
+          "acpSessionId": "acp-1",
+          "updateType": "tool_call",
+          "toolCallId": "call-1",
+          "toolTitle": "Read file",
+          "toolKind": "read",
+          "toolStatus": "in_progress"
+        }
+        """#
+
+        let msg = try decode(ACPSessionUpdateMessage.self, json)
+        XCTAssertEqual(msg.updateType, .toolCall)
+        XCTAssertEqual(msg.toolCallId, "call-1")
+        XCTAssertEqual(msg.toolTitle, "Read file")
+        XCTAssertEqual(msg.toolKind, "read")
+        XCTAssertEqual(msg.toolStatus, "in_progress")
+        XCTAssertNil(msg.content)
+    }
+
+    func test_acpSessionUpdate_decodes_allKnownUpdateTypes() throws {
+        let cases: [(String, ACPSessionUpdateMessage.UpdateType)] = [
+            ("agent_message_chunk", .agentMessageChunk),
+            ("agent_thought_chunk", .agentThoughtChunk),
+            ("user_message_chunk", .userMessageChunk),
+            ("tool_call", .toolCall),
+            ("tool_call_update", .toolCallUpdate),
+            ("plan", .plan)
+        ]
+
+        for (raw, expected) in cases {
+            let json = #"{"acpSessionId":"x","updateType":"\#(raw)"}"#
+            let msg = try decode(ACPSessionUpdateMessage.self, json)
+            XCTAssertEqual(msg.updateType, expected, "failed for raw=\(raw)")
+        }
+    }
+
+    func test_acpSessionUpdate_unknownUpdateType_fallsBackToUnknown() throws {
+        let json = #"""
+        {
+          "acpSessionId": "acp-1",
+          "updateType": "future_update_kind"
+        }
+        """#
+
+        let msg = try decode(ACPSessionUpdateMessage.self, json)
+        XCTAssertEqual(msg.updateType, .unknown)
+    }
+
+    func test_acpSessionUpdate_synthesizesUniqueIdsAtDecode() throws {
+        let json = #"""
+        {
+          "acpSessionId": "acp-1",
+          "updateType": "plan"
+        }
+        """#
+
+        let a = try decode(ACPSessionUpdateMessage.self, json)
+        let b = try decode(ACPSessionUpdateMessage.self, json)
+        XCTAssertNotEqual(a.id, b.id, "Each decode should generate a fresh id for SwiftUI diffing")
+        // Equality is content-based, so the two decodes are still equal.
+        XCTAssertEqual(a, b)
+    }
+
+    func test_acpSessionUpdate_idIsNotPartOfWireFormat() throws {
+        let original = ACPSessionUpdateMessage(
+            acpSessionId: "acp-1",
+            updateType: .agentMessageChunk,
+            content: "hi"
+        )
+        let dict = try encodeToDict(original)
+        XCTAssertNil(dict["id"], "Synthetic id should not appear in encoded JSON")
+    }
+
+    func test_acpSessionUpdate_roundTrip_preservesContent() throws {
+        let original = ACPSessionUpdateMessage(
+            acpSessionId: "acp-1",
+            updateType: .toolCallUpdate,
+            content: nil,
+            toolCallId: "call-1",
+            toolTitle: "Edit file",
+            toolKind: "edit",
+            toolStatus: "completed"
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ACPSessionUpdateMessage.self, from: data)
+        // Equality compares wire fields, not the synthetic id.
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.updateType, .toolCallUpdate)
+        XCTAssertEqual(decoded.toolCallId, "call-1")
+    }
+
+    // MARK: - ACPSessionCompletedMessage
+
+    func test_acpSessionCompleted_decodes() throws {
+        let json = #"""
+        {
+          "acpSessionId": "acp-c",
+          "stopReason": "end_turn"
+        }
+        """#
+
+        let msg = try decode(ACPSessionCompletedMessage.self, json)
+
+        XCTAssertEqual(msg.acpSessionId, "acp-c")
+        XCTAssertEqual(msg.stopReason, .endTurn)
+    }
+
+    func test_acpSessionCompleted_decodesAllStopReasons() throws {
+        let cases: [(String, ACPSessionState.StopReason)] = [
+            ("end_turn", .endTurn),
+            ("max_tokens", .maxTokens),
+            ("max_turn_requests", .maxTurnRequests),
+            ("refusal", .refusal),
+            ("cancelled", .cancelled)
+        ]
+
+        for (raw, expected) in cases {
+            let json = #"{"acpSessionId":"x","stopReason":"\#(raw)"}"#
+            let msg = try decode(ACPSessionCompletedMessage.self, json)
+            XCTAssertEqual(msg.stopReason, expected, "failed for raw=\(raw)")
+        }
+    }
+
+    func test_acpSessionCompleted_roundTrip() throws {
+        let original = ACPSessionCompletedMessage(
+            acpSessionId: "acp-c",
+            stopReason: .cancelled
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ACPSessionCompletedMessage.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+
+    // MARK: - ACPSessionErrorMessage
+
+    func test_acpSessionError_decodes() throws {
+        let json = #"""
+        {
+          "acpSessionId": "acp-e",
+          "error": "agent crashed"
+        }
+        """#
+
+        let msg = try decode(ACPSessionErrorMessage.self, json)
+        XCTAssertEqual(msg.acpSessionId, "acp-e")
+        XCTAssertEqual(msg.error, "agent crashed")
+    }
+
+    func test_acpSessionError_roundTrip() throws {
+        let original = ACPSessionErrorMessage(
+            acpSessionId: "acp-e",
+            error: "spawn failed"
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ACPSessionErrorMessage.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+}

--- a/clients/shared/Network/ACPMessages.swift
+++ b/clients/shared/Network/ACPMessages.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+// MARK: - ACPSessionState
+
+/// Runtime state of an Agent Client Protocol (ACP) session.
+///
+/// Mirrors `AcpSessionState` in `assistant/src/acp/types.ts`. The TypeScript
+/// definition allows new `status` and `stopReason` literal values to be added
+/// without bumping a wire version, so the Swift decoders fall back to
+/// `.unknown` rather than failing — this keeps the client tolerant of daemon
+/// version skew.
+public struct ACPSessionState: Codable, Equatable, Identifiable, Sendable {
+    public let id: String
+    public let agentId: String
+    public let acpSessionId: String
+    /// Conversation that spawned this session.
+    public let parentConversationId: String?
+    public let status: Status
+    public let startedAt: Int
+    public let completedAt: Int?
+    public let error: String?
+    public let stopReason: StopReason?
+
+    public init(
+        id: String,
+        agentId: String,
+        acpSessionId: String,
+        parentConversationId: String? = nil,
+        status: Status,
+        startedAt: Int,
+        completedAt: Int? = nil,
+        error: String? = nil,
+        stopReason: StopReason? = nil
+    ) {
+        self.id = id
+        self.agentId = agentId
+        self.acpSessionId = acpSessionId
+        self.parentConversationId = parentConversationId
+        self.status = status
+        self.startedAt = startedAt
+        self.completedAt = completedAt
+        self.error = error
+        self.stopReason = stopReason
+    }
+
+    public enum Status: String, Codable, Equatable, Sendable {
+        case initializing
+        case running
+        case completed
+        case failed
+        case cancelled
+        case unknown
+
+        /// Fall back to `.unknown` for unrecognized statuses so version skew
+        /// between daemon and client never silently drops a session update.
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(String.self)
+            self = Status(rawValue: raw) ?? .unknown
+        }
+    }
+
+    public enum StopReason: String, Codable, Equatable, Sendable {
+        case endTurn = "end_turn"
+        case maxTokens = "max_tokens"
+        case maxTurnRequests = "max_turn_requests"
+        case refusal
+        case cancelled
+        case unknown
+
+        /// Fall back to `.unknown` for unrecognized stop reasons.
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(String.self)
+            self = StopReason(rawValue: raw) ?? .unknown
+        }
+    }
+}
+
+// MARK: - ACPSessionSpawnedMessage
+
+/// Wire event: a new ACP session has been spawned.
+///
+/// Wire type: `"acp_session_spawned"`. Mirrors `AcpSessionSpawned` in
+/// `assistant/src/daemon/message-types/acp.ts`. The discriminating `type`
+/// field is consumed by `ServerMessage`'s top-level decoder, so it is not
+/// re-decoded here.
+public struct ACPSessionSpawnedMessage: Codable, Equatable, Sendable {
+    public let acpSessionId: String
+    public let agent: String
+    public let parentConversationId: String
+
+    public init(acpSessionId: String, agent: String, parentConversationId: String) {
+        self.acpSessionId = acpSessionId
+        self.agent = agent
+        self.parentConversationId = parentConversationId
+    }
+}
+
+// MARK: - ACPSessionUpdateMessage
+
+/// Wire event: streaming update from an ACP session.
+///
+/// Wire type: `"acp_session_update"`. Mirrors `AcpSessionUpdate` in
+/// `assistant/src/daemon/message-types/acp.ts`.
+///
+/// `id` is a SwiftUI-only stable identity for list diffing — generated
+/// fresh on each decode/init and excluded from `CodingKeys`, so it does
+/// not appear on the wire. Equality is content-based to keep two decodes
+/// of the same payload comparable.
+public struct ACPSessionUpdateMessage: Codable, Equatable, Identifiable, Sendable {
+    public let id: UUID = UUID()
+    public let acpSessionId: String
+    public let updateType: UpdateType
+    public let content: String?
+    public let toolCallId: String?
+    public let toolTitle: String?
+    public let toolKind: String?
+    public let toolStatus: String?
+
+    public init(
+        acpSessionId: String,
+        updateType: UpdateType,
+        content: String? = nil,
+        toolCallId: String? = nil,
+        toolTitle: String? = nil,
+        toolKind: String? = nil,
+        toolStatus: String? = nil
+    ) {
+        self.acpSessionId = acpSessionId
+        self.updateType = updateType
+        self.content = content
+        self.toolCallId = toolCallId
+        self.toolTitle = toolTitle
+        self.toolKind = toolKind
+        self.toolStatus = toolStatus
+    }
+
+    public enum UpdateType: String, Codable, Equatable, Sendable {
+        case agentMessageChunk = "agent_message_chunk"
+        case agentThoughtChunk = "agent_thought_chunk"
+        case userMessageChunk = "user_message_chunk"
+        case toolCall = "tool_call"
+        case toolCallUpdate = "tool_call_update"
+        case plan
+        case unknown
+
+        /// Fall back to `.unknown` for unrecognized update types.
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(String.self)
+            self = UpdateType(rawValue: raw) ?? .unknown
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case acpSessionId
+        case updateType
+        case content
+        case toolCallId
+        case toolTitle
+        case toolKind
+        case toolStatus
+    }
+
+    public static func == (lhs: ACPSessionUpdateMessage, rhs: ACPSessionUpdateMessage) -> Bool {
+        lhs.acpSessionId == rhs.acpSessionId
+            && lhs.updateType == rhs.updateType
+            && lhs.content == rhs.content
+            && lhs.toolCallId == rhs.toolCallId
+            && lhs.toolTitle == rhs.toolTitle
+            && lhs.toolKind == rhs.toolKind
+            && lhs.toolStatus == rhs.toolStatus
+    }
+}
+
+// MARK: - ACPSessionCompletedMessage
+
+/// Wire event: an ACP session has completed.
+///
+/// Wire type: `"acp_session_completed"`. Mirrors `AcpSessionCompleted` in
+/// `assistant/src/daemon/message-types/acp.ts`.
+public struct ACPSessionCompletedMessage: Codable, Equatable, Sendable {
+    public let acpSessionId: String
+    public let stopReason: ACPSessionState.StopReason
+
+    public init(acpSessionId: String, stopReason: ACPSessionState.StopReason) {
+        self.acpSessionId = acpSessionId
+        self.stopReason = stopReason
+    }
+}
+
+// MARK: - ACPSessionErrorMessage
+
+/// Wire event: an ACP session encountered an error.
+///
+/// Wire type: `"acp_session_error"`. Mirrors `AcpSessionError` in
+/// `assistant/src/daemon/message-types/acp.ts`.
+public struct ACPSessionErrorMessage: Codable, Equatable, Sendable {
+    public let acpSessionId: String
+    public let error: String
+
+    public init(acpSessionId: String, error: String) {
+        self.acpSessionId = acpSessionId
+        self.error = error
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ACPSessionState` and four ACP wire-event structs in `clients/shared/Network/ACPMessages.swift`.
- Round-trip Codable tests for each struct.
- PR 12 wires these into the `ServerMessage` enum.

Part of plan: acp-sessions-ui.md (PR 11 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
