### PR TITLE
feat(macos): live status indicator on inline acp_spawn tool block

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -1038,18 +1038,25 @@ struct ToolCallStepDetailRow: View {
     /// substitutes the chevron-down with a chevron-right glyph to hint at
     /// "tap to navigate" rather than "tap to expand". The whole row is a
     /// `Button` so the tap target spans the full row width.
+    ///
+    /// The leading status dot is **live** — it subscribes to
+    /// ``ACPSessionStore`` and re-renders as the daemon streams status
+    /// updates for this session, so an inline block transitions
+    /// running → completed/failed without the user expanding it. When the
+    /// store has no entry for the session id (history cleared, daemon
+    /// restarted) the dot falls back to the static tool-call result so a
+    /// successful spawn still reads as "completed".
     @ViewBuilder
     private func acpSpawnDeepLinkRow(acpSessionId: String) -> some View {
         Button {
             Self.openACPSession(id: acpSessionId)
         } label: {
             HStack(spacing: VSpacing.sm) {
-                // Always succeeded — `acpSessionIdToOpen` is gated on
-                // `isComplete && !isError`, so a failed spawn falls back
-                // to the regular collapsible row instead of this card.
-                VIconView(.circleCheck, size: 12)
-                    .foregroundStyle(VColor.primaryBase)
-                    .frame(width: 16)
+                ACPSpawnStatusDot(
+                    acpSessionId: acpSessionId,
+                    store: AppDelegate.shared?.services.acpSessionStore
+                )
+                .frame(width: 16)
                 Text(ToolCallData.displaySafe(stepTitle))
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentDefault)
@@ -1390,6 +1397,112 @@ struct ToolCallStepDetailRow: View {
         return attributed
     }
 
+}
+
+// MARK: - ACP Spawn Status Dot
+
+/// Render decision for the leading status indicator on the inline
+/// `acp_spawn` deep-link row. Resolved as a pure function from the live
+/// store status (when present) so unit tests can pin-point each visual
+/// state without standing up the SwiftUI view tree.
+///
+/// `internal` so unit tests can read the resolved value; production
+/// callers go through ``ACPSpawnStatusDot``.
+enum ACPSpawnStatusIndicator: Equatable {
+    /// The session is still working — render a pulsing dot. Both
+    /// `.running` and `.initializing` map to this state since neither is a
+    /// terminal stop condition the user can act on.
+    case pulsing
+    /// The session reached a terminal state — render a static glyph in
+    /// the supplied semantic role. Color is derived from the role at
+    /// render time so the resolver can stay UI-framework-agnostic.
+    case icon(glyph: Glyph, role: Role)
+
+    enum Glyph: Equatable {
+        case check
+        case xmark
+        case dash
+    }
+
+    enum Role: Equatable {
+        /// Successful terminal — green check.
+        case positive
+        /// Errored terminal — red x.
+        case negative
+        /// Cancelled / unknown / muted terminal — gray dash.
+        case muted
+    }
+
+    /// Map a live ``ACPSessionState/Status`` into a render decision.
+    /// Falls back to a static "completed" check when the store has no
+    /// entry for the session id (`status` is nil) — for an `acp_spawn`
+    /// row to render at all the tool call already succeeded, so a
+    /// missing-from-store entry is almost always "history was cleared
+    /// after a successful run" rather than "something unobservable went
+    /// wrong". Treating it as completed keeps the inline block honest
+    /// instead of perpetually pulsing on a stale id.
+    static func resolve(forStatus status: ACPSessionState.Status?) -> ACPSpawnStatusIndicator {
+        guard let status else {
+            return .icon(glyph: .check, role: .positive)
+        }
+        switch status {
+        case .running, .initializing:
+            return .pulsing
+        case .completed:
+            return .icon(glyph: .check, role: .positive)
+        case .failed:
+            return .icon(glyph: .xmark, role: .negative)
+        case .cancelled:
+            return .icon(glyph: .dash, role: .muted)
+        case .unknown:
+            // Daemon version skew — treat as completed so the inline
+            // block matches the spawn tool's own "we got back a session
+            // id" semantics rather than stalling on a ghost pulse.
+            return .icon(glyph: .check, role: .positive)
+        }
+    }
+}
+
+/// Live status indicator for the inline `acp_spawn` deep-link row.
+///
+/// Reads the matching ``ACPSessionViewModel`` off the supplied store —
+/// because `ACPSessionStore` is `@Observable`, simply touching
+/// `store.sessions[id]?.state.status` inside `body` enrolls this view in
+/// SwiftUI's per-property observation graph, so a daemon SSE update
+/// flips the dot without a manual refresh. The store is optional
+/// because the chat transcript renders inside test harnesses and
+/// pre-launch contexts where ``AppDelegate/shared`` is nil; a missing
+/// store falls through to the static-completed indicator.
+private struct ACPSpawnStatusDot: View {
+    let acpSessionId: String
+    let store: ACPSessionStore?
+
+    var body: some View {
+        let status = store?.sessions[acpSessionId]?.state.status
+        switch ACPSpawnStatusIndicator.resolve(forStatus: status) {
+        case .pulsing:
+            VBusyIndicator(size: 8)
+        case .icon(let glyph, let role):
+            VIconView(Self.icon(for: glyph), size: 12)
+                .foregroundStyle(Self.color(for: role))
+        }
+    }
+
+    private static func icon(for glyph: ACPSpawnStatusIndicator.Glyph) -> VIcon {
+        switch glyph {
+        case .check: return .circleCheck
+        case .xmark: return .circleX
+        case .dash: return .circleDashed
+        }
+    }
+
+    private static func color(for role: ACPSpawnStatusIndicator.Role) -> Color {
+        switch role {
+        case .positive: return VColor.primaryBase
+        case .negative: return VColor.systemNegativeStrong
+        case .muted: return VColor.contentTertiary
+        }
+    }
 }
 
 // MARK: - Thinking Step Row

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatBubbleACPSpawnTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatBubbleACPSpawnTests.swift
@@ -281,4 +281,137 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
             "Re-tapping the same session must not stack duplicate detail views"
         )
     }
