### PR TITLE
feat(live-voice): add live voice streaming TTS helper (PR 14)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
@@ -1,0 +1,238 @@
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  _resetTtsProviderRegistry,
+  registerTtsProvider,
+} from "../../tts/provider-registry.js";
+import type {
+  TtsProvider,
+  TtsSynthesisRequest,
+  TtsSynthesisResult,
+} from "../../tts/types.js";
+import type {
+  LiveVoiceTtsAudioChunk,
+  LiveVoiceTtsConfig,
+} from "../live-voice-tts.js";
+
+let config = makeConfig();
+
+const { LiveVoiceTtsError, streamLiveVoiceTtsAudio } =
+  await import("../live-voice-tts.js");
+
+beforeEach(() => {
+  config = makeConfig();
+  _resetTtsProviderRegistry();
+});
+
+describe("streamLiveVoiceTtsAudio", () => {
+  test("streams Fish Audio chunks through the configured TTS registry", async () => {
+    const requests: TtsSynthesisRequest[] = [];
+    const provider: TtsProvider = {
+      id: "fish-audio",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize(): Promise<TtsSynthesisResult> {
+        throw new Error("buffered synthesis should not be used");
+      },
+      async synthesizeStream(
+        request: TtsSynthesisRequest,
+        onChunk: (chunk: Uint8Array) => void,
+      ): Promise<TtsSynthesisResult> {
+        requests.push(request);
+        onChunk(Buffer.from("chunk-one"));
+        onChunk(Buffer.from("chunk-two"));
+        return {
+          audio: Buffer.from("chunk-onechunk-two"),
+          contentType: "audio/mpeg",
+        };
+      },
+    };
+    registerTtsProvider(provider);
+
+    const frames: LiveVoiceTtsAudioChunk[] = [];
+    const result = await streamLiveVoiceTtsAudio({
+      config,
+      text: "hello from live voice",
+      sampleRate: 24_000,
+      onAudioChunk: (chunk) => frames.push(chunk),
+    });
+
+    expect(requests).toEqual([
+      {
+        text: "hello from live voice",
+        useCase: "phone-call",
+        voiceId: undefined,
+        signal: undefined,
+        outputFormat: undefined,
+      },
+    ]);
+    expect(frames).toEqual([
+      {
+        type: "tts_audio",
+        seq: 0,
+        contentType: "audio/mpeg",
+        sampleRate: 24_000,
+        dataBase64: Buffer.from("chunk-one").toString("base64"),
+      },
+      {
+        type: "tts_audio",
+        seq: 1,
+        contentType: "audio/mpeg",
+        sampleRate: 24_000,
+        dataBase64: Buffer.from("chunk-two").toString("base64"),
+      },
+    ]);
+    expect(result).toEqual({
+      provider: "fish-audio",
+      contentType: "audio/mpeg",
+      sampleRate: 24_000,
+      chunks: 2,
+      bytes: Buffer.byteLength("chunk-onechunk-two"),
+    });
+  });
+
+  test("returns a typed configuration error for a non-streaming provider", async () => {
+    config = makeConfig({ provider: "elevenlabs" });
+    registerTtsProvider({
+      id: "elevenlabs",
+      capabilities: { supportsStreaming: false, supportedFormats: ["mp3"] },
+      async synthesize(): Promise<TtsSynthesisResult> {
+        return { audio: Buffer.from("audio"), contentType: "audio/mpeg" };
+      },
+    });
+
+    await expect(
+      streamLiveVoiceTtsAudio({
+        config,
+        text: "hello",
+        onAudioChunk: () => {},
+      }),
+    ).rejects.toMatchObject({
+      name: "LiveVoiceTtsError",
+      code: "LIVE_VOICE_TTS_STREAMING_UNAVAILABLE",
+      provider: "elevenlabs",
+    });
+  });
+
+  test("returns a typed configuration error when provider credentials are missing", async () => {
+    registerTtsProvider({
+      id: "fish-audio",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize(): Promise<TtsSynthesisResult> {
+        throw new Error("buffered synthesis should not be used");
+      },
+      async synthesizeStream(): Promise<TtsSynthesisResult> {
+        const err = new Error("Fish Audio API key not configured");
+        Object.assign(err, { code: "FISH_AUDIO_TTS_NO_API_KEY" });
+        throw err;
+      },
+    });
+
+    await expect(
+      streamLiveVoiceTtsAudio({
+        config,
+        text: "hello",
+        onAudioChunk: () => {},
+      }),
+    ).rejects.toMatchObject({
+      name: "LiveVoiceTtsError",
+      code: "LIVE_VOICE_TTS_CONFIGURATION_ERROR",
+      provider: "fish-audio",
+    });
+  });
+
+  test("wraps provider streaming failures as synthesis errors", async () => {
+    registerTtsProvider({
+      id: "fish-audio",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize(): Promise<TtsSynthesisResult> {
+        throw new Error("buffered synthesis should not be used");
+      },
+      async synthesizeStream(): Promise<TtsSynthesisResult> {
+        throw new Error("provider exploded");
+      },
+    });
+
+    try {
+      await streamLiveVoiceTtsAudio({
+        config,
+        text: "hello",
+        onAudioChunk: () => {},
+      });
+      throw new Error("Expected streamLiveVoiceTtsAudio to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LiveVoiceTtsError);
+      expect(err).toMatchObject({
+        code: "LIVE_VOICE_TTS_SYNTHESIS_FAILED",
+        provider: "fish-audio",
+      });
+      expect((err as Error).message).toContain("provider exploded");
+    }
+  });
+
+  test("keeps live voice TTS behind the registry instead of direct provider SDKs", () => {
+    const source = readFileSync(
+      new URL("../live-voice-tts.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain("getTtsProvider");
+    expect(source).toContain("resolveTtsConfig");
+    expect(source).not.toMatch(/fish-audio-client/);
+    expect(source).not.toMatch(/from\s+["']@/);
+    expect(source).not.toContain("fetch(");
+  });
+});
+
+function makeConfig(
+  overrides: {
+    provider?: string;
+    format?: "mp3" | "wav" | "opus";
+    sampleRate?: number;
+  } = {},
+): LiveVoiceTtsConfig {
+  return {
+    services: {
+      tts: {
+        provider: overrides.provider ?? "fish-audio",
+        providers: {
+          "fish-audio": {
+            referenceId: "fish-ref-123",
+            chunkLength: 200,
+            format: overrides.format ?? "mp3",
+            latency: "normal",
+            speed: 1.0,
+          },
+          elevenlabs: {
+            voiceId: "voice-123",
+            voiceModelId: "",
+            speed: 1.0,
+            stability: 0.5,
+            similarityBoost: 0.75,
+            conversationTimeoutSeconds: 30,
+          },
+          deepgram: {
+            model: "aura-asteria-en",
+            format: "mp3",
+          },
+          xai: {
+            voiceId: "eve",
+            language: "auto",
+            format: "mp3",
+            sampleRate: overrides.sampleRate ?? 24_000,
+            bitRate: 128_000,
+          },
+        },
+      },
+    },
+  } as LiveVoiceTtsConfig;
+}

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -1,0 +1,237 @@
+import { getTtsProvider } from "../tts/provider-registry.js";
+import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+import type {
+  TtsProvider,
+  TtsProviderId,
+  TtsSynthesisRequest,
+  TtsUseCase,
+} from "../tts/types.js";
+
+export const DEFAULT_LIVE_VOICE_TTS_SAMPLE_RATE = 24_000;
+
+export type LiveVoiceTtsConfig = Parameters<typeof resolveTtsConfig>[0];
+
+export interface LiveVoiceTtsAudioChunk {
+  type: "tts_audio";
+  seq: number;
+  contentType: string;
+  sampleRate: number;
+  dataBase64: string;
+}
+
+export interface LiveVoiceTtsOptions {
+  text: string;
+  voiceId?: string;
+  signal?: AbortSignal;
+  useCase?: TtsUseCase;
+  outputFormat?: TtsSynthesisRequest["outputFormat"];
+  sampleRate?: number;
+  config?: LiveVoiceTtsConfig;
+  onAudioChunk: (chunk: LiveVoiceTtsAudioChunk) => void;
+}
+
+export interface LiveVoiceTtsResult {
+  provider: TtsProviderId;
+  contentType: string;
+  sampleRate: number;
+  chunks: number;
+  bytes: number;
+}
+
+export type LiveVoiceTtsErrorCode =
+  | "LIVE_VOICE_TTS_PROVIDER_NOT_CONFIGURED"
+  | "LIVE_VOICE_TTS_STREAMING_UNAVAILABLE"
+  | "LIVE_VOICE_TTS_CONFIGURATION_ERROR"
+  | "LIVE_VOICE_TTS_SYNTHESIS_FAILED";
+
+export class LiveVoiceTtsError extends Error {
+  readonly code: LiveVoiceTtsErrorCode;
+  readonly provider?: TtsProviderId;
+  override readonly cause?: unknown;
+
+  constructor(
+    code: LiveVoiceTtsErrorCode,
+    message: string,
+    options: { provider?: TtsProviderId; cause?: unknown } = {},
+  ) {
+    super(message);
+    this.name = "LiveVoiceTtsError";
+    this.code = code;
+    this.provider = options.provider;
+    this.cause = options.cause;
+  }
+}
+
+interface ResolvedStreamingTtsProvider {
+  provider: TtsProvider;
+  providerId: TtsProviderId;
+  providerConfig: Record<string, unknown>;
+}
+
+export async function streamLiveVoiceTtsAudio(
+  options: LiveVoiceTtsOptions,
+): Promise<LiveVoiceTtsResult> {
+  const { provider, providerId, providerConfig } =
+    await resolveLiveVoiceStreamingTtsProvider(options.config);
+  const sampleRate = resolveSampleRate(options.sampleRate, providerConfig);
+  const chunkContentType = resolveChunkContentType(
+    providerConfig,
+    options.outputFormat,
+  );
+  let seq = 0;
+  let chunks = 0;
+  let bytes = 0;
+
+  try {
+    const result = await provider.synthesizeStream!(
+      {
+        text: options.text,
+        useCase: options.useCase ?? "phone-call",
+        voiceId: options.voiceId,
+        signal: options.signal,
+        outputFormat: options.outputFormat,
+      },
+      (audioChunk) => {
+        if (audioChunk.byteLength === 0) return;
+
+        chunks += 1;
+        bytes += audioChunk.byteLength;
+        options.onAudioChunk({
+          type: "tts_audio",
+          seq: seq++,
+          contentType: chunkContentType,
+          sampleRate,
+          dataBase64: Buffer.from(audioChunk).toString("base64"),
+        });
+      },
+    );
+
+    return {
+      provider: providerId,
+      contentType: result.contentType || chunkContentType,
+      sampleRate,
+      chunks,
+      bytes,
+    };
+  } catch (err) {
+    throw normalizeProviderError(err, providerId);
+  }
+}
+
+async function resolveLiveVoiceStreamingTtsProvider(
+  configOverride?: LiveVoiceTtsConfig,
+): Promise<ResolvedStreamingTtsProvider> {
+  const config = configOverride ?? (await loadAssistantConfig());
+  const { provider: providerId, providerConfig } = resolveTtsConfig(config);
+
+  let provider: TtsProvider;
+  try {
+    provider = getTtsProvider(providerId);
+  } catch (err) {
+    throw new LiveVoiceTtsError(
+      "LIVE_VOICE_TTS_PROVIDER_NOT_CONFIGURED",
+      `TTS provider "${providerId}" is not configured or registered.`,
+      { provider: providerId, cause: err },
+    );
+  }
+
+  if (
+    !provider.capabilities.supportsStreaming ||
+    typeof provider.synthesizeStream !== "function"
+  ) {
+    throw new LiveVoiceTtsError(
+      "LIVE_VOICE_TTS_STREAMING_UNAVAILABLE",
+      `TTS provider "${providerId}" does not support streaming synthesis required by live voice.`,
+      { provider: providerId },
+    );
+  }
+
+  return { provider, providerId, providerConfig };
+}
+
+async function loadAssistantConfig(): Promise<LiveVoiceTtsConfig> {
+  const { getConfig } = await import("../config/loader.js");
+  return getConfig();
+}
+
+function normalizeProviderError(
+  err: unknown,
+  providerId: TtsProviderId,
+): LiveVoiceTtsError {
+  if (err instanceof LiveVoiceTtsError) return err;
+
+  const message = err instanceof Error ? err.message : String(err);
+  if (isProviderConfigurationError(err)) {
+    return new LiveVoiceTtsError(
+      "LIVE_VOICE_TTS_CONFIGURATION_ERROR",
+      `Live voice TTS provider "${providerId}" is missing required configuration or credentials: ${message}`,
+      { provider: providerId, cause: err },
+    );
+  }
+
+  return new LiveVoiceTtsError(
+    "LIVE_VOICE_TTS_SYNTHESIS_FAILED",
+    `Live voice TTS synthesis failed (provider: ${providerId}): ${message}`,
+    { provider: providerId, cause: err },
+  );
+}
+
+function isProviderConfigurationError(err: unknown): boolean {
+  const code =
+    err instanceof Error && "code" in err
+      ? String((err as Error & { code?: unknown }).code)
+      : undefined;
+  if (
+    code?.endsWith("_NO_API_KEY") ||
+    code?.endsWith("_NO_REFERENCE_ID") ||
+    code?.endsWith("_NO_VOICE_ID")
+  ) {
+    return true;
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  return /(?:api key|credential|reference id|voice id).*not configured/i.test(
+    message,
+  );
+}
+
+function resolveChunkContentType(
+  providerConfig: Record<string, unknown>,
+  outputFormat: TtsSynthesisRequest["outputFormat"],
+): string {
+  if (outputFormat === "pcm") return "audio/pcm";
+
+  const format =
+    typeof providerConfig.format === "string" ? providerConfig.format : "mp3";
+  switch (format) {
+    case "wav":
+      return "audio/wav";
+    case "opus":
+      return "audio/opus";
+    case "pcm":
+      return "audio/pcm";
+    case "mp3":
+    default:
+      return "audio/mpeg";
+  }
+}
+
+function resolveSampleRate(
+  explicitSampleRate: number | undefined,
+  providerConfig: Record<string, unknown>,
+): number {
+  if (isPositiveFiniteNumber(explicitSampleRate)) {
+    return explicitSampleRate;
+  }
+
+  const configuredSampleRate = providerConfig.sampleRate;
+  if (isPositiveFiniteNumber(configuredSampleRate)) {
+    return configuredSampleRate;
+  }
+
+  return DEFAULT_LIVE_VOICE_TTS_SAMPLE_RATE;
+}
+
+function isPositiveFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}


### PR DESCRIPTION
## PR 14: add live voice streaming TTS helper

### Depends on

None.

### Branch

`live-voice-channel/pr-14-streaming-tts-helper`

### Files

- `assistant/src/live-voice/live-voice-tts.ts`
- `assistant/src/live-voice/__tests__/live-voice-tts.test.ts`

### Scope

Add a helper that resolves configured TTS through the existing TTS registry and produces audio chunks suitable for `tts_audio` frames. It should:

- call the existing TTS configuration/provider resolution path
- require a provider with `synthesizeStream`
- use the already supported call/message playback use case rather than adding a new provider API
- emit content type, sample rate, and chunk sequence metadata
- return typed configuration errors when streaming TTS is unavailable

Do not wire this into `LiveVoiceSession` yet.

### Acceptance Criteria

- Tests cover streaming provider, non-streaming provider, missing credential, and provider error cases.
- No direct provider SDK import is added.
- Fish Audio continues to be reached through the existing provider registry.

### Verification

Run:

```bash
export PATH="$HOME/.bun/bin:$PATH"
cd assistant && bun test src/live-voice/__tests__/live-voice-tts.test.ts
cd assistant && bunx tsc --noEmit
```

---

_Implements PR 14 of `.private/plans/live-voice-channel.md` (live-voice-channel run-plan). Direct-to-main wave 1: no feature branch, CI + external review skipped per orchestrator flags. Implementation drafted by codex agent under @velissa-ai's orchestration._
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
