### PR TITLE
feat(live-voice): wire gateway live voice route (PR 5)

### DIFF
--- a/gateway/src/__tests__/live-voice-websocket.test.ts
+++ b/gateway/src/__tests__/live-voice-websocket.test.ts
@@ -405,4 +405,50 @@ describe("live voice gateway boundary", () => {
     expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+assistant\//);
     expect(source).not.toContain('from "assistant/');
   });
+
+  test("gateway index routes live voice websocket upgrades before the runtime proxy", () => {
+    const source = readFileSync(
+      new URL("../index.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain("createLiveVoiceWebsocketHandler");
+    expect(source).toContain("getLiveVoiceWebsocketHandlers");
+    expect(source).toContain("type LiveVoiceSocketData");
+    expect(source).toContain("function isLiveVoiceSocketData");
+    expect(source).toContain("const handleLiveVoiceWs");
+    expect(source).toContain("const liveVoiceWebsocketHandlers");
+
+    const liveVoiceRouteIndex = source.indexOf(
+      'url.pathname === "/v1/live-voice"',
+    );
+    const runtimeProxyDispatchIndex = source.indexOf(
+      "const response = router(req, url, resolveClientIp, svr);",
+    );
+
+    expect(liveVoiceRouteIndex).toBeGreaterThan(-1);
+    expect(runtimeProxyDispatchIndex).toBeGreaterThan(-1);
+    expect(liveVoiceRouteIndex).toBeLessThan(runtimeProxyDispatchIndex);
+
+    expect(source).toContain("handleLiveVoiceWs(req, server)");
+    expect(source).toContain('url.pathname === "/v1/stt/stream"');
+    expect(source).toContain("handleSttStreamWs(req, server)");
+  });
+
+  test("gateway websocket lifecycle dispatches live voice socket data", () => {
+    const source = readFileSync(
+      new URL("../index.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toMatch(
+      /if \(isLiveVoiceSocketData\(ws\.data\)\) \{\s+liveVoiceWebsocketHandlers\.open\(ws as never\);\s+return;\s+\}/,
+    );
+    expect(source).toMatch(
+      /if \(isLiveVoiceSocketData\(ws\.data\)\) \{\s+liveVoiceWebsocketHandlers\.message\(ws as never, message\);\s+return;\s+\}/,
+    );
+    expect(source).toMatch(
+      /if \(isLiveVoiceSocketData\(ws\.data\)\) \{\s+liveVoiceWebsocketHandlers\.close\(ws as never, code, reason\);\s+return;\s+\}/,
+    );
+  });
 });

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -47,6 +47,11 @@ import {
   getSttStreamWebsocketHandlers,
   type SttStreamSocketData,
 } from "./http/routes/stt-stream-websocket.js";
+import {
+  createLiveVoiceWebsocketHandler,
+  getLiveVoiceWebsocketHandlers,
+  type LiveVoiceSocketData,
+} from "./http/routes/live-voice-websocket.js";
 import { createWhatsAppWebhookHandler } from "./http/routes/whatsapp-webhook.js";
 
 import { createEmailWebhookHandler } from "./http/routes/email-webhook.js";
@@ -228,6 +233,14 @@ function isSttStreamSocketData(data: unknown): data is SttStreamSocketData {
   );
 }
 
+function isLiveVoiceSocketData(data: unknown): data is LiveVoiceSocketData {
+  return (
+    !!data &&
+    typeof data === "object" &&
+    (data as { wsType?: unknown }).wsType === "live-voice"
+  );
+}
+
 function getClientIp(
   req: Request,
   server: ReturnType<typeof Bun.serve>,
@@ -310,10 +323,12 @@ async function main() {
   });
   const handleBrowserRelayWs = createBrowserRelayWebsocketHandler(config);
   const handleSttStreamWs = createSttStreamWebsocketHandler(config);
+  const handleLiveVoiceWs = createLiveVoiceWebsocketHandler(config);
   const twilioRelayWebsocketHandlers = getRelayWebsocketHandlers();
   const twilioMediaStreamWebsocketHandlers = getMediaStreamWebsocketHandlers();
   const browserRelayWebsocketHandlers = getBrowserRelayWebsocketHandlers();
   const sttStreamWebsocketHandlers = getSttStreamWebsocketHandlers();
