### PR TITLE
feat(clients): ACPClient for /v1/acp/* HTTP endpoints

### DIFF
--- a/clients/macos/vellum-assistantTests/Network/ACPClientTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/ACPClientTests.swift
@@ -1,0 +1,373 @@
+import Foundation
+import XCTest
+
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+private final class MockACPClientURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            XCTFail("requestHandler not set")
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+final class ACPClientTests: XCTestCase {
+    private let assistantId = "assistant-acp-test"
+    private let gatewayPort = 7833
+    private var originalPrimaryLockfileData: Data?
+    private var primaryLockfileExisted = false
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        MockACPClientURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(MockACPClientURLProtocol.self)
+
+        let primaryLockfileURL = LockfilePaths.primary
+        primaryLockfileExisted = FileManager.default.fileExists(atPath: primaryLockfileURL.path)
+        if primaryLockfileExisted {
+            originalPrimaryLockfileData = try Data(contentsOf: primaryLockfileURL)
+        }
+
+        try installLockfileFixture()
+    }
+
+    override func tearDownWithError() throws {
+        URLProtocol.unregisterClass(MockACPClientURLProtocol.self)
+        MockACPClientURLProtocol.requestHandler = nil
+
+        if primaryLockfileExisted {
+            try originalPrimaryLockfileData?.write(to: LockfilePaths.primary, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: LockfilePaths.primary)
+        }
+
+        try super.tearDownWithError()
+    }
+
+    // MARK: - listSessions
+
+    func testListSessionsBuildsExpectedPathAndDecodesResponse() async throws {
+        let requestExpectation = expectation(description: "list sessions request")
+        var capturedRequest: URLRequest?
+
+        MockACPClientURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(
+                #"""
+                {
+                  "sessions": [
+                    {
+                      "id": "sess-1",
+                      "agentId": "claude-code",
+                      "acpSessionId": "acp-1",
+                      "parentConversationId": "conv-1",
+                      "status": "running",
+                      "startedAt": 1700000000000
+                    },
+                    {
+                      "id": "sess-2",
+                      "agentId": "agent-x",
+                      "acpSessionId": "acp-2",
+                      "parentConversationId": "conv-2",
+                      "status": "completed",
+                      "startedAt": 1700000010000,
+                      "completedAt": 1700000020000,
+                      "stopReason": "end_turn"
+                    }
+                  ]
+                }
+                """#.utf8
+            )
+            return (response, data)
+        }
+
+        let result = await ACPClient.listSessions()
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        let url = try XCTUnwrap(capturedRequest?.url?.absoluteString)
+        XCTAssertTrue(
+            url.hasPrefix("http://127.0.0.1:7833/v1/assistants/assistant-acp-test/acp/sessions/"),
+            "Unexpected path: \(url)"
+        )
+        XCTAssertEqual(capturedRequest?.httpMethod, "GET")
+        XCTAssertTrue(url.contains("limit=50"), "Default limit should be encoded as ?limit=50: \(url)")
+
+        guard case let .success(sessions) = result else {
+            return XCTFail("Expected success, got \(result)")
+        }
+        XCTAssertEqual(sessions.count, 2)
+        XCTAssertEqual(sessions[0].id, "sess-1")
+        XCTAssertEqual(sessions[0].status, .running)
+        XCTAssertEqual(sessions[1].stopReason, .endTurn)
+    }
+
+    func testListSessionsEncodesConversationIdAndCustomLimit() async throws {
+        let requestExpectation = expectation(description: "list sessions filtered request")
+        var capturedURL: URL?
+
+        MockACPClientURLProtocol.requestHandler = { request in
+            capturedURL = request.url
+            requestExpectation.fulfill()
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"sessions":[]}"#.utf8))
+        }
+
+        _ = await ACPClient.listSessions(limit: 10, conversationId: "conv-xyz")
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        let url = try XCTUnwrap(capturedURL?.absoluteString)
+        XCTAssertTrue(url.contains("limit=10"), "Expected ?limit=10 in URL: \(url)")
+        XCTAssertTrue(url.contains("conversationId=conv-xyz"), "Expected ?conversationId=conv-xyz in URL: \(url)")
+    }
+
+    func testListSessionsReturnsFailureForNonSuccessStatus() async {
+        MockACPClientURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"error":{"message":"boom"}}"#.utf8))
+        }
+
+        let result = await ACPClient.listSessions()
+
+        guard case .failure(.httpError(let statusCode)) = result else {
+            return XCTFail("Expected .httpError, got \(result)")
+        }
+        XCTAssertEqual(statusCode, 500)
+    }
+
+    func testListSessionsReturnsDecodingFailureForMalformedBody() async {
+        MockACPClientURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"unexpected":"shape"}"#.utf8))
+        }
+
+        let result = await ACPClient.listSessions()
+
+        guard case .failure(.decodingFailed) = result else {
+            return XCTFail("Expected .decodingFailed, got \(result)")
+        }
+    }
+
+    // MARK: - cancelSession
+
+    func testCancelSessionPostsExpectedPath() async throws {
+        let requestExpectation = expectation(description: "cancel session request")
+        var capturedRequest: URLRequest?
+
+        MockACPClientURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"acpSessionId":"acp-1","cancelled":true}"#.utf8))
+        }
+
+        let result = await ACPClient.cancelSession(id: "acp-1")
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        XCTAssertEqual(
+            capturedRequest?.url?.absoluteString,
+            "http://127.0.0.1:7833/v1/assistants/assistant-acp-test/acp/acp-1/cancel/"
+        )
+        XCTAssertEqual(capturedRequest?.httpMethod, "POST")
+
+        guard case .success(let cancelled) = result else {
+            return XCTFail("Expected success, got \(result)")
+        }
+        XCTAssertTrue(cancelled)
+    }
+
+    func testCancelSessionTreats404AsAlreadyTerminal() async {
+        MockACPClientURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"error":{"message":"not found"}}"#.utf8))
+        }
+
+        let result = await ACPClient.cancelSession(id: "acp-missing")
+
+        guard case .success(let cancelled) = result else {
+            return XCTFail("Expected success(false) for 404, got \(result)")
+        }
+        XCTAssertFalse(cancelled, "404 should report success(false) — session already terminal")
+    }
+
+    func testCancelSessionReturnsFailureFor5xx() async {
+        MockACPClientURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 503,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        let result = await ACPClient.cancelSession(id: "acp-1")
+
+        guard case .failure(.httpError(let statusCode)) = result else {
+            return XCTFail("Expected .httpError for 503, got \(result)")
+        }
+        XCTAssertEqual(statusCode, 503)
+    }
+
+    // MARK: - steerSession
+
+    func testSteerSessionPostsExpectedPathAndBody() async throws {
+        let requestExpectation = expectation(description: "steer session request")
+        var capturedRequest: URLRequest?
+
+        MockACPClientURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"acpSessionId":"acp-1","steered":true}"#.utf8))
+        }
+
+        let result = await ACPClient.steerSession(id: "acp-1", instruction: "be more concise")
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        XCTAssertEqual(
+            capturedRequest?.url?.absoluteString,
+            "http://127.0.0.1:7833/v1/assistants/assistant-acp-test/acp/acp-1/steer/"
+        )
+        XCTAssertEqual(capturedRequest?.httpMethod, "POST")
+
+        let body = try requestJSONBody(from: try XCTUnwrap(capturedRequest))
+        XCTAssertEqual(body["instruction"] as? String, "be more concise")
+
+        guard case .success(let steered) = result else {
+            return XCTFail("Expected success, got \(result)")
+        }
+        XCTAssertTrue(steered)
+    }
+
+    func testSteerSessionTreats404AsAlreadyTerminal() async {
+        MockACPClientURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        let result = await ACPClient.steerSession(id: "acp-missing", instruction: "hello")
+
+        guard case .success(let steered) = result else {
+            return XCTFail("Expected success(false) for 404, got \(result)")
+        }
+        XCTAssertFalse(steered)
+    }
+
+    // MARK: - Helpers
+
+    private func installLockfileFixture() throws {
+        let lockfile: [String: Any] = [
+            "activeAssistant": assistantId,
+            "assistants": [
+                [
+                    "assistantId": assistantId,
+                    "cloud": "local",
+                    "hatchedAt": "2026-03-19T12:00:00Z",
+                    "resources": [
+                        "gatewayPort": gatewayPort,
+                    ],
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: lockfile, options: [.sortedKeys])
+        try data.write(to: LockfilePaths.primary, options: .atomic)
+    }
+
+    private func requestJSONBody(from request: URLRequest) throws -> [String: Any] {
+        let body: Data
+        if let httpBody = request.httpBody {
+            body = httpBody
+        } else {
+            let stream = try XCTUnwrap(request.httpBodyStream)
+            stream.open()
+            defer { stream.close() }
+
+            var data = Data()
+            var buffer = [UInt8](repeating: 0, count: 1024)
+            while stream.hasBytesAvailable {
+                let bytesRead = stream.read(&buffer, maxLength: buffer.count)
+                if bytesRead < 0 {
+                    throw try XCTUnwrap(stream.streamError)
+                }
+                if bytesRead == 0 {
+                    break
+                }
+                data.append(buffer, count: bytesRead)
+            }
+            body = data
+        }
+
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+    }
+}

--- a/clients/shared/Network/ACPClient.swift
+++ b/clients/shared/Network/ACPClient.swift
@@ -1,0 +1,158 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ACPClient")
+
+/// Errors surfaced by ``ACPClient``.
+///
+/// Distinguishes the three failure modes the UI cares about so the
+/// observable store (PR 15) can render network outages, server-side
+/// failures, and decoding mismatches differently from "session simply
+/// not found anymore" (which the methods report as a successful no-op).
+public enum ACPClientError: LocalizedError {
+    /// Request failed before reaching the daemon (network, auth, URL
+    /// construction). Wraps the original ``GatewayHTTPClient/ClientError``.
+    case transport(underlying: GatewayHTTPClient.ClientError)
+    /// Daemon responded with a non-2xx, non-404 status.
+    case httpError(statusCode: Int)
+    /// Response body did not match the expected schema.
+    case decodingFailed(underlying: Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .transport(let underlying):
+            return underlying.localizedDescription
+        case .httpError(let statusCode):
+            return "ACP request failed (HTTP \(statusCode))"
+        case .decodingFailed(let underlying):
+            return "Failed to decode ACP response: \(underlying.localizedDescription)"
+        }
+    }
+}
+
+/// Static HTTP client for ACP (Agent Client Protocol) session management.
+///
+/// Routes through ``GatewayHTTPClient`` so managed assistants use the
+/// platform proxy with session-token auth while local assistants hit the
+/// local gateway with bearer-token auth.
+public enum ACPClient {
+
+    /// Lists active ACP sessions known to the daemon.
+    ///
+    /// - Parameters:
+    ///   - limit: Maximum number of sessions to return. Defaults to 50.
+    ///   - conversationId: Optional filter — when set, only sessions whose
+    ///     `parentConversationId` matches are returned.
+    public static func listSessions(
+        limit: Int = 50,
+        conversationId: String? = nil
+    ) async -> Result<[ACPSessionState], ACPClientError> {
+        var params: [String: String] = ["limit": String(limit)]
+        if let conversationId {
+            params["conversationId"] = conversationId
+        }
+
+        let response: GatewayHTTPClient.Response
+        do {
+            response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/acp/sessions",
+                params: params,
+                timeout: 15
+            )
+        } catch let error as GatewayHTTPClient.ClientError {
+            log.error("listSessions transport error: \(error.localizedDescription)")
+            return .failure(.transport(underlying: error))
+        } catch {
+            log.error("listSessions error: \(error.localizedDescription)")
+            return .failure(.transport(underlying: .invalidURL))
+        }
+
+        guard response.isSuccess else {
+            log.error("listSessions failed (HTTP \(response.statusCode))")
+            return .failure(.httpError(statusCode: response.statusCode))
+        }
+        do {
+            let decoded = try JSONDecoder().decode(SessionsListResponse.self, from: response.data)
+            return .success(decoded.sessions)
+        } catch {
+            log.error("listSessions decode error: \(error.localizedDescription)")
+            return .failure(.decodingFailed(underlying: error))
+        }
+    }
+
+    /// Cancels an active ACP session.
+    ///
+    /// - Parameter id: The ACP session id (the daemon's `acpSessionId`).
+    /// - Returns: `.success(true)` on a 2xx response, `.success(false)` on a
+    ///   404 (session already terminal or unknown — treated as a positive
+    ///   "not running" signal), `.failure` on transport or other server errors.
+    public static func cancelSession(
+        id: String
+    ) async -> Result<Bool, ACPClientError> {
+        return await postExpectingAck(
+            path: "assistants/{assistantId}/acp/\(id)/cancel",
+            body: [:],
+            label: "cancelSession"
+        )
+    }
+
+    /// Sends a steering instruction to an active ACP session.
+    ///
+    /// - Parameters:
+    ///   - id: The ACP session id (the daemon's `acpSessionId`).
+    ///   - instruction: Free-form natural-language instruction the agent
+    ///     should incorporate into its next turn.
+    /// - Returns: `.success(true)` on a 2xx response, `.success(false)` on a
+    ///   404, `.failure` on transport or other server errors.
+    public static func steerSession(
+        id: String,
+        instruction: String
+    ) async -> Result<Bool, ACPClientError> {
+        return await postExpectingAck(
+            path: "assistants/{assistantId}/acp/\(id)/steer",
+            body: ["instruction": instruction],
+            label: "steerSession"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Sends a POST that returns an acknowledgement (200) or 404 (already gone).
+    /// 404 is mapped to `.success(false)` so callers can distinguish "definitely
+    /// not running" from "we don't know" — matching the Subagent abort contract.
+    private static func postExpectingAck(
+        path: String,
+        body: [String: Any],
+        label: String
+    ) async -> Result<Bool, ACPClientError> {
+        let response: GatewayHTTPClient.Response
+        do {
+            response = try await GatewayHTTPClient.post(
+                path: path,
+                json: body,
+                timeout: 10
+            )
+        } catch let error as GatewayHTTPClient.ClientError {
+            log.error("\(label) transport error: \(error.localizedDescription)")
+            return .failure(.transport(underlying: error))
+        } catch {
+            log.error("\(label) error: \(error.localizedDescription)")
+            return .failure(.transport(underlying: .invalidURL))
+        }
+
+        if response.isSuccess {
+            return .success(true)
+        }
+        if response.statusCode == 404 {
+            log.info("\(label) returned 404 — session already terminal or unknown")
+            return .success(false)
+        }
+        log.error("\(label) failed (HTTP \(response.statusCode))")
+        return .failure(.httpError(statusCode: response.statusCode))
+    }
+
+    /// Wire envelope for `GET /v1/acp/sessions`.
+    private struct SessionsListResponse: Decodable {
+        let sessions: [ACPSessionState]
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ACPClient.listSessions/cancelSession/steerSession` static methods.
- Mock-driven tests in `ACPClientTests.swift`.

Part of plan: acp-sessions-ui.md (PR 13 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
