### PR TITLE
feat(live-voice): run final transcripts through the assistant loop (PR 13)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type {
+  VoiceTurnCallbacks,
+  VoiceTurnOptions,
+} from "../../calls/voice-session-bridge.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import {
+  LiveVoiceSession,
+  type LiveVoiceTurnStarter,
+} from "../live-voice-session.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import {
+  createLiveVoiceServerFrameSequencer,
+  type LiveVoiceClientStartFrame,
+  type LiveVoiceServerFrame,
+} from "../protocol.js";
+
+const START_FRAME = {
+  type: "start",
+  conversationId: "conversation-123",
+  audio: {
+    mimeType: "audio/pcm",
+    sampleRate: 24_000,
+    channels: 1,
+  },
+} as const satisfies LiveVoiceClientStartFrame;
+
+class MockStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+  stopped = false;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  constructor(private readonly stopEvents: SttStreamServerEvent[] = []) {}
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(): void {}
+
+  stop(): void {
+    this.stopped = true;
+    for (const event of this.stopEvents) {
+      this.emit(event);
+    }
+  }
+
+  emit(event: SttStreamServerEvent): void {
+    this.onEvent?.(event);
+  }
+}
+
+function createContext(startFrame: LiveVoiceClientStartFrame = START_FRAME): {
+  context: LiveVoiceSessionFactoryContext;
+  frames: LiveVoiceServerFrame[];
+} {
+  const sequencer = createLiveVoiceServerFrameSequencer();
+  const frames: LiveVoiceServerFrame[] = [];
+
+  return {
+    frames,
+    context: {
+      sessionId: "session-123",
+      startFrame,
+      sendFrame: mock(async (payload) => {
+        const frame = sequencer.next(payload);
+        frames.push(frame);
+        return frame;
+      }),
+    },
+  };
+}
+
+function createStartFrameWithoutConversationId(): LiveVoiceClientStartFrame {
+  return {
+    type: "start",
+    audio: START_FRAME.audio,
+  };
+}
+
+function createSessionHarness(
+  options: {
+    startFrame?: LiveVoiceClientStartFrame;
+    transcriber?: MockStreamingTranscriber;
+    startVoiceTurn?: LiveVoiceTurnStarter;
+    createTurnId?: () => string;
+  } = {},
+) {
+  const transcriber =
+    options.transcriber ??
+    new MockStreamingTranscriber([
+      { type: "final", text: "world" },
+      { type: "closed" },
+    ]);
+  const { context, frames } = createContext(options.startFrame);
+  const startVoiceTurn =
+    options.startVoiceTurn ??
+    mock(async () => ({ turnId: "bridge-turn-1", abort: mock() }));
+
+  const session = new LiveVoiceSession(context, {
+    resolveTranscriber: mock(async () => transcriber),
+    startVoiceTurn,
+    createTurnId: options.createTurnId ?? (() => "live-turn-1"),
+  });
+
+  return { frames, session, startVoiceTurn, transcriber };
+}
+
+async function waitForFrameCount(
+  frames: LiveVoiceServerFrame[],
+  count: number,
+): Promise<void> {
+  for (let attempt = 0; attempt < 20 && frames.length < count; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+async function flushAsyncCallbacks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("LiveVoiceSession assistant turn", () => {
+  test("runs final transcripts through the voice bridge and forwards ordered assistant events", async () => {
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.assistant_text_delta?.({
+        type: "assistant_text_delta",
+        text: "Hello ",
+        conversationId: options.conversationId,
+      });
+      options.callbacks?.assistant_text_delta?.({
+        type: "assistant_text_delta",
+        text: "there",
+        conversationId: options.conversationId,
+      });
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-123",
+      });
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { frames, session, transcriber } = createSessionHarness({
+      startVoiceTurn,
+    });
+
+    await session.start();
+    transcriber.emit({ type: "final", text: "hello" });
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitForFrameCount(frames, 7);
+
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+    const voiceTurnOptions = startVoiceTurn.mock.calls[0]?.[0];
+    expect(voiceTurnOptions).toMatchObject({
+      conversationId: "conversation-123",
+      voiceSessionId: "session-123",
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+      content: "hello world",
+      isInbound: true,
+    });
+    expect(voiceTurnOptions?.signal).toBeInstanceOf(AbortSignal);
+    expect(frames.map((frame) => frame.type)).toEqual([
+      "ready",
+      "stt_final",
+      "stt_final",
+      "thinking",
+      "assistant_text_delta",
+      "assistant_text_delta",
+      "tts_done",
+    ]);
+    expect(frames[3]).toMatchObject({
+      type: "thinking",
+      turnId: "live-turn-1",
+    });
+    expect(frames[4]).toMatchObject({
+      type: "assistant_text_delta",
+      text: "Hello ",
+    });
+    expect(frames[5]).toMatchObject({
+      type: "assistant_text_delta",
+      text: "there",
+    });
+    expect(frames[6]).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
+    });
+  });
+
+  test("does not start an assistant turn for whitespace-only final transcripts", async () => {
+    const transcriber = new MockStreamingTranscriber([
+      { type: "final", text: "   \n\t  " },
+      { type: "closed" },
+    ]);
+    const startVoiceTurn = mock(async (_options: VoiceTurnOptions) => ({
+      turnId: "bridge-turn-1",
+      abort: mock(),
+    }));
+    const { frames, session } = createSessionHarness({
+      transcriber,
+      startVoiceTurn,
+    });
+
+    await session.start();
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitForFrameCount(frames, 2);
+
+    expect(startVoiceTurn).not.toHaveBeenCalled();
+    expect(frames.map((frame) => frame.type)).toEqual(["ready", "stt_final"]);
+  });
+
+  test("falls back to the session id when start omits a conversation id", async () => {
+    const startVoiceTurn = mock(async (_options: VoiceTurnOptions) => ({
+      turnId: "bridge-turn-1",
+      abort: mock(),
+    }));
+    const { frames, session } = createSessionHarness({
+      startFrame: createStartFrameWithoutConversationId(),
+      startVoiceTurn,
+    });
+
+    await session.start();
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitForFrameCount(frames, 3);
+
+    expect(frames[0]).toMatchObject({
+      type: "ready",
+      conversationId: "session-123",
+    });
+    expect(startVoiceTurn.mock.calls[0]?.[0]).toMatchObject({
+      conversationId: "session-123",
+    });
+  });
+
+  test("interrupt aborts the in-flight turn and ignores late bridge events", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    let signal: AbortSignal | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      signal = options.signal;
+      return { turnId: "bridge-turn-1", abort };
+    });
+    const { frames, session } = createSessionHarness({ startVoiceTurn });
+
+    await session.start();
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitForFrameCount(frames, 3);
+
+    await session.handleClientFrame({ type: "interrupt" });
+    const frameCountAfterInterrupt = frames.length;
+    callbacks?.assistant_text_delta?.({
+      type: "assistant_text_delta",
+      text: "late",
+      conversationId: "conversation-123",
+    });
+    callbacks?.message_complete?.({
+      type: "message_complete",
+      conversationId: "conversation-123",
+      messageId: "assistant-message-late",
+    });
+    await flushAsyncCallbacks();
+
+    expect(signal?.aborted).toBe(true);
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(frames).toHaveLength(frameCountAfterInterrupt);
+    expect(frames.map((frame) => frame.type)).toEqual([
+      "ready",
+      "stt_final",
+      "thinking",
+    ]);
+  });
+});

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1,5 +1,10 @@
 import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
 