+  const liveVoiceWebsocketHandlers = getLiveVoiceWebsocketHandlers();
   const { handler: handleWhatsAppWebhook, dedupCache: whatsappDedupCache } =
     createWhatsAppWebhookHandler(config, {
       credentials: credentialCache,
@@ -1317,6 +1332,10 @@ async function main() {
           sttStreamWebsocketHandlers.open(ws as never);
           return;
         }
+        if (isLiveVoiceSocketData(ws.data)) {
+          liveVoiceWebsocketHandlers.open(ws as never);
+          return;
+        }
         twilioRelayWebsocketHandlers.open(ws as never);
       },
       message(ws, message) {
@@ -1332,6 +1351,10 @@ async function main() {
           sttStreamWebsocketHandlers.message(ws as never, message);
           return;
         }
+        if (isLiveVoiceSocketData(ws.data)) {
+          liveVoiceWebsocketHandlers.message(ws as never, message);
+          return;
+        }
         twilioRelayWebsocketHandlers.message(ws as never, message);
       },
       close(ws, code, reason) {
@@ -1345,6 +1368,10 @@ async function main() {
         }
         if (isSttStreamSocketData(ws.data)) {
           sttStreamWebsocketHandlers.close(ws as never, code, reason);
+          return;
+        }
+        if (isLiveVoiceSocketData(ws.data)) {
+          liveVoiceWebsocketHandlers.close(ws as never, code, reason);
           return;
         }
         twilioRelayWebsocketHandlers.close(ws as never, code, reason);
@@ -1486,6 +1513,12 @@ async function main() {
 
       if (url.pathname === "/v1/stt/stream") {
         const upgradeResult = handleSttStreamWs(req, server);
+        if (upgradeResult !== undefined) return upgradeResult;
+        return undefined as unknown as Response;
+      }
+
+      if (url.pathname === "/v1/live-voice") {
+        const upgradeResult = handleLiveVoiceWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;
         return undefined as unknown as Response;
       }

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1083,6 +1083,56 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/live-voice": {
+        get: {
+          summary: "Live voice WebSocket",
+          description:
+            "Accepts a WebSocket upgrade for the live voice channel. Authenticates the client using an edge JWT (actor principal), opens an upstream assistant WebSocket at /v1/live-voice using a gateway service token, and proxies text and binary audio frames opaquely in both directions.",
+          operationId: "liveVoiceWebsocket",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "token",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              description:
+                "Edge JWT for authentication (alternative to Authorization header, since browser WebSocket upgrades cannot set custom headers).",
+            },
+          ],
+          responses: {
+            "101": {
+              description:
+                "WebSocket upgrade successful; bidirectional live voice frame proxying begins.",
+            },
+            "401": {
+              description: "Unauthorized - missing or invalid token",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "426": {
+              description:
+                "Upgrade Required - request is not a WebSocket upgrade",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "500": {
+              description: "WebSocket upgrade failed",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/webhooks/oauth/callback": {
         get: {
           summary: "OAuth2 callback",


### PR DESCRIPTION
## PR 5: wire gateway live voice route

### Depends on

PR 4.

### Branch

`live-voice-channel/pr-05-gateway-route`

### Files

- `gateway/src/index.ts`
- `gateway/src/__tests__/live-voice-websocket.test.ts`

### Scope

Register the live voice WebSocket handler in the gateway:

- import `createLiveVoiceWebsocketHandler`, `getLiveVoiceWebsocketHandlers`, and the socket data type
- add an `isLiveVoiceSocketData` type guard
- instantiate the handler near the STT stream handler
- route `url.pathname === "/v1/live-voice"` before the runtime proxy fallback
- route WebSocket `open`, `message`, and `close` events to the live voice handler

### Acceptance Criteria

- `/v1/live-voice` reaches the live voice handler and not the generic HTTP proxy.
- Existing `/v1/stt/stream` behavior is unchanged.
- Gateway typecheck passes without weakening socket data types.

### Verification

Run:

```bash
export PATH="$HOME/.bun/bin:$PATH"
cd gateway && bun test src/__tests__/live-voice-websocket.test.ts
cd gateway && bunx tsc --noEmit
```

Orchestrated by velissa-ai via run-plan; implemented by Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
