### PR TITLE
feat(macos): Clear completed history button in ACPSessionsPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
@@ -17,6 +17,11 @@ struct ACPSessionsPanel: View {
     @Bindable var store: ACPSessionStore
     var onClose: (() -> Void)?
 
+    /// Drives the destructive-confirmation alert for the overflow menu's
+    /// "Clear completed history" action. Hoisted to view state so the menu
+    /// itself can dismiss while the alert remains presented.
+    @State private var showClearCompletedConfirm: Bool = false
+
     var body: some View {
         VSidePanel(
             title: "Coding Agents",
@@ -39,9 +44,17 @@ struct ACPSessionsPanel: View {
                 Task { await store.seed() }
             }
         }
+        .alert("Clear completed history?", isPresented: $showClearCompletedConfirm) {
+            Button("Cancel", role: .cancel) {}
+            Button("Clear", role: .destructive) {
+                Task { await store.clearCompleted() }
+            }
+        } message: {
+            Text("This removes every completed, failed, and cancelled coding agent from the list. Active agents stay.")
+        }
     }
 
-    // MARK: - Header bar (count + refresh)
+    // MARK: - Header bar (count + refresh + overflow menu)
 
     @ViewBuilder
     private var headerBar: some View {
@@ -58,11 +71,40 @@ struct ACPSessionsPanel: View {
                 action: { Task { await store.seed() } }
             )
             .accessibilityLabel("Refresh coding agents")
+            overflowMenu
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.sm)
 
         Divider().background(VColor.borderBase)
+    }
+
+    /// Header overflow ("…") menu. Currently only houses the destructive
+    /// "Clear completed history" action; future bulk actions (e.g.
+    /// "Cancel all running") slot into the same menu.
+    @ViewBuilder
+    private var overflowMenu: some View {
+        Menu {
+            Button("Clear completed history", role: .destructive) {
+                showClearCompletedConfirm = true
+            }
+            .disabled(!hasTerminalSessions)
+        } label: {
+            VIconView(.ellipsis, size: 14)
+                .foregroundStyle(VColor.contentTertiary)
+                .frame(width: 24, height: 24)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .accessibilityLabel("More coding agent actions")
+    }
+
+    /// Whether any session in the store is in a terminal state. Drives the
+    /// disabled state of "Clear completed history" so the action only lights
+    /// up when there is actually something to clear.
+    private var hasTerminalSessions: Bool {
+        store.sessions.values.contains { ACPSessionStore.isTerminal($0.state.status) }
     }
 
     private var countLabel: String {

--- a/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
@@ -3,6 +3,33 @@ import XCTest
 @testable import VellumAssistantLib
 @testable import VellumAssistantShared
 
+/// Stand-in `URLProtocol` for the ACP panel tests that exercise
+/// ``ACPSessionStore/clearCompleted``. Only the clear-completed test path
+/// installs a handler — the pure-function tests above never hit the network.
+private final class MockACPSessionsPanelURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            XCTFail("requestHandler not set")
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
 /// Logic-only assertions for ``ACPSessionsPanel``. Pixel-level rendering is
 /// out of scope; we cover the panel's visible-state contract: empty vs
 /// populated, count label, agent/status label mapping, parent-conversation
@@ -10,6 +37,28 @@ import XCTest
 /// non-trivial logic).
 @MainActor
 final class ACPSessionsPanelTests: XCTestCase {
+    private let assistantId = "assistant-acp-panel-test"
+    private let gatewayPort = 7833
+    private var originalPrimaryLockfileData: Data?
+    private var primaryLockfileExisted = false
+    private var lockfileInstalled = false
+
+    override func tearDownWithError() throws {
+        if lockfileInstalled {
+            URLProtocol.unregisterClass(MockACPSessionsPanelURLProtocol.self)
+            MockACPSessionsPanelURLProtocol.requestHandler = nil
+
+            if primaryLockfileExisted {
+                try originalPrimaryLockfileData?.write(to: LockfilePaths.primary, options: .atomic)
+            } else {
+                try? FileManager.default.removeItem(at: LockfilePaths.primary)
+            }
+            lockfileInstalled = false
+            originalPrimaryLockfileData = nil
+            primaryLockfileExisted = false
+        }
+        try super.tearDownWithError()
+    }
 
     // MARK: - Empty state vs populated
 
@@ -105,6 +154,92 @@ final class ACPSessionsPanelTests: XCTestCase {
         XCTAssertFalse(label.isEmpty)
     }
 
+    // MARK: - Terminal-status classification
+
+    func test_isTerminal_recognisesCompletedFailedAndCancelled() {
+        XCTAssertTrue(ACPSessionStore.isTerminal(.completed))
+        XCTAssertTrue(ACPSessionStore.isTerminal(.failed))
+        XCTAssertTrue(ACPSessionStore.isTerminal(.cancelled))
+    }
+
+    func test_isTerminal_treatsActiveAndUnknownAsLive() {
+        // `.unknown` is intentionally non-terminal — version-skew fallbacks
+        // must not silently drop sessions whose real status we can't read.
+        XCTAssertFalse(ACPSessionStore.isTerminal(.initializing))
+        XCTAssertFalse(ACPSessionStore.isTerminal(.running))
+        XCTAssertFalse(ACPSessionStore.isTerminal(.unknown))
+    }
+
+    // MARK: - clearCompleted
+
+    /// Mixed-state store + successful HTTP response: terminal sessions are
+    /// optimistically pruned from both ``sessions`` and ``sessionOrder``,
+    /// while running/initializing rows survive untouched.
+    func test_clearCompleted_removesTerminalSessionsAndKeepsRunningOnes() async throws {
+        try installLockfileFixture()
+
+        let store = ACPSessionStore()
+        injectFixture(into: store, acpSessionId: "acp-running", agentId: "claude-code", startedAt: 100, status: .running)
+        injectFixture(into: store, acpSessionId: "acp-completed", agentId: "codex", startedAt: 200, status: .completed)
+        injectFixture(into: store, acpSessionId: "acp-failed", agentId: "claude-code", startedAt: 300, status: .failed)
+        injectFixture(into: store, acpSessionId: "acp-cancelled", agentId: "codex", startedAt: 400, status: .cancelled)
+        injectFixture(into: store, acpSessionId: "acp-init", agentId: "claude-code", startedAt: 500, status: .initializing)
+
+        let requestExpectation = expectation(description: "clear completed request")
+        MockACPSessionsPanelURLProtocol.requestHandler = { request in
+            requestExpectation.fulfill()
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"deleted":3}"#.utf8))
+        }
+
+        let result = await store.clearCompleted()
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        guard case .success(let count) = result else {
+            return XCTFail("Expected success, got \(result)")
+        }
+        XCTAssertEqual(count, 3)
+        XCTAssertEqual(Set(store.sessions.keys), ["acp-running", "acp-init"])
+        XCTAssertEqual(Set(store.sessionOrder), ["acp-running", "acp-init"])
+        XCTAssertNil(store.sessions["acp-completed"])
+        XCTAssertNil(store.sessions["acp-failed"])
+        XCTAssertNil(store.sessions["acp-cancelled"])
+    }
+
+    /// Failed HTTP call must not touch local state — terminal rows stay
+    /// visible so the user can retry without losing their place.
+    func test_clearCompleted_leavesStoreUntouchedOnFailure() async throws {
+        try installLockfileFixture()
+
+        let store = ACPSessionStore()
+        injectFixture(into: store, acpSessionId: "acp-running", agentId: "claude-code", startedAt: 100, status: .running)
+        injectFixture(into: store, acpSessionId: "acp-completed", agentId: "codex", startedAt: 200, status: .completed)
+
+        MockACPSessionsPanelURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"error":{"message":"boom"}}"#.utf8))
+        }
+
+        let result = await store.clearCompleted()
+
+        guard case .failure = result else {
+            return XCTFail("Expected failure, got \(result)")
+        }
+        XCTAssertEqual(Set(store.sessions.keys), ["acp-running", "acp-completed"])
+        XCTAssertEqual(Set(store.sessionOrder), ["acp-running", "acp-completed"])
+    }
+
     // MARK: - Helpers
 
     /// Inserts a synthetic ACP session into the store via the same