+import type {
+  VoiceTurnHandle,
+  VoiceTurnOptions,
+} from "../calls/voice-session-bridge.js";
 import {
   listProviderIds,
   supportsBoundary,
@@ -25,6 +30,7 @@ type LiveVoiceSessionState =
   | "active"
   | "utterance_released"
   | "transcriber_closed"
+  | "interrupted"
   | "failed"
   | "closed";
 
@@ -32,18 +38,34 @@ export type LiveVoiceStreamingTranscriberResolver = (
   options: ResolveStreamingTranscriberOptions,
 ) => Promise<StreamingTranscriber | null>;
 
+export type LiveVoiceTurnStarter = (
+  options: VoiceTurnOptions,
+) => Promise<VoiceTurnHandle>;
+
 export interface LiveVoiceSessionOptions {
   resolveTranscriber?: LiveVoiceStreamingTranscriberResolver;
+  startVoiceTurn?: LiveVoiceTurnStarter;
+  createTurnId?: () => string;
 }
 
 export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly context: LiveVoiceSessionFactoryContext;
   private readonly resolveTranscriber: LiveVoiceStreamingTranscriberResolver;
+  private readonly startVoiceTurn: LiveVoiceTurnStarter | null;
+  private readonly createTurnId: () => string;
   private readonly conversationId: string;
   private state: LiveVoiceSessionState = "initializing";
   private transcriber: StreamingTranscriber | null = null;
   private readonly finalTranscriptSegments: string[] = [];
   private outboundFrames: Promise<void> = Promise.resolve();
+  private pttReleased = false;
+  private assistantTurnStarted = false;
+  private activeAssistantTurn: {
+    token: symbol;
+    abortController: AbortController;
+    handle: VoiceTurnHandle | null;
+    completed: boolean;
+  } | null = null;
 
   constructor(
     context: LiveVoiceSessionFactoryContext,
@@ -52,6 +74,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.context = context;
     this.resolveTranscriber =
       options.resolveTranscriber ?? defaultResolveStreamingTranscriber;
+    this.startVoiceTurn = options.startVoiceTurn ?? null;
+    this.createTurnId = options.createTurnId ?? randomUUID;
     this.conversationId =
       context.startFrame.conversationId ?? context.sessionId;
   }
@@ -127,6 +151,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         await this.releaseUtterance();
         return;
       case "interrupt":
+        await this.interrupt();
         return;
       case "end":
         await this.close("client_end");
@@ -146,6 +171,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.state = "closed";
     stopTranscriberBestEffort(this.transcriber);
     this.transcriber = null;
+    this.cancelAssistantTurn();
     await this.drainOutboundFrames();
   }
 
