### PR TITLE
feat(live-voice): expose message ids for live voice attachment linking (PR 17)

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -512,6 +512,7 @@ describe("voice-session-bridge", () => {
     const textDeltaEvents: ServerMessage[] = [];
     const completeEvents: ServerMessage[] = [];
     let persistedUserMessageId: string | undefined;
+    let persistedAssistantMessageId: string | undefined;
 
     await startVoiceTurn({
       conversationId: conversation.id,
@@ -531,6 +532,9 @@ describe("voice-session-bridge", () => {
           persistedUserMessageId = messageId;
           capturedVoiceSessionId = session.callSessionId;
         },
+        persisted_assistant_message_id: (messageId) => {
+          persistedAssistantMessageId = messageId;
+        },
       },
     });
 
@@ -543,6 +547,7 @@ describe("voice-session-bridge", () => {
     );
     expect(textDeltaEvents).toEqual([events[0]]);
     expect(completeEvents).toEqual([events[1]]);
+    expect(persistedAssistantMessageId).toBe("assistant-msg-1");
 
     const persisted = getMessages(conversation.id).find(
       (message) => message.id === persistedUserMessageId,

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -101,6 +101,7 @@ export interface VoiceTurnCallbacks {
     >,
   ) => void;
   persisted_user_message_id?: (messageId: string) => void;
+  persisted_assistant_message_id?: (messageId: string) => void;
 }
 
 export interface VoiceTurnOptions {
@@ -290,6 +291,16 @@ export async function startVoiceTurn(
     onMessageComplete: (msg) => {
       opts.onComplete?.();
       opts.callbacks?.message_complete?.(msg);
+      if (msg.type === "message_complete" && msg.messageId) {
+        try {
+          opts.callbacks?.persisted_assistant_message_id?.(msg.messageId);
+        } catch (err) {
+          log.warn(
+            { err, messageId: msg.messageId },
+            "Voice turn assistant-message callback threw",
+          );
+        }
+      }
     },
     onError: (message) => {
       opts.onError?.(message);

--- a/assistant/src/live-voice/__tests__/live-voice-archive.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-archive.test.ts
@@ -30,6 +30,9 @@ import {
   archiveLiveVoiceAssistantResponseAudio,
   archiveLiveVoiceAudioArtifact,
   archiveLiveVoiceUserUtteranceAudio,
+  linkLiveVoiceAssistantResponseAudioToMessage,
+  linkLiveVoiceAudioArtifactToMessage,
+  linkLiveVoiceUserUtteranceAudioToMessage,
 } from "../live-voice-archive.js";
 
 initializeDb();
@@ -80,6 +83,13 @@ function countAttachmentsForMessage(messageId: string): number {
   const row = rawGet<{ count: number }>(
     `SELECT COUNT(*) AS count FROM message_attachments WHERE message_id = ?`,
     messageId,
+  );
+  return row?.count ?? 0;
+}
+
+function countAllAttachments(): number {
+  const row = rawGet<{ count: number }>(
+    `SELECT COUNT(*) AS count FROM attachments`,
   );
   return row?.count ?? 0;
 }
@@ -189,6 +199,83 @@ describe("live voice audio archive", () => {
     expect(serializedMetadata).not.toContain("providerConfig");
   });
 
+  test("links user utterance audio to a persisted user message id", async () => {
+    const { message } = await createMessage("user");
+
+    const result = linkLiveVoiceUserUtteranceAudioToMessage({
+      messageId: message.id,
+      sessionId: "session-user-link",
+      turnId: "turn-user-link",
+      mimeType: "audio/wav",
+      audio: {
+        type: "base64",
+        dataBase64: Buffer.from("linked user audio").toString("base64"),
+      },
+    });
+
+    expect(result.type).toBe("archived");
+    if (result.type !== "archived") throw new Error("expected archive result");
+    expect(result.artifact).toMatchObject({
+      archiveKey: "live-voice:session-user-link:turn-user-link:user",
+      role: "user",
+    });
+    expect(getAttachmentsForMessage(message.id)).toHaveLength(1);
+    expect(getLiveVoiceArtifacts(message.id)).toEqual([result.artifact]);
+  });
+
+  test("links assistant response audio when the assistant message id is available", async () => {
+    const { message } = await createMessage("assistant");
+
+    const result = linkLiveVoiceAssistantResponseAudioToMessage({
+      messageId: message.id,
+      sessionId: "session-assistant-link",
+      turnId: "turn-assistant-link",
+      mimeType: "audio/pcm",
+      sampleRate: 24000,
+      audio: {
+        type: "base64",
+        dataBase64: Buffer.from("linked assistant audio").toString("base64"),
+      },
+    });
+
+    expect(result.type).toBe("archived");
+    if (result.type !== "archived") throw new Error("expected archive result");
+    expect(result.artifact).toMatchObject({
+      archiveKey:
+        "live-voice:session-assistant-link:turn-assistant-link:assistant",
+      role: "assistant",
+      sampleRate: 24000,
+    });
+    expect(getAttachmentsForMessage(message.id)).toHaveLength(1);
+    expect(getLiveVoiceArtifacts(message.id)).toEqual([result.artifact]);
+  });
+
+  test("returns an unlinked result when the assistant message id is unavailable", () => {
+    const result = linkLiveVoiceAssistantResponseAudioToMessage({
+      messageId: undefined,
+      sessionId: "session-assistant-unlinked",
+      turnId: "turn-assistant-unlinked",
+      mimeType: "audio/pcm",
+      audio: {
+        type: "base64",
+        dataBase64: Buffer.from("unlinked assistant audio").toString("base64"),
+      },
+    });
+
+    expect(result).toEqual({
+      type: "unlinked",
+      warning: {
+        code: "message_id_unavailable",
+        message:
+          "Live voice audio archive could not be linked because no message id was available.",
+      },
+      sessionId: "session-assistant-unlinked",
+      turnId: "turn-assistant-unlinked",
+      role: "assistant",
+    });
+    expect(countAllAttachments()).toBe(0);
+  });
+
   test("is idempotent for the session turn role key", async () => {
     const { message } = await createMessage("user");
 
@@ -280,6 +367,60 @@ describe("live voice audio archive", () => {
     expect(second.artifact.attachmentId).toBe(first.artifact.attachmentId);
     expect(countAttachmentsForMessage(message.id)).toBe(1);
     expect(getLiveVoiceArtifacts(message.id)).toHaveLength(1);
+  });
+
+  test("links an existing archived audio artifact to another message id", async () => {
+    const conversation = createConversation();
+    const sourceMessage = await addMessage(
+      conversation.id,
+      "user",
+      "Example source utterance",
+      { userMessageChannel: "vellum", userMessageInterface: "macos" },
+      { skipIndexing: true },
+    );
+    const targetMessage = await addMessage(
+      conversation.id,
+      "user",
+      "Example target utterance",
+      { userMessageChannel: "vellum", userMessageInterface: "macos" },
+      { skipIndexing: true },
+    );
+
+    const archived = archiveLiveVoiceUserUtteranceAudio({
+      messageId: sourceMessage.id,
+      sessionId: "session-artifact-link",
+      turnId: "turn-artifact-link",
+      mimeType: "audio/wav",
+      audio: {
+        type: "base64",
+        dataBase64: Buffer.from("existing artifact audio").toString("base64"),
+      },
+    });
+    expect(archived.type).toBe("archived");
+    if (archived.type !== "archived") {
+      throw new Error("expected archive result");
+    }
+
+    const linked = linkLiveVoiceAudioArtifactToMessage({
+      messageId: targetMessage.id,
+      artifact: archived.artifact,
+    });
+
+    expect(linked.type).toBe("archived");
+    if (linked.type !== "archived") throw new Error("expected link result");
+    expect(linked.idempotent).toBe(false);
+    expect(linked.artifact.attachmentId).toBe(archived.artifact.attachmentId);
+    expect(getAttachmentsForMessage(targetMessage.id)).toHaveLength(1);
+    expect(getLiveVoiceArtifacts(targetMessage.id)).toEqual([linked.artifact]);
+
+    const second = linkLiveVoiceAudioArtifactToMessage({
+      messageId: targetMessage.id,
+      artifact: archived.artifact,
+    });
+    expect(second.type).toBe("archived");
+    if (second.type !== "archived") throw new Error("expected link result");
+    expect(second.idempotent).toBe(true);
+    expect(countAttachmentsForMessage(targetMessage.id)).toBe(1);
   });
 
   test("returns typed warnings for non-fatal archive failures", async () => {

--- a/assistant/src/live-voice/live-voice-archive.ts
+++ b/assistant/src/live-voice/live-voice-archive.ts
@@ -3,6 +3,9 @@ import { existsSync, statSync } from "node:fs";
 import {
   attachFileBackedAttachmentToMessage,
   attachInlineAttachmentToMessage,
+  attachmentExists,
+  getAttachmentById,
+  linkAttachmentToMessage,
 } from "../memory/attachments-store.js";
 import { rawAll, rawGet, rawRun } from "../memory/db.js";
 import { getLogger } from "../util/logger.js";
@@ -54,8 +57,11 @@ export interface LiveVoiceAudioArtifactMetadata {
 
 export type LiveVoiceAudioArchiveWarningCode =
   | "archive_failed"
+  | "attachment_not_found"
   | "invalid_audio_source"
   | "invalid_metadata"
+  | "link_failed"
+  | "message_id_unavailable"
   | "message_not_found"
   | "unsupported_mime_type";
 
@@ -71,9 +77,24 @@ export type LiveVoiceAudioArchiveResult =
       idempotent: boolean;
     }
   | {
+      type: "unlinked";
+      warning: LiveVoiceAudioArchiveWarning;
+      sessionId: string;
+      turnId: string;
+      role: LiveVoiceAudioArchiveRole;
+      artifact?: LiveVoiceAudioArtifactMetadata;
+    }
+  | {
       type: "warning";
       warning: LiveVoiceAudioArchiveWarning;
     };
+
+interface LiveVoiceAudioUnlinkedContext {
+  sessionId: string;
+  turnId: string;
+  role: LiveVoiceAudioArchiveRole;
+  artifact?: LiveVoiceAudioArtifactMetadata;
+}
 
 interface AttachmentLookupRow {
   id: string;
@@ -110,6 +131,32 @@ function resultWarning(
   message: string,
 ): LiveVoiceAudioArchiveResult {
   return { type: "warning", warning: { code, message } };
+}
+
+function resultUnlinked(
+  code: LiveVoiceAudioArchiveWarningCode,
+  message: string,
+  input: LiveVoiceAudioUnlinkedContext,
+): LiveVoiceAudioArchiveResult {
+  return {
+    type: "unlinked",
+    warning: { code, message },
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    role: input.role,
+    ...(input.artifact ? { artifact: input.artifact } : {}),
+  };
+}
+
+function unlinkedContextForArtifact(
+  artifact: LiveVoiceAudioArtifactMetadata,
+): LiveVoiceAudioUnlinkedContext {
+  return {
+    sessionId: artifact.sessionId,
+    turnId: artifact.turnId,
+    role: artifact.role,
+    artifact,
+  };
 }
 
 function normalizeMimeType(mimeType: string): string {
@@ -537,6 +584,19 @@ type ArchiveLiveVoiceRolelessAudioInput = Omit<
   "role"
 >;
 
+type LinkLiveVoiceRolelessAudioInput = Omit<
+  ArchiveLiveVoiceAudioInput,
+  "messageId" | "role"
+> & {
+  messageId?: string | null;
+};
+
+export interface LinkLiveVoiceAudioArtifactInput {
+  messageId?: string | null;
+  artifact: LiveVoiceAudioArtifactMetadata;
+  position?: number;
+}
+
 export function archiveLiveVoiceUserUtteranceAudio(
   input: ArchiveLiveVoiceRolelessAudioInput,
 ): LiveVoiceAudioArchiveResult {
@@ -547,4 +607,152 @@ export function archiveLiveVoiceAssistantResponseAudio(
   input: ArchiveLiveVoiceRolelessAudioInput,
 ): LiveVoiceAudioArchiveResult {
   return archiveLiveVoiceAudioArtifact({ ...input, role: "assistant" });
+}
+
+function normalizeMessageId(messageId: string | null | undefined): string {
+  return messageId?.trim() ?? "";
+}
+
+function linkLiveVoiceAudioToMessage(
+  input: LinkLiveVoiceRolelessAudioInput & {
+    role: LiveVoiceAudioArchiveRole;
+  },
+): LiveVoiceAudioArchiveResult {
+  const messageId = normalizeMessageId(input.messageId);
+  if (!messageId) {
+    return resultUnlinked(
+      "message_id_unavailable",
+      "Live voice audio archive could not be linked because no message id was available.",
+      input,
+    );
+  }
+
+  const { messageId: _messageId, ...archiveInput } = input;
+  return archiveLiveVoiceAudioArtifact({
+    ...archiveInput,
+    messageId,
+  });
+}
+
+export function linkLiveVoiceUserUtteranceAudioToMessage(
+  input: LinkLiveVoiceRolelessAudioInput,
+): LiveVoiceAudioArchiveResult {
+  return linkLiveVoiceAudioToMessage({ ...input, role: "user" });
+}
+
+export function linkLiveVoiceAssistantResponseAudioToMessage(
+  input: LinkLiveVoiceRolelessAudioInput,
+): LiveVoiceAudioArchiveResult {
+  return linkLiveVoiceAudioToMessage({ ...input, role: "assistant" });
+}
+
+export function linkLiveVoiceAudioArtifactToMessage(
+  input: LinkLiveVoiceAudioArtifactInput,
+): LiveVoiceAudioArchiveResult {
+  const { artifact } = input;
+  if (!isArtifactMetadata(artifact)) {
+    return resultWarning(
+      "invalid_metadata",
+      "Live voice audio archive artifact metadata is invalid.",
+    );
+  }
+
+  const messageId = normalizeMessageId(input.messageId);
+  if (!messageId) {
+    return resultUnlinked(
+      "message_id_unavailable",
+      "Live voice audio archive could not be linked because no message id was available.",
+      unlinkedContextForArtifact(artifact),
+    );
+  }
+
+  const state = readMessageMetadata(messageId);
+  if (state === "not_found") {
+    return resultUnlinked(
+      "message_not_found",
+      "Live voice audio archive target message was not found.",
+      unlinkedContextForArtifact(artifact),
+    );
+  }
+  if (state === "invalid_metadata") {
+    return resultUnlinked(
+      "invalid_metadata",
+      "Live voice audio archive target message metadata is invalid.",
+      unlinkedContextForArtifact(artifact),
+    );
+  }
+
+  const existingMetadataArtifact = findExistingMetadataArtifact(
+    messageId,
+    artifact.archiveKey,
+    state.artifacts,
+  );
+  if (existingMetadataArtifact) {
+    return {
+      type: "archived",
+      artifact: existingMetadataArtifact,
+      idempotent: true,
+    };
+  }
+
+  if (messageAttachmentLinkExists(messageId, artifact.attachmentId)) {
+    persistArtifactMetadata(messageId, artifact);
+    return { type: "archived", artifact, idempotent: true };
+  }
+
+  if (!attachmentExists(artifact.attachmentId)) {
+    return resultUnlinked(
+      "attachment_not_found",
+      "Live voice audio archive attachment was not found.",
+      unlinkedContextForArtifact(artifact),
+    );
+  }
+
+  try {
+    const linkedAttachmentId = linkAttachmentToMessage(
+      messageId,
+      artifact.attachmentId,
+      input.position ?? nextAttachmentPosition(messageId),
+    );
+    const linkedAttachment = getAttachmentById(linkedAttachmentId);
+    const linkedArtifact = linkedAttachment
+      ? artifactFromAttachment({
+          attachmentId: linkedAttachment.id,
+          archiveKey: artifact.archiveKey,
+          sessionId: artifact.sessionId,
+          turnId: artifact.turnId,
+          role: artifact.role,
+          mimeType: linkedAttachment.mimeType,
+          sampleRate: artifact.sampleRate,
+          durationMs: artifact.durationMs,
+          sizeBytes: linkedAttachment.sizeBytes,
+          filename: linkedAttachment.originalFilename,
+          archivedAt: linkedAttachment.createdAt,
+        })
+      : { ...artifact, attachmentId: linkedAttachmentId };
+
+    if (!persistArtifactMetadata(messageId, linkedArtifact)) {
+      log.warn(
+        { messageId, archiveKey: artifact.archiveKey },
+        "Linked live voice audio but could not persist metadata",
+      );
+    }
+
+    return { type: "archived", artifact: linkedArtifact, idempotent: false };
+  } catch (err) {
+    log.warn(
+      {
+        messageId,
+        attachmentId: artifact.attachmentId,
+        archiveKey: artifact.archiveKey,
+        errorName: err instanceof Error ? err.name : typeof err,
+      },
+      "Failed to link live voice audio artifact",
+    );
+    return resultUnlinked(
+      "link_failed",
+      "Live voice audio archive could not be linked without blocking the turn.",
+      unlinkedContextForArtifact(artifact),
+    );
+  }
 }


### PR DESCRIPTION
## PR 17: expose message ids for live voice attachment linking

### Depends on

PR 12, PR 16.

### Branch

`live-voice-channel/pr-17-message-id-hooks`

### Files

- `assistant/src/calls/voice-session-bridge.ts`
- `assistant/src/live-voice/live-voice-archive.ts`
- `assistant/src/__tests__/voice-session-bridge.test.ts`
- `assistant/src/live-voice/__tests__/live-voice-archive.test.ts`

### Scope

Expose the persisted message ids needed to link archived audio to the normal conversation transcript:

- add a local-live-voice callback for the persisted user message id
- use `message_complete.messageId` for the assistant message id when available
- keep phone-call behavior unchanged
- add helper methods to link archived audio attachments to those message ids

### Acceptance Criteria

- User utterance audio can be linked to the persisted user message.
- Assistant TTS audio can be linked to the persisted assistant message when `messageId` is present.
- If the assistant message id is unavailable, the archive helper records a non-fatal unlinked result and the live session can still finish.

### Verification

Run:

```bash
export PATH="$HOME/.bun/bin:$PATH"
cd assistant && bun test src/__tests__/voice-session-bridge.test.ts src/live-voice/__tests__/live-voice-archive.test.ts
cd assistant && bunx tsc --noEmit
```

Orchestrated by velissa-ai via run-plan; implemented by Codex.