### PR TITLE
feat(macos): per-conversation filter on ACPSessionsPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -153,6 +153,7 @@ extension MainWindowView {
         case .acpSessions:
             ACPSessionsPanel(
                 store: acpSessionStore,
+                activeConversationId: conversationManager.activeConversationId?.uuidString,
                 onClose: { windowState.navigateBackOrDismiss() }
             )
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
@@ -20,12 +20,21 @@ import VellumAssistantShared
 /// the parent having to reach back into the store on every tick.
 struct ACPSessionsPanel: View {
     @Bindable var store: ACPSessionStore
+    /// Currently active conversation id used to drive the
+    /// "This conversation" / "All" filter. When `nil` the segmented control
+    /// is hidden and every session is shown — there is no conversation to
+    /// scope against.
+    var activeConversationId: String?
     var onClose: (() -> Void)?
 
     /// Drives the destructive-confirmation alert for the overflow menu's
     /// "Clear completed history" action. Hoisted to view state so the menu
     /// itself can dismiss while the alert remains presented.
     @State private var showClearCompletedConfirm: Bool = false
+
+    /// Per-conversation filter preference, persisted in `UserDefaults`
+    /// under `acp.filter.<conversationId>`.
+    @State private var filterStorage = ACPSessionsPanelFilterStorage()
 
     var body: some View {
         NavigationStack {
@@ -90,6 +99,10 @@ struct ACPSessionsPanel: View {
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.sm)
 
+        if activeConversationId != nil {
+            filterPicker
+        }
+
         Divider().background(VColor.borderBase)
     }
 
@@ -121,9 +134,54 @@ struct ACPSessionsPanel: View {
         store.sessions.values.contains { ACPSessionStore.isTerminal($0.state.status) }
     }
 
+    @ViewBuilder
+    private var filterPicker: some View {
+        Picker("Filter coding agents", selection: filterBinding) {
+            Text("This conversation").tag(ACPSessionsPanelFilter.thisConversation)
+            Text("All").tag(ACPSessionsPanelFilter.all)
+        }
+        .labelsHidden()
+        .pickerStyle(.segmented)
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.bottom, VSpacing.sm)
+        .accessibilityLabel("Filter coding agents")
+    }
+
+    private var filterBinding: Binding<ACPSessionsPanelFilter> {
+        Binding(
+            get: { activeFilter },
+            set: { newValue in filterStorage.setFilter(newValue, for: activeConversationId) }
+        )
+    }
+
+    /// Currently effective filter for the panel. Reads the stored
+    /// preference if one exists; otherwise falls back to a context-aware
+    /// default — `.thisConversation` when at least one session matches the
+    /// active conversation, `.all` otherwise. The default is computed at
+    /// read-time rather than seeded into storage so the picker updates
+    /// naturally when sessions stream in after the panel mounts.
+    private var activeFilter: ACPSessionsPanelFilter {
+        guard let activeConversationId else { return .all }
+        if filterStorage.hasStoredFilter(for: activeConversationId) {
+            return filterStorage.filter(for: activeConversationId)
+        }
+        return store.sessions(forConversation: activeConversationId).isEmpty
+            ? .all : .thisConversation
+    }
+
     private var countLabel: String {
-        let count = store.sessionOrder.count
+        let count = filteredSessions.count
         return count == 1 ? "1 agent" : "\(count) agents"
+    }
+
+    /// Sessions that should appear in the list once the active filter is
+    /// applied. Defined here so the count label and the list iterate the
+    /// same set without recomputing.
+    private var filteredSessions: [ACPSessionViewModel] {
+        guard let activeConversationId, activeFilter == .thisConversation else {
+            return store.sessionOrder.compactMap { store.sessions[$0] }
+        }
+        return store.sessions(forConversation: activeConversationId)
     }
 
     // MARK: - Session list
@@ -137,23 +195,82 @@ struct ACPSessionsPanel: View {
         // initial paint simpler and avoids the lazy-container row recycling
         // overhead for short lists.
         VStack(alignment: .leading, spacing: 0) {
-            ForEach(store.sessionOrder, id: \.self) { sessionId in
-                if let viewModel = store.sessions[sessionId] {
-                    // `NavigationLink(value:)` defers detail construction
-                    // to the parent's `navigationDestination`, so passing
-                    // the live `ACPSessionViewModel` does not capture a
-                    // stale snapshot — the destination reads observable
-                    // properties off the same instance the store mutates.
-                    NavigationLink(value: viewModel) {
-                        ACPSessionsPanelRow(state: viewModel.state)
-                    }
-                    .buttonStyle(.plain)
-                    if sessionId != store.sessionOrder.last {
-                        Divider().background(VColor.borderBase)
-                    }
+            let visible = filteredSessions
+            ForEach(visible, id: \.id) { viewModel in
+                // `NavigationLink(value:)` defers detail construction to
+                // the parent's `navigationDestination`, so passing the live
+                // `ACPSessionViewModel` does not capture a stale snapshot
+                // — the destination reads observable properties off the
+                // same instance the store mutates.
+                NavigationLink(value: viewModel) {
+                    ACPSessionsPanelRow(state: viewModel.state)
+                }
+                .buttonStyle(.plain)
+                if viewModel.id != visible.last?.id {
+                    Divider().background(VColor.borderBase)
                 }
             }
         }
+    }
+}
+
+// MARK: - Filter
+
+/// Two-state filter for ``ACPSessionsPanel``. Persisted to `UserDefaults`
+/// via its raw value — never rename or remove cases without a migration.
+enum ACPSessionsPanelFilter: String {
+    case thisConversation
+    case all
+}
+
+/// Conversation-keyed filter preference. Reads/writes are keyed by the
+/// active conversation id so each conversation remembers its own
+/// preference independently.
+///
+/// Persistence lives in `UserDefaults`; the `@Observable` cache is what
+/// drives SwiftUI invalidation when the binding flips, since `UserDefaults`
+/// writes alone do not trigger view updates.
+@Observable
+final class ACPSessionsPanelFilterStorage {
+    /// Observed cache. Mutating an entry invalidates any view that reads
+    /// the same key via ``filter(for:)``. Persisted writes flow through
+    /// `UserDefaults` so the preference survives relaunches.
+    private var cache: [String: ACPSessionsPanelFilter] = [:]
+
+    /// Defaults instance used for persistence. Held as a property so tests
+    /// can substitute an isolated suite without touching
+    /// `UserDefaults.standard`.
+    @ObservationIgnored private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func filter(for conversationId: String?) -> ACPSessionsPanelFilter {
+        guard let conversationId else { return .all }
+        if let cached = cache[conversationId] { return cached }
+        if let raw = defaults.string(forKey: Self.key(for: conversationId)),
+           let value = ACPSessionsPanelFilter(rawValue: raw) {
+            return value
+        }
+        return .thisConversation
+    }
+
+    func setFilter(_ filter: ACPSessionsPanelFilter, for conversationId: String?) {
+        guard let conversationId else { return }
+        // Update the observed cache first so SwiftUI invalidates views that
+        // read this key, then persist for relaunch.
+        cache[conversationId] = filter
+        defaults.set(filter.rawValue, forKey: Self.key(for: conversationId))
+    }
+
+    func hasStoredFilter(for conversationId: String) -> Bool {
+        if cache[conversationId] != nil { return true }
+        return defaults.object(forKey: Self.key(for: conversationId)) != nil
+    }
+
+    static func key(for conversationId: String) -> String {
+        "acp.filter.\(conversationId)"
     }
 }
 

--- a/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
@@ -240,6 +240,112 @@ final class ACPSessionsPanelTests: XCTestCase {
         XCTAssertEqual(Set(store.sessionOrder), ["acp-running", "acp-completed"])
     }
 
+    // MARK: - Per-conversation filter
+
+    func test_sessionsForConversation_returnsOnlyMatchingSessions() {
+        let store = ACPSessionStore()
+        injectFixture(
+            into: store,
+            acpSessionId: "acp-conv-a-old",
+            agentId: "claude-code",
+            parentConversationId: "conv-a",
+            startedAt: 100
+        )
+        injectFixture(
+            into: store,
+            acpSessionId: "acp-conv-b",
+            agentId: "codex",
+            parentConversationId: "conv-b",
+            startedAt: 200
+        )
+        injectFixture(
+            into: store,
+            acpSessionId: "acp-conv-a-new",
+            agentId: "claude-code",
+            parentConversationId: "conv-a",
+            startedAt: 300
+        )
+
+        let convA = store.sessions(forConversation: "conv-a")
+        XCTAssertEqual(
+            convA.map(\.state.acpSessionId),
+            ["acp-conv-a-new", "acp-conv-a-old"],
+            "Filter must preserve newest-first ordering from sessionOrder"
+        )
+
+        let convB = store.sessions(forConversation: "conv-b").map(\.state.acpSessionId)
+        XCTAssertEqual(convB, ["acp-conv-b"])
+
+        XCTAssertTrue(
+            store.sessions(forConversation: "conv-missing").isEmpty,
+            "Filtering on a conversation with no sessions must return an empty array"
+        )
+    }
+
+    func test_sessionsForConversation_panelFilterEndToEnd() {
+        let store = ACPSessionStore()
+        injectFixture(
+            into: store,
+            acpSessionId: "acp-other",
+            agentId: "codex",
+            parentConversationId: "conv-other",
+            startedAt: 100
+        )
+        injectFixture(
+            into: store,
+            acpSessionId: "acp-active",
+            agentId: "claude-code",
+            parentConversationId: "conv-active",
+            startedAt: 200
+        )
+
+        let suiteName = "ACPSessionsPanelTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Failed to allocate isolated UserDefaults suite")
+        }
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        let storage = ACPSessionsPanelFilterStorage(defaults: defaults)
+
+        // Default for a conversation with matches is `.thisConversation`.
+        XCTAssertEqual(storage.filter(for: "conv-active"), .thisConversation)
+        XCTAssertFalse(storage.hasStoredFilter(for: "conv-active"))
+
+        // "This conversation" filter renders only the active conversation's
+        // sessions.
+        let scoped = store.sessions(forConversation: "conv-active")
+        XCTAssertEqual(scoped.map(\.state.acpSessionId), ["acp-active"])
+
+        // Toggling to `.all` persists across lookups.
+        storage.setFilter(.all, for: "conv-active")
+        XCTAssertEqual(storage.filter(for: "conv-active"), .all)
+        XCTAssertTrue(storage.hasStoredFilter(for: "conv-active"))
+
+        // With the filter switched off, the panel iterates `sessionOrder`
+        // and shows every session newest-first.
+        let allSessions = store.sessionOrder.compactMap { store.sessions[$0]?.state.acpSessionId }
+        XCTAssertEqual(allSessions, ["acp-active", "acp-other"])
+
+        // A different conversation has its own preference and is unaffected.
+        XCTAssertEqual(storage.filter(for: "conv-other"), .thisConversation)
+    }
+
+    func test_filterStorage_returnsAllForNilConversation() {
+        let suiteName = "ACPSessionsPanelTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Failed to allocate isolated UserDefaults suite")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let storage = ACPSessionsPanelFilterStorage(defaults: defaults)
+
+        // No active conversation → no scope to filter against, so the
+        // storage reports `.all` and silently ignores writes.
+        XCTAssertEqual(storage.filter(for: nil), .all)
+        storage.setFilter(.thisConversation, for: nil)
+        XCTAssertEqual(storage.filter(for: nil), .all)
+    }
+
     // MARK: - Helpers
 
     /// Inserts a synthetic ACP session into the store via the same
