### PR TITLE
feat(macos): ACPSessionsPanel pushes detail view on row tap

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
@@ -12,26 +12,40 @@ import VellumAssistantShared
 /// shape, same panel chrome — so the two coding-agent surfaces feel like a
 /// single family. Each row is intentionally information-dense (badge +
 /// status pill + elapsed + parent conversation) so the panel can act as a
-/// glance dashboard before the list-to-detail nav lands in PR 22.
+/// glance dashboard.
+///
+/// List → detail navigation uses `NavigationStack`: tapping a row pushes
+/// ``ACPSessionDetailView`` with the live ``ACPSessionViewModel`` (not a
+/// snapshot) so streaming updates flow into the open detail view without
+/// the parent having to reach back into the store on every tick.
 struct ACPSessionsPanel: View {
     @Bindable var store: ACPSessionStore
     var onClose: (() -> Void)?
 
     var body: some View {
-        VSidePanel(
-            title: "Coding Agents",
-            titleFont: VFont.titleSmall,
-            onClose: onClose,
-            pinnedContent: { headerBar }
-        ) {
-            if store.sessionOrder.isEmpty {
-                VEmptyState(
-                    title: "No coding agents yet",
-                    subtitle: "Ask the assistant to spawn Claude or Codex.",
-                    icon: "terminal"
-                )
-            } else {
-                sessionList
+        NavigationStack {
+            VSidePanel(
+                title: "Coding Agents",
+                titleFont: VFont.titleSmall,
+                onClose: onClose,
+                pinnedContent: { headerBar }
+            ) {
+                if store.sessionOrder.isEmpty {
+                    VEmptyState(
+                        title: "No coding agents yet",
+                        subtitle: "Ask the assistant to spawn Claude or Codex.",
+                        icon: "terminal"
+                    )
+                } else {
+                    sessionList
+                }
+            }
+            .navigationDestination(for: ACPSessionViewModel.self) { viewModel in
+                // Pass the live view model — `ACPSessionViewModel` is
+                // `@Observable`, so SwiftUI re-renders the detail view as
+                // its `state` / `events` mutate via SSE without forcing a
+                // pop-and-push cycle.
+                ACPSessionDetailView(session: viewModel)
             }
         }
         .onAppear {
@@ -83,7 +97,15 @@ struct ACPSessionsPanel: View {
         VStack(alignment: .leading, spacing: 0) {
             ForEach(store.sessionOrder, id: \.self) { sessionId in
                 if let viewModel = store.sessions[sessionId] {
-                    ACPSessionsPanelRow(state: viewModel.state)
+                    // `NavigationLink(value:)` defers detail construction
+                    // to the parent's `navigationDestination`, so passing
+                    // the live `ACPSessionViewModel` does not capture a
+                    // stale snapshot — the destination reads observable
+                    // properties off the same instance the store mutates.
+                    NavigationLink(value: viewModel) {
+                        ACPSessionsPanelRow(state: viewModel.state)
+                    }
+                    .buttonStyle(.plain)
                     if sessionId != store.sessionOrder.last {
                         Divider().background(VColor.borderBase)
                     }
@@ -97,8 +119,8 @@ struct ACPSessionsPanel: View {
 
 /// Single row in the Coding Agents list. Renders an agent badge, a status
 /// pill, the elapsed time since `startedAt`, and a truncated parent
-/// conversation id. Disclosure indicator is purely visual until PR 22 wires
-/// the list-to-detail navigation.
+/// conversation id. The trailing chevron previews the list-to-detail push
+/// driven by the parent's `NavigationStack`.
 struct ACPSessionsPanelRow: View {
     let state: ACPSessionState
 

--- a/clients/shared/Network/ACPSessionStore.swift
+++ b/clients/shared/Network/ACPSessionStore.swift
@@ -13,7 +13,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ACPSe
 /// updates to one session's `events` only invalidate views that read that
 /// specific view model.
 @MainActor @Observable
-public final class ACPSessionViewModel: Identifiable {
+public final class ACPSessionViewModel: Identifiable, Hashable {
     /// Snapshot of the session as last reported by the daemon.
     public var state: ACPSessionState
     /// Stream of update messages received for this session, capped at
@@ -34,6 +34,21 @@ public final class ACPSessionViewModel: Identifiable {
         if events.count > ACPSessionStore.eventsCapPerSession {
             events.removeFirst(events.count - ACPSessionStore.eventsCapPerSession)
         }
+    }
+
+    // MARK: - Hashable
+
+    /// Identity-based equality and hashing. The store keeps exactly one
+    /// view-model instance per `acpSessionId` for its lifetime, so the
+    /// instance pointer is the right notion of "same session" for routing
+    /// (`NavigationStack` value-typed paths). Equating by `state` would
+    /// break the navigation path the moment the session's status changes.
+    public nonisolated static func == (lhs: ACPSessionViewModel, rhs: ACPSessionViewModel) -> Bool {
+        lhs === rhs
+    }
+
+    public nonisolated func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
     }
 }
 


### PR DESCRIPTION
## Summary
- Wraps `ACPSessionsPanel` in NavigationStack; rows push `ACPSessionDetailView` on tap.
- Passes live `ACPSessionViewModel` for streaming updates.

Part of plan: acp-sessions-ui.md (PR 22 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
