### PR TITLE
feat(live-voice): add macOS live voice audio capture adapter (PR 7)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioCapture.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioCapture.swift
@@ -1,0 +1,309 @@
+import AVFoundation
+import Foundation
+
+struct LiveVoiceAudioCaptureChunk: Equatable {
+    let pcm16LittleEndian: Data
+    let sampleRate: Int
+    let channelCount: Int
+    let frameCount: Int
+    let amplitude: Float
+}
+
+protocol LiveVoiceAudioEngineControlling: AnyObject {
+    func installTapAndStart(
+        bufferSize: AVAudioFrameCount,
+        block: @escaping AVAudioNodeTapBlock
+    ) -> Bool
+    func stopAndRemoveTap()
+    func stop()
+}
+
+extension AudioEngineController: LiveVoiceAudioEngineControlling {}
+
+protocol LiveVoiceMicrophonePermissioning {
+    func requestMicrophoneAccess() async -> Bool
+}
+
+struct SystemLiveVoiceMicrophonePermissionRequester: LiveVoiceMicrophonePermissioning {
+    func requestMicrophoneAccess() async -> Bool {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized:
+            return true
+        case .notDetermined:
+            return await AVCaptureDevice.requestAccess(for: .audio)
+        case .denied, .restricted:
+            PermissionManager.requestMicrophoneAccess()
+            return false
+        @unknown default:
+            PermissionManager.requestMicrophoneAccess()
+            return false
+        }
+    }
+}
+
+final class LiveVoiceAudioCapture {
+    typealias ChunkHandler = (LiveVoiceAudioCaptureChunk) -> Void
+    typealias AmplitudeHandler = (Float) -> Void
+
+    private enum CaptureState {
+        case idle
+        case starting
+        case running
+        case shutDown
+    }
+
+    private let engineController: any LiveVoiceAudioEngineControlling
+    private let microphonePermission: any LiveVoiceMicrophonePermissioning
+    private let bufferSize: AVAudioFrameCount
+    private let lock = NSLock()
+
+    private var state: CaptureState = .idle
+    private var generation: UInt64 = 0
+    private var chunkHandler: ChunkHandler?
+    private var amplitudeHandler: AmplitudeHandler?
+
+    init(
+        engineController: any LiveVoiceAudioEngineControlling = AudioEngineController(label: "com.vellum.audioEngine.liveVoiceCapture"),
+        microphonePermission: any LiveVoiceMicrophonePermissioning = SystemLiveVoiceMicrophonePermissionRequester(),
+        bufferSize: AVAudioFrameCount = 1024
+    ) {
+        self.engineController = engineController
+        self.microphonePermission = microphonePermission
+        self.bufferSize = bufferSize
+    }
+
+    @discardableResult
+    func start(
+        onChunk: @escaping ChunkHandler,
+        onAmplitude: AmplitudeHandler? = nil
+    ) async -> Bool {
+        let captureGeneration: UInt64
+        switch beginStart(onChunk: onChunk, onAmplitude: onAmplitude) {
+        case .alreadyActive:
+            return true
+        case .shutDown:
+            return false
+        case .starting(let generation):
+            captureGeneration = generation
+        }
+
+        let microphoneGranted = await microphonePermission.requestMicrophoneAccess()
+        guard microphoneGranted else {
+            resetStartingCaptureIfCurrent(captureGeneration)
+            return false
+        }
+
+        guard isCurrentStartingCapture(captureGeneration) else {
+            return false
+        }
+
+        let tapBlock: AVAudioNodeTapBlock = { [weak self] buffer, _ in
+            self?.handle(buffer: buffer, generation: captureGeneration)
+        }
+
+        let started = engineController.installTapAndStart(bufferSize: bufferSize, block: tapBlock)
+        guard started else {
+            resetStartingCaptureIfCurrent(captureGeneration)
+            return false
+        }
+
+        let isCurrentStart = finishStartIfCurrent(captureGeneration)
+
+        if !isCurrentStart {
+            engineController.stopAndRemoveTap()
+        }
+
+        return isCurrentStart
+    }
+
+    func stop() {
+        let handlerToReset: AmplitudeHandler?
+        let shouldRemoveTap: Bool
+
+        lock.lock()
+        switch state {
+        case .starting:
+            generation &+= 1
+            state = .idle
+            chunkHandler = nil
+            handlerToReset = amplitudeHandler
+            amplitudeHandler = nil
+            shouldRemoveTap = false
+        case .running:
+            generation &+= 1
+            state = .idle
+            chunkHandler = nil
+            handlerToReset = amplitudeHandler
+            amplitudeHandler = nil
+            shouldRemoveTap = true
+        case .idle, .shutDown:
+            handlerToReset = nil
+            shouldRemoveTap = false
+        }
+        lock.unlock()
+
+        if shouldRemoveTap {
+            engineController.stopAndRemoveTap()
+        }
+        handlerToReset?(0)
+    }
+
+    func shutdown() {
+        let handlerToReset: AmplitudeHandler?
+        let shouldRemoveTap: Bool
+        let shouldStopEngine: Bool
+
+        lock.lock()
+        switch state {
+        case .shutDown:
+            handlerToReset = nil
+            shouldRemoveTap = false
+            shouldStopEngine = false
+        case .idle, .starting, .running:
+            shouldRemoveTap = state == .running
+            shouldStopEngine = true
+            generation &+= 1
+            state = .shutDown
+            chunkHandler = nil
+            handlerToReset = amplitudeHandler
+            amplitudeHandler = nil
+        }
+        lock.unlock()
+
+        if shouldRemoveTap {
+            engineController.stopAndRemoveTap()
+        }
+        if shouldStopEngine {
+            engineController.stop()
+            handlerToReset?(0)
+        }
+    }
+
+    private enum StartAttempt {
+        case alreadyActive
+        case shutDown
+        case starting(UInt64)
+    }
+
+    private func beginStart(
+        onChunk: @escaping ChunkHandler,
+        onAmplitude: AmplitudeHandler?
+    ) -> StartAttempt {
+        lock.lock()
+        defer { lock.unlock() }
+
+        switch state {
+        case .starting, .running:
+            return .alreadyActive
+        case .shutDown:
+            return .shutDown
+        case .idle:
+            generation &+= 1
+            state = .starting
+            chunkHandler = onChunk
+            amplitudeHandler = onAmplitude
+            return .starting(generation)
+        }
+    }
+
+    private func handle(buffer: AVAudioPCMBuffer, generation captureGeneration: UInt64) {
+        guard let chunk = Self.makeChunk(from: buffer) else { return }
+
+        let chunkHandler: ChunkHandler?
+        let amplitudeHandler: AmplitudeHandler?
+
+        lock.lock()
+        let acceptsBuffer = generation == captureGeneration && (state == .starting || state == .running)
+        if acceptsBuffer {
+            chunkHandler = self.chunkHandler
+            amplitudeHandler = self.amplitudeHandler
+        } else {
+            chunkHandler = nil
+            amplitudeHandler = nil
+        }
+        lock.unlock()
+
+        chunkHandler?(chunk)
+        amplitudeHandler?(chunk.amplitude)
+    }
+
+    private func isCurrentStartingCapture(_ captureGeneration: UInt64) -> Bool {
+        lock.lock()
+        let isCurrent = generation == captureGeneration && state == .starting
+        lock.unlock()
+        return isCurrent
+    }
+
+    private func finishStartIfCurrent(_ captureGeneration: UInt64) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let isCurrent = generation == captureGeneration && state == .starting
+        if isCurrent {
+            state = .running
+        }
+        return isCurrent
+    }
+
+    private func resetStartingCaptureIfCurrent(_ captureGeneration: UInt64) {
+        let handlerToReset: AmplitudeHandler?
+
+        lock.lock()
+        if generation == captureGeneration, state == .starting {
+            state = .idle
+            chunkHandler = nil
+            handlerToReset = amplitudeHandler
+            amplitudeHandler = nil
+        } else {
+            handlerToReset = nil
+        }
+        lock.unlock()
+
+        handlerToReset?(0)
+    }
+
+    static func makeChunk(from buffer: AVAudioPCMBuffer) -> LiveVoiceAudioCaptureChunk? {
+        guard let channelData = buffer.floatChannelData else { return nil }
+
+        let frameCount = Int(buffer.frameLength)
+        let inputChannelCount = Int(buffer.format.channelCount)
+        let sampleRate = Int(buffer.format.sampleRate.rounded())
+        guard frameCount > 0, inputChannelCount > 0, sampleRate > 0 else { return nil }
+
+        var pcmData = Data(capacity: frameCount * MemoryLayout<Int16>.size)
+        var squareSum: Float = 0
+        let channelZero = channelData[0]
+
+        for frame in 0..<frameCount {
+            let sourceIndex = buffer.format.isInterleaved ? frame * inputChannelCount : frame
+            let clamped = max(-1, min(1, channelZero[sourceIndex]))
+            let sample = pcmInt16Sample(from: clamped)
+            squareSum += clamped * clamped
+            withUnsafeBytes(of: sample.littleEndian) { pcmData.append(contentsOf: $0) }
+        }
+
+        let rms = sqrt(squareSum / Float(frameCount))
+        let amplitude = min(rms * 5, 1)
+
+        return LiveVoiceAudioCaptureChunk(
+            pcm16LittleEndian: pcmData,
+            sampleRate: sampleRate,
+            channelCount: 1,
+            frameCount: frameCount,
+            amplitude: amplitude
+        )
+    }
+
+    static func pcmInt16Sample(from sample: Float) -> Int16 {
+        let clamped = max(-1, min(1, sample))
+        if clamped <= -1 {
+            return Int16.min
+        }
+        if clamped >= 1 {
+            return Int16.max
+        }
+
+        let scale: Float = clamped < 0 ? 32768 : 32767
+        return Int16((clamped * scale).rounded(.towardZero))
+    }
+}

