### PR TITLE
feat(live-voice): add live voice session manager lock (PR 2)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  type LiveVoiceSession,
+  type LiveVoiceSessionCloseReason,
+  type LiveVoiceSessionFactoryContext,
+  LiveVoiceSessionManager,
+} from "../live-voice-session-manager.js";
+import type {
+  LiveVoiceClientFrame,
+  LiveVoiceClientStartFrame,
+  LiveVoiceServerFrame,
+} from "../protocol.js";
+
+const START_FRAME = {
+  type: "start",
+  conversationId: "conversation-123",
+  audio: {
+    mimeType: "audio/pcm",
+    sampleRate: 24_000,
+    channels: 1,
+  },
+} as const satisfies LiveVoiceClientStartFrame;
+
+interface TestSession extends LiveVoiceSession {
+  readonly clientFrames: LiveVoiceClientFrame[];
+  readonly binaryChunks: Uint8Array[];
+  readonly closeReasons: LiveVoiceSessionCloseReason[];
+}
+
+function createTestSession(overrides: Partial<LiveVoiceSession> = {}) {
+  const session: TestSession = {
+    clientFrames: [],
+    binaryChunks: [],
+    closeReasons: [],
+    start: mock(() => {}),
+    handleClientFrame: mock((frame: LiveVoiceClientFrame) => {
+      session.clientFrames.push(frame);
+    }),
+    handleBinaryAudio: mock((chunk: Uint8Array) => {
+      session.binaryChunks.push(chunk);
+    }),
+    close: mock((reason: LiveVoiceSessionCloseReason) => {
+      session.closeReasons.push(reason);
+    }),
+    ...overrides,
+  };
+  return session;
+}
+
+function createSink() {
+  const frames: LiveVoiceServerFrame[] = [];
+  return {
+    frames,
+    sink: {
+      sendFrame: mock((frame: LiveVoiceServerFrame) => {
+        frames.push(frame);
+      }),
+    },
+  };
+}
+
+describe("LiveVoiceSessionManager", () => {
+  test("creates and starts the first accepted live voice session", async () => {
+    const sessions: TestSession[] = [];
+    const contexts: LiveVoiceSessionFactoryContext[] = [];
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: () => "session-1",
+      createSession: (context) => {
+        contexts.push(context);
+        const session = createTestSession({
+          start: mock(async () => {
+            await context.sendFrame({
+              type: "ready",
+              sessionId: context.sessionId,
+              conversationId:
+                context.startFrame.conversationId ?? "conversation-new",
+            });
+          }),
+        });
+        sessions.push(session);
+        return session;
+      },
+    });
+    const { frames, sink } = createSink();
+
+    const result = await manager.startSession(START_FRAME, sink);
+
+    expect(result).toEqual({ status: "accepted", sessionId: "session-1" });
+    expect(manager.activeSessionId).toBe("session-1");
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]?.sessionId).toBe("session-1");
+    expect(contexts[0]?.startFrame).toEqual(START_FRAME);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.start).toHaveBeenCalledTimes(1);
+    expect(frames).toEqual([
+      {
+        type: "ready",
+        seq: 1,
+        sessionId: "session-1",
+        conversationId: "conversation-123",
+      },
+    ]);
+  });
+
+  test("rejects concurrent start attempts with a busy frame", async () => {
+    const sessions: TestSession[] = [];
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: mock(() => `session-${sessions.length + 1}`),
+      createSession: () => {
+        const session = createTestSession();
+        sessions.push(session);
+        return session;
+      },
+    });
+    const first = createSink();
+    const second = createSink();
+
+    const accepted = await manager.startSession(START_FRAME, first.sink);
+    const rejected = await manager.startSession(START_FRAME, second.sink);
+
+    expect(accepted).toEqual({ status: "accepted", sessionId: "session-1" });
+    expect(rejected).toEqual({
+      status: "busy",
+      activeSessionId: "session-1",
+      frame: {
+        type: "busy",
+        seq: 1,
+        activeSessionId: "session-1",
+      },
+    });
+    expect(second.frames).toEqual([
+      {
+        type: "busy",
+        seq: 1,
+        activeSessionId: "session-1",
+      },
+    ]);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.start).toHaveBeenCalledTimes(1);
+  });
+
+  test("releases the active session once for repeated close events", async () => {
+    const session = createTestSession();
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: () => "session-1",
+      createSession: () => session,
+    });
+
+    await manager.startSession(START_FRAME, createSink().sink);
+    const firstRelease = await manager.releaseSession(
+      "session-1",
+      "websocket_close",
+    );
+    const secondRelease = await manager.releaseSession(
+      "session-1",
+      "websocket_close",
+    );
+
+    expect(firstRelease).toEqual({
+      released: true,
+      sessionId: "session-1",
+    });
+    expect(secondRelease).toEqual({ released: false });
+    expect(session.close).toHaveBeenCalledTimes(1);
+    expect(session.closeReasons).toEqual(["websocket_close"]);
+    expect(manager.activeSessionId).toBeNull();
+  });
+
+  test("releases the lock on a normal end frame", async () => {
+    const sessions: TestSession[] = [];
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: mock(() => `session-${sessions.length + 1}`),
+      createSession: () => {
+        const session = createTestSession();
+        sessions.push(session);
+        return session;
+      },
+    });
+
+    await manager.startSession(START_FRAME, createSink().sink);
+    const result = await manager.handleClientFrame("session-1", {
+      type: "end",
+    });
+    const next = await manager.startSession(START_FRAME, createSink().sink);
+
+    expect(result).toEqual({ status: "handled", sessionId: "session-1" });
+    expect(sessions[0]?.clientFrames).toEqual([{ type: "end" }]);
+    expect(sessions[0]?.closeReasons).toEqual(["client_end"]);
+    expect(next).toEqual({ status: "accepted", sessionId: "session-2" });
+    expect(sessions).toHaveLength(2);
+  });
+
+  test("releases the lock when session start throws", async () => {
+    const sessions: TestSession[] = [];
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: mock(() => `session-${sessions.length + 1}`),
+      createSession: (context) => {
+        const session = createTestSession(
+          context.sessionId === "session-1"
+            ? {
+                start: mock(() => {
+                  throw new Error("session start failed");
+                }),
+              }
+            : {},
+        );
+        sessions.push(session);
+        return session;
+      },
+    });
+
+    await expect(
+      manager.startSession(START_FRAME, createSink().sink),
+    ).rejects.toThrow("session start failed");
+    const retry = await manager.startSession(START_FRAME, createSink().sink);
+
+    expect(sessions[0]?.closeReasons).toEqual(["error"]);
+    expect(retry).toEqual({ status: "accepted", sessionId: "session-2" });
+    expect(manager.activeSessionId).toBe("session-2");
+  });
+
+  test("releases the lock when session frame handling throws", async () => {
+    const session = createTestSession({
+      handleClientFrame: mock(() => {
+        throw new Error("client frame failed");
+      }),
+    });
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: () => "session-1",
+      createSession: () => session,
+    });
+
+    await manager.startSession(START_FRAME, createSink().sink);
+
+    await expect(
+      manager.handleClientFrame("session-1", { type: "interrupt" }),
+    ).rejects.toThrow("client frame failed");
+    expect(session.closeReasons).toEqual(["error"]);
+    expect(manager.activeSessionId).toBeNull();
+  });
+
+  test("releases the lock when binary audio handling throws", async () => {
+    const session = createTestSession({
+      handleBinaryAudio: mock(() => {
+        throw new Error("binary audio failed");
+      }),
+    });
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: () => "session-1",
+      createSession: () => session,
+    });
+
+    await manager.startSession(START_FRAME, createSink().sink);
+
+    await expect(
+      manager.handleBinaryAudio("session-1", new Uint8Array([1, 2, 3])),
+    ).rejects.toThrow("binary audio failed");
+    expect(session.closeReasons).toEqual(["error"]);
+    expect(manager.activeSessionId).toBeNull();
+  });
+
+  test("ignores stale session ids without releasing the active lock", async () => {
+    const session = createTestSession();
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: () => "session-1",
+      createSession: () => session,
+    });
+
+    await manager.startSession(START_FRAME, createSink().sink);
+
+    expect(
+      await manager.handleClientFrame("session-stale", { type: "end" }),
+    ).toEqual({ status: "not_found" });
+    expect(
+      await manager.handleBinaryAudio("session-stale", new Uint8Array([1])),
+    ).toEqual({ status: "not_found" });
+    expect(
+      await manager.releaseSession("session-stale", "websocket_close"),
+    ).toEqual({ released: false });
+    expect(session.close).not.toHaveBeenCalled();
+    expect(manager.activeSessionId).toBe("session-1");
+  });
+
+  test("does not import runtime, gateway, provider, or conversation modules", async () => {
+    const source = await Bun.file(
+      new URL("../live-voice-session-manager.ts", import.meta.url),
+    ).text();
+    const imports = Array.from(
+      source.matchAll(/from\s+["']([^"']+)["']/g),
+      (match) => match[1],
+    );
+
+    expect(imports).toEqual(["node:crypto", "./protocol.js"]);
+    for (const importPath of imports) {
+      expect(importPath).not.toContain("runtime");
+      expect(importPath).not.toContain("gateway");
+      expect(importPath).not.toContain("stt");
+      expect(importPath).not.toContain("tts");
+      expect(importPath).not.toContain("conversation");
+    }
+  });
+});

