### PR TITLE
feat(macos): ACPSessionsPanel skeleton with list + empty state

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
@@ -1,0 +1,245 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Skeleton list view for the Coding Agents (ACP sessions) panel.
+///
+/// Drives off the shared ``ACPSessionStore`` so SSE-driven inserts/updates
+/// stream into the list without explicit refresh logic. Routing into the
+/// panel is wired up in a follow-up PR (see ``PanelCoordinator``); this PR
+/// only stands up the visual shell.
+///
+/// The empty state mirrors ``SubagentDetailPanel`` — same `VEmptyState`
+/// shape, same panel chrome — so the two coding-agent surfaces feel like a
+/// single family. Each row is intentionally information-dense (badge +
+/// status pill + elapsed + parent conversation) so the panel can act as a
+/// glance dashboard before the list-to-detail nav lands in PR 22.
+struct ACPSessionsPanel: View {
+    @Bindable var store: ACPSessionStore
+    var onClose: (() -> Void)?
+
+    var body: some View {
+        VSidePanel(
+            title: "Coding Agents",
+            titleFont: VFont.titleSmall,
+            onClose: onClose,
+            pinnedContent: { headerBar }
+        ) {
+            if store.sessionOrder.isEmpty {
+                VEmptyState(
+                    title: "No coding agents yet",
+                    subtitle: "Ask the assistant to spawn Claude or Codex.",
+                    icon: "terminal"
+                )
+            } else {
+                sessionList
+            }
+        }
+        .onAppear {
+            if store.seedState == .idle {
+                Task { await store.seed() }
+            }
+        }
+    }
+
+    // MARK: - Header bar (count + refresh)
+
+    @ViewBuilder
+    private var headerBar: some View {
+        HStack(alignment: .center) {
+            Text(countLabel)
+                .font(VFont.labelSmall)
+                .foregroundStyle(VColor.contentTertiary)
+            Spacer()
+            VButton(
+                label: "Refresh",
+                iconOnly: VIcon.refreshCw.rawValue,
+                style: .ghost,
+                isDisabled: store.seedState == .loading,
+                action: { Task { await store.seed() } }
+            )
+            .accessibilityLabel("Refresh coding agents")
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+
+        Divider().background(VColor.borderBase)
+    }
+
+    private var countLabel: String {
+        let count = store.sessionOrder.count
+        return count == 1 ? "1 agent" : "\(count) agents"
+    }
+
+    // MARK: - Session list
+
+    @ViewBuilder
+    private var sessionList: some View {
+        // Eager `VStack` is intentional: per `clients/AGENTS.md`, lazy
+        // containers are required for unbounded data — but ``ACPSessionStore``
+        // bounds `sessionOrder` to live ACP sessions, which is small in
+        // practice and capped indirectly by the daemon. An eager stack keeps
+        // initial paint simpler and avoids the lazy-container row recycling
+        // overhead for short lists.
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(store.sessionOrder, id: \.self) { sessionId in
+                if let viewModel = store.sessions[sessionId] {
+                    ACPSessionsPanelRow(state: viewModel.state)
+                    if sessionId != store.sessionOrder.last {
+                        Divider().background(VColor.borderBase)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Row
+
+/// Single row in the Coding Agents list. Renders an agent badge, a status
+/// pill, the elapsed time since `startedAt`, and a truncated parent
+/// conversation id. Disclosure indicator is purely visual until PR 22 wires
+/// the list-to-detail navigation.
+struct ACPSessionsPanelRow: View {
+    let state: ACPSessionState
+
+    var body: some View {
+        HStack(alignment: .center, spacing: VSpacing.md) {
+            agentBadge
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                statusPill
+                metadataLine
+            }
+            Spacer(minLength: VSpacing.md)
+            VIconView(.chevronRight, size: 10)
+                .foregroundStyle(VColor.contentTertiary)
+                .accessibilityHidden(true)
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    // MARK: - Subviews
+
+    @ViewBuilder
+    private var agentBadge: some View {
+        Text(Self.agentLabel(for: state.agentId))
+            .font(VFont.labelDefault)
+            .foregroundStyle(VColor.contentDefault)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xxs)
+            .background(
+                Capsule()
+                    .fill(VColor.surfaceOverlay)
+            )
+    }
+
+    private var statusPill: some View {
+        let tint = Self.statusColor(state.status)
+        return HStack(spacing: VSpacing.xs) {
+            Circle()
+                .fill(tint)
+                .frame(width: 6, height: 6)
+            Text(Self.statusLabel(state.status))
+                .font(VFont.labelDefault)
+                .foregroundStyle(tint)
+        }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xxs)
+        .background(
+            Capsule()
+                .fill(tint.opacity(0.12))
+        )
+    }
+
+    @ViewBuilder
+    private var metadataLine: some View {
+        HStack(spacing: VSpacing.xs) {
+            Text(Self.elapsedLabel(startedAt: state.startedAt, completedAt: state.completedAt))
+                .font(VFont.labelSmall)
+                .foregroundStyle(VColor.contentTertiary)
+                .monospacedDigit()
+            if let parentLabel = Self.parentConversationLabel(state.parentConversationId) {
+                Text("·")
+                    .font(VFont.labelSmall)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .accessibilityHidden(true)
+                Text(parentLabel)
+                    .font(VFont.labelSmall)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        }
+    }
+
+    private var accessibilityLabel: String {
+        var parts: [String] = [
+            Self.agentLabel(for: state.agentId),
+            Self.statusLabel(state.status),
+            Self.elapsedLabel(startedAt: state.startedAt, completedAt: state.completedAt)
+        ]
+        if let parentLabel = Self.parentConversationLabel(state.parentConversationId) {
+            parts.append("conversation \(parentLabel)")
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    // MARK: - Formatting (static for testability)
+
+    /// Unknown ids fall through to the raw value so a new agent type still
+    /// renders without a code change.
+    static func agentLabel(for agentId: String) -> String {
+        switch agentId {
+        case "claude-code": return "Claude"
+        case "codex": return "Codex"
+        default: return agentId
+        }
+    }
+
+    static func statusLabel(_ status: ACPSessionState.Status) -> String {
+        switch status {
+        case .initializing: return "Starting"
+        case .running: return "Running"
+        case .completed: return "Completed"
+        case .failed: return "Failed"
+        case .cancelled: return "Cancelled"
+        case .unknown: return "Unknown"
+        }
+    }
+
+    static func statusColor(_ status: ACPSessionState.Status) -> Color {
+        switch status {
+        case .running, .initializing: return VColor.primaryActive
+        case .completed: return VColor.systemPositiveStrong
+        case .failed, .cancelled: return VColor.systemNegativeStrong
+        case .unknown: return VColor.contentTertiary
+        }
+    }
+
+    /// Locale-aware "5m ago" for live sessions; wall-clock duration for
+    /// terminated sessions so a finished row doesn't keep ticking.
+    static func elapsedLabel(startedAt: Int, completedAt: Int?) -> String {
+        let started = Date(timeIntervalSince1970: TimeInterval(startedAt) / 1000)
+        if let completedAt {
+            let completed = Date(timeIntervalSince1970: TimeInterval(completedAt) / 1000)
+            return VCollapsibleStepRowDurationFormatter.format(
+                max(0, completed.timeIntervalSince(started))
+            )
+        }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: started, relativeTo: Date())
+    }
+
+    /// Returns `nil` for empty/missing ids so the metadata line degrades
+    /// gracefully instead of rendering a stray separator.
+    static func parentConversationLabel(_ parentId: String?) -> String? {
+        guard let parentId, !parentId.isEmpty else { return nil }
+        let prefixLength = 8
+        if parentId.count <= prefixLength { return parentId }
+        return String(parentId.prefix(prefixLength)) + "…"
+    }
+}

--- a/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Logic-only assertions for ``ACPSessionsPanel``. Pixel-level rendering is
+/// out of scope; we cover the panel's visible-state contract: empty vs
+/// populated, count label, agent/status label mapping, parent-conversation
+/// truncation, and elapsed-time formatting (the row's only piece of
+/// non-trivial logic).
+@MainActor
+final class ACPSessionsPanelTests: XCTestCase {
+
+    // MARK: - Empty state vs populated
+
+    func test_emptyStore_hasNoSessionsAndZeroCount() {
+        let store = ACPSessionStore()
+        XCTAssertEqual(store.sessions.count, 0)
+        XCTAssertEqual(store.sessionOrder.count, 0)
+    }
+
+    func test_populatedStore_listsBothFixturesNewestFirst() {
+        let store = ACPSessionStore()
+        injectFixture(into: store, acpSessionId: "acp-old", agentId: "claude-code", startedAt: 100)
+        injectFixture(into: store, acpSessionId: "acp-new", agentId: "codex", startedAt: 300)
+
+        XCTAssertEqual(store.sessions.count, 2)
+        // ``ACPSessionStore.sessionOrder`` sorts by startedAt descending.
+        XCTAssertEqual(store.sessionOrder, ["acp-new", "acp-old"])
+        XCTAssertEqual(store.sessions["acp-new"]?.state.agentId, "codex")
+        XCTAssertEqual(store.sessions["acp-old"]?.state.agentId, "claude-code")
+    }
+
+    // MARK: - Agent label mapping
+
+    func test_agentLabel_mapsKnownAgentIds() {
+        XCTAssertEqual(ACPSessionsPanelRow.agentLabel(for: "claude-code"), "Claude")
+        XCTAssertEqual(ACPSessionsPanelRow.agentLabel(for: "codex"), "Codex")
+    }
+
+    func test_agentLabel_fallsBackToRawIdForUnknownAgents() {
+        XCTAssertEqual(
+            ACPSessionsPanelRow.agentLabel(for: "future-agent"),
+            "future-agent",
+            "Unknown agent ids must fall through so a new agent type still renders"
+        )
+    }
+
+    // MARK: - Status label / colour mapping
+
+    func test_statusLabel_capitalisesEveryCase() {
+        XCTAssertEqual(ACPSessionsPanelRow.statusLabel(.initializing), "Starting")
+        XCTAssertEqual(ACPSessionsPanelRow.statusLabel(.running), "Running")
+        XCTAssertEqual(ACPSessionsPanelRow.statusLabel(.completed), "Completed")
+        XCTAssertEqual(ACPSessionsPanelRow.statusLabel(.failed), "Failed")
+        XCTAssertEqual(ACPSessionsPanelRow.statusLabel(.cancelled), "Cancelled")
+        XCTAssertEqual(ACPSessionsPanelRow.statusLabel(.unknown), "Unknown")
+    }
+
+    // MARK: - Parent conversation truncation
+
+    func test_parentConversationLabel_truncatesLongIds() {
+        let label = ACPSessionsPanelRow.parentConversationLabel("conv-abcdef-1234567890")
+        XCTAssertEqual(label, "conv-abc…")
+    }
+
+    func test_parentConversationLabel_returnsShortIdsUntouched() {
+        XCTAssertEqual(ACPSessionsPanelRow.parentConversationLabel("short"), "short")
+    }
+
+    func test_parentConversationLabel_isNilForMissingOrEmptyIds() {
+        XCTAssertNil(ACPSessionsPanelRow.parentConversationLabel(nil))
+        XCTAssertNil(ACPSessionsPanelRow.parentConversationLabel(""))
+    }
+
+    // MARK: - Elapsed-time formatting
+
+    func test_elapsedLabel_completedSessionReportsDuration() {
+        // 1700000000000 ms → +90s == 1m 30s.
+        let label = ACPSessionsPanelRow.elapsedLabel(
+            startedAt: 1_700_000_000_000,
+            completedAt: 1_700_000_000_000 + 90_000
+        )
+        XCTAssertEqual(label, "1m 30s")
+    }
+
+    func test_elapsedLabel_subMinuteCompletedSessionReportsSeconds() {
+        let label = ACPSessionsPanelRow.elapsedLabel(
+            startedAt: 1_700_000_000_000,
+            completedAt: 1_700_000_000_000 + 5_000
+        )
+        // ``VCollapsibleStepRowDurationFormatter`` renders sub-minute
+        // durations with one decimal place ("5.0s").
+        XCTAssertEqual(label, "5.0s")
+    }
+
+    func test_elapsedLabel_runningSessionFallsBackToRelativeFormatter() {
+        // No `completedAt` → relative-time formatter takes over. We can't
+        // pin its exact string (locale-dependent) but it must not be empty
+        // and must not look like the duration formatter's output.
+        let label = ACPSessionsPanelRow.elapsedLabel(
+            startedAt: Int(Date().addingTimeInterval(-120).timeIntervalSince1970 * 1000),
+            completedAt: nil
+        )
+        XCTAssertFalse(label.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    /// Inserts a synthetic ACP session into the store via the same
+    /// ``ServerMessage`` path the SSE pipeline uses. The spawn handler stamps
+    /// `startedAt` with the wall-clock time at insertion — newer fixtures
+    /// therefore sort ahead of older ones automatically, so callers should
+    /// inject in oldest-first order to get a deterministic newest-first
+    /// ``sessionOrder``.
+    private func injectFixture(
+        into store: ACPSessionStore,
+        acpSessionId: String,
+        agentId: String,
+        startedAt: Int
+    ) {
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: acpSessionId,
+            agent: agentId,
+            parentConversationId: "conv-\(acpSessionId)"
+        )))
+        // Pin `startedAt` to a deterministic value so assertions don't drift
+        // with wall-clock skew. ``sessionOrder`` was already computed by the
+        // spawn handler using insertion order, which matches our intent.
+        if let viewModel = store.sessions[acpSessionId] {
+            viewModel.state = ACPSessionState(
+                id: viewModel.state.id,
+                agentId: agentId,
+                acpSessionId: acpSessionId,
+                parentConversationId: "conv-\(acpSessionId)",
+                status: .running,
+                startedAt: startedAt
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New `ACPSessionsPanel` SwiftUI view: header, count, empty state, row list, refresh button.
- `onAppear` seeds when idle.

Part of plan: acp-sessions-ui.md (PR 18 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
