### PR TITLE
feat(macos): Steer textbox + button in ACPSessionDetailView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -3,11 +3,13 @@ import VellumAssistantShared
 
 // MARK: - ACPSessionDetailView
 
-/// Read-only timeline of an ACP (Agent Client Protocol) session.
+/// Detail view of an ACP (Agent Client Protocol) session.
 ///
-/// Renders a header (agent + status + elapsed + parent-conversation link) and
-/// a scrolling timeline of `ACPSessionUpdateMessage` events grouped into
-/// visual rows. Tool calls coalesce with their `tool_call_update` siblings
+/// Renders a header (agent + status + elapsed + parent-conversation link), a
+/// scrolling timeline of `ACPSessionUpdateMessage` events grouped into visual
+/// rows, and — for running sessions when a ``ACPSessionStore`` is supplied —
+/// a steering footer (textbox + button) that lets the user redirect the
+/// agent mid-run. Tool calls coalesce with their `tool_call_update` siblings
 /// (latest update wins) so a streaming tool that emits multiple status
 /// transitions still renders as a single row.
 ///
@@ -16,12 +18,14 @@ import VellumAssistantShared
 /// without being yanked back. Resumes when the user returns to the bottom.
 ///
 /// A Cancel button surfaces while the session is `running`/`initializing`
-/// (PR 24); steer and delete affordances arrive in later PRs (25, 26).
+/// (PR 24); a Steer textbox + button surfaces while the session is `running`
+/// (PR 25). The delete affordance arrives in PR 26.
 struct ACPSessionDetailView: View {
     let session: ACPSessionViewModel
-    /// Store used to drive optimistic mutations from this view (cancel today;
-    /// steer in PR 25). Held by reference so the view always invokes the
-    /// caller-owned instance — there's only one ``ACPSessionStore`` per app.
+    /// Store used to drive optimistic mutations from this view (cancel and
+    /// steer today; delete in PR 26). Held by reference so the view always
+    /// invokes the caller-owned instance — there's only one ``ACPSessionStore``
+    /// per app.
     let store: ACPSessionStore
     /// Tap on the parent-conversation link. Wired by PR 22; nil hides the link.
     var onSelectParentConversation: ((String) -> Void)? = nil
@@ -52,6 +56,9 @@ struct ACPSessionDetailView: View {
     /// session is still running. The view only reads it when the session is
     /// non-terminal so terminal sessions don't wake the timer.
     @State private var nowTick: Date = Date()
+    /// Bound text content of the steer textbox. Cleared on every successful
+    /// submission so the field is ready for the next instruction.
+    @State private var steerInput: String = ""
 
     /// Persisted preference for whether agent-thought bubbles render in the
     /// timeline. Defaults to `true` so first-time users see the assistant's
@@ -67,6 +74,10 @@ struct ACPSessionDetailView: View {
             header
             Divider().background(VColor.borderBase)
             timeline
+            if session.state.status == .running {
+                Divider().background(VColor.borderBase)
+                steerFooter
+            }
         }
     }
 
@@ -511,6 +522,72 @@ struct ACPSessionDetailView: View {
             .accessibilityLabel("Agent thought: \(content)")
             Spacer(minLength: 0)
         }
+    }
+
+    // MARK: - Steer Footer
+
+    @ViewBuilder
+    private var steerFooter: some View {
+        HStack(alignment: .center, spacing: VSpacing.sm) {
+            VTextField(
+                placeholder: "Redirect this agent…",
+                text: $steerInput,
+                onSubmit: dispatchSteer
+            )
+            VButton(
+                label: "Steer",
+                style: .primary,
+                isDisabled: steerInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                action: dispatchSteer
+            )
+        }
+        .padding(EdgeInsets(top: VSpacing.md, leading: VSpacing.lg, bottom: VSpacing.md, trailing: VSpacing.lg))
+    }
+
+    /// View-side wrapper that snapshots and clears `steerInput` *before*
+    /// handing the raw text off to ``submitSteer(rawInstruction:)``.
+    /// Keeping the `@State` mutation here means the helper itself is purely
+    /// a function of its arguments, which is what the unit test exploits.
+    private func dispatchSteer() {
+        let toSubmit = steerInput
+        steerInput = ""
+        submitSteer(rawInstruction: toSubmit)
+    }
+
+    /// Trim ``rawInstruction``, append a synthetic `→ steered: …` row to the
+    /// timeline so the user sees the instruction land immediately, then
+    /// dispatch the steer call against the store. Empty/whitespace input is
+    /// a no-op so a stray return-key press is harmless.
+    ///
+    /// The textbox is cleared by the caller (the SwiftUI footer) before this
+    /// runs — that keeps `steerInput`'s `@State` mutation on the rendering
+    /// path, which is also where SwiftUI requires it. Tests can call this
+    /// helper directly with the desired pre-trim string and assert the spy
+    /// store recorded the trimmed instruction, without relying on `@State`
+    /// semantics in a detached view value.
+    ///
+    /// `internal` rather than `private` so unit tests in `VellumAssistantLib`
+    /// can drive submission without round-tripping through SwiftUI focus
+    /// state — there is no supported way to programmatically tap a `Button`
+    /// in an XCTest unit target.
+    func submitSteer(rawInstruction: String) {
+        let instruction = rawInstruction.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !instruction.isEmpty else { return }
+
+        // Synthetic local-only event — surfaces the steer in the timeline
+        // before the daemon's confirmation round-trips back as an SSE update.
+        // We piggy-back on `userMessageChunk` rather than introducing a new
+        // wire-side update type so `buildRows` keeps a closed switch and the
+        // entry coalesces naturally with any prior user-message run.
+        session.appendEvent(ACPSessionUpdateMessage(
+            acpSessionId: session.state.acpSessionId,
+            updateType: .userMessageChunk,
+            content: "→ steered: \(instruction)"
+        ))
+
+        // `acpSessionId` (not `state.id`) is the daemon-side session handle
+        // the steer route accepts and the store keys its dictionary by.
+        Task { await store.steer(id: session.state.acpSessionId, instruction: instruction) }
     }
 }
 

