### PR TITLE
feat(live-voice): add live voice protocol types (PR 1)

### DIFF
--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createLiveVoiceServerFrameSequencer,
+  type LiveVoiceClientFrame,
+  type LiveVoiceServerFrame,
+  parseLiveVoiceBinaryAudioFrame,
+  parseLiveVoiceClientTextFrame,
+  validateLiveVoiceClientFrame,
+} from "../protocol.js";
+
+describe("parseLiveVoiceClientTextFrame", () => {
+  test("parses start frames with audio configuration", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({
+        type: "start",
+        conversationId: "conversation-123",
+        audio: {
+          mimeType: "audio/pcm",
+          sampleRate: 24000,
+          channels: 1,
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.frame).toEqual({
+      type: "start",
+      conversationId: "conversation-123",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        channels: 1,
+      },
+    });
+  });
+
+  test("parses base64 JSON audio frames", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({ type: "audio", dataBase64: "AQIDBA==" }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.frame).toEqual({
+      type: "audio",
+      dataBase64: "AQIDBA==",
+    });
+  });
+
+  test("parses control frames", () => {
+    for (const frame of [
+      { type: "ptt_release" },
+      { type: "interrupt" },
+      { type: "end" },
+    ] satisfies LiveVoiceClientFrame[]) {
+      const result = parseLiveVoiceClientTextFrame(JSON.stringify(frame));
+      expect(result).toEqual({ ok: true, frame });
+    }
+  });
+
+  test("returns typed protocol errors for invalid JSON", () => {
+    const result = parseLiveVoiceClientTextFrame("{");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error.code).toBe("invalid_json");
+  });
+
+  test("returns typed protocol errors for non-object JSON", () => {
+    const result = parseLiveVoiceClientTextFrame("[]");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error).toMatchObject({
+      code: "invalid_frame",
+    });
+  });
+
+  test("returns typed protocol errors for unknown frame types", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({ type: "pause" }),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error).toMatchObject({
+      code: "unknown_type",
+      field: "type",
+      frameType: "pause",
+    });
+  });
+
+  test("returns typed protocol errors for missing required fields", () => {
+    const startResult = parseLiveVoiceClientTextFrame(
+      JSON.stringify({ type: "start" }),
+    );
+    const audioResult = parseLiveVoiceClientTextFrame(
+      JSON.stringify({ type: "audio" }),
+    );
+
+    expect(startResult.ok).toBe(false);
+    if (!startResult.ok) {
+      expect(startResult.error).toMatchObject({
+        code: "missing_required_field",
+        field: "audio",
+        frameType: "start",
+      });
+    }
+
+    expect(audioResult.ok).toBe(false);
+    if (!audioResult.ok) {
+      expect(audioResult.error).toMatchObject({
+        code: "missing_required_field",
+        field: "dataBase64",
+        frameType: "audio",
+      });
+    }
+  });
+
+  test("returns typed protocol errors for malformed audio payloads", () => {
+    const notString = parseLiveVoiceClientTextFrame(
+      JSON.stringify({ type: "audio", dataBase64: 42 }),
+    );
+    const malformed = parseLiveVoiceClientTextFrame(
+      JSON.stringify({ type: "audio", dataBase64: "not base64" }),
+    );
+    const empty = parseLiveVoiceClientTextFrame(
+      JSON.stringify({ type: "audio", dataBase64: "" }),
+    );
+
+    for (const result of [notString, malformed, empty]) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("invalid_audio_payload");
+      }
+    }
+  });
+
+  test("validates audio configuration fields", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "start",
+      audio: {
+        mimeType: "audio/wav",
+        sampleRate: 24000,
+        channels: 1,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "audio.mimeType",
+      frameType: "start",
+    });
+  });
+
+  test("returns typed protocol errors for missing audio configuration fields", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "start",
+      audio: {
+        mimeType: "audio/pcm",
+        channels: 1,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error).toMatchObject({
+      code: "missing_required_field",
+      field: "audio.sampleRate",
+      frameType: "start",
+    });
+  });
+});
+
+describe("parseLiveVoiceBinaryAudioFrame", () => {
+  test("wraps ArrayBuffer binary audio frames", () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const result = parseLiveVoiceBinaryAudioFrame(bytes.buffer);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.frame.type).toBe("binary_audio");
+    expect(Array.from(result.frame.data)).toEqual([1, 2, 3]);
+  });
+
+  test("wraps ArrayBufferView binary audio frames", () => {
+    const source = new Uint8Array([9, 8, 7, 6]);
+    const result = parseLiveVoiceBinaryAudioFrame(source.subarray(1, 3));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(Array.from(result.frame.data)).toEqual([8, 7]);
+  });
+
+  test("returns typed protocol errors for malformed binary audio frames", () => {
+    for (const data of ["AQIDBA==", new Uint8Array().buffer]) {
+      const result = parseLiveVoiceBinaryAudioFrame(data);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatchObject({
+          code: "invalid_audio_payload",
+          field: "data",
+          frameType: "binary_audio",
+        });
+      }
+    }
+  });
+});
+
+describe("LiveVoiceServerFrameSequencer", () => {
+  test("adds per-session sequence numbers to outbound server frames", () => {
+    const sequencer = createLiveVoiceServerFrameSequencer();
+
+    const ready = sequencer.next({
+      type: "ready",
+      sessionId: "session-123",
+      conversationId: "conversation-123",
+    });
+    const partial = sequencer.next({
+      type: "stt_partial",
+      text: "hello",
+    });
+    const tts = sequencer.next({
+      type: "tts_audio",
+      mimeType: "audio/pcm",
+      sampleRate: 24000,
+      dataBase64: "AQIDBA==",
+    });
+
+    expect(ready.seq).toBe(1);
+    expect(partial.seq).toBe(2);
+    expect(tts.seq).toBe(3);
+    expect(sequencer.lastSeq).toBe(3);
+  });
+
+  test("keeps sequence numbers independent per session sequencer", () => {
+    const firstSession = createLiveVoiceServerFrameSequencer();
+    const secondSession = createLiveVoiceServerFrameSequencer();
+
+    expect(
+      firstSession.next({
+        type: "thinking",
+        turnId: "turn-1",
+      }).seq,
+    ).toBe(1);
+    expect(
+      firstSession.next({
+        type: "assistant_text_delta",
+        text: "hello",
+      }).seq,
+    ).toBe(2);
+    expect(
+      secondSession.next({
+        type: "thinking",
+        turnId: "turn-2",
+      }).seq,
+    ).toBe(1);
+  });
+
+  test("preserves the server frame discriminated union after sequencing", () => {
+    const sequencer = createLiveVoiceServerFrameSequencer(41);
+    const frame: LiveVoiceServerFrame = sequencer.next({
+      type: "metrics",
+      turnId: "turn-123",
+      sttMs: 25,
+      totalMs: 100,
+    });
+
+    expect(frame).toEqual({
+      type: "metrics",
+      turnId: "turn-123",
+      sttMs: 25,
+      totalMs: 100,
+      seq: 42,
+    });
+  });
+});

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -1,0 +1,512 @@
+export const LIVE_VOICE_CLIENT_FRAME_TYPES = [
+  "start",
+  "audio",
+  "ptt_release",
+  "interrupt",
+  "end",
+] as const;
+
+export type LiveVoiceClientFrameType =
+  (typeof LIVE_VOICE_CLIENT_FRAME_TYPES)[number];
+
+export const LIVE_VOICE_SERVER_FRAME_TYPES = [
+  "ready",
+  "busy",
+  "stt_partial",
+  "stt_final",
+  "thinking",
+  "assistant_text_delta",
+  "tts_audio",
+  "tts_done",
+  "metrics",
+  "archived",
+  "error",
+] as const;
+
+export type LiveVoiceServerFrameType =
+  (typeof LIVE_VOICE_SERVER_FRAME_TYPES)[number];
+
+export const LiveVoiceProtocolErrorCode = {
+  InvalidJson: "invalid_json",
+  InvalidFrame: "invalid_frame",
+  UnknownType: "unknown_type",
+  MissingRequiredField: "missing_required_field",
+  InvalidField: "invalid_field",
+  InvalidAudioPayload: "invalid_audio_payload",
+} as const;
+
+export type LiveVoiceProtocolErrorCode =
+  (typeof LiveVoiceProtocolErrorCode)[keyof typeof LiveVoiceProtocolErrorCode];
+
+export const LIVE_VOICE_PROTOCOL_ERROR_CODES = [
+  LiveVoiceProtocolErrorCode.InvalidJson,
+  LiveVoiceProtocolErrorCode.InvalidFrame,
+  LiveVoiceProtocolErrorCode.UnknownType,
+  LiveVoiceProtocolErrorCode.MissingRequiredField,
+  LiveVoiceProtocolErrorCode.InvalidField,
+  LiveVoiceProtocolErrorCode.InvalidAudioPayload,
+] as const satisfies readonly LiveVoiceProtocolErrorCode[];
+
+export interface LiveVoiceProtocolError {
+  readonly code: LiveVoiceProtocolErrorCode;
+  readonly message: string;
+  readonly field?: string;
+  readonly frameType?: string;
+}
+
+export type LiveVoiceParseResult<T> =
+  | { ok: true; frame: T }
+  | { ok: false; error: LiveVoiceProtocolError };
+
+export interface LiveVoiceAudioConfig {
+  readonly mimeType: "audio/pcm";
+  readonly sampleRate: number;
+  readonly channels: 1;
+}
+
+export interface LiveVoiceClientStartFrame {
+  readonly type: "start";
+  readonly conversationId?: string;
+  readonly audio: LiveVoiceAudioConfig;
+}
+
+export interface LiveVoiceClientAudioFrame {
+  readonly type: "audio";
+  readonly dataBase64: string;
+}
+
+export interface LiveVoiceClientPttReleaseFrame {
+  readonly type: "ptt_release";
+}
+
+export interface LiveVoiceClientInterruptFrame {
+  readonly type: "interrupt";
+}
+
+export interface LiveVoiceClientEndFrame {
+  readonly type: "end";
+}
+
+export type LiveVoiceClientFrame =
+  | LiveVoiceClientStartFrame
+  | LiveVoiceClientAudioFrame
+  | LiveVoiceClientPttReleaseFrame
+  | LiveVoiceClientInterruptFrame
+  | LiveVoiceClientEndFrame;
+
+export interface LiveVoiceBinaryAudioFrame {
+  readonly type: "binary_audio";
+  readonly data: Uint8Array;
+}
+
+export interface LiveVoiceServerFrameBase {
+  readonly type: LiveVoiceServerFrameType;
+  readonly seq: number;
+}
+
+export interface LiveVoiceReadyServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "ready";
+  readonly sessionId: string;
+  readonly conversationId: string;
+}
+
+export interface LiveVoiceBusyServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "busy";
+  readonly activeSessionId: string;
+}
+
+export interface LiveVoiceSttPartialServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "stt_partial";
+  readonly text: string;
+}
+
+export interface LiveVoiceSttFinalServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "stt_final";
+  readonly text: string;
+}
+
+export interface LiveVoiceThinkingServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "thinking";
+  readonly turnId: string;
+}
+
+export interface LiveVoiceAssistantTextDeltaServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "assistant_text_delta";
+  readonly text: string;
+}
+
+export interface LiveVoiceTtsAudioServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "tts_audio";
+  readonly mimeType: "audio/pcm";
+  readonly sampleRate: number;
+  readonly dataBase64: string;
+}
+
+export interface LiveVoiceTtsDoneServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "tts_done";
+  readonly turnId: string;
+}
+
+export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "metrics";
+  readonly turnId: string;
+  readonly sttMs?: number;
+  readonly llmFirstDeltaMs?: number;
+  readonly ttsFirstAudioMs?: number;
+  readonly totalMs?: number;
+}
+
+export interface LiveVoiceArchivedServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "archived";
+  readonly conversationId: string;
+  readonly sessionId: string;
+}
+
+export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "error";
+  readonly code: LiveVoiceProtocolErrorCode;
+  readonly message: string;
+}
+
+export type LiveVoiceServerFrame =
+  | LiveVoiceReadyServerFrame
+  | LiveVoiceBusyServerFrame
+  | LiveVoiceSttPartialServerFrame
+  | LiveVoiceSttFinalServerFrame
+  | LiveVoiceThinkingServerFrame
+  | LiveVoiceAssistantTextDeltaServerFrame
+  | LiveVoiceTtsAudioServerFrame
+  | LiveVoiceTtsDoneServerFrame
+  | LiveVoiceMetricsServerFrame
+  | LiveVoiceArchivedServerFrame
+  | LiveVoiceErrorServerFrame;
+
+type WithoutSeq<T extends LiveVoiceServerFrameBase> = Omit<T, "seq">;
+
+export type LiveVoiceServerFramePayload =
+  | WithoutSeq<LiveVoiceReadyServerFrame>
+  | WithoutSeq<LiveVoiceBusyServerFrame>
+  | WithoutSeq<LiveVoiceSttPartialServerFrame>
+  | WithoutSeq<LiveVoiceSttFinalServerFrame>
+  | WithoutSeq<LiveVoiceThinkingServerFrame>
+  | WithoutSeq<LiveVoiceAssistantTextDeltaServerFrame>
+  | WithoutSeq<LiveVoiceTtsAudioServerFrame>
+  | WithoutSeq<LiveVoiceTtsDoneServerFrame>
+  | WithoutSeq<LiveVoiceMetricsServerFrame>
+  | WithoutSeq<LiveVoiceArchivedServerFrame>
+  | WithoutSeq<LiveVoiceErrorServerFrame>;
+
+export class LiveVoiceServerFrameSequencer {
+  private seq: number;
+
+  constructor(initialSeq = 0) {
+    this.seq = initialSeq;
+  }
+
+  next(frame: LiveVoiceServerFramePayload): LiveVoiceServerFrame {
+    this.seq += 1;
+    return { ...frame, seq: this.seq } as LiveVoiceServerFrame;
+  }
+
+  get lastSeq(): number {
+    return this.seq;
+  }
+}
+
+export function createLiveVoiceServerFrameSequencer(
+  initialSeq = 0,
+): LiveVoiceServerFrameSequencer {
+  return new LiveVoiceServerFrameSequencer(initialSeq);
+}
+
+export function parseLiveVoiceClientTextFrame(
+  text: string,
+): LiveVoiceParseResult<LiveVoiceClientFrame> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return protocolError("invalid_json", "Live voice frame is not valid JSON");
+  }
+
+  return validateLiveVoiceClientFrame(parsed);
+}
+
+export function validateLiveVoiceClientFrame(
+  value: unknown,
+): LiveVoiceParseResult<LiveVoiceClientFrame> {
+  if (!isRecord(value)) {
+    return protocolError(
+      "invalid_frame",
+      "Live voice frame must be a JSON object",
+    );
+  }
+
+  if (!("type" in value)) {
+    return protocolError(
+      "missing_required_field",
+      "Live voice frame is missing required field type",
+      "type",
+    );
+  }
+
+  if (typeof value.type !== "string") {
+    return protocolError(
+      "invalid_field",
+      "Live voice frame field type must be a string",
+      "type",
+    );
+  }
+
+  if (!isLiveVoiceClientFrameType(value.type)) {
+    return protocolError(
+      "unknown_type",
+      `Unknown live voice client frame type: ${value.type}`,
+      "type",
+      value.type,
+    );
+  }
+
+  switch (value.type) {
+    case "start":
+      return validateStartFrame(value);
+    case "audio":
+      return validateAudioFrame(value);
+    case "ptt_release":
+      return { ok: true, frame: { type: "ptt_release" } };
+    case "interrupt":
+      return { ok: true, frame: { type: "interrupt" } };
+    case "end":
+      return { ok: true, frame: { type: "end" } };
+  }
+}
+
+export function parseLiveVoiceBinaryAudioFrame(
+  data: unknown,
+): LiveVoiceParseResult<LiveVoiceBinaryAudioFrame> {
+  if (data instanceof ArrayBuffer) {
+    if (data.byteLength === 0) {
+      return invalidAudioPayload(
+        "Binary audio frame is empty",
+        "data",
+        "binary_audio",
+      );
+    }
+    return {
+      ok: true,
+      frame: { type: "binary_audio", data: new Uint8Array(data) },
+    };
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    if (data.byteLength === 0) {
+      return invalidAudioPayload(
+        "Binary audio frame is empty",
+        "data",
+        "binary_audio",
+      );
+    }
+    return {
+      ok: true,
+      frame: {
+        type: "binary_audio",
+        data: new Uint8Array(data.buffer, data.byteOffset, data.byteLength),
+      },
+    };
+  }
+
+  return invalidAudioPayload(
+    "Binary audio frame must be ArrayBuffer data",
+    "data",
+    "binary_audio",
+  );
+}
+
+function validateStartFrame(
+  value: Record<string, unknown>,
+): LiveVoiceParseResult<LiveVoiceClientStartFrame> {
+  if (!("audio" in value)) {
+    return protocolError(
+      "missing_required_field",
+      "start frame is missing required field audio",
+      "audio",
+      "start",
+    );
+  }
+
+  if (!isRecord(value.audio)) {
+    return protocolError(
+      "invalid_field",
+      "start frame field audio must be an object",
+      "audio",
+      "start",
+    );
+  }
+
+  const audio = value.audio;
+  const audioConfig = validateAudioConfig(audio);
+  if (!audioConfig.ok) return audioConfig;
+
+  if ("conversationId" in value && !isNonEmptyString(value.conversationId)) {
+    return protocolError(
+      "invalid_field",
+      "start frame field conversationId must be a non-empty string",
+      "conversationId",
+      "start",
+    );
+  }
+
+  return {
+    ok: true,
+    frame: {
+      type: "start",
+      ...(typeof value.conversationId === "string"
+        ? { conversationId: value.conversationId }
+        : {}),
+      audio: audioConfig.frame,
+    },
+  };
+}
+
+function validateAudioFrame(
+  value: Record<string, unknown>,
+): LiveVoiceParseResult<LiveVoiceClientAudioFrame> {
+  if (!("dataBase64" in value)) {
+    return protocolError(
+      "missing_required_field",
+      "audio frame is missing required field dataBase64",
+      "dataBase64",
+      "audio",
+    );
+  }
+
+  if (typeof value.dataBase64 !== "string") {
+    return invalidAudioPayload("audio frame dataBase64 must be a string");
+  }
+
+  if (!isValidBase64Payload(value.dataBase64)) {
+    return invalidAudioPayload("audio frame dataBase64 is malformed");
+  }
+
+  return {
+    ok: true,
+    frame: { type: "audio", dataBase64: value.dataBase64 },
+  };
+}
+
+function validateAudioConfig(
+  value: Record<string, unknown>,
+): LiveVoiceParseResult<LiveVoiceAudioConfig> {
+  if (!("mimeType" in value)) {
+    return protocolError(
+      "missing_required_field",
+      "start frame audio is missing required field mimeType",
+      "audio.mimeType",
+      "start",
+    );
+  }
+
+  if (value.mimeType !== "audio/pcm") {
+    return protocolError(
+      "invalid_field",
+      "start frame audio.mimeType must be audio/pcm",
+      "audio.mimeType",
+      "start",
+    );
+  }
+
+  if (!("sampleRate" in value)) {
+    return protocolError(
+      "missing_required_field",
+      "start frame audio is missing required field sampleRate",
+      "audio.sampleRate",
+      "start",
+    );
+  }
+
+  if (!isPositiveInteger(value.sampleRate)) {
+    return protocolError(
+      "invalid_field",
+      "start frame audio.sampleRate must be a positive integer",
+      "audio.sampleRate",
+      "start",
+    );
+  }
+
+  if (!("channels" in value)) {
+    return protocolError(
+      "missing_required_field",
+      "start frame audio is missing required field channels",
+      "audio.channels",
+      "start",
+    );
+  }
+
+  if (value.channels !== 1) {
+    return protocolError(
+      "invalid_field",
+      "start frame audio.channels must be 1",
+      "audio.channels",
+      "start",
+    );
+  }
+
+  return {
+    ok: true,
+    frame: {
+      mimeType: "audio/pcm",
+      sampleRate: value.sampleRate,
+      channels: 1,
+    },
+  };
+}
+
+function isLiveVoiceClientFrameType(
+  value: string,
+): value is LiveVoiceClientFrameType {
+  return (LIVE_VOICE_CLIENT_FRAME_TYPES as readonly string[]).includes(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isValidBase64Payload(value: string): boolean {
+  if (value.length === 0 || value.length % 4 !== 0) return false;
+  return /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+    value,
+  );
+}
+
+function invalidAudioPayload(
+  message: string,
+  field = "dataBase64",
+  frameType = "audio",
+): LiveVoiceParseResult<never> {
+  return protocolError("invalid_audio_payload", message, field, frameType);
+}
+
+function protocolError<T = never>(
+  code: LiveVoiceProtocolErrorCode,
+  message: string,
+  field?: string,
+  frameType?: string,
+): LiveVoiceParseResult<T> {
+  return {
+    ok: false,
+    error: {
+      code,
+      message,
+      ...(field ? { field } : {}),
+      ...(frameType ? { frameType } : {}),
+    },
+  };
+}


### PR DESCRIPTION
## PR 1: add live voice protocol types

### Depends on

None.

### Branch

`live-voice-channel/pr-01-protocol-types`

### Files

- `assistant/src/live-voice/protocol.ts`
- `assistant/src/live-voice/__tests__/protocol.test.ts`

### Scope

Add assistant-side protocol types and validation helpers only. Define discriminated unions for client frames:

- `start`
- `audio`
- `ptt_release`
- `interrupt`
- `end`

Define server frames:

- `ready`
- `busy`
- `stt_partial`
- `stt_final`
- `thinking`
- `assistant_text_delta`
- `tts_audio`
- `tts_done`
- `metrics`
- `archived`
- `error`

Include parse helpers for JSON text frames, a binary-audio wrapper type for WebSocket binary frames, and a narrow error-code enum. Keep this file independent of Bun WebSocket APIs so session and runtime tests can use it without booting a server.

### Acceptance Criteria

- Invalid JSON, unknown frame types, missing required fields, and malformed audio payloads return typed protocol errors instead of throwing.
- The protocol preserves a per-session sequence number on outbound server frames.
- No runtime route, gateway route, STT, TTS, or conversation logic is added in this PR.

### Verification

Run:

```bash
export PATH="$HOME/.bun/bin:$PATH"
cd assistant && bun test src/live-voice/__tests__/protocol.test.ts
cd assistant && bunx tsc --noEmit
```

---

_Implements PR 1 of `.private/plans/live-voice-channel.md` (live-voice-channel run-plan). Direct-to-main wave 1: no feature branch, CI + external review skipped per orchestrator flags. Implementation drafted by codex agent under @velissa-ai's orchestration._
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
