### PR TITLE
feat(live-voice): emit archive and metrics events from live sessions (PR 19)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-events.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-events.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type {
+  VoiceTurnCallbacks,
+  VoiceTurnOptions,
+} from "../../calls/voice-session-bridge.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import type { LiveVoiceAudioArchiveResult } from "../live-voice-archive.js";
+import {
+  LiveVoiceSession,
+  type LiveVoiceSessionArchiveAudioInput,
+  type LiveVoiceSessionAudioArchiver,
+  type LiveVoiceTtsStreamer,
+  type LiveVoiceTurnStarter,
+} from "../live-voice-session.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import type {
+  LiveVoiceTtsAudioChunk,
+  LiveVoiceTtsOptions,
+  LiveVoiceTtsResult,
+} from "../live-voice-tts.js";
+import {
+  createLiveVoiceServerFrameSequencer,
+  type LiveVoiceClientStartFrame,
+  type LiveVoiceServerFrame,
+} from "../protocol.js";
+
+const START_FRAME = {
+  type: "start",
+  conversationId: "conversation-123",
+  audio: {
+    mimeType: "audio/pcm",
+    sampleRate: 24_000,
+    channels: 1,
+  },
+} as const satisfies LiveVoiceClientStartFrame;
+
+class MockStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  constructor(
+    private readonly stopEvents: SttStreamServerEvent[] = [
+      { type: "final", text: "hello" },
+      { type: "closed" },
+    ],
+  ) {}
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(): void {}
+
+  stop(): void {
+    for (const event of this.stopEvents) {
+      this.onEvent?.(event);
+    }
+  }
+}
+
+function createContext(): {
+  context: LiveVoiceSessionFactoryContext;
+  frames: LiveVoiceServerFrame[];
+} {
+  const sequencer = createLiveVoiceServerFrameSequencer();
+  const frames: LiveVoiceServerFrame[] = [];
+
+  return {
+    frames,
+    context: {
+      sessionId: "session-123",
+      startFrame: START_FRAME,
+      sendFrame: mock(async (payload) => {
+        const frame = sequencer.next(payload);
+        frames.push(frame);
+        return frame;
+      }),
+    },
+  };
+}
+
+function makeClock(): () => number {
+  let now = 1_000;
+  return () => {
+    now += 10;
+    return now;
+  };
+}
+
+function createSessionHarness(options: {
+  archiveAudio: LiveVoiceSessionAudioArchiver;
+  startVoiceTurn: LiveVoiceTurnStarter;
+  streamTtsAudio?: LiveVoiceTtsStreamer | null;
+}) {
+  const transcriber = new MockStreamingTranscriber();
+  const { context, frames } = createContext();
+  const session = new LiveVoiceSession(context, {
+    resolveTranscriber: mock(async () => transcriber),
+    startVoiceTurn: options.startVoiceTurn,
+    streamTtsAudio: options.streamTtsAudio ?? null,
+    archiveAudio: options.archiveAudio,
+    emitMetrics: true,
+    metricsClock: makeClock(),
+    createTurnId: () => "live-turn-1",
+  });
+
+  return { frames, session, transcriber };
+}
+
+async function startReleasedTurn(
+  session: LiveVoiceSession,
+  userAudio = "user audio bytes",
+): Promise<void> {
+  await session.start();
+  await session.handleClientFrame({
+    type: "audio",
+    dataBase64: Buffer.from(userAudio).toString("base64"),
+  });
+  await session.handleClientFrame({ type: "ptt_release" });
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message = "Timed out waiting for live voice event test condition",
+): Promise<void> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(message);
+}
+
+function makeArchiveResult(
+  input: LiveVoiceSessionArchiveAudioInput,
+): LiveVoiceAudioArchiveResult {
+  const attachmentId = `${input.role}-attachment-123`;
+  return {
+    type: "archived",
+    artifact: {
+      source: "live-voice",
+      archiveKey: `live-voice:${input.sessionId}:${input.turnId}:${input.role}`,
+      attachmentId,
+      sessionId: input.sessionId,
+      turnId: input.turnId,
+      role: input.role,
+      mimeType: input.mimeType,
+      ...(input.sampleRate !== undefined
+        ? { sampleRate: input.sampleRate }
+        : {}),
+      ...(input.durationMs !== undefined
+        ? { durationMs: input.durationMs }
+        : {}),
+      sizeBytes: Buffer.byteLength(input.audio.dataBase64, "base64"),
+      filename: `${attachmentId}.pcm`,
+      archivedAt: 1_234,
+    },
+    idempotent: false,
+  };
+}
+
+function makeTtsChunk(text: string): LiveVoiceTtsAudioChunk {
+  return {
+    type: "tts_audio",
+    seq: 0,
+    contentType: "audio/pcm",
+    sampleRate: 24_000,
+    dataBase64: Buffer.from(text).toString("base64"),
+  };
+}
+
+function makeTtsResult(text: string): LiveVoiceTtsResult {
+  return {
+    provider: "fish-audio",
+    contentType: "audio/pcm",
+    sampleRate: 24_000,
+    chunks: 1,
+    bytes: Buffer.byteLength(text),
+  };
+}
+
+function makeTextDelta(
+  text: string,
+): Parameters<NonNullable<VoiceTurnCallbacks["assistant_text_delta"]>>[0] {
+  return {
+    type: "assistant_text_delta",
+    text,
+    conversationId: "conversation-123",
+  };
+}
+
+function makeMessageComplete(): Parameters<
+  NonNullable<VoiceTurnCallbacks["message_complete"]>
+>[0] {
+  return {
+    type: "message_complete",
+    conversationId: "conversation-123",
+    messageId: "assistant-message-123",
+  };
+}
+
+function frameTypes(frames: LiveVoiceServerFrame[]): string[] {
+  return frames.map((frame) => frame.type);
+}
+
+describe("LiveVoiceSession archive and metrics events", () => {
+  test("archives user and assistant audio and emits completion and session metrics", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const archiveAudio = mock(
+      async (input: LiveVoiceSessionArchiveAudioInput) =>
+        makeArchiveResult(input),
+    );
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      options.callbacks?.persisted_user_message_id?.("user-message-123");
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio bytes"));
+      return makeTtsResult("assistant audio bytes");
+    });
+    const { frames, session } = createSessionHarness({
+      archiveAudio,
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta("Hello there."));
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+      ),
+    );
+    await session.close("client_end");
+
+    expect(frameTypes(frames)).toContain("tts_done");
+    expect(archiveAudio).toHaveBeenCalledTimes(2);
+    expect(archiveAudio.mock.calls.map((call) => call[0].role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+    expect(archiveAudio.mock.calls[0]?.[0]).toMatchObject({
+      messageId: "user-message-123",
+      sessionId: "session-123",
+      turnId: "live-turn-1",
+      role: "user",
+    });
+    expect(archiveAudio.mock.calls[1]?.[0]).toMatchObject({
+      messageId: "assistant-message-123",
+      sessionId: "session-123",
+      turnId: "live-turn-1",
+      role: "assistant",
+    });
+    expect(
+      Buffer.from(
+        archiveAudio.mock.calls[0]![0].audio.dataBase64,
+        "base64",
+      ).toString(),
+    ).toBe("user audio bytes");
+    expect(
+      Buffer.from(
+        archiveAudio.mock.calls[1]![0].audio.dataBase64,
+        "base64",
+      ).toString(),
+    ).toBe("assistant audio bytes");
+
+    const archivedFrames = frames.filter((frame) => frame.type === "archived");
+    expect(archivedFrames).toHaveLength(2);
+    expect(archivedFrames.map((frame) => frame.attachmentIds)).toEqual([
+      ["user-attachment-123"],
+      ["assistant-attachment-123"],
+    ]);
+
+    const completedMetrics = frames.find(
+      (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+    );
+    expect(completedMetrics).toMatchObject({
+      type: "metrics",
+      sessionId: "session-123",
+      conversationId: "conversation-123",
+      turnId: "live-turn-1",
+      metrics: {
+        summary: {
+          completedTurnCount: 1,
+          cancelledTurnCount: 0,
+        },
+      },
+    });
+    expect(frames.at(-1)).toMatchObject({
+      type: "metrics",
+      event: "session_ended",
+      sessionId: "session-123",
+    });
+    expect(
+      (
+        session as unknown as {
+          currentUserAudioChunks: Buffer[];
+          activeAssistantTurn: unknown;
+        }
+      ).currentUserAudioChunks,
+    ).toHaveLength(0);
+    expect(
+      (
+        session as unknown as {
+          activeAssistantTurn: unknown;
+        }
+      ).activeAssistantTurn,
+    ).toBeNull();
+  });
+
+  test("emits cancelled metrics and releases buffers when interrupted", async () => {
+    const abort = mock();
+    const archiveAudio = mock(
+      async (input: LiveVoiceSessionArchiveAudioInput) =>
+        makeArchiveResult(input),
+    );
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.persisted_user_message_id?.("user-message-123");
+      return { turnId: "bridge-turn-1", abort };
+    });
+    const { frames, session } = createSessionHarness({
+      archiveAudio,
+      startVoiceTurn,
+    });
+
+    await startReleasedTurn(session);
+    await session.handleClientFrame({ type: "interrupt" });
+
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+    expect(frames.find((frame) => frame.type === "archived")).toMatchObject({
+      type: "archived",
+      role: "user",
+      attachmentIds: ["user-attachment-123"],
+    });
+    expect(frames.find((frame) => frame.type === "metrics")).toMatchObject({
+      type: "metrics",
+      event: "turn_cancelled",
+      turnId: "live-turn-1",
+      metrics: {
+        summary: {
+          completedTurnCount: 0,
+          cancelledTurnCount: 1,
+        },
+      },
+    });
+    expect(
+      (
+        session as unknown as {
+          currentUserAudioChunks: Buffer[];
+        }
+      ).currentUserAudioChunks,
+    ).toHaveLength(0);
+  });
+
+  test("emits warning archive frames and error-turn metrics without throwing", async () => {
+    const archiveAudio = mock(async () => {
+      throw new Error("archive store unavailable");
+    });
+    const startVoiceTurn = mock(async () => {
+      throw new Error("assistant turn failed");
+    });
+    const { frames, session } = createSessionHarness({
+      archiveAudio,
+      startVoiceTurn,
+    });
+
+    await startReleasedTurn(session);
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_cancelled",
+      ),
+    );
+
+    expect(frames.find((frame) => frame.type === "error")).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("assistant turn failed"),
+    });
+    expect(frames.find((frame) => frame.type === "archived")).toMatchObject({
+      type: "archived",
+      role: "user",
+      warning: {
+        code: "archive_failed",
+        message: expect.stringContaining("archive store unavailable"),
+      },
+    });
+    expect(frames.find((frame) => frame.type === "metrics")).toMatchObject({
+      type: "metrics",
+      event: "turn_cancelled",
+      turnId: "live-turn-1",
+      metrics: {
+        summary: {
+          cancelledTurnCount: 1,
+        },
+      },
+    });
+    expect(
+      (
+        session as unknown as {
+          currentUserAudioChunks: Buffer[];
+        }
+      ).currentUserAudioChunks,
+    ).toHaveLength(0);
+  });
+});

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -15,6 +15,14 @@ import type {
   SttStreamServerEvent,
 } from "../stt/types.js";
 import type {
+  LiveVoiceAudioArchiveResult,
+  LiveVoiceAudioArchiveRole,
+} from "./live-voice-archive.js";
+import {
+  type LiveVoiceMetricsClock,
+  LiveVoiceMetricsCollector,
+} from "./live-voice-metrics.js";
+import type {
   LiveVoiceSession as LiveVoiceSessionContract,
   LiveVoiceSessionCloseReason,
   LiveVoiceSessionFactoryContext,
@@ -54,21 +62,50 @@ export type LiveVoiceTtsStreamer = (
   options: LiveVoiceTtsOptions,
 ) => Promise<LiveVoiceTtsResult>;
 
+export interface LiveVoiceSessionArchiveAudioInput {
+  messageId?: string | null;
+  sessionId: string;
+  turnId: string;
+  role: LiveVoiceAudioArchiveRole;
+  mimeType: string;
+  sampleRate?: number;
+  durationMs?: number;
+  audio: {
+    type: "base64";
+    dataBase64: string;
+  };
+}
+
+export type LiveVoiceSessionAudioArchiver = (
+  input: LiveVoiceSessionArchiveAudioInput,
+) => LiveVoiceAudioArchiveResult | Promise<LiveVoiceAudioArchiveResult>;
+
 export interface LiveVoiceSessionOptions {
   resolveTranscriber?: LiveVoiceStreamingTranscriberResolver;
   startVoiceTurn?: LiveVoiceTurnStarter;
   streamTtsAudio?: LiveVoiceTtsStreamer | null;
+  archiveAudio?: LiveVoiceSessionAudioArchiver | null;
+  emitMetrics?: boolean;
+  metricsClock?: LiveVoiceMetricsClock;
   createTurnId?: () => string;
 }
 
 interface ActiveAssistantTurn {
   token: symbol;
+  turnId: string;
   abortController: AbortController;
   handle: VoiceTurnHandle | null;
   assistantCompleted: boolean;
   ttsDone: boolean;
+  finalized: boolean;
   ttsBuffer: string;
   ttsQueue: Promise<void>;
+  userMessageId: string | null;
+  assistantMessageId: string | null;
+  userAudioChunks: Buffer[];
+  assistantAudioChunks: Buffer[];
+  assistantAudioMimeType: string;
+  assistantAudioSampleRate?: number;
 }
 
 export class LiveVoiceSession implements LiveVoiceSessionContract {
@@ -76,6 +113,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly resolveTranscriber: LiveVoiceStreamingTranscriberResolver;
   private readonly startVoiceTurn: LiveVoiceTurnStarter | null;
   private readonly streamTtsAudio: LiveVoiceTtsStreamer | null;
+  private readonly archiveAudio: LiveVoiceSessionAudioArchiver | null;
+  private readonly emitMetrics: boolean;
+  private readonly metrics: LiveVoiceMetricsCollector;
   private readonly createTurnId: () => string;
   private readonly conversationId: string;
   private state: LiveVoiceSessionState = "initializing";
@@ -85,6 +125,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private pttReleased = false;
   private assistantTurnStarted = false;
   private activeAssistantTurn: ActiveAssistantTurn | null = null;
+  private currentTurnId: string | null = null;
+  private currentUserMessageId: string | null = null;
+  private currentUserAudioChunks: Buffer[] = [];
+  private metricsTurnStarted = false;
+  private metricsTurnFinished = false;
+  private sessionEndMetricsEmitted = false;
 
   constructor(
     context: LiveVoiceSessionFactoryContext,
@@ -95,9 +141,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       options.resolveTranscriber ?? defaultResolveStreamingTranscriber;
     this.startVoiceTurn = options.startVoiceTurn ?? null;
     this.streamTtsAudio = options.streamTtsAudio ?? null;
+    this.archiveAudio = options.archiveAudio ?? null;
+    this.emitMetrics = options.emitMetrics ?? false;
     this.createTurnId = options.createTurnId ?? randomUUID;
     this.conversationId =
       context.startFrame.conversationId ?? context.sessionId;
+    this.metrics = new LiveVoiceMetricsCollector({
+      sessionId: context.sessionId,
+      conversationId: this.conversationId,
+      ...(options.metricsClock ? { clock: options.metricsClock } : {}),
+    });
   }
 
   get finalTranscriptText(): string {
@@ -139,6 +192,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
 
       this.state = "active";
+      this.metrics.markReady();
       await this.sendFrame({
         type: "ready",
         sessionId: this.context.sessionId,
@@ -191,7 +245,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.state = "closed";
     stopTranscriberBestEffort(this.transcriber);
     this.transcriber = null;
-    this.cancelAssistantTurn();
+    await this.cancelAssistantTurn("session_closed");
+    await this.emitSessionEndMetrics();
     await this.drainOutboundFrames();
   }
 
@@ -206,6 +261,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     if (this.state !== "active") return;
 
+    this.collectUserAudio(chunk);
     try {
       this.transcriber?.sendAudio(
         chunk,
@@ -220,6 +276,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           err,
         )}`,
       });
+      await this.finalizePendingTurn("audio_error");
     }
   }
 
@@ -230,6 +287,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     if (this.state === "transcriber_closed") {
       this.pttReleased = true;
+      this.markPushToTalkReleased();
       await this.startAssistantTurnIfReady();
       await this.drainOutboundFrames();
       return;
@@ -238,6 +296,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (this.state !== "active") return;
 
     this.pttReleased = true;
+    this.markPushToTalkReleased();
     this.state = "utterance_released";
     try {
       this.transcriber?.stop();
@@ -267,6 +326,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     switch (event.type) {
       case "partial":
+        this.markFirstPartial();
         await this.sendFrame({ type: "stt_partial", text: event.text });
         return;
       case "final": {
@@ -274,6 +334,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         if (transcript.length > 0) {
           this.finalTranscriptSegments.push(transcript);
         }
+        this.markFinalTranscript();
         await this.sendFrame({ type: "stt_final", text: event.text });
         await this.startAssistantTurnIfReady();
         return;
@@ -284,6 +345,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           code: LiveVoiceProtocolErrorCode.InvalidField,
           message: event.message,
         });
+        await this.finalizePendingTurn("stt_error");
         return;
       case "closed":
         if (!this.isClosed) {
@@ -301,7 +363,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.state = "interrupted";
     stopTranscriberBestEffort(this.transcriber);
     this.transcriber = null;
-    this.cancelAssistantTurn();
+    await this.cancelAssistantTurn("interrupt");
     await this.drainOutboundFrames();
   }
 
@@ -323,20 +385,31 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (!this.startVoiceTurn) return;
 
     const content = this.finalTranscriptText.trim();
-    if (content.length === 0) return;
+    if (content.length === 0) {
+      await this.finalizePendingTurn("empty_transcript");
+      return;
+    }
 
     this.assistantTurnStarted = true;
     const token = Symbol("live-voice-assistant-turn");
-    const turnId = this.createTurnId();
+    const turnId = this.ensureTurnId();
+    this.startMetricsTurnIfNeeded(turnId);
     const abortController = new AbortController();
     this.activeAssistantTurn = {
       token,
+      turnId,
       abortController,
       handle: null,
       assistantCompleted: false,
       ttsDone: false,
+      finalized: false,
       ttsBuffer: "",
       ttsQueue: Promise.resolve(),
+      userMessageId: this.currentUserMessageId,
+      assistantMessageId: null,
+      userAudioChunks: this.currentUserAudioChunks,
+      assistantAudioChunks: [],
+      assistantAudioMimeType: "audio/pcm",
     };
 
     await this.sendFrame({ type: "thinking", turnId });
@@ -358,6 +431,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         callbacks: {
           assistant_text_delta: (msg) => {
             if (!this.isForwardingAssistantText(token)) return;
+            this.markFirstAssistantDelta(turnId);
             void this.sendFrame({
               type: "assistant_text_delta",
               text: msg.text,
@@ -373,18 +447,42 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             ) {
               return;
             }
-            if (msg.type !== "message_complete") return;
             activeTurn.assistantCompleted = true;
-            this.completeTtsForTurn(token, turnId);
+            if (msg.type === "generation_cancelled") {
+              void this.finalizeAssistantTurn(
+                activeTurn,
+                "cancelled",
+                "generation_cancelled",
+              );
+              return;
+            }
+            activeTurn.assistantMessageId = msg.messageId ?? null;
+            this.completeTtsForTurn(token);
+          },
+          persisted_user_message_id: (messageId) => {
+            const activeTurn = this.activeAssistantTurn;
+            if (activeTurn?.token !== token) return;
+            activeTurn.userMessageId = messageId;
+            this.currentUserMessageId = messageId;
+          },
+          persisted_assistant_message_id: (messageId) => {
+            const activeTurn = this.activeAssistantTurn;
+            if (activeTurn?.token !== token) return;
+            activeTurn.assistantMessageId = messageId;
           },
         },
         onError: (message) => {
           if (!this.isActiveAssistantTurn(token)) return;
-          void this.sendFrame({
-            type: "error",
-            code: LiveVoiceProtocolErrorCode.InvalidField,
-            message,
-          });
+          void (async () => {
+            await this.sendFrame({
+              type: "error",
+              code: LiveVoiceProtocolErrorCode.InvalidField,
+              message,
+            });
+            const activeTurn = this.activeAssistantTurn;
+            if (activeTurn?.token !== token) return;
+            await this.finalizeAssistantTurn(activeTurn, "cancelled", "error");
+          })();
         },
       });
 
@@ -393,7 +491,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         handle.abort();
         return;
       }
-      if (activeTurn.ttsDone) {
+      if (activeTurn.finalized) {
         this.activeAssistantTurn = null;
         return;
       }
@@ -410,20 +508,28 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           err,
         )}`,
       });
+      await this.finalizePendingTurn("assistant_start_error");
     }
   }
 