--- a/assistant/src/live-voice/live-voice-session-manager.ts
+++ b/assistant/src/live-voice/live-voice-session-manager.ts
@@ -1,0 +1,214 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  createLiveVoiceServerFrameSequencer,
+  type LiveVoiceClientFrame,
+  type LiveVoiceClientStartFrame,
+  type LiveVoiceServerFrame,
+  type LiveVoiceServerFramePayload,
+} from "./protocol.js";
+
+type MaybePromise<T> = T | Promise<T>;
+
+export type LiveVoiceSessionCloseReason =
+  | "client_end"
+  | "error"
+  | "websocket_close"
+  | "manager_shutdown";
+
+export interface LiveVoiceSession {
+  start(): MaybePromise<void>;
+  handleClientFrame(frame: LiveVoiceClientFrame): MaybePromise<void>;
+  handleBinaryAudio(chunk: Uint8Array): MaybePromise<void>;
+  close(reason: LiveVoiceSessionCloseReason): MaybePromise<void>;
+}
+
+export interface LiveVoiceServerFrameSink {
+  sendFrame(frame: LiveVoiceServerFrame): MaybePromise<void>;
+}
+
+export interface LiveVoiceSessionFactoryContext {
+  sessionId: string;
+  startFrame: LiveVoiceClientStartFrame;
+  sendFrame(frame: LiveVoiceServerFramePayload): Promise<LiveVoiceServerFrame>;
+}
+
+export type LiveVoiceSessionFactory = (
+  context: LiveVoiceSessionFactoryContext,
+) => LiveVoiceSession;
+
+export interface LiveVoiceSessionManagerOptions {
+  createSession: LiveVoiceSessionFactory;
+  createSessionId?: () => string;
+}
+
+export type LiveVoiceStartSessionResult =
+  | {
+      status: "accepted";
+      sessionId: string;
+    }
+  | {
+      status: "busy";
+      activeSessionId: string;
+      frame: LiveVoiceServerFrame;
+    };
+
+export type LiveVoiceSessionDispatchResult =
+  | {
+      status: "handled";
+      sessionId: string;
+    }
+  | {
+      status: "not_found";
+    };
+
+export type LiveVoiceSessionReleaseResult =
+  | {
+      released: true;
+      sessionId: string;
+    }
+  | {
+      released: false;
+    };
+
+interface ActiveLiveVoiceSession {
+  sessionId: string;
+  session: LiveVoiceSession;
+}
+
+export class LiveVoiceSessionManager {
+  private readonly createSession: LiveVoiceSessionFactory;
+  private readonly createSessionId: () => string;
+  private activeSession: ActiveLiveVoiceSession | null = null;
+
+  constructor(options: LiveVoiceSessionManagerOptions) {
+    this.createSession = options.createSession;
+    this.createSessionId = options.createSessionId ?? randomUUID;
+  }
+
+  get activeSessionId(): string | null {
+    return this.activeSession?.sessionId ?? null;
+  }
+
+  async startSession(
+    startFrame: LiveVoiceClientStartFrame,
+    sink: LiveVoiceServerFrameSink,
+  ): Promise<LiveVoiceStartSessionResult> {
+    const existingSessionId = this.activeSessionId;
+    if (existingSessionId !== null) {
+      const busySequencer = createLiveVoiceServerFrameSequencer();
+      const frame = busySequencer.next({
+        type: "busy",
+        activeSessionId: existingSessionId,
+      });
+      await sink.sendFrame(frame);
+      return {
+        status: "busy",
+        activeSessionId: existingSessionId,
+        frame,
+      };
+    }
+
+    const sessionId = this.createSessionId();
+    const sequencer = createLiveVoiceServerFrameSequencer();
+    const context: LiveVoiceSessionFactoryContext = {
+      sessionId,
+      startFrame,
+      sendFrame: async (payload) => {
+        const frame = sequencer.next(payload);
+        await sink.sendFrame(frame);
+        return frame;
+      },
+    };
+    const session = this.createSession(context);
+    this.activeSession = { sessionId, session };
+
+    try {
+      await session.start();
+    } catch (err) {
+      await this.releaseAfterSessionError(sessionId);
+      throw err;
+    }
+
+    return { status: "accepted", sessionId };
+  }
+
+  async handleClientFrame(
+    sessionId: string,
+    frame: LiveVoiceClientFrame,
+  ): Promise<LiveVoiceSessionDispatchResult> {
+    const active = this.findActiveSession(sessionId);
+    if (active === null) {
+      return { status: "not_found" };
+    }
+
+    try {
+      await active.session.handleClientFrame(frame);
+    } catch (err) {
+      await this.releaseAfterSessionError(sessionId);
+      throw err;
+    }
+
+    if (frame.type === "end") {
+      await this.releaseSession(sessionId, "client_end");
+    }
+
+    return { status: "handled", sessionId };
+  }
+
+  async handleBinaryAudio(
+    sessionId: string,
+    chunk: Uint8Array,
+  ): Promise<LiveVoiceSessionDispatchResult> {
+    const active = this.findActiveSession(sessionId);
+    if (active === null) {
+      return { status: "not_found" };
+    }
+
+    try {
+      await active.session.handleBinaryAudio(chunk);
+    } catch (err) {
+      await this.releaseAfterSessionError(sessionId);
+      throw err;
+    }
+
+    return { status: "handled", sessionId };
+  }
+
+  async releaseSession(
+    sessionId: string,
+    reason: LiveVoiceSessionCloseReason = "websocket_close",
+  ): Promise<LiveVoiceSessionReleaseResult> {
+    const active = this.findActiveSession(sessionId);
+    if (active === null) {
+      return { released: false };
+    }
+
+    this.activeSession = null;
+    await active.session.close(reason);
+    return { released: true, sessionId };
+  }
+
+  private findActiveSession(sessionId: string): ActiveLiveVoiceSession | null {
+    const active = this.activeSession;
+    if (active === null || active.sessionId !== sessionId) {
+      return null;
+    }
+
+    return active;
+  }
+
+  private async releaseAfterSessionError(sessionId: string): Promise<void> {
+    try {
+      await this.releaseSession(sessionId, "error");
+    } catch {
+      // The original session error is more useful to callers than a cleanup error.
+    }
+  }
+}
+
+export function createLiveVoiceSessionManager(
+  options: LiveVoiceSessionManagerOptions,
+): LiveVoiceSessionManager {
+  return new LiveVoiceSessionManager(options);
+}


### PR DESCRIPTION
## PR 2: add live voice session manager lock

### Depends on

PR 1.

### Branch

`live-voice-channel/pr-02-session-manager`

### Files

- `assistant/src/live-voice/live-voice-session-manager.ts`
- `assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts`

### Scope

Add a small `LiveVoiceSessionManager` that owns the V1 single-active-session invariant. The manager should accept a session factory, create a session for the first accepted connection, reject concurrent sessions with a `busy` frame payload, and release the lock on normal end, error, or WebSocket close.

The session factory can be a stub interface in this PR:

- `start()`
- `handleClientFrame(frame)`
- `handleBinaryAudio(chunk)`
- `close(reason)`

### Acceptance Criteria

- A second start attempt while a session is active receives `busy` with the active session id and no new session is created.
- Lock release is idempotent.
- The manager does not import runtime HTTP server code, gateway code, STT providers, TTS providers, or conversation classes.

### Verification

Run:

```bash
export PATH="$HOME/.bun/bin:$PATH"
cd assistant && bun test src/live-voice/__tests__/live-voice-session-manager.test.ts
cd assistant && bunx tsc --noEmit
```

Orchestrated by velissa-ai via run-plan; implemented by Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
