### PR TITLE
feat(acp): DELETE /v1/acp/sessions bulk-clear terminal sessions

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -354,6 +354,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "acp/steer", scopes: ["chat.write"] },
   { endpoint: "acp/cancel", scopes: ["chat.write"] },
   { endpoint: "acp/close", scopes: ["chat.write"] },
+  { endpoint: "acp/sessions:DELETE", scopes: ["chat.write"] },
   { endpoint: "acp", scopes: ["chat.read"] },
 
   // Model config

--- a/assistant/src/runtime/routes/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-routes.test.ts
@@ -4,12 +4,25 @@
  * binary_not_found). Mirrors the resolver's test setup using the shared
  * `installAcpConfigStub` and `installWhichStub` helpers so the host
  * environment doesn't influence the resolver's PATH preflight.
+ *
+ * Also covers DELETE /v1/acp/sessions?status=completed — the bulk-clear
+ * route that wipes terminal-state rows (completed/failed/cancelled) from
+ * `acp_session_history` while leaving running/initializing rows intact.
  */
 
-import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 
 import { installAcpConfigStub } from "../../acp/__tests__/helpers/acp-config-stub.js";
 import { installWhichStub } from "../../acp/__tests__/helpers/which-stub.js";
+import { getDb, getSqlite, initializeDb } from "../../memory/db.js";
+import { acpSessionHistory } from "../../memory/schema.js";
 
 const config = await installAcpConfigStub();
 const which = installWhichStub();