@@ -117,7 +252,8 @@ final class ACPSessionsPanelTests: XCTestCase {
         into store: ACPSessionStore,
         acpSessionId: String,
         agentId: String,
-        startedAt: Int
+        startedAt: Int,
+        status: ACPSessionState.Status = .running
     ) {
         store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
             acpSessionId: acpSessionId,
@@ -133,9 +269,41 @@ final class ACPSessionsPanelTests: XCTestCase {
                 agentId: agentId,
                 acpSessionId: acpSessionId,
                 parentConversationId: "conv-\(acpSessionId)",
-                status: .running,
+                status: status,
                 startedAt: startedAt
             )
         }
+    }
+
+    /// Stand up the lockfile + URL protocol mock that ``ACPClient`` needs to
+    /// resolve the gateway base URL. Only the network-touching tests call
+    /// this — the pure-function tests above run without it. Tear-down is
+    /// handled in ``tearDownWithError``.
+    private func installLockfileFixture() throws {
+        MockACPSessionsPanelURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(MockACPSessionsPanelURLProtocol.self)
+
+        let primaryLockfileURL = LockfilePaths.primary
+        primaryLockfileExisted = FileManager.default.fileExists(atPath: primaryLockfileURL.path)
+        if primaryLockfileExisted {
+            originalPrimaryLockfileData = try Data(contentsOf: primaryLockfileURL)
+        }
+
+        let lockfile: [String: Any] = [
+            "activeAssistant": assistantId,
+            "assistants": [
+                [
+                    "assistantId": assistantId,
+                    "cloud": "local",
+                    "hatchedAt": "2026-03-19T12:00:00Z",
+                    "resources": [
+                        "gatewayPort": gatewayPort,
+                    ],
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: lockfile, options: [.sortedKeys])
+        try data.write(to: primaryLockfileURL, options: .atomic)
+        lockfileInstalled = true
     }
 }

--- a/clients/shared/Network/ACPSessionStore.swift
+++ b/clients/shared/Network/ACPSessionStore.swift
@@ -255,7 +255,38 @@ public final class ACPSessionStore {
         return await ACPClient.steerSession(id: id, instruction: instruction)
     }
 
+    /// Bulk-clear every terminal session (`completed`/`failed`/`cancelled`)
+    /// from the store. Wraps ``ACPClient/clearCompleted()`` and, on success,
+    /// optimistically prunes the matching rows from ``sessions`` and
+    /// ``sessionOrder`` so the panel updates without waiting for an SSE
+    /// round-trip. Active sessions (`running`/`initializing`/`unknown`) are
+    /// preserved verbatim — the daemon ignores them server-side too.
+    @discardableResult
+    public func clearCompleted() async -> Result<Int, ACPClientError> {
+        let result = await ACPClient.clearCompleted()
+        if case .success = result {
+            sessions = sessions.filter { _, viewModel in
+                !Self.isTerminal(viewModel.state.status)
+            }
+            sessionOrder.removeAll { sessions[$0] == nil }
+        }
+        return result
+    }
+
     // MARK: - Helpers
+
+    /// Status values that count as terminal for the "clear completed" action.
+    /// `.unknown` is intentionally excluded — when the client falls back to
+    /// `.unknown` due to daemon version skew we have no way to tell whether
+    /// the session is still live, so it stays in the list.
+    public static func isTerminal(_ status: ACPSessionState.Status) -> Bool {
+        switch status {
+        case .completed, .failed, .cancelled:
+            return true
+        case .initializing, .running, .unknown:
+            return false
+        }
+    }
 
     /// Build an `ACPSessionState` for a terminal transition (completed,
     /// cancelled, failed). Stamps `completedAt` with the current wall clock


### PR DESCRIPTION
## Summary
- Adds `ACPSessionStore.clearCompleted()`.
- Adds '…' menu in panel header with confirm-Alert-gated 'Clear completed history' item.

Part of plan: acp-sessions-ui.md (PR 27 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