@@ -252,13 +358,15 @@ final class ACPSessionsPanelTests: XCTestCase {
         into store: ACPSessionStore,
         acpSessionId: String,
         agentId: String,
+        parentConversationId: String? = nil,
         startedAt: Int,
         status: ACPSessionState.Status = .running
     ) {
+        let parent = parentConversationId ?? "conv-\(acpSessionId)"
         store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
             acpSessionId: acpSessionId,
             agent: agentId,
-            parentConversationId: "conv-\(acpSessionId)"
+            parentConversationId: parent
         )))
         // Pin `startedAt` to a deterministic value so assertions don't drift
         // with wall-clock skew. ``sessionOrder`` was already computed by the
@@ -268,7 +376,7 @@ final class ACPSessionsPanelTests: XCTestCase {
                 id: viewModel.state.id,
                 agentId: agentId,
                 acpSessionId: acpSessionId,
-                parentConversationId: "conv-\(acpSessionId)",
+                parentConversationId: parent,
                 status: status,
                 startedAt: startedAt
             )

--- a/clients/shared/Network/ACPSessionStore.swift
+++ b/clients/shared/Network/ACPSessionStore.swift
@@ -163,6 +163,21 @@ public final class ACPSessionStore {
             .map(\.state.acpSessionId)
     }
 
+    // MARK: - Filtering
+
+    /// View models for sessions whose `parentConversationId` matches the
+    /// supplied conversation id, in the same newest-first order as
+    /// ``sessionOrder``. Used by the panel's per-conversation filter so the
+    /// list can scope to "this conversation" without rebuilding the order
+    /// array on every render.
+    public func sessions(forConversation id: String) -> [ACPSessionViewModel] {
+        sessionOrder.compactMap { sessionId in
+            guard let viewModel = sessions[sessionId],
+                  viewModel.state.parentConversationId == id else { return nil }
+            return viewModel
+        }
+    }
+
     // MARK: - SSE Event Handling
 
     /// Apply an SSE `ServerMessage` to the store. Non-ACP cases are ignored


### PR DESCRIPTION
## Summary
- Adds `ACPSessionStore.sessions(forConversation:)`.
- Adds segmented control 'This conversation' / 'All' above the list.
- Per-conversation preference persisted via `@AppStorage".

Part of plan: acp-sessions-ui.md (PR 28 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
