### PR TITLE
feat(macos): delete completed session from history in detail view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -7,9 +7,9 @@ import VellumAssistantShared
 ///
 /// Renders a header (agent + status + elapsed + parent-conversation link), a
 /// scrolling timeline of `ACPSessionUpdateMessage` events grouped into visual
-/// rows, and — for running sessions when a ``ACPSessionStore`` is supplied —
-/// a steering footer (textbox + button) that lets the user redirect the
-/// agent mid-run. Tool calls coalesce with their `tool_call_update` siblings
+/// rows, and a context-sensitive footer: a steering textbox+button for
+/// running sessions, or a "Delete from history" button once the session is
+/// terminal. Tool calls coalesce with their `tool_call_update` siblings
 /// (latest update wins) so a streaming tool that emits multiple status
 /// transitions still renders as a single row.
 ///
@@ -19,19 +19,23 @@ import VellumAssistantShared
 ///
 /// A Cancel button surfaces while the session is `running`/`initializing`
 /// (PR 24); a Steer textbox + button surfaces while the session is `running`
-/// (PR 25). The delete affordance arrives in PR 26.
+/// (PR 25); a "Delete from history" button surfaces once the session is
+/// terminal (PR 26).
 struct ACPSessionDetailView: View {
     let session: ACPSessionViewModel
-    /// Store used to drive optimistic mutations from this view (cancel and
-    /// steer today; delete in PR 26). Held by reference so the view always
-    /// invokes the caller-owned instance — there's only one ``ACPSessionStore``
-    /// per app.
+    /// Store used to drive optimistic mutations from this view (cancel,
+    /// steer, delete). Held by reference so the view always invokes the
+    /// caller-owned instance — there's only one ``ACPSessionStore`` per app.
     let store: ACPSessionStore
     /// Tap on the parent-conversation link. Wired by PR 22; nil hides the link.
     var onSelectParentConversation: ((String) -> Void)? = nil
     /// Optional close action — surfaces the design-system close button when
     /// this view is hosted inside a panel container that can dismiss itself.
     var onClose: (() -> Void)? = nil
+    /// Pop-to-list callback fired after a successful "Delete from history".
+    /// Hosting view (the panel's `NavigationStack`) is responsible for the
+    /// actual back-pop; we just signal that the underlying row is gone.
+    var onDismiss: (() -> Void)? = nil
 
     /// True while a cancel HTTP request is in flight. Disables the button and
     /// shows an inline spinner so the user can't double-tap.
@@ -59,6 +63,9 @@ struct ACPSessionDetailView: View {
     /// Bound text content of the steer textbox. Cleared on every successful
     /// submission so the field is ready for the next instruction.
     @State private var steerInput: String = ""
+    /// True while a "Delete from history" request is in flight. Gates the
+    /// button so a flurry of taps can't spawn duplicate requests.
+    @State private var isDeleting = false
 
     /// Persisted preference for whether agent-thought bubbles render in the
     /// timeline. Defaults to `true` so first-time users see the assistant's
@@ -77,6 +84,10 @@ struct ACPSessionDetailView: View {
             if session.state.status == .running {
                 Divider().background(VColor.borderBase)
                 steerFooter
+            }
+            if isDeletable {
+                Divider().background(VColor.borderBase)
+                deleteFooter
             }
         }
     }
@@ -588,6 +599,55 @@ struct ACPSessionDetailView: View {
         // `acpSessionId` (not `state.id`) is the daemon-side session handle
         // the steer route accepts and the store keys its dictionary by.
         Task { await store.steer(id: session.state.acpSessionId, instruction: instruction) }
+    }
+
+    // MARK: - Delete Footer
+
+    /// Delete-from-history is only meaningful once the session has reached a
+    /// terminal status. The daemon also enforces this with a 409 on active
+    /// sessions, so gating the button is purely about avoiding a confusing
+    /// affordance that would always fail.
+    ///
+    /// `internal` rather than `private` so unit tests in `VellumAssistantLib`
+    /// can verify the gating without rendering the view.
+    var isDeletable: Bool {
+        ACPSessionStore.isTerminal(session.state.status)
+    }
+
+    @ViewBuilder
+    private var deleteFooter: some View {
+        HStack(alignment: .center, spacing: VSpacing.sm) {
+            Spacer()
+            VButton(
+                label: "Delete from history",
+                leftIcon: "trash",
+                style: .dangerGhost,
+                size: .compact,
+                isDisabled: isDeleting
+            ) {
+                handleDeleteTap()
+            }
+            .accessibilityLabel("Delete session from history")
+        }
+        .padding(EdgeInsets(top: VSpacing.md, leading: VSpacing.lg, bottom: VSpacing.md, trailing: VSpacing.lg))
+    }
+
+    /// `internal` rather than `private` so unit tests in `VellumAssistantLib`
+    /// can drive the delete flow without reaching into SwiftUI's view tree.
+    func handleDeleteTap() {
+        guard !isDeleting else { return }
+        isDeleting = true
+        let id = session.state.acpSessionId
+        Task { @MainActor in
+            let result = await store.delete(id: id)
+            isDeleting = false
+            // Pop only on a successful row removal so the user has a chance
+            // to react if the daemon reports a 409 (still active) or other
+            // failure — the row stays put and the button re-enables.
+            if case .success = result {
+                onDismiss?()
+            }
+        }
     }
 }
 