+
+    // MARK: - ACPSpawnStatusIndicator
+
+    /// `.running` and `.initializing` are both "still working" from the
+    /// user's perspective — neither is a terminal state they can act on,
+    /// so the inline block must show the same pulsing dot for both. If
+    /// `.initializing` ever rendered as a static glyph the user would
+    /// misread a session that just started as already done.
+    func test_acpSpawnStatusIndicator_pulsesWhileRunningOrInitializing() {
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forStatus: .running),
+            .pulsing
+        )
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forStatus: .initializing),
+            .pulsing
+        )
+    }
+
+    /// Successful terminal — green check. This is the dominant path for
+    /// the inline block (most sessions complete normally) so the visual
+    /// must read as a positive confirmation, not a generic neutral icon.
+    func test_acpSpawnStatusIndicator_completedRendersPositiveCheck() {
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forStatus: .completed),
+            .icon(glyph: .check, role: .positive)
+        )
+    }
+
+    /// Errored terminal — red x. The inline block normally falls back to
+    /// the regular collapsible row when the spawn tool itself errored,
+    /// but a session can still flip to `.failed` *after* the spawn
+    /// returned successfully (daemon-side process crash, agent error)
+    /// so the live indicator must surface that as a clear negative.
+    func test_acpSpawnStatusIndicator_failedRendersNegativeXmark() {
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forStatus: .failed),
+            .icon(glyph: .xmark, role: .negative)
+        )
+    }
+
+    /// Cancelled terminal — muted dash. Cancellation is user-initiated
+    /// (or a parent shutdown) and isn't an error, so it gets the gray
+    /// muted role rather than the red one used for `.failed`.
+    func test_acpSpawnStatusIndicator_cancelledRendersMutedDash() {
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forStatus: .cancelled),
+            .icon(glyph: .dash, role: .muted)
+        )
+    }
+
+    /// `.unknown` arrives only via daemon version skew. We treat it as a
+    /// successful completion because the inline block only renders for
+    /// `acp_spawn` results that already returned a session id, so the
+    /// row's mere existence is evidence the spawn worked. Pulsing
+    /// indefinitely on a status the client doesn't recognize would
+    /// strand the user on a stuck-looking row.
+    func test_acpSpawnStatusIndicator_unknownStatusFallsBackToCompleted() {
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forStatus: .unknown),
+            .icon(glyph: .check, role: .positive)
+        )
+    }
+
+    /// Nil (no entry in the store — history was cleared, daemon
+    /// restarted) falls back to the static "completed" indicator. Same
+    /// reasoning as `.unknown`: the row only renders when the tool call
+    /// itself succeeded.
+    func test_acpSpawnStatusIndicator_missingStoreEntryFallsBackToCompleted() {
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forStatus: nil),
+            .icon(glyph: .check, role: .positive)
+        )
+    }
+
+    /// End-to-end scenario the PR is meant to enable: a running session
+    /// flips to completed and the indicator switches from pulsing to
+    /// the positive check without any view-side input. Drives through
+    /// the same `ACPSessionStore.handle` pipeline production code uses
+    /// so the test catches regressions in either the resolver or the
+    /// store's status-transition logic.
+    func test_acpSpawnStatusIndicator_transitionsFromRunningToCompletedViaStore() {
+        let store = ACPSessionStore()
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-live",
+            agent: "claude-code",
+            parentConversationId: "conv-live"
+        )))
+
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(
+                forStatus: store.sessions["acp-live"]?.state.status
+            ),
+            .pulsing,
+            "Newly spawned session must render pulsing while running"
+        )
+
+        store.handle(.acpSessionCompleted(ACPSessionCompletedMessage(
+            acpSessionId: "acp-live",
+            stopReason: .endTurn
+        )))
+
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(
+                forStatus: store.sessions["acp-live"]?.state.status
+            ),
+            .icon(glyph: .check, role: .positive),
+            "Completed session must render the positive check"
+        )
+    }
+
+    /// Mirror of the above for the failure path — `.failed` flowing
+    /// through `acpSessionError` must surface as the negative red x.
+    func test_acpSpawnStatusIndicator_transitionsFromRunningToFailedViaStore() {
+        let store = ACPSessionStore()
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-fail",
+            agent: "codex",
+            parentConversationId: "conv-fail"
+        )))
+
+        store.handle(.acpSessionError(ACPSessionErrorMessage(
+            acpSessionId: "acp-fail",
+            error: "agent crashed"
+        )))
+
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(
+                forStatus: store.sessions["acp-fail"]?.state.status
+            ),
+            .icon(glyph: .xmark, role: .negative)
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Inline `acp_spawn` tool block subscribes to `ACPSessionStore.sessions[id].state.status`.
- Pulsing dot for running/initializing, check for completed, red x for failed, dash for cancelled. Falls back to static badge if store lacks the session.

Part of plan: acp-sessions-ui.md (PR 30 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
