### PR TITLE
feat(live-voice): add assistant live voice WebSocket shell (PR 3)

### DIFF
--- a/assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts
+++ b/assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../config/loader.js", () => {
+  const config = {
+    model: "test",
+    provider: "test",
+    platform: { baseUrl: "https://example.com" },
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+    contextWindow: { maxInputTokens: 200_000 },
+    services: {
+      stt: { provider: "deepgram" },
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+      },
+      "web-search": {
+        mode: "your-own",
+        provider: "inference-provider-native",
+      },
+    },
+  };
+  return {
+    loadConfig: () => config,
+    getConfig: () => config,
+    invalidateConfigCache: () => {},
+  };
+});
+
+import { CURRENT_POLICY_EPOCH } from "../../runtime/auth/policy.js";
+import { mintToken } from "../../runtime/auth/token-service.js";
+import { RuntimeHttpServer } from "../../runtime/http-server.js";
+
+type JsonFrame = Record<string, unknown>;
+
+const savedAuthEnv = {
+  DISABLE_HTTP_AUTH: process.env.DISABLE_HTTP_AUTH,
+  VELLUM_UNSAFE_AUTH_BYPASS: process.env.VELLUM_UNSAFE_AUTH_BYPASS,
+};
+
+function mintGatewayToken(): string {
+  return mintToken({
+    aud: "vellum-daemon",
+    sub: "svc:gateway:self",
+    scope_profile: "gateway_ingress_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 3600,
+  });
+}
+
+function mintActorToken(): string {
+  return mintToken({
+    aud: "vellum-daemon",
+    sub: "actor:self:user-123",
+    scope_profile: "actor_client_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 3600,
+  });
+}
+
+function startFrame(conversationId = "conversation-123"): string {
+  return JSON.stringify({
+    type: "start",
+    conversationId,
+    audio: {
+      mimeType: "audio/pcm",
+      sampleRate: 24_000,
+      channels: 1,
+    },
+  });
+}
+
+async function waitForOpen(ws: WebSocket, timeoutMs = 2000): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) return;
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for WebSocket open"));
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.removeEventListener("open", onOpen);
+      ws.removeEventListener("error", onError);
+    };
+    const onOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = () => {
+      cleanup();
+      reject(new Error("WebSocket failed to open"));
+    };
+    ws.addEventListener("open", onOpen);
+    ws.addEventListener("error", onError);
+  });
+}
+
+async function waitForClose(ws: WebSocket, timeoutMs = 2000): Promise<void> {
+  if (ws.readyState === WebSocket.CLOSED) return;
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for WebSocket close"));
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.removeEventListener("close", onClose);
+      ws.removeEventListener("error", onError);
+    };
+    const onClose = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = () => {
+      cleanup();
+      reject(new Error("WebSocket close failed"));
+    };
+    ws.addEventListener("close", onClose);
+    ws.addEventListener("error", onError);
+  });
+}
+
+async function waitForJsonFrame(
+  ws: WebSocket,
+  timeoutMs = 2000,
+): Promise<JsonFrame> {
+  await waitForOpen(ws, timeoutMs);
+  return await new Promise<JsonFrame>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for WebSocket message"));
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.removeEventListener("message", onMessage);
+      ws.removeEventListener("close", onClose);
+      ws.removeEventListener("error", onError);
+    };
+    const onMessage = (event: MessageEvent) => {
+      cleanup();
+      const data = event.data;
+      if (typeof data !== "string") {
+        reject(new Error("Expected text WebSocket message"));
+        return;
+      }
+      resolve(JSON.parse(data) as JsonFrame);
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error("WebSocket closed before message"));
+    };
+    const onError = () => {
+      cleanup();
+      reject(new Error("WebSocket errored before message"));
+    };
+    ws.addEventListener("message", onMessage);
+    ws.addEventListener("close", onClose);
+    ws.addEventListener("error", onError);
+  });
+}
+
+function closeClient(ws: WebSocket): void {
+  if (
+    ws.readyState === WebSocket.CONNECTING ||
+    ws.readyState === WebSocket.OPEN
+  ) {
+    ws.close(1000, "test shutdown");
+  }
+}
+
+describe("RuntimeHttpServer live voice WebSocket shell", () => {
+  let server: RuntimeHttpServer;
+  let baseUrl: string;
+  let wsBaseUrl: string;
+  let clients: WebSocket[];
+
+  beforeEach(async () => {
+    delete process.env.DISABLE_HTTP_AUTH;
+    delete process.env.VELLUM_UNSAFE_AUTH_BYPASS;
+    clients = [];
+    const port = 21100 + Math.floor(Math.random() * 300);
+    server = new RuntimeHttpServer({ port, hostname: "127.0.0.1" });
+    await server.start();
+    baseUrl = `http://127.0.0.1:${server.actualPort}`;
+    wsBaseUrl = `ws://127.0.0.1:${server.actualPort}`;
+  });
+
+  afterEach(async () => {
+    for (const client of clients) {
+      closeClient(client);
+    }
+    await server.stop();
+    if (savedAuthEnv.DISABLE_HTTP_AUTH === undefined) {
+      delete process.env.DISABLE_HTTP_AUTH;
+    } else {
+      process.env.DISABLE_HTTP_AUTH = savedAuthEnv.DISABLE_HTTP_AUTH;
+    }
+    if (savedAuthEnv.VELLUM_UNSAFE_AUTH_BYPASS === undefined) {
+      delete process.env.VELLUM_UNSAFE_AUTH_BYPASS;
+    } else {
+      process.env.VELLUM_UNSAFE_AUTH_BYPASS =
+        savedAuthEnv.VELLUM_UNSAFE_AUTH_BYPASS;
+    }
+  });
+
+  function openLiveVoiceClient(token = mintGatewayToken()): WebSocket {
+    const ws = new WebSocket(
+      `${wsBaseUrl}/v1/live-voice?token=${encodeURIComponent(token)}`,
+    );
+    clients.push(ws);
+    return ws;
+  }
+
+  test("rejects unauthorized upgrades before creating a WebSocket", async () => {
+    const baseHeaders = {
+      Upgrade: "websocket",
+      Connection: "Upgrade",
+      "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+      "Sec-WebSocket-Version": "13",
+    };
+
+    const missingToken = await fetch(`${baseUrl}/v1/live-voice`, {
+      headers: baseHeaders,
+    });
+    expect(missingToken.status).toBe(401);
+
+    const actorToken = await fetch(
+      `${baseUrl}/v1/live-voice?token=${mintActorToken()}`,
+      { headers: baseHeaders },
+    );
+    expect(actorToken.status).toBe(401);
+
+    const externalOrigin = await fetch(
+      `${baseUrl}/v1/live-voice?token=${mintGatewayToken()}`,
+      {
+        headers: {
+          ...baseHeaders,
+          Origin: "https://external.example.com",
+        },
+      },
+    );
+    expect(externalOrigin.status).toBe(403);
+  });
+
+  test("sends ready for a well-formed start frame", async () => {
+    const ws = openLiveVoiceClient();
+    await waitForOpen(ws);
+
+    ws.send(startFrame("conversation-ready"));
+    const ready = await waitForJsonFrame(ws);
+
+    expect(ready).toMatchObject({
+      type: "ready",
+      seq: 1,
+      conversationId: "conversation-ready",
+    });
+    expect(typeof ready.sessionId).toBe("string");
+  });
+
+  test("sends an error for malformed frames and can still start", async () => {
+    const ws = openLiveVoiceClient();
+    await waitForOpen(ws);
+
+    ws.send("{");
+    const error = await waitForJsonFrame(ws);
+    expect(error).toMatchObject({
+      type: "error",
+      seq: 1,
+      code: "invalid_json",
+    });
+
+    ws.send(startFrame("conversation-after-error"));
+    const ready = await waitForJsonFrame(ws);
+    expect(ready).toMatchObject({
+      type: "ready",
+      conversationId: "conversation-after-error",
+    });
+    expect(typeof ready.sessionId).toBe("string");
+  });
+
+  test("releases the session lock when the WebSocket closes", async () => {
+    const first = openLiveVoiceClient();
+    const second = openLiveVoiceClient();
+    await Promise.all([waitForOpen(first), waitForOpen(second)]);
+
+    first.send(startFrame("conversation-first"));
+    const firstReady = await waitForJsonFrame(first);
+    expect(firstReady.type).toBe("ready");
+
+    second.send(startFrame("conversation-second"));
+    const busy = await waitForJsonFrame(second);
+    expect(busy).toMatchObject({
+      type: "busy",
+      activeSessionId: firstReady.sessionId,
+    });
+
+    first.close(1000, "client finished");
+    await waitForClose(first);
+
+    second.send(startFrame("conversation-second"));
+    const secondReady = await waitForJsonFrame(second);
+    expect(secondReady).toMatchObject({
+      type: "ready",
+      conversationId: "conversation-second",
+    });
+    expect(secondReady.sessionId).not.toBe(firstReady.sessionId);
+  });
+});

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -44,6 +44,19 @@ import {
 import { getConfig } from "../config/loader.js";
 import { normalizeConversationType } from "../daemon/message-types/shared.js";
 import {
+  type LiveVoiceSession,
+  type LiveVoiceSessionFactoryContext,
+  LiveVoiceSessionManager,
+} from "../live-voice/live-voice-session-manager.js";
+import {
+  type LiveVoiceClientFrame,
+  type LiveVoiceProtocolError,
+  LiveVoiceProtocolErrorCode,
+  type LiveVoiceServerFrame,
+  parseLiveVoiceBinaryAudioFrame,
+  parseLiveVoiceClientTextFrame,
+} from "../live-voice/protocol.js";
+import {
   type AttentionState,
   type Confidence,
   getAttentionStateByConversationIds,
@@ -326,6 +339,36 @@ interface SttStreamWebSocketData {
   session?: SttStreamSession;
 }
 
+/**
+ * WebSocket data attached to `/v1/live-voice` connections. The `wsType`
+ * discriminator routes frames to the live voice protocol shell instead of
+ * the other WebSocket handlers.
+ */
+interface LiveVoiceWebSocketData {
+  wsType: "live-voice";
+  sessionId?: string;
+  lastSeq: number;
+}
+
+class RuntimeLiveVoiceStubSession implements LiveVoiceSession {
+  constructor(private readonly context: LiveVoiceSessionFactoryContext) {}
+
+  async start(): Promise<void> {
+    await this.context.sendFrame({
+      type: "ready",
+      sessionId: this.context.sessionId,
+      conversationId:
+        this.context.startFrame.conversationId ?? this.context.sessionId,
+    });
+  }
+
+  handleClientFrame(_frame: LiveVoiceClientFrame): void {}
+
+  handleBinaryAudio(_chunk: Uint8Array): void {}
+
+  close(): void {}
+}
+
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
@@ -352,6 +395,7 @@ export class RuntimeHttpServer {
   private onProviderCredentialsChanged?: RuntimeHttpServerOptions["onProviderCredentialsChanged"];
   private getHeartbeatService?: RuntimeHttpServerOptions["getHeartbeatService"];
   private getFilingService?: RuntimeHttpServerOptions["getFilingService"];
+  private readonly liveVoiceSessionManager: LiveVoiceSessionManager;
   private router: HttpRouter;
 
   constructor(options: RuntimeHttpServerOptions = {}) {
@@ -376,6 +420,9 @@ export class RuntimeHttpServer {
     this.onProviderCredentialsChanged = options.onProviderCredentialsChanged;
     this.getHeartbeatService = options.getHeartbeatService;
     this.getFilingService = options.getFilingService;
+    this.liveVoiceSessionManager = new LiveVoiceSessionManager({
+      createSession: (context) => new RuntimeLiveVoiceStubSession(context),
+    });
     this.router = new HttpRouter(this.buildRouteTable());
   }
 
@@ -389,7 +436,8 @@ export class RuntimeHttpServer {
       | RelayWebSocketData
       | BrowserRelayWebSocketData
       | MediaStreamWebSocketData
-      | SttStreamWebSocketData;
+      | SttStreamWebSocketData
+      | LiveVoiceWebSocketData;
     this.server = Bun.serve<AllWebSocketData>({
       port: this.port,
       hostname: this.hostname,
@@ -397,7 +445,7 @@ export class RuntimeHttpServer {
       maxRequestBodySize: MAX_REQUEST_BODY_BYTES,
       fetch: (req, server) => this.handleRequest(req, server),
       websocket: {
-        open(ws) {
+        open: (ws) => {
           const data = ws.data as AllWebSocketData;
           if ("wsType" in data && data.wsType === "browser-relay") {
             // When the JWT sub resolved to a guardian principal at upgrade
@@ -504,6 +552,10 @@ export class RuntimeHttpServer {
             );
             return;
           }
+          if ("wsType" in data && data.wsType === "live-voice") {
+            log.info("Live voice WebSocket opened");
+            return;
+          }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
           log.info({ callSessionId }, "ConversationRelay WebSocket opened");
           if (callSessionId) {
@@ -514,7 +566,7 @@ export class RuntimeHttpServer {
             activeRelayConnections.set(callSessionId, connection);
           }
         },
-        message(ws, message) {
+        message: (ws, message) => {
           const data = ws.data as AllWebSocketData;
           const raw =
             typeof message === "string"
@@ -665,13 +717,32 @@ export class RuntimeHttpServer {
             }
             return;
           }
+          if ("wsType" in data && data.wsType === "live-voice") {
+            void this.handleLiveVoiceMessage(
+              ws as ServerWebSocket<LiveVoiceWebSocketData>,
+              message,
+            ).catch((err) => {
+              log.warn(
+                { error: err instanceof Error ? err.message : String(err) },
+                "Live voice WebSocket message handler failed",
+              );
+              this.sendLiveVoiceError(
+                ws as ServerWebSocket<LiveVoiceWebSocketData>,
+                {
+                  code: LiveVoiceProtocolErrorCode.InvalidFrame,
+                  message: "Live voice frame handling failed",
+                },
+              );
+            });
+            return;
+          }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
           if (callSessionId) {
             const connection = activeRelayConnections.get(callSessionId);
             connection?.handleMessage(raw);
           }
         },
-        close(ws, code, reason) {
+        close: (ws, code, reason) => {
           const data = ws.data as AllWebSocketData;
           if ("wsType" in data && data.wsType === "browser-relay") {
             // Always attempt to unregister — the registry uses connectionId
@@ -730,6 +801,18 @@ export class RuntimeHttpServer {
                 activeSttStreamSessions.delete(sttData.sessionId);
               }
             }
+            return;
+          }
+          if ("wsType" in data && data.wsType === "live-voice") {
+            log.info(
+              {
+                sessionId: data.sessionId,
+                code,
+                reason: reason?.toString(),
+              },
+              "Live voice WebSocket closed",
+            );
+            this.releaseLiveVoiceSession(data, "websocket_close");
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
@@ -897,6 +980,14 @@ export class RuntimeHttpServer {
       activeSttStreamSessions.delete(sessionId);
     }
 
+    const liveVoiceSessionId = this.liveVoiceSessionManager.activeSessionId;
+    if (liveVoiceSessionId) {
+      await this.liveVoiceSessionManager.releaseSession(
+        liveVoiceSessionId,
+        "manager_shutdown",
+      );
+    }
+
     if (this.server) {
       this.server.stop(true);
       this.server = null;
@@ -969,6 +1060,15 @@ export class RuntimeHttpServer {
       req.headers.get("upgrade")?.toLowerCase() === "websocket"
     ) {
       return this.handleSttStreamUpgrade(req, server);
+    }
+
+    // WebSocket upgrade for live voice — same private-network restrictions
+    // and gateway-service token verification as STT streaming.
+    if (
+      path === "/v1/live-voice" &&
+      req.headers.get("upgrade")?.toLowerCase() === "websocket"
+    ) {
+      return this.handleLiveVoiceUpgrade(req, server);
     }
 
     // Twilio webhook endpoints — before auth check because Twilio
@@ -1222,6 +1322,28 @@ export class RuntimeHttpServer {
     return undefined!;
   }
 
+  private verifyGatewayServiceToken(req: Request): Response | null {
+    if (isHttpAuthDisabled()) return null;
+
+    const wsUrl = new URL(req.url);
+    const token = wsUrl.searchParams.get("token");
+    if (!token) {
+      return httpError("UNAUTHORIZED", "Unauthorized", 401);
+    }
+
+    const jwtResult = verifyToken(token, "vellum-daemon");
+    if (!jwtResult.ok) {
+      return httpError("UNAUTHORIZED", "Unauthorized", 401);
+    }
+
+    const subResult = parseSub(jwtResult.claims.sub);
+    if (!subResult.ok || subResult.principalType !== "svc_gateway") {
+      return httpError("UNAUTHORIZED", "Unauthorized", 401);
+    }
+
+    return null;
+  }
+
   private handleRelayUpgrade(
     req: Request,
     server: ReturnType<typeof Bun.serve>,
@@ -1235,21 +1357,8 @@ export class RuntimeHttpServer {
     }
 
     // Verify the gateway service token before accepting the upgrade.
-    if (!isHttpAuthDisabled()) {
-      const wsUrl = new URL(req.url);
-      const token = wsUrl.searchParams.get("token");
-      if (!token) {
-        return httpError("UNAUTHORIZED", "Unauthorized", 401);
-      }
-      const jwtResult = verifyToken(token, "vellum-daemon");
-      if (!jwtResult.ok) {
-        return httpError("UNAUTHORIZED", "Unauthorized", 401);
-      }
-      const subResult = parseSub(jwtResult.claims.sub);
-      if (!subResult.ok || subResult.principalType !== "svc_gateway") {
-        return httpError("UNAUTHORIZED", "Unauthorized", 401);
-      }
-    }
+    const tokenError = this.verifyGatewayServiceToken(req);
+    if (tokenError) return tokenError;
 
     const wsUrl = new URL(req.url);
     const callSessionId = wsUrl.searchParams.get("callSessionId");
@@ -1277,21 +1386,8 @@ export class RuntimeHttpServer {
     }
 
     // Verify the gateway service token before accepting the upgrade.
-    if (!isHttpAuthDisabled()) {
-      const wsUrl = new URL(req.url);
-      const token = wsUrl.searchParams.get("token");
-      if (!token) {
-        return httpError("UNAUTHORIZED", "Unauthorized", 401);
-      }
-      const jwtResult = verifyToken(token, "vellum-daemon");
-      if (!jwtResult.ok) {
-        return httpError("UNAUTHORIZED", "Unauthorized", 401);
-      }
-      const subResult = parseSub(jwtResult.claims.sub);
-      if (!subResult.ok || subResult.principalType !== "svc_gateway") {
-        return httpError("UNAUTHORIZED", "Unauthorized", 401);
-      }
-    }
+    const tokenError = this.verifyGatewayServiceToken(req);
+    if (tokenError) return tokenError;
 
     const wsUrl = new URL(req.url);
     const callSessionId = wsUrl.searchParams.get("callSessionId");
@@ -1334,23 +1430,8 @@ export class RuntimeHttpServer {
     }
 
     // Verify the gateway service token before accepting the upgrade.
-    if (!isHttpAuthDisabled()) {
-      const wsUrl = new URL(req.url);
-      const token = wsUrl.searchParams.get("token");
-      if (!token) {
-        return httpError("UNAUTHORIZED", "Unauthorized", 401);
-      }
-      const jwtResult = verifyToken(token, "vellum-daemon");
-      if (!jwtResult.ok) {
-        return httpError("UNAUTHORIZED", "Unauthorized", 401);
-      }
-      // Accept gateway service tokens (svc:gateway:*) — these are the
-      // only tokens the gateway mints for upstream connections.
-      const subResult = parseSub(jwtResult.claims.sub);
-      if (!subResult.ok || subResult.principalType !== "svc_gateway") {
-        return httpError("UNAUTHORIZED", "Unauthorized", 401);
-      }
-    }
+    const tokenError = this.verifyGatewayServiceToken(req);
+    if (tokenError) return tokenError;
 
     const wsUrl = new URL(req.url);
     // provider is optional compatibility metadata — the runtime resolves
@@ -1381,6 +1462,175 @@ export class RuntimeHttpServer {
     }
     // Bun's WebSocket upgrade consumes the request — no Response is sent.
     return undefined!;
+  }
+
+  /**
+   * Handle WebSocket upgrade for `/v1/live-voice`.
+   *
+   * The gateway owns downstream client auth and forwards this upstream with
+   * a short-lived gateway service token. The runtime accepts only private
+   * network peers/origins so the shell is not publicly reachable.
+   */
+  private handleLiveVoiceUpgrade(
+    req: Request,
+    server: ReturnType<typeof Bun.serve>,
+  ): Response {
+    if (!isPrivateNetworkPeer(server, req) || !isPrivateNetworkOrigin(req)) {
+      return httpError(
+        "FORBIDDEN",
+        "Direct live voice access disabled — only private network peers allowed",
+        403,
+      );
+    }
+
+    const tokenError = this.verifyGatewayServiceToken(req);
+    if (tokenError) return tokenError;
+
+    const upgraded = server.upgrade(req, {
+      data: {
+        wsType: "live-voice",
+        lastSeq: 0,
+      } satisfies LiveVoiceWebSocketData,
+    });
+    if (!upgraded) {
+      return new Response("WebSocket upgrade failed", { status: 500 });
+    }
+    return undefined!;
+  }
+
+  private async handleLiveVoiceMessage(
+    ws: ServerWebSocket<LiveVoiceWebSocketData>,
+    message: string | ArrayBuffer | ArrayBufferView,
+  ): Promise<void> {
+    if (typeof message === "string") {
+      const result = parseLiveVoiceClientTextFrame(message);
+      if (!result.ok) {
+        this.sendLiveVoiceError(ws, result.error);
+        return;
+      }
+      await this.dispatchLiveVoiceClientFrame(ws, result.frame);
+      return;
+    }
+
+    const result = parseLiveVoiceBinaryAudioFrame(message);
+    if (!result.ok) {
+      this.sendLiveVoiceError(ws, result.error);
+      return;
+    }
+
+    const sessionId = ws.data.sessionId;
+    if (!sessionId) {
+      this.sendLiveVoiceStateError(
+        ws,
+        "Live voice binary audio received before start",
+      );
+      return;
+    }
+
+    const handled = await this.liveVoiceSessionManager.handleBinaryAudio(
+      sessionId,
+      result.frame.data,
+    );
+    if (handled.status === "not_found") {
+      ws.data.sessionId = undefined;
+      this.sendLiveVoiceStateError(ws, "Live voice session is not active");
+    }
+  }
+
+  private async dispatchLiveVoiceClientFrame(
+    ws: ServerWebSocket<LiveVoiceWebSocketData>,
+    frame: LiveVoiceClientFrame,
+  ): Promise<void> {
+    if (frame.type === "start") {
+      if (ws.data.sessionId) {
+        this.sendLiveVoiceStateError(ws, "Live voice session already started");
+        return;
+      }
+
+      const result = await this.liveVoiceSessionManager.startSession(frame, {
+        sendFrame: async (serverFrame) => {
+          this.sendLiveVoiceFrame(ws, serverFrame);
+        },
+      });
+      if (result.status === "accepted") {
+        ws.data.sessionId = result.sessionId;
+      }
+      return;
+    }
+
+    const sessionId = ws.data.sessionId;
+    if (!sessionId) {
+      this.sendLiveVoiceStateError(
+        ws,
+        `Live voice ${frame.type} frame received before start`,
+      );
+      return;
+    }
+
+    const handled = await this.liveVoiceSessionManager.handleClientFrame(
+      sessionId,
+      frame,
+    );
+    if (handled.status === "not_found") {
+      ws.data.sessionId = undefined;
+      this.sendLiveVoiceStateError(ws, "Live voice session is not active");
+      return;
+    }
+
+    if (frame.type === "end") {
+      ws.data.sessionId = undefined;
+    }
+  }
+
+  private sendLiveVoiceStateError(
+    ws: ServerWebSocket<LiveVoiceWebSocketData>,
+    message: string,
+  ): void {
+    this.sendLiveVoiceError(ws, {
+      code: LiveVoiceProtocolErrorCode.InvalidFrame,
+      message,
+    });
+  }
+
+  private sendLiveVoiceError(
+    ws: ServerWebSocket<LiveVoiceWebSocketData>,
+    error: Pick<LiveVoiceProtocolError, "code" | "message">,
+  ): void {
+    this.sendLiveVoiceFrame(ws, {
+      type: "error",
+      seq: ws.data.lastSeq + 1,
+      code: error.code,
+      message: error.message,
+    });
+  }
+
+  private sendLiveVoiceFrame(
+    ws: ServerWebSocket<LiveVoiceWebSocketData>,
+    frame: LiveVoiceServerFrame,
+  ): void {
+    ws.data.lastSeq = Math.max(ws.data.lastSeq, frame.seq);
+    ws.send(JSON.stringify(frame));
+  }
+
+  private releaseLiveVoiceSession(
+    data: LiveVoiceWebSocketData,
+    reason: "websocket_close",
+  ): void {
+    const sessionId = data.sessionId;
+    data.sessionId = undefined;
+    if (!sessionId) return;
+
+    void this.liveVoiceSessionManager
+      .releaseSession(sessionId, reason)
+      .catch((err) => {
+        log.warn(
+          {
+            error: err instanceof Error ? err.message : String(err),
+            sessionId,
+          },
+          "Failed to release live voice session",
+        );
+      });
   }
 
   private async handleTwilioWebhook(


### PR DESCRIPTION
## PR 3: add assistant live voice WebSocket shell

### Depends on

PR 1, PR 2.

### Branch

`live-voice-channel/pr-03-runtime-websocket-shell`

### Files

- `assistant/src/runtime/http-server.ts`
- `assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts`

### Scope

Add the `/v1/live-voice` WebSocket upgrade path to `RuntimeHttpServer`, mirroring the existing `/v1/stt/stream` security posture:

- require private-network peer or allowed origin where the STT stream path does
- require the gateway service token unless auth is disabled
- attach a `LiveVoiceWebSocketData` record to the Bun WebSocket
- dispatch text frames through the protocol parser
- dispatch binary frames as raw audio chunks
- close and release the session manager on socket close

This PR should use a stub session implementation from PR 2 and should not run STT, LLM, or TTS.

### Acceptance Criteria

- Unauthorized upgrades are rejected before a WebSocket is created.
- A well-formed `start` frame receives `ready`.
- Malformed frames receive an `error` frame and leave the socket in a consistent state.
- Closing the socket releases the session lock.

### Verification

Run:

```bash
export PATH="$HOME/.bun/bin:$PATH"
cd assistant && bun test src/live-voice/__tests__/runtime-websocket-shell.test.ts
cd assistant && bunx tsc --noEmit
```

Orchestrated by velissa-ai via run-plan; implemented by Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
