### PR TITLE
feat(clients): ACPClient deleteSession + clearCompleted methods

### DIFF
--- a/clients/macos/vellum-assistantTests/Network/ACPClientTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/ACPClientTests.swift
@@ -324,6 +324,153 @@ final class ACPClientTests: XCTestCase {
         XCTAssertFalse(steered)
     }
 
+    // MARK: - deleteSession
+
+    func testDeleteSessionSendsExpectedRequestAndDecodesResponse() async throws {
+        let requestExpectation = expectation(description: "delete session request")
+        var capturedRequest: URLRequest?
+
+        MockACPClientURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"deleted":true}"#.utf8))
+        }
+
+        let result = await ACPClient.deleteSession(id: "acp-1")
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        XCTAssertEqual(
+            capturedRequest?.url?.absoluteString,
+            "http://127.0.0.1:7833/v1/assistants/assistant-acp-test/acp/sessions/acp-1/"
+        )
+        XCTAssertEqual(capturedRequest?.httpMethod, "DELETE")
+
+        guard case .success(let deleted) = result else {
+            return XCTFail("Expected success, got \(result)")
+        }
+        XCTAssertTrue(deleted)
+    }
+
+    func testDeleteSessionPropagatesDeletedFalseForUnknownId() async {
+        // The daemon returns 200 with `deleted: false` when the row was
+        // already gone — verify the client surfaces that as `.success(false)`
+        // rather than collapsing it into the success-true case.
+        MockACPClientURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"deleted":false}"#.utf8))
+        }
+
+        let result = await ACPClient.deleteSession(id: "acp-missing")
+
+        guard case .success(let deleted) = result else {
+            return XCTFail("Expected success, got \(result)")
+        }
+        XCTAssertFalse(deleted)
+    }
+
+    func testDeleteSessionReturnsHttpErrorFor409Conflict() async {
+        MockACPClientURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 409,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"error":{"message":"still running"}}"#.utf8))
+        }
+
+        let result = await ACPClient.deleteSession(id: "acp-running")
+
+        guard case .failure(.httpError(let statusCode)) = result else {
+            return XCTFail("Expected .httpError(409), got \(result)")
+        }
+        XCTAssertEqual(statusCode, 409)
+    }
+
+    func testDeleteSessionReturnsDecodingFailureForMalformedBody() async {
+        MockACPClientURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"unexpected":"shape"}"#.utf8))
+        }
+
+        let result = await ACPClient.deleteSession(id: "acp-1")
+
+        guard case .failure(.decodingFailed) = result else {
+            return XCTFail("Expected .decodingFailed, got \(result)")
+        }
+    }
+
+    // MARK: - clearCompleted
+
+    func testClearCompletedSendsExpectedRequestAndDecodesCount() async throws {
+        let requestExpectation = expectation(description: "clear completed request")
+        var capturedRequest: URLRequest?
+
+        MockACPClientURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"deleted":3}"#.utf8))
+        }
+
+        let result = await ACPClient.clearCompleted()
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        let url = try XCTUnwrap(capturedRequest?.url?.absoluteString)
+        XCTAssertTrue(
+            url.hasPrefix("http://127.0.0.1:7833/v1/assistants/assistant-acp-test/acp/sessions"),
+            "Unexpected path prefix: \(url)"
+        )
+        XCTAssertTrue(url.contains("status=completed"), "Expected ?status=completed in URL: \(url)")
+        XCTAssertEqual(capturedRequest?.httpMethod, "DELETE")
+
+        guard case .success(let count) = result else {
+            return XCTFail("Expected success, got \(result)")
+        }
+        XCTAssertEqual(count, 3)
+    }
+
+    func testClearCompletedReturnsDecodingFailureForMalformedBody() async {
+        MockACPClientURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"unexpected":"shape"}"#.utf8))
+        }
+
+        let result = await ACPClient.clearCompleted()
+
+        guard case .failure(.decodingFailed) = result else {
+            return XCTFail("Expected .decodingFailed, got \(result)")
+        }
+    }
+
     // MARK: - Helpers
 
     private func installLockfileFixture() throws {

--- a/clients/shared/Network/ACPClient.swift
+++ b/clients/shared/Network/ACPClient.swift
@@ -115,7 +115,84 @@ public enum ACPClient {
         )
     }
 