@@ -139,5 +152,133 @@ describe("POST /v1/acp/spawn", () => {
     expect(body.error.message).toContain(
       "agent, task, and conversationId are required",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/acp/sessions?status=completed — bulk-clear terminal rows
+// ---------------------------------------------------------------------------
+
+function getBulkDeleteHandler() {
+  const route = acpRouteDefinitions().find(
+    (r) => r.endpoint === "acp/sessions" && r.method === "DELETE",
+  );
+  if (!route) throw new Error("DELETE acp/sessions route not registered");
+  return route.handler;
+}
+
+function makeBulkDeleteCtx(rawQuery: string) {
+  const url = new URL(`http://localhost/v1/acp/sessions${rawQuery}`);
+  return {
+    url,
+    req: new Request(url, { method: "DELETE" }),
+    server: {} as ReturnType<typeof Bun.serve>,
+    authContext: {} as never,
+    params: {},
+  };
+}
+
+function seedHistoryRow(id: string, status: string, startedAt: number): void {
+  getDb()
+    .insert(acpSessionHistory)
+    .values({
+      id,
+      agentId: "agent-x",
+      acpSessionId: `proto-${id}`,
+      parentConversationId: "conv-test",
+      startedAt,
+      completedAt: status === "running" ? null : startedAt + 1000,
+      status,
+      stopReason: status === "completed" ? "end_turn" : null,
+      error: status === "failed" ? "boom" : null,
+      eventLogJson: "[]",
+    })
+    .run();
+}
+
+interface RowSnapshot {
+  id: string;
+  status: string;
+}
+
+function listRows(): RowSnapshot[] {
+  return getSqlite()
+    .query("SELECT id, status FROM acp_session_history ORDER BY id")
+    .all() as RowSnapshot[];
+}
+
+describe("DELETE /v1/acp/sessions?status=completed", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    getSqlite().run("DELETE FROM acp_session_history");
+  });
+
+  test("removes only terminal-state rows; running/initializing rows survive", async () => {
+    seedHistoryRow("row-completed", "completed", 1000);
+    seedHistoryRow("row-failed", "failed", 2000);
+    seedHistoryRow("row-cancelled", "cancelled", 3000);
+    seedHistoryRow("row-running", "running", 4000);
+    seedHistoryRow("row-initializing", "initializing", 5000);
+
+    const handler = getBulkDeleteHandler();
+    const res = await handler(makeBulkDeleteCtx("?status=completed"));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { deleted: number };
+    expect(body.deleted).toBe(3);
+
+    const remaining = listRows();
+    expect(remaining.map((r) => r.status).sort()).toEqual([
+      "initializing",
+      "running",
+    ]);
+  });
+
+  test("returns deleted=0 when no terminal rows are present", async () => {
+    seedHistoryRow("row-running", "running", 1000);
+
+    const handler = getBulkDeleteHandler();
+    const res = await handler(makeBulkDeleteCtx("?status=completed"));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { deleted: number };
+    expect(body.deleted).toBe(0);
+
+    const remaining = listRows();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe("row-running");
+  });
+
+  test("rejects missing status query param with 400", async () => {
+    seedHistoryRow("row-completed", "completed", 1000);
+
+    const handler = getBulkDeleteHandler();
+    const res = await handler(makeBulkDeleteCtx(""));
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("status");
+    // Row must still be present — guard short-circuited before the delete.
+    expect(listRows()).toHaveLength(1);
+  });
+
+  test("rejects status values other than 'completed' with 400", async () => {
+    seedHistoryRow("row-completed", "completed", 1000);
+
+    const handler = getBulkDeleteHandler();
+    const res = await handler(makeBulkDeleteCtx("?status=failed"));
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(listRows()).toHaveLength(1);
   });
 });

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -4,7 +4,7 @@
  * Exposes spawn, steer, cancel, close, sessions, and permission operations
  * over HTTP.
  */
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 
 import {
@@ -14,10 +14,20 @@ import {
 import { resolveAcpAgent } from "../../acp/resolve-agent.js";
 import type { AcpSessionState } from "../../acp/types.js";
 import { getDb } from "../../memory/db.js";
+import { rawChanges } from "../../memory/raw-query.js";
 import { acpSessionHistory } from "../../memory/schema.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
+
+/**
+ * Terminal-state values for `acp_session_history.status`. The bulk-delete
+ * route accepts `?status=completed` as a UX shorthand for "every terminal
+ * state" — sessions are only persisted to the history table on terminal
+ * transition, so clearing this set wipes the visible history without
+ * touching live (running/initializing) sessions.
+ */
+const TERMINAL_SESSION_STATUSES = ["completed", "failed", "cancelled"] as const;
 
 const log = getLogger("acp-routes");
 
@@ -249,6 +259,47 @@ export function acpRouteDefinitions(): RouteDefinition[] {
           url.searchParams.get("conversationId") ?? undefined;
         const sessions = listMergedSessions({ limit, conversationId });
         return Response.json({ sessions });
+      },
+    },
+
+    {
+      endpoint: "acp/sessions",
+      method: "DELETE",
+      summary: "Bulk-clear terminal ACP sessions",
+      description:
+        "Remove every terminal-state row (completed/failed/cancelled) from " +
+        "the persisted `acp_session_history` table. Active sessions " +
+        "(running/initializing) are untouched. The `?status=completed` query " +
+        "param is a UX shorthand for all terminal statuses — it is the only " +
+        "value currently accepted; other values are rejected with 400.",
+      tags: ["acp"],
+      queryParams: [
+        {
+          name: "status",
+          required: true,
+          description:
+            "Must be `completed`. Shorthand for all terminal statuses (completed/failed/cancelled).",
+        },
+      ],
+      responseBody: z.object({
+        deleted: z.number().int(),
+      }),
+      handler: ({ url }) => {
+        const status = url.searchParams.get("status");
+        if (status !== "completed") {
+          return httpError(
+            "BAD_REQUEST",
+            "status query param is required and must be 'completed'",
+            400,
+          );
+        }
+        getDb()
+          .delete(acpSessionHistory)
+          .where(inArray(acpSessionHistory.status, TERMINAL_SESSION_STATUSES))
+          .run();
+        const deleted = rawChanges();
+        log.info({ deleted }, "Bulk-cleared terminal ACP session history");
+        return Response.json({ deleted });
       },
     },
   ];


### PR DESCRIPTION
## Summary
- Adds `DELETE /v1/acp/sessions?status=completed` route. Removes all terminal-state rows from `acp_session_history`.
- Rejects other status values with 400. Returns `{ deleted: <count> }`.

Part of plan: acp-sessions-ui.md (PR 10 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
