### PR TITLE
feat(macos): wire ACPSessionStore subscriber to SSE stream

### DIFF
--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -12,6 +12,12 @@ public final class AppServices {
     let secretPromptManager = SecretPromptManager()
     let zoomManager = ZoomManager()
 
+    /// Shared observable store for ACP (Agent Client Protocol) sessions.
+    /// `ConversationManager`'s SSE subscriber forwards every `acpSession*`
+    /// event to `handle(_:)`; list/detail panels and the inline ACP tool
+    /// block all read from this single instance.
+    public let acpSessionStore = ACPSessionStore()
+
     /// Shared settings state consumed by SettingsPanel and its tab views.
     public lazy var settingsStore: SettingsStore = SettingsStore(
         connectionManager: connectionManager,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -80,6 +80,7 @@ final class ConversationManager: ConversationRestorerDelegate {
     private let conversationInferenceProfileClient: any ConversationInferenceProfileClientProtocol
     private let conversationAnalysisClient: ConversationAnalysisClientProtocol
     private let conversationRestorer: ConversationRestorer
+    private let acpSessionStore: ACPSessionStore?
 
     // MARK: - Pre-Chat Onboarding
 
@@ -205,6 +206,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         conversationHostAccessClient: any ConversationHostAccessClientProtocol = ConversationHostAccessClient(),
         conversationInferenceProfileClient: any ConversationInferenceProfileClientProtocol = ConversationInferenceProfileClient(),
         conversationAnalysisClient: ConversationAnalysisClientProtocol = ConversationAnalysisClient(),
+        acpSessionStore: ACPSessionStore? = nil,
         isFirstLaunch: Bool = false,
         preChatContext: PreChatOnboardingContext? = nil
     ) {
@@ -217,6 +219,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         self.conversationHostAccessClient = conversationHostAccessClient
         self.conversationInferenceProfileClient = conversationInferenceProfileClient
         self.conversationAnalysisClient = conversationAnalysisClient
+        self.acpSessionStore = acpSessionStore
         self.conversationRestorer = ConversationRestorer(connectionManager: connectionManager, eventStreamClient: eventStreamClient)
         self.selectionStore = ConversationSelectionStore(listStore: listStore)
 
@@ -260,6 +263,8 @@ final class ConversationManager: ConversationRestorerDelegate {
                         serverConversationId: message.conversationId,
                         profile: message.profile
                     )
+                case .acpSessionSpawned, .acpSessionUpdate, .acpSessionCompleted, .acpSessionError:
+                    self.acpSessionStore?.handle(message)
                 default:
                     break
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -330,6 +330,7 @@ public final class MainWindow {
         self.conversationManager = ConversationManager(
             connectionManager: services.connectionManager,
             eventStreamClient: services.connectionManager.eventStreamClient,
+            acpSessionStore: services.acpSessionStore,
             isFirstLaunch: isFirstLaunch,
             preChatContext: preChatContext
         )


### PR DESCRIPTION
## Summary
- Instantiates a shared `ACPSessionStore` in the macOS app's root setup.
- Subscribes `store.handle(_:)` to `acpSession*` events from `EventStreamClient`.

Part of plan: acp-sessions-ui.md (PR 16 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