+    /// Removes a persisted ACP session row from history.
+    ///
+    /// The daemon refuses with 409 when the session is still active in
+    /// memory (running/initializing) — surface that conflict to callers
+    /// so the UI can prompt the user to cancel first. Idempotent for
+    /// unknown ids: the daemon reports `deleted: false` and we propagate
+    /// that as `.success(false)`.
+    ///
+    /// - Parameter id: The ACP session id (the daemon's `acpSessionId`).
+    /// - Returns: `.success(true)` when the row was removed,
+    ///   `.success(false)` when no row matched (already gone),
+    ///   `.failure(.httpError(statusCode: 409))` when the session is
+    ///   still active, `.failure` on transport, decoding, or other
+    ///   server errors.
+    public static func deleteSession(
+        id: String
+    ) async -> Result<Bool, ACPClientError> {
+        return await deleteExpectingPayload(
+            path: "assistants/{assistantId}/acp/sessions/\(id)",
+            timeout: 10,
+            as: DeleteSessionResponse.self,
+            label: "deleteSession"
+        ).map(\.deleted)
+    }
+
+    /// Bulk-removes every terminal-state session row from history.
+    ///
+    /// Backs the panel-level "clear completed" action. The daemon
+    /// rejects every status value other than `completed` (treated as a
+    /// shorthand for all terminal statuses), so we hardcode the query
+    /// string here rather than expose it as a parameter.
+    ///
+    /// - Returns: `.success(count)` with the number of rows removed,
+    ///   `.failure` on transport, decoding, or non-2xx responses.
+    public static func clearCompleted() async -> Result<Int, ACPClientError> {
+        return await deleteExpectingPayload(
+            path: "assistants/{assistantId}/acp/sessions?status=completed",
+            timeout: 15,
+            as: ClearCompletedResponse.self,
+            label: "clearCompleted"
+        ).map(\.deleted)
+    }
+
     // MARK: - Helpers
+
+    /// Sends a DELETE and decodes the response body. Unlike ``postExpectingAck``,
+    /// 404 is **not** mapped to success — the DELETE routes here either succeed
+    /// with a structured payload or surface a meaningful error status (e.g. 409
+    /// when a session is still active).
+    private static func deleteExpectingPayload<T: Decodable>(
+        path: String,
+        timeout: TimeInterval,
+        as type: T.Type,
+        label: String
+    ) async -> Result<T, ACPClientError> {
+        let response: GatewayHTTPClient.Response
+        do {
+            response = try await GatewayHTTPClient.delete(path: path, timeout: timeout)
+        } catch let error as GatewayHTTPClient.ClientError {
+            log.error("\(label) transport error: \(error.localizedDescription)")
+            return .failure(.transport(underlying: error))
+        } catch {
+            log.error("\(label) error: \(error.localizedDescription)")
+            return .failure(.transport(underlying: .invalidURL))
+        }
+
+        guard response.isSuccess else {
+            log.error("\(label) failed (HTTP \(response.statusCode))")
+            return .failure(.httpError(statusCode: response.statusCode))
+        }
+        do {
+            let decoded = try JSONDecoder().decode(type, from: response.data)
+            return .success(decoded)
+        } catch {
+            log.error("\(label) decode error: \(error.localizedDescription)")
+            return .failure(.decodingFailed(underlying: error))
+        }
+    }
 
     /// Sends a POST that returns an acknowledgement (200) or 404 (already gone).
     /// 404 is mapped to `.success(false)` so callers can distinguish "definitely
@@ -154,5 +231,15 @@ public enum ACPClient {
     /// Wire envelope for `GET /v1/acp/sessions`.
     private struct SessionsListResponse: Decodable {
         let sessions: [ACPSessionState]
+    }
+
+    /// Wire envelope for `DELETE /v1/acp/sessions/:id`.
+    private struct DeleteSessionResponse: Decodable {
+        let deleted: Bool
+    }
+
+    /// Wire envelope for `DELETE /v1/acp/sessions?status=completed`.
+    private struct ClearCompletedResponse: Decodable {
+        let deleted: Int
     }
 }


### PR DESCRIPTION
## Summary
- Adds `ACPClient.deleteSession` (DELETE /v1/acp/sessions/:id) and `ACPClient.clearCompleted` (DELETE /v1/acp/sessions?status=completed).
- Tests cover success, 409 conflict, and decoding-failure paths.

Part of plan: acp-sessions-ui.md (PR 14 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
