### PR TITLE
feat(live-voice): connect live voice sessions to streaming STT (PR 11)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -1,0 +1,237 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, mock, test } from "bun:test";
+
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import {
+  LiveVoiceSession,
+  type LiveVoiceStreamingTranscriberResolver,
+} from "../live-voice-session.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import {
+  createLiveVoiceServerFrameSequencer,
+  type LiveVoiceClientStartFrame,
+  type LiveVoiceServerFrame,
+} from "../protocol.js";
+
+const START_FRAME = {
+  type: "start",
+  conversationId: "conversation-123",
+  audio: {
+    mimeType: "audio/pcm",
+    sampleRate: 24_000,
+    channels: 1,
+  },
+} as const satisfies LiveVoiceClientStartFrame;
+
+class MockStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+  readonly audioChunks: Buffer[] = [];
+  readonly mimeTypes: string[] = [];
+  started = false;
+  stopped = false;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.started = true;
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(audio: Buffer, mimeType: string): void {
+    this.audioChunks.push(audio);
+    this.mimeTypes.push(mimeType);
+    this.onEvent?.({
+      type: "partial",
+      text: `partial-${this.audioChunks.length}`,
+    });
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.onEvent?.({ type: "final", text: "final transcript" });
+    this.onEvent?.({ type: "closed" });
+  }
+
+  emit(event: SttStreamServerEvent): void {
+    this.onEvent?.(event);
+  }
+}
+
+function createContext(overrides: Partial<LiveVoiceClientStartFrame> = {}): {
+  context: LiveVoiceSessionFactoryContext;
+  frames: LiveVoiceServerFrame[];
+} {
+  const sequencer = createLiveVoiceServerFrameSequencer();
+  const frames: LiveVoiceServerFrame[] = [];
+  const startFrame = {
+    ...START_FRAME,
+    ...overrides,
+  } as LiveVoiceClientStartFrame;
+
+  return {
+    frames,
+    context: {
+      sessionId: "session-123",
+      startFrame,
+      sendFrame: mock(async (payload) => {
+        const frame = sequencer.next(payload);
+        frames.push(frame);
+        return frame;
+      }),
+    },
+  };
+}
+
+function createSessionWithTranscriber(
+  transcriber = new MockStreamingTranscriber(),
+) {
+  const { context, frames } = createContext();
+  const resolver = mock(async () => transcriber);
+  const session = new LiveVoiceSession(context, {
+    resolveTranscriber: resolver,
+  });
+  return { frames, resolver, session, transcriber };
+}
+
+describe("LiveVoiceSession STT", () => {
+  test("resolves streaming STT through the injected resolver and sends ready", async () => {
+    const { frames, resolver, session, transcriber } =
+      createSessionWithTranscriber();
+
+    await session.start();
+
+    expect(resolver).toHaveBeenCalledWith({ sampleRate: 24_000 });
+    expect(transcriber.started).toBe(true);
+    expect(frames).toEqual([
+      {
+        type: "ready",
+        seq: 1,
+        sessionId: "session-123",
+        conversationId: "conversation-123",
+      },
+    ]);
+  });
+
+  test("forwards binary audio to the transcriber and emits STT frames", async () => {
+    const { frames, session, transcriber } = createSessionWithTranscriber();
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1, 2, 3]));
+    transcriber.emit({ type: "final", text: "hello world" });
+    await session.handleClientFrame({ type: "ptt_release" });
+
+    expect(transcriber.audioChunks.map((chunk) => [...chunk])).toEqual([
+      [1, 2, 3],
+    ]);
+    expect(transcriber.mimeTypes).toEqual(["audio/pcm"]);
+    expect(frames.map((frame) => frame.type)).toEqual([
+      "ready",
+      "stt_partial",
+      "stt_final",
+      "stt_final",
+    ]);
+    expect(frames[1]).toMatchObject({
+      type: "stt_partial",
+      seq: 2,
+      text: "partial-1",
+    });
+    expect(frames[2]).toMatchObject({
+      type: "stt_final",
+      seq: 3,
+      text: "hello world",
+    });
+    expect(session.finalTranscriptText).toBe("hello world final transcript");
+  });
+
+  test("treats ptt_release as end-of-utterance and rejects later audio", async () => {
+    const { frames, session, transcriber } = createSessionWithTranscriber();
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1]));
+    await session.handleClientFrame({ type: "ptt_release" });
+    await session.handleBinaryAudio(new Uint8Array([2]));
+    await session.handleClientFrame({
+      type: "audio",
+      dataBase64: Buffer.from([3]).toString("base64"),
+    });
+
+    expect(transcriber.stopped).toBe(true);
+    expect(transcriber.audioChunks.map((chunk) => [...chunk])).toEqual([[1]]);
+    expect(frames.filter((frame) => frame.type === "error")).toEqual([
+      {
+        type: "error",
+        seq: 4,
+        code: "invalid_audio_payload",
+        message: "Live voice audio received after push-to-talk release.",
+      },
+      {
+        type: "error",
+        seq: 5,
+        code: "invalid_audio_payload",
+        message: "Live voice audio received after push-to-talk release.",
+      },
+    ]);
+  });
+
+  test("returns a readable error frame when streaming STT is unavailable", async () => {
+    const { context, frames } = createContext();
+    const resolver = mock(async () => null);
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: resolver,
+    });
+
+    await session.start();
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      type: "error",
+      code: "invalid_field",
+    });
+    const [errorFrame] = frames;
+    if (errorFrame?.type !== "error") {
+      throw new Error("Expected a live voice error frame");
+    }
+    expect(errorFrame.message).toContain(
+      "Live voice transcription is unavailable",
+    );
+    expect(errorFrame.message).toContain("credentials configured");
+  });
+
+  test("returns a readable error frame when provider setup throws", async () => {
+    const { context, frames } = createContext();
+    const resolver: LiveVoiceStreamingTranscriberResolver = mock(async () => {
+      throw new Error("provider credentials rejected");
+    });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: resolver,
+    });
+
+    await expect(session.start()).resolves.toBeUndefined();
+
+    expect(frames).toEqual([
+      {
+        type: "error",
+        seq: 1,
+        code: "invalid_field",
+        message:
+          "Live voice transcription could not be started: provider credentials rejected",
+      },
+    ]);
+  });
+
+  test("uses the production streaming transcriber resolver by default", () => {
+    const source = readFileSync(
+      new URL("../live-voice-session.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain("resolveStreamingTranscriber");
+    expect(source).not.toMatch(/from\s+["']@anthropic-ai\/sdk/);
+    expect(source).not.toMatch(/from\s+["']openai/);
+    expect(source).not.toMatch(/from\s+["']@google\/genai/);
+    expect(source).not.toMatch(/fetch\(/);
+  });
+});

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1,0 +1,305 @@
+import { Buffer } from "node:buffer";
+
+import {
+  listProviderIds,
+  supportsBoundary,
+} from "../providers/speech-to-text/provider-catalog.js";
+import type { ResolveStreamingTranscriberOptions } from "../providers/speech-to-text/resolve.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../stt/types.js";
+import type {
+  LiveVoiceSession as LiveVoiceSessionContract,
+  LiveVoiceSessionCloseReason,
+  LiveVoiceSessionFactoryContext,
+} from "./live-voice-session-manager.js";
+import {
+  type LiveVoiceClientFrame,
+  LiveVoiceProtocolErrorCode,
+  type LiveVoiceServerFramePayload,
+} from "./protocol.js";
+
+type LiveVoiceSessionState =
+  | "initializing"
+  | "active"
+  | "utterance_released"
+  | "transcriber_closed"
+  | "failed"
+  | "closed";
+
+export type LiveVoiceStreamingTranscriberResolver = (
+  options: ResolveStreamingTranscriberOptions,
+) => Promise<StreamingTranscriber | null>;
+
+export interface LiveVoiceSessionOptions {
+  resolveTranscriber?: LiveVoiceStreamingTranscriberResolver;
+}
+
+export class LiveVoiceSession implements LiveVoiceSessionContract {
+  private readonly context: LiveVoiceSessionFactoryContext;
+  private readonly resolveTranscriber: LiveVoiceStreamingTranscriberResolver;
+  private readonly conversationId: string;
+  private state: LiveVoiceSessionState = "initializing";
+  private transcriber: StreamingTranscriber | null = null;
+  private readonly finalTranscriptSegments: string[] = [];
+  private outboundFrames: Promise<void> = Promise.resolve();
+
+  constructor(
+    context: LiveVoiceSessionFactoryContext,
+    options: LiveVoiceSessionOptions = {},
+  ) {
+    this.context = context;
+    this.resolveTranscriber =
+      options.resolveTranscriber ?? defaultResolveStreamingTranscriber;
+    this.conversationId =
+      context.startFrame.conversationId ?? context.sessionId;
+  }
+
+  get finalTranscriptText(): string {
+    return this.finalTranscriptSegments.join(" ");
+  }
+
+  async start(): Promise<void> {
+    if (this.state !== "initializing") return;
+
+    try {
+      const transcriber = await this.resolveTranscriber({
+        sampleRate: this.context.startFrame.audio.sampleRate,
+      });
+
+      if (this.isClosed) {
+        stopTranscriberBestEffort(transcriber);
+        return;
+      }
+
+      if (!transcriber) {
+        this.state = "failed";
+        await this.sendFrame({
+          type: "error",
+          code: LiveVoiceProtocolErrorCode.InvalidField,
+          message: unavailableTranscriberMessage(),
+        });
+        return;
+      }
+
+      this.transcriber = transcriber;
+      await transcriber.start((event) => {
+        void this.handleTranscriberEvent(event);
+      });
+
+      if (this.isClosed) {
+        stopTranscriberBestEffort(transcriber);
+        this.transcriber = null;
+        return;
+      }
+
+      this.state = "active";
+      await this.sendFrame({
+        type: "ready",
+        sessionId: this.context.sessionId,
+        conversationId: this.conversationId,
+      });
+    } catch (err) {
+      stopTranscriberBestEffort(this.transcriber);
+      this.transcriber = null;
+      if (this.isClosed) return;
+
+      this.state = "failed";
+      await this.sendFrame({
+        type: "error",
+        code: LiveVoiceProtocolErrorCode.InvalidField,
+        message: `Live voice transcription could not be started: ${errorMessage(
+          err,
+        )}`,
+      });
+    }
+  }
+
+  async handleClientFrame(frame: LiveVoiceClientFrame): Promise<void> {
+    if (this.state === "closed" || this.state === "failed") return;
+
+    switch (frame.type) {
+      case "audio":
+        await this.handleAudio(Buffer.from(frame.dataBase64, "base64"));
+        return;
+      case "ptt_release":
+        await this.releaseUtterance();
+        return;
+      case "interrupt":
+        return;
+      case "end":
+        await this.close("client_end");
+        return;
+      case "start":
+        return;
+    }
+  }
+
+  async handleBinaryAudio(chunk: Uint8Array): Promise<void> {
+    await this.handleAudio(Buffer.from(chunk));
+  }
+
+  async close(_reason: LiveVoiceSessionCloseReason): Promise<void> {
+    if (this.isClosed) return;
+
+    this.state = "closed";
+    stopTranscriberBestEffort(this.transcriber);
+    this.transcriber = null;
+    await this.drainOutboundFrames();
+  }
+
+  private async handleAudio(chunk: Buffer): Promise<void> {
+    if (
+      this.state === "utterance_released" ||
+      this.state === "transcriber_closed"
+    ) {
+      await this.sendAudioAfterReleaseError();
+      return;
+    }
+
+    if (this.state !== "active") return;
+
+    try {
+      this.transcriber?.sendAudio(
+        chunk,
+        this.context.startFrame.audio.mimeType,
+      );
+      await this.drainOutboundFrames();
+    } catch (err) {
+      await this.sendFrame({
+        type: "error",
+        code: LiveVoiceProtocolErrorCode.InvalidAudioPayload,
+        message: `Live voice audio could not be sent to transcription: ${errorMessage(
+          err,
+        )}`,
+      });
+    }
+  }
+
+  private async releaseUtterance(): Promise<void> {
+    if (
+      this.state === "utterance_released" ||
+      this.state === "transcriber_closed"
+    ) {
+      return;
+    }
+
+    if (this.state !== "active") return;
+
+    this.state = "utterance_released";
+    try {
+      this.transcriber?.stop();
+    } catch (err) {
+      await this.sendFrame({
+        type: "error",
+        code: LiveVoiceProtocolErrorCode.InvalidField,
+        message: `Live voice transcription could not be stopped: ${errorMessage(
+          err,
+        )}`,
+      });
+    }
+    await this.drainOutboundFrames();
+  }
+
+  private async handleTranscriberEvent(
+    event: SttStreamServerEvent,
+  ): Promise<void> {
+    if (this.isClosed || this.state === "failed") return;
+
+    switch (event.type) {
+      case "partial":
+        await this.sendFrame({ type: "stt_partial", text: event.text });
+        return;
+      case "final": {
+        const transcript = event.text.trim();
+        if (transcript.length > 0) {
+          this.finalTranscriptSegments.push(transcript);
+        }
+        await this.sendFrame({ type: "stt_final", text: event.text });
+        return;
+      }
+      case "error":
+        await this.sendFrame({
+          type: "error",
+          code: LiveVoiceProtocolErrorCode.InvalidField,
+          message: event.message,
+        });
+        return;
+      case "closed":
+        if (!this.isClosed) {
+          this.state = "transcriber_closed";
+          this.transcriber = null;
+        }
+        return;
+    }
+  }
+
+  private async sendAudioAfterReleaseError(): Promise<void> {
+    await this.sendFrame({
+      type: "error",
+      code: LiveVoiceProtocolErrorCode.InvalidAudioPayload,
+      message: "Live voice audio received after push-to-talk release.",
+    });
+  }
+
+  private async sendFrame(frame: LiveVoiceServerFramePayload): Promise<void> {
+    this.outboundFrames = this.outboundFrames
+      .catch(() => {})
+      .then(async () => {
+        await this.context.sendFrame(frame);
+      })
+      .catch(() => {
+        // Transport failures are handled by the WebSocket/session owner.
+      });
+
+    await this.outboundFrames;
+  }
+
+  private async drainOutboundFrames(): Promise<void> {
+    await this.outboundFrames.catch(() => {});
+  }
+
+  private get isClosed(): boolean {
+    return this.state === "closed";
+  }
+}
+
+export function createLiveVoiceSession(
+  context: LiveVoiceSessionFactoryContext,
+  options: LiveVoiceSessionOptions = {},
+): LiveVoiceSession {
+  return new LiveVoiceSession(context, options);
+}
+
+async function defaultResolveStreamingTranscriber(
+  options: ResolveStreamingTranscriberOptions,
+): Promise<StreamingTranscriber | null> {
+  const { resolveStreamingTranscriber } =
+    await import("../providers/speech-to-text/resolve.js");
+  return resolveStreamingTranscriber(options);
+}
+
+function unavailableTranscriberMessage(): string {
+  const supportedProviders = listProviderIds()
+    .filter((id) => supportsBoundary(id, "daemon-streaming"))
+    .join(", ");
+
+  return `Live voice transcription is unavailable. Check that the configured STT provider supports streaming transcription and has credentials configured. Streaming-capable providers: ${supportedProviders}.`;
+}
+
+function stopTranscriberBestEffort(
+  transcriber: StreamingTranscriber | null,
+): void {
+  if (!transcriber) return;
+
+  try {
+    transcriber.stop();
+  } catch {
+    // Best effort cleanup during failed startup or session close.
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}


### PR DESCRIPTION
## PR 11: connect live voice sessions to streaming STT

### Depends on

PR 2.

### Branch

`live-voice-channel/pr-11-live-stt`

### Files

- `assistant/src/live-voice/live-voice-session.ts`
- `assistant/src/live-voice/__tests__/live-voice-stt.test.ts`

### Scope

Replace the stub session factory with a real `LiveVoiceSession` STT phase. The session should:

- resolve the configured streaming transcriber through `resolveStreamingTranscriber`
- forward binary audio chunks into the transcriber
- emit `stt_partial` and `stt_final` frames
- accumulate final transcript text for the later assistant turn
- treat `ptt_release` as end-of-utterance, not WebSocket close
- return protocol `error` frames for unsupported provider or missing credential states

Do not call the conversation loop or TTS yet.

### Acceptance Criteria

- STT resolver is injected for tests and uses provider abstraction in production.
- Provider setup errors are user-readable and do not crash the runtime server.
- Audio after `ptt_release` is ignored or rejected consistently.

### Verification

Orchestrated by velissa-ai via run-plan; implemented by Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
