### PR TITLE
feat(macos): render agent thought chunks as italic secondary text

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -45,6 +45,12 @@ struct ACPSessionDetailView: View {
     /// non-terminal so terminal sessions don't wake the timer.
     @State private var nowTick: Date = Date()
 
+    /// Persisted preference for whether agent-thought bubbles render in the
+    /// timeline. Defaults to `true` so first-time users see the assistant's
+    /// reasoning surface without hunting for a toggle. Persists across
+    /// detail-view re-opens via `@AppStorage`.
+    @AppStorage("acp.showThoughts") private var showThoughts: Bool = true
+
     private static let elapsedTickInterval: TimeInterval = 1
     private static let scrollAtBottomTolerance: CGFloat = 4
 
@@ -80,9 +86,26 @@ struct ACPSessionDetailView: View {
                     parentConversationLink(id: parent, onTap: onSelectParentConversation)
                 }
                 Spacer()
+                showThoughtsToggle
             }
         }
         .padding(EdgeInsets(top: VSpacing.lg, leading: VSpacing.lg, bottom: VSpacing.md, trailing: VSpacing.lg))
+    }
+
+    /// Header-strip toggle that hides agent-thought bubbles from the
+    /// timeline. The lightbulb icon doubles as a glance-affordance so the
+    /// row reads as "thoughts on/off" without a separate help string.
+    /// Accessibility is delegated to `VToggle`, which already publishes
+    /// the on/off value and a tap trait — wrapping it again would produce
+    /// duplicate VoiceOver announcements.
+    @ViewBuilder
+    private var showThoughtsToggle: some View {
+        HStack(spacing: VSpacing.xs) {
+            VIconView(.lightbulb, size: 12)
+                .foregroundStyle(VColor.contentSecondary)
+                .accessibilityHidden(true)
+            VToggle(isOn: $showThoughts, label: "Show thoughts")
+        }
     }
 
     @ViewBuilder
