### PR TITLE
feat(live-voice): add macOS live voice streaming playback adapter (PR 8)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioPlayer.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioPlayer.swift
@@ -1,0 +1,363 @@
+import AVFoundation
+import Foundation
+import Observation
+
+struct LiveVoiceAudioChunk: Equatable {
+    let data: Data
+    let mimeType: String
+    let sampleRate: Int
+    let channels: Int
+    let sequence: Int?
+
+    init(
+        data: Data,
+        mimeType: String,
+        sampleRate: Int,
+        channels: Int = 1,
+        sequence: Int? = nil
+    ) {
+        self.data = data
+        self.mimeType = mimeType
+        self.sampleRate = sampleRate
+        self.channels = channels
+        self.sequence = sequence
+    }
+}
+
+enum LiveVoiceAudioStopReason: Equatable {
+    case interrupt
+    case end
+    case sessionError
+    case manual
+}
+
+enum LiveVoiceAudioPlaybackState: Equatable {
+    case idle
+    case playing
+    case stopped(LiveVoiceAudioStopReason)
+    case failed(String)
+}
+
+@MainActor
+protocol LiveVoiceAudioOutput: AnyObject {
+    func play(
+        _ chunk: LiveVoiceAudioChunk,
+        completion: @escaping @MainActor (Result<Void, Error>) -> Void
+    )
+    func stop()
+}
+
+enum LiveVoiceAudioOutputError: Error, LocalizedError, Equatable {
+    case malformedPCMData
+    case unsupportedPCMFormat
+    case playbackStartFailed
+    case playbackFinishedUnsuccessfully
+    case audioEngineStartFailed(String)
+    case decodingFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .malformedPCMData:
+            "Malformed PCM audio data"
+        case .unsupportedPCMFormat:
+            "Unsupported PCM audio format"
+        case .playbackStartFailed:
+            "Failed to start audio playback"
+        case .playbackFinishedUnsuccessfully:
+            "Audio playback finished unsuccessfully"
+        case .audioEngineStartFailed(let message):
+            "Failed to start audio engine: \(message)"
+        case .decodingFailed(let message):
+            "Failed to decode audio: \(message)"
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class LiveVoiceAudioPlayer {
+    private(set) var state: LiveVoiceAudioPlaybackState = .idle
+
+    var isPlaying: Bool {
+        state == .playing
+    }
+
+    var queuedChunkCount: Int {
+        queuedChunks.count
+    }
+
+    @ObservationIgnored private let output: any LiveVoiceAudioOutput
+    @ObservationIgnored private var queuedChunks: [LiveVoiceAudioChunk] = []
+    @ObservationIgnored private var activeChunk: LiveVoiceAudioChunk?
+    @ObservationIgnored private var playbackGeneration: UInt64 = 0
+    @ObservationIgnored private var acceptsAudio = true
+
+    init(output: (any LiveVoiceAudioOutput)? = nil) {
+        self.output = output ?? AVFoundationLiveVoiceAudioOutput()
+    }
+
+    func enqueueTTSAudio(
+        data: Data,
+        mimeType: String,
+        sampleRate: Int,
+        channels: Int = 1,
+        sequence: Int? = nil
+    ) {
+        enqueueTTSAudio(
+            LiveVoiceAudioChunk(
+                data: data,
+                mimeType: mimeType,
+                sampleRate: sampleRate,
+                channels: channels,
+                sequence: sequence
+            )
+        )
+    }
+
+    func enqueueTTSAudio(_ chunk: LiveVoiceAudioChunk) {
+        guard acceptsAudio else { return }
+        guard !chunk.data.isEmpty else { return }
+
+        queuedChunks.append(chunk)
+        playNextChunkIfNeeded()
+    }
+
+    func handleInterrupt() {
+        stop(reason: .interrupt)
+    }
+
+    func handleEnd() {
+        stop(reason: .end)
+    }
+
+    func handleSessionError() {
+        stop(reason: .sessionError)
+    }
+
+    func stop(reason: LiveVoiceAudioStopReason = .manual) {
+        playbackGeneration &+= 1
+        acceptsAudio = false
+        queuedChunks.removeAll()
+        activeChunk = nil
+        output.stop()
+        state = .stopped(reason)
+    }
+
+    func resetForNextResponse() {
+        playbackGeneration &+= 1
+        output.stop()
+        queuedChunks.removeAll()
+        activeChunk = nil
+        acceptsAudio = true
+        state = .idle
+    }
+
+    private func playNextChunkIfNeeded() {
+        guard acceptsAudio, activeChunk == nil, !queuedChunks.isEmpty else { return }
+
+        let chunk = queuedChunks.removeFirst()
+        let generation = playbackGeneration
+        activeChunk = chunk
+        state = .playing
+
+        output.play(chunk) { [weak self] result in
+            self?.handlePlaybackCompletion(result, generation: generation)
+        }
+    }
+
+    private func handlePlaybackCompletion(_ result: Result<Void, Error>, generation: UInt64) {
+        guard generation == playbackGeneration, activeChunk != nil else { return }
+
+        activeChunk = nil
+
+        switch result {
+        case .success:
+            if queuedChunks.isEmpty {
+                state = .idle
+            } else {
+                playNextChunkIfNeeded()
+            }
+
+        case .failure(let error):
+            playbackGeneration &+= 1
+            acceptsAudio = false
+            queuedChunks.removeAll()
+            output.stop()
+            state = .failed(error.localizedDescription)
+        }
+    }
+}
+
+@MainActor
+final class AVFoundationLiveVoiceAudioOutput: NSObject, LiveVoiceAudioOutput, AVAudioPlayerDelegate {
+    private struct PCMFormatKey: Equatable {
+        let sampleRate: Int
+        let channels: Int
+    }
+
+    private var audioPlayer: AVAudioPlayer?
+    private var pcmEngine: AVAudioEngine?
+    private var pcmPlayerNode: AVAudioPlayerNode?
+    private var pcmFormatKey: PCMFormatKey?
+    private var completion: (@MainActor (Result<Void, Error>) -> Void)?
+
+    func play(
+        _ chunk: LiveVoiceAudioChunk,
+        completion: @escaping @MainActor (Result<Void, Error>) -> Void
+    ) {
+        stop()
+        self.completion = completion
+
+        do {
+            if chunk.mimeType.lowercased().hasPrefix("audio/pcm") {
+                try playPCM(chunk)
+            } else {
+                try playBufferedAudio(chunk)
+            }
+        } catch {
+            self.completion = nil
+            completion(.failure(error))
+        }
+    }
+
+    func stop() {
+        completion = nil
+
+        audioPlayer?.stop()
+        audioPlayer?.delegate = nil
+        audioPlayer = nil
+
+        pcmPlayerNode?.stop()
+        pcmEngine?.stop()
+    }
+
+    private func playBufferedAudio(_ chunk: LiveVoiceAudioChunk) throws {
+        do {
+            let player = try AVAudioPlayer(data: chunk.data)
+            player.delegate = self
+            audioPlayer = player
+
+            guard player.play() else {
+                throw LiveVoiceAudioOutputError.playbackStartFailed
+            }
+        } catch let error as LiveVoiceAudioOutputError {
+            throw error
+        } catch {
+            throw LiveVoiceAudioOutputError.decodingFailed(error.localizedDescription)
+        }
+    }
+
+    private func playPCM(_ chunk: LiveVoiceAudioChunk) throws {
+        guard chunk.channels == 1, chunk.sampleRate > 0 else {
+            throw LiveVoiceAudioOutputError.unsupportedPCMFormat
+        }
+        guard chunk.data.count.isMultiple(of: MemoryLayout<Int16>.size) else {
+            throw LiveVoiceAudioOutputError.malformedPCMData
+        }
+
+        let sampleCount = chunk.data.count / MemoryLayout<Int16>.size
+        guard sampleCount > 0 else {
+            complete(.success(()))
+            return
+        }
+
+        let key = PCMFormatKey(sampleRate: chunk.sampleRate, channels: chunk.channels)
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: Double(chunk.sampleRate),
+            channels: AVAudioChannelCount(chunk.channels),
+            interleaved: false
+        ),
+            let buffer = AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: AVAudioFrameCount(sampleCount)
+            ),
+            let channelData = buffer.int16ChannelData
+        else {
+            throw LiveVoiceAudioOutputError.unsupportedPCMFormat
+        }
+
+        buffer.frameLength = AVAudioFrameCount(sampleCount)
+        chunk.data.withUnsafeBytes { rawBuffer in
+            guard let source = rawBuffer.bindMemory(to: Int16.self).baseAddress else { return }
+            channelData[0].update(from: source, count: sampleCount)
+        }
+
+        try ensurePCMEngine(format: format, key: key)
+
+        guard let node = pcmPlayerNode else {
+            throw LiveVoiceAudioOutputError.playbackStartFailed
+        }
+
+        node.scheduleBuffer(
+            buffer,
+            completionCallbackType: .dataPlayedBack
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.complete(.success(()))
+            }
+        }
+        if !node.isPlaying {
+            node.play()
+        }
+    }
+
+    private func ensurePCMEngine(format: AVAudioFormat, key: PCMFormatKey) throws {
+        if let engine = pcmEngine, pcmPlayerNode != nil, pcmFormatKey == key {
+            guard !engine.isRunning else { return }
+            do {
+                try engine.start()
+                return
+            } catch {
+                throw LiveVoiceAudioOutputError.audioEngineStartFailed(error.localizedDescription)
+            }
+        }
+
+        pcmPlayerNode?.stop()
+        pcmEngine?.stop()
+
+        let engine = AVAudioEngine()
+        let node = AVAudioPlayerNode()
+        engine.attach(node)
+        engine.connect(node, to: engine.mainMixerNode, format: format)
+        engine.prepare()
+
+        do {
+            try engine.start()
+        } catch {
+            throw LiveVoiceAudioOutputError.audioEngineStartFailed(error.localizedDescription)
+        }
+
+        pcmEngine = engine
+        pcmPlayerNode = node
+        pcmFormatKey = key
+    }
+
+    private func complete(_ result: Result<Void, Error>) {
+        guard let completion else { return }
+        self.completion = nil
+        completion(result)
+    }
+
+    // MARK: - AVAudioPlayerDelegate
+
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor [weak self] in
+            self?.complete(
+                flag ? .success(()) : .failure(LiveVoiceAudioOutputError.playbackFinishedUnsuccessfully)
+            )
+        }
+    }
+
+    nonisolated func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
+        Task { @MainActor [weak self] in
+            self?.complete(
+                .failure(
+                    LiveVoiceAudioOutputError.decodingFailed(
+                        error?.localizedDescription ?? "Unknown decoding error"
+                    )
+                )
+            )
+        }
+    }
+}