@@ -178,15 +204,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   private async releaseUtterance(): Promise<void> {
-    if (
-      this.state === "utterance_released" ||
-      this.state === "transcriber_closed"
-    ) {
+    if (this.state === "utterance_released") {
+      return;
+    }
+
+    if (this.state === "transcriber_closed") {
+      this.pttReleased = true;
+      await this.startAssistantTurnIfReady();
+      await this.drainOutboundFrames();
       return;
     }
 
     if (this.state !== "active") return;
 
+    this.pttReleased = true;
     this.state = "utterance_released";
     try {
       this.transcriber?.stop();
@@ -199,13 +230,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         )}`,
       });
     }
+    await this.startAssistantTurnIfReady();
     await this.drainOutboundFrames();
   }
 
   private async handleTranscriberEvent(
     event: SttStreamServerEvent,
   ): Promise<void> {
-    if (this.isClosed || this.state === "failed") return;
+    if (
+      this.isClosed ||
+      this.state === "failed" ||
+      this.state === "interrupted"
+    ) {
+      return;
+    }
 
     switch (event.type) {
       case "partial":
@@ -217,6 +255,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           this.finalTranscriptSegments.push(transcript);
         }
         await this.sendFrame({ type: "stt_final", text: event.text });
+        await this.startAssistantTurnIfReady();
         return;
       }
       case "error":
@@ -230,9 +269,146 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         if (!this.isClosed) {
           this.state = "transcriber_closed";
           this.transcriber = null;
+          await this.startAssistantTurnIfReady();
         }
         return;
     }
+  }
+
+  private async interrupt(): Promise<void> {
+    if (this.isClosed || this.state === "failed") return;
+
+    this.state = "interrupted";
+    stopTranscriberBestEffort(this.transcriber);
+    this.transcriber = null;
+    this.cancelAssistantTurn();
+    await this.drainOutboundFrames();
+  }
+
+  private async startAssistantTurnIfReady(): Promise<void> {
+    if (
+      !this.pttReleased ||
+      this.assistantTurnStarted ||
+      this.isClosed ||
+      this.state === "failed"
+    ) {
+      return;
+    }
+    if (
+      this.state !== "utterance_released" &&
+      this.state !== "transcriber_closed"
+    ) {
+      return;
+    }
+    if (!this.startVoiceTurn) return;
+
+    const content = this.finalTranscriptText.trim();
+    if (content.length === 0) return;
+
+    this.assistantTurnStarted = true;
+    const token = Symbol("live-voice-assistant-turn");
+    const turnId = this.createTurnId();
+    const abortController = new AbortController();
+    this.activeAssistantTurn = {
+      token,
+      abortController,
+      handle: null,
+      completed: false,
+    };
+
+    await this.sendFrame({ type: "thinking", turnId });
+    if (!this.isForwardingAssistantTurn(token)) return;
+
+    try {
+      const handle = await this.startVoiceTurn({
+        conversationId: this.conversationId,
+        voiceSessionId: this.context.sessionId,
+        userMessageChannel: "vellum",
+        assistantMessageChannel: "vellum",
+        userMessageInterface: "macos",
+        assistantMessageInterface: "macos",
+        voiceControlPrompt:
+          "You are speaking in a local live voice session. Keep replies brief and conversational.",
+        content,
+        isInbound: true,
+        signal: abortController.signal,
+        callbacks: {
+          assistant_text_delta: (msg) => {
+            if (!this.isForwardingAssistantTurn(token)) return;
+            void this.sendFrame({
+              type: "assistant_text_delta",
+              text: msg.text,
+            });
+          },
+          message_complete: (msg) => {
+            const activeTurn = this.activeAssistantTurn;
+            if (
+              activeTurn?.token !== token ||
+              activeTurn.completed ||
+              this.isClosed
+            ) {
+              return;
+            }
+            if (msg.type !== "message_complete") return;
+            activeTurn.completed = true;
+            void this.sendFrame({ type: "tts_done", turnId });
+          },
+        },
+        onError: (message) => {
+          if (!this.isForwardingAssistantTurn(token)) return;
+          void this.sendFrame({
+            type: "error",
+            code: LiveVoiceProtocolErrorCode.InvalidField,
+            message,
+          });
+        },
+      });
+
+      const activeTurn = this.activeAssistantTurn;
+      if (activeTurn?.token !== token) {
+        handle.abort();
+        return;
+      }
+      if (activeTurn.completed) {
+        this.activeAssistantTurn = null;
+        return;
+      }
+
+      this.activeAssistantTurn = {
+        token,
+        abortController,
+        handle,
+        completed: false,
+      };
+    } catch (err) {
+      if (!this.isForwardingAssistantTurn(token)) return;
+
+      this.activeAssistantTurn = null;
+      await this.sendFrame({
+        type: "error",
+        code: LiveVoiceProtocolErrorCode.InvalidField,
+        message: `Live voice assistant turn could not be started: ${errorMessage(
+          err,
+        )}`,
+      });
+    }
+  }
+
+  private cancelAssistantTurn(): void {
+    const turn = this.activeAssistantTurn;
+    if (!turn) return;
+
+    this.activeAssistantTurn = null;
+    turn.abortController.abort();
+    turn.handle?.abort();
+  }
+
+  private isForwardingAssistantTurn(token: symbol): boolean {
+    return (
+      this.activeAssistantTurn?.token === token &&
+      !this.activeAssistantTurn.completed &&
+      !this.isClosed
+    );
   }
 
   private async sendAudioAfterReleaseError(): Promise<void> {
@@ -269,7 +445,10 @@ export function createLiveVoiceSession(
   context: LiveVoiceSessionFactoryContext,
   options: LiveVoiceSessionOptions = {},
 ): LiveVoiceSession {
-  return new LiveVoiceSession(context, options);
+  return new LiveVoiceSession(context, {
+    ...options,
+    startVoiceTurn: options.startVoiceTurn ?? defaultStartVoiceTurn,
+  });
 }
 
 async function defaultResolveStreamingTranscriber(
@@ -278,6 +457,13 @@ async function defaultResolveStreamingTranscriber(
   const { resolveStreamingTranscriber } =
     await import("../providers/speech-to-text/resolve.js");
   return resolveStreamingTranscriber(options);
+}
+
+async function defaultStartVoiceTurn(
+  options: VoiceTurnOptions,
+): Promise<VoiceTurnHandle> {
+  const { startVoiceTurn } = await import("../calls/voice-session-bridge.js");
+  return startVoiceTurn(options);
 }
 
 function unavailableTranscriberMessage(): string {


### PR DESCRIPTION
## PR 13: run final transcripts through the assistant loop

### Depends on

PR 11, PR 12.

### Branch

`live-voice-channel/pr-13-agent-turn`

### Files

- `assistant/src/live-voice/live-voice-session.ts`
- `assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts`

### Scope

When a live voice utterance has at least one final transcript and the client sends `ptt_release`, call the generalized voice bridge and stream assistant events back to the WebSocket:

- emit `thinking` before the conversation turn starts
- emit `assistant_text_delta` as text deltas arrive
- emit a completion event when the bridge reports `message_complete`
- cancel or ignore late events after `interrupt`, `end`, or WebSocket close

### Acceptance Criteria

- Empty or whitespace-only final transcripts do not start an assistant turn.
- The conversation id from `start` is used; missing conversation id falls back through the same get-or-create behavior as normal chat.
- Assistant deltas are forwarded in order.
- Interrupt closes the in-flight turn path without leaking session state.

### Verification

Run:

```bash
export PATH="$HOME/.bun/bin:$PATH"
cd assistant && bun test src/live-voice/__tests__/live-voice-agent-turn.test.ts
cd assistant && bunx tsc --noEmit
```


Orchestrated by velissa-ai via run-plan; implemented by Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