--- a/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionDetailViewTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionDetailViewTests.swift
@@ -6,13 +6,13 @@ import XCTest
 
 /// Unit tests for ``ACPSessionDetailView``.
 ///
-/// The view is read-only and stateless beyond auto-scroll bookkeeping, so
-/// the meaningful surface to test is the pure event-stream → timeline-row
-/// reduction (`buildRows(events:)`) plus a smoke test that proves each
-/// fixture builds a body without crashing. SwiftUI does not give us a
-/// way to assert layout output in unit tests, so we cover that contract
-/// at the row-model level — the only place errors can hide that aren't
-/// also caught by the macOS build job.
+/// The bulk of the view's logic is the pure event-stream → timeline-row
+/// reduction (`buildRows(events:)`); we cover that exhaustively below plus a
+/// smoke test that proves each fixture builds a body without crashing. The
+/// cancel button and steer footer add interactive surfaces — their tap
+/// handlers are exposed at internal access so tests can drive them via the
+/// ``SpyACPSessionStore`` instead of round-tripping through SwiftUI's view
+/// tree (XCTest can't tap a `Button` in a unit-test target).
 @MainActor
 final class ACPSessionDetailViewTests: XCTestCase {
 
@@ -35,11 +35,13 @@ final class ACPSessionDetailViewTests: XCTestCase {
 
     // MARK: - Mock store
 
-    /// Records invocations of ``ACPSessionStore/cancel(id:)`` so detail-view
-    /// tests can assert taps reach the store without spinning up the full
-    /// `URLProtocol` mocking apparatus that the network-layer tests use.
+    /// Records invocations of ``ACPSessionStore/cancel(id:)`` and
+    /// ``ACPSessionStore/steer(id:instruction:)`` so detail-view tests can
+    /// assert taps reach the store without spinning up the full `URLProtocol`
+    /// mocking apparatus that the network-layer tests use.
     private final class SpyACPSessionStore: ACPSessionStore {
         var cancelInvocations: [String] = []
+        var steerInvocations: [(id: String, instruction: String)] = []
 
         override func cancel(id: String) async -> Result<Bool, ACPClientError> {
             cancelInvocations.append(id)
@@ -59,6 +61,14 @@ final class ACPSessionDetailViewTests: XCTestCase {
                     stopReason: .cancelled
                 )
             }
+            return .success(true)
+        }
+
+        override func steer(id: String, instruction: String) async -> Result<Bool, ACPClientError> {
+            steerInvocations.append((id: id, instruction: instruction))
+            // The real store does not mutate state synchronously on steer —
+            // the daemon round-trips an SSE update to confirm. Mirror that:
+            // no view-model mutation here, just record and ack.
             return .success(true)
         }
     }
@@ -483,7 +493,7 @@ final class ACPSessionDetailViewTests: XCTestCase {
 
         // The Task spawned inside `handleCancelTap` runs on the main actor;
         // yield until it completes so the assertion sees the recorded call.
-        await waitForCancelInvocation(store: store)
+        await waitForSpyInvocation { !store.cancelInvocations.isEmpty }
 
         XCTAssertEqual(store.cancelInvocations, [session.state.acpSessionId])
     }
@@ -503,12 +513,56 @@ final class ACPSessionDetailViewTests: XCTestCase {
         XCTAssertFalse(cancelled.isCancelable)
     }
 
-    /// Spin briefly on the main actor until the spy records the awaited
-    /// cancel invocation. Bounded so a regression that drops the call still
+    // MARK: - Steer footer
+
+    func test_submitSteer_invokesStoreWithTrimmedInstructionAndAppendsSyntheticEvent() async {
+        let store = SpyACPSessionStore()
+        let session = makeSession(status: .running)
+        store.sessions[session.state.acpSessionId] = session
+
+        let view = ACPSessionDetailView(session: session, store: store)
+        // Leading/trailing whitespace exercises the trim path — return-key
+        // submissions often pick up a stray space.
+        view.submitSteer(rawInstruction: "   slow down and explain   ")
+
+        // Synthetic event lands immediately for instant feedback.
+        XCTAssertEqual(session.events.count, 1, "Synthetic feedback row should append immediately")
+        XCTAssertEqual(session.events.first?.updateType, .userMessageChunk)
+        XCTAssertEqual(session.events.first?.content, "→ steered: slow down and explain")
+
+        await waitForSpyInvocation { !store.steerInvocations.isEmpty }
+
+        XCTAssertEqual(store.steerInvocations.count, 1)
+        XCTAssertEqual(store.steerInvocations.first?.id, session.state.acpSessionId)
+        XCTAssertEqual(
+            store.steerInvocations.first?.instruction,
+            "slow down and explain",
+            "Trimmed instruction must reach the store"
+        )
+    }
+
+    func test_submitSteer_emptyInputIsNoOp() async {
+        let store = SpyACPSessionStore()
+        let session = makeSession(status: .running)
+        store.sessions[session.state.acpSessionId] = session
+
+        let view = ACPSessionDetailView(session: session, store: store)
+        view.submitSteer(rawInstruction: "   ")
+
+        // Yield once — give any erroneous Task a chance to run so the
+        // assertion below catches a regression that calls store anyway.
+        await Task.yield()
+
+        XCTAssertTrue(session.events.isEmpty, "Whitespace-only input should not append a synthetic row")
+        XCTAssertTrue(store.steerInvocations.isEmpty, "Empty input must not reach the store")
+    }
+
+    /// Spin briefly on the main actor until ``predicate`` returns true.
+    /// Bounded so a regression that drops the awaited invocation still
     /// fails the test rather than hanging forever.
-    private func waitForCancelInvocation(store: SpyACPSessionStore) async {
+    private func waitForSpyInvocation(_ predicate: () -> Bool) async {
         for _ in 0..<50 {
-            if !store.cancelInvocations.isEmpty { return }
+            if predicate() { return }
             await Task.yield()
         }
     }

--- a/clients/shared/Network/ACPSessionStore.swift
+++ b/clients/shared/Network/ACPSessionStore.swift
@@ -29,7 +29,11 @@ public final class ACPSessionViewModel: Identifiable, Hashable {
 
     /// Append a new update event, dropping the oldest entries to stay within
     /// the per-session retention cap.
-    func appendEvent(_ event: ACPSessionUpdateMessage) {
+    ///
+    /// Public so feature-layer code (e.g. ``ACPSessionDetailView``'s steer
+    /// footer) can inject synthetic local-only events for immediate user
+    /// feedback before the daemon round-trips a confirming SSE update.
+    public func appendEvent(_ event: ACPSessionUpdateMessage) {
         events.append(event)
         if events.count > ACPSessionStore.eventsCapPerSession {
             events.removeFirst(events.count - ACPSessionStore.eventsCapPerSession)


### PR DESCRIPTION
## Summary
- Adds Steer textbox + button below timeline (visible only for running sessions).
- Calls `store.steer(id:instruction:)`; appends synthetic '→ steered: …' row for immediate feedback.
- Clears textbox on submit.

Part of plan: acp-sessions-ui.md (PR 25 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
