### PR TITLE
feat(live-voice): wire macOS voice mode to the live channel (PR 10)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -270,7 +270,8 @@ public final class MainWindow {
     let documentManager = DocumentManager()
     private let assistantFeatureFlagStore: AssistantFeatureFlagStore
     var onMicrophoneToggle: (() -> Void)?
-    let voiceModeManager = VoiceModeManager()
+    let liveVoiceChannelManager: LiveVoiceChannelManager
+    let voiceModeManager: VoiceModeManager
     let updateManager: UpdateManager
 
     /// Retained delegate that intercepts the close button to hide the window.
@@ -327,6 +328,13 @@ public final class MainWindow {
         self.updateManager = updateManager
         self.assistantFeatureFlagStore = assistantFeatureFlagStore
         self.initialAssistantName = initialAssistantName
+        let liveVoiceChannelManager = LiveVoiceChannelManager()
+        self.liveVoiceChannelManager = liveVoiceChannelManager
+        let connectionManager = services.connectionManager
+        self.voiceModeManager = VoiceModeManager(
+            liveVoiceChannelManager: liveVoiceChannelManager,
+            liveVoiceAvailability: { connectionManager.isConnected }
+        )
         self.conversationManager = ConversationManager(
             connectionManager: services.connectionManager,
             eventStreamClient: services.connectionManager.eventStreamClient,

--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
@@ -98,6 +98,13 @@ final class LiveVoiceChannelManager {
             failWithoutActiveClient(message: "A conversation is required to start live voice.")
             return
         }
+        if state == .idle, client != nil {
+            if activeConversationId == trimmedConversationId {
+                await startListening()
+                return
+            }
+            await end()
+        }
         guard state == .idle || state == .failed else { return }
 
         sessionGeneration &+= 1
@@ -120,6 +127,11 @@ final class LiveVoiceChannelManager {
         )
     }
 
+    func startListening() async {
+        guard state == .idle, client != nil else { return }
+        startCapture(generation: sessionGeneration)
+    }
+
     func stopListening() async {
         guard state != .idle, state != .failed, state != .ending else { return }
         guard captureRunning || captureStartInFlight else { return }
@@ -133,7 +145,8 @@ final class LiveVoiceChannelManager {
     }
 
     func end() async {
-        guard state != .idle, state != .failed, state != .ending else { return }
+        guard state != .failed, state != .ending else { return }
+        guard state != .idle || client != nil || captureRunning || captureStartInFlight else { return }
 
         state = .ending
         sessionGeneration &+= 1
@@ -280,7 +293,7 @@ final class LiveVoiceChannelManager {
             }
 
             self.captureRunning = true
-            if self.state == .connecting {
+            if self.state == .connecting || self.state == .idle {
                 self.state = .listening
             }
         }

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -6,6 +6,21 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "VoiceModeManager")
 
+@MainActor
+protocol LiveVoiceChannelManaging: AnyObject {
+    var state: LiveVoiceChannelManager.State { get }
+    var partialTranscript: String { get }
+    var finalTranscript: String { get }
+    var errorMessage: String { get }
+
+    func start(conversationId: String) async
+    func startListening() async
+    func stopListening() async
+    func end() async
+}
+
+extension LiveVoiceChannelManager: LiveVoiceChannelManaging {}
+
 /// Voice-mode state model.
 ///
 /// Marked `@Observable` so views reading only `state` are not invalidated by
@@ -21,6 +36,11 @@ final class VoiceModeManager {
 
     enum State: Equatable {
         case off, idle, listening, processing, speaking
+    }
+
+    private enum VoicePath {
+        case turnBased
+        case liveChannel
     }
 
     var state: State = .off {
@@ -42,6 +62,8 @@ final class VoiceModeManager {
     /// Injected separately from `voiceService` so VoiceModeManager does not
     /// need to know about `OpenAIVoiceService` or any concrete voice service type.
     @ObservationIgnored private let speechRecognizerAdapter: any SpeechRecognizerAdapter
+    @ObservationIgnored private let liveVoiceChannelManager: (any LiveVoiceChannelManaging)?
+    @ObservationIgnored private let liveVoiceAvailability: @MainActor () -> Bool
 
     /// Typed accessor for UI views that need observed amplitude properties.
     var openAIVoiceService: OpenAIVoiceService? {
@@ -70,12 +92,20 @@ final class VoiceModeManager {
     /// Last observed value from the isThinking observation loop, used to
     /// deduplicate redundant same-value writes and only act on actual transitions.
     @ObservationIgnored private var lastObservedIsThinking: Bool = false
+    @ObservationIgnored private var activeVoicePath: VoicePath = .turnBased
+    @ObservationIgnored private var liveVoiceObservationGeneration: Int = 0
+    @ObservationIgnored private var liveVoiceStartTask: Task<Void, Never>?
+    @ObservationIgnored private var liveFallbackAttemptedForSession = false
 
     init(
         voiceService: any VoiceServiceProtocol = OpenAIVoiceService(),
+        liveVoiceChannelManager: (any LiveVoiceChannelManaging)? = nil,
+        liveVoiceAvailability: @escaping @MainActor () -> Bool = { false },
         speechRecognizerAdapter: any SpeechRecognizerAdapter = AppleSpeechRecognizerAdapter()
     ) {
         self.voiceService = voiceService
+        self.liveVoiceChannelManager = liveVoiceChannelManager
+        self.liveVoiceAvailability = liveVoiceAvailability
         self.speechRecognizerAdapter = speechRecognizerAdapter
     }
 
@@ -105,8 +135,9 @@ final class VoiceModeManager {
         // Whisper), native speech recognition permission is not required — the
         // service handles transcription. Skip the speech auth guard entirely.
         let sttConfigured = STTProviderRegistry.isServiceConfigured
+        let liveVoiceEligible = canStartLiveVoiceSession(for: chatViewModel)
 
-        guard sttConfigured || speechRecognizerAdapter.authorizationStatus() == .authorized else {
+        guard liveVoiceEligible || sttConfigured || speechRecognizerAdapter.authorizationStatus() == .authorized else {
             log.error("Voice mode: speech recognition not authorized")
             awaitingAuthorization = true
             let status = speechRecognizerAdapter.authorizationStatus()
@@ -135,6 +166,8 @@ final class VoiceModeManager {
         awaitingAuthorization = false
         self.chatViewModel = chatViewModel
         self.settingsStore = settingsStore
+        activeVoicePath = .turnBased
+        liveFallbackAttemptedForSession = false
 
         // Provide the conversation ID to the voice service so the gateway TTS
         // endpoint can resolve the correct provider context.
@@ -151,12 +184,14 @@ final class VoiceModeManager {
 
         // Stream text deltas to TTS as they arrive
         chatViewModel.onVoiceTextDelta = { [weak self] delta in
-            self?.handleTextDelta(delta)
+            guard let self, self.activeVoicePath == .turnBased else { return }
+            self.handleTextDelta(delta)
         }
 
         // When the full response is complete, flush remaining text to TTS
         chatViewModel.onVoiceResponseComplete = { [weak self] _ in
-            self?.handleResponseComplete()
+            guard let self, self.activeVoicePath == .turnBased else { return }
+            self.handleResponseComplete()
         }
         chatViewModel.isVoiceModeActive = true
 
@@ -203,6 +238,17 @@ final class VoiceModeManager {
         // startListening() during teardown.
         state = .off
 
+        stopLiveVoiceObservation()
+        liveVoiceStartTask?.cancel()
+        liveVoiceStartTask = nil
+        if let liveVoiceChannelManager {
+            Task { @MainActor in
+                await liveVoiceChannelManager.end()
+            }
+        }
+        activeVoicePath = .turnBased
+        liveFallbackAttemptedForSession = false
+
         // Fully shut down audio engine to release the microphone
         voiceService.shutdown()
 
@@ -240,7 +286,11 @@ final class VoiceModeManager {
         case .listening:
             stopListening()
         case .speaking:
-            handleBargeIn()
+            if activeVoicePath == .liveChannel {
+                startListening()
+            } else {
+                handleBargeIn()
+            }
         default:
             break
         }
@@ -248,6 +298,27 @@ final class VoiceModeManager {
 
     func startListening() {
         guard state == .idle else { return }
+        if canStartLiveVoiceSession(for: chatViewModel),
+           let conversationId = liveVoiceConversationId(for: chatViewModel) {
+            startLiveVoiceListening(conversationId: conversationId)
+            return
+        }
+
+        startTurnBasedListeningWithAuthorization()
+    }
+
+    private func startTurnBasedListeningWithAuthorization() {
+        guard STTProviderRegistry.isServiceConfigured || speechRecognizerAdapter.authorizationStatus() == .authorized else {
+            requestTurnBasedSpeechAuthorizationThenStart()
+            return
+        }
+
+        startTurnBasedListening()
+    }
+
+    private func startTurnBasedListening() {
+        guard state == .idle else { return }
+        activeVoicePath = .turnBased
         partialTranscription = ""
         liveTranscription = ""
         errorMessage = ""
@@ -263,9 +334,170 @@ final class VoiceModeManager {
 
     private func stopListening() {
         guard state == .listening else { return }
+
+        if activeVoicePath == .liveChannel {
+            state = .processing
+            let liveVoiceChannelManager = liveVoiceChannelManager
+            Task { @MainActor in
+                await liveVoiceChannelManager?.stopListening()
+            }
+            log.info("Voice mode: released live voice push-to-talk")
+            return
+        }
+
         voiceService.cancelRecording()
         state = .idle
         log.info("Voice mode: stopped listening")
+    }
+
+    private func requestTurnBasedSpeechAuthorizationThenStart() {
+        let status = speechRecognizerAdapter.authorizationStatus()
+        guard status == .notDetermined else {
+            errorMessage = "Speech recognition permission is required for standard voice mode."
+            state = .idle
+            log.warning("Voice mode: standard voice fallback unavailable (speech status: \(status.rawValue))")
+            return
+        }
+
+        awaitingAuthorization = true
+        speechRecognizerAdapter.requestAuthorization { [weak self] newStatus in
+            Task { @MainActor in
+                guard let self, self.awaitingAuthorization, self.state == .idle else { return }
+                self.awaitingAuthorization = false
+                guard newStatus == .authorized else {
+                    self.errorMessage = "Speech recognition permission is required for standard voice mode."
+                    log.warning("Voice mode: speech recognition authorization denied during fallback")
+                    return
+                }
+                self.startTurnBasedListening()
+            }
+        }
+    }
+
+    private func liveVoiceConversationId(for chatViewModel: ChatViewModel?) -> String? {
+        guard let conversationId = chatViewModel?.conversationId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !conversationId.isEmpty else {
+            return nil
+        }
+        return conversationId
+    }
+
+    private func canStartLiveVoiceSession(for chatViewModel: ChatViewModel?) -> Bool {
+        liveVoiceChannelManager != nil
+            && liveVoiceAvailability()
+            && pendingPermissionIds.isEmpty
+            && liveVoiceConversationId(for: chatViewModel) != nil
+    }
+
+    private func startLiveVoiceListening(conversationId: String) {
+        guard let liveVoiceChannelManager else { return }
+
+        activeVoicePath = .liveChannel
+        liveFallbackAttemptedForSession = false
+        partialTranscription = ""
+        liveTranscription = ""
+        errorMessage = ""
+        state = .listening
+        startLiveVoiceObservation()
+
+        liveVoiceStartTask?.cancel()
+        liveVoiceStartTask = Task { @MainActor [weak self, weak liveVoiceChannelManager] in
+            guard let self, let liveVoiceChannelManager else { return }
+            await liveVoiceChannelManager.start(conversationId: conversationId)
+            guard !Task.isCancelled, self.activeVoicePath == .liveChannel else { return }
+            self.syncLiveVoiceState(from: liveVoiceChannelManager)
+        }
+        log.info("Voice mode: starting live voice channel")
+    }
+
+    private func startLiveVoiceObservation() {
+        liveVoiceObservationGeneration += 1
+        observeLiveVoiceLoop(generation: liveVoiceObservationGeneration)
+    }
+
+    private func stopLiveVoiceObservation() {
+        liveVoiceObservationGeneration += 1
+    }
+
+    private func observeLiveVoiceLoop(generation: Int) {
+        guard generation == liveVoiceObservationGeneration,
+              activeVoicePath == .liveChannel,
+              let liveVoiceChannelManager else { return }
+
+        withObservationTracking {
+            _ = liveVoiceChannelManager.state
+            _ = liveVoiceChannelManager.partialTranscript
+            _ = liveVoiceChannelManager.finalTranscript
+            _ = liveVoiceChannelManager.errorMessage
+        } onChange: { [weak self, weak liveVoiceChannelManager] in
+            Task { @MainActor [weak self, weak liveVoiceChannelManager] in
+                guard let self,
+                      let liveVoiceChannelManager,
+                      generation == self.liveVoiceObservationGeneration else { return }
+                self.syncLiveVoiceState(from: liveVoiceChannelManager)
+                self.observeLiveVoiceLoop(generation: generation)
+            }
+        }
+    }
+
+    private func syncLiveVoiceState(from liveVoiceChannelManager: any LiveVoiceChannelManaging) {
+        guard activeVoicePath == .liveChannel, state != .off else { return }
+
+        let visibleTranscript = liveVoiceChannelManager.partialTranscript.isEmpty
+            ? liveVoiceChannelManager.finalTranscript
+            : liveVoiceChannelManager.partialTranscript
+        if liveTranscription != visibleTranscript {
+            liveTranscription = visibleTranscript
+        }
+        if partialTranscription != liveVoiceChannelManager.finalTranscript {
+            partialTranscription = liveVoiceChannelManager.finalTranscript
+        }
+
+        switch liveVoiceChannelManager.state {
+        case .idle:
+            state = .idle
+        case .connecting, .listening:
+            state = .listening
+        case .transcribing, .thinking, .ending:
+            state = .processing
+        case .speaking:
+            state = .speaking
+        case .failed:
+            handleLiveVoiceFailure(message: liveVoiceChannelManager.errorMessage)
+        }
+    }
+
+    private func handleLiveVoiceFailure(message: String) {
+        guard activeVoicePath == .liveChannel else { return }
+        stopLiveVoiceObservation()
+
+        let fallbackMessage = message.isEmpty ? "Live voice is unavailable." : message
+        guard !liveFallbackAttemptedForSession else {
+            errorMessage = fallbackMessage
+            state = .idle
+            return
+        }
+
+        liveFallbackAttemptedForSession = true
+        activeVoicePath = .turnBased
+        errorMessage = "Live voice is unavailable. Using standard voice mode."
+        state = .idle
+        log.warning("Voice mode: live channel failed, falling back to standard voice mode — \(fallbackMessage, privacy: .public)")
+        startTurnBasedListeningWithAuthorization()
+    }
+
+    private func leaveLiveVoiceChannelForTurnBasedVoice() {
+        guard activeVoicePath == .liveChannel else { return }
+
+        stopLiveVoiceObservation()
+        liveVoiceStartTask?.cancel()
+        liveVoiceStartTask = nil
+        activeVoicePath = .turnBased
+
+        let liveVoiceChannelManager = liveVoiceChannelManager
+        Task { @MainActor in
+            await liveVoiceChannelManager?.end()
+        }
     }
 
     // MARK: - Silence Detection → Transcription
@@ -376,6 +608,11 @@ final class VoiceModeManager {
 
         pendingPermissionIds = pending.map { $0.requestId }
 
+        let wasUsingLiveVoice = activeVoicePath == .liveChannel
+        if wasUsingLiveVoice {
+            leaveLiveVoiceChannelForTurnBasedVoice()
+        }
+
         // Stop any current activity before speaking the permission prompt
         switch state {
         case .speaking:
@@ -384,9 +621,15 @@ final class VoiceModeManager {
             ttsTimeoutTask?.cancel()
             ttsTimeoutTask = nil
             state = .processing
-            voiceService.stopSpeaking()
+            if !wasUsingLiveVoice {
+                voiceService.stopSpeaking()
+            }
         case .listening:
-            voiceService.cancelRecording()
+            if wasUsingLiveVoice {
+                state = .processing
+            } else {
+                voiceService.cancelRecording()
+            }
         default:
             break
         }

--- a/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
@@ -295,6 +295,38 @@ final class LiveVoiceChannelManagerTests: XCTestCase {
         XCTAssertNil(manager.sessionId)
     }
 
+    func testStartListeningResumesCaptureOnIdleOpenSession() async {
+        await startReadySession()
+
+        await manager.stopListening()
+        client.emit(.sttFinal(text: "hello", seq: 1))
+        client.emit(.ttsDone(turnId: "turn-123"))
+        XCTAssertEqual(manager.state, .idle)
+
+        await manager.startListening()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(capture.startCallCount, 2)
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(client.startCalls.count, 1)
+    }
+
+    func testEndClosesIdleOpenSession() async {
+        await startReadySession()
+
+        await manager.stopListening()
+        client.emit(.sttFinal(text: "hello", seq: 1))
+        client.emit(.ttsDone(turnId: "turn-123"))
+        XCTAssertEqual(manager.state, .idle)
+
+        await manager.end()
+
+        XCTAssertEqual(client.endCallCount, 1)
+        XCTAssertEqual(playback.endCallCount, 1)
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertNil(manager.activeConversationId)
+    }
+
     func testFailureCleansUpResourcesAndStoresError() async {
         await startReadySession()
 

--- a/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Observation
 import Speech
 @testable import VellumAssistantLib
 @testable import VellumAssistantShared
@@ -27,6 +28,49 @@ private final class MockSpeechRecognizerAdapter: SpeechRecognizerAdapter {
 
     var isRecognizerAvailable: Bool {
         stubbedIsRecognizerAvailable
+    }
+}
+
+@MainActor
+@Observable
+private final class FakeLiveVoiceChannelManager: LiveVoiceChannelManaging {
+    var state: LiveVoiceChannelManager.State = .idle
+    var partialTranscript: String = ""
+    var finalTranscript: String = ""
+    var errorMessage: String = ""
+
+    private(set) var startCalls: [String] = []
+    private(set) var startListeningCallCount = 0
+    private(set) var stopListeningCallCount = 0
+    private(set) var endCallCount = 0
+
+    func start(conversationId: String) async {
+        startCalls.append(conversationId)
+        state = .connecting
+    }
+
+    func startListening() async {
+        startListeningCallCount += 1
+        state = .listening
+    }
+
+    func stopListening() async {
+        stopListeningCallCount += 1
+        state = .transcribing
+    }
+
+    func end() async {
+        endCallCount += 1
+        state = .idle
+    }
+
+    func becomeReady() {
+        state = .listening
+    }
+
+    func fail(message: String) {
+        errorMessage = message
+        state = .failed
     }
 }
 
@@ -704,6 +748,147 @@ final class VoiceModeManagerTests: XCTestCase {
         sttManager.deactivate()
     }
 
+    // MARK: - Live Voice Channel Wiring
+
+    func testStartListeningUsesLiveChannelWhenAvailable() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        let speechAdapter = MockSpeechRecognizerAdapter()
+        speechAdapter.stubbedAuthorizationStatus = .denied
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true },
+            speechRecognizerAdapter: speechAdapter
+        )
+
+        manager.activate(chatViewModel: chatViewModel)
+        manager.startListening()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(liveManager.startCalls, ["conv-123"])
+        XCTAssertFalse(mockVoiceService.startRecordingCalled)
+        XCTAssertTrue(chatViewModel.isVoiceModeActive)
+    }
+
+    func testStartListeningFallsBackWhenLiveChannelUnavailable() {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { false }
+        )
+        forceActivate()
+
+        manager.startListening()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertTrue(mockVoiceService.startRecordingCalled)
+        XCTAssertTrue(liveManager.startCalls.isEmpty)
+    }
+
+    func testLiveChannelFailureFallsBackToTurnBasedVoice() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.fail(message: "Live voice connection rejected")
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertTrue(mockVoiceService.startRecordingCalled)
+        XCTAssertEqual(liveManager.startCalls, ["conv-123"])
+    }
+
+    func testLiveChannelStopListeningReleasesPushToTalk() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.becomeReady()
+        await flushAsyncTasks()
+
+        manager.toggleListening()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(liveManager.stopListeningCallCount, 1)
+        XCTAssertEqual(manager.state, .processing)
+        XCTAssertFalse(mockVoiceService.cancelRecordingCalled)
+    }
+
+    func testDeactivateEndsLiveChannelAndClearsVoiceMode() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+        chatViewModel.isVoiceModeActive = true
+
+        manager.startListening()
+        await flushAsyncTasks()
+        manager.deactivate()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .off)
+        XCTAssertEqual(liveManager.endCallCount, 1)
+        XCTAssertFalse(chatViewModel.isVoiceModeActive)
+        XCTAssertTrue(mockVoiceService.shutdownCalled)
+    }
+
+    func testPendingPermissionEndsLiveChannelAndUsesExistingPrompt() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        let speechAdapter = MockSpeechRecognizerAdapter()
+        speechAdapter.stubbedAuthorizationStatus = .authorized
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true },
+            speechRecognizerAdapter: speechAdapter
+        )
+
+        manager.activate(chatViewModel: chatViewModel)
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.becomeReady()
+        await flushAsyncTasks()
+
+        let confirmation = makeConfirmation(toolName: "bash", input: ["command": AnyCodable("echo hello")])
+        chatViewModel.messages = [
+            ChatMessage(
+                role: .assistant,
+                text: "",
+                confirmation: confirmation
+            )
+        ]
+        await flushAsyncTasks()
+
+        XCTAssertEqual(liveManager.endCallCount, 1)
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertEqual(manager.pendingPermissionIds, [confirmation.requestId])
+        XCTAssertTrue(mockVoiceService.feedTextDeltaCalled)
+        XCTAssertTrue(mockVoiceService.finishTextStreamCalled)
+    }
+
     // MARK: - Helpers
 
     private func makeConfirmation(
@@ -722,5 +907,10 @@ final class VoiceModeManagerTests: XCTestCase {
             persistentDecisionsAllowed: true,
             state: .pending
         )
+    }
+
+    private func flushAsyncTasks() async {
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 1_000_000)
     }
 }


### PR DESCRIPTION
## PR 10: wire macOS voice mode to the live channel

### Depends on

PR 5, PR 9.

### Branch

`live-voice-channel/pr-10-macos-voice-mode-wiring`

### Files

- `clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift`
- `clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift`
- `clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift`
- `clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift`
- `clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift`

### Scope

Wire live voice behind the existing `voice-mode` product entrypoint instead of adding a new feature flag. Keep existing voice-mode UI labels, composer controls, and deactivation behavior, but route active conversations through `LiveVoiceChannelManager` when gateway live voice is available.

Implementation guidance:

- inject `LiveVoiceChannelManager` into `VoiceModeManager` rather than constructing it from global state
- keep `OpenAIVoiceService` as the fallback path if the live channel connection is rejected or unavailable
- preserve existing `chatViewModel.isVoiceModeActive`, waveform, transcription, and permission prompting behavior
- do not add new menu items unless existing voice controls need a small state label update

### Acceptance Criteria

- Existing voice mode activation/deactivation tests pass.
- Live voice failures fall back to the existing turn-based voice service or surface a clear recoverable error without leaving the mic active.
- Conversation switching still deactivates voice mode.
- No new feature flag is added to `meta/feature-flags/feature-flag-registry.json`.

### Verification

Run:

```bash
cd clients
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter VoiceModeManagerTests
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter LiveVoiceChannelManagerTests
```

Orchestrated by velissa-ai via run-plan; implemented by Codex.

Apple references checked (2026-04-26):
- Observation: https://developer.apple.com/documentation/observation
- URLSessionWebSocketTask: https://developer.apple.com/documentation/foundation/urlsessionwebsockettask
- AVCaptureDevice authorizationStatus(for:): https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624613-authorizationstatus
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