--- a/clients/macos/vellum-assistantTests/LiveVoiceAudioCaptureTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceAudioCaptureTests.swift
@@ -1,0 +1,242 @@
+import AVFoundation
+import XCTest
+@testable import VellumAssistantLib
+
+private final class MockLiveVoiceAudioEngineController: LiveVoiceAudioEngineControlling {
+    var installCallCount = 0
+    var stopAndRemoveTapCallCount = 0
+    var stopCallCount = 0
+    var installResult = true
+    var lastBufferSize: AVAudioFrameCount?
+    var tapBlock: AVAudioNodeTapBlock?
+
+    func installTapAndStart(
+        bufferSize: AVAudioFrameCount,
+        block: @escaping AVAudioNodeTapBlock
+    ) -> Bool {
+        installCallCount += 1
+        lastBufferSize = bufferSize
+        tapBlock = block
+        return installResult
+    }
+
+    func stopAndRemoveTap() {
+        stopAndRemoveTapCallCount += 1
+        tapBlock = nil
+    }
+
+    func stop() {
+        stopCallCount += 1
+    }
+}
+
+private final class MockLiveVoiceMicrophonePermission: LiveVoiceMicrophonePermissioning {
+    var requestCallCount = 0
+    var result = true
+
+    func requestMicrophoneAccess() async -> Bool {
+        requestCallCount += 1
+        return result
+    }
+}
+
+final class LiveVoiceAudioCaptureTests: XCTestCase {
+    func testFloatPCMConvertsToInt16LittleEndianMonoChunk() {
+        let buffer = makeBuffer(samples: [-1, -0.5, 0, 0.5, 1, -1.5, 1.5], sampleRate: 16_000)
+
+        let chunk = LiveVoiceAudioCapture.makeChunk(from: buffer)
+
+        XCTAssertEqual(chunk?.sampleRate, 16_000)
+        XCTAssertEqual(chunk?.channelCount, 1)
+        XCTAssertEqual(chunk?.frameCount, 7)
+        XCTAssertEqual(chunk?.pcm16LittleEndian.count, 14)
+        XCTAssertEqual(readInt16LE(chunk!.pcm16LittleEndian, offset: 0), Int16.min)
+        XCTAssertEqual(readInt16LE(chunk!.pcm16LittleEndian, offset: 2), -16_384)
+        XCTAssertEqual(readInt16LE(chunk!.pcm16LittleEndian, offset: 4), 0)
+        XCTAssertEqual(readInt16LE(chunk!.pcm16LittleEndian, offset: 6), 16_383)
+        XCTAssertEqual(readInt16LE(chunk!.pcm16LittleEndian, offset: 8), Int16.max)
+        XCTAssertEqual(readInt16LE(chunk!.pcm16LittleEndian, offset: 10), Int16.min)
+        XCTAssertEqual(readInt16LE(chunk!.pcm16LittleEndian, offset: 12), Int16.max)
+    }
+
+    func testCapturedBufferReportsChunkAndScaledAmplitude() async {
+        let engine = MockLiveVoiceAudioEngineController()
+        let permission = MockLiveVoiceMicrophonePermission()
+        let capture = LiveVoiceAudioCapture(
+            engineController: engine,
+            microphonePermission: permission,
+            bufferSize: 256
+        )
+        var chunks: [LiveVoiceAudioCaptureChunk] = []
+        var amplitudes: [Float] = []
+
+        let started = await capture.start(
+            onChunk: { chunks.append($0) },
+            onAmplitude: { amplitudes.append($0) }
+        )
+
+        XCTAssertTrue(started)
+        XCTAssertEqual(engine.lastBufferSize, 256)
+
+        let buffer = makeBuffer(samples: [0.1, -0.1, 0.1, -0.1], sampleRate: 24_000)
+        engine.tapBlock?(buffer, AVAudioTime(sampleTime: 0, atRate: 24_000))
+
+        XCTAssertEqual(chunks.count, 1)
+        XCTAssertEqual(chunks[0].sampleRate, 24_000)
+        XCTAssertEqual(chunks[0].frameCount, 4)
+        XCTAssertEqual(readInt16LE(chunks[0].pcm16LittleEndian, offset: 0), 3_276)
+        XCTAssertEqual(readInt16LE(chunks[0].pcm16LittleEndian, offset: 2), -3_276)
+        XCTAssertEqual(amplitudes.count, 1)
+        XCTAssertEqual(amplitudes[0], 0.5, accuracy: 0.0001)
+    }
+
+    func testStartingTwiceDoesNotInstallDuplicateTap() async {
+        let engine = MockLiveVoiceAudioEngineController()
+        let permission = MockLiveVoiceMicrophonePermission()
+        let capture = LiveVoiceAudioCapture(
+            engineController: engine,
+            microphonePermission: permission
+        )
+
+        let firstStart = await capture.start(onChunk: { _ in })
+        let secondStart = await capture.start(onChunk: { _ in XCTFail("Second start should not replace the active handler") })
+
+        XCTAssertTrue(firstStart)
+        XCTAssertTrue(secondStart)
+        XCTAssertEqual(permission.requestCallCount, 1)
+        XCTAssertEqual(engine.installCallCount, 1)
+    }
+
+    func testStoppingCaptureReleasesTapWithoutEngineShutdown() async {
+        let engine = MockLiveVoiceAudioEngineController()
+        let permission = MockLiveVoiceMicrophonePermission()
+        let capture = LiveVoiceAudioCapture(
+            engineController: engine,
+            microphonePermission: permission
+        )
+        var amplitudes: [Float] = []
+
+        _ = await capture.start(onChunk: { _ in }, onAmplitude: { amplitudes.append($0) })
+        capture.stop()
+        capture.stop()
+
+        XCTAssertEqual(engine.stopAndRemoveTapCallCount, 1)
+        XCTAssertEqual(engine.stopCallCount, 0)
+        XCTAssertEqual(amplitudes, [0])
+    }
+
+    func testDeniedMicrophonePermissionDoesNotInstallTap() async {
+        let engine = MockLiveVoiceAudioEngineController()
+        let permission = MockLiveVoiceMicrophonePermission()
+        permission.result = false
+        let capture = LiveVoiceAudioCapture(
+            engineController: engine,
+            microphonePermission: permission
+        )
+        var amplitudes: [Float] = []
+
+        let started = await capture.start(onChunk: { _ in }, onAmplitude: { amplitudes.append($0) })
+
+        XCTAssertFalse(started)
+        XCTAssertEqual(permission.requestCallCount, 1)
+        XCTAssertEqual(engine.installCallCount, 0)
+        XCTAssertEqual(engine.stopAndRemoveTapCallCount, 0)
+        XCTAssertEqual(amplitudes, [0])
+    }
+
+    func testStopWhilePermissionRequestIsPendingPreventsTapInstall() async {
+        let engine = MockLiveVoiceAudioEngineController()
+        let permission = PendingLiveVoiceMicrophonePermission()
+        let capture = LiveVoiceAudioCapture(
+            engineController: engine,
+            microphonePermission: permission
+        )
+        var amplitudes: [Float] = []
+
+        let startTask = Task {
+            await capture.start(onChunk: { _ in }, onAmplitude: { amplitudes.append($0) })
+        }
+        await permission.waitForRequest()
+
+        capture.stop()
+        await permission.complete(with: true)
+
+        let started = await startTask.value
+
+        XCTAssertFalse(started)
+        XCTAssertEqual(engine.installCallCount, 0)
+        XCTAssertEqual(engine.stopAndRemoveTapCallCount, 0)
+        XCTAssertEqual(amplitudes, [0])
+    }
+
+    func testShutdownIsIdempotentAndPreventsRestart() async {
+        let engine = MockLiveVoiceAudioEngineController()
+        let permission = MockLiveVoiceMicrophonePermission()
+        let capture = LiveVoiceAudioCapture(
+            engineController: engine,
+            microphonePermission: permission
+        )
+
+        _ = await capture.start(onChunk: { _ in })
+        capture.shutdown()
+        capture.shutdown()
+        let restarted = await capture.start(onChunk: { _ in })
+
+        XCTAssertFalse(restarted)
+        XCTAssertEqual(engine.stopAndRemoveTapCallCount, 1)
+        XCTAssertEqual(engine.stopCallCount, 1)
+        XCTAssertEqual(engine.installCallCount, 1)
+    }
+
+    private func makeBuffer(samples: [Float], sampleRate: Double) -> AVAudioPCMBuffer {
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        )!
+        let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(samples.count)
+        )!
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        for (index, sample) in samples.enumerated() {
+            buffer.floatChannelData![0][index] = sample
+        }
+        return buffer
+    }
+
+    private func readInt16LE(_ data: Data, offset: Int) -> Int16 {
+        data.withUnsafeBytes { bytes in
+            bytes.load(fromByteOffset: offset, as: Int16.self).littleEndian
+        }
+    }
+}
+
+private actor PendingLiveVoiceMicrophonePermission: LiveVoiceMicrophonePermissioning {
+    private var continuation: CheckedContinuation<Bool, Never>?
+    private var requestWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func requestMicrophoneAccess() async -> Bool {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            let waiters = requestWaiters
+            requestWaiters.removeAll()
+            for waiter in waiters {
+                waiter.resume()
+            }
+        }
+    }
+
+    func waitForRequest() async {
+        if continuation != nil {
+            return
+        }
+        await withCheckedContinuation { requestWaiters.append($0) }
+    }
+
+    func complete(with result: Bool) {
+        continuation?.resume(returning: result)
+        continuation = nil
+    }
+}


