### PR TITLE
fix(macos-tests): drop removed version field from STTProviderRegistry tests

### DIFF
--- a/clients/shared/Tests/STTStreamingClientTests.swift
+++ b/clients/shared/Tests/STTStreamingClientTests.swift
@@ -268,7 +268,6 @@ final class STTStreamingClientTests: XCTestCase {
     func testFullCatalogDecodingWithStreamingMode() throws {
         let json = """
         {
-            "version": 2,
             "providers": [
                 {
                     "id": "openai-whisper",
@@ -292,7 +291,6 @@ final class STTStreamingClientTests: XCTestCase {
         }
         """
         let catalog = try JSONDecoder().decode(STTProviderRegistry.self, from: json.data(using: .utf8)!)
-        XCTAssertEqual(catalog.version, 2)
         XCTAssertEqual(catalog.providers.count, 2)
         XCTAssertEqual(catalog.providers[0].conversationStreamingMode, .incrementalBatch)
         XCTAssertEqual(catalog.providers[1].conversationStreamingMode, .realtimeWs)
@@ -303,7 +301,6 @@ final class STTStreamingClientTests: XCTestCase {
     /// Build a test registry with all providers for capability testing.
     private func buildTestRegistry() -> STTProviderRegistry {
         STTProviderRegistry(
-            version: 2,
             providers: [
                 STTProviderCatalogEntry(
                     id: "openai-whisper",


### PR DESCRIPTION
## Summary
- PR #28219 removed the `version` field from `STTProviderRegistry` but `STTStreamingClientTests.swift` still referenced it (in JSON fixture, an `XCTAssertEqual`, and the `buildTestRegistry` initializer call), breaking the macOS Tests CI job.
- Drops those references so the tests compile against the current registry shape.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24946125254/job/73047782324
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
