### PR TITLE
feat(live-voice): add live voice audio archive helper (PR 16)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-archive.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-archive.test.ts
@@ -1,0 +1,388 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  getAttachmentContent,
+  getAttachmentsForMessage,
+} from "../../memory/attachments-store.js";
+import {
+  addMessage,
+  createConversation,
+} from "../../memory/conversation-crud.js";
+import {
+  getDb,
+  initializeDb,
+  rawAll,
+  rawGet,
+  rawRun,
+} from "../../memory/db.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import type { LiveVoiceAudioArtifactMetadata } from "../live-voice-archive.js";
+import {
+  archiveLiveVoiceAssistantResponseAudio,
+  archiveLiveVoiceAudioArtifact,
+  archiveLiveVoiceUserUtteranceAudio,
+} from "../live-voice-archive.js";
+
+initializeDb();
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+async function createMessage(role: "user" | "assistant" = "user") {
+  const conversation = createConversation();
+  const message = await addMessage(
+    conversation.id,
+    role,
+    role === "user" ? "Example user utterance" : "Example assistant response",
+    role === "user"
+      ? { userMessageChannel: "vellum", userMessageInterface: "macos" }
+      : {
+          assistantMessageChannel: "vellum",
+          assistantMessageInterface: "macos",
+        },
+    { skipIndexing: true },
+  );
+  return { conversation, message };
+}
+
+function getMessageMetadata(messageId: string): Record<string, unknown> {
+  const row = rawGet<{ metadata: string | null }>(
+    `SELECT metadata FROM messages WHERE id = ?`,
+    messageId,
+  );
+  expect(row).toBeDefined();
+  return row?.metadata ? JSON.parse(row.metadata) : {};
+}
+
+function getLiveVoiceArtifacts(
+  messageId: string,
+): LiveVoiceAudioArtifactMetadata[] {
+  const metadata = getMessageMetadata(messageId);
+  expect(Array.isArray(metadata.liveVoiceAudioArtifacts)).toBe(true);
+  return metadata.liveVoiceAudioArtifacts as LiveVoiceAudioArtifactMetadata[];
+}
+
+function countAttachmentsForMessage(messageId: string): number {
+  const row = rawGet<{ count: number }>(
+    `SELECT COUNT(*) AS count FROM message_attachments WHERE message_id = ?`,
+    messageId,
+  );
+  return row?.count ?? 0;
+}
+
+describe("live voice audio archive", () => {
+  beforeEach(resetTables);
+
+  test("archives user utterance audio through the attachment store", async () => {
+    const { message } = await createMessage("user");
+    const audio = Buffer.from("user audio bytes");
+
+    const result = archiveLiveVoiceUserUtteranceAudio({
+      messageId: message.id,
+      sessionId: "session-123",
+      turnId: "turn-abc",
+      mimeType: "audio/wav",
+      sampleRate: 16000,
+      durationMs: 1250,
+      audio: {
+        type: "base64",
+        dataBase64: audio.toString("base64"),
+      },
+    });
+
+    expect(result.type).toBe("archived");
+    if (result.type !== "archived") throw new Error("expected archive result");
+    expect(result.idempotent).toBe(false);
+    expect(result.artifact).toMatchObject({
+      source: "live-voice",
+      archiveKey: "live-voice:session-123:turn-abc:user",
+      sessionId: "session-123",
+      turnId: "turn-abc",
+      role: "user",
+      mimeType: "audio/wav",
+      sampleRate: 16000,
+      durationMs: 1250,
+      filename: "live-voice-user-session-123-turn-abc.wav",
+    });
+
+    expect(getAttachmentContent(result.artifact.attachmentId)).toEqual(audio);
+
+    const attachments = getAttachmentsForMessage(message.id);
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]?.id).toBe(result.artifact.attachmentId);
+    expect(attachments[0]?.originalFilename).toBe(
+      "live-voice-user-session-123-turn-abc.wav",
+    );
+    expect(attachments[0]?.mimeType).toBe("audio/wav");
+
+    const artifacts = getLiveVoiceArtifacts(message.id);
+    expect(artifacts).toEqual([result.artifact]);
+  });
+
+  test("archives assistant spoken response audio from a file-backed source", async () => {
+    const { message } = await createMessage("assistant");
+    const audioDir = join(getWorkspaceDir(), "tmp-audio");
+    mkdirSync(audioDir, { recursive: true });
+    const sourcePath = join(audioDir, "assistant-response.mp3");
+    const audio = Buffer.from("assistant audio bytes");
+    writeFileSync(sourcePath, audio);
+
+    const result = archiveLiveVoiceAssistantResponseAudio({
+      messageId: message.id,
+      sessionId: "session-456",
+      turnId: "turn-def",
+      mimeType: "audio/mpeg",
+      sampleRate: 24000,
+      durationMs: 980,
+      audio: {
+        type: "file",
+        filePath: sourcePath,
+      },
+    });
+
+    expect(result.type).toBe("archived");
+    if (result.type !== "archived") throw new Error("expected archive result");
+    expect(result.artifact).toMatchObject({
+      role: "assistant",
+      mimeType: "audio/mpeg",
+      filename: "live-voice-assistant-session-456-turn-def.mp3",
+      sizeBytes: audio.length,
+    });
+
+    const row = rawGet<{
+      dataBase64: string;
+      filePath: string | null;
+      sourcePath: string | null;
+    }>(
+      `SELECT
+         data_base64 AS dataBase64,
+         file_path AS filePath,
+         source_path AS sourcePath
+       FROM attachments
+       WHERE id = ?`,
+      result.artifact.attachmentId,
+    );
+    expect(row?.dataBase64).toBe("");
+    expect(row?.filePath).toBeTruthy();
+    expect(row?.filePath).not.toBe(sourcePath);
+    expect(row?.sourcePath).toBe(sourcePath);
+    expect(existsSync(row!.filePath!)).toBe(true);
+    expect(readFileSync(row!.filePath!)).toEqual(audio);
+
+    const serializedMetadata = JSON.stringify(getMessageMetadata(message.id));
+    expect(serializedMetadata).not.toContain(sourcePath);
+    expect(serializedMetadata).not.toContain("api_key");
+    expect(serializedMetadata).not.toContain("providerConfig");
+  });
+
+  test("is idempotent for the session turn role key", async () => {
+    const { message } = await createMessage("user");
+
+    const first = archiveLiveVoiceAudioArtifact({
+      messageId: message.id,
+      sessionId: "session-repeat",
+      turnId: "turn-repeat",
+      role: "user",
+      mimeType: "audio/pcm",
+      sampleRate: 48000,
+      audio: {
+        type: "base64",
+        dataBase64: Buffer.from("first audio").toString("base64"),
+      },
+    });
+    const second = archiveLiveVoiceAudioArtifact({
+      messageId: message.id,
+      sessionId: "session-repeat",
+      turnId: "turn-repeat",
+      role: "user",
+      mimeType: "audio/pcm",
+      sampleRate: 48000,
+      audio: {
+        type: "base64",
+        dataBase64: Buffer.from("second audio").toString("base64"),
+      },
+    });
+
+    expect(first.type).toBe("archived");
+    expect(second.type).toBe("archived");
+    if (first.type !== "archived" || second.type !== "archived") {
+      throw new Error("expected archived results");
+    }
+    expect(second.idempotent).toBe(true);
+    expect(second.artifact.attachmentId).toBe(first.artifact.attachmentId);
+    expect(countAttachmentsForMessage(message.id)).toBe(1);
+    expect(getAttachmentContent(first.artifact.attachmentId)?.toString()).toBe(
+      "first audio",
+    );
+
+    const assistantResult = archiveLiveVoiceAudioArtifact({
+      messageId: message.id,
+      sessionId: "session-repeat",
+      turnId: "turn-repeat",
+      role: "assistant",
+      mimeType: "audio/pcm",
+      audio: {
+        type: "base64",
+        dataBase64: Buffer.from("assistant audio").toString("base64"),
+      },
+    });
+    expect(assistantResult.type).toBe("archived");
+    expect(countAttachmentsForMessage(message.id)).toBe(2);
+  });
+
+  test("restores metadata idempotency from the deterministic attachment filename", async () => {
+    const { message } = await createMessage("assistant");
+    const first = archiveLiveVoiceAssistantResponseAudio({
+      messageId: message.id,
+      sessionId: "session-crash",
+      turnId: "turn-crash",
+      mimeType: "audio/ogg",
+      audio: {
+        type: "base64",
+        dataBase64: Buffer.from("archived before metadata loss").toString(
+          "base64",
+        ),
+      },
+    });
+    expect(first.type).toBe("archived");
+    if (first.type !== "archived") throw new Error("expected archive result");
+
+    rawRun(`UPDATE messages SET metadata = NULL WHERE id = ?`, message.id);
+
+    const second = archiveLiveVoiceAssistantResponseAudio({
+      messageId: message.id,
+      sessionId: "session-crash",
+      turnId: "turn-crash",
+      mimeType: "audio/ogg",
+      audio: {
+        type: "base64",
+        dataBase64: Buffer.from("duplicate attempt").toString("base64"),
+      },
+    });
+
+    expect(second.type).toBe("archived");
+    if (second.type !== "archived") throw new Error("expected archive result");
+    expect(second.idempotent).toBe(true);
+    expect(second.artifact.attachmentId).toBe(first.artifact.attachmentId);
+    expect(countAttachmentsForMessage(message.id)).toBe(1);
+    expect(getLiveVoiceArtifacts(message.id)).toHaveLength(1);
+  });
+
+  test("returns typed warnings for non-fatal archive failures", async () => {
+    const { message } = await createMessage("user");
+
+    const missingFile = archiveLiveVoiceUserUtteranceAudio({
+      messageId: message.id,
+      sessionId: "session-warning",
+      turnId: "turn-warning",
+      mimeType: "audio/wav",
+      audio: {
+        type: "file",
+        filePath: join(getWorkspaceDir(), "missing.wav"),
+      },
+    });
+    expect(missingFile).toEqual({
+      type: "warning",
+      warning: {
+        code: "invalid_audio_source",
+        message: "Live voice audio file is not readable.",
+      },
+    });
+
+    const unsupportedMime = archiveLiveVoiceUserUtteranceAudio({
+      messageId: message.id,
+      sessionId: "session-warning",
+      turnId: "turn-warning-2",
+      mimeType: "application/octet-stream",
+      audio: {
+        type: "base64",
+        dataBase64: Buffer.from("not audio").toString("base64"),
+      },
+    });
+    expect(unsupportedMime).toEqual({
+      type: "warning",
+      warning: {
+        code: "unsupported_mime_type",
+        message: "Live voice audio archive only accepts audio MIME types.",
+      },
+    });
+
+    const missingMessage = archiveLiveVoiceUserUtteranceAudio({
+      messageId: "missing-message",
+      sessionId: "session-warning",
+      turnId: "turn-warning-3",
+      mimeType: "audio/wav",
+      audio: {
+        type: "base64",
+        dataBase64: Buffer.from("audio").toString("base64"),
+      },
+    });
+    expect(missingMessage.type).toBe("warning");
+    if (missingMessage.type !== "warning") {
+      throw new Error("expected warning result");
+    }
+    expect(missingMessage.warning.code).toBe("message_not_found");
+    expect(countAttachmentsForMessage(message.id)).toBe(0);
+  });
+
+  test("keeps archive metadata scoped to allowed live voice fields", async () => {
+    const { message } = await createMessage("assistant");
+
+    const result = archiveLiveVoiceAssistantResponseAudio({
+      messageId: message.id,
+      sessionId: "session-metadata",
+      turnId: "turn-metadata",
+      mimeType: "audio/mp4",
+      durationMs: 500,
+      audio: {
+        type: "base64",
+        dataBase64: Buffer.from("metadata audio").toString("base64"),
+      },
+    });
+
+    expect(result.type).toBe("archived");
+    const [artifact] = getLiveVoiceArtifacts(message.id);
+    expect(Object.keys(artifact!).sort()).toEqual([
+      "archiveKey",
+      "archivedAt",
+      "attachmentId",
+      "durationMs",
+      "filename",
+      "mimeType",
+      "role",
+      "sessionId",
+      "sizeBytes",
+      "source",
+      "turnId",
+    ]);
+
+    const attachmentRows = rawAll<{
+      originalFilename: string;
+      mimeType: string;
+    }>(
+      `SELECT original_filename AS originalFilename, mime_type AS mimeType
+       FROM attachments`,
+    );
+    expect(attachmentRows).toEqual([
+      {
+        originalFilename:
+          "live-voice-assistant-session-metadata-turn-metadata.m4a",
+        mimeType: "audio/mp4",
+      },
+    ]);
+  });
+});

