### PR TITLE
feat(live-voice): stream assistant text to live voice TTS (PR 15)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type {
+  VoiceTurnCallbacks,
+  VoiceTurnOptions,
+} from "../../calls/voice-session-bridge.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import {
+  LiveVoiceSession,
+  type LiveVoiceTtsStreamer,
+  type LiveVoiceTurnStarter,
+} from "../live-voice-session.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import type {
+  LiveVoiceTtsAudioChunk,
+  LiveVoiceTtsOptions,
+  LiveVoiceTtsResult,
+} from "../live-voice-tts.js";
+import {
+  createLiveVoiceServerFrameSequencer,
+  type LiveVoiceClientStartFrame,
+  type LiveVoiceServerFrame,
+} from "../protocol.js";
+
+const START_FRAME = {
+  type: "start",
+  conversationId: "conversation-123",
+  audio: {
+    mimeType: "audio/pcm",
+    sampleRate: 24_000,
+    channels: 1,
+  },
+} as const satisfies LiveVoiceClientStartFrame;
+
+class MockStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+  stopped = false;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  constructor(
+    private readonly stopEvents: SttStreamServerEvent[] = [
+      { type: "final", text: "hello" },
+      { type: "closed" },
+    ],
+  ) {}
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(): void {}
+
+  stop(): void {
+    this.stopped = true;
+    for (const event of this.stopEvents) {
+      this.onEvent?.(event);
+    }
+  }
+}
+
+function createContext(): {
+  context: LiveVoiceSessionFactoryContext;
+  frames: LiveVoiceServerFrame[];
+} {
+  const sequencer = createLiveVoiceServerFrameSequencer();
+  const frames: LiveVoiceServerFrame[] = [];
+
+  return {
+    frames,
+    context: {
+      sessionId: "session-123",
+      startFrame: START_FRAME,
+      sendFrame: mock(async (payload) => {
+        const frame = sequencer.next(payload);
+        frames.push(frame);
+        return frame;
+      }),
+    },
+  };
+}
+
+function createSessionHarness(options: {
+  startVoiceTurn: LiveVoiceTurnStarter;
+  streamTtsAudio: LiveVoiceTtsStreamer;
+}) {
+  const transcriber = new MockStreamingTranscriber();
+  const { context, frames } = createContext();
+  const session = new LiveVoiceSession(context, {
+    resolveTranscriber: mock(async () => transcriber),
+    startVoiceTurn: options.startVoiceTurn,
+    streamTtsAudio: options.streamTtsAudio,
+    createTurnId: () => "live-turn-1",
+  });
+
+  return { frames, session, transcriber };
+}
+
+async function startReleasedTurn(session: LiveVoiceSession): Promise<void> {
+  await session.start();
+  await session.handleClientFrame({ type: "ptt_release" });
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message = "Timed out waiting for live voice test condition",
+): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(message);
+}
+
+async function flushAsyncCallbacks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function makeTtsChunk(text: string): LiveVoiceTtsAudioChunk {
+  return {
+    type: "tts_audio",
+    seq: 0,
+    contentType: "audio/pcm",
+    sampleRate: 24_000,
+    dataBase64: Buffer.from(text).toString("base64"),
+  };
+}
+
+function makeTtsResult(text: string): LiveVoiceTtsResult {
+  return {
+    provider: "fish-audio",
+    contentType: "audio/pcm",
+    sampleRate: 24_000,
+    chunks: 1,
+    bytes: Buffer.byteLength(text),
+  };
+}
+
+function makeTextDelta(
+  text: string,
+): Parameters<NonNullable<VoiceTurnCallbacks["assistant_text_delta"]>>[0] {
+  return {
+    type: "assistant_text_delta",
+    text,
+    conversationId: "conversation-123",
+  };
+}
+
+function makeMessageComplete(): Parameters<
+  NonNullable<VoiceTurnCallbacks["message_complete"]>
+>[0] {
+  return {
+    type: "message_complete",
+    conversationId: "conversation-123",
+    messageId: "assistant-message-123",
+  };
+}
+
+describe("LiveVoiceSession TTS", () => {
+  test("starts streaming TTS audio before the assistant message completes at a segment boundary", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const ttsTexts: string[] = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      ttsTexts.push(options.text);
+      options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+      return makeTtsResult(options.text);
+    });
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta("Hello there."));
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+
+    expect(ttsTexts).toEqual(["Hello there."]);
+    expect(frames.map((frame) => frame.type)).toContain("assistant_text_delta");
+    expect(frames.map((frame) => frame.type)).toContain("tts_audio");
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+
+    callbacks?.assistant_text_delta?.(makeTextDelta(" Still listening"));
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsTexts).toEqual(["Hello there.", "Still listening"]);
+    expect(frames.filter((frame) => frame.type === "tts_audio")).toHaveLength(
+      2,
+    );
+    expect(frames.at(-1)).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
+    });
+  });
+
+  test("flushes long assistant text as a conservative TTS segment before completion", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const ttsTexts: string[] = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      ttsTexts.push(options.text);
+      options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+      return makeTtsResult(options.text);
+    });
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta("steady ".repeat(32)));
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+
+    expect(ttsTexts).toHaveLength(1);
+    expect(ttsTexts[0]?.length).toBeGreaterThan(100);
+    expect(ttsTexts[0]?.length).toBeLessThanOrEqual(181);
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+  });
+
+  test("reports TTS errors without cancelling the persisted assistant text turn", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort };
+    });
+    const streamTtsAudio = mock(async () => {
+      throw new Error("provider unavailable");
+    });
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta("This should persist."));
+    await waitFor(() => frames.some((frame) => frame.type === "error"));
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(abort).not.toHaveBeenCalled();
+    expect(
+      frames.some(
+        (frame) =>
+          frame.type === "assistant_text_delta" &&
+          frame.text === "This should persist.",
+      ),
+    ).toBe(true);
+    expect(frames.find((frame) => frame.type === "error")).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("provider unavailable"),
+    });
+    expect(frames.at(-1)).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
+    });
+  });
+
+  test("interrupt prevents late TTS chunks from reaching the socket", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    let ttsOptions: LiveVoiceTtsOptions | undefined;
+    let resolveTts: ((result: LiveVoiceTtsResult) => void) | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort };
+    });
+    const streamTtsAudio = mock(
+      (options: LiveVoiceTtsOptions) =>
+        new Promise<LiveVoiceTtsResult>((resolve) => {
+          ttsOptions = options;
+          resolveTts = resolve;
+        }),
+    );
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta("Please speak now."));
+    await waitFor(() => ttsOptions !== undefined);
+
+    await session.handleClientFrame({ type: "interrupt" });
+    const frameCountAfterInterrupt = frames.length;
+    ttsOptions?.onAudioChunk(makeTtsChunk("late audio"));
+    resolveTts?.(makeTtsResult("late audio"));
+    await flushAsyncCallbacks();
+
+    expect(ttsOptions?.signal?.aborted).toBe(true);
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(frames).toHaveLength(frameCountAfterInterrupt);
+    expect(frames.some((frame) => frame.type === "tts_audio")).toBe(false);
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+  });
+});

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -19,6 +19,10 @@ import type {
   LiveVoiceSessionCloseReason,
   LiveVoiceSessionFactoryContext,
 } from "./live-voice-session-manager.js";