--- a/clients/macos/vellum-assistantTests/LiveVoiceAudioPlayerTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceAudioPlayerTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+private final class MockLiveVoiceAudioOutput: LiveVoiceAudioOutput {
+    private(set) var playedChunks: [LiveVoiceAudioChunk] = []
+    private(set) var stopCallCount = 0
+
+    private var completions: [@MainActor (Result<Void, Error>) -> Void] = []
+
+    func play(
+        _ chunk: LiveVoiceAudioChunk,
+        completion: @escaping @MainActor (Result<Void, Error>) -> Void
+    ) {
+        playedChunks.append(chunk)
+        completions.append(completion)
+    }
+
+    func stop() {
+        stopCallCount += 1
+    }
+
+    func completeNextSuccessfully() {
+        guard !completions.isEmpty else {
+            XCTFail("Expected a pending playback completion")
+            return
+        }
+
+        let completion = completions.removeFirst()
+        completion(.success(()))
+    }
+
+    func failNext(_ error: Error = TestPlaybackError()) {
+        guard !completions.isEmpty else {
+            XCTFail("Expected a pending playback completion")
+            return
+        }
+
+        let completion = completions.removeFirst()
+        completion(.failure(error))
+    }
+}
+
+private struct TestPlaybackError: Error, LocalizedError {
+    var errorDescription: String? { "test playback failure" }
+}
+
+@MainActor
+final class LiveVoiceAudioPlayerTests: XCTestCase {
+    private var output: MockLiveVoiceAudioOutput!
+    private var player: LiveVoiceAudioPlayer!
+
+    override func setUp() {
+        super.setUp()
+        output = MockLiveVoiceAudioOutput()
+        player = LiveVoiceAudioPlayer(output: output)
+    }
+
+    override func tearDown() {
+        player = nil
+        output = nil
+        super.tearDown()
+    }
+
+    func testPlaybackStartsLazilyOnFirstTTSChunk() {
+        XCTAssertEqual(player.state, .idle)
+        XCTAssertFalse(player.isPlaying)
+        XCTAssertTrue(output.playedChunks.isEmpty)
+
+        player.enqueueTTSAudio(chunk(sequence: 1))
+
+        XCTAssertEqual(output.playedChunks.map(\.sequence), [1])
+        XCTAssertEqual(player.state, .playing)
+        XCTAssertTrue(player.isPlaying)
+    }
+
+    func testRapidEnqueuePreservesDeterministicChunkOrder() {
+        let expectedSequences = Array(0..<100)
+
+        for sequence in expectedSequences {
+            player.enqueueTTSAudio(chunk(sequence: sequence))
+        }
+
+        XCTAssertEqual(output.playedChunks.map(\.sequence), [0])
+        XCTAssertEqual(player.queuedChunkCount, 99)
+
+        for expectedSequence in expectedSequences.dropFirst() {
+            output.completeNextSuccessfully()
+            XCTAssertEqual(output.playedChunks.last?.sequence, expectedSequence)
+        }
+
+        output.completeNextSuccessfully()
+
+        XCTAssertEqual(output.playedChunks.map(\.sequence), expectedSequences)
+        XCTAssertEqual(player.queuedChunkCount, 0)
+        XCTAssertEqual(player.state, .idle)
+        XCTAssertFalse(player.isPlaying)
+    }
+
+    func testStopDrainsQueuedChunksAndIgnoresLateCompletion() {
+        player.enqueueTTSAudio(chunk(sequence: 1))
+        player.enqueueTTSAudio(chunk(sequence: 2))
+        player.enqueueTTSAudio(chunk(sequence: 3))
+
+        XCTAssertEqual(output.playedChunks.map(\.sequence), [1])
+        XCTAssertEqual(player.queuedChunkCount, 2)
+
+        player.stop(reason: .interrupt)
+
+        XCTAssertEqual(output.stopCallCount, 1)
+        XCTAssertEqual(player.state, .stopped(.interrupt))
+        XCTAssertEqual(player.queuedChunkCount, 0)
+        XCTAssertFalse(player.isPlaying)
+
+        output.completeNextSuccessfully()
+
+        XCTAssertEqual(output.playedChunks.map(\.sequence), [1])
+        XCTAssertEqual(player.state, .stopped(.interrupt))
+    }
+
+    func testStopPreventsLatePlaybackUntilReset() {
+        player.enqueueTTSAudio(chunk(sequence: 1))
+        player.stop(reason: .end)
+
+        player.enqueueTTSAudio(chunk(sequence: 2))
+
+        XCTAssertEqual(output.playedChunks.map(\.sequence), [1])
+        XCTAssertEqual(player.state, .stopped(.end))
+
+        player.resetForNextResponse()
+        player.enqueueTTSAudio(chunk(sequence: 3))
+
+        XCTAssertEqual(output.playedChunks.map(\.sequence), [1, 3])
+        XCTAssertEqual(player.state, .playing)
+    }
+
+    func testInterruptEndAndSessionErrorStopImmediately() {
+        player.enqueueTTSAudio(chunk(sequence: 1))
+        player.handleInterrupt()
+        XCTAssertEqual(output.stopCallCount, 1)
+        XCTAssertEqual(player.state, .stopped(.interrupt))
+
+        player.resetForNextResponse()
+        player.enqueueTTSAudio(chunk(sequence: 2))
+        player.handleEnd()
+        XCTAssertEqual(output.stopCallCount, 3)
+        XCTAssertEqual(player.state, .stopped(.end))
+
+        player.resetForNextResponse()
+        player.enqueueTTSAudio(chunk(sequence: 3))
+        player.handleSessionError()
+        XCTAssertEqual(output.stopCallCount, 5)
+        XCTAssertEqual(player.state, .stopped(.sessionError))
+    }
+
+    func testPlaybackFailureStopsQueueAndPreventsLatePlayback() {
+        player.enqueueTTSAudio(chunk(sequence: 1))
+        player.enqueueTTSAudio(chunk(sequence: 2))
+
+        output.failNext()
+
+        XCTAssertEqual(player.state, .failed("test playback failure"))
+        XCTAssertEqual(player.queuedChunkCount, 0)
+        XCTAssertEqual(output.stopCallCount, 1)
+
+        player.enqueueTTSAudio(chunk(sequence: 3))
+        XCTAssertEqual(output.playedChunks.map(\.sequence), [1])
+    }
+
+    func testEmptyChunksAreIgnored() {
+        player.enqueueTTSAudio(
+            data: Data(),
+            mimeType: "audio/pcm",
+            sampleRate: 24_000,
+            sequence: 1
+        )
+
+        XCTAssertTrue(output.playedChunks.isEmpty)
+        XCTAssertEqual(player.state, .idle)
+    }
+
+    private func chunk(sequence: Int) -> LiveVoiceAudioChunk {
+        LiveVoiceAudioChunk(
+            data: Data([UInt8(sequence % 256), UInt8((sequence + 1) % 256)]),
+            mimeType: "audio/pcm",
+            sampleRate: 24_000,
+            sequence: sequence
+        )
+    }
+}


### PR DESCRIPTION
## PR 8: add macOS live voice streaming playback adapter

### Depends on

None.

### Branch

`live-voice-channel/pr-08-audio-playback`

### Files

- `clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioPlayer.swift`
- `clients/macos/vellum-assistantTests/LiveVoiceAudioPlayerTests.swift`

### Scope

Add a testable playback adapter for streamed assistant audio. Use a small protocol boundary around the actual AVFoundation output so unit tests can verify queueing and interruption without real devices.

The adapter should:

- accept server `tts_audio` chunks
- queue chunks in order
- start playback lazily on first audio chunk
- stop immediately on `interrupt`, `end`, or session error
- expose playback state for the live voice manager

### Acceptance Criteria

- Chunk ordering is deterministic under rapid enqueue.
- `stop()` drains queued chunks and prevents late playback.
- The adapter has no dependency on `OpenAIVoiceService`.

### Verification

Run:

```bash
cd clients
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter LiveVoiceAudioPlayerTests
```

---

_Implements PR 8 of `.private/plans/live-voice-channel.md` (live-voice-channel run-plan). Direct-to-main wave 1: no feature branch, CI + external review skipped per orchestrator flags. Implementation drafted by codex agent under @velissa-ai's orchestration._
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