--- a/assistant/src/live-voice/live-voice-archive.ts
+++ b/assistant/src/live-voice/live-voice-archive.ts
@@ -1,0 +1,550 @@
+import { existsSync, statSync } from "node:fs";
+
+import {
+  attachFileBackedAttachmentToMessage,
+  attachInlineAttachmentToMessage,
+} from "../memory/attachments-store.js";
+import { rawAll, rawGet, rawRun } from "../memory/db.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("live-voice-archive");
+
+const LIVE_VOICE_AUDIO_METADATA_KEY = "liveVoiceAudioArtifacts";
+const LIVE_VOICE_AUDIO_SOURCE = "live-voice";
+
+export type LiveVoiceAudioArchiveRole = "user" | "assistant";
+
+export type LiveVoiceAudioSource =
+  | {
+      type: "base64";
+      dataBase64: string;
+    }
+  | {
+      type: "file";
+      filePath: string;
+      sizeBytes?: number;
+    };
+
+export interface ArchiveLiveVoiceAudioInput {
+  messageId: string;
+  sessionId: string;
+  turnId: string;
+  role: LiveVoiceAudioArchiveRole;
+  mimeType: string;
+  sampleRate?: number;
+  durationMs?: number;
+  audio: LiveVoiceAudioSource;
+  position?: number;
+}
+
+export interface LiveVoiceAudioArtifactMetadata {
+  source: typeof LIVE_VOICE_AUDIO_SOURCE;
+  archiveKey: string;
+  attachmentId: string;
+  sessionId: string;
+  turnId: string;
+  role: LiveVoiceAudioArchiveRole;
+  mimeType: string;
+  sampleRate?: number;
+  durationMs?: number;
+  sizeBytes: number;
+  filename: string;
+  archivedAt: number;
+}
+
+export type LiveVoiceAudioArchiveWarningCode =
+  | "archive_failed"
+  | "invalid_audio_source"
+  | "invalid_metadata"
+  | "message_not_found"
+  | "unsupported_mime_type";
+
+export interface LiveVoiceAudioArchiveWarning {
+  code: LiveVoiceAudioArchiveWarningCode;
+  message: string;
+}
+
+export type LiveVoiceAudioArchiveResult =
+  | {
+      type: "archived";
+      artifact: LiveVoiceAudioArtifactMetadata;
+      idempotent: boolean;
+    }
+  | {
+      type: "warning";
+      warning: LiveVoiceAudioArchiveWarning;
+    };
+
+interface AttachmentLookupRow {
+  id: string;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  createdAt: number;
+}
+
+interface MessageMetadataState {
+  metadata: Record<string, unknown>;
+  artifacts: LiveVoiceAudioArtifactMetadata[];
+}
+
+const AUDIO_EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+  "audio/aac": "aac",
+  "audio/flac": "flac",
+  "audio/m4a": "m4a",
+  "audio/mpeg": "mp3",
+  "audio/mp4": "m4a",
+  "audio/ogg": "ogg",
+  "audio/opus": "opus",
+  "audio/pcm": "pcm",
+  "audio/raw": "raw",
+  "audio/wav": "wav",
+  "audio/webm": "webm",
+  "audio/x-m4a": "m4a",
+  "audio/x-mulaw": "wav",
+  "audio/x-wav": "wav",
+};
+
+function resultWarning(
+  code: LiveVoiceAudioArchiveWarningCode,
+  message: string,
+): LiveVoiceAudioArchiveResult {
+  return { type: "warning", warning: { code, message } };
+}
+
+function normalizeMimeType(mimeType: string): string {
+  return mimeType.toLowerCase().trim().split(";")[0]?.trim() ?? "";
+}
+
+function sanitizeFilenamePart(value: string): string {
+  const sanitized = value.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return sanitized.slice(0, 80) || "unknown";
+}
+
+function buildArchiveKey(input: {
+  sessionId: string;
+  turnId: string;
+  role: LiveVoiceAudioArchiveRole;
+}): string {
+  return `${LIVE_VOICE_AUDIO_SOURCE}:${input.sessionId}:${input.turnId}:${input.role}`;
+}
+
+function buildFilenameStem(input: {
+  sessionId: string;
+  turnId: string;
+  role: LiveVoiceAudioArchiveRole;
+}): string {
+  return [
+    "live-voice",
+    input.role,
+    sanitizeFilenamePart(input.sessionId),
+    sanitizeFilenamePart(input.turnId),
+  ].join("-");
+}
+
+function extensionForAudioMimeType(mimeType: string): string {
+  const mapped = AUDIO_EXTENSION_BY_MIME_TYPE[mimeType];
+  if (mapped) return mapped;
+  const subtype = mimeType.slice("audio/".length);
+  return sanitizeFilenamePart(subtype.replace(/^x-/, "")) || "audio";
+}
+
+function buildFilename(input: {
+  sessionId: string;
+  turnId: string;
+  role: LiveVoiceAudioArchiveRole;
+  mimeType: string;
+}): string {
+  return `${buildFilenameStem(input)}.${extensionForAudioMimeType(
+    input.mimeType,
+  )}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isLiveVoiceRole(value: unknown): value is LiveVoiceAudioArchiveRole {
+  return value === "user" || value === "assistant";
+}
+
+function isArtifactMetadata(
+  value: unknown,
+): value is LiveVoiceAudioArtifactMetadata {
+  if (!isRecord(value)) return false;
+  return (
+    value.source === LIVE_VOICE_AUDIO_SOURCE &&
+    typeof value.archiveKey === "string" &&
+    typeof value.attachmentId === "string" &&
+    typeof value.sessionId === "string" &&
+    typeof value.turnId === "string" &&
+    isLiveVoiceRole(value.role) &&
+    typeof value.mimeType === "string" &&
+    typeof value.sizeBytes === "number" &&
+    typeof value.filename === "string" &&
+    typeof value.archivedAt === "number"
+  );
+}
+
+function readMessageMetadata(
+  messageId: string,
+): MessageMetadataState | "not_found" | "invalid_metadata" {
+  const row = rawGet<{ metadata: string | null }>(
+    `SELECT metadata FROM messages WHERE id = ?`,
+    messageId,
+  );
+  if (!row) return "not_found";
+
+  if (!row.metadata) {
+    return { metadata: {}, artifacts: [] };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(row.metadata);
+  } catch {
+    return "invalid_metadata";
+  }
+
+  if (!isRecord(parsed)) {
+    return "invalid_metadata";
+  }
+
+  const rawArtifacts = parsed[LIVE_VOICE_AUDIO_METADATA_KEY];
+  const artifacts = Array.isArray(rawArtifacts)
+    ? rawArtifacts.filter(isArtifactMetadata)
+    : [];
+
+  return { metadata: parsed, artifacts };
+}
+
+function messageAttachmentLinkExists(
+  messageId: string,
+  attachmentId: string,
+): boolean {
+  const row = rawGet<{ id: string }>(
+    `SELECT id
+     FROM message_attachments
+     WHERE message_id = ? AND attachment_id = ?
+     LIMIT 1`,
+    messageId,
+    attachmentId,
+  );
+  return !!row;
+}
+
+function findExistingMetadataArtifact(
+  messageId: string,
+  archiveKey: string,
+  artifacts: LiveVoiceAudioArtifactMetadata[],
+): LiveVoiceAudioArtifactMetadata | null {
+  const artifact = artifacts.find((candidate) => {
+    return (
+      candidate.archiveKey === archiveKey &&
+      messageAttachmentLinkExists(messageId, candidate.attachmentId)
+    );
+  });
+  return artifact ?? null;
+}
+
+function findExistingAttachmentByFilename(
+  messageId: string,
+  filenameStem: string,
+): AttachmentLookupRow | null {
+  const rows = rawAll<AttachmentLookupRow>(
+    `SELECT
+       a.id AS id,
+       a.original_filename AS originalFilename,
+       a.mime_type AS mimeType,
+       a.size_bytes AS sizeBytes,
+       a.created_at AS createdAt
+     FROM attachments a
+     JOIN message_attachments ma ON ma.attachment_id = a.id
+     WHERE ma.message_id = ?
+     ORDER BY ma.position ASC, a.created_at ASC`,
+    messageId,
+  );
+
+  return (
+    rows.find((row) => row.originalFilename.startsWith(`${filenameStem}.`)) ??
+    null
+  );
+}
+
+function nextAttachmentPosition(messageId: string): number {
+  const row = rawGet<{ nextPosition: number | null }>(
+    `SELECT COALESCE(MAX(position) + 1, 0) AS nextPosition
+     FROM message_attachments
+     WHERE message_id = ?`,
+    messageId,
+  );
+  return row?.nextPosition ?? 0;
+}
+
+function persistArtifactMetadata(
+  messageId: string,
+  artifact: LiveVoiceAudioArtifactMetadata,
+): boolean {
+  const state = readMessageMetadata(messageId);
+  if (state === "not_found" || state === "invalid_metadata") return false;
+
+  const nextArtifacts = [
+    ...state.artifacts.filter(
+      (candidate) => candidate.archiveKey !== artifact.archiveKey,
+    ),
+    artifact,
+  ];
+
+  rawRun(
+    `UPDATE messages SET metadata = ? WHERE id = ?`,
+    JSON.stringify({
+      ...state.metadata,
+      [LIVE_VOICE_AUDIO_METADATA_KEY]: nextArtifacts,
+    }),
+    messageId,
+  );
+  return true;
+}
+
+function sanitizeOptionalPositiveNumber(
+  value: number | undefined,
+): number | undefined {
+  if (value == null) return undefined;
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function validateInput(input: ArchiveLiveVoiceAudioInput):
+  | {
+      archiveKey: string;
+      filename: string;
+      filenameStem: string;
+      mimeType: string;
+      sampleRate: number | undefined;
+      durationMs: number | undefined;
+    }
+  | LiveVoiceAudioArchiveResult {
+  if (!input.sessionId.trim() || !input.turnId.trim()) {
+    return resultWarning(
+      "invalid_metadata",
+      "Live voice audio archive requires a session id and turn id.",
+    );
+  }
+
+  if (!isLiveVoiceRole(input.role)) {
+    return resultWarning(
+      "invalid_metadata",
+      "Live voice audio archive requires a user or assistant role.",
+    );
+  }
+
+  const mimeType = normalizeMimeType(input.mimeType);
+  if (!mimeType.startsWith("audio/")) {
+    return resultWarning(
+      "unsupported_mime_type",
+      "Live voice audio archive only accepts audio MIME types.",
+    );
+  }
+
+  if (
+    input.sampleRate != null &&
+    (!Number.isFinite(input.sampleRate) || input.sampleRate <= 0)
+  ) {
+    return resultWarning(
+      "invalid_metadata",
+      "Live voice audio archive sample rate must be a positive finite number.",
+    );
+  }
+
+  if (
+    input.durationMs != null &&
+    (!Number.isFinite(input.durationMs) || input.durationMs <= 0)
+  ) {
+    return resultWarning(
+      "invalid_metadata",
+      "Live voice audio archive duration must be a positive finite number.",
+    );
+  }
+
+  const archiveKey = buildArchiveKey(input);
+  const filenameStem = buildFilenameStem(input);
+  return {
+    archiveKey,
+    filename: buildFilename({ ...input, mimeType }),
+    filenameStem,
+    mimeType,
+    sampleRate: sanitizeOptionalPositiveNumber(input.sampleRate),
+    durationMs: sanitizeOptionalPositiveNumber(input.durationMs),
+  };
+}
+
+function artifactFromAttachment(input: {
+  attachmentId: string;
+  archiveKey: string;
+  sessionId: string;
+  turnId: string;
+  role: LiveVoiceAudioArchiveRole;
+  mimeType: string;
+  sampleRate?: number;
+  durationMs?: number;
+  sizeBytes: number;
+  filename: string;
+  archivedAt: number;
+}): LiveVoiceAudioArtifactMetadata {
+  return {
+    source: LIVE_VOICE_AUDIO_SOURCE,
+    archiveKey: input.archiveKey,
+    attachmentId: input.attachmentId,
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    role: input.role,
+    mimeType: input.mimeType,
+    ...(input.sampleRate != null ? { sampleRate: input.sampleRate } : {}),
+    ...(input.durationMs != null ? { durationMs: input.durationMs } : {}),
+    sizeBytes: input.sizeBytes,
+    filename: input.filename,
+    archivedAt: input.archivedAt,
+  };
+}
+
+export function archiveLiveVoiceAudioArtifact(
+  input: ArchiveLiveVoiceAudioInput,
+): LiveVoiceAudioArchiveResult {
+  const validated = validateInput(input);
+  if ("type" in validated) return validated;
+
+  const state = readMessageMetadata(input.messageId);
+  if (state === "not_found") {
+    return resultWarning(
+      "message_not_found",
+      "Live voice audio archive target message was not found.",
+    );
+  }
+  if (state === "invalid_metadata") {
+    return resultWarning(
+      "invalid_metadata",
+      "Live voice audio archive target message metadata is invalid.",
+    );
+  }
+
+  const existingMetadataArtifact = findExistingMetadataArtifact(
+    input.messageId,
+    validated.archiveKey,
+    state.artifacts,
+  );
+  if (existingMetadataArtifact) {
+    return {
+      type: "archived",
+      artifact: existingMetadataArtifact,
+      idempotent: true,
+    };
+  }
+
+  const existingAttachment = findExistingAttachmentByFilename(
+    input.messageId,
+    validated.filenameStem,
+  );
+  if (existingAttachment) {
+    const artifact = artifactFromAttachment({
+      attachmentId: existingAttachment.id,
+      archiveKey: validated.archiveKey,
+      sessionId: input.sessionId,
+      turnId: input.turnId,
+      role: input.role,
+      mimeType: existingAttachment.mimeType,
+      sampleRate: validated.sampleRate,
+      durationMs: validated.durationMs,
+      sizeBytes: existingAttachment.sizeBytes,
+      filename: existingAttachment.originalFilename,
+      archivedAt: existingAttachment.createdAt,
+    });
+    persistArtifactMetadata(input.messageId, artifact);
+    return { type: "archived", artifact, idempotent: true };
+  }
+
+  try {
+    const position = input.position ?? nextAttachmentPosition(input.messageId);
+    const stored =
+      input.audio.type === "base64"
+        ? attachInlineAttachmentToMessage(
+            input.messageId,
+            position,
+            validated.filename,
+            validated.mimeType,
+            input.audio.dataBase64,
+          )
+        : (() => {
+            if (!existsSync(input.audio.filePath)) {
+              return null;
+            }
+            const sizeBytes =
+              input.audio.sizeBytes ?? statSync(input.audio.filePath).size;
+            return attachFileBackedAttachmentToMessage(
+              input.messageId,
+              position,
+              validated.filename,
+              validated.mimeType,
+              input.audio.filePath,
+              sizeBytes,
+            );
+          })();
+
+    if (!stored) {
+      return resultWarning(
+        "invalid_audio_source",
+        "Live voice audio file is not readable.",
+      );
+    }
+
+    const artifact = artifactFromAttachment({
+      attachmentId: stored.id,
+      archiveKey: validated.archiveKey,
+      sessionId: input.sessionId,
+      turnId: input.turnId,
+      role: input.role,
+      mimeType: validated.mimeType,
+      sampleRate: validated.sampleRate,
+      durationMs: validated.durationMs,
+      sizeBytes: stored.sizeBytes,
+      filename: stored.originalFilename,
+      archivedAt: stored.createdAt,
+    });
+    if (!persistArtifactMetadata(input.messageId, artifact)) {
+      log.warn(
+        { messageId: input.messageId, archiveKey: validated.archiveKey },
+        "Archived live voice audio but could not persist metadata",
+      );
+    }
+
+    return { type: "archived", artifact, idempotent: false };
+  } catch (err) {
+    log.warn(
+      {
+        messageId: input.messageId,
+        archiveKey: validated.archiveKey,
+        errorName: err instanceof Error ? err.name : typeof err,
+      },
+      "Failed to archive live voice audio artifact",
+    );
+    return resultWarning(
+      "archive_failed",
+      "Live voice audio archive failed without blocking the turn.",
+    );
+  }
+}
+
+type ArchiveLiveVoiceRolelessAudioInput = Omit<
+  ArchiveLiveVoiceAudioInput,
+  "role"
+>;
+
+export function archiveLiveVoiceUserUtteranceAudio(
+  input: ArchiveLiveVoiceRolelessAudioInput,
+): LiveVoiceAudioArchiveResult {
+  return archiveLiveVoiceAudioArtifact({ ...input, role: "user" });
+}
+
+export function archiveLiveVoiceAssistantResponseAudio(
+  input: ArchiveLiveVoiceRolelessAudioInput,
+): LiveVoiceAudioArchiveResult {
+  return archiveLiveVoiceAudioArtifact({ ...input, role: "assistant" });
+}


### PR DESCRIPTION
## PR 16: add live voice audio archive helper

### Depends on

None.

### Branch

`live-voice-channel/pr-16-audio-archive-helper`

### Files

- `assistant/src/live-voice/live-voice-archive.ts`
- `assistant/src/live-voice/__tests__/live-voice-archive.test.ts`

### Scope

Add an archive helper that writes live voice audio artifacts through the existing attachment store. The helper should support:

- user utterance audio
- assistant spoken response audio
- file-backed attachment creation for large audio
- metadata for session id, turn id, role, mime type, sample rate, and duration when available

Do not change attachment schemas or migrations in this PR unless tests prove they are required. Prefer existing audio MIME handling.

### Acceptance Criteria

- Archive writes are idempotent for a session/turn/role key.
- The helper never writes credentials or raw provider configuration.
- Failures return typed archive results so the live session can emit `archived` or a non-fatal warning.

### Verification

Run:

```bash
export PATH="$HOME/.bun/bin:$PATH"
cd assistant && bun test src/live-voice/__tests__/live-voice-archive.test.ts
cd assistant && bunx tsc --noEmit
```

---

_Implements PR 16 of `.private/plans/live-voice-channel.md` (live-voice-channel run-plan). Direct-to-main wave 1: no feature branch, CI + external review skipped per orchestrator flags. Implementation drafted by codex agent under @velissa-ai's orchestration._
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
