### PR TITLE
feat(ios): add Coding Agents entry point to iOS root nav

### DIFF
--- a/clients/ios/Views/ACPSessionsView.swift
+++ b/clients/ios/Views/ACPSessionsView.swift
@@ -22,10 +22,10 @@ struct ACPSessionsView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Bindable var store: ACPSessionStore
 
-    /// Optional close hook so callers presenting this in a modal context
-    /// (e.g. the temporary debug shortcut from ``IOSRootNavigationView``)
-    /// can dismiss it. PR 34 will replace the debug shortcut with a real
-    /// menu entry and may not need this.
+    /// Optional close hook so callers presenting this view in a modal context
+    /// (the Coding Agents sheet driven from ``IOSRootNavigationView``'s
+    /// terminal-icon toolbar entry) can dismiss it via the in-view close
+    /// button.
     var onClose: (() -> Void)?
 
     @State private var selectedSessionId: String?

--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -77,6 +77,12 @@ struct ConversationListView: View {
     /// Nil on compact, where the chat header hosts the Settings gear instead.
     var onShowSettings: (() -> Void)?
 
+    /// Invoked when the user taps the Coding Agents entry point in the iPad
+    /// sidebar toolbar. The presenting sheet itself is owned by
+    /// `IOSRootNavigationView`. Nil on compact, where the chat header hosts
+    /// the Coding Agents button instead.
+    var onShowACPSessions: (() -> Void)?
+
     /// Invoked when the user archives the currently active conversation.
     /// The parent is responsible for (a) choosing a replacement conversation
     /// and (b) marking it as *seeded* (not an explicit open), so the
@@ -224,6 +230,14 @@ struct ConversationListView: View {
                         VIconView(.settings, size: 20)
                     }
                     .accessibilityLabel("Settings")
+                }
+            }
+            if let onShowACPSessions {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: onShowACPSessions) {
+                        VIconView(.terminal, size: 20)
+                    }
+                    .accessibilityLabel("Coding Agents")
                 }
             }
         }
@@ -568,6 +582,14 @@ struct ConversationListView: View {
                     .accessibilityLabel("Settings")
                 }
             }
+            if let onShowACPSessions {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: onShowACPSessions) {
+                        VIconView(.terminal, size: 20)
+                    }
+                    .accessibilityLabel("Coding Agents")
+                }
+            }
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {
                     let conversation = store.newConversation()
@@ -761,6 +783,9 @@ struct ConversationChatView: View {
     /// Presents the Settings bottom sheet. Non-nil only on compact size classes;
     /// iPad reaches Settings via the persistent sidebar toolbar instead.
     var onShowSettings: (() -> Void)?
+    /// Presents the Coding Agents (ACP sessions) sheet. Non-nil only on compact
+    /// size classes; iPad reaches it via the persistent sidebar toolbar.
+    var onShowACPSessions: (() -> Void)?
 
     var body: some View {
         let anchorRequest = store.pendingAnchorRequest(for: conversation.id)
@@ -808,6 +833,15 @@ struct ConversationChatView: View {
                         VIconView(.settings, size: 20)
                     }
                     .accessibilityLabel("Settings")
+                }
+                .hideSharedToolbarBackgroundIfAvailable()
+            }
+            if horizontalSizeClass == .compact, let onShowACPSessions {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: onShowACPSessions) {
+                        VIconView(.terminal, size: 20)
+                    }
+                    .accessibilityLabel("Coding Agents")
                 }
                 .hideSharedToolbarBackgroundIfAvailable()
             }

--- a/clients/ios/Views/IOSRootNavigationView.swift
+++ b/clients/ios/Views/IOSRootNavigationView.swift
@@ -32,9 +32,10 @@ struct IOSRootNavigationView: View {
 
     @State private var isDrawerOpen: Bool = false
     @State private var isSettingsPresented: Bool = false
-    /// TODO(PR 34): replace this debug shortcut with a real menu entry.
-    /// Until that PR ships, the only way to reach ``ACPSessionsView`` from
-    /// the iOS app is a 2.0s long-press anywhere on this view's root.
+    /// Drives the Coding Agents (ACP sessions) modal sheet. Toggled by the
+    /// terminal-icon toolbar entry on each surface that exposes a top-level
+    /// destination (`compactEmptyRoot`, `ConversationChatView` on compact, and
+    /// `ConversationListView` on iPad). Mirrors `isSettingsPresented`.
     @State private var isACPSessionsPresented: Bool = false
     @State private var activeConversationId: UUID?
     /// True when `activeConversationId` was populated by the auto-seed path
@@ -83,25 +84,15 @@ struct IOSRootNavigationView: View {
                 conversationStore: store
             )
         }
-        // TODO(PR 34): the menu entry from PR 34 will replace this debug
-        // shortcut. Until then the long-press below is the only way to
-        // reach ``ACPSessionsView`` from the iOS app. The 2.0s minimum
-        // duration is well past the system's text-selection threshold,
-        // so a UITextView's edit menu still wins on chat content. The
-        // gesture is registered as `simultaneousGesture` so the compact
-        // layout's edge-drag gesture continues to recognize alongside it.
+        // Coding Agents (ACP sessions) sheet. Driven from the terminal-icon
+        // toolbar entry on each top-level surface — see `compactEmptyRoot`,
+        // `ConversationChatView` (compact), and `ConversationListView` (iPad).
         .sheet(isPresented: $isACPSessionsPresented) {
             ACPSessionsView(
                 store: clientProvider.acpSessionStore,
                 onClose: { isACPSessionsPresented = false }
             )
         }
-        .simultaneousGesture(
-            LongPressGesture(minimumDuration: 2.0)
-                .onEnded { _ in
-                    isACPSessionsPresented = true
-                }
-        )
         .task {
             seedActiveConversationIfNeeded()
             applyPendingSelectionRequestIfNeeded()
@@ -239,7 +230,8 @@ struct IOSRootNavigationView: View {
                 conversation: conversation,
                 onOpenDrawer: openDrawer,
                 onComposeNew: composeNewConversation,
-                onShowSettings: { isSettingsPresented = true }
+                onShowSettings: { isSettingsPresented = true },
+                onShowACPSessions: { isACPSessionsPresented = true }
             )
             .task(id: id) {
                 store.loadHistoryIfNeeded(for: id)
@@ -308,6 +300,13 @@ struct IOSRootNavigationView: View {
                 .accessibilityLabel("Settings")
             }
             .hideSharedToolbarBackgroundIfAvailable()
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: { isACPSessionsPresented = true }) {
+                    VIconView(.terminal, size: 20)
+                }
+                .accessibilityLabel("Coding Agents")
+            }
+            .hideSharedToolbarBackgroundIfAvailable()
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: composeNewConversation) {
                     VIconView(.squarePen, size: 20)
@@ -324,6 +323,7 @@ struct IOSRootNavigationView: View {
         ConversationListView(
             store: store,
             onShowSettings: { isSettingsPresented = true },
+            onShowACPSessions: { isACPSessionsPresented = true },
             selectedConversationId: $activeConversationId
         )
     }


### PR DESCRIPTION
## Summary
- Adds 'Coding Agents' top-level entry in `IOSRootNavigationView` for both iPhone and iPad.
- Removes the PR 32 temporary debug long-press shortcut.

Part of plan: acp-sessions-ui.md (PR 34 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