-  private cancelAssistantTurn(): void {
+  private async cancelAssistantTurn(reason: string): Promise<void> {
     const turn = this.activeAssistantTurn;
-    if (!turn) return;
+    if (!turn) {
+      await this.finalizePendingTurn(reason);
+      return;
+    }
 
     this.activeAssistantTurn = null;
     turn.abortController.abort();
     turn.handle?.abort();
+    await this.finalizeAssistantTurn(turn, "cancelled", reason);
   }
 
   private isActiveAssistantTurn(token: symbol): boolean {
-    return this.activeAssistantTurn?.token === token && !this.isClosed;
+    const activeTurn = this.activeAssistantTurn;
+    return (
+      activeTurn?.token === token && !activeTurn.finalized && !this.isClosed
+    );
   }
 
   private isForwardingAssistantText(token: symbol): boolean {
@@ -431,6 +537,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     return (
       activeTurn?.token === token &&
       !activeTurn.assistantCompleted &&
+      !activeTurn.finalized &&
       !this.isClosed
     );
   }
@@ -440,6 +547,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     return (
       activeTurn?.token === token &&
       !activeTurn.ttsDone &&
+      !activeTurn.finalized &&
       !activeTurn.abortController.signal.aborted &&
       !this.isClosed
     );
@@ -455,7 +563,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.flushTtsBuffer(token, false);
   }
 