@@ -175,7 +198,11 @@ struct ACPSessionDetailView: View {
 
     @ViewBuilder
     private var timeline: some View {
-        let rows = Self.buildRows(events: session.events)
+        let allRows = Self.buildRows(events: session.events)
+        let rows = showThoughts ? allRows : allRows.filter { row in
+            if case .thought = row { return false }
+            return true
+        }
         if rows.isEmpty {
             VEmptyState(
                 title: "No events yet",
@@ -401,15 +428,27 @@ struct ACPSessionDetailView: View {
 
     @ViewBuilder
     private func thoughtRow(content: String) -> some View {
-        // TODO(PR 23 — acp-sessions-ui): replace this stub with the proper
-        // collapsible "thinking" rendering. Kept minimal here so the view
-        // doesn't crash when an `agent_thought_chunk` arrives, and so the
-        // user still sees *something* until PR 23 lands.
+        // Italicised + secondary-tone bubble distinguishes the agent's
+        // internal reasoning from spoken output. The lightbulb icon doubles
+        // as an affordance — a glance tells the user "this is a thought,
+        // not a message" before they read the text.
         HStack(spacing: 0) {
-            Text(content)
-                .font(VFont.bodyMediumDefault.italic())
-                .foregroundStyle(VColor.contentTertiary)
-                .textSelection(.enabled)
+            HStack(alignment: .top, spacing: VSpacing.xs) {
+                VIconView(.lightbulb, size: 12)
+                    .foregroundStyle(Color.secondary)
+                    .padding(.top, 2)
+                Text(content)
+                    .font(VFont.bodyMediumDefault.italic())
+                    .foregroundStyle(Color.secondary)
+                    .textSelection(.enabled)
+            }
+            .padding(VSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.surfaceOverlay.opacity(0.4))
+            )
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Agent thought: \(content)")
             Spacer(minLength: 0)
         }
     }

--- a/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionDetailViewTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionDetailViewTests.swift
@@ -16,6 +16,23 @@ import XCTest
 @MainActor
 final class ACPSessionDetailViewTests: XCTestCase {
 
+    // MARK: - Setup / Teardown
+
+    /// AppStorage key for the "Show thoughts" header toggle.
+    private static let showThoughtsKey = "acp.showThoughts"
+
+    override func setUp() {
+        super.setUp()
+        // Reset the toggle to its default between cases so a leak in one
+        // test doesn't taint the next.
+        UserDefaults.standard.removeObject(forKey: Self.showThoughtsKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: Self.showThoughtsKey)
+        super.tearDown()
+    }
+
     // MARK: - Fixtures
 
     private func makeSession(
@@ -324,5 +341,97 @@ final class ACPSessionDetailViewTests: XCTestCase {
             onClose: {}
         )
         _ = view.body
+    }
+
+    // MARK: - Show-thoughts toggle
+
+    /// `buildRows` is the contract the timeline renders against. With a
+    /// mixed event stream we expect a thought row to be present, and the
+    /// test then asserts that filtering it out (the path the view takes
+    /// when `showThoughts == false`) leaves the other rows intact.
+    func test_buildRows_thoughtRowIsEmitted_andCanBeFilteredOut() {
+        let allRows = ACPSessionDetailView.buildRows(events: [
+            update(.userMessageChunk, content: "do the thing"),
+            update(.agentThoughtChunk, content: "let me think about this"),
+            update(.agentMessageChunk, content: "Sure, here goes."),
+        ])
+
+        // Sanity: a thought row exists in the unfiltered output.
+        XCTAssertEqual(allRows.count, 3)
+        XCTAssertTrue({
+            if case .thought = allRows[1] { return true }; return false
+        }())
+
+        let filtered = allRows.filter { row in
+            if case .thought = row { return false }
+            return true
+        }
+        XCTAssertEqual(filtered.count, 2, "Filtering thoughts should drop only the thought row")
+        XCTAssertTrue({
+            if case .userMessage = filtered[0] { return true }; return false
+        }())
+        XCTAssertTrue({
+            if case .agentMessage(_, let content) = filtered[1], content == "Sure, here goes." { return true }; return false
+        }())
+    }
+
+    /// When `showThoughts` is off, the body must still build cleanly with a
+    /// fixture that contains thought events. This is the cheap crash-guard
+    /// for the filtered-rendering path.
+    func test_body_buildsWithoutCrash_whenShowThoughtsIsOff() {
+        UserDefaults.standard.set(false, forKey: Self.showThoughtsKey)
+
+        let session = makeSession(events: [
+            update(.agentMessageChunk, content: "Working"),
+            update(.agentThoughtChunk, content: "(thinking)"),
+            update(.agentMessageChunk, content: " on it."),
+        ])
+        let view = ACPSessionDetailView(session: session)
+        _ = view.body
+    }
+
+    /// Round-trip the AppStorage value to confirm the toggle persists
+    /// across detail-view re-opens. Two views are constructed with the
+    /// same key, and the second instance must observe the value the first
+    /// stored.
+    func test_showThoughtsToggle_persistsAcrossViewInstances() {
+        UserDefaults.standard.set(false, forKey: Self.showThoughtsKey)
+
+        let session = makeSession(events: [update(.agentThoughtChunk, content: "hmm")])
+        // First instance — building the body forces SwiftUI to wire up the
+        // @AppStorage binding to UserDefaults.
+        _ = ACPSessionDetailView(session: session).body
+        // Second instance — must read back the persisted value.
+        _ = ACPSessionDetailView(session: session).body
+
+        XCTAssertEqual(
+            UserDefaults.standard.bool(forKey: Self.showThoughtsKey),
+            false,
+            "AppStorage value should persist across view re-instantiations"
+        )
+
+        // Flip and confirm the new value persists too.
+        UserDefaults.standard.set(true, forKey: Self.showThoughtsKey)
+        _ = ACPSessionDetailView(session: session).body
+        XCTAssertEqual(
+            UserDefaults.standard.bool(forKey: Self.showThoughtsKey),
+            true
+        )
+    }
+
+    /// Default value for the toggle is `true` — `@AppStorage` does *not*
+    /// write its default into the underlying store until the user mutates
+    /// the binding, so building the view with a missing key must leave the
+    /// store untouched. This guards against accidentally swapping the
+    /// declared default to `false` (which would be a behaviour change for
+    /// every existing user).
+    func test_showThoughtsToggle_defaultDoesNotPersistUntilToggled() {
+        UserDefaults.standard.removeObject(forKey: Self.showThoughtsKey)
+        let session = makeSession(events: [update(.agentThoughtChunk, content: "hi")])
+        _ = ACPSessionDetailView(session: session).body
+        XCTAssertNil(
+            UserDefaults.standard.object(forKey: Self.showThoughtsKey),
+            "@AppStorage default value should not be written to the store at view build time"
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Replaces PR 21 stub with italic + secondary-color thought bubbles.
- Adds 'Show thoughts' header toggle (`@AppStorage("acp.showThoughts")`, default on).

Part of plan: acp-sessions-ui.md (PR 23 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
