### PR TITLE
feat(live-voice): add macOS live voice channel manager (PR 9)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
@@ -1,0 +1,353 @@
+import Foundation
+import Observation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "LiveVoiceChannelManager")
+
+protocol LiveVoiceAudioCapturing: AnyObject {
+    func start(onChunk: @escaping (LiveVoiceAudioCaptureChunk) -> Void) async -> Bool
+    func stop()
+    func shutdown()
+}
+
+extension LiveVoiceAudioCapture: LiveVoiceAudioCapturing {
+    func start(onChunk: @escaping (LiveVoiceAudioCaptureChunk) -> Void) async -> Bool {
+        await start(onChunk: onChunk, onAmplitude: nil)
+    }
+}
+
+@MainActor
+protocol LiveVoiceAudioPlaying: AnyObject {
+    var isPlaying: Bool { get }
+
+    func enqueueTTSAudio(
+        data: Data,
+        mimeType: String,
+        sampleRate: Int,
+        channels: Int,
+        sequence: Int?
+    )
+    func handleInterrupt()
+    func handleEnd()
+    func handleSessionError()
+    func resetForNextResponse()
+}
+
+extension LiveVoiceAudioPlayer: LiveVoiceAudioPlaying {}
+
+@MainActor
+@Observable
+final class LiveVoiceChannelManager {
+    enum State: Equatable {
+        case idle
+        case connecting
+        case listening
+        case transcribing
+        case thinking
+        case speaking
+        case ending
+        case failed
+    }
+
+    private(set) var state: State = .idle
+    private(set) var activeConversationId: String?
+    private(set) var sessionId: String?
+    private(set) var partialTranscript: String = ""
+    private(set) var finalTranscript: String = ""
+    private(set) var assistantTranscript: String = ""
+    private(set) var errorMessage: String = ""
+
+    var isActive: Bool {
+        switch state {
+        case .idle, .failed:
+            return false
+        case .connecting, .listening, .transcribing, .thinking, .speaking, .ending:
+            return true
+        }
+    }
+
+    @ObservationIgnored private let clientFactory: @MainActor () -> any LiveVoiceChannelClientProtocol
+    @ObservationIgnored private let capture: any LiveVoiceAudioCapturing
+    @ObservationIgnored private let playback: any LiveVoiceAudioPlaying
+    @ObservationIgnored private let bargeInAmplitudeThreshold: Float
+
+    @ObservationIgnored private var client: (any LiveVoiceChannelClientProtocol)?
+    @ObservationIgnored private var captureStartTask: Task<Void, Never>?
+    @ObservationIgnored private var sessionGeneration: UInt64 = 0
+    @ObservationIgnored private var captureRunning = false
+    @ObservationIgnored private var captureStartInFlight = false
+    @ObservationIgnored private var responseAudioStarted = false
+    @ObservationIgnored private var interruptSentForCurrentResponse = false
+
+    init(
+        clientFactory: @escaping @MainActor () -> any LiveVoiceChannelClientProtocol = { LiveVoiceChannelClient() },
+        capture: any LiveVoiceAudioCapturing = LiveVoiceAudioCapture(),
+        playback: (any LiveVoiceAudioPlaying)? = nil,
+        bargeInAmplitudeThreshold: Float = 0.05
+    ) {
+        self.clientFactory = clientFactory
+        self.capture = capture
+        self.playback = playback ?? LiveVoiceAudioPlayer()
+        self.bargeInAmplitudeThreshold = bargeInAmplitudeThreshold
+    }
+
+    func start(conversationId: String) async {
+        let trimmedConversationId = conversationId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedConversationId.isEmpty else {
+            failWithoutActiveClient(message: "A conversation is required to start live voice.")
+            return
+        }
+        guard state == .idle || state == .failed else { return }
+
+        sessionGeneration &+= 1
+        let generation = sessionGeneration
+        let newClient = clientFactory()
+
+        resetObservedSessionState(conversationId: trimmedConversationId)
+        client = newClient
+        state = .connecting
+
+        await newClient.start(
+            conversationId: trimmedConversationId,
+            audioFormat: .pcm16kMono,
+            onEvent: { [weak self] event in
+                self?.handle(event, generation: generation)
+            },
+            onFailure: { [weak self] failure in
+                self?.handle(failure, generation: generation)
+            }
+        )
+    }
+
+    func stopListening() async {
+        guard state != .idle, state != .failed, state != .ending else { return }
+        guard captureRunning || captureStartInFlight else { return }
+
+        stopCapture()
+        await client?.releasePushToTalk()
+
+        if state == .listening {
+            state = .transcribing
+        }
+    }
+
+    func end() async {
+        guard state != .idle, state != .failed, state != .ending else { return }
+
+        state = .ending
+        sessionGeneration &+= 1
+        let clientToEnd = client
+
+        stopCapture()
+        playback.handleEnd()
+        resetIgnoredSessionState()
+
+        await clientToEnd?.end()
+
+        resetObservedSessionState(conversationId: nil)
+        state = .idle
+    }
+
+    private func resetObservedSessionState(conversationId: String?) {
+        activeConversationId = conversationId
+        sessionId = nil
+        partialTranscript = ""
+        finalTranscript = ""
+        assistantTranscript = ""
+        errorMessage = ""
+    }
+
+    private func resetIgnoredSessionState() {
+        client = nil
+        responseAudioStarted = false
+        interruptSentForCurrentResponse = false
+    }
+
+    private func handle(_ event: LiveVoiceChannelEvent, generation: UInt64) {
+        guard generation == sessionGeneration else { return }
+
+        switch event {
+        case .ready(let sessionId, let conversationId):
+            guard state == .connecting else { return }
+            self.sessionId = sessionId
+            activeConversationId = conversationId
+            startCapture(generation: generation)
+
+        case .sttPartial(let text, _):
+            update(&partialTranscript, to: text)
+            if state == .listening || state == .transcribing {
+                state = .transcribing
+            }
+
+        case .sttFinal(let text, _):
+            update(&finalTranscript, to: text)
+            update(&partialTranscript, to: "")
+            if state != .ending {
+                state = .thinking
+            }
+
+        case .thinking:
+            prepareForAssistantResponse()
+            if state != .ending {
+                state = .thinking
+            }
+
+        case .assistantTextDelta(let text, _):
+            guard !text.isEmpty else { return }
+            assistantTranscript += text
+            if state == .listening || state == .transcribing {
+                state = .thinking
+            }
+
+        case .ttsAudio(let data, let mimeType, let sampleRate, let seq):
+            beginAssistantAudioIfNeeded()
+            playback.enqueueTTSAudio(
+                data: data,
+                mimeType: mimeType,
+                sampleRate: sampleRate,
+                channels: 1,
+                sequence: seq
+            )
+            state = .speaking
+
+        case .ttsDone:
+            responseAudioStarted = false
+            if state == .speaking || state == .thinking {
+                state = captureRunning ? .listening : .idle
+            }
+
+        case .metrics, .archived:
+            break
+        }
+    }
+
+    private func handle(_ failure: LiveVoiceChannelFailure, generation: UInt64) {
+        guard generation == sessionGeneration else { return }
+
+        log.warning("Live voice session failed: \(failure.localizedDescription, privacy: .public)")
+        sessionGeneration &+= 1
+        stopCapture()
+        playback.handleSessionError()
+
+        let failedClient = client
+        resetIgnoredSessionState()
+
+        errorMessage = failure.errorDescription ?? failure.localizedDescription
+        state = .failed
+
+        Task {
+            await failedClient?.close()
+        }
+    }
+
+    private func failWithoutActiveClient(message: String) {
+        resetObservedSessionState(conversationId: nil)
+        stopCapture()
+        playback.handleSessionError()
+        resetIgnoredSessionState()
+        errorMessage = message
+        state = .failed
+    }
+
+    private func startCapture(generation: UInt64) {
+        captureStartTask?.cancel()
+        captureStartTask = Task { @MainActor [weak self] in
+            guard let self, generation == self.sessionGeneration else { return }
+
+            self.captureStartInFlight = true
+            let started = await self.capture.start { [weak self] chunk in
+                Task { @MainActor [weak self] in
+                    self?.handleCapturedAudioChunk(chunk, generation: generation)
+                }
+            }
+            self.captureStartInFlight = false
+            self.captureStartTask = nil
+
+            guard generation == self.sessionGeneration, !Task.isCancelled else {
+                if started {
+                    self.capture.stop()
+                }
+                return
+            }
+
+            guard started else {
+                self.handle(
+                    .protocolError(code: "capture_failed", message: "Microphone capture could not start."),
+                    generation: generation
+                )
+                return
+            }
+
+            self.captureRunning = true
+            if self.state == .connecting {
+                self.state = .listening
+            }
+        }
+    }
+
+    private func handleCapturedAudioChunk(_ chunk: LiveVoiceAudioCaptureChunk, generation: UInt64) {
+        guard generation == sessionGeneration, captureRunning else { return }
+
+        let audioData = chunk.pcm16LittleEndian
+        if !audioData.isEmpty, let client {
+            Task {
+                await client.sendAudio(audioData)
+            }
+        }
+
+        guard chunk.amplitude >= bargeInAmplitudeThreshold else { return }
+        interruptIfAssistantAudioIsPlaying(generation: generation)
+    }
+
+    private func interruptIfAssistantAudioIsPlaying(generation: UInt64) {
+        guard generation == sessionGeneration else { return }
+        guard playback.isPlaying, !interruptSentForCurrentResponse else { return }
+
+        interruptSentForCurrentResponse = true
+        playback.handleInterrupt()
+        if state == .speaking {
+            state = captureRunning ? .listening : .idle
+        }
+
+        let interruptedClient = client
+        Task {
+            await interruptedClient?.interrupt()
+        }
+    }
+
+    private func prepareForAssistantResponse() {
+        responseAudioStarted = false
+        interruptSentForCurrentResponse = false
+        update(&assistantTranscript, to: "")
+    }
+
+    private func beginAssistantAudioIfNeeded() {
+        guard !responseAudioStarted else { return }
+
+        responseAudioStarted = true
+        interruptSentForCurrentResponse = false
+        playback.resetForNextResponse()
+    }
+
+    private func stopCapture() {
+        captureStartTask?.cancel()
+        captureStartTask = nil
+
+        if captureRunning || captureStartInFlight {
+            capture.stop()
+        }
+        captureRunning = false
+        captureStartInFlight = false
+    }
+
+    private func update<T: Equatable>(_ value: inout T, to newValue: T) {
+        guard value != newValue else { return }
+        value = newValue
+    }
+
+    deinit {
+        captureStartTask?.cancel()
+        capture.shutdown()
+    }
+}