--- a/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionDetailViewTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionDetailViewTests.swift
@@ -35,13 +35,19 @@ final class ACPSessionDetailViewTests: XCTestCase {
 
     // MARK: - Mock store
 
-    /// Records invocations of ``ACPSessionStore/cancel(id:)`` and
-    /// ``ACPSessionStore/steer(id:instruction:)`` so detail-view tests can
-    /// assert taps reach the store without spinning up the full `URLProtocol`
-    /// mocking apparatus that the network-layer tests use.
+    /// Records invocations of ``ACPSessionStore``'s mutating entry points so
+    /// detail-view tests can assert taps reach the store without spinning up
+    /// the full `URLProtocol` mocking apparatus that the network-layer tests
+    /// use. Tests can flip ``deleteResult`` to simulate a daemon failure
+    /// (e.g. the 409 returned for active sessions).
     private final class SpyACPSessionStore: ACPSessionStore {
         var cancelInvocations: [String] = []
         var steerInvocations: [(id: String, instruction: String)] = []
+        var deleteInvocations: [String] = []
+        /// Result the next ``delete(id:)`` call should return. Defaults to
+        /// `.success(true)` (the deleted-from-history happy path); tests
+        /// override to `.failure(...)` to drive the error branch.
+        var deleteResult: Result<Bool, ACPClientError> = .success(true)
 
         override func cancel(id: String) async -> Result<Bool, ACPClientError> {
             cancelInvocations.append(id)
@@ -70,6 +76,17 @@ final class ACPSessionDetailViewTests: XCTestCase {
             // the daemon round-trips an SSE update to confirm. Mirror that:
             // no view-model mutation here, just record and ack.
             return .success(true)
+        }
+
+        override func delete(id: String) async -> Result<Bool, ACPClientError> {
+            deleteInvocations.append(id)
+            // Mirror the production store: only drop the row when the
+            // (mocked) HTTP call would have succeeded.
+            if case .success = deleteResult {
+                sessions.removeValue(forKey: id)
+                sessionOrder.removeAll { $0 == id }
+            }
+            return deleteResult
         }
     }
 
@@ -555,6 +572,80 @@ final class ACPSessionDetailViewTests: XCTestCase {
 
         XCTAssertTrue(session.events.isEmpty, "Whitespace-only input should not append a synthetic row")
         XCTAssertTrue(store.steerInvocations.isEmpty, "Empty input must not reach the store")
+    }
+
+    // MARK: - Delete from history
+
+    func test_isDeletable_terminalStatusesOnly() {
+        let store = ACPSessionStore()
+        let running = ACPSessionDetailView(session: makeSession(status: .running), store: store)
+        let initializing = ACPSessionDetailView(session: makeSession(status: .initializing), store: store)
+        let completed = ACPSessionDetailView(session: makeSession(status: .completed), store: store)
+        let failed = ACPSessionDetailView(session: makeSession(status: .failed), store: store)
+        let cancelled = ACPSessionDetailView(session: makeSession(status: .cancelled), store: store)
+        let unknown = ACPSessionDetailView(session: makeSession(status: .unknown), store: store)
+
+        XCTAssertTrue(completed.isDeletable)
+        XCTAssertTrue(failed.isDeletable)
+        XCTAssertTrue(cancelled.isDeletable)
+        XCTAssertFalse(running.isDeletable)
+        XCTAssertFalse(initializing.isDeletable)
+        XCTAssertFalse(unknown.isDeletable, "Unknown is treated as live until proven terminal")
+    }
+
+    func test_handleDeleteTap_invokesStoreDeleteOnce_andDismisses() async {
+        let store = SpyACPSessionStore()
+        let session = makeSession(status: .completed)
+        store.sessions[session.state.acpSessionId] = session
+        store.sessionOrder = [session.state.acpSessionId]
+
+        let dismissed = expectation(description: "onDismiss fires")
+        let view = ACPSessionDetailView(
+            session: session,
+            store: store,
+            onDismiss: { dismissed.fulfill() }
+        )
+        view.handleDeleteTap()
+
+        // `onDismiss` only fires after the Task spawned inside
+        // `handleDeleteTap` finishes running on the main actor; expectations
+        // make the wait observable without polling.
+        await fulfillment(of: [dismissed], timeout: 1.0)
+
+        XCTAssertEqual(store.deleteInvocations, [session.state.acpSessionId])
+        XCTAssertNil(store.sessions[session.state.acpSessionId],
+                     "Spy store mirror should drop the row on success")
+        XCTAssertFalse(store.sessionOrder.contains(session.state.acpSessionId))
+    }
+
+    func test_handleDeleteTap_doesNotDismiss_whenStoreReportsFailure() async {
+        let store = SpyACPSessionStore()
+        // 409 maps to an `httpError` failure; the view must keep the row in
+        // place and skip the dismissal so the user has a chance to react.
+        store.deleteResult = .failure(.httpError(statusCode: 409))
+        let session = makeSession(status: .completed)
+        store.sessions[session.state.acpSessionId] = session
+        store.sessionOrder = [session.state.acpSessionId]
+
+        var dismissCount = 0
+        let view = ACPSessionDetailView(
+            session: session,
+            store: store,
+            onDismiss: { dismissCount += 1 }
+        )
+        view.handleDeleteTap()
+
+        await waitForSpyInvocation { !store.deleteInvocations.isEmpty }
+        // After the spy records the call the in-flight Task must also finish
+        // its post-await work (resetting `isDeleting`, skipping `onDismiss`).
+        // Yielding once gives the scheduler a chance to drain it before the
+        // negative assertion below.
+        await Task.yield()
+
+        XCTAssertEqual(store.deleteInvocations, [session.state.acpSessionId])
+        XCTAssertEqual(dismissCount, 0, "onDismiss must not fire on failure")
+        XCTAssertNotNil(store.sessions[session.state.acpSessionId],
+                        "Failed delete should leave the row in place")
     }
 
     /// Spin briefly on the main actor until ``predicate`` returns true.

--- a/clients/macos/vellum-assistantTests/Network/ACPSessionStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/ACPSessionStoreTests.swift
@@ -394,6 +394,75 @@ final class ACPSessionStoreTests: XCTestCase {
         XCTAssertEqual(after.events.count, 1)
     }
 
+    // MARK: - Delete
+
+    func test_delete_removesSessionAndOrderEntry_onSuccess() async {
+        let store = ACPSessionStore()
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-1",
+            agent: "a",
+            parentConversationId: "c"
+        )))
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-2",
+            agent: "a",
+            parentConversationId: "c"
+        )))
+        XCTAssertEqual(store.sessions.count, 2)
+        XCTAssertEqual(Set(store.sessionOrder), Set(["acp-1", "acp-2"]))
+
+        MockACPSessionStoreURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "DELETE")
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"deleted":true}"#.utf8))
+        }
+
+        let result = await store.delete(id: "acp-1")
+
+        guard case .success(true) = result else {
+            return XCTFail("Expected .success(true), got \(result)")
+        }
+        XCTAssertNil(store.sessions["acp-1"], "Deleted session should be removed from sessions")
+        XCTAssertNotNil(store.sessions["acp-2"], "Other sessions should be left alone")
+        XCTAssertFalse(store.sessionOrder.contains("acp-1"), "sessionOrder should not include deleted id")
+        XCTAssertTrue(store.sessionOrder.contains("acp-2"))
+    }
+
+    func test_delete_leavesStoreUntouched_onFailure() async {
+        let store = ACPSessionStore()
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-active",
+            agent: "a",
+            parentConversationId: "c"
+        )))
+        XCTAssertNotNil(store.sessions["acp-active"])
+
+        // Daemon returns 409 when the session is still active — store must
+        // not optimistically drop the row.
+        MockACPSessionStoreURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 409,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        let result = await store.delete(id: "acp-active")
+
+        guard case .failure = result else {
+            return XCTFail("Expected .failure, got \(result)")
+        }
+        XCTAssertNotNil(store.sessions["acp-active"], "Failed delete should leave the row in place")
+        XCTAssertTrue(store.sessionOrder.contains("acp-active"))
+    }
+
     // MARK: - Helpers
 
     private func installLockfileFixture() throws {

--- a/clients/shared/Network/ACPSessionStore.swift
+++ b/clients/shared/Network/ACPSessionStore.swift
@@ -297,6 +297,28 @@ open class ACPSessionStore {
         return await ACPClient.steerSession(id: id, instruction: instruction)
     }
 
+    /// Delete a terminal session row from history. On a successful HTTP
+    /// 2xx response, removes the matching ``ACPSessionViewModel`` from
+    /// ``sessions`` and ``sessionOrder`` so list views update immediately.
+    /// `.success(false)` (the daemon reported no row matched) is also
+    /// treated as "gone now" — we still drop the in-memory entry so the
+    /// UI converges on the daemon's view of the world. Failures (including
+    /// the 409 the daemon returns when a session is still active) leave
+    /// the store untouched; callers can surface the error to the user.
+    ///
+    /// `open` so detail-view tests can spy on invocations without standing
+    /// up the full `URLProtocol` mock; production callers should never
+    /// subclass.
+    @discardableResult
+    open func delete(id: String) async -> Result<Bool, ACPClientError> {
+        let result = await ACPClient.deleteSession(id: id)
+        if case .success = result {
+            sessions.removeValue(forKey: id)
+            sessionOrder.removeAll { $0 == id }
+        }
+        return result
+    }
+
     /// Bulk-clear every terminal session (`completed`/`failed`/`cancelled`)
     /// from the store. Wraps ``ACPClient/clearCompleted()`` and, on success,
     /// optimistically prunes the matching rows from ``sessions`` and


### PR DESCRIPTION
## Summary
- Adds `ACPSessionStore.delete(id:)` wrapping `ACPClient.deleteSession`.
- Adds 'Delete from history' button in detail-view footer for terminal sessions; pops back on success.

Part of plan: acp-sessions-ui.md (PR 26 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
