### PR TITLE
feat(clients): decode ACP SSE events into ServerMessage cases

### DIFF
--- a/clients/macos/vellum-assistantTests/Network/ServerMessageACPTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/ServerMessageACPTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class ServerMessageACPTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func decodeMessage(_ json: String) throws -> ServerMessage {
+        try JSONDecoder().decode(ServerMessage.self, from: Data(json.utf8))
+    }
+
+    // MARK: - acp_session_spawned
+
+    func test_decodes_acpSessionSpawned() throws {
+        let json = #"""
+        {
+          "type": "acp_session_spawned",
+          "acpSessionId": "acp-spawn",
+          "agent": "claude-code",
+          "parentConversationId": "conv-1"
+        }
+        """#
+
+        let msg = try decodeMessage(json)
+
+        guard case .acpSessionSpawned(let payload) = msg else {
+            XCTFail("Expected .acpSessionSpawned, got \(msg)")
+            return
+        }
+        XCTAssertEqual(payload.acpSessionId, "acp-spawn")
+        XCTAssertEqual(payload.agent, "claude-code")
+        XCTAssertEqual(payload.parentConversationId, "conv-1")
+    }
+
+    // MARK: - acp_session_update
+
+    func test_decodes_acpSessionUpdate_agentMessageChunk() throws {
+        let json = #"""
+        {
+          "type": "acp_session_update",
+          "acpSessionId": "acp-1",
+          "updateType": "agent_message_chunk",
+          "content": "Hello, world"
+        }
+        """#
+
+        let msg = try decodeMessage(json)
+
+        guard case .acpSessionUpdate(let payload) = msg else {
+            XCTFail("Expected .acpSessionUpdate, got \(msg)")
+            return
+        }
+        XCTAssertEqual(payload.acpSessionId, "acp-1")
+        XCTAssertEqual(payload.updateType, .agentMessageChunk)
+        XCTAssertEqual(payload.content, "Hello, world")
+    }
+
+    func test_decodes_acpSessionUpdate_toolCall() throws {
+        let json = #"""
+        {
+          "type": "acp_session_update",
+          "acpSessionId": "acp-1",
+          "updateType": "tool_call",
+          "toolCallId": "call-1",
+          "toolTitle": "Read file",
+          "toolKind": "read",
+          "toolStatus": "in_progress"
+        }
+        """#
+
+        let msg = try decodeMessage(json)
+
+        guard case .acpSessionUpdate(let payload) = msg else {
+            XCTFail("Expected .acpSessionUpdate, got \(msg)")
+            return
+        }
+        XCTAssertEqual(payload.updateType, .toolCall)
+        XCTAssertEqual(payload.toolCallId, "call-1")
+        XCTAssertEqual(payload.toolTitle, "Read file")
+        XCTAssertEqual(payload.toolKind, "read")
+        XCTAssertEqual(payload.toolStatus, "in_progress")
+    }
+
+    // MARK: - acp_session_completed
+
+    func test_decodes_acpSessionCompleted() throws {
+        let json = #"""
+        {
+          "type": "acp_session_completed",
+          "acpSessionId": "acp-c",
+          "stopReason": "end_turn"
+        }
+        """#
+
+        let msg = try decodeMessage(json)
+
+        guard case .acpSessionCompleted(let payload) = msg else {
+            XCTFail("Expected .acpSessionCompleted, got \(msg)")
+            return
+        }
+        XCTAssertEqual(payload.acpSessionId, "acp-c")
+        XCTAssertEqual(payload.stopReason, .endTurn)
+    }
+
+    // MARK: - acp_session_error
+
+    func test_decodes_acpSessionError() throws {
+        let json = #"""
+        {
+          "type": "acp_session_error",
+          "acpSessionId": "acp-e",
+          "error": "agent crashed"
+        }
+        """#
+
+        let msg = try decodeMessage(json)
+
+        guard case .acpSessionError(let payload) = msg else {
+            XCTFail("Expected .acpSessionError, got \(msg)")
+            return
+        }
+        XCTAssertEqual(payload.acpSessionId, "acp-e")
+        XCTAssertEqual(payload.error, "agent crashed")
+    }
+
+    // MARK: - Forward compatibility
+
+    /// Unrecognized `acp_session_*` types must fall through to `.unknown(...)`
+    /// so a daemon emitting a new ACP event variant cannot crash older clients.
+    func test_unknownAcpSessionType_fallsBackToUnknown() throws {
+        let json = #"""
+        {
+          "type": "acp_session_future_event",
+          "acpSessionId": "acp-x"
+        }
+        """#
+
+        let msg = try decodeMessage(json)
+
+        guard case .unknown(let type) = msg else {
+            XCTFail("Expected .unknown, got \(msg)")
+            return
+        }
+        XCTAssertEqual(type, "acp_session_future_event")
+    }
+}

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2649,6 +2649,10 @@ public enum ServerMessage: Decodable, Sendable {
     case subagentStatusChanged(SubagentStatusChanged)
     indirect case subagentEvent(SubagentEventMessage)
     case subagentDetailResponse(SubagentDetailResponse)
+    case acpSessionSpawned(ACPSessionSpawnedMessage)
+    case acpSessionUpdate(ACPSessionUpdateMessage)
+    case acpSessionCompleted(ACPSessionCompletedMessage)
+    case acpSessionError(ACPSessionErrorMessage)
     case workspaceFilesListResponse(WorkspaceFilesListResponseMessage)
     case workspaceFileReadResponse(WorkspaceFileReadResponseMessage)
     case identityGetResponse(IdentityGetResponseMessage)
@@ -3078,6 +3082,18 @@ public enum ServerMessage: Decodable, Sendable {
         case "subagent_detail_response":
             let message = try SubagentDetailResponse(from: decoder)
             self = .subagentDetailResponse(message)
+        case "acp_session_spawned":
+            let message = try ACPSessionSpawnedMessage(from: decoder)
+            self = .acpSessionSpawned(message)
+        case "acp_session_update":
+            let message = try ACPSessionUpdateMessage(from: decoder)
+            self = .acpSessionUpdate(message)
+        case "acp_session_completed":
+            let message = try ACPSessionCompletedMessage(from: decoder)
+            self = .acpSessionCompleted(message)
+        case "acp_session_error":
+            let message = try ACPSessionErrorMessage(from: decoder)
+            self = .acpSessionError(message)
         case "workspace_files_list_response":
             let message = try WorkspaceFilesListResponseMessage(from: decoder)
             self = .workspaceFilesListResponse(message)


### PR DESCRIPTION
## Summary
- Adds four `acpSession*` cases to the `ServerMessage` enum.
- Hand-decodes `acp_session_spawned/update/completed/error` from SSE.
- Round-trip tests in `ServerMessageACPTests.swift`.

Part of plan: acp-sessions-ui.md (PR 12 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
