### PR TITLE
feat(macos): ACPSessionDetailView with read-only timeline

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -1,0 +1,641 @@
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - ACPSessionDetailView
+
+/// Read-only timeline of an ACP (Agent Client Protocol) session.
+///
+/// Renders a header (agent + status + elapsed + parent-conversation link) and
+/// a scrolling timeline of `ACPSessionUpdateMessage` events grouped into
+/// visual rows. Tool calls coalesce with their `tool_call_update` siblings
+/// (latest update wins) so a streaming tool that emits multiple status
+/// transitions still renders as a single row.
+///
+/// Auto-scrolls to the latest event while the user is parked at the bottom;
+/// pauses auto-scroll once the user scrolls up so they can read past content
+/// without being yanked back. Resumes when the user returns to the bottom.
+///
+/// Cancel, steer, and delete affordances arrive in later PRs (24, 25, 26);
+/// this view is intentionally read-only.
+struct ACPSessionDetailView: View {
+    let session: ACPSessionViewModel
+    /// Tap on the parent-conversation link. Wired by PR 22; nil hides the link.
+    var onSelectParentConversation: ((String) -> Void)? = nil
+    /// Optional close action — surfaces the design-system close button when
+    /// this view is hosted inside a panel container that can dismiss itself.
+    var onClose: (() -> Void)? = nil
+
+    /// Sentinel ID anchored at the bottom of the LazyVStack so the
+    /// `ScrollViewReader` can scroll to "the latest" without depending on
+    /// per-event identity (which churns as the events array mutates).
+    private static let bottomAnchorId = "ACPSessionDetail.bottomAnchor"
+
+    /// True while auto-scroll is active. Flipped to false the moment the
+    /// user scrolls upward, and back to true once they return to the bottom.
+    @State private var autoScrollEnabled = true
+    /// Last observed scroll offset reported by the timeline, used to detect
+    /// the direction of the most recent user-driven scroll.
+    @State private var lastScrollOffset: CGFloat = 0
+    /// Last observed bottom offset (content height − viewport height).
+    /// Compared against `lastScrollOffset` to decide whether the user is
+    /// currently parked at the bottom.
+    @State private var lastMaxScrollOffset: CGFloat = 0
+    /// Wall clock used to refresh the elapsed time once per second while the
+    /// session is still running. The view only reads it when the session is
+    /// non-terminal so terminal sessions don't wake the timer.
+    @State private var nowTick: Date = Date()
+
+    private static let elapsedTickInterval: TimeInterval = 1
+    private static let scrollAtBottomTolerance: CGFloat = 4
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider().background(VColor.borderBase)
+            timeline
+        }
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var header: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(alignment: .center, spacing: VSpacing.sm) {
+                Text(session.state.agentId)
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(1)
+                statusPill
+                Spacer()
+                if let onClose {
+                    VButton(label: "Close", iconOnly: "xmark", style: .ghost, action: onClose)
+                }
+            }
+
+            HStack(alignment: .center, spacing: VSpacing.md) {
+                elapsedView
+                if let parent = session.state.parentConversationId,
+                   let onSelectParentConversation {
+                    parentConversationLink(id: parent, onTap: onSelectParentConversation)
+                }
+                Spacer()
+            }
+        }
+        .padding(EdgeInsets(top: VSpacing.lg, leading: VSpacing.lg, bottom: VSpacing.md, trailing: VSpacing.lg))
+    }
+
+    @ViewBuilder
+    private var statusPill: some View {
+        VBadge(
+            label: statusLabel(session.state.status),
+            tone: statusTone(session.state.status),
+            emphasis: .subtle
+        )
+        .accessibilityLabel("Status: \(statusLabel(session.state.status))")
+    }
+
+    private func statusLabel(_ status: ACPSessionState.Status) -> String {
+        switch status {
+        case .initializing: return "Starting"
+        case .running:      return "Running"
+        case .completed:    return "Completed"
+        case .failed:       return "Failed"
+        case .cancelled:    return "Cancelled"
+        case .unknown:      return "Unknown"
+        }
+    }
+
+    private func statusTone(_ status: ACPSessionState.Status) -> VBadge.Tone {
+        switch status {
+        case .running, .initializing: return .accent
+        case .completed:              return .positive
+        case .failed:                 return .danger
+        case .cancelled, .unknown:    return .neutral
+        }
+    }
+
+    @ViewBuilder
+    private var elapsedView: some View {
+        let formatted = Self.formatElapsed(elapsedSeconds())
+        Text(formatted)
+            .font(VFont.numericMono)
+            .foregroundStyle(VColor.contentSecondary)
+            .accessibilityLabel("Elapsed: \(formatted)")
+            .onReceive(Timer.publish(every: Self.elapsedTickInterval, on: .main, in: .common).autoconnect()) { tick in
+                // Skip ticks once the session reaches a terminal state — its
+                // `completedAt` is frozen and re-rendering would just thrash.
+                guard session.state.completedAt == nil else { return }
+                nowTick = tick
+            }
+    }
+
+    /// Returns the elapsed runtime in seconds. Reading `nowTick` here is
+    /// intentional — it forces SwiftUI to track the timer and re-evaluate
+    /// once per second while the session is running.
+    private func elapsedSeconds() -> TimeInterval {
+        let startedSeconds = TimeInterval(session.state.startedAt) / 1000
+        let endSeconds: TimeInterval
+        if let completedAt = session.state.completedAt {
+            endSeconds = TimeInterval(completedAt) / 1000
+        } else {
+            endSeconds = nowTick.timeIntervalSince1970
+        }
+        return max(0, endSeconds - startedSeconds)
+    }
+
+    static func formatElapsed(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds.rounded(.down))
+        let h = total / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
+        if h > 0 {
+            return String(format: "%d:%02d:%02d", h, m, s)
+        }
+        return String(format: "%d:%02d", m, s)
+    }
+
+    @ViewBuilder
+    private func parentConversationLink(id: String, onTap: @escaping (String) -> Void) -> some View {
+        Button {
+            onTap(id)
+        } label: {
+            HStack(spacing: VSpacing.xxs) {
+                VIconView(.link, size: 11)
+                Text("Parent conversation")
+                    .font(VFont.labelDefault)
+            }
+            .foregroundStyle(VColor.primaryBase)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Open parent conversation")
+    }
+
+    // MARK: - Timeline
+
+    @ViewBuilder
+    private var timeline: some View {
+        let rows = Self.buildRows(events: session.events)
+        if rows.isEmpty {
+            VEmptyState(
+                title: "No events yet",
+                subtitle: "Events will appear as the session runs",
+                icon: "waveform.path"
+            )
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: VSpacing.md) {
+                        ForEach(rows) { row in
+                            renderRow(row)
+                        }
+                        // Sentinel — `.id` for ScrollViewReader anchoring.
+                        Color.clear
+                            .frame(height: 1)
+                            .id(Self.bottomAnchorId)
+                    }
+                    .padding(EdgeInsets(top: VSpacing.lg, leading: VSpacing.lg, bottom: VSpacing.lg, trailing: VSpacing.lg))
+                    // Read the scroll position via the bounds of the inner
+                    // content. .named("acp-timeline") matches the coordinate
+                    // space declared on the ScrollView below.
+                    .background(scrollOffsetReader)
+                }
+                .coordinateSpace(name: "acp-timeline")
+                .onPreferenceChange(ACPSessionDetailScrollOffsetKey.self) { contentMinY in
+                    handleScrollOffsetChange(contentMinY)
+                }
+                .onChange(of: session.events.count) {
+                    if autoScrollEnabled {
+                        // .easeOut keeps the jump readable when many events
+                        // arrive at once.
+                        withAnimation(.easeOut(duration: 0.1)) {
+                            proxy.scrollTo(Self.bottomAnchorId, anchor: .bottom)
+                        }
+                    }
+                }
+                .onAppear {
+                    // First-paint: park at the bottom so the user lands on
+                    // the latest activity instead of the start of the log.
+                    proxy.scrollTo(Self.bottomAnchorId, anchor: .bottom)
+                }
+            }
+        }
+    }
+
+    /// Background view that publishes the timeline's scroll offset through a
+    /// SwiftUI `PreferenceKey` so the parent can observe scroll direction
+    /// without resorting to AppKit gesture recognizers.
+    @ViewBuilder
+    private var scrollOffsetReader: some View {
+        GeometryReader { geo in
+            // The inner content's `minY` in the named coordinate space goes
+            // negative as the user scrolls down. We publish it as-is and
+            // negate at the consumer to get a positive "offset from top".
+            Color.clear.preference(
+                key: ACPSessionDetailScrollOffsetKey.self,
+                value: geo.frame(in: .named("acp-timeline")).minY
+            )
+        }
+    }
+
+    private func handleScrollOffsetChange(_ contentMinY: CGFloat) {
+        // We don't know the viewport height inside the preference reader, so
+        // we infer "user is at the bottom" by tracking the largest offset
+        // we've seen — that value matches the bottom whenever the user is
+        // already there. A jump *upward* from the previous offset pauses
+        // auto-scroll; a return to the high-water mark resumes it.
+        let currentOffset = -contentMinY
+        defer { lastScrollOffset = currentOffset }
+
+        if currentOffset > lastMaxScrollOffset {
+            lastMaxScrollOffset = currentOffset
+        }
+
+        let movedUp = currentOffset < lastScrollOffset - Self.scrollAtBottomTolerance
+        let returnedToBottom = abs(currentOffset - lastMaxScrollOffset) < Self.scrollAtBottomTolerance
+
+        if movedUp {
+            autoScrollEnabled = false
+        } else if returnedToBottom {
+            autoScrollEnabled = true
+        }
+    }
+
+    // MARK: - Row Rendering
+
+    @ViewBuilder
+    private func renderRow(_ row: TimelineRow) -> some View {
+        switch row {
+        case .agentMessage(_, let content):
+            messageBubble(content: content, isUser: false)
+        case .userMessage(_, let content):
+            messageBubble(content: content, isUser: true)
+        case .toolCall(_, let toolCallId, let title, let kind, let status):
+            toolCallRow(toolCallId: toolCallId, title: title, kind: kind, status: status)
+        case .plan(_, let items):
+            planChecklist(items: items)
+        case .thought(_, let content):
+            thoughtRow(content: content)
+        }
+    }
+
+    @ViewBuilder
+    private func messageBubble(content: String, isUser: Bool) -> some View {
+        HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(isUser ? "USER" : "AGENT")
+                    .font(VFont.labelSmall)
+                    .foregroundStyle(VColor.contentTertiary)
+                MarkdownSegmentView(segments: parseMarkdownSegments(content))
+                    .equatable()
+                    .textSelection(.enabled)
+            }
+            .padding(VSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(isUser ? VColor.primaryBase.opacity(0.08) : VColor.surfaceOverlay.opacity(0.6))
+            )
+            Spacer(minLength: 0)
+        }
+    }
+
+    @ViewBuilder
+    private func toolCallRow(toolCallId: String, title: String, kind: String?, status: String?) -> some View {
+        HStack(alignment: .center, spacing: VSpacing.sm) {
+            VIconView(toolKindIcon(kind), size: 14)
+                .foregroundStyle(VColor.contentSecondary)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(title)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(1)
+                if let kind, !kind.isEmpty {
+                    Text(kind)
+                        .font(VFont.labelSmall)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+            }
+            Spacer(minLength: 0)
+            toolStatusPill(status: status)
+        }
+        .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surfaceOverlay.opacity(0.6))
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Tool call: \(title), status \(toolStatusLabel(status))")
+    }
+
+    @ViewBuilder
+    private func toolStatusPill(status: String?) -> some View {
+        VBadge(
+            label: toolStatusLabel(status),
+            tone: toolStatusTone(status),
+            emphasis: .subtle
+        )
+    }
+
+    private func toolStatusLabel(_ status: String?) -> String {
+        // Daemon emits lowercase status strings (`pending`, `running`,
+        // `completed`, `failed`, etc). Display-cased here so the pill reads
+        // naturally without forcing every UI consumer to title-case.
+        guard let status, !status.isEmpty else { return "Pending" }
+        return status.replacingOccurrences(of: "_", with: " ").capitalized
+    }
+
+    private func toolStatusTone(_ status: String?) -> VBadge.Tone {
+        switch (status ?? "").lowercased() {
+        case "completed", "succeeded", "success": return .positive
+        case "failed", "error":                    return .danger
+        case "running", "in_progress":             return .accent
+        default:                                    return .neutral
+        }
+    }
+
+    private func toolKindIcon(_ kind: String?) -> VIcon {
+        // Map the well-known ACP tool kinds to design-system icons. Unknown
+        // kinds fall back to a generic wrench so a future server-side kind
+        // addition still renders as something recognisably tool-shaped.
+        switch (kind ?? "").lowercased() {
+        case "read", "fetch":          return .fileText
+        case "edit", "write":          return .squarePen
+        case "search", "grep":         return .search
+        case "execute", "bash", "shell", "run": return .terminal
+        case "browse", "web":          return .globe
+        case "think":                  return .sparkles
+        default:                        return .wrench
+        }
+    }
+
+    @ViewBuilder
+    private func planChecklist(items: [PlanItem]) -> some View {
+        // Use HStack + Spacer to take leading width without spawning a
+        // `_FlexFrameLayout` inside the LazyVStack cell — see
+        // `clients/macos/AGENTS.md` § "No .frame(maxWidth:) in LazyVStack".
+        HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("PLAN")
+                    .font(VFont.labelSmall)
+                    .foregroundStyle(VColor.contentTertiary)
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    HStack(alignment: .top, spacing: VSpacing.xs) {
+                        VIconView(item.isComplete ? .circleCheck : .circle, size: 12)
+                            .foregroundStyle(item.isComplete ? VColor.systemPositiveStrong : VColor.contentTertiary)
+                        Text(item.text)
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(item.isComplete ? VColor.contentTertiary : VColor.contentDefault)
+                            .strikethrough(item.isComplete, color: VColor.contentTertiary)
+                            .textSelection(.enabled)
+                    }
+                }
+            }
+            .padding(VSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.surfaceOverlay.opacity(0.4))
+            )
+            Spacer(minLength: 0)
+        }
+    }
+
+    @ViewBuilder
+    private func thoughtRow(content: String) -> some View {
+        // TODO(PR 23 — acp-sessions-ui): replace this stub with the proper
+        // collapsible "thinking" rendering. Kept minimal here so the view
+        // doesn't crash when an `agent_thought_chunk` arrives, and so the
+        // user still sees *something* until PR 23 lands.
+        HStack(spacing: 0) {
+            Text(content)
+                .font(VFont.bodyMediumDefault.italic())
+                .foregroundStyle(VColor.contentTertiary)
+                .textSelection(.enabled)
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+// MARK: - Timeline Row Model
+
+extension ACPSessionDetailView {
+    /// A single visual row in the timeline. Tool-call updates fold into
+    /// their parent `.toolCall` row (latest status wins); `.unknown` events
+    /// are dropped silently. The `id` is stable per row so SwiftUI's diffing
+    /// reuses the same view across re-renders.
+    enum TimelineRow: Identifiable, Equatable {
+        case agentMessage(id: String, content: String)
+        case userMessage(id: String, content: String)
+        case toolCall(id: String, toolCallId: String, title: String, kind: String?, status: String?)
+        case plan(id: String, items: [PlanItem])
+        case thought(id: String, content: String)
+
+        var id: String {
+            switch self {
+            case .agentMessage(let id, _),
+                 .userMessage(let id, _),
+                 .toolCall(let id, _, _, _, _),
+                 .plan(let id, _),
+                 .thought(let id, _):
+                return id
+            }
+        }
+    }
+
+    struct PlanItem: Equatable {
+        let text: String
+        let isComplete: Bool
+    }
+
+    /// Build the timeline rows for the given event stream.
+    ///
+    /// - Tool-call updates (`.toolCallUpdate`) are folded onto the matching
+    ///   `.toolCall` row by `toolCallId` so the row's `status` reflects the
+    ///   latest update rather than the original one.
+    /// - Consecutive same-role chunk events (`agent_message_chunk`,
+    ///   `user_message_chunk`, `agent_thought_chunk`) are concatenated so
+    ///   the timeline shows one bubble per logical message rather than one
+    ///   per token.
+    /// - `.unknown` and `toolCallUpdate` standalone are not emitted.
+    static func buildRows(events: [ACPSessionUpdateMessage]) -> [TimelineRow] {
+        var rows: [TimelineRow] = []
+        // Index of the row in `rows` for each toolCallId we've already
+        // emitted, so we can rewrite the status in-place when an update
+        // arrives.
+        var toolCallRowIndex: [String: Int] = [:]
+        // Track the role of the last *chunk* row so we can append to it
+        // instead of emitting a new row for the next token.
+        enum LastChunkKind { case agent, user, thought }
+        var lastChunk: LastChunkKind? = nil
+
+        for event in events {
+            switch event.updateType {
+            case .agentMessageChunk:
+                let content = event.content ?? ""
+                if lastChunk == .agent, case .agentMessage(let id, let prior) = rows.last {
+                    rows[rows.count - 1] = .agentMessage(id: id, content: prior + content)
+                } else {
+                    rows.append(.agentMessage(id: event.id.uuidString, content: content))
+                    lastChunk = .agent
+                }
+            case .userMessageChunk:
+                let content = event.content ?? ""
+                if lastChunk == .user, case .userMessage(let id, let prior) = rows.last {
+                    rows[rows.count - 1] = .userMessage(id: id, content: prior + content)
+                } else {
+                    rows.append(.userMessage(id: event.id.uuidString, content: content))
+                    lastChunk = .user
+                }
+            case .agentThoughtChunk:
+                let content = event.content ?? ""
+                if lastChunk == .thought, case .thought(let id, let prior) = rows.last {
+                    rows[rows.count - 1] = .thought(id: id, content: prior + content)
+                } else {
+                    rows.append(.thought(id: event.id.uuidString, content: content))
+                    lastChunk = .thought
+                }
+            case .toolCall:
+                lastChunk = nil
+                let toolCallId = event.toolCallId ?? event.id.uuidString
+                let title = event.toolTitle ?? toolCallId
+                let row = TimelineRow.toolCall(
+                    id: event.id.uuidString,
+                    toolCallId: toolCallId,
+                    title: title,
+                    kind: event.toolKind,
+                    status: event.toolStatus
+                )
+                toolCallRowIndex[toolCallId] = rows.count
+                rows.append(row)
+            case .toolCallUpdate:
+                lastChunk = nil
+                guard let toolCallId = event.toolCallId,
+                      let rowIndex = toolCallRowIndex[toolCallId],
+                      case .toolCall(let id, _, let title, let kind, _) = rows[rowIndex]
+                else {
+                    // Update arrived without a matching parent — drop it.
+                    // The parent could have been dropped from the events
+                    // ring buffer; surfacing a standalone "update" row
+                    // would be confusing.
+                    continue
+                }
+                rows[rowIndex] = .toolCall(
+                    id: id,
+                    toolCallId: toolCallId,
+                    title: event.toolTitle ?? title,
+                    kind: event.toolKind ?? kind,
+                    status: event.toolStatus
+                )
+            case .plan:
+                lastChunk = nil
+                let items = parsePlanItems(event.content ?? "")
+                rows.append(.plan(id: event.id.uuidString, items: items))
+            case .unknown:
+                // Tolerated by design — ACP allows unknown updateType
+                // values; rather than crashing or showing a placeholder we
+                // drop them silently.
+                continue
+            }
+        }
+        return rows
+    }
+
+    /// Parses the `content` payload of a `.plan` update into checklist
+    /// items. The wire shape is intentionally loose (free-form string from
+    /// the daemon), so we accept a small handful of common formats:
+    ///
+    /// 1. JSON object/array with `items: [{ text, status }]`.
+    /// 2. JSON array of `{ text, status }` rows.
+    /// 3. Markdown-style checklist lines (`- [x] foo` / `- [ ] bar`).
+    /// 4. Plain bulleted lines (`- foo`) — treated as incomplete.
+    /// 5. Anything else falls through as a single-item plan with the raw
+    ///    text, so a malformed payload still renders something legible.
+    static func parsePlanItems(_ content: String) -> [PlanItem] {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        if let data = trimmed.data(using: .utf8),
+           let parsed = try? JSONSerialization.jsonObject(with: data) {
+            if let items = parsePlanJSON(parsed) {
+                return items
+            }
+        }
+
+        var items: [PlanItem] = []
+        for line in trimmed.components(separatedBy: .newlines) {
+            let lineTrim = line.trimmingCharacters(in: .whitespaces)
+            if lineTrim.isEmpty { continue }
+            if let item = parseChecklistLine(lineTrim) {
+                items.append(item)
+            } else {
+                items.append(PlanItem(text: lineTrim, isComplete: false))
+            }
+        }
+        return items.isEmpty ? [PlanItem(text: trimmed, isComplete: false)] : items
+    }
+
+    private static func parsePlanJSON(_ value: Any) -> [PlanItem]? {
+        if let array = value as? [Any] {
+            return array.compactMap { entry in
+                if let dict = entry as? [String: Any], let text = dict["text"] as? String {
+                    return PlanItem(text: text, isComplete: planItemIsComplete(dict["status"]))
+                }
+                if let str = entry as? String {
+                    return PlanItem(text: str, isComplete: false)
+                }
+                return nil
+            }
+        }
+        if let dict = value as? [String: Any], let items = dict["items"] {
+            return parsePlanJSON(items)
+        }
+        return nil
+    }
+
+    private static func planItemIsComplete(_ status: Any?) -> Bool {
+        guard let raw = status as? String else { return false }
+        switch raw.lowercased() {
+        case "completed", "complete", "done": return true
+        default: return false
+        }
+    }
+
+    private static func parseChecklistLine(_ line: String) -> PlanItem? {
+        let lower = line.lowercased()
+        // Order matters: check `- [x]` / `- [ ]` first because they look
+        // like a bulleted line too.
+        if lower.hasPrefix("- [x]") || lower.hasPrefix("* [x]") || lower.hasPrefix("[x]") {
+            let stripped = line.drop(while: { $0 != "]" }).dropFirst()
+            return PlanItem(
+                text: String(stripped).trimmingCharacters(in: .whitespaces),
+                isComplete: true
+            )
+        }
+        if lower.hasPrefix("- [ ]") || lower.hasPrefix("* [ ]") || lower.hasPrefix("[ ]") {
+            let stripped = line.drop(while: { $0 != "]" }).dropFirst()
+            return PlanItem(
+                text: String(stripped).trimmingCharacters(in: .whitespaces),
+                isComplete: false
+            )
+        }
+        if line.hasPrefix("- ") || line.hasPrefix("* ") {
+            return PlanItem(
+                text: String(line.dropFirst(2)).trimmingCharacters(in: .whitespaces),
+                isComplete: false
+            )
+        }
+        return nil
+    }
+}
+
+// MARK: - Scroll Offset Plumbing
+
+/// Publishes the timeline's content `minY` through a `PreferenceKey` so the
+/// parent can observe scroll direction without dropping into AppKit gesture
+/// recognizers. The value is the inner content's frame origin in the named
+/// coordinate space — negative once scrolled past the top.
+private struct ACPSessionDetailScrollOffsetKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}

--- a/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionDetailViewTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionDetailViewTests.swift
@@ -1,0 +1,328 @@
+import SwiftUI
+import XCTest
+
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Unit tests for ``ACPSessionDetailView``.
+///
+/// The view is read-only and stateless beyond auto-scroll bookkeeping, so
+/// the meaningful surface to test is the pure event-stream → timeline-row
+/// reduction (`buildRows(events:)`) plus a smoke test that proves each
+/// fixture builds a body without crashing. SwiftUI does not give us a
+/// way to assert layout output in unit tests, so we cover that contract
+/// at the row-model level — the only place errors can hide that aren't
+/// also caught by the macOS build job.
+@MainActor
+final class ACPSessionDetailViewTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeSession(
+        agentId: String = "claude-code",
+        status: ACPSessionState.Status = .running,
+        startedAtMillis: Int = 1_700_000_000_000,
+        completedAtMillis: Int? = nil,
+        parentConversationId: String? = "conv-1",
+        events: [ACPSessionUpdateMessage] = []
+    ) -> ACPSessionViewModel {
+        let state = ACPSessionState(
+            id: "sess-1",
+            agentId: agentId,
+            acpSessionId: "acp-1",
+            parentConversationId: parentConversationId,
+            status: status,
+            startedAt: startedAtMillis,
+            completedAt: completedAtMillis
+        )
+        let viewModel = ACPSessionViewModel(state: state)
+        for event in events {
+            viewModel.appendEvent(event)
+        }
+        return viewModel
+    }
+
+    private func update(
+        _ type: ACPSessionUpdateMessage.UpdateType,
+        content: String? = nil,
+        toolCallId: String? = nil,
+        toolTitle: String? = nil,
+        toolKind: String? = nil,
+        toolStatus: String? = nil
+    ) -> ACPSessionUpdateMessage {
+        ACPSessionUpdateMessage(
+            acpSessionId: "acp-1",
+            updateType: type,
+            content: content,
+            toolCallId: toolCallId,
+            toolTitle: toolTitle,
+            toolKind: toolKind,
+            toolStatus: toolStatus
+        )
+    }
+
+    // MARK: - Row reduction
+
+    func test_buildRows_concatenatesAgentMessageChunks() {
+        let rows = ACPSessionDetailView.buildRows(events: [
+            update(.agentMessageChunk, content: "Hello, "),
+            update(.agentMessageChunk, content: "world!"),
+        ])
+
+        XCTAssertEqual(rows.count, 1, "Consecutive agent chunks should fold into a single row")
+        guard case let .agentMessage(_, content) = rows[0] else {
+            return XCTFail("Expected .agentMessage row, got \(rows[0])")
+        }
+        XCTAssertEqual(content, "Hello, world!")
+    }
+
+    func test_buildRows_concatenatesUserMessageChunks() {
+        let rows = ACPSessionDetailView.buildRows(events: [
+            update(.userMessageChunk, content: "ping "),
+            update(.userMessageChunk, content: "pong"),
+        ])
+
+        XCTAssertEqual(rows.count, 1)
+        guard case let .userMessage(_, content) = rows[0] else {
+            return XCTFail("Expected .userMessage row, got \(rows[0])")
+        }
+        XCTAssertEqual(content, "ping pong")
+    }
+
+    func test_buildRows_concatenatesThoughtChunks() {
+        let rows = ACPSessionDetailView.buildRows(events: [
+            update(.agentThoughtChunk, content: "Hmm, "),
+            update(.agentThoughtChunk, content: "let me think."),
+        ])
+
+        XCTAssertEqual(rows.count, 1)
+        guard case let .thought(_, content) = rows[0] else {
+            return XCTFail("Expected .thought row, got \(rows[0])")
+        }
+        XCTAssertEqual(content, "Hmm, let me think.")
+    }
+
+    func test_buildRows_breaksChunkRunOnNonMatchingType() {
+        let rows = ACPSessionDetailView.buildRows(events: [
+            update(.agentMessageChunk, content: "Sure, "),
+            update(.toolCall, toolCallId: "t1", toolTitle: "search", toolStatus: "running"),
+            update(.agentMessageChunk, content: "found it."),
+        ])
+
+        XCTAssertEqual(rows.count, 3, "Tool call should split the agent chunk run")
+        guard case .agentMessage(_, let first) = rows[0],
+              case .toolCall = rows[1],
+              case .agentMessage(_, let second) = rows[2]
+        else {
+            return XCTFail("Unexpected row shape: \(rows)")
+        }
+        XCTAssertEqual(first, "Sure, ")
+        XCTAssertEqual(second, "found it.")
+    }
+
+    func test_buildRows_coalescesToolCallUpdatesIntoLatestStatus() {
+        let rows = ACPSessionDetailView.buildRows(events: [
+            update(.toolCall, toolCallId: "t1", toolTitle: "ripgrep", toolKind: "search", toolStatus: "pending"),
+            update(.toolCallUpdate, toolCallId: "t1", toolStatus: "running"),
+            update(.toolCallUpdate, toolCallId: "t1", toolStatus: "completed"),
+        ])
+
+        XCTAssertEqual(rows.count, 1, "Tool-call updates must fold onto the parent row")
+        guard case let .toolCall(_, toolCallId, title, kind, status) = rows[0] else {
+            return XCTFail("Expected .toolCall row, got \(rows[0])")
+        }
+        XCTAssertEqual(toolCallId, "t1")
+        XCTAssertEqual(title, "ripgrep")
+        XCTAssertEqual(kind, "search")
+        XCTAssertEqual(status, "completed", "Latest status should win")
+    }
+
+    func test_buildRows_toolCallUpdateOverridesTitleAndKindWhenProvided() {
+        let rows = ACPSessionDetailView.buildRows(events: [
+            update(.toolCall, toolCallId: "t1", toolTitle: "old title", toolKind: "old", toolStatus: "running"),
+            update(.toolCallUpdate, toolCallId: "t1", toolTitle: "new title", toolKind: "new", toolStatus: "completed"),
+        ])
+
+        guard case let .toolCall(_, _, title, kind, status) = rows[0] else {
+            return XCTFail("Expected .toolCall row")
+        }
+        XCTAssertEqual(title, "new title")
+        XCTAssertEqual(kind, "new")
+        XCTAssertEqual(status, "completed")
+    }
+
+    func test_buildRows_orphanToolCallUpdate_isDropped() {
+        let rows = ACPSessionDetailView.buildRows(events: [
+            update(.toolCallUpdate, toolCallId: "ghost", toolStatus: "running"),
+        ])
+
+        XCTAssertTrue(rows.isEmpty, "Tool-call update without a matching parent should be dropped")
+    }
+
+    func test_buildRows_unknownEventType_isDropped() {
+        let rows = ACPSessionDetailView.buildRows(events: [
+            update(.unknown, content: "no idea"),
+        ])
+
+        XCTAssertTrue(rows.isEmpty, "Unknown event types should not surface in the timeline")
+    }
+
+    func test_buildRows_planEvent_parsesMarkdownChecklist() {
+        let rows = ACPSessionDetailView.buildRows(events: [
+            update(.plan, content: """
+            - [x] First step
+            - [ ] Second step
+            - [ ] Third step
+            """),
+        ])
+
+        XCTAssertEqual(rows.count, 1)
+        guard case let .plan(_, items) = rows[0] else {
+            return XCTFail("Expected .plan row")
+        }
+        XCTAssertEqual(items.count, 3)
+        XCTAssertEqual(items[0], .init(text: "First step", isComplete: true))
+        XCTAssertEqual(items[1], .init(text: "Second step", isComplete: false))
+        XCTAssertEqual(items[2], .init(text: "Third step", isComplete: false))
+    }
+
+    func test_buildRows_planEvent_parsesJSONShape() {
+        let rows = ACPSessionDetailView.buildRows(events: [
+            update(.plan, content: """
+            {"items":[
+              {"text":"Build","status":"completed"},
+              {"text":"Test","status":"in_progress"}
+            ]}
+            """),
+        ])
+
+        guard case let .plan(_, items) = rows[0] else {
+            return XCTFail("Expected .plan row")
+        }
+        XCTAssertEqual(items.count, 2)
+        XCTAssertEqual(items[0], .init(text: "Build", isComplete: true))
+        XCTAssertEqual(items[1], .init(text: "Test", isComplete: false))
+    }
+
+    func test_buildRows_planEvent_emptyContent_yieldsEmptyItems() {
+        let rows = ACPSessionDetailView.buildRows(events: [
+            update(.plan, content: ""),
+        ])
+
+        guard case let .plan(_, items) = rows[0] else {
+            return XCTFail("Expected .plan row")
+        }
+        XCTAssertTrue(items.isEmpty)
+    }
+
+    func test_buildRows_orderingPreserved_acrossMixedEvents() {
+        let rows = ACPSessionDetailView.buildRows(events: [
+            update(.userMessageChunk, content: "search for foo"),
+            update(.agentMessageChunk, content: "Looking..."),
+            update(.toolCall, toolCallId: "t1", toolTitle: "rg", toolStatus: "running"),
+            update(.toolCallUpdate, toolCallId: "t1", toolStatus: "completed"),
+            update(.agentMessageChunk, content: " Found 3 hits."),
+            update(.plan, content: "- [x] Step\n- [ ] Next"),
+        ])
+
+        XCTAssertEqual(rows.count, 5)
+        XCTAssertTrue({
+            if case .userMessage = rows[0] { return true }; return false
+        }())
+        XCTAssertTrue({
+            if case .agentMessage(_, let c) = rows[1], c == "Looking..." { return true }; return false
+        }())
+        XCTAssertTrue({
+            if case .toolCall(_, _, _, _, let s) = rows[2], s == "completed" { return true }; return false
+        }())
+        XCTAssertTrue({
+            if case .agentMessage(_, let c) = rows[3], c == " Found 3 hits." { return true }; return false
+        }())
+        XCTAssertTrue({
+            if case .plan = rows[4] { return true }; return false
+        }())
+    }
+
+    // MARK: - Plan parsing
+
+    func test_parsePlanItems_handlesPlainBulletedList() {
+        let items = ACPSessionDetailView.parsePlanItems("- foo\n- bar")
+        XCTAssertEqual(items, [
+            .init(text: "foo", isComplete: false),
+            .init(text: "bar", isComplete: false),
+        ])
+    }
+
+    func test_parsePlanItems_handlesUnformattedFallback() {
+        let items = ACPSessionDetailView.parsePlanItems("just a single thing")
+        XCTAssertEqual(items, [.init(text: "just a single thing", isComplete: false)])
+    }
+
+    // MARK: - Elapsed formatting
+
+    func test_formatElapsed_belowOneHour_usesMinuteSecond() {
+        XCTAssertEqual(ACPSessionDetailView.formatElapsed(0), "0:00")
+        XCTAssertEqual(ACPSessionDetailView.formatElapsed(5), "0:05")
+        XCTAssertEqual(ACPSessionDetailView.formatElapsed(125), "2:05")
+        XCTAssertEqual(ACPSessionDetailView.formatElapsed(3599), "59:59")
+    }
+
+    func test_formatElapsed_oneHourOrMore_usesHourMinuteSecond() {
+        XCTAssertEqual(ACPSessionDetailView.formatElapsed(3600), "1:00:00")
+        XCTAssertEqual(ACPSessionDetailView.formatElapsed(3725), "1:02:05")
+    }
+
+    // MARK: - View body smoke tests
+
+    /// Each event-type fixture must build a body without trapping. SwiftUI
+    /// preview crashes (e.g. nil-unwrap inside a `@ViewBuilder` switch)
+    /// would otherwise only surface at runtime — these tests are the cheap
+    /// guard.
+    func test_body_buildsWithoutCrash_acrossAllEventTypes() {
+        let session = makeSession(events: [
+            update(.userMessageChunk, content: "go ahead"),
+            update(.agentMessageChunk, content: "Working on it"),
+            update(.agentThoughtChunk, content: "(thinking)"),
+            update(.toolCall, toolCallId: "t1", toolTitle: "rg", toolKind: "search", toolStatus: "running"),
+            update(.toolCallUpdate, toolCallId: "t1", toolStatus: "completed"),
+            update(.plan, content: "- [x] First\n- [ ] Second"),
+            update(.unknown, content: "ignored"),
+        ])
+
+        let view = ACPSessionDetailView(session: session)
+        _ = view.body
+    }
+
+    func test_body_buildsWithoutCrash_emptyEventStream() {
+        let session = makeSession(events: [])
+        let view = ACPSessionDetailView(session: session)
+        _ = view.body
+    }
+
+    func test_body_buildsWithoutCrash_terminalSession() {
+        let session = makeSession(
+            status: .completed,
+            startedAtMillis: 1_700_000_000_000,
+            completedAtMillis: 1_700_000_005_000,
+            events: [update(.agentMessageChunk, content: "done")]
+        )
+        let view = ACPSessionDetailView(session: session)
+        _ = view.body
+    }
+
+    func test_body_buildsWithoutCrash_noParentConversation() {
+        let session = makeSession(parentConversationId: nil, events: [])
+        let view = ACPSessionDetailView(session: session)
+        _ = view.body
+    }
+
+    func test_body_buildsWithoutCrash_withCloseHandler() {
+        let session = makeSession(events: [])
+        let view = ACPSessionDetailView(
+            session: session,
+            onSelectParentConversation: { _ in },
+            onClose: {}
+        )
+        _ = view.body
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ACPSessionDetailView` with header + scrolling timeline.
- Renders agent/user message chunks, tool calls (coalesced with updates), plan blocks; thought-chunk styling stubbed (full polish in PR 23).

Part of plan: acp-sessions-ui.md (PR 21 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
