### PR TITLE
feat(clients): ACPSessionStore observable state for ACP sessions

### DIFF
--- a/clients/macos/vellum-assistantTests/Network/ACPSessionStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/ACPSessionStoreTests.swift
@@ -1,0 +1,416 @@
+import Foundation
+import XCTest
+
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+private final class MockACPSessionStoreURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            XCTFail("requestHandler not set")
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+final class ACPSessionStoreTests: XCTestCase {
+    private let assistantId = "assistant-acp-store-test"
+    private let gatewayPort = 7834
+    private var originalPrimaryLockfileData: Data?
+    private var primaryLockfileExisted = false
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        MockACPSessionStoreURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(MockACPSessionStoreURLProtocol.self)
+
+        let primaryLockfileURL = LockfilePaths.primary
+        primaryLockfileExisted = FileManager.default.fileExists(atPath: primaryLockfileURL.path)
+        if primaryLockfileExisted {
+            originalPrimaryLockfileData = try Data(contentsOf: primaryLockfileURL)
+        }
+
+        try installLockfileFixture()
+    }
+
+    override func tearDownWithError() throws {
+        URLProtocol.unregisterClass(MockACPSessionStoreURLProtocol.self)
+        MockACPSessionStoreURLProtocol.requestHandler = nil
+
+        if primaryLockfileExisted {
+            try originalPrimaryLockfileData?.write(to: LockfilePaths.primary, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: LockfilePaths.primary)
+        }
+
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Lifecycle: spawn → update → completed
+
+    func test_spawnedUpdateCompleted_transitionsState() {
+        let store = ACPSessionStore()
+
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-1",
+            agent: "claude-code",
+            parentConversationId: "conv-1"
+        )))
+
+        XCTAssertEqual(store.sessions.count, 1)
+        let viewModel = try! XCTUnwrap(store.sessions["acp-1"])
+        XCTAssertEqual(viewModel.state.status, .running)
+        XCTAssertEqual(viewModel.state.parentConversationId, "conv-1")
+        XCTAssertEqual(store.sessionOrder, ["acp-1"])
+
+        store.handle(.acpSessionUpdate(ACPSessionUpdateMessage(
+            acpSessionId: "acp-1",
+            updateType: .agentMessageChunk,
+            content: "Hello"
+        )))
+
+        XCTAssertEqual(viewModel.events.count, 1)
+        XCTAssertEqual(viewModel.events.first?.content, "Hello")
+
+        store.handle(.acpSessionCompleted(ACPSessionCompletedMessage(
+            acpSessionId: "acp-1",
+            stopReason: .endTurn
+        )))
+
+        XCTAssertEqual(viewModel.state.status, .completed)
+        XCTAssertEqual(viewModel.state.stopReason, .endTurn)
+        XCTAssertNotNil(viewModel.state.completedAt)
+    }
+
+    func test_completed_withCancelledStopReason_setsCancelledStatus() {
+        let store = ACPSessionStore()
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-1",
+            agent: "a",
+            parentConversationId: "c"
+        )))
+
+        store.handle(.acpSessionCompleted(ACPSessionCompletedMessage(
+            acpSessionId: "acp-1",
+            stopReason: .cancelled
+        )))
+
+        let viewModel = try! XCTUnwrap(store.sessions["acp-1"])
+        XCTAssertEqual(viewModel.state.status, .cancelled)
+        XCTAssertEqual(viewModel.state.stopReason, .cancelled)
+    }
+
+    func test_error_setsFailedStatusAndErrorString() {
+        let store = ACPSessionStore()
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-1",
+            agent: "a",
+            parentConversationId: "c"
+        )))
+
+        store.handle(.acpSessionError(ACPSessionErrorMessage(
+            acpSessionId: "acp-1",
+            error: "agent crashed"
+        )))
+
+        let viewModel = try! XCTUnwrap(store.sessions["acp-1"])
+        XCTAssertEqual(viewModel.state.status, .failed)
+        XCTAssertEqual(viewModel.state.error, "agent crashed")
+        XCTAssertNotNil(viewModel.state.completedAt)
+    }
+
+    // MARK: - Orphan buffering and stitching
+
+    func test_updateBeforeSpawn_isBufferedAndAppliedOnSpawn() {
+        let store = ACPSessionStore()
+
+        // Update arrives first, before any spawn — buffered as orphan.
+        store.handle(.acpSessionUpdate(ACPSessionUpdateMessage(
+            acpSessionId: "acp-1",
+            updateType: .agentMessageChunk,
+            content: "early"
+        )))
+
+        XCTAssertTrue(store.sessions.isEmpty, "Update without parent should not create a session")
+
+        // Spawn arrives — orphan is drained onto the new view model.
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-1",
+            agent: "a",
+            parentConversationId: "c"
+        )))
+
+        let viewModel = try! XCTUnwrap(store.sessions["acp-1"])
+        XCTAssertEqual(viewModel.events.count, 1)
+        XCTAssertEqual(viewModel.events.first?.content, "early")
+    }
+
+    func test_updateBeforeSpawn_isStitchedOnSeed() async {
+        let store = ACPSessionStore()
+
+        store.handle(.acpSessionUpdate(ACPSessionUpdateMessage(
+            acpSessionId: "acp-seeded",
+            updateType: .agentMessageChunk,
+            content: "early"
+        )))
+
+        // Seed returns a snapshot containing the orphan's parent session.
+        MockACPSessionStoreURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(
+                #"""
+                {
+                  "sessions": [
+                    {
+                      "id": "sess-seeded",
+                      "agentId": "claude-code",
+                      "acpSessionId": "acp-seeded",
+                      "parentConversationId": "conv-seeded",
+                      "status": "running",
+                      "startedAt": 1700000000000
+                    }
+                  ]
+                }
+                """#.utf8
+            )
+            return (response, data)
+        }
+
+        await store.seed()
+
+        XCTAssertEqual(store.seedState, .loaded)
+        let viewModel = try! XCTUnwrap(store.sessions["acp-seeded"])
+        XCTAssertEqual(viewModel.events.count, 1)
+        XCTAssertEqual(viewModel.events.first?.content, "early")
+    }
+
+    func test_orphanBuffer_capsAtPerSessionLimit() {
+        let store = ACPSessionStore()
+        let sessionId = "acp-cap"
+
+        // Push 1.5x the cap so the oldest are forced out.
+        let total = ACPSessionStore.orphanCapPerSession + 50
+        for index in 0..<total {
+            store.handle(.acpSessionUpdate(ACPSessionUpdateMessage(
+                acpSessionId: sessionId,
+                updateType: .agentMessageChunk,
+                content: "msg-\(index)"
+            )))
+        }
+
+        // Spawn drains the bounded buffer.
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: sessionId,
+            agent: "a",
+            parentConversationId: "c"
+        )))
+
+        let viewModel = try! XCTUnwrap(store.sessions[sessionId])
+        XCTAssertEqual(viewModel.events.count, ACPSessionStore.orphanCapPerSession)
+        // Oldest entries should have been dropped — first kept event is index 50.
+        XCTAssertEqual(viewModel.events.first?.content, "msg-50")
+        XCTAssertEqual(viewModel.events.last?.content, "msg-\(total - 1)")
+    }
+
+    // MARK: - Seed merge / dedupe
+
+    func test_seed_mergesSnapshotIntoSessions_inMemoryWinsOnCollision() async {
+        let store = ACPSessionStore()
+
+        // Existing in-memory session populated via SSE.
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-existing",
+            agent: "claude-code",
+            parentConversationId: "conv-existing"
+        )))
+        let originalViewModel = try! XCTUnwrap(store.sessions["acp-existing"])
+
+        MockACPSessionStoreURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            // Snapshot includes both the existing in-memory session AND a
+            // brand-new one. The existing entry should be left alone; the
+            // new entry should be inserted.
+            let data = Data(
+                #"""
+                {
+                  "sessions": [
+                    {
+                      "id": "sess-a",
+                      "agentId": "stale",
+                      "acpSessionId": "acp-existing",
+                      "status": "completed",
+                      "startedAt": 1
+                    },
+                    {
+                      "id": "sess-b",
+                      "agentId": "agent-x",
+                      "acpSessionId": "acp-new",
+                      "status": "running",
+                      "startedAt": 2000000000000
+                    }
+                  ]
+                }
+                """#.utf8
+            )
+            return (response, data)
+        }
+
+        await store.seed()
+
+        XCTAssertEqual(store.seedState, .loaded)
+        XCTAssertEqual(store.sessions.count, 2)
+        // Existing view model should be the SAME instance — not replaced.
+        XCTAssertTrue(store.sessions["acp-existing"] === originalViewModel,
+                      "In-memory entry should win on id collision")
+        XCTAssertEqual(originalViewModel.state.agentId, "claude-code",
+                       "In-memory state should not be overwritten by stale snapshot")
+        XCTAssertNotNil(store.sessions["acp-new"])
+    }
+
+    func test_seed_sortsSessionOrderByStartedAtDescending() async {
+        let store = ACPSessionStore()
+        MockACPSessionStoreURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(
+                #"""
+                {
+                  "sessions": [
+                    {"id":"s1","agentId":"a","acpSessionId":"acp-old","status":"running","startedAt":100},
+                    {"id":"s2","agentId":"a","acpSessionId":"acp-newest","status":"running","startedAt":300},
+                    {"id":"s3","agentId":"a","acpSessionId":"acp-mid","status":"running","startedAt":200}
+                  ]
+                }
+                """#.utf8
+            )
+            return (response, data)
+        }
+
+        await store.seed()
+
+        XCTAssertEqual(store.sessionOrder, ["acp-newest", "acp-mid", "acp-old"])
+    }
+
+    func test_seed_recordsErrorOnTransportFailure() async {
+        let store = ACPSessionStore()
+        MockACPSessionStoreURLProtocol.requestHandler = { _ in
+            throw NSError(domain: "test", code: -1, userInfo: nil)
+        }
+
+        await store.seed()
+
+        guard case .error = store.seedState else {
+            return XCTFail("Expected .error seedState, got \(store.seedState)")
+        }
+    }
+
+    // MARK: - Events buffer cap
+
+    func test_eventsBuffer_capsAt500_dropsOldest() {
+        let store = ACPSessionStore()
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-1",
+            agent: "a",
+            parentConversationId: "c"
+        )))
+
+        for index in 0..<600 {
+            store.handle(.acpSessionUpdate(ACPSessionUpdateMessage(
+                acpSessionId: "acp-1",
+                updateType: .agentMessageChunk,
+                content: "msg-\(index)"
+            )))
+        }
+
+        let viewModel = try! XCTUnwrap(store.sessions["acp-1"])
+        XCTAssertEqual(viewModel.events.count, ACPSessionStore.eventsCapPerSession)
+        // Oldest 100 should have been dropped — first kept event is index 100.
+        XCTAssertEqual(viewModel.events.first?.content, "msg-100")
+        XCTAssertEqual(viewModel.events.last?.content, "msg-599")
+    }
+
+    // MARK: - Spawn dedupe
+
+    func test_duplicateSpawn_doesNotReplaceExistingViewModel() {
+        let store = ACPSessionStore()
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-1",
+            agent: "a",
+            parentConversationId: "c"
+        )))
+        let original = try! XCTUnwrap(store.sessions["acp-1"])
+        original.appendEvent(ACPSessionUpdateMessage(
+            acpSessionId: "acp-1",
+            updateType: .agentMessageChunk,
+            content: "x"
+        ))
+
+        // A second spawn for the same id (e.g. resume after reconnect) must
+        // not blow away the accumulated events.
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-1",
+            agent: "a",
+            parentConversationId: "c"
+        )))
+
+        let after = try! XCTUnwrap(store.sessions["acp-1"])
+        XCTAssertTrue(after === original, "Duplicate spawn should not replace the view model")
+        XCTAssertEqual(after.events.count, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func installLockfileFixture() throws {
+        let lockfile: [String: Any] = [
+            "activeAssistant": assistantId,
+            "assistants": [
+                [
+                    "assistantId": assistantId,
+                    "cloud": "local",
+                    "hatchedAt": "2026-03-19T12:00:00Z",
+                    "resources": [
+                        "gatewayPort": gatewayPort,
+                    ],
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: lockfile, options: [.sortedKeys])
+        try data.write(to: LockfilePaths.primary, options: .atomic)
+    }
+}

--- a/clients/shared/Network/ACPSessionStore.swift
+++ b/clients/shared/Network/ACPSessionStore.swift
@@ -1,0 +1,285 @@
+import Foundation
+import Observation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ACPSessionStore")
+
+// MARK: - ACPSessionViewModel
+
+/// Per-session observable state for ACP (Agent Client Protocol) sessions.
+///
+/// Stored in `ACPSessionStore.sessions` keyed by `acpSessionId`. Each session
+/// gets its own instance so SwiftUI tracks observation per session: streaming
+/// updates to one session's `events` only invalidate views that read that
+/// specific view model.
+@MainActor @Observable
+public final class ACPSessionViewModel: Identifiable {
+    /// Snapshot of the session as last reported by the daemon.
+    public var state: ACPSessionState
+    /// Stream of update messages received for this session, capped at
+    /// ``ACPSessionStore/eventsCapPerSession`` entries — older events are
+    /// dropped first to bound memory.
+    public var events: [ACPSessionUpdateMessage] = []
+
+    public var id: String { state.acpSessionId }
+
+    public init(state: ACPSessionState) {
+        self.state = state
+    }
+
+    /// Append a new update event, dropping the oldest entries to stay within
+    /// the per-session retention cap.
+    func appendEvent(_ event: ACPSessionUpdateMessage) {
+        events.append(event)
+        if events.count > ACPSessionStore.eventsCapPerSession {
+            events.removeFirst(events.count - ACPSessionStore.eventsCapPerSession)
+        }
+    }
+}
+
+// MARK: - ACPSessionStore
+
+/// Observable store for ACP sessions.
+///
+/// Holds a per-session ``ACPSessionViewModel`` keyed by `acpSessionId` plus
+/// an `[acpSessionId]` order array sorted by `startedAt` descending so list
+/// views render newest-first without re-sorting on every change.
+///
+/// SSE events from the gateway flow through ``handle(_:)``: a `spawned`
+/// event creates a view model, `update` events append to its `events`,
+/// `completed`/`error` events update its `state.status` and timestamps.
+/// Updates that arrive before their parent `spawned` are buffered in
+/// ``orphanedUpdates`` and stitched in on the next ``seed()`` call.
+///
+/// Initial population happens via ``seed()``, which calls
+/// ``ACPClient/listSessions(limit:conversationId:)`` and merges the polled
+/// snapshot with whatever has already been observed via SSE — in-memory
+/// entries win on id collisions so we never overwrite live state with a
+/// stale snapshot.
+@MainActor @Observable
+public final class ACPSessionStore {
+
+    /// Maximum number of events retained per session before older events
+    /// are dropped. Prevents unbounded memory growth on long-running
+    /// sessions that produce a high volume of token / tool-call updates.
+    public static let eventsCapPerSession = 500
+    /// Maximum number of orphan updates buffered per session id before the
+    /// parent `spawned` event arrives. Past this cap, oldest orphans are
+    /// dropped — preserves recent context if the buffer ever fills up.
+    public static let orphanCapPerSession = 100
+
+    public enum SeedState: Equatable {
+        case idle
+        case loading
+        case loaded
+        case error(String)
+    }
+
+    /// Per-session observable state. Mutating an entry's properties only
+    /// invalidates views that read that specific view model; mutating the
+    /// dictionary itself (insert/remove) invalidates list-level readers.
+    public var sessions: [String: ACPSessionViewModel] = [:]
+    /// `acpSessionId` order sorted by `startedAt` descending — list views
+    /// iterate this to render rows in newest-first order.
+    public var sessionOrder: [String] = []
+    /// State of the most recent ``seed()`` call. Views show a loading
+    /// placeholder while `.loading`, an error banner on `.error`, etc.
+    public var seedState: SeedState = .idle
+
+    /// Update messages received before their parent `spawned` event,
+    /// keyed by `acpSessionId`. Reapplied during ``seed()`` once the
+    /// parent appears in the polled snapshot.
+    @ObservationIgnored
+    private var orphanedUpdates: [String: [ACPSessionUpdateMessage]] = [:]
+
+    /// Creates an empty store. ``seed()`` should be called once to populate
+    /// from the daemon; SSE events received in the meantime are buffered
+    /// or applied immediately as appropriate.
+    public nonisolated init() {}
+
+    // MARK: - Seeding
+
+    /// Populate the store from the daemon's `/v1/acp/sessions` endpoint.
+    ///
+    /// Merges the polled snapshot with whatever is already in memory (from
+    /// SSE). On id collisions the in-memory entry wins — the snapshot is
+    /// strictly older than any SSE event we have already applied. Any
+    /// orphan updates whose parent session now exists are flushed onto the
+    /// matching view model in arrival order.
+    public func seed() async {
+        seedState = .loading
+        let result = await ACPClient.listSessions()
+        switch result {
+        case .success(let snapshot):
+            mergeSnapshot(snapshot)
+            flushOrphans()
+            seedState = .loaded
+        case .failure(let error):
+            log.error("seed failed: \(error.localizedDescription)")
+            seedState = .error(error.localizedDescription)
+        }
+    }
+
+    private func mergeSnapshot(_ snapshot: [ACPSessionState]) {
+        // In-memory entries already populated via SSE win on collision —
+        // SSE is strictly newer than the polled snapshot.
+        for state in snapshot where sessions[state.acpSessionId] == nil {
+            sessions[state.acpSessionId] = ACPSessionViewModel(state: state)
+        }
+        rebuildSessionOrder()
+    }
+
+    /// Drain any orphan updates whose parent session now exists. Called from
+    /// both ``seed()`` (after merging the snapshot) and ``handleSpawned`` (so
+    /// updates that lost the race with their parent are stitched in).
+    private func flushOrphans() {
+        for (sessionId, updates) in orphanedUpdates {
+            guard let viewModel = sessions[sessionId] else { continue }
+            for update in updates {
+                viewModel.appendEvent(update)
+            }
+            orphanedUpdates.removeValue(forKey: sessionId)
+        }
+    }
+
+    private func rebuildSessionOrder() {
+        sessionOrder = sessions.values
+            .sorted { $0.state.startedAt > $1.state.startedAt }
+            .map(\.state.acpSessionId)
+    }
+
+    // MARK: - SSE Event Handling
+
+    /// Apply an SSE `ServerMessage` to the store. Non-ACP cases are ignored
+    /// so callers can forward every SSE event without filtering.
+    public func handle(_ message: ServerMessage) {
+        switch message {
+        case .acpSessionSpawned(let spawned):
+            handleSpawned(spawned)
+        case .acpSessionUpdate(let update):
+            handleUpdate(update)
+        case .acpSessionCompleted(let completed):
+            handleCompleted(completed)
+        case .acpSessionError(let error):
+            handleError(error)
+        default:
+            break
+        }
+    }
+
+    private func handleSpawned(_ message: ACPSessionSpawnedMessage) {
+        if sessions[message.acpSessionId] == nil {
+            // Spawned events carry fewer fields than `ACPSessionState`. Fill
+            // in placeholder timestamps; the daemon will overwrite via the
+            // next status-changing event or a subsequent seed snapshot.
+            let state = ACPSessionState(
+                id: message.acpSessionId,
+                agentId: message.agent,
+                acpSessionId: message.acpSessionId,
+                parentConversationId: message.parentConversationId,
+                status: .running,
+                startedAt: nowMillis()
+            )
+            sessions[message.acpSessionId] = ACPSessionViewModel(state: state)
+            rebuildSessionOrder()
+        }
+        flushOrphans()
+    }
+
+    private func handleUpdate(_ message: ACPSessionUpdateMessage) {
+        if let viewModel = sessions[message.acpSessionId] {
+            viewModel.appendEvent(message)
+            return
+        }
+        // Buffer until the parent spawn arrives or the next seed stitches
+        // it in. Past the per-session cap drop the oldest entries.
+        var pending = orphanedUpdates[message.acpSessionId] ?? []
+        pending.append(message)
+        if pending.count > Self.orphanCapPerSession {
+            pending.removeFirst(pending.count - Self.orphanCapPerSession)
+        }
+        orphanedUpdates[message.acpSessionId] = pending
+    }
+
+    private func handleCompleted(_ message: ACPSessionCompletedMessage) {
+        guard let viewModel = sessions[message.acpSessionId] else { return }
+        viewModel.state = makeTerminalState(
+            from: viewModel.state,
+            status: message.stopReason == .cancelled ? .cancelled : .completed,
+            stopReason: message.stopReason,
+            error: viewModel.state.error
+        )
+    }
+
+    private func handleError(_ message: ACPSessionErrorMessage) {
+        guard let viewModel = sessions[message.acpSessionId] else { return }
+        viewModel.state = makeTerminalState(
+            from: viewModel.state,
+            status: .failed,
+            stopReason: viewModel.state.stopReason,
+            error: message.error
+        )
+    }
+
+    // MARK: - Optimistic mutations
+
+    /// Cancel an active session. Optimistically marks the session as
+    /// cancelled on success so the UI updates without waiting for the
+    /// daemon's `acp_session_completed` SSE round-trip.
+    @discardableResult
+    public func cancel(id: String) async -> Result<Bool, ACPClientError> {
+        let result = await ACPClient.cancelSession(id: id)
+        if case .success(true) = result, let viewModel = sessions[id] {
+            // Reuse existing `completedAt` if the daemon already reported it;
+            // otherwise leave it nil and let the SSE event fill it in.
+            viewModel.state = ACPSessionState(
+                id: viewModel.state.id,
+                agentId: viewModel.state.agentId,
+                acpSessionId: viewModel.state.acpSessionId,
+                parentConversationId: viewModel.state.parentConversationId,
+                status: .cancelled,
+                startedAt: viewModel.state.startedAt,
+                completedAt: viewModel.state.completedAt,
+                error: viewModel.state.error,
+                stopReason: .cancelled
+            )
+        }
+        return result
+    }
+
+    /// Send a steering instruction to an active session. Does not mutate
+    /// state directly — the daemon emits a regular update event the store
+    /// then reflects via ``handle(_:)``.
+    @discardableResult
+    public func steer(id: String, instruction: String) async -> Result<Bool, ACPClientError> {
+        return await ACPClient.steerSession(id: id, instruction: instruction)
+    }
+
+    // MARK: - Helpers
+
+    /// Build an `ACPSessionState` for a terminal transition (completed,
+    /// cancelled, failed). Stamps `completedAt` with the current wall clock
+    /// since the daemon's terminal SSE events do not carry it.
+    private func makeTerminalState(
+        from current: ACPSessionState,
+        status: ACPSessionState.Status,
+        stopReason: ACPSessionState.StopReason?,
+        error: String?
+    ) -> ACPSessionState {
+        ACPSessionState(
+            id: current.id,
+            agentId: current.agentId,
+            acpSessionId: current.acpSessionId,
+            parentConversationId: current.parentConversationId,
+            status: status,
+            startedAt: current.startedAt,
+            completedAt: nowMillis(),
+            error: error,
+            stopReason: stopReason
+        )
+    }
+
+    private func nowMillis() -> Int {
+        Int(Date().timeIntervalSince1970 * 1000)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `@Observable @MainActor` `ACPSessionStore` keyed by `acpSessionId`.
- Handles spawn/update/completed/error SSE events; orphan update buffer; events cap at 500.
- `seed()` merges polled snapshot with in-memory state.

Part of plan: acp-sessions-ui.md (PR 15 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
