### PR TITLE
feat(macos): tap acp_spawn tool block to open ACPSessionDetailView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -815,7 +815,12 @@ private final class StepDetailAttributedStringCacheEntry: NSObject {
 /// chrome; this wrapper builds the title string, resolves the visual state,
 /// and renders the expanded "Technical details / Output" body specific to
 /// `ToolCallData`.
-private struct ToolCallStepDetailRow: View {
+///
+/// `internal` rather than `private` so unit tests can reach the static
+/// `acp_spawn` deep-link helpers (`extractAcpSessionId`,
+/// `applyACPSessionDeepLink`) without standing up the full SwiftUI view
+/// tree. Production callers stay scoped to this file.
+struct ToolCallStepDetailRow: View {
     @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore
 
     let toolCall: ToolCallData
@@ -909,19 +914,65 @@ private struct ToolCallStepDetailRow: View {
         return .running
     }
 
+    /// Returns the `acpSessionId` payload field when this row should render
+    /// as a tap-to-open `acp_spawn` shortcut. Nil for any other tool, for
+    /// errored / still-running spawns, or when the result JSON is missing
+    /// or unparseable. Restricting to successful, complete spawns keeps the
+    /// chat-side behaviour unsurprising — a still-running or failed spawn
+    /// has no detail view to jump to, so the row falls back to the regular
+    /// expandable shape so the user can read the live output / error.
+    var acpSessionIdToOpen: String? {
+        guard toolCall.toolName == "acp_spawn",
+              toolCall.isComplete,
+              !toolCall.isError,
+              let result = toolCall.result,
+              !result.isEmpty else {
+            return nil
+        }
+        return ToolCallStepDetailRow.extractAcpSessionId(from: result)
+    }
+
+    /// Best-effort JSON probe for the `acpSessionId` field in
+    /// `acp_spawn`'s result payload. The tool returns a JSON object on
+    /// the first line and may append a free-form outdated-adapter
+    /// warning after a blank line (see `assistant/src/tools/acp/spawn.ts`),
+    /// so we parse the leading line rather than the full string —
+    /// otherwise the appended diagnostic invalidates the JSON and the
+    /// deep link would silently disappear in that case. On failure or
+    /// any non-JSON shape we return nil so the caller falls back to the
+    /// regular collapsible row. Static so unit tests can exercise the
+    /// parser without standing up the full view.
+    static func extractAcpSessionId(from result: String) -> String? {
+        let leading = result.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
+            .first.map(String.init) ?? ""
+        guard let data = leading.data(using: .utf8) else { return nil }
+        let parsed = try? JSONSerialization.jsonObject(with: data)
+        guard let dict = parsed as? [String: Any] else { return nil }
+        guard let id = dict["acpSessionId"] as? String, !id.isEmpty else {
+            return nil
+        }
+        return id
+    }
+
     var body: some View {
-        VCollapsibleStepRow(
-            title: ToolCallData.displaySafe(stepTitle),
-            state: rowState,
-            startedAt: toolCall.startedAt,
-            completedAt: toolCall.isComplete ? toolCall.completedAt : nil,
-            hasDetails: hasDetails,
-            isExpanded: $isDetailExpanded,
-            onExpand: { onRehydrate?() },
-            leadingAccessory: { leadingAccessory },
-            trailingAccessory: { trailingAccessory },
-            detailContent: { stepDetailContent }
-        )
+        Group {
+            if let acpSessionId = acpSessionIdToOpen {
+                acpSpawnDeepLinkRow(acpSessionId: acpSessionId)
+            } else {
+                VCollapsibleStepRow(
+                    title: ToolCallData.displaySafe(stepTitle),
+                    state: rowState,
+                    startedAt: toolCall.startedAt,
+                    completedAt: toolCall.isComplete ? toolCall.completedAt : nil,
+                    hasDetails: hasDetails,
+                    isExpanded: $isDetailExpanded,
+                    onExpand: { onRehydrate?() },
+                    leadingAccessory: { leadingAccessory },
+                    trailingAccessory: { trailingAccessory },
+                    detailContent: { stepDetailContent }
+                )
+            }
+        }
         .sheet(item: $ruleEditorToolCall) { tc in
             if assistantFeatureFlagStore.isEnabled("permission-controls-v3") {
                 V3RuleEditorModal(
@@ -977,6 +1028,89 @@ private struct ToolCallStepDetailRow: View {
                 )
             }
         }
+    }
+
+    // MARK: - acp_spawn Deep Link
+
+    /// Compact tap-to-open card replacing the standard `VCollapsibleStepRow`
+    /// for completed `acp_spawn` tool calls. Visually mirrors the regular
+    /// row's collapsed header so the chat transcript stays consistent, but
+    /// substitutes the chevron-down with a chevron-right glyph to hint at
+    /// "tap to navigate" rather than "tap to expand". The whole row is a
+    /// `Button` so the tap target spans the full row width.
+    @ViewBuilder
+    private func acpSpawnDeepLinkRow(acpSessionId: String) -> some View {
+        Button {
+            Self.openACPSession(id: acpSessionId)
+        } label: {
+            HStack(spacing: VSpacing.sm) {
+                // Always succeeded — `acpSessionIdToOpen` is gated on
+                // `isComplete && !isError`, so a failed spawn falls back
+                // to the regular collapsible row instead of this card.
+                VIconView(.circleCheck, size: 12)
+                    .foregroundStyle(VColor.primaryBase)
+                    .frame(width: 16)
+                Text(ToolCallData.displaySafe(stepTitle))
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer()
+                if let started = toolCall.startedAt,
+                   let completed = toolCall.completedAt {
+                    Text(VCollapsibleStepRowDurationFormatter.format(completed.timeIntervalSince(started)))
+                        .font(VFont.labelSmall)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+                VIconView(.chevronRight, size: 9)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .contentShape(Rectangle())
+            .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm + VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.xs + VSpacing.xs))
+        }
+        .buttonStyle(.plain)
+        .pointerCursor()
+        .accessibilityLabel("\(ToolCallData.displaySafe(stepTitle)). Tap to open coding agent session.")
+    }
+
+    /// Drive the right-slot panel + detail-view deep link. Routes through
+    /// the shared `MainWindowState` and `ACPSessionStore` instances on the
+    /// app delegate — no environment plumbing needed because the action is
+    /// fire-and-forget and only one of each store ever exists per process.
+    /// The panel observes `selectedSessionId` and pushes the matching view
+    /// model onto its `NavigationStack`; the layout-config mutation makes
+    /// the panel itself visible if it isn't already.
+    ///
+    /// `internal` and `static` so unit tests can exercise the side effects
+    /// against an injected `MainWindowState` / `ACPSessionStore` pair.
+    static func openACPSession(id: String) {
+        guard let appDelegate = AppDelegate.shared else { return }
+        applyACPSessionDeepLink(
+            id: id,
+            windowState: appDelegate.mainWindow?.windowState,
+            store: appDelegate.services.acpSessionStore
+        )
+    }
+
+    /// Pure side-effect helper for ``openACPSession(id:)``. Set the right
+    /// slot to `.native(.acpSessions)` and mark it visible, then poke the
+    /// store so the panel pushes the matching detail view. Either argument
+    /// being nil is a no-op — both are required for the deep link to land.
+    @MainActor
+    static func applyACPSessionDeepLink(
+        id: String,
+        windowState: MainWindowState?,
+        store: ACPSessionStore?
+    ) {
+        guard let windowState, let store else { return }
+        windowState.showRightSlot(.native(.acpSessions))
+        // Setting the id triggers ``ACPSessionsPanel/consumeSelectedSessionIdIfPresent``
+        // which pushes the matching view model onto the panel's
+        // `NavigationStack`. If the spawn event hasn't streamed in yet
+        // the panel will land on the list and the user can re-tap once
+        // the row appears — the daemon emits `acp_session_spawned`
+        // synchronously with the tool result so this race is rare.
+        store.selectedSessionId = id
     }
 
     // MARK: - Accessories

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -308,6 +308,21 @@ public final class MainWindowState {
         LayoutConfigStore.save(layoutConfig)
     }
 
+    /// Replace the right slot's content and force the slot visible. Used by
+    /// client-side deep links (e.g. tapping an inline `acp_spawn` tool block
+    /// to open the Coding Agents panel). Unlike ``toggleRightSlot(_:)`` this
+    /// always opens the slot — re-tapping a deep-link source must converge
+    /// on "panel open" rather than flipping it shut. Persists the updated
+    /// layout so the slot stays open across relaunches.
+    func showRightSlot(_ content: SlotContent) {
+        layoutConfig.right = SlotConfig(
+            content: content,
+            width: layoutConfig.right.width,
+            visible: true
+        )
+        LayoutConfigStore.save(layoutConfig)
+    }
+
     func clearDynamicWorkspaceState() {
         activeDynamicSurface = nil
         activeDynamicParsedSurface = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
@@ -36,8 +36,17 @@ struct ACPSessionsPanel: View {
     /// under `acp.filter.<conversationId>`.
     @State private var filterStorage = ACPSessionsPanelFilterStorage()
 
+    /// Mutable navigation path so external triggers (e.g. tapping an
+    /// inline `acp_spawn` tool block in a chat bubble) can push a detail
+    /// view programmatically. The value type stored on the path is
+    /// ``ACPSessionViewModel`` to match the existing
+    /// `navigationDestination(for: ACPSessionViewModel.self)` block —
+    /// reusing the live view model means streaming SSE updates flow into
+    /// the detail view without a pop-and-push cycle.
+    @State private var navigationPath: [ACPSessionViewModel] = []
+
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $navigationPath) {
             VSidePanel(
                 title: "Coding Agents",
                 titleFont: VFont.titleSmall,
@@ -59,13 +68,21 @@ struct ACPSessionsPanel: View {
                 // `@Observable`, so SwiftUI re-renders the detail view as
                 // its `state` / `events` mutate via SSE without forcing a
                 // pop-and-push cycle.
-                ACPSessionDetailView(session: viewModel)
+                ACPSessionDetailView(session: viewModel, store: store)
             }
         }
         .onAppear {
             if store.seedState == .idle {
                 Task { await store.seed() }
             }
+            // If a deep-link landed before the panel mounted (e.g. tapping
+            // an inline tool block opens the panel and sets the id in the
+            // same tick), consume it now so the user lands directly on the
+            // detail view instead of the list.
+            consumeSelectedSessionIdIfPresent()
+        }
+        .onChange(of: store.selectedSessionId) {
+            consumeSelectedSessionIdIfPresent()
         }
         .alert("Clear completed history?", isPresented: $showClearCompletedConfirm) {
             Button("Cancel", role: .cancel) {}
@@ -75,6 +92,40 @@ struct ACPSessionsPanel: View {
         } message: {
             Text("This removes every completed, failed, and cancelled coding agent from the list. Active agents stay.")
         }
+    }
+
+    /// Consume a pending `store.selectedSessionId`, pushing the matching
+    /// view model onto the navigation path. Defers to the pure helper
+    /// ``consumeSelectedSessionIdIfPresent(store:path:)`` so unit tests
+    /// can exercise the consumption logic without standing up a SwiftUI
+    /// view tree (which strips `@State` mutations on detached struct
+    /// values).
+    ///
+    /// Idempotent on the path: if the requested session is already at the
+    /// top of the stack, we still clear the store field but skip the push
+    /// to avoid stacking duplicate detail views. Resilient to a deep-link
+    /// arriving before its matching SSE `acp_session_spawned` event — the
+    /// field stays set so a subsequent consume (driven by the next
+    /// `onChange` tick or panel mount) can flush once the row appears.
+    func consumeSelectedSessionIdIfPresent() {
+        Self.consumeSelectedSessionIdIfPresent(store: store, path: &navigationPath)
+    }
+
+    /// Pure helper that drives the deep-link consumption against an
+    /// arbitrary store + path pair. `static` so tests can call it
+    /// directly with their own `[ACPSessionViewModel]` storage.
+    static func consumeSelectedSessionIdIfPresent(
+        store: ACPSessionStore,
+        path: inout [ACPSessionViewModel]
+    ) {
+        guard let id = store.selectedSessionId,
+              let viewModel = store.sessions[id] else {
+            return
+        }
+        // Clear first so reentrant `onChange` invocations don't loop.
+        store.selectedSessionId = nil
+        if path.last === viewModel { return }
+        path.append(viewModel)
     }
 
     // MARK: - Header bar (count + refresh + overflow menu)

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatBubbleACPSpawnTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatBubbleACPSpawnTests.swift
@@ -1,0 +1,284 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Unit tests for the inline `acp_spawn` tap-to-open shortcut wired up on
+/// the chat-side `ToolCallStepDetailRow`. The view itself is tested only
+/// through its pure helpers (no SwiftUI view tree spun up) — pixel-level
+/// rendering is covered indirectly by the existing
+/// ``ACPSessionsPanelTests`` end-to-end coverage.
+///
+/// The `applyACPSessionDeepLink` tests mutate `MainWindowState`'s persisted
+/// layout config (the on-disk `layout-config.json`). We snapshot the file
+/// in `setUp` and restore in `tearDown` so the developer's local app
+/// state isn't trashed by running the suite.
+@MainActor
+final class ChatBubbleACPSpawnTests: XCTestCase {
+    private var layoutConfigBackup: Data?
+    private var layoutConfigExisted = false
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let url = Self.layoutConfigURL()
+        layoutConfigExisted = FileManager.default.fileExists(atPath: url.path)
+        if layoutConfigExisted {
+            layoutConfigBackup = try Data(contentsOf: url)
+        }
+    }
+
+    override func tearDownWithError() throws {
+        let url = Self.layoutConfigURL()
+        if layoutConfigExisted, let data = layoutConfigBackup {
+            try data.write(to: url, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: url)
+        }
+        layoutConfigBackup = nil
+        layoutConfigExisted = false
+        try super.tearDownWithError()
+    }
+
+    /// Mirrors `LayoutConfigStore.configURL` — keep this in sync if the
+    /// production path changes. Hard-coded so the tests don't reach into
+    /// the production enum's `private` static.
+    private static func layoutConfigURL() -> URL {
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!
+        return appSupport
+            .appendingPathComponent(VellumEnvironment.current.appSupportDirectoryName, isDirectory: true)
+            .appendingPathComponent("layout-config.json")
+    }
+
+    // MARK: - extractAcpSessionId
+
+    /// Happy path: the tool returns a JSON object with `acpSessionId` set.
+    /// We must surface exactly that string so the deep link lands on the
+    /// matching session row.
+    func test_extractAcpSessionId_returnsIdFromCanonicalPayload() {
+        let payload = #"{"acpSessionId":"acp-abc-123","protocolSessionId":"proto-x","agent":"claude","cwd":"/tmp","status":"running","message":"…"}"#
+        XCTAssertEqual(
+            ToolCallStepDetailRow.extractAcpSessionId(from: payload),
+            "acp-abc-123"
+        )
+    }
+
+    /// The daemon appends an outdated-adapter warning after a blank line
+    /// in some payloads (see `assistant/src/tools/acp/spawn.ts`). The
+    /// parser scans only the leading line so the deep link still lights
+    /// up in that case — losing the affordance just because the user has
+    /// an out-of-date adapter installed would be a frustrating regression.
+    func test_extractAcpSessionId_returnsIdEvenWithTrailingWarningLines() {
+        let payload = """
+        {"acpSessionId":"acp-xyz-789","protocolSessionId":"proto","agent":"claude","cwd":"/tmp","status":"running","message":"…"}
+
+        Note: claude-agent-acp is outdated (installed: 1.0.0, latest: 1.1.0).
+        """
+        XCTAssertEqual(
+            ToolCallStepDetailRow.extractAcpSessionId(from: payload),
+            "acp-xyz-789"
+        )
+    }
+
+    /// Empty / malformed payloads must return nil so the row falls back to
+    /// the standard collapsible layout (with technical details visible) —
+    /// silently rendering an unparseable row as a tap-to-open card would
+    /// strand the user on a broken link.
+    func test_extractAcpSessionId_returnsNilForEmptyOrMalformedJson() {
+        XCTAssertNil(ToolCallStepDetailRow.extractAcpSessionId(from: ""))
+        XCTAssertNil(ToolCallStepDetailRow.extractAcpSessionId(from: "not-json"))
+        XCTAssertNil(ToolCallStepDetailRow.extractAcpSessionId(from: "{"))
+    }
+
+    /// A JSON object that doesn't carry `acpSessionId` (e.g. an error
+    /// payload) must be treated as "no deep link" — same fallback as
+    /// malformed JSON.
+    func test_extractAcpSessionId_returnsNilWhenFieldMissing() {
+        let payload = #"{"error":"binary not found","agent":"claude"}"#
+        XCTAssertNil(ToolCallStepDetailRow.extractAcpSessionId(from: payload))
+    }
+
+    /// `acpSessionId` exists but is empty — also treated as no link, since
+    /// the panel keys its `sessions` dictionary by id and an empty string
+    /// would never resolve.
+    func test_extractAcpSessionId_returnsNilForEmptyIdString() {
+        let payload = #"{"acpSessionId":"","agent":"claude"}"#
+        XCTAssertNil(ToolCallStepDetailRow.extractAcpSessionId(from: payload))
+    }
+
+    /// A non-string `acpSessionId` (number, null) must not crash the parse
+    /// or coerce to a stringified value — it must surface as nil so the
+    /// fallback row renders.
+    func test_extractAcpSessionId_returnsNilForNonStringIdValues() {
+        XCTAssertNil(ToolCallStepDetailRow.extractAcpSessionId(from: #"{"acpSessionId":42}"#))
+        XCTAssertNil(ToolCallStepDetailRow.extractAcpSessionId(from: #"{"acpSessionId":null}"#))
+    }
+
+    // MARK: - applyACPSessionDeepLink
+
+    /// End-to-end of the deep-link side effects: the right slot flips to
+    /// `.native(.acpSessions)` with `visible: true`, and the store's
+    /// `selectedSessionId` carries the requested id (the panel consumes it
+    /// on its next observation tick).
+    func test_applyACPSessionDeepLink_setsRightSlotAndStoreId() {
+        let windowState = MainWindowState()
+        // Reset the right slot to a known-empty pre-state so the assertion
+        // below isn't tainted by whatever ``LayoutConfigStore.load`` rehydrated
+        // from a previous test (or a developer's local app run). This is a
+        // pure test-fixture override — production callers go through
+        // `applyLayoutConfig` / `showRightSlot`.
+        windowState.layoutConfig.right = SlotConfig(content: .empty, width: 400, visible: false)
+        let store = ACPSessionStore()
+        XCTAssertNil(store.selectedSessionId)
+
+        ToolCallStepDetailRow.applyACPSessionDeepLink(
+            id: "acp-target-id",
+            windowState: windowState,
+            store: store
+        )
+
+        XCTAssertEqual(
+            windowState.layoutConfig.right.content,
+            .native(.acpSessions),
+            "Right slot must be flipped to the Coding Agents panel"
+        )
+        XCTAssertTrue(
+            windowState.layoutConfig.right.visible,
+            "Right slot must be made visible so the panel actually renders"
+        )
+        XCTAssertEqual(
+            store.selectedSessionId,
+            "acp-target-id",
+            "Store must carry the requested session id so the panel can push the matching detail view"
+        )
+    }
+
+    /// Width is preserved when flipping the right slot — the user's
+    /// chosen panel size from a prior interaction should not be reset to
+    /// the default just because we're swapping content.
+    func test_applyACPSessionDeepLink_preservesPersistedRightSlotWidth() {
+        let windowState = MainWindowState()
+        windowState.layoutConfig.right = SlotConfig(
+            content: .empty,
+            width: 512,
+            visible: false
+        )
+        let store = ACPSessionStore()
+
+        ToolCallStepDetailRow.applyACPSessionDeepLink(
+            id: "acp-target",
+            windowState: windowState,
+            store: store
+        )
+
+        XCTAssertEqual(windowState.layoutConfig.right.width, 512)
+    }
+
+    /// Either the window state or the store being nil must short-circuit
+    /// the deep link without crashing. `AppDelegate.shared?.mainWindow` is
+    /// nil during early launch and inside background helpers, so the
+    /// guard is a real production path, not just defensive cosmetics.
+    func test_applyACPSessionDeepLink_isNoOpWhenWindowStateOrStoreIsNil() {
+        let windowState = MainWindowState()
+        // Override persisted layout so prior runs don't bleed into this
+        // test's assertions on right-slot mutation.
+        windowState.layoutConfig.right = SlotConfig(content: .empty, width: 400, visible: false)
+        let store = ACPSessionStore()
+
+        ToolCallStepDetailRow.applyACPSessionDeepLink(
+            id: "acp-id",
+            windowState: nil,
+            store: store
+        )
+        XCTAssertNil(store.selectedSessionId, "Store must not be touched when windowState is nil")
+        XCTAssertEqual(windowState.layoutConfig.right.content, .empty)
+
+        ToolCallStepDetailRow.applyACPSessionDeepLink(
+            id: "acp-id",
+            windowState: windowState,
+            store: nil
+        )
+        XCTAssertEqual(
+            windowState.layoutConfig.right.content,
+            .empty,
+            "Right slot must not be touched when store is nil"
+        )
+    }
+
+    // MARK: - ACPSessionsPanel deep-link consumption
+
+    /// When `selectedSessionId` matches a session already in the store,
+    /// invoking the consume helper pushes that view model onto the panel's
+    /// navigation path. The store's field is cleared on consume so a
+    /// repeated set-with-same-id still triggers a fresh push.
+    func test_acpSessionsPanel_consumesSelectedSessionIdAndPushesDetail() {
+        let store = ACPSessionStore()
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-deep-link",
+            agent: "claude-code",
+            parentConversationId: "conv-deep"
+        )))
+
+        var path: [ACPSessionViewModel] = []
+        store.selectedSessionId = "acp-deep-link"
+        ACPSessionsPanel.consumeSelectedSessionIdIfPresent(store: store, path: &path)
+
+        XCTAssertEqual(path.count, 1, "Detail view must be pushed onto the panel's NavigationStack")
+        XCTAssertEqual(
+            path.last?.state.acpSessionId,
+            "acp-deep-link",
+            "Pushed view model must match the requested session"
+        )
+        XCTAssertNil(
+            store.selectedSessionId,
+            "selectedSessionId must be cleared after the panel consumes it so a later set still fires a push"
+        )
+    }
+
+    /// If the requested id has no matching row yet (e.g. the deep link
+    /// landed before the SSE `acp_session_spawned` event), consume must
+    /// be a no-op so the user lands on the list and the field stays set
+    /// for a later arrival to flush.
+    func test_acpSessionsPanel_consumeIsNoOpWhenSessionMissing() {
+        let store = ACPSessionStore()
+        var path: [ACPSessionViewModel] = []
+        store.selectedSessionId = "acp-not-yet-spawned"
+
+        ACPSessionsPanel.consumeSelectedSessionIdIfPresent(store: store, path: &path)
+
+        XCTAssertEqual(path.count, 0, "No push when the session row doesn't exist yet")
+        XCTAssertEqual(
+            store.selectedSessionId,
+            "acp-not-yet-spawned",
+            "Field must stay set so a later spawn + re-trigger can still flush the deep link"
+        )
+    }
+
+    /// Pushing the same view model twice in a row must collapse to one
+    /// push so a re-tap on the same `acp_spawn` block doesn't stack
+    /// duplicate detail views on top of each other.
+    func test_acpSessionsPanel_consumeIsIdempotentForSameTopOfStack() {
+        let store = ACPSessionStore()
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-same",
+            agent: "codex",
+            parentConversationId: "conv-x"
+        )))
+
+        var path: [ACPSessionViewModel] = []
+
+        store.selectedSessionId = "acp-same"
+        ACPSessionsPanel.consumeSelectedSessionIdIfPresent(store: store, path: &path)
+        XCTAssertEqual(path.count, 1)
+
+        // Re-triggering with the same id must not stack a duplicate row.
+        store.selectedSessionId = "acp-same"
+        ACPSessionsPanel.consumeSelectedSessionIdIfPresent(store: store, path: &path)
+        XCTAssertEqual(
+            path.count,
+            1,
+            "Re-tapping the same session must not stack duplicate detail views"
+        )
+    }
+}

--- a/clients/shared/Network/ACPSessionStore.swift
+++ b/clients/shared/Network/ACPSessionStore.swift
@@ -110,6 +110,15 @@ open class ACPSessionStore {
     /// placeholder while `.loading`, an error banner on `.error`, etc.
     public var seedState: SeedState = .idle
 
+    /// Programmatic deep-link target. When set to a non-nil
+    /// `acpSessionId`, ``ACPSessionsPanel`` reacts by pushing the
+    /// matching ``ACPSessionViewModel`` onto its `NavigationStack`. The
+    /// panel clears this back to `nil` after consuming the value so a
+    /// later set with the same id still triggers a fresh push. Used by
+    /// the inline `acp_spawn` tool block to jump straight from a chat
+    /// bubble into the corresponding session detail view.
+    public var selectedSessionId: String?
+
     /// Update messages received before their parent `spawned` event,
     /// keyed by `acpSessionId`. Reapplied during ``seed()`` once the
     /// parent appears in the polled snapshot.


### PR DESCRIPTION
## Summary
- Inline `acp_spawn` tool blocks now open the Coding Agents panel + detail view on tap.
- `ACPSessionStore.selectedSessionId` drives panel auto-push.

Part of plan: acp-sessions-ui.md (PR 29 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
