### PR TITLE
feat(macos): Cancel button in ACPSessionDetailView for running sessions

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -15,15 +15,23 @@ import VellumAssistantShared
 /// pauses auto-scroll once the user scrolls up so they can read past content
 /// without being yanked back. Resumes when the user returns to the bottom.
 ///
-/// Cancel, steer, and delete affordances arrive in later PRs (24, 25, 26);
-/// this view is intentionally read-only.
+/// A Cancel button surfaces while the session is `running`/`initializing`
+/// (PR 24); steer and delete affordances arrive in later PRs (25, 26).
 struct ACPSessionDetailView: View {
     let session: ACPSessionViewModel
+    /// Store used to drive optimistic mutations from this view (cancel today;
+    /// steer in PR 25). Held by reference so the view always invokes the
+    /// caller-owned instance — there's only one ``ACPSessionStore`` per app.
+    let store: ACPSessionStore
     /// Tap on the parent-conversation link. Wired by PR 22; nil hides the link.
     var onSelectParentConversation: ((String) -> Void)? = nil
     /// Optional close action — surfaces the design-system close button when
     /// this view is hosted inside a panel container that can dismiss itself.
     var onClose: (() -> Void)? = nil
+
+    /// True while a cancel HTTP request is in flight. Disables the button and
+    /// shows an inline spinner so the user can't double-tap.
+    @State private var cancelInFlight = false
 
     /// Sentinel ID anchored at the bottom of the LazyVStack so the
     /// `ScrollViewReader` can scroll to "the latest" without depending on
@@ -74,6 +82,9 @@ struct ACPSessionDetailView: View {
                     .lineLimit(1)
                 statusPill
                 Spacer()
+                if isCancelable {
+                    cancelControl
+                }
                 if let onClose {
                     VButton(label: "Close", iconOnly: "xmark", style: .ghost, action: onClose)
                 }
@@ -105,6 +116,55 @@ struct ACPSessionDetailView: View {
                 .foregroundStyle(VColor.contentSecondary)
                 .accessibilityHidden(true)
             VToggle(isOn: $showThoughts, label: "Show thoughts")
+        }
+    }
+
+    /// Cancel is only meaningful while the session is still running — terminal
+    /// statuses already reached an end state and re-cancelling is a no-op at
+    /// the daemon. We treat `.initializing` as cancelable too so the user can
+    /// abort a stuck-starting session.
+    ///
+    /// `internal` rather than `private` so unit tests in `VellumAssistantLib`
+    /// can verify the gating without rendering the view.
+    var isCancelable: Bool {
+        switch session.state.status {
+        case .running, .initializing: return true
+        case .completed, .failed, .cancelled, .unknown: return false
+        }
+    }
+
+    @ViewBuilder
+    private var cancelControl: some View {
+        HStack(spacing: VSpacing.xs) {
+            if cancelInFlight {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel("Cancelling session")
+            }
+            VButton(
+                label: "Cancel",
+                style: .dangerGhost,
+                size: .compact,
+                isDisabled: cancelInFlight
+            ) {
+                handleCancelTap()
+            }
+            .accessibilityLabel("Cancel session")
+        }
+    }
+
+    /// `internal` rather than `private` so unit tests in `VellumAssistantLib`
+    /// can drive the cancel flow without reaching into SwiftUI's view tree.
+    func handleCancelTap() {
+        guard !cancelInFlight else { return }
+        cancelInFlight = true
+        let id = session.state.acpSessionId
+        Task { @MainActor in
+            // The store flips `state.status` optimistically on success, which
+            // hides this control via `isCancelable`. On failure we reset the
+            // in-flight flag so the user can retry.
+            _ = await store.cancel(id: id)
+            cancelInFlight = false
         }
     }
 

--- a/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionDetailViewTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionDetailViewTests.swift
@@ -33,6 +33,36 @@ final class ACPSessionDetailViewTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - Mock store
+
+    /// Records invocations of ``ACPSessionStore/cancel(id:)`` so detail-view
+    /// tests can assert taps reach the store without spinning up the full
+    /// `URLProtocol` mocking apparatus that the network-layer tests use.
+    private final class SpyACPSessionStore: ACPSessionStore {
+        var cancelInvocations: [String] = []
+
+        override func cancel(id: String) async -> Result<Bool, ACPClientError> {
+            cancelInvocations.append(id)
+            // Mirror the real store's optimistic update so views reading
+            // `session.state.status` after the call see a terminal state —
+            // no different from the production path on a successful HTTP 200.
+            if let viewModel = sessions[id] {
+                viewModel.state = ACPSessionState(
+                    id: viewModel.state.id,
+                    agentId: viewModel.state.agentId,
+                    acpSessionId: viewModel.state.acpSessionId,
+                    parentConversationId: viewModel.state.parentConversationId,
+                    status: .cancelled,
+                    startedAt: viewModel.state.startedAt,
+                    completedAt: viewModel.state.completedAt,
+                    error: viewModel.state.error,
+                    stopReason: .cancelled
+                )
+            }
+            return .success(true)
+        }
+    }
+
     // MARK: - Fixtures
 
     private func makeSession(
@@ -306,13 +336,13 @@ final class ACPSessionDetailViewTests: XCTestCase {
             update(.unknown, content: "ignored"),
         ])
 
-        let view = ACPSessionDetailView(session: session)
+        let view = ACPSessionDetailView(session: session, store: ACPSessionStore())
         _ = view.body
     }
 
     func test_body_buildsWithoutCrash_emptyEventStream() {
         let session = makeSession(events: [])
-        let view = ACPSessionDetailView(session: session)
+        let view = ACPSessionDetailView(session: session, store: ACPSessionStore())
         _ = view.body
     }
 