+import type {
+  LiveVoiceTtsOptions,
+  LiveVoiceTtsResult,
+} from "./live-voice-tts.js";
 import {
   type LiveVoiceClientFrame,
   LiveVoiceProtocolErrorCode,
@@ -34,6 +38,10 @@ type LiveVoiceSessionState =
   | "failed"
   | "closed";
 
+const LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD = 180;
+const SENTENCE_ENDING_PUNCTUATION = new Set([".", "!", "?"]);
+const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
+
 export type LiveVoiceStreamingTranscriberResolver = (
   options: ResolveStreamingTranscriberOptions,
 ) => Promise<StreamingTranscriber | null>;
@@ -42,16 +50,32 @@ export type LiveVoiceTurnStarter = (
   options: VoiceTurnOptions,
 ) => Promise<VoiceTurnHandle>;
 
+export type LiveVoiceTtsStreamer = (
+  options: LiveVoiceTtsOptions,
+) => Promise<LiveVoiceTtsResult>;
+
 export interface LiveVoiceSessionOptions {
   resolveTranscriber?: LiveVoiceStreamingTranscriberResolver;
   startVoiceTurn?: LiveVoiceTurnStarter;
+  streamTtsAudio?: LiveVoiceTtsStreamer | null;
   createTurnId?: () => string;
+}
+
+interface ActiveAssistantTurn {
+  token: symbol;
+  abortController: AbortController;
+  handle: VoiceTurnHandle | null;
+  assistantCompleted: boolean;
+  ttsDone: boolean;
+  ttsBuffer: string;
+  ttsQueue: Promise<void>;
 }
 
 export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly context: LiveVoiceSessionFactoryContext;
   private readonly resolveTranscriber: LiveVoiceStreamingTranscriberResolver;
   private readonly startVoiceTurn: LiveVoiceTurnStarter | null;
+  private readonly streamTtsAudio: LiveVoiceTtsStreamer | null;
   private readonly createTurnId: () => string;
   private readonly conversationId: string;
   private state: LiveVoiceSessionState = "initializing";
@@ -60,12 +84,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private outboundFrames: Promise<void> = Promise.resolve();
   private pttReleased = false;
   private assistantTurnStarted = false;
-  private activeAssistantTurn: {
-    token: symbol;
-    abortController: AbortController;
-    handle: VoiceTurnHandle | null;
-    completed: boolean;
-  } | null = null;
+  private activeAssistantTurn: ActiveAssistantTurn | null = null;
 
   constructor(
     context: LiveVoiceSessionFactoryContext,
@@ -75,6 +94,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.resolveTranscriber =
       options.resolveTranscriber ?? defaultResolveStreamingTranscriber;
     this.startVoiceTurn = options.startVoiceTurn ?? null;
+    this.streamTtsAudio = options.streamTtsAudio ?? null;
     this.createTurnId = options.createTurnId ?? randomUUID;
     this.conversationId =
       context.startFrame.conversationId ?? context.sessionId;
@@ -313,11 +333,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       token,
       abortController,
       handle: null,
-      completed: false,
+      assistantCompleted: false,
+      ttsDone: false,
+      ttsBuffer: "",
+      ttsQueue: Promise.resolve(),
     };
 
     await this.sendFrame({ type: "thinking", turnId });
-    if (!this.isForwardingAssistantTurn(token)) return;
+    if (!this.isActiveAssistantTurn(token)) return;
 
     try {
       const handle = await this.startVoiceTurn({
@@ -334,28 +357,29 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         signal: abortController.signal,
         callbacks: {
           assistant_text_delta: (msg) => {
-            if (!this.isForwardingAssistantTurn(token)) return;
+            if (!this.isForwardingAssistantText(token)) return;
             void this.sendFrame({
               type: "assistant_text_delta",
               text: msg.text,
             });
+            this.bufferAssistantTextForTts(token, msg.text);
           },
           message_complete: (msg) => {
             const activeTurn = this.activeAssistantTurn;
             if (
               activeTurn?.token !== token ||
-              activeTurn.completed ||
+              activeTurn.assistantCompleted ||
               this.isClosed
             ) {
               return;
             }
             if (msg.type !== "message_complete") return;
-            activeTurn.completed = true;
-            void this.sendFrame({ type: "tts_done", turnId });
+            activeTurn.assistantCompleted = true;
+            this.completeTtsForTurn(token, turnId);
           },
         },
         onError: (message) => {
-          if (!this.isForwardingAssistantTurn(token)) return;
+          if (!this.isActiveAssistantTurn(token)) return;
           void this.sendFrame({
             type: "error",
             code: LiveVoiceProtocolErrorCode.InvalidField,
@@ -369,19 +393,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         handle.abort();
         return;
       }
-      if (activeTurn.completed) {
+      if (activeTurn.ttsDone) {
         this.activeAssistantTurn = null;
         return;
       }
 
-      this.activeAssistantTurn = {
-        token,
-        abortController,
-        handle,
-        completed: false,
-      };
+      activeTurn.handle = handle;
     } catch (err) {
-      if (!this.isForwardingAssistantTurn(token)) return;
+      if (!this.isActiveAssistantTurn(token)) return;
 
       this.activeAssistantTurn = null;
       await this.sendFrame({
@@ -403,12 +422,134 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     turn.handle?.abort();
   }
 
-  private isForwardingAssistantTurn(token: symbol): boolean {
+  private isActiveAssistantTurn(token: symbol): boolean {
+    return this.activeAssistantTurn?.token === token && !this.isClosed;
+  }
+
+  private isForwardingAssistantText(token: symbol): boolean {
+    const activeTurn = this.activeAssistantTurn;
     return (
-      this.activeAssistantTurn?.token === token &&
-      !this.activeAssistantTurn.completed &&
+      activeTurn?.token === token &&
+      !activeTurn.assistantCompleted &&
       !this.isClosed
     );
+  }
+
+  private isForwardingTts(token: symbol): boolean {
+    const activeTurn = this.activeAssistantTurn;
+    return (
+      activeTurn?.token === token &&
+      !activeTurn.ttsDone &&
+      !activeTurn.abortController.signal.aborted &&
+      !this.isClosed
+    );
+  }
+
+  private bufferAssistantTextForTts(token: symbol, text: string): void {
+    if (!this.streamTtsAudio || text.length === 0) return;
+
+    const activeTurn = this.activeAssistantTurn;
+    if (activeTurn?.token !== token || activeTurn.assistantCompleted) return;
+
+    activeTurn.ttsBuffer += text;
+    this.flushTtsBuffer(token, false);
+  }
+
+  private completeTtsForTurn(token: symbol, turnId: string): void {
+    const activeTurn = this.activeAssistantTurn;
+    if (activeTurn?.token !== token) return;
+
+    this.flushTtsBuffer(token, true);
+    activeTurn.ttsQueue = activeTurn.ttsQueue
+      .catch(() => {})
+      .then(async () => {
+        const currentTurn = this.activeAssistantTurn;
+        if (currentTurn?.token !== token || currentTurn.ttsDone) return;
+
+        currentTurn.ttsDone = true;
+        await this.sendFrame({ type: "tts_done", turnId }, () =>
+          this.isActiveAssistantTurn(token),
+        );
+
+        if (this.activeAssistantTurn?.token === token) {
+          if (currentTurn.handle) {
+            this.activeAssistantTurn = null;
+          }
+        }
+      });
+  }
+
+  private flushTtsBuffer(token: symbol, force: boolean): void {
+    const activeTurn = this.activeAssistantTurn;
+    if (activeTurn?.token !== token) return;
+
+    if (!this.streamTtsAudio) {
+      activeTurn.ttsBuffer = "";
+      return;
+    }
+
+    const { segments, remainder } = extractSpeakableSegments(
+      activeTurn.ttsBuffer,
+      force,
+    );
+    activeTurn.ttsBuffer = remainder;
+
+    for (const segment of segments) {
+      this.enqueueTtsSegment(token, segment);
+    }
+  }
+
+  private enqueueTtsSegment(token: symbol, segment: string): void {
+    const activeTurn = this.activeAssistantTurn;
+    const streamTtsAudio = this.streamTtsAudio;
+    if (activeTurn?.token !== token || !streamTtsAudio) return;
+
+    activeTurn.ttsQueue = activeTurn.ttsQueue
+      .catch(() => {})
+      .then(async () => {
+        const currentTurn = this.activeAssistantTurn;
+        if (
+          currentTurn?.token !== token ||
+          currentTurn.abortController.signal.aborted
+        ) {
+          return;
+        }
+
+        try {
+          let ttsAudioFrames: Promise<void> = Promise.resolve();
+          await streamTtsAudio({
+            text: segment,
+            signal: currentTurn.abortController.signal,
+            outputFormat: "pcm",
+            sampleRate: this.context.startFrame.audio.sampleRate,
+            onAudioChunk: (chunk) => {
+              if (!this.isForwardingTts(token)) return;
+              ttsAudioFrames = ttsAudioFrames.then(() =>
+                this.sendFrame(
+                  {
+                    type: "tts_audio",
+                    mimeType: "audio/pcm",
+                    sampleRate: chunk.sampleRate,
+                    dataBase64: chunk.dataBase64,
+                  },
+                  () => this.isForwardingTts(token),
+                ),
+              );
+            },
+          });
+          await ttsAudioFrames;
+        } catch (err) {
+          if (!this.isForwardingTts(token)) return;
+          await this.sendFrame(
+            {
+              type: "error",
+              code: LiveVoiceProtocolErrorCode.InvalidField,
+              message: `Live voice TTS failed: ${errorMessage(err)}`,
+            },
+            () => this.isForwardingTts(token),
+          );
+        }
+      });
   }
 
   private async sendAudioAfterReleaseError(): Promise<void> {
@@ -419,10 +560,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     });
   }
 
-  private async sendFrame(frame: LiveVoiceServerFramePayload): Promise<void> {
+  private async sendFrame(
+    frame: LiveVoiceServerFramePayload,
+    shouldSend: () => boolean = () => true,
+  ): Promise<void> {
     this.outboundFrames = this.outboundFrames
       .catch(() => {})
       .then(async () => {
+        if (!shouldSend()) return;
         await this.context.sendFrame(frame);
       })
       .catch(() => {
@@ -448,6 +593,10 @@ export function createLiveVoiceSession(
   return new LiveVoiceSession(context, {
     ...options,
     startVoiceTurn: options.startVoiceTurn ?? defaultStartVoiceTurn,
+    streamTtsAudio:
+      options.streamTtsAudio === undefined
+        ? defaultStreamLiveVoiceTtsAudio
+        : options.streamTtsAudio,
   });
 }
 
@@ -464,6 +613,88 @@ async function defaultStartVoiceTurn(
 ): Promise<VoiceTurnHandle> {
   const { startVoiceTurn } = await import("../calls/voice-session-bridge.js");
   return startVoiceTurn(options);
+}
+
+async function defaultStreamLiveVoiceTtsAudio(
+  options: LiveVoiceTtsOptions,
+): Promise<LiveVoiceTtsResult> {
+  const { streamLiveVoiceTtsAudio } = await import("./live-voice-tts.js");
+  return streamLiveVoiceTtsAudio(options);
+}
+
+function extractSpeakableSegments(
+  text: string,
+  force: boolean,
+): { segments: string[]; remainder: string } {
+  const segments: string[] = [];
+  let remainder = text;
+
+  while (remainder.length > 0) {
+    const boundary = findSpeakableBoundary(remainder);
+    if (boundary === null) break;
+
+    const segment = remainder.slice(0, boundary).trim();
+    if (segment.length > 0) {
+      segments.push(segment);
+    }
+    remainder = remainder.slice(boundary);
+  }
+
+  if (force) {
+    const segment = remainder.trim();
+    if (segment.length > 0) {
+      segments.push(segment);
+    }
+    remainder = "";
+  }
+
+  return { segments, remainder };
+}
+
+function findSpeakableBoundary(text: string): number | null {
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === "\n") return index + 1;
+    if (!char || !SENTENCE_ENDING_PUNCTUATION.has(char)) continue;
+
+    let boundary = index + 1;
+    while (
+      boundary < text.length &&
+      TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
+    ) {
+      boundary += 1;
+    }
+
+    if (boundary === text.length || isWhitespace(text[boundary] ?? "")) {
+      return boundary;
+    }
+  }
+
+  if (text.length < LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD) {
+    return null;
+  }
+
+  const preferredBoundary = findLastWhitespaceBoundary(
+    text,
+    LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD,
+  );
+  return preferredBoundary ?? LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD;
+}
+
+function findLastWhitespaceBoundary(
+  text: string,
+  maxLength: number,
+): number | null {
+  for (let index = maxLength; index > Math.floor(maxLength * 0.6); index -= 1) {
+    if (isWhitespace(text[index] ?? "")) {
+      return index + 1;
+    }
+  }
+  return null;
+}
+
+function isWhitespace(value: string): boolean {
+  return /\s/.test(value);
 }
 
 function unavailableTranscriberMessage(): string {


### PR DESCRIPTION
## PR 15: stream assistant text to live voice TTS

### Depends on

PR 13, PR 14.

### Branch

`live-voice-channel/pr-15-tts-session-wiring`

### Files

- `assistant/src/live-voice/live-voice-session.ts`
- `assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts`

### Scope

Wire TTS into the live voice session after assistant text starts arriving. Keep the first version simple and predictable:

- buffer assistant text deltas into speakable segments
- flush on sentence-ending punctuation, newline, or a conservative character threshold
- send each segment through the streaming TTS helper
- emit `tts_audio` chunks and `tts_done`
- stop queued and active TTS work on `interrupt`, `end`, or WebSocket close

### Acceptance Criteria

- The session starts sending TTS before the full assistant message completes when a segment boundary is reached.
- TTS errors emit an `error` frame but do not invalidate the persisted assistant text turn.
- Interrupt prevents late TTS chunks from reaching the socket.

### Verification

Run:

```bash
export PATH="$HOME/.bun/bin:$PATH"
cd assistant && bun test src/live-voice/__tests__/live-voice-tts-session.test.ts
cd assistant && bunx tsc --noEmit
```

Orchestrated by velissa-ai via run-plan; implemented by Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