-  private completeTtsForTurn(token: symbol, turnId: string): void {
+  private completeTtsForTurn(token: symbol): void {
     const activeTurn = this.activeAssistantTurn;
     if (activeTurn?.token !== token) return;
 
@@ -467,12 +575,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         if (currentTurn?.token !== token || currentTurn.ttsDone) return;
 
         currentTurn.ttsDone = true;
-        await this.sendFrame({ type: "tts_done", turnId }, () =>
-          this.isActiveAssistantTurn(token),
+        await this.sendFrame(
+          { type: "tts_done", turnId: currentTurn.turnId },
+          () => this.isActiveAssistantTurn(token),
         );
+        await this.finalizeAssistantTurn(currentTurn, "completed");
 
         if (this.activeAssistantTurn?.token === token) {
-          if (currentTurn.handle) {
+          if (currentTurn.handle && currentTurn.finalized) {
             this.activeAssistantTurn = null;
           }
         }
@@ -524,6 +634,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             sampleRate: this.context.startFrame.audio.sampleRate,
             onAudioChunk: (chunk) => {
               if (!this.isForwardingTts(token)) return;
+              const activeTurn = this.activeAssistantTurn;
+              if (activeTurn?.token !== token) return;
+              activeTurn.assistantAudioChunks.push(
+                Buffer.from(chunk.dataBase64, "base64"),
+              );
+              activeTurn.assistantAudioMimeType = chunk.contentType;
+              activeTurn.assistantAudioSampleRate = chunk.sampleRate;
+              this.metrics.markFirstTtsAudio(activeTurn.turnId);
               ttsAudioFrames = ttsAudioFrames.then(() =>
                 this.sendFrame(
                   {
@@ -550,6 +668,241 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           );
         }
       });
+  }
+
+  private collectUserAudio(chunk: Buffer): void {
+    const turnId = this.ensureTurnId();
+    this.currentUserAudioChunks.push(Buffer.from(chunk));
+    this.startMetricsTurnIfNeeded(turnId);
+    this.metrics.markFirstAudio(turnId);
+  }
+
+  private markPushToTalkReleased(): void {
+    const turnId = this.ensureTurnId();
+    this.startMetricsTurnIfNeeded(turnId);
+    this.metrics.markPushToTalkRelease(turnId);
+  }
+
+  private markFirstPartial(): void {
+    const turnId = this.ensureTurnId();
+    this.startMetricsTurnIfNeeded(turnId);
+    this.metrics.markFirstPartial(turnId);
+  }
+
+  private markFinalTranscript(): void {
+    const turnId = this.ensureTurnId();
+    this.startMetricsTurnIfNeeded(turnId);
+    this.metrics.markFinalTranscript(turnId);
+  }
+
+  private markFirstAssistantDelta(turnId: string): void {
+    this.startMetricsTurnIfNeeded(turnId);
+    this.metrics.markFirstAssistantDelta(turnId);
+  }
+
+  private ensureTurnId(): string {
+    if (!this.currentTurnId) {
+      this.currentTurnId = this.createTurnId();
+    }
+    return this.currentTurnId;
+  }
+
+  private startMetricsTurnIfNeeded(turnId: string): void {
+    if (this.metricsTurnStarted || this.metricsTurnFinished) return;
+    this.metrics.startTurn(turnId);
+    this.metricsTurnStarted = true;
+  }
+
+  private async finalizePendingTurn(reason: string): Promise<void> {
+    const turnId = this.currentTurnId;
+    if (!turnId) return;
+
+    await this.archiveBufferedAudio({
+      turnId,
+      userMessageId: this.currentUserMessageId,
+      assistantMessageId: null,
+      userAudioChunks: this.currentUserAudioChunks,
+      assistantAudioChunks: [],
+      assistantAudioMimeType: "audio/pcm",
+    });
+    await this.finishMetricsTurn("cancelled", reason, turnId);
+  }
+
+  private async finalizeAssistantTurn(
+    turn: ActiveAssistantTurn,
+    status: "completed" | "cancelled",
+    reason = "completed",
+  ): Promise<void> {
+    if (turn.finalized) return;
+
+    turn.finalized = true;
+    await this.archiveBufferedAudio({
+      turnId: turn.turnId,
+      userMessageId: turn.userMessageId,
+      assistantMessageId: turn.assistantMessageId,
+      userAudioChunks: turn.userAudioChunks,
+      assistantAudioChunks: turn.assistantAudioChunks,
+      assistantAudioMimeType: turn.assistantAudioMimeType,
+      ...(turn.assistantAudioSampleRate !== undefined
+        ? { assistantAudioSampleRate: turn.assistantAudioSampleRate }
+        : {}),
+    });
+    await this.finishMetricsTurn(status, reason, turn.turnId);
+
+    if (this.activeAssistantTurn?.token === turn.token && turn.handle) {
+      this.activeAssistantTurn = null;
+    }
+  }
+
+  private async archiveBufferedAudio(input: {
+    turnId: string;
+    userMessageId: string | null;
+    assistantMessageId: string | null;
+    userAudioChunks: Buffer[];
+    assistantAudioChunks: Buffer[];
+    assistantAudioMimeType: string;
+    assistantAudioSampleRate?: number;
+  }): Promise<void> {
+    const userAudio = takeBufferedAudio(input.userAudioChunks);
+    if (userAudio) {
+      await this.archiveBufferedRoleAudio({
+        turnId: input.turnId,
+        role: "user",
+        messageId: input.userMessageId,
+        mimeType: this.context.startFrame.audio.mimeType,
+        sampleRate: this.context.startFrame.audio.sampleRate,
+        audio: userAudio,
+      });
+    }
+
+    const assistantAudio = takeBufferedAudio(input.assistantAudioChunks);
+    if (assistantAudio) {
+      const sampleRate =
+        input.assistantAudioSampleRate ??
+        this.context.startFrame.audio.sampleRate;
+      await this.archiveBufferedRoleAudio({
+        turnId: input.turnId,
+        role: "assistant",
+        messageId: input.assistantMessageId,
+        mimeType: input.assistantAudioMimeType,
+        sampleRate,
+        audio: assistantAudio,
+      });
+    }
+  }
+
+  private async archiveBufferedRoleAudio(input: {
+    turnId: string;
+    role: LiveVoiceAudioArchiveRole;
+    messageId: string | null;
+    mimeType: string;
+    sampleRate: number;
+    audio: Buffer;
+  }): Promise<void> {
+    const archiveAudio = this.archiveAudio;
+    if (!archiveAudio) return;
+
+    const durationMs = estimatePcmDurationMs({
+      byteLength: input.audio.byteLength,
+      mimeType: input.mimeType,
+      sampleRate: input.sampleRate,
+    });
+    let result: LiveVoiceAudioArchiveResult;
+    try {
+      result = await archiveAudio({
+        messageId: input.messageId,
+        sessionId: this.context.sessionId,
+        turnId: input.turnId,
+        role: input.role,
+        mimeType: input.mimeType,
+        sampleRate: input.sampleRate,
+        ...(durationMs !== undefined ? { durationMs } : {}),
+        audio: {
+          type: "base64",
+          dataBase64: input.audio.toString("base64"),
+        },
+      });
+    } catch (err) {
+      result = {
+        type: "warning",
+        warning: {
+          code: "archive_failed",
+          message: `Live voice audio archive failed without blocking the turn: ${errorMessage(
+            err,
+          )}`,
+        },
+      };
+    }
+
+    await this.sendArchiveFrame(input.turnId, input.role, result);
+  }
+
+  private async sendArchiveFrame(
+    turnId: string,
+    role: LiveVoiceAudioArchiveRole,
+    result: LiveVoiceAudioArchiveResult,
+  ): Promise<void> {
+    const artifact =
+      result.type === "archived" || result.type === "unlinked"
+        ? result.artifact
+        : undefined;
+    const warning = result.type === "archived" ? undefined : result.warning;
+    await this.sendFrame({
+      type: "archived",
+      conversationId: this.conversationId,
+      sessionId: this.context.sessionId,
+      turnId,
+      role,
+      ...(artifact
+        ? {
+            attachmentId: artifact.attachmentId,
+            attachmentIds: [artifact.attachmentId],
+          }
+        : {}),
+      ...(warning ? { warning } : {}),
+    });
+  }
+
+  private async finishMetricsTurn(
+    status: "completed" | "cancelled",
+    reason: string,
+    turnId: string,
+  ): Promise<void> {
+    if (!this.metricsTurnStarted || this.metricsTurnFinished) return;
+
+    if (status === "completed") {
+      this.metrics.completeTurn(turnId);
+    } else {
+      this.metrics.cancelTurn(reason, turnId);
+    }
+    this.metricsTurnFinished = true;
+
+    if (!this.emitMetrics) return;
+    await this.emitMetricsFrame(
+      status === "completed" ? "turn_completed" : "turn_cancelled",
+      turnId,
+    );
+  }
+
+  private async emitSessionEndMetrics(): Promise<void> {
+    if (!this.emitMetrics || this.sessionEndMetricsEmitted) return;
+
+    this.sessionEndMetricsEmitted = true;
+    await this.emitMetricsFrame("session_ended");
+  }
+
+  private async emitMetricsFrame(
+    event: string,
+    turnId = this.currentTurnId ?? this.context.sessionId,
+  ): Promise<void> {
+    await this.sendFrame({
+      type: "metrics",
+      event,
+      sessionId: this.context.sessionId,
+      conversationId: this.conversationId,
+      turnId,
+      metrics: this.metrics.getSnapshot(),
+    });
   }
 
   private async sendAudioAfterReleaseError(): Promise<void> {
@@ -597,6 +950,11 @@ export function createLiveVoiceSession(
       options.streamTtsAudio === undefined
         ? defaultStreamLiveVoiceTtsAudio
         : options.streamTtsAudio,
+    archiveAudio:
+      options.archiveAudio === undefined
+        ? defaultArchiveLiveVoiceAudio
+        : options.archiveAudio,
+    emitMetrics: options.emitMetrics ?? true,
   });
 }
 
@@ -620,6 +978,18 @@ async function defaultStreamLiveVoiceTtsAudio(
 ): Promise<LiveVoiceTtsResult> {
   const { streamLiveVoiceTtsAudio } = await import("./live-voice-tts.js");
   return streamLiveVoiceTtsAudio(options);
+}
+
+async function defaultArchiveLiveVoiceAudio(
+  input: LiveVoiceSessionArchiveAudioInput,
+): Promise<LiveVoiceAudioArchiveResult> {
+  const {
+    linkLiveVoiceAssistantResponseAudioToMessage,
+    linkLiveVoiceUserUtteranceAudioToMessage,
+  } = await import("./live-voice-archive.js");
+  return input.role === "user"
+    ? linkLiveVoiceUserUtteranceAudioToMessage(input)
+    : linkLiveVoiceAssistantResponseAudioToMessage(input);
 }
 
 function extractSpeakableSegments(
@@ -695,6 +1065,33 @@ function findLastWhitespaceBoundary(
 
 function isWhitespace(value: string): boolean {
   return /\s/.test(value);
+}
+
+function takeBufferedAudio(chunks: Buffer[]): Buffer | null {
+  if (chunks.length === 0) return null;
+
+  const audio = Buffer.concat(chunks);
+  chunks.length = 0;
+  return audio.byteLength > 0 ? audio : null;
+}
+
+function estimatePcmDurationMs(input: {
+  byteLength: number;
+  mimeType: string;
+  sampleRate: number;
+}): number | undefined {
+  if (
+    input.byteLength <= 0 ||
+    input.sampleRate <= 0 ||
+    input.mimeType.toLowerCase().split(";")[0]?.trim() !== "audio/pcm"
+  ) {
+    return undefined;
+  }
+
+  const bytesPerMonoSample = 2;
+  return Math.round(
+    (input.byteLength / (input.sampleRate * bytesPerMonoSample)) * 1000,
+  );
 }
 
 function unavailableTranscriberMessage(): string {

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -149,7 +149,11 @@ export interface LiveVoiceTtsDoneServerFrame extends LiveVoiceServerFrameBase {
 
 export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "metrics";
+  readonly event?: string;
+  readonly sessionId?: string;
+  readonly conversationId?: string;
   readonly turnId: string;
+  readonly metrics?: unknown;
   readonly sttMs?: number;
   readonly llmFirstDeltaMs?: number;
   readonly ttsFirstAudioMs?: number;
@@ -160,6 +164,14 @@ export interface LiveVoiceArchivedServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "archived";
   readonly conversationId: string;
   readonly sessionId: string;
+  readonly turnId?: string;
+  readonly role?: "user" | "assistant";
+  readonly attachmentId?: string;
+  readonly attachmentIds?: string[];
+  readonly warning?: {
+    readonly code: string;
+    readonly message: string;
+  };
 }
 
 export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {


### PR DESCRIPTION
## PR 19: emit archive and metrics events from live sessions

### Depends on

PR 15, PR 17, PR 18.

### Branch

`live-voice-channel/pr-19-session-archive-metrics`

### Files

- `assistant/src/live-voice/live-voice-session.ts`
- `assistant/src/live-voice/__tests__/live-voice-events.test.ts`

### Scope

Wire archival and metrics into the live session:

- collect user audio chunks per utterance
- collect assistant TTS chunks per assistant turn
- archive both sides after the turn completes or ends
- emit `archived` frames with attachment ids or a non-fatal warning
- emit `metrics` frames at turn completion and session end

### Acceptance Criteria

- Archive failures do not fail the conversation turn.
- Metrics are emitted for successful, interrupted, and error turns.
- Audio buffers are released after archival to avoid unbounded memory growth.

### Verification

Run:

```bash
export PATH="$HOME/.bun/bin:$PATH"
cd assistant && bun test src/live-voice/__tests__/live-voice-events.test.ts
cd assistant && bunx tsc --noEmit
```

Orchestrated by velissa-ai via run-plan; implemented by Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