### PR DESCRIPTION
## PR 7: add macOS live voice audio capture adapter

### Depends on

None.

### Branch

`live-voice-channel/pr-07-audio-capture`

### Files

- `clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioCapture.swift`
- `clients/macos/vellum-assistantTests/LiveVoiceAudioCaptureTests.swift`

### Scope

Extract a live voice capture adapter around `AudioEngineController` without changing existing `VoiceInputManager` behavior. The adapter should:

- request microphone access through the existing voice permission path
- install the engine tap through `AudioEngineController`
- convert captured float PCM buffers to 16-bit little-endian PCM chunks
- report amplitude for the existing waveform UI
- expose `start`, `stop`, and `shutdown` methods with idempotent cleanup

### Acceptance Criteria

- Audio conversion is covered by unit tests with deterministic sample buffers.
- Starting capture twice does not install duplicate taps.
- Stopping capture releases the audio engine tap without shutting down unrelated voice services.

### Verification

Run:

```bash
cd clients
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter LiveVoiceAudioCaptureTests
```

---

_Implements PR 7 of `.private/plans/live-voice-channel.md` (live-voice-channel run-plan). Direct-to-main wave 1: no feature branch, CI + external review skipped per orchestrator flags. Implementation drafted by codex agent under @velissa-ai's orchestration._
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