--- a/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
@@ -1,0 +1,344 @@
+import Foundation
+import Observation
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+private final class FakeLiveVoiceChannelClient: LiveVoiceChannelClientProtocol, @unchecked Sendable {
+    private(set) var startCalls: [(conversationId: String?, audioFormat: LiveVoiceChannelAudioFormat)] = []
+    private(set) var audioFrames: [Data] = []
+    private(set) var releasePushToTalkCallCount = 0
+    private(set) var interruptCallCount = 0
+    private(set) var endCallCount = 0
+    private(set) var closeCallCount = 0
+
+    private var onEvent: (@MainActor (LiveVoiceChannelEvent) -> Void)?
+    private var onFailure: (@MainActor (LiveVoiceChannelFailure) -> Void)?
+
+    func start(
+        conversationId: String?,
+        audioFormat: LiveVoiceChannelAudioFormat,
+        onEvent: @escaping @MainActor (LiveVoiceChannelEvent) -> Void,
+        onFailure: @escaping @MainActor (LiveVoiceChannelFailure) -> Void
+    ) async {
+        startCalls.append((conversationId, audioFormat))
+        self.onEvent = onEvent
+        self.onFailure = onFailure
+    }
+
+    func sendAudio(_ data: Data) async {
+        audioFrames.append(data)
+    }
+
+    func releasePushToTalk() async {
+        releasePushToTalkCallCount += 1
+    }
+
+    func interrupt() async {
+        interruptCallCount += 1
+    }
+
+    func end() async {
+        endCallCount += 1
+    }
+
+    func close() async {
+        closeCallCount += 1
+    }
+
+    func emit(_ event: LiveVoiceChannelEvent) {
+        onEvent?(event)
+    }
+
+    func fail(_ failure: LiveVoiceChannelFailure) {
+        onFailure?(failure)
+    }
+}
+
+private final class FakeLiveVoiceAudioCapture: LiveVoiceAudioCapturing {
+    var startResult = true
+    private(set) var startCallCount = 0
+    private(set) var stopCallCount = 0
+    private(set) var shutdownCallCount = 0
+
+    private var onChunk: ((LiveVoiceAudioCaptureChunk) -> Void)?
+
+    func start(onChunk: @escaping (LiveVoiceAudioCaptureChunk) -> Void) async -> Bool {
+        startCallCount += 1
+        self.onChunk = onChunk
+        return startResult
+    }
+
+    func stop() {
+        stopCallCount += 1
+        onChunk = nil
+    }
+
+    func shutdown() {
+        shutdownCallCount += 1
+        onChunk = nil
+    }
+
+    func emitChunk(
+        data: Data = Data([1, 2, 3, 4]),
+        sampleRate: Int = 16_000,
+        channelCount: Int = 1,
+        frameCount: Int = 2,
+        amplitude: Float = 0.01
+    ) {
+        onChunk?(
+            LiveVoiceAudioCaptureChunk(
+                pcm16LittleEndian: data,
+                sampleRate: sampleRate,
+                channelCount: channelCount,
+                frameCount: frameCount,
+                amplitude: amplitude
+            )
+        )
+    }
+}
+
+@MainActor
+private final class FakeLiveVoiceAudioPlayback: LiveVoiceAudioPlaying {
+    private(set) var enqueuedChunks: [LiveVoiceAudioChunk] = []
+    private(set) var interruptCallCount = 0
+    private(set) var endCallCount = 0
+    private(set) var sessionErrorCallCount = 0
+    private(set) var resetCallCount = 0
+
+    var isPlaying = false
+
+    func enqueueTTSAudio(
+        data: Data,
+        mimeType: String,
+        sampleRate: Int,
+        channels: Int,
+        sequence: Int?
+    ) {
+        enqueuedChunks.append(
+            LiveVoiceAudioChunk(
+                data: data,
+                mimeType: mimeType,
+                sampleRate: sampleRate,
+                channels: channels,
+                sequence: sequence
+            )
+        )
+        isPlaying = true
+    }
+
+    func handleInterrupt() {
+        interruptCallCount += 1
+        isPlaying = false
+    }
+
+    func handleEnd() {
+        endCallCount += 1
+        isPlaying = false
+    }
+
+    func handleSessionError() {
+        sessionErrorCallCount += 1
+        isPlaying = false
+    }
+
+    func resetForNextResponse() {
+        resetCallCount += 1
+        enqueuedChunks.removeAll()
+        isPlaying = false
+    }
+}
+
+@MainActor
+final class LiveVoiceChannelManagerTests: XCTestCase {
+    private var client: FakeLiveVoiceChannelClient!
+    private var capture: FakeLiveVoiceAudioCapture!
+    private var playback: FakeLiveVoiceAudioPlayback!
+    private var manager: LiveVoiceChannelManager!
+
+    override func setUp() {
+        super.setUp()
+        client = FakeLiveVoiceChannelClient()
+        capture = FakeLiveVoiceAudioCapture()
+        playback = FakeLiveVoiceAudioPlayback()
+        manager = LiveVoiceChannelManager(
+            clientFactory: { [client] in client! },
+            capture: capture,
+            playback: playback,
+            bargeInAmplitudeThreshold: 0.2
+        )
+    }
+
+    override func tearDown() {
+        manager = nil
+        playback = nil
+        capture = nil
+        client = nil
+        super.tearDown()
+    }
+
+    func testStartOpensClientAndStartsCaptureAfterReady() async {
+        await manager.start(conversationId: " conv-123 ")
+
+        XCTAssertEqual(manager.state, .connecting)
+        XCTAssertEqual(manager.activeConversationId, "conv-123")
+        XCTAssertEqual(client.startCalls.count, 1)
+        XCTAssertEqual(client.startCalls[0].conversationId, "conv-123")
+        XCTAssertEqual(client.startCalls[0].audioFormat, .pcm16kMono)
+        XCTAssertEqual(capture.startCallCount, 0)
+
+        client.emit(.ready(sessionId: "session-123", conversationId: "conv-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(manager.sessionId, "session-123")
+        XCTAssertEqual(capture.startCallCount, 1)
+    }
+
+    func testAudioChunksStreamWithoutMutatingObservedState() async {
+        await startReadySession()
+
+        let observedInvalidations = ObservationCounter()
+        withObservationTracking {
+            _ = manager.state
+            _ = manager.partialTranscript
+            _ = manager.finalTranscript
+            _ = manager.assistantTranscript
+        } onChange: {
+            Task { @MainActor in observedInvalidations.increment() }
+        }
+
+        capture.emitChunk(data: Data([1, 2]), amplitude: 0.01)
+        capture.emitChunk(data: Data([3, 4]), amplitude: 0.01)
+        capture.emitChunk(data: Data([5, 6]), amplitude: 0.01)
+        await flushAsyncTasks()
+
+        XCTAssertEqual(client.audioFrames, [Data([1, 2]), Data([3, 4]), Data([5, 6])])
+        XCTAssertEqual(observedInvalidations.value, 0)
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testStopListeningSendsPushToTalkRelease() async {
+        await startReadySession()
+
+        await manager.stopListening()
+
+        XCTAssertEqual(capture.stopCallCount, 1)
+        XCTAssertEqual(client.releasePushToTalkCallCount, 1)
+        XCTAssertEqual(manager.state, .transcribing)
+    }
+
+    func testSttEventsUpdateTranscriptState() async {
+        await startReadySession()
+
+        client.emit(.sttPartial(text: "hel", seq: 1))
+        XCTAssertEqual(manager.state, .transcribing)
+        XCTAssertEqual(manager.partialTranscript, "hel")
+        XCTAssertEqual(manager.finalTranscript, "")
+
+        client.emit(.sttFinal(text: "hello", seq: 2))
+        XCTAssertEqual(manager.state, .thinking)
+        XCTAssertEqual(manager.partialTranscript, "")
+        XCTAssertEqual(manager.finalTranscript, "hello")
+    }
+
+    func testAssistantSpeechStreamsToPlaybackAndReturnsToListening() async {
+        await startReadySession()
+
+        client.emit(.thinking(turnId: "turn-123"))
+        client.emit(.assistantTextDelta(text: "Hi", seq: 3))
+        client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertEqual(manager.assistantTranscript, "Hi")
+        XCTAssertEqual(playback.resetCallCount, 1)
+        XCTAssertEqual(playback.enqueuedChunks.count, 1)
+        XCTAssertEqual(playback.enqueuedChunks[0].data, Data([9, 8]))
+        XCTAssertEqual(playback.enqueuedChunks[0].mimeType, "audio/pcm")
+        XCTAssertEqual(playback.enqueuedChunks[0].sampleRate, 16_000)
+        XCTAssertEqual(playback.enqueuedChunks[0].sequence, 4)
+
+        client.emit(.ttsDone(turnId: "turn-123"))
+
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testSpeakingOverAssistantAudioSendsInterruptOnce() async {
+        await startReadySession()
+
+        client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertTrue(playback.isPlaying)
+
+        capture.emitChunk(data: Data([1, 2]), amplitude: 0.5)
+        capture.emitChunk(data: Data([3, 4]), amplitude: 0.7)
+        await flushAsyncTasks()
+
+        XCTAssertEqual(playback.interruptCallCount, 1)
+        XCTAssertEqual(client.interruptCallCount, 1)
+        XCTAssertEqual(client.audioFrames, [Data([1, 2]), Data([3, 4])])
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testEndCleansUpResourcesAndReturnsToIdle() async {
+        await startReadySession()
+        client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+
+        await manager.end()
+
+        XCTAssertEqual(client.endCallCount, 1)
+        XCTAssertEqual(capture.stopCallCount, 1)
+        XCTAssertEqual(playback.endCallCount, 1)
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertNil(manager.activeConversationId)
+        XCTAssertNil(manager.sessionId)
+    }
+
+    func testFailureCleansUpResourcesAndStoresError() async {
+        await startReadySession()
+
+        client.fail(.connectionFailed(message: "connection dropped"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .failed)
+        XCTAssertEqual(manager.errorMessage, "connection dropped")
+        XCTAssertEqual(capture.stopCallCount, 1)
+        XCTAssertEqual(playback.sessionErrorCallCount, 1)
+        XCTAssertEqual(client.closeCallCount, 1)
+    }
+
+    func testCaptureStartFailureFailsSession() async {
+        capture.startResult = false
+
+        await manager.start(conversationId: "conv-123")
+        client.emit(.ready(sessionId: "session-123", conversationId: "conv-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .failed)
+        XCTAssertEqual(manager.errorMessage, "Microphone capture could not start.")
+        XCTAssertEqual(playback.sessionErrorCallCount, 1)
+        XCTAssertEqual(client.closeCallCount, 1)
+    }
+
+    private func startReadySession() async {
+        await manager.start(conversationId: "conv-123")
+        client.emit(.ready(sessionId: "session-123", conversationId: "conv-123"))
+        await flushAsyncTasks()
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    private func flushAsyncTasks() async {
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 1_000_000)
+    }
+}
+
+@MainActor
+private final class ObservationCounter {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
+}


### PR DESCRIPTION
## PR 9: add macOS live voice channel manager

### Depends on

PR 6, PR 7, PR 8.

### Branch

`live-voice-channel/pr-09-macos-live-manager`

### Files

- `clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift`
- `clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift`

### Scope

Add an `@Observable @MainActor` manager that coordinates the Swift WebSocket client, capture adapter, and playback adapter. It should keep the state model separate from existing `VoiceModeManager` until the next PR.

States:

- `idle`
- `connecting`
- `listening`
- `transcribing`
- `thinking`
- `speaking`
- `ending`
- `failed`

Responsibilities:

- open a live voice session for a selected conversation id
- start capture after server `ready`
- stream audio chunks to the client
- send `ptt_release` when capture stops
- update partial/final transcript text from STT events
- stream TTS audio into playback
- send `interrupt` when the user speaks while assistant audio is playing
- clean up all resources on `end` or failure

### Acceptance Criteria

- State transitions are covered with fake client/capture/playback dependencies.
- No SwiftUI view invalidates on every audio chunk; high-frequency audio remains outside observed properties.
- Existing turn-based `VoiceModeManager` tests still pass.

### Verification

Run:

```bash
cd clients
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter LiveVoiceChannelManagerTests
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter VoiceModeManagerTests
```

Orchestrated by velissa-ai via run-plan; implemented by Codex.

Apple refs checked (2026-04-25): https://developer.apple.com/documentation/swiftui/managing-model-data-in-your-app, https://developer.apple.com/documentation/Observation/Observable%28%29
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