@@ -323,13 +353,13 @@ final class ACPSessionDetailViewTests: XCTestCase {
             completedAtMillis: 1_700_000_005_000,
             events: [update(.agentMessageChunk, content: "done")]
         )
-        let view = ACPSessionDetailView(session: session)
+        let view = ACPSessionDetailView(session: session, store: ACPSessionStore())
         _ = view.body
     }
 
     func test_body_buildsWithoutCrash_noParentConversation() {
         let session = makeSession(parentConversationId: nil, events: [])
-        let view = ACPSessionDetailView(session: session)
+        let view = ACPSessionDetailView(session: session, store: ACPSessionStore())
         _ = view.body
     }
 
@@ -337,6 +367,7 @@ final class ACPSessionDetailViewTests: XCTestCase {
         let session = makeSession(events: [])
         let view = ACPSessionDetailView(
             session: session,
+            store: ACPSessionStore(),
             onSelectParentConversation: { _ in },
             onClose: {}
         )
@@ -386,7 +417,7 @@ final class ACPSessionDetailViewTests: XCTestCase {
             update(.agentThoughtChunk, content: "(thinking)"),
             update(.agentMessageChunk, content: " on it."),
         ])
-        let view = ACPSessionDetailView(session: session)
+        let view = ACPSessionDetailView(session: session, store: ACPSessionStore())
         _ = view.body
     }
 
