### PR TITLE
feat(macos): add Coding Agents toolbar button to open ACPSessionsPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -291,6 +291,23 @@ public final class MainWindowState {
         LayoutConfigStore.save(layoutConfig)
     }
 
+    /// Whether the right slot is currently showing the given native panel.
+    func isRightSlotShowing(_ panel: NativePanelId) -> Bool {
+        layoutConfig.right.visible && layoutConfig.right.content == .native(panel)
+    }
+
+    /// Toggle the right slot between showing the given native panel and hidden.
+    /// Persists the updated layout via `LayoutConfigStore`.
+    func toggleRightSlot(_ panel: NativePanelId) {
+        if isRightSlotShowing(panel) {
+            layoutConfig.right.visible = false
+        } else {
+            layoutConfig.right.content = .native(panel)
+            layoutConfig.right.visible = true
+        }
+        LayoutConfigStore.save(layoutConfig)
+    }
+
     func clearDynamicWorkspaceState() {
         activeDynamicSurface = nil
         activeDynamicParsedSurface = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -512,6 +512,16 @@ struct MainWindowView: View {
                     .vTooltip(homeTooltip)
                 }
 
+                VButton(
+                    label: "Coding Agents",
+                    iconOnly: VIcon.terminal.rawValue,
+                    style: .ghost,
+                    isActive: windowState.isRightSlotShowing(.acpSessions)
+                ) {
+                    windowState.toggleRightSlot(.acpSessions)
+                }
+                .vTooltip("Coding Agents")
+
                 VButton(label: "Search", iconOnly: VIcon.search.rawValue, style: .ghost) {
                     AppDelegate.shared?.toggleCommandPalette()
                 }


### PR DESCRIPTION
## Summary
- New 'Coding Agents' toolbar button (`terminal.fill` icon) toggles `.native(.acpSessions)` in the right slot.

Part of plan: acp-sessions-ui.md (PR 20 of 36)