### PR TITLE
feat(live-voice): generalize the voice session bridge for local live voice (PR 12)

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -1,11 +1,17 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type {
+  TurnChannelContext,
+  TurnInterfaceContext,
+} from "../channels/types.js";
 import type { Conversation } from "../daemon/conversation.js";
+import { persistUserMessage as persistUserMessageImpl } from "../daemon/conversation-messaging.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 
 let mockedConfig: {
   secretDetection: { enabled: boolean };
   calls: { disclosure: { enabled: boolean; text: string } };
+  memory: { enabled: boolean };
 } = {
   secretDetection: { enabled: false },
   calls: {
@@ -14,6 +20,7 @@ let mockedConfig: {
       text: "",
     },
   },
+  memory: { enabled: false },
 };
 
 mock.module("../util/logger.js", () => ({
@@ -31,7 +38,10 @@ import {
   setVoiceBridgeDeps,
   startVoiceTurn,
 } from "../calls/voice-session-bridge.js";
-import { createConversation } from "../memory/conversation-crud.js";
+import {
+  createConversation,
+  getMessages,
+} from "../memory/conversation-crud.js";
 import { getDb, initializeDb } from "../memory/db.js";
 
 initializeDb();
@@ -53,6 +63,7 @@ function makeStreamingSession(events: ServerMessage[]): Conversation {
     setTrustContext: () => {},
     setCommandIntent: () => {},
     setTurnChannelContext: () => {},
+    setTurnInterfaceContext: () => {},
     setVoiceCallControlPrompt: () => {},
     updateClient: () => {},
     ensureActorScopedHistory: async () => {},
@@ -68,6 +79,78 @@ function makeStreamingSession(events: ServerMessage[]): Conversation {
     handleConfirmationResponse: () => {},
     abort: () => {},
   } as unknown as Conversation;
+}
+
+function makePersistingStreamingSession(
+  conversationId: string,
+  events: ServerMessage[],
+): Conversation & { callSessionId?: string } {
+  type PersistUserMessageContext = Parameters<typeof persistUserMessageImpl>[0];
+
+  let turnChannelContext: TurnChannelContext | null = null;
+  let turnInterfaceContext: TurnInterfaceContext | null = null;
+  const session = {
+    conversationId,
+    messages: [],
+    processing: false,
+    abortController: null,
+    currentRequestId: undefined,
+    queue: {} as never,
+    trustContext: undefined,
+    memoryPolicy: {
+      scopeId: "default",
+      includeDefaultFallback: false,
+    },
+    isProcessing: () => session.processing,
+    persistUserMessage: async (
+      ...args: Parameters<Conversation["persistUserMessage"]>
+    ) => persistUserMessageImpl(session, ...args),
+    getTurnChannelContext: () => turnChannelContext,
+    getTurnInterfaceContext: () => turnInterfaceContext,
+    setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setTrustContext: (ctx: Parameters<Conversation["setTrustContext"]>[0]) => {
+      session.trustContext = ctx ?? undefined;
+    },
+    setCommandIntent: () => {},
+    setTurnChannelContext: (ctx: TurnChannelContext) => {
+      turnChannelContext = ctx;
+    },
+    setTurnInterfaceContext: (ctx: TurnInterfaceContext) => {
+      turnInterfaceContext = ctx;
+    },
+    setVoiceCallControlPrompt: () => {},
+    updateClient: () => {},
+    ensureActorScopedHistory: async () => {},
+    runAgentLoop: async (
+      _content: string,
+      _messageId: string,
+      onEvent: (msg: ServerMessage) => void,
+    ) => {
+      for (const event of events) {
+        onEvent(event);
+      }
+      session.processing = false;
+      session.abortController = null;
+      session.currentRequestId = undefined;
+    },
+    handleConfirmationResponse: () => {},
+    abort: () => {},
+  } as unknown as Conversation &
+    PersistUserMessageContext & {
+      callSessionId?: string;
+    };
+
+  return session;
+}
+
+function parsePersistedMetadata(
+  metadata: string | null | undefined,
+): Record<string, unknown> {
+  if (!metadata) {
+    throw new Error("Expected persisted message metadata");
+  }
+  return JSON.parse(metadata) as Record<string, unknown>;
 }
 
 /**
@@ -90,6 +173,7 @@ describe("voice-session-bridge", () => {
           text: "",
         },
       },
+      memory: { enabled: false },
     };
     const db = getDb();
     db.run("DELETE FROM messages");
@@ -191,6 +275,7 @@ describe("voice-session-bridge", () => {
       setTrustContext: () => {},
       setCommandIntent: () => {},
       setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
       updateClient: () => {},
       ensureActorScopedHistory: async () => {},
@@ -281,6 +366,7 @@ describe("voice-session-bridge", () => {
       setTrustContext: () => {},
       setCommandIntent: () => {},
       setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
       updateClient: () => {},
       ensureActorScopedHistory: async () => {},
@@ -346,6 +432,128 @@ describe("voice-session-bridge", () => {
     expect(capturedTurnChannelContext).toEqual({
       userMessageChannel: "phone",
       assistantMessageChannel: "phone",
+    });
+  });
+
+  test("startVoiceTurn defaults persisted voice metadata to phone", async () => {
+    const conversation = createConversation(
+      "voice bridge phone metadata default test",
+    );
+    const events: ServerMessage[] = [
+      { type: "message_complete", conversationId: conversation.id },
+    ];
+    const session = makePersistingStreamingSession(conversation.id, events);
+    injectDeps(() => session);
+
+    let persistedUserMessageId: string | undefined;
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: "Hello",
+      isInbound: true,
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+      callbacks: {
+        persisted_user_message_id: (messageId) => {
+          persistedUserMessageId = messageId;
+        },
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const persisted = getMessages(conversation.id).find(
+      (message) => message.id === persistedUserMessageId,
+    );
+    const metadata = parsePersistedMetadata(persisted?.metadata);
+    expect(persisted).toBeDefined();
+    expect(metadata).toMatchObject({
+      userMessageChannel: "phone",
+      assistantMessageChannel: "phone",
+      userMessageInterface: "phone",
+      assistantMessageInterface: "phone",
+    });
+  });
+
+  test("startVoiceTurn can persist local live voice metadata and callbacks", async () => {
+    const conversation = createConversation(
+      "voice bridge local live voice metadata test",
+    );
+    const events: ServerMessage[] = [
+      {
+        type: "assistant_text_delta",
+        text: "Hi",
+        conversationId: conversation.id,
+      },
+      {
+        type: "message_complete",
+        conversationId: conversation.id,
+        messageId: "assistant-msg-1",
+      },
+    ];
+
+    let capturedTransport: { channelId: string } | undefined;
+    let capturedVoiceSessionId: string | undefined;
+    const capturedPrompts: Array<string | null> = [];
+    const session = makePersistingStreamingSession(conversation.id, events);
+    session.setVoiceCallControlPrompt = (prompt: string | null) => {
+      capturedPrompts.push(prompt);
+    };
+
+    setVoiceBridgeDeps({
+      getOrCreateConversation: async (_conversationId, transport) => {
+        capturedTransport = transport;
+        return session;
+      },
+      resolveAttachments: () => [],
+    });
+
+    const textDeltaEvents: ServerMessage[] = [];
+    const completeEvents: ServerMessage[] = [];
+    let persistedUserMessageId: string | undefined;
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      voiceSessionId: "local-live-voice-session-1",
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+      voiceControlPrompt:
+        "You are speaking in a local live voice session. Keep replies brief and conversational.",
+      content: "Hello from local live voice",
+      isInbound: true,
+      callbacks: {
+        assistant_text_delta: (msg) => textDeltaEvents.push(msg),
+        message_complete: (msg) => completeEvents.push(msg),
+        persisted_user_message_id: (messageId) => {
+          persistedUserMessageId = messageId;
+          capturedVoiceSessionId = session.callSessionId;
+        },
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(capturedTransport).toEqual({ channelId: "vellum" });
+    expect(capturedVoiceSessionId).toBe("local-live-voice-session-1");
+    expect(capturedPrompts[0]).toBe(
+      "You are speaking in a local live voice session. Keep replies brief and conversational.",
+    );
+    expect(textDeltaEvents).toEqual([events[0]]);
+    expect(completeEvents).toEqual([events[1]]);
+
+    const persisted = getMessages(conversation.id).find(
+      (message) => message.id === persistedUserMessageId,
+    );
+    const metadata = parsePersistedMetadata(persisted?.metadata);
+    expect(persisted).toBeDefined();
+    expect(metadata).toMatchObject({
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
     });
   });
 
@@ -449,6 +657,7 @@ describe("voice-session-bridge", () => {
           text: "At the very beginning of the call, introduce yourself as an assistant calling on behalf of the person you represent.",
         },
       },
+      memory: { enabled: false },
     };
 
     const conversation = createConversation(
@@ -521,6 +730,7 @@ describe("voice-session-bridge", () => {
       setTrustContext: () => {},
       setCommandIntent: () => {},
       setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
       updateClient: (handler: (msg: ServerMessage) => void) => {
         clientHandler = handler;
@@ -605,6 +815,7 @@ describe("voice-session-bridge", () => {
       setTrustContext: () => {},
       setCommandIntent: () => {},
       setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
       updateClient: (handler: (msg: ServerMessage) => void) => {
         clientHandler = handler;
@@ -672,6 +883,7 @@ describe("voice-session-bridge", () => {
       setTrustContext: () => {},
       setCommandIntent: () => {},
       setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
       updateClient: (handler: (msg: ServerMessage) => void) => {
         clientHandler = handler;
@@ -735,6 +947,7 @@ describe("voice-session-bridge", () => {
       setTrustContext: () => {},
       setCommandIntent: () => {},
       setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
       updateClient: (handler: (msg: ServerMessage) => void) => {
         clientHandler = handler;
@@ -807,6 +1020,7 @@ describe("voice-session-bridge", () => {
       setTrustContext: () => {},
       setCommandIntent: () => {},
       setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
       updateClient: (handler: (msg: ServerMessage) => void) => {
         clientHandler = handler;
@@ -881,6 +1095,7 @@ describe("voice-session-bridge", () => {
       setTrustContext: () => {},
       setCommandIntent: () => {},
       setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
       updateClient: () => {},
       ensureActorScopedHistory: async () => {},

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -11,7 +11,12 @@
  */
 
 import { consumeGrantForInvocation } from "../approvals/approval-primitive.js";
-import type { ChannelId } from "../channels/types.js";
+import type {
+  ChannelId,
+  InterfaceId,
+  TurnChannelContext,
+  TurnInterfaceContext,
+} from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import type { Conversation } from "../daemon/conversation.js";
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
@@ -72,17 +77,49 @@ export function setVoiceBridgeDeps(d: VoiceBridgeDeps): void {
  * standard channel path.
  */
 export interface VoiceRunEventSink {
-  onTextDelta(text: string): void;
-  onMessageComplete(): void;
+  onTextDelta(
+    msg: Extract<ServerMessage, { type: "assistant_text_delta" }>,
+  ): void;
+  onMessageComplete(
+    msg: Extract<
+      ServerMessage,
+      { type: "message_complete" } | { type: "generation_cancelled" }
+    >,
+  ): void;
   onError(message: string): void;
   onToolUse(toolName: string, input: Record<string, unknown>): void;
+}
+
+export interface VoiceTurnCallbacks {
+  assistant_text_delta?: (
+    msg: Extract<ServerMessage, { type: "assistant_text_delta" }>,
+  ) => void;
+  message_complete?: (
+    msg: Extract<
+      ServerMessage,
+      { type: "message_complete" } | { type: "generation_cancelled" }
+    >,
+  ) => void;
+  persisted_user_message_id?: (messageId: string) => void;
 }
 
 export interface VoiceTurnOptions {
   /** The conversation ID for this voice call's session. */
   conversationId: string;
+  /** Voice session ID for scoped grant matching. Defaults to callSessionId. */
+  voiceSessionId?: string;
   /** The call session ID for scoped grant matching. */
   callSessionId?: string;
+  /** Source channel for persisted user messages. Defaults to phone. */
+  userMessageChannel?: ChannelId;
+  /** Source channel for persisted assistant messages. Defaults to userMessageChannel. */
+  assistantMessageChannel?: ChannelId;
+  /** Source interface for persisted user messages. Defaults to phone. */
+  userMessageInterface?: InterfaceId;
+  /** Source interface for persisted assistant messages. Defaults to userMessageInterface. */
+  assistantMessageInterface?: InterfaceId;
+  /** Per-turn control prompt. Undefined uses the phone prompt; null disables it. */
+  voiceControlPrompt?: string | null;
   /** The transcribed caller utterance or synthetic marker. */
   content: string;
   /** Assistant scope for multi-assistant channels. */
@@ -96,11 +133,13 @@ export interface VoiceTurnOptions {
   /** When true, skip the disclosure announcement for this call. */
   skipDisclosure?: boolean;
   /** Called for each streaming text token from the agent loop. */
-  onTextDelta: (text: string) => void;
+  onTextDelta?: (text: string) => void;
   /** Called when the agent loop completes a full response. */
-  onComplete: () => void;
+  onComplete?: () => void;
   /** Called when the agent loop encounters an error. */
-  onError: (message: string) => void;
+  onError?: (message: string) => void;
+  /** Event-name callbacks used by non-phone voice clients. */
+  callbacks?: VoiceTurnCallbacks;
   /** Optional AbortSignal for external cancellation (e.g. barge-in). */
   signal?: AbortSignal;
 }
@@ -244,9 +283,17 @@ export async function startVoiceTurn(
   }
 
   const eventSink: VoiceRunEventSink = {
-    onTextDelta: opts.onTextDelta,
-    onMessageComplete: opts.onComplete,
-    onError: opts.onError,
+    onTextDelta: (msg) => {
+      opts.onTextDelta?.(msg.text);
+      opts.callbacks?.assistant_text_delta?.(msg);
+    },
+    onMessageComplete: (msg) => {
+      opts.onComplete?.();
+      opts.callbacks?.message_complete?.(msg);
+    },
+    onError: (message) => {
+      opts.onError?.(message);
+    },
     onToolUse: (toolName, input) => {
       log.debug({ toolName, input }, "Voice turn tool_use event");
     },
@@ -258,6 +305,17 @@ export async function startVoiceTurn(
   // - everyone else (including unknown): auto-deny confirmations.
   const trustClass = opts.trustContext?.trustClass;
   const isGuardian = trustClass === "guardian";
+  const voiceSessionId = opts.voiceSessionId ?? opts.callSessionId;
+  const turnChannelContext: TurnChannelContext = {
+    userMessageChannel: opts.userMessageChannel ?? "phone",
+    assistantMessageChannel:
+      opts.assistantMessageChannel ?? opts.userMessageChannel ?? "phone",
+  };
+  const turnInterfaceContext: TurnInterfaceContext = {
+    userMessageInterface: opts.userMessageInterface ?? "phone",
+    assistantMessageInterface:
+      opts.assistantMessageInterface ?? opts.userMessageInterface ?? "phone",
+  };
 
   // Replace the [CALL_OPENING] marker with a neutral instruction before
   // persisting. The marker must not appear as a user message in conversation
@@ -274,16 +332,19 @@ export async function startVoiceTurn(
   // control markers (ASK_GUARDIAN, END_CALL, etc.) and recognize opener turns.
   const isCallerGuardian = opts.trustContext?.trustClass === "guardian";
 
-  const voiceCallControlPrompt = buildVoiceCallControlPrompt({
-    isInbound: opts.isInbound,
-    task: opts.task,
-    isCallerGuardian,
-    skipDisclosure: opts.skipDisclosure,
-  });
+  const voiceCallControlPrompt =
+    opts.voiceControlPrompt === undefined
+      ? buildVoiceCallControlPrompt({
+          isInbound: opts.isInbound,
+          task: opts.task,
+          isCallerGuardian,
+          skipDisclosure: opts.skipDisclosure,
+        })
+      : opts.voiceControlPrompt;
 
   // Get or create the conversation
   const transport = {
-    channelId: "phone" as ChannelId,
+    channelId: turnChannelContext.userMessageChannel,
   };
   const conversation = await deps.getOrCreateConversation(
     opts.conversationId,
@@ -313,15 +374,16 @@ export async function startVoiceTurn(
 
   // Configure conversation for this voice turn
   conversation.setAssistantId(opts.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID);
-  conversation.callSessionId = opts.callSessionId;
+  conversation.callSessionId = voiceSessionId;
   conversation.setTrustContext(opts.trustContext ?? null);
   conversation.setCommandIntent(null);
-  conversation.setTurnChannelContext({
-    userMessageChannel: "phone",
-    assistantMessageChannel: "phone",
-  });
+  conversation.setTurnChannelContext(turnChannelContext);
+  conversation.setTurnInterfaceContext?.(turnInterfaceContext);
   conversation.setChannelCapabilities(
-    resolveChannelCapabilities("phone", undefined),
+    resolveChannelCapabilities(
+      turnChannelContext.userMessageChannel,
+      turnInterfaceContext.userMessageInterface,
+    ),
   );
   conversation.setVoiceCallControlPrompt(voiceCallControlPrompt);
 
@@ -332,6 +394,14 @@ export async function startVoiceTurn(
     [],
     requestId,
   );
+  try {
+    opts.callbacks?.persisted_user_message_id?.(messageId);
+  } catch (err) {
+    log.warn(
+      { err, turnId, messageId },
+      "Voice turn persisted-message callback threw",
+    );
+  }
 
   // Serialized publish chain so hub subscribers observe events in order.
   let hubChain: Promise<void> = Promise.resolve();
@@ -388,9 +458,9 @@ export async function startVoiceTurn(
               toolName: msg.toolName,
               inputDigest,
               consumingRequestId: msg.requestId,
-              executionChannel: "phone",
+              executionChannel: turnChannelContext.userMessageChannel,
               conversationId: opts.conversationId,
-              callSessionId: opts.callSessionId,
+              callSessionId: voiceSessionId,
               requesterExternalUserId:
                 opts.trustContext?.requesterExternalUserId,
             },
@@ -495,13 +565,13 @@ export async function startVoiceTurn(
 
           // Forward voice-relevant events to the real-time event sink
           if (msg.type === "assistant_text_delta") {
-            eventSink.onTextDelta(msg.text);
+            eventSink.onTextDelta(msg);
           } else if (msg.type === "message_complete") {
-            eventSink.onMessageComplete();
+            eventSink.onMessageComplete(msg);
           } else if (msg.type === "generation_cancelled") {
             // Treat cancellation as a completed turn so the voice
             // turnComplete promise settles instead of hanging forever.
-            eventSink.onMessageComplete();
+            eventSink.onMessageComplete(msg);
           } else if (msg.type === "error") {
             eventSink.onError(msg.message);
           } else if (msg.type === "conversation_error") {


### PR DESCRIPTION
## PR 12: generalize the voice session bridge for local live voice

### Depends on

None.

### Branch

`live-voice-channel/pr-12-voice-bridge-context`

### Files

- `assistant/src/calls/voice-session-bridge.ts`
- `assistant/src/__tests__/voice-session-bridge.test.ts`

### Scope

Extend the existing phone voice bridge instead of forking a second conversation path. Add an options shape that preserves phone defaults while allowing local live voice to provide:

- voice session id
- `userMessageChannel: "vellum"`
- `assistantMessageChannel: "vellum"`
- `userMessageInterface: "macos"`
- `assistantMessageInterface: "macos"`
- a live-voice-appropriate control prompt or no phone call prompt
- callbacks for `assistant_text_delta`, `message_complete`, and persisted user message id

Keep the normal `persistUserMessage` plus `runAgentLoop` path, and keep approval handling model-mediated through the existing conversation/guardian flow.

### Acceptance Criteria

- Existing phone bridge tests remain unchanged or are updated only for explicit default assertions.
- A new local-live-voice test proves persisted metadata uses `vellum` and `macos`, not `phone`.
- No direct provider calls are introduced.
- No system prompt bulk is added; any live-voice instruction is minimal and local to the turn bridge.

### Verification

Run:

```bash
export PATH="$HOME/.bun/bin:$PATH"
cd assistant && bun test src/__tests__/voice-session-bridge.test.ts
cd assistant && bunx tsc --noEmit
```

---

_Implements PR 12 of `.private/plans/live-voice-channel.md` (live-voice-channel run-plan). Direct-to-main wave 1: no feature branch, CI + external review skipped per orchestrator flags. Implementation drafted by codex agent under @velissa-ai's orchestration._
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