@@ -397,12 +428,13 @@ final class ACPSessionDetailViewTests: XCTestCase {
     func test_showThoughtsToggle_persistsAcrossViewInstances() {
         UserDefaults.standard.set(false, forKey: Self.showThoughtsKey)
 
+        let store = ACPSessionStore()
         let session = makeSession(events: [update(.agentThoughtChunk, content: "hmm")])
         // First instance — building the body forces SwiftUI to wire up the
         // @AppStorage binding to UserDefaults.
-        _ = ACPSessionDetailView(session: session).body
+        _ = ACPSessionDetailView(session: session, store: store).body
         // Second instance — must read back the persisted value.
-        _ = ACPSessionDetailView(session: session).body
+        _ = ACPSessionDetailView(session: session, store: store).body
 
         XCTAssertEqual(
             UserDefaults.standard.bool(forKey: Self.showThoughtsKey),
@@ -412,7 +444,7 @@ final class ACPSessionDetailViewTests: XCTestCase {
 
         // Flip and confirm the new value persists too.
         UserDefaults.standard.set(true, forKey: Self.showThoughtsKey)
-        _ = ACPSessionDetailView(session: session).body
+        _ = ACPSessionDetailView(session: session, store: store).body
         XCTAssertEqual(
             UserDefaults.standard.bool(forKey: Self.showThoughtsKey),
             true
@@ -428,10 +460,56 @@ final class ACPSessionDetailViewTests: XCTestCase {
     func test_showThoughtsToggle_defaultDoesNotPersistUntilToggled() {
         UserDefaults.standard.removeObject(forKey: Self.showThoughtsKey)
         let session = makeSession(events: [update(.agentThoughtChunk, content: "hi")])
-        _ = ACPSessionDetailView(session: session).body
+        _ = ACPSessionDetailView(session: session, store: ACPSessionStore()).body
         XCTAssertNil(
             UserDefaults.standard.object(forKey: Self.showThoughtsKey),
             "@AppStorage default value should not be written to the store at view build time"
         )
+    }
+
+    // MARK: - Cancel button
+
+    func test_handleCancelTap_invokesStoreCancelExactlyOnce() async {
+        let store = SpyACPSessionStore()
+        let session = makeSession(status: .running)
+        // Register the session with the store so the optimistic mutation in
+        // the spy override has a view model to update — mirrors how the
+        // production store is populated via `seed()` / SSE before the user
+        // can interact with the detail view.
+        store.sessions[session.state.acpSessionId] = session
+
+        let view = ACPSessionDetailView(session: session, store: store)
+        view.handleCancelTap()
+
+        // The Task spawned inside `handleCancelTap` runs on the main actor;
+        // yield until it completes so the assertion sees the recorded call.
+        await waitForCancelInvocation(store: store)
+
+        XCTAssertEqual(store.cancelInvocations, [session.state.acpSessionId])
+    }
+
+    func test_isCancelable_runningAndInitializing() {
+        let store = ACPSessionStore()
+        let running = ACPSessionDetailView(session: makeSession(status: .running), store: store)
+        let initializing = ACPSessionDetailView(session: makeSession(status: .initializing), store: store)
+        let completed = ACPSessionDetailView(session: makeSession(status: .completed), store: store)
+        let failed = ACPSessionDetailView(session: makeSession(status: .failed), store: store)
+        let cancelled = ACPSessionDetailView(session: makeSession(status: .cancelled), store: store)
+
+        XCTAssertTrue(running.isCancelable)
+        XCTAssertTrue(initializing.isCancelable)
+        XCTAssertFalse(completed.isCancelable)
+        XCTAssertFalse(failed.isCancelable)
+        XCTAssertFalse(cancelled.isCancelable)
+    }
+
+    /// Spin briefly on the main actor until the spy records the awaited
+    /// cancel invocation. Bounded so a regression that drops the call still
+    /// fails the test rather than hanging forever.
+    private func waitForCancelInvocation(store: SpyACPSessionStore) async {
+        for _ in 0..<50 {
+            if !store.cancelInvocations.isEmpty { return }
+            await Task.yield()
+        }
     }
 }

--- a/clients/shared/Network/ACPSessionStore.swift
+++ b/clients/shared/Network/ACPSessionStore.swift
@@ -71,8 +71,13 @@ public final class ACPSessionViewModel: Identifiable, Hashable {
 /// snapshot with whatever has already been observed via SSE — in-memory
 /// entries win on id collisions so we never overwrite live state with a
 /// stale snapshot.
+///
+/// Not `final` so detail/list view tests can subclass and spy on
+/// ``cancel(id:)`` / ``steer(id:instruction:)`` without spinning up a full
+/// `URLProtocol` mock — the only public mutating entry points are explicitly
+/// `open` for that reason. Production callers should never subclass.
 @MainActor @Observable
-public final class ACPSessionStore {
+open class ACPSessionStore {
 
     /// Maximum number of events retained per session before older events
     /// are dropped. Prevents unbounded memory growth on long-running
@@ -241,8 +246,11 @@ public final class ACPSessionStore {
     /// Cancel an active session. Optimistically marks the session as
     /// cancelled on success so the UI updates without waiting for the
     /// daemon's `acp_session_completed` SSE round-trip.
+    ///
+    /// `open` so detail-view tests can subclass and observe invocation
+    /// without an HTTP round-trip — see ``ACPSessionStore`` doc.
     @discardableResult
-    public func cancel(id: String) async -> Result<Bool, ACPClientError> {
+    open func cancel(id: String) async -> Result<Bool, ACPClientError> {
         let result = await ACPClient.cancelSession(id: id)
         if case .success(true) = result, let viewModel = sessions[id] {
             // Reuse existing `completedAt` if the daemon already reported it;


### PR DESCRIPTION
## Summary
- Adds Cancel button (visible only for running/initializing sessions) calling `store.cancel(id:)`.
- Disables + spinner during in-flight call.

Part of plan: acp-sessions-ui.md (PR 24 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
